### PR TITLE
feat(codex): expose Default and Plan collaboration modes

### DIFF
--- a/bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart
@@ -1,6 +1,7 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
 import "../codex_app_server_client.dart";
+import "../models/codex_collaboration_mode.dart";
 import "models/codex_skill_dto.dart";
 import "models/codex_thread_dto.dart";
 import "models/codex_turn_input_dto.dart";
@@ -57,13 +58,31 @@ class CodexAppServerApi {
     required List<CodexTurnInputDto> input,
     required String? model,
     required String? effort,
+    required CodexCollaborationMode? collaborationMode,
   }) async {
     final params = <String, dynamic>{
       "threadId": threadId,
       "input": input.map((item) => item.toJson()).toList(growable: false),
     };
-    if (model != null) params["model"] = model;
-    if (effort != null) params["effort"] = effort;
+    if (collaborationMode == null) {
+      if (model != null) params["model"] = model;
+      if (effort != null) params["effort"] = effort;
+    } else {
+      if (model == null || model.isEmpty) {
+        throw StateError(
+          "turn/start collaborationMode requires a resolved model",
+        );
+      }
+      params["collaborationMode"] = {
+        "mode": collaborationMode.wireValue,
+        "settings": {
+          "model": model,
+          "reasoning_effort": effort,
+          // Null asks Codex to supply its version-matched built-in mode prompt.
+          "developer_instructions": null,
+        },
+      };
+    }
     await _client.request(method: "turn/start", params: params);
   }
 

--- a/bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart
@@ -2,6 +2,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
 import "../codex_app_server_client.dart";
 import "../models/codex_collaboration_mode.dart";
+import "models/codex_collaboration_mode_dto.dart";
 import "models/codex_skill_dto.dart";
 import "models/codex_thread_dto.dart";
 import "models/codex_turn_input_dto.dart";
@@ -73,15 +74,15 @@ class CodexAppServerApi {
           "turn/start collaborationMode requires a resolved model",
         );
       }
-      params["collaborationMode"] = {
-        "mode": collaborationMode.wireValue,
-        "settings": {
-          "model": model,
-          "reasoning_effort": effort,
+      params["collaborationMode"] = CodexCollaborationModeDto(
+        mode: collaborationMode.wireValue,
+        settings: CodexCollaborationModeSettingsDto(
+          model: model,
+          reasoningEffort: effort,
           // Null asks Codex to supply its version-matched built-in mode prompt.
-          "developer_instructions": null,
-        },
-      };
+          developerInstructions: null,
+        ),
+      ).toJson();
     }
     await _client.request(method: "turn/start", params: params);
   }

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_collaboration_mode_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_collaboration_mode_dto.dart
@@ -1,0 +1,21 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "codex_collaboration_mode_dto.freezed.dart";
+part "codex_collaboration_mode_dto.g.dart";
+
+@Freezed(fromJson: false, toJson: true)
+sealed class CodexCollaborationModeDto with _$CodexCollaborationModeDto {
+  const factory CodexCollaborationModeDto({
+    required String mode,
+    required CodexCollaborationModeSettingsDto settings,
+  }) = _CodexCollaborationModeDto;
+}
+
+@Freezed(fromJson: false, toJson: true)
+sealed class CodexCollaborationModeSettingsDto with _$CodexCollaborationModeSettingsDto {
+  const factory CodexCollaborationModeSettingsDto({
+    required String model,
+    @JsonKey(name: "reasoning_effort") required String? reasoningEffort,
+    @JsonKey(name: "developer_instructions") required String? developerInstructions,
+  }) = _CodexCollaborationModeSettingsDto;
+}

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_collaboration_mode_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_collaboration_mode_dto.freezed.dart
@@ -1,0 +1,307 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'codex_collaboration_mode_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$CodexCollaborationModeDto {
+
+ String get mode; CodexCollaborationModeSettingsDto get settings;
+/// Create a copy of CodexCollaborationModeDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexCollaborationModeDtoCopyWith<CodexCollaborationModeDto> get copyWith => _$CodexCollaborationModeDtoCopyWithImpl<CodexCollaborationModeDto>(this as CodexCollaborationModeDto, _$identity);
+
+  /// Serializes this CodexCollaborationModeDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexCollaborationModeDto&&(identical(other.mode, mode) || other.mode == mode)&&(identical(other.settings, settings) || other.settings == settings));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,mode,settings);
+
+@override
+String toString() {
+  return 'CodexCollaborationModeDto(mode: $mode, settings: $settings)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexCollaborationModeDtoCopyWith<$Res>  {
+  factory $CodexCollaborationModeDtoCopyWith(CodexCollaborationModeDto value, $Res Function(CodexCollaborationModeDto) _then) = _$CodexCollaborationModeDtoCopyWithImpl;
+@useResult
+$Res call({
+ String mode, CodexCollaborationModeSettingsDto settings
+});
+
+
+$CodexCollaborationModeSettingsDtoCopyWith<$Res> get settings;
+
+}
+/// @nodoc
+class _$CodexCollaborationModeDtoCopyWithImpl<$Res>
+    implements $CodexCollaborationModeDtoCopyWith<$Res> {
+  _$CodexCollaborationModeDtoCopyWithImpl(this._self, this._then);
+
+  final CodexCollaborationModeDto _self;
+  final $Res Function(CodexCollaborationModeDto) _then;
+
+/// Create a copy of CodexCollaborationModeDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? mode = null,Object? settings = null,}) {
+  return _then(_self.copyWith(
+mode: null == mode ? _self.mode : mode // ignore: cast_nullable_to_non_nullable
+as String,settings: null == settings ? _self.settings : settings // ignore: cast_nullable_to_non_nullable
+as CodexCollaborationModeSettingsDto,
+  ));
+}
+/// Create a copy of CodexCollaborationModeDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CodexCollaborationModeSettingsDtoCopyWith<$Res> get settings {
+  
+  return $CodexCollaborationModeSettingsDtoCopyWith<$Res>(_self.settings, (value) {
+    return _then(_self.copyWith(settings: value));
+  });
+}
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createFactory: false)
+
+class _CodexCollaborationModeDto implements CodexCollaborationModeDto {
+  const _CodexCollaborationModeDto({required this.mode, required this.settings});
+  
+
+@override final  String mode;
+@override final  CodexCollaborationModeSettingsDto settings;
+
+/// Create a copy of CodexCollaborationModeDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexCollaborationModeDtoCopyWith<_CodexCollaborationModeDto> get copyWith => __$CodexCollaborationModeDtoCopyWithImpl<_CodexCollaborationModeDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$CodexCollaborationModeDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexCollaborationModeDto&&(identical(other.mode, mode) || other.mode == mode)&&(identical(other.settings, settings) || other.settings == settings));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,mode,settings);
+
+@override
+String toString() {
+  return 'CodexCollaborationModeDto(mode: $mode, settings: $settings)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexCollaborationModeDtoCopyWith<$Res> implements $CodexCollaborationModeDtoCopyWith<$Res> {
+  factory _$CodexCollaborationModeDtoCopyWith(_CodexCollaborationModeDto value, $Res Function(_CodexCollaborationModeDto) _then) = __$CodexCollaborationModeDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String mode, CodexCollaborationModeSettingsDto settings
+});
+
+
+@override $CodexCollaborationModeSettingsDtoCopyWith<$Res> get settings;
+
+}
+/// @nodoc
+class __$CodexCollaborationModeDtoCopyWithImpl<$Res>
+    implements _$CodexCollaborationModeDtoCopyWith<$Res> {
+  __$CodexCollaborationModeDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexCollaborationModeDto _self;
+  final $Res Function(_CodexCollaborationModeDto) _then;
+
+/// Create a copy of CodexCollaborationModeDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? mode = null,Object? settings = null,}) {
+  return _then(_CodexCollaborationModeDto(
+mode: null == mode ? _self.mode : mode // ignore: cast_nullable_to_non_nullable
+as String,settings: null == settings ? _self.settings : settings // ignore: cast_nullable_to_non_nullable
+as CodexCollaborationModeSettingsDto,
+  ));
+}
+
+/// Create a copy of CodexCollaborationModeDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CodexCollaborationModeSettingsDtoCopyWith<$Res> get settings {
+  
+  return $CodexCollaborationModeSettingsDtoCopyWith<$Res>(_self.settings, (value) {
+    return _then(_self.copyWith(settings: value));
+  });
+}
+}
+
+/// @nodoc
+mixin _$CodexCollaborationModeSettingsDto {
+
+ String get model;@JsonKey(name: "reasoning_effort") String? get reasoningEffort;@JsonKey(name: "developer_instructions") String? get developerInstructions;
+/// Create a copy of CodexCollaborationModeSettingsDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexCollaborationModeSettingsDtoCopyWith<CodexCollaborationModeSettingsDto> get copyWith => _$CodexCollaborationModeSettingsDtoCopyWithImpl<CodexCollaborationModeSettingsDto>(this as CodexCollaborationModeSettingsDto, _$identity);
+
+  /// Serializes this CodexCollaborationModeSettingsDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexCollaborationModeSettingsDto&&(identical(other.model, model) || other.model == model)&&(identical(other.reasoningEffort, reasoningEffort) || other.reasoningEffort == reasoningEffort)&&(identical(other.developerInstructions, developerInstructions) || other.developerInstructions == developerInstructions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,model,reasoningEffort,developerInstructions);
+
+@override
+String toString() {
+  return 'CodexCollaborationModeSettingsDto(model: $model, reasoningEffort: $reasoningEffort, developerInstructions: $developerInstructions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexCollaborationModeSettingsDtoCopyWith<$Res>  {
+  factory $CodexCollaborationModeSettingsDtoCopyWith(CodexCollaborationModeSettingsDto value, $Res Function(CodexCollaborationModeSettingsDto) _then) = _$CodexCollaborationModeSettingsDtoCopyWithImpl;
+@useResult
+$Res call({
+ String model,@JsonKey(name: "reasoning_effort") String? reasoningEffort,@JsonKey(name: "developer_instructions") String? developerInstructions
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexCollaborationModeSettingsDtoCopyWithImpl<$Res>
+    implements $CodexCollaborationModeSettingsDtoCopyWith<$Res> {
+  _$CodexCollaborationModeSettingsDtoCopyWithImpl(this._self, this._then);
+
+  final CodexCollaborationModeSettingsDto _self;
+  final $Res Function(CodexCollaborationModeSettingsDto) _then;
+
+/// Create a copy of CodexCollaborationModeSettingsDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? model = null,Object? reasoningEffort = freezed,Object? developerInstructions = freezed,}) {
+  return _then(_self.copyWith(
+model: null == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
+as String,reasoningEffort: freezed == reasoningEffort ? _self.reasoningEffort : reasoningEffort // ignore: cast_nullable_to_non_nullable
+as String?,developerInstructions: freezed == developerInstructions ? _self.developerInstructions : developerInstructions // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createFactory: false)
+
+class _CodexCollaborationModeSettingsDto implements CodexCollaborationModeSettingsDto {
+  const _CodexCollaborationModeSettingsDto({required this.model, @JsonKey(name: "reasoning_effort") required this.reasoningEffort, @JsonKey(name: "developer_instructions") required this.developerInstructions});
+  
+
+@override final  String model;
+@override@JsonKey(name: "reasoning_effort") final  String? reasoningEffort;
+@override@JsonKey(name: "developer_instructions") final  String? developerInstructions;
+
+/// Create a copy of CodexCollaborationModeSettingsDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexCollaborationModeSettingsDtoCopyWith<_CodexCollaborationModeSettingsDto> get copyWith => __$CodexCollaborationModeSettingsDtoCopyWithImpl<_CodexCollaborationModeSettingsDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$CodexCollaborationModeSettingsDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexCollaborationModeSettingsDto&&(identical(other.model, model) || other.model == model)&&(identical(other.reasoningEffort, reasoningEffort) || other.reasoningEffort == reasoningEffort)&&(identical(other.developerInstructions, developerInstructions) || other.developerInstructions == developerInstructions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,model,reasoningEffort,developerInstructions);
+
+@override
+String toString() {
+  return 'CodexCollaborationModeSettingsDto(model: $model, reasoningEffort: $reasoningEffort, developerInstructions: $developerInstructions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexCollaborationModeSettingsDtoCopyWith<$Res> implements $CodexCollaborationModeSettingsDtoCopyWith<$Res> {
+  factory _$CodexCollaborationModeSettingsDtoCopyWith(_CodexCollaborationModeSettingsDto value, $Res Function(_CodexCollaborationModeSettingsDto) _then) = __$CodexCollaborationModeSettingsDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String model,@JsonKey(name: "reasoning_effort") String? reasoningEffort,@JsonKey(name: "developer_instructions") String? developerInstructions
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexCollaborationModeSettingsDtoCopyWithImpl<$Res>
+    implements _$CodexCollaborationModeSettingsDtoCopyWith<$Res> {
+  __$CodexCollaborationModeSettingsDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexCollaborationModeSettingsDto _self;
+  final $Res Function(_CodexCollaborationModeSettingsDto) _then;
+
+/// Create a copy of CodexCollaborationModeSettingsDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? model = null,Object? reasoningEffort = freezed,Object? developerInstructions = freezed,}) {
+  return _then(_CodexCollaborationModeSettingsDto(
+model: null == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
+as String,reasoningEffort: freezed == reasoningEffort ? _self.reasoningEffort : reasoningEffort // ignore: cast_nullable_to_non_nullable
+as String?,developerInstructions: freezed == developerInstructions ? _self.developerInstructions : developerInstructions // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_collaboration_mode_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_collaboration_mode_dto.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'codex_collaboration_mode_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Map<String, dynamic> _$CodexCollaborationModeDtoToJson(
+  _CodexCollaborationModeDto instance,
+) => <String, dynamic>{
+  'mode': instance.mode,
+  'settings': instance.settings.toJson(),
+};
+
+Map<String, dynamic> _$CodexCollaborationModeSettingsDtoToJson(
+  _CodexCollaborationModeSettingsDto instance,
+) => <String, dynamic>{
+  'model': instance.model,
+  'reasoning_effort': instance.reasoningEffort,
+  'developer_instructions': instance.developerInstructions,
+};

--- a/bridge/sesori_plugin_codex/lib/src/codex_app_server_client.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_app_server_client.dart
@@ -180,7 +180,8 @@ class CodexAppServerClient {
             "version": clientVersion,
           },
           "capabilities": {
-            "experimentalApi": false,
+            // Codex gates turn/start.collaborationMode behind this capability.
+            "experimentalApi": true,
             // codex 0.139.0 added this capability: opting in makes codex send
             // `attestation/generate` server-requests (for upstream
             // `x-oai-attestation`) which the bridge does not handle. Stay opted

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -848,22 +848,38 @@ class CodexPlugin implements CodexManagedApi {
   @override
   Future<List<PluginAgent>> getAgents({required String projectId}) async {
     final (:modelID, :providerID) = _sessionService.resolveModelDefaults(projectId: projectId);
-    final agentModel = modelID == null
+    var resolvedModelID = modelID;
+    if (resolvedModelID == null) {
+      String? firstVisibleModelID;
+      for (final model in await _listModels()) {
+        if (model["hidden"] == true) continue;
+        final id = model["id"] as String?;
+        if (id == null || id.isEmpty) continue;
+        firstVisibleModelID ??= id;
+        if (model["isDefault"] == true) {
+          resolvedModelID = id;
+          break;
+        }
+      }
+      resolvedModelID ??= firstVisibleModelID;
+    }
+    final agentModel = resolvedModelID == null
         ? null
         : PluginAgentModel(
-            modelID: modelID,
+            modelID: resolvedModelID,
             providerID: providerID,
             variant: null,
           );
     return [
       for (final collaborationMode in CodexCollaborationMode.values)
-        PluginAgent(
-          name: collaborationMode.agentName,
-          description: collaborationMode.description,
-          model: agentModel,
-          mode: PluginAgentMode.primary,
-          hidden: false,
-        ),
+        if (agentModel != null || collaborationMode == CodexCollaborationMode.defaultMode)
+          PluginAgent(
+            name: collaborationMode.agentName,
+            description: collaborationMode.description,
+            model: agentModel,
+            mode: PluginAgentMode.primary,
+            hidden: false,
+          ),
     ];
   }
 

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -592,7 +592,7 @@ class CodexPlugin implements CodexManagedApi {
     }
     _rolloutTailer.start(sessionId: sessionId);
     try {
-      final resumed = await _sessionService.sendCommand(
+      final dispatch = await _sessionService.sendCommand(
         threadId: sessionId,
         command: command,
         arguments: arguments,
@@ -600,7 +600,14 @@ class CodexPlugin implements CodexManagedApi {
         effort: variant?.id,
         collaborationMode: CodexCollaborationMode.fromAgent(agent: agent),
       );
-      _applyResumedThread(threadId: sessionId, response: resumed);
+      _applyResumedThread(
+        threadId: sessionId,
+        response: dispatch.resumedThread,
+      );
+      final resolvedModel = dispatch.resolvedModel;
+      if (resolvedModel != null) {
+        _eventMapper.setThreadModel(sessionId, resolvedModel);
+      }
     } on Object {
       _rolloutTailer.stop(sessionId: sessionId);
       rethrow;
@@ -665,6 +672,10 @@ class CodexPlugin implements CodexManagedApi {
         threadId: threadId,
         response: dispatch.resumedThread,
       );
+      final resolvedModel = dispatch.resolvedModel;
+      if (resolvedModel != null) {
+        _eventMapper.setThreadModel(threadId, resolvedModel);
+      }
     } on Object {
       _rolloutTailer.stop(sessionId: threadId);
       rethrow;

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -11,6 +11,7 @@ import "codex_app_server_client.dart";
 import "codex_config_reader.dart";
 import "codex_event_mapper.dart";
 import "codex_metadata_repository.dart";
+import "models/codex_collaboration_mode.dart";
 import "repositories/codex_catalog_repository.dart";
 import "repositories/codex_message_repository.dart";
 import "repositories/codex_skill_repository.dart";
@@ -547,6 +548,7 @@ class CodexPlugin implements CodexManagedApi {
         threadId: threadId,
         parts: parts,
         variant: variant,
+        collaborationMode: CodexCollaborationMode.fromAgent(agent: agent),
       );
     }
     return _sessionService.toPluginSession(
@@ -570,6 +572,7 @@ class CodexPlugin implements CodexManagedApi {
       parts: parts,
       model: model,
       variant: variant,
+      collaborationMode: CodexCollaborationMode.fromAgent(agent: agent),
     );
   }
 
@@ -595,6 +598,7 @@ class CodexPlugin implements CodexManagedApi {
         arguments: arguments,
         model: model?.modelID,
         effort: variant?.id,
+        collaborationMode: CodexCollaborationMode.fromAgent(agent: agent),
       );
       _applyResumedThread(threadId: sessionId, response: resumed);
     } on Object {
@@ -628,6 +632,7 @@ class CodexPlugin implements CodexManagedApi {
     required List<PluginPromptPart> parts,
     ({String providerID, String modelID})? model,
     PluginSessionVariant? variant,
+    required CodexCollaborationMode? collaborationMode,
   }) async {
     if (model != null) {
       // A turn/start model override applies to this turn and subsequent ones,
@@ -637,8 +642,9 @@ class CodexPlugin implements CodexManagedApi {
     // The bridge carries codex's reasoning effort as the session "variant": the
     // id is a codex ReasoningEffort token (low/medium/high/xhigh) that maps
     // straight onto turn/start's `effort` override (applies to this turn and
-    // subsequent ones). A null/empty variant is the "default" selection — we
-    // send no `effort` so codex falls back to the model's defaultReasoningEffort.
+    // subsequent ones). A null/empty variant lets the selected collaboration
+    // mode supply its own default (Plan uses medium), or Codex use the model's
+    // defaultReasoningEffort when no collaboration mode was selected.
     final effort = variant?.id;
     // Capture the current EOF before Codex can append this turn's response
     // items. `start` is idempotent when turn/started arrives afterwards.
@@ -649,6 +655,7 @@ class CodexPlugin implements CodexManagedApi {
         parts: parts,
         model: model?.modelID,
         effort: effort == null || effort.isEmpty ? null : effort,
+        collaborationMode: collaborationMode,
       );
       if (!dispatch.started) {
         _rolloutTailer.stop(sessionId: threadId);
@@ -830,20 +837,22 @@ class CodexPlugin implements CodexManagedApi {
   @override
   Future<List<PluginAgent>> getAgents({required String projectId}) async {
     final (:modelID, :providerID) = _sessionService.resolveModelDefaults(projectId: projectId);
+    final agentModel = modelID == null
+        ? null
+        : PluginAgentModel(
+            modelID: modelID,
+            providerID: providerID,
+            variant: null,
+          );
     return [
-      PluginAgent(
-        name: "codex",
-        description: "Codex CLI session",
-        model: modelID == null
-            ? null
-            : PluginAgentModel(
-                modelID: modelID,
-                providerID: providerID,
-                variant: null,
-              ),
-        mode: PluginAgentMode.primary,
-        hidden: false,
-      ),
+      for (final collaborationMode in CodexCollaborationMode.values)
+        PluginAgent(
+          name: collaborationMode.agentName,
+          description: collaborationMode.description,
+          model: agentModel,
+          mode: PluginAgentMode.primary,
+          hidden: false,
+        ),
     ];
   }
 

--- a/bridge/sesori_plugin_codex/lib/src/models/codex_collaboration_mode.dart
+++ b/bridge/sesori_plugin_codex/lib/src/models/codex_collaboration_mode.dart
@@ -1,0 +1,39 @@
+enum CodexCollaborationMode {
+  defaultMode(
+    agentName: "Default",
+    wireValue: "default",
+    description: "Executes tasks, making project changes when needed",
+    defaultReasoningEffort: null,
+  ),
+  plan(
+    agentName: "Plan",
+    wireValue: "plan",
+    description: "Researches without making changes and creates an implementation plan",
+    defaultReasoningEffort: "medium",
+  );
+
+  const CodexCollaborationMode({
+    required this.agentName,
+    required this.wireValue,
+    required this.description,
+    required this.defaultReasoningEffort,
+  });
+
+  final String agentName;
+  final String wireValue;
+  final String description;
+  final String? defaultReasoningEffort;
+
+  static CodexCollaborationMode? fromAgent({required String? agent}) {
+    final normalized = agent?.trim().toLowerCase();
+    return switch (normalized) {
+      "default" => defaultMode,
+      "plan" => plan,
+      // COMPATIBILITY 2026-07-24 (v1.6.0): Earlier Codex plugins persisted
+      // their sole agent as "codex". Remove this alias after v1.6.0 prompt
+      // defaults are no longer supported.
+      "codex" => defaultMode,
+      _ => null,
+    };
+  }
+}

--- a/bridge/sesori_plugin_codex/lib/src/models/codex_collaboration_mode.dart
+++ b/bridge/sesori_plugin_codex/lib/src/models/codex_collaboration_mode.dart
@@ -27,6 +27,10 @@ enum CodexCollaborationMode {
   static CodexCollaborationMode? fromAgent({required String? agent}) {
     final normalized = agent?.trim().toLowerCase();
     return switch (normalized) {
+      // COMPATIBILITY 2026-07-24 (v1.6.0): Older apps omit the agent and
+      // expect normal execution. Remove this mapping when those app versions
+      // are no longer supported.
+      null => defaultMode,
       "default" => defaultMode,
       "plan" => plan,
       // COMPATIBILITY 2026-07-24 (v1.6.0): Earlier Codex plugins persisted

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_thread_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_thread_repository.dart
@@ -5,6 +5,7 @@ import "../api/codex_app_server_api.dart";
 import "../api/models/codex_thread_dto.dart";
 import "../api/models/codex_turn_input_dto.dart";
 import "../codex_app_server_client.dart";
+import "../models/codex_collaboration_mode.dart";
 import "models/codex_thread_record.dart";
 
 sealed class CodexThreadOperationException implements Exception {
@@ -69,6 +70,7 @@ class CodexThreadRepository {
     required List<PluginPromptPart> parts,
     required String? model,
     required String? effort,
+    required CodexCollaborationMode? collaborationMode,
   }) async {
     final input = parts.map(_mapTurnInput).whereType<CodexTurnInputDto>().toList();
     if (input.isEmpty) return false;
@@ -79,6 +81,7 @@ class CodexThreadRepository {
         input: input,
         model: model,
         effort: effort,
+        collaborationMode: collaborationMode,
       ),
     );
     return true;

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
@@ -3,6 +3,7 @@ import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show nor
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "../codex_metadata_repository.dart";
+import "../models/codex_collaboration_mode.dart";
 import "../repositories/codex_catalog_repository.dart";
 import "../repositories/codex_message_repository.dart";
 import "../repositories/codex_skill_repository.dart";
@@ -38,6 +39,7 @@ class CodexSessionService {
   CodexThreadRepository? _threadRepository;
   CodexSkillRepository? _skillRepository;
   final Set<String> _loadedThreads = {};
+  final Map<String, String> _threadModels = {};
 
   void attachAppServerRepositories({
     required CodexThreadRepository threadRepository,
@@ -51,6 +53,7 @@ class CodexSessionService {
     _threadRepository = null;
     _skillRepository = null;
     _loadedThreads.clear();
+    _threadModels.clear();
   }
 
   Future<List<PluginSession>> listAllSessions() => _catalogRepository.listAllSessions();
@@ -95,6 +98,7 @@ class CodexSessionService {
       modelProvider: modelProvider,
     );
     _loadedThreads.add(thread.id);
+    _rememberThreadModel(threadId: thread.id, model: thread.model ?? model);
     return thread;
   }
 
@@ -105,6 +109,7 @@ class CodexSessionService {
     if (!force && _loadedThreads.contains(threadId)) return null;
     final thread = await _connectedThreadRepository.resumeThread(threadId: threadId);
     _loadedThreads.add(threadId);
+    _rememberThreadModel(threadId: threadId, model: thread.model);
     return thread;
   }
 
@@ -113,24 +118,44 @@ class CodexSessionService {
     required List<PluginPromptPart> parts,
     required String? model,
     required String? effort,
+    required CodexCollaborationMode? collaborationMode,
   }) async {
     var resumed = await resumeThreadIfNeeded(threadId: threadId, force: false);
+    var turnModel = _resolveTurnModel(
+      threadId: threadId,
+      requestedModel: model,
+      collaborationMode: collaborationMode,
+    );
+    final turnEffort = effort ?? collaborationMode?.defaultReasoningEffort;
     try {
       final started = await _connectedThreadRepository.startTurn(
         threadId: threadId,
         parts: parts,
-        model: model,
-        effort: effort,
+        model: turnModel,
+        effort: turnEffort,
+        collaborationMode: collaborationMode,
       );
+      if (started) {
+        _rememberThreadModel(threadId: threadId, model: turnModel);
+      }
       return (resumedThread: resumed, started: started);
     } on CodexThreadNotFoundException {
       resumed = await resumeThreadIfNeeded(threadId: threadId, force: true);
+      turnModel = _resolveTurnModel(
+        threadId: threadId,
+        requestedModel: model,
+        collaborationMode: collaborationMode,
+      );
       final started = await _connectedThreadRepository.startTurn(
         threadId: threadId,
         parts: parts,
-        model: model,
-        effort: effort,
+        model: turnModel,
+        effort: turnEffort,
+        collaborationMode: collaborationMode,
       );
+      if (started) {
+        _rememberThreadModel(threadId: threadId, model: turnModel);
+      }
       return (resumedThread: resumed, started: started);
     }
   }
@@ -141,25 +166,42 @@ class CodexSessionService {
     required String arguments,
     required String? model,
     required String? effort,
+    required CodexCollaborationMode? collaborationMode,
   }) async {
     var resumed = await resumeThreadIfNeeded(threadId: threadId, force: false);
+    var turnModel = _resolveTurnModel(
+      threadId: threadId,
+      requestedModel: model,
+      collaborationMode: collaborationMode,
+    );
+    final turnEffort = effort ?? collaborationMode?.defaultReasoningEffort;
     try {
       await _dispatchCommand(
         threadId: threadId,
         command: command,
         arguments: arguments,
-        model: model,
-        effort: effort,
+        model: turnModel,
+        effort: turnEffort,
+        collaborationMode: collaborationMode,
       );
     } on CodexThreadNotFoundException {
       resumed = await resumeThreadIfNeeded(threadId: threadId, force: true);
+      turnModel = _resolveTurnModel(
+        threadId: threadId,
+        requestedModel: model,
+        collaborationMode: collaborationMode,
+      );
       await _dispatchCommand(
         threadId: threadId,
         command: command,
         arguments: arguments,
-        model: model,
-        effort: effort,
+        model: turnModel,
+        effort: turnEffort,
+        collaborationMode: collaborationMode,
       );
+    }
+    if (command != compactionCommandName) {
+      _rememberThreadModel(threadId: threadId, model: turnModel);
     }
     return resumed;
   }
@@ -170,6 +212,7 @@ class CodexSessionService {
     required String arguments,
     required String? model,
     required String? effort,
+    required CodexCollaborationMode? collaborationMode,
   }) async {
     if (command == compactionCommandName) {
       await _connectedThreadRepository.compactThread(threadId: threadId);
@@ -181,7 +224,31 @@ class CodexSessionService {
       parts: [PluginPromptPart.text(text: invocation)],
       model: model,
       effort: effort,
+      collaborationMode: collaborationMode,
     );
+  }
+
+  String? _resolveTurnModel({
+    required String threadId,
+    required String? requestedModel,
+    required CodexCollaborationMode? collaborationMode,
+  }) {
+    if (requestedModel != null && requestedModel.isNotEmpty) {
+      return requestedModel;
+    }
+    if (collaborationMode == null) return null;
+    return _threadModels[threadId] ??
+        _catalogRepository.findSessionById(sessionId: threadId)?.model ??
+        _metadataRepository.readConfigDefaults().model;
+  }
+
+  void _rememberThreadModel({
+    required String threadId,
+    required String? model,
+  }) {
+    if (model != null && model.isNotEmpty) {
+      _threadModels[threadId] = model;
+    }
   }
 
   CodexThreadRecord? decodeStartedNotificationParams({
@@ -212,6 +279,7 @@ class CodexSessionService {
   void deleteSession({required String sessionId}) {
     _catalogRepository.deleteSession(sessionId: sessionId);
     _loadedThreads.remove(sessionId);
+    _threadModels.remove(sessionId);
   }
 
   Future<List<PluginMessageWithParts>> getSessionMessages({

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
@@ -126,14 +126,18 @@ class CodexSessionService {
       requestedModel: model,
       collaborationMode: collaborationMode,
     );
-    final turnEffort = effort ?? collaborationMode?.defaultReasoningEffort;
+    var turnMode = _resolveCollaborationMode(
+      model: turnModel,
+      collaborationMode: collaborationMode,
+    );
+    var turnEffort = effort ?? turnMode?.defaultReasoningEffort;
     try {
       final started = await _connectedThreadRepository.startTurn(
         threadId: threadId,
         parts: parts,
         model: turnModel,
         effort: turnEffort,
-        collaborationMode: collaborationMode,
+        collaborationMode: turnMode,
       );
       if (started) {
         _rememberThreadModel(threadId: threadId, model: turnModel);
@@ -150,12 +154,17 @@ class CodexSessionService {
         requestedModel: model,
         collaborationMode: collaborationMode,
       );
+      turnMode = _resolveCollaborationMode(
+        model: turnModel,
+        collaborationMode: collaborationMode,
+      );
+      turnEffort = effort ?? turnMode?.defaultReasoningEffort;
       final started = await _connectedThreadRepository.startTurn(
         threadId: threadId,
         parts: parts,
         model: turnModel,
         effort: turnEffort,
-        collaborationMode: collaborationMode,
+        collaborationMode: turnMode,
       );
       if (started) {
         _rememberThreadModel(threadId: threadId, model: turnModel);
@@ -182,7 +191,11 @@ class CodexSessionService {
       requestedModel: model,
       collaborationMode: collaborationMode,
     );
-    final turnEffort = effort ?? collaborationMode?.defaultReasoningEffort;
+    var turnMode = _resolveCollaborationMode(
+      model: turnModel,
+      collaborationMode: collaborationMode,
+    );
+    var turnEffort = effort ?? turnMode?.defaultReasoningEffort;
     try {
       await _dispatchCommand(
         threadId: threadId,
@@ -190,7 +203,7 @@ class CodexSessionService {
         arguments: arguments,
         model: turnModel,
         effort: turnEffort,
-        collaborationMode: collaborationMode,
+        collaborationMode: turnMode,
       );
     } on CodexThreadNotFoundException {
       resumed = await resumeThreadIfNeeded(threadId: threadId, force: true);
@@ -199,13 +212,18 @@ class CodexSessionService {
         requestedModel: model,
         collaborationMode: collaborationMode,
       );
+      turnMode = _resolveCollaborationMode(
+        model: turnModel,
+        collaborationMode: collaborationMode,
+      );
+      turnEffort = effort ?? turnMode?.defaultReasoningEffort;
       await _dispatchCommand(
         threadId: threadId,
         command: command,
         arguments: arguments,
         model: turnModel,
         effort: turnEffort,
-        collaborationMode: collaborationMode,
+        collaborationMode: turnMode,
       );
     }
     if (command != compactionCommandName) {
@@ -251,6 +269,18 @@ class CodexSessionService {
     return _threadModels[threadId] ??
         _catalogRepository.findSessionById(sessionId: threadId)?.model ??
         _metadataRepository.readConfigDefaults().model;
+  }
+
+  CodexCollaborationMode? _resolveCollaborationMode({
+    required String? model,
+    required CodexCollaborationMode? collaborationMode,
+  }) {
+    // An unmodeled turn already has Default semantics; Plan must not silently
+    // degrade into execution mode when its required model is unavailable.
+    if (model == null && collaborationMode == CodexCollaborationMode.defaultMode) {
+      return null;
+    }
+    return collaborationMode;
   }
 
   void _rememberThreadModel({

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
@@ -113,7 +113,7 @@ class CodexSessionService {
     return thread;
   }
 
-  Future<({CodexThreadRecord? resumedThread, bool started})> startTurn({
+  Future<({CodexThreadRecord? resumedThread, String? resolvedModel, bool started})> startTurn({
     required String threadId,
     required List<PluginPromptPart> parts,
     required String? model,
@@ -138,7 +138,11 @@ class CodexSessionService {
       if (started) {
         _rememberThreadModel(threadId: threadId, model: turnModel);
       }
-      return (resumedThread: resumed, started: started);
+      return (
+        resumedThread: resumed,
+        resolvedModel: turnModel,
+        started: started,
+      );
     } on CodexThreadNotFoundException {
       resumed = await resumeThreadIfNeeded(threadId: threadId, force: true);
       turnModel = _resolveTurnModel(
@@ -156,11 +160,15 @@ class CodexSessionService {
       if (started) {
         _rememberThreadModel(threadId: threadId, model: turnModel);
       }
-      return (resumedThread: resumed, started: started);
+      return (
+        resumedThread: resumed,
+        resolvedModel: turnModel,
+        started: started,
+      );
     }
   }
 
-  Future<CodexThreadRecord?> sendCommand({
+  Future<({CodexThreadRecord? resumedThread, String? resolvedModel})> sendCommand({
     required String threadId,
     required String command,
     required String arguments,
@@ -203,7 +211,10 @@ class CodexSessionService {
     if (command != compactionCommandName) {
       _rememberThreadModel(threadId: threadId, model: turnModel);
     }
-    return resumed;
+    return (
+      resumedThread: resumed,
+      resolvedModel: command == compactionCommandName ? null : turnModel,
+    );
   }
 
   Future<void> _dispatchCommand({

--- a/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
@@ -65,12 +65,11 @@ void main() {
         expect(await plugin.getSessionMessages("s-1"), isEmpty);
         expect(await plugin.getSessionStatuses(), isEmpty);
         expect(plugin.getActiveSessionsSummary(), isEmpty);
-        // With no config or rollout history, codex still surfaces its single
-        // agent (the harness identity) but with no resolvable model, and no
-        // providers.
+        // With no config or rollout history, Codex still surfaces its two
+        // collaboration modes without a resolvable model, and no providers.
         final agents = await plugin.getAgents(projectId: "/repo/example");
-        expect(agents.single.name, equals("codex"));
-        expect(agents.single.model, isNull);
+        expect(agents.map((agent) => agent.name), equals(["Default", "Plan"]));
+        expect(agents.every((agent) => agent.model == null), isTrue);
         expect(
           (await plugin.getProviders(projectId: "/repo/example")).providers,
           isEmpty,
@@ -143,22 +142,25 @@ void main() {
           keepaliveInterval: const Duration(seconds: 30),
         );
 
-        final agent = (await plugin.getAgents(projectId: "/repo/example")).single;
-        expect(agent.name, equals("codex"));
+        final agents = await plugin.getAgents(projectId: "/repo/example");
+        expect(agents.map((agent) => agent.name), equals(["Default", "Plan"]));
+        final agent = agents.first;
+        expect(agent.name, equals("Default"));
         expect(agent.model?.modelID, equals("gpt-5.4-codex"));
         expect(agent.model?.providerID, equals("openai"));
+        expect(agents.last.model, equals(agent.model));
 
         final providers = (await plugin.getProviders(projectId: "/repo/example")).providers;
         expect(providers.single.id, equals("openai"));
         expect(providers.single.defaultModelID, equals("gpt-5.4-codex"));
 
         // The other derived project resolves its own rollout's defaults.
-        final otherAgent = (await plugin.getAgents(projectId: "/repo/other")).single;
+        final otherAgent = (await plugin.getAgents(projectId: "/repo/other")).first;
         expect(otherAgent.model?.modelID, equals("claude-x"));
         expect(otherAgent.model?.providerID, equals("anthropic"));
 
         // A project with no sessions falls back to the global config.toml.
-        final freshAgent = (await plugin.getAgents(projectId: "/repo/fresh")).single;
+        final freshAgent = (await plugin.getAgents(projectId: "/repo/fresh")).first;
         expect(freshAgent.model?.modelID, equals("gpt-5.5"));
         expect(freshAgent.model?.providerID, equals("openai"));
         await plugin.dispose();
@@ -189,6 +191,12 @@ void main() {
       fake.outgoing.first.then((Object? frame) {
         final decoded = jsonDecode(frame as String) as Map<String, dynamic>;
         expect(decoded["method"], equals("initialize"));
+        final params = decoded["params"] as Map<String, dynamic>;
+        final capabilities = params["capabilities"] as Map<String, dynamic>;
+        expect(
+          capabilities["experimentalApi"],
+          isTrue,
+        );
         fake.serverSink.add(
           jsonEncode({
             "jsonrpc": "2.0",

--- a/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
@@ -65,10 +65,10 @@ void main() {
         expect(await plugin.getSessionMessages("s-1"), isEmpty);
         expect(await plugin.getSessionStatuses(), isEmpty);
         expect(plugin.getActiveSessionsSummary(), isEmpty);
-        // With no config or rollout history, Codex still surfaces its two
-        // collaboration modes without a resolvable model, and no providers.
+        // With no config, rollout history, or live connection, Codex exposes
+        // only Default because Plan requires a resolved model.
         final agents = await plugin.getAgents(projectId: "/repo/example");
-        expect(agents.map((agent) => agent.name), equals(["Default", "Plan"]));
+        expect(agents.map((agent) => agent.name), equals(["Default"]));
         expect(agents.every((agent) => agent.model == null), isTrue);
         expect(
           (await plugin.getProviders(projectId: "/repo/example")).providers,

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -107,6 +107,7 @@ void main() {
         const _Response(
           result: {
             "thread": {"id": "t-existing", "cwd": "/work/sample"},
+            "model": "gpt-5.4",
           },
         ),
         const _Response(result: {"turnId": "u-skill"}),
@@ -120,7 +121,7 @@ void main() {
         arguments: "staged changes",
         userVisibleArguments: "staged changes",
         variant: null,
-        agent: null,
+        agent: "Plan",
         model: null,
       );
       await plugin.sendCommand(
@@ -146,6 +147,14 @@ void main() {
       });
       final input = fake.sentParamsFor("turn/start")["input"] as List;
       expect(input.single["text"], r"$review staged changes");
+      expect(fake.sentParamsFor("turn/start")["collaborationMode"], {
+        "mode": "plan",
+        "settings": {
+          "model": "gpt-5.4",
+          "reasoning_effort": "medium",
+          "developer_instructions": null,
+        },
+      });
     });
 
     test("a live event emitted during the first turn is scoped to the new session's directory", () async {
@@ -317,9 +326,7 @@ void main() {
       final stopwatch = Stopwatch()..start();
 
       await expectLater(
-        plugin
-            .renameSession(sessionId: "t-stalled", title: "Renamed")
-            .timeout(const Duration(seconds: 4)),
+        plugin.renameSession(sessionId: "t-stalled", title: "Renamed").timeout(const Duration(seconds: 4)),
         throwsA(isA<TimeoutException>()),
       );
 
@@ -354,6 +361,40 @@ void main() {
       expect(methods, equals(["initialize", "thread/resume", "turn/start"]));
       expect(fake.sentParamsFor("thread/resume")["threadId"], equals("t-existing"));
       expect(fake.sentParamsFor("turn/start")["threadId"], equals("t-existing"));
+    });
+
+    test("sendPrompt sends Default mode explicitly so it replaces Plan mode", () async {
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "model": "gpt-5.4-mini",
+            "modelProvider": "openai",
+            "thread": {"id": "t-default-mode"},
+          },
+        ),
+        const _Response(result: {"turnId": "u-default"}),
+      ]);
+
+      await plugin.sendPrompt(
+        sessionId: "t-default-mode",
+        parts: const [PluginPromptPart.text(text: "implement it")],
+        variant: null,
+        agent: "Default",
+        model: null,
+      );
+
+      final params = fake.sentParamsFor("turn/start");
+      expect(params.containsKey("model"), isFalse);
+      expect(params.containsKey("effort"), isFalse);
+      expect(params["collaborationMode"], {
+        "mode": "default",
+        "settings": {
+          "model": "gpt-5.4-mini",
+          "reasoning_effort": null,
+          "developer_instructions": null,
+        },
+      });
     });
 
     test("sendPrompt does not re-resume a thread created in this run", () async {
@@ -894,7 +935,7 @@ void main() {
       expect(result.providers.single.defaultModelID, equals("gpt-5.4-mini"));
     });
 
-    test("sendPrompt forwards the selected variant as the turn/start effort", () async {
+    test("sendPrompt forwards the selected variant in Plan mode settings", () async {
       fake.respondInOrder([
         const _Response(result: _initOk),
         const _Response(
@@ -911,11 +952,20 @@ void main() {
         sessionId: "t-effort",
         parts: const [PluginPromptPart.text(text: "think hard")],
         variant: const PluginSessionVariant(id: "high"),
-        agent: null,
+        agent: "Plan",
         model: null,
       );
 
-      expect(fake.sentParamsFor("turn/start")["effort"], equals("high"));
+      final params = fake.sentParamsFor("turn/start");
+      expect(params.containsKey("effort"), isFalse);
+      expect(params["collaborationMode"], {
+        "mode": "plan",
+        "settings": {
+          "model": "gpt-5.5",
+          "reasoning_effort": "high",
+          "developer_instructions": null,
+        },
+      });
     });
 
     test("sendPrompt without a variant sends no effort (codex uses its default)", () async {
@@ -940,11 +990,12 @@ void main() {
       expect(fake.sentParamsFor("turn/start").containsKey("effort"), isFalse);
     });
 
-    test("createSession applies the variant on the first turn", () async {
+    test("legacy codex agent selects Default mode on the first turn", () async {
       fake.respondInOrder([
         const _Response(result: _initOk),
         const _Response(
           result: {
+            "model": "gpt-5.5",
             "thread": {"id": "t-new"},
           },
         ),
@@ -956,12 +1007,19 @@ void main() {
         parentSessionId: null,
         parts: const [PluginPromptPart.text(text: "start low")],
         variant: const PluginSessionVariant(id: "low"),
-        agent: null,
+        agent: "codex",
         model: null,
       );
 
       expect(fake.sentMethods, equals(["initialize", "thread/start", "turn/start"]));
-      expect(fake.sentParamsFor("turn/start")["effort"], equals("low"));
+      expect(fake.sentParamsFor("turn/start")["collaborationMode"], {
+        "mode": "default",
+        "settings": {
+          "model": "gpt-5.5",
+          "reasoning_effort": "low",
+          "developer_instructions": null,
+        },
+      });
     });
   });
 }

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -10,6 +10,7 @@ import "dart:io";
 import "package:codex_plugin/codex_plugin.dart";
 import "package:path/path.dart" as p;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" as shared;
 import "package:test/test.dart";
 import "package:web_socket_channel/web_socket_channel.dart";
 
@@ -395,6 +396,81 @@ void main() {
           "developer_instructions": null,
         },
       });
+    });
+
+    test("collaboration mode stamps live messages with its resolved rollout model", () async {
+      const sessionId = "019a0000-1111-2222-3333-eeeeeeeeeeee";
+      File(p.join(codexHome.path, "config.toml")).writeAsStringSync(
+        'model = "gpt-global"\nmodel_provider = "openai"\n',
+      );
+      final rollout = File(
+        p.join(
+          codexHome.path,
+          "sessions/2026/07/24/rollout-2026-07-24T08-00-00-$sessionId.jsonl",
+        ),
+      )..createSync(recursive: true);
+      rollout.writeAsStringSync(
+        "${jsonEncode({
+          "type": "session_meta",
+          "payload": {
+            "id": sessionId,
+            "timestamp": "2026-07-24T08:00:00Z",
+            "cwd": "/work/sample",
+            "model_provider": "openai",
+          },
+        })}\n"
+        "${jsonEncode({
+          "type": "turn_context",
+          "payload": {"model": "gpt-session"},
+        })}\n",
+      );
+      final resolvedFake = _FakeAppServer();
+      const serverUrl = "ws://127.0.0.1:0";
+      final resolvedPlugin = createInjectedCodexPlugin(
+        serverUrl: serverUrl,
+        environment: {"CODEX_HOME": codexHome.path},
+        projectCwd: "/work/sample",
+        clientFactory: () => CodexAppServerClient(
+          serverUrl: serverUrl,
+          channelFactory: (_) => resolvedFake.channel,
+        ),
+        keepaliveInterval: const Duration(seconds: 30),
+      );
+      addTearDown(resolvedPlugin.dispose);
+      resolvedFake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "thread": {"id": sessionId, "modelProvider": "openai"},
+          },
+        ),
+        const _Response(result: {"turnId": "u-resolved"}),
+      ]);
+      final events = <BridgeSseEvent>[];
+      final subscription = resolvedPlugin.events.listen(events.add);
+      addTearDown(subscription.cancel);
+
+      await resolvedPlugin.sendPrompt(
+        sessionId: sessionId,
+        parts: const [PluginPromptPart.text(text: "plan this")],
+        variant: null,
+        agent: "Plan",
+        model: null,
+      );
+      resolvedFake.pushNotification("item/completed", {
+        "threadId": sessionId,
+        "turnId": "u-resolved",
+        "item": {
+          "type": "agentMessage",
+          "id": "i-resolved",
+          "text": "The plan",
+        },
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      final messageEvent = events.whereType<BridgeSseMessageUpdated>().single;
+      final message = shared.Message.fromJson(messageEvent.info) as shared.MessageAssistant;
+      expect(message.modelID, "gpt-session");
     });
 
     test("sendPrompt does not re-resume a thread created in this run", () async {

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -956,6 +956,30 @@ void main() {
       expect(fake.sentMethods, contains("model/list"));
     });
 
+    test("getAgents uses the live catalog to expose Plan without local model metadata", () async {
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "data": [
+              {
+                "id": "gpt-5.5",
+                "displayName": "GPT-5.5",
+                "hidden": false,
+                "isDefault": true,
+              },
+            ],
+          },
+        ),
+      ]);
+
+      await plugin.healthCheck();
+      final agents = await plugin.getAgents(projectId: "/work/sample");
+
+      expect(agents.map((agent) => agent.name), ["Default", "Plan"]);
+      expect(agents.every((agent) => agent.model?.modelID == "gpt-5.5"), isTrue);
+    });
+
     test("getProviders preselects the project's own latest rollout model over codex's live default", () async {
       // The selected project's newest rollout used gpt-5.4-mini, while codex's
       // live catalog marks gpt-5.5 as the global default — the project-scoped

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -365,7 +365,7 @@ void main() {
       expect(fake.sentParamsFor("turn/start")["threadId"], equals("t-existing"));
     });
 
-    test("sendPrompt sends Default mode explicitly so it replaces Plan mode", () async {
+    test("sendPrompt treats an omitted agent as Default so it replaces Plan mode", () async {
       fake.respondInOrder([
         const _Response(result: _initOk),
         const _Response(
@@ -382,7 +382,7 @@ void main() {
         sessionId: "t-default-mode",
         parts: const [PluginPromptPart.text(text: "implement it")],
         variant: null,
-        agent: "Default",
+        agent: null,
         model: null,
       );
 

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -45,7 +45,7 @@ void main() {
       } catch (_) {}
     });
 
-    test("createSession round-trips thread/start and turn/start", () async {
+    test("createSession preserves a Default turn when no model resolves", () async {
       // Respond to: initialize, thread/start, turn/start.
       fake.respondInOrder([
         const _Response(result: _initOk),
@@ -68,7 +68,7 @@ void main() {
         parentSessionId: null,
         parts: const [PluginPromptPart.text(text: "hello codex")],
         variant: null,
-        agent: null,
+        agent: "Default",
         model: null,
       );
 
@@ -82,6 +82,7 @@ void main() {
       final turnStartParams = fake.sentParamsFor("turn/start");
       expect(turnStartParams["threadId"], equals("t-new"));
       expect((turnStartParams["input"] as List).first["text"], equals("hello codex"));
+      expect(turnStartParams.containsKey("collaborationMode"), isFalse);
     });
 
     test("lists skills, invokes them with dollar syntax, and compacts natively", () async {

--- a/bridge/sesori_plugin_codex/test/codex_session_service_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_session_service_test.dart
@@ -3,6 +3,7 @@ import "package:codex_plugin/src/api/codex_rollout_api.dart";
 import "package:codex_plugin/src/codex_app_server_client.dart";
 import "package:codex_plugin/src/codex_config_reader.dart";
 import "package:codex_plugin/src/codex_metadata_repository.dart";
+import "package:codex_plugin/src/models/codex_collaboration_mode.dart";
 import "package:codex_plugin/src/repositories/codex_catalog_repository.dart";
 import "package:codex_plugin/src/repositories/codex_message_repository.dart";
 import "package:codex_plugin/src/repositories/codex_skill_repository.dart";
@@ -91,6 +92,7 @@ void main() {
       arguments: "staged changes",
       model: "gpt-5.6",
       effort: "high",
+      collaborationMode: CodexCollaborationMode.plan,
     );
 
     final input = threadRepository.lastParts.single as PluginPromptPartText;
@@ -104,6 +106,7 @@ void main() {
       arguments: "",
       model: null,
       effort: null,
+      collaborationMode: null,
     );
     expect(threadRepository.compactCount, 1);
   });
@@ -174,6 +177,7 @@ class _StubThreadRepository extends CodexThreadRepository {
     required List<PluginPromptPart> parts,
     required String? model,
     required String? effort,
+    required CodexCollaborationMode? collaborationMode,
   }) async {
     lastParts = parts;
     lastModel = model;


### PR DESCRIPTION
## Summary

- Expose Codex's upstream `Default` and `Plan` collaboration modes in the existing agent selector, with Default first.
- Translate the selected agent inside the Codex plugin and send the complete experimental `turn/start.collaborationMode` payload for new sessions, prompts, and command-backed turns.
- Preserve persisted `codex` selections as Default and retain the existing null-agent path for older callers.

## Upstream Basis

- Codex declares only `Default` and `Plan` as user-visible collaboration modes; legacy `code`, `pair_programming`, `execute`, and `custom` values normalize to Default or remain internal.
- Plan uses Codex's built-in instructions and its upstream medium reasoning-effort default when the user has not selected an effort.
- The existing minimum supported Codex version, `0.139.0`, already supports `turn/start.collaborationMode`, so no runtime-floor change is required.

References:

- https://github.com/openai/codex/blob/rust-v0.145.0/codex-rs/protocol/src/config_types.rs#L605-L651
- https://github.com/openai/codex/blob/rust-v0.145.0/codex-rs/models-manager/src/collaboration_mode_presets.rs
- https://developers.openai.com/codex/app-server/

## Testing

- `dart pub get`
- `dart test`
- `dart analyze --fatal-infos`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose Codex collaboration modes in the agent selector and send `turn/start.collaborationMode` when a model is resolved. Plan stays hidden until a model is available; Default is always available and now also used when the agent is omitted, while unmodeled Default turns keep legacy behavior.

- **New Features**
  - Agent selector shows “Default” (first) and “Plan”; Plan is hidden until a model is available; legacy `codex` and omitted agents map to Default.
  - Dispatch: when a mode is selected or defaulted and a model resolves, send `collaborationMode` with settings `{model, reasoning_effort, developer_instructions:null}`; otherwise send plain `model`/`effort` (unmodeled Default omits `collaborationMode`).
  - Model handling: resolve from last turn, session rollout, or config; remember and propagate the resolved model so events carry it; require a non-empty model when sending `collaborationMode`. Agent listing falls back to Codex’s live catalog to choose a visible/default model when local defaults are missing.
  - Reasoning effort: variant overrides; Plan defaults to “medium”; Default uses the model’s default. Enable `experimentalApi` capability to unlock collaboration mode support.

- **Migration**
  - No changes needed. Null/omitted agents and persisted “codex” map to Default. To use Plan, pass agent “Plan”; omit variant to use medium by default, or set a variant to override.

<sup>Written for commit 0f3867b48d489800b22fbd7424924ecc44875054. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

