### PR TITLE
fix(cursor): discover catalog before first session

### DIFF
--- a/bridge/sesori_plugin_cursor/lib/src/api/cursor_catalog_probe_api.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/api/cursor_catalog_probe_api.dart
@@ -2,6 +2,8 @@ import "dart:async";
 
 import "package:acp_plugin/acp_plugin.dart";
 
+import "models/cursor_available_models_dto.dart";
+
 /// Layer-1 ACP operations used by Cursor's isolated catalog-probe process.
 class CursorCatalogProbeApi {
   CursorCatalogProbeApi({required AcpStdioClient client}) : _client = client;
@@ -11,6 +13,8 @@ class CursorCatalogProbeApi {
   final AcpStdioClient _client;
   AcpInitializeResult? _initializeResult;
   bool _disposed = false;
+
+  static const String _listAvailableModelsMethod = "cursor/list_available_models";
 
   /// Connects and performs Cursor's ACP v1 initialize/authenticate handshake.
   Future<AcpInitializeResult> open({required Duration timeout}) async {
@@ -84,6 +88,20 @@ class CursorCatalogProbeApi {
       cursor = nextCursor;
     }
     throw StateError("Cursor session/list exceeded $_maxPages pages");
+  }
+
+  /// Reads Cursor's account model catalog without creating a session.
+  Future<CursorAvailableModelsDto> listAvailableModels({required Duration timeout}) async {
+    if (_initializeResult == null || !_client.isConnected) {
+      throw StateError("Cursor catalog probe is not initialized");
+    }
+    final raw = await _client.request(
+      method: _listAvailableModelsMethod,
+      timeout: timeout,
+    );
+    return CursorAvailableModelsDto.fromJson(
+      raw is Map ? raw.cast<String, dynamic>() : const {},
+    );
   }
 
   /// Loads one existing session and parses its typed ACP result.

--- a/bridge/sesori_plugin_cursor/lib/src/api/models/cursor_available_models_dto.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/api/models/cursor_available_models_dto.dart
@@ -1,0 +1,49 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "cursor_available_models_dto.freezed.dart";
+part "cursor_available_models_dto.g.dart";
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CursorAvailableModelsDto with _$CursorAvailableModelsDto {
+  const factory CursorAvailableModelsDto({
+    @Default(<CursorAvailableModelDto>[]) List<CursorAvailableModelDto> models,
+  }) = _CursorAvailableModelsDto;
+
+  factory CursorAvailableModelsDto.fromJson(Map<String, dynamic> json) => _$CursorAvailableModelsDtoFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CursorAvailableModelDto with _$CursorAvailableModelDto {
+  const factory CursorAvailableModelDto({
+    required String value,
+    required String? name,
+    @Default(<CursorModelConfigOptionDto>[]) List<CursorModelConfigOptionDto> configOptions,
+  }) = _CursorAvailableModelDto;
+
+  factory CursorAvailableModelDto.fromJson(Map<String, dynamic> json) => _$CursorAvailableModelDtoFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CursorModelConfigOptionDto with _$CursorModelConfigOptionDto {
+  const factory CursorModelConfigOptionDto({
+    required String id,
+    required String? name,
+    required String? description,
+    required String? category,
+    required String? currentValue,
+    @Default(<CursorConfigOptionValueDto>[]) List<CursorConfigOptionValueDto> options,
+  }) = _CursorModelConfigOptionDto;
+
+  factory CursorModelConfigOptionDto.fromJson(Map<String, dynamic> json) => _$CursorModelConfigOptionDtoFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CursorConfigOptionValueDto with _$CursorConfigOptionValueDto {
+  const factory CursorConfigOptionValueDto({
+    required String value,
+    required String? name,
+    required String? description,
+  }) = _CursorConfigOptionValueDto;
+
+  factory CursorConfigOptionValueDto.fromJson(Map<String, dynamic> json) => _$CursorConfigOptionValueDtoFromJson(json);
+}

--- a/bridge/sesori_plugin_cursor/lib/src/api/models/cursor_available_models_dto.freezed.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/api/models/cursor_available_models_dto.freezed.dart
@@ -1,0 +1,575 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'cursor_available_models_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$CursorAvailableModelsDto {
+
+ List<CursorAvailableModelDto> get models;
+/// Create a copy of CursorAvailableModelsDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CursorAvailableModelsDtoCopyWith<CursorAvailableModelsDto> get copyWith => _$CursorAvailableModelsDtoCopyWithImpl<CursorAvailableModelsDto>(this as CursorAvailableModelsDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CursorAvailableModelsDto&&const DeepCollectionEquality().equals(other.models, models));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(models));
+
+@override
+String toString() {
+  return 'CursorAvailableModelsDto(models: $models)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CursorAvailableModelsDtoCopyWith<$Res>  {
+  factory $CursorAvailableModelsDtoCopyWith(CursorAvailableModelsDto value, $Res Function(CursorAvailableModelsDto) _then) = _$CursorAvailableModelsDtoCopyWithImpl;
+@useResult
+$Res call({
+ List<CursorAvailableModelDto> models
+});
+
+
+
+
+}
+/// @nodoc
+class _$CursorAvailableModelsDtoCopyWithImpl<$Res>
+    implements $CursorAvailableModelsDtoCopyWith<$Res> {
+  _$CursorAvailableModelsDtoCopyWithImpl(this._self, this._then);
+
+  final CursorAvailableModelsDto _self;
+  final $Res Function(CursorAvailableModelsDto) _then;
+
+/// Create a copy of CursorAvailableModelsDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? models = null,}) {
+  return _then(_self.copyWith(
+models: null == models ? _self.models : models // ignore: cast_nullable_to_non_nullable
+as List<CursorAvailableModelDto>,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CursorAvailableModelsDto implements CursorAvailableModelsDto {
+  const _CursorAvailableModelsDto({final  List<CursorAvailableModelDto> models = const <CursorAvailableModelDto>[]}): _models = models;
+  factory _CursorAvailableModelsDto.fromJson(Map<String, dynamic> json) => _$CursorAvailableModelsDtoFromJson(json);
+
+ final  List<CursorAvailableModelDto> _models;
+@override@JsonKey() List<CursorAvailableModelDto> get models {
+  if (_models is EqualUnmodifiableListView) return _models;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_models);
+}
+
+
+/// Create a copy of CursorAvailableModelsDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CursorAvailableModelsDtoCopyWith<_CursorAvailableModelsDto> get copyWith => __$CursorAvailableModelsDtoCopyWithImpl<_CursorAvailableModelsDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CursorAvailableModelsDto&&const DeepCollectionEquality().equals(other._models, _models));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_models));
+
+@override
+String toString() {
+  return 'CursorAvailableModelsDto(models: $models)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CursorAvailableModelsDtoCopyWith<$Res> implements $CursorAvailableModelsDtoCopyWith<$Res> {
+  factory _$CursorAvailableModelsDtoCopyWith(_CursorAvailableModelsDto value, $Res Function(_CursorAvailableModelsDto) _then) = __$CursorAvailableModelsDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ List<CursorAvailableModelDto> models
+});
+
+
+
+
+}
+/// @nodoc
+class __$CursorAvailableModelsDtoCopyWithImpl<$Res>
+    implements _$CursorAvailableModelsDtoCopyWith<$Res> {
+  __$CursorAvailableModelsDtoCopyWithImpl(this._self, this._then);
+
+  final _CursorAvailableModelsDto _self;
+  final $Res Function(_CursorAvailableModelsDto) _then;
+
+/// Create a copy of CursorAvailableModelsDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? models = null,}) {
+  return _then(_CursorAvailableModelsDto(
+models: null == models ? _self._models : models // ignore: cast_nullable_to_non_nullable
+as List<CursorAvailableModelDto>,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$CursorAvailableModelDto {
+
+ String get value; String? get name; List<CursorModelConfigOptionDto> get configOptions;
+/// Create a copy of CursorAvailableModelDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CursorAvailableModelDtoCopyWith<CursorAvailableModelDto> get copyWith => _$CursorAvailableModelDtoCopyWithImpl<CursorAvailableModelDto>(this as CursorAvailableModelDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CursorAvailableModelDto&&(identical(other.value, value) || other.value == value)&&(identical(other.name, name) || other.name == name)&&const DeepCollectionEquality().equals(other.configOptions, configOptions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,value,name,const DeepCollectionEquality().hash(configOptions));
+
+@override
+String toString() {
+  return 'CursorAvailableModelDto(value: $value, name: $name, configOptions: $configOptions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CursorAvailableModelDtoCopyWith<$Res>  {
+  factory $CursorAvailableModelDtoCopyWith(CursorAvailableModelDto value, $Res Function(CursorAvailableModelDto) _then) = _$CursorAvailableModelDtoCopyWithImpl;
+@useResult
+$Res call({
+ String value, String? name, List<CursorModelConfigOptionDto> configOptions
+});
+
+
+
+
+}
+/// @nodoc
+class _$CursorAvailableModelDtoCopyWithImpl<$Res>
+    implements $CursorAvailableModelDtoCopyWith<$Res> {
+  _$CursorAvailableModelDtoCopyWithImpl(this._self, this._then);
+
+  final CursorAvailableModelDto _self;
+  final $Res Function(CursorAvailableModelDto) _then;
+
+/// Create a copy of CursorAvailableModelDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? value = null,Object? name = freezed,Object? configOptions = null,}) {
+  return _then(_self.copyWith(
+value: null == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,configOptions: null == configOptions ? _self.configOptions : configOptions // ignore: cast_nullable_to_non_nullable
+as List<CursorModelConfigOptionDto>,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CursorAvailableModelDto implements CursorAvailableModelDto {
+  const _CursorAvailableModelDto({required this.value, required this.name, final  List<CursorModelConfigOptionDto> configOptions = const <CursorModelConfigOptionDto>[]}): _configOptions = configOptions;
+  factory _CursorAvailableModelDto.fromJson(Map<String, dynamic> json) => _$CursorAvailableModelDtoFromJson(json);
+
+@override final  String value;
+@override final  String? name;
+ final  List<CursorModelConfigOptionDto> _configOptions;
+@override@JsonKey() List<CursorModelConfigOptionDto> get configOptions {
+  if (_configOptions is EqualUnmodifiableListView) return _configOptions;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_configOptions);
+}
+
+
+/// Create a copy of CursorAvailableModelDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CursorAvailableModelDtoCopyWith<_CursorAvailableModelDto> get copyWith => __$CursorAvailableModelDtoCopyWithImpl<_CursorAvailableModelDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CursorAvailableModelDto&&(identical(other.value, value) || other.value == value)&&(identical(other.name, name) || other.name == name)&&const DeepCollectionEquality().equals(other._configOptions, _configOptions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,value,name,const DeepCollectionEquality().hash(_configOptions));
+
+@override
+String toString() {
+  return 'CursorAvailableModelDto(value: $value, name: $name, configOptions: $configOptions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CursorAvailableModelDtoCopyWith<$Res> implements $CursorAvailableModelDtoCopyWith<$Res> {
+  factory _$CursorAvailableModelDtoCopyWith(_CursorAvailableModelDto value, $Res Function(_CursorAvailableModelDto) _then) = __$CursorAvailableModelDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String value, String? name, List<CursorModelConfigOptionDto> configOptions
+});
+
+
+
+
+}
+/// @nodoc
+class __$CursorAvailableModelDtoCopyWithImpl<$Res>
+    implements _$CursorAvailableModelDtoCopyWith<$Res> {
+  __$CursorAvailableModelDtoCopyWithImpl(this._self, this._then);
+
+  final _CursorAvailableModelDto _self;
+  final $Res Function(_CursorAvailableModelDto) _then;
+
+/// Create a copy of CursorAvailableModelDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? value = null,Object? name = freezed,Object? configOptions = null,}) {
+  return _then(_CursorAvailableModelDto(
+value: null == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,configOptions: null == configOptions ? _self._configOptions : configOptions // ignore: cast_nullable_to_non_nullable
+as List<CursorModelConfigOptionDto>,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$CursorModelConfigOptionDto {
+
+ String get id; String? get name; String? get description; String? get category; String? get currentValue; List<CursorConfigOptionValueDto> get options;
+/// Create a copy of CursorModelConfigOptionDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CursorModelConfigOptionDtoCopyWith<CursorModelConfigOptionDto> get copyWith => _$CursorModelConfigOptionDtoCopyWithImpl<CursorModelConfigOptionDto>(this as CursorModelConfigOptionDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CursorModelConfigOptionDto&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description)&&(identical(other.category, category) || other.category == category)&&(identical(other.currentValue, currentValue) || other.currentValue == currentValue)&&const DeepCollectionEquality().equals(other.options, options));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,description,category,currentValue,const DeepCollectionEquality().hash(options));
+
+@override
+String toString() {
+  return 'CursorModelConfigOptionDto(id: $id, name: $name, description: $description, category: $category, currentValue: $currentValue, options: $options)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CursorModelConfigOptionDtoCopyWith<$Res>  {
+  factory $CursorModelConfigOptionDtoCopyWith(CursorModelConfigOptionDto value, $Res Function(CursorModelConfigOptionDto) _then) = _$CursorModelConfigOptionDtoCopyWithImpl;
+@useResult
+$Res call({
+ String id, String? name, String? description, String? category, String? currentValue, List<CursorConfigOptionValueDto> options
+});
+
+
+
+
+}
+/// @nodoc
+class _$CursorModelConfigOptionDtoCopyWithImpl<$Res>
+    implements $CursorModelConfigOptionDtoCopyWith<$Res> {
+  _$CursorModelConfigOptionDtoCopyWithImpl(this._self, this._then);
+
+  final CursorModelConfigOptionDto _self;
+  final $Res Function(CursorModelConfigOptionDto) _then;
+
+/// Create a copy of CursorModelConfigOptionDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = freezed,Object? description = freezed,Object? category = freezed,Object? currentValue = freezed,Object? options = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,category: freezed == category ? _self.category : category // ignore: cast_nullable_to_non_nullable
+as String?,currentValue: freezed == currentValue ? _self.currentValue : currentValue // ignore: cast_nullable_to_non_nullable
+as String?,options: null == options ? _self.options : options // ignore: cast_nullable_to_non_nullable
+as List<CursorConfigOptionValueDto>,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CursorModelConfigOptionDto implements CursorModelConfigOptionDto {
+  const _CursorModelConfigOptionDto({required this.id, required this.name, required this.description, required this.category, required this.currentValue, final  List<CursorConfigOptionValueDto> options = const <CursorConfigOptionValueDto>[]}): _options = options;
+  factory _CursorModelConfigOptionDto.fromJson(Map<String, dynamic> json) => _$CursorModelConfigOptionDtoFromJson(json);
+
+@override final  String id;
+@override final  String? name;
+@override final  String? description;
+@override final  String? category;
+@override final  String? currentValue;
+ final  List<CursorConfigOptionValueDto> _options;
+@override@JsonKey() List<CursorConfigOptionValueDto> get options {
+  if (_options is EqualUnmodifiableListView) return _options;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_options);
+}
+
+
+/// Create a copy of CursorModelConfigOptionDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CursorModelConfigOptionDtoCopyWith<_CursorModelConfigOptionDto> get copyWith => __$CursorModelConfigOptionDtoCopyWithImpl<_CursorModelConfigOptionDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CursorModelConfigOptionDto&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description)&&(identical(other.category, category) || other.category == category)&&(identical(other.currentValue, currentValue) || other.currentValue == currentValue)&&const DeepCollectionEquality().equals(other._options, _options));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,description,category,currentValue,const DeepCollectionEquality().hash(_options));
+
+@override
+String toString() {
+  return 'CursorModelConfigOptionDto(id: $id, name: $name, description: $description, category: $category, currentValue: $currentValue, options: $options)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CursorModelConfigOptionDtoCopyWith<$Res> implements $CursorModelConfigOptionDtoCopyWith<$Res> {
+  factory _$CursorModelConfigOptionDtoCopyWith(_CursorModelConfigOptionDto value, $Res Function(_CursorModelConfigOptionDto) _then) = __$CursorModelConfigOptionDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String? name, String? description, String? category, String? currentValue, List<CursorConfigOptionValueDto> options
+});
+
+
+
+
+}
+/// @nodoc
+class __$CursorModelConfigOptionDtoCopyWithImpl<$Res>
+    implements _$CursorModelConfigOptionDtoCopyWith<$Res> {
+  __$CursorModelConfigOptionDtoCopyWithImpl(this._self, this._then);
+
+  final _CursorModelConfigOptionDto _self;
+  final $Res Function(_CursorModelConfigOptionDto) _then;
+
+/// Create a copy of CursorModelConfigOptionDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = freezed,Object? description = freezed,Object? category = freezed,Object? currentValue = freezed,Object? options = null,}) {
+  return _then(_CursorModelConfigOptionDto(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,category: freezed == category ? _self.category : category // ignore: cast_nullable_to_non_nullable
+as String?,currentValue: freezed == currentValue ? _self.currentValue : currentValue // ignore: cast_nullable_to_non_nullable
+as String?,options: null == options ? _self._options : options // ignore: cast_nullable_to_non_nullable
+as List<CursorConfigOptionValueDto>,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$CursorConfigOptionValueDto {
+
+ String get value; String? get name; String? get description;
+/// Create a copy of CursorConfigOptionValueDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CursorConfigOptionValueDtoCopyWith<CursorConfigOptionValueDto> get copyWith => _$CursorConfigOptionValueDtoCopyWithImpl<CursorConfigOptionValueDto>(this as CursorConfigOptionValueDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CursorConfigOptionValueDto&&(identical(other.value, value) || other.value == value)&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,value,name,description);
+
+@override
+String toString() {
+  return 'CursorConfigOptionValueDto(value: $value, name: $name, description: $description)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CursorConfigOptionValueDtoCopyWith<$Res>  {
+  factory $CursorConfigOptionValueDtoCopyWith(CursorConfigOptionValueDto value, $Res Function(CursorConfigOptionValueDto) _then) = _$CursorConfigOptionValueDtoCopyWithImpl;
+@useResult
+$Res call({
+ String value, String? name, String? description
+});
+
+
+
+
+}
+/// @nodoc
+class _$CursorConfigOptionValueDtoCopyWithImpl<$Res>
+    implements $CursorConfigOptionValueDtoCopyWith<$Res> {
+  _$CursorConfigOptionValueDtoCopyWithImpl(this._self, this._then);
+
+  final CursorConfigOptionValueDto _self;
+  final $Res Function(CursorConfigOptionValueDto) _then;
+
+/// Create a copy of CursorConfigOptionValueDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? value = null,Object? name = freezed,Object? description = freezed,}) {
+  return _then(_self.copyWith(
+value: null == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CursorConfigOptionValueDto implements CursorConfigOptionValueDto {
+  const _CursorConfigOptionValueDto({required this.value, required this.name, required this.description});
+  factory _CursorConfigOptionValueDto.fromJson(Map<String, dynamic> json) => _$CursorConfigOptionValueDtoFromJson(json);
+
+@override final  String value;
+@override final  String? name;
+@override final  String? description;
+
+/// Create a copy of CursorConfigOptionValueDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CursorConfigOptionValueDtoCopyWith<_CursorConfigOptionValueDto> get copyWith => __$CursorConfigOptionValueDtoCopyWithImpl<_CursorConfigOptionValueDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CursorConfigOptionValueDto&&(identical(other.value, value) || other.value == value)&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,value,name,description);
+
+@override
+String toString() {
+  return 'CursorConfigOptionValueDto(value: $value, name: $name, description: $description)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CursorConfigOptionValueDtoCopyWith<$Res> implements $CursorConfigOptionValueDtoCopyWith<$Res> {
+  factory _$CursorConfigOptionValueDtoCopyWith(_CursorConfigOptionValueDto value, $Res Function(_CursorConfigOptionValueDto) _then) = __$CursorConfigOptionValueDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String value, String? name, String? description
+});
+
+
+
+
+}
+/// @nodoc
+class __$CursorConfigOptionValueDtoCopyWithImpl<$Res>
+    implements _$CursorConfigOptionValueDtoCopyWith<$Res> {
+  __$CursorConfigOptionValueDtoCopyWithImpl(this._self, this._then);
+
+  final _CursorConfigOptionValueDto _self;
+  final $Res Function(_CursorConfigOptionValueDto) _then;
+
+/// Create a copy of CursorConfigOptionValueDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? value = null,Object? name = freezed,Object? description = freezed,}) {
+  return _then(_CursorConfigOptionValueDto(
+value: null == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/bridge/sesori_plugin_cursor/lib/src/api/models/cursor_available_models_dto.g.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/api/models/cursor_available_models_dto.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cursor_available_models_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_CursorAvailableModelsDto _$CursorAvailableModelsDtoFromJson(Map json) =>
+    _CursorAvailableModelsDto(
+      models:
+          (json['models'] as List<dynamic>?)
+              ?.map(
+                (e) => CursorAvailableModelDto.fromJson(
+                  Map<String, dynamic>.from(e as Map),
+                ),
+              )
+              .toList() ??
+          const <CursorAvailableModelDto>[],
+    );
+
+_CursorAvailableModelDto _$CursorAvailableModelDtoFromJson(Map json) =>
+    _CursorAvailableModelDto(
+      value: json['value'] as String,
+      name: json['name'] as String?,
+      configOptions:
+          (json['configOptions'] as List<dynamic>?)
+              ?.map(
+                (e) => CursorModelConfigOptionDto.fromJson(
+                  Map<String, dynamic>.from(e as Map),
+                ),
+              )
+              .toList() ??
+          const <CursorModelConfigOptionDto>[],
+    );
+
+_CursorModelConfigOptionDto _$CursorModelConfigOptionDtoFromJson(Map json) =>
+    _CursorModelConfigOptionDto(
+      id: json['id'] as String,
+      name: json['name'] as String?,
+      description: json['description'] as String?,
+      category: json['category'] as String?,
+      currentValue: json['currentValue'] as String?,
+      options:
+          (json['options'] as List<dynamic>?)
+              ?.map(
+                (e) => CursorConfigOptionValueDto.fromJson(
+                  Map<String, dynamic>.from(e as Map),
+                ),
+              )
+              .toList() ??
+          const <CursorConfigOptionValueDto>[],
+    );
+
+_CursorConfigOptionValueDto _$CursorConfigOptionValueDtoFromJson(Map json) =>
+    _CursorConfigOptionValueDto(
+      value: json['value'] as String,
+      name: json['name'] as String?,
+      description: json['description'] as String?,
+    );

--- a/bridge/sesori_plugin_cursor/lib/src/models/cursor_catalog_models.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/models/cursor_catalog_models.dart
@@ -24,6 +24,35 @@ class CursorThoughtLevelSnapshot {
   final String? defaultValue;
 }
 
+/// Cursor's stable execution modes, available before the first session exists.
+enum CursorMode {
+  agent(id: "agent", displayName: "Agent"),
+  plan(id: "plan", displayName: "Plan"),
+  ask(id: "ask", displayName: "Ask");
+
+  const CursorMode({required this.id, required this.displayName});
+
+  final String id;
+  final String displayName;
+}
+
+/// Account catalog returned without creating or loading a Cursor session.
+class CursorCatalogBootstrapSnapshot {
+  CursorCatalogBootstrapSnapshot({
+    required List<CursorCatalogOption> models,
+    required List<CursorCatalogOption> modes,
+    required this.defaultModeId,
+    required Map<String, CursorThoughtLevelSnapshot> thoughtLevelsByModel,
+  }) : models = List.unmodifiable(models),
+       modes = List.unmodifiable(modes),
+       thoughtLevelsByModel = Map.unmodifiable(thoughtLevelsByModel);
+
+  final List<CursorCatalogOption> models;
+  final List<CursorCatalogOption> modes;
+  final String defaultModeId;
+  final Map<String, CursorThoughtLevelSnapshot> thoughtLevelsByModel;
+}
+
 /// Typed Cursor catalog data parsed from an ACP session result.
 class CursorCatalogSnapshot {
   CursorCatalogSnapshot({

--- a/bridge/sesori_plugin_cursor/lib/src/repositories/cursor_catalog_repository.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/repositories/cursor_catalog_repository.dart
@@ -25,6 +25,17 @@ class CursorCatalogRepository {
     return capabilities.listSessions && capabilities.loadSession;
   }
 
+  /// Returns null only when this Cursor build does not expose model discovery.
+  Future<CursorCatalogBootstrapSnapshot?> loadAvailableCatalog({required Duration timeout}) async {
+    try {
+      final result = await _api.listAvailableModels(timeout: timeout);
+      return CursorCatalogMapper.mapAvailableModels(result: result);
+    } on AcpRpcException catch (error) {
+      if (error.code == -32601) return null;
+      rethrow;
+    }
+  }
+
   /// Unions unfiltered, launch, and requested-scope enumeration results.
   Future<CursorCatalogCandidateListResult> listCandidates({
     required String scope,

--- a/bridge/sesori_plugin_cursor/lib/src/repositories/mappers/cursor_catalog_mapper.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/repositories/mappers/cursor_catalog_mapper.dart
@@ -1,9 +1,49 @@
 import "package:acp_plugin/acp_plugin.dart";
 
+import "../../api/models/cursor_available_models_dto.dart";
 import "../../models/cursor_catalog_models.dart";
 
 /// Maps Cursor's raw ACP config options into the internal catalog model.
 abstract final class CursorCatalogMapper {
+  static CursorCatalogBootstrapSnapshot mapAvailableModels({
+    required CursorAvailableModelsDto result,
+  }) {
+    final models = <CursorCatalogOption>[];
+    final thoughtLevelsByModel = <String, CursorThoughtLevelSnapshot>{};
+    for (final model in result.models) {
+      final modelId = model.value;
+      if (modelId.isEmpty) continue;
+      models.add(
+        CursorCatalogOption(
+          value: modelId,
+          name: switch (model.name) {
+            final name? when name.isNotEmpty => name,
+            _ => modelId,
+          },
+          description: null,
+        ),
+      );
+      final thoughtLevel = _mapAvailableThoughtLevel(model: model);
+      if (thoughtLevel != null) {
+        thoughtLevelsByModel[modelId] = thoughtLevel;
+      }
+    }
+
+    return CursorCatalogBootstrapSnapshot(
+      models: models,
+      modes: [
+        for (final mode in CursorMode.values)
+          CursorCatalogOption(
+            value: mode.id,
+            name: mode.displayName,
+            description: null,
+          ),
+      ],
+      defaultModeId: CursorMode.agent.id,
+      thoughtLevelsByModel: thoughtLevelsByModel,
+    );
+  }
+
   static CursorCatalogSnapshot mapSession({required AcpNewSessionResult result}) {
     final modelConfig = _findConfig(result: result, category: "model");
     final modeConfig = _findConfig(result: result, category: "mode");
@@ -24,6 +64,54 @@ abstract final class CursorCatalogMapper {
               defaultValue: _currentValue(config: thoughtConfig),
             ),
     );
+  }
+
+  static CursorThoughtLevelSnapshot? _mapAvailableThoughtLevel({
+    required CursorAvailableModelDto model,
+  }) {
+    CursorModelConfigOptionDto? effort;
+    CursorModelConfigOptionDto? reasoning;
+    for (final option in model.configOptions) {
+      if (option.category != "thought_level") continue;
+      switch (option.id) {
+        case "effort":
+          effort = option;
+        case "reasoning":
+          reasoning = option;
+        case _:
+          break;
+      }
+    }
+    final selected = switch ((reasoning, effort)) {
+      (final reasoning?, _) when _hasMultiLevelAvailableOptions(config: reasoning) => reasoning,
+      (_, final effort?) when _hasMultiLevelAvailableOptions(config: effort) => effort,
+      _ => null,
+    };
+    if (selected == null) return null;
+    final values = [
+      for (final option in selected.options)
+        if (option.value.isNotEmpty) option.value,
+    ];
+    final currentValue = selected.currentValue;
+    if (currentValue != null && currentValue.isNotEmpty && values.remove(currentValue)) {
+      values.insert(0, currentValue);
+    }
+    return CursorThoughtLevelSnapshot(
+      configId: selected.id,
+      variants: values,
+      defaultValue: currentValue,
+    );
+  }
+
+  static bool _hasMultiLevelAvailableOptions({
+    required CursorModelConfigOptionDto config,
+  }) {
+    final values = config.options.map((option) => option.value).where((value) => value.isNotEmpty).toSet();
+    if (values.length <= 1) return false;
+    if (values.length == 2 && (values.containsAll({"true", "false"}) || values.containsAll({"on", "off"}))) {
+      return false;
+    }
+    return true;
   }
 
   static Map<String, dynamic>? _findConfig({

--- a/bridge/sesori_plugin_cursor/lib/src/services/cursor_catalog_service.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/services/cursor_catalog_service.dart
@@ -76,6 +76,30 @@ class CursorCatalogService {
       final supported = await _repository.open(
         timeout: _remaining(stopwatch: stopwatch),
       );
+
+      try {
+        final bootstrap = await _repository.loadAvailableCatalog(
+          timeout: _remaining(stopwatch: stopwatch),
+        );
+        if (bootstrap != null) {
+          _tracker.applyBootstrapSnapshot(snapshot: bootstrap);
+        }
+      } on Object catch (error, stack) {
+        Log.w(
+          "[cursor] account catalog discovery failed; falling back to existing sessions",
+          error,
+          stack,
+        );
+      }
+
+      if (_tracker.isComplete) {
+        _tracker.recordOutcome(
+          scope: scope,
+          outcome: CursorCatalogProbeOutcome.complete,
+        );
+        return;
+      }
+
       if (!supported) {
         _tracker.recordOutcome(
           scope: scope,

--- a/bridge/sesori_plugin_cursor/lib/src/trackers/cursor_catalog_tracker.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/trackers/cursor_catalog_tracker.dart
@@ -23,6 +23,18 @@ class CursorCatalogTracker {
 
   bool get isComplete => _models.isNotEmpty && _modes.isNotEmpty && _provisionalThoughtLevelVariants.isNotEmpty;
 
+  void applyBootstrapSnapshot({required CursorCatalogBootstrapSnapshot snapshot}) {
+    if (_models.isEmpty && snapshot.models.isNotEmpty) _models = snapshot.models;
+    if (_modes.isEmpty && snapshot.modes.isNotEmpty) _modes = snapshot.modes;
+    _defaultModeId ??= snapshot.defaultModeId;
+    for (final entry in snapshot.thoughtLevelsByModel.entries) {
+      _thoughtLevelsByModel.putIfAbsent(entry.key, () => entry.value);
+      if (_provisionalThoughtLevelVariants.isEmpty && entry.value.variants.isNotEmpty) {
+        _provisionalThoughtLevelVariants = entry.value.variants;
+      }
+    }
+  }
+
   CursorCatalogCaptureResult applySnapshot({
     required CursorCatalogSnapshot snapshot,
     required bool fromNewSession,

--- a/bridge/sesori_plugin_cursor/test/cursor_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_catalog_repository_test.dart
@@ -1,5 +1,6 @@
 import "package:acp_plugin/acp_plugin.dart";
 import "package:cursor_plugin/src/api/cursor_catalog_probe_api.dart";
+import "package:cursor_plugin/src/api/models/cursor_available_models_dto.dart";
 import "package:cursor_plugin/src/repositories/cursor_catalog_repository.dart";
 import "package:test/test.dart";
 
@@ -151,6 +152,59 @@ void main() {
       expect(snapshot.thoughtLevel?.configId, "effort");
       expect(snapshot.thoughtLevel?.variants, ["medium", "low", "high"]);
     });
+
+    test("maps account models, stable modes, and per-model thought levels", () async {
+      api.availableModels = CursorAvailableModelsDto.fromJson({
+        "models": [
+          {"value": "default", "name": "Auto"},
+          {
+            "value": "gpt-5.6-sol",
+            "name": "GPT-5.6 Sol",
+            "configOptions": [
+              {
+                "id": "reasoning",
+                "name": "Reasoning",
+                "category": "thought_level",
+                "currentValue": "medium",
+                "options": [
+                  {"value": "none", "name": "None"},
+                  {"value": "low", "name": "Low"},
+                  {"value": "medium", "name": "Medium"},
+                  {"value": "high", "name": "High"},
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      final snapshot = await repository.loadAvailableCatalog(
+        timeout: const Duration(seconds: 1),
+      );
+
+      expect(snapshot, isNotNull);
+      expect(snapshot!.models.map((model) => model.value), ["default", "gpt-5.6-sol"]);
+      expect(snapshot.modes.map((mode) => mode.value), ["agent", "plan", "ask"]);
+      expect(snapshot.defaultModeId, "agent");
+      expect(snapshot.thoughtLevelsByModel["gpt-5.6-sol"]?.configId, "reasoning");
+      expect(
+        snapshot.thoughtLevelsByModel["gpt-5.6-sol"]?.variants,
+        ["medium", "none", "low", "high"],
+      );
+    });
+
+    test("maps an unsupported account catalog extension to absence", () async {
+      api.availableModelsError = AcpRpcException(
+        method: "cursor/list_available_models",
+        code: -32601,
+        message: "method not found",
+      );
+
+      expect(
+        await repository.loadAvailableCatalog(timeout: const Duration(seconds: 1)),
+        isNull,
+      );
+    });
   });
 }
 
@@ -217,6 +271,8 @@ class _FakeCursorCatalogProbeApi implements CursorCatalogProbeApi {
   final Map<String?, List<AcpSessionInfo>> sessionsByScope = {};
   final Map<String?, Object> errorsByScope = {};
   final List<String?> listedScopes = [];
+  CursorAvailableModelsDto availableModels = const CursorAvailableModelsDto();
+  Object? availableModelsError;
 
   @override
   Future<AcpInitializeResult> open({required Duration timeout}) async {
@@ -239,6 +295,13 @@ class _FakeCursorCatalogProbeApi implements CursorCatalogProbeApi {
     final error = errorsByScope[cwd];
     if (error != null) throw error;
     return sessionsByScope[cwd] ?? const [];
+  }
+
+  @override
+  Future<CursorAvailableModelsDto> listAvailableModels({required Duration timeout}) async {
+    final error = availableModelsError;
+    if (error != null) throw error;
+    return availableModels;
   }
 
   @override

--- a/bridge/sesori_plugin_cursor/test/cursor_catalog_service_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_catalog_service_test.dart
@@ -44,6 +44,51 @@ void main() {
       expect(repository.resetCount, 1, reason: "the dedicated probe process is short-lived");
     });
 
+    test("uses the account catalog when no existing session is available", () async {
+      repository.bootstrapSnapshot = CursorCatalogBootstrapSnapshot(
+        models: const [
+          CursorCatalogOption(value: "default", name: "Auto", description: null),
+          CursorCatalogOption(value: "gpt-5.6-sol", name: "GPT-5.6 Sol", description: null),
+        ],
+        modes: const [
+          CursorCatalogOption(value: "agent", name: "Agent", description: null),
+          CursorCatalogOption(value: "plan", name: "Plan", description: null),
+          CursorCatalogOption(value: "ask", name: "Ask", description: null),
+        ],
+        defaultModeId: "agent",
+        thoughtLevelsByModel: {
+          "gpt-5.6-sol": CursorThoughtLevelSnapshot(
+            configId: "reasoning",
+            variants: const ["medium", "none", "low", "high"],
+            defaultValue: "medium",
+          ),
+        },
+      );
+
+      await service.ensureCatalog(scope: "/project");
+
+      expect(tracker.isComplete, isTrue);
+      expect(tracker.models.map((model) => model.value), ["default", "gpt-5.6-sol"]);
+      expect(tracker.modes.map((mode) => mode.value), ["agent", "plan", "ask"]);
+      expect(tracker.variantsForModel(modelId: "gpt-5.6-sol"), ["medium", "none", "low", "high"]);
+      expect(repository.listedScopes, isEmpty, reason: "no historical session walk is needed");
+      expect(
+        tracker.outcomeForScope(scope: "/project"),
+        CursorCatalogProbeOutcome.complete,
+      );
+    });
+
+    test("falls back to existing sessions when account catalog discovery fails", () async {
+      repository.bootstrapError = StateError("extension unavailable");
+      repository.candidates = _candidates([(id: "session", updatedAtMs: 1)]);
+      repository.snapshots["session"] = _snapshot(includeThoughtLevel: true);
+
+      await service.ensureCatalog(scope: "/project");
+
+      expect(repository.loadedSessionIds, ["session"]);
+      expect(tracker.isComplete, isTrue);
+    });
+
     test("loads at most eight candidates", () async {
       repository.candidates = _candidates([
         for (var i = 0; i < 10; i++) (id: "s$i", updatedAtMs: i),
@@ -235,12 +280,21 @@ class _FakeCursorCatalogRepository implements CursorCatalogRepository {
   Completer<void>? listGate;
   bool probeSupported = true;
   bool delayLoadsUntilTimeout = false;
+  CursorCatalogBootstrapSnapshot? bootstrapSnapshot;
+  Object? bootstrapError;
   int resetCount = 0;
   int _concurrentLists = 0;
   int maxConcurrentLists = 0;
 
   @override
   Future<bool> open({required Duration timeout}) async => probeSupported;
+
+  @override
+  Future<CursorCatalogBootstrapSnapshot?> loadAvailableCatalog({required Duration timeout}) async {
+    final error = bootstrapError;
+    if (error != null) throw error;
+    return bootstrapSnapshot;
+  }
 
   @override
   Future<CursorCatalogCandidateListResult> listCandidates({

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
@@ -144,6 +144,7 @@ void main() {
         "agentCapabilities": <String, dynamic>{},
         "authMethods": <Object?>[],
       });
+      await respond("cursor/list_available_models", const {"models": <Object?>[]});
       return future;
     }
 
@@ -904,6 +905,7 @@ void main() {
         "agentCapabilities": <String, dynamic>{},
         "authMethods": <Object?>[],
       });
+      await respond("cursor/list_available_models", const {"models": <Object?>[]});
       expect((await providers).providers, isEmpty);
     });
 
@@ -1041,6 +1043,7 @@ void main() {
     void Function() autoAnswer({
       required List<Map<String, dynamic>> listSessions,
       required Map<String, Map<String, dynamic>> loadResults,
+      List<Map<String, dynamic>>? availableModels,
       Map<String?, List<Map<String, dynamic>>>? listSessionsByScope,
       bool rejectUnfiltered = false,
       List<String>? loadOrder,
@@ -1064,6 +1067,16 @@ void main() {
                     },
                     "authMethods": <Object?>[],
                   };
+                case "cursor/list_available_models":
+                  if (availableModels == null) {
+                    fake.emit({
+                      "jsonrpc": "2.0",
+                      "id": id,
+                      "error": {"code": -32601, "message": "method not found"},
+                    });
+                    continue;
+                  }
+                  result = {"models": availableModels};
                 case "session/list":
                   final params = (frame["params"] as Map?)?.cast<String, dynamic>();
                   final listScope = params?["cwd"] as String?;
@@ -1094,6 +1107,56 @@ void main() {
       }());
       return () => running = false;
     }
+
+    test("discovers agents and models before the first Cursor session", () async {
+      final stop = autoAnswer(
+        listSessions: const [],
+        loadResults: const {},
+        availableModels: [
+          {"value": "default", "name": "Auto"},
+          {
+            "value": "gpt-5.6-sol",
+            "name": "GPT-5.6 Sol",
+            "configOptions": [
+              {
+                "id": "reasoning",
+                "name": "Reasoning",
+                "category": "thought_level",
+                "currentValue": "medium",
+                "options": [
+                  {"value": "none", "name": "None"},
+                  {"value": "low", "name": "Low"},
+                  {"value": "medium", "name": "Medium"},
+                  {"value": "high", "name": "High"},
+                ],
+              },
+            ],
+          },
+        ],
+      );
+
+      final providers = await plugin.getProviders(projectId: cwd);
+      final agents = await plugin.getAgents(projectId: cwd);
+      stop();
+
+      expect(providers.providers.single.models.map((model) => model.id), ["default", "gpt-5.6-sol"]);
+      expect(providers.providers.single.defaultModelID, "default");
+      expect(
+        providers.providers.single.models.last.variants,
+        ["medium", "none", "low", "high"],
+      );
+      expect(agents.map((agent) => agent.name), ["Agent", "Plan", "Ask"]);
+      expect(
+        allWritten().where((frame) => frame["method"] == "session/list"),
+        isEmpty,
+        reason: "account discovery does not require a historical session",
+      );
+      expect(
+        allWritten().where((frame) => frame["method"] == "session/new"),
+        isEmpty,
+        reason: "catalog discovery must not create a throwaway session",
+      );
+    });
 
     test("seeds provisional effort when the newest session is non-reasoning but an older one is reasoning", () async {
       final loadOrder = <String>[];


### PR DESCRIPTION
## Summary

- discover Cursor's account model catalog before any session exists through `cursor/list_available_models`
- seed stable Agent, Plan, and Ask modes plus per-model effort/reasoning variants
- retain the bounded `session/list` / `session/load` discovery path for older Cursor builds and extension failures
- avoid creating throwaway Cursor sessions

## Root cause

The catalog warm-up previously depended entirely on loading an existing Cursor session. A successful empty `session/list` was recorded as exhausted, so provider requests remained empty for that bridge run. Creating the first real session populated the in-memory catalog, and that persisted Cursor session made discovery work after later restarts.

## Compatibility

The account catalog method is optional. Builds that return JSON-RPC method-not-found continue through the existing historical-session discovery path. There are no shared, public, or wire contract changes.

## Verification

- `dart test` in `bridge/sesori_plugin_cursor` (79 tests passed)
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_cursor`
- `git diff --check origin/main...HEAD`
- architecture implementation review approved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Discover the Cursor account model catalog before any session exists using `cursor/list_available_models`, so providers and agents show up on first run without creating throwaway sessions. Falls back to the historical session path on older Cursor builds.

- **New Features**
  - Read models via `cursor/list_available_models` without a session.
  - Seed stable modes: Agent, Plan, Ask.
  - Capture per-model thought level variants and defaults from config options.

- **Bug Fixes**
  - Providers and agents are discoverable on first run.
  - No temporary sessions created during catalog warm-up.
  - Graceful fallback to `session/list` + `session/load` when the method is unavailable.

<sup>Written for commit d202b2b97a7ba83241a32a85dde4806f4d168092. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

