### PR TITLE
fix(codex): keep live tool events consistent with history

### DIFF
--- a/bridge/sesori_plugin_codex/lib/codex_plugin.dart
+++ b/bridge/sesori_plugin_codex/lib/codex_plugin.dart
@@ -11,6 +11,7 @@ export "src/codex_config_reader.dart";
 export "src/codex_event_mapper.dart";
 export "src/codex_metadata_repository.dart";
 export "src/codex_plugin_impl.dart";
+export "src/codex_rollout_tool_mapper.dart";
 export "src/codex_skill_reader.dart";
 // Runtime lifecycle: the descriptor is the public entry point the bridge
 // registers in bin/bridge.dart.
@@ -18,3 +19,4 @@ export "src/runtime/codex_bridge_plugin.dart";
 export "src/runtime/codex_managed_api.dart";
 export "src/runtime/codex_plugin_descriptor.dart";
 export "src/runtime/codex_runtime_manifest.dart";
+export "src/services/codex_rollout_tailer.dart";

--- a/bridge/sesori_plugin_codex/lib/src/api/codex_rollout_api.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/codex_rollout_api.dart
@@ -22,6 +22,16 @@ class CodexRolloutTailChunk {
   final List<int> trailingBytes;
 }
 
+class CodexRolloutTailPosition {
+  const CodexRolloutTailPosition({
+    required this.offset,
+    required this.trailingBytes,
+  });
+
+  final int offset;
+  final List<int> trailingBytes;
+}
+
 /// Layer-1 filesystem boundary for Codex's on-disk rollout history.
 class CodexRolloutApi {
   CodexRolloutApi({Map<String, String>? environment}) : _environment = environment ?? Platform.environment;
@@ -102,9 +112,46 @@ class CodexRolloutApi {
     );
   }
 
-  int rolloutLength({required String rolloutPath}) {
+  CodexRolloutTailPosition rolloutTailPosition({
+    required String rolloutPath,
+  }) {
     final file = File(rolloutPath);
-    return file.existsSync() ? file.lengthSync() : 0;
+    if (!file.existsSync()) {
+      return const CodexRolloutTailPosition(
+        offset: 0,
+        trailingBytes: [],
+      );
+    }
+    final handle = file.openSync();
+    try {
+      final length = handle.lengthSync();
+      var position = length;
+      final reverseSuffixChunks = <List<int>>[];
+      while (position > 0) {
+        final start = position > 8192 ? position - 8192 : 0;
+        handle.setPositionSync(start);
+        final bytes = handle.readSync(position - start);
+        final newline = bytes.lastIndexOf(0x0A);
+        if (newline >= 0) {
+          reverseSuffixChunks.add(bytes.sublist(newline + 1));
+          break;
+        }
+        reverseSuffixChunks.add(bytes);
+        position = start;
+      }
+      return CodexRolloutTailPosition(
+        offset: length,
+        // COMPATIBILITY 2026-07-23 (Codex JSONL writer): tailing starts at
+        // logical EOF but must retain an already-written partial final record.
+        // Otherwise its later newline would be decoded without the skipped
+        // prefix. Remove with the live JSONL tail workaround itself.
+        trailingBytes: [
+          for (final chunk in reverseSuffixChunks.reversed) ...chunk,
+        ],
+      );
+    } finally {
+      handle.closeSync();
+    }
   }
 
   CodexRolloutTailChunk readTranscriptChunk({

--- a/bridge/sesori_plugin_codex/lib/src/api/codex_rollout_api.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/codex_rollout_api.dart
@@ -10,6 +10,18 @@ import "models/codex_rollout_dto.dart";
 
 typedef CodexSessionIndexLine = ({CodexSessionIndexEntryDto? entry, String raw});
 
+class CodexRolloutTailChunk {
+  const CodexRolloutTailChunk({
+    required this.lines,
+    required this.nextOffset,
+    required this.trailingBytes,
+  });
+
+  final List<CodexRolloutLineDto> lines;
+  final int nextOffset;
+  final List<int> trailingBytes;
+}
+
 /// Layer-1 filesystem boundary for Codex's on-disk rollout history.
 class CodexRolloutApi {
   CodexRolloutApi({Map<String, String>? environment}) : _environment = environment ?? Platform.environment;
@@ -88,6 +100,79 @@ class CodexRolloutApi {
       malformedWarning: "[codex] skipping malformed rollout transcript record",
       ignoreMalformedLastLine: true,
     );
+  }
+
+  int rolloutLength({required String rolloutPath}) {
+    final file = File(rolloutPath);
+    return file.existsSync() ? file.lengthSync() : 0;
+  }
+
+  CodexRolloutTailChunk readTranscriptChunk({
+    required String rolloutPath,
+    required int offset,
+    required List<int> trailingBytes,
+  }) {
+    final file = File(rolloutPath);
+    if (!file.existsSync()) {
+      return CodexRolloutTailChunk(
+        lines: const [],
+        nextOffset: offset,
+        trailingBytes: trailingBytes,
+      );
+    }
+    final handle = file.openSync();
+    try {
+      final length = handle.lengthSync();
+      if (offset > length) {
+        throw StateError(
+          "Codex rollout shrank while being tailed: $rolloutPath "
+          "(offset=$offset, length=$length)",
+        );
+      }
+      handle.setPositionSync(offset);
+      final appended = handle.readSync(length - offset);
+      if (appended.isEmpty) {
+        return CodexRolloutTailChunk(
+          lines: const [],
+          nextOffset: offset,
+          trailingBytes: trailingBytes,
+        );
+      }
+      final combined = <int>[...trailingBytes, ...appended];
+      final lastNewline = combined.lastIndexOf(0x0A);
+      if (lastNewline < 0) {
+        return CodexRolloutTailChunk(
+          lines: const [],
+          nextOffset: length,
+          trailingBytes: combined,
+        );
+      }
+      final completeBytes = combined.sublist(0, lastNewline);
+      final remainingBytes = combined.sublist(lastNewline + 1);
+      final rawLines = <String>[];
+      var lineStart = 0;
+      for (var i = 0; i <= completeBytes.length; i++) {
+        if (i != completeBytes.length && completeBytes[i] != 0x0A) continue;
+        final bytes = completeBytes.sublist(lineStart, i);
+        lineStart = i + 1;
+        if (bytes.isEmpty) continue;
+        rawLines.add(utf8.decode(bytes));
+      }
+      return CodexRolloutTailChunk(
+        lines: _decodeRolloutLines(
+          rawLines,
+          malformedWarning: "[codex] skipping malformed live rollout transcript record",
+        ),
+        nextOffset: length,
+        // COMPATIBILITY 2026-07-23 (Codex JSONL writer): an observer can read
+        // between the record bytes and their terminating newline. Retain that
+        // suffix without warning; remove only if Codex exposes atomic appended
+        // records instead of a concurrently-written JSONL file.
+        trailingBytes: remainingBytes,
+      );
+    } finally {
+      handle.closeSync();
+    }
   }
 
   void deleteRollout({required String rolloutPath}) {

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -2,8 +2,10 @@ import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show nor
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" as shared;
 
+import "api/models/codex_rollout_dto.dart";
 import "codex_app_server_client.dart";
 import "codex_config_reader.dart";
+import "codex_rollout_tool_mapper.dart";
 import "repositories/models/codex_thread_record.dart";
 
 /// Translates `codex app-server` `ServerNotification` frames into
@@ -53,6 +55,13 @@ class CodexEventMapper {
   /// global [config] default — making a model switch look like it never took
   /// effect even though codex honoured it. Falls back to [config] when unknown.
   final Map<String, String> _threadModel = {};
+  static const CodexRolloutToolMapper _rolloutToolMapper = CodexRolloutToolMapper();
+
+  /// Raw rollout state keyed by the same `call_id` app-server uses as a
+  /// command item id. It lets late normalized item notifications reuse the
+  /// richer result instead of replacing it with their smaller projection.
+  final Map<String, CodexRolloutToolCall> _rolloutToolCalls = {};
+  final Map<String, CodexRolloutToolResult> _rolloutToolResults = {};
 
   /// Last-known thread times, used to turn activity notifications into a
   /// timestamp-bearing `session.updated` payload. Codex sends the activity
@@ -244,6 +253,51 @@ class CodexEventMapper {
     return const [];
   }
 
+  /// Maps a complete response-item record observed in the active rollout.
+  ///
+  /// App-server's stable item stream remains the low-latency source. These
+  /// records update the same message ids with executor metadata and also
+  /// surface raw-only calls such as code-mode `exec` and `wait`.
+  List<BridgeSseEvent> mapRolloutLine({
+    required String threadId,
+    required CodexRolloutLineDto line,
+  }) {
+    if (line.type != CodexRolloutLineType.responseItem) return const [];
+    final payload = line.payload;
+    if (payload == null) return const [];
+    final call = _rolloutToolMapper.mapCall(payload);
+    if (call != null) {
+      _rolloutToolCalls[_rolloutToolKey(threadId, call.id)] = call;
+      return _toolItemEvents(
+        threadId: threadId,
+        itemId: call.id,
+        tool: call.tool,
+        title: call.title,
+        status: PluginToolStatus.running,
+      );
+    }
+    final result = _rolloutToolMapper.mapResult(payload);
+    if (result == null) return const [];
+    final key = _rolloutToolKey(threadId, result.callId);
+    final originalCall = _rolloutToolCalls[key];
+    if (originalCall == null) return const [];
+    _rolloutToolResults[key] = result;
+    return _toolItemEvents(
+      threadId: threadId,
+      itemId: originalCall.id,
+      tool: originalCall.tool,
+      title: originalCall.title,
+      status: result.status,
+      output: result.output,
+    );
+  }
+
+  void clearRolloutTurn({required String threadId}) {
+    final prefix = "$threadId\u0000";
+    _rolloutToolCalls.removeWhere((key, _) => key.startsWith(prefix));
+    _rolloutToolResults.removeWhere((key, _) => key.startsWith(prefix));
+  }
+
   /// `item/*/delta` notifications stream text into an already-known part.
   List<BridgeSseEvent> _deltaEvent({
     required Map<String, dynamic> params,
@@ -312,13 +366,29 @@ class CodexEventMapper {
           text: _extractReasoningText(item),
         );
       case "commandExecution":
+        final canonical = _canonicalRolloutTool(
+          threadId: threadId,
+          itemId: itemId,
+        );
+        final exitCode = item["exitCode"];
+        final appServerStatus = exitCode is num && exitCode.toInt() != 0
+            ? PluginToolStatus.error
+            : _toolStatus(item["status"], completed: completed);
         return _toolItemEvents(
           threadId: threadId,
           itemId: itemId,
-          tool: "shell",
-          title: item["command"] as String?,
-          status: _toolStatus(item["status"], completed: completed),
-          output: item["aggregatedOutput"] as String?,
+          tool: canonical?.call.tool ?? "shell",
+          title:
+              canonical?.call.title ??
+              _rolloutToolMapper.logicalCommandTitle(
+                item["command"] as String?,
+              ),
+          status: canonical?.result.status ?? appServerStatus,
+          output:
+              canonical?.result.output ??
+              _rolloutToolMapper.clipOutput(
+                item["aggregatedOutput"] as String?,
+              ),
         );
       case "fileChange":
         return _toolItemEvents(
@@ -340,16 +410,26 @@ class CodexEventMapper {
           error: _asMap(item["error"])?["message"] as String?,
         );
       case "dynamicToolCall":
+        final canonical = _canonicalRolloutTool(
+          threadId: threadId,
+          itemId: itemId,
+        );
         return _toolItemEvents(
           threadId: threadId,
           itemId: itemId,
-          tool: switch (item["tool"]) {
-            final String tool when tool.isNotEmpty => tool,
-            _ => "tool",
-          },
-          title: _dynamicToolTitle(item["arguments"]),
-          status: _toolStatus(item["status"], completed: completed),
-          output: _dynamicToolOutput(item["contentItems"]),
+          tool:
+              canonical?.call.tool ??
+              switch (item["tool"]) {
+                final String tool when tool.isNotEmpty => tool,
+                _ => "tool",
+              },
+          title: canonical?.call.title ?? _dynamicToolTitle(item["arguments"]),
+          status: canonical?.result.status ?? _toolStatus(item["status"], completed: completed),
+          output:
+              canonical?.result.output ??
+              _rolloutToolMapper.clipOutput(
+                _dynamicToolOutput(item["contentItems"]),
+              ),
         );
       case "webSearch":
         return _toolItemEvents(
@@ -427,6 +507,18 @@ class CodexEventMapper {
     }
     return completed ? PluginToolStatus.completed : PluginToolStatus.running;
   }
+
+  ({CodexRolloutToolCall call, CodexRolloutToolResult result})? _canonicalRolloutTool({
+    required String threadId,
+    required String itemId,
+  }) {
+    final key = _rolloutToolKey(threadId, itemId);
+    final call = _rolloutToolCalls[key];
+    final result = _rolloutToolResults[key];
+    return call == null || result == null ? null : (call: call, result: result);
+  }
+
+  String _rolloutToolKey(String threadId, String callId) => "$threadId\u0000$callId";
 
   /// A short title for a `fileChange` item: the touched paths (codex's
   /// `changes` are `{path, kind, diff}` entries).

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -383,7 +383,9 @@ class CodexEventMapper {
               _rolloutToolMapper.logicalCommandTitle(
                 item["command"] as String?,
               ),
-          status: canonical?.result.status ?? appServerStatus,
+          status: appServerStatus == PluginToolStatus.error
+              ? PluginToolStatus.error
+              : canonical?.result.status ?? appServerStatus,
           output:
               canonical?.result.output ??
               _rolloutToolMapper.clipOutput(

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -69,6 +69,7 @@ class CodexPlugin implements CodexManagedApi {
   CodexAppServerClient? _client;
   Future<bool>? _connectFuture;
   StreamSubscription<CodexServerNotification>? _notificationSubscription;
+  Future<void> _notificationWork = Future<void>.value();
   StreamSubscription<CodexRolloutAppend>? _rolloutSubscription;
   ApprovalRegistry? _approvalRegistry;
 
@@ -287,43 +288,62 @@ class CodexPlugin implements CodexManagedApi {
   /// and turn-id bookkeeping current.
   void _subscribeToNotifications(CodexAppServerClient client) {
     _notificationSubscription = client.notifications.listen((notification) {
-      if (notification.method == "thread/started") {
-        final thread = _sessionService.decodeStartedNotificationParams(
-          params: notification.params,
-        );
-        if (thread == null) return;
-        _maintainThreadStarted(thread);
-        _eventMapper.mapThreadStarted(thread).forEach(_eventBuffer.add);
-        return;
-      }
-      final threadId = notification.params["threadId"] as String?;
-      if (notification.method == "turn/started" && threadId != null) {
-        // Calls initiated through this plugin start tailing before turn/start.
-        // This fallback covers a turn started by another app-server client.
-        _rolloutTailer.start(sessionId: threadId);
-      }
-      final activityChanged = _maintainBookkeeping(notification);
-      if (notification.method == "turn/completed" && threadId != null) {
-        // Drain first so the final tool update is delivered before session.idle.
-        _rolloutTailer.drain(sessionId: threadId);
-      }
-      _eventMapper.map(notification).forEach(_eventBuffer.add);
-      if (notification.method == "item/completed" && threadId != null) {
-        // The app-server item is provisional; a rollout output written for the
-        // same call id immediately enriches it with executor metadata.
-        _rolloutTailer.drain(sessionId: threadId);
-      }
-      if (threadId != null &&
-          (notification.method == "turn/completed" ||
-              notification.method == "error" ||
-              notification.method == "thread/closed")) {
-        _rolloutTailer.stop(sessionId: threadId);
-        _eventMapper.clearRolloutTurn(threadId: threadId);
-      }
-      if (activityChanged) {
-        _eventBuffer.add(const BridgeSseProjectUpdated());
-      }
+      // Serialize notification side effects so a terminal rollout drain cannot
+      // let session.idle overtake its final tool update.
+      _notificationWork = _notificationWork
+          .then((_) => _handleNotification(notification))
+          .catchError((Object error, StackTrace stackTrace) {
+            Log.e(
+              "[codex] failed to map app-server notification",
+              error,
+              stackTrace,
+            );
+          });
     });
+  }
+
+  Future<void> _handleNotification(
+    CodexServerNotification notification,
+  ) async {
+    if (notification.method == "thread/started") {
+      final thread = _sessionService.decodeStartedNotificationParams(
+        params: notification.params,
+      );
+      if (thread == null) return;
+      _maintainThreadStarted(thread);
+      _eventMapper.mapThreadStarted(thread).forEach(_eventBuffer.add);
+      return;
+    }
+    final threadId = notification.params["threadId"] as String?;
+    if (notification.method == "turn/started" && threadId != null) {
+      // Calls initiated through this plugin start tailing before turn/start.
+      // This fallback covers a turn started by another app-server client.
+      _rolloutTailer.start(sessionId: threadId);
+    }
+    if (notification.method == "turn/completed" && threadId != null) {
+      await _rolloutTailer.finish(sessionId: threadId);
+    }
+    final activityChanged = _maintainBookkeeping(notification);
+    _eventMapper.map(notification).forEach(_eventBuffer.add);
+    if (notification.method == "item/completed" && threadId != null) {
+      // The app-server item is provisional; a rollout output written for the
+      // same call id immediately enriches it with executor metadata.
+      _rolloutTailer.drain(sessionId: threadId);
+    }
+    if (threadId != null &&
+        (notification.method == "error" ||
+            notification.method == "thread/closed")) {
+      _rolloutTailer.stop(sessionId: threadId);
+    }
+    if (threadId != null &&
+        (notification.method == "turn/completed" ||
+            notification.method == "error" ||
+            notification.method == "thread/closed")) {
+      _eventMapper.clearRolloutTurn(threadId: threadId);
+    }
+    if (activityChanged) {
+      _eventBuffer.add(const BridgeSseProjectUpdated());
+    }
   }
 
   void _handleRolloutAppend(CodexRolloutAppend append) {
@@ -1074,6 +1094,7 @@ class CodexPlugin implements CodexManagedApi {
     _keepaliveTimer = null;
     await _notificationSubscription?.cancel();
     _notificationSubscription = null;
+    await _notificationWork;
     await _rolloutSubscription?.cancel();
     _rolloutSubscription = null;
     await _rolloutTailer.dispose();

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -17,6 +17,7 @@ import "repositories/codex_message_repository.dart";
 import "repositories/codex_thread_repository.dart";
 import "repositories/models/codex_thread_record.dart";
 import "runtime/codex_managed_api.dart";
+import "services/codex_rollout_tailer.dart";
 import "services/codex_session_service.dart";
 
 /// Phase 4 of the Codex backend plugin.
@@ -50,6 +51,7 @@ class CodexPlugin implements CodexManagedApi {
   final CodexAppServerClient Function()? _clientFactory;
   final CodexSessionService _sessionService;
   final CodexEventMapper _eventMapper;
+  final CodexRolloutTailer _rolloutTailer;
   final String _projectCwd;
   final Duration _keepaliveInterval;
 
@@ -67,6 +69,7 @@ class CodexPlugin implements CodexManagedApi {
   CodexAppServerClient? _client;
   Future<bool>? _connectFuture;
   StreamSubscription<CodexServerNotification>? _notificationSubscription;
+  StreamSubscription<CodexRolloutAppend>? _rolloutSubscription;
   ApprovalRegistry? _approvalRegistry;
 
   /// Periodic no-op RPC timer. codex `app-server` closes a connection that goes
@@ -103,6 +106,11 @@ class CodexPlugin implements CodexManagedApi {
     final configReader = CodexConfigReader();
     final rolloutApi = CodexRolloutApi();
     final catalogRepository = CodexCatalogRepository(rolloutApi: rolloutApi);
+    final rolloutTailer = CodexRolloutTailer(
+      rolloutApi: rolloutApi,
+      catalogRepository: catalogRepository,
+      pollInterval: const Duration(milliseconds: 50),
+    );
     final metadataRepository = CodexMetadataRepository(
       skillReader: CodexSkillReader(),
       configReader: configReader,
@@ -125,6 +133,7 @@ class CodexPlugin implements CodexManagedApi {
         projectCwd: resolvedProjectCwd,
         config: configReader.readDefaults(),
       ),
+      rolloutTailer: rolloutTailer,
       projectCwd: resolvedProjectCwd,
       onConnected: onConnected,
       onDisconnected: onDisconnected,
@@ -138,6 +147,7 @@ class CodexPlugin implements CodexManagedApi {
     required CodexAppServerClient Function() clientFactory,
     required CodexSessionService sessionService,
     required CodexEventMapper eventMapper,
+    required CodexRolloutTailer rolloutTailer,
     required String projectCwd,
     required void Function()? onConnected,
     required void Function()? onDisconnected,
@@ -148,6 +158,7 @@ class CodexPlugin implements CodexManagedApi {
          clientFactory: clientFactory,
          sessionService: sessionService,
          eventMapper: eventMapper,
+         rolloutTailer: rolloutTailer,
          projectCwd: projectCwd,
          onConnected: onConnected,
          onDisconnected: onDisconnected,
@@ -160,6 +171,7 @@ class CodexPlugin implements CodexManagedApi {
     required CodexAppServerClient Function()? clientFactory,
     required CodexSessionService sessionService,
     required CodexEventMapper eventMapper,
+    required CodexRolloutTailer rolloutTailer,
     required String projectCwd,
     required void Function()? onConnected,
     required void Function()? onDisconnected,
@@ -170,10 +182,15 @@ class CodexPlugin implements CodexManagedApi {
        _clientFactory = clientFactory,
        _sessionService = sessionService,
        _eventMapper = eventMapper,
+       _rolloutTailer = rolloutTailer,
        _projectCwd = projectCwd,
        _onConnected = onConnected,
        _onDisconnected = onDisconnected,
-       _eventBuffer = BufferedUntilFirstListener<BridgeSseEvent>();
+       _eventBuffer = BufferedUntilFirstListener<BridgeSseEvent>() {
+    _rolloutSubscription = _rolloutTailer.appends.listen(
+      _handleRolloutAppend,
+    );
+  }
 
   String get serverUrl => _serverUrl;
 
@@ -249,6 +266,7 @@ class CodexPlugin implements CodexManagedApi {
     _connectFuture = null;
     _client = null;
     _sessionService.detachThreadRepository();
+    _rolloutTailer.stopAll();
     _keepaliveTimer?.cancel();
     _keepaliveTimer = null;
     _approvalRegistry = null;
@@ -278,12 +296,38 @@ class CodexPlugin implements CodexManagedApi {
         _eventMapper.mapThreadStarted(thread).forEach(_eventBuffer.add);
         return;
       }
+      final threadId = notification.params["threadId"] as String?;
+      if (notification.method == "turn/started" && threadId != null) {
+        // Calls initiated through this plugin start tailing before turn/start.
+        // This fallback covers a turn started by another app-server client.
+        _rolloutTailer.start(sessionId: threadId);
+      }
       final activityChanged = _maintainBookkeeping(notification);
+      if (notification.method == "turn/completed" && threadId != null) {
+        // Drain first so the final tool update is delivered before session.idle.
+        _rolloutTailer.drain(sessionId: threadId);
+      }
       _eventMapper.map(notification).forEach(_eventBuffer.add);
+      if (notification.method == "item/completed" && threadId != null) {
+        // The app-server item is provisional; a rollout output written for the
+        // same call id immediately enriches it with executor metadata.
+        _rolloutTailer.drain(sessionId: threadId);
+      }
+      if (threadId != null &&
+          (notification.method == "turn/completed" ||
+              notification.method == "error" ||
+              notification.method == "thread/closed")) {
+        _rolloutTailer.stop(sessionId: threadId);
+        _eventMapper.clearRolloutTurn(threadId: threadId);
+      }
       if (activityChanged) {
         _eventBuffer.add(const BridgeSseProjectUpdated());
       }
     });
+  }
+
+  void _handleRolloutAppend(CodexRolloutAppend append) {
+    _eventMapper.mapRolloutLine(threadId: append.sessionId, line: append.line).forEach(_eventBuffer.add);
   }
 
   void _maintainThreadStarted(CodexThreadRecord thread) {
@@ -578,15 +622,23 @@ class CodexPlugin implements CodexManagedApi {
     if (effort != null && effort.isNotEmpty) {
       params["effort"] = effort;
     }
+    // Capture the current EOF before Codex can append this turn's response
+    // items. `start` is idempotent when turn/started arrives afterwards.
+    _rolloutTailer.start(sessionId: threadId);
     try {
-      await client.request(method: "turn/start", params: params);
-    } on CodexRpcException catch (error) {
-      // Defensive: even if we believed the thread was loaded, the app-server
-      // may have dropped it (or our tracking is stale). Force a resume and
-      // retry the turn exactly once before giving up.
-      if (!_isThreadNotFound(error)) rethrow;
-      await _ensureThreadLoaded(threadId, force: true);
-      await client.request(method: "turn/start", params: params);
+      try {
+        await client.request(method: "turn/start", params: params);
+      } on CodexRpcException catch (error) {
+        // Defensive: even if we believed the thread was loaded, the app-server
+        // may have dropped it (or our tracking is stale). Force a resume and
+        // retry the turn exactly once before giving up.
+        if (!_isThreadNotFound(error)) rethrow;
+        await _ensureThreadLoaded(threadId, force: true);
+        await client.request(method: "turn/start", params: params);
+      }
+    } on Object {
+      _rolloutTailer.stop(sessionId: threadId);
+      rethrow;
     }
   }
 
@@ -719,6 +771,8 @@ class CodexPlugin implements CodexManagedApi {
     _activeTurnByThread.remove(sessionId);
     _sessionStatuses.remove(sessionId);
     _threadDirectory.remove(sessionId);
+    _rolloutTailer.stop(sessionId: sessionId);
+    _eventMapper.clearRolloutTurn(threadId: sessionId);
     _eventMapper.forgetThread(sessionId);
   }
 
@@ -1020,6 +1074,9 @@ class CodexPlugin implements CodexManagedApi {
     _keepaliveTimer = null;
     await _notificationSubscription?.cancel();
     _notificationSubscription = null;
+    await _rolloutSubscription?.cancel();
+    _rolloutSubscription = null;
+    await _rolloutTailer.dispose();
     await _approvalRegistry?.dispose();
     _approvalRegistry = null;
     await _client?.dispose();

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -290,15 +290,16 @@ class CodexPlugin implements CodexManagedApi {
     _notificationSubscription = client.notifications.listen((notification) {
       // Serialize notification side effects so a terminal rollout drain cannot
       // let session.idle overtake its final tool update.
-      _notificationWork = _notificationWork
-          .then((_) => _handleNotification(notification))
-          .catchError((Object error, StackTrace stackTrace) {
-            Log.e(
-              "[codex] failed to map app-server notification",
-              error,
-              stackTrace,
-            );
-          });
+      _notificationWork = _notificationWork.then((_) => _handleNotification(notification)).catchError((
+        Object error,
+        StackTrace stackTrace,
+      ) {
+        Log.e(
+          "[codex] failed to map app-server notification",
+          error,
+          stackTrace,
+        );
+      });
     });
   }
 
@@ -330,9 +331,7 @@ class CodexPlugin implements CodexManagedApi {
       // same call id immediately enriches it with executor metadata.
       _rolloutTailer.drain(sessionId: threadId);
     }
-    if (threadId != null &&
-        (notification.method == "error" ||
-            notification.method == "thread/closed")) {
+    if (threadId != null && (notification.method == "error" || notification.method == "thread/closed")) {
       _rolloutTailer.stop(sessionId: threadId);
     }
     if (threadId != null &&

--- a/bridge/sesori_plugin_codex/lib/src/codex_rollout_tool_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_rollout_tool_mapper.dart
@@ -1,0 +1,227 @@
+import "dart:convert";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" show jsonDecodeMap;
+
+import "api/models/codex_rollout_dto.dart";
+
+class CodexRolloutToolCall {
+  const CodexRolloutToolCall({
+    required this.id,
+    required this.tool,
+    required this.title,
+  });
+
+  final String id;
+  final String tool;
+  final String? title;
+}
+
+class CodexRolloutToolResult {
+  const CodexRolloutToolResult({
+    required this.callId,
+    required this.status,
+    required this.output,
+  });
+
+  final String callId;
+  final PluginToolStatus status;
+  final String? output;
+}
+
+/// Pure normalization shared by live rollout enrichment and history replay.
+///
+/// Codex's stable app-server items intentionally expose a smaller projection
+/// than the persisted response items. Keeping the raw call/result rules here
+/// prevents the live and reload paths from independently inventing titles,
+/// statuses, or output clipping.
+class CodexRolloutToolMapper {
+  const CodexRolloutToolMapper();
+
+  CodexRolloutToolCall? mapCall(CodexRolloutPayloadDto payload) {
+    if (payload.type != CodexRolloutPayloadType.functionCall &&
+        payload.type != CodexRolloutPayloadType.customToolCall) {
+      return null;
+    }
+    final id = _usefulText(payload.callId) ?? _usefulText(payload.id);
+    if (id == null) return null;
+    final name = _usefulText(payload.name) ?? "tool";
+    return CodexRolloutToolCall(
+      id: id,
+      tool: normalizeToolName(name),
+      title: toolCallTitle(payload.arguments ?? payload.input),
+    );
+  }
+
+  CodexRolloutToolResult? mapResult(CodexRolloutPayloadDto payload) {
+    if (payload.type != CodexRolloutPayloadType.functionCallOutput &&
+        payload.type != CodexRolloutPayloadType.customToolCallOutput) {
+      return null;
+    }
+    final callId = _usefulText(payload.callId);
+    if (callId == null) return null;
+    final rawOutput = toolOutputText(payload.output);
+    return CodexRolloutToolResult(
+      callId: callId,
+      status: toolOutputStatus(rawOutput),
+      output: clipOutput(rawOutput),
+    );
+  }
+
+  String normalizeToolName(String name) {
+    final normalized = name.toLowerCase();
+    if (normalized.contains("stdin")) return "shell";
+    if (normalized.contains("patch") || normalized.contains("edit") || normalized.contains("write")) {
+      return "edit";
+    }
+    if (normalized.contains("exec") ||
+        normalized.contains("shell") ||
+        normalized.contains("bash") ||
+        normalized.contains("command")) {
+      return "shell";
+    }
+    return name;
+  }
+
+  String? toolCallTitle(String? argumentsJson) {
+    if (argumentsJson == null || argumentsJson.isEmpty) return null;
+    final arguments = _tryDecodeToolArguments(raw: argumentsJson);
+    if (arguments != null) {
+      for (final value in [
+        arguments.cmd,
+        arguments.command,
+        arguments.path,
+        arguments.filePath,
+        arguments.query,
+      ]) {
+        if (value is String && value.isNotEmpty) return value;
+        if (value is List && value.isNotEmpty) return value.join(" ");
+      }
+    }
+    final embeddedCommand = _embeddedExecCommand(source: argumentsJson);
+    if (embeddedCommand != null && embeddedCommand.isNotEmpty) {
+      return embeddedCommand;
+    }
+    return argumentsJson.length > 120 ? argumentsJson.substring(0, 120) : argumentsJson;
+  }
+
+  /// Removes the launcher added by app-server so the provisional live title
+  /// matches the logical `cmd` persisted in the rollout.
+  ///
+  /// COMPATIBILITY 2026-07-23 (Codex app-server 0.144.x): commandExecution
+  /// wraps commands as `<shell> -lc <command>`, while response-item arguments
+  /// retain the original command. Remove this normalization when app-server's
+  /// stable item title carries the original command itself.
+  String? logicalCommandTitle(String? command) {
+    final value = _usefulText(command);
+    if (value == null) return null;
+    final match = RegExp(
+      r"^(?:\S*/)?(?:zsh|bash|sh)\s+-lc\s+(.+)$",
+    ).firstMatch(value);
+    if (match == null) return value;
+    final payload = match.group(1)?.trim();
+    if (payload == null || payload.isEmpty) return value;
+    if (payload.length >= 2) {
+      final first = payload[0];
+      final last = payload[payload.length - 1];
+      if (first == "'" && last == "'") {
+        return payload.substring(1, payload.length - 1);
+      }
+      if (first == '"' && last == '"') {
+        try {
+          final decoded = jsonDecode(payload);
+          if (decoded is String && decoded.isNotEmpty) return decoded;
+        } on FormatException {
+          // Keep the unparsed payload below; the rollout call will shortly
+          // replace it with the authoritative logical command.
+        }
+      }
+    }
+    return payload;
+  }
+
+  String? toolOutputText(List<CodexRolloutContentDto>? output) {
+    final texts = [
+      for (final item in output ?? const <CodexRolloutContentDto>[])
+        if (item.text case final text?
+            when (item.type == CodexRolloutContentType.inputText || item.type == CodexRolloutContentType.outputText) &&
+                text.isNotEmpty)
+          text,
+    ];
+    return texts.isEmpty ? null : texts.join();
+  }
+
+  /// Derives process failure from the executor envelope retained in rollout
+  /// output. Merely receiving a tool-output record means the tool returned; it
+  /// does not mean the process it observed exited successfully.
+  ///
+  /// COMPATIBILITY 2026-07-23 (Codex rollout 0.144.x): process exit status is
+  /// encoded in human-readable tool output instead of a structured field.
+  /// Replace this parser with the structured value once response-item output
+  /// exposes one, while continuing to read these strings for old histories.
+  PluginToolStatus toolOutputStatus(String? output) {
+    if (output == null) return PluginToolStatus.completed;
+    final match = RegExp(
+      "^(?:Process exited with code|Process exited with exit code|"
+      r"Script (?:completed|exited) with (?:code|exit code))\s+(-?\d+)\s*$",
+      caseSensitive: false,
+      multiLine: true,
+    ).firstMatch(output);
+    final exitCode = match == null ? null : int.tryParse(match.group(1)!);
+    return exitCode != null && exitCode != 0 ? PluginToolStatus.error : PluginToolStatus.completed;
+  }
+
+  String? clipOutput(String? output) {
+    if (output == null || output.runes.length <= maxToolOutputLength) {
+      return output;
+    }
+    return String.fromCharCodes(output.runes.take(maxToolOutputLength));
+  }
+
+  CodexToolArgumentsDto? _tryDecodeToolArguments({required String raw}) {
+    try {
+      return CodexToolArgumentsDto.fromJson(jsonDecodeMap(raw));
+    } on Object {
+      return null;
+    }
+  }
+
+  String? _embeddedExecCommand({required String source}) {
+    const marker = "tools.exec_command(";
+    final markerIndex = source.indexOf(marker);
+    if (markerIndex < 0) return null;
+
+    final argumentsStart = markerIndex + marker.length;
+    final commandMatch = RegExp(
+      r'(?:^|[,{]\s*)(?:"cmd"|cmd)\s*:\s*',
+    ).firstMatch(source.substring(argumentsStart));
+    if (commandMatch == null) return null;
+    final valueStart = argumentsStart + commandMatch.end;
+    if (valueStart >= source.length || source.codeUnitAt(valueStart) != 0x22) {
+      return null;
+    }
+
+    var escaped = false;
+    for (var index = valueStart + 1; index < source.length; index++) {
+      final codeUnit = source.codeUnitAt(index);
+      if (escaped) {
+        escaped = false;
+      } else if (codeUnit == 0x5C) {
+        escaped = true;
+      } else if (codeUnit == 0x22) {
+        try {
+          final decoded = jsonDecode(source.substring(valueStart, index + 1));
+          return decoded is String ? decoded : null;
+        } on FormatException {
+          return null;
+        }
+      }
+    }
+    return null;
+  }
+
+  String? _usefulText(String? value) {
+    final trimmed = value?.trim();
+    return trimmed == null || trimmed.isEmpty ? null : trimmed;
+  }
+}

--- a/bridge/sesori_plugin_codex/lib/src/codex_rollout_tool_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_rollout_tool_mapper.dart
@@ -102,7 +102,9 @@ class CodexRolloutToolMapper {
     if (embeddedCommand != null && embeddedCommand.isNotEmpty) {
       return embeddedCommand;
     }
-    return argumentsJson.length > 120 ? argumentsJson.substring(0, 120) : argumentsJson;
+    return argumentsJson.runes.length > 120
+        ? String.fromCharCodes(argumentsJson.runes.take(120))
+        : argumentsJson;
   }
 
   /// Removes the launcher added by app-server so the provisional live title

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
@@ -1,17 +1,16 @@
-import "dart:convert";
-
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
-import "package:sesori_shared/sesori_shared.dart" show jsonDecodeMap;
 
 import "../api/codex_rollout_api.dart";
 import "../api/models/codex_rollout_dto.dart";
 import "../codex_config_reader.dart";
+import "../codex_rollout_tool_mapper.dart";
 
 /// Layer-2 mapping from typed rollout transcript DTOs to plugin messages.
 class CodexMessageRepository {
   CodexMessageRepository({required CodexRolloutApi rolloutApi}) : _rolloutApi = rolloutApi;
 
   final CodexRolloutApi _rolloutApi;
+  static const CodexRolloutToolMapper _toolMapper = CodexRolloutToolMapper();
 
   List<PluginMessageWithParts> readMessages({
     required String rolloutPath,
@@ -32,17 +31,12 @@ class CodexMessageRepository {
       );
     }
 
-    final toolOutputs = <String, String?>{};
+    final toolOutputs = <String, CodexRolloutToolResult>{};
     for (final line in lines) {
       final payload = line.payload;
-      if (payload?.type != CodexRolloutPayloadType.functionCallOutput &&
-          payload?.type != CodexRolloutPayloadType.customToolCallOutput) {
-        continue;
-      }
-      final callId = payload?.callId;
-      if (callId != null && payload?.output != null) {
-        toolOutputs[callId] = _toolOutputText(payload?.output);
-      }
+      if (payload == null) continue;
+      final result = _toolMapper.mapResult(payload);
+      if (result != null) toolOutputs[result.callId] = result;
     }
 
     final messages = <PluginMessageWithParts>[];
@@ -80,20 +74,18 @@ class CodexMessageRepository {
 
       if (payload.type == CodexRolloutPayloadType.functionCall ||
           payload.type == CodexRolloutPayloadType.customToolCall) {
-        final callId = payload.callId;
-        final name = payload.name ?? "tool";
-        final output = callId == null ? null : toolOutputs[callId];
-        final completed = callId != null && toolOutputs.containsKey(callId);
-        messageCounter += 1;
+        final call = _toolMapper.mapCall(payload);
+        if (call == null) continue;
+        final result = toolOutputs[call.id];
         messages.add(
           _toolMessage(
-            messageId: "m-$messageCounter",
+            messageId: call.id,
             sessionId: sessionId,
-            info: assistantInfo("m-$messageCounter", messageTime),
-            tool: _normalizeToolName(name),
-            title: _toolCallTitle(payload.arguments ?? payload.input),
-            status: completed ? PluginToolStatus.completed : PluginToolStatus.running,
-            output: output,
+            info: assistantInfo(call.id, messageTime),
+            tool: call.tool,
+            title: call.title,
+            status: result?.status ?? PluginToolStatus.running,
+            output: result?.output,
           ),
         );
         continue;
@@ -104,11 +96,15 @@ class CodexMessageRepository {
       }
       if (payload.type == CodexRolloutPayloadType.webSearchCall) {
         messageCounter += 1;
+        final messageId = _persistedOrLegacyMessageId(
+          payload: payload,
+          legacyCounter: messageCounter,
+        );
         messages.add(
           _toolMessage(
-            messageId: "m-$messageCounter",
+            messageId: messageId,
             sessionId: sessionId,
-            info: assistantInfo("m-$messageCounter", messageTime),
+            info: assistantInfo(messageId, messageTime),
             tool: "web_search",
             title: payload.action?.query,
             status: PluginToolStatus.completed,
@@ -126,7 +122,10 @@ class CodexMessageRepository {
         if (reasoning.isEmpty) continue;
 
         messageCounter += 1;
-        final messageId = "m-$messageCounter";
+        final messageId = _persistedOrLegacyMessageId(
+          payload: payload,
+          legacyCounter: messageCounter,
+        );
         messages.add(
           PluginMessageWithParts(
             info: assistantInfo(messageId, messageTime),
@@ -165,7 +164,10 @@ class CodexMessageRepository {
       if (texts.isEmpty) continue;
 
       messageCounter += 1;
-      final messageId = "m-$messageCounter";
+      final messageId = _persistedOrLegacyMessageId(
+        payload: payload,
+        legacyCounter: messageCounter,
+      );
       final info = payload.role == CodexRolloutRole.user
           ? PluginMessage.user(
               id: messageId,
@@ -178,38 +180,26 @@ class CodexMessageRepository {
         PluginMessageWithParts(
           info: info,
           parts: [
-            for (var i = 0; i < texts.length; i++)
-              PluginMessagePart(
-                id: "$messageId-p$i",
-                sessionID: sessionId,
-                messageID: messageId,
-                type: PluginMessagePartType.text,
-                text: texts[i],
-                tool: null,
-                state: null,
-                prompt: null,
-                description: null,
-                agent: null,
-                agentName: null,
-                attempt: null,
-                retryError: null,
-              ),
+            PluginMessagePart(
+              id: "$messageId-text",
+              sessionID: sessionId,
+              messageID: messageId,
+              type: PluginMessagePartType.text,
+              text: texts.join(),
+              tool: null,
+              state: null,
+              prompt: null,
+              description: null,
+              agent: null,
+              agentName: null,
+              attempt: null,
+              retryError: null,
+            ),
           ],
         ),
       );
     }
     return messages;
-  }
-
-  String? _toolOutputText(List<CodexRolloutContentDto>? output) {
-    final texts = _contentTexts(
-      output,
-      acceptedTypes: const {
-        CodexRolloutContentType.inputText,
-        CodexRolloutContentType.outputText,
-      },
-    );
-    return texts.isEmpty ? null : texts.join();
   }
 
   List<String> _contentTexts(
@@ -231,9 +221,6 @@ class CodexMessageRepository {
     required String? title,
     required String? output,
   }) {
-    final clipped = output != null && output.runes.length > maxToolOutputLength
-        ? String.fromCharCodes(output.runes.take(maxToolOutputLength))
-        : output;
     return PluginMessageWithParts(
       info: info,
       parts: [
@@ -247,8 +234,8 @@ class CodexMessageRepository {
           state: PluginToolState(
             status: status,
             title: title,
-            output: clipped,
-            error: null,
+            output: output,
+            error: status == PluginToolStatus.error ? output : null,
           ),
           prompt: null,
           description: null,
@@ -261,82 +248,17 @@ class CodexMessageRepository {
     );
   }
 
-  String _normalizeToolName(String name) {
-    final normalized = name.toLowerCase();
-    if (normalized.contains("patch") || normalized.contains("edit") || normalized.contains("write")) {
-      return "edit";
-    }
-    if (normalized.contains("exec") ||
-        normalized.contains("shell") ||
-        normalized.contains("bash") ||
-        normalized.contains("command")) {
-      return "shell";
-    }
-    return name;
-  }
-
-  String? _toolCallTitle(String? argumentsJson) {
-    if (argumentsJson == null || argumentsJson.isEmpty) return null;
-    final arguments = _tryDecodeToolArguments(raw: argumentsJson);
-    if (arguments != null) {
-      for (final value in [
-        arguments.cmd,
-        arguments.command,
-        arguments.path,
-        arguments.filePath,
-        arguments.query,
-      ]) {
-        if (value is String && value.isNotEmpty) return value;
-        if (value is List && value.isNotEmpty) return value.join(" ");
-      }
-    }
-    final embeddedCommand = _embeddedExecCommand(source: argumentsJson);
-    if (embeddedCommand != null && embeddedCommand.isNotEmpty) {
-      return embeddedCommand;
-    }
-    return argumentsJson.length > 120 ? argumentsJson.substring(0, 120) : argumentsJson;
-  }
-
-  CodexToolArgumentsDto? _tryDecodeToolArguments({required String raw}) {
-    try {
-      return CodexToolArgumentsDto.fromJson(jsonDecodeMap(raw));
-    } on Object {
-      return null;
-    }
-  }
-
-  String? _embeddedExecCommand({required String source}) {
-    const marker = "tools.exec_command(";
-    final markerIndex = source.indexOf(marker);
-    if (markerIndex < 0) return null;
-
-    final argumentsStart = markerIndex + marker.length;
-    final commandMatch = RegExp(
-      r'(?:^|[,{]\s*)(?:"cmd"|cmd)\s*:\s*',
-    ).firstMatch(source.substring(argumentsStart));
-    if (commandMatch == null) return null;
-    final valueStart = argumentsStart + commandMatch.end;
-    if (valueStart >= source.length || source.codeUnitAt(valueStart) != 0x22) {
-      return null;
-    }
-
-    var escaped = false;
-    for (var index = valueStart + 1; index < source.length; index++) {
-      final codeUnit = source.codeUnitAt(index);
-      if (escaped) {
-        escaped = false;
-      } else if (codeUnit == 0x5C) {
-        escaped = true;
-      } else if (codeUnit == 0x22) {
-        try {
-          final decoded = jsonDecode(source.substring(valueStart, index + 1));
-          return decoded is String ? decoded : null;
-        } on FormatException {
-          return null;
-        }
-      }
-    }
-    return null;
+  String _persistedOrLegacyMessageId({
+    required CodexRolloutPayloadDto payload,
+    required int legacyCounter,
+  }) {
+    final persisted = payload.id?.trim();
+    if (persisted != null && persisted.isNotEmpty) return persisted;
+    // COMPATIBILITY 2026-07-23 (legacy Codex rollouts): older response-item
+    // messages can omit `payload.id`. Keep a deterministic replay-local id so
+    // those histories remain visible. Remove after histories without persisted
+    // response-item ids are no longer supported.
+    return "m-$legacyCounter";
   }
 
   PluginMessageTime? _messageTimeFrom(String? raw) {

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_rollout_tailer.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_rollout_tailer.dart
@@ -1,0 +1,127 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
+import "../api/codex_rollout_api.dart";
+import "../api/models/codex_rollout_dto.dart";
+import "../repositories/codex_catalog_repository.dart";
+
+class CodexRolloutAppend {
+  const CodexRolloutAppend({
+    required this.sessionId,
+    required this.line,
+  });
+
+  final String sessionId;
+  final CodexRolloutLineDto line;
+}
+
+/// Streams complete records appended to rollouts for turns active in this
+/// bridge process.
+///
+/// COMPATIBILITY 2026-07-23 (Codex app-server 0.144.x): stable item events do
+/// not expose every response-item call (notably code-mode `exec` and `wait`),
+/// and experimental raw events are disabled when a thread is resumed. Remove
+/// this tailer when a stable app-server stream covers raw calls and outputs for
+/// both newly started and resumed threads.
+class CodexRolloutTailer {
+  CodexRolloutTailer({
+    required CodexRolloutApi rolloutApi,
+    required CodexCatalogRepository catalogRepository,
+    required Duration pollInterval,
+  }) : _rolloutApi = rolloutApi,
+       _catalogRepository = catalogRepository,
+       _pollInterval = pollInterval;
+
+  final CodexRolloutApi _rolloutApi;
+  final CodexCatalogRepository _catalogRepository;
+  final Duration _pollInterval;
+
+  // Synchronous delivery is intentional: a final drain on turn/completed must
+  // enqueue tool updates before the plugin emits session.idle. Remove `sync`
+  // only if the plugin starts awaiting an ordered async rollout pipeline.
+  final StreamController<CodexRolloutAppend> _appends = StreamController<CodexRolloutAppend>.broadcast(sync: true);
+  final Map<String, _CodexRolloutCursor> _cursors = {};
+  Timer? _timer;
+
+  Stream<CodexRolloutAppend> get appends => _appends.stream;
+
+  void start({required String sessionId}) {
+    if (_cursors.containsKey(sessionId)) return;
+    final path = _catalogRepository.findRolloutPath(sessionId: sessionId);
+    _cursors[sessionId] = _CodexRolloutCursor(
+      path: path,
+      offset: path == null ? 0 : _rolloutApi.rolloutLength(rolloutPath: path),
+      trailingBytes: const [],
+    );
+    _timer ??= Timer.periodic(_pollInterval, (_) => drainAll());
+  }
+
+  void drainAll() {
+    for (final sessionId in _cursors.keys.toList(growable: false)) {
+      drain(sessionId: sessionId);
+    }
+  }
+
+  void drain({required String sessionId}) {
+    final cursor = _cursors[sessionId];
+    if (cursor == null) return;
+    var path = cursor.path;
+    if (path == null) {
+      path = _catalogRepository.findRolloutPath(sessionId: sessionId);
+      if (path == null) return;
+      cursor.path = path;
+    }
+    try {
+      final chunk = _rolloutApi.readTranscriptChunk(
+        rolloutPath: path,
+        offset: cursor.offset,
+        trailingBytes: cursor.trailingBytes,
+      );
+      cursor
+        ..offset = chunk.nextOffset
+        ..trailingBytes = chunk.trailingBytes;
+      for (final line in chunk.lines) {
+        _appends.add(CodexRolloutAppend(sessionId: sessionId, line: line));
+      }
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        "[codex] stopped live rollout tail for $sessionId after a read failure",
+        error,
+        stackTrace,
+      );
+      stop(sessionId: sessionId);
+    }
+  }
+
+  void stop({required String sessionId}) {
+    _cursors.remove(sessionId);
+    if (_cursors.isEmpty) {
+      _timer?.cancel();
+      _timer = null;
+    }
+  }
+
+  void stopAll() {
+    _cursors.clear();
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  Future<void> dispose() async {
+    stopAll();
+    await _appends.close();
+  }
+}
+
+class _CodexRolloutCursor {
+  _CodexRolloutCursor({
+    required this.path,
+    required this.offset,
+    required this.trailingBytes,
+  });
+
+  String? path;
+  int offset;
+  List<int> trailingBytes;
+}

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_rollout_tailer.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_rollout_tailer.dart
@@ -25,6 +25,8 @@ class CodexRolloutAppend {
 /// this tailer when a stable app-server stream covers raw calls and outputs for
 /// both newly started and resumed threads.
 class CodexRolloutTailer {
+  static const int _terminalDrainPollAttempts = 10;
+
   CodexRolloutTailer({
     required CodexRolloutApi rolloutApi,
     required CodexCatalogRepository catalogRepository,
@@ -48,11 +50,30 @@ class CodexRolloutTailer {
 
   void start({required String sessionId}) {
     if (_cursors.containsKey(sessionId)) return;
-    final path = _catalogRepository.findRolloutPath(sessionId: sessionId);
+    final String? path;
+    final CodexRolloutTailPosition position;
+    try {
+      path = _catalogRepository.findRolloutPath(sessionId: sessionId);
+      position = path == null
+          ? const CodexRolloutTailPosition(
+              offset: 0,
+              trailingBytes: [],
+            )
+          : _rolloutApi.rolloutTailPosition(rolloutPath: path);
+    } on Object catch (error, stackTrace) {
+      // Live rollout enrichment is auxiliary. A stat/open failure must not
+      // prevent the authoritative turn/start RPC from reaching Codex.
+      Log.w(
+        "[codex] could not start live rollout tail for $sessionId",
+        error,
+        stackTrace,
+      );
+      return;
+    }
     _cursors[sessionId] = _CodexRolloutCursor(
       path: path,
-      offset: path == null ? 0 : _rolloutApi.rolloutLength(rolloutPath: path),
-      trailingBytes: const [],
+      offset: position.offset,
+      trailingBytes: position.trailingBytes,
     );
     _timer ??= Timer.periodic(_pollInterval, (_) => drainAll());
   }
@@ -66,13 +87,13 @@ class CodexRolloutTailer {
   void drain({required String sessionId}) {
     final cursor = _cursors[sessionId];
     if (cursor == null) return;
-    var path = cursor.path;
-    if (path == null) {
-      path = _catalogRepository.findRolloutPath(sessionId: sessionId);
-      if (path == null) return;
-      cursor.path = path;
-    }
     try {
+      var path = cursor.path;
+      if (path == null) {
+        path = _catalogRepository.findRolloutPath(sessionId: sessionId);
+        if (path == null) return;
+        cursor.path = path;
+      }
       final chunk = _rolloutApi.readTranscriptChunk(
         rolloutPath: path,
         offset: cursor.offset,
@@ -92,6 +113,36 @@ class CodexRolloutTailer {
       );
       stop(sessionId: sessionId);
     }
+  }
+
+  /// Drains a terminal partial record before releasing this turn's cursor.
+  ///
+  /// Complete records stop synchronously. Only a suffix observed without its
+  /// newline waits, bounded to ten normal poll intervals so a broken writer
+  /// cannot hold `session.idle` indefinitely.
+  Future<void> finish({required String sessionId}) async {
+    drain(sessionId: sessionId);
+    var cursor = _cursors[sessionId];
+    if (cursor == null) return;
+    if (cursor.trailingBytes.isEmpty) {
+      stop(sessionId: sessionId);
+      return;
+    }
+    for (var attempt = 0; attempt < _terminalDrainPollAttempts; attempt++) {
+      await Future<void>.delayed(_pollInterval);
+      drain(sessionId: sessionId);
+      cursor = _cursors[sessionId];
+      if (cursor == null) return;
+      if (cursor.trailingBytes.isEmpty) {
+        stop(sessionId: sessionId);
+        return;
+      }
+    }
+    Log.w(
+      "[codex] timed out waiting for the final live rollout record for "
+      "$sessionId",
+    );
+    stop(sessionId: sessionId);
   }
 
   void stop({required String sessionId}) {

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_rollout_tailer.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_rollout_tailer.dart
@@ -115,16 +115,17 @@ class CodexRolloutTailer {
     }
   }
 
-  /// Drains a terminal partial record before releasing this turn's cursor.
+  /// Discovers and drains terminal rollout data before releasing this cursor.
   ///
-  /// Complete records stop synchronously. Only a suffix observed without its
-  /// newline waits, bounded to ten normal poll intervals so a broken writer
-  /// cannot hold `session.idle` indefinitely.
+  /// An already discovered rollout with complete records stops synchronously.
+  /// A rollout not created yet, or a suffix observed without its newline, waits
+  /// up to ten normal poll intervals so Codex's writer can finish without a
+  /// missing or broken writer holding `session.idle` indefinitely.
   Future<void> finish({required String sessionId}) async {
     drain(sessionId: sessionId);
     var cursor = _cursors[sessionId];
     if (cursor == null) return;
-    if (cursor.trailingBytes.isEmpty) {
+    if (cursor.path != null && cursor.trailingBytes.isEmpty) {
       stop(sessionId: sessionId);
       return;
     }
@@ -133,13 +134,13 @@ class CodexRolloutTailer {
       drain(sessionId: sessionId);
       cursor = _cursors[sessionId];
       if (cursor == null) return;
-      if (cursor.trailingBytes.isEmpty) {
+      if (cursor.path != null && cursor.trailingBytes.isEmpty) {
         stop(sessionId: sessionId);
         return;
       }
     }
     Log.w(
-      "[codex] timed out waiting for the final live rollout record for "
+      "[codex] timed out discovering or completing the live rollout for "
       "$sessionId",
     );
     stop(sessionId: sessionId);

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_rollout_tailer.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_rollout_tailer.dart
@@ -74,6 +74,7 @@ class CodexRolloutTailer {
       path: path,
       offset: position.offset,
       trailingBytes: position.trailingBytes,
+      hasObservedAppend: false,
     );
     _timer ??= Timer.periodic(_pollInterval, (_) => drainAll());
   }
@@ -99,9 +100,11 @@ class CodexRolloutTailer {
         offset: cursor.offset,
         trailingBytes: cursor.trailingBytes,
       );
+      final observedAppend = chunk.nextOffset > cursor.offset;
       cursor
         ..offset = chunk.nextOffset
-        ..trailingBytes = chunk.trailingBytes;
+        ..trailingBytes = chunk.trailingBytes
+        ..hasObservedAppend = cursor.hasObservedAppend || observedAppend;
       for (final line in chunk.lines) {
         _appends.add(CodexRolloutAppend(sessionId: sessionId, line: line));
       }
@@ -117,15 +120,16 @@ class CodexRolloutTailer {
 
   /// Discovers and drains terminal rollout data before releasing this cursor.
   ///
-  /// An already discovered rollout with complete records stops synchronously.
-  /// A rollout not created yet, or a suffix observed without its newline, waits
-  /// up to ten normal poll intervals so Codex's writer can finish without a
-  /// missing or broken writer holding `session.idle` indefinitely.
+  /// An already discovered rollout stops synchronously only after this turn
+  /// observed appended bytes and has no partial suffix. A rollout not created
+  /// yet, an idle existing rollout, or a suffix without its newline waits up to
+  /// ten normal poll intervals so Codex's writer can finish without a missing
+  /// or broken writer holding `session.idle` indefinitely.
   Future<void> finish({required String sessionId}) async {
     drain(sessionId: sessionId);
     var cursor = _cursors[sessionId];
     if (cursor == null) return;
-    if (cursor.path != null && cursor.trailingBytes.isEmpty) {
+    if (_isTerminallyDrained(cursor)) {
       stop(sessionId: sessionId);
       return;
     }
@@ -134,7 +138,7 @@ class CodexRolloutTailer {
       drain(sessionId: sessionId);
       cursor = _cursors[sessionId];
       if (cursor == null) return;
-      if (cursor.path != null && cursor.trailingBytes.isEmpty) {
+      if (_isTerminallyDrained(cursor)) {
         stop(sessionId: sessionId);
         return;
       }
@@ -145,6 +149,9 @@ class CodexRolloutTailer {
     );
     stop(sessionId: sessionId);
   }
+
+  bool _isTerminallyDrained(_CodexRolloutCursor cursor) =>
+      cursor.path != null && cursor.hasObservedAppend && cursor.trailingBytes.isEmpty;
 
   void stop({required String sessionId}) {
     _cursors.remove(sessionId);
@@ -171,9 +178,15 @@ class _CodexRolloutCursor {
     required this.path,
     required this.offset,
     required this.trailingBytes,
+    required this.hasObservedAppend,
   });
 
   String? path;
   int offset;
   List<int> trailingBytes;
+
+  // COMPATIBILITY 2026-07-23 (Codex JSONL writer): a non-null path at EOF does
+  // not prove the current turn is flushed; Codex may append its first bytes
+  // just after turn/completed. Remove with the live rollout tail workaround.
+  bool hasObservedAppend;
 }

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -581,6 +581,75 @@ void main() {
       mapper.clearRolloutTurn(threadId: "t-raw");
     });
 
+    test("a structured non-zero exit overrides an unclassified raw result", () {
+      final call = CodexRolloutLineDto.fromJson({
+        "type": "response_item",
+        "payload": {
+          "type": "function_call",
+          "call_id": "call-structured-failure",
+          "name": "exec_command",
+          "arguments": '{"cmd":"/usr/bin/false"}',
+        },
+      });
+      final output = CodexRolloutLineDto.fromJson({
+        "type": "response_item",
+        "payload": {
+          "type": "function_call_output",
+          "call_id": "call-structured-failure",
+          "output": "opaque executor output",
+        },
+      });
+      mapper
+        ..mapRolloutLine(threadId: "t-structured", line: call)
+        ..mapRolloutLine(threadId: "t-structured", line: output);
+
+      final events = mapper.map(
+        const CodexServerNotification(
+          method: "item/completed",
+          params: {
+            "threadId": "t-structured",
+            "item": {
+              "type": "commandExecution",
+              "id": "call-structured-failure",
+              "command": "/bin/zsh -lc /usr/bin/false",
+              "aggregatedOutput": "",
+              "exitCode": 1,
+              "status": "completed",
+            },
+          },
+        ),
+      );
+
+      final part = (events[1] as BridgeSseMessagePartUpdated).part;
+      expect(part.state?.status, PluginToolStatus.error);
+      expect(part.state?.output, "opaque executor output");
+      expect(part.state?.error, "opaque executor output");
+      mapper.clearRolloutTurn(threadId: "t-structured");
+    });
+
+    test("raw fallback titles clip non-BMP text by Unicode code point", () {
+      final prefix = List<String>.filled(119, "a").join();
+      final line = CodexRolloutLineDto.fromJson({
+        "type": "response_item",
+        "payload": {
+          "type": "function_call",
+          "call_id": "call-unicode",
+          "name": "unknown_tool",
+          "arguments": "$prefix😀trailing",
+        },
+      });
+
+      final events = mapper.mapRolloutLine(
+        threadId: "t-unicode",
+        line: line,
+      );
+
+      final title = (events[1] as BridgeSseMessagePartUpdated).part.state?.title;
+      expect(title, "$prefix😀");
+      expect(title?.runes, hasLength(120));
+      mapper.clearRolloutTurn(threadId: "t-unicode");
+    });
+
     test("commandExecution (started/inProgress) → running tool part", () {
       final events = mapper.map(
         const CodexServerNotification(

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -2,6 +2,7 @@ import "dart:io";
 
 import "package:codex_plugin/codex_plugin.dart";
 import "package:codex_plugin/src/api/codex_app_server_api.dart";
+import "package:codex_plugin/src/api/models/codex_rollout_dto.dart";
 import "package:codex_plugin/src/repositories/codex_thread_repository.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" as shared;
@@ -469,7 +470,7 @@ void main() {
             "item": {
               "type": "commandExecution",
               "id": "i-cmd",
-              "command": "ls -la",
+              "command": "/bin/zsh -lc 'ls -la'",
               "aggregatedOutput": "total 0\nfoo.dart",
               "exitCode": 0,
               "status": "completed",
@@ -490,6 +491,94 @@ void main() {
       expect(part.state?.status, PluginToolStatus.completed);
       expect(part.state?.title, "ls -la");
       expect(part.state?.output, contains("foo.dart"));
+    });
+
+    test("commandExecution treats a non-zero exit code as an error", () {
+      final events = mapper.map(
+        const CodexServerNotification(
+          method: "item/completed",
+          params: {
+            "threadId": "t-1",
+            "item": {
+              "type": "commandExecution",
+              "id": "i-failed",
+              "command": "/bin/zsh -lc /usr/bin/false",
+              "aggregatedOutput": "",
+              "exitCode": 1,
+              // Some app-server versions have reported `completed` here even
+              // though the explicit process exit code is authoritative.
+              "status": "completed",
+            },
+          },
+        ),
+      );
+
+      final part = (events[1] as BridgeSseMessagePartUpdated).part;
+      expect(part.state?.title, "/usr/bin/false");
+      expect(part.state?.status, PluginToolStatus.error);
+      expect(part.state?.error, "");
+    });
+
+    test("raw rollout output enriches and cannot be downgraded by a later item", () {
+      final call = CodexRolloutLineDto.fromJson({
+        "timestamp": "2026-07-23T08:00:00Z",
+        "type": "response_item",
+        "payload": {
+          "type": "function_call",
+          "id": "fc-failed",
+          "call_id": "call-failed",
+          "name": "exec_command",
+          "arguments": '{"cmd":"/usr/bin/false"}',
+        },
+      });
+      final output = CodexRolloutLineDto.fromJson({
+        "timestamp": "2026-07-23T08:00:01Z",
+        "type": "response_item",
+        "payload": {
+          "type": "function_call_output",
+          "call_id": "call-failed",
+          "output":
+              "Chunk ID: failed\n"
+              "Wall time: 0.01 seconds\n"
+              "Process exited with code 1\n"
+              "Final output:\n",
+        },
+      });
+
+      final running = mapper.mapRolloutLine(threadId: "t-raw", line: call);
+      final completed = mapper.mapRolloutLine(
+        threadId: "t-raw",
+        line: output,
+      );
+      final lateItem = mapper.map(
+        const CodexServerNotification(
+          method: "item/completed",
+          params: {
+            "threadId": "t-raw",
+            "item": {
+              "type": "commandExecution",
+              "id": "call-failed",
+              "command": "/bin/zsh -lc /usr/bin/false",
+              "aggregatedOutput": "",
+              "exitCode": 1,
+              "status": "failed",
+            },
+          },
+        ),
+      );
+
+      expect(
+        (running[1] as BridgeSseMessagePartUpdated).part.state?.title,
+        "/usr/bin/false",
+      );
+      final rawPart = (completed[1] as BridgeSseMessagePartUpdated).part;
+      final latePart = (lateItem[1] as BridgeSseMessagePartUpdated).part;
+      expect(rawPart.state?.status, PluginToolStatus.error);
+      expect(rawPart.state?.output, contains("Chunk ID: failed"));
+      expect(latePart.state?.status, rawPart.state?.status);
+      expect(latePart.state?.output, rawPart.state?.output);
+      expect(latePart.state?.error, rawPart.state?.error);
+      mapper.clearRolloutTurn(threadId: "t-raw");
     });
 
     test("commandExecution (started/inProgress) → running tool part", () {

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -200,7 +200,11 @@ void main() {
       // it without a redundant resume round-trip.
       fake.respondInOrder([
         const _Response(result: _initOk),
-        const _Response(result: {"thread": {"id": "t-fresh"}}),
+        const _Response(
+          result: {
+            "thread": {"id": "t-fresh"},
+          },
+        ),
         const _Response(result: {"turnId": "u-1"}),
       ]);
 
@@ -229,7 +233,11 @@ void main() {
       // the first turn/start fails, then resume + retry must recover it.
       fake.respondInOrder([
         const _Response(result: _initOk),
-        const _Response(result: {"thread": {"id": "t-dropped"}}),
+        const _Response(
+          result: {
+            "thread": {"id": "t-dropped"},
+          },
+        ),
         const _Response(error: {"code": -32600, "message": "thread not found"}),
         const _Response(
           result: {
@@ -270,7 +278,11 @@ void main() {
       // unknown to this run, so the prompt resumes it before the turn.
       fake.respondInOrder([
         const _Response(result: _initOk),
-        const _Response(result: {"thread": {"id": "t-1"}}),
+        const _Response(
+          result: {
+            "thread": {"id": "t-1"},
+          },
+        ),
         const _Response(result: {"turnId": "u-active"}),
         const _Response(result: null),
       ]);
@@ -304,7 +316,15 @@ void main() {
 
       // Subscribe BEFORE the connection so buffered events flow.
       final events = <BridgeSseEvent>[];
-      final subscription = plugin.events.listen(events.add);
+      final terminalActivityUpdate = Completer<void>();
+      var projectUpdates = 0;
+      final subscription = plugin.events.listen((event) {
+        events.add(event);
+        if (event is BridgeSseProjectUpdated) {
+          projectUpdates++;
+          if (projectUpdates == 2) terminalActivityUpdate.complete();
+        }
+      });
 
       // Trigger _ensureConnected.
       await plugin.healthCheck();
@@ -340,8 +360,10 @@ void main() {
         "turn": {"id": "u-1", "completedAt": 1700000010},
       });
 
-      // Drain microtasks so all notification handlers run.
-      await Future<void>.delayed(Duration.zero);
+      // A terminal notification may briefly wait for Codex to create/finish
+      // its rollout file. Await the activity invalidation emitted after idle
+      // instead of assuming the ordered async event pipeline is synchronous.
+      await terminalActivityUpdate.future.timeout(const Duration(seconds: 2));
       await subscription.cancel();
 
       expect(
@@ -594,13 +616,11 @@ void main() {
       await kaPlugin.healthCheck(); // connect → starts keepalive
       await Future<void>.delayed(const Duration(milliseconds: 90));
 
-      final firedWhileConnected =
-          kaFake.sentMethods.where((m) => m == "model/list").length;
+      final firedWhileConnected = kaFake.sentMethods.where((m) => m == "model/list").length;
       expect(firedWhileConnected, greaterThanOrEqualTo(2));
 
       await kaPlugin.dispose();
-      final afterDispose =
-          kaFake.sentMethods.where((m) => m == "model/list").length;
+      final afterDispose = kaFake.sentMethods.where((m) => m == "model/list").length;
       await Future<void>.delayed(const Duration(milliseconds: 60));
       // No further keepalives once disposed.
       expect(
@@ -740,7 +760,11 @@ void main() {
     test("sendPrompt without a variant sends no effort (codex uses its default)", () async {
       fake.respondInOrder([
         const _Response(result: _initOk),
-        const _Response(result: {"thread": {"id": "t-default"}}),
+        const _Response(
+          result: {
+            "thread": {"id": "t-default"},
+          },
+        ),
         const _Response(result: {"turnId": "u-1"}),
       ]);
 
@@ -758,7 +782,11 @@ void main() {
     test("createSession applies the variant on the first turn", () async {
       fake.respondInOrder([
         const _Response(result: _initOk),
-        const _Response(result: {"thread": {"id": "t-new"}}),
+        const _Response(
+          result: {
+            "thread": {"id": "t-new"},
+          },
+        ),
         const _Response(result: {"turnId": "u-1"}),
       ]);
 
@@ -890,8 +918,7 @@ class _FakeAppServer {
   /// `thread/name/updated` while `turn/start` is still in flight).
   void Function(String method)? onRequest;
 
-  List<String> get sentMethods =>
-      _sent.map((f) => f.method).toList(growable: false);
+  List<String> get sentMethods => _sent.map((f) => f.method).toList(growable: false);
 
   Map<String, dynamic> sentParamsFor(String method) {
     final frame = _sent.firstWhere((f) => f.method == method);
@@ -982,8 +1009,7 @@ class _SinkAdapter implements WebSocketSink {
   void add(Object? data) => _controller.add(data);
 
   @override
-  void addError(Object error, [StackTrace? stackTrace]) =>
-      _controller.addError(error, stackTrace);
+  void addError(Object error, [StackTrace? stackTrace]) => _controller.addError(error, stackTrace);
 
   @override
   Future<void> addStream(Stream<Object?> stream) async {

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -363,6 +363,206 @@ void main() {
       expect(plugin.getActiveSessionsSummary(), isEmpty);
     });
 
+    test("live rollout tools converge exactly with reloaded history", () async {
+      const sessionId = "019a0000-1111-2222-3333-aaaaaaaaaaaa";
+      final rollout = File(
+        p.join(
+          codexHome.path,
+          "sessions/2026/07/23/"
+          "rollout-2026-07-23T08-00-00-$sessionId.jsonl",
+        ),
+      )..createSync(recursive: true);
+      rollout.writeAsStringSync(
+        "${jsonEncode({
+          "timestamp": "2026-07-23T08:00:00Z",
+          "type": "session_meta",
+          "payload": {
+            "id": sessionId,
+            "timestamp": "2026-07-23T08:00:00Z",
+            "cwd": "/work/sample",
+            "model_provider": "openai",
+            "cli_version": "0.144.1",
+          },
+        })}\n",
+      );
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "thread": {"id": sessionId},
+          },
+        ),
+        const _Response(result: {"turnId": "u-live"}),
+      ]);
+      final events = <BridgeSseEvent>[];
+      final subscription = plugin.events.listen(events.add);
+
+      await plugin.sendPrompt(
+        sessionId: sessionId,
+        parts: const [PluginPromptPart.text(text: "run the live event fixture")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+
+      final records = <Map<String, Object?>>[
+        _toolCall(
+          id: "fc-immediate",
+          callId: "call-immediate",
+          name: "exec_command",
+          arguments: '{"cmd":"printf \'LIVE-EVENT-TEST immediate-complete\\\\n\'"}',
+        ),
+        _toolOutput(
+          callId: "call-immediate",
+          output: _processOutput(
+            chunkId: "immediate",
+            exitCode: 0,
+            output: "LIVE-EVENT-TEST immediate-complete\n",
+          ),
+        ),
+        _customToolCall(
+          id: "ct-exec-1",
+          callId: "call-exec-1",
+          input:
+              'const r = await tools.exec_command({cmd:"sleep 5"}); '
+              "text(r.output);",
+        ),
+        _customToolOutput(
+          callId: "call-exec-1",
+          output:
+              "Script running with cell ID 1\n"
+              "Wall time: 0.01 seconds\n"
+              "Output:\n",
+        ),
+        _toolCall(
+          id: "fc-wait-1",
+          callId: "call-wait-1",
+          name: "wait",
+          arguments: '{"cell_id":"1","yield_time_ms":10000,"max_tokens":20000}',
+        ),
+        _toolOutput(
+          callId: "call-wait-1",
+          output:
+              "Script completed with exit code 0\n"
+              "Final output:\n",
+        ),
+        _customToolCall(
+          id: "ct-exec-2",
+          callId: "call-exec-2",
+          input:
+              'const r = await tools.exec_command({cmd:"sleep 2"}); '
+              "text(r.output);",
+        ),
+        _customToolOutput(
+          callId: "call-exec-2",
+          output:
+              "Script running with cell ID 2\n"
+              "Wall time: 0.01 seconds\n"
+              "Output:\n",
+        ),
+        _toolCall(
+          id: "fc-wait-2",
+          callId: "call-wait-2",
+          name: "wait",
+          arguments: '{"cell_id":"2","yield_time_ms":10000,"max_tokens":20000}',
+        ),
+        _toolOutput(
+          callId: "call-wait-2",
+          output:
+              "Script completed with exit code 0\n"
+              "Final output:\n",
+        ),
+        _toolCall(
+          id: "fc-failed",
+          callId: "call-failed",
+          name: "exec_command",
+          arguments: '{"cmd":"/usr/bin/false"}',
+        ),
+        _toolOutput(
+          callId: "call-failed",
+          output: _processOutput(
+            chunkId: "failed",
+            exitCode: 1,
+            output: "",
+          ),
+        ),
+        _toolCall(
+          id: "fc-recovery",
+          callId: "call-recovery",
+          name: "exec_command",
+          arguments: '{"cmd":"printf \'LIVE-EVENT-TEST recovery-complete\\\\n\'"}',
+        ),
+        _toolOutput(
+          callId: "call-recovery",
+          output: _processOutput(
+            chunkId: "recovery",
+            exitCode: 0,
+            output: "LIVE-EVENT-TEST recovery-complete\n",
+          ),
+        ),
+      ];
+      rollout.writeAsStringSync(
+        "${records.map(jsonEncode).join("\n")}\n",
+        mode: FileMode.append,
+      );
+
+      fake.pushNotification("turn/completed", {
+        "threadId": sessionId,
+        "turn": {"id": "u-live"},
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      final finalLiveParts = <String, PluginMessagePart>{};
+      for (final event in events.whereType<BridgeSseMessagePartUpdated>()) {
+        final part = event.part;
+        if (part.type == PluginMessagePartType.tool) {
+          finalLiveParts[part.messageID] = part;
+        }
+      }
+      final history = await plugin.getSessionMessages(sessionId);
+
+      expect(finalLiveParts.keys, {
+        "call-immediate",
+        "call-exec-1",
+        "call-wait-1",
+        "call-exec-2",
+        "call-wait-2",
+        "call-failed",
+        "call-recovery",
+      });
+      expect(history, hasLength(finalLiveParts.length));
+      for (final message in history) {
+        final historicalPart = message.parts.single;
+        final livePart = finalLiveParts[message.info.id];
+        expect(livePart, isNotNull, reason: message.info.id);
+        expect(livePart?.id, historicalPart.id);
+        expect(livePart?.tool, historicalPart.tool);
+        expect(livePart?.state?.title, historicalPart.state?.title);
+        expect(livePart?.state?.status, historicalPart.state?.status);
+        expect(livePart?.state?.output, historicalPart.state?.output);
+        expect(livePart?.state?.error, historicalPart.state?.error);
+      }
+      expect(
+        finalLiveParts["call-immediate"]?.state?.title,
+        r"printf 'LIVE-EVENT-TEST immediate-complete\n'",
+      );
+      expect(finalLiveParts["call-exec-1"]?.state?.title, "sleep 5");
+      expect(
+        finalLiveParts["call-failed"]?.state?.status,
+        PluginToolStatus.error,
+      );
+      expect(
+        finalLiveParts["call-failed"]?.state?.output,
+        contains("Process exited with code 1"),
+      );
+      expect(
+        events.lastIndexWhere((event) => event is BridgeSseMessagePartUpdated),
+        lessThan(events.lastIndexWhere((event) => event is BridgeSseSessionIdle)),
+      );
+
+      await subscription.cancel();
+    });
+
     test("keepalive sends periodic model/list RPCs while connected, stops on dispose", () async {
       final kaFake = _FakeAppServer();
       const serverUrl = "ws://127.0.0.1:0";
@@ -579,6 +779,79 @@ class _Response {
   final Object? result;
   final Map<String, dynamic>? error;
 }
+
+Map<String, Object?> _toolCall({
+  required String id,
+  required String callId,
+  required String name,
+  required String arguments,
+}) => {
+  "timestamp": "2026-07-23T08:00:01Z",
+  "type": "response_item",
+  "payload": {
+    "type": "function_call",
+    "id": id,
+    "call_id": callId,
+    "name": name,
+    "arguments": arguments,
+  },
+};
+
+Map<String, Object?> _customToolCall({
+  required String id,
+  required String callId,
+  required String input,
+}) => {
+  "timestamp": "2026-07-23T08:00:01Z",
+  "type": "response_item",
+  "payload": {
+    "type": "custom_tool_call",
+    "id": id,
+    "call_id": callId,
+    "name": "exec",
+    "input": input,
+  },
+};
+
+Map<String, Object?> _toolOutput({
+  required String callId,
+  required String output,
+}) => {
+  "timestamp": "2026-07-23T08:00:02Z",
+  "type": "response_item",
+  "payload": {
+    "type": "function_call_output",
+    "call_id": callId,
+    "output": output,
+  },
+};
+
+Map<String, Object?> _customToolOutput({
+  required String callId,
+  required String output,
+}) => {
+  "timestamp": "2026-07-23T08:00:02Z",
+  "type": "response_item",
+  "payload": {
+    "type": "custom_tool_call_output",
+    "call_id": callId,
+    "output": [
+      {"type": "input_text", "text": output},
+    ],
+  },
+};
+
+String _processOutput({
+  required String chunkId,
+  required int exitCode,
+  required String output,
+}) =>
+    "Chunk ID: $chunkId\n"
+    "Wall time: 0.01 seconds\n"
+    "Process exited with code $exitCode\n"
+    "Original token count: 3\n"
+    "Final output:\n"
+    "$output";
 
 /// Fake app-server that records every method/params it received and
 /// replies in the order [respondInOrder] queued. Lets us push

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -501,8 +501,12 @@ void main() {
           ),
         ),
       ];
+      final encodedRecords = records.map(jsonEncode).toList();
+      final finalRecord = encodedRecords.removeLast();
+      final finalRecordSplit = finalRecord.length ~/ 2;
       rollout.writeAsStringSync(
-        "${records.map(jsonEncode).join("\n")}\n",
+        "${encodedRecords.join("\n")}\n"
+        "${finalRecord.substring(0, finalRecordSplit)}",
         mode: FileMode.append,
       );
 
@@ -510,7 +514,14 @@ void main() {
         "threadId": sessionId,
         "turn": {"id": "u-live"},
       });
-      await Future<void>.delayed(Duration.zero);
+      // Complete the final output after turn/completed has observed its partial
+      // suffix. The terminal drain must still deliver it before session.idle.
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      rollout.writeAsStringSync(
+        "${finalRecord.substring(finalRecordSplit)}\n",
+        mode: FileMode.append,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 30));
 
       final finalLiveParts = <String, PluginMessagePart>{};
       for (final event in events.whereType<BridgeSseMessagePartUpdated>()) {

--- a/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
@@ -154,6 +154,56 @@ void main() {
       expect(output, isNot(contains("secret-source-content")));
     });
 
+    test("readTranscriptChunk retains a partial trailing record until newline", () {
+      final path = p.join(codexHome.path, "live-tail.jsonl");
+      final first = jsonEncode({
+        "type": "response_item",
+        "payload": {
+          "type": "function_call",
+          "name": "wait",
+          "call_id": "call-1",
+          "arguments": "{}",
+        },
+      });
+      final second = jsonEncode({
+        "type": "response_item",
+        "payload": {
+          "type": "function_call_output",
+          "call_id": "call-1",
+          "output": "done",
+        },
+      });
+      final split = second.length ~/ 2;
+      File(path).writeAsStringSync("$first\n${second.substring(0, split)}");
+
+      final initial = rolloutApi.readTranscriptChunk(
+        rolloutPath: path,
+        offset: 0,
+        trailingBytes: const [],
+      );
+
+      expect(initial.lines, hasLength(1));
+      expect(initial.lines.single.payload?.callId, "call-1");
+      expect(initial.trailingBytes, isNotEmpty);
+
+      File(path).writeAsStringSync(
+        "${second.substring(split)}\n",
+        mode: FileMode.append,
+      );
+      final completed = rolloutApi.readTranscriptChunk(
+        rolloutPath: path,
+        offset: initial.nextOffset,
+        trailingBytes: initial.trailingBytes,
+      );
+
+      expect(completed.lines, hasLength(1));
+      expect(
+        completed.lines.single.payload?.type,
+        CodexRolloutPayloadType.functionCallOutput,
+      );
+      expect(completed.trailingBytes, isEmpty);
+    });
+
     test("current structured rollout records are not reported as malformed", () {
       final path = _writeRollout(
         codexHome,
@@ -403,6 +453,7 @@ void main() {
           jsonEncode({
             "type": "response_item",
             "payload": {
+              "id": "user-1",
               "role": "user",
               "content": [
                 {"type": "input_text", "text": "hello, codex"},
@@ -412,6 +463,7 @@ void main() {
           jsonEncode({
             "type": "response_item",
             "payload": {
+              "id": "assistant-1",
               "role": "assistant",
               "content": [
                 {"type": "output_text", "text": "hello back!"},
@@ -436,6 +488,10 @@ void main() {
       expect(messages[1].info, isA<PluginMessageAssistant>());
       expect(messages[1].parts.first.text, equals("hello back!"));
       expect(messages[0].info.sessionID, equals("019a0000-1111-2222-3333-aaaaaaaaaaaa"));
+      expect(messages[0].info.id, "user-1");
+      expect(messages[0].parts.single.id, "user-1-text");
+      expect(messages[1].info.id, "assistant-1");
+      expect(messages[1].parts.single.id, "assistant-1-text");
     });
 
     test("readMessages surfaces transcript read failures", () {
@@ -520,6 +576,8 @@ void main() {
       expect(messages, hasLength(3));
 
       final exec = messages[0].parts.single;
+      expect(messages[0].info.id, "c1");
+      expect(exec.id, "c1-tool");
       expect(exec.type, equals(PluginMessagePartType.tool));
       expect(exec.tool, equals("shell"));
       expect(exec.state?.status, equals(PluginToolStatus.completed));

--- a/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
@@ -204,6 +204,55 @@ void main() {
       expect(completed.trailingBytes, isEmpty);
     });
 
+    test("rolloutTailPosition seeds an existing partial final record", () {
+      final path = p.join(codexHome.path, "live-tail-start.jsonl");
+      final ignored = jsonEncode({
+        "type": "response_item",
+        "payload": {
+          "type": "function_call",
+          "name": "wait",
+          "call_id": "old-call",
+          "arguments": "{}",
+        },
+      });
+      final current = jsonEncode({
+        "type": "response_item",
+        "payload": {
+          "type": "function_call_output",
+          "call_id": "current-call",
+          "output": "done",
+        },
+      });
+      final split = current.length ~/ 2;
+      File(path).writeAsStringSync(
+        "$ignored\n${current.substring(0, split)}",
+      );
+
+      final position = rolloutApi.rolloutTailPosition(
+        rolloutPath: path,
+      );
+
+      expect(position.offset, File(path).lengthSync());
+      expect(
+        utf8.decode(position.trailingBytes),
+        current.substring(0, split),
+      );
+
+      File(path).writeAsStringSync(
+        "${current.substring(split)}\n",
+        mode: FileMode.append,
+      );
+      final completed = rolloutApi.readTranscriptChunk(
+        rolloutPath: path,
+        offset: position.offset,
+        trailingBytes: position.trailingBytes,
+      );
+
+      expect(completed.lines, hasLength(1));
+      expect(completed.lines.single.payload?.callId, "current-call");
+      expect(completed.trailingBytes, isEmpty);
+    });
+
     test("current structured rollout records are not reported as malformed", () {
       final path = _writeRollout(
         codexHome,

--- a/bridge/sesori_plugin_codex/test/codex_rollout_tailer_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_tailer_test.dart
@@ -88,6 +88,51 @@ void main() {
       expect(appends.single.sessionId, "session-1");
       expect(appends.single.line.payload?.callId, "current-call");
     });
+
+    test("finish waits for a rollout created after completion begins", () async {
+      final directory = Directory.systemTemp.createTempSync("codex-tail-");
+      addTearDown(() {
+        try {
+          directory.deleteSync(recursive: true);
+        } catch (_) {}
+      });
+      final path = p.join(directory.path, "rollout.jsonl");
+      final api = CodexRolloutApi(environment: const {});
+      final repository = _MutableCatalogRepository(rolloutApi: api);
+      final tailer = CodexRolloutTailer(
+        rolloutApi: api,
+        catalogRepository: repository,
+        pollInterval: const Duration(milliseconds: 5),
+      );
+      final appends = <CodexRolloutAppend>[];
+      final subscription = tailer.appends.listen(appends.add);
+      addTearDown(() async {
+        await subscription.cancel();
+        await tailer.dispose();
+      });
+
+      tailer.start(sessionId: "session-1");
+      final createTimer = Timer(const Duration(milliseconds: 10), () {
+        File(path).writeAsStringSync(
+          "${jsonEncode({
+            "type": "response_item",
+            "payload": {
+              "type": "function_call_output",
+              "call_id": "late-call",
+              "output": "done",
+            },
+          })}\n",
+        );
+        repository.path = path;
+      });
+      addTearDown(createTimer.cancel);
+
+      await tailer.finish(sessionId: "session-1");
+
+      expect(appends, hasLength(1));
+      expect(appends.single.sessionId, "session-1");
+      expect(appends.single.line.payload?.callId, "late-call");
+    });
   });
 }
 
@@ -109,6 +154,15 @@ class _FixedCatalogRepository extends CodexCatalogRepository {
   });
 
   final String path;
+
+  @override
+  String? findRolloutPath({required String sessionId}) => path;
+}
+
+class _MutableCatalogRepository extends CodexCatalogRepository {
+  _MutableCatalogRepository({required super.rolloutApi});
+
+  String? path;
 
   @override
   String? findRolloutPath({required String sessionId}) => path;

--- a/bridge/sesori_plugin_codex/test/codex_rollout_tailer_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_tailer_test.dart
@@ -133,6 +133,63 @@ void main() {
       expect(appends.single.sessionId, "session-1");
       expect(appends.single.line.payload?.callId, "late-call");
     });
+
+    test("finish waits for a late append to an existing rollout", () async {
+      final directory = Directory.systemTemp.createTempSync("codex-tail-");
+      addTearDown(() {
+        try {
+          directory.deleteSync(recursive: true);
+        } catch (_) {}
+      });
+      final path = p.join(directory.path, "rollout.jsonl");
+      File(path).writeAsStringSync(
+        "${jsonEncode({
+          "type": "response_item",
+          "payload": {
+            "type": "function_call_output",
+            "call_id": "previous-call",
+            "output": "old",
+          },
+        })}\n",
+      );
+      final api = CodexRolloutApi(environment: const {});
+      final tailer = CodexRolloutTailer(
+        rolloutApi: api,
+        catalogRepository: _FixedCatalogRepository(
+          rolloutApi: api,
+          path: path,
+        ),
+        pollInterval: const Duration(milliseconds: 5),
+      );
+      final appends = <CodexRolloutAppend>[];
+      final subscription = tailer.appends.listen(appends.add);
+      addTearDown(() async {
+        await subscription.cancel();
+        await tailer.dispose();
+      });
+
+      tailer.start(sessionId: "session-1");
+      final appendTimer = Timer(const Duration(milliseconds: 10), () {
+        File(path).writeAsStringSync(
+          "${jsonEncode({
+            "type": "response_item",
+            "payload": {
+              "type": "function_call_output",
+              "call_id": "late-existing-call",
+              "output": "done",
+            },
+          })}\n",
+          mode: FileMode.append,
+        );
+      });
+      addTearDown(appendTimer.cancel);
+
+      await tailer.finish(sessionId: "session-1");
+
+      expect(appends, hasLength(1));
+      expect(appends.single.sessionId, "session-1");
+      expect(appends.single.line.payload?.callId, "late-existing-call");
+    });
   });
 }
 

--- a/bridge/sesori_plugin_codex/test/codex_rollout_tailer_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_tailer_test.dart
@@ -1,0 +1,115 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+
+import "package:codex_plugin/src/api/codex_rollout_api.dart";
+import "package:codex_plugin/src/repositories/codex_catalog_repository.dart";
+import "package:codex_plugin/src/services/codex_rollout_tailer.dart";
+import "package:path/path.dart" as p;
+import "package:test/test.dart";
+
+void main() {
+  group("CodexRolloutTailer", () {
+    test("start fails soft when the existing rollout cannot be statted", () async {
+      final api = _ThrowingPositionApi();
+      final tailer = CodexRolloutTailer(
+        rolloutApi: api,
+        catalogRepository: _FixedCatalogRepository(
+          rolloutApi: api,
+          path: "/unreadable/rollout.jsonl",
+        ),
+        pollInterval: const Duration(milliseconds: 5),
+      );
+      addTearDown(tailer.dispose);
+
+      expect(
+        () => tailer.start(sessionId: "session-1"),
+        returnsNormally,
+      );
+    });
+
+    test("finish waits for a partial record present when tailing starts", () async {
+      final directory = Directory.systemTemp.createTempSync("codex-tail-");
+      addTearDown(() {
+        try {
+          directory.deleteSync(recursive: true);
+        } catch (_) {}
+      });
+      final path = p.join(directory.path, "rollout.jsonl");
+      final completeOldRecord = jsonEncode({
+        "type": "response_item",
+        "payload": {
+          "type": "function_call",
+          "name": "wait",
+          "call_id": "old-call",
+          "arguments": "{}",
+        },
+      });
+      final finalRecord = jsonEncode({
+        "type": "response_item",
+        "payload": {
+          "type": "function_call_output",
+          "call_id": "current-call",
+          "output": "done",
+        },
+      });
+      final split = finalRecord.length ~/ 2;
+      File(path).writeAsStringSync(
+        "$completeOldRecord\n${finalRecord.substring(0, split)}",
+      );
+      final api = CodexRolloutApi(environment: const {});
+      final tailer = CodexRolloutTailer(
+        rolloutApi: api,
+        catalogRepository: _FixedCatalogRepository(
+          rolloutApi: api,
+          path: path,
+        ),
+        pollInterval: const Duration(milliseconds: 5),
+      );
+      final appends = <CodexRolloutAppend>[];
+      final subscription = tailer.appends.listen(appends.add);
+      addTearDown(() async {
+        await subscription.cancel();
+        await tailer.dispose();
+      });
+
+      tailer.start(sessionId: "session-1");
+      final appendTimer = Timer(const Duration(milliseconds: 10), () {
+        File(path).writeAsStringSync(
+          "${finalRecord.substring(split)}\n",
+          mode: FileMode.append,
+        );
+      });
+      addTearDown(appendTimer.cancel);
+
+      await tailer.finish(sessionId: "session-1");
+
+      expect(appends, hasLength(1));
+      expect(appends.single.sessionId, "session-1");
+      expect(appends.single.line.payload?.callId, "current-call");
+    });
+  });
+}
+
+class _ThrowingPositionApi extends CodexRolloutApi {
+  _ThrowingPositionApi() : super(environment: const {});
+
+  @override
+  CodexRolloutTailPosition rolloutTailPosition({
+    required String rolloutPath,
+  }) {
+    throw const FileSystemException("stat failed");
+  }
+}
+
+class _FixedCatalogRepository extends CodexCatalogRepository {
+  _FixedCatalogRepository({
+    required super.rolloutApi,
+    required this.path,
+  });
+
+  final String path;
+
+  @override
+  String? findRolloutPath({required String sessionId}) => path;
+}

--- a/bridge/sesori_plugin_codex/test/support/codex_plugin_test_factory.dart
+++ b/bridge/sesori_plugin_codex/test/support/codex_plugin_test_factory.dart
@@ -9,8 +9,10 @@ CodexPlugin createInjectedCodexPlugin({
   required String projectCwd,
   required CodexAppServerClient Function() clientFactory,
   required Duration keepaliveInterval,
+  Duration rolloutPollInterval = const Duration(milliseconds: 10),
 }) {
   final rolloutApi = CodexRolloutApi(environment: environment);
+  final catalogRepository = CodexCatalogRepository(rolloutApi: rolloutApi);
   final configReader = CodexConfigReader(environment: environment);
   final metadataRepository = CodexMetadataRepository(
     skillReader: CodexSkillReader(environment: environment),
@@ -22,7 +24,7 @@ CodexPlugin createInjectedCodexPlugin({
     capabilityToken: null,
     clientFactory: clientFactory,
     sessionService: CodexSessionService(
-      catalogRepository: CodexCatalogRepository(rolloutApi: rolloutApi),
+      catalogRepository: catalogRepository,
       messageRepository: CodexMessageRepository(rolloutApi: rolloutApi),
       metadataRepository: metadataRepository,
       launchDirectory: projectCwd,
@@ -31,6 +33,11 @@ CodexPlugin createInjectedCodexPlugin({
       pluginId: CodexPlugin.pluginId,
       projectCwd: projectCwd,
       config: configReader.readDefaults(),
+    ),
+    rolloutTailer: CodexRolloutTailer(
+      rolloutApi: rolloutApi,
+      catalogRepository: catalogRepository,
+      pollInterval: rolloutPollInterval,
     ),
     projectCwd: projectCwd,
     onConnected: null,


### PR DESCRIPTION
## Summary

- tail the active Codex rollout alongside the stable app-server stream so raw-only code-mode `exec`, `wait`, and executor envelopes appear live
- normalize IDs, shell titles, tool output, clipping, and exit status through one mapper shared by live events and history replay
- drain rollout updates before `session.idle` and preserve incomplete JSONL writes until their terminating newline
- keep legacy histories without persisted response-item IDs readable through an explicitly documented compatibility fallback

No bridge wire-contract changes are required.

## Why

Codex app-server 0.144.x exposes only a reduced projection of some persisted response items. That made live SSE omit entire tool calls or show launcher-wrapped titles and incomplete output; reopening the session then rendered a different history. Non-zero process exits could also be shown as successful after reload.

## Verification

- `dart analyze --fatal-infos`
- `dart test` — 163 tests passed

The integration fixture covers immediate completion, code-mode `exec`, multiple `wait` calls, a non-zero exit, recovery, and field-for-field convergence between the final live tool state and reloaded history.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps Codex live tool events in lockstep with rollout history by tailing the active JSONL and merging raw call/output with stable item notifications. Live tool state now exactly matches history (IDs, titles, status, output), and terminal updates arrive before `session.idle`.

- **Bug Fixes**
  - Tail the active rollout to stream raw-only tool calls/results; seed from EOF (including a partial final record), keep incomplete JSONL bytes until newline, drain on `item/completed`, and finish on `turn/completed` with a bounded wait that covers late rollout discovery and the first append so events precede `session.idle`; stop on `thread/closed` and errors.
  - Merge rollout and item streams via canonical tool records keyed by call ID so enriched raw results can’t be downgraded; normalize tool names, strip `-lc` from shell titles, clip output by Unicode code point, and treat non‑zero exits as `error` with the output mirrored to `state.error`.
  - Serialize notification handling, start tailing before `turn/start` (fallback on `turn/started`), clear per-thread rollout state at turn end, await the terminal drain on `turn/completed`, and await pending work on dispose to keep ordering consistent.

- **Refactors**
  - Added rollout tailing APIs (`rolloutTailPosition`, `readTranscriptChunk`) and `CodexRolloutTailer` for safe live JSONL streaming.
  - Introduced `CodexRolloutToolMapper` and routed live events and history through it; `CodexMessageRepository` now uses persisted response-item IDs and single text parts with a documented fallback for legacy histories; exported the new tailer and mapper.

<sup>Written for commit ada4ba9a3f99ccbb9ddfd8a8663fb290eb04e2e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

