### PR TITLE
Reduce routine SSE event log noise

### DIFF
--- a/client/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/client/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -563,7 +563,7 @@ class ConnectionService {
         return;
       }
 
-      logd("[SSE] event: ${eventData.runtimeType}");
+      logt("[SSE] event: ${eventData.runtimeType}");
       final directory = switch (decoded["directory"]) {
         final String value => value,
         _ => null,

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -272,11 +272,11 @@ class SessionListCubit extends Cubit<SessionListState> {
 
   void _onSessionUpdated(Session session) {
     if (session.projectID != _projectId) {
-      logd("[SessionList] session.updated ignored id=${session.id} reason=project_mismatch");
+      logt("[SessionList] session.updated ignored id=${session.id} reason=project_mismatch");
       return;
     }
     if (state is! SessionListLoaded) {
-      logd("[SessionList] session.updated ignored id=${session.id} reason=state_not_loaded");
+      logt("[SessionList] session.updated ignored id=${session.id} reason=state_not_loaded");
       return;
     }
 

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -104,7 +104,7 @@ class SessionListCubit extends Cubit<SessionListState> {
   void _handleEvent(SseEvent event) {
     try {
       if (isClosed) return;
-      logd("[SessionList] event received: ${event.data.runtimeType}");
+      logt("[SessionList] event received: ${event.data.runtimeType}");
       final data = event.data;
       switch (data) {
         case SesoriSessionCreated(:final info):
@@ -290,7 +290,7 @@ class SessionListCubit extends Cubit<SessionListState> {
     }
 
     _allSessions = _sessionListService.upsertSession(sessions: _allSessions, session: session);
-    logd("[SessionList] session.updated updated id=${session.id}");
+    logt("[SessionList] session.updated updated id=${session.id}");
     _emitFiltered();
   }
 


### PR DESCRIPTION
## Summary

- move high-volume SSE event receipt logs from debug to trace
- move routine session update success and expected filter logs from debug to trace
- keep the diagnostics available when trace logging is explicitly enabled

## Testing

- `dart pub get` (`client`)
- `dart analyze` (`client/module_core`)
- `dart test` (`client/module_core`)
- `dart analyze` (`client/app`)
- `flutter test` (`client/app`)
- `dart analyze` (`client/desktop`)
- `flutter test` (`client/desktop`)
