### PR TITLE
fix(client): retry transient relay disconnects

### DIFF
--- a/client/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/client/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -249,9 +249,9 @@ class ConnectionService {
   /// for ongoing heartbeat monitoring.
   Future<ApiResponse<HealthResponse>> connect(
     ServerConnectionConfig config,
-  ) => _connectViaRelay(config);
+  ) async => (await _connectViaRelay(config)).response;
 
-  Future<ApiResponse<HealthResponse>> _connectViaRelay(
+  Future<({ApiResponse<HealthResponse> response, int? closeCode})> _connectViaRelay(
     ServerConnectionConfig config, {
     bool Function()? isStale,
   }) async {
@@ -261,7 +261,7 @@ class ConnectionService {
     // the previous socket was tearing down, don't open a replacement — otherwise
     // two sockets briefly race for the same account (relay close code 4005).
     if (isStale?.call() ?? false) {
-      return ApiResponse.error(ApiError.generic());
+      return (response: ApiResponse<HealthResponse>.error(ApiError.generic()), closeCode: null);
     }
 
     final relayClient = _relayClientFactory.call(
@@ -275,7 +275,7 @@ class ConnectionService {
     if (isStale?.call() ?? false) {
       _clearConnectingRelayClient(relayClient);
       await relayClient.disconnect();
-      return ApiResponse.error(ApiError.generic());
+      return (response: ApiResponse<HealthResponse>.error(ApiError.generic()), closeCode: null);
     }
 
     try {
@@ -286,7 +286,7 @@ class ConnectionService {
       if (isStale?.call() ?? false) {
         _clearConnectingRelayClient(relayClient);
         await relayClient.disconnect();
-        return ApiResponse.error(ApiError.generic());
+        return (response: ApiResponse<HealthResponse>.error(ApiError.generic()), closeCode: null);
       }
 
       // connect() returned but isConnected is false: the relay accepted and is
@@ -301,8 +301,7 @@ class ConnectionService {
       // transport state being `connected` too: a bridge-absent park sets the
       // state to connected with no session encryptor, whereas a disposed/early
       // return leaves it in `connecting` — only the former should park here.
-      if (relayClient.connectionState == RelayClientConnectionState.connected &&
-          !relayClient.isConnected) {
+      if (relayClient.connectionState == RelayClientConnectionState.connected && !relayClient.isConnected) {
         const bridgeOfflineHealth = HealthResponse(healthy: true, version: "", filesystemAccessDegraded: null);
         _clearConnectingRelayClient(relayClient);
         _relayClient = relayClient;
@@ -318,10 +317,13 @@ class ConnectionService {
         } catch (error, stackTrace) {
           loge("Failed to set up watchers after bridge-absent relay connect", error, stackTrace);
           await _disconnectRelayClient();
-          return ApiResponse.error(ApiError.generic());
+          return (
+            response: ApiResponse<HealthResponse>.error(ApiError.generic()),
+            closeCode: relayClient.lastCloseCode,
+          );
         }
         _status.add(ConnectionStatus.bridgeOffline(config: config, health: bridgeOfflineHealth));
-        return ApiResponse.success(bridgeOfflineHealth);
+        return (response: ApiResponse.success(bridgeOfflineHealth), closeCode: null);
       }
 
       // A resume_ack already proves the bridge is reachable; only fresh-DH
@@ -356,11 +358,14 @@ class ConnectionService {
         if (response.status < 200 || response.status >= 300 || response.body == null) {
           _clearConnectingRelayClient(relayClient);
           await relayClient.disconnect();
-          return ApiResponse.error(
-            ApiError.nonSuccessCode(
-              errorCode: response.status,
-              rawErrorString: response.body,
+          return (
+            response: ApiResponse<HealthResponse>.error(
+              ApiError.nonSuccessCode(
+                errorCode: response.status,
+                rawErrorString: response.body,
+              ),
             ),
+            closeCode: relayClient.lastCloseCode,
           );
         }
 
@@ -373,7 +378,7 @@ class ConnectionService {
       if (isStale?.call() ?? false) {
         _clearConnectingRelayClient(relayClient);
         await relayClient.disconnect();
-        return ApiResponse.error(ApiError.generic());
+        return (response: ApiResponse<HealthResponse>.error(ApiError.generic()), closeCode: null);
       }
 
       // Cache health only after the staleness gate, so a superseded attempt
@@ -394,12 +399,16 @@ class ConnectionService {
       } catch (error, stackTrace) {
         loge("Failed to setup SSE streams after successful relay connect", error, stackTrace);
         await _disconnectRelayClient();
-        return ApiResponse.error(ApiError.generic());
+        return (
+          response: ApiResponse<HealthResponse>.error(ApiError.generic()),
+          closeCode: relayClient.lastCloseCode,
+        );
       }
       _status.add(ConnectionStatus.connected(config: config, health: health));
-      return ApiResponse.success(health);
+      return (response: ApiResponse.success(health), closeCode: null);
     } catch (error, stackTrace) {
       loge("Failed to connect via relay", error, stackTrace);
+      final closeCode = relayClient.lastCloseCode;
       _clearConnectingRelayClient(relayClient);
       try {
         await relayClient.disconnect().timeout(const Duration(seconds: 3));
@@ -407,7 +416,7 @@ class ConnectionService {
         logw("Best-effort relay disconnect failed after connect error: ${disconnectError.toString()}");
         loge("Relay disconnect cleanup failed", disconnectError, disconnectStackTrace);
       }
-      return ApiResponse.error(ApiError.generic());
+      return (response: ApiResponse<HealthResponse>.error(ApiError.generic()), closeCode: closeCode);
     }
   }
 
@@ -450,8 +459,13 @@ class ConnectionService {
     final config = activeConfig;
     if (config == null) return;
 
+    _reconnectTimer?.cancel();
+    if (_reconnectDelayCompleter case final completer? when !completer.isCompleted) {
+      completer.complete();
+    }
+    _relayReconnectBackoff = const Duration(seconds: 1);
     _status.add(ConnectionStatus.reconnecting(config: config));
-    unawaited(_reconnectRelayWithRefresh(config));
+    unawaited(_reconnectRelayWithRefresh(config, immediate: true));
   }
 
   // ---------------------------------------------------------------------------
@@ -674,8 +688,7 @@ class ConnectionService {
         (status is ConnectionConnected || status is ConnectionBridgeOffline) &&
         backgroundedFor >= _resumeReconnectThreshold;
 
-    final needsReconnect =
-        status is ConnectionLost || status is ConnectionReconnecting || connectionLikelyStale;
+    final needsReconnect = status is ConnectionLost || status is ConnectionReconnecting || connectionLikelyStale;
     if (!needsReconnect) return;
 
     logd("App resumed — triggering reconnect (status=${status.runtimeType}, backgrounded=$backgroundedFor)");
@@ -757,6 +770,30 @@ class ConnectionService {
     // keeping two attempts from opening relay sockets concurrently.
     final attemptId = ++_reconnectAttemptId;
 
+    void handleFailure({required int? closeCode}) {
+      if (attemptId != _reconnectAttemptId) return;
+      if (_isInBackground) {
+        _status.add(ConnectionStatus.connectionLost(config: config));
+        return;
+      }
+      if (_status.value is ConnectionDisconnected) return;
+      if (!RelayCloseCodes.shouldReconnect(closeCode)) {
+        logw("Relay reconnect stopped by terminal closeCode=$closeCode");
+        _status.add(ConnectionStatus.connectionLost(config: config));
+        return;
+      }
+
+      _relayReconnectBackoff = Duration(
+        milliseconds: min(
+          _relayReconnectBackoff.inMilliseconds * 2,
+          _maxRelayReconnectBackoff.inMilliseconds,
+        ),
+      );
+      logw("Relay reconnect failed; retrying automatically");
+      _status.add(ConnectionStatus.reconnecting(config: config));
+      unawaited(_reconnectRelayWithRefresh(config));
+    }
+
     if (!immediate) {
       final backoff = _relayReconnectBackoff;
       final jitter = (backoff.inMilliseconds * 0.25 * (Random().nextDouble() * 2 - 1)).round();
@@ -772,8 +809,10 @@ class ConnectionService {
         }
       });
       await completer.future;
-      _reconnectTimer = null;
-      _reconnectDelayCompleter = null;
+      if (identical(_reconnectDelayCompleter, completer)) {
+        _reconnectTimer = null;
+        _reconnectDelayCompleter = null;
+      }
       if (attemptId != _reconnectAttemptId) return;
       if (_isInBackground) {
         _status.add(ConnectionStatus.connectionLost(config: config));
@@ -809,7 +848,7 @@ class ConnectionService {
         authToken: authToken,
       );
 
-      final result = await _connectViaRelay(
+      final connectResult = await _connectViaRelay(
         freshConfig,
         isStale: () => attemptId != _reconnectAttemptId || _status.value is ConnectionDisconnected || _isInBackground,
       );
@@ -823,31 +862,12 @@ class ConnectionService {
       }
       if (_status.value is ConnectionDisconnected) return;
 
-      if (result is ErrorResponse<HealthResponse>) {
-        logw("Relay reconnect failed; marking connection as lost");
-        _relayReconnectBackoff = Duration(
-          milliseconds: min(
-            _relayReconnectBackoff.inMilliseconds * 2,
-            _maxRelayReconnectBackoff.inMilliseconds,
-          ),
-        );
-        _status.add(ConnectionStatus.connectionLost(config: config));
+      if (connectResult.response is ErrorResponse<HealthResponse>) {
+        handleFailure(closeCode: connectResult.closeCode);
       }
     } catch (error, stackTrace) {
       loge("Relay reconnect attempt failed unexpectedly", error, stackTrace);
-      if (attemptId != _reconnectAttemptId) return;
-      if (_isInBackground) {
-        _status.add(ConnectionStatus.connectionLost(config: config));
-        return;
-      }
-      if (_status.value is ConnectionDisconnected) return;
-      _relayReconnectBackoff = Duration(
-        milliseconds: min(
-          _relayReconnectBackoff.inMilliseconds * 2,
-          _maxRelayReconnectBackoff.inMilliseconds,
-        ),
-      );
-      _status.add(ConnectionStatus.connectionLost(config: config));
+      handleFailure(closeCode: null);
     }
   }
 

--- a/client/module_core/lib/src/capabilities/server_connection/models/connection_status.dart
+++ b/client/module_core/lib/src/capabilities/server_connection/models/connection_status.dart
@@ -16,13 +16,14 @@ sealed class ConnectionStatus with _$ConnectionStatus {
     required HealthResponse health,
   }) = ConnectionConnected;
 
-  /// SSE dropped, auto-reconnecting (≤5s window).
+  /// SSE dropped, auto-reconnecting with bounded exponential backoff.
   /// UI stays as-is — no overlay yet.
   const factory ConnectionStatus.reconnecting({
     required ServerConnectionConfig config,
   }) = ConnectionReconnecting;
 
-  /// Auto-reconnect failed after timeout.
+  /// Auto-reconnect cannot continue automatically (for example, a terminal
+  /// relay close, missing authentication, or the app entering the background).
   /// Overlay shows with Reconnect / Disconnect actions.
   const factory ConnectionStatus.connectionLost({
     required ServerConnectionConfig config,

--- a/client/module_core/lib/src/capabilities/server_connection/models/connection_status.dart
+++ b/client/module_core/lib/src/capabilities/server_connection/models/connection_status.dart
@@ -16,14 +16,15 @@ sealed class ConnectionStatus with _$ConnectionStatus {
     required HealthResponse health,
   }) = ConnectionConnected;
 
-  /// SSE dropped, auto-reconnecting with bounded exponential backoff.
+  /// A relay connection attempt is in progress. Automatic retries use bounded
+  /// exponential backoff; manual and lifecycle attempts may be immediate.
   /// UI stays as-is — no overlay yet.
   const factory ConnectionStatus.reconnecting({
     required ServerConnectionConfig config,
   }) = ConnectionReconnecting;
 
-  /// Auto-reconnect cannot continue automatically (for example, a terminal
-  /// relay close, missing authentication, or the app entering the background).
+  /// Automatic reconnect is paused or stopped (for example, while the app is
+  /// backgrounded, authentication is missing, or the relay close is terminal).
   /// Overlay shows with Reconnect / Disconnect actions.
   const factory ConnectionStatus.connectionLost({
     required ServerConnectionConfig config,

--- a/client/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
+++ b/client/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
@@ -120,29 +120,7 @@ void main() {
       await authStateController.close();
     });
 
-    test("disconnect cancels reconnect timer before token refresh", () async {
-      final service = ConnectionService(
-        cryptoService,
-        roomKeyStorage,
-        authTokenProvider,
-        authSession,
-        lifecycleSource,
-        failureReporter,
-      );
-      addTearDown(service.dispose);
-
-      service.emitStatusForTesting(const ConnectionStatus.connectionLost(config: config));
-      service.reconnect();
-
-      await Future<void>.delayed(const Duration(milliseconds: 50));
-      service.disconnect();
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-
-      verifyNever(() => authTokenProvider.getFreshAccessToken(minTtl: any(named: "minTtl")));
-      expect(service.currentStatus, isA<ConnectionDisconnected>());
-    });
-
-    test("backgrounding during reconnect delay prevents refresh and reconnect", () async {
+    test("disconnect during token refresh prevents reconnect", () async {
       final tokenCompleter = Completer<String?>();
       when(
         () => authTokenProvider.getFreshAccessToken(minTtl: any(named: "minTtl")),
@@ -171,7 +149,46 @@ void main() {
       service.emitStatusForTesting(const ConnectionStatus.connectionLost(config: config));
       service.reconnect();
 
-      await Future<void>.delayed(const Duration(milliseconds: 1400));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      verify(() => authTokenProvider.getFreshAccessToken(minTtl: any(named: "minTtl"))).called(1);
+      service.disconnect();
+      tokenCompleter.complete("fresh-token");
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(factory.callCount, 0);
+      expect(service.currentStatus, isA<ConnectionDisconnected>());
+    });
+
+    test("backgrounding during token refresh prevents reconnect", () async {
+      final tokenCompleter = Completer<String?>();
+      when(
+        () => authTokenProvider.getFreshAccessToken(minTtl: any(named: "minTtl")),
+      ).thenAnswer((_) => tokenCompleter.future);
+
+      final relayClient = MockRelayClient();
+      final factory = _TestRelayClientFactory(
+        ({
+          required String relayHost,
+          required RelayCryptoService cryptoService,
+          required RoomKeyStorage roomKeyStorage,
+          required String? authToken,
+        }) => relayClient,
+      );
+      final service = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        failureReporter,
+        relayClientFactory: factory,
+      );
+      addTearDown(service.dispose);
+
+      service.emitStatusForTesting(const ConnectionStatus.connectionLost(config: config));
+      service.reconnect();
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
       verify(() => authTokenProvider.getFreshAccessToken(minTtl: any(named: "minTtl"))).called(1);
 
       lifecycleController.add(LifecycleState.paused);
@@ -503,20 +520,90 @@ void main() {
       },
     );
 
-    test("a non-resume reconnect still waits the backoff before its first attempt", () async {
+    test("transient failures retry automatically and manual reconnect bypasses accumulated backoff", () async {
       final sseController = StreamController<RelaySseEvent>.broadcast();
       addTearDown(sseController.close);
 
-      final relayClient = MockRelayClient();
-      when(relayClient.connect).thenAnswer((_) async {});
-      when(() => relayClient.didResume).thenReturn(false);
-      when(() => relayClient.isConnected).thenReturn(true);
-      when(() => relayClient.connectionState).thenReturn(RelayClientConnectionState.connected);
-      when(() => relayClient.sendRequest(any())).thenAnswer(
+      final firstFailure = Completer<void>();
+      final secondFailure = Completer<void>();
+      final firstFailedClient = MockRelayClient();
+      final secondFailedClient = MockRelayClient();
+      final connectedClient = MockRelayClient();
+
+      when(firstFailedClient.connect).thenAnswer((_) async => throw StateError("first transient failure"));
+      when(() => firstFailedClient.lastCloseCode).thenReturn(null);
+      when(firstFailedClient.disconnect).thenAnswer((_) async {
+        if (!firstFailure.isCompleted) firstFailure.complete();
+      });
+      when(secondFailedClient.connect).thenAnswer((_) async => throw StateError("second transient failure"));
+      when(() => secondFailedClient.lastCloseCode).thenReturn(null);
+      when(secondFailedClient.disconnect).thenAnswer((_) async {
+        if (!secondFailure.isCompleted) secondFailure.complete();
+      });
+
+      when(connectedClient.connect).thenAnswer((_) async {});
+      when(() => connectedClient.didResume).thenReturn(false);
+      when(() => connectedClient.isConnected).thenReturn(true);
+      when(() => connectedClient.connectionState).thenReturn(RelayClientConnectionState.connected);
+      when(() => connectedClient.sendRequest(any())).thenAnswer(
         (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
       );
-      when(() => relayClient.subscribeSse(any())).thenAnswer((_) => sseController.stream);
-      when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
+      when(() => connectedClient.subscribeSse(any())).thenAnswer((_) => sseController.stream);
+      when(() => connectedClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
+      when(connectedClient.disconnect).thenAnswer((_) async {});
+
+      final clients = <MockRelayClient>[firstFailedClient, secondFailedClient, connectedClient];
+      var nextClient = 0;
+      final factory = _TestRelayClientFactory(
+        ({
+          required String relayHost,
+          required RelayCryptoService cryptoService,
+          required RoomKeyStorage roomKeyStorage,
+          required String? authToken,
+        }) => clients[nextClient++],
+      );
+      final service = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        failureReporter,
+        relayClientFactory: factory,
+      );
+      addTearDown(service.dispose);
+
+      service.emitStatusForTesting(const ConnectionStatus.connectionLost(config: config));
+      final connected = service.status.firstWhere((status) => status is ConnectionConnected);
+
+      // A manual reconnect starts immediately. Its transient failure must retain
+      // the reconnecting state and schedule another attempt without user input.
+      service.reconnect();
+      await firstFailure.future.timeout(const Duration(seconds: 1));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(factory.callCount, 1);
+      expect(service.currentStatus, isA<ConnectionReconnecting>());
+
+      await secondFailure.future.timeout(const Duration(seconds: 4));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(factory.callCount, 2);
+      expect(service.currentStatus, isA<ConnectionReconnecting>());
+
+      // The second failure has accumulated a multi-second automatic backoff.
+      // Manual Retry must cancel it and open the next connection immediately.
+      service.reconnect();
+      await connected.timeout(const Duration(seconds: 1));
+
+      expect(factory.callCount, 3);
+      expect(service.currentStatus, isA<ConnectionConnected>());
+    });
+
+    test("terminal close code stops automatic reconnects", () async {
+      final relayClient = MockRelayClient();
+      when(relayClient.connect).thenAnswer((_) async => throw StateError("account full"));
+      when(() => relayClient.lastCloseCode).thenReturn(RelayCloseCodes.accountFull);
       when(relayClient.disconnect).thenAnswer((_) async {});
 
       final factory = _TestRelayClientFactory(
@@ -538,16 +625,14 @@ void main() {
       );
       addTearDown(service.dispose);
 
-      // Manual reconnect is NOT the resume path, so it keeps the exponential
-      // backoff (seeded at 1s): no attempt fires on the immediate tick.
       service.emitStatusForTesting(const ConnectionStatus.connectionLost(config: config));
+      final stopped = service.status.skip(1).firstWhere((status) => status is ConnectionLost);
+
       service.reconnect();
+      await stopped.timeout(const Duration(seconds: 1));
 
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-      expect(factory.callCount, 0);
-
-      await Future<void>.delayed(const Duration(milliseconds: 1400));
       expect(factory.callCount, 1);
+      expect(service.currentStatus, isA<ConnectionLost>());
     });
 
     test("a superseded reconnect attempt aborts after its async gap and does not open a second socket", () async {


### PR DESCRIPTION
## Summary

- keep transient relay failures in the automatic reconnect loop with capped exponential backoff
- make manual reconnect cancel accumulated delay, reset backoff, and attempt immediately
- preserve terminal relay close-code policy by carrying the failed socket's close code through the internal connect result
- update connection-state documentation and reconnect lifecycle coverage

## Context

The reconnect path previously made one attempt and then parked in `ConnectionLost`, even though its documentation described subsequent backoff retries. Manual Retry also inherited the failed attempt's enlarged backoff, so repeated taps could appear ineffective for several seconds.

The observed failures happened after the bridge had been running for a long time, while its relay socket remained established. No app relay/SSE change landed that day, and neither the relay nor auth server had a code change that day. The source of the transient phone-side drops therefore remains unconfirmed from the available logs. This PR fixes the pre-existing recovery weakness that made any such transient drop require user intervention.

## Validation

- `dart test test/capabilities/server_connection/connection_service_reconnect_test.dart`
- `dart test` (602 tests)
- `dart analyze`
- `git diff --check`
- architecture implementation review approved with no findings
