### PR TITLE
fix(cursor): use cursor-agent executable by default

### DIFF
--- a/bridge/sesori_plugin_cursor/lib/src/cursor_binary.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_binary.dart
@@ -1,15 +1,14 @@
 import "package:acp_plugin/acp_plugin.dart";
 
-/// Builds the launch spec for `agent acp`.
+/// Builds the launch spec for `cursor-agent acp`.
 ///
 /// Auth is out of band: the default process factory inherits the bridge's
 /// environment, so `CURSOR_API_KEY` / `CURSOR_AUTH_TOKEN` (or a prior
-/// `agent login`) are passed through automatically.
+/// `cursor-agent login`) are passed through automatically.
 abstract final class CursorBinary {
-  /// The Cursor CLI's official binary name (`agent`, per cursor.com/docs/cli;
-  /// `agent acp` is the documented ACP server mode). Older installs that only
-  /// ship the legacy `cursor-agent` name can point `--cursor-bin` at it.
-  static const String defaultBinary = "agent";
+  /// The stable Cursor CLI executable. The user-facing `agent` command can be
+  /// registered as shell state, which is unavailable to a headless bridge.
+  static const String defaultBinary = "cursor-agent";
 
   static AcpLaunchSpec launchSpec({
     String binary = defaultBinary,

--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
@@ -38,7 +38,7 @@ CursorPlugin _defaultBuildPlugin({
 
 /// The const Cursor plugin descriptor.
 ///
-/// Cursor drives an `agent acp` stdio subprocess over the generic ACP
+/// Cursor drives a `cursor-agent acp` stdio subprocess over the generic ACP
 /// machinery, so it needs no managed-runtime supervisor (no listening port to
 /// reclaim, no ownership file). It declares its CLI surface, probes the
 /// Cursor CLI binary for availability, and on [start] spawns the agent
@@ -78,7 +78,7 @@ class CursorPluginDescriptor extends BridgePluginDescriptor {
   static const List<PluginOption> cliOptions = [
     PluginValueOption(
       name: binOption,
-      help: "Path to the Cursor CLI binary (agent)",
+      help: "Path to the Cursor CLI binary (cursor-agent)",
       defaultsTo: CursorBinary.defaultBinary,
       allowedValues: null,
       valueHelp: "path",
@@ -285,7 +285,6 @@ class CursorPluginDescriptor extends BridgePluginDescriptor {
       "",
       "Verify it is installed:  $executablePath --version",
       "Install the Cursor CLI:  curl https://cursor.com/install -fsS | bash",
-      "Legacy installs that only ship `cursor-agent` can use --cursor-bin cursor-agent.",
     ].join("\n");
   }
 

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
@@ -151,10 +151,10 @@ void main() {
       expect(plugin.id, "cursor");
     });
 
-    test("the default binary is the official Cursor CLI name", () {
-      expect(CursorBinary.defaultBinary, "agent");
+    test("the default binary is the stable Cursor CLI executable", () {
+      expect(CursorBinary.defaultBinary, "cursor-agent");
       final spec = CursorBinary.launchSpec(cwd: "/repo");
-      expect(spec.command, "agent");
+      expect(spec.command, "cursor-agent");
       expect(spec.args, ["acp"]);
     });
 


### PR DESCRIPTION
## Summary

- use the stable `cursor-agent` executable for Cursor availability probes and ACP startup by default
- keep explicit `--cursor-bin` overrides unchanged
- align Cursor CLI help, documentation, and the default launch-spec test

## Why

The user-facing `agent` command can be registered as shell state rather than a standalone executable. A headless bridge launches processes directly and cannot resolve shell functions created through `eval`, while `cursor-agent` is the installed executable.

## Testing

- `dart test`
- `dart analyze --fatal-infos`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the default Cursor CLI binary to `cursor-agent` for availability probes and ACP startup. This fixes headless launches where `agent` is a shell function, while keeping `--cursor-bin` overrides intact.

- **Bug Fixes**
  - Default command is now `cursor-agent` in the launch spec and tests.
  - CLI help/docs updated to reference `cursor-agent acp`.
  - Removed legacy note about using `cursor-agent`; users can still set `--cursor-bin` if needed.

<sup>Written for commit 76154ee475e1f68e8e39cc89f637a1249eb348c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

