### PR TITLE
feat(bridge): add generation-scoped plugin runtime

### DIFF
--- a/.plan/active/setup-aware-plugin-lifecycle/PLAN.md
+++ b/.plan/active/setup-aware-plugin-lifecycle/PLAN.md
@@ -3,11 +3,13 @@
 ## Status
 
 - **Plan slug:** `setup-aware-plugin-lifecycle`
-- **Status:** redesign approved; implementation stack is being rebuilt
-- **Implementation base:** latest `origin/main` at `5a91f582`
+- **Status:** Stage 10 merged; oversized Stage 11-P01 is frozen and being
+  replaced by four reviewable stacked PRs
+- **Implementation base:** latest `origin/main` at `583748ab`
 - **Predecessor:** parallel-plugin Stages 0-9 and bridge-app-onboarding W02 are merged
-- **Delivery:** five stacked PRs; the old unmerged PRs #507-#511 are closed and
-  are reopened only after their replacement stage is implemented and verified
+- **Delivery:** Stage 11-P01 is split into runtime mechanics, operation routing,
+  dynamic events/durable fencing, and bridge-owned projects/default behavior;
+  the later dormancy, management, and client stages are rebuilt on that stack
 
 This plan replaces the first unmerged implementation. Nothing introduced only
 by that implementation needs compatibility handling. Released contracts still
@@ -69,7 +71,8 @@ available:
 
 - All plugin lists use case-insensitive display-name order with plugin ID as the
   deterministic tie-breaker.
-- The bridge default is the first currently selectable plugin in that order.
+- The bridge default prefers OpenCode when it is selectable, then falls back to
+  the first currently selectable plugin in that order.
 - No default or last-used plugin is persisted by the bridge.
 - The mobile new-session chooser persists last-used plugin per client and
   bridge. It uses that plugin when still routable and otherwise uses the
@@ -233,8 +236,10 @@ full CLI parser registers every plugin option
 ```
 
 The onboarding checkpoint remains standalone/interactive and no longer depends
-on at least one usable plugin. Project operations that still require a default
-return the existing typed unavailable response when none exists.
+on at least one usable plugin. Aggregate projects are bridge-owned and may
+contain sessions from multiple plugins. Project create/open/rename use only the
+durable bridge catalog and local filesystem; they never select, start, acquire,
+or call a plugin.
 
 ### Runtime boundary
 
@@ -251,8 +256,10 @@ revision, and lifecycle snapshots. `BridgeRuntimeRunner` remains the Layer-5
 composer. `Orchestrator` owns management SSE emission and dynamic backend-event
 routing.
 
-Every plugin-backed operation uses `PluginRuntime.use`, `useStream`, or
-`useIfActive`. Catalog-only reads never acquire. Aggregate status reads inspect
+Every plugin-backed operation uses `PluginRuntime.use`, `useAndCommit`,
+`useStream`, or `useIfActive`. `useAndCommit` keeps backend preparation
+interruptible, then protects its short durable commit from generation
+replacement. Catalog-only reads never acquire. Aggregate status reads inspect
 active generations only. A generation result or event is accepted only while
 its captured generation remains current.
 
@@ -282,28 +289,33 @@ Stage 11-P02 adds the shared `BridgeSettingsRepository` and `ServerClock` when
 idle policy first needs them. `BridgeRuntimeRunner` constructs every owner and
 injects the same instances into `Orchestrator` and `DebugServer`.
 
-The Stage 11-P01 method migration is complete before the branch is done:
+The Stage 11-P01 replacement stack completes this method migration:
 
 | Consumer | Acquisition |
 |---|---|
-| `SessionRepository` concrete backend operations | `use` the request or persisted binding's plugin; durable writes occur only after a current-generation result. |
+| `SessionRepository` concrete backend operations | `use` the request or persisted binding's plugin; session creation uses `useAndCommit` so generation replacement cannot split backend creation from its durable binding commit. |
 | `SessionRepository` aggregate activity/status reads | `useIfActive`; never wake every plugin. |
-| `ProjectRepository` open/rename | `use` the live nullable derived default; missing default remains typed unavailable. |
+| `ProjectRepository` create/open/rename | No plugin acquisition; use the durable bridge catalog and local filesystem only. |
+| `ProjectActivityRepository` reconciliation | `useIfActive` for the explicitly reconciled plugin source; plugin observations are evidence for bridge-owned aggregates. |
 | `AgentRepository`, `ProviderRepository` | `use` the explicit plugin ID. |
 | `QuestionRepository`, `PermissionRepository` | `use` the persisted session binding; aggregate project questions use active generations only. |
 | `WorktreeRepository` backend cleanup | observable best-effort `use` after git success; its future retains the lease and logs recovered failure. |
 | `CatalogImportRepository` | `useStream` for enumeration through atomic publication/cancellation. |
 | `PluginEventListener`, `SessionEventDispatcher` | one generation-attributed runtime event stream; no startup API-map subscriptions. |
 
-Stage 11-P01 is independently coherent: every eligible setup-ready plugin still
-starts eagerly and remains resident, matching Stage 10 while all backend access
-and events move behind the dynamic boundary. Stage 11-P02 alone switches initial
-residency to dormant and enables idle stop.
+Across the Stage 11-P01 replacement stack every eligible setup-ready plugin
+still starts eagerly and remains resident, matching Stage 10 while backend
+access and events move behind the dynamic boundary. The first slice adds the
+tested runtime kernel without activating it. The operation-routing slice then
+uses a narrow stack-local live API view only for consumers not migrated yet;
+the dynamic-event and bridge-owned-project slices remove that view completely.
+It is not a released compatibility contract. Stage 11-P02 alone switches
+initial residency to dormant and enables idle stop.
 
 The exact operation path is:
 
 ```text
-handler -> service -> owning repository -> PluginRuntime.use/useStream
+handler -> service -> owning repository -> PluginRuntime.use/useAndCommit/useStream
   -> per-plugin transition lock checks eligibility and setup
   -> join or start one generation
   -> increment lease before API escapes the lock
@@ -311,6 +323,12 @@ handler -> service -> owning repository -> PluginRuntime.use/useStream
   -> verify captured generation before accepting result/publication
   -> release lease in finally/cancel/error
 ```
+
+For a backend result that must be durably bound, `useAndCommit` splits the body
+into interruptible preparation and a short protected commit. Force stop and
+terminal retirement fence new acquisitions, wait for an entered commit, then
+replace the generation; if replacement wins before commit entry, no durable
+write starts.
 
 The exact stop/replace path is:
 
@@ -530,16 +548,36 @@ the listed source files and committed with their stage.
 | Bridge config/CLI | `bridge/app/bin/bridge.dart`; `bridge_settings.dart`, `bridge_settings_repository.dart`; `bridge_config_service.dart`; `plugin_registry.dart`, `plugin_cli_options_mapper.dart`, `bridge_cli_options.dart`. Delete `plugin_bootstrap_selection.dart`. |
 | Bridge startup/policy/routes | `bridge_runtime_runner.dart`, `plugin_lifecycle_service.dart`, `orchestrator.dart`, `project_repository.dart`, `catalog_import_service.dart`, `get_plugin_setup_handler.dart`, `get_plugins_handler.dart`. |
 
-### Stage 11-P01 / PR #508 files
+### Stage 11-P01A — runtime mechanics files
 
 | Workspace | Production files/classes |
 |---|---|
-| Mechanical runtime | Add concrete `plugin_generation_factory.dart`, `plugin_runtime.dart`, and `plugin_lifecycle_repository.dart`; modify `bridge_runtime_runner.dart` and `plugin_lifecycle_service.dart`. |
-| Event composition | `orchestrator.dart`, `plugin_event_listener.dart`, `session_event_dispatcher.dart`, `bridge_runtime.dart`. |
-| Plugin-backed repositories | `session_repository.dart`, `project_repository.dart`, `agent_repository.dart`, `provider_repository.dart`, `question_repository.dart`, `permission_repository.dart`, `worktree_repository.dart`, `catalog_import_repository.dart`. |
-| Owning services | `session_creation_service.dart`, `session_lifecycle_service.dart`, `permission_auto_approval_service.dart`, `project_activity_service.dart`, `catalog_import_service.dart`. |
+| Mechanical runtime | Add concrete `plugin_generation_factory.dart` and `plugin_runtime.dart`, including typed operations, acquisitions, streams, generation fencing, durable commit protection, transitions, and bounded teardown. This slice does not activate the new runtime in the bridge composer. |
 
-### Stage 11-P02 / PR #509 files
+### Stage 11-P01B — plugin operation routing files
+
+| Workspace | Production files/classes |
+|---|---|
+| Runtime composition/policy | Add `plugin_lifecycle_repository.dart`; modify `bridge_runtime_runner.dart`, `plugin_lifecycle_service.dart`, and `orchestrator.dart`. |
+| Plugin-backed operations | `session_operation.dart`, `session_repository.dart`, `agent_repository.dart`, `provider_repository.dart`, `question_repository.dart`, `permission_repository.dart`, `worktree_repository.dart`, `session_creation_service.dart`, and `session_lifecycle_service.dart`. Session creation applies `useAndCommit` in the same slice as its routing cutover. |
+| Temporary stack seam | Expose only the live eager-generation APIs needed by not-yet-migrated event/catalog/project consumers. Do not persist or publish this seam; delete it by P01D. |
+
+### Stage 11-P01C — dynamic events and durable fencing files
+
+| Workspace | Production files/classes |
+|---|---|
+| Event composition | Consume the runtime event seam in `orchestrator.dart`, `plugin_event_listener.dart`, `session_event_dispatcher.dart`, `session_event_service.dart`, and `session_event_tracker.dart`. |
+| Durable plugin evidence | `session_repository.dart`, new `project_activity_repository.dart`, `project_activity_service.dart`, `catalog_import_repository.dart`, and `catalog_import_service.dart`; preserve generation attribution through normalization and through each transaction publication point. |
+
+### Stage 11-P01D — bridge-owned projects and defaults files
+
+| Workspace | Production files/classes |
+|---|---|
+| Aggregate projects | `project_repository.dart`, `project_activity_repository.dart`, `project_activity_service.dart`, `rename_project_handler.dart`, and `orchestrator.dart`; project create/open/rename become plugin-neutral. |
+| Default policy | `plugin_lifecycle_service.dart`, `plugin_registry.dart`, and `bridge_runtime_runner.dart`; prefer OpenCode when selectable, otherwise deterministic first selectable, otherwise null. Missing released `pluginId` still means OpenCode. |
+| Ownership documentation | Project DAO/table/catalog identity and foundation directory comments, generated database output, and scoped bridge instructions. Remove the temporary live API seam. |
+
+### Stage 11-P02 / former PR #509 files
 
 | Workspace | Production files/classes |
 |---|---|
@@ -548,7 +586,7 @@ the listed source files and committed with their stage.
 | Bridge policy/settings | `plugin_runtime.dart`, `plugin_lifecycle_repository.dart`, `plugin_lifecycle_service.dart`, `bridge_settings.dart`, `bridge_settings_repository.dart`, `bridge_runtime_runner.dart`. |
 | Dormancy cleanup | Add `plugin_catalog_hydration_listener.dart`; modify `catalog_import_repository.dart`, `catalog_import_service.dart`, session/project repositories, `project_activity_service.dart`, `orchestrator.dart`. |
 
-### Stage 12 / PR #510 files
+### Stage 12 / former PR #510 files
 
 | Workspace | Production files/classes |
 |---|---|
@@ -558,7 +596,7 @@ the listed source files and committed with their stage.
 | Routes | Add `get_plugin_management_handler.dart`, `post_plugin_lifecycle_command_handler.dart`, `patch_plugin_idle_timeout_handler.dart`; wire the same instances into relay/debug routing. |
 | Client exhaustive switches | Only minimum `SseEvent`/tracker changes needed for the additive invalidation event; no management feature yet. |
 
-### Stage 13 / PR #511 files
+### Stage 13 / former PR #511 files
 
 | Workspace | Production files/classes |
 |---|---|
@@ -574,29 +612,49 @@ the listed source files and committed with their stage.
 - config model/repository and local plugin commands;
 - unconditional plugin CLI option registration;
 - descriptor setup states/probes without installation;
-- alphabetical eligibility/default and zero-plugin startup;
+- deterministic eligibility, OpenCode-preferred default, and zero-plugin startup;
 - snapshot setup API and compatible plugin list.
 
-### Stage 11-P01 / PR #508 — dynamic runtime boundary
+### Stage 11-P01A — runtime mechanics
 
-- generation starter, runtime API, lifecycle repository;
-- migrate every backend operation and dynamic event source to acquisition;
-- retain generation fencing, independent failure, and zero-plugin composition.
+- add the concrete generation factory and generation-scoped runtime kernel;
+- cover acquisitions, leases, typed operations, transitions, event attribution,
+  durable commit protection, failure isolation, and bounded teardown;
+- leave current bridge composition unchanged until the next stacked slice.
 
-### Stage 11-P02 / PR #509 — dormant runtime and numeric idle timeout
+### Stage 11-P01B — plugin operation routing
+
+- activate the runtime/lifecycle repository in the composition root;
+- migrate ordinary plugin-backed repository calls to runtime acquisition;
+- apply durable session-binding protection with the creation cutover;
+- retain a narrow temporary view for event/catalog/project consumers.
+
+### Stage 11-P01C — dynamic events and durable generation fencing
+
+- replace startup-fixed event subscriptions with generation-attributed events;
+- fence session projection, catalog publication, and plugin activity evidence;
+- drain routed work before runtime disposal.
+
+### Stage 11-P01D — bridge-owned projects and default behavior
+
+- make project create/open/rename bridge-owned and plugin-neutral;
+- prefer OpenCode as the selectable default with deterministic fallback;
+- remove the temporary API view and finalize ownership guidance.
+
+### Stage 11-P02 / former PR #509 — dormant runtime and numeric idle timeout
 
 - plugin-owned work state and authentication-loss signal;
 - all-ready-dormant startup, demand activation, marker-before-hydration;
 - numeric default/override config and safe idle suspension;
 - remove startup/reconnect enumeration that wakes dormant plugins.
 
-### Stage 12 / PR #510 — headless management
+### Stage 12 / former PR #510 — headless management
 
 - simplified management DTOs/routes, safe/force commands, revision/SSE;
 - live denylist mutations and setup refresh;
 - numeric idle-timeout updates and one hydration listener.
 
-### Stage 13 / PR #511 — redesigned mobile plugin settings
+### Stage 13 / former PR #511 — redesigned mobile plugin settings
 
 - module-core API -> repository -> service -> cubit and preference storage;
 - per-bridge last-used new-session choice;
@@ -604,10 +662,10 @@ the listed source files and committed with their stage.
   settings primitives;
 - focused interaction, conflict/force, reconnect, and route tests.
 
-Each branch is rebuilt from its predecessor after #507 starts at latest
-`origin/main`. Histories may be force-with-lease rewritten as explicitly
-approved. A closed PR is reopened only after its replacement stage passes
-focused verification.
+P01A starts at latest `origin/main`; each later replacement branch stacks on its
+verified predecessor. Frozen #508 remains reference material and is not
+rewritten. Existing descendants #509-#511 are rebuilt or retargeted only after
+P01D is complete.
 
 ## Verification
 

--- a/.plan/active/setup-aware-plugin-lifecycle/PLAN.md
+++ b/.plan/active/setup-aware-plugin-lifecycle/PLAN.md
@@ -612,7 +612,7 @@ the listed source files and committed with their stage.
 - config model/repository and local plugin commands;
 - unconditional plugin CLI option registration;
 - descriptor setup states/probes without installation;
-- deterministic eligibility, OpenCode-preferred default, and zero-plugin startup;
+- alphabetical eligibility/default and zero-plugin startup;
 - snapshot setup API and compatible plugin list.
 
 ### Stage 11-P01A — runtime mechanics

--- a/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
+++ b/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
@@ -118,11 +118,15 @@ run their focused verification again.
 - Started a clean replacement branch from `origin/main` at `583748ab`.
 - Added the concrete `PluginGenerationFactory` and `PluginRuntime` kernel plus
   focused runtime tests. The bridge composition remains unchanged in this slice.
-- Focused generation-factory and runtime tests passed (36 tests).
+- Focused generation-factory and runtime tests passed (40 tests).
 - `dart analyze --fatal-infos` passed in `bridge/app`.
 - Architecture implementation review approved the runtime/factory ownership,
   lifecycle, dependency direction, and enabling-slice boundary with no findings.
 - Committed as `fbd02dee`, pushed, and opened as PR #547.
+- PR review hardened generation-owned stream cancellation, command/disposal
+  serialization, and access revocation. The second architecture pass identified
+  a paused-consumer teardown dependency; source cancellation and lease release
+  now complete without waiting for downstream `done` delivery.
 
 ## Delivery Rules
 

--- a/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
+++ b/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
@@ -6,9 +6,8 @@
   stack in progress
 - **Base:** `origin/main` at `583748ab`
 - **Current branch:** `setup-aware-plugin-lifecycle-runtime-mechanics`
-- **Current stage:** Stage 11-P01A — runtime mechanics verified and approved
-- **Next action:** publish P01A as the base of the smaller replacement stack,
-  then start P01B from that verified head
+- **Current stage:** Stage 11-P01A — runtime mechanics open as PR #547
+- **Next action:** monitor #547 and build P01B from its verified head
 
 ## Frozen Oversized Stack
 
@@ -33,7 +32,7 @@ run their focused verification again.
 | Done | Stage | Branch | PR state |
 |---|---|---|---|
 | [x] | Stage 10 — setup discovery and denylist | `aware-plugin-lifecycle` | #507 merged |
-| [x] | Stage 11-P01A — runtime mechanics | `setup-aware-plugin-lifecycle-runtime-mechanics` | verified; ready to publish |
+| [x] | Stage 11-P01A — runtime mechanics | `setup-aware-plugin-lifecycle-runtime-mechanics` | #547 open and monitored |
 | [ ] | Stage 11-P01B — plugin operation routing | `setup-aware-plugin-lifecycle-operation-routing` | stack after P01A |
 | [ ] | Stage 11-P01C — dynamic events and durable fencing | `setup-aware-plugin-lifecycle-durable-events` | stack after P01B |
 | [ ] | Stage 11-P01D — bridge-owned projects and defaults | `setup-aware-plugin-lifecycle-project-ownership` | stack after P01C |
@@ -123,6 +122,7 @@ run their focused verification again.
 - `dart analyze --fatal-infos` passed in `bridge/app`.
 - Architecture implementation review approved the runtime/factory ownership,
   lifecycle, dependency direction, and enabling-slice boundary with no findings.
+- Committed as `fbd02dee`, pushed, and opened as PR #547.
 
 ## Delivery Rules
 

--- a/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
+++ b/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
@@ -2,24 +2,28 @@
 
 ## Plan State
 
-- **Status:** Stage 10 delivered; replacement stack rebuilding
-- **Base:** `origin/main` at `5a91f582`
-- **Current branch:** `aware-plugin-lifecycle`
-- **Current stage:** Stage 11-P01 rebuild
-- **Next action:** rebuild Stage 11-P01 from rewritten Stage 10, verify it,
-  rewrite its branch, reopen #508, and start its monitor
+- **Status:** Stage 10 merged; PR #508 frozen as reference; smaller replacement
+  stack in progress
+- **Base:** `origin/main` at `583748ab`
+- **Current branch:** `setup-aware-plugin-lifecycle-runtime-mechanics`
+- **Current stage:** Stage 11-P01A — runtime mechanics verified and approved
+- **Next action:** publish P01A as the base of the smaller replacement stack,
+  then start P01B from that verified head
 
-## Closed First Implementation
+## Frozen Oversized Stack
 
-The first unmerged stack was closed before redesign:
+PR #508 passed its verification but is too large to review effectively. It is
+frozen at `f6cd675d` as source material while the behavior is rebuilt in smaller
+PRs. Its descendants are not advanced until the replacement runtime boundary is
+complete.
 
 | Old PR | State | Replacement |
 |---|---|---|
-| #507 | Reopened | Redesigned Stage 10 at `794e853e`; CI/review monitored |
-| #508 | Closed | Reopen after redesigned Stage 11-P01 is implemented and verified |
-| #509 | Closed | Reopen after redesigned Stage 11-P02 is implemented and verified |
-| #510 | Closed | Reopen after redesigned Stage 12 is implemented and verified |
-| #511 | Closed | Reopen after redesigned Stage 13 is implemented on merged Settings architecture |
+| #507 | Merged | Redesigned Stage 10, merged as `4ef55675` |
+| #508 | Open, frozen | Oversized Stage 11-P01 reference at `f6cd675d`; replaced by P01A-P01D |
+| #509 | Open, frozen | Dormancy descendant; rebuild/retarget after P01D |
+| #510 | Open, frozen | Management descendant; rebuild/retarget after rebuilt dormancy stage |
+| #511 | Open, frozen | Client descendant; rebuild/retarget after rebuilt management stage |
 
 Old verification results are historical evidence only; replacement stages must
 run their focused verification again.
@@ -28,11 +32,14 @@ run their focused verification again.
 
 | Done | Stage | Branch | PR state |
 |---|---|---|---|
-| [x] | Stage 10 — setup discovery and denylist | `aware-plugin-lifecycle` | #507 open and monitored |
-| [ ] | Stage 11-P01 — dynamic runtime boundary | `setup-aware-plugin-lifecycle-s11-p01` | #508 closed |
-| [ ] | Stage 11-P02 — dormancy and numeric idle timeout | `setup-aware-plugin-lifecycle-s11-p02` | #509 closed |
-| [ ] | Stage 12 — headless management | `setup-aware-plugin-lifecycle-s12-p01` | #510 closed |
-| [ ] | Stage 13 — redesigned mobile plugin settings | `setup-aware-plugin-lifecycle-s13-p01` | #511 closed |
+| [x] | Stage 10 — setup discovery and denylist | `aware-plugin-lifecycle` | #507 merged |
+| [x] | Stage 11-P01A — runtime mechanics | `setup-aware-plugin-lifecycle-runtime-mechanics` | verified; ready to publish |
+| [ ] | Stage 11-P01B — plugin operation routing | `setup-aware-plugin-lifecycle-operation-routing` | stack after P01A |
+| [ ] | Stage 11-P01C — dynamic events and durable fencing | `setup-aware-plugin-lifecycle-durable-events` | stack after P01B |
+| [ ] | Stage 11-P01D — bridge-owned projects and defaults | `setup-aware-plugin-lifecycle-project-ownership` | stack after P01C |
+| [ ] | Stage 11-P02 — dormancy and numeric idle timeout | rebuild branch TBD | frozen #509 descendant |
+| [ ] | Stage 12 — headless management | rebuild branch TBD | frozen #510 descendant |
+| [ ] | Stage 13 — redesigned mobile plugin settings | rebuild branch TBD | frozen #511 descendant |
 
 ## Locked Redesign Deltas
 
@@ -40,14 +47,20 @@ run their focused verification again.
 - All plugin CLI options are registered; `--plugin` is removed.
 - Setup inspection skips denied plugins and never installs.
 - Setup adds `notInspected` and removes `canProvision`.
-- Alphabetical ordering/default replaces persisted order and bridge last-used.
+- Deterministic ordering replaces persisted order and bridge last-used; the
+  derived default prefers OpenCode when selectable, then the first selectable
+  plugin in display-name/ID order.
 - Client stores last-used per bridge after the settings stage.
 - Every ready plugin starts dormant.
 - Idle configuration is integer minutes; `<= 0` never idle-stops after demand.
 - Headless management removes authority/order/serialized enabled.
 - Settings work targets the merged Prego Settings landing/sub-page architecture.
-- No compatibility machinery is retained for any contract from the closed
-  unmerged stack.
+- No compatibility machinery is retained for any contract from the superseded
+  oversized stack.
+- Aggregate projects are bridge-owned and may include sessions from multiple
+  plugins. Create/open/rename never select, start, acquire, or call a plugin.
+- P01B may use one narrow stack-local live API view for consumers migrated in
+  P01C/P01D. It is removed by P01D and is not a released contract.
 
 ## Review
 
@@ -88,12 +101,34 @@ run their focused verification again.
 - Rebased cleanly onto `origin/main` at `5a91f582` on 2026-07-20; the Stage 10
   production commit is now `794e853e`.
 
+### 2026-07-23 — frozen Stage 11-P01 reference
+
+- PR #508 reached head `f6cd675d`, was synchronized through `main` at
+  `583748ab`, and was mergeable with CI 10/10.
+- The reference implementation contains the approved generation runtime,
+  operation routing, durable fencing, bridge-owned projects, and
+  OpenCode-preferred default behavior.
+- Focused runtime/session/create, project/open/rename/activity, event/catalog,
+  lifecycle/default, and routing verification passed; bridge-app
+  `dart analyze --fatal-infos` passed.
+- The implementation is frozen rather than rewritten because its 83-file,
+  roughly 5.5k-addition diff is not reviewable as one PR.
+
+### 2026-07-23 — Stage 11-P01A runtime mechanics
+
+- Started a clean replacement branch from `origin/main` at `583748ab`.
+- Added the concrete `PluginGenerationFactory` and `PluginRuntime` kernel plus
+  focused runtime tests. The bridge composition remains unchanged in this slice.
+- Focused generation-factory and runtime tests passed (36 tests).
+- `dart analyze --fatal-infos` passed in `bridge/app`.
+- Architecture implementation review approved the runtime/factory ownership,
+  lifecycle, dependency direction, and enabling-slice boundary with no findings.
+
 ## Delivery Rules
 
-- Start Stage 10 from latest `origin/main`; stack every later branch from its
-  verified predecessor.
-- Force-with-lease history rewrites are explicitly authorized for these closed
-  branches.
-- Reopen a PR only after its replacement stage is complete and focused checks
-  pass.
-- Start a PR monitor immediately after each PR is reopened.
+- Start P01A from latest `origin/main`; stack P01B-P01D from each verified
+  predecessor.
+- Keep #508 frozen until replacement PRs exist; do not force-rewrite it.
+- Rebuild or retarget #509-#511 only after P01D is complete.
+- Open each replacement PR only after its focused checks pass, then monitor that
+  PR immediately.

--- a/bridge/app/lib/src/bridge/runtime/plugin_generation_factory.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_generation_factory.dart
@@ -1,0 +1,320 @@
+import "dart:async";
+import "dart:io" as io;
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../../server/api/loopback_port_api.dart";
+import "../../server/api/runtime_file_api.dart";
+import "../../server/host/bridge_host_info_impl.dart";
+import "../../server/host/bridge_host_json_store.dart";
+import "../../server/host/bridge_host_port_service.dart";
+import "../../server/host/bridge_host_process_service.dart";
+import "../../server/host/bridge_plugin_host_impl.dart";
+import "../../server/host/plugin_state_directory.dart";
+import "../../server/repositories/process_repository.dart";
+import "../../server/repositories/startup_mutex_repository.dart";
+import "../../server/services/bridge_instance_service.dart";
+import "../../updater/models/managed_runtime_paths.dart";
+import "bridge_runtime_server_exception.dart";
+
+class PluginRuntimeRegistration {
+  const PluginRuntimeRegistration({
+    required this.descriptor,
+    required this.config,
+    required this.stateDirectory,
+  });
+
+  final BridgePluginDescriptor descriptor;
+  final PluginConfig config;
+  final String stateDirectory;
+}
+
+/// A failure isolated to one descriptor's runtime resolution or start attempt.
+///
+/// Shared startup infrastructure failures, such as bridge ownership or mutex
+/// contention, are deliberately not wrapped so the composition root can abort
+/// the whole bridge with their original typed exception.
+class PluginGenerationStartFailedException implements Exception {
+  const PluginGenerationStartFailedException({
+    required this.pluginId,
+    required this.cause,
+  });
+
+  final String pluginId;
+  final Object cause;
+
+  @override
+  String toString() => 'PluginGenerationStartFailedException: Plugin "$pluginId" failed to start: $cause';
+}
+
+sealed class PluginGenerationStartEvent {
+  const PluginGenerationStartEvent();
+}
+
+final class PluginGenerationProvisionProgress extends PluginGenerationStartEvent {
+  const PluginGenerationProvisionProgress({required this.event});
+
+  final RuntimeProvisionProgress event;
+}
+
+final class PluginGenerationStarted extends PluginGenerationStartEvent {
+  const PluginGenerationStarted({required this.plugin});
+
+  final BridgePlugin plugin;
+}
+
+class PluginGenerationFactory {
+  PluginGenerationFactory({
+    required ManagedRuntimePaths managedRuntimePaths,
+    required ProcessIdentity currentBridgeIdentity,
+    required String ownerSessionId,
+    required StartupMutexRepository startupMutexRepository,
+    required BridgeInstanceService bridgeInstanceService,
+    required ProcessRepository processRepository,
+    required RuntimeFileApi runtimeFileApi,
+    required ServerClock clock,
+    required Map<String, String> environment,
+    required ProcessUser? currentUser,
+  }) : _managedRuntimePaths = managedRuntimePaths,
+       _currentBridgeIdentity = currentBridgeIdentity,
+       _ownerSessionId = ownerSessionId,
+       _startupMutexRepository = startupMutexRepository,
+       _bridgeInstanceService = bridgeInstanceService,
+       _processRepository = processRepository,
+       _clock = clock,
+       _environment = Map<String, String>.unmodifiable(environment),
+       _currentUser = currentUser,
+       _fileApisByStateDirectory = <String, RuntimeFileApi>{
+         runtimeFileApi.runtimeDirectory: runtimeFileApi,
+       };
+
+  final ManagedRuntimePaths _managedRuntimePaths;
+  final ProcessIdentity _currentBridgeIdentity;
+  final String _ownerSessionId;
+  final StartupMutexRepository _startupMutexRepository;
+  final BridgeInstanceService _bridgeInstanceService;
+  final ProcessRepository _processRepository;
+  final ServerClock _clock;
+  final Map<String, String> _environment;
+  final ProcessUser? _currentUser;
+  final Map<String, RuntimeFileApi> _fileApisByStateDirectory;
+  final List<_GenerationStartRequest> _pending = <_GenerationStartRequest>[];
+  bool _drainScheduled = false;
+  bool _draining = false;
+
+  Future<void> enforceBridgeOwnership() => _attemptBatch(attempt: 1, batch: const []);
+
+  Stream<PluginGenerationStartEvent> start({
+    required PluginRuntimeRegistration registration,
+    required StartAbortSignal startAborted,
+  }) {
+    late final StreamController<PluginGenerationStartEvent> controller;
+    controller = StreamController<PluginGenerationStartEvent>(
+      onListen: () {
+        _pending.add(
+          _GenerationStartRequest(
+            registration: registration,
+            startAborted: startAborted,
+            controller: controller,
+          ),
+        );
+        _scheduleDrain();
+      },
+    );
+    return controller.stream;
+  }
+
+  void _scheduleDrain() {
+    if (_drainScheduled || _draining) return;
+    _drainScheduled = true;
+    scheduleMicrotask(_drainPending);
+  }
+
+  Future<void> _drainPending() async {
+    _drainScheduled = false;
+    if (_draining || _pending.isEmpty) return;
+    _draining = true;
+    try {
+      while (_pending.isNotEmpty) {
+        final batch = List<_GenerationStartRequest>.of(_pending);
+        _pending.clear();
+        try {
+          await _attemptBatch(attempt: 1, batch: batch);
+        } on Object catch (error, stackTrace) {
+          for (final request in batch) {
+            request.controller.addError(error, stackTrace);
+          }
+        } finally {
+          for (final request in batch) {
+            await request.controller.close();
+          }
+        }
+      }
+    } finally {
+      _draining = false;
+      if (_pending.isNotEmpty) _scheduleDrain();
+    }
+  }
+
+  Future<void> _attemptBatch({
+    required int attempt,
+    required List<_GenerationStartRequest> batch,
+  }) {
+    return _startupMutexRepository.withLock<void>(
+      bridgePid: _currentBridgeIdentity.pid,
+      bridgeStartMarker: _currentBridgeIdentity.startMarker,
+      onLockAcquired: () async {
+        Log.d("acquired startup lock");
+        final resolution = await _bridgeInstanceService.enforceSingleLiveBridge(
+          currentPid: _currentBridgeIdentity.pid,
+        );
+        switch (resolution.status) {
+          case BridgeInstanceResolutionStatus.allowed:
+            final startSettlements = <Future<void>>[];
+            for (final request in batch) {
+              try {
+                final host = await _buildHost(request: request, resolution: resolution);
+                await for (final event in request.registration.descriptor.ensureRuntime(host: host)) {
+                  request.controller.add(PluginGenerationProvisionProgress(event: event));
+                  if (event case ProvisionReady(:final binaryPath)) {
+                    host.provisionedRuntimePath = binaryPath;
+                  }
+                }
+                startSettlements.add(
+                  _settleDescriptorStart(
+                    request: request,
+                    start: request.registration.descriptor.start(host),
+                  ),
+                );
+              } on PluginStartAbortedException catch (error, stackTrace) {
+                request.controller.addError(error, stackTrace);
+              } on Object catch (error, stackTrace) {
+                request.controller.addError(
+                  PluginGenerationStartFailedException(
+                    pluginId: request.registration.descriptor.id,
+                    cause: error,
+                  ),
+                  stackTrace,
+                );
+              }
+            }
+            await Future.wait(startSettlements);
+          case BridgeInstanceResolutionStatus.declined:
+            throw const BridgeRuntimeServerException(
+              "Startup aborted because another Sesori bridge is already running and replacement was declined.",
+            );
+          case BridgeInstanceResolutionStatus.nonInteractive:
+            throw const BridgeRuntimeServerException(
+              "Startup aborted because another Sesori bridge is already running and this session is non-interactive.",
+            );
+        }
+      },
+      onLockRejected: (rejection) async {
+        final lock = rejection.lock;
+        final holderMatch = rejection.holderMatch;
+        if (lock == null || holderMatch == null) {
+          throw BridgeRuntimeServerException(
+            "Startup aborted because another Sesori bridge startup is already in progress. If this persists, delete ${rejection.lockFilePath} and retry.",
+          );
+        }
+        final status = await _bridgeInstanceService.resolveStartupLockContention(
+          lock: lock,
+          holder: holderMatch,
+          currentPid: _currentBridgeIdentity.pid,
+        );
+        switch (status) {
+          case BridgeInstanceResolutionStatus.allowed:
+            if (attempt < 2) return _attemptBatch(attempt: attempt + 1, batch: batch);
+            throw const BridgeRuntimeServerException(
+              "Startup aborted because another Sesori bridge startup is still in progress after attempting replacement.",
+            );
+          case BridgeInstanceResolutionStatus.declined:
+            throw const BridgeRuntimeServerException(
+              "Startup aborted because another Sesori bridge startup is already in progress and replacement was declined.",
+            );
+          case BridgeInstanceResolutionStatus.nonInteractive:
+            throw BridgeRuntimeServerException(
+              "Startup aborted because another Sesori bridge startup is already in progress and this session is non-interactive. Bridge pid ${holderMatch.identity.pid} holds ${rejection.lockFilePath}; kill that process or delete the file to recover.",
+            );
+        }
+      },
+    );
+  }
+
+  Future<void> _settleDescriptorStart({
+    required _GenerationStartRequest request,
+    required Future<BridgePlugin> start,
+  }) async {
+    try {
+      request.controller.add(
+        PluginGenerationStarted(plugin: await start),
+      );
+    } on PluginStartAbortedException catch (error, stackTrace) {
+      request.controller.addError(error, stackTrace);
+    } on Object catch (error, stackTrace) {
+      request.controller.addError(
+        PluginGenerationStartFailedException(
+          pluginId: request.registration.descriptor.id,
+          cause: error,
+        ),
+        stackTrace,
+      );
+    }
+  }
+
+  Future<BridgePluginHostImpl> _buildHost({
+    required _GenerationStartRequest request,
+    required BridgeInstanceResolution resolution,
+  }) async {
+    final descriptor = request.registration.descriptor;
+    final expectedStateDirectory = pluginStateDirectoryPath(
+      paths: _managedRuntimePaths,
+      pluginId: descriptor.id,
+      stateStorage: descriptor.stateStorage,
+    );
+    final stateDirectory = request.registration.stateDirectory;
+    if (stateDirectory != expectedStateDirectory) {
+      throw StateError('Plugin "${descriptor.id}" registration has an unexpected state directory.');
+    }
+    await io.Directory(stateDirectory).create(recursive: true);
+    final fileApi = _fileApisByStateDirectory.putIfAbsent(
+      stateDirectory,
+      () => RuntimeFileApi(runtimeDirectory: stateDirectory),
+    );
+    return BridgePluginHostImpl(
+      config: request.registration.config,
+      stateDirectory: stateDirectory,
+      environment: _environment,
+      clock: _clock,
+      startAborted: request.startAborted,
+      bridge: BridgeHostInfoImpl(
+        identity: _currentBridgeIdentity,
+        ownerSessionId: _ownerSessionId,
+        terminatedBridgeIdentities: resolution.terminatedBridges,
+        processRepository: _processRepository,
+      ),
+      processes: BridgeHostProcessService(
+        processStarter: io.Process.start,
+        processRepository: _processRepository,
+        clock: _clock,
+        currentUser: _currentUser,
+        isWindows: io.Platform.isWindows,
+        platform: io.Platform.operatingSystem,
+      ),
+      ports: const BridgeHostPortService(loopbackPortApi: LoopbackPortApi()),
+      store: BridgeHostJsonStore(fileApi: fileApi),
+    );
+  }
+}
+
+class _GenerationStartRequest {
+  const _GenerationStartRequest({
+    required this.registration,
+    required this.startAborted,
+    required this.controller,
+  });
+
+  final PluginRuntimeRegistration registration;
+  final StartAbortSignal startAborted;
+  final StreamController<PluginGenerationStartEvent> controller;
+}

--- a/bridge/app/lib/src/bridge/runtime/plugin_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_runtime.dart
@@ -253,6 +253,7 @@ class PluginRuntime {
     StreamSubscription<T>? sourceSubscription;
     _PluginLease? lease;
     Future<void>? termination;
+    Future<void> Function()? generationCancellation;
     var cancelled = false;
     var released = false;
 
@@ -266,7 +267,12 @@ class PluginRuntime {
 
     late final StreamController<T> controller;
 
-    Future<void> finish({Object? error, StackTrace? stackTrace, required bool cancelSource}) {
+    Future<void> finish({
+      Object? error,
+      StackTrace? stackTrace,
+      required bool cancelSource,
+      bool surfaceCancellationError = false,
+    }) {
       return termination ??= () async {
         if (error != null && !cancelled && !controller.isClosed) {
           controller.addError(error, stackTrace);
@@ -278,6 +284,7 @@ class PluginRuntime {
         try {
           if (cancelSource) await sourceSubscription?.cancel();
         } on Object catch (cancelError, cancelStackTrace) {
+          if (surfaceCancellationError) rethrow;
           if (error == null && !cancelled && !controller.isClosed) {
             controller.addError(cancelError, cancelStackTrace);
           } else {
@@ -288,8 +295,14 @@ class PluginRuntime {
             );
           }
         } finally {
+          final activeLease = lease;
+          final cancellation = generationCancellation;
+          if (activeLease != null && cancellation != null) {
+            activeLease.slot.operationStreamCancellations.remove(cancellation);
+          }
+          generationCancellation = null;
           releaseLease();
-          if (!cancelled && !controller.isClosed) await controller.close();
+          if (!cancelled && !controller.isClosed) unawaited(controller.close());
         }
       }();
     }
@@ -303,6 +316,8 @@ class PluginRuntime {
             releaseLease();
             return;
           }
+          generationCancellation = () => finish(cancelSource: true);
+          acquired.slot.operationStreamCancellations.add(generationCancellation!);
           sourceSubscription = body(acquired.api, acquired.generation).listen(
             (value) {
               try {
@@ -333,11 +348,8 @@ class PluginRuntime {
       onResume: () => sourceSubscription?.resume(),
       onCancel: () async {
         cancelled = true;
-        try {
-          await sourceSubscription?.cancel();
-        } finally {
-          releaseLease();
-        }
+        if (termination != null) return;
+        await finish(cancelSource: true, surfaceCancellationError: true);
       },
     );
     return controller.stream;
@@ -471,6 +483,7 @@ class PluginRuntime {
           }
           try {
             await slot.cleanupFuture;
+            await slot.commandTransitionCompleter?.future;
             await _waitForDurableCommits(slot);
             await _cancelAndShutdownGeneration(slot: slot, plugin: slot.plugin);
           } on Object catch (error, stackTrace) {
@@ -491,6 +504,9 @@ class PluginRuntime {
     required PluginStopIntent intent,
   }) async {
     final slot = _requireSlot(pluginId);
+    if (_shuttingDown) {
+      return PluginRuntimeCommandFailed(snapshot: _snapshotFor(slot), message: "bridge is shutting down");
+    }
     if (!slot.eligible) {
       return PluginRuntimeCommandConflict(
         snapshot: _snapshotFor(slot),
@@ -518,8 +534,10 @@ class PluginRuntime {
     }
     final hadPlugin = slot.plugin != null || slot.startFuture != null;
     final transitionOwner = Object();
+    final transitionCompleter = Completer<void>();
     slot
       ..commandTransitionOwner = transitionOwner
+      ..commandTransitionCompleter = transitionCompleter
       ..transition = PluginRuntimeTransition.stopping;
     _publishSnapshots();
     String? failureMessage;
@@ -545,9 +563,11 @@ class PluginRuntime {
       if (identical(slot.commandTransitionOwner, transitionOwner)) {
         slot
           ..commandTransitionOwner = null
+          ..commandTransitionCompleter = null
           ..transition = PluginRuntimeTransition.none;
       }
       _publishSnapshots();
+      if (!transitionCompleter.isCompleted) transitionCompleter.complete();
     }
     if (failureMessage != null) {
       return PluginRuntimeCommandFailed(snapshot: _snapshotFor(slot), message: failureMessage);
@@ -562,6 +582,9 @@ class PluginRuntime {
     required PluginStopIntent intent,
   }) async {
     final slot = _requireSlot(pluginId);
+    if (_shuttingDown) {
+      return PluginRuntimeCommandFailed(snapshot: _snapshotFor(slot), message: "bridge is shutting down");
+    }
     if (!slot.eligible) {
       return PluginRuntimeCommandConflict(
         snapshot: _snapshotFor(slot),
@@ -589,8 +612,10 @@ class PluginRuntime {
     }
 
     final transitionOwner = Object();
+    final transitionCompleter = Completer<void>();
     slot
       ..commandTransitionOwner = transitionOwner
+      ..commandTransitionCompleter = transitionCompleter
       ..transition = PluginRuntimeTransition.restarting;
     _publishSnapshots();
     String? failureMessage;
@@ -632,9 +657,11 @@ class PluginRuntime {
       if (identical(slot.commandTransitionOwner, transitionOwner)) {
         slot
           ..commandTransitionOwner = null
+          ..commandTransitionCompleter = null
           ..transition = PluginRuntimeTransition.none;
       }
       _publishSnapshots();
+      if (!transitionCompleter.isCompleted) transitionCompleter.complete();
     }
     if (failureMessage != null) {
       return PluginRuntimeCommandFailed(snapshot: _snapshotFor(slot), message: failureMessage);
@@ -1021,10 +1048,13 @@ class PluginRuntime {
 
   Future<void> _cancelGenerationSubscriptions(_PluginRuntimeSlot slot) async {
     final subscriptions = [slot.statusSubscription, slot.eventSubscription];
+    final operationStreamCancellations = slot.operationStreamCancellations.toList(growable: false);
     slot
       ..statusSubscription = null
-      ..eventSubscription = null;
+      ..eventSubscription = null
+      ..operationStreamCancellations.clear();
     await Future.wait([
+      for (final cancel in operationStreamCancellations) cancel(),
       for (final subscription in subscriptions)
         if (subscription != null) subscription.cancel(),
     ]);
@@ -1052,7 +1082,7 @@ class PluginRuntime {
   }
 
   bool _isRoutable(_PluginRuntimeSlot slot) {
-    return slot.eligible && !_blocksAcquisition(slot) && _hasOperationalGeneration(slot);
+    return slot.eligible && slot.startAllowed && !_blocksAcquisition(slot) && _hasOperationalGeneration(slot);
   }
 
   bool _hasOperationalGeneration(_PluginRuntimeSlot slot) {
@@ -1124,6 +1154,7 @@ class _PluginRuntimeSlot {
   PluginRuntimeState state = PluginRuntimeState.disabled;
   PluginRuntimeTransition transition = PluginRuntimeTransition.none;
   Object? commandTransitionOwner;
+  Completer<void>? commandTransitionCompleter;
   int leaseCount = 0;
   int durableCommitCount = 0;
   Completer<void>? durableCommitsDrained;
@@ -1135,6 +1166,7 @@ class _PluginRuntimeSlot {
   StreamSubscription<PluginStatus>? statusSubscription;
   // ignore: cancel_subscriptions - generation ownership cancels these in PluginRuntime.
   StreamSubscription<BridgeSseEvent>? eventSubscription;
+  final Set<Future<void> Function()> operationStreamCancellations = <Future<void> Function()>{};
 }
 
 class _PluginLease {

--- a/bridge/app/lib/src/bridge/runtime/plugin_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_runtime.dart
@@ -1,0 +1,1146 @@
+import "dart:async";
+
+import "package:rxdart/rxdart.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "plugin_generation_factory.dart";
+
+class PluginRuntimeAccess {
+  const PluginRuntimeAccess({
+    required this.pluginId,
+    required this.eligible,
+    required this.startAllowed,
+  });
+
+  final String pluginId;
+  final bool eligible;
+  final bool startAllowed;
+}
+
+enum PluginRuntimeState { disabled, blocked, dormant, starting, active, degraded, stopping, failed }
+
+enum PluginRuntimeTransition { none, starting, stopping, restarting }
+
+enum PluginStopIntent { safe, force }
+
+enum PluginRuntimeConflictReason { inFlight, transitioning, notEligible }
+
+class PluginRuntimeSnapshot {
+  const PluginRuntimeSnapshot({
+    required this.pluginId,
+    required this.projectOwnership,
+    required this.setup,
+    required this.eligible,
+    required this.startAllowed,
+    required this.generation,
+    required this.state,
+    required this.leaseCount,
+    required this.transition,
+  });
+
+  final String pluginId;
+  final PluginProjectOwnership projectOwnership;
+  final PluginSetupStatus setup;
+  final bool eligible;
+  final bool startAllowed;
+  final int? generation;
+  final PluginRuntimeState state;
+  final int leaseCount;
+  final PluginRuntimeTransition transition;
+}
+
+typedef SourcedPluginRuntimeEvent = ({String pluginId, int generation, BridgeSseEvent event});
+typedef SourcedPluginProvisionProgress = ({String pluginId, RuntimeProvisionProgress event});
+
+sealed class PluginRuntimeCommandResult {
+  const PluginRuntimeCommandResult({required this.snapshot});
+
+  final PluginRuntimeSnapshot snapshot;
+}
+
+final class PluginRuntimeCommandApplied extends PluginRuntimeCommandResult {
+  const PluginRuntimeCommandApplied({required super.snapshot});
+}
+
+final class PluginRuntimeCommandCurrent extends PluginRuntimeCommandResult {
+  const PluginRuntimeCommandCurrent({required super.snapshot});
+}
+
+final class PluginRuntimeCommandConflict extends PluginRuntimeCommandResult {
+  const PluginRuntimeCommandConflict({required super.snapshot, required this.reasons});
+
+  final List<PluginRuntimeConflictReason> reasons;
+}
+
+final class PluginRuntimeCommandFailed extends PluginRuntimeCommandResult {
+  const PluginRuntimeCommandFailed({required super.snapshot, required this.message});
+
+  final String message;
+}
+
+class PluginRuntime {
+  PluginRuntime({
+    required List<PluginRuntimeRegistration> registrations,
+    required PluginGenerationFactory generationFactory,
+    required HostProcessService setupProcesses,
+    required Map<String, String> environment,
+    required ServerClock clock,
+    required Duration shutdownBudget,
+  }) : _generationFactory = generationFactory,
+       _setupProcesses = setupProcesses,
+       _environment = Map<String, String>.unmodifiable(environment),
+       _clock = clock,
+       _shutdownBudget = shutdownBudget,
+       _slots = <String, _PluginRuntimeSlot>{
+         for (final registration in registrations)
+           registration.descriptor.id: _PluginRuntimeSlot(registration: registration),
+       } {
+    if (_slots.length != registrations.length) {
+      throw ArgumentError.value(registrations, "registrations", "must not contain duplicate plugin ids");
+    }
+    _snapshotsSubject = BehaviorSubject<List<PluginRuntimeSnapshot>>.seeded(_buildSnapshots());
+  }
+
+  final PluginGenerationFactory _generationFactory;
+  final HostProcessService _setupProcesses;
+  final Map<String, String> _environment;
+  final ServerClock _clock;
+  final Duration _shutdownBudget;
+  final Map<String, _PluginRuntimeSlot> _slots;
+  late final BehaviorSubject<List<PluginRuntimeSnapshot>> _snapshotsSubject;
+  final PublishSubject<SourcedPluginRuntimeEvent> _backendEventsSubject = PublishSubject<SourcedPluginRuntimeEvent>();
+  final PublishSubject<SourcedPluginProvisionProgress> _provisionProgressSubject =
+      PublishSubject<SourcedPluginProvisionProgress>();
+  bool _shuttingDown = false;
+  Future<void>? _disposeStartedApisFuture;
+  Future<void>? _disposeFuture;
+  bool _apiDisposalStarted = false;
+  final Map<BridgePluginApi, Future<void>> _apiDisposals = Map<BridgePluginApi, Future<void>>.identity();
+
+  Stream<List<PluginRuntimeSnapshot>> get snapshots => _snapshotsSubject.stream;
+  List<PluginRuntimeSnapshot> get snapshot => List<PluginRuntimeSnapshot>.unmodifiable(_buildSnapshots());
+  Stream<SourcedPluginRuntimeEvent> get backendEvents => _backendEventsSubject.stream;
+  Stream<SourcedPluginProvisionProgress> get provisionProgress => _provisionProgressSubject.stream;
+
+  Set<String> get activePluginIds => {
+    for (final slot in _slots.values)
+      if (_isRoutable(slot)) slot.registration.descriptor.id,
+  };
+
+  Set<String> get startAllowedPluginIds => {
+    for (final slot in _slots.values)
+      if (slot.eligible && slot.startAllowed) slot.registration.descriptor.id,
+  };
+
+  PluginDiagnostics? describe({required String pluginId}) => _requireSlot(pluginId).plugin?.describe();
+
+  Future<Map<String, PluginSetupStatus>> inspectSetup({
+    required Set<String> pluginIds,
+    required bool markUnselectedNotInspected,
+  }) async {
+    final selectedIds = Set<String>.unmodifiable(pluginIds);
+    final unknownIds = selectedIds.difference(_slots.keys.toSet());
+    if (unknownIds.isNotEmpty) {
+      throw ArgumentError.value(pluginIds, "pluginIds", "contains unknown plugin ids: $unknownIds");
+    }
+    if (markUnselectedNotInspected) {
+      for (final slot in _slots.values) {
+        if (!selectedIds.contains(slot.registration.descriptor.id)) {
+          slot.setup = const PluginSetupNotInspected();
+        }
+      }
+    }
+    final results = await Future.wait(
+      selectedIds.map((pluginId) async {
+        final slot = _slots[pluginId]!;
+        final descriptor = slot.registration.descriptor;
+        try {
+          return (
+            pluginId: pluginId,
+            setup: await descriptor.inspectSetup(
+              config: slot.registration.config,
+              processes: _setupProcesses,
+              environment: _environment,
+              stateDirectory: slot.registration.stateDirectory,
+            ),
+          );
+        } on Object catch (error, stackTrace) {
+          Log.w('Plugin "$pluginId" setup inspection failed', error, stackTrace);
+          return (
+            pluginId: pluginId,
+            setup: const PluginSetupUnknown(
+              actionHint: "Plugin setup could not be determined. Check the bridge console and retry.",
+            ),
+          );
+        }
+      }),
+    );
+    for (final result in results) {
+      _slots[result.pluginId]!.setup = result.setup;
+    }
+    _publishSnapshots();
+    return Map<String, PluginSetupStatus>.unmodifiable({
+      for (final slot in _slots.values) slot.registration.descriptor.id: slot.setup,
+    });
+  }
+
+  void applyAccess({required List<PluginRuntimeAccess> entries}) {
+    final byId = <String, PluginRuntimeAccess>{for (final entry in entries) entry.pluginId: entry};
+    if (byId.length != entries.length || byId.keys.toSet().difference(_slots.keys.toSet()).isNotEmpty) {
+      throw ArgumentError.value(entries, "entries", "must contain unique registered plugin ids");
+    }
+    for (final slot in _slots.values) {
+      final entry = byId[slot.registration.descriptor.id];
+      slot
+        ..eligible = entry?.eligible ?? false
+        ..startAllowed = entry?.startAllowed ?? false;
+    }
+    _publishSnapshots();
+  }
+
+  Future<void> startEager({required List<String> pluginIds}) async {
+    final starts = <Future<BridgePlugin?>>[];
+    for (final pluginId in pluginIds) {
+      starts.add(_ensureStarted(slot: _requireSlot(pluginId)));
+    }
+    await Future.wait(starts);
+  }
+
+  Future<T> use<T>({
+    required String pluginId,
+    required Enum operation,
+    required Future<T> Function(BridgePluginApi api) body,
+  }) async {
+    final lease = await _acquire(pluginId: pluginId, operation: operation, startIfNeeded: true);
+    try {
+      final result = await body(lease.api);
+      _requireCurrentGeneration(lease: lease, operation: operation);
+      return result;
+    } finally {
+      _release(lease);
+    }
+  }
+
+  /// Runs interruptible plugin work, then linearizes a short durable commit
+  /// before this generation can be replaced. Force-stop remains able to
+  /// interrupt [prepare], but waits for an entered [commit] to finish.
+  Future<R> useAndCommit<P, R>({
+    required String pluginId,
+    required Enum operation,
+    required Future<P> Function(BridgePluginApi api) prepare,
+    required Future<R> Function(P prepared) commit,
+  }) async {
+    final lease = await _acquire(pluginId: pluginId, operation: operation, startIfNeeded: true);
+    var commitProtected = false;
+    try {
+      final prepared = await prepare(lease.api);
+      _beginDurableCommit(lease: lease, operation: operation);
+      commitProtected = true;
+      final result = await commit(prepared);
+      _requireSameGeneration(lease: lease, operation: operation);
+      return result;
+    } finally {
+      if (commitProtected) _endDurableCommit(lease.slot);
+      _release(lease);
+    }
+  }
+
+  Stream<T> useStream<T>({
+    required String pluginId,
+    required Enum operation,
+    required Stream<T> Function(BridgePluginApi api, int generation) body,
+  }) {
+    StreamSubscription<T>? sourceSubscription;
+    _PluginLease? lease;
+    Future<void>? termination;
+    var cancelled = false;
+    var released = false;
+
+    void releaseLease() {
+      if (released) return;
+      final activeLease = lease;
+      if (activeLease == null) return;
+      released = true;
+      _release(activeLease);
+    }
+
+    late final StreamController<T> controller;
+
+    Future<void> finish({Object? error, StackTrace? stackTrace, required bool cancelSource}) {
+      return termination ??= () async {
+        if (error != null && !cancelled && !controller.isClosed) {
+          controller.addError(error, stackTrace);
+        }
+        // A synchronous source can invoke its callback before listen() returns
+        // the subscription. Yield once so the retained subscription is visible
+        // before terminal cancellation reads it.
+        await Future<void>.value();
+        try {
+          if (cancelSource) await sourceSubscription?.cancel();
+        } on Object catch (cancelError, cancelStackTrace) {
+          if (error == null && !cancelled && !controller.isClosed) {
+            controller.addError(cancelError, cancelStackTrace);
+          } else {
+            Log.w(
+              'Plugin "$pluginId" stream cancellation failed during ${operation.name}',
+              cancelError,
+              cancelStackTrace,
+            );
+          }
+        } finally {
+          releaseLease();
+          if (!cancelled && !controller.isClosed) await controller.close();
+        }
+      }();
+    }
+
+    controller = StreamController<T>(
+      onListen: () async {
+        try {
+          final acquired = await _acquire(pluginId: pluginId, operation: operation, startIfNeeded: true);
+          lease = acquired;
+          if (cancelled) {
+            releaseLease();
+            return;
+          }
+          sourceSubscription = body(acquired.api, acquired.generation).listen(
+            (value) {
+              try {
+                _requireCurrentGeneration(lease: acquired, operation: operation);
+                controller.add(value);
+              } on Object catch (error, stackTrace) {
+                unawaited(finish(error: error, stackTrace: stackTrace, cancelSource: true));
+              }
+            },
+            onError: (Object error, StackTrace stackTrace) {
+              unawaited(finish(error: error, stackTrace: stackTrace, cancelSource: true));
+            },
+            onDone: () {
+              try {
+                _requireCurrentGeneration(lease: acquired, operation: operation);
+                unawaited(finish(cancelSource: false));
+              } on Object catch (error, stackTrace) {
+                unawaited(finish(error: error, stackTrace: stackTrace, cancelSource: false));
+              }
+            },
+          );
+          if (cancelled) await finish(cancelSource: true);
+        } on Object catch (error, stackTrace) {
+          await finish(error: error, stackTrace: stackTrace, cancelSource: true);
+        }
+      },
+      onPause: () => sourceSubscription?.pause(),
+      onResume: () => sourceSubscription?.resume(),
+      onCancel: () async {
+        cancelled = true;
+        try {
+          await sourceSubscription?.cancel();
+        } finally {
+          releaseLease();
+        }
+      },
+    );
+    return controller.stream;
+  }
+
+  Future<T?> useIfActive<T>({
+    required String pluginId,
+    required Enum operation,
+    required Future<T> Function(BridgePluginApi api, int generation) body,
+  }) async {
+    final slot = _requireOperationSlot(pluginId: pluginId, operation: operation);
+    if (!_isRoutable(slot)) return null;
+    final lease = await _acquire(pluginId: pluginId, operation: operation, startIfNeeded: false);
+    try {
+      final result = await body(lease.api, lease.generation);
+      _requireCurrentGeneration(lease: lease, operation: operation);
+      return result;
+    } finally {
+      _release(lease);
+    }
+  }
+
+  bool isCurrentGeneration({required String pluginId, required int generation}) {
+    final slot = _slots[pluginId];
+    return slot != null && slot.generation == generation && _isRoutable(slot);
+  }
+
+  void requireCurrentGeneration({
+    required String pluginId,
+    required int generation,
+    required Enum operation,
+  }) {
+    if (!isCurrentGeneration(pluginId: pluginId, generation: generation)) {
+      throw PluginOperationException(
+        operation.name,
+        statusCode: 503,
+        message: "plugin generation changed during operation",
+      );
+    }
+  }
+
+  Future<PluginRuntimeCommandResult> start({required String pluginId}) async {
+    final slot = _requireSlot(pluginId);
+    if (!slot.eligible) {
+      return PluginRuntimeCommandConflict(
+        snapshot: _snapshotFor(slot),
+        reasons: const [PluginRuntimeConflictReason.notEligible],
+      );
+    }
+    if (_isRoutable(slot)) return PluginRuntimeCommandCurrent(snapshot: _snapshotFor(slot));
+    if (slot.transition != PluginRuntimeTransition.none && slot.transition != PluginRuntimeTransition.starting) {
+      return PluginRuntimeCommandConflict(
+        snapshot: _snapshotFor(slot),
+        reasons: const [PluginRuntimeConflictReason.transitioning],
+      );
+    }
+    final plugin = await _ensureStarted(slot: slot);
+    if (plugin == null || !_isRoutable(slot)) {
+      return PluginRuntimeCommandFailed(snapshot: _snapshotFor(slot), message: "plugin failed to start");
+    }
+    return PluginRuntimeCommandApplied(snapshot: _snapshotFor(slot));
+  }
+
+  Future<PluginRuntimeCommandResult> stop({
+    required String pluginId,
+    required PluginStopIntent intent,
+  }) => _stop(pluginId: pluginId, intent: intent);
+
+  Future<PluginRuntimeCommandResult> restart({
+    required String pluginId,
+    required PluginStopIntent intent,
+  }) => _restart(pluginId: pluginId, intent: intent);
+
+  void beginShutdown() {
+    if (_shuttingDown) return;
+    _shuttingDown = true;
+    for (final slot in _slots.values) {
+      slot.startAbortController?.abort();
+    }
+  }
+
+  Future<void> disposeStartedApis() => _disposeStartedApisFuture ??= _disposeStartedApis();
+
+  Future<void> _disposeStartedApis() async {
+    _apiDisposalStarted = true;
+    final errors = <({Object error, StackTrace stackTrace})>[];
+
+    Future<void> capture(Future<void> operation) async {
+      try {
+        await operation;
+      } on PluginStartAbortedException {
+        // Expected when beginShutdown aborts an in-flight generation start.
+      } on Object catch (error, stackTrace) {
+        errors.add((error: error, stackTrace: stackTrace));
+      }
+    }
+
+    final starts = [for (final slot in _slots.values) ?slot.startFuture];
+    await Future.wait([
+      for (final slot in _slots.values)
+        if (slot.plugin case final plugin?) capture(_disposeApi(plugin.api)),
+      for (final start in starts) capture(start.then<void>((_) {})),
+    ]);
+    await Future.wait([
+      for (final slot in _slots.values)
+        if (slot.plugin case final plugin?) capture(_disposeApi(plugin.api)),
+    ]);
+    if (errors case [final first, ...]) {
+      Error.throwWithStackTrace(first.error, first.stackTrace);
+    }
+  }
+
+  Future<void> _disposeApi(BridgePluginApi api) {
+    return _apiDisposals.putIfAbsent(api, () => Future<void>.sync(api.dispose));
+  }
+
+  Future<void> dispose() => _disposeFuture ??= _dispose();
+
+  Future<void> _dispose() async {
+    beginShutdown();
+    final errors = <({Object error, StackTrace stackTrace})>[];
+    await Future.wait([
+      for (final slot in _slots.values)
+        () async {
+          try {
+            await slot.startFuture;
+          } on PluginStartAbortedException {
+            // Expected after beginShutdown aborts an in-flight generation start.
+          } on Object catch (error, stackTrace) {
+            errors.add((error: error, stackTrace: stackTrace));
+          }
+          try {
+            await slot.cleanupFuture;
+            await _waitForDurableCommits(slot);
+            await _cancelAndShutdownGeneration(slot: slot, plugin: slot.plugin);
+          } on Object catch (error, stackTrace) {
+            errors.add((error: error, stackTrace: stackTrace));
+          }
+        }(),
+    ]);
+    await _backendEventsSubject.close();
+    await _provisionProgressSubject.close();
+    await _snapshotsSubject.close();
+    if (errors case [final first, ...]) {
+      Error.throwWithStackTrace(first.error, first.stackTrace);
+    }
+  }
+
+  Future<PluginRuntimeCommandResult> _stop({
+    required String pluginId,
+    required PluginStopIntent intent,
+  }) async {
+    final slot = _requireSlot(pluginId);
+    if (!slot.eligible) {
+      return PluginRuntimeCommandConflict(
+        snapshot: _snapshotFor(slot),
+        reasons: const [PluginRuntimeConflictReason.notEligible],
+      );
+    }
+    final forceCanTakeOverTransition =
+        intent == PluginStopIntent.force &&
+        slot.commandTransitionOwner == null &&
+        slot.cleanupFuture == null &&
+        (slot.transition == PluginRuntimeTransition.starting ||
+            (slot.transition == PluginRuntimeTransition.stopping && slot.plugin != null));
+    if (slot.commandTransitionOwner != null ||
+        (slot.transition != PluginRuntimeTransition.none && !forceCanTakeOverTransition)) {
+      return PluginRuntimeCommandConflict(
+        snapshot: _snapshotFor(slot),
+        reasons: const [PluginRuntimeConflictReason.transitioning],
+      );
+    }
+    if (intent == PluginStopIntent.safe && slot.leaseCount > 0) {
+      return PluginRuntimeCommandConflict(
+        snapshot: _snapshotFor(slot),
+        reasons: const [PluginRuntimeConflictReason.inFlight],
+      );
+    }
+    final hadPlugin = slot.plugin != null || slot.startFuture != null;
+    final transitionOwner = Object();
+    slot
+      ..commandTransitionOwner = transitionOwner
+      ..transition = PluginRuntimeTransition.stopping;
+    _publishSnapshots();
+    String? failureMessage;
+    try {
+      await _stopCurrentGeneration(slot: slot, intent: intent);
+      if (!identical(slot.commandTransitionOwner, transitionOwner)) {
+        return PluginRuntimeCommandConflict(
+          snapshot: _snapshotFor(slot),
+          reasons: const [PluginRuntimeConflictReason.transitioning],
+        );
+      }
+      slot.state = PluginRuntimeState.dormant;
+    } on Object catch (error) {
+      if (!identical(slot.commandTransitionOwner, transitionOwner)) {
+        return PluginRuntimeCommandConflict(
+          snapshot: _snapshotFor(slot),
+          reasons: const [PluginRuntimeConflictReason.transitioning],
+        );
+      }
+      slot.state = PluginRuntimeState.failed;
+      failureMessage = "$error";
+    } finally {
+      if (identical(slot.commandTransitionOwner, transitionOwner)) {
+        slot
+          ..commandTransitionOwner = null
+          ..transition = PluginRuntimeTransition.none;
+      }
+      _publishSnapshots();
+    }
+    if (failureMessage != null) {
+      return PluginRuntimeCommandFailed(snapshot: _snapshotFor(slot), message: failureMessage);
+    }
+    return hadPlugin
+        ? PluginRuntimeCommandApplied(snapshot: _snapshotFor(slot))
+        : PluginRuntimeCommandCurrent(snapshot: _snapshotFor(slot));
+  }
+
+  Future<PluginRuntimeCommandResult> _restart({
+    required String pluginId,
+    required PluginStopIntent intent,
+  }) async {
+    final slot = _requireSlot(pluginId);
+    if (!slot.eligible) {
+      return PluginRuntimeCommandConflict(
+        snapshot: _snapshotFor(slot),
+        reasons: const [PluginRuntimeConflictReason.notEligible],
+      );
+    }
+    final forceCanTakeOverTransition =
+        intent == PluginStopIntent.force &&
+        slot.commandTransitionOwner == null &&
+        slot.cleanupFuture == null &&
+        (slot.transition == PluginRuntimeTransition.starting ||
+            (slot.transition == PluginRuntimeTransition.stopping && slot.plugin != null));
+    if (slot.commandTransitionOwner != null ||
+        (slot.transition != PluginRuntimeTransition.none && !forceCanTakeOverTransition)) {
+      return PluginRuntimeCommandConflict(
+        snapshot: _snapshotFor(slot),
+        reasons: const [PluginRuntimeConflictReason.transitioning],
+      );
+    }
+    if (intent == PluginStopIntent.safe && slot.leaseCount > 0) {
+      return PluginRuntimeCommandConflict(
+        snapshot: _snapshotFor(slot),
+        reasons: const [PluginRuntimeConflictReason.inFlight],
+      );
+    }
+
+    final transitionOwner = Object();
+    slot
+      ..commandTransitionOwner = transitionOwner
+      ..transition = PluginRuntimeTransition.restarting;
+    _publishSnapshots();
+    String? failureMessage;
+    try {
+      await _stopCurrentGeneration(slot: slot, intent: intent);
+      if (!identical(slot.commandTransitionOwner, transitionOwner)) {
+        return PluginRuntimeCommandConflict(
+          snapshot: _snapshotFor(slot),
+          reasons: const [PluginRuntimeConflictReason.transitioning],
+        );
+      }
+      slot.state = PluginRuntimeState.dormant;
+      if (_shuttingDown) {
+        failureMessage = "bridge is shutting down";
+      } else {
+        final plugin = await _beginStart(
+          slot: slot,
+          transition: PluginRuntimeTransition.restarting,
+          clearTransitionOnSettle: false,
+        );
+        if (!identical(slot.commandTransitionOwner, transitionOwner)) {
+          return PluginRuntimeCommandConflict(
+            snapshot: _snapshotFor(slot),
+            reasons: const [PluginRuntimeConflictReason.transitioning],
+          );
+        }
+        if (plugin == null || !_hasOperationalGeneration(slot)) failureMessage = "plugin failed to restart";
+      }
+    } on Object catch (error) {
+      if (!identical(slot.commandTransitionOwner, transitionOwner)) {
+        return PluginRuntimeCommandConflict(
+          snapshot: _snapshotFor(slot),
+          reasons: const [PluginRuntimeConflictReason.transitioning],
+        );
+      }
+      slot.state = PluginRuntimeState.failed;
+      failureMessage = "$error";
+    } finally {
+      if (identical(slot.commandTransitionOwner, transitionOwner)) {
+        slot
+          ..commandTransitionOwner = null
+          ..transition = PluginRuntimeTransition.none;
+      }
+      _publishSnapshots();
+    }
+    if (failureMessage != null) {
+      return PluginRuntimeCommandFailed(snapshot: _snapshotFor(slot), message: failureMessage);
+    }
+    return PluginRuntimeCommandApplied(snapshot: _snapshotFor(slot));
+  }
+
+  Future<void> _stopCurrentGeneration({
+    required _PluginRuntimeSlot slot,
+    required PluginStopIntent intent,
+  }) async {
+    if (intent == PluginStopIntent.force) slot.startAbortController?.abort();
+    Object? startError;
+    StackTrace? startStackTrace;
+    try {
+      await slot.startFuture;
+    } on PluginStartAbortedException catch (error, stackTrace) {
+      if (intent != PluginStopIntent.force && !_shuttingDown) {
+        startError = error;
+        startStackTrace = stackTrace;
+      }
+    } on Object catch (error, stackTrace) {
+      startError = error;
+      startStackTrace = stackTrace;
+    }
+    await slot.cleanupFuture;
+    await _waitForDurableCommits(slot);
+    final plugin = slot.plugin;
+    slot
+      ..plugin = null
+      ..state = PluginRuntimeState.stopping;
+    _publishSnapshots();
+    Object? cleanupError;
+    StackTrace? cleanupStackTrace;
+    try {
+      await _cancelAndShutdownGeneration(slot: slot, plugin: plugin);
+    } on Object catch (error, stackTrace) {
+      cleanupError = error;
+      cleanupStackTrace = stackTrace;
+    }
+    if (startError != null) Error.throwWithStackTrace(startError, startStackTrace!);
+    if (cleanupError != null) Error.throwWithStackTrace(cleanupError, cleanupStackTrace!);
+  }
+
+  Future<_PluginLease> _acquire({
+    required String pluginId,
+    required Enum operation,
+    required bool startIfNeeded,
+  }) async {
+    if (_shuttingDown) {
+      throw PluginOperationException(operation.name, statusCode: 503, message: "bridge is shutting down");
+    }
+    final slot = _requireOperationSlot(pluginId: pluginId, operation: operation);
+    if (!slot.eligible || !slot.startAllowed) {
+      throw PluginOperationException(operation.name, statusCode: 503, message: "plugin $pluginId is unavailable");
+    }
+    if (_blocksAcquisition(slot)) {
+      throw PluginOperationException(operation.name, statusCode: 503, message: "plugin $pluginId is transitioning");
+    }
+    if (!_isRoutable(slot) && startIfNeeded) await _ensureStarted(slot: slot);
+    if (_blocksAcquisition(slot)) {
+      throw PluginOperationException(operation.name, statusCode: 503, message: "plugin $pluginId is transitioning");
+    }
+    final plugin = slot.plugin;
+    final generation = slot.generation;
+    if (plugin == null || generation == null || !_isRoutable(slot)) {
+      throw PluginOperationException(operation.name, statusCode: 503, message: "plugin $pluginId is not running");
+    }
+    slot.leaseCount++;
+    _publishSnapshots();
+    return _PluginLease(slot: slot, generation: generation, api: plugin.api);
+  }
+
+  void _release(_PluginLease lease) {
+    if (lease.slot.leaseCount > 0) lease.slot.leaseCount--;
+    _publishSnapshots();
+  }
+
+  void _beginDurableCommit({required _PluginLease lease, required Enum operation}) {
+    _requireCurrentGeneration(lease: lease, operation: operation);
+    lease.slot.durableCommitCount++;
+  }
+
+  void _endDurableCommit(_PluginRuntimeSlot slot) {
+    if (slot.durableCommitCount > 0) slot.durableCommitCount--;
+    if (slot.durableCommitCount != 0) return;
+    slot.durableCommitsDrained?.complete();
+    slot.durableCommitsDrained = null;
+  }
+
+  Future<void> _waitForDurableCommits(_PluginRuntimeSlot slot) {
+    if (slot.durableCommitCount == 0) return Future<void>.value();
+    return (slot.durableCommitsDrained ??= Completer<void>()).future;
+  }
+
+  void _requireCurrentGeneration({required _PluginLease lease, required Enum operation}) {
+    requireCurrentGeneration(
+      pluginId: lease.slot.registration.descriptor.id,
+      generation: lease.generation,
+      operation: operation,
+    );
+    if (!identical(lease.slot.plugin?.api, lease.api)) {
+      throw PluginOperationException(
+        operation.name,
+        statusCode: 503,
+        message: "plugin generation changed during operation",
+      );
+    }
+  }
+
+  void _requireSameGeneration({required _PluginLease lease, required Enum operation}) {
+    if (lease.slot.generation != lease.generation || !identical(lease.slot.plugin?.api, lease.api)) {
+      throw PluginOperationException(
+        operation.name,
+        statusCode: 503,
+        message: "plugin generation changed during operation",
+      );
+    }
+  }
+
+  Future<BridgePlugin?> _ensureStarted({required _PluginRuntimeSlot slot}) {
+    if (_isRoutable(slot)) return Future<BridgePlugin?>.value(slot.plugin);
+    final existing = slot.startFuture;
+    if (existing != null) return existing;
+    if (_shuttingDown || !slot.eligible || !slot.startAllowed || slot.transition != PluginRuntimeTransition.none) {
+      return Future<BridgePlugin?>.value();
+    }
+    return _beginStart(
+      slot: slot,
+      transition: PluginRuntimeTransition.starting,
+      clearTransitionOnSettle: true,
+    );
+  }
+
+  Future<BridgePlugin?> _beginStart({
+    required _PluginRuntimeSlot slot,
+    required PluginRuntimeTransition transition,
+    required bool clearTransitionOnSettle,
+  }) {
+    final pluginId = slot.registration.descriptor.id;
+    Log.v('Starting plugin "$pluginId" generation at ${_clock.now().toIso8601String()}');
+    final generation = (slot.generation ?? 0) + 1;
+    final abortController = StartAbortController();
+    slot
+      ..generation = generation
+      ..transition = transition
+      ..state = PluginRuntimeState.starting
+      ..startAbortController = abortController;
+    _publishSnapshots();
+
+    late final Future<BridgePlugin?> tracked;
+    tracked =
+        _startGeneration(
+          slot: slot,
+          generation: generation,
+          abortController: abortController,
+        ).whenComplete(() {
+          if (identical(slot.startFuture, tracked)) slot.startFuture = null;
+          if (identical(slot.startAbortController, abortController)) slot.startAbortController = null;
+          if (clearTransitionOnSettle && slot.transition == transition) {
+            slot.transition = PluginRuntimeTransition.none;
+          }
+          _publishSnapshots();
+        });
+    slot.startFuture = tracked;
+    return tracked;
+  }
+
+  Future<BridgePlugin?> _startGeneration({
+    required _PluginRuntimeSlot slot,
+    required int generation,
+    required StartAbortController abortController,
+  }) async {
+    final pluginId = slot.registration.descriptor.id;
+    BridgePlugin? started;
+    try {
+      await for (final event in _generationFactory.start(
+        registration: slot.registration,
+        startAborted: abortController.signal,
+      )) {
+        switch (event) {
+          case PluginGenerationProvisionProgress(:final event):
+            _provisionProgressSubject.add((pluginId: pluginId, event: event));
+          case PluginGenerationStarted(:final plugin):
+            started = plugin;
+        }
+      }
+      if (started == null) {
+        throw PluginGenerationStartFailedException(
+          pluginId: pluginId,
+          cause: StateError('Plugin "$pluginId" start produced no terminal plugin.'),
+        );
+      }
+      if (_shuttingDown || abortController.isAborted) {
+        await started.shutdown(budget: _shutdownBudget);
+        throw const PluginStartAbortedException();
+      }
+      _validateStartedPlugin(slot: slot, plugin: started);
+      slot.plugin = started;
+      // ignore: cancel_subscriptions - retained by the slot and cancelled when this generation stops.
+      slot.statusSubscription = started.status.listen(
+        (status) => _applyStatus(slot: slot, generation: generation, status: status),
+        onError: (Object error, StackTrace stackTrace) {
+          if (slot.generation != generation) return;
+          if (_shuttingDown) return;
+          Log.w('Plugin "$pluginId" status stream failed', error, stackTrace);
+          _retireFailedGeneration(slot: slot, generation: generation, reason: "status stream failed");
+        },
+        onDone: () {
+          if (slot.generation != generation || slot.plugin == null) return;
+          if (_shuttingDown) return;
+          Log.w('Plugin "$pluginId" status stream closed before the generation stopped');
+          _retireFailedGeneration(slot: slot, generation: generation, reason: "status stream closed");
+        },
+      );
+      // ignore: cancel_subscriptions - retained by the slot and cancelled when this generation stops.
+      slot.eventSubscription = started.api.events.listen(
+        (event) {
+          if (slot.generation == generation && !_backendEventsSubject.isClosed) {
+            _backendEventsSubject.add((pluginId: pluginId, generation: generation, event: event));
+          }
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          if (_shuttingDown) return;
+          if (slot.generation == generation && !_backendEventsSubject.isClosed) {
+            _backendEventsSubject.addError(error, stackTrace);
+          }
+          if (slot.generation == generation) {
+            Log.w('Plugin "$pluginId" event stream failed', error, stackTrace);
+            _retireFailedGeneration(slot: slot, generation: generation, reason: "event stream failed");
+          }
+        },
+        onDone: () {
+          if (slot.generation != generation || slot.plugin == null) return;
+          if (_shuttingDown) return;
+          Log.w('Plugin "$pluginId" event stream closed before the generation stopped');
+          _retireFailedGeneration(slot: slot, generation: generation, reason: "event stream closed");
+        },
+      );
+      _applyStatus(slot: slot, generation: generation, status: started.currentStatus);
+      if (_apiDisposalStarted) await _disposeApi(started.api);
+      return started;
+    } on PluginStartAbortedException {
+      slot.state = PluginRuntimeState.failed;
+      if (started != null && !identical(slot.plugin, started)) {
+        await _shutdownFailedStart(pluginId: pluginId, plugin: started);
+      }
+      rethrow;
+    } on PluginGenerationStartFailedException catch (error, stackTrace) {
+      Log.w('Plugin "$pluginId" failed to start', error, stackTrace);
+      slot.state = PluginRuntimeState.failed;
+      if (started != null) await _discardStartedPlugin(slot: slot, pluginId: pluginId, plugin: started);
+      return null;
+    } on Object catch (error, stackTrace) {
+      slot.state = PluginRuntimeState.failed;
+      if (started == null) rethrow;
+      if (_shuttingDown || abortController.isAborted) {
+        await _discardStartedPlugin(slot: slot, pluginId: pluginId, plugin: started);
+        Error.throwWithStackTrace(error, stackTrace);
+      }
+      Log.w('Plugin "$pluginId" returned an invalid generation', error, stackTrace);
+      await _discardStartedPlugin(slot: slot, pluginId: pluginId, plugin: started);
+      return null;
+    }
+  }
+
+  Future<void> _discardStartedPlugin({
+    required _PluginRuntimeSlot slot,
+    required String pluginId,
+    required BridgePlugin plugin,
+  }) async {
+    if (identical(slot.plugin, plugin)) slot.plugin = null;
+    try {
+      await _cancelGenerationSubscriptions(slot);
+    } on Object catch (error, stackTrace) {
+      Log.w('Plugin "$pluginId" subscription cleanup after a failed start also failed', error, stackTrace);
+    }
+    await _shutdownFailedStart(pluginId: pluginId, plugin: plugin);
+  }
+
+  Future<void> _shutdownFailedStart({required String pluginId, required BridgePlugin plugin}) async {
+    try {
+      await plugin.shutdown(budget: _shutdownBudget);
+    } on Object catch (error, stackTrace) {
+      Log.w('Plugin "$pluginId" cleanup after a failed start also failed', error, stackTrace);
+    }
+  }
+
+  void _validateStartedPlugin({required _PluginRuntimeSlot slot, required BridgePlugin plugin}) {
+    final descriptor = slot.registration.descriptor;
+    if (plugin.api.id != descriptor.id) {
+      throw StateError('Plugin "${descriptor.id}" returned API id "${plugin.api.id}".');
+    }
+    final matchesOwnership = switch (descriptor.projectOwnership) {
+      PluginProjectOwnership.native => plugin.api is NativeProjectsPluginApi,
+      PluginProjectOwnership.bridgeDerived => plugin.api is BridgeDerivedProjectsPluginApi,
+    };
+    if (!matchesOwnership) {
+      throw StateError('Plugin "${descriptor.id}" returned an API that contradicts its project ownership declaration.');
+    }
+  }
+
+  void _applyStatus({
+    required _PluginRuntimeSlot slot,
+    required int generation,
+    required PluginStatus status,
+  }) {
+    if (slot.generation != generation) return;
+    if (_shuttingDown) return;
+    if (status case PluginFailed(:final reason, :final cause)) {
+      Log.w('Plugin "${slot.registration.descriptor.id}" failed after startup: $reason', cause);
+      _retireFailedGeneration(slot: slot, generation: generation, reason: reason);
+      return;
+    }
+    if (status is PluginStopped) {
+      _retireFailedGeneration(slot: slot, generation: generation, reason: "plugin stopped");
+      return;
+    }
+    if (status is PluginStopping) {
+      slot.state = PluginRuntimeState.stopping;
+      if (slot.commandTransitionOwner == null) {
+        slot.transition = PluginRuntimeTransition.stopping;
+      }
+      _publishSnapshots();
+      return;
+    }
+    slot.state = switch (status) {
+      PluginStarting() || PluginReady() => PluginRuntimeState.active,
+      PluginDegraded() || PluginRestarting() => PluginRuntimeState.degraded,
+      PluginStopping() => throw StateError("handled above"),
+      PluginFailed() || PluginStopped() => throw StateError("handled above"),
+    };
+    _publishSnapshots();
+  }
+
+  void _retireFailedGeneration({
+    required _PluginRuntimeSlot slot,
+    required int generation,
+    required String reason,
+  }) {
+    if (slot.generation != generation) return;
+    final plugin = slot.plugin;
+    if (plugin == null || slot.cleanupFuture != null) return;
+    slot.state = PluginRuntimeState.stopping;
+    if (slot.commandTransitionOwner == null) {
+      slot.transition = PluginRuntimeTransition.stopping;
+    }
+    _publishSnapshots();
+
+    late final Future<void> cleanup;
+    cleanup = () async {
+      try {
+        await _waitForDurableCommits(slot);
+        if (slot.generation != generation || !identical(slot.plugin, plugin)) return;
+        slot
+          ..plugin = null
+          ..state = PluginRuntimeState.failed;
+        _publishSnapshots();
+        await _cancelAndShutdownGeneration(slot: slot, plugin: plugin);
+      } on Object catch (error, stackTrace) {
+        Log.w(
+          'Plugin "${slot.registration.descriptor.id}" cleanup after $reason failed',
+          error,
+          stackTrace,
+        );
+      } finally {
+        try {
+          await slot.startFuture;
+        } on Object {
+          // The initiating start failure is already surfaced by its owner.
+        }
+        if (identical(slot.cleanupFuture, cleanup)) slot.cleanupFuture = null;
+        if (slot.commandTransitionOwner == null &&
+            slot.generation == generation &&
+            slot.transition == PluginRuntimeTransition.stopping) {
+          slot.transition = PluginRuntimeTransition.none;
+        }
+        _publishSnapshots();
+      }
+    }();
+    slot.cleanupFuture = cleanup;
+    unawaited(cleanup);
+  }
+
+  Future<void> _cancelGenerationSubscriptions(_PluginRuntimeSlot slot) async {
+    final subscriptions = [slot.statusSubscription, slot.eventSubscription];
+    slot
+      ..statusSubscription = null
+      ..eventSubscription = null;
+    await Future.wait([
+      for (final subscription in subscriptions)
+        if (subscription != null) subscription.cancel(),
+    ]);
+  }
+
+  Future<void> _cancelAndShutdownGeneration({
+    required _PluginRuntimeSlot slot,
+    required BridgePlugin? plugin,
+  }) async {
+    Object? firstError;
+    StackTrace? firstStackTrace;
+    try {
+      await _cancelGenerationSubscriptions(slot);
+    } on Object catch (error, stackTrace) {
+      firstError = error;
+      firstStackTrace = stackTrace;
+    }
+    try {
+      await plugin?.shutdown(budget: _shutdownBudget);
+    } on Object catch (error, stackTrace) {
+      firstError ??= error;
+      firstStackTrace ??= stackTrace;
+    }
+    if (firstError != null) Error.throwWithStackTrace(firstError, firstStackTrace!);
+  }
+
+  bool _isRoutable(_PluginRuntimeSlot slot) {
+    return slot.eligible && !_blocksAcquisition(slot) && _hasOperationalGeneration(slot);
+  }
+
+  bool _hasOperationalGeneration(_PluginRuntimeSlot slot) {
+    return slot.plugin != null &&
+        (slot.state == PluginRuntimeState.active || slot.state == PluginRuntimeState.degraded);
+  }
+
+  bool _blocksAcquisition(_PluginRuntimeSlot slot) {
+    return switch (slot.transition) {
+      PluginRuntimeTransition.none || PluginRuntimeTransition.starting => false,
+      PluginRuntimeTransition.stopping || PluginRuntimeTransition.restarting => true,
+    };
+  }
+
+  _PluginRuntimeSlot _requireSlot(String pluginId) {
+    final slot = _slots[pluginId];
+    if (slot == null) throw ArgumentError.value(pluginId, "pluginId", "is not registered");
+    return slot;
+  }
+
+  _PluginRuntimeSlot _requireOperationSlot({required String pluginId, required Enum operation}) {
+    final slot = _slots[pluginId];
+    if (slot == null) {
+      throw PluginOperationException(
+        operation.name,
+        statusCode: 503,
+        message: "plugin $pluginId is unknown and unavailable",
+      );
+    }
+    return slot;
+  }
+
+  List<PluginRuntimeSnapshot> _buildSnapshots() => [for (final slot in _slots.values) _snapshotFor(slot)];
+
+  PluginRuntimeSnapshot _snapshotFor(_PluginRuntimeSlot slot) {
+    final state = !slot.eligible
+        ? PluginRuntimeState.disabled
+        : !slot.startAllowed
+        ? PluginRuntimeState.blocked
+        : slot.plugin == null && slot.startFuture == null && slot.state != PluginRuntimeState.failed
+        ? PluginRuntimeState.dormant
+        : slot.state;
+    return PluginRuntimeSnapshot(
+      pluginId: slot.registration.descriptor.id,
+      projectOwnership: slot.registration.descriptor.projectOwnership,
+      setup: slot.setup,
+      eligible: slot.eligible,
+      startAllowed: slot.startAllowed,
+      generation: slot.generation,
+      state: state,
+      leaseCount: slot.leaseCount,
+      transition: slot.transition,
+    );
+  }
+
+  void _publishSnapshots() {
+    if (!_snapshotsSubject.isClosed) _snapshotsSubject.add(_buildSnapshots());
+  }
+}
+
+class _PluginRuntimeSlot {
+  _PluginRuntimeSlot({required this.registration});
+
+  final PluginRuntimeRegistration registration;
+  PluginSetupStatus setup = const PluginSetupUnknown(actionHint: null);
+  bool eligible = false;
+  bool startAllowed = false;
+  int? generation;
+  PluginRuntimeState state = PluginRuntimeState.disabled;
+  PluginRuntimeTransition transition = PluginRuntimeTransition.none;
+  Object? commandTransitionOwner;
+  int leaseCount = 0;
+  int durableCommitCount = 0;
+  Completer<void>? durableCommitsDrained;
+  BridgePlugin? plugin;
+  Future<BridgePlugin?>? startFuture;
+  Future<void>? cleanupFuture;
+  StartAbortController? startAbortController;
+  // ignore: cancel_subscriptions - generation ownership cancels these in PluginRuntime.
+  StreamSubscription<PluginStatus>? statusSubscription;
+  // ignore: cancel_subscriptions - generation ownership cancels these in PluginRuntime.
+  StreamSubscription<BridgeSseEvent>? eventSubscription;
+}
+
+class _PluginLease {
+  const _PluginLease({required this.slot, required this.generation, required this.api});
+
+  final _PluginRuntimeSlot slot;
+  final int generation;
+  final BridgePluginApi api;
+}

--- a/bridge/app/test/bridge/runtime/plugin_generation_factory_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_generation_factory_test.dart
@@ -1,0 +1,554 @@
+import "dart:io";
+
+import "package:sesori_bridge/src/bridge/runtime/bridge_runtime_server_exception.dart";
+import "package:sesori_bridge/src/bridge/runtime/plugin_generation_factory.dart";
+import "package:sesori_bridge/src/server/api/runtime_file_api.dart";
+import "package:sesori_bridge/src/server/foundation/process_match.dart";
+import "package:sesori_bridge/src/server/host/plugin_state_directory.dart";
+import "package:sesori_bridge/src/server/models/bridge_startup_lock.dart";
+import "package:sesori_bridge/src/server/repositories/process_repository.dart";
+import "package:sesori_bridge/src/server/repositories/startup_mutex_repository.dart";
+import "package:sesori_bridge/src/server/services/bridge_instance_service.dart";
+import "package:sesori_bridge/src/updater/models/managed_runtime_paths.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+// The plugin-specific start flows (managed start, attach mode, ownership
+// records) live with OpenCodePluginDescriptor in sesori_plugin_opencode;
+// these tests cover the generation factory's mutex → singleton → host → start
+// orchestration with a fake descriptor.
+void main() {
+  group("PluginGenerationFactory", () {
+    late _FakeStartupMutexRepository startupMutexRepository;
+    late _FakeBridgeInstanceService bridgeInstanceService;
+    late _RecordingDescriptor descriptor;
+    late ProcessIdentity currentBridgeIdentity;
+    late Directory runtimeDirectory;
+    late List<BridgePlugin> startedPlugins;
+
+    setUp(() async {
+      startupMutexRepository = _FakeStartupMutexRepository();
+      bridgeInstanceService = _FakeBridgeInstanceService();
+      descriptor = _RecordingDescriptor();
+      currentBridgeIdentity = _identity(pid: 100, startMarker: "bridge-start");
+      runtimeDirectory = await Directory.systemTemp.createTemp("bridge-runtime-server-test");
+      startedPlugins = [];
+    });
+
+    tearDown(() async {
+      for (final plugin in startedPlugins) {
+        await plugin.shutdown(budget: const Duration(seconds: 1));
+      }
+      if (runtimeDirectory.existsSync()) {
+        await runtimeDirectory.delete(recursive: true);
+      }
+    });
+
+    Future<BridgePlugin> startPlugin({
+      String? stateDirectory,
+      List<RuntimeProvisionProgress>? observedProgress,
+    }) async {
+      final directory = stateDirectory ?? runtimeDirectory.path;
+      final managedRuntimePaths = ManagedRuntimePaths(
+        installRoot: directory,
+        binaryPath: "$directory/bin/sesori-bridge",
+        cacheDirectory: directory,
+      );
+      final factory = PluginGenerationFactory(
+        managedRuntimePaths: managedRuntimePaths,
+        currentBridgeIdentity: currentBridgeIdentity,
+        ownerSessionId: "owner-session",
+        startupMutexRepository: startupMutexRepository,
+        bridgeInstanceService: bridgeInstanceService,
+        processRepository: _FakeProcessRepository(),
+        runtimeFileApi: RuntimeFileApi(runtimeDirectory: directory),
+        clock: const ServerClock(),
+        environment: const <String, String>{"HOME": "/home/alex"},
+        currentUser: ProcessUser.fromRawUser("alex"),
+      );
+      BridgePlugin? startedPlugin;
+      await for (final event in factory.start(
+        registration: PluginRuntimeRegistration(
+          descriptor: descriptor,
+          config: const PluginConfig(values: <String, Object?>{"port": "4096"}),
+          stateDirectory: pluginStateDirectoryPath(
+            paths: managedRuntimePaths,
+            pluginId: descriptor.id,
+            stateStorage: descriptor.stateStorage,
+          ),
+        ),
+        startAborted: StartAbortSignal.never,
+      )) {
+        switch (event) {
+          case PluginGenerationProvisionProgress(:final event):
+            observedProgress?.add(event);
+          case PluginGenerationStarted(:final plugin):
+            startedPlugin = plugin;
+        }
+      }
+      final plugin = startedPlugin;
+      if (plugin == null) throw StateError("Factory did not return a started plugin.");
+      startedPlugins.add(plugin);
+      return plugin;
+    }
+
+    test("allowed resolution starts the descriptor on a fully wired host", () async {
+      final terminatedBridge = _identity(pid: 200, startMarker: "old-bridge-start");
+      bridgeInstanceService.resolution = BridgeInstanceResolution(
+        status: BridgeInstanceResolutionStatus.allowed,
+        existingBridges: const <ProcessIdentity>[],
+        terminatedBridges: <ProcessIdentity>[terminatedBridge],
+      );
+
+      final plugin = await startPlugin();
+
+      expect(startupMutexRepository.lockRequests, hasLength(1));
+      expect(startupMutexRepository.lockRequests.single, equals((pid: 100, startMarker: "bridge-start")));
+      expect(bridgeInstanceService.currentPids, equals(<int>[100]));
+      expect(
+        <String>[
+          ...startupMutexRepository.operations,
+          ...bridgeInstanceService.operations,
+          ...descriptor.operations,
+        ],
+        equals(<String>["mutex.acquire", "singleton.check", "descriptor.start"]),
+      );
+      expect(identical(plugin, descriptor.startedPlugin), isTrue);
+
+      final host = descriptor.startedHosts.single;
+      expect(host.config.value("port"), equals("4096"));
+      expect(host.stateDirectory, equals("${runtimeDirectory.path}/plugins/fake"));
+      expect(host.environment, containsPair("HOME", "/home/alex"));
+      expect(host.bridge.identity.pid, equals(100));
+      expect(host.bridge.ownerSessionId, equals("owner-session"));
+      expect(
+        host.bridge.terminatedBridgeIdentities.map((identity) => identity.pid),
+        equals(<int>[200]),
+        reason: "stale cleanup must be authorized to reclaim records of the bridge this one replaced",
+      );
+    });
+
+    test("zero-plugin startup still performs single-live-bridge enforcement", () async {
+      final factory = PluginGenerationFactory(
+        managedRuntimePaths: ManagedRuntimePaths(
+          installRoot: runtimeDirectory.path,
+          binaryPath: "${runtimeDirectory.path}/bin/sesori-bridge",
+          cacheDirectory: runtimeDirectory.path,
+        ),
+        currentBridgeIdentity: currentBridgeIdentity,
+        ownerSessionId: "owner-session",
+        startupMutexRepository: startupMutexRepository,
+        bridgeInstanceService: bridgeInstanceService,
+        processRepository: _FakeProcessRepository(),
+        runtimeFileApi: RuntimeFileApi(runtimeDirectory: runtimeDirectory.path),
+        clock: const ServerClock(),
+        environment: const <String, String>{},
+        currentUser: null,
+      );
+      await factory.enforceBridgeOwnership();
+
+      expect(startupMutexRepository.lockRequests, hasLength(1));
+      expect(bridgeInstanceService.currentPids, [currentBridgeIdentity.pid]);
+      expect(descriptor.startedHosts, isEmpty);
+    });
+
+    test("the state directory exists before the descriptor starts", () async {
+      final stateDirectory = "${runtimeDirectory.path}/nested/runtime";
+
+      await startPlugin(stateDirectory: stateDirectory);
+
+      expect(descriptor.stateDirectoryExistedAtStartLog.single, isTrue);
+    });
+
+    test("singleton decline aborts before the descriptor starts", () async {
+      bridgeInstanceService.resolution = const BridgeInstanceResolution(
+        status: BridgeInstanceResolutionStatus.declined,
+        existingBridges: <ProcessIdentity>[],
+        terminatedBridges: <ProcessIdentity>[],
+      );
+
+      await expectLater(
+        startPlugin(),
+        throwsA(
+          isA<BridgeRuntimeServerException>().having(
+            (error) => error.message,
+            "message",
+            contains("declined"),
+          ),
+        ),
+      );
+
+      expect(descriptor.startedHosts, isEmpty);
+    });
+
+    test("non-interactive singleton conflict aborts before the descriptor starts", () async {
+      bridgeInstanceService.resolution = const BridgeInstanceResolution(
+        status: BridgeInstanceResolutionStatus.nonInteractive,
+        existingBridges: <ProcessIdentity>[],
+        terminatedBridges: <ProcessIdentity>[],
+      );
+
+      await expectLater(
+        startPlugin(),
+        throwsA(
+          isA<BridgeRuntimeServerException>().having(
+            (error) => error.message,
+            "message",
+            contains("non-interactive"),
+          ),
+        ),
+      );
+
+      expect(descriptor.startedHosts, isEmpty);
+    });
+
+    test("mutex rejection aborts before singleton or descriptor work", () async {
+      startupMutexRepository.rejectLock = true;
+      startupMutexRepository.rejection = _startupLockRejection();
+      bridgeInstanceService.startupLockStatus = BridgeInstanceResolutionStatus.declined;
+
+      await expectLater(
+        startPlugin(),
+        throwsA(
+          isA<BridgeRuntimeServerException>().having(
+            (error) => error.message,
+            "message",
+            contains("already in progress"),
+          ),
+        ),
+      );
+
+      expect(bridgeInstanceService.currentPids, isEmpty);
+      expect(descriptor.startedHosts, isEmpty);
+    });
+
+    test("mutex rejection with unidentifiable holder includes lock path recovery", () async {
+      startupMutexRepository.rejectLock = true;
+      startupMutexRepository.rejection = const StartupLockRejection(
+        lock: null,
+        holderMatch: null,
+        lockFilePath: "/tmp/bridge-startup.lock",
+      );
+
+      await expectLater(
+        startPlugin(),
+        throwsA(
+          isA<BridgeRuntimeServerException>().having(
+            (error) => error.message,
+            "message",
+            allOf(contains("delete /tmp/bridge-startup.lock"), contains("already in progress")),
+          ),
+        ),
+      );
+
+      expect(bridgeInstanceService.startupLockContentionCalls, isEmpty);
+    });
+
+    test("startup lock takeover retries mutex and starts the descriptor", () async {
+      startupMutexRepository.rejectSequence = <bool>[true, false];
+      startupMutexRepository.rejection = _startupLockRejection();
+      bridgeInstanceService.startupLockStatus = BridgeInstanceResolutionStatus.allowed;
+
+      final plugin = await startPlugin();
+
+      expect(identical(plugin, descriptor.startedPlugin), isTrue);
+      expect(startupMutexRepository.lockRequests, hasLength(2));
+      expect(bridgeInstanceService.startupLockContentionCalls.single.lock.bridgePid, equals(201));
+      expect(bridgeInstanceService.currentPids, equals(<int>[100]));
+    });
+
+    test("startup lock replacement decline aborts with declined message", () async {
+      startupMutexRepository.rejectLock = true;
+      startupMutexRepository.rejection = _startupLockRejection();
+      bridgeInstanceService.startupLockStatus = BridgeInstanceResolutionStatus.declined;
+
+      await expectLater(
+        startPlugin(),
+        throwsA(
+          isA<BridgeRuntimeServerException>().having(
+            (error) => error.message,
+            "message",
+            contains("replacement was declined"),
+          ),
+        ),
+      );
+    });
+
+    test("startup lock nonInteractive message includes pid and lock path", () async {
+      startupMutexRepository.rejectLock = true;
+      startupMutexRepository.rejection = _startupLockRejection(lockFilePath: "/tmp/start.lock");
+      bridgeInstanceService.startupLockStatus = BridgeInstanceResolutionStatus.nonInteractive;
+
+      await expectLater(
+        startPlugin(),
+        throwsA(
+          isA<BridgeRuntimeServerException>().having(
+            (error) => error.message,
+            "message",
+            allOf(contains("non-interactive"), contains("Bridge pid 201"), contains("/tmp/start.lock")),
+          ),
+        ),
+      );
+    });
+
+    test("startup lock allowed but still locked on retry aborts without infinite loop", () async {
+      startupMutexRepository.rejectSequence = <bool>[true, true];
+      startupMutexRepository.rejection = _startupLockRejection();
+      bridgeInstanceService.startupLockStatus = BridgeInstanceResolutionStatus.allowed;
+
+      await expectLater(
+        startPlugin(),
+        throwsA(
+          isA<BridgeRuntimeServerException>().having(
+            (error) => error.message,
+            "message",
+            contains("still in progress after attempting replacement"),
+          ),
+        ),
+      );
+
+      expect(startupMutexRepository.lockRequests, hasLength(2));
+    });
+
+    test("a start aborted inside the descriptor settles as PluginStartAbortedException", () async {
+      descriptor.startErrors.add(const PluginStartAbortedException());
+
+      await expectLater(startPlugin(), throwsA(isA<PluginStartAbortedException>()));
+    });
+
+    group("runtime-resolution tee", () {
+      test("emits each runtime-resolution event in order", () async {
+        descriptor.provisionEvents.addAll(const <RuntimeProvisionProgress>[
+          ProvisionResolving(),
+          ProvisionDownloading(receivedBytes: 256, totalBytes: 1024),
+          ProvisionReady(binaryPath: "/bin/opencode"),
+        ]);
+        final observed = <RuntimeProvisionProgress>[];
+
+        await startPlugin(observedProgress: observed);
+
+        expect(observed, equals(descriptor.provisionEvents));
+      });
+
+      test("teeing does not disturb the runner recording ProvisionReady.binaryPath on the host", () async {
+        descriptor.provisionEvents.addAll(const <RuntimeProvisionProgress>[
+          ProvisionResolving(),
+          ProvisionReady(binaryPath: "/opt/opencode/bin/opencode"),
+        ]);
+
+        await startPlugin(observedProgress: <RuntimeProvisionProgress>[]);
+
+        expect(descriptor.startedHosts.single.provisionedRuntimePath, equals("/opt/opencode/bin/opencode"));
+      });
+
+      test("standalone mode (no notifier) still records the resolved path with no tee", () async {
+        descriptor.provisionEvents.add(const ProvisionReady(binaryPath: "/opt/opencode/bin/opencode"));
+
+        // No provisionNotifier passed — the standalone/byte-identical path.
+        await startPlugin();
+
+        expect(descriptor.startedHosts.single.provisionedRuntimePath, equals("/opt/opencode/bin/opencode"));
+      });
+    });
+  });
+}
+
+ProcessIdentity _identity({required int pid, required String? startMarker}) {
+  return ProcessIdentity(
+    pid: pid,
+    startMarker: startMarker,
+    executablePath: "/usr/local/bin/sesori-bridge",
+    commandLine: "/usr/local/bin/sesori-bridge",
+    ownerUser: ProcessUser.fromRawUser("alex"),
+    platform: "macos",
+    capturedAt: DateTime.utc(2026, 5, 15, 12),
+  );
+}
+
+StartupLockRejection _startupLockRejection({String lockFilePath = "/tmp/bridge-startup.lock"}) {
+  final holderIdentity = _identity(pid: 201, startMarker: "holder-start");
+  return StartupLockRejection(
+    lock: const BridgeStartupLock(bridgePid: 201, bridgeStartMarker: "holder-start"),
+    holderMatch: ProcessMatch(
+      identity: holderIdentity,
+      kind: ProcessMatchKind.sesoriBridge,
+      isCurrentUserProcess: true,
+    ),
+    lockFilePath: lockFilePath,
+  );
+}
+
+/// Records the host every `start()` receives and returns a steady fake plugin,
+/// so the tests can assert exactly what the runner wires up.
+class _RecordingDescriptor extends BridgePluginDescriptor {
+  _RecordingDescriptor();
+
+  final List<PluginHost> startedHosts = <PluginHost>[];
+  final List<String> operations = <String>[];
+  final _FakeBridgePlugin startedPlugin = _FakeBridgePlugin();
+  final List<bool> stateDirectoryExistedAtStartLog = <bool>[];
+
+  /// When non-empty, `start()` throws the first entry instead of returning.
+  final List<Object> startErrors = <Object>[];
+
+  /// Emitted, in order, from `ensureRuntime()` before `start()`.
+  final List<RuntimeProvisionProgress> provisionEvents = <RuntimeProvisionProgress>[];
+
+  @override
+  String get id => "fake";
+
+  @override
+  String get displayName => "Fake";
+
+  @override
+  PluginProjectOwnership get projectOwnership => PluginProjectOwnership.native;
+
+  @override
+  List<PluginOption> get options => const [];
+
+  @override
+  Stream<RuntimeProvisionProgress> ensureRuntime({required PluginHost host}) async* {
+    for (final event in provisionEvents) {
+      yield event;
+    }
+  }
+
+  @override
+  Future<BridgePlugin> start(PluginHost host) async {
+    operations.add("descriptor.start");
+    startedHosts.add(host);
+    stateDirectoryExistedAtStartLog.add(Directory(host.stateDirectory).existsSync());
+    if (startErrors.isNotEmpty) {
+      throw startErrors.first;
+    }
+    return startedPlugin;
+  }
+}
+
+class _FakeBridgePlugin implements BridgePlugin {
+  final PluginStatusController _status = PluginStatusController(initial: const PluginReady());
+  final BridgePluginApi _api = _FakeBridgePluginApi();
+
+  @override
+  BridgePluginApi get api => _api;
+
+  @override
+  Stream<PluginStatus> get status => _status.stream;
+
+  @override
+  PluginStatus get currentStatus => _status.current;
+
+  @override
+  PluginDiagnostics describe() {
+    return const PluginDiagnostics(pluginId: "fake", endpoint: "http://127.0.0.1:1", details: {});
+  }
+
+  @override
+  Future<void> shutdown({required Duration? budget}) async {}
+}
+
+class _FakeBridgePluginApi extends NativeProjectsPluginApi {
+  @override
+  String get id => "fake";
+
+  @override
+  Stream<BridgeSseEvent> get events => const Stream.empty();
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Never invoked in these tests: the host's process service is constructed
+/// but the fake descriptor short-circuits before any process work.
+class _FakeProcessRepository implements ProcessRepository {
+  @override
+  Future<int> startDetached({
+    required String executable,
+    required List<String> arguments,
+    Map<String, String>? environment,
+  }) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeStartupMutexRepository implements StartupMutexRepository {
+  bool rejectLock = false;
+  List<bool>? rejectSequence;
+  StartupLockRejection? rejection;
+  final List<({int pid, String? startMarker})> lockRequests = <({int pid, String? startMarker})>[];
+  final List<String> operations = <String>[];
+
+  @override
+  Future<T> withLock<T>({
+    required int bridgePid,
+    required String? bridgeStartMarker,
+    required Future<T> Function() onLockAcquired,
+    required Future<T> Function(StartupLockRejection rejection) onLockRejected,
+  }) async {
+    lockRequests.add((pid: bridgePid, startMarker: bridgeStartMarker));
+    operations.add("mutex.acquire");
+    final shouldReject = rejectSequence?.removeAt(0) ?? rejectLock;
+    if (shouldReject) {
+      return onLockRejected(
+        rejection ??
+            const StartupLockRejection(
+              lock: null,
+              holderMatch: null,
+              lockFilePath: "/tmp/bridge-startup.lock",
+            ),
+      );
+    }
+    return onLockAcquired();
+  }
+}
+
+class _FakeBridgeInstanceService implements BridgeInstanceService {
+  @override
+  Future<void> awaitPredecessorBridgeExit({
+    required int predecessorPid,
+    required Duration timeout,
+  }) async {}
+
+  BridgeInstanceResolution resolution = const BridgeInstanceResolution(
+    status: BridgeInstanceResolutionStatus.allowed,
+    existingBridges: <ProcessIdentity>[],
+    terminatedBridges: <ProcessIdentity>[],
+  );
+  final List<int> currentPids = <int>[];
+  final List<String> operations = <String>[];
+  BridgeInstanceResolutionStatus startupLockStatus = BridgeInstanceResolutionStatus.allowed;
+  final List<({BridgeStartupLock lock, ProcessMatch holder, int currentPid})> startupLockContentionCalls =
+      <({BridgeStartupLock lock, ProcessMatch holder, int currentPid})>[];
+
+  @override
+  Future<BridgeInstanceResolution> enforceSingleLiveBridge({required int currentPid}) async {
+    currentPids.add(currentPid);
+    operations.add("singleton.check");
+    return resolution;
+  }
+
+  @override
+  Future<List<ProcessIdentity>> terminateBridges({
+    required int currentPid,
+    required List<ProcessIdentity> existingBridges,
+  }) async {
+    operations.add("singleton.terminate");
+    return existingBridges;
+  }
+
+  @override
+  Future<BridgeInstanceResolutionStatus> resolveStartupLockContention({
+    required BridgeStartupLock lock,
+    required ProcessMatch holder,
+    required int currentPid,
+  }) async {
+    startupLockContentionCalls.add((lock: lock, holder: holder, currentPid: currentPid));
+    return startupLockStatus;
+  }
+}

--- a/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
@@ -1,0 +1,708 @@
+import "dart:async";
+
+import "package:rxdart/rxdart.dart";
+import "package:sesori_bridge/src/bridge/runtime/bridge_runtime_server_exception.dart";
+import "package:sesori_bridge/src/bridge/runtime/plugin_generation_factory.dart";
+import "package:sesori_bridge/src/bridge/runtime/plugin_runtime.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("unknown plugin acquisitions preserve the typed unavailable contract", () async {
+    final runtime = _runtime(
+      factory: _FakeGenerationFactory(startGate: Future<void>.value()),
+    );
+    addTearDown(runtime.dispose);
+
+    Matcher unavailableFor(String operation) => isA<PluginOperationException>()
+        .having((error) => error.operation, "operation", operation)
+        .having((error) => error.statusCode, "statusCode", 503)
+        .having((error) => error.message, "message", contains("unknown"));
+
+    await expectLater(
+      runtime.use(pluginId: "removed-plugin", operation: _TestOperation.read, body: (_) async {}),
+      throwsA(unavailableFor("read")),
+    );
+    await expectLater(
+      runtime.useStream<int>(
+        pluginId: "removed-plugin",
+        operation: _TestOperation.watch,
+        body: (_, _) => const Stream<int>.empty(),
+      ),
+      emitsError(unavailableFor("watch")),
+    );
+    await expectLater(
+      runtime.useIfActive<void>(
+        pluginId: "removed-plugin",
+        operation: _TestOperation.activeRead,
+        body: (_, _) async {},
+      ),
+      throwsA(unavailableFor("activeRead")),
+    );
+    expect(
+      () => runtime.requireCurrentGeneration(
+        pluginId: "removed-plugin",
+        generation: 1,
+        operation: _TestOperation.directFence,
+      ),
+      throwsA(
+        isA<PluginOperationException>()
+            .having((error) => error.operation, "operation", "directFence")
+            .having((error) => error.statusCode, "statusCode", 503),
+      ),
+    );
+  });
+
+  test("concurrent acquisitions join one start and hold independent leases", () async {
+    final startGate = Completer<void>();
+    final operationGate = Completer<void>();
+    final factory = _FakeGenerationFactory(startGate: startGate.future);
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+
+    final first = runtime.use(
+      pluginId: "one",
+      operation: _TestOperation.first,
+      body: (_) => operationGate.future,
+    );
+    final second = runtime.use(
+      pluginId: "one",
+      operation: _TestOperation.second,
+      body: (_) => operationGate.future,
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(factory.startCount, 1);
+    startGate.complete();
+    await _waitUntil(() => runtime.snapshot.single.leaseCount == 2);
+    expect(runtime.activePluginIds, {"one"});
+
+    operationGate.complete();
+    await Future.wait([first, second]);
+    expect(runtime.snapshot.single.leaseCount, 0);
+  });
+
+  test("stream acquisition retains its lease until cancellation", () async {
+    final factory = _FakeGenerationFactory(startGate: Future<void>.value());
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    final source = StreamController<int>();
+
+    final subscription = runtime
+        .useStream(
+          pluginId: "one",
+          operation: _TestOperation.stream,
+          body: (_, _) => source.stream,
+        )
+        .listen((_) {});
+    await _waitUntil(() => runtime.snapshot.single.leaseCount == 1 && source.hasListener);
+
+    await subscription.cancel();
+    await _waitUntil(() => runtime.snapshot.single.leaseCount == 0);
+    await source.close();
+  });
+
+  test("stream acquisition releases its lease and cancels its source after an error", () async {
+    final factory = _FakeGenerationFactory(startGate: Future<void>.value());
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    final source = StreamController<int>();
+    final cancelled = Completer<void>();
+    source.onCancel = cancelled.complete;
+
+    final error = StateError("source failed");
+    final completion = expectLater(
+      runtime.useStream(
+        pluginId: "one",
+        operation: _TestOperation.stream,
+        body: (_, _) => source.stream,
+      ),
+      emitsError(same(error)),
+    );
+    await _waitUntil(() => runtime.snapshot.single.leaseCount == 1 && source.hasListener);
+
+    source.addError(error);
+
+    await completion;
+    await cancelled.future;
+    expect(runtime.snapshot.single.leaseCount, 0);
+    await source.close();
+  });
+
+  test("stream cancellation releases its lease when source cancellation fails", () async {
+    final factory = _FakeGenerationFactory(startGate: Future<void>.value());
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    final cancellationError = StateError("cancel failed");
+    final source = StreamController<int>(
+      onCancel: () => Future<void>.error(cancellationError),
+    );
+    final subscription = runtime
+        .useStream(
+          pluginId: "one",
+          operation: _TestOperation.stream,
+          body: (_, _) => source.stream,
+        )
+        .listen((_) {});
+    await _waitUntil(() => runtime.snapshot.single.leaseCount == 1 && source.hasListener);
+
+    await expectLater(subscription.cancel(), throwsA(same(cancellationError)));
+
+    expect(runtime.snapshot.single.leaseCount, 0);
+    await source.close();
+  });
+
+  test("stream cancellation before acquisition releases the eventual lease", () async {
+    final startGate = Completer<void>();
+    final factory = _FakeGenerationFactory(startGate: startGate.future);
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    var bodyCalled = false;
+    final subscription = runtime
+        .useStream(
+          pluginId: "one",
+          operation: _TestOperation.stream,
+          body: (_, _) {
+            bodyCalled = true;
+            return const Stream<int>.empty();
+          },
+        )
+        .listen((_) {});
+    await _waitUntil(() => factory.startCount == 1);
+
+    await subscription.cancel();
+    startGate.complete();
+    await _waitUntil(
+      () => runtime.snapshot.single.state == PluginRuntimeState.active && runtime.snapshot.single.leaseCount == 0,
+    );
+
+    expect(bodyCalled, isFalse);
+  });
+
+  test("a safe stop blocks acquisitions once its transition begins", () async {
+    final shutdownGate = Completer<void>();
+    final factory = _FakeGenerationFactory(
+      startGate: Future<void>.value(),
+      pluginFactory: (_) => _FakePlugin(api: _FakeApi(), shutdownGate: shutdownGate.future),
+    );
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.startEager(pluginIds: const ["one"]);
+
+    final stopping = runtime.stop(pluginId: "one", intent: PluginStopIntent.safe);
+    await _waitUntil(() => runtime.snapshot.single.transition == PluginRuntimeTransition.stopping);
+
+    await expectLater(
+      runtime.use(pluginId: "one", operation: _TestOperation.duringStop, body: (_) async {}),
+      throwsA(isA<PluginOperationException>()),
+    );
+
+    shutdownGate.complete();
+    expect(await stopping, isA<PluginRuntimeCommandApplied>());
+    expect(runtime.snapshot.single.state, PluginRuntimeState.dormant);
+  });
+
+  test("a command-owned stop rejects force takeover until teardown finishes", () async {
+    final shutdownGate = Completer<void>();
+    final factory = _FakeGenerationFactory(
+      startGate: Future<void>.value(),
+      pluginFactory: (generation) => _FakePlugin(
+        api: _FakeApi(),
+        shutdownGate: generation == 1 ? shutdownGate.future : null,
+      ),
+    );
+    final runtime = _runtime(factory: factory);
+    addTearDown(() async {
+      if (!shutdownGate.isCompleted) shutdownGate.complete();
+      await runtime.dispose();
+    });
+    await runtime.startEager(pluginIds: const ["one"]);
+    final originalPlugin = factory.plugins.single;
+
+    final stopping = runtime.stop(pluginId: "one", intent: PluginStopIntent.safe);
+    final takeover = await runtime.restart(pluginId: "one", intent: PluginStopIntent.force);
+
+    expect(takeover, isA<PluginRuntimeCommandConflict>());
+    expect(factory.startCount, 1);
+    shutdownGate.complete();
+    expect(await stopping, isA<PluginRuntimeCommandApplied>());
+    expect(originalPlugin.shutdownInvocationCount, 1);
+    expect(runtime.snapshot.single.generation, 1);
+    expect(runtime.snapshot.single.state, PluginRuntimeState.dormant);
+    expect(runtime.snapshot.single.transition, PluginRuntimeTransition.none);
+  });
+
+  test("a force stop fences an operation that completes after shutdown", () async {
+    final operationGate = Completer<void>();
+    final factory = _FakeGenerationFactory(startGate: Future<void>.value());
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.startEager(pluginIds: const ["one"]);
+    final operation = runtime.use(
+      pluginId: "one",
+      operation: _TestOperation.forceFenced,
+      body: (_) => operationGate.future,
+    );
+    await _waitUntil(() => runtime.snapshot.single.leaseCount == 1);
+
+    expect(
+      await runtime.stop(pluginId: "one", intent: PluginStopIntent.force),
+      isA<PluginRuntimeCommandApplied>(),
+    );
+    operationGate.complete();
+
+    await expectLater(
+      operation,
+      throwsA(
+        isA<PluginOperationException>().having(
+          (error) => error.operation,
+          "operation",
+          "forceFenced",
+        ),
+      ),
+    );
+    expect(runtime.snapshot.single.state, PluginRuntimeState.dormant);
+  });
+
+  test("a force stop waits for a generation's durable commit", () async {
+    final commitStarted = Completer<void>();
+    final commitGate = Completer<void>();
+    final factory = _FakeGenerationFactory(startGate: Future<void>.value());
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.startEager(pluginIds: const ["one"]);
+
+    final operation = runtime.useAndCommit<String, String>(
+      pluginId: "one",
+      operation: _TestOperation.durableCommit,
+      prepare: (_) async => "prepared",
+      commit: (prepared) async {
+        commitStarted.complete();
+        await commitGate.future;
+        return prepared;
+      },
+    );
+    await commitStarted.future;
+
+    var stopCompleted = false;
+    final stopping = runtime.stop(pluginId: "one", intent: PluginStopIntent.force).whenComplete(() {
+      stopCompleted = true;
+    });
+    await _waitUntil(() => runtime.snapshot.single.transition == PluginRuntimeTransition.stopping);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(stopCompleted, isFalse);
+    expect(factory.plugins.single.shutdownInvocationCount, 0);
+
+    commitGate.complete();
+    expect(await operation, "prepared");
+    expect(await stopping, isA<PluginRuntimeCommandApplied>());
+    expect(factory.plugins.single.shutdownInvocationCount, 1);
+  });
+
+  test("a terminal failure waits for a generation's durable commit", () async {
+    final commitStarted = Completer<void>();
+    final commitGate = Completer<void>();
+    final factory = _FakeGenerationFactory(startGate: Future<void>.value());
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.startEager(pluginIds: const ["one"]);
+    final plugin = factory.plugins.single;
+
+    final operation = runtime.useAndCommit<String, String>(
+      pluginId: "one",
+      operation: _TestOperation.durableCommit,
+      prepare: (_) async => "prepared",
+      commit: (prepared) async {
+        commitStarted.complete();
+        await commitGate.future;
+        return prepared;
+      },
+    );
+    await commitStarted.future;
+
+    plugin.statuses.add(const PluginFailed(reason: "terminal", cause: null));
+    await _waitUntil(() => runtime.snapshot.single.transition == PluginRuntimeTransition.stopping);
+    expect(plugin.shutdownInvocationCount, 0);
+
+    commitGate.complete();
+    expect(await operation, "prepared");
+    await _waitUntil(
+      () =>
+          runtime.snapshot.single.state == PluginRuntimeState.failed &&
+          runtime.snapshot.single.transition == PluginRuntimeTransition.none,
+    );
+    expect(plugin.shutdownInvocationCount, 1);
+  });
+
+  test("restart keeps its transition serialized through the successor start", () async {
+    final factory = _FakeGenerationFactory(startGate: Future<void>.value());
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.startEager(pluginIds: const ["one"]);
+
+    final result = await runtime.restart(pluginId: "one", intent: PluginStopIntent.safe);
+
+    expect(result, isA<PluginRuntimeCommandApplied>());
+    expect(factory.startCount, 2);
+    expect(runtime.snapshot.single.generation, 2);
+    expect(runtime.snapshot.single.state, PluginRuntimeState.active);
+    expect(runtime.snapshot.single.transition, PluginRuntimeTransition.none);
+  });
+
+  test("a force restart aborts an in-flight start before starting its successor", () async {
+    final startGate = Completer<void>();
+    final factory = _FakeGenerationFactory(startGate: startGate.future);
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    final initialStart = runtime.startEager(pluginIds: const ["one"]);
+    await _waitUntil(() => factory.startCount == 1);
+
+    final restarting = runtime.restart(pluginId: "one", intent: PluginStopIntent.force);
+    startGate.complete();
+
+    await expectLater(initialStart, throwsA(isA<PluginStartAbortedException>()));
+    expect(await restarting, isA<PluginRuntimeCommandApplied>());
+    expect(factory.startCount, 2);
+    expect(runtime.snapshot.single.generation, 2);
+    expect(runtime.snapshot.single.state, PluginRuntimeState.active);
+  });
+
+  test("a force restart recovers a generation stuck in PluginStopping", () async {
+    final factory = _FakeGenerationFactory(startGate: Future<void>.value());
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.startEager(pluginIds: const ["one"]);
+    final stoppingPlugin = factory.plugins.single;
+
+    stoppingPlugin.statuses.add(const PluginStopping());
+    await _waitUntil(() => runtime.snapshot.single.transition == PluginRuntimeTransition.stopping);
+
+    expect(
+      await runtime.restart(pluginId: "one", intent: PluginStopIntent.safe),
+      isA<PluginRuntimeCommandConflict>(),
+    );
+    expect(
+      await runtime.restart(pluginId: "one", intent: PluginStopIntent.force),
+      isA<PluginRuntimeCommandApplied>(),
+    );
+    expect(stoppingPlugin.shutdownCount, 1);
+    expect(factory.startCount, 2);
+    expect(runtime.snapshot.single.generation, 2);
+    expect(runtime.snapshot.single.state, PluginRuntimeState.active);
+    expect(runtime.snapshot.single.transition, PluginRuntimeTransition.none);
+  });
+
+  test("a terminal plugin failure fences its generation and allows a later retry", () async {
+    final factory = _FakeGenerationFactory(startGate: Future<void>.value());
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.startEager(pluginIds: const ["one"]);
+    final failedPlugin = factory.plugins.single;
+
+    failedPlugin.statuses.add(const PluginFailed(reason: "terminal", cause: null));
+    await _waitUntil(
+      () =>
+          runtime.snapshot.single.state == PluginRuntimeState.failed &&
+          runtime.snapshot.single.transition == PluginRuntimeTransition.none,
+    );
+
+    final result = await runtime.use(
+      pluginId: "one",
+      operation: _TestOperation.retry,
+      body: (_) async => "retried",
+    );
+
+    expect(result, "retried");
+    expect(factory.startCount, 2);
+    expect(runtime.snapshot.single.generation, 2);
+    expect(failedPlugin.shutdownCount, 1);
+  });
+
+  test("shared factory failures propagate instead of degrading one plugin", () async {
+    const error = BridgeRuntimeServerException("bridge ownership failed");
+    final factory = _FakeGenerationFactory(
+      startGate: Future<void>.value(),
+      startError: error,
+    );
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+
+    await expectLater(
+      runtime.startEager(pluginIds: const ["one"]),
+      throwsA(same(error)),
+    );
+  });
+
+  test("descriptor-local factory failures leave the plugin failed without aborting eager startup", () async {
+    final factory = _FakeGenerationFactory(
+      startGate: Future<void>.value(),
+      startError: const PluginGenerationStartFailedException(
+        pluginId: "one",
+        cause: "descriptor failed",
+      ),
+    );
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+
+    await runtime.startEager(pluginIds: const ["one"]);
+
+    expect(runtime.snapshot.single.state, PluginRuntimeState.failed);
+    expect(runtime.activePluginIds, isEmpty);
+  });
+
+  test("an invalid returned plugin is shut down and never routed", () async {
+    final factory = _FakeGenerationFactory(
+      startGate: Future<void>.value(),
+      pluginFactory: (_) => _FakePlugin(api: _FakeApi(id: "wrong")),
+    );
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+
+    await runtime.startEager(pluginIds: const ["one"]);
+
+    expect(runtime.activePluginIds, isEmpty);
+    expect(runtime.snapshot.single.state, PluginRuntimeState.failed);
+    expect(factory.plugins.single.shutdownCount, 1);
+  });
+
+  test("shutdown cleans up a plugin that returns after API disposal begins", () async {
+    final startGate = Completer<void>();
+    final factory = _FakeGenerationFactory(
+      startGate: startGate.future,
+      honorAbort: false,
+    );
+    final runtime = _runtime(factory: factory);
+    final starting = runtime.startEager(pluginIds: const ["one"]);
+    await _waitUntil(() => factory.startCount == 1);
+
+    runtime.beginShutdown();
+    final disposingApis = runtime.disposeStartedApis();
+    startGate.complete();
+
+    await expectLater(starting, throwsA(isA<PluginStartAbortedException>()));
+    await disposingApis;
+    expect(factory.plugins.single.shutdownCount, 1);
+    await runtime.dispose();
+  });
+
+  test("event closure during API disposal does not hide a later shutdown failure", () async {
+    final shutdownError = StateError("runtime shutdown failed");
+    final factory = _FakeGenerationFactory(
+      startGate: Future<void>.value(),
+      pluginFactory: (_) => _FakePlugin(
+        api: _FakeApi(closeEventsOnDispose: true),
+        shutdownError: shutdownError,
+      ),
+    );
+    final runtime = _runtime(factory: factory);
+    await runtime.startEager(pluginIds: const ["one"]);
+
+    runtime.beginShutdown();
+    await runtime.disposeStartedApis();
+    expect(runtime.snapshot.single.state, PluginRuntimeState.active);
+
+    await expectLater(runtime.dispose(), throwsA(same(shutdownError)));
+  });
+
+  test("backend events carry plugin and generation attribution", () async {
+    final factory = _FakeGenerationFactory(startGate: Future<void>.value());
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.startEager(pluginIds: const ["one"]);
+
+    final eventFuture = runtime.backendEvents.first;
+    factory.api.eventsController.add(const BridgeSseProjectUpdated());
+    final sourced = await eventFuture;
+
+    expect(sourced.pluginId, "one");
+    expect(sourced.generation, 1);
+    expect(sourced.event, isA<BridgeSseProjectUpdated>());
+  });
+}
+
+enum _TestOperation {
+  read,
+  watch,
+  activeRead,
+  directFence,
+  first,
+  second,
+  stream,
+  duringStop,
+  forceFenced,
+  durableCommit,
+  retry,
+}
+
+PluginRuntime _runtime({required _FakeGenerationFactory factory}) {
+  final runtime = PluginRuntime(
+    registrations: const [
+      PluginRuntimeRegistration(
+        descriptor: _FakeDescriptor(),
+        config: PluginConfig(values: {}),
+        stateDirectory: ".",
+      ),
+    ],
+    generationFactory: factory,
+    setupProcesses: const _UnusedHostProcessService(),
+    environment: const {},
+    clock: const ServerClock(),
+    shutdownBudget: const Duration(seconds: 1),
+  );
+  runtime.applyAccess(
+    entries: const [
+      PluginRuntimeAccess(
+        pluginId: "one",
+        eligible: true,
+        startAllowed: true,
+      ),
+    ],
+  );
+  return runtime;
+}
+
+Future<void> _waitUntil(bool Function() predicate) async {
+  for (var attempt = 0; attempt < 100; attempt++) {
+    if (predicate()) return;
+    await Future<void>.delayed(Duration.zero);
+  }
+  throw StateError("condition did not become true");
+}
+
+class _FakeGenerationFactory implements PluginGenerationFactory {
+  _FakeGenerationFactory({
+    required this.startGate,
+    this.pluginFactory,
+    this.startError,
+    this.honorAbort = true,
+  });
+
+  final Future<void> startGate;
+  final _FakePlugin Function(int generation)? pluginFactory;
+  final Object? startError;
+  final bool honorAbort;
+  final List<_FakePlugin> plugins = <_FakePlugin>[];
+  int startCount = 0;
+
+  _FakeApi get api => plugins.last.api;
+
+  @override
+  Future<void> enforceBridgeOwnership() async {}
+
+  @override
+  Stream<PluginGenerationStartEvent> start({
+    required PluginRuntimeRegistration registration,
+    required StartAbortSignal startAborted,
+  }) async* {
+    startCount++;
+    await startGate;
+    if (startError case final error?) throw error;
+    if (honorAbort && startAborted.isAborted) throw const PluginStartAbortedException();
+    final plugin = pluginFactory?.call(startCount) ?? _FakePlugin(api: _FakeApi());
+    plugins.add(plugin);
+    yield PluginGenerationStarted(plugin: plugin);
+  }
+}
+
+class _FakeDescriptor extends BridgePluginDescriptor {
+  const _FakeDescriptor();
+
+  @override
+  String get id => "one";
+
+  @override
+  String get displayName => "One";
+
+  @override
+  PluginProjectOwnership get projectOwnership => PluginProjectOwnership.native;
+
+  @override
+  List<PluginOption> get options => const [];
+
+  @override
+  Future<BridgePlugin> start(PluginHost host) => throw UnsupportedError("fake factory owns construction");
+}
+
+class _FakePlugin implements BridgePlugin {
+  _FakePlugin({required this.api, this.shutdownGate, this.shutdownError});
+
+  final BehaviorSubject<PluginStatus> statuses = BehaviorSubject.seeded(const PluginReady());
+  final Future<void>? shutdownGate;
+  final Object? shutdownError;
+  Future<void>? _shutdownFuture;
+  int shutdownInvocationCount = 0;
+  int shutdownCount = 0;
+
+  @override
+  final _FakeApi api;
+
+  @override
+  PluginStatus get currentStatus => statuses.value;
+
+  @override
+  Stream<PluginStatus> get status => statuses.stream;
+
+  @override
+  PluginDiagnostics describe() => const PluginDiagnostics(pluginId: "one", endpoint: null, details: {});
+
+  @override
+  Future<void> shutdown({required Duration? budget}) {
+    shutdownInvocationCount++;
+    return _shutdownFuture ??= _shutdown();
+  }
+
+  Future<void> _shutdown() async {
+    shutdownCount++;
+    await shutdownGate;
+    await api.dispose();
+    if (shutdownError case final error?) throw error;
+    if (!api.eventsController.isClosed) await api.eventsController.close();
+    if (!statuses.isClosed) await statuses.close();
+  }
+}
+
+class _FakeApi extends NativeProjectsPluginApi {
+  _FakeApi({this.id = "one", this.closeEventsOnDispose = false});
+
+  final StreamController<BridgeSseEvent> eventsController = StreamController.broadcast();
+  final bool closeEventsOnDispose;
+  int disposeCount = 0;
+
+  @override
+  final String id;
+
+  @override
+  Stream<BridgeSseEvent> get events => eventsController.stream;
+
+  @override
+  Future<void> dispose() async {
+    disposeCount++;
+    if (closeEventsOnDispose && !eventsController.isClosed) await eventsController.close();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _UnusedHostProcessService implements HostProcessService {
+  const _UnusedHostProcessService();
+
+  @override
+  Future<ProcessIdentity?> inspect({required int pid}) => throw UnsupportedError("unused");
+
+  @override
+  Future<SignalResult> signalForce({required int pid}) => throw UnsupportedError("unused");
+
+  @override
+  Future<SignalResult> signalGraceful({required int pid}) => throw UnsupportedError("unused");
+
+  @override
+  Future<SpawnedProcess> spawn({
+    required String executable,
+    required List<String> arguments,
+    required Map<String, String>? environment,
+    required String? workingDirectory,
+    required bool runInShell,
+  }) => throw UnsupportedError("unused");
+}

--- a/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
@@ -179,6 +179,89 @@ void main() {
     expect(bodyCalled, isFalse);
   });
 
+  test("generation teardown cancels active operation streams and releases their leases", () async {
+    final factory = _FakeGenerationFactory(startGate: Future<void>.value());
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.startEager(pluginIds: const ["one"]);
+    final source = StreamController<int>();
+    final sourceCancelled = Completer<void>();
+    source.onCancel = sourceCancelled.complete;
+    final completion = expectLater(
+      runtime.useStream(
+        pluginId: "one",
+        operation: _TestOperation.stream,
+        body: (_, _) => source.stream,
+      ),
+      emitsDone,
+    );
+    await _waitUntil(() => runtime.snapshot.single.leaseCount == 1 && source.hasListener);
+
+    expect(
+      await runtime.stop(pluginId: "one", intent: PluginStopIntent.force),
+      isA<PluginRuntimeCommandApplied>(),
+    );
+
+    await sourceCancelled.future;
+    await completion;
+    expect(runtime.snapshot.single.leaseCount, 0);
+    await source.close();
+  });
+
+  test("generation teardown does not wait for a paused operation stream consumer", () async {
+    final factory = _FakeGenerationFactory(startGate: Future<void>.value());
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.startEager(pluginIds: const ["one"]);
+    final source = StreamController<int>();
+    final sourceCancelled = Completer<void>();
+    source.onCancel = sourceCancelled.complete;
+    final subscription = runtime
+        .useStream(
+          pluginId: "one",
+          operation: _TestOperation.stream,
+          body: (_, _) => source.stream,
+        )
+        .listen((_) {});
+    await _waitUntil(() => runtime.snapshot.single.leaseCount == 1 && source.hasListener);
+    subscription.pause();
+
+    final result = await runtime
+        .stop(pluginId: "one", intent: PluginStopIntent.force)
+        .timeout(const Duration(seconds: 1));
+
+    expect(result, isA<PluginRuntimeCommandApplied>());
+    await sourceCancelled.future;
+    expect(runtime.snapshot.single.leaseCount, 0);
+    subscription.resume();
+    await subscription.cancel();
+    await source.close();
+  });
+
+  test("revoking start permission removes an active generation from routing", () async {
+    final factory = _FakeGenerationFactory(startGate: Future<void>.value());
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.startEager(pluginIds: const ["one"]);
+
+    runtime.applyAccess(
+      entries: const [
+        PluginRuntimeAccess(pluginId: "one", eligible: true, startAllowed: false),
+      ],
+    );
+
+    expect(runtime.activePluginIds, isEmpty);
+    expect(runtime.isCurrentGeneration(pluginId: "one", generation: 1), isFalse);
+    expect(
+      await runtime.useIfActive(
+        pluginId: "one",
+        operation: _TestOperation.activeRead,
+        body: (_, _) async => "unexpected",
+      ),
+      isNull,
+    );
+  });
+
   test("a safe stop blocks acquisitions once its transition begins", () async {
     final shutdownGate = Completer<void>();
     final factory = _FakeGenerationFactory(
@@ -230,6 +313,28 @@ void main() {
     expect(runtime.snapshot.single.generation, 1);
     expect(runtime.snapshot.single.state, PluginRuntimeState.dormant);
     expect(runtime.snapshot.single.transition, PluginRuntimeTransition.none);
+  });
+
+  test("runtime disposal waits for command-owned generation teardown", () async {
+    final shutdownGate = Completer<void>();
+    final factory = _FakeGenerationFactory(
+      startGate: Future<void>.value(),
+      pluginFactory: (_) => _FakePlugin(api: _FakeApi(), shutdownGate: shutdownGate.future),
+    );
+    final runtime = _runtime(factory: factory);
+    await runtime.startEager(pluginIds: const ["one"]);
+
+    final stopping = runtime.stop(pluginId: "one", intent: PluginStopIntent.safe);
+    await _waitUntil(() => factory.plugins.single.shutdownInvocationCount == 1);
+    var disposeCompleted = false;
+    final disposing = runtime.dispose().whenComplete(() => disposeCompleted = true);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(disposeCompleted, isFalse);
+
+    shutdownGate.complete();
+    expect(await stopping, isA<PluginRuntimeCommandApplied>());
+    await disposing;
   });
 
   test("a force stop fences an operation that completes after shutdown", () async {


### PR DESCRIPTION
## Summary

- add the concrete `PluginGenerationFactory` for mutex-protected, bridge-owned plugin starts
- add the generation-scoped `PluginRuntime` kernel with typed acquisitions, leases, streams, fencing, durable commit protection, failure isolation, and bounded teardown
- split the oversized #508 delivery plan into four reviewable replacement PRs

This is the first replacement slice for #508. It intentionally adds and tests the runtime kernel without activating it in `BridgeRuntimeRunner`; plugin composition and operation routing follow in the next stacked PR. Current bridge behavior is unchanged.

## Verification

- `dart test test/bridge/runtime/plugin_generation_factory_test.dart` (15 tests)
- `dart test test/bridge/runtime/plugin_runtime_test.dart` (21 tests)
- `dart analyze --fatal-infos`
- `git diff --check`
- architecture implementation review: approved with no findings

## Stack

- Base: `main`
- Next: plugin operation routing
- Frozen reference: #508 at `f6cd675d`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a generation-scoped plugin runtime and a mutex-protected generation factory; not wired into the runner yet, so current bridge behavior is unchanged. Updated plan/tracker docs to track this runtime mechanics PR.

- **New Features**
  - `PluginRuntime`: typed acquisitions, leases, streams, fencing and durable commit protection, failure isolation, bounded teardown.
  - `PluginGenerationFactory`: bridge-owned plugin start and attach with a startup mutex.
  - Focused unit tests for runtime and factory.

- **Bug Fixes**
  - Serialized runtime stream teardown to prevent concurrent disposal races.

<sup>Written for commit 7230a98a21562031b16238f654f99ce80e5d8af6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

