### PR TITLE
chore(cursor): update CLI target to 2026.07.20

### DIFF
--- a/bridge/sesori_plugin_cursor/lib/src/cursor_binary.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_binary.dart
@@ -6,8 +6,8 @@ import "package:acp_plugin/acp_plugin.dart";
 /// environment, so `CURSOR_API_KEY` / `CURSOR_AUTH_TOKEN` (or a prior
 /// `cursor-agent login`) are passed through automatically.
 abstract final class CursorBinary {
-  /// The stable Cursor CLI executable. The user-facing `agent` command can be
-  /// registered as shell state, which is unavailable to a headless bridge.
+  /// The current installer exposes both names for the same payload. Use
+  /// `cursor-agent` because older installs may not provide the `agent` symlink.
   static const String defaultBinary = "cursor-agent";
 
   static AcpLaunchSpec launchSpec({

--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
@@ -64,7 +64,7 @@ class CursorPluginDescriptor extends BridgePluginDescriptor {
   /// silently no-op model switching and history replay, so the experience is
   /// broken in ways the user can't see. Keep this target aligned with the
   /// latest verified Cursor CLI build.
-  static const String minVersion = "2026.07.16";
+  static const String minVersion = "2026.07.20";
 
   /// CLI option naming the Cursor CLI binary (path or PATH name). Declared
   /// as the bare local name — the bridge's [PluginCliOptionsMapper] namespaces

--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
@@ -62,9 +62,13 @@ class CursorPluginDescriptor extends BridgePluginDescriptor {
   /// Minimum Cursor CLI build the bridge supports. Earlier builds (e.g.
   /// `2026.05.28`) advertise the `acp` model picker and `session/load` but
   /// silently no-op model switching and history replay, so the experience is
-  /// broken in ways the user can't see. Keep this target aligned with the
-  /// latest verified Cursor CLI build.
-  static const String minVersion = "2026.07.20";
+  /// broken in ways the user can't see. Raise this floor only when bridge
+  /// behavior requires a newer Cursor capability.
+  static const String minVersion = "2026.07.16";
+
+  /// Latest official-installer build targeted for the future bundled Cursor
+  /// runtime. This records the preferred build without changing availability.
+  static const String targetVersion = "2026.07.20-8cc9c0b";
 
   /// CLI option naming the Cursor CLI binary (path or PATH name). Declared
   /// as the bare local name — the bridge's [PluginCliOptionsMapper] namespaces

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
@@ -21,7 +21,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 1,
-            stdoutBytes: utf8.encode("2026.07.16-899851b\n"),
+            stdoutBytes: utf8.encode("2026.07.20-8cc9c0b\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(
@@ -67,7 +67,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 3,
-            stdoutBytes: utf8.encode("2026.07.16\n"),
+            stdoutBytes: utf8.encode("2026.07.20\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(
@@ -98,7 +98,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 5,
-            stdoutBytes: utf8.encode("2026.07.16\n"),
+            stdoutBytes: utf8.encode("2026.07.20\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(
@@ -135,7 +135,7 @@ void main() {
       final processes = _ProbeProcessService(
         process: _ProbeProcess(
           pid: 4242,
-          stdoutBytes: utf8.encode("2026.07.16-899851b\n"),
+          stdoutBytes: utf8.encode("2026.07.20-8cc9c0b\n"),
           exitCode: Future<int>.value(0),
         ),
       );

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
@@ -21,7 +21,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 1,
-            stdoutBytes: utf8.encode("2026.07.20-8cc9c0b\n"),
+            stdoutBytes: utf8.encode("${CursorPluginDescriptor.targetVersion}\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(
@@ -67,7 +67,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 3,
-            stdoutBytes: utf8.encode("2026.07.20\n"),
+            stdoutBytes: utf8.encode("2026.07.16\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(
@@ -98,7 +98,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 5,
-            stdoutBytes: utf8.encode("2026.07.20\n"),
+            stdoutBytes: utf8.encode("2026.07.16\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(
@@ -131,11 +131,16 @@ void main() {
       },
     );
 
+    test("tracks the installer target separately from the compatibility floor", () {
+      expect(CursorPluginDescriptor.minVersion, "2026.07.16");
+      expect(CursorPluginDescriptor.targetVersion, "2026.07.20-8cc9c0b");
+    });
+
     test("reports available when '<bin> --version' exits 0 with a recent build", () async {
       final processes = _ProbeProcessService(
         process: _ProbeProcess(
           pid: 4242,
-          stdoutBytes: utf8.encode("2026.07.20-8cc9c0b\n"),
+          stdoutBytes: utf8.encode("${CursorPluginDescriptor.targetVersion}\n"),
           exitCode: Future<int>.value(0),
         ),
       );


### PR DESCRIPTION
## Summary

- add an exact Cursor CLI `targetVersion` of `2026.07.20-8cc9c0b` for the planned bundled runtime
- preserve the capability-based `minVersion` compatibility floor at `2026.07.16`
- cover the target and minimum independently in availability tests
- clarify that the current installer exposes both `agent` and `cursor-agent` while retaining `cursor-agent` for older-install compatibility

## Release Source

The official installer at `https://cursor.com/install` currently advertises the unambiguous build `2026.07.20-8cc9c0b`.

## Testing

- `dart test` (74 tests)
- `dart analyze --fatal-infos`
- `git diff --check`

Architecture review: approved with no findings.
