### PR TITLE
Revert "fix(release): temporarily gate plugins to OpenCode"

### DIFF
--- a/.plan/active/setup-aware-plugin-lifecycle/PLAN.md
+++ b/.plan/active/setup-aware-plugin-lifecycle/PLAN.md
@@ -43,15 +43,6 @@ available:
   explicitly supplied invalid value remains a fatal CLI usage error even when
   that plugin is denied.
 - Eligibility is exactly `plugin id not in plugins.disabled`.
-- **Temporary next-release exception (2026-07-24):** PR A intersects ordinary
-  eligibility with an OpenCode-only release gate, filters client discovery to
-  OpenCode, hides the mobile new-session plugin chooser, and keeps session
-  submission on that sole choice. Registrations, namespaced CLI options,
-  implementation packages, and persisted settings remain intact; the gate does
-  not rewrite `plugins.disabled`.
-- PR B is an exact revert of PR A and merges immediately after the synchronized
-  release, before lifecycle delivery resumes. The temporary gate must not be
-  carried into Stage 11-P02 or later work.
 - Unknown disabled IDs and unknown plugin configuration objects survive a
   current bridge rewrite. Local config commands reject unknown IDs to catch
   typos.

--- a/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
+++ b/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
@@ -9,15 +9,6 @@
 - **Current stage:** Stage 11-P01D — bridge-owned projects and defaults open as PR #550
 - **Next action:** resolve #550 against merged #549/main and continue monitoring it
 
-## Temporary Release Gate
-
-- 2026-07-24: isolate the next synchronized release with a temporary
-  OpenCode-only PR A. It keeps all plugin registrations/settings intact while
-  blocking Codex/Cursor runtime eligibility and hiding client plugin selection.
-- Immediately after the release, merge PR B as an exact revert of PR A before
-  synchronizing or delivering Stage 11-P02. This release overlay is not part of
-  the setup-aware lifecycle implementation.
-
 ## Frozen Oversized Stack
 
 PR #508 passed its verification but is too large to review effectively. It is

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -451,11 +451,7 @@ class ConfigPluginsCommand extends cli.Command<void> {
       final entriesById = {for (final entry in snapshot.plugins) entry.pluginId: entry};
       for (final descriptor in descriptors) {
         final entry = entriesById[descriptor.id]!;
-        final configuredStatus = entry.enabled ? 'configured enabled' : 'configured disabled';
-        final status = temporaryOpenCodeOnlyReleasePluginIds.contains(descriptor.id)
-            ? (entry.enabled ? 'enabled' : 'disabled')
-            : 'unavailable in this release ($configuredStatus)';
-        stdout.writeln('${descriptor.displayName} (${descriptor.id}): $status');
+        stdout.writeln('${descriptor.displayName} (${descriptor.id}): ${entry.enabled ? 'enabled' : 'disabled'}');
       }
       if (snapshot.unknownDisabledPluginIds.isNotEmpty) {
         stdout.writeln('Unknown disabled plugin IDs: ${snapshot.unknownDisabledPluginIds.join(', ')}');
@@ -477,12 +473,7 @@ class ConfigPluginsCommand extends cli.Command<void> {
     } on UnknownPluginConfigException catch (error) {
       usageException('$error Known plugins: ${knownIds.join(', ')}.');
     }
-    if (temporaryOpenCodeOnlyReleasePluginIds.contains(pluginId)) {
-      stdout.writeln('Plugin "$pluginId" ${enabled ? 'enabled' : 'disabled'}.');
-    } else {
-      stdout.writeln('Plugin "$pluginId" ${enabled ? 'enabled' : 'disabled'} in configuration.');
-      stdout.writeln('Plugin "$pluginId" is unavailable in this release.');
-    }
+    stdout.writeln('Plugin "$pluginId" ${enabled ? 'enabled' : 'disabled'}.');
     stdout.writeln('Restart sesori-bridge to apply.');
   }
 }

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -621,19 +621,16 @@ class BridgeRuntimeRunner {
             ],
           );
       pluginLifecycleService = activePluginLifecycleService;
-      final releaseDisabledPluginIds = disabledPluginIdsForTemporaryOpenCodeOnlyRelease(
-        configuredDisabledPluginIds: bridgeSettings.plugins.disabledPluginIds,
-      );
       final eligiblePluginIds = {
         for (final descriptor in knownPlugins)
-          if (!releaseDisabledPluginIds.contains(descriptor.id)) descriptor.id,
+          if (!bridgeSettings.plugins.isDisabled(pluginId: descriptor.id)) descriptor.id,
       };
       final setupById = await lifecycleRepository.inspect(
         pluginIds: eligiblePluginIds,
         markUnselectedNotInspected: true,
       );
       final startupPolicy = activePluginLifecycleService.initialize(
-        disabledPluginIds: releaseDisabledPluginIds,
+        disabledPluginIds: bridgeSettings.plugins.disabledPluginIds,
         setupById: setupById,
       );
       for (final importPluginId in options.importPluginIds) {

--- a/bridge/app/lib/src/bridge/runtime/plugin_registry.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_registry.dart
@@ -16,21 +16,3 @@ const List<BridgePluginDescriptor> knownPlugins = [
 /// Product-preferred default when OpenCode is selectable. Lifecycle policy
 /// falls back to the first selectable registration when it is not.
 String get preferredDefaultPluginId => const OpenCodePluginDescriptor().id;
-
-/// TEMPORARY RELEASE GATE (2026-07-24): only OpenCode is approved for the next
-/// synchronized App + Bridge release. Keep every descriptor registered so CLI
-/// options and persisted settings remain known. Revert this gate immediately
-/// after that release.
-final Set<String> temporaryOpenCodeOnlyReleasePluginIds = Set<String>.unmodifiable({
-  preferredDefaultPluginId,
-});
-
-Set<String> disabledPluginIdsForTemporaryOpenCodeOnlyRelease({
-  required Set<String> configuredDisabledPluginIds,
-}) {
-  return Set<String>.unmodifiable({
-    ...configuredDisabledPluginIds,
-    for (final plugin in knownPlugins)
-      if (!temporaryOpenCodeOnlyReleasePluginIds.contains(plugin.id)) plugin.id,
-  });
-}

--- a/bridge/app/test/bridge/runtime/plugin_registry_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_registry_test.dart
@@ -16,21 +16,4 @@ void main() {
       expect(plugin.options.map((option) => option.name).toSet(), hasLength(plugin.options.length));
     }
   });
-
-  test("temporary release gate cannot be bypassed by plugin configuration", () {
-    expect(temporaryOpenCodeOnlyReleasePluginIds, {"opencode"});
-
-    expect(
-      disabledPluginIdsForTemporaryOpenCodeOnlyRelease(
-        configuredDisabledPluginIds: const {},
-      ),
-      {"codex", "cursor"},
-    );
-    expect(
-      disabledPluginIdsForTemporaryOpenCodeOnlyRelease(
-        configuredDisabledPluginIds: const {"opencode", "future-plugin"},
-      ),
-      {"opencode", "codex", "cursor", "future-plugin"},
-    );
-  });
 }

--- a/client/app/lib/features/new_session/new_session_screen.dart
+++ b/client/app/lib/features/new_session/new_session_screen.dart
@@ -12,6 +12,7 @@ import "../../core/widgets/agent_model_buttons.dart";
 import "../../core/widgets/connection_banner.dart";
 import "../session_detail/widgets/prompt_input.dart";
 import "new_session_loading_overlay.dart";
+import "new_session_plugin_chooser.dart";
 
 class NewSessionScreen extends StatelessWidget {
   final String projectId;
@@ -204,6 +205,16 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
+                          NewSessionPluginChooser(
+                            plugins: composerData?.plugins ?? const [],
+                            selectedPluginId: composerData?.plugin?.id,
+                            isComposerDataLoading: composerData?.isLoading ?? false,
+                            isSelectionEnabled: !(composerData?.isPluginDiscoveryInFlight ?? false),
+                            onSelected: (pluginId) => context.read<NewSessionCubit>().selectPlugin(
+                              pluginId: pluginId,
+                            ),
+                          ),
+                          if (composerData?.plugins.isNotEmpty ?? false) SizedBox(height: prego.spacing.sm),
                           if (composerData?.supportsDedicatedWorktrees ?? false)
                             SwitchListTile(
                               title: Text(loc.newSessionDedicatedWorktree),

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -10,6 +10,7 @@ import "package:mocktail/mocktail.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/capabilities/voice/voice_transcription_service.dart";
+import "package:sesori_mobile/features/new_session/new_session_plugin_chooser.dart";
 import "package:sesori_mobile/features/new_session/new_session_screen.dart";
 import "package:sesori_mobile/features/session_detail/widgets/prompt_input.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
@@ -233,7 +234,7 @@ void main() {
     expect(find.widgetWithText(GlassButton, "xhigh"), findsOneWidget);
   });
 
-  testWidgets("does not render plugin selection even when discovery returns multiple plugins", (tester) async {
+  testWidgets("renders bridge order with generic degraded and blocked presentation", (tester) async {
     when(pluginRepository.listPlugins).thenAnswer(
       (_) async => ApiResponse.success(
         const PluginListResponse(
@@ -267,16 +268,60 @@ void main() {
     await tester.pumpWidget(_buildApp());
     await tester.pumpAndSettle();
 
-    final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
-    expect(find.text(loc.newSessionPluginChooserLabel), findsNothing);
-    expect(find.text("First Tool"), findsNothing);
-    expect(find.text("Second Tool"), findsNothing);
-    expect(find.text("Third Tool"), findsNothing);
-    expect(find.byKey(const Key("new_session_plugin_failed-id")), findsNothing);
-    expect(find.byKey(const Key("new_session_plugin_degraded-id")), findsNothing);
-    expect(find.byKey(const Key("new_session_plugin_unavailable-id")), findsNothing);
+    expect(find.byType(NewSessionPluginChooser), findsOneWidget);
+    expect(tester.getTopLeft(find.text("First Tool")).dy, lessThan(tester.getTopLeft(find.text("Second Tool")).dy));
+    expect(tester.getTopLeft(find.text("Second Tool")).dy, lessThan(tester.getTopLeft(find.text("Third Tool")).dy));
+    expect(find.text("Needs attention"), findsOneWidget);
+    expect(find.text("Failed"), findsOneWidget);
+    expect(find.text("Unavailable"), findsOneWidget);
+    expect(find.text("Restart the bridge to retry."), findsOneWidget);
+    expect(find.text("Check the bridge console."), findsOneWidget);
+
+    expect(
+      tester.widget<InkWell>(find.byKey(const Key("new_session_plugin_failed-id"))).onTap,
+      isNull,
+    );
+    expect(
+      tester.widget<InkWell>(find.byKey(const Key("new_session_plugin_unavailable-id"))).onTap,
+      isNull,
+    );
+    expect(
+      tester.widget<InkWell>(find.byKey(const Key("new_session_plugin_degraded-id"))).onTap,
+      isNotNull,
+    );
     expect(find.text("failed-id"), findsNothing);
     expect(find.text("degraded-id"), findsNothing);
+  });
+
+  testWidgets("uses on-brand foreground tokens for a selected plugin in dark mode", (tester) async {
+    when(pluginRepository.listPlugins).thenAnswer(
+      (_) async => ApiResponse.success(
+        const PluginListResponse(
+          plugins: [
+            PluginMetadata(
+              id: "degraded-id",
+              displayName: "Selected Tool",
+              isDefault: true,
+              state: PluginLifecycleState.degraded,
+              actionHint: "Check the bridge console.",
+            ),
+          ],
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(_buildApp(themeMode: ThemeMode.dark));
+    await tester.pumpAndSettle();
+
+    expect(tester.widget<Text>(find.text("Selected Tool")).style?.color, PregoColorsDark.textPrimaryOnBrand);
+    expect(tester.widget<Text>(find.text("Needs attention")).style?.color, PregoColorsDark.textSecondaryOnBrand);
+    expect(
+      tester.widget<Text>(find.text("Check the bridge console.")).style?.color,
+      PregoColorsDark.textSecondaryOnBrand,
+    );
+    final selectedRow = find.byKey(const Key("new_session_plugin_degraded-id"));
+    final radio = find.descendant(of: selectedRow, matching: find.byIcon(Icons.radio_button_checked));
+    expect(tester.widget<Icon>(radio).color, PregoColorsDark.iconFgBrandOnBrand);
   });
 
   testWidgets("keeps model and variant controls available when no agents load", (tester) async {
@@ -295,7 +340,7 @@ void main() {
     expect(find.widgetWithText(GlassButton, "Default"), findsOneWidget);
   });
 
-  testWidgets("keeps the composer pinned while worktree options scroll", (tester) async {
+  testWidgets("scrolls plugin and worktree options while keeping the composer pinned", (tester) async {
     await tester.binding.setSurfaceSize(const Size(700, 400));
     addTearDown(() => tester.binding.setSurfaceSize(null));
     when(pluginRepository.listPlugins).thenAnswer(
@@ -320,7 +365,10 @@ void main() {
 
     final optionsScroll = find.byKey(const Key("new_session_options_scroll"));
     expect(optionsScroll, findsOneWidget);
-    expect(find.byKey(const Key("new_session_plugin_plugin-0")), findsNothing);
+    expect(
+      find.descendant(of: optionsScroll, matching: find.byType(NewSessionPluginChooser)),
+      findsOneWidget,
+    );
     expect(find.descendant(of: optionsScroll, matching: find.byType(SwitchListTile)), findsOneWidget);
     expect(find.descendant(of: optionsScroll, matching: find.byType(PromptInput)), findsNothing);
     expect(tester.takeException(), isNull);
@@ -378,7 +426,161 @@ void main() {
     expect(find.text(loc.newSessionDedicatedWorktree), findsNothing);
   });
 
-  testWidgets("refresh discovery failure keeps the composer usable without plugin selection", (tester) async {
+  testWidgets("keeps chooser usable while clearing and reloading composer data", (tester) async {
+    const toolA = PluginMetadata(
+      id: "tool-a",
+      displayName: "Tool A",
+      isDefault: true,
+      state: PluginLifecycleState.ready,
+      actionHint: null,
+    );
+    const toolB = PluginMetadata(
+      id: "tool-b",
+      displayName: "Tool B",
+      isDefault: false,
+      state: PluginLifecycleState.degraded,
+      actionHint: "Check the bridge console.",
+    );
+    when(pluginRepository.listPlugins).thenAnswer(
+      (_) async => ApiResponse.success(const PluginListResponse(plugins: [toolA, toolB])),
+    );
+    final toolBAgents = Completer<ApiResponse<Agents>>();
+    when(
+      () => sessionService.listAgents(
+        projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
+      ),
+    ).thenAnswer((invocation) {
+      final pluginId = invocation.namedArguments[#pluginId] as String;
+      if (pluginId == "tool-b") return toolBAgents.future;
+      return Future.value(
+        ApiResponse.success(
+          Agents(
+            agents: [_testAgent(name: "coder", description: "Coder", variant: "xhigh")],
+          ),
+        ),
+      );
+    });
+
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+    expect(find.widgetWithText(GlassButton, "coder"), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key("new_session_plugin_tool-b")));
+    await tester.pump();
+
+    expect(find.widgetWithText(GlassButton, "coder"), findsNothing);
+    final disabledComposer = find.ancestor(
+      of: find.byType(PromptInput),
+      matching: find.byWidgetPredicate((widget) => widget is IgnorePointer && widget.ignoring),
+    );
+    expect(disabledComposer, findsOneWidget);
+    expect(
+      tester.widget<InkWell>(find.byKey(const Key("new_session_plugin_tool-a"))).onTap,
+      isNotNull,
+    );
+
+    await tester.tap(find.byKey(const Key("new_session_plugin_tool-a")));
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(GlassButton, "coder"), findsOneWidget);
+    verifyNever(
+      () => sessionService.createSessionWithMessage(
+        projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
+        text: any(named: "text"),
+        agent: any(named: "agent"),
+        providerID: any(named: "providerID"),
+        modelID: any(named: "modelID"),
+        variant: any(named: "variant"),
+        command: any(named: "command"),
+        dedicatedWorktree: any(named: "dedicatedWorktree"),
+      ),
+    );
+    toolBAgents.complete(ApiResponse.success(const Agents(agents: [])));
+  });
+
+  testWidgets("disables plugin selection only while reconnect discovery is in flight", (tester) async {
+    const toolA = PluginMetadata(
+      id: "tool-a",
+      displayName: "Tool A",
+      isDefault: true,
+      state: PluginLifecycleState.ready,
+      actionHint: null,
+    );
+    const toolB = PluginMetadata(
+      id: "tool-b",
+      displayName: "Tool B",
+      isDefault: false,
+      state: PluginLifecycleState.ready,
+      actionHint: null,
+    );
+    final reconnectDiscovery = Completer<ApiResponse<PluginListResponse>>();
+    var discoveryCalls = 0;
+    when(pluginRepository.listPlugins).thenAnswer((_) {
+      discoveryCalls++;
+      if (discoveryCalls == 1) {
+        return Future.value(ApiResponse.success(const PluginListResponse(plugins: [toolA, toolB])));
+      }
+      return reconnectDiscovery.future;
+    });
+
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+
+    connectionStatus
+      ..add(const ConnectionStatus.disconnected())
+      ..add(
+        const ConnectionStatus.connected(
+          config: ServerConnectionConfig(relayHost: "relay.example.com"),
+          health: HealthResponse(
+            healthy: true,
+            version: "test",
+            filesystemAccessDegraded: null,
+          ),
+        ),
+      );
+    await tester.pump();
+    await tester.pump();
+
+    expect(discoveryCalls, 2);
+    expect(tester.widget<NewSessionPluginChooser>(find.byType(NewSessionPluginChooser)).isSelectionEnabled, isFalse);
+    expect(
+      tester.widget<InkWell>(find.byKey(const Key("new_session_plugin_tool-b"))).onTap,
+      isNull,
+    );
+    await tester.tap(find.byKey(const Key("new_session_plugin_tool-b")));
+    await tester.pump();
+    expect(
+      find.descendant(
+        of: find.byKey(const Key("new_session_plugin_tool-a")),
+        matching: find.byIcon(Icons.radio_button_checked),
+      ),
+      findsOneWidget,
+    );
+    verifyNever(() => sessionService.listAgents(projectId: "project-1", pluginId: "tool-b"));
+
+    reconnectDiscovery.complete(ApiResponse.success(const PluginListResponse(plugins: [toolA, toolB])));
+    await tester.pumpAndSettle();
+
+    expect(tester.widget<NewSessionPluginChooser>(find.byType(NewSessionPluginChooser)).isSelectionEnabled, isTrue);
+    expect(
+      tester.widget<InkWell>(find.byKey(const Key("new_session_plugin_tool-b"))).onTap,
+      isNotNull,
+    );
+    await tester.tap(find.byKey(const Key("new_session_plugin_tool-b")));
+    await tester.pumpAndSettle();
+    expect(
+      find.descendant(
+        of: find.byKey(const Key("new_session_plugin_tool-b")),
+        matching: find.byIcon(Icons.radio_button_checked),
+      ),
+      findsOneWidget,
+    );
+    verify(() => sessionService.listAgents(projectId: "project-1", pluginId: "tool-b")).called(1);
+  });
+
+  testWidgets("refresh discovery failure keeps the chooser and composer usable", (tester) async {
     var discoveryCalls = 0;
     when(pluginRepository.listPlugins).thenAnswer((_) async {
       discoveryCalls++;
@@ -420,7 +622,7 @@ void main() {
     final context = tester.element(find.byType(NewSessionScreen));
     final loc = AppLocalizations.of(context)!;
     expect(find.text(loc.apiErrorServerRejected), findsOneWidget);
-    expect(find.byKey(const Key("new_session_plugin_plugin-1")), findsNothing);
+    expect(find.byKey(const Key("new_session_plugin_plugin-1")), findsOneWidget);
     expect(
       find.ancestor(
         of: find.byType(PromptInput),

--- a/client/module_core/lib/src/repositories/plugin_repository.dart
+++ b/client/module_core/lib/src/repositories/plugin_repository.dart
@@ -12,21 +12,6 @@ class PluginRepository {
 
   Future<ApiResponse<PluginListResponse>> listPlugins() async {
     final response = await _api.listPlugins();
-    if (response case SuccessResponse(:final data)) {
-      // TEMPORARY RELEASE GATE (2026-07-24): expose only OpenCode to every
-      // client, including clients connected to an older multi-plugin bridge.
-      // Revert this gate immediately after the next synchronized release.
-      PluginMetadata? openCode;
-      for (final plugin in data.plugins) {
-        if (plugin.id == legacyMissingPluginId) {
-          openCode = plugin.copyWith(isDefault: true);
-          break;
-        }
-      }
-      return ApiResponse.success(
-        PluginListResponse(plugins: [?openCode]),
-      );
-    }
     if (response case ErrorResponse(error: NonSuccessCodeError(errorCode: 404))) {
       // COMPATIBILITY 2026-07-18 (v1.6.0): Bridges without plugin discovery return 404 and can only target OpenCode. Remove this fallback once those bridges are unsupported.
       return ApiResponse.success(

--- a/client/module_core/lib/src/repositories/session_repository.dart
+++ b/client/module_core/lib/src/repositories/session_repository.dart
@@ -148,10 +148,7 @@ class SessionRepository {
   }) {
     return _api.createSessionWithMessage(
       projectId: projectId,
-      // TEMPORARY RELEASE GATE (2026-07-24): force the create wire payload to
-      // OpenCode even if a caller retained stale multi-plugin discovery state.
-      // Revert this override immediately after the next synchronized release.
-      pluginId: legacyMissingPluginId,
+      pluginId: pluginId,
       text: text,
       agent: agent,
       model: model,

--- a/client/module_core/test/repositories/plugin_repository_test.dart
+++ b/client/module_core/test/repositories/plugin_repository_test.dart
@@ -16,20 +16,20 @@ void main() {
     repository = PluginRepository(api: api);
   });
 
-  test("temporary release gate exposes only OpenCode and makes it the default", () async {
+  test("returns the backend-neutral plugin response unchanged", () async {
     const response = PluginListResponse(
       plugins: [
         PluginMetadata(
-          id: "codex",
-          displayName: "Codex",
-          isDefault: true,
-          state: PluginLifecycleState.ready,
-          actionHint: null,
+          id: "plugin-b",
+          displayName: "Plugin B",
+          isDefault: false,
+          state: PluginLifecycleState.failed,
+          actionHint: "Restart the bridge.",
         ),
         PluginMetadata(
-          id: legacyMissingPluginId,
-          displayName: "OpenCode",
-          isDefault: false,
+          id: "plugin-a",
+          displayName: "Plugin A",
+          isDefault: true,
           state: PluginLifecycleState.ready,
           actionHint: null,
         ),
@@ -37,47 +37,7 @@ void main() {
     );
     when(api.listPlugins).thenAnswer((_) async => ApiResponse.success(response));
 
-    expect(
-      await repository.listPlugins(),
-      ApiResponse<PluginListResponse>.success(
-        const PluginListResponse(
-          plugins: [
-            PluginMetadata(
-              id: legacyMissingPluginId,
-              displayName: "OpenCode",
-              isDefault: true,
-              state: PluginLifecycleState.ready,
-              actionHint: null,
-            ),
-          ],
-        ),
-      ),
-    );
-  });
-
-  test("temporary release gate returns no choice when OpenCode is absent", () async {
-    when(api.listPlugins).thenAnswer(
-      (_) async => ApiResponse.success(
-        const PluginListResponse(
-          plugins: [
-            PluginMetadata(
-              id: "codex",
-              displayName: "Codex",
-              isDefault: true,
-              state: PluginLifecycleState.ready,
-              actionHint: null,
-            ),
-          ],
-        ),
-      ),
-    );
-
-    expect(
-      await repository.listPlugins(),
-      ApiResponse<PluginListResponse>.success(
-        const PluginListResponse(plugins: []),
-      ),
-    );
+    expect(await repository.listPlugins(), ApiResponse<PluginListResponse>.success(response));
   });
 
   test("maps an unsupported discovery route to the legacy OpenCode plugin", () async {

--- a/client/module_core/test/repositories/session_repository_test.dart
+++ b/client/module_core/test/repositories/session_repository_test.dart
@@ -126,47 +126,6 @@ void main() {
     verify(() => api.rejectQuestion(requestId: "question-1", sessionId: "session-1")).called(1);
   });
 
-  test("temporary release gate forces session creation to OpenCode", () async {
-    final api = MockSessionApi();
-    final repository = SessionRepository(api: api);
-    when(
-      () => api.createSessionWithMessage(
-        projectId: any(named: "projectId"),
-        pluginId: any(named: "pluginId"),
-        text: any(named: "text"),
-        agent: any(named: "agent"),
-        model: any(named: "model"),
-        variant: any(named: "variant"),
-        command: any(named: "command"),
-        dedicatedWorktree: any(named: "dedicatedWorktree"),
-      ),
-    ).thenAnswer((_) async => ApiResponse.success(testSession(id: "session-1")));
-
-    await repository.createSessionWithMessage(
-      projectId: "project-1",
-      pluginId: "codex",
-      text: "hello",
-      agent: null,
-      model: null,
-      variant: null,
-      command: null,
-      dedicatedWorktree: false,
-    );
-
-    verify(
-      () => api.createSessionWithMessage(
-        projectId: "project-1",
-        pluginId: legacyMissingPluginId,
-        text: "hello",
-        agent: null,
-        model: null,
-        variant: null,
-        command: null,
-        dedicatedWorktree: false,
-      ),
-    ).called(1);
-  });
-
   test("listProviders does not cache an empty response but caches one with models", () async {
     final api = MockSessionApi();
     final repository = SessionRepository(api: api);


### PR DESCRIPTION
Reverts sesori-ai/sesori_apps_monorepo#555

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the temporary OpenCode-only gate and restores full multi‑plugin behavior across Bridge and Mobile. Users can choose plugins again, and sessions use the selected plugin.

- **New Features**
  - Bridge runtime/CLI: removed the release gate; eligibility now uses configured disabled IDs; CLI shows enabled/disabled directly.
  - Mobile New Session: restored plugin chooser with selection; shows ready/degraded/failed/unavailable states and dark‑mode styling.
  - API: `PluginRepository.listPlugins` returns the server response unchanged; `SessionRepository.createSessionWithMessage` sends the selected `pluginId`.
  - Tests: updated and expanded coverage for chooser behavior, reconnect discovery, scrolling, and composer interaction.

<sup>Written for commit 91a12c789e26f8676e1fd2d70a4902b48e1b18c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

