### PR TITLE
fix(client): honor Cursor defaultModelID for new sessions

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/provider_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/provider_mapper.dart
@@ -37,7 +37,6 @@ PluginProvidersResult mapProviderResponse({
       id: providerInfo.id,
       name: providerInfo.name,
       models: models,
-      defaultModels: response.defaultValue,
     );
   }).toList();
 
@@ -95,80 +94,81 @@ PluginProvider _mapProvider({
   required String id,
   required String name,
   required List<PluginModel> models,
-  required Map<String, String> defaultModels,
 }) {
-  final defaultModelID = defaultModels[id];
-
+  // OpenCode's per-provider `default` map is frequently stale (e.g. Kimi).
+  // Omit it so clients fall back to newest-by-releaseDate selection instead
+  // of trusting the API default. Plugins that publish a trustworthy default
+  // (e.g. Cursor's ACP current model) set defaultModelID themselves.
   return switch (id.toLowerCase()) {
     "anthropic" => PluginProvider.anthropic(
       id: id,
       name: name,
       authType: PluginProviderAuthType.apiKey,
       models: models,
-      defaultModelID: defaultModelID,
+      defaultModelID: null,
     ),
     "openai" => PluginProvider.openAI(
       id: id,
       name: name,
       authType: PluginProviderAuthType.apiKey,
       models: models,
-      defaultModelID: defaultModelID,
+      defaultModelID: null,
     ),
     "google" => PluginProvider.google(
       id: id,
       name: name,
       authType: PluginProviderAuthType.apiKey,
       models: models,
-      defaultModelID: defaultModelID,
+      defaultModelID: null,
     ),
     "mistral" => PluginProvider.mistral(
       id: id,
       name: name,
       authType: PluginProviderAuthType.apiKey,
       models: models,
-      defaultModelID: defaultModelID,
+      defaultModelID: null,
     ),
     "groq" => PluginProvider.groq(
       id: id,
       name: name,
       authType: PluginProviderAuthType.apiKey,
       models: models,
-      defaultModelID: defaultModelID,
+      defaultModelID: null,
     ),
     "xai" => PluginProvider.xAI(
       id: id,
       name: name,
       authType: PluginProviderAuthType.apiKey,
       models: models,
-      defaultModelID: defaultModelID,
+      defaultModelID: null,
     ),
     "deepseek" => PluginProvider.deepseek(
       id: id,
       name: name,
       authType: PluginProviderAuthType.apiKey,
       models: models,
-      defaultModelID: defaultModelID,
+      defaultModelID: null,
     ),
     "amazon-bedrock" || "bedrock" => PluginProvider.amazonBedrock(
       id: id,
       name: name,
       authType: PluginProviderAuthType.unknown,
       models: models,
-      defaultModelID: defaultModelID,
+      defaultModelID: null,
     ),
     "azure" => PluginProvider.azure(
       id: id,
       name: name,
       authType: PluginProviderAuthType.apiKey,
       models: models,
-      defaultModelID: defaultModelID,
+      defaultModelID: null,
     ),
     _ => PluginProvider.custom(
       id: id,
       name: name,
       authType: PluginProviderAuthType.unknown,
       models: models,
-      defaultModelID: defaultModelID,
+      defaultModelID: null,
     ),
   };
 }

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -324,7 +324,7 @@ void main() {
       expect(anthropic.name, equals("Anthropic"));
       expect(anthropic.authType, equals(PluginProviderAuthType.apiKey));
       expect(anthropic.models, hasLength(2));
-      expect(anthropic.defaultModelID, equals("claude-3-sonnet"));
+      expect(anthropic.defaultModelID, isNull);
 
       final opus = anthropic.models.firstWhere((m) => m.id == "claude-3-opus");
       expect(opus.name, equals("Claude 3 Opus"));

--- a/bridge/sesori_plugin_opencode/test/provider_mapper_test.dart
+++ b/bridge/sesori_plugin_opencode/test/provider_mapper_test.dart
@@ -5,6 +5,25 @@ import "package:test/test.dart";
 
 void main() {
   group("mapProviderResponse", () {
+    test("omits OpenCode's API default map so clients use newest-by-date", () {
+      final response = ConfigProvidersResponse.fromJson(
+        _providersJson(<String, dynamic>{
+          "gpt-4.1-mini": _modelJson(
+            id: "openai/gpt-4.1-mini",
+            name: "GPT-4.1 Mini",
+            variants: const <String, dynamic>{},
+            family: "gpt-4.1",
+            status: "active",
+            releaseDate: "2025-04-01",
+          ),
+        }),
+      );
+
+      final mapped = mapProviderResponse(response: response);
+
+      expect(mapped.providers.single.defaultModelID, isNull);
+    });
+
     test("preserves synthetic model IDs and treats alpha/beta statuses as available", () {
       final response = ConfigProvidersResponse.fromJson(
         _providersJson(<String, dynamic>{
@@ -31,7 +50,7 @@ void main() {
       expect(mapped.providers, hasLength(1));
       final provider = mapped.providers.first;
       expect(provider.id, equals("openai"));
-      expect(provider.defaultModelID, equals("openai/gpt-4.1-mini"));
+      expect(provider.defaultModelID, isNull);
       expect(provider.models, hasLength(2));
       final alphaModel = provider.models.firstWhere((model) => model.id == "openai/gpt-4.1-alpha");
       expect(alphaModel.isAvailable, isTrue);

--- a/client/module_core/lib/src/cubits/new_session/new_session_cubit.dart
+++ b/client/module_core/lib/src/cubits/new_session/new_session_cubit.dart
@@ -254,7 +254,10 @@ class NewSessionCubit extends Cubit<NewSessionState> {
     } else {
       AgentModel? pickedModel;
       for (final provider in providers) {
-        final picked = _defaultModelSelector.pickFromProvider(models: provider.models);
+        final picked = _defaultModelSelector.pickFromProvider(
+          models: provider.models,
+          defaultModelID: provider.defaultModelID,
+        );
         if (picked != null) {
           pickedModel = AgentModel(providerID: provider.id, modelID: picked.id, variant: null);
           break;

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -1397,6 +1397,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
       for (final provider in providers) {
         final picked = _defaultModelSelector.pickFromProvider(
           models: provider.models,
+          defaultModelID: provider.defaultModelID,
         );
         if (picked != null) {
           pickedModel = AgentModel(

--- a/client/module_core/lib/src/utils/model_filter/default_model_selector.dart
+++ b/client/module_core/lib/src/utils/model_filter/default_model_selector.dart
@@ -3,22 +3,24 @@ import "package:sesori_shared/sesori_shared.dart";
 /// Pure helper that selects a single representative [ProviderModel] from a
 /// family or from a whole provider's [ProviderInfo.models] map.
 ///
-/// The selector uses only signals already present in the upstream data, so
-/// the same logic works for every provider without per-provider knowledge:
+/// When a plugin publishes a trustworthy [ProviderInfo.defaultModelID]
+/// (and that model is available), [pickFromProvider] uses it. Plugins that
+/// do not trust their backend default — OpenCode, whose API default is
+/// frequently stale — omit the field so the selector falls through to the
+/// date-based ranking below.
+///
+/// Absent a published default, ranking uses only signals already present in
+/// the upstream data, so the same logic works for every provider without
+/// per-provider knowledge:
 ///
 /// 1. The model with the most recent [ProviderModel.releaseDate]. Models
 ///    without a release date sort last.
-/// 2. The first available model in iteration order.
+/// 2. Deterministic `id` tie-break.
 ///
 /// The "(latest)" marker in a model name is intentionally ignored as a
 /// ranking signal. Providers may label an older model as "latest" (e.g.
 /// `Claude Sonnet 4.5 (latest)` vs. a newer `Claude Sonnet 4.8`), so the
 /// release date is a more reliable signal for picking the current default.
-///
-/// The provider's backend-supplied [ProviderInfo.defaultModelID] is
-/// intentionally ignored. It is a provider-wide default that is frequently
-/// stale (e.g. Kimi), and the family-level newest-by-date signal is a more
-/// reliable default for the picker.
 ///
 /// There is intentionally no "newer than X months" cutoff. Deprecated
 /// models are already filtered out by [ProviderModel.isAvailable] in
@@ -38,12 +40,21 @@ class DefaultModelSelector {
 
   /// Selects a single default model across an entire provider.
   ///
-  /// Groups [models] by family, picks the best model per family using
+  /// Prefer [defaultModelID] when it resolves to an available model. Otherwise
+  /// groups [models] by family, picks the best model per family using
   /// [pickFromFamily], then returns the best of those representatives
   /// using the same ranking (newest release date, then `id`).
   ///
   /// Returns `null` if [models] contains no available models.
-  ProviderModel? pickFromProvider({required Map<String, ProviderModel> models}) {
+  ProviderModel? pickFromProvider({
+    required Map<String, ProviderModel> models,
+    required String? defaultModelID,
+  }) {
+    if (defaultModelID != null) {
+      final preferred = models[defaultModelID];
+      if (preferred != null && preferred.isAvailable) return preferred;
+    }
+
     // 1. Group by family, pick the best per family.
     final byFamily = <String, List<ProviderModel>>{};
     for (final m in models.values) {

--- a/client/module_core/test/utils/model_filter/default_model_selector_test.dart
+++ b/client/module_core/test/utils/model_filter/default_model_selector_test.dart
@@ -160,7 +160,7 @@ void main() {
         "a": _model(id: "a", isAvailable: false),
       };
       expect(
-        selector.pickFromProvider(models: models),
+        selector.pickFromProvider(models: models, defaultModelID: null),
         isNull,
       );
     });
@@ -194,12 +194,55 @@ void main() {
           releaseDate: DateTime(2026, 4),
         ),
       };
-      final picked = selector.pickFromProvider(models: models);
+      final picked = selector.pickFromProvider(models: models, defaultModelID: null);
       expect(picked?.id, "k2p6");
     });
 
     test(
-      "ignores the provider's API defaultModelID and still picks newest by date",
+      "honors a published defaultModelID when that model is available",
+      () {
+        final models = {
+          "claude-fable-5": _model(
+            id: "claude-fable-5",
+            name: "Fable 5",
+            releaseDate: null,
+          ),
+          "gpt-5.4": _model(
+            id: "gpt-5.4",
+            name: "GPT-5.4",
+            releaseDate: null,
+          ),
+        };
+        final picked = selector.pickFromProvider(
+          models: models,
+          defaultModelID: "gpt-5.4",
+        );
+        expect(picked?.id, "gpt-5.4");
+      },
+    );
+
+    test(
+      "falls back to newest-by-date when defaultModelID is omitted",
+      () {
+        final models = {
+          "newer": _model(
+            id: "newer",
+            family: "k2",
+            releaseDate: DateTime(2026, 4),
+          ),
+          "older": _model(
+            id: "older",
+            family: "k2",
+            releaseDate: DateTime(2025, 11),
+          ),
+        };
+        final picked = selector.pickFromProvider(models: models, defaultModelID: null);
+        expect(picked?.id, "newer");
+      },
+    );
+
+    test(
+      "falls back to newest-by-date when defaultModelID is unavailable",
       () {
         final models = {
           "newer": _model(
@@ -211,9 +254,36 @@ void main() {
             id: "api-default",
             family: "k2",
             releaseDate: DateTime(2025, 11),
+            isAvailable: false,
           ),
         };
-        final picked = selector.pickFromProvider(models: models);
+        final picked = selector.pickFromProvider(
+          models: models,
+          defaultModelID: "api-default",
+        );
+        expect(picked?.id, "newer");
+      },
+    );
+
+    test(
+      "falls back to newest-by-date when defaultModelID is unknown",
+      () {
+        final models = {
+          "newer": _model(
+            id: "newer",
+            family: "k2",
+            releaseDate: DateTime(2026, 4),
+          ),
+          "older": _model(
+            id: "older",
+            family: "k2",
+            releaseDate: DateTime(2025, 11),
+          ),
+        };
+        final picked = selector.pickFromProvider(
+          models: models,
+          defaultModelID: "missing",
+        );
         expect(picked?.id, "newer");
       },
     );
@@ -235,7 +305,7 @@ void main() {
             releaseDate: DateTime(2026, 4),
           ),
         };
-        final picked = selector.pickFromProvider(models: models);
+        final picked = selector.pickFromProvider(models: models, defaultModelID: null);
         // zeta-family is alphabetically later but has the newer model.
         expect(picked?.id, "zeta-newer");
       },
@@ -258,7 +328,7 @@ void main() {
             releaseDate: DateTime(2025, 1),
           ),
         };
-        final picked = selector.pickFromProvider(models: models);
+        final picked = selector.pickFromProvider(models: models, defaultModelID: null);
         expect(picked?.id, "newer-plain");
       },
     );
@@ -280,7 +350,7 @@ void main() {
             releaseDate: DateTime(2026, 4),
           ),
         };
-        final picked = selector.pickFromProvider(models: models);
+        final picked = selector.pickFromProvider(models: models, defaultModelID: null);
         expect(picked?.id, "alpha");
       },
     );
@@ -299,7 +369,7 @@ void main() {
           releaseDate: DateTime(2025, 11),
         ),
       };
-      final picked = selector.pickFromProvider(models: models);
+      final picked = selector.pickFromProvider(models: models, defaultModelID: null);
       expect(picked?.id, "fallback");
     });
   });


### PR DESCRIPTION
## Summary
- New/session-detail model auto-select now prefers `ProviderInfo.defaultModelID` when that model is available; otherwise it keeps newest-by-releaseDate.
- OpenCode stops publishing its (often stale) API `default` map as `defaultModelID`, so OpenCode still uses date-based defaults.
- Cursor already publishes ACP's current model as `defaultModelID`, so new Cursor sessions stop alphabetically landing on Fable 5.

## Test plan
- [ ] Create a new Cursor session in the app and confirm the preselected model matches Cursor's current/default model (not Fable 5 unless that is Cursor's default).
- [ ] Create a new OpenCode session and confirm defaults still prefer newest-by-date within a provider (e.g. Kimi K2.6 over older family members).
- [ ] Switch plugins / clear persisted selection and confirm Cursor again picks ACP default.
- [ ] `dart test test/utils/model_filter/default_model_selector_test.dart` (module_core)
- [ ] `dart test test/provider_mapper_test.dart` (sesori_plugin_opencode)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect plugin `defaultModelID` for model auto-select and stop using OpenCode’s stale defaults. Cursor sessions now start on ACP’s current model instead of alphabetically picking Fable 5.

- **Bug Fixes**
  - Default picker now prefers `ProviderInfo.defaultModelID` when it points to an available model; otherwise falls back to newest-by-releaseDate with deterministic tie-breaks.
  - `sesori_plugin_opencode`: removed forwarding of the API’s per-provider `default` map; all providers now expose `defaultModelID: null` to keep date-based defaults.
  - Passed `defaultModelID` through `NewSessionCubit` and `SessionDetailCubit` to the selector.
  - Added/updated tests to cover preferred-default, unavailable/unknown default fallbacks, and OpenCode behavior.

<sup>Written for commit f70d3721e4fe5b6070ad0bf9550891ce032247f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

