### PR TITLE
refactor(bridge): separate session title ownership

### DIFF
--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -363,7 +363,6 @@ class Orchestrator {
     );
     final sessionEventService = SessionEventService(
       sessionRepository: sessionRepository,
-      sessionMutationDispatcher: sessionMutationDispatcher,
       eventMapper: const SessionEventMapper(),
       eventTracker: SessionEventTracker(
         maxPendingEntriesPerPlugin: SessionEventTracker.defaultMaxPendingEntries,
@@ -413,7 +412,6 @@ class Orchestrator {
         GetSessionsHandler(
           sessionRepository: sessionRepository,
           prSyncService: prSyncService,
-          sessionMutationDispatcher: sessionMutationDispatcher,
         ),
         CreateSessionHandler(sessionCreationService: sessionCreationService),
         RenameSessionHandler(sessionMutationDispatcher: sessionMutationDispatcher),
@@ -1187,7 +1185,6 @@ class OrchestratorSession {
           parentId: info.parentID,
           occurredAt: info.time?.created,
         );
-        await _sessionMutationDispatcher.applyPendingTitle(sessionId: info.id);
       case SesoriSessionDeleted(:final info):
         await _sessionUnseenService.recordSessionDeleted(sessionId: info.id, projectId: info.projectID);
       case SesoriMessageUpdated(:final info):

--- a/bridge/app/lib/src/bridge/repositories/mappers/plugin_session_mapper.dart
+++ b/bridge/app/lib/src/bridge/repositories/mappers/plugin_session_mapper.dart
@@ -68,7 +68,7 @@ Session enrichSharedSession({
       // owns its own attribution, so its reported projectID is kept. The
       // directory intentionally stays the session's real cwd either way.
       projectID: adoptStoredProjectId ? storedSession.projectId : session.projectID,
-      title: storedSession.title ?? session.title ?? storedSession.catalogTitle,
+      title: storedSession.title ?? storedSession.catalogTitle,
       time: mergedTime,
       hasWorktree: storedSession.worktreePath != null,
       promptDefaults: _promptDefaultsFromStoredSession(storedSession),

--- a/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
@@ -5,7 +5,6 @@ import "package:sesori_shared/sesori_shared.dart";
 
 import "../repositories/session_repository.dart";
 import "../services/pr_sync_service.dart";
-import "../services/session_mutation_dispatcher.dart";
 import "request_handler.dart";
 
 /// Handles `GET /sessions` — returns sessions for a given project.
@@ -14,17 +13,14 @@ import "request_handler.dart";
 class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionListResponse> {
   final SessionRepository _sessionRepository;
   final PrSyncService _prSyncService;
-  final SessionMutationDispatcher _sessionMutationDispatcher;
   final Duration _prRefreshTimeout;
 
   GetSessionsHandler({
     required SessionRepository sessionRepository,
     required PrSyncService prSyncService,
-    required SessionMutationDispatcher sessionMutationDispatcher,
     Duration prRefreshTimeout = const Duration(seconds: 5),
   }) : _sessionRepository = sessionRepository,
        _prSyncService = prSyncService,
-       _sessionMutationDispatcher = sessionMutationDispatcher,
        _prRefreshTimeout = prRefreshTimeout,
        super(
          HttpMethod.post,
@@ -58,13 +54,6 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
       limit: limit,
     );
 
-    for (final session in sessions) {
-      try {
-        await _sessionMutationDispatcher.applyPendingTitle(sessionId: session.id);
-      } on Object catch (e, st) {
-        Log.w("GetSessionsHandler: pending title failed for sessionId=${session.id}", e, st);
-      }
-    }
     try {
       sessions = await _sessionRepository.enrichSessions(sessions: sessions);
     } on Object catch (e, st) {

--- a/bridge/app/lib/src/bridge/services/session_creation_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_creation_service.dart
@@ -70,7 +70,6 @@ class SessionCreationService {
             )
           : null,
     );
-    await _sessionMutationDispatcher.applyPendingTitle(sessionId: created.id);
     await _maybeSendCommand(
       session: created,
       command: normalizedCommand,

--- a/bridge/app/lib/src/bridge/services/session_event_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_event_service.dart
@@ -7,26 +7,22 @@ import "../repositories/mappers/session_event_mapper.dart";
 import "../repositories/models/stored_session.dart";
 import "../repositories/session_repository.dart";
 import "../repositories/trackers/session_event_tracker.dart";
-import "session_mutation_dispatcher.dart";
 
 typedef SourcedBridgeEvent = ({String pluginId, int projectionUpdatedAt, BridgeSseEvent event});
 typedef _ProjectedSession = ({StoredSession binding, bool inserted});
 
 class SessionEventService {
   final SessionRepository _sessionRepository;
-  final SessionMutationDispatcher _sessionMutationDispatcher;
   final SessionEventMapper _eventMapper;
   final SessionEventTracker _eventTracker;
   final FailureReporter _failureReporter;
 
   SessionEventService({
     required SessionRepository sessionRepository,
-    required SessionMutationDispatcher sessionMutationDispatcher,
     required SessionEventMapper eventMapper,
     required SessionEventTracker eventTracker,
     required FailureReporter failureReporter,
   }) : _sessionRepository = sessionRepository,
-       _sessionMutationDispatcher = sessionMutationDispatcher,
        _eventMapper = eventMapper,
        _eventTracker = eventTracker,
        _failureReporter = failureReporter;
@@ -326,12 +322,6 @@ class SessionEventService {
     required Session session,
     required bool titleChanged,
   }) async {
-    if (titleChanged) {
-      await _sessionMutationDispatcher.captureTitle(
-        sessionId: session.id,
-        title: session.title,
-      );
-    }
     final catalogSession = await _sessionRepository.getCatalogSession(sessionId: session.id);
     if (catalogSession == null) return null;
     return BridgeSseSessionUpdated(info: catalogSession.toJson(), titleChanged: titleChanged);

--- a/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
@@ -6,14 +6,10 @@ import "package:sesori_shared/sesori_shared.dart";
 import "../repositories/models/session_operation.dart";
 import "../repositories/session_repository.dart";
 
-/// Serializes bridge-owned session mutations that share pending-title state.
+/// Serializes bridge-owned session mutations and backend propagation.
 class SessionMutationDispatcher {
-  static const _backendTitleGuardDuration = Duration(seconds: 1);
-
   final SessionRepository _sessionRepository;
   final StreamController<Session> _deletedSessionsController = StreamController<Session>.broadcast(sync: true);
-  final Map<String, String?> _pendingTitles = {};
-  final Map<String, ({DateTime? expiresAt, Object token})> _backendTitleGuards = {};
   Future<void> _tail = Future<void>.value();
   Future<void> _backendTail = Future<void>.value();
   bool _disposed = false;
@@ -21,18 +17,6 @@ class SessionMutationDispatcher {
   SessionMutationDispatcher({required SessionRepository sessionRepository}) : _sessionRepository = sessionRepository;
 
   Stream<Session> get deletedSessions => _deletedSessionsController.stream;
-
-  Future<void> captureTitle({required String sessionId, required String? title}) {
-    return _serialized(() async {
-      final guard = _backendTitleGuards[sessionId];
-      if (guard != null) {
-        final active = guard.expiresAt == null || DateTime.now().isBefore(guard.expiresAt!);
-        if (active) return;
-        _backendTitleGuards.remove(sessionId);
-      }
-      await _captureTitle(sessionId: sessionId, title: title);
-    });
-  }
 
   /// Completes after the authoritative DB title is stored. Backend propagation
   /// continues on its own serialized tail so later DB writes stay immediate
@@ -47,23 +31,10 @@ class SessionMutationDispatcher {
           message: "session $sessionId was not found",
         );
       }
-      final guardToken = Object();
-      _backendTitleGuards[sessionId] = (expiresAt: null, token: guardToken);
       unawaited(
-        _serializedBackend(() => _propagateTitle(sessionId: sessionId, title: title, guardToken: guardToken)),
+        _serializedBackend(() => _propagateTitle(sessionId: sessionId, title: title)),
       );
       return renamed;
-    });
-  }
-
-  Future<void> applyPendingTitle({required String sessionId}) {
-    return _serialized(() async {
-      if (!_pendingTitles.containsKey(sessionId)) return;
-      final stored = await _sessionRepository.setSessionTitleIfStored(
-        sessionId: sessionId,
-        title: _pendingTitles[sessionId],
-      );
-      if (stored) _pendingTitles.remove(sessionId);
     });
   }
 
@@ -71,8 +42,6 @@ class SessionMutationDispatcher {
     if (_disposed) return Future.error(StateError("SessionMutationDispatcher is disposed"));
     return _serialized(() async {
       final deleted = await _serializedBackend(() => _sessionRepository.deleteSession(sessionId: sessionId));
-      _pendingTitles.remove(sessionId);
-      _backendTitleGuards.remove(sessionId);
       _deletedSessionsController.add(deleted);
     });
   }
@@ -84,7 +53,6 @@ class SessionMutationDispatcher {
     _disposed = true;
     return _serialized(() async {
       await _serializedBackend(() async {});
-      _backendTitleGuards.clear();
       await _deletedSessionsController.close();
     });
   }
@@ -92,35 +60,12 @@ class SessionMutationDispatcher {
   Future<void> _propagateTitle({
     required String sessionId,
     required String title,
-    required Object guardToken,
   }) async {
     try {
       await _sessionRepository.renameSession(sessionId: sessionId, title: title);
     } catch (error, stackTrace) {
       Log.w("Could not propagate title for session $sessionId to its plugin", error, stackTrace);
-    } finally {
-      final guard = _backendTitleGuards[sessionId];
-      if (identical(guard?.token, guardToken) && guard?.expiresAt == null) {
-        _backendTitleGuards[sessionId] = (
-          expiresAt: DateTime.now().add(_backendTitleGuardDuration),
-          token: guardToken,
-        );
-        Timer(_backendTitleGuardDuration, () {
-          if (identical(_backendTitleGuards[sessionId]?.token, guardToken)) {
-            _backendTitleGuards.remove(sessionId);
-          }
-        });
-      }
     }
-  }
-
-  Future<void> _captureTitle({required String sessionId, required String? title}) async {
-    if (await _sessionRepository.isSessionTombstoned(sessionId: sessionId)) return;
-    final stored = await _sessionRepository.setSessionTitleIfStored(
-      sessionId: sessionId,
-      title: title,
-    );
-    if (!stored) _pendingTitles[sessionId] = title;
   }
 
   Future<T> _serialized<T>(Future<T> Function() operation) {

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -145,6 +145,14 @@ void main() {
           variant: "variant-1",
         ),
       );
+      await db.sessionDao.updateObservedSessionProjection(
+        sessionId: "s1",
+        directory: "/tmp/project",
+        catalogTitle: "Catalog title",
+        updateCatalogTitle: true,
+        updatedAt: 10,
+        projectionUpdatedAt: 10,
+      );
       await db.pullRequestDao.upsertPr(
         pullRequest: const PullRequestDto(
           projectId: "p1",
@@ -199,7 +207,7 @@ void main() {
           projectID: "p1",
           directory: "/tmp/project",
           parentID: null,
-          title: "session",
+          title: "Live plugin title",
           time: SessionTime(created: 1, updated: 2, archived: null),
           pullRequest: null,
           promptDefaults: null,
@@ -210,6 +218,7 @@ void main() {
       expect(result.pluginId, equals(plugin.id));
       expect(result.time?.updated, equals(2));
       expect(result.time?.archived, isNull);
+      expect(result.title, "Catalog title");
       expect(result.branchName, equals("feature/one"));
       expect(result.hasWorktree, isTrue);
       expect(result.promptDefaults?.agent, equals("agent-1"));

--- a/bridge/app/test/bridge/routing/catalog_read_handlers_test.dart
+++ b/bridge/app/test/bridge/routing/catalog_read_handlers_test.dart
@@ -7,7 +7,6 @@ import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.
 import "package:sesori_bridge/src/bridge/routing/get_child_sessions_handler.dart";
 import "package:sesori_bridge/src/bridge/routing/get_session_handler.dart";
 import "package:sesori_bridge/src/bridge/routing/get_sessions_handler.dart";
-import "package:sesori_bridge/src/bridge/services/session_mutation_dispatcher.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -20,7 +19,6 @@ void main() {
     late AppDatabase database;
     late _NeverCompletingPlugin plugin;
     late SessionRepository repository;
-    late SessionMutationDispatcher mutationDispatcher;
 
     setUp(() async {
       database = createTestDatabase();
@@ -32,7 +30,6 @@ void main() {
         pullRequestDao: database.pullRequestDao,
         unseenCalculator: const SessionUnseenCalculator(),
       );
-      mutationDispatcher = SessionMutationDispatcher(sessionRepository: repository);
       await database.projectsDao.recordOpenedProject(
         projectId: "project",
         path: "/projects/project",
@@ -70,7 +67,6 @@ void main() {
     });
 
     tearDown(() async {
-      await mutationDispatcher.dispose();
       await repository.dispose();
       await database.close();
     });
@@ -79,7 +75,6 @@ void main() {
       final sessionsHandler = GetSessionsHandler(
         sessionRepository: repository,
         prSyncService: FakePrSyncService(),
-        sessionMutationDispatcher: mutationDispatcher,
       );
       final detailHandler = GetSessionHandler(repository);
       final childrenHandler = GetChildSessionsHandler(sessionRepository: repository);

--- a/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
@@ -5,7 +5,6 @@ import "package:sesori_bridge/src/api/database/tables/pull_requests_table.dart";
 import "package:sesori_bridge/src/api/database/tables/session_table.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/routing/get_sessions_handler.dart";
-import "package:sesori_bridge/src/bridge/services/session_mutation_dispatcher.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -21,7 +20,6 @@ void main() {
     late FakePrSyncService prSyncService;
     late FakeSessionRepository sessionRepository;
     late AppDatabase db;
-    late _TrackingSessionMutationDispatcher sessionTitleService;
     late GetSessionsHandler handler;
 
     setUp(() {
@@ -36,11 +34,9 @@ void main() {
         pullRequestRepository: pullRequestRepository,
         persistenceDatabase: db,
       );
-      sessionTitleService = _TrackingSessionMutationDispatcher();
       handler = GetSessionsHandler(
         sessionRepository: sessionRepository,
         prSyncService: prSyncService,
-        sessionMutationDispatcher: sessionTitleService,
       );
     });
 
@@ -85,7 +81,6 @@ void main() {
       final realHandler = GetSessionsHandler(
         sessionRepository: realRepository,
         prSyncService: prSyncService,
-        sessionMutationDispatcher: SessionMutationDispatcher(sessionRepository: realRepository),
       );
 
       final response = await realHandler.handleInternal(
@@ -186,11 +181,9 @@ void main() {
         throwsA(same(failure)),
       );
       expect(plugin.lastGetSessionsWorktree, "project-1");
-      expect(sessionTitleService.appliedSessionIds, isEmpty);
     });
 
     test("persists sessions after successful fetch", () async {
-      sessionTitleService.failSessionIds.add("s2");
       plugin.sessionsResult = [
         const PluginSession(
           id: "s1",
@@ -228,40 +221,6 @@ void main() {
 
       final rows = await db.select(db.sessionTable).get();
       expect(rows.map((row) => row.sessionId).toList()..sort(), equals(["s1", "s2", "s3"]));
-      expect(sessionTitleService.appliedSessionIds, ["s1", "s3"]);
-    });
-
-    test("returns sessions re-enriched after pending titles are applied", () async {
-      plugin.sessionsResult = const [
-        PluginSession(
-          id: "s1",
-          projectID: "project-1",
-          directory: "/tmp/project-1",
-          parentID: null,
-          title: "Backend title",
-          time: null,
-        ),
-      ];
-      final titleService = _TrackingSessionMutationDispatcher(
-        onApply: (sessionId) {
-          sessionRepository.enrichedTitleOverrides[sessionId] = "Pending title";
-        },
-      );
-      final localHandler = GetSessionsHandler(
-        sessionRepository: sessionRepository,
-        prSyncService: prSyncService,
-        sessionMutationDispatcher: titleService,
-      );
-
-      final response = await localHandler.handle(
-        makeRequest("POST", "/sessions"),
-        body: const SessionListRequest(projectId: "project-1", start: null, limit: null),
-        pathParams: {},
-        queryParams: {},
-        fragment: null,
-      );
-
-      expect(response.items.single.title, "Pending title");
     });
 
     test("start and limit are null when absent from body", () async {
@@ -772,7 +731,6 @@ void main() {
       final realHandler = GetSessionsHandler(
         sessionRepository: realRepository,
         prSyncService: prSyncService,
-        sessionMutationDispatcher: SessionMutationDispatcher(sessionRepository: realRepository),
       );
       await db.projectsDao.insertProjectsIfMissing(projectIds: ["p1"]);
       await db.sessionDao.insertSession(
@@ -996,7 +954,6 @@ void main() {
       final timeoutHandler = GetSessionsHandler(
         sessionRepository: sessionRepository,
         prSyncService: slowPrSyncService,
-        sessionMutationDispatcher: SessionMutationDispatcher(sessionRepository: sessionRepository),
         prRefreshTimeout: const Duration(milliseconds: 50),
       );
 
@@ -1044,7 +1001,6 @@ void main() {
       final enrichedHandler = GetSessionsHandler(
         sessionRepository: sessionRepository,
         prSyncService: fastPrSyncService,
-        sessionMutationDispatcher: SessionMutationDispatcher(sessionRepository: sessionRepository),
       );
 
       final result = await enrichedHandler.handle(
@@ -1062,37 +1018,4 @@ void main() {
       expect(sessionRepository.getSessionsCallCount, equals(1));
     });
   });
-}
-
-class _TrackingSessionMutationDispatcher implements SessionMutationDispatcher {
-  final List<String> appliedSessionIds = [];
-  final Set<String> failSessionIds = {};
-  final void Function(String sessionId)? onApply;
-
-  _TrackingSessionMutationDispatcher({this.onApply});
-
-  @override
-  Stream<Session> get deletedSessions => const Stream.empty();
-
-  @override
-  Future<void> applyPendingTitle({required String sessionId}) async {
-    if (failSessionIds.contains(sessionId)) throw StateError("title write failed");
-    appliedSessionIds.add(sessionId);
-    onApply?.call(sessionId);
-  }
-
-  @override
-  Future<void> captureTitle({required String sessionId, required String? title}) async {}
-
-  @override
-  Future<void> deleteSession({required String sessionId}) async {}
-
-  @override
-  Future<void> drain() async {}
-
-  @override
-  Future<void> dispose() async {}
-
-  @override
-  Future<Session> renameSession({required String sessionId, required String title}) => throw UnimplementedError();
 }

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -960,7 +960,6 @@ class FakeSessionRepository implements SessionRepository {
   int getSessionsCallCount = 0;
   ({String projectId, int? start, int? limit})? lastGetSessionsArgs;
   String? projectPathResult;
-  final Map<String, String?> enrichedTitleOverrides = {};
   Object? publicationError;
 
   FakeSessionRepository({
@@ -1123,19 +1122,13 @@ class FakeSessionRepository implements SessionRepository {
       for (final session in sessions)
         if (_selectBestPr(prsBySessionId[session.id]) case final pr?) session.id: pullRequestInfoFromDto(pr),
     };
-    final enriched = enrichSharedSessions(
+    return enrichSharedSessions(
       sessions: sessions,
       storedSessionsById: dbSessions,
       pullRequestsBySessionId: pullRequestsBySessionId,
       unseenCalculator: const SessionUnseenCalculator(),
       adoptStoredProjectId: false,
     );
-    return [
-      for (final session in enriched)
-        enrichedTitleOverrides.containsKey(session.id)
-            ? session.copyWith(title: enrichedTitleOverrides[session.id])
-            : session,
-    ];
   }
 
   static PullRequestDto? _selectBestPr(List<PullRequestDto>? prs) {

--- a/bridge/app/test/bridge/services/session_event_service_test.dart
+++ b/bridge/app/test/bridge/services/session_event_service_test.dart
@@ -4,7 +4,6 @@ import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/repositories/trackers/session_event_tracker.dart";
 import "package:sesori_bridge/src/bridge/services/session_event_service.dart";
-import "package:sesori_bridge/src/bridge/services/session_mutation_dispatcher.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -17,7 +16,6 @@ void main() {
     late AppDatabase database;
     late _EventPlugin plugin;
     late SessionRepository repository;
-    late SessionMutationDispatcher mutationDispatcher;
     late SessionEventTracker eventTracker;
     late SessionEventService service;
 
@@ -31,11 +29,9 @@ void main() {
         pullRequestDao: database.pullRequestDao,
         unseenCalculator: const SessionUnseenCalculator(),
       );
-      mutationDispatcher = SessionMutationDispatcher(sessionRepository: repository);
       eventTracker = SessionEventTracker(maxPendingEntriesPerPlugin: 1024);
       service = SessionEventService(
         sessionRepository: repository,
-        sessionMutationDispatcher: mutationDispatcher,
         eventMapper: const SessionEventMapper(),
         eventTracker: eventTracker,
         failureReporter: FakeFailureReporter(),
@@ -43,7 +39,6 @@ void main() {
     });
 
     tearDown(() async {
-      await mutationDispatcher.dispose();
       await database.close();
     });
 
@@ -229,6 +224,43 @@ void main() {
       final child = Session.fromJson((output.first as BridgeSseSessionCreated).info);
       expect(child.id, matches(RegExp(r"^ses_[0-9a-f]{32}$")));
       expect(child.parentID, "stable-root");
+    });
+
+    test("plugin title updates the catalog fallback without replacing the Sesori title", () async {
+      await _insertRoot(
+        database: database,
+        pluginId: plugin.id,
+        sessionId: "stable-root",
+        backendSessionId: "backend-root",
+      );
+      await database.sessionDao.setTitle(
+        sessionId: "stable-root",
+        title: "Sesori title",
+        updatedAt: 2,
+        projectionUpdatedAt: 2,
+      );
+
+      final output = await service.normalize(
+        source: (
+          pluginId: plugin.id,
+          projectionUpdatedAt: 3,
+          event: BridgeSseSessionUpdated(
+            info: _sessionInfo(
+              sessionId: "backend-root",
+              parentId: null,
+              projectId: "backend-project",
+              directory: "/repo",
+            ),
+            titleChanged: true,
+          ),
+        ),
+      );
+
+      final row = await database.sessionDao.getSession(sessionId: "stable-root");
+      expect(row?.title, "Sesori title");
+      expect(row?.catalogTitle, "title-backend-root");
+      final updated = output.single as BridgeSseSessionUpdated;
+      expect(Session.fromJson(updated.info).title, "Sesori title");
     });
 
     test("does not attach a child to a parent owned by another plugin", () async {

--- a/bridge/app/test/bridge/services/session_mutation_dispatcher_test.dart
+++ b/bridge/app/test/bridge/services/session_mutation_dispatcher_test.dart
@@ -52,15 +52,6 @@ void main() {
       );
     }
 
-    test("applies a title captured before the session row exists", () async {
-      await dispatcher.captureTitle(sessionId: "s1", title: "Early title");
-      await insertSession();
-
-      await dispatcher.applyPendingTitle(sessionId: "s1");
-
-      expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "Early title");
-    });
-
     test("rejects a rename when its root binding does not exist", () async {
       await expectLater(
         dispatcher.renameSession(sessionId: "s1", title: "User rename"),
@@ -107,97 +98,10 @@ void main() {
 
       final renamed = await dispatcher.renameSession(sessionId: "s1", title: "Stored title");
       await dispatcher.drain();
-      await dispatcher.captureTitle(sessionId: "s1", title: "Old backend title");
 
       expect(renamed.title, "Stored title");
       expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "Stored title");
       expect(plugin.renameCalls, 1);
-    });
-
-    test("accepts a later backend rename that reuses an older local title", () async {
-      await insertSession();
-
-      await dispatcher.renameSession(sessionId: "s1", title: "First title");
-      await dispatcher.renameSession(sessionId: "s1", title: "Second title");
-      await dispatcher.renameSession(sessionId: "s1", title: "Third title");
-      await dispatcher.drain();
-      await Future<void>.delayed(const Duration(milliseconds: 1100));
-      await dispatcher.captureTitle(sessionId: "s1", title: "First title");
-
-      expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "First title");
-    });
-
-    test("suppresses an older rename event without blocking later backend titles", () async {
-      final renameStarted = Completer<void>();
-      final releaseRename = Completer<void>();
-      plugin
-        ..renameStarted = renameStarted
-        ..releaseRename = releaseRename.future;
-      await insertSession();
-
-      await dispatcher.renameSession(sessionId: "s1", title: "First title");
-      await renameStarted.future;
-      final newerRename = dispatcher.renameSession(sessionId: "s1", title: "Newer title");
-      final staleEvent = dispatcher.captureTitle(sessionId: "s1", title: "First title");
-
-      releaseRename.complete();
-      await newerRename;
-      await staleEvent;
-
-      expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "Newer title");
-
-      await dispatcher.captureTitle(sessionId: "s1", title: "Newer title");
-      await dispatcher.captureTitle(sessionId: "s1", title: "External title");
-      expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "Newer title");
-
-      await Future<void>.delayed(const Duration(milliseconds: 1100));
-      await dispatcher.captureTitle(sessionId: "s1", title: "External title");
-      expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "External title");
-    });
-
-    test("applies a pending null by removing the stored title copy", () async {
-      await dispatcher.captureTitle(sessionId: "s1", title: null);
-      await insertSession();
-      await db.sessionDao.setTitle(
-        sessionId: "s1",
-        title: "stale",
-        updatedAt: 2,
-        projectionUpdatedAt: 2,
-      );
-
-      await dispatcher.applyPendingTitle(sessionId: "s1");
-
-      expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, isNull);
-    });
-
-    test("deletion discards a pending title", () async {
-      plugin.sessions = const [
-        PluginSession(
-          id: "s1",
-          projectID: "/repo",
-          directory: "/repo",
-          parentID: null,
-          title: null,
-          time: null,
-        ),
-      ];
-      await insertSession();
-      final deletionEvent = expectLater(
-        dispatcher.deletedSessions,
-        emits(
-          isA<Session>()
-              .having((session) => session.id, "id", "s1")
-              .having((session) => session.projectID, "projectID", "/repo"),
-        ),
-      );
-      await dispatcher.captureTitle(sessionId: "s1", title: "stale");
-      await dispatcher.deleteSession(sessionId: "s1");
-      await deletionEvent;
-      await insertSession();
-
-      await dispatcher.applyPendingTitle(sessionId: "s1");
-
-      expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, isNull);
     });
 
     test("a rename waits for deletion and cannot reach the plugin afterward", () async {

--- a/bridge/app/tool/benchmarks/catalog_import_event_soak.dart
+++ b/bridge/app/tool/benchmarks/catalog_import_event_soak.dart
@@ -18,7 +18,6 @@ import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/repositories/trackers/session_event_tracker.dart";
 import "package:sesori_bridge/src/bridge/services/session_event_service.dart";
-import "package:sesori_bridge/src/bridge/services/session_mutation_dispatcher.dart";
 import "package:sesori_bridge/src/bridge/sse/bridge_event_mapper.dart";
 import "package:sesori_bridge/src/bridge/sse/sse_manager.dart";
 import "package:sesori_bridge/src/repositories/catalog_import_repository.dart";
@@ -114,7 +113,6 @@ class _CatalogImportEventSoak {
     final releaseWriter = Completer<void>();
     AppDatabase? database;
     SessionRepository? sessionRepository;
-    SessionMutationDispatcher? mutationDispatcher;
     _CountingSSEManager? sseManager;
     StreamSubscription<CatalogImportProgress>? importSubscription;
     Future<void>? heldWriter;
@@ -167,14 +165,12 @@ class _CatalogImportEventSoak {
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
         aggregateSourceDeadline: const Duration(seconds: 5),
       );
-      mutationDispatcher = SessionMutationDispatcher(sessionRepository: sessionRepository);
       final eventTracker = SessionEventTracker(
         maxPendingEntriesPerPlugin: SessionEventTracker.defaultMaxPendingEntries,
       );
       final failureReporter = _BenchmarkFailureReporter();
       final eventService = SessionEventService(
         sessionRepository: sessionRepository,
-        sessionMutationDispatcher: mutationDispatcher,
         eventMapper: const SessionEventMapper(),
         eventTracker: eventTracker,
         failureReporter: failureReporter,
@@ -402,8 +398,6 @@ class _CatalogImportEventSoak {
 
       sseManager.stop();
       sseManager = null;
-      await mutationDispatcher.dispose();
-      mutationDispatcher = null;
       await sessionRepository.dispose();
       sessionRepository = null;
       await database.close();
@@ -424,7 +418,6 @@ class _CatalogImportEventSoak {
       }
       await importSubscription?.cancel();
       sseManager?.stop();
-      if (mutationDispatcher != null) await mutationDispatcher.dispose();
       if (sessionRepository != null) await sessionRepository.dispose();
       if (database != null) await database.close();
       try {

--- a/bridge/app/tool/benchmarks/event_projection_benchmark.dart
+++ b/bridge/app/tool/benchmarks/event_projection_benchmark.dart
@@ -11,7 +11,6 @@ import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/repositories/trackers/session_event_tracker.dart";
 import "package:sesori_bridge/src/bridge/services/session_event_service.dart";
-import "package:sesori_bridge/src/bridge/services/session_mutation_dispatcher.dart";
 import "package:sesori_bridge/src/bridge/sse/bridge_event_mapper.dart";
 import "package:sesori_bridge/src/bridge/sse/sse_manager.dart";
 import "package:sesori_bridge/src/repositories/project_catalog_identity_calculator.dart";
@@ -72,7 +71,6 @@ class _EventProjectionBenchmark {
     final databaseFile = File(p.join(temporaryDirectory.path, "benchmark.sqlite"));
     AppDatabase? database;
     SessionRepository? repository;
-    SessionMutationDispatcher? mutationDispatcher;
     SSEManager? sseManager;
 
     try {
@@ -91,11 +89,9 @@ class _EventProjectionBenchmark {
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
         aggregateSourceDeadline: const Duration(seconds: 5),
       );
-      mutationDispatcher = SessionMutationDispatcher(sessionRepository: repository);
       final failureReporter = _BenchmarkFailureReporter();
       final service = SessionEventService(
         sessionRepository: repository,
-        sessionMutationDispatcher: mutationDispatcher,
         eventMapper: const SessionEventMapper(),
         eventTracker: SessionEventTracker(
           maxPendingEntriesPerPlugin: SessionEventTracker.defaultMaxPendingEntries,
@@ -118,8 +114,6 @@ class _EventProjectionBenchmark {
       final databaseSchemaVersion = database.schemaVersion;
       sseManager.stop();
       sseManager = null;
-      await mutationDispatcher.dispose();
-      mutationDispatcher = null;
       await repository.dispose();
       repository = null;
       await database.close();
@@ -157,7 +151,6 @@ class _EventProjectionBenchmark {
       };
     } finally {
       sseManager?.stop();
-      if (mutationDispatcher != null) await mutationDispatcher.dispose();
       if (repository != null) await repository.dispose();
       if (database != null) await database.close();
       try {

--- a/bridge/app/tool/benchmarks/live_list_baseline.dart
+++ b/bridge/app/tool/benchmarks/live_list_baseline.dart
@@ -14,7 +14,6 @@ import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
 import "package:sesori_bridge/src/bridge/repositories/project_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
-import "package:sesori_bridge/src/bridge/services/session_mutation_dispatcher.dart";
 import "package:sesori_bridge/src/repositories/project_catalog_identity_calculator.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
@@ -237,7 +236,6 @@ class _LiveListBenchmark {
     );
 
     final sessionRepository = _sessionRepository(database: database, plugins: operationalPlugins);
-    final mutationDispatcher = SessionMutationDispatcher(sessionRepository: sessionRepository);
     final pageSize = min(100, _configuration.sessionCount);
 
     try {
@@ -256,7 +254,6 @@ class _LiveListBenchmark {
           pluginCounters: pluginCounters,
           operation: () => _sessionEndpointCoreCount(
             repository: sessionRepository,
-            mutationDispatcher: mutationDispatcher,
             projectId: _projectDirectory,
             start: 0,
             limit: pageSize,
@@ -283,7 +280,6 @@ class _LiveListBenchmark {
           pluginCounters: pluginCounters,
           operation: () => _sessionEndpointCoreCount(
             repository: sessionRepository,
-            mutationDispatcher: mutationDispatcher,
             projectId: _smallProjectDirectory,
             start: null,
             limit: null,
@@ -349,7 +345,6 @@ class _LiveListBenchmark {
       );
       return results;
     } finally {
-      await mutationDispatcher.dispose();
       await sessionRepository.dispose();
     }
   }
@@ -457,7 +452,6 @@ class _LiveListBenchmark {
 
   Future<int> _sessionEndpointCoreCount({
     required SessionRepository repository,
-    required SessionMutationDispatcher mutationDispatcher,
     required String projectId,
     required int? start,
     required int? limit,
@@ -469,9 +463,6 @@ class _LiveListBenchmark {
       start: start,
       limit: limit,
     );
-    for (final session in sessions) {
-      await mutationDispatcher.applyPendingTitle(sessionId: session.id);
-    }
     sessions = await repository.enrichSessions(sessions: sessions);
     _verifyBoundaries(
       name: "session catalog for $projectId",


### PR DESCRIPTION
## Summary
- keep the bridge-owned `sessions.title` override authoritative while plugin observations update `catalogTitle`
- remove title guards, timers, pending-title state, and obsolete dispatcher dependencies
- render durable sessions consistently from `title ?? catalogTitle` while retaining DB-first asynchronous plugin rename propagation

## Testing
- `dart analyze --fatal-infos` in `bridge/app`
- `dart test test/bridge/services/session_event_service_test.dart`
- `dart test test/bridge/services/session_mutation_dispatcher_test.dart`
- `dart test test/bridge/services/session_creation_service_test.dart`
- `dart test test/bridge/routing/create_session_handler_test.dart`
- `dart test test/bridge/routing/get_sessions_handler_test.dart`
- `dart test test/bridge/routing/catalog_read_handlers_test.dart`
- `dart test test/bridge/repositories/session_repository_test.dart`
- `dart test test/repositories/catalog_import_repository_test.dart`
- `dart test test/bridge/repositories/mappers/catalog_mappers_test.dart`
- `dart test test/bridge/debug_server_test.dart`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `sessions.title` the single source of truth while treating plugin-reported titles as `catalogTitle`. This removes fragile pending-title logic and makes session titles render consistently from `title ?? catalogTitle`.

- **Refactors**
  - `SessionMutationDispatcher`: removed pending-title state, backend title guards, and related timers; now only serializes DB writes and backend rename propagation.
  - Title flow: plugins update `catalogTitle`; bridge updates `title`; enrichment reads `storedSession.title ?? storedSession.catalogTitle`.
  - Removed dispatcher dependencies from `GetSessionsHandler` and `SessionEventService` (no more `applyPendingTitle`/`captureTitle` calls).
  - Orchestrator and handlers simplified; obsolete calls dropped.
  - Tests and benchmarks updated to reflect the new ownership model.

- **Migration**
  - Remove any calls to `captureTitle` and `applyPendingTitle`.
  - When rendering, prefer `session.title ?? session.catalogTitle`.

<sup>Written for commit cec00818fb0af49a7a3eb82a71b2c42a521825a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

