### PR TITLE
fix(notifications): clean up push token on logout

### DIFF
--- a/client/app/lib/core/platform/firebase_push_messaging_source.dart
+++ b/client/app/lib/core/platform/firebase_push_messaging_source.dart
@@ -110,6 +110,9 @@ class FirebasePushMessagingSource implements PushMessagingSource {
   }
 
   @override
+  Future<void> deleteToken() => _messaging.deleteToken();
+
+  @override
   Future<NotificationOpenRequest?> getInitialNotificationOpen() async {
     if (_initialNotificationOpenConsumed) {
       return null;

--- a/client/app/lib/features/settings/profile_screen.dart
+++ b/client/app/lib/features/settings/profile_screen.dart
@@ -23,7 +23,10 @@ class ProfileScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => SettingsCubit(authSession: getIt<AuthSession>()),
+      create: (_) => SettingsCubit(
+        authSession: getIt<AuthSession>(),
+        notificationRegistrationService: getIt<NotificationRegistrationService>(),
+      ),
       child: const _ProfileBody(),
     );
   }

--- a/client/app/lib/features/settings/settings_screen.dart
+++ b/client/app/lib/features/settings/settings_screen.dart
@@ -26,7 +26,10 @@ class SettingsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => SettingsCubit(authSession: getIt<AuthSession>()),
+      create: (_) => SettingsCubit(
+        authSession: getIt<AuthSession>(),
+        notificationRegistrationService: getIt<NotificationRegistrationService>(),
+      ),
       child: const _SettingsBody(),
     );
   }

--- a/client/app/test/core/platform/firebase_push_messaging_source_test.dart
+++ b/client/app/test/core/platform/firebase_push_messaging_source_test.dart
@@ -135,4 +135,12 @@ void main() {
     expect(token, isNull);
     verifyNever(() => messaging.getToken());
   });
+
+  test("deleteToken delegates to Firebase Messaging", () async {
+    when(() => messaging.deleteToken()).thenAnswer((_) async {});
+
+    await source.deleteToken();
+
+    verify(() => messaging.deleteToken()).called(1);
+  });
 }

--- a/client/app/test/features/settings/settings_screen_test.dart
+++ b/client/app/test/features/settings/settings_screen_test.dart
@@ -27,6 +27,8 @@ class _StubAuthSession extends Mock implements AuthSession {
   AuthState get currentState => _authState.value;
 }
 
+class _MockNotificationRegistrationService extends Mock implements NotificationRegistrationService {}
+
 Widget _app() {
   final router = GoRouter(
     routes: [
@@ -64,6 +66,9 @@ void main() {
 
     await GetIt.instance.reset();
     GetIt.instance.registerSingleton<AuthSession>(_StubAuthSession());
+    GetIt.instance.registerSingleton<NotificationRegistrationService>(
+      _MockNotificationRegistrationService(),
+    );
   });
 
   tearDown(() async {

--- a/client/module_core/lib/src/cubits/settings/settings_cubit.dart
+++ b/client/module_core/lib/src/cubits/settings/settings_cubit.dart
@@ -51,6 +51,11 @@ class SettingsCubit extends Cubit<SettingsState> {
       if (isClosed) return;
       emit(state.copyWith(logoutStatus: SettingsLogoutStatus.success));
     } catch (_) {
+      try {
+        await _notificationRegistrationService.resumeRegistrationAfterFailedLogout();
+      } catch (error, stackTrace) {
+        logw("Failed to restore push notifications after logout failed", error, stackTrace);
+      }
       if (isClosed) return;
       emit(state.copyWith(logoutStatus: SettingsLogoutStatus.failure));
     }

--- a/client/module_core/lib/src/cubits/settings/settings_cubit.dart
+++ b/client/module_core/lib/src/cubits/settings/settings_cubit.dart
@@ -4,15 +4,21 @@ import "package:bloc/bloc.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
 
+import "../../logging/logging.dart";
+import "../../services/notification_registration_service.dart";
 import "settings_state.dart";
 
 class SettingsCubit extends Cubit<SettingsState> {
   final AuthSession _authSession;
+  final NotificationRegistrationService _notificationRegistrationService;
   final CompositeSubscription _subscriptions = CompositeSubscription();
 
-  SettingsCubit({required AuthSession authSession})
-    : _authSession = authSession,
-      super(SettingsState(account: _accountFrom(authSession.currentState))) {
+  SettingsCubit({
+    required AuthSession authSession,
+    required NotificationRegistrationService notificationRegistrationService,
+  }) : _authSession = authSession,
+       _notificationRegistrationService = notificationRegistrationService,
+       super(SettingsState(account: _accountFrom(authSession.currentState))) {
     // Keep the signed-in account in sync: the session is restored
     // asynchronously on launch, so the account may resolve after the cubit is
     // first constructed. Initial value comes from currentState above so the UI
@@ -36,6 +42,11 @@ class SettingsCubit extends Cubit<SettingsState> {
     emit(state.copyWith(logoutStatus: SettingsLogoutStatus.inProgress));
 
     try {
+      try {
+        await _notificationRegistrationService.unregisterCurrentDevice();
+      } catch (error, stackTrace) {
+        logw("Failed to clean up push notifications during logout", error, stackTrace);
+      }
       await _authSession.logoutCurrentDevice();
       if (isClosed) return;
       emit(state.copyWith(logoutStatus: SettingsLogoutStatus.success));

--- a/client/module_core/lib/src/platform/push_messaging_source.dart
+++ b/client/module_core/lib/src/platform/push_messaging_source.dart
@@ -10,6 +10,8 @@ abstract interface class PushMessagingSource {
 
   Future<String?> getToken();
 
+  Future<void> deleteToken();
+
   Stream<String> get tokenRefreshStream;
 
   Stream<PushNotificationMessage> get foregroundMessageStream;

--- a/client/module_core/lib/src/services/notification_registration_service.dart
+++ b/client/module_core/lib/src/services/notification_registration_service.dart
@@ -70,6 +70,11 @@ class NotificationRegistrationService {
     return _enqueueSync(_unregisterCurrentDevice);
   }
 
+  /// Restores push registration when local auth remains after logout fails.
+  Future<void> resumeRegistrationAfterFailedLogout() {
+    return _enqueueSync(_resumeRegistrationAfterFailedLogout);
+  }
+
   Future<void> _syncForState({required AuthState state}) async {
     switch (state) {
       case AuthAuthenticated():
@@ -126,6 +131,14 @@ class NotificationRegistrationService {
         logw("Failed to unregister push token during logout", error, stackTrace);
       }
     }
+  }
+
+  Future<void> _resumeRegistrationAfterFailedLogout() async {
+    if (_authSession.currentState is! AuthAuthenticated) return;
+
+    _registrationSuspended = false;
+    _unauthenticatedObservedWhileSuspended = false;
+    await _registerCurrentToken();
   }
 
   Future<void> _deleteLocalToken() async {

--- a/client/module_core/lib/src/services/notification_registration_service.dart
+++ b/client/module_core/lib/src/services/notification_registration_service.dart
@@ -18,6 +18,9 @@ class NotificationRegistrationService {
   String? _currentRegisteredToken;
   AuthState? _initialAuthStateToIgnore;
   Future<void> _syncQueue = Future<void>.value();
+  bool _localTokenDeleted = false;
+  bool _registrationSuspended = false;
+  bool _unauthenticatedObservedWhileSuspended = false;
   bool _started = false;
   bool _disposed = false;
 
@@ -61,12 +64,26 @@ class NotificationRegistrationService {
     return next;
   }
 
+  /// Stops push delivery for this installation before local auth is cleared.
+  /// Cleanup is best-effort so a failure cannot prevent local logout.
+  Future<void> unregisterCurrentDevice() {
+    return _enqueueSync(_unregisterCurrentDevice);
+  }
+
   Future<void> _syncForState({required AuthState state}) async {
     switch (state) {
       case AuthAuthenticated():
+        if (_registrationSuspended) {
+          if (!_unauthenticatedObservedWhileSuspended) return;
+          _registrationSuspended = false;
+          _unauthenticatedObservedWhileSuspended = false;
+        }
         await _registerCurrentToken();
       case AuthUnauthenticated() || AuthFailed():
-        await _unregisterCurrentToken();
+        if (_registrationSuspended) {
+          _unauthenticatedObservedWhileSuspended = true;
+        }
+        await _deleteLocalToken();
       case AuthInitial() || AuthAuthenticating():
         return;
     }
@@ -74,22 +91,55 @@ class NotificationRegistrationService {
 
   Future<void> _registerCurrentToken() async {
     final token = await _pushMessagingSource.getToken();
-    if (token == null || token.isEmpty || token == _currentRegisteredToken) {
+    if (token == null || token.isEmpty) {
       return;
     }
+    _localTokenDeleted = false;
+    if (token == _currentRegisteredToken) return;
 
     await _repository.registerToken(token: token, platform: _pushMessagingSource.devicePlatform);
     _currentRegisteredToken = token;
   }
 
-  Future<void> _unregisterCurrentToken() async {
-    final token = _currentRegisteredToken ?? await _pushMessagingSource.getToken();
-    if (token == null) {
+  Future<void> _unregisterCurrentDevice() async {
+    // Do not let queued auth work or a refresh re-register before logout.
+    _registrationSuspended = true;
+    _unauthenticatedObservedWhileSuspended = false;
+
+    var token = _currentRegisteredToken;
+    if (token == null && !_localTokenDeleted) {
+      try {
+        token = await _pushMessagingSource.getToken();
+        if (token != null && token.isNotEmpty) {
+          _localTokenDeleted = false;
+        }
+      } catch (error, stackTrace) {
+        logw("Failed to read push token during logout", error, stackTrace);
+      }
+    }
+
+    if (token != null && token.isNotEmpty) {
+      try {
+        await _repository.unregisterToken(token: token);
+        _currentRegisteredToken = null;
+      } catch (error, stackTrace) {
+        logw("Failed to unregister push token during logout", error, stackTrace);
+      }
+    }
+  }
+
+  Future<void> _deleteLocalToken() async {
+    if (_localTokenDeleted) {
+      _currentRegisteredToken = null;
       return;
     }
 
-    await _repository.unregisterToken(token: token);
-    _currentRegisteredToken = null;
+    try {
+      await _pushMessagingSource.deleteToken();
+      _localTokenDeleted = true;
+    } finally {
+      _currentRegisteredToken = null;
+    }
   }
 
   void _onAuthStateChanged(AuthState state) {
@@ -115,6 +165,18 @@ class NotificationRegistrationService {
   }
 
   Future<void> _handleTokenRefresh({required String newToken}) async {
+    if (newToken.isEmpty) return;
+
+    _localTokenDeleted = false;
+    final authState = _authSession.currentState;
+    if (_registrationSuspended && authState is AuthAuthenticated) {
+      return;
+    }
+    if (authState is! AuthAuthenticated) {
+      await _syncForState(state: authState);
+      return;
+    }
+
     final oldToken = _currentRegisteredToken;
     if (oldToken != null && oldToken != newToken) {
       try {
@@ -123,10 +185,6 @@ class NotificationRegistrationService {
         logw("Failed to unregister old push token", error, stackTrace);
       }
       _currentRegisteredToken = null;
-    }
-
-    if (_authSession.currentState is! AuthAuthenticated || newToken.isEmpty) {
-      return;
     }
 
     await _repository.registerToken(token: newToken, platform: _pushMessagingSource.devicePlatform);

--- a/client/module_core/test/cubits/settings/settings_cubit_test.dart
+++ b/client/module_core/test/cubits/settings/settings_cubit_test.dart
@@ -32,6 +32,9 @@ void main() {
       when(() => authSession.currentState).thenAnswer((_) => authStates.value);
       when(() => authSession.authStateStream).thenAnswer((_) => authStates);
       when(() => notificationRegistrationService.unregisterCurrentDevice()).thenAnswer((_) async {});
+      when(
+        () => notificationRegistrationService.resumeRegistrationAfterFailedLogout(),
+      ).thenAnswer((_) async {});
     });
 
     tearDown(() => authStates.close());
@@ -116,7 +119,11 @@ void main() {
       await cubit.logout();
 
       expect(await futureStatuses, [SettingsLogoutStatus.inProgress, SettingsLogoutStatus.failure]);
-      verify(() => authSession.logoutCurrentDevice()).called(1);
+      verifyInOrder([
+        () => notificationRegistrationService.unregisterCurrentDevice(),
+        () => authSession.logoutCurrentDevice(),
+        () => notificationRegistrationService.resumeRegistrationAfterFailedLogout(),
+      ]);
     });
 
     test("ignores duplicate logout calls while already in progress", () async {

--- a/client/module_core/test/cubits/settings/settings_cubit_test.dart
+++ b/client/module_core/test/cubits/settings/settings_cubit_test.dart
@@ -5,13 +5,17 @@ import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_dart_core/src/cubits/settings/settings_cubit.dart";
 import "package:sesori_dart_core/src/cubits/settings/settings_state.dart";
+import "package:sesori_dart_core/src/services/notification_registration_service.dart";
 import "package:test/test.dart";
 
 class _MockAuthSession extends Mock implements AuthSession {}
 
+class _MockNotificationRegistrationService extends Mock implements NotificationRegistrationService {}
+
 void main() {
   group("SettingsCubit", () {
     late _MockAuthSession authSession;
+    late _MockNotificationRegistrationService notificationRegistrationService;
     late BehaviorSubject<AuthState> authStates;
 
     const user = AuthUser(
@@ -23,9 +27,11 @@ void main() {
 
     setUp(() {
       authSession = _MockAuthSession();
+      notificationRegistrationService = _MockNotificationRegistrationService();
       authStates = BehaviorSubject<AuthState>.seeded(const AuthState.unauthenticated());
       when(() => authSession.currentState).thenAnswer((_) => authStates.value);
       when(() => authSession.authStateStream).thenAnswer((_) => authStates);
+      when(() => notificationRegistrationService.unregisterCurrentDevice()).thenAnswer((_) async {});
     });
 
     tearDown(() => authStates.close());
@@ -33,7 +39,10 @@ void main() {
     test("initial state is idle with the account from the current auth state", () {
       authStates.add(const AuthState.authenticated(user: user));
 
-      final cubit = SettingsCubit(authSession: authSession);
+      final cubit = SettingsCubit(
+        authSession: authSession,
+        notificationRegistrationService: notificationRegistrationService,
+      );
       addTearDown(cubit.close);
 
       expect(cubit.state.logoutStatus, SettingsLogoutStatus.idle);
@@ -41,7 +50,10 @@ void main() {
     });
 
     test("updates the account when the auth state stream emits", () async {
-      final cubit = SettingsCubit(authSession: authSession);
+      final cubit = SettingsCubit(
+        authSession: authSession,
+        notificationRegistrationService: notificationRegistrationService,
+      );
       addTearDown(cubit.close);
 
       expect(cubit.state.account, isNull);
@@ -55,20 +67,49 @@ void main() {
     test("emits inProgress then success after logout succeeds", () async {
       when(() => authSession.logoutCurrentDevice()).thenAnswer((_) async {});
 
-      final cubit = SettingsCubit(authSession: authSession);
+      final cubit = SettingsCubit(
+        authSession: authSession,
+        notificationRegistrationService: notificationRegistrationService,
+      );
       addTearDown(cubit.close);
 
       final futureStatuses = cubit.stream.map((s) => s.logoutStatus).take(2).toList();
       await cubit.logout();
 
       expect(await futureStatuses, [SettingsLogoutStatus.inProgress, SettingsLogoutStatus.success]);
+      verifyInOrder([
+        () => notificationRegistrationService.unregisterCurrentDevice(),
+        () => authSession.logoutCurrentDevice(),
+      ]);
+    });
+
+    test("still logs out when push notification cleanup fails", () async {
+      when(
+        () => notificationRegistrationService.unregisterCurrentDevice(),
+      ).thenThrow(StateError("cleanup failed"));
+      when(() => authSession.logoutCurrentDevice()).thenAnswer((_) async {});
+
+      final cubit = SettingsCubit(
+        authSession: authSession,
+        notificationRegistrationService: notificationRegistrationService,
+      );
+      addTearDown(cubit.close);
+
+      final futureStatuses = cubit.stream.map((s) => s.logoutStatus).take(2).toList();
+      await cubit.logout();
+
+      expect(await futureStatuses, [SettingsLogoutStatus.inProgress, SettingsLogoutStatus.success]);
+      verify(() => notificationRegistrationService.unregisterCurrentDevice()).called(1);
       verify(() => authSession.logoutCurrentDevice()).called(1);
     });
 
     test("emits inProgress then failure when logout throws", () async {
       when(() => authSession.logoutCurrentDevice()).thenThrow(StateError("boom"));
 
-      final cubit = SettingsCubit(authSession: authSession);
+      final cubit = SettingsCubit(
+        authSession: authSession,
+        notificationRegistrationService: notificationRegistrationService,
+      );
       addTearDown(cubit.close);
 
       final futureStatuses = cubit.stream.map((s) => s.logoutStatus).take(2).toList();
@@ -82,7 +123,10 @@ void main() {
       final completer = Completer<void>();
       when(() => authSession.logoutCurrentDevice()).thenAnswer((_) => completer.future);
 
-      final cubit = SettingsCubit(authSession: authSession);
+      final cubit = SettingsCubit(
+        authSession: authSession,
+        notificationRegistrationService: notificationRegistrationService,
+      );
       addTearDown(cubit.close);
 
       final firstLogout = cubit.logout();
@@ -95,6 +139,7 @@ void main() {
       await firstLogout;
 
       expect(cubit.state.logoutStatus, SettingsLogoutStatus.success);
+      verify(() => notificationRegistrationService.unregisterCurrentDevice()).called(1);
       verify(() => authSession.logoutCurrentDevice()).called(1);
     });
   });

--- a/client/module_core/test/routing/notification_open_dispatcher_test.dart
+++ b/client/module_core/test/routing/notification_open_dispatcher_test.dart
@@ -223,6 +223,9 @@ class FakePushMessagingSource implements PushMessagingSource {
   Future<String?> getToken() async => null;
 
   @override
+  Future<void> deleteToken() async {}
+
+  @override
   Future<void> initialize() async {}
 
   @override

--- a/client/module_core/test/services/foreground_notification_dispatcher_test.dart
+++ b/client/module_core/test/services/foreground_notification_dispatcher_test.dart
@@ -175,6 +175,9 @@ class FakePushMessagingSource implements PushMessagingSource {
   Future<String?> getToken() async => null;
 
   @override
+  Future<void> deleteToken() async {}
+
+  @override
   Future<void> initialize() async {}
 
   @override

--- a/client/module_core/test/services/notification_registration_service_test.dart
+++ b/client/module_core/test/services/notification_registration_service_test.dart
@@ -197,6 +197,25 @@ void main() {
       expect(repository.unregisteredTokens, equals(["token-1"]));
     });
 
+    test("failed logout resumes registration for the authenticated user", () async {
+      await service.start();
+      await service.unregisterCurrentDevice();
+
+      await service.resumeRegistrationAfterFailedLogout();
+      pushMessagingSource.emitTokenRefresh("token-2");
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        repository.registeredTokens,
+        equals([
+          const RegisteredToken(token: "token-1", platform: DevicePlatform.android),
+          const RegisteredToken(token: "token-1", platform: DevicePlatform.android),
+          const RegisteredToken(token: "token-2", platform: DevicePlatform.android),
+        ]),
+      );
+      expect(repository.unregisteredTokens, equals(["token-1", "token-1"]));
+    });
+
     test("keeps listening after an initial sync failure", () async {
       repository.failNextRegisterToken = true;
 

--- a/client/module_core/test/services/notification_registration_service_test.dart
+++ b/client/module_core/test/services/notification_registration_service_test.dart
@@ -17,13 +17,16 @@ void main() {
     late FakeAuthSession authSession;
     late FakePushMessagingSource pushMessagingSource;
     late NotificationRegistrationService service;
+    late List<String> operations;
 
     setUp(() {
-      repository = RecordingNotificationRepository();
+      operations = <String>[];
+      repository = RecordingNotificationRepository(operations: operations);
       authSession = FakeAuthSession(initialState: _authenticatedState());
       pushMessagingSource = FakePushMessagingSource(
         initialToken: "token-1",
         devicePlatform: DevicePlatform.android,
+        operations: operations,
       );
       service = NotificationRegistrationService(
         repository: repository,
@@ -38,7 +41,7 @@ void main() {
       await pushMessagingSource.dispose();
     });
 
-    test("auth state and token refresh drive registration pipeline only", () async {
+    test("auth state and token refresh keep server and local registration in sync", () async {
       await service.start();
 
       expect(
@@ -67,38 +70,45 @@ void main() {
       authSession.emit(const AuthState.unauthenticated());
       await Future<void>.delayed(Duration.zero);
 
-      expect(repository.unregisteredTokens, equals(["token-1", "token-2"]));
+      expect(repository.unregisteredTokens, equals(["token-1"]));
+      expect(pushMessagingSource.deleteTokenCalls, 1);
+      expect(pushMessagingSource.currentToken, isNull);
     });
 
-    test("unauthenticated refresh does not register until auth returns", () async {
+    test("unauthenticated refresh is deleted until auth returns", () async {
       authSession.emit(const AuthState.unauthenticated());
       await service.start();
       await Future<void>.delayed(Duration.zero);
 
       expect(repository.registeredTokens, isEmpty);
+      expect(pushMessagingSource.deleteTokenCalls, 1);
 
       pushMessagingSource.currentToken = "token-2";
       pushMessagingSource.emitTokenRefresh("token-2");
       await Future<void>.delayed(Duration.zero);
 
       expect(repository.registeredTokens, isEmpty);
+      expect(pushMessagingSource.deleteTokenCalls, 2);
+      expect(pushMessagingSource.currentToken, isNull);
 
+      pushMessagingSource.currentToken = "token-3";
       authSession.emit(_authenticatedState());
       await Future<void>.delayed(Duration.zero);
 
       expect(
         repository.registeredTokens,
         equals([
-          const RegisteredToken(token: "token-2", platform: DevicePlatform.android),
+          const RegisteredToken(token: "token-3", platform: DevicePlatform.android),
         ]),
       );
     });
 
-    test("unauthenticated startup unregisters the current device token after restart", () async {
+    test("unauthenticated startup deletes the current local token after restart", () async {
       authSession = FakeAuthSession(initialState: const AuthState.unauthenticated());
       pushMessagingSource = FakePushMessagingSource(
         initialToken: "token-1",
         devicePlatform: DevicePlatform.android,
+        operations: operations,
       );
       service = NotificationRegistrationService(
         repository: repository,
@@ -109,6 +119,81 @@ void main() {
       await service.start();
 
       expect(repository.registeredTokens, isEmpty);
+      expect(repository.unregisteredTokens, isEmpty);
+      expect(pushMessagingSource.deleteTokenCalls, 1);
+      expect(pushMessagingSource.currentToken, isNull);
+    });
+
+    test("logout cleanup unregisters remotely before auth deletes the local token", () async {
+      await service.start();
+      operations.clear();
+
+      await service.unregisterCurrentDevice();
+
+      expect(operations, equals(["unregister:token-1"]));
+      expect(repository.unregisteredTokens, equals(["token-1"]));
+      expect(pushMessagingSource.deleteTokenCalls, 0);
+
+      pushMessagingSource.emitTokenRefresh("token-2");
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        repository.registeredTokens,
+        equals([
+          const RegisteredToken(token: "token-1", platform: DevicePlatform.android),
+        ]),
+      );
+      expect(pushMessagingSource.deleteTokenCalls, 0);
+
+      authSession.emit(const AuthState.unauthenticated());
+      await Future<void>.delayed(Duration.zero);
+
+      expect(operations, equals(["unregister:token-1", "delete-local"]));
+      expect(pushMessagingSource.deleteTokenCalls, 1);
+    });
+
+    test("unauthenticated cleanup retries local deletion after failures", () async {
+      await service.start();
+      repository.failNextUnregisterToken = true;
+      pushMessagingSource.failNextDeleteToken = true;
+
+      await service.unregisterCurrentDevice();
+
+      expect(repository.unregisteredTokens, equals(["token-1"]));
+      expect(pushMessagingSource.deleteTokenCalls, 0);
+
+      authSession.emit(const AuthState.unauthenticated());
+      await Future<void>.delayed(Duration.zero);
+
+      expect(pushMessagingSource.deleteTokenCalls, 1);
+
+      pushMessagingSource.emitTokenRefresh("token-2");
+      await Future<void>.delayed(Duration.zero);
+
+      expect(pushMessagingSource.deleteTokenCalls, 2);
+      expect(pushMessagingSource.currentToken, isNull);
+    });
+
+    test("queued authenticated work cannot clear logout suspension", () async {
+      await service.start();
+      final tokenCompleter = Completer<String?>();
+      pushMessagingSource.tokenFuture = tokenCompleter.future;
+
+      authSession.emit(_authenticatedState());
+      await Future<void>.delayed(Duration.zero);
+      final cleanupFuture = service.unregisterCurrentDevice();
+      pushMessagingSource.emitTokenRefresh("token-2");
+
+      tokenCompleter.complete("token-1");
+      await cleanupFuture;
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        repository.registeredTokens,
+        equals([
+          const RegisteredToken(token: "token-1", platform: DevicePlatform.android),
+        ]),
+      );
       expect(repository.unregisteredTokens, equals(["token-1"]));
     });
 
@@ -121,6 +206,7 @@ void main() {
 
       authSession.emit(const AuthState.unauthenticated());
       await Future<void>.delayed(Duration.zero);
+      pushMessagingSource.currentToken = "token-1";
       authSession.emit(_authenticatedState());
       await Future<void>.delayed(Duration.zero);
 
@@ -134,7 +220,7 @@ void main() {
       pushMessagingSource.emitTokenRefresh("token-2");
       await Future<void>.delayed(Duration.zero);
 
-      expect(repository.unregisteredTokens, equals(["token-1", "token-1"]));
+      expect(repository.unregisteredTokens, equals(["token-1"]));
       expect(
         repository.registeredTokens,
         equals([
@@ -161,7 +247,8 @@ void main() {
           const RegisteredToken(token: "token-1", platform: DevicePlatform.android),
         ]),
       );
-      expect(repository.unregisteredTokens, equals(["token-1"]));
+      expect(repository.unregisteredTokens, isEmpty);
+      expect(pushMessagingSource.deleteTokenCalls, 1);
     });
 
     test("processes the first changed auth snapshot after startup sync", () async {
@@ -183,7 +270,8 @@ void main() {
           const RegisteredToken(token: "token-1", platform: DevicePlatform.android),
         ]),
       );
-      expect(repository.unregisteredTokens, equals(["token-1"]));
+      expect(repository.unregisteredTokens, isEmpty);
+      expect(pushMessagingSource.deleteTokenCalls, 1);
     });
   });
 }
@@ -191,7 +279,11 @@ void main() {
 class RecordingNotificationRepository implements NotificationRepository {
   final List<RegisteredToken> registeredTokens = <RegisteredToken>[];
   final List<String> unregisteredTokens = <String>[];
+  final List<String> operations;
   bool failNextRegisterToken = false;
+  bool failNextUnregisterToken = false;
+
+  RecordingNotificationRepository({required this.operations});
 
   @override
   Future<void> registerToken({required String token, required DevicePlatform platform}) async {
@@ -200,11 +292,17 @@ class RecordingNotificationRepository implements NotificationRepository {
       throw StateError("register token failed");
     }
     registeredTokens.add(RegisteredToken(token: token, platform: platform));
+    operations.add("register:$token");
   }
 
   @override
   Future<void> unregisterToken({required String token}) async {
     unregisteredTokens.add(token);
+    operations.add("unregister:$token");
+    if (failNextUnregisterToken) {
+      failNextUnregisterToken = false;
+      throw StateError("unregister token failed");
+    }
   }
 }
 
@@ -277,11 +375,18 @@ class FakePushMessagingSource implements PushMessagingSource {
 
   @override
   final DevicePlatform devicePlatform;
+  final List<String> operations;
 
   String? currentToken;
   Future<String?>? tokenFuture;
+  int deleteTokenCalls = 0;
+  bool failNextDeleteToken = false;
 
-  FakePushMessagingSource({required String? initialToken, required this.devicePlatform}) : currentToken = initialToken;
+  FakePushMessagingSource({
+    required String? initialToken,
+    required this.devicePlatform,
+    required this.operations,
+  }) : currentToken = initialToken;
 
   @override
   Stream<PushNotificationMessage> get foregroundMessageStream => _foregroundMessageController.stream;
@@ -291,6 +396,17 @@ class FakePushMessagingSource implements PushMessagingSource {
 
   @override
   Future<String?> getToken() async => tokenFuture ?? currentToken;
+
+  @override
+  Future<void> deleteToken() async {
+    deleteTokenCalls++;
+    operations.add("delete-local");
+    if (failNextDeleteToken) {
+      failNextDeleteToken = false;
+      throw StateError("delete token failed");
+    }
+    currentToken = null;
+  }
 
   @override
   Future<void> initialize() async {}


### PR DESCRIPTION
## Summary

- deregister the current device's push token from the auth server before local logout clears its bearer token
- invalidate the local Firebase token after the auth state becomes unauthenticated
- suppress token refresh registration during logout and repair leaked tokens on logged-out startup
- cover cleanup ordering, failures, queued lifecycle work, and Firebase adapter behavior

## Why

Device-local logout previously cleared authentication first. The notification registration listener then attempted the authenticated token-delete request without credentials, leaving the server-side token associated with the user and allowing push notifications after logout.

This uses the existing owner-scoped `DELETE /notifications/tokens/:token` endpoint and does not invalidate sessions or notification tokens on other devices.

## Testing

- `dart test test/services/notification_registration_service_test.dart test/cubits/settings/settings_cubit_test.dart` (`client/module_core`)
- `flutter test test/core/platform/firebase_push_messaging_source_test.dart` (`client/app`)
- `flutter test test/features/settings/settings_screen_test.dart` (`client/app`)
- `dart analyze` (`client/module_core`)
- `dart analyze` (`client/app`)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop push notifications after logout by unregistering the device’s token on the server before clearing auth, deleting the local Firebase token when unauthenticated, and resuming registration if logout fails. Prevents post-logout pushes and cleans up leaked tokens on startup.

- **Bug Fixes**
  - Unregister the current device’s token before logout; if cleanup fails, logout still completes and registration is resumed.
  - Delete the local push token when unauthenticated and on logged-out startup; suspend token refresh/registration during logout to avoid re-registering.
  - Register tokens only when authenticated; on refresh, unregister old and register new safely.

- **Refactors**
  - Add deleteToken() to `PushMessagingSource` and implement in Firebase source.
  - `SettingsCubit` now depends on `NotificationRegistrationService`; settings/profile screens provide it via DI.

<sup>Written for commit 9b552235a421133ccbe45a2e2bb5a0aee775860c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

