### PR TITLE
feat(bridge): support isolated data directories

### DIFF
--- a/bridge/app/README.md
+++ b/bridge/app/README.md
@@ -160,7 +160,7 @@ In addition to flags, the bridge supports subcommands:
 | `config plugins enable <id>` | Remove a known plugin from the denylist. Restart the bridge to apply. |
 | `config plugins disable <id>` | Add a known plugin to the denylist. Restart the bridge to apply. |
 | `config edit` | Open the bridge configuration file in your default editor |
-| `logout` | Clear stored authentication tokens. You will be asked to log in again on next start. |
+| `logout [--data-dir <path>]` | Clear stored authentication tokens. You will be asked to log in again on next start. |
 
 `config edit` opens `~/.config/sesori/config.json`. A generated config includes:
 
@@ -223,13 +223,19 @@ host-wide startup mutex and plugin runtime state remain shared intentionally.
 ```bash
 dart run bin/bridge.dart --data-dir /tmp/sesori-bridge-account-a
 dart run bin/bridge.dart --data-dir /tmp/sesori-bridge-account-b
+
+# After stopping account A's source-run bridge, unregister it and clear its credentials
+dart run bin/bridge.dart logout --data-dir /tmp/sesori-bridge-account-a
 ```
 
 The override isolates Sesori credentials, bridge identity, catalog database,
 and onboarding markers. Bridge settings in `~/.config/sesori`, managed plugin
 runtime state, and backend CLI credentials remain shared. Packaged native
 bridges still enforce the normal single-live-bridge rule; this workflow is for
-source-run test processes.
+source-run test processes. A custom-directory logout deliberately does not stop
+any bridge process, so stop the corresponding source-run bridge first. Server
+unregistration is best-effort: if it fails, credentials are still removed but
+the custom directory's `bridge_id` remains.
 
 Plugin-specific examples (OpenCode):
 

--- a/bridge/app/README.md
+++ b/bridge/app/README.md
@@ -128,6 +128,7 @@ Bridge core flags:
 | `--relay` | `wss://relay.sesori.com` | Relay server URL |
 | `--import-plugin` | *(none)* | Start an import for this eligible plugin after startup. Repeatable. |
 | `--auth-backend` | `https://api.sesori.com` | Auth backend URL (also reads `AUTH_BACKEND_URL` env var) |
+| `--data-dir` | platform Sesori data directory | Override account-bound storage for tokens, bridge ID, database, and onboarding markers |
 | `--debug-port` | *(disabled)* | Start a debug HTTP server on this port for Postman/curl testing |
 | `--log-level` | `info` | Minimum **diagnostic log** level (written to stderr): `verbose`, `debug`, `info`, `warning`, `error` |
 | `--version` | — | Print the bridge version and exit |
@@ -214,6 +215,21 @@ legacy `pluginId` still always means OpenCode.
 # Log out (clear stored tokens)
 ./dist/bridge-macos-arm64 logout
 ```
+
+For local multi-account testing, give each `dart run` bridge a unique data
+directory. Start the second bridge after the first finishes plugin startup; the
+host-wide startup mutex and plugin runtime state remain shared intentionally.
+
+```bash
+dart run bin/bridge.dart --data-dir /tmp/sesori-bridge-account-a
+dart run bin/bridge.dart --data-dir /tmp/sesori-bridge-account-b
+```
+
+The override isolates Sesori credentials, bridge identity, catalog database,
+and onboarding markers. Bridge settings in `~/.config/sesori`, managed plugin
+runtime state, and backend CLI credentials remain shared. Packaged native
+bridges still enforce the normal single-live-bridge rule; this workflow is for
+source-run test processes.
 
 Plugin-specific examples (OpenCode):
 

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -211,12 +211,38 @@ class LogoutCommand extends cli.Command<void> {
   final description = 'Clear stored authentication tokens';
 
   LogoutCommand() {
-    argParser.addOption('auth-backend', defaultsTo: '', help: 'Auth backend URL');
+    argParser
+      ..addOption('auth-backend', defaultsTo: '', help: 'Auth backend URL')
+      ..addOption(
+        'data-dir',
+        valueHelp: 'path',
+        help: 'Override the account data directory (tokens, bridge ID, and database)',
+      );
   }
 
   @override
   Future<void> run() async {
-    final dataDirectory = sesoriDataDirectory();
+    final dataDirectoryFlag = argResults!['data-dir'] as String?;
+    final defaultDataDirectory = sesoriDataDirectory();
+    final String dataDirectory;
+    try {
+      dataDirectory = BridgeCliOptions.resolveDataDirectory(
+        dataDirectoryFlag: dataDirectoryFlag,
+        defaultDataDirectory: defaultDataDirectory,
+      );
+    } on ArgParserException catch (error) {
+      usageException(error.message);
+    }
+    final isCustomDataDirectory = !BridgeCliOptions.isDefaultDataDirectory(
+      dataDirectory: dataDirectory,
+      defaultDataDirectory: defaultDataDirectory,
+    );
+    if (isCustomDataDirectory) {
+      Console.warning(
+        'Stop the source-run bridge using $dataDirectory before logging out; '
+        'custom data-directory logout does not stop running bridge processes.',
+      );
+    }
     final authBackendUrl = BridgeCliOptions.resolveAuthBackendUrl(
       authBackendFlag: argResults!['auth-backend'] as String,
       environment: Platform.environment,
@@ -273,7 +299,9 @@ class LogoutCommand extends cli.Command<void> {
       clearTokens: () => clearTokens(dataDirectory: dataDirectory),
     );
 
-    final result = await logoutRunner.logout(currentPid: pid);
+    final result = isCustomDataDirectory
+        ? await logoutRunner.logoutStoppedBridge()
+        : await logoutRunner.logout(currentPid: pid);
     switch (result.status) {
       case BridgeLogoutStatus.loggedOut:
         Console.message('Authentication cleared. You will be asked to log in on next start.');

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -299,9 +299,10 @@ class LogoutCommand extends cli.Command<void> {
       clearTokens: () => clearTokens(dataDirectory: dataDirectory),
     );
 
-    final result = isCustomDataDirectory
-        ? await logoutRunner.logoutStoppedBridge()
-        : await logoutRunner.logout(currentPid: pid);
+    final result = await logoutRunner.logout(
+      currentPid: pid,
+      manageRunningBridges: !isCustomDataDirectory,
+    );
     switch (result.status) {
       case BridgeLogoutStatus.loggedOut:
         Console.message('Authentication cleared. You will be asked to log in on next start.');

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -102,6 +102,11 @@ class RunCommand extends cli.Command<void> {
     argParser
       ..addOption('auth-backend', defaultsTo: '', help: 'Auth backend URL')
       ..addOption(
+        'data-dir',
+        valueHelp: 'path',
+        help: 'Override the account data directory (tokens, bridge ID, and database)',
+      )
+      ..addOption(
         'debug-port',
         defaultsTo: '',
         help: 'Start a debug HTTP server on this port (for Postman/curl testing)',
@@ -149,6 +154,7 @@ class RunCommand extends cli.Command<void> {
         results: results,
         environment: Platform.environment,
         defaultAuthUrl: _defaultAuthURL,
+        defaultDataDirectory: sesoriDataDirectory(),
       );
     } on ArgParserException catch (e) {
       usageException(e.message);
@@ -210,6 +216,7 @@ class LogoutCommand extends cli.Command<void> {
 
   @override
   Future<void> run() async {
+    final dataDirectory = sesoriDataDirectory();
     final authBackendUrl = BridgeCliOptions.resolveAuthBackendUrl(
       authBackendFlag: argResults!['auth-backend'] as String,
       environment: Platform.environment,
@@ -254,10 +261,16 @@ class LogoutCommand extends cli.Command<void> {
         clock: const ServerClock(),
       ),
       terminalPromptRepository: terminalPromptRepository,
-      unregisterBridge: () => _unregisterBridgeRegistration(authBackendUrl: authBackendUrl),
-      appOnboardingStateRepository: AppOnboardingStateRepository(
-        storage: AppOnboardingStateStorage(directoryPath: appOnboardingStateDirectoryPath()),
+      unregisterBridge: () => _unregisterBridgeRegistration(
+        authBackendUrl: authBackendUrl,
+        dataDirectory: dataDirectory,
       ),
+      appOnboardingStateRepository: AppOnboardingStateRepository(
+        storage: AppOnboardingStateStorage(
+          directoryPath: appOnboardingStateDirectoryPath(dataDirectory: dataDirectory),
+        ),
+      ),
+      clearTokens: () => clearTokens(dataDirectory: dataDirectory),
     );
 
     final result = await logoutRunner.logout(currentPid: pid);
@@ -282,14 +295,19 @@ class LogoutCommand extends cli.Command<void> {
 
 /// Removes this bridge's registration on the auth server before the token
 /// file is deleted. Callers treat any failure as non-fatal.
-Future<void> _unregisterBridgeRegistration({required String authBackendUrl}) async {
-  final bridgeIdStorage = BridgeIdStorage(filePath: bridgeIdPath());
+Future<void> _unregisterBridgeRegistration({
+  required String authBackendUrl,
+  required String dataDirectory,
+}) async {
+  final bridgeIdStorage = BridgeIdStorage(
+    filePath: bridgeIdPath(dataDirectory: dataDirectory),
+  );
   // Adopt a legacy id persisted inside token.json first, so a never-reconnected
   // legacy install still unregisters cleanly; the service reads the bridge id
   // back out of storage.
   await BridgeIdMigrationService(
     bridgeIdStorage: bridgeIdStorage,
-    readLegacyBridgeId: readLegacyBridgeId,
+    readLegacyBridgeId: () => readLegacyBridgeId(dataDirectory: dataDirectory),
   ).migrate();
   if (await bridgeIdStorage.read() == null) {
     // Nothing registered to remove.
@@ -298,7 +316,7 @@ Future<void> _unregisterBridgeRegistration({required String authBackendUrl}) asy
 
   final TokenData tokens;
   try {
-    tokens = await loadTokens();
+    tokens = await loadTokens(dataDirectory: dataDirectory);
   } on Object catch (e) {
     // A registered bridge with no usable token file — there is no credential
     // left to authenticate the unregister call. Logout still proceeds, but
@@ -311,8 +329,8 @@ Future<void> _unregisterBridgeRegistration({required String authBackendUrl}) asy
   final tokenManager = TokenManager(
     initialToken: tokens.accessToken,
     authBackendUrl: authBackendUrl,
-    loadTokens: loadTokens,
-    saveTokens: saveTokens,
+    loadTokens: () => loadTokens(dataDirectory: dataDirectory),
+    saveTokens: (data) => saveTokens(data: data, dataDirectory: dataDirectory),
   );
   try {
     final registrationService = BridgeRegistrationService(

--- a/bridge/app/lib/src/api/app_onboarding_state_storage.dart
+++ b/bridge/app/lib/src/api/app_onboarding_state_storage.dart
@@ -1,9 +1,8 @@
 import "dart:io";
 
 import "package:path/path.dart" as path;
-import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show sesoriDataDirectory;
 
-String appOnboardingStateDirectoryPath() => path.join(sesoriDataDirectory(), "app_onboarding");
+String appOnboardingStateDirectoryPath({required String dataDirectory}) => path.join(dataDirectory, "app_onboarding");
 
 /// Raw file boundary for opaque app-onboarding completion markers.
 class AppOnboardingStateStorage {

--- a/bridge/app/lib/src/api/database/database.dart
+++ b/bridge/app/lib/src/api/database/database.dart
@@ -259,8 +259,24 @@ class AppDatabase extends _$AppDatabase {
     if (!dbDir.existsSync()) {
       dbDir.createSync(recursive: true);
     }
+    if (!Platform.isWindows) {
+      _setUnixMode(targetPath: dbDir.path, mode: "700");
+    }
     final dbFile = File(path.join(dbDir.path, "sesori.db"));
+    if (!Platform.isWindows) {
+      if (!dbFile.existsSync()) {
+        dbFile.createSync();
+      }
+      _setUnixMode(targetPath: dbFile.path, mode: "600");
+    }
     return openFile(file: dbFile);
+  }
+
+  static void _setUnixMode({required String targetPath, required String mode}) {
+    final result = Process.runSync("chmod", [mode, targetPath]);
+    if (result.exitCode != 0) {
+      throw FileSystemException("Failed to set mode $mode", targetPath);
+    }
   }
 
   static AppDatabase openFile({required File file}) {

--- a/bridge/app/lib/src/api/database/database.dart
+++ b/bridge/app/lib/src/api/database/database.dart
@@ -2,7 +2,7 @@ import "dart:io";
 
 import "package:drift/drift.dart";
 import "package:drift/native.dart";
-import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+import "package:path/path.dart" as path;
 import "package:sesori_shared/sesori_shared.dart";
 
 import "daos/catalog_hydrations_dao.dart";
@@ -254,12 +254,12 @@ class AppDatabase extends _$AppDatabase {
     },
   );
 
-  static AppDatabase create() {
-    final dbDir = Directory(sesoriDataDirectory());
+  static AppDatabase create({required String dataDirectory}) {
+    final dbDir = Directory(dataDirectory);
     if (!dbDir.existsSync()) {
       dbDir.createSync(recursive: true);
     }
-    final dbFile = File("${dbDir.path}/sesori.db");
+    final dbFile = File(path.join(dbDir.path, "sesori.db"));
     return openFile(file: dbFile);
   }
 

--- a/bridge/app/lib/src/auth/token.dart
+++ b/bridge/app/lib/src/auth/token.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:sesori_bridge_foundation/sesori_bridge_foundation.dart';
+import 'package:path/path.dart' as path;
 import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Log;
 import 'package:sesori_shared/sesori_shared.dart';
 
@@ -45,9 +45,9 @@ class TokenData {
   }
 }
 
-String tokenPath() => '${sesoriDataDirectory()}/token.json';
+String tokenPath({required String dataDirectory}) => path.join(dataDirectory, 'token.json');
 
-String bridgeIdPath() => '${sesoriDataDirectory()}/bridge_id';
+String bridgeIdPath({required String dataDirectory}) => path.join(dataDirectory, 'bridge_id');
 
 /// Reads the bridge id persisted by an older bridge inside `token.json`.
 ///
@@ -57,8 +57,8 @@ String bridgeIdPath() => '${sesoriDataDirectory()}/bridge_id';
 /// minting a duplicate entry. Returns null when the token file is absent,
 /// corrupt, or has no `bridgeId` key.
 // COMPATIBILITY 2026-06-30 (v1.3.0): Old installs persist bridgeId inside token.json. Remove this reader with BridgeIdMigrationService once those installs are unsupported.
-Future<String?> readLegacyBridgeId() async {
-  final file = File(tokenPath());
+Future<String?> readLegacyBridgeId({required String dataDirectory}) async {
+  final file = File(tokenPath(dataDirectory: dataDirectory));
 
   try {
     final json = jsonDecodeMap(await file.readAsString());
@@ -79,9 +79,9 @@ Future<String?> readLegacyBridgeId() async {
 
 /// Saves the token data to the token file.
 /// Creates the directory structure if it doesn't exist.
-Future<void> saveTokens(TokenData data) async {
-  final path = tokenPath();
-  final dir = Directory(path).parent;
+Future<void> saveTokens({required TokenData data, required String dataDirectory}) async {
+  final filePath = tokenPath(dataDirectory: dataDirectory);
+  final dir = Directory(filePath).parent;
 
   // Create directory with restricted permissions (0o700 on Unix)
   await dir.create(recursive: true);
@@ -93,17 +93,16 @@ Future<void> saveTokens(TokenData data) async {
   final formatted = const JsonEncoder.withIndent('  ').convert(data.toJson());
 
   // Write file then restrict permissions (0o600 on Unix)
-  await File(path).writeAsString(formatted);
+  await File(filePath).writeAsString(formatted);
   if (!Platform.isWindows) {
-    await Process.run('chmod', ['600', path]);
+    await Process.run('chmod', ['600', filePath]);
   }
 }
 
 /// Loads the token data from the token file.
 /// Throws FileSystemException if the file does not exist.
-Future<TokenData> loadTokens() async {
-  final path = tokenPath();
-  final file = File(path);
+Future<TokenData> loadTokens({required String dataDirectory}) async {
+  final file = File(tokenPath(dataDirectory: dataDirectory));
 
   try {
     final content = await file.readAsString();
@@ -116,9 +115,8 @@ Future<TokenData> loadTokens() async {
 
 /// Clears the token file by deleting it.
 /// Does not throw an error if the file does not exist.
-Future<void> clearTokens() async {
-  final path = tokenPath();
-  final file = File(path);
+Future<void> clearTokens({required String dataDirectory}) async {
+  final file = File(tokenPath(dataDirectory: dataDirectory));
 
   if (file.existsSync()) {
     await file.delete();

--- a/bridge/app/lib/src/bridge/runtime/bridge_cli_options.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_cli_options.dart
@@ -1,3 +1,5 @@
+import "dart:io" show Directory, FileSystemEntity, FileSystemEntityType;
+
 import "package:args/args.dart" show ArgParserException, ArgResults;
 import "package:path/path.dart" as path;
 
@@ -83,7 +85,18 @@ class BridgeCliOptions {
     required String dataDirectory,
     required String defaultDataDirectory,
   }) {
-    return path.equals(dataDirectory, defaultDataDirectory);
+    return path.equals(
+      _dataDirectoryIdentity(dataDirectory),
+      _dataDirectoryIdentity(defaultDataDirectory),
+    );
+  }
+
+  static String _dataDirectoryIdentity(String dataDirectory) {
+    final normalized = path.normalize(path.absolute(dataDirectory));
+    if (FileSystemEntity.typeSync(normalized, followLinks: true) == FileSystemEntityType.notFound) {
+      return normalized;
+    }
+    return Directory(normalized).resolveSymbolicLinksSync();
   }
 
   /// Resolves the auth backend URL from the CLI flag, the

--- a/bridge/app/lib/src/bridge/runtime/bridge_cli_options.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_cli_options.dart
@@ -45,13 +45,10 @@ class BridgeCliOptions {
       defaultAuthUrl: defaultAuthUrl,
     );
     final debugPortRaw = results["debug-port"] as String;
-    final dataDirectoryRaw = results["data-dir"] as String?;
-    if (dataDirectoryRaw != null && dataDirectoryRaw.trim().isEmpty) {
-      throw ArgParserException("--data-dir must not be empty.");
-    }
-    final dataDirectory = dataDirectoryRaw == null
-        ? defaultDataDirectory
-        : path.normalize(path.absolute(dataDirectoryRaw));
+    final dataDirectory = resolveDataDirectory(
+      dataDirectoryFlag: results["data-dir"] as String?,
+      defaultDataDirectory: defaultDataDirectory,
+    );
 
     // Supervised-only option: trim and treat blank as absent. Do NOT validate
     // it here (no URI parse) — strict parse-time validation would risk failing
@@ -69,6 +66,24 @@ class BridgeCliOptions {
       importPluginIds: List.unmodifiable(results["import-plugin"] as List<String>),
       controlUrl: controlUrl,
     );
+  }
+
+  static String resolveDataDirectory({
+    required String? dataDirectoryFlag,
+    required String defaultDataDirectory,
+  }) {
+    if (dataDirectoryFlag == null) return defaultDataDirectory;
+    if (dataDirectoryFlag.trim().isEmpty) {
+      throw ArgParserException("--data-dir must not be empty.");
+    }
+    return path.normalize(path.absolute(dataDirectoryFlag));
+  }
+
+  static bool isDefaultDataDirectory({
+    required String dataDirectory,
+    required String defaultDataDirectory,
+  }) {
+    return path.equals(dataDirectory, defaultDataDirectory);
   }
 
   /// Resolves the auth backend URL from the CLI flag, the

--- a/bridge/app/lib/src/bridge/runtime/bridge_cli_options.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_cli_options.dart
@@ -1,9 +1,11 @@
-import "package:args/args.dart" show ArgResults;
+import "package:args/args.dart" show ArgParserException, ArgResults;
+import "package:path/path.dart" as path;
 
 class BridgeCliOptions {
   final List<String> cliArgs;
   final String relayUrl;
   final String authBackendUrl;
+  final String dataDirectory;
   final int? debugPort;
   final String logLevelName;
   final List<String> importPluginIds;
@@ -16,6 +18,7 @@ class BridgeCliOptions {
     required this.cliArgs,
     required this.relayUrl,
     required this.authBackendUrl,
+    required this.dataDirectory,
     required this.debugPort,
     required this.logLevelName,
     required this.importPluginIds,
@@ -33,6 +36,7 @@ class BridgeCliOptions {
     required ArgResults results,
     required Map<String, String> environment,
     required String defaultAuthUrl,
+    required String defaultDataDirectory,
   }) {
     final authBackendFlag = results["auth-backend"] as String;
     final authBackendUrl = resolveAuthBackendUrl(
@@ -41,6 +45,13 @@ class BridgeCliOptions {
       defaultAuthUrl: defaultAuthUrl,
     );
     final debugPortRaw = results["debug-port"] as String;
+    final dataDirectoryRaw = results["data-dir"] as String?;
+    if (dataDirectoryRaw != null && dataDirectoryRaw.trim().isEmpty) {
+      throw ArgParserException("--data-dir must not be empty.");
+    }
+    final dataDirectory = dataDirectoryRaw == null
+        ? defaultDataDirectory
+        : path.normalize(path.absolute(dataDirectoryRaw));
 
     // Supervised-only option: trim and treat blank as absent. Do NOT validate
     // it here (no URI parse) — strict parse-time validation would risk failing
@@ -52,6 +63,7 @@ class BridgeCliOptions {
       cliArgs: cliArgs,
       relayUrl: results["relay"] as String,
       authBackendUrl: authBackendUrl,
+      dataDirectory: dataDirectory,
       debugPort: debugPortRaw.isNotEmpty ? int.tryParse(debugPortRaw) : null,
       logLevelName: results["log-level"] as String,
       importPluginIds: List.unmodifiable(results["import-plugin"] as List<String>),

--- a/bridge/app/lib/src/bridge/runtime/bridge_logout_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_logout_runner.dart
@@ -57,44 +57,35 @@ class BridgeLogoutRunner {
   final AppOnboardingStateRepository _appOnboardingStateRepository;
   final Future<void> Function() _clearTokens;
 
-  Future<BridgeLogoutResult> logout({required int currentPid}) async {
-    final existingBridges = await _bridgeInstanceRepository.listLiveBridgeCandidates(currentPid: currentPid);
-
+  Future<BridgeLogoutResult> logout({
+    required int currentPid,
+    required bool manageRunningBridges,
+  }) async {
     var runningBridgeCount = 0;
-    if (existingBridges.isNotEmpty) {
-      final decision = await _terminalPromptRepository.askStopBridgesBeforeLogout(
-        bridgeCount: existingBridges.length,
-      );
-      switch (decision) {
-        case TerminalPromptDecision.decline:
-          return BridgeLogoutResult(
-            status: BridgeLogoutStatus.cancelled,
-            runningBridgeCount: existingBridges.length,
-          );
-        case TerminalPromptDecision.nonInteractive:
-          runningBridgeCount = existingBridges.length;
-        case TerminalPromptDecision.replace:
-          final terminatedBridges = await _bridgeInstanceService.terminateBridges(
-            currentPid: currentPid,
-            existingBridges: existingBridges,
-          );
-          runningBridgeCount = existingBridges.length - terminatedBridges.length;
+    if (manageRunningBridges) {
+      final existingBridges = await _bridgeInstanceRepository.listLiveBridgeCandidates(currentPid: currentPid);
+      if (existingBridges.isNotEmpty) {
+        final decision = await _terminalPromptRepository.askStopBridgesBeforeLogout(
+          bridgeCount: existingBridges.length,
+        );
+        switch (decision) {
+          case TerminalPromptDecision.decline:
+            return BridgeLogoutResult(
+              status: BridgeLogoutStatus.cancelled,
+              runningBridgeCount: existingBridges.length,
+            );
+          case TerminalPromptDecision.nonInteractive:
+            runningBridgeCount = existingBridges.length;
+          case TerminalPromptDecision.replace:
+            final terminatedBridges = await _bridgeInstanceService.terminateBridges(
+              currentPid: currentPid,
+              existingBridges: existingBridges,
+            );
+            runningBridgeCount = existingBridges.length - terminatedBridges.length;
+        }
       }
     }
 
-    return _clearStoredState(runningBridgeCount: runningBridgeCount);
-  }
-
-  /// Clears one custom data directory after its source-run bridge has stopped.
-  ///
-  /// Source-run bridges are not part of native bridge process discovery. This
-  /// path therefore skips host-wide termination so logging out a test account
-  /// cannot stop an unrelated packaged bridge.
-  Future<BridgeLogoutResult> logoutStoppedBridge() {
-    return _clearStoredState(runningBridgeCount: 0);
-  }
-
-  Future<BridgeLogoutResult> _clearStoredState({required int runningBridgeCount}) async {
     try {
       await _appOnboardingStateRepository.clearAll();
     } on Object catch (error) {

--- a/bridge/app/lib/src/bridge/runtime/bridge_logout_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_logout_runner.dart
@@ -82,6 +82,19 @@ class BridgeLogoutRunner {
       }
     }
 
+    return _clearStoredState(runningBridgeCount: runningBridgeCount);
+  }
+
+  /// Clears one custom data directory after its source-run bridge has stopped.
+  ///
+  /// Source-run bridges are not part of native bridge process discovery. This
+  /// path therefore skips host-wide termination so logging out a test account
+  /// cannot stop an unrelated packaged bridge.
+  Future<BridgeLogoutResult> logoutStoppedBridge() {
+    return _clearStoredState(runningBridgeCount: 0);
+  }
+
+  Future<BridgeLogoutResult> _clearStoredState({required int runningBridgeCount}) async {
     try {
       await _appOnboardingStateRepository.clearAll();
     } on Object catch (error) {

--- a/bridge/app/lib/src/bridge/runtime/bridge_logout_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_logout_runner.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Log;
 
-import '../../auth/token.dart' as token_store;
 import '../../repositories/app_onboarding_state_repository.dart';
 import '../../server/foundation/terminal_prompt_decision.dart';
 import '../../server/repositories/bridge_instance_repository.dart';
@@ -43,7 +42,7 @@ class BridgeLogoutRunner {
     required TerminalPromptRepository terminalPromptRepository,
     required Future<void> Function() unregisterBridge,
     required AppOnboardingStateRepository appOnboardingStateRepository,
-    Future<void> Function() clearTokens = token_store.clearTokens,
+    required Future<void> Function() clearTokens,
   }) : _bridgeInstanceRepository = bridgeInstanceRepository,
        _bridgeInstanceService = bridgeInstanceService,
        _terminalPromptRepository = terminalPromptRepository,

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -330,16 +330,21 @@ class BridgeRuntimeRunner {
         browserOpenability: detectBrowserOpenability,
       ),
       environment: environment,
-      loadTokens: loadTokens,
-      saveTokens: saveTokens,
-      clearTokens: clearTokens,
+      loadTokens: () => loadTokens(dataDirectory: options.dataDirectory),
+      saveTokens: (data) => saveTokens(
+        data: data,
+        dataDirectory: options.dataDirectory,
+      ),
+      clearTokens: () => clearTokens(dataDirectory: options.dataDirectory),
     );
 
     // Persisted bridge-id storage (its own file, not token.json). Constructed
     // here so the supervised registration service below can share it; the
     // legacy-id migration that populates it still runs at its normal point
     // before authentication.
-    final bridgeIdStorage = BridgeIdStorage(filePath: bridgeIdPath());
+    final bridgeIdStorage = BridgeIdStorage(
+      filePath: bridgeIdPath(dataDirectory: options.dataDirectory),
+    );
 
     try {
       // Copy a legacy bridge id out of token.json into its own storage before
@@ -352,7 +357,9 @@ class BridgeRuntimeRunner {
       // the legacy source still intact.
       await BridgeIdMigrationService(
         bridgeIdStorage: bridgeIdStorage,
-        readLegacyBridgeId: readLegacyBridgeId,
+        readLegacyBridgeId: () => readLegacyBridgeId(
+          dataDirectory: options.dataDirectory,
+        ),
       ).migrate();
 
       // Supervised mode (desktop GUI): bring up the loopback control channel
@@ -543,8 +550,11 @@ class BridgeRuntimeRunner {
         final tokenManager = TokenManager(
           initialToken: authAccessToken,
           authBackendUrl: options.authBackendUrl,
-          loadTokens: loadTokens,
-          saveTokens: saveTokens,
+          loadTokens: () => loadTokens(dataDirectory: options.dataDirectory),
+          saveTokens: (data) => saveTokens(
+            data: data,
+            dataDirectory: options.dataDirectory,
+          ),
         );
         shutdownCoordinator.add(disposable: tokenManager.dispose);
         accessTokenProvider = tokenManager;
@@ -683,7 +693,11 @@ class BridgeRuntimeRunner {
             ),
           ),
           stateRepository: AppOnboardingStateRepository(
-            storage: AppOnboardingStateStorage(directoryPath: appOnboardingStateDirectoryPath()),
+            storage: AppOnboardingStateStorage(
+              directoryPath: appOnboardingStateDirectoryPath(
+                dataDirectory: options.dataDirectory,
+              ),
+            ),
           ),
           formatter: AppOnboardingFormatter(out: io.stdout, environment: environment),
           tokenRefresher: tokenRefresher,
@@ -808,7 +822,9 @@ class BridgeRuntimeRunner {
         Log.w("Startup diagnostics failed; continuing without a degraded-access warning", error, stackTrace);
       }
 
-      final database = AppDatabase.create();
+      final database = AppDatabase.create(
+        dataDirectory: options.dataDirectory,
+      );
       final failureReporter = LogFailureReporter();
       final composition = Orchestrator(
         config: BridgeConfig(

--- a/bridge/app/test/api/app_onboarding_state_storage_test.dart
+++ b/bridge/app/test/api/app_onboarding_state_storage_test.dart
@@ -5,6 +5,13 @@ import "package:sesori_bridge/src/api/app_onboarding_state_storage.dart";
 import "package:test/test.dart";
 
 void main() {
+  test("derives the marker directory from the supplied data directory", () {
+    expect(
+      appOnboardingStateDirectoryPath(dataDirectory: path.join("root", "account-a")),
+      path.join("root", "account-a", "app_onboarding"),
+    );
+  });
+
   group("AppOnboardingStateStorage", () {
     late Directory temporaryDirectory;
     late String markerDirectory;

--- a/bridge/app/test/auth/token_test.dart
+++ b/bridge/app/test/auth/token_test.dart
@@ -1,3 +1,6 @@
+import "dart:io";
+
+import "package:path/path.dart" as path;
 import "package:sesori_bridge/src/auth/token.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -63,6 +66,54 @@ void main() {
         }),
         throwsA(isA<FormatException>()),
       );
+    });
+  });
+
+  group("token persistence", () {
+    late Directory temporaryDirectory;
+
+    setUp(() async {
+      temporaryDirectory = await Directory.systemTemp.createTemp("sesori-token-test-");
+    });
+
+    tearDown(() {
+      if (temporaryDirectory.existsSync()) {
+        temporaryDirectory.deleteSync(recursive: true);
+      }
+    });
+
+    test("keeps credentials and bridge identity paths inside the supplied root", () {
+      expect(
+        tokenPath(dataDirectory: temporaryDirectory.path),
+        path.join(temporaryDirectory.path, "token.json"),
+      );
+      expect(
+        bridgeIdPath(dataDirectory: temporaryDirectory.path),
+        path.join(temporaryDirectory.path, "bridge_id"),
+      );
+    });
+
+    test("reads, writes, and clears only the supplied root", () async {
+      final firstRoot = path.join(temporaryDirectory.path, "first");
+      final secondRoot = path.join(temporaryDirectory.path, "second");
+      final data = TokenData(
+        accessToken: "access-token",
+        refreshToken: "refresh-token",
+        lastProvider: AuthProvider.github,
+      );
+
+      await saveTokens(data: data, dataDirectory: firstRoot);
+
+      expect(File(tokenPath(dataDirectory: firstRoot)).existsSync(), isTrue);
+      expect(File(tokenPath(dataDirectory: secondRoot)).existsSync(), isFalse);
+      final restored = await loadTokens(dataDirectory: firstRoot);
+      expect(restored.accessToken, data.accessToken);
+      expect(restored.refreshToken, data.refreshToken);
+      expect(restored.lastProvider, data.lastProvider);
+
+      await clearTokens(dataDirectory: firstRoot);
+
+      expect(File(tokenPath(dataDirectory: firstRoot)).existsSync(), isFalse);
     });
   });
 }

--- a/bridge/app/test/bridge/runtime/bridge_cli_options_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_cli_options_test.dart
@@ -1,4 +1,5 @@
 import "package:args/args.dart";
+import "package:path/path.dart" as path;
 import "package:sesori_bridge/src/bridge/runtime/bridge_cli_options.dart";
 import "package:test/test.dart";
 
@@ -25,6 +26,30 @@ void main() {
     final options = _parseOptions(args: ["--debug-port", "8080"]);
 
     expect(options.debugPort, 8080);
+  });
+
+  group("data directory", () {
+    test("uses the canonical default when the flag is absent", () {
+      final options = _parseOptions(args: const []);
+
+      expect(options.dataDirectory, "/default/sesori-data");
+    });
+
+    test("normalizes an explicit path to an absolute path", () {
+      final options = _parseOptions(args: const ["--data-dir", "relative-data"]);
+
+      expect(
+        options.dataDirectory,
+        path.normalize(path.absolute("relative-data")),
+      );
+    });
+
+    test("rejects an empty explicit path", () {
+      expect(
+        () => _parseOptions(args: const ["--data-dir", "   "]),
+        throwsA(isA<ArgParserException>()),
+      );
+    });
   });
 
   test("import plugin values retain order and duplicates", () {
@@ -83,6 +108,7 @@ BridgeCliOptions _parseOptions({required List<String> args}) {
   final parser = ArgParser()
     ..addOption("relay", defaultsTo: "wss://relay.sesori.com")
     ..addOption("auth-backend", defaultsTo: "")
+    ..addOption("data-dir")
     ..addMultiOption("import-plugin")
     ..addOption("debug-port", defaultsTo: "")
     ..addOption(
@@ -98,5 +124,6 @@ BridgeCliOptions _parseOptions({required List<String> args}) {
     results: results,
     environment: const {},
     defaultAuthUrl: "https://api.sesori.com",
+    defaultDataDirectory: "/default/sesori-data",
   );
 }

--- a/bridge/app/test/bridge/runtime/bridge_cli_options_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_cli_options_test.dart
@@ -1,3 +1,5 @@
+import "dart:io";
+
 import "package:args/args.dart";
 import "package:path/path.dart" as path;
 import "package:sesori_bridge/src/bridge/runtime/bridge_cli_options.dart";
@@ -61,16 +63,17 @@ void main() {
       );
     });
 
-    test("recognizes an explicitly resolved canonical directory as the default", () {
-      final explicitDefault = BridgeCliOptions.resolveDataDirectory(
-        dataDirectoryFlag: "/default/other/../sesori-data/.",
-        defaultDataDirectory: "/default/sesori-data",
-      );
+    test("recognizes a symlink to the canonical directory as the default", () async {
+      if (Platform.isWindows) return;
+      final temporaryDirectory = await Directory.systemTemp.createTemp("sesori-data-alias-test-");
+      addTearDown(() => temporaryDirectory.delete(recursive: true));
+      final defaultDirectory = Directory(path.join(temporaryDirectory.path, "default"))..createSync();
+      final alias = Link(path.join(temporaryDirectory.path, "alias"))..createSync(defaultDirectory.path);
 
       expect(
         BridgeCliOptions.isDefaultDataDirectory(
-          dataDirectory: explicitDefault,
-          defaultDataDirectory: "/default/sesori-data",
+          dataDirectory: alias.path,
+          defaultDataDirectory: defaultDirectory.path,
         ),
         isTrue,
       );

--- a/bridge/app/test/bridge/runtime/bridge_cli_options_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_cli_options_test.dart
@@ -50,6 +50,31 @@ void main() {
         throwsA(isA<ArgParserException>()),
       );
     });
+
+    test("can be resolved independently for another command", () {
+      expect(
+        BridgeCliOptions.resolveDataDirectory(
+          dataDirectoryFlag: "relative-logout-data",
+          defaultDataDirectory: "/default/sesori-data",
+        ),
+        path.normalize(path.absolute("relative-logout-data")),
+      );
+    });
+
+    test("recognizes an explicitly resolved canonical directory as the default", () {
+      final explicitDefault = BridgeCliOptions.resolveDataDirectory(
+        dataDirectoryFlag: "/default/other/../sesori-data/.",
+        defaultDataDirectory: "/default/sesori-data",
+      );
+
+      expect(
+        BridgeCliOptions.isDefaultDataDirectory(
+          dataDirectory: explicitDefault,
+          defaultDataDirectory: "/default/sesori-data",
+        ),
+        isTrue,
+      );
+    });
   });
 
   test("import plugin values retain order and duplicates", () {

--- a/bridge/app/test/bridge/runtime/bridge_logout_runner_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_logout_runner_test.dart
@@ -71,6 +71,20 @@ void main() {
       expect(bridgeInstanceService.terminateRequests, isEmpty);
     });
 
+    test('stopped-bridge logout skips host-wide process handling', () async {
+      bridgeInstanceRepository.liveBridges = <ProcessIdentity>[_candidate(pid: 200)];
+
+      final result = await service.logoutStoppedBridge();
+
+      expect(result.status, equals(BridgeLogoutStatus.loggedOut));
+      expect(clearTokensCalls, equals(1));
+      expect(appOnboardingStateRepository.clearCalls, equals(1));
+      expect(unregisterBridgeCalls, equals(1));
+      expect(bridgeInstanceRepository.listCalls, equals(0));
+      expect(terminalPromptRepository.askCount, equals(0));
+      expect(bridgeInstanceService.terminateRequests, isEmpty);
+    });
+
     test('decline keeps tokens and does not terminate bridges', () async {
       bridgeInstanceRepository.liveBridges = <ProcessIdentity>[_candidate(pid: 200)];
       terminalPromptRepository.decision = TerminalPromptDecision.decline;
@@ -224,9 +238,11 @@ ProcessIdentity _candidate({required int pid}) {
 
 class _FakeBridgeInstanceRepository implements BridgeInstanceRepository {
   List<ProcessIdentity> liveBridges = <ProcessIdentity>[];
+  int listCalls = 0;
 
   @override
   Future<List<ProcessIdentity>> listLiveBridgeCandidates({required int currentPid}) async {
+    listCalls += 1;
     return liveBridges;
   }
 }

--- a/bridge/app/test/bridge/runtime/bridge_logout_runner_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_logout_runner_test.dart
@@ -61,7 +61,7 @@ void main() {
     });
 
     test('clears tokens without prompting when no bridge is running', () async {
-      final result = await service.logout(currentPid: 100);
+      final result = await service.logout(currentPid: 100, manageRunningBridges: true);
 
       expect(result.status, equals(BridgeLogoutStatus.loggedOut));
       expect(result.runningBridgeCount, equals(0));
@@ -71,10 +71,10 @@ void main() {
       expect(bridgeInstanceService.terminateRequests, isEmpty);
     });
 
-    test('stopped-bridge logout skips host-wide process handling', () async {
+    test('skips host-wide process handling when it is disabled', () async {
       bridgeInstanceRepository.liveBridges = <ProcessIdentity>[_candidate(pid: 200)];
 
-      final result = await service.logoutStoppedBridge();
+      final result = await service.logout(currentPid: 100, manageRunningBridges: false);
 
       expect(result.status, equals(BridgeLogoutStatus.loggedOut));
       expect(clearTokensCalls, equals(1));
@@ -89,7 +89,7 @@ void main() {
       bridgeInstanceRepository.liveBridges = <ProcessIdentity>[_candidate(pid: 200)];
       terminalPromptRepository.decision = TerminalPromptDecision.decline;
 
-      final result = await service.logout(currentPid: 100);
+      final result = await service.logout(currentPid: 100, manageRunningBridges: true);
 
       expect(result.status, equals(BridgeLogoutStatus.cancelled));
       expect(result.runningBridgeCount, equals(1));
@@ -105,7 +105,7 @@ void main() {
       ];
       terminalPromptRepository.decision = TerminalPromptDecision.nonInteractive;
 
-      final result = await service.logout(currentPid: 100);
+      final result = await service.logout(currentPid: 100, manageRunningBridges: true);
 
       expect(result.status, equals(BridgeLogoutStatus.loggedOutWithRunningBridges));
       expect(result.runningBridgeCount, equals(2));
@@ -120,7 +120,7 @@ void main() {
       terminalPromptRepository.decision = TerminalPromptDecision.replace;
       bridgeInstanceService.terminatedBridges = <ProcessIdentity>[bridge];
 
-      final result = await service.logout(currentPid: 100);
+      final result = await service.logout(currentPid: 100, manageRunningBridges: true);
 
       expect(result.status, equals(BridgeLogoutStatus.loggedOut));
       expect(result.runningBridgeCount, equals(0));
@@ -137,7 +137,7 @@ void main() {
       terminalPromptRepository.decision = TerminalPromptDecision.replace;
       bridgeInstanceService.terminatedBridges = <ProcessIdentity>[first];
 
-      final result = await service.logout(currentPid: 100);
+      final result = await service.logout(currentPid: 100, manageRunningBridges: true);
 
       expect(result.status, equals(BridgeLogoutStatus.loggedOutWithRunningBridges));
       expect(result.runningBridgeCount, equals(1));
@@ -147,7 +147,7 @@ void main() {
     test('reports failure when clearing tokens throws', () async {
       clearTokensError = const FileSystemException('cannot delete token file');
 
-      final result = await service.logout(currentPid: 100);
+      final result = await service.logout(currentPid: 100, manageRunningBridges: true);
 
       expect(result.status, equals(BridgeLogoutStatus.failed));
       expect(result.error, equals(clearTokensError));
@@ -157,7 +157,7 @@ void main() {
       const error = FileSystemException('cannot delete onboarding state');
       appOnboardingStateRepository.clearError = error;
 
-      final result = await service.logout(currentPid: 100);
+      final result = await service.logout(currentPid: 100, manageRunningBridges: true);
 
       expect(result.status, equals(BridgeLogoutStatus.failed));
       expect(result.error, same(error));
@@ -167,7 +167,7 @@ void main() {
     });
 
     test('unregisters the bridge before clearing tokens', () async {
-      final result = await service.logout(currentPid: 100);
+      final result = await service.logout(currentPid: 100, manageRunningBridges: true);
 
       expect(result.status, equals(BridgeLogoutStatus.loggedOut));
       expect(unregisterBridgeCalls, equals(1));
@@ -180,7 +180,7 @@ void main() {
     test('still clears tokens when unregistering the bridge fails', () async {
       unregisterBridgeError = Exception('auth server unreachable');
 
-      final result = await service.logout(currentPid: 100);
+      final result = await service.logout(currentPid: 100, manageRunningBridges: true);
 
       expect(result.status, equals(BridgeLogoutStatus.loggedOut));
       expect(unregisterBridgeCalls, equals(1));
@@ -191,7 +191,7 @@ void main() {
       bridgeInstanceRepository.liveBridges = <ProcessIdentity>[_candidate(pid: 200)];
       terminalPromptRepository.decision = TerminalPromptDecision.decline;
 
-      final result = await service.logout(currentPid: 100);
+      final result = await service.logout(currentPid: 100, manageRunningBridges: true);
 
       expect(result.status, equals(BridgeLogoutStatus.cancelled));
       expect(unregisterBridgeCalls, equals(0));

--- a/bridge/app/test/bridge/runtime/bridge_runtime_auth_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_auth_test.dart
@@ -142,6 +142,7 @@ BridgeCliOptions _options({required String authBackendUrl}) {
     cliArgs: const [],
     relayUrl: 'wss://relay.example.com',
     authBackendUrl: authBackendUrl,
+    dataDirectory: '/tmp/sesori-test-data',
     debugPort: null,
     logLevelName: 'info',
     importPluginIds: const [],

--- a/bridge/app/test/persistence/database_path_test.dart
+++ b/bridge/app/test/persistence/database_path_test.dart
@@ -1,0 +1,26 @@
+import "dart:io";
+
+import "package:path/path.dart" as path;
+import "package:sesori_bridge/src/api/database/database.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("creates the database inside the supplied data directory", () async {
+    final temporaryDirectory = await Directory.systemTemp.createTemp("sesori-database-path-test-");
+    addTearDown(() async {
+      if (temporaryDirectory.existsSync()) {
+        await temporaryDirectory.delete(recursive: true);
+      }
+    });
+    final dataDirectory = path.join(temporaryDirectory.path, "account-a");
+    final database = AppDatabase.create(dataDirectory: dataDirectory);
+
+    try {
+      await database.customSelect("SELECT 1").getSingle();
+    } finally {
+      await database.close();
+    }
+
+    expect(File(path.join(dataDirectory, "sesori.db")).existsSync(), isTrue);
+  });
+}

--- a/bridge/app/test/persistence/database_path_test.dart
+++ b/bridge/app/test/persistence/database_path_test.dart
@@ -22,5 +22,9 @@ void main() {
     }
 
     expect(File(path.join(dataDirectory, "sesori.db")).existsSync(), isTrue);
+    if (!Platform.isWindows) {
+      expect(FileStat.statSync(dataDirectory).mode & 0x1ff, equals(0x1c0));
+      expect(FileStat.statSync(path.join(dataDirectory, "sesori.db")).mode & 0x1ff, equals(0x180));
+    }
   });
 }


### PR DESCRIPTION
## Summary
- add `run --data-dir <path>` for source-run multi-account bridge testing
- inject the selected root into tokens, bridge identity and migration, onboarding markers, and the Drift database while preserving the existing default layout
- add `logout --data-dir <path>` through the existing logout entrypoint without weakening host-wide native bridge lifecycle safeguards
- secure selected data roots as `0700` and the main SQLite database as `0600` on Unix
- keep bridge settings, plugin runtime ownership, the startup mutex, updater state, backend credentials, and native single-live enforcement host-wide
- document the parallel testing workflow and cover CLI parsing plus file-backed state isolation

## Testing
- `dart test test/bridge/runtime/bridge_cli_options_test.dart test/bridge/runtime/bridge_runtime_auth_test.dart test/api/app_onboarding_state_storage_test.dart test/auth/token_test.dart test/persistence/database_path_test.dart test/bridge/runtime/bridge_logout_runner_test.dart`
- `dart analyze --fatal-infos`
- `dart run bin/bridge.dart run --help`
- `dart run bin/bridge.dart logout --data-dir <temporary-path> --auth-backend http://127.0.0.1:1`

## Review
- initial Aristotle architecture implementation review approved with no findings
- follow-up logout-scope review finding addressed before push
