### PR TITLE
fix(bridge): restore Codex and Cursor session activity

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -171,7 +171,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   AcpApprovalRegistry buildApprovalRegistry(AcpStdioClient client) {
     return AcpApprovalRegistry.forClient(
       client: client,
-      emit: _eventBuffer.add,
+      emit: emitActivityEvent,
       activeSessionResolver: () => activeTurnSessionId,
     );
   }
@@ -220,6 +220,13 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   AcpStdioClient? get client => _client;
   AcpInitializeResult? get initializeResult => _initResult;
   void emitEvent(BridgeSseEvent event) => _eventBuffer.add(event);
+
+  /// Approval state participates in the activity summary, so invalidate that
+  /// summary after forwarding each approval transition.
+  void emitActivityEvent(BridgeSseEvent event) {
+    _eventBuffer.add(event);
+    _eventBuffer.add(const BridgeSseProjectUpdated());
+  }
 
   // --- BridgePluginApi ---
 
@@ -881,6 +888,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
           status: const shared.SessionStatus.busy().toJson(),
         ),
       );
+      _eventBuffer.add(const BridgeSseProjectUpdated());
     }
     final expectedGeneration = state.generation;
     // Each link isolates its own failure (_runTurn never throws), so one
@@ -1017,6 +1025,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     if (state.pending == 0) {
       _sessionStatuses[sessionId] = const PluginSessionStatus.idle();
       _eventBuffer.add(BridgeSseSessionIdle(sessionID: sessionId));
+      _eventBuffer.add(const BridgeSseProjectUpdated());
     }
     if (failed || refused) {
       _eventBuffer.add(BridgeSseSessionError(sessionID: sessionId));

--- a/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
@@ -10,10 +10,12 @@ void main() {
   group("AcpPlugin.getActiveSessionsSummary", () {
     late FakeAcpProcess fake;
     late AcpPlugin plugin;
+    late List<BridgeSseEvent> emitted;
     const cwd = "/repo";
 
     setUp(() {
       fake = FakeAcpProcess();
+      emitted = [];
       plugin = AcpPlugin(
         id: "acp",
         agentDisplayName: "ACP",
@@ -22,6 +24,7 @@ void main() {
         eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp", pluginId: "acp"),
         processFactory: (_) async => fake,
       );
+      plugin.events.listen(emitted.add);
     });
 
     tearDown(() async {
@@ -97,10 +100,12 @@ void main() {
       expect(active.awaitingInput, isFalse);
       expect(active.isRetrying, isFalse);
       expect(active.childSessionIds, isEmpty, reason: "ACP sessions are flat");
+      expect(emitted.whereType<BridgeSseProjectUpdated>(), hasLength(1));
 
       // Resolve the turn -> session goes idle -> summary clears.
       await respond("session/prompt", {"stopReason": "end_turn"});
       expect(plugin.getActiveSessionsSummary(), isEmpty);
+      expect(emitted.whereType<BridgeSseProjectUpdated>(), hasLength(2));
     });
 
     test("a session awaiting a permission is surfaced with awaitingInput", () async {
@@ -129,6 +134,17 @@ void main() {
       expect(active.id, sessionId);
       expect(active.awaitingInput, isTrue);
       expect(active.mainAgentRunning, isFalse, reason: "no prompt turn in flight");
+      expect(emitted.whereType<BridgeSseProjectUpdated>(), hasLength(1));
+
+      final requestId = emitted.whereType<BridgeSsePermissionAsked>().single.requestID;
+      await plugin.replyToPermission(
+        requestId: requestId,
+        sessionId: sessionId,
+        reply: PluginPermissionReply.once,
+      );
+      await pump();
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+      expect(emitted.whereType<BridgeSseProjectUpdated>(), hasLength(2));
     });
   });
 }

--- a/bridge/sesori_plugin_codex/lib/src/approval_registry.dart
+++ b/bridge/sesori_plugin_codex/lib/src/approval_registry.dart
@@ -191,6 +191,9 @@ class ApprovalRegistry {
   String? sessionIdFor(String bridgeRequestId) =>
       _pending[bridgeRequestId]?.sessionId;
 
+  bool hasPendingInput(String sessionId) =>
+      _pending.values.any((entry) => entry.sessionId == sessionId);
+
   /// Acknowledges a permission ask with a once/always/reject decision.
   ///
   /// Returns true when the response was sent, false if the id had

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -54,6 +54,12 @@ class CodexEventMapper {
   /// effect even though codex honoured it. Falls back to [config] when unknown.
   final Map<String, String> _threadModel = {};
 
+  /// Last-known thread times, used to turn activity notifications into a
+  /// timestamp-bearing `session.updated` payload. Codex sends the activity
+  /// time on the turn, not on a thread/session event.
+  final Map<String, int> _threadCreatedAt = {};
+  final Map<String, int> _threadUpdatedAt = {};
+
   /// Records the model codex resolved for [threadId] so subsequent
   /// live-streamed assistant messages are stamped with the model actually in
   /// use. Passing a null/empty [model] clears the override (falls back to the
@@ -98,6 +104,30 @@ class CodexEventMapper {
     }
   }
 
+  /// Retains the earliest creation and latest update time seen for [record].
+  void setThreadTime(CodexThreadRecord record) {
+    final createdAt = record.createdAt;
+    final previousCreatedAt = _threadCreatedAt[record.id];
+    if (createdAt != null &&
+        (previousCreatedAt == null || createdAt < previousCreatedAt)) {
+      _threadCreatedAt[record.id] = createdAt;
+    }
+    final updatedAt = record.updatedAt;
+    final previousUpdatedAt = _threadUpdatedAt[record.id];
+    if (updatedAt != null &&
+        (previousUpdatedAt == null || updatedAt > previousUpdatedAt)) {
+      _threadUpdatedAt[record.id] = updatedAt;
+    }
+  }
+
+  void forgetThread(String threadId) {
+    _threadCreatedAt.remove(threadId);
+    _threadUpdatedAt.remove(threadId);
+    _threadModel.remove(threadId);
+    _threadProvider.remove(threadId);
+    _threadDirectory.remove(threadId);
+  }
+
   /// The project id a live session event should carry for [threadId]: the
   /// plugin-fed directory, else the notification's own [cwd], else the launch
   /// cwd — always normalized to match the bridge's derived project id.
@@ -106,6 +136,7 @@ class CodexEventMapper {
 
   /// Maps a repository-normalized `thread/started` record.
   List<BridgeSseEvent> mapThreadStarted(CodexThreadRecord record) {
+    setThreadTime(record);
     setThreadProvider(record.id, record.modelProvider);
     setThreadDirectory(record.id, record.directory);
     return [
@@ -127,6 +158,7 @@ class CodexEventMapper {
             info: _minimalSession(
               id: threadId,
               title: params["threadName"] as String?,
+              time: null,
             ).toJson(),
             titleChanged: true,
           ),
@@ -146,6 +178,10 @@ class CodexEventMapper {
         final threadId = params["threadId"] as String?;
         if (threadId == null) return const [];
         return [
+          _sessionActivityUpdated(
+            threadId: threadId,
+            timestampSeconds: _asMap(params["turn"])?["startedAt"],
+          ),
           BridgeSseSessionStatus(
             sessionID: threadId,
             status: const shared.SessionStatus.busy().toJson(),
@@ -155,7 +191,13 @@ class CodexEventMapper {
       case "turn/completed":
         final threadId = params["threadId"] as String?;
         if (threadId == null) return const [];
-        return [BridgeSseSessionIdle(sessionID: threadId)];
+        return [
+          _sessionActivityUpdated(
+            threadId: threadId,
+            timestampSeconds: _asMap(params["turn"])?["completedAt"],
+          ),
+          BridgeSseSessionIdle(sessionID: threadId),
+        ];
 
       case "item/started":
       case "item/completed":
@@ -532,11 +574,41 @@ class CodexEventMapper {
     );
   }
 
+  BridgeSseSessionUpdated _sessionActivityUpdated({
+    required String threadId,
+    required Object? timestampSeconds,
+  }) {
+    final observedAt = timestampSeconds is num
+        ? (timestampSeconds * Duration.millisecondsPerSecond).round()
+        : DateTime.now().millisecondsSinceEpoch;
+    final previousUpdated = _threadUpdatedAt[threadId];
+    final updatedAt = previousUpdated != null && previousUpdated > observedAt
+        ? previousUpdated
+        : observedAt;
+    _threadUpdatedAt[threadId] = updatedAt;
+    return BridgeSseSessionUpdated(
+      info: _minimalSession(
+        id: threadId,
+        title: null,
+        time: shared.SessionTime(
+          created: _threadCreatedAt[threadId] ?? updatedAt,
+          updated: updatedAt,
+          archived: null,
+        ),
+      ).toJson(),
+      titleChanged: false,
+    );
+  }
+
   /// Builds a minimal [shared.Session] for notifications that only carry an
   /// id (and maybe a title). The bridge enrichment + the mobile client merge
   /// this against existing session state, so the missing fields are filled
   /// in downstream.
-  shared.Session _minimalSession({required String id, required String? title}) {
+  shared.Session _minimalSession({
+    required String id,
+    required String? title,
+    required shared.SessionTime? time,
+  }) {
     final projectId = _projectIdForThread(id);
     return shared.Session(
       branchName: null,
@@ -546,7 +618,7 @@ class CodexEventMapper {
       directory: projectId,
       parentID: null,
       title: title,
-      time: null,
+      time: time,
       pullRequest: null,
       promptDefaults: null,
     );

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -639,9 +639,14 @@ class CodexEventMapper {
   /// sesori [shared.SessionStatus] union. Anything that is not explicitly
   /// `idle` is treated as busy.
   shared.SessionStatus _codexStatusToSessionStatus(Object? raw) {
+    return isIdleThreadStatus(raw) ? const shared.SessionStatus.idle() : const shared.SessionStatus.busy();
+  }
+
+  /// Parses the direct and nested status shapes emitted by codex.
+  bool isIdleThreadStatus(Object? raw) {
     final map = _asMap(raw);
     final type = (map?["type"] ?? _asMap(map?["status"])?["type"]) as String?;
-    return type == "idle" ? const shared.SessionStatus.idle() : const shared.SessionStatus.busy();
+    return type == "idle";
   }
 
   /// Concatenates the `text` of every text-bearing entry in a codex `content`

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -258,8 +258,11 @@ class CodexPlugin implements CodexManagedApi {
         _eventMapper.mapThreadStarted(thread).forEach(_eventBuffer.add);
         return;
       }
-      _maintainBookkeeping(notification);
+      final activityChanged = _maintainBookkeeping(notification);
       _eventMapper.map(notification).forEach(_eventBuffer.add);
+      if (activityChanged) {
+        _eventBuffer.add(const BridgeSseProjectUpdated());
+      }
     });
   }
 
@@ -274,7 +277,7 @@ class CodexPlugin implements CodexManagedApi {
   /// bridge permission/question events.
   void _attachApprovalRegistry(CodexAppServerClient client) {
     final registry = ApprovalRegistry(
-      emit: _eventBuffer.add,
+      emit: _emitApprovalEvent,
       respond: (id, result) => client.respondToServerRequest(id: id, result: result),
       respondError: (id, code, message) => client.respondToServerRequestWithError(
         id: id,
@@ -284,6 +287,11 @@ class CodexPlugin implements CodexManagedApi {
     );
     _approvalRegistry = registry;
     registry.attach(client.serverRequests);
+  }
+
+  void _emitApprovalEvent(BridgeSseEvent event) {
+    _eventBuffer.add(event);
+    _eventBuffer.add(const BridgeSseProjectUpdated());
   }
 
   /// Starts (or restarts) the idle-keepalive timer. Sends a cheap read RPC on
@@ -307,33 +315,60 @@ class CodexPlugin implements CodexManagedApi {
     );
   }
 
-  void _maintainBookkeeping(CodexServerNotification notification) {
+  bool _maintainBookkeeping(CodexServerNotification notification) {
     final params = notification.params;
     final threadId = params["threadId"] as String?;
     switch (notification.method) {
       case "turn/started":
-        if (threadId == null) return;
+        if (threadId == null) return false;
         final turn = (params["turn"] as Map?)?.cast<String, dynamic>();
         final turnId = turn?["id"] as String?;
         if (turnId != null) _activeTurnByThread[threadId] = turnId;
-        _sessionStatuses[threadId] = const PluginSessionStatus.busy();
+        return _setSessionStatus(threadId, const PluginSessionStatus.busy());
       case "turn/completed":
-        if (threadId == null) return;
+        if (threadId == null) return false;
         _activeTurnByThread.remove(threadId);
-        _sessionStatuses[threadId] = const PluginSessionStatus.idle();
+        return _setSessionStatus(threadId, const PluginSessionStatus.idle());
       case "error":
-        if (threadId == null) return;
+        if (threadId == null) return false;
         _activeTurnByThread.remove(threadId);
         // PluginSessionStatus has no explicit "error" — surfacing as idle
         // and letting the mapped BridgeSseSessionError carry the signal.
-        _sessionStatuses[threadId] = const PluginSessionStatus.idle();
+        return _setSessionStatus(threadId, const PluginSessionStatus.idle());
+      case "thread/status/changed":
+        if (threadId == null) return false;
+        return _setSessionStatus(
+          threadId,
+          _pluginStatus(params["status"]),
+        );
       case "thread/closed":
-        if (threadId == null) return;
+        if (threadId == null) return false;
         _activeTurnByThread.remove(threadId);
-        _sessionStatuses.remove(threadId);
+        final wasActive = _isActiveStatus(_sessionStatuses.remove(threadId));
         // The app-server unloaded this thread; a later turn must resume it.
         _sessionService.markThreadUnloaded(threadId: threadId);
+        return wasActive;
     }
+    return false;
+  }
+
+  bool _setSessionStatus(String threadId, PluginSessionStatus status) {
+    final wasActive = _isActiveStatus(_sessionStatuses[threadId]);
+    _sessionStatuses[threadId] = status;
+    return wasActive != _isActiveStatus(status);
+  }
+
+  bool _isActiveStatus(PluginSessionStatus? status) =>
+      status is PluginSessionStatusBusy || status is PluginSessionStatusRetry;
+
+  PluginSessionStatus _pluginStatus(Object? raw) {
+    final status = raw is Map ? raw.cast<String, dynamic>() : null;
+    final nested = status?["status"];
+    final nestedStatus = nested is Map ? nested.cast<String, dynamic>() : null;
+    final type = (status?["type"] ?? nestedStatus?["type"]) as String?;
+    return type == "idle"
+        ? const PluginSessionStatus.idle()
+        : const PluginSessionStatus.busy();
   }
 
   /// Cold-start hook the runtime descriptor awaits before reporting the
@@ -409,6 +444,7 @@ class CodexPlugin implements CodexManagedApi {
       model: model?.modelID,
       modelProvider: model?.providerID,
     );
+    _eventMapper.setThreadTime(thread);
     final threadId = thread.id;
     // codex's ThreadStartResponse carries the resolved model alongside the
     // thread; record it so live-streamed assistant messages are stamped with
@@ -563,6 +599,7 @@ class CodexPlugin implements CodexManagedApi {
       force: force,
     );
     if (response == null) return;
+    _eventMapper.setThreadTime(response);
     _eventMapper.setThreadModel(threadId, response.model);
     _eventMapper.setThreadProvider(threadId, response.modelProvider);
     // A thread resumed from a prior bridge run never re-emits `thread/started`,
@@ -670,6 +707,7 @@ class CodexPlugin implements CodexManagedApi {
     _activeTurnByThread.remove(sessionId);
     _sessionStatuses.remove(sessionId);
     _threadDirectory.remove(sessionId);
+    _eventMapper.forgetThread(sessionId);
   }
 
   @override
@@ -938,7 +976,31 @@ class CodexPlugin implements CodexManagedApi {
   }
 
   @override
-  List<PluginProjectActivitySummary> getActiveSessionsSummary() => const [];
+  List<PluginProjectActivitySummary> getActiveSessionsSummary() {
+    final registry = _approvalRegistry;
+    final byProject = <String, List<PluginActiveSession>>{};
+    for (final entry in _sessionStatuses.entries) {
+      final running = _isActiveStatus(entry.value);
+      final awaitingInput = registry?.hasPendingInput(entry.key) ?? false;
+      if (!running && !awaitingInput) continue;
+      (byProject[_directoryForSession(entry.key)] ??= []).add(
+        PluginActiveSession(
+          id: entry.key,
+          mainAgentRunning: running,
+          awaitingInput: awaitingInput,
+          isRetrying: false,
+          childSessionIds: const [],
+        ),
+      );
+    }
+    return [
+      for (final entry in byProject.entries)
+        PluginProjectActivitySummary(
+          id: entry.key,
+          activeSessions: entry.value,
+        ),
+    ];
+  }
 
   @override
   Future<void> dispose() async {

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -237,11 +237,15 @@ class CodexPlugin implements CodexManagedApi {
   /// forwards the signal to the runtime descriptor's status reporter.
   void _handleClientDisconnected() {
     final registry = _approvalRegistry;
-    final hadVisibleActivity = _sessionStatuses.entries.any(
-      (entry) =>
-          _isActiveStatus(entry.value) ||
-          (registry?.hasPendingInput(entry.key) ?? false),
-    );
+    final activeSessionIds = [
+      for (final entry in _sessionStatuses.entries)
+        if (_isActiveStatus(entry.value)) entry.key,
+    ];
+    final hadVisibleActivity =
+        activeSessionIds.isNotEmpty ||
+        _sessionStatuses.keys.any(
+          (sessionId) => registry?.hasPendingInput(sessionId) ?? false,
+        );
     _connectFuture = null;
     _client = null;
     _sessionService.detachThreadRepository();
@@ -251,6 +255,9 @@ class CodexPlugin implements CodexManagedApi {
     unawaited(registry?.dispose());
     _sessionStatuses.clear();
     _activeTurnByThread.clear();
+    for (final sessionId in activeSessionIds) {
+      _eventBuffer.add(BridgeSseSessionIdle(sessionID: sessionId));
+    }
     if (hadVisibleActivity) {
       _eventBuffer.add(const BridgeSseProjectUpdated());
     }

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -233,14 +233,25 @@ class CodexPlugin implements CodexManagedApi {
   /// Invoked when the underlying transport drops unexpectedly. Resets the
   /// cached connection state (so [healthCheck]/[_ensureConnected] no longer
   /// hand back a stale successful future for a dead socket and instead
-  /// re-establish on the next call), then forwards the signal to the runtime
-  /// descriptor's status reporter.
+  /// re-establish on the next call), clears connection-scoped activity, then
+  /// forwards the signal to the runtime descriptor's status reporter.
   void _handleClientDisconnected() {
+    final registry = _approvalRegistry;
+    final hadVisibleActivity = _sessionStatuses.entries.any(
+      (entry) =>
+          _isActiveStatus(entry.value) ||
+          (registry?.hasPendingInput(entry.key) ?? false),
+    );
     _connectFuture = null;
     _client = null;
     _sessionService.detachThreadRepository();
     _keepaliveTimer?.cancel();
     _keepaliveTimer = null;
+    _sessionStatuses.clear();
+    _activeTurnByThread.clear();
+    if (hadVisibleActivity) {
+      _eventBuffer.add(const BridgeSseProjectUpdated());
+    }
     _onDisconnected?.call();
   }
 
@@ -339,7 +350,9 @@ class CodexPlugin implements CodexManagedApi {
         if (threadId == null) return false;
         return _setSessionStatus(
           threadId,
-          _pluginStatus(params["status"]),
+          _eventMapper.isIdleThreadStatus(params["status"])
+              ? const PluginSessionStatus.idle()
+              : const PluginSessionStatus.busy(),
         );
       case "thread/closed":
         if (threadId == null) return false;
@@ -360,16 +373,6 @@ class CodexPlugin implements CodexManagedApi {
 
   bool _isActiveStatus(PluginSessionStatus? status) =>
       status is PluginSessionStatusBusy || status is PluginSessionStatusRetry;
-
-  PluginSessionStatus _pluginStatus(Object? raw) {
-    final status = raw is Map ? raw.cast<String, dynamic>() : null;
-    final nested = status?["status"];
-    final nestedStatus = nested is Map ? nested.cast<String, dynamic>() : null;
-    final type = (status?["type"] ?? nestedStatus?["type"]) as String?;
-    return type == "idle"
-        ? const PluginSessionStatus.idle()
-        : const PluginSessionStatus.busy();
-  }
 
   /// Cold-start hook the runtime descriptor awaits before reporting the
   /// plugin ready: opens the WebSocket, performs the `initialize` handshake,

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -247,6 +247,8 @@ class CodexPlugin implements CodexManagedApi {
     _sessionService.detachThreadRepository();
     _keepaliveTimer?.cancel();
     _keepaliveTimer = null;
+    _approvalRegistry = null;
+    unawaited(registry?.dispose());
     _sessionStatuses.clear();
     _activeTurnByThread.clear();
     if (hadVisibleActivity) {

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart
@@ -21,7 +21,7 @@ import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 /// the downloaded archive), confirm the [_assets] filenames still match the
 /// release, raise [minPathVersion] only if the bridge starts to require a newer
 /// codex API, and re-run the integration tests. The hashes below are the
-/// published asset digests for codex `rust-v0.144.5`.
+/// published asset digests for codex `rust-v0.145.0`.
 class CodexRuntimeManifest extends RuntimeManifest {
   const CodexRuntimeManifest();
 
@@ -29,7 +29,7 @@ class CodexRuntimeManifest extends RuntimeManifest {
   static final SemanticVersion _minPathVersion = SemanticVersion.parse(value: "0.139.0");
 
   /// The exact codex version the managed runtime installs.
-  static final SemanticVersion _bundledVersion = SemanticVersion.parse(value: "0.144.5");
+  static final SemanticVersion _bundledVersion = SemanticVersion.parse(value: "0.145.0");
 
   static const String _releaseBaseUrl = "https://github.com/openai/codex/releases/download";
 
@@ -43,13 +43,13 @@ class CodexRuntimeManifest extends RuntimeManifest {
       PlatformArch.arm64: RuntimeAsset(
         assetName: "codex-aarch64-apple-darwin.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "a5b77d2fb393f201777809425ab28d9beb65ee0c0b2bf792f09eaf8ef1151592",
+        sha256: "072a30a65f05666735889ef0f60b56db186adbdde9d5c5cc1a64be0b598530fe",
         archiveBinaryName: "codex-aarch64-apple-darwin",
       ),
       PlatformArch.x64: RuntimeAsset(
         assetName: "codex-x86_64-apple-darwin.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "ff5c894a9ffa6d97c225c8d3c869c7ef7573dcbd0cf9b762ecfb9fa96dbb7d88",
+        sha256: "4216d7a40aa49d74b65fab93d2a86d2e25a902482b827dbdb3f357777b09fadf",
         archiveBinaryName: "codex-x86_64-apple-darwin",
       ),
     },
@@ -57,13 +57,13 @@ class CodexRuntimeManifest extends RuntimeManifest {
       PlatformArch.arm64: RuntimeAsset(
         assetName: "codex-aarch64-unknown-linux-musl.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "5433789cd66e0db3b78cccd218d894471ed9e92fe93465120d1356508952084d",
+        sha256: "d384f90bc842450b42bd675feef06a12a46a3b1ca97efcb22566b270e4a11227",
         archiveBinaryName: "codex-aarch64-unknown-linux-musl",
       ),
       PlatformArch.x64: RuntimeAsset(
         assetName: "codex-x86_64-unknown-linux-musl.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "b6bea13bedf493232f6717714c45e783788c695cedcf37c344f73afc97b1ec9f",
+        sha256: "bfaf13c9ba34f2ad764e4a916c49cf7177aeba329cf0f719e2227566fc8d662a",
         archiveBinaryName: "codex-x86_64-unknown-linux-musl",
       ),
     },
@@ -71,13 +71,13 @@ class CodexRuntimeManifest extends RuntimeManifest {
       PlatformArch.arm64: RuntimeAsset(
         assetName: "codex-aarch64-pc-windows-msvc.exe.zip",
         format: ArchiveFormat.zip,
-        sha256: "e5f319f9f737605731aecf4208b7cda88df9ef0f98fa22c9935944bd7f267469",
+        sha256: "e38667194ddf24dfeb877ab9f6346b55bd979ff52bee9dbf4123e2a48f3627e2",
         archiveBinaryName: "codex-aarch64-pc-windows-msvc.exe",
       ),
       PlatformArch.x64: RuntimeAsset(
         assetName: "codex-x86_64-pc-windows-msvc.exe.zip",
         format: ArchiveFormat.zip,
-        sha256: "c5fa9ad03f266640465da5677f2bcebd2db02a604940d1264b6a342d5136df91",
+        sha256: "bc6ae808bf5a9cdf113364ac281594d6da76dc103c19129e9d32caed54ec3cda",
         archiveBinaryName: "codex-x86_64-pc-windows-msvc.exe",
       ),
     },

--- a/bridge/sesori_plugin_codex/test/approval_registry_test.dart
+++ b/bridge/sesori_plugin_codex/test/approval_registry_test.dart
@@ -140,6 +140,7 @@ void main() {
         expect(pending.single.displaySessionId, equals("t-7"));
         expect(pending.single.tool, equals("exec"));
         expect(pending.single.description, equals("clean build dir"));
+        expect(registry.hasPendingInput("t-7"), isTrue);
         // Questions and permissions are disjoint: a permission is never a
         // pending question.
         expect(registry.pendingForSession("t-7"), isEmpty);
@@ -169,6 +170,7 @@ void main() {
       expect(respondCalls.single.id, equals(100));
       expect((respondCalls.single.result as Map)["decision"], equals("accept"));
       expect(emitted.single, isA<BridgeSsePermissionReplied>());
+      expect(registry.hasPendingInput("t-1"), isFalse);
     });
 
     test("replyPermission(always) sends 'acceptForSession'", () async {
@@ -349,6 +351,7 @@ void main() {
         final pending = registry.pendingForSession("t-3");
         expect(pending, hasLength(1));
         expect(pending.single.id, equals(asked.id));
+        expect(registry.hasPendingInput("t-3"), isTrue);
       },
     );
 

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -255,7 +255,7 @@ void main() {
       expect(events.whereType<BridgeSseSessionIdle>().single.sessionID, "t-activity");
     });
 
-    test("thread/status/changed maps active→busy and idle→idle", () {
+    test("thread/status/changed maps direct active and nested idle statuses", () {
       final active = mapper.map(
         const CodexServerNotification(
           method: "thread/status/changed",
@@ -270,7 +270,9 @@ void main() {
           method: "thread/status/changed",
           params: {
             "threadId": "t-1",
-            "status": {"type": "idle"},
+            "status": {
+              "status": {"type": "idle"},
+            },
           },
         ),
       );

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -173,30 +173,86 @@ void main() {
       expect(session.projectID, "/repo/app/packages/ui");
     });
 
-    test("turn/started → SessionStatus(busy) parseable as SessionStatus", () {
-      final events = mapper.map(
+    test("turn/started updates session time and emits busy status", () {
+      final activityMapper = CodexEventMapper(
+        pluginId: CodexPlugin.pluginId,
+        projectCwd: projectCwd,
+      );
+      mapThreadStarted(
+        activityMapper,
         const CodexServerNotification(
-          method: "turn/started",
+          method: "thread/started",
           params: {
-            "threadId": "t-1",
-            "turn": {"id": "u-1"},
+            "thread": {
+              "id": "t-activity",
+              "cwd": projectCwd,
+              "createdAt": 1779293088,
+              "updatedAt": 1779293090,
+            },
           },
         ),
       );
 
-      expect(events, hasLength(1));
-      final status = events.single as BridgeSseSessionStatus;
-      expect(status.sessionID, "t-1");
+      final events = activityMapper.map(
+        const CodexServerNotification(
+          method: "turn/started",
+          params: {
+            "threadId": "t-activity",
+            "turn": {"id": "u-1", "startedAt": 1779293100},
+          },
+        ),
+      );
+
+      expect(events, hasLength(2));
+      final updated = events.whereType<BridgeSseSessionUpdated>().single;
+      final session = shared.Session.fromJson(updated.info);
+      expect(session.time?.created, 1779293088000);
+      expect(session.time?.updated, 1779293100000);
+      expect(updated.titleChanged, isFalse);
+      expect(parseAsSesori(updated), isA<shared.SesoriSessionUpdated>());
+
+      final status = events.whereType<BridgeSseSessionStatus>().single;
+      expect(status.sessionID, "t-activity");
       expect(shared.SessionStatus.fromJson(status.status), isA<shared.SessionStatusBusy>());
       expect(parseAsSesori(status), isA<shared.SesoriSessionStatus>());
     });
 
-    test("turn/completed → SessionIdle", () {
-      final events = mapper.map(
-        const CodexServerNotification(method: "turn/completed", params: {"threadId": "t-1"}),
+    test("turn/completed updates session time and emits idle status", () {
+      final activityMapper = CodexEventMapper(
+        pluginId: CodexPlugin.pluginId,
+        projectCwd: projectCwd,
       );
-      expect(events, hasLength(1));
-      expect((events.single as BridgeSseSessionIdle).sessionID, "t-1");
+      mapThreadStarted(
+        activityMapper,
+        const CodexServerNotification(
+          method: "thread/started",
+          params: {
+            "thread": {
+              "id": "t-activity",
+              "cwd": projectCwd,
+              "createdAt": 1779293088,
+              "updatedAt": 1779293090,
+            },
+          },
+        ),
+      );
+
+      final events = activityMapper.map(
+        const CodexServerNotification(
+          method: "turn/completed",
+          params: {
+            "threadId": "t-activity",
+            "turn": {"id": "u-1", "completedAt": 1779293110},
+          },
+        ),
+      );
+      expect(events, hasLength(2));
+      final session = shared.Session.fromJson(
+        events.whereType<BridgeSseSessionUpdated>().single.info,
+      );
+      expect(session.time?.created, 1779293088000);
+      expect(session.time?.updated, 1779293110000);
+      expect(events.whereType<BridgeSseSessionIdle>().single.sessionID, "t-activity");
     });
 
     test("thread/status/changed maps active→busy and idle→idle", () {

--- a/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
@@ -262,8 +262,13 @@ void main() {
       final firstSummary = Completer<void>();
       final approvalSummary = Completer<void>();
       final clearedSummary = Completer<void>();
+      final sessionIdle = Completer<String>();
       var invalidations = 0;
-      final subscription = plugin.events.where((event) => event is BridgeSseProjectUpdated).listen((_) {
+      final subscription = plugin.events.listen((event) {
+        if (event is BridgeSseSessionIdle) {
+          sessionIdle.complete(event.sessionID);
+        }
+        if (event is! BridgeSseProjectUpdated) return;
         invalidations++;
         if (invalidations == 1) firstSummary.complete();
         if (invalidations == 2) approvalSummary.complete();
@@ -320,6 +325,10 @@ void main() {
 
       await socket.close(WebSocketStatus.goingAway);
 
+      expect(
+        await sessionIdle.future.timeout(const Duration(seconds: 2)),
+        "t-running",
+      );
       await clearedSummary.future.timeout(const Duration(seconds: 2));
       expect(plugin.getActiveSessionsSummary(), isEmpty);
       expect(

--- a/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
@@ -260,12 +260,14 @@ void main() {
       );
       addTearDown(plugin.dispose);
       final firstSummary = Completer<void>();
+      final approvalSummary = Completer<void>();
       final clearedSummary = Completer<void>();
       var invalidations = 0;
       final subscription = plugin.events.where((event) => event is BridgeSseProjectUpdated).listen((_) {
         invalidations++;
         if (invalidations == 1) firstSummary.complete();
-        if (invalidations == 2) clearedSummary.complete();
+        if (invalidations == 2) approvalSummary.complete();
+        if (invalidations == 3) clearedSummary.complete();
       });
       addTearDown(subscription.cancel);
 
@@ -297,11 +299,33 @@ void main() {
       );
       await firstSummary.future.timeout(const Duration(seconds: 2));
       expect(plugin.getActiveSessionsSummary(), isNotEmpty);
+      socket.add(
+        jsonEncode({
+          "jsonrpc": "2.0",
+          "id": 99,
+          "method": "item/commandExecution/requestApproval",
+          "params": {
+            "threadId": "t-running",
+            "turnId": "turn-1",
+            "itemId": "item-1",
+            "command": "ls",
+          },
+        }),
+      );
+      await approvalSummary.future.timeout(const Duration(seconds: 2));
+      expect(
+        await plugin.getPendingPermissions(sessionId: "t-running"),
+        hasLength(1),
+      );
 
       await socket.close(WebSocketStatus.goingAway);
 
       await clearedSummary.future.timeout(const Duration(seconds: 2));
       expect(plugin.getActiveSessionsSummary(), isEmpty);
+      expect(
+        await plugin.getPendingPermissions(sessionId: "t-running"),
+        isEmpty,
+      );
     });
 
     test("dispose closes event buffer without error", () async {

--- a/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
@@ -10,6 +10,7 @@ import "dart:io";
 
 import "package:codex_plugin/codex_plugin.dart";
 import "package:path/path.dart" as p;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 import "package:web_socket_channel/web_socket_channel.dart";
 
@@ -231,6 +232,76 @@ void main() {
 
       expect(await plugin.healthCheck(), isFalse);
       await plugin.dispose();
+    });
+
+    test("an unexpected transport drop clears live session activity", () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
+      final socketReady = Completer<WebSocket>();
+      server.listen((request) async {
+        final socket = await WebSocketTransformer.upgrade(request);
+        socketReady.complete(socket);
+        socket.listen((frame) {
+          final decoded = jsonDecode(frame as String) as Map<String, dynamic>;
+          if (decoded["method"] != "initialize") return;
+          socket.add(
+            jsonEncode({
+              "jsonrpc": "2.0",
+              "id": decoded["id"],
+              "result": _initOk,
+            }),
+          );
+        });
+      });
+      final plugin = CodexPlugin(
+        serverUrl: "ws://127.0.0.1:${server.port}",
+        projectCwd: "/repo/example",
+        keepaliveInterval: const Duration(seconds: 30),
+      );
+      addTearDown(plugin.dispose);
+      final firstSummary = Completer<void>();
+      final clearedSummary = Completer<void>();
+      var invalidations = 0;
+      final subscription = plugin.events.where((event) => event is BridgeSseProjectUpdated).listen((_) {
+        invalidations++;
+        if (invalidations == 1) firstSummary.complete();
+        if (invalidations == 2) clearedSummary.complete();
+      });
+      addTearDown(subscription.cancel);
+
+      expect(await plugin.healthCheck(), isTrue);
+      final socket = await socketReady.future;
+      socket.add(
+        jsonEncode({
+          "jsonrpc": "2.0",
+          "method": "thread/started",
+          "params": {
+            "thread": {
+              "id": "t-running",
+              "cwd": "/repo/example",
+              "createdAt": 1700000000,
+              "updatedAt": 1700000000,
+            },
+          },
+        }),
+      );
+      socket.add(
+        jsonEncode({
+          "jsonrpc": "2.0",
+          "method": "turn/started",
+          "params": {
+            "threadId": "t-running",
+            "turn": {"id": "turn-1", "startedAt": 1700000001},
+          },
+        }),
+      );
+      await firstSummary.future.timeout(const Duration(seconds: 2));
+      expect(plugin.getActiveSessionsSummary(), isNotEmpty);
+
+      await socket.close(WebSocketStatus.goingAway);
+
+      await clearedSummary.future.timeout(const Duration(seconds: 2));
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
     });
 
     test("dispose closes event buffer without error", () async {

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -309,17 +309,36 @@ void main() {
       // Trigger _ensureConnected.
       await plugin.healthCheck();
 
+      fake.pushNotification("thread/started", {
+        "thread": {
+          "id": "t-1",
+          "cwd": "/work/sample",
+          "createdAt": 1700000000,
+          "updatedAt": 1700000000,
+        },
+      });
       fake.pushNotification("turn/started", {
         "threadId": "t-1",
-        "turn": {"id": "u-1"},
+        "turn": {"id": "u-1", "startedAt": 1700000005},
       });
+      await Future<void>.delayed(Duration.zero);
+
+      final running = plugin.getActiveSessionsSummary();
+      expect(running, hasLength(1));
+      expect(running.single.id, "/work/sample");
+      expect(running.single.activeSessions.single.id, "t-1");
+      expect(running.single.activeSessions.single.mainAgentRunning, isTrue);
+
       fake.pushNotification("item/agentMessage/delta", {
         "threadId": "t-1",
         "turnId": "u-1",
         "itemId": "i-1",
         "delta": "Hi",
       });
-      fake.pushNotification("turn/completed", {"threadId": "t-1"});
+      fake.pushNotification("turn/completed", {
+        "threadId": "t-1",
+        "turn": {"id": "u-1", "completedAt": 1700000010},
+      });
 
       // Drain microtasks so all notification handlers run.
       await Future<void>.delayed(Duration.zero);
@@ -328,15 +347,20 @@ void main() {
       expect(
         events.map((e) => e.runtimeType.toString()).toList(),
         containsAllInOrder([
+          "BridgeSseSessionUpdated",
           "BridgeSseSessionStatus",
+          "BridgeSseProjectUpdated",
           "BridgeSseMessagePartDelta",
+          "BridgeSseSessionUpdated",
           "BridgeSseSessionIdle",
+          "BridgeSseProjectUpdated",
         ]),
       );
 
       // Active session status is tracked from the notifications.
       final statuses = await plugin.getSessionStatuses();
       expect(statuses["t-1"], isA<PluginSessionStatusIdle>());
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
     });
 
     test("keepalive sends periodic model/list RPCs while connected, stops on dispose", () async {

--- a/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
@@ -15,7 +15,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 1,
-            stdoutBytes: utf8.encode("codex 0.144.5\n"),
+            stdoutBytes: utf8.encode("codex 0.145.0\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(
@@ -106,7 +106,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 3,
-            stdoutBytes: utf8.encode("codex 0.144.5\n"),
+            stdoutBytes: utf8.encode("codex 0.145.0\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(
@@ -137,7 +137,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 5,
-            stdoutBytes: utf8.encode("codex 0.144.5\n"),
+            stdoutBytes: utf8.encode("codex 0.145.0\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(
@@ -165,7 +165,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 7,
-            stdoutBytes: utf8.encode("codex 0.144.5\n"),
+            stdoutBytes: utf8.encode("codex 0.145.0\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(

--- a/bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart
@@ -14,7 +14,7 @@ void main() {
     });
 
     test("pinned versions", () {
-      expect(manifest.bundledVersion.toString(), "0.144.5");
+      expect(manifest.bundledVersion.toString(), "0.145.0");
       expect(manifest.minPathVersion.toString(), "0.139.0");
       expect(manifest.runtimeId, const CodexPluginDescriptor().id);
       expect(manifest.pathExecutableName, "codex");
@@ -83,7 +83,7 @@ void main() {
       )!;
       expect(
         manifest.downloadUrlFor(asset: asset),
-        equals("https://github.com/openai/codex/releases/download/rust-v0.144.5/codex-aarch64-apple-darwin.tar.gz"),
+        equals("https://github.com/openai/codex/releases/download/rust-v0.145.0/codex-aarch64-apple-darwin.tar.gz"),
       );
     });
 

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
@@ -86,7 +86,7 @@ class CursorPlugin extends AcpPlugin {
   AcpApprovalRegistry buildApprovalRegistry(AcpStdioClient client) {
     return CursorApprovalRegistry(
       client: client,
-      emit: emitEvent,
+      emit: emitActivityEvent,
       activeSessionResolver: () => activeTurnSessionId,
     );
   }


### PR DESCRIPTION
## Summary

- publish Codex turn timestamps through `session.updated` so session rows update their displayed time and retain recency after a turn completes
- expose Codex busy and awaiting-input state through project activity summaries, and invalidate summaries on Codex and ACP/Cursor activity transitions so loading indicators and running-session ordering update live
- bump the managed Codex runtime from `0.144.5` to stable `0.145.0` with all six published release digests while preserving the `0.139.0` PATH compatibility floor

## Investigation

The client already consumes backend-neutral `projects.summary` and `session.updated` events correctly. Codex tracked busy/idle internally but returned an empty activity summary and emitted no timestamp-bearing session update. ACP/Cursor built the right summary and already preserved Cursor's `updatedAt`, but did not invalidate that summary as turns or approvals changed.

## Verification

- `dart test` in `bridge/sesori_plugin_codex`
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_codex`
- `dart test` in `bridge/sesori_plugin_acp`
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_acp`
- `dart test` in `bridge/sesori_plugin_cursor`
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_cursor`
- `git diff --check`

Codex `rust-v0.145.0` was confirmed stable, its six expected assets all publish SHA-256 digests, and npm reports `@openai/codex@0.145.0`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores live session activity and timestamps for Codex and Cursor so running sessions and loading states update in real time, and clears activity and pending approvals on disconnect while marking any active sessions idle. Also bumps the managed Codex runtime to 0.145.0 while keeping the `0.139.0` PATH compatibility floor.

- **Bug Fixes**
  - Codex: emit `session.updated` with turn timestamps and keep session time in sync on `turn/started` and `turn/completed`.
  - Codex: update busy/idle from `thread/status/changed`; clear state on thread close.
  - Codex: on disconnect, publish `session.idle` for previously active sessions, clear live activity and pending approvals, and invalidate the project summary.
  - ACP/Cursor: invalidate project summaries on turn and approval ask/reply so loading indicators and running-session ordering update live.
  - Expose active sessions per project via `getActiveSessionsSummary` (running or awaiting input).

- **Dependencies**
  - Upgrade managed Codex runtime to `rust-v0.145.0` with updated asset digests; PATH compatibility floor remains `0.139.0`.

<sup>Written for commit 0c20a50157f35572ef186840591feec9d6d7f90f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

