### PR TITLE
fix(codex): isolate app-server from the shared model cache

### DIFF
--- a/bridge/sesori_plugin_codex/lib/src/codex_config_reader.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_config_reader.dart
@@ -102,9 +102,15 @@ class CodexConfigReader {
     required String line,
     required String key,
   }) {
-    if (!line.startsWith("$key ") && !line.startsWith("$key=")) return null;
     final eq = line.indexOf("=");
-    if (eq < 0 || line.substring(0, eq).trim() != key) return null;
+    if (eq < 0) return null;
+    final assignmentKey = line.substring(0, eq).trim();
+    // TOML allows basic-quoted and literal-quoted keys even when the same key
+    // could be bare. Recognize all three exact forms so the bridge never
+    // overrides a valid user-supplied compatibility setting.
+    if (assignmentKey != key && assignmentKey != '"$key"' && assignmentKey != "'$key'") {
+      return null;
+    }
     return _normalize(line.substring(eq + 1).trim());
   }
 

--- a/bridge/sesori_plugin_codex/lib/src/codex_config_reader.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_config_reader.dart
@@ -18,7 +18,7 @@ class CodexConfigDefaults {
   final String? modelProvider;
 }
 
-/// Reads the top-level `model` and `model_provider` keys from
+/// Reads selected top-level keys from
 /// `~/.codex/config.toml`.
 ///
 /// CODEX_HOME resolution mirrors codex itself (and `CodexRolloutApi`):
@@ -44,20 +44,8 @@ class CodexConfigReader {
   }
 
   CodexConfigDefaults readDefaults() {
-    final home = _codexHome;
-    if (home == null) return const CodexConfigDefaults.empty();
-
-    final file = File(p.join(home, "config.toml"));
-    if (!file.existsSync()) return const CodexConfigDefaults.empty();
-
-    final List<String> rawLines;
-    try {
-      rawLines = file.readAsLinesSync();
-    } catch (_) {
-      // Permission/IO error reading the config: this is only a fallback
-      // source, so degrade to no defaults rather than failing the caller.
-      return const CodexConfigDefaults.empty();
-    }
+    final rawLines = _readTopLevelLines();
+    if (rawLines == null) return const CodexConfigDefaults.empty();
 
     String? model;
     String? modelProvider;
@@ -74,6 +62,40 @@ class CodexConfigReader {
     }
 
     return CodexConfigDefaults(model: model, modelProvider: modelProvider);
+  }
+
+  /// Whether the user already selected a static catalog in global config.
+  ///
+  /// COMPATIBILITY 2026-07-23 (Codex custom providers): a user-supplied
+  /// `model_catalog_json` replaces the bundled catalog and may define private
+  /// or local models. The managed runtime must not override that explicit
+  /// choice with its cache-isolation catalog.
+  bool hasExplicitModelCatalog() {
+    final rawLines = _readTopLevelLines();
+    if (rawLines == null) return false;
+    for (final rawLine in rawLines) {
+      final line = rawLine.split("#").first.trim();
+      if (line.isEmpty) continue;
+      if (line.startsWith("[")) break;
+      if (_parseStringAssignment(line: line, key: "model_catalog_json") != null) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  List<String>? _readTopLevelLines() {
+    final home = _codexHome;
+    if (home == null) return null;
+    final file = File(p.join(home, "config.toml"));
+    if (!file.existsSync()) return null;
+    try {
+      return file.readAsLinesSync();
+    } catch (_) {
+      // Config values here are fallback/compatibility signals. A read failure
+      // must not make metadata queries or plugin startup fail.
+      return null;
+    }
   }
 
   static String? _parseStringAssignment({

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_model_catalog.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_model_catalog.dart
@@ -39,9 +39,13 @@ Future<String?> prepareCodexModelCatalog({
       );
     }
     final decoded = jsonDecode(result.stdout);
-    if (decoded is! Map<String, dynamic> || decoded["models"] is! List || (decoded["models"] as List).isEmpty) {
+    final models = decoded is Map<String, dynamic> ? decoded["models"] : null;
+    // Codex deserializes every static-catalog entry as a model object during
+    // startup. Reject a surprising debug-command shape here so this
+    // compatibility workaround falls back instead of breaking app-server.
+    if (models is! List || models.isEmpty || models.any((model) => model is! Map<String, dynamic>)) {
       throw const FormatException(
-        "Codex bundled model catalog did not contain a non-empty models list",
+        "Codex bundled model catalog did not contain model objects",
       );
     }
     // HostJsonStore makes replacement atomic, bridge startup is serialized

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_model_catalog.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_model_catalog.dart
@@ -1,0 +1,69 @@
+import "dart:convert";
+
+import "package:path/path.dart" as p;
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show CommandExecutor;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show HostJsonStore, Log;
+
+/// Backend-namespaced static catalog generated from the exact Codex binary
+/// selected for this bridge start.
+const String codexModelCatalogFileName = "codex-model-catalog.json";
+
+/// Generates a version-matched static model catalog and returns its absolute
+/// path, or `null` when isolation cannot be prepared.
+///
+/// COMPATIBILITY 2026-07-23 (Codex 0.144.x/0.145.x): different Codex versions
+/// share `models_cache.json` under CODEX_HOME even though its model schema is
+/// not forward/backward compatible. Supplying `model_catalog_json` selects
+/// Codex's static model manager, which neither reads nor renews that shared
+/// cache. Remove this workaround once upstream versions the cache or guarantees
+/// cross-version schema compatibility.
+Future<String?> prepareCodexModelCatalog({
+  required CommandExecutor commandExecutor,
+  required HostJsonStore store,
+  required String stateDirectory,
+  required String executablePath,
+  required Map<String, String> environment,
+  required Duration timeout,
+}) async {
+  try {
+    final result = await commandExecutor.run(
+      executablePath,
+      const ["debug", "models", "--bundled"],
+      environment: environment,
+      timeout: timeout,
+    );
+    if (result.exitCode != 0) {
+      throw StateError(
+        "Codex bundled model catalog command exited with code "
+        "${result.exitCode}",
+      );
+    }
+    final decoded = jsonDecode(result.stdout);
+    if (decoded is! Map<String, dynamic> || decoded["models"] is! List || (decoded["models"] as List).isEmpty) {
+      throw const FormatException(
+        "Codex bundled model catalog did not contain a non-empty models list",
+      );
+    }
+    // HostJsonStore makes replacement atomic, bridge startup is serialized
+    // across instances, and Codex reads a static catalog only during startup.
+    // Those three guarantees let later starts safely refresh one
+    // backend-specific file instead of accumulating a file per Codex version.
+    await store.write(
+      name: codexModelCatalogFileName,
+      contents: jsonEncode(decoded),
+    );
+    return p.join(stateDirectory, codexModelCatalogFileName);
+  } on Object catch (error, stackTrace) {
+    // COMPATIBILITY 2026-07-23 (Codex >=0.139): preserve startup for an
+    // explicitly selected or patched binary that lacks `debug models
+    // --bundled`. The normal cache path may still be noisy, so keep this
+    // recovered fallback observable as one warning.
+    Log.w(
+      "[codex] failed to prepare an isolated model catalog; "
+      "falling back to Codex's normal model cache",
+      error,
+      stackTrace,
+    );
+    return null;
+  }
+}

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
@@ -6,9 +6,11 @@ import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 
+import "../codex_config_reader.dart";
 import "../codex_plugin_impl.dart";
 import "codex_bridge_plugin.dart";
 import "codex_managed_api.dart";
+import "codex_model_catalog.dart";
 import "codex_ownership_record.dart";
 import "codex_record_mapper.dart";
 import "codex_runtime_manifest.dart";
@@ -366,6 +368,29 @@ class CodexPluginDescriptor extends BridgePluginDescriptor {
       throw const PluginStartAbortedException();
     }
 
+    final hasExplicitModelCatalog = CodexConfigReader(
+      environment: host.environment,
+    ).hasExplicitModelCatalog();
+    final modelCatalogPath = hasExplicitModelCatalog
+        ? null
+        : await prepareCodexModelCatalog(
+            commandExecutor: HostProcessCommandExecutor(
+              processes: host.processes,
+              runInShell: io.Platform.isWindows,
+              // The bundled catalog includes complete model instructions, so
+              // unlike diagnostic probes its stdout must not be truncated.
+              maxCapturedOutputCharactersPerStream: null,
+            ),
+            store: host.store,
+            stateDirectory: host.stateDirectory,
+            executablePath: executablePath,
+            environment: host.environment,
+            timeout: _versionProbeTimeout,
+          );
+    if (host.startAborted.isAborted) {
+      throw const PluginStartAbortedException();
+    }
+
     const mapper = CodexRecordMapper();
 
     final service = ManagedProcessService<CodexOwnershipRecord>(
@@ -407,6 +432,7 @@ class CodexPluginDescriptor extends BridgePluginDescriptor {
     final spec = buildCodexManagedRuntimeSpec(
       host: host,
       executablePath: executablePath,
+      modelCatalogPath: modelCatalogPath,
       portPolicy: portPolicy,
     );
 

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_policy.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_policy.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:convert";
 import "dart:io" as io;
 import "dart:math";
 
@@ -101,8 +102,20 @@ Iterable<int> codexDynamicCandidates({Iterable<int>? candidates, Random? random}
 /// The argument vector `codex app-server` is spawned with for a chosen [port].
 /// Kept in one place so the spawn and the ownership record agree byte-for-byte
 /// (the supervisor matches a record to a live process by its command line).
-List<String> codexAppServerArgs({required int port}) =>
-    <String>["app-server", "--listen", "ws://$codexLoopbackHost:$port"];
+List<String> codexAppServerArgs({
+  required int port,
+  required String? modelCatalogPath,
+}) => <String>[
+  "app-server",
+  if (modelCatalogPath != null) ...[
+    "-c",
+    // A JSON string is also a valid TOML basic string and safely carries
+    // spaces, quotes, and Windows path separators through Codex's `-c` parser.
+    "model_catalog_json=${jsonEncode(modelCatalogPath)}",
+  ],
+  "--listen",
+  "ws://$codexLoopbackHost:$port",
+];
 
 /// The `ws://` URL the [CodexAppServerClient] connects to for a chosen [port].
 String codexServerUrl({required int port}) => "ws://$codexLoopbackHost:$port";
@@ -117,10 +130,14 @@ Future<SpawnedProcess> spawnCodexProcess({
   required PluginHost host,
   required String executablePath,
   required int port,
+  required String? modelCatalogPath,
 }) async {
   final process = await host.processes.spawn(
     executable: executablePath,
-    arguments: codexAppServerArgs(port: port),
+    arguments: codexAppServerArgs(
+      port: port,
+      modelCatalogPath: modelCatalogPath,
+    ),
     environment: host.environment,
     workingDirectory: null,
     runInShell: io.Platform.isWindows,
@@ -148,14 +165,20 @@ Future<RuntimeHealthProbe> probeCodexHealth({
 /// Builds the "starting" ownership record from the post-spawn facts. The args
 /// mirror [codexAppServerArgs] so the persisted command line matches the live
 /// process for supervisor identity matching.
-CodexOwnershipRecord buildCodexOwnershipRecord(RuntimeRecordDraft draft) {
+CodexOwnershipRecord buildCodexOwnershipRecord(
+  RuntimeRecordDraft draft, {
+  required String? modelCatalogPath,
+}) {
   return CodexOwnershipRecord(
     ownerSessionId: draft.ownerSessionId,
     codexPid: draft.runtimeIdentity.pid,
     codexStartMarker: draft.runtimeIdentity.startMarker,
     codexExecutablePath: draft.runtimeIdentity.executablePath ?? "",
     codexCommand: draft.runtimeIdentity.executablePath ?? "codex",
-    codexArgs: codexAppServerArgs(port: draft.port),
+    codexArgs: codexAppServerArgs(
+      port: draft.port,
+      modelCatalogPath: modelCatalogPath,
+    ),
     port: draft.port,
     bridgePid: draft.bridgeIdentity.pid,
     bridgeStartMarker: draft.bridgeIdentity.startMarker,
@@ -171,14 +194,22 @@ CodexOwnershipRecord buildCodexOwnershipRecord(RuntimeRecordDraft draft) {
 ManagedRuntimeSpec<CodexOwnershipRecord> buildCodexManagedRuntimeSpec({
   required PluginHost host,
   required String executablePath,
+  required String? modelCatalogPath,
   required RuntimePortPolicy portPolicy,
 }) {
   return ManagedRuntimeSpec<CodexOwnershipRecord>(
-    spawn: ({required int port}) =>
-        spawnCodexProcess(host: host, executablePath: executablePath, port: port),
+    spawn: ({required int port}) => spawnCodexProcess(
+      host: host,
+      executablePath: executablePath,
+      port: port,
+      modelCatalogPath: modelCatalogPath,
+    ),
     probeHealth: probeCodexHealth,
     probePortBindable: ({required int port}) => host.ports.isBindable(host: codexLoopbackHost, port: port),
-    buildRecord: buildCodexOwnershipRecord,
+    buildRecord: (draft) => buildCodexOwnershipRecord(
+      draft,
+      modelCatalogPath: modelCatalogPath,
+    ),
     portPolicy: portPolicy,
     healthPolicy: RuntimeHealthPolicy.deadline(
       deadline: codexHealthDeadline,

--- a/bridge/sesori_plugin_codex/test/codex_config_reader_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_config_reader_test.dart
@@ -59,5 +59,24 @@ void main() {
       final defaults = reader.readDefaults();
       expect(defaults.model, isNull);
     });
+
+    test("detects an explicit top-level model catalog", () {
+      writeConfig(
+        'model_catalog_json = "/private/models.json"\n'
+        "[profiles.work]\n"
+        'model_catalog_json = "/ignored/profile-models.json"\n',
+      );
+
+      expect(reader.hasExplicitModelCatalog(), isTrue);
+    });
+
+    test("does not treat a profile-scoped model catalog as global", () {
+      writeConfig(
+        "[profiles.work]\n"
+        'model_catalog_json = "/profile-models.json"\n',
+      );
+
+      expect(reader.hasExplicitModelCatalog(), isFalse);
+    });
   });
 }

--- a/bridge/sesori_plugin_codex/test/codex_config_reader_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_config_reader_test.dart
@@ -70,6 +70,20 @@ void main() {
       expect(reader.hasExplicitModelCatalog(), isTrue);
     });
 
+    test("detects quoted top-level model catalog keys", () {
+      for (final key in [
+        '"model_catalog_json"',
+        "'model_catalog_json'",
+      ]) {
+        writeConfig('$key = "/private/models.json"\n');
+        expect(
+          reader.hasExplicitModelCatalog(),
+          isTrue,
+          reason: "TOML key form $key should preserve the user's catalog",
+        );
+      }
+    });
+
     test("does not treat a profile-scoped model catalog as global", () {
       writeConfig(
         "[profiles.work]\n"

--- a/bridge/sesori_plugin_codex/test/runtime/codex_model_catalog_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_model_catalog_test.dart
@@ -89,6 +89,28 @@ void main() {
       expect(path, isNull);
       expect(store.files, isEmpty);
     });
+
+    test("rejects non-object model entries", () async {
+      final store = _MemoryJsonStore();
+
+      final path = await prepareCodexModelCatalog(
+        commandExecutor: _FakeCommandExecutor(
+          result: const CommandResult(
+            exitCode: 0,
+            stdout: '{"models":[{"slug":"valid"},"invalid"]}',
+            stderr: "",
+          ),
+        ),
+        store: store,
+        stateDirectory: "/state/runtime",
+        executablePath: "/custom/codex",
+        environment: const {},
+        timeout: const Duration(seconds: 10),
+      );
+
+      expect(path, isNull);
+      expect(store.files, isEmpty);
+    });
   });
 }
 

--- a/bridge/sesori_plugin_codex/test/runtime/codex_model_catalog_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_model_catalog_test.dart
@@ -1,0 +1,161 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:codex_plugin/src/runtime/codex_model_catalog.dart";
+import "package:path/path.dart" as p;
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("prepareCodexModelCatalog", () {
+    test("stores a validated catalog rendered by the selected binary", () async {
+      final executor = _FakeCommandExecutor(
+        result: const CommandResult(
+          exitCode: 0,
+          stdout: '{"models":[{"slug":"gpt-test"}]}',
+          stderr: "",
+        ),
+      );
+      final store = _MemoryJsonStore();
+
+      final path = await prepareCodexModelCatalog(
+        commandExecutor: executor,
+        store: store,
+        stateDirectory: "/state/runtime",
+        executablePath: "/managed/codex",
+        environment: const {"CODEX_HOME": "/codex-home"},
+        timeout: const Duration(seconds: 10),
+      );
+
+      expect(
+        path,
+        p.join("/state/runtime", codexModelCatalogFileName),
+      );
+      expect(executor.executable, "/managed/codex");
+      expect(executor.arguments, const ["debug", "models", "--bundled"]);
+      expect(executor.environment, const {"CODEX_HOME": "/codex-home"});
+      expect(executor.timeout, const Duration(seconds: 10));
+      expect(
+        jsonDecode(store.files[codexModelCatalogFileName]!),
+        {
+          "models": [
+            {"slug": "gpt-test"},
+          ],
+        },
+      );
+    });
+
+    test("falls back without writing when catalog generation fails", () async {
+      final store = _MemoryJsonStore();
+
+      final path = await prepareCodexModelCatalog(
+        commandExecutor: _FakeCommandExecutor(
+          result: const CommandResult(
+            exitCode: 2,
+            stdout: "",
+            stderr: "unsupported",
+          ),
+        ),
+        store: store,
+        stateDirectory: "/state/runtime",
+        executablePath: "/custom/codex",
+        environment: const {},
+        timeout: const Duration(seconds: 10),
+      );
+
+      expect(path, isNull);
+      expect(store.files, isEmpty);
+    });
+
+    test("rejects malformed or empty catalog output", () async {
+      final store = _MemoryJsonStore();
+
+      final path = await prepareCodexModelCatalog(
+        commandExecutor: _FakeCommandExecutor(
+          result: const CommandResult(
+            exitCode: 0,
+            stdout: '{"models":[]}',
+            stderr: "",
+          ),
+        ),
+        store: store,
+        stateDirectory: "/state/runtime",
+        executablePath: "/custom/codex",
+        environment: const {},
+        timeout: const Duration(seconds: 10),
+      );
+
+      expect(path, isNull);
+      expect(store.files, isEmpty);
+    });
+  });
+}
+
+class _FakeCommandExecutor implements CommandExecutor {
+  _FakeCommandExecutor({required this.result});
+
+  final CommandResult result;
+  String? executable;
+  List<String>? arguments;
+  Map<String, String>? environment;
+  Duration? timeout;
+
+  @override
+  Future<CommandResult> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    Duration? timeout,
+  }) async {
+    this.executable = executable;
+    this.arguments = arguments;
+    this.environment = environment;
+    this.timeout = timeout;
+    return result;
+  }
+}
+
+class _MemoryJsonStore implements HostJsonStore {
+  final Map<String, String> files = {};
+
+  @override
+  Future<void> delete({required String name}) async {
+    files.remove(name);
+  }
+
+  @override
+  Future<void> quarantine({
+    required String name,
+    required String quarantinedName,
+  }) async {
+    final value = files.remove(name);
+    if (value != null) files[quarantinedName] = value;
+  }
+
+  @override
+  Future<String?> read({required String name}) async => files[name];
+
+  @override
+  Future<String?> update({
+    required String name,
+    required FutureOr<String?> Function(String? current) transform,
+  }) async {
+    final next = await transform(files[name]);
+    if (next == null) {
+      files.remove(name);
+    } else {
+      files[name] = next;
+    }
+    return next;
+  }
+
+  @override
+  Future<void> write({
+    required String name,
+    required String contents,
+  }) async {
+    files[name] = contents;
+  }
+}

--- a/bridge/sesori_plugin_codex/test/runtime/codex_runtime_policy_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_runtime_policy_test.dart
@@ -22,7 +22,26 @@ ProcessIdentity _identity({required int pid, required String? executablePath, re
 void main() {
   group("codexAppServerArgs / codexServerUrl", () {
     test("spawn args pin the loopback WebSocket on the chosen port", () {
-      expect(codexAppServerArgs(port: 51000), equals(<String>["app-server", "--listen", "ws://127.0.0.1:51000"]));
+      expect(
+        codexAppServerArgs(port: 51000, modelCatalogPath: null),
+        equals(<String>["app-server", "--listen", "ws://127.0.0.1:51000"]),
+      );
+    });
+
+    test("spawn args encode the isolated model catalog as TOML", () {
+      expect(
+        codexAppServerArgs(
+          port: 51000,
+          modelCatalogPath: r"C:\Sesori State\codex-model-catalog.json",
+        ),
+        equals(<String>[
+          "app-server",
+          "-c",
+          r'model_catalog_json="C:\\Sesori State\\codex-model-catalog.json"',
+          "--listen",
+          "ws://127.0.0.1:51000",
+        ]),
+      );
     });
 
     test("the server url matches the spawn listen address", () {
@@ -75,6 +94,7 @@ void main() {
           bridgeIdentity: _identity(pid: 900, executablePath: "/bin/bridge", startMarker: "bridge-marker"),
           startedAt: DateTime.utc(2026, 6, 1, 9, 30),
         ),
+        modelCatalogPath: "/state/codex-model-catalog.json",
       );
 
       expect(record.ownerSessionId, equals("owner-1"));
@@ -82,7 +102,16 @@ void main() {
       expect(record.codexStartMarker, equals("marker"));
       expect(record.codexExecutablePath, equals("/bin/codex"));
       expect(record.codexCommand, equals("/bin/codex"));
-      expect(record.codexArgs, equals(<String>["app-server", "--listen", "ws://127.0.0.1:51000"]));
+      expect(
+        record.codexArgs,
+        equals(<String>[
+          "app-server",
+          "-c",
+          'model_catalog_json="/state/codex-model-catalog.json"',
+          "--listen",
+          "ws://127.0.0.1:51000",
+        ]),
+      );
       expect(record.port, equals(51000));
       expect(record.bridgePid, equals(900));
       expect(record.bridgeStartMarker, equals("bridge-marker"));
@@ -99,6 +128,7 @@ void main() {
           bridgeIdentity: _identity(pid: 900, executablePath: "/bin/bridge", startMarker: null),
           startedAt: DateTime.utc(2026, 6, 1),
         ),
+        modelCatalogPath: null,
       );
       expect(record.codexExecutablePath, equals(""));
       expect(record.codexCommand, equals("codex"));


### PR DESCRIPTION
## Summary

- render the bundled model catalog from the exact Codex binary selected for this bridge start
- validate and atomically persist that catalog in Codex-namespaced Sesori runtime state
- launch app-server with `model_catalog_json`, selecting Codex's static model manager so it never reads or renews the shared `~/.codex/models_cache.json`
- persist the exact extra launch arguments in runtime ownership records
- preserve an explicit user `model_catalog_json` for custom/local providers and retain a documented, observable fallback for unusual binaries that cannot render a bundled catalog

No bridge wire-contract changes are required.

## Why

Multiple Codex versions share one `models_cache.json`, but model entries are not schema-compatible. In the reported case, the bridge's 0.144.x runtime repeatedly failed to decode a cache written by 0.145.x because `supports_reasoning_summaries` was missing; ETag notifications then retriggered the same TTL-renew failure.

A static, version-matched catalog removes that shared mutable cache from the managed app-server's code path. The compatibility comments include the exact upstream condition for removing the workaround.

## Compatibility / tradeoff

`--bundled` is deliberately used so catalog generation cannot touch the incompatible shared cache or require a network refresh. Therefore the managed app-server uses the selected binary's bundled catalog for that run; catalog updates arrive with a newer selected Codex binary or bridge restart. An explicit user catalog remains authoritative and is never replaced.

If catalog preparation fails, startup continues through Codex's normal cache path with one warning, preserving support for explicitly selected/patched binaries rather than turning this mitigation into a hard startup failure.

## Verification

- `dart analyze --fatal-infos`
- `dart test` — 165 tests passed

Coverage includes catalog validation/persistence, graceful fallback, explicit custom-catalog detection, Windows-safe TOML argument encoding, and ownership-record parity with the spawned command.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates the Codex app-server from the shared model cache by rendering a version-matched bundled catalog at startup and passing it via `model_catalog_json`. This prevents cross-version schema errors and noisy cache renewals.

- **Bug Fixes**
  - Generate and validate the catalog with `codex debug models --bundled`; require a non-empty `models` array of objects; store atomically in the backend state with full stdout capture.
  - Launch app-server with `-c model_catalog_json=...` using JSON-encoded TOML for safe Windows paths; persist the exact args in ownership records.
  - Detect an explicit global `model_catalog_json` in `~/.codex/config.toml` (including quoted keys) and never override it; ignore profile-scoped settings.
  - If catalog prep fails or the command is unsupported, fall back to Codex’s normal cache with a single warning; add tests for generation/validation/fallback, config detection, and args/record parity.

<sup>Written for commit 41f8cc7bb047d71c667a0d8a1a6f49f8640a2cf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

