### PR TITLE
fix(bridge): route cleanup checks through runtime

### DIFF
--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -356,12 +356,21 @@ class SessionRepository {
   Future<List<String>> get persistedSessionCleanupPluginIds async {
     final pluginIds = <String>[];
     for (final pluginId in _runtime.activePluginIds) {
-      final supportsCleanup = await _runtime.useIfActive(
-        pluginId: pluginId,
-        operation: SessionOperation.cleanupSession,
-        body: (plugin, _) async => plugin is PersistedSessionCleanupApi,
-      );
-      if (supportsCleanup ?? false) pluginIds.add(pluginId);
+      try {
+        final supportsCleanup = await _runtime.useIfActive(
+          pluginId: pluginId,
+          operation: SessionOperation.cleanupSession,
+          body: (plugin, _) async => plugin is PersistedSessionCleanupApi,
+        );
+        if (supportsCleanup ?? false) pluginIds.add(pluginId);
+      } on Object catch (error, stackTrace) {
+        Log.w(
+          "Failed to inspect persisted session cleanup capability "
+          "(plugin=$pluginId); retrying next startup",
+          error,
+          stackTrace,
+        );
+      }
     }
     pluginIds.sort();
     return List<String>.unmodifiable(pluginIds);

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -353,20 +353,36 @@ class SessionRepository {
     return _tombstonesFor(binding.pluginId).contains(binding.backendSessionId);
   }
 
-  List<String> get persistedSessionCleanupPluginIds {
-    final pluginIds = [
-      for (final entry in _runtime.operationalApis.entries)
-        if (entry.value is PersistedSessionCleanupApi) entry.key,
-    ]..sort();
+  Future<List<String>> get persistedSessionCleanupPluginIds async {
+    final pluginIds = <String>[];
+    for (final pluginId in _runtime.activePluginIds) {
+      final supportsCleanup = await _runtime.useIfActive(
+        pluginId: pluginId,
+        operation: SessionOperation.cleanupSession,
+        body: (plugin, _) async => plugin is PersistedSessionCleanupApi,
+      );
+      if (supportsCleanup ?? false) pluginIds.add(pluginId);
+    }
+    pluginIds.sort();
     return List<String>.unmodifiable(pluginIds);
   }
 
-  Future<Set<String>> getTombstonedBackendSessionIdsForCleanup({required String pluginId}) {
-    _requirePersistedSessionCleanupApi(
+  Future<Set<String>> getTombstonedBackendSessionIdsForCleanup({required String pluginId}) async {
+    final tombstones = await _runtime.useIfActive(
       pluginId: pluginId,
-      plugin: _runtime.operationalApis[pluginId],
+      operation: SessionOperation.cleanupSession,
+      body: (plugin, _) {
+        _requirePersistedSessionCleanupApi(
+          pluginId: pluginId,
+          plugin: plugin,
+        );
+        return _sessionDao.getTombstonedSessionIds(pluginId: pluginId);
+      },
     );
-    return _sessionDao.getTombstonedSessionIds(pluginId: pluginId);
+    if (tombstones == null) {
+      throw StateError('Plugin "$pluginId" is not active');
+    }
+    return tombstones;
   }
 
   Future<void> deletePersistedSession({

--- a/bridge/app/lib/src/bridge/services/deleted_session_storage_cleanup_service.dart
+++ b/bridge/app/lib/src/bridge/services/deleted_session_storage_cleanup_service.dart
@@ -23,7 +23,7 @@ class DeletedSessionStorageCleanupService {
   }
 
   Future<void> _reconcile() async {
-    for (final pluginId in _sessionRepository.persistedSessionCleanupPluginIds) {
+    for (final pluginId in await _sessionRepository.persistedSessionCleanupPluginIds) {
       final Set<String> sessionIds;
       try {
         sessionIds = await _sessionRepository.getTombstonedBackendSessionIdsForCleanup(

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -89,7 +89,7 @@ void main() {
         deletedAt: 1,
       );
 
-      expect(repository.persistedSessionCleanupPluginIds, [cleanupPlugin.id]);
+      expect(await repository.persistedSessionCleanupPluginIds, [cleanupPlugin.id]);
       expect(
         await repository.getTombstonedBackendSessionIdsForCleanup(
           pluginId: cleanupPlugin.id,
@@ -123,7 +123,7 @@ void main() {
         unseenCalculator: const SessionUnseenCalculator(),
       );
 
-      expect(repository.persistedSessionCleanupPluginIds, isEmpty);
+      expect(await repository.persistedSessionCleanupPluginIds, isEmpty);
     });
 
     test("coalesces tombstone loading and serves later lookups from memory", () async {

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -126,6 +126,31 @@ void main() {
       expect(await repository.persistedSessionCleanupPluginIds, isEmpty);
     });
 
+    test("isolates persisted cleanup capability probe failures", () async {
+      final db = createTestDatabase();
+      addTearDown(db.close);
+      final failingPlugin = _FakeDerivedPlugin(
+        launchDirectory: "/failing",
+        allSessions: const [],
+      );
+      final cleanupPlugin = _FakePersistedCleanupPlugin();
+      final repository = SessionRepository(
+        runtime: _CapabilityProbeFailingRuntime(
+          plugins: [failingPlugin, cleanupPlugin],
+          failingPluginId: failingPlugin.id,
+        ),
+        bridgeDerivedProjectPluginIds: {failingPlugin.id},
+        sessionDao: db.sessionDao,
+        projectsDao: db.projectsDao,
+        pullRequestDao: db.pullRequestDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+        projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
+        aggregateSourceDeadline: const Duration(seconds: 5),
+      );
+
+      expect(await repository.persistedSessionCleanupPluginIds, [cleanupPlugin.id]);
+    });
+
     test("coalesces tombstone loading and serves later lookups from memory", () async {
       final db = createTestDatabase();
       addTearDown(db.close);
@@ -2236,6 +2261,35 @@ class _GenerationReplacingRuntime extends TestPluginRuntime {
     observationCollected.complete();
     await _replacement.future;
     return result;
+  }
+}
+
+class _CapabilityProbeFailingRuntime extends TestPluginRuntime {
+  _CapabilityProbeFailingRuntime({
+    required Iterable<BridgePluginApi> plugins,
+    required String failingPluginId,
+  }) : _failingPluginId = failingPluginId,
+       super(
+         plugins: {for (final plugin in plugins) plugin.id: plugin},
+         eligiblePluginIds: null,
+       );
+
+  final String _failingPluginId;
+
+  @override
+  Future<T?> useIfActive<T>({
+    required String pluginId,
+    required Enum operation,
+    required Future<T> Function(BridgePluginApi api, int generation) body,
+  }) {
+    if (pluginId == _failingPluginId) {
+      throw StateError("plugin generation changed");
+    }
+    return super.useIfActive(
+      pluginId: pluginId,
+      operation: operation,
+      body: body,
+    );
   }
 }
 

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -748,7 +748,7 @@ class _NoopSessionRepository implements SessionRepository {
   Future<bool> isSessionTombstoned({required String sessionId}) async => false;
 
   @override
-  List<String> get persistedSessionCleanupPluginIds => const [];
+  Future<List<String>> get persistedSessionCleanupPluginIds async => const [];
 
   @override
   Future<Set<String>> getTombstonedBackendSessionIdsForCleanup({required String pluginId}) async => const {};
@@ -1012,7 +1012,7 @@ class FakeSessionRepository implements SessionRepository {
   Future<bool> isSessionTombstoned({required String sessionId}) async => false;
 
   @override
-  List<String> get persistedSessionCleanupPluginIds => const [];
+  Future<List<String>> get persistedSessionCleanupPluginIds async => const [];
 
   @override
   Future<Set<String>> getTombstonedBackendSessionIdsForCleanup({required String pluginId}) async => const {};

--- a/bridge/app/test/bridge/services/deleted_session_storage_cleanup_service_test.dart
+++ b/bridge/app/test/bridge/services/deleted_session_storage_cleanup_service_test.dart
@@ -63,7 +63,7 @@ class _FakeSessionRepository implements SessionRepository {
   final List<({String pluginId, String backendSessionId})> cleanupCalls = [];
 
   @override
-  List<String> get persistedSessionCleanupPluginIds => cleanupPluginIds;
+  Future<List<String>> get persistedSessionCleanupPluginIds async => cleanupPluginIds;
 
   @override
   Future<Set<String>> getTombstonedBackendSessionIdsForCleanup({required String pluginId}) async {

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -513,7 +513,7 @@ class _FakeSessionRepository implements SessionRepository {
   Future<bool> isSessionTombstoned({required String sessionId}) async => false;
 
   @override
-  List<String> get persistedSessionCleanupPluginIds => const [];
+  Future<List<String>> get persistedSessionCleanupPluginIds async => const [];
 
   @override
   Future<Set<String>> getTombstonedBackendSessionIdsForCleanup({required String pluginId}) async => const {};


### PR DESCRIPTION
## Summary

- replace stale persisted-session cleanup access to the removed `PluginRuntime.operationalApis` view
- discover cleanup capabilities and read tombstones through generation-scoped runtime leases
- await capability discovery during startup cleanup and update affected test fakes

## Root cause

PR #546 merged cleanup code that still referenced the temporary operational API view after that view had been removed from `PluginRuntime`. This broke Bridge CI analysis and native compilation on `main`.

## Verification

- `dart analyze --fatal-infos` in `bridge/app`
- `dart test test/bridge/repositories/session_repository_test.dart test/bridge/services/deleted_session_storage_cleanup_service_test.dart` in `bridge/app`
- `dart build cli -o build` in `bridge/app`
- architecture implementation review approved with no findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routed persisted‑session cleanup through the runtime using generation‑scoped leases, replacing the removed operational API view. Fixes startup cleanup and restores Bridge CI analysis and native build.

- **Bug Fixes**
  - Discover cleanup capability via runtime leases (`useIfActive`) and read tombstones within the `cleanupSession` operation; isolate per‑plugin probe failures so one plugin won't block cleanup.
  - Await capability discovery during startup cleanup; updated tests and fakes.

- **Migration**
  - `persistedSessionCleanupPluginIds` is now async; await it at call sites.

<sup>Written for commit b2d19aa321012b21d1522081c3630150ef5b4dc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

