### PR TITLE
fix(codex): honor YOLO for MCP tool approvals

### DIFF
--- a/bridge/sesori_plugin_codex/lib/src/approval_registry.dart
+++ b/bridge/sesori_plugin_codex/lib/src/approval_registry.dart
@@ -4,7 +4,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "codex_app_server_client.dart";
 
-/// Codex methods that we surface as permission asks.
+/// Codex methods that always surface as permission asks.
 ///
 /// These are the JSON-RPC method names codex `app-server` (0.142.0) sends as
 /// server-originated requests when it needs the user to allow / deny a
@@ -14,6 +14,8 @@ import "codex_app_server_client.dart";
 /// `execCommandApproval` requests (emitted only on the legacy
 /// `sendUserTurn`/`sendUserMessage` path we never call) are intentionally not
 /// handled — an unexpected one returns a soft -32601 rather than routing.
+/// Tagged MCP tool-call elicitations are classified from their payload in
+/// `_isMcpToolApproval` because that wire method also carries genuine forms.
 const Set<String> _permissionMethods = {
   "item/commandExecution/requestApproval",
   "item/fileChange/requestApproval",
@@ -22,7 +24,8 @@ const Set<String> _permissionMethods = {
 
 /// Codex methods that we surface as questions (free-form user input or
 /// MCP-driven elicitations). These get rendered by mobile as a question
-/// prompt rather than the binary allow/deny UI.
+/// prompt rather than the binary allow/deny UI unless an elicitation is
+/// explicitly tagged as an MCP tool-call approval.
 const Set<String> _questionMethods = {
   // v2 wire names.
   "item/tool/requestUserInput",
@@ -40,6 +43,10 @@ const String _elicitationMethod = "mcpServer/elicitation/request";
 /// The v2 user-input method. Its response is
 /// `{answers: {<questionId>: {answers: [..]}}}`.
 const String _userInputMethod = "item/tool/requestUserInput";
+
+const String _elicitationApprovalKindKey = "codex_approval_kind";
+
+enum _ElicitationApprovalKind { mcpToolCall, toolSuggestion }
 
 /// A pending codex approval, kept until the user answers or codex
 /// rescinds it.
@@ -255,8 +262,9 @@ class ApprovalRegistry {
 
   void _handle(CodexServerRequest request) {
     final method = request.method;
-    final isPermission = _permissionMethods.contains(method);
-    final isQuestion = _questionMethods.contains(method);
+    final isMcpToolApproval = method == _elicitationMethod && _isMcpToolApproval(request.params);
+    final isPermission = _permissionMethods.contains(method) || isMcpToolApproval;
+    final isQuestion = _questionMethods.contains(method) && !isMcpToolApproval;
     if (!isPermission && !isQuestion) {
       // Don't recognise — return a soft error so codex doesn't hang.
       _respondError(request.id, -32601, "method not handled by bridge: $method");
@@ -348,10 +356,31 @@ class ApprovalRegistry {
   /// request's wire method:
   ///   - command/file change   → `{decision: accept|acceptForSession|decline}`
   ///   - permissions request    → `{permissions: GrantedPermissionProfile, scope}`
+  ///   - MCP tool approval      → `{action, content, _meta}`
   Map<String, dynamic> _permissionResponse(
     _PendingApproval entry,
     PluginPermissionReply reply,
   ) {
+    if (entry.method == _elicitationMethod) {
+      return switch (reply) {
+        PluginPermissionReply.once => const {
+          "action": "accept",
+          "content": null,
+          "_meta": null,
+        },
+        PluginPermissionReply.always => const {
+          "action": "accept",
+          "content": null,
+          "_meta": {"persist": "always"},
+        },
+        PluginPermissionReply.reject => const {
+          "action": "decline",
+          "content": null,
+          "_meta": null,
+        },
+      };
+    }
+
     if (entry.method == _permissionsRequestMethod) {
       // Grant the requested profile on approve (turn- or session-scoped);
       // grant nothing on reject. RequestPermissionProfile and
@@ -439,7 +468,35 @@ class ApprovalRegistry {
     if (command is String && command.isNotEmpty) return command;
     final reason = params["reason"];
     if (reason is String && reason.isNotEmpty) return reason;
+    final message = params["message"];
+    if (message is String && message.isNotEmpty) return message;
     return method;
+  }
+
+  bool _isMcpToolApproval(Map<String, dynamic> params) {
+    if (params["mode"] != "form") return false;
+    final meta = _asMap(params["_meta"]);
+    if (_parseElicitationApprovalKind(
+          meta?[_elicitationApprovalKindKey],
+        ) !=
+        _ElicitationApprovalKind.mcpToolCall) {
+      return false;
+    }
+    if (!params.containsKey("requestedSchema")) return false;
+    final rawSchema = params["requestedSchema"];
+    if (rawSchema == null) return true;
+    final schema = _asMap(rawSchema);
+    if (schema?["type"] != "object") return false;
+    final properties = _asMap(schema?["properties"]);
+    return properties != null && properties.isEmpty;
+  }
+
+  _ElicitationApprovalKind? _parseElicitationApprovalKind(Object? raw) {
+    return switch (raw) {
+      "mcp_tool_call" => _ElicitationApprovalKind.mcpToolCall,
+      "tool_suggestion" => _ElicitationApprovalKind.toolSuggestion,
+      _ => null,
+    };
   }
 
   String? _extractSessionId(Map<String, dynamic> params) {

--- a/bridge/sesori_plugin_codex/test/approval_registry_test.dart
+++ b/bridge/sesori_plugin_codex/test/approval_registry_test.dart
@@ -328,6 +328,114 @@ void main() {
     // --- v2 elicitation + user input questions ---
 
     test(
+      "empty MCP tool-call elicitation surfaces as an approvable permission",
+      () async {
+        requests.add(
+          const CodexServerRequest(
+            id: 199,
+            method: "mcpServer/elicitation/request",
+            params: {
+              "threadId": "t-3",
+              "turnId": "turn-1",
+              "serverName": "codex_apps",
+              "mode": "form",
+              "message": "Allow Calendar to create an event?",
+              "_meta": {
+                "codex_approval_kind": "mcp_tool_call",
+                "persist": ["session", "always"],
+                "tool_name": "calendar_create_event",
+              },
+              "requestedSchema": {
+                "type": "object",
+                "properties": <String, Object?>{},
+              },
+            },
+          ),
+        );
+        await pump();
+
+        final asked = emitted.single as BridgeSsePermissionAsked;
+        expect(asked.sessionID, equals("t-3"));
+        expect(asked.description, equals("Allow Calendar to create an event?"));
+        expect(registry.pendingPermissionsForSession("t-3"), hasLength(1));
+        expect(registry.pendingForSession("t-3"), isEmpty);
+
+        final replied = registry.replyPermission(
+          asked.requestID,
+          PluginPermissionReply.once,
+        );
+        expect(replied, isTrue);
+        expect(respondCalls.single.id, equals(199));
+        expect(
+          respondCalls.single.result,
+          equals({
+            "action": "accept",
+            "content": null,
+            "_meta": null,
+          }),
+        );
+      },
+    );
+
+    test(
+      "MCP tool-call metadata cannot turn a non-empty form into a permission",
+      () async {
+        requests.add(
+          const CodexServerRequest(
+            id: 198,
+            method: "mcpServer/elicitation/request",
+            params: {
+              "threadId": "t-3",
+              "serverName": "custom-mcp",
+              "mode": "form",
+              "message": "Which environment should I use?",
+              "_meta": {"codex_approval_kind": "mcp_tool_call"},
+              "requestedSchema": {
+                "type": "object",
+                "properties": {
+                  "environment": {"type": "string"},
+                },
+              },
+            },
+          ),
+        );
+        await pump();
+
+        expect(emitted.single, isA<BridgeSseQuestionAsked>());
+        expect(registry.pendingPermissionsForSession("t-3"), isEmpty);
+        expect(registry.pendingForSession("t-3"), hasLength(1));
+      },
+    );
+
+    test("tool suggestions remain questions", () async {
+      requests.add(
+        const CodexServerRequest(
+          id: 197,
+          method: "mcpServer/elicitation/request",
+          params: {
+            "threadId": "t-3",
+            "serverName": "codex_apps",
+            "mode": "form",
+            "message": "Install Google Calendar?",
+            "_meta": {
+              "codex_approval_kind": "tool_suggestion",
+              "tool_type": "connector",
+              "suggest_type": "install",
+            },
+            "requestedSchema": {
+              "type": "object",
+              "properties": <String, Object?>{},
+            },
+          },
+        ),
+      );
+      await pump();
+
+      expect(emitted.single, isA<BridgeSseQuestionAsked>());
+      expect(registry.pendingPermissionsForSession("t-3"), isEmpty);
+    });
+
+    test(
       "mcpServer/elicitation/request surfaces as QuestionAsked and is pending",
       () async {
         requests.add(


### PR DESCRIPTION
## Summary

- classify Codex 0.145 MCP tool-call elicitations with an empty form schema as permission requests
- send Codex's elicitation response shape so bridge YOLO mode can auto-approve them
- keep genuine MCP forms and tool-install suggestions on the question path

## Root Cause

Codex 0.145 sends MCP tool execution approvals over `mcpServer/elicitation/request`, tagged with `_meta.codex_approval_kind: mcp_tool_call`. `ApprovalRegistry` classified these requests only by their JSON-RPC method and therefore surfaced every elicitation as a question, bypassing the bridge's permission auto-approval service.

## Testing

- `dart test` in `bridge/sesori_plugin_codex` (163 tests)
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_codex`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor YOLO auto-approval for Codex MCP tool-call elicitations by classifying tagged empty-form elicitations as permissions and replying with the expected `{action, content, _meta}` shape. Genuine MCP forms and tool suggestions remain questions.

- **Bug Fixes**
  - Treat `mcpServer/elicitation/request` with `_meta.codex_approval_kind: mcp_tool_call` and an empty `requestedSchema` as permission asks.
  - Return elicitation-style permission replies: once → `{"action":"accept"}`, always → `{"action":"accept","_meta":{"persist":"always"}}`, reject → `{"action":"decline"}`.
  - Keep non-empty MCP forms and `_meta.codex_approval_kind: tool_suggestion` on the question path.

<sup>Written for commit 46615fd11ddb4976a2f129d13188c285ad2ffe86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

