### PR TITLE
[setup-aware-plugin-management] fix(bridge): keep attach-only plugins resident [step 1/6]

### DIFF
--- a/.plan/active/setup-aware-plugin-lifecycle/PLAN.md
+++ b/.plan/active/setup-aware-plugin-lifecycle/PLAN.md
@@ -3,14 +3,15 @@
 ## Status
 
 - **Plan slug:** `setup-aware-plugin-lifecycle`
-- **Status:** Stage 10 and the complete replacement P01A-P01D stack are merged;
-  Stage 11-P02 is rebuilt and locally verified in draft PR #556
-- **Implementation base:** latest `origin/main` at `2bb376b2`; local P02 has
-  merged that base after the synchronized release and gate revert, without rebasing
+- **Status:** Stage 10, the complete replacement P01A-P01D stack, and Stage
+  11-P02 are merged; Stage 12 is redesigned as a six-PR child series
+- **Implementation base:** `origin/main` at `41e03f12`, which includes merged
+  transient-residency PR #556
 - **Predecessor:** parallel-plugin Stages 0-9 and bridge-app-onboarding W02 are merged
-- **Delivery:** Stage 11-P01 is split into runtime mechanics, operation routing,
-  dynamic events/durable fencing, and bridge-owned projects/default behavior;
-  the later dormancy, management, and client stages are rebuilt on that stack
+- **Delivery:** Stage 12 is tracked in
+  `.plan/active/setup-aware-plugin-management` and isolates attach-only
+  residency, read contracts, invalidation, timeout writes, runtime transaction
+  mechanics, and commands before the later client stage
 
 This plan replaces the first unmerged implementation. Nothing introduced only
 by that implementation needs compatibility handling. Released contracts still
@@ -93,6 +94,14 @@ available:
   resident after hydration.
 - Applying one timeout to all plugins sets the default and removes every known
   per-plugin timeout override while preserving unrelated unknown fields.
+- A descriptor can declare from validated plugin config that its backend must
+  remain resident after first demand. Such a plugin has an effective timeout of
+  `0` regardless of persisted default or per-plugin timeout, without rewriting
+  either setting.
+- OpenCode configured with `--opencode-no-auto-start` declares resident policy:
+  Sesori may attach on demand but must not later detach its own plugin adapter
+  because the externally owned server is expected to remain continuously
+  available.
 - Safe automatic or manual stop requires no operation lease, affirmative plugin
   idle state, and no unsettled lifecycle transition or event handoff.
 
@@ -186,6 +195,14 @@ plugin config, bounded host-process access, environment, and read-only state
 directory. Concrete OpenCode, Codex, and Cursor descriptors classify their own
 runtime and authentication evidence and return only generic setup status and a
 sanitized nullable action hint.
+
+`BridgePluginDescriptor.residencyPolicy({required PluginConfig config})` is a
+pure, generic declaration with a transient default. Backend-specific CLI
+interpretation stays inside the descriptor; the runner passes only
+`PluginResidencyPolicy` into registered lifecycle metadata.
+`PluginLifecycleService` remains the sole owner of effective timeout calculation
+and maps resident policy to effective timeout `0` for both idle scheduling and
+management presentation.
 
 Probe output is bounded and discarded inside the plugin package. Tokens,
 accounts, credential paths, and raw command output never cross the descriptor
@@ -421,13 +438,14 @@ They depend only on `PluginLifecycleService`, parse generated shared models, and
 map typed service exceptions to HTTP status. `GetPluginSetupHandler` remains the
 separate snapshot handler.
 
-`PluginLifecycleService` exposes `managementSnapshot`, replay-latest
-`managementSnapshots`, `managementRevisions`, `command(pluginId, request)`, and
-`updateIdleTimeout(request)`. It owns one short global settings-mutation tail and
-one active-command record per plugin. Equal commands join. A different command
-for the same transitioning plugin returns a typed `transitioning` 409. Different
-plugins can start/stop concurrently; only shared config writes enter the global
-tail.
+`PluginLifecycleService` exposes synchronous `managementSnapshot`, the sole
+change stream `managementRevisions`, `command(pluginId, request)`, and
+`updateIdleTimeout(request)`. It retains one plain response only for material
+change comparison; there is no unused snapshot stream. It owns one short global
+settings-mutation tail and one active-command record per plugin. Equal commands
+join. A different command for the same transitioning plugin returns a typed
+`transitioning` 409. Different plugins can start/stop concurrently; only shared
+config writes enter the global tail.
 
 Disable uses explicit downward state transitions; no lower layer invokes a
 settings callback:
@@ -587,15 +605,48 @@ the listed source files and committed with their stage.
 | Bridge policy/settings | `plugin_runtime.dart`, `plugin_lifecycle_repository.dart`, `plugin_lifecycle_service.dart`, `bridge_settings.dart`, `bridge_settings_repository.dart`, `bridge_runtime_runner.dart`. |
 | Dormancy cleanup | Add `plugin_catalog_hydration_listener.dart`; modify `catalog_import_repository.dart`, `catalog_import_service.dart`, session/project repositories, `project_activity_service.dart`, `orchestrator.dart`. |
 
-### Stage 12 / former PR #510 files
+### Stage 12-P01 — attach-only residency and diagnostics
 
 | Workspace | Production files/classes |
 |---|---|
-| Shared | Add `plugin_management.dart`; modify `sesori_sse_event.dart` and barrel exports. |
-| Bridge settings/policy | `bridge_settings.dart`, `bridge_settings_repository.dart`, `plugin_runtime.dart`, `plugin_lifecycle_repository.dart`, `plugin_lifecycle_service.dart`. |
-| Triggers/composition | Keep `plugin_catalog_hydration_listener.dart`; widen its ready-ID source through `plugin_lifecycle_service.dart`; modify `catalog_import_service.dart`, `bridge_runtime_runner.dart`, `orchestrator.dart`. |
-| Routes | Add `get_plugin_management_handler.dart`, `post_plugin_lifecycle_command_handler.dart`, `patch_plugin_idle_timeout_handler.dart`; wire the same instances into relay/debug routing. |
-| Client exhaustive switches | Only minimum `SseEvent`/tracker changes needed for the additive invalidation event; no management feature yet. |
+| Plugin contract/OpenCode | Add generic `PluginResidencyPolicy` and descriptor declaration; OpenCode maps `--opencode-no-auto-start` to resident policy. |
+| Bridge policy/composition | Carry policy in registered lifecycle metadata, return effective timeout `0` for resident plugins, and leave persisted settings untouched. |
+| Diagnostics | Add generic debug-level generation start/stop and idle-suspension outcome logs without duplicating warning/error paths. |
+
+### Stage 12-P02 — read-only management snapshots
+
+| Workspace | Production files/classes |
+|---|---|
+| Shared | Add only management read enums/rows/response in `plugin_management.dart`, generated output, tests, and barrel export. |
+| Bridge policy/routes | Add stable management mapping in `plugin_lifecycle_service.dart`, `get_plugin_management_handler.dart`, and relay/debug route composition. No mutation API or SSE yet. |
+
+### Stage 12-P03 — revision and SSE invalidation
+
+| Workspace | Production files/classes |
+|---|---|
+| Shared | Add the compatible management `revision` field and `plugin.management.changed` SSE variant; regenerate sources. |
+| Bridge/client seam | Publish revisions only for materially changed settled snapshots, map them to SSE in `orchestrator.dart`, and update minimum client exhaustive switches without management UI. |
+
+### Stage 12-P04 — live idle-timeout mutations
+
+| Workspace | Production files/classes |
+|---|---|
+| Shared/settings | Add typed apply-all, set-override, and clear-override requests; retain integer validation and unknown settings fields. |
+| Bridge policy/routes | Add the global settings mutation tail, live timer resynchronization, and `patch_plugin_idle_timeout_handler.dart`. |
+
+### Stage 12-P05 — transactional plugin disable
+
+| Workspace | Production files/classes |
+|---|---|
+| Runtime/repository | Add enabled/draining/disabled access gates plus `prepareDisable`, `commitDisable`, and `rollbackDisable`, preserving current generation/stream/commit fencing. |
+| Shared/policy/routes | Add the disable command variant, typed conflicts, per-plugin command serialization, persistence rollback, and `post_plugin_lifecycle_command_handler.dart` in the shared relay/debug router. |
+
+### Stage 12-P06 — remaining commands and dynamic eligibility
+
+| Workspace | Production files/classes |
+|---|---|
+| Shared/policy | Add enable/restart/refresh request variants, setup-inspection fencing, and live eligibility/default updates. |
+| Catalog/composition | Expose runtime-backed enabled/import-eligible sets through the existing `CatalogImportRepository`, make `CatalogImportService` validate those sets, and retain the single marker-gated hydration listener without changing runner/orchestrator ownership. |
 
 ### Stage 13 / former PR #511 files
 
@@ -652,11 +703,20 @@ the listed source files and committed with their stage.
 - remove startup enumeration that wakes dormant plugins; reconnect
   reconciliation remains source-scoped and active-only.
 
-### Stage 12 / former PR #510 — headless management
+### Stage 12 / former PR #510 — reviewable headless-management series
 
-- simplified management DTOs/routes, safe/force commands, revision/SSE;
-- live denylist mutations and setup refresh;
-- numeric idle-timeout updates and one hydration listener.
+- P01: attach-only resident policy and lifecycle diagnostics;
+- P02: read-only management DTO and GET snapshot;
+- P03: process-local revision and additive SSE invalidation;
+- P04: live numeric idle-timeout mutations;
+- P05: end-to-end safe/force disable with transactional runtime access and
+  persistence rollback;
+- P06: enable/restart/refresh, stale setup fencing, and dynamic default/catalog
+  eligibility.
+
+The exact branches, PR titles, dependency gates, and per-slice verification are
+tracked in `.plan/active/setup-aware-plugin-management`. Frozen PR #510 remains
+source material only and is never rebased, merged, or cherry-picked.
 
 ### Stage 13 / former PR #511 — redesigned mobile plugin settings
 
@@ -666,10 +726,9 @@ the listed source files and committed with their stage.
   settings primitives;
 - focused interaction, conflict/force, reconnect, and route tests.
 
-P01A starts at latest `origin/main`; each later replacement branch stacks on its
-verified predecessor. Frozen #508 remains reference material and is not
-rewritten. Existing descendants #509-#511 are rebuilt or retargeted only after
-P01D is complete.
+Each remaining replacement branch starts from the latest merged predecessor.
+Frozen #508-#511 remain reference material and are not rewritten. Stage 13 is
+rebuilt only after Stage 12-P06 merges.
 
 ## Verification
 

--- a/.plan/active/setup-aware-plugin-lifecycle/PLAN.md
+++ b/.plan/active/setup-aware-plugin-lifecycle/PLAN.md
@@ -726,9 +726,12 @@ source material only and is never rebased, merged, or cherry-picked.
   settings primitives;
 - focused interaction, conflict/force, reconnect, and route tests.
 
-Each remaining replacement branch starts from the latest merged predecessor.
-Frozen #508-#511 remain reference material and are not rewritten. Stage 13 is
-rebuilt only after Stage 12-P06 merges.
+Keep one open replacement PR and one local successor built from that PR's latest
+reviewed head. After the predecessor merges, merge updated `origin/main` into
+the successor, reverify, and open it before beginning the next local slice.
+Never work farther than one slice ahead. Frozen #508-#511 remain reference
+material and are not rewritten. Stage 13 is rebuilt only after Stage 12-P06
+merges.
 
 ## Verification
 

--- a/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
+++ b/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
@@ -303,8 +303,9 @@ run their focused verification again.
 
 ## Delivery Rules
 
-- Start every remaining child slice from latest merged `origin/main`; do not
-  stack an open replacement PR on another open replacement PR.
+- Keep exactly one open child PR and one local successor built from the open
+  PR's latest reviewed head. After merge, merge updated `origin/main` into the
+  successor and reverify before opening it; never work more than one PR ahead.
 - Keep #508 frozen until replacement PRs exist; do not force-rewrite it.
 - Keep #510 and #511 frozen; rebuild their behavior rather than retargeting
   their obsolete descendant branches.

--- a/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
+++ b/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
@@ -2,13 +2,12 @@
 
 ## Plan State
 
-- **Status:** Stage 10 merged; PR #508 frozen as reference; smaller replacement
-  stack in progress
-- **Base:** `origin/main` at `2bb376b2`
-- **Current branch:** `setup-aware-plugin-lifecycle-dormant-runtime`
-- **Current stage:** Stage 11-P02 — dormant runtime and numeric idle timeout rebuild
-- **Next action:** monitor ready PR #556 through review and CI, then merge when
-  approved
+- **Status:** Stage 10 and Stage 11 replacement work are merged; Stage 12 has
+  been redesigned as a six-PR child series
+- **Base:** `origin/main` at `41e03f12`
+- **Current branch:** `setup-aware-plugin-management-resident-attach`
+- **Current stage:** Stage 12-P01 — attach-only residency and diagnostics
+- **Next action:** commit and open verified Stage 12-P01 when explicitly requested
 
 ## Frozen Oversized Stack
 
@@ -37,8 +36,8 @@ run their focused verification again.
 | [x] | Stage 11-P01B — plugin operation routing | `setup-aware-plugin-lifecycle-operation-routing` | #548 merged as `96f63c69` |
 | [x] | Stage 11-P01C — dynamic events and durable fencing | `setup-aware-plugin-lifecycle-durable-events` | #549 merged as `cd0e0a31` |
 | [x] | Stage 11-P01D — bridge-owned projects and defaults | `setup-aware-plugin-lifecycle-project-ownership` | #550 merged as `5020c003` |
-| [x] | Stage 11-P02 — dormancy and numeric idle timeout | `setup-aware-plugin-lifecycle-dormant-runtime` | #556 ready; synchronized and locally verified |
-| [ ] | Stage 12 — headless management | rebuild branch TBD | frozen #510 descendant |
+| [x] | Stage 11-P02 — dormancy and numeric idle timeout | `setup-aware-plugin-lifecycle-dormant-runtime` | #556 merged as `41e03f12` |
+| [ ] | Stage 12 — headless management | six-PR child series | tracked in `setup-aware-plugin-management` |
 | [ ] | Stage 13 — redesigned mobile plugin settings | rebuild branch TBD | frozen #511 descendant |
 
 ## Locked Redesign Deltas
@@ -53,6 +52,8 @@ run their focused verification again.
 - Client stores last-used per bridge after the settings stage.
 - Every ready plugin starts dormant.
 - Idle configuration is integer minutes; `<= 0` never idle-stops after demand.
+- Descriptor-declared resident mode has effective timeout `0` without mutating
+  persisted timeout settings; OpenCode `--opencode-no-auto-start` uses it.
 - Headless management removes authority/order/serialized enabled.
 - Settings work targets the merged Prego Settings landing/sub-page architecture.
 - No compatibility machinery is retained for any contract from the superseded
@@ -281,15 +282,31 @@ run their focused verification again.
   acceptances newer than its status snapshot. Full bridge-app (2,094 tests),
   OpenCode (401), ACP (151), and Codex (191) suites plus fatal analysis in all
   four packages passed.
+- PR #556 merged into `main` as `41e03f12` with CI passing 11/11 and no
+  unresolved review threads.
+
+### 2026-07-25 — Stage 12 redesign
+
+- Re-inspected frozen PR #510 at substantive commit `c4104e73`; its 36-file,
+  3,286-addition diff remains source material only.
+- Split delivery into an independently tracked six-PR series: attach-only
+  residency/diagnostics, read snapshots, revision/SSE, timeout mutations,
+  transactional runtime mechanics, and lifecycle commands/dynamic eligibility.
+- Preserved current-main architecture that the frozen descendant predates,
+  including durable commit fencing, OpenCode-preferred default selection,
+  operation-stream cancellation, and the single hydration listener.
+- The architecture review's specificity gate was corrected in one permitted
+  recheck. Its valid local finding removed a duplicate management snapshot
+  stream. Its requested broad runner/orchestrator composition migration was
+  kept out of this series; P06 uses the existing catalog repository seam and
+  introduces no new composition crossing.
 
 ## Delivery Rules
 
-- Start P01A from latest `origin/main`; stack P01B-P01D from each verified
-  predecessor.
+- Start every remaining child slice from latest merged `origin/main`; do not
+  stack an open replacement PR on another open replacement PR.
 - Keep #508 frozen until replacement PRs exist; do not force-rewrite it.
-- Rebuild or retarget #509-#511 only after P01D is complete.
-- Open each replacement PR only after its focused checks pass, then monitor that
-  PR immediately.
-- Temporary OpenCode-only release gate PR #555 shipped and exact revert #557
-  landed before #556 was synchronized. Continue to merge later `main` drift
-  without rebasing before marking the draft ready.
+- Keep #510 and #511 frozen; rebuild their behavior rather than retargeting
+  their obsolete descendant branches.
+- Use the exact six titles and fixed total in the child plan. Open and monitor
+  one replacement PR at a time after its focused checks pass.

--- a/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
+++ b/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
@@ -7,7 +7,7 @@
 - **Base:** `origin/main` at `41e03f12`
 - **Current branch:** `setup-aware-plugin-management-resident-attach`
 - **Current stage:** Stage 12-P01 — attach-only residency and diagnostics
-- **Next action:** commit and open verified Stage 12-P01 when explicitly requested
+- **Next action:** monitor Stage 12-P01 PR #563 through CI and review
 
 ## Frozen Oversized Stack
 
@@ -37,7 +37,7 @@ run their focused verification again.
 | [x] | Stage 11-P01C — dynamic events and durable fencing | `setup-aware-plugin-lifecycle-durable-events` | #549 merged as `cd0e0a31` |
 | [x] | Stage 11-P01D — bridge-owned projects and defaults | `setup-aware-plugin-lifecycle-project-ownership` | #550 merged as `5020c003` |
 | [x] | Stage 11-P02 — dormancy and numeric idle timeout | `setup-aware-plugin-lifecycle-dormant-runtime` | #556 merged as `41e03f12` |
-| [ ] | Stage 12 — headless management | six-PR child series | tracked in `setup-aware-plugin-management` |
+| [ ] | Stage 12 — headless management | six-PR child series | P01 PR #563 open; tracked in `setup-aware-plugin-management` |
 | [ ] | Stage 13 — redesigned mobile plugin settings | rebuild branch TBD | frozen #511 descendant |
 
 ## Locked Redesign Deltas

--- a/.plan/active/setup-aware-plugin-management/PLAN.md
+++ b/.plan/active/setup-aware-plugin-management/PLAN.md
@@ -39,8 +39,11 @@ public contract that a later slice must break.
   creating a second trigger.
 - Current-main durable commit, stream cancellation, generation fencing,
   OpenCode-preferred default, and bridge-owned project behavior are preserved.
-- Each PR starts from the latest merged predecessor on `origin/main`. There is
-  no open stacked PR chain.
+- Keep exactly one open PR and one local successor branch. While step N is in
+  review, build step N+1 from its latest reviewed head but do not open N+1.
+- After step N merges, merge updated `origin/main` into the local N+1 branch,
+  resolve conservatively, reverify, and only then open N+1. Start N+2 locally
+  after N+1 opens; never build farther than one successor ahead.
 
 ## Delivery Sequence
 

--- a/.plan/active/setup-aware-plugin-management/PLAN.md
+++ b/.plan/active/setup-aware-plugin-management/PLAN.md
@@ -1,0 +1,402 @@
+# Setup-Aware Plugin Management
+
+## Status
+
+- **Plan slug:** `setup-aware-plugin-management`
+- **Parent plan:** `.plan/active/setup-aware-plugin-lifecycle`
+- **Status:** redesigned from frozen PR #510; Stage 12-P01 is active
+- **Implementation base:** `origin/main` at `41e03f12`
+- **Reference only:** PR #510, substantive commit `c4104e73`, fixture follow-up
+  `bf0433b8`
+
+This child plan owns the replacement delivery sequence for parent Stage 12. It
+inherits the parent's locked product decisions and final architecture. Frozen
+PR #510 is evidence, not mergeable history: no replacement branch rebases,
+merges, or cherry-picks it.
+
+## Goal
+
+Deliver observable attach-only residency and the complete headless plugin
+management seam in six independently reviewable PRs. Each merged slice is
+useful on its own, preserves existing client behavior, and leaves no temporary
+public contract that a later slice must break.
+
+## Locked Boundaries
+
+- Backend-specific configuration interpretation stays in the owning plugin
+  descriptor. Bridge core consumes only generic residency/setup/runtime state.
+- `BridgeSettingsRepository` remains the only JSON settings owner. Runtime-only
+  residency policy never rewrites a user's default or per-plugin timeout.
+- Management transport additions remain backward/forward compatible across app
+  and bridge versions. Internal Dart interfaces update all repository consumers
+  in lockstep and receive no compatibility shims.
+- `PluginRuntime` owns mechanics; `PluginLifecycleRepository` maps them;
+  `PluginLifecycleService` owns policy, persistence sequencing, management
+  snapshots, and revisions; handlers only parse/map HTTP; `Orchestrator` alone
+  emits SSE.
+- The existing `PluginCatalogHydrationListener` remains the only automatic
+  hydration trigger. Management code widens its ready-ID input rather than
+  creating a second trigger.
+- Current-main durable commit, stream cancellation, generation fencing,
+  OpenCode-preferred default, and bridge-owned project behavior are preserved.
+- Each PR starts from the latest merged predecessor on `origin/main`. There is
+  no open stacked PR chain.
+
+## Delivery Sequence
+
+| Step | Branch | Exact PR title | Review boundary |
+|---|---|---|---|
+| 1/6 | `setup-aware-plugin-management-resident-attach` | `[setup-aware-plugin-management] fix(bridge): keep attach-only plugins resident [step 1/6]` | Generic residency declaration, OpenCode mapping, effective timeout `0`, and start/stop diagnostics. |
+| 2/6 | `setup-aware-plugin-management-read-snapshots` | `[setup-aware-plugin-management] feat(bridge): expose plugin management snapshots [step 2/6]` | Shared read DTOs and read-only GET route. |
+| 3/6 | `setup-aware-plugin-management-invalidation` | `[setup-aware-plugin-management] feat(bridge): invalidate plugin management snapshots [step 3/6]` | Process-local revision and additive SSE invalidation. |
+| 4/6 | `setup-aware-plugin-management-idle-timeouts` | `[setup-aware-plugin-management] feat(bridge): update plugin idle timeouts live [step 4/6]` | Typed timeout writes, settings serialization, and live timer resync. |
+| 5/6 | `setup-aware-plugin-management-disable` | `[setup-aware-plugin-management] feat(bridge): add transactional plugin disable [step 5/6]` | End-to-end safe/force disable with runtime access gates and durable commit/rollback. |
+| 6/6 | `setup-aware-plugin-management-commands` | `[setup-aware-plugin-management] feat(bridge): add remaining plugin lifecycle commands [step 6/6]` | Enable/restart/refresh, setup fencing, and dynamic default/catalog eligibility. |
+
+## Stage 12-P01: Attach-Only Residency
+
+Add `PluginResidencyPolicy { transient, resident }` to
+`sesori_plugin_interface`.
+`BridgePluginDescriptor.residencyPolicy({required PluginConfig config})` is pure
+and defaults to `transient`. `OpenCodePluginDescriptor` returns
+`resident` exactly when validated config has `no-auto-start`; all other bundled
+plugins retain the default.
+
+`BridgeRuntimeRunner` evaluates that descriptor-owned policy and includes it in
+the immutable registered metadata passed to `PluginLifecycleService`. The
+service centralizes effective timeout calculation:
+
+```text
+resident descriptor policy -> effective idle timeout 0
+otherwise -> plugin override -> default override -> hardcoded 10
+```
+
+The settings object is never changed by this read-time override. Therefore a
+user can leave an explicit timeout configured, run attach-only temporarily, and
+recover the same configured value when returning to managed mode. Existing
+timer cancellation follows automatically because non-positive effective values
+cannot schedule an idle timer.
+
+Add runtime-level debug diagnostics that identify plugin and generation for
+start attempt/success and command stop begin/success. Add idle-policy diagnostics
+for timer expiry and applied/current/conflict/failure outcomes. Warning/error
+paths that already surface failures remain single-logged.
+
+Production files:
+
+- `bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_residency_policy.dart`
+- `bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin_descriptor.dart`
+- `bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart`
+- `bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart`
+- `bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart`
+- `bridge/app/lib/src/bridge/runtime/plugin_runtime.dart`
+- `bridge/app/lib/src/services/plugin_lifecycle_service.dart`
+
+## Stage 12-P02: Read-Only Snapshots
+
+Add shared read types only: forward-safe runtime/work enums,
+`PluginManagementMetadata`, and `PluginManagementResponse`. The first response
+contains nullable derived default ID, configured default timeout, and every
+registration in deterministic display-name/ID order. Each row contains setup,
+runtime/work state, effective timeout, whether a persisted per-plugin override
+exists, and a sanitized action hint. Resident policy reports effective timeout
+`0` while retaining the persisted-override boolean.
+
+`PluginLifecycleService.managementSnapshot` maps existing lifecycle and settings
+state without adding mutation state. `Orchestrator.create` registers
+`GetPluginManagementHandler(lifecycleService: _pluginLifecycleService)` once in
+the existing `RequestRouter.handlers` list. `BridgeRuntimeRunner` continues to
+give `DebugServer` the resulting `BridgeRuntime.session.router`, so relay and
+debug requests use the same router and service instance. The GET never probes,
+starts, stops, or writes.
+
+Production files:
+
+- `shared/sesori_shared/lib/src/models/sesori/plugin_management.dart` and barrel
+- generated Freezed/JSON companions from that source
+- `bridge/app/lib/src/services/plugin_lifecycle_service.dart`
+- `bridge/app/lib/src/routing/get_plugin_management_handler.dart`
+- `bridge/app/lib/src/bridge/orchestrator.dart`
+- `bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart`
+
+## Stage 12-P03: Revision And Invalidation
+
+Add `@Default(0) int revision` to `PluginManagementResponse`, with
+`// COMPATIBILITY 2026-07-25 (v1.6.1): Stage 12-P02 and older bridge payloads
+omit revision; default to the initial process revision. Remove when those bridge
+versions are unsupported.`, and add the `plugin.management.changed` variant to
+`SesoriSseEvent`. The lifecycle service retains one plain
+`PluginManagementResponse` as its last published comparison snapshot and owns a
+broadcast `StreamController<int>` as the only management change stream. It
+compares a freshly built externally visible response with revision normalized
+away and advances/emits the process-local revision only after a materially
+changed, settled snapshot is queryable. `managementSnapshot` remains a
+synchronous GET value; there is no unused `managementSnapshots` stream.
+
+`Orchestrator.create` passes `PluginLifecycleService.managementRevisions` into
+`OrchestratorSession`. The session subscribes in its constructor, maps each
+value to `SesoriSseEvent.pluginManagementChanged(revision: revision)`, and adds
+the subscription to its existing `_subscriptions` composite. The existing
+`_subscriptions.cancel()` in `OrchestratorSession.run` disposes it before the
+lifecycle service is closed. No lower layer emits SSE.
+
+The additive client variant is globally scoped and ignored by existing session
+consumers. Update every exhaustive switch in exactly these source files:
+
+- `client/module_core/lib/src/capabilities/server_connection/models/sse_event.dart`
+  maps it to null session ID;
+- `client/module_core/lib/src/services/sse_event_tracker.dart` ignores it;
+- `client/module_core/lib/src/cubits/session_list/session_list_cubit.dart`
+  ignores it; and
+- `client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart`
+  ignores it in both global relevance and global processing switches.
+
+No management API, service, cubit, DI, or UI enters this slice.
+
+Production files:
+
+- `shared/sesori_shared/lib/src/models/sesori/plugin_management.dart`
+- `shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart`
+- generated `plugin_management.freezed.dart`, `plugin_management.g.dart`,
+  `sesori_sse_event.freezed.dart`, and `sesori_sse_event.g.dart`
+- `shared/sesori_shared/test/models/plugin_management_contract_test.dart` and
+  `shared/sesori_shared/test/models/sesori_sse_event_test.dart`
+- `bridge/app/lib/src/services/plugin_lifecycle_service.dart`
+- `bridge/app/lib/src/bridge/orchestrator.dart`
+- the four named `client/module_core` source files above
+
+## Stage 12-P04: Live Timeout Mutations
+
+Add the sealed apply-all, set-override, and clear-override requests with strict
+integer decoding. `PatchPluginIdleTimeoutHandler` parses the generated request,
+validates known IDs through `PluginLifecycleService.updateIdleTimeout`, and maps
+bad input to 400, unknown IDs to 404, and failed writes to 500. The service owns
+one `_settingsMutationTail`; each operation enters that tail, calls
+`BridgeSettingsRepository.loadSettings()`, derives one new `BridgeSettings`,
+then calls `saveSettings(settings: updated)` before changing live policy.
+
+In `bridge_settings.dart`, replace
+`BridgePluginSettings.withDefaultIdleTimeout({idleTimeoutMins,
+clearOverrides})` with
+`withDefaultIdleTimeout({required int idleTimeoutMins, required Set<String>
+clearOverridePluginIds})`. It clears `idleTimeoutMins` only when an entry key is
+in that known-ID set, preserving every unknown plugin entry and all
+`PluginLifecycleSettings.additionalProperties`. `withPluginIdleTimeout` remains
+the one-entry set/clear primitive. `BridgeSettingsRepository` remains the sole
+I/O owner; no second settings repository or writer is added.
+
+After a successful durable write, resynchronize existing timers and publish one
+new management revision if the public snapshot changed. Resident plugins still
+report and execute effective timeout `0`; their persisted overrides remain
+editable and recover when residency returns to transient. Failed writes return
+an explicit failure and do not publish success.
+
+`Orchestrator.create` registers
+`PatchPluginIdleTimeoutHandler(lifecycleService: _pluginLifecycleService)` in the
+same `RequestRouter.handlers` list as P02's GET. `DebugServer` continues using
+`BridgeRuntime.session.router`; no debug-only handler, router, service, or
+repository is constructed.
+
+Production files:
+
+- `shared/sesori_shared/lib/src/models/sesori/plugin_management.dart` plus
+  generated companions and `plugin_management_contract_test.dart`
+- `bridge/app/lib/src/repositories/bridge_settings.dart`
+- `bridge/app/lib/src/repositories/bridge_settings_repository.dart` as the
+  existing load/save dependency, with no new persistence owner
+- `bridge/app/lib/src/services/plugin_lifecycle_service.dart`
+- `bridge/app/lib/src/routing/patch_plugin_idle_timeout_handler.dart`
+- `bridge/app/lib/src/bridge/orchestrator.dart`
+
+## Stage 12-P05: Transactional Disable
+
+Ship safe/force disable end-to-end, so every mechanical seam introduced here has
+a production caller. The P05 version of sealed
+`PluginLifecycleCommandRequest` contains the final-wire `disable` variant and
+`PluginStopMode`; P06 additively adds the other variants. Add the typed conflict
+response and forward-safe conflict-reason enum now.
+
+In `PluginRuntime`, replace the eligible boolean with
+`PluginRuntimeAccessGate { enabled, draining, disabled }` and add these exact
+mechanical methods:
+
+```dart
+Future<PluginRuntimeCommandResult> prepareDisable({
+  required String pluginId,
+  required PluginStopIntent intent,
+});
+void commitDisable({required String pluginId});
+void rollbackDisable({required String pluginId});
+```
+
+`prepareDisable` moves enabled to draining before checking safe/force stop,
+which fences new starts and acquisitions. Conflict/failure restores enabled
+before returning its existing typed `PluginRuntimeCommandResult`. Success,
+including an already-dormant generation, retains the slot's
+`commandTransitionOwner`, `commandTransitionCompleter`, draining gate, and
+stopping transition. `commitDisable` changes draining to disabled and clears
+start permission; `rollbackDisable` restores enabled/dormant. Both validate the
+retained state, clear the owner/transition, complete the retained completer so
+shutdown cannot hang, and publish a final snapshot. Ordinary `stop` used by idle
+suspension remains non-transactional and settles directly to dormant.
+
+`PluginLifecycleRepository` mirrors those three methods without policy. The
+lifecycle service's per-plugin active-command record is the sole production
+consumer and equal disable commands join. Its disable flow is:
+
+```text
+repository.prepareDisable
+  -> conflict/failure: map typed result; no settings write
+  -> prepared: enter P04 settings tail
+       -> load latest settings
+       -> save with plugins.withPluginDisabled(disabled: true)
+       -> success: repository.commitDisable, update eligible/default metadata
+       -> failure: repository.rollbackDisable, restore live metadata,
+                   return explicit command failure
+```
+
+The service always commits or rolls back a prepared disable in `try/catch`; it
+never leaves draining state after a persistence outcome. No settings callback or
+repository dependency enters `PluginRuntime`.
+
+`PostPluginLifecycleCommandHandler` parses the P05 disable request and maps 400,
+404, typed 409 conflict, and explicit 500 failure. `Orchestrator.create`
+registers it in the one existing `RequestRouter.handlers` list; the debug server
+continues to reuse `BridgeRuntime.session.router` and the same lifecycle service.
+Preserve existing durable-commit drain, operation-stream cancellation, lease
+drain, generation event fencing, and bounded shutdown behavior from current
+`main`.
+
+Production files:
+
+- `shared/sesori_shared/lib/src/models/sesori/plugin_management.dart`, its
+  generated companions, barrel export, and
+  `shared/sesori_shared/test/models/plugin_management_contract_test.dart`
+- `bridge/app/lib/src/bridge/runtime/plugin_runtime.dart`
+- `bridge/app/lib/src/repositories/plugin_lifecycle_repository.dart`
+- `bridge/app/lib/src/services/plugin_lifecycle_service.dart`
+- `bridge/app/lib/src/routing/post_plugin_lifecycle_command_handler.dart`
+- `bridge/app/lib/src/bridge/orchestrator.dart`
+- `bridge/app/tool/benchmarks/benchmark_plugin_runtime.dart` and
+  `multi_plugin_startup_benchmark.dart` only for required snapshot/access-gate
+  constructor updates
+
+## Stage 12-P06: Remaining Commands And Dynamic Eligibility
+
+Add the `enable`, `restart`, and `refresh` variants to the existing sealed
+request. The P05 handler and route remain unchanged and decode the expanded
+union; no second command handler or route is added. Restart reuses
+`PluginRuntime.restart`; enable reuses `PluginRuntime.start`; refresh only
+inspects setup.
+
+`PluginLifecycleService` owns one active command per plugin. Equal commands join;
+a different same-plugin command conflicts; unrelated plugin commands may run
+concurrently. All denylist writes share the P04 settings tail.
+
+```text
+enable: persist eligible -> apply access -> inspect -> start when ready
+restart: require eligible -> inspect -> replace generation when ready
+refresh: inspect only -> update setup/access -> leave newly ready plugin dormant
+```
+
+Add a per-slot `setupInspectionRevision`. `PluginRuntime.inspectSetup` captures
+that revision and generation before each asynchronous descriptor probe and
+applies a result only if both still match. Auth loss and disable increment the
+revision, so stale enable/restart/refresh results cannot overwrite newer setup or
+generation state. `PluginLifecycleRepository.inspect` remains the mapping seam.
+
+Eligibility/default metadata is rebuilt from final state while preserving the
+parent plan's OpenCode-preferred deterministic fallback. The existing ready-ID
+stream emits additions after successful enable/refresh; the one existing
+`PluginCatalogHydrationListener` applies its durable marker gate and no second
+hydration owner is added.
+
+To make that listener work after startup, add all registered IDs in deterministic
+display-name/ID order to `PluginCompositionView.orderedPluginIds`. Remove
+`CatalogImportService`'s startup-fixed `_enabledPluginIds`; it continues to
+depend only on its existing `CatalogImportRepository` plus static ordered IDs
+and hydration policies:
+
+```dart
+CatalogImportService({
+  required CatalogImportRepository repository,
+  required List<String> orderedPluginIds,
+  required Map<String, CatalogEmptyHydrationPolicy> emptyHydrationPolicies,
+});
+```
+
+The service stores an immutable ordered list/set and reads the injected
+repository's new runtime-backed `eligiblePluginIds` and existing
+`importEligiblePluginIds` getters at validation/status time. Unknown means
+absent from the static set; not enabled means absent from `eligiblePluginIds`;
+unavailable means enabled but absent from `importEligiblePluginIds`.
+`CatalogImportRepository` already owns `PluginRuntime`, so these getters map
+existing runtime access/start gates at the Layer-2 boundary and do not create a
+new dependency. Build `emptyHydrationPolicies` for every ordered registration
+rather than only the startup-enabled subset. `latestStatuses` walks
+`orderedPluginIds` and includes only IDs currently in `eligiblePluginIds`.
+
+The exact dynamic flow is:
+
+```text
+enable/refresh command settles
+  -> PluginLifecycleService applies runtime access/setup and publishes readyPluginIds
+  -> existing PluginCatalogHydrationListener observes a newly added ID
+  -> existing listener calls CatalogImportService.start(automatic)
+  -> CatalogImportService validates static known IDs plus CatalogImportRepository's
+     runtime-backed enabled/import-eligible sets
+  -> marker-gated import proceeds
+```
+
+`BridgeRuntimeRunner` and `Orchestrator` retain their current composition
+contract; P06 forwards no new lifecycle collaborator between them.
+`Orchestrator` already constructs one `CatalogImportRepository` from its injected
+runtime and passes that repository to `CatalogImportService`. There is no
+callback, duplicate repository, same-layer service dependency, or second
+hydration listener. The P05 command handler stays registered in
+`Orchestrator.create`'s one router, and debug continues sharing
+`BridgeRuntime.session.router`.
+
+Production files:
+
+- `shared/sesori_shared/lib/src/models/sesori/plugin_management.dart`, its
+  generated companions, and `plugin_management_contract_test.dart` for the
+  three new variants
+- `bridge/app/lib/src/bridge/runtime/plugin_runtime.dart` for inspection fencing
+- `bridge/app/lib/src/repositories/plugin_lifecycle_repository.dart`
+- `bridge/app/lib/src/repositories/catalog_import_repository.dart` for dynamic
+  runtime-backed enabled/import-eligible getters
+- `bridge/app/lib/src/services/plugin_lifecycle_service.dart`
+- `bridge/app/lib/src/services/catalog_import_service.dart`
+- `bridge/app/lib/src/bridge/orchestrator.dart`
+
+`plugin_catalog_hydration_listener.dart` remains unchanged production code;
+focused listener/service integration tests prove that its existing additions
+logic drives a newly enabled plugin through the dynamic service validation.
+
+## Verification Gates
+
+- P01: interface descriptor tests and fatal analysis; OpenCode descriptor tests
+  and fatal analysis; bridge lifecycle/runtime tests and fatal analysis.
+- P02: shared contract tests/codegen/fatal analysis; bridge lifecycle/handler,
+  orchestrator/debug-router tests and fatal analysis.
+- P03: shared management/SSE tests/codegen/fatal analysis; bridge revision/SSE
+  tests; affected module-core tests and fatal analysis.
+- P04: shared request tests/codegen/fatal analysis; bridge settings,
+  lifecycle, handler, and concurrency tests plus fatal analysis.
+- P05: shared command/conflict tests/codegen/fatal analysis; focused runtime,
+  repository, lifecycle, disable-route, router, benchmark compilation, and
+  bridge-app fatal analysis.
+- P06: shared command/conflict tests/codegen/fatal analysis; bridge lifecycle,
+  routing, hydration, catalog, runner, orchestrator, and debug-server tests plus
+  fatal analysis.
+- Every architecture-bearing implementation slice receives one Aristotle
+  implementation review after relevant local verification and before delivery.
+- Do not rerun unchanged passing commands; CI supplies the full repository
+  matrix after each PR opens.
+
+## Completion
+
+Stage 12 is complete only when all six PRs are merged, frozen PR #510 is closed
+as superseded, the parent tracker records merge commits and verification, and
+Stage 13 starts from the merged P06 result.

--- a/.plan/active/setup-aware-plugin-management/TRACKER.md
+++ b/.plan/active/setup-aware-plugin-management/TRACKER.md
@@ -11,7 +11,7 @@
 
 | Done | Slice | Branch | PR state |
 |---|---|---|---|
-| [ ] | P01 — attach-only residency and diagnostics | `setup-aware-plugin-management-resident-attach` | PR #563 open; monitoring |
+| [x] | P01 — attach-only residency and diagnostics | `setup-aware-plugin-management-resident-attach` | PR #563 open; monitoring |
 | [ ] | P02 — read-only management snapshots | `setup-aware-plugin-management-read-snapshots` | waits for P01 merge |
 | [ ] | P03 — revision and SSE invalidation | `setup-aware-plugin-management-invalidation` | waits for P02 merge |
 | [ ] | P04 — live idle-timeout mutations | `setup-aware-plugin-management-idle-timeouts` | waits for P03 merge |

--- a/.plan/active/setup-aware-plugin-management/TRACKER.md
+++ b/.plan/active/setup-aware-plugin-management/TRACKER.md
@@ -1,0 +1,77 @@
+# Setup-Aware Plugin Management: Tracker
+
+## Current State
+
+- **Base:** `origin/main` at `41e03f12`
+- **Current branch:** `setup-aware-plugin-management-resident-attach`
+- **Current slice:** Stage 12-P01 / step 1 of 6
+- **Next action:** commit and open the verified P01 when explicitly requested
+
+## Delivery
+
+| Done | Slice | Branch | PR state |
+|---|---|---|---|
+| [ ] | P01 — attach-only residency and diagnostics | `setup-aware-plugin-management-resident-attach` | implemented, verified, and architecture-approved; local only |
+| [ ] | P02 — read-only management snapshots | `setup-aware-plugin-management-read-snapshots` | waits for P01 merge |
+| [ ] | P03 — revision and SSE invalidation | `setup-aware-plugin-management-invalidation` | waits for P02 merge |
+| [ ] | P04 — live idle-timeout mutations | `setup-aware-plugin-management-idle-timeouts` | waits for P03 merge |
+| [ ] | P05 — transactional plugin disable | `setup-aware-plugin-management-disable` | waits for P04 merge |
+| [ ] | P06 — remaining commands and dynamic eligibility | `setup-aware-plugin-management-commands` | waits for P05 merge |
+
+## Source Material
+
+- Frozen PR #510: https://github.com/sesori-ai/sesori_apps_monorepo/pull/510
+- Substantive old commit: `c4104e73`
+- Blocked-setup fixture follow-up: `bf0433b8`
+- Old size: 36 files, 3,286 additions, 228 deletions
+- Never merge, rebase, or cherry-pick the frozen descendant stack. Reconstruct
+  each behavior against current `main` and preserve newer lifecycle invariants.
+
+## Review Record
+
+- The first 2026-07-25 architecture pass rejected the specificity gate. The
+  plan was expanded with every requested shared/client switch, settings method,
+  runtime transaction signature, production consumer, route registration, and
+  dynamic catalog data flow.
+- The permitted specificity recheck passed its gate and rejected two choices.
+  Removed the unused replay-latest management snapshot stream; synchronous GET
+  state plus the revision stream are now the only read/change mechanisms.
+- The other finding requested moving all pre-existing lifecycle construction
+  from `BridgeRuntimeRunner` into `Orchestrator`. That considerable refactor is
+  outside this management scope and would blur the current bootstrap/session
+  phase boundary. P06 was narrowed instead: dynamic catalog validation uses the
+  already-injected `CatalogImportRepository`, adding no new runner/orchestrator
+  dependency. A composition-boundary refactor, if desired, belongs in a
+  dedicated plan and PR.
+- P01 architecture implementation review approved all 17 changed files with no
+  findings. The generic descriptor policy, OpenCode-owned interpretation,
+  lifecycle timeout ownership, and unchanged runtime boundary were accepted.
+
+## Verification Log
+
+### 2026-07-25 — P01 attach-only residency and diagnostics
+
+- Added generic descriptor-declared transient/resident policy; OpenCode maps
+  `--opencode-no-auto-start` to resident while every other descriptor inherits
+  transient behavior.
+- Lifecycle effective-timeout calculation now returns `0` for resident policy
+  without changing the positive persisted timeout. Added regression coverage
+  proving no idle timer or stop is scheduled while the stored value remains 45.
+- Promoted plugin generation start tracing to debug and added start completion,
+  command stop begin/completion, idle expiry, and recovered idle outcome logs.
+- Focused interface descriptor tests passed (12), OpenCode descriptor tests
+  passed (32), and bridge lifecycle/runtime/setup-route/recovery tests passed
+  (50).
+- `dart analyze --fatal-infos` passed sequentially in plugin interface,
+  OpenCode, Codex, ACP, Cursor, and bridge app. `git diff --check` passed.
+- Aristotle implementation review approved the complete working-tree diff with
+  no architecture findings.
+
+## Delivery Rules
+
+- Use the exact title and fixed `1/6` through `6/6` order from `PLAN.md`.
+- Start each branch from the latest merged predecessor on `origin/main`.
+- Open only one replacement PR at a time after focused verification and
+  architecture implementation review pass.
+- Monitor each opened PR immediately and address review/CI before starting the
+  next branch.

--- a/.plan/active/setup-aware-plugin-management/TRACKER.md
+++ b/.plan/active/setup-aware-plugin-management/TRACKER.md
@@ -72,8 +72,10 @@
 ## Delivery Rules
 
 - Use the exact title and fixed `1/6` through `6/6` order from `PLAN.md`.
-- Start each branch from the latest merged predecessor on `origin/main`.
-- Open only one replacement PR at a time after focused verification and
-  architecture implementation review pass.
+- Keep one open PR and one local successor. Cut the successor from the open
+  PR's latest reviewed head, but do not open it until its predecessor merges.
+- After the predecessor merges, merge updated `origin/main` into the successor,
+  reverify, and open it. Only then begin the following local successor; never
+  work more than one PR ahead.
 - Monitor each opened PR immediately and address review/CI before starting the
-  next branch.
+  next branch's implementation.

--- a/.plan/active/setup-aware-plugin-management/TRACKER.md
+++ b/.plan/active/setup-aware-plugin-management/TRACKER.md
@@ -5,13 +5,13 @@
 - **Base:** `origin/main` at `41e03f12`
 - **Current branch:** `setup-aware-plugin-management-resident-attach`
 - **Current slice:** Stage 12-P01 / step 1 of 6
-- **Next action:** commit and open the verified P01 when explicitly requested
+- **Next action:** monitor PR #563 through CI and review
 
 ## Delivery
 
 | Done | Slice | Branch | PR state |
 |---|---|---|---|
-| [ ] | P01 — attach-only residency and diagnostics | `setup-aware-plugin-management-resident-attach` | implemented, verified, and architecture-approved; local only |
+| [ ] | P01 — attach-only residency and diagnostics | `setup-aware-plugin-management-resident-attach` | PR #563 open; monitoring |
 | [ ] | P02 — read-only management snapshots | `setup-aware-plugin-management-read-snapshots` | waits for P01 merge |
 | [ ] | P03 — revision and SSE invalidation | `setup-aware-plugin-management-invalidation` | waits for P02 merge |
 | [ ] | P04 — live idle-timeout mutations | `setup-aware-plugin-management-idle-timeouts` | waits for P03 merge |
@@ -66,6 +66,8 @@
   OpenCode, Codex, ACP, Cursor, and bridge app. `git diff --check` passed.
 - Aristotle implementation review approved the complete working-tree diff with
   no architecture findings.
+- Committed as `f0831886`, pushed, and opened PR #563 with the fixed step-1/6
+  series title.
 
 ## Delivery Rules
 

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -620,7 +620,12 @@ class BridgeRuntimeRunner {
             idleTimerScheduler: const PluginIdleTimerScheduler(),
           )..registerPlugins(
             plugins: [
-              for (final descriptor in knownPlugins) (id: descriptor.id, displayName: descriptor.displayName),
+              for (final descriptor in knownPlugins)
+                (
+                  id: descriptor.id,
+                  displayName: descriptor.displayName,
+                  residencyPolicy: descriptor.residencyPolicy(config: pluginConfigs[descriptor.id]!),
+                ),
             ],
           );
       pluginLifecycleService = activePluginLifecycleService;

--- a/bridge/app/lib/src/bridge/runtime/plugin_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_runtime.dart
@@ -608,6 +608,8 @@ class PluginRuntime {
       );
     }
     if (!hadPlugin) return PluginRuntimeCommandCurrent(snapshot: _snapshotFor(slot));
+    final generationLabel = slot.generation?.toString() ?? "pending";
+    Log.d('Stopping plugin "$pluginId" generation $generationLabel (${intent.name})');
     final transitionOwner = Object();
     final transitionCompleter = Completer<void>();
     slot
@@ -647,6 +649,7 @@ class PluginRuntime {
     if (failureMessage != null) {
       return PluginRuntimeCommandFailed(snapshot: _snapshotFor(slot), message: failureMessage);
     }
+    Log.d('Plugin "$pluginId" generation $generationLabel stopped');
     return hadPlugin
         ? PluginRuntimeCommandApplied(snapshot: _snapshotFor(slot))
         : PluginRuntimeCommandCurrent(snapshot: _snapshotFor(slot));
@@ -910,8 +913,8 @@ class PluginRuntime {
     required bool clearTransitionOnSettle,
   }) {
     final pluginId = slot.registration.descriptor.id;
-    Log.v('Starting plugin "$pluginId" generation at ${_clock.now().toIso8601String()}');
     final generation = (slot.generation ?? 0) + 1;
+    Log.d('Starting plugin "$pluginId" generation $generation at ${_clock.now().toIso8601String()}');
     final abortController = StartAbortController();
     slot
       ..generation = generation
@@ -1041,6 +1044,7 @@ class PluginRuntime {
         },
       );
       _applyStatus(slot: slot, generation: generation, status: started.currentStatus);
+      Log.d('Plugin "$pluginId" generation $generation started (${slot.state.name})');
       if (_apiDisposalStarted) await _disposeApi(started.api);
       return started;
     } on PluginStartAbortedException {

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -15,7 +15,7 @@ typedef PluginCompositionView = ({
   Map<String, PluginProjectOwnership> projectOwnershipById,
 });
 
-typedef RegisteredPluginMetadata = ({String id, String displayName});
+typedef RegisteredPluginMetadata = ({String id, String displayName, PluginResidencyPolicy residencyPolicy});
 
 typedef PluginStartupPolicy = ({
   List<String> eligiblePluginIds,
@@ -47,6 +47,7 @@ class PluginLifecycleService {
   final PluginIdleTimerScheduler _idleTimerScheduler;
   List<RegisteredPluginMetadata>? _registeredPlugins;
   Set<String>? _knownPluginIds;
+  Map<String, PluginResidencyPolicy>? _residencyPolicyById;
   List<String>? _eligiblePluginIds;
   List<String>? _setupReadyPluginIds;
   Map<String, PluginMetadata> _metadataById = <String, PluginMetadata>{};
@@ -71,6 +72,9 @@ class PluginLifecycleService {
       });
     _registeredPlugins = List<RegisteredPluginMetadata>.unmodifiable(sorted);
     _knownPluginIds = Set<String>.unmodifiable(ids);
+    _residencyPolicyById = Map<String, PluginResidencyPolicy>.unmodifiable({
+      for (final plugin in plugins) plugin.id: plugin.residencyPolicy,
+    });
   }
 
   PluginStartupPolicy initialize({
@@ -385,6 +389,9 @@ class PluginLifecycleService {
   }
 
   int _effectiveIdleTimeoutMins(String pluginId) {
+    final residencyPolicy = _residencyPolicyById?[pluginId];
+    if (residencyPolicy == null) throw StateError("Plugin lifecycle has not been registered.");
+    if (residencyPolicy == PluginResidencyPolicy.resident) return 0;
     return _bridgeSettingsRepository.currentSettings.plugins.idleTimeoutMinsFor(pluginId: pluginId);
   }
 
@@ -395,9 +402,23 @@ class PluginLifecycleService {
     if (_disposing || !identical(_idleTimers[pluginId]?.timer, timer)) return;
     _idleTimers.remove(pluginId);
     final snapshot = _lifecycleRepository.snapshot.where((entry) => entry.pluginId == pluginId).firstOrNull;
-    if (snapshot == null || _effectiveIdleTimeoutMins(pluginId) <= 0 || !_isIdleCandidate(snapshot)) return;
+    final timeoutMins = _effectiveIdleTimeoutMins(pluginId);
+    if (snapshot == null || timeoutMins <= 0 || !_isIdleCandidate(snapshot)) return;
+    Log.d('Plugin "$pluginId" idle timeout elapsed (${timeoutMins}m); requesting safe suspension');
     try {
-      await _lifecycleRepository.stopSafely(pluginId: pluginId);
+      final result = await _lifecycleRepository.stopSafely(pluginId: pluginId);
+      switch (result) {
+        case PluginRuntimeCommandApplied():
+          break;
+        case PluginRuntimeCommandCurrent():
+          Log.d('Idle suspension for plugin "$pluginId" was already current');
+        case PluginRuntimeCommandConflict(:final reasons):
+          Log.d(
+            'Idle suspension deferred for plugin "$pluginId" (${reasons.map((reason) => reason.name).join(", ")})',
+          );
+        case PluginRuntimeCommandFailed(:final message):
+          Log.w('Idle suspension failed for plugin "$pluginId": $message');
+      }
     } on Object catch (error, stackTrace) {
       Log.w('Idle suspension failed for plugin "$pluginId"', error, stackTrace);
     }

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -32,7 +32,9 @@ void main() {
             idleTimerScheduler: const PluginIdleTimerScheduler(),
           )
           ..registerPlugins(
-            plugins: const [(id: "opencode", displayName: "OpenCode")],
+            plugins: const [
+              (id: "opencode", displayName: "OpenCode", residencyPolicy: PluginResidencyPolicy.transient),
+            ],
           )
           ..initialize(
             disabledPluginIds: const {"opencode"},

--- a/bridge/app/test/bridge/routing/get_plugin_setup_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_plugin_setup_handler_test.dart
@@ -29,8 +29,8 @@ void main() {
             )
             ..registerPlugins(
               plugins: const [
-                (id: "ready", displayName: "Ready"),
-                (id: "blocked", displayName: "Blocked"),
+                (id: "ready", displayName: "Ready", residencyPolicy: PluginResidencyPolicy.transient),
+                (id: "blocked", displayName: "Blocked", residencyPolicy: PluginResidencyPolicy.transient),
               ],
             )
             ..initialize(

--- a/bridge/app/test/helpers/plugin_lifecycle_test_support.dart
+++ b/bridge/app/test/helpers/plugin_lifecycle_test_support.dart
@@ -22,13 +22,16 @@ Future<PluginLifecycleService> createPluginLifecycleService({
   final runtime = createTestPluginRuntime(plugins: plugins);
   final service =
       PluginLifecycleService(
-            lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
-            preferredDefaultPluginId: legacyMissingPluginId,
-            bridgeSettingsRepository: createTestBridgeSettingsRepository(),
-            idleTimerScheduler: const PluginIdleTimerScheduler(),
+          lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
+          preferredDefaultPluginId: legacyMissingPluginId,
+          bridgeSettingsRepository: createTestBridgeSettingsRepository(),
+          idleTimerScheduler: const PluginIdleTimerScheduler(),
         )
         ..registerPlugins(
-          plugins: [for (final plugin in plugins) (id: plugin.id, displayName: plugin.id)],
+          plugins: [
+            for (final plugin in plugins)
+              (id: plugin.id, displayName: plugin.id, residencyPolicy: PluginResidencyPolicy.transient),
+          ],
         )
         ..initialize(
           disabledPluginIds: const {},

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -18,9 +18,9 @@ void main() {
     final service = _service(
       runtime: runtime,
       plugins: const [
-        (id: "zeta", displayName: "Zeta"),
-        (id: "beta", displayName: "Beta"),
-        (id: "alpha", displayName: "Alpha"),
+        (id: "zeta", displayName: "Zeta", residencyPolicy: PluginResidencyPolicy.transient),
+        (id: "beta", displayName: "Beta", residencyPolicy: PluginResidencyPolicy.transient),
+        (id: "alpha", displayName: "Alpha", residencyPolicy: PluginResidencyPolicy.transient),
       ],
     );
     addTearDown(service.dispose);
@@ -49,8 +49,8 @@ void main() {
     final service = _service(
       runtime: runtime,
       plugins: const [
-        (id: "alpha", displayName: "Alpha"),
-        (id: "opencode", displayName: "OpenCode"),
+        (id: "alpha", displayName: "Alpha", residencyPolicy: PluginResidencyPolicy.transient),
+        (id: "opencode", displayName: "OpenCode", residencyPolicy: PluginResidencyPolicy.transient),
       ],
     );
     addTearDown(service.dispose);
@@ -78,8 +78,8 @@ void main() {
     final service = _service(
       runtime: runtime,
       plugins: const [
-        (id: "opencode", displayName: "OpenCode"),
-        (id: "alpha", displayName: "Alpha"),
+        (id: "opencode", displayName: "OpenCode", residencyPolicy: PluginResidencyPolicy.transient),
+        (id: "alpha", displayName: "Alpha", residencyPolicy: PluginResidencyPolicy.transient),
       ],
     );
     addTearDown(service.dispose);
@@ -102,8 +102,8 @@ void main() {
     final service = _service(
       runtime: runtime,
       plugins: const [
-        (id: "opencode", displayName: "OpenCode"),
-        (id: "alpha", displayName: "Alpha"),
+        (id: "opencode", displayName: "OpenCode", residencyPolicy: PluginResidencyPolicy.transient),
+        (id: "alpha", displayName: "Alpha", residencyPolicy: PluginResidencyPolicy.transient),
       ],
     );
     addTearDown(service.dispose);
@@ -127,8 +127,8 @@ void main() {
     final service = _service(
       runtime: runtime,
       plugins: const [
-        (id: "alpha", displayName: "Alpha"),
-        (id: "beta", displayName: "Beta"),
+        (id: "alpha", displayName: "Alpha", residencyPolicy: PluginResidencyPolicy.transient),
+        (id: "beta", displayName: "Beta", residencyPolicy: PluginResidencyPolicy.transient),
       ],
     );
     addTearDown(service.dispose);
@@ -153,8 +153,8 @@ void main() {
     final service = _service(
       runtime: runtime,
       plugins: const [
-        (id: "opencode", displayName: "OpenCode"),
-        (id: "cursor", displayName: "Cursor"),
+        (id: "opencode", displayName: "OpenCode", residencyPolicy: PluginResidencyPolicy.transient),
+        (id: "cursor", displayName: "Cursor", residencyPolicy: PluginResidencyPolicy.transient),
       ],
     );
     addTearDown(service.dispose);
@@ -193,8 +193,8 @@ void main() {
     final service = _service(
       runtime: runtime,
       plugins: const [
-        (id: "beta", displayName: "Beta"),
-        (id: "alpha", displayName: "Alpha"),
+        (id: "beta", displayName: "Beta", residencyPolicy: PluginResidencyPolicy.transient),
+        (id: "alpha", displayName: "Alpha", residencyPolicy: PluginResidencyPolicy.transient),
       ],
     );
     addTearDown(service.dispose);
@@ -231,7 +231,9 @@ void main() {
     addTearDown(runtime.dispose);
     final service = _service(
       runtime: runtime,
-      plugins: const [(id: "alpha", displayName: "Alpha")],
+      plugins: const [
+        (id: "alpha", displayName: "Alpha", residencyPolicy: PluginResidencyPolicy.transient),
+      ],
     );
     addTearDown(service.dispose);
 
@@ -244,12 +246,17 @@ void main() {
   test("ready plugin ids replay setup-ready dormant plugins", () async {
     final repository = _IdleLifecycleRepository(initialState: PluginRuntimeState.dormant);
     addTearDown(repository.dispose);
-    final service = PluginLifecycleService(
-      lifecycleRepository: repository,
-      preferredDefaultPluginId: legacyMissingPluginId,
-      bridgeSettingsRepository: createTestBridgeSettingsRepository(),
-      idleTimerScheduler: const PluginIdleTimerScheduler(),
-    )..registerPlugins(plugins: const [(id: "one", displayName: "One")]);
+    final service =
+        PluginLifecycleService(
+          lifecycleRepository: repository,
+          preferredDefaultPluginId: legacyMissingPluginId,
+          bridgeSettingsRepository: createTestBridgeSettingsRepository(),
+          idleTimerScheduler: const PluginIdleTimerScheduler(),
+        )..registerPlugins(
+          plugins: const [
+            (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
+          ],
+        );
     addTearDown(service.dispose);
     service.initialize(
       disabledPluginIds: const {},
@@ -264,12 +271,17 @@ void main() {
     final repository = _IdleLifecycleRepository();
     addTearDown(repository.dispose);
     final timerScheduler = _ControllablePluginIdleTimerScheduler();
-    final service = PluginLifecycleService(
-      lifecycleRepository: repository,
-      preferredDefaultPluginId: legacyMissingPluginId,
-      bridgeSettingsRepository: createTestBridgeSettingsRepository(),
-      idleTimerScheduler: timerScheduler,
-    )..registerPlugins(plugins: const [(id: "one", displayName: "One")]);
+    final service =
+        PluginLifecycleService(
+          lifecycleRepository: repository,
+          preferredDefaultPluginId: legacyMissingPluginId,
+          bridgeSettingsRepository: createTestBridgeSettingsRepository(),
+          idleTimerScheduler: timerScheduler,
+        )..registerPlugins(
+          plugins: const [
+            (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
+          ],
+        );
     addTearDown(service.dispose);
     service.initialize(
       disabledPluginIds: const {},
@@ -293,20 +305,25 @@ void main() {
     final repository = _IdleLifecycleRepository();
     addTearDown(repository.dispose);
     final timerScheduler = _ControllablePluginIdleTimerScheduler();
-    final service = PluginLifecycleService(
-      lifecycleRepository: repository,
-      preferredDefaultPluginId: legacyMissingPluginId,
-      bridgeSettingsRepository: createTestBridgeSettingsRepository(
-        settings: const BridgeSettings(
-          plugins: BridgePluginSettings(
-            settingsByPluginId: {
-              "one": PluginLifecycleSettings(idleTimeoutMins: 0),
-            },
+    final service =
+        PluginLifecycleService(
+          lifecycleRepository: repository,
+          preferredDefaultPluginId: legacyMissingPluginId,
+          bridgeSettingsRepository: createTestBridgeSettingsRepository(
+            settings: const BridgeSettings(
+              plugins: BridgePluginSettings(
+                settingsByPluginId: {
+                  "one": PluginLifecycleSettings(idleTimeoutMins: 0),
+                },
+              ),
+            ),
           ),
-        ),
-      ),
-      idleTimerScheduler: timerScheduler,
-    )..registerPlugins(plugins: const [(id: "one", displayName: "One")]);
+          idleTimerScheduler: timerScheduler,
+        )..registerPlugins(
+          plugins: const [
+            (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
+          ],
+        );
     addTearDown(service.dispose);
     service.initialize(
       disabledPluginIds: const {},
@@ -318,6 +335,44 @@ void main() {
 
     expect(timerScheduler.timers, isEmpty);
     expect(repository.stopCalls, isZero);
+  });
+
+  test("resident policy overrides a positive timeout without rewriting settings", () async {
+    final repository = _IdleLifecycleRepository();
+    addTearDown(repository.dispose);
+    final timerScheduler = _ControllablePluginIdleTimerScheduler();
+    final settingsRepository = createTestBridgeSettingsRepository(
+      settings: const BridgeSettings(
+        plugins: BridgePluginSettings(
+          settingsByPluginId: {
+            "one": PluginLifecycleSettings(idleTimeoutMins: 45),
+          },
+        ),
+      ),
+    );
+    final service =
+        PluginLifecycleService(
+          lifecycleRepository: repository,
+          preferredDefaultPluginId: legacyMissingPluginId,
+          bridgeSettingsRepository: settingsRepository,
+          idleTimerScheduler: timerScheduler,
+        )..registerPlugins(
+          plugins: const [
+            (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.resident),
+          ],
+        );
+    addTearDown(service.dispose);
+    service.initialize(
+      disabledPluginIds: const {},
+      setupById: const {"one": PluginSetupReady()},
+    );
+
+    repository.publish(workState: PluginWorkState.idle, leaseCount: 0);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(timerScheduler.timers, isEmpty);
+    expect(repository.stopCalls, isZero);
+    expect(settingsRepository.currentSettings.plugins.idleTimeoutMinsFor(pluginId: "one"), 45);
   });
 }
 
@@ -443,8 +498,7 @@ class _ControllablePluginIdleTimerScheduler implements PluginIdleTimerScheduler 
 }
 
 class _ControllablePluginIdleTimer implements Timer {
-  _ControllablePluginIdleTimer({required this.duration, required void Function() onElapsed})
-    : _onElapsed = onElapsed;
+  _ControllablePluginIdleTimer({required this.duration, required void Function() onElapsed}) : _onElapsed = onElapsed;
 
   final Duration duration;
   final void Function() _onElapsed;

--- a/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
+++ b/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
@@ -15,6 +15,7 @@ export "src/lifecycle/plugin_config.dart";
 export "src/lifecycle/plugin_diagnostics.dart";
 export "src/lifecycle/plugin_option.dart";
 export "src/lifecycle/plugin_project_ownership.dart";
+export "src/lifecycle/plugin_residency_policy.dart";
 export "src/lifecycle/plugin_setup_status.dart";
 export "src/lifecycle/plugin_start_exception.dart";
 export "src/lifecycle/plugin_state_storage.dart";

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin_descriptor.dart
@@ -7,6 +7,7 @@ import "plugin_availability.dart";
 import "plugin_config.dart";
 import "plugin_option.dart";
 import "plugin_project_ownership.dart";
+import "plugin_residency_policy.dart";
 import "plugin_setup_status.dart";
 import "plugin_state_storage.dart";
 import "runtime_provision_progress.dart";
@@ -50,6 +51,14 @@ abstract class BridgePluginDescriptor {
   ///
   /// Must be pure: no I/O, no side effects. The default accepts everything.
   void validateConfig(PluginConfig config) {}
+
+  /// Declares whether an activated plugin may be suspended after idle time.
+  ///
+  /// This is derived from validated plugin configuration without I/O. The
+  /// default applies the bridge's configured timeout.
+  PluginResidencyPolicy residencyPolicy({required PluginConfig config}) {
+    return PluginResidencyPolicy.transient;
+  }
 
   /// Inspects whether this plugin's runtime and authentication are already set
   /// up without installing, starting, or initiating a login flow.

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_residency_policy.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_residency_policy.dart
@@ -1,0 +1,8 @@
+/// Whether an activated plugin may be suspended after confirmed idle time.
+enum PluginResidencyPolicy {
+  /// Apply the bridge's configured idle timeout.
+  transient,
+
+  /// Keep the plugin adapter active until explicit or bridge shutdown.
+  resident,
+}

--- a/bridge/sesori_plugin_interface/test/lifecycle/bridge_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_interface/test/lifecycle/bridge_plugin_descriptor_test.dart
@@ -15,6 +15,15 @@ void main() {
       expect(() => descriptor.validateConfig(const PluginConfig.empty()), returnsNormally);
     });
 
+    test('uses configured transient residency by default', () {
+      const descriptor = _MinimalDescriptor();
+
+      expect(
+        descriptor.residencyPolicy(config: const PluginConfig.empty()),
+        PluginResidencyPolicy.transient,
+      );
+    });
+
     test('a descriptor can reject configuration with PluginConfigException', () {
       const descriptor = _ValidatingDescriptor();
       const config = PluginConfig(values: {'no-auto-start': true, 'port': null});

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
@@ -247,6 +247,11 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
   void validateConfig(PluginConfig config) => validateConfigValues(config);
 
   @override
+  PluginResidencyPolicy residencyPolicy({required PluginConfig config}) {
+    return config.flag("no-auto-start") ? PluginResidencyPolicy.resident : PluginResidencyPolicy.transient;
+  }
+
+  @override
   Future<PluginSetupStatus> inspectSetup({
     required PluginConfig config,
     required HostProcessService processes,

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
@@ -18,6 +18,15 @@ import "open_code_runtime_policy.dart";
 
 const int _setupProbeOutputLimit = 64 * 1024;
 
+abstract final class _OpenCodeConfigKey {
+  static const String port = "port";
+  static const String host = "host";
+  static const String noAutoStart = "no-auto-start";
+  static const String password = "password";
+  static const String noPassword = "no-password";
+  static const String binary = "bin";
+}
+
 /// Builds the [OpenCodeManagedApi] for a resolved server. The production default
 /// constructs an [OpenCodePlugin] with auto-initialization disabled (the
 /// descriptor awaits [OpenCodeManagedApi.initialize] explicitly); tests inject a
@@ -107,7 +116,7 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
   /// so none of those need an alias.
   static const List<PluginOption> cliOptions = [
     PluginValueOption.integer(
-      name: "port",
+      name: _OpenCodeConfigKey.port,
       help: "Port for opencode server to listen on",
       defaultsTo: null,
       valueHelp: null,
@@ -115,7 +124,7 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
       deprecatedAliases: ["port"],
     ),
     PluginValueOption(
-      name: "host",
+      name: _OpenCodeConfigKey.host,
       help:
           "Host the opencode server binds to (auto-start) or is reached at "
           "(--opencode-no-auto-start). Defaults to 127.0.0.1. Use 0.0.0.0 to "
@@ -128,7 +137,7 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
       validate: null,
     ),
     PluginFlagOption(
-      name: "no-auto-start",
+      name: _OpenCodeConfigKey.noAutoStart,
       help: "Skip auto-starting opencode server (use existing server)",
       defaultsTo: false,
       negatable: true,
@@ -136,7 +145,7 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
       deprecatedAliases: ["no-auto-start"],
     ),
     PluginValueOption(
-      name: "password",
+      name: _OpenCodeConfigKey.password,
       help: "Override server password (auto-generated if not set)",
       defaultsTo: "",
       allowedValues: null,
@@ -146,13 +155,13 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
       deprecatedAliases: ["password"],
     ),
     PluginFlagOption(
-      name: "no-password",
+      name: _OpenCodeConfigKey.noPassword,
       help: "Disable OpenCode server authentication",
       defaultsTo: false,
       negatable: false,
     ),
     PluginValueOption(
-      name: "bin",
+      name: _OpenCodeConfigKey.binary,
       help: "Path to opencode binary",
       defaultsTo: null,
       allowedValues: null,
@@ -163,17 +172,18 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
 
   /// Static counterpart of [validateConfig] for argument-parse-time callers.
   static void validateConfigValues(PluginConfig config) {
-    if (config.flag("no-auto-start") && config.intValue("port") == null) {
+    if (config.flag(_OpenCodeConfigKey.noAutoStart) && config.intValue(_OpenCodeConfigKey.port) == null) {
       throw const PluginConfigException("The --opencode-no-auto-start flag requires --opencode-port to be set.");
     }
-    if (config.flag("no-password") && (config.value("password")?.isNotEmpty ?? false)) {
+    if (config.flag(_OpenCodeConfigKey.noPassword) &&
+        (config.value(_OpenCodeConfigKey.password)?.isNotEmpty ?? false)) {
       throw const PluginConfigException("The --opencode-no-password flag cannot be used with --opencode-password.");
     }
     // The host is used in both modes (bind target when managed, connect target
     // when attaching), so validate it up front — a malformed value would
     // otherwise only fail deep in start(), after the startup mutex has run and
     // the single-live-bridge replacement may have stopped a healthy resident.
-    final host = (config.value("host") ?? "").trim();
+    final host = (config.value(_OpenCodeConfigKey.host) ?? "").trim();
     if (host.isEmpty) {
       throw const PluginConfigException("The --opencode-host option cannot be empty.");
     }
@@ -189,7 +199,9 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
     // unauthenticated OpenCode server on the network. Block that combination;
     // a wildcard/LAN bind with the default Basic-auth password stays allowed,
     // and --opencode-no-password on a loopback host stays allowed.
-    if (!config.flag("no-auto-start") && config.flag("no-password") && !_isLoopbackHost(host)) {
+    if (!config.flag(_OpenCodeConfigKey.noAutoStart) &&
+        config.flag(_OpenCodeConfigKey.noPassword) &&
+        !_isLoopbackHost(host)) {
       throw PluginConfigException(
         "The --opencode-no-password flag cannot be combined with a non-loopback --opencode-host "
         "('$host') when auto-starting: it would expose an unauthenticated OpenCode server on the "
@@ -248,7 +260,9 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
 
   @override
   PluginResidencyPolicy residencyPolicy({required PluginConfig config}) {
-    return config.flag("no-auto-start") ? PluginResidencyPolicy.resident : PluginResidencyPolicy.transient;
+    return config.flag(_OpenCodeConfigKey.noAutoStart)
+        ? PluginResidencyPolicy.resident
+        : PluginResidencyPolicy.transient;
   }
 
   @override
@@ -258,11 +272,11 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
     required Map<String, String> environment,
     required String stateDirectory,
   }) async {
-    if (config.flag("no-auto-start")) {
+    if (config.flag(_OpenCodeConfigKey.noAutoStart)) {
       return const PluginSetupReady();
     }
 
-    final explicitBin = config.value("bin")?.trim();
+    final explicitBin = config.value(_OpenCodeConfigKey.binary)?.trim();
     final hasExplicitBin = explicitBin != null && explicitBin.isNotEmpty;
     const manifest = OpenCodeRuntimeManifest();
     final executable = hasExplicitBin ? explicitBin : manifest.pathExecutableName;
@@ -373,10 +387,10 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
     required HostProcessService processes,
     required Map<String, String> environment,
   }) async {
-    if (config.flag("no-auto-start")) {
+    if (config.flag(_OpenCodeConfigKey.noAutoStart)) {
       return const PluginAvailable();
     }
-    final explicitBin = config.value("bin")?.trim();
+    final explicitBin = config.value(_OpenCodeConfigKey.binary)?.trim();
     if (explicitBin != null && explicitBin.isNotEmpty) {
       const manifest = OpenCodeRuntimeManifest();
       return RuntimeAvailabilityProber(
@@ -405,10 +419,10 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
   @override
   Stream<RuntimeProvisionProgress> ensureRuntime({required PluginHost host}) async* {
     final config = host.config;
-    if (config.flag("no-auto-start")) {
+    if (config.flag(_OpenCodeConfigKey.noAutoStart)) {
       return;
     }
-    final explicitBin = config.value("bin")?.trim();
+    final explicitBin = config.value(_OpenCodeConfigKey.binary)?.trim();
     if (explicitBin != null && explicitBin.isNotEmpty) {
       return;
     }
@@ -453,19 +467,19 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
     }
 
     final config = host.config;
-    final requestedPort = config.intValue("port");
-    final noPassword = config.flag("no-password");
+    final requestedPort = config.intValue(_OpenCodeConfigKey.port);
+    final noPassword = config.flag(_OpenCodeConfigKey.noPassword);
     // Mirror the legacy flow's `password.normalize()`: trim, and map a blank
     // value to "no password supplied" — otherwise the same CLI input would
     // select a different password (or demand auth the user never set) after
     // the flip.
-    final providedPassword = config.value("password")?.normalize();
+    final providedPassword = config.value(_OpenCodeConfigKey.password)?.normalize();
 
     // The host OpenCode binds to (managed mode) or is reached at (attach mode);
     // defaults to 127.0.0.1. The connect host is what the bridge dials for
     // HTTP/SSE/health — loopback when the bind host is a non-connectable
     // wildcard (0.0.0.0 / ::), otherwise the bind host itself.
-    final bindHost = config.value("host")!.trim();
+    final bindHost = config.value(_OpenCodeConfigKey.host)!.trim();
     final connectHost = resolveOpenCodeConnectHost(bindHost: bindHost);
 
     final probeClientFactory = _probeClientFactory ?? http.Client.new;
@@ -497,7 +511,7 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
     final String serverUrl;
     final String? apiPassword;
 
-    if (config.flag("no-auto-start")) {
+    if (config.flag(_OpenCodeConfigKey.noAutoStart)) {
       // Attach mode: probe an existing server, never own or kill it.
       final attachPort = requestedPort!;
       port = attachPort;
@@ -532,7 +546,7 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
       // Precedence: an explicit --opencode-bin wins (trusted, no version gate),
       // else the path ensureRuntime resolved (a recent PATH install or the
       // managed download), exposed via the host.
-      final explicitBin = config.value("bin")?.trim();
+      final explicitBin = config.value(_OpenCodeConfigKey.binary)?.trim();
       final resolvedExecutable = (explicitBin != null && explicitBin.isNotEmpty)
           ? explicitBin
           : host.provisionedRuntimePath;

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_test.dart
@@ -37,6 +37,21 @@ void main() {
       expect(aliasesByName["bin"], isEmpty);
     });
 
+    test("keeps attach mode resident and managed mode transient", () {
+      expect(
+        descriptor.residencyPolicy(
+          config: const PluginConfig(values: {"no-auto-start": true}),
+        ),
+        PluginResidencyPolicy.resident,
+      );
+      expect(
+        descriptor.residencyPolicy(
+          config: const PluginConfig(values: {"no-auto-start": false}),
+        ),
+        PluginResidencyPolicy.transient,
+      );
+    });
+
     test("validateConfig requires --port when --no-auto-start is set", () {
       expect(
         () => descriptor.validateConfig(


### PR DESCRIPTION
## Summary

- add a backend-neutral transient/resident policy to plugin descriptors
- keep OpenCode attach mode (`--opencode-no-auto-start`) resident with effective idle timeout `0` without rewriting persisted timeout settings
- add debug diagnostics for plugin generation start, stop, and idle-suspension decisions
- replace frozen management PR #510 with a documented six-PR delivery series

## Behavior

OpenCode remains demand-started in attach mode. Once attached, the bridge does not schedule idle suspension for its plugin adapter. Explicit lifecycle commands and bridge shutdown remain separate from idle timeout policy.

Use `--log-level debug` to see generation start attempt/success, stop begin/success, and idle-trigger diagnostics.

## Verification

- `dart test test/lifecycle/bridge_plugin_descriptor_test.dart` in `bridge/sesori_plugin_interface` (12 tests)
- `dart test test/runtime/open_code_plugin_descriptor_test.dart` in `bridge/sesori_plugin_opencode` (32 tests)
- focused lifecycle/runtime/setup-route/recovery tests in `bridge/app` (50 tests)
- `dart analyze --fatal-infos` in plugin interface, OpenCode, Codex, ACP, Cursor, and bridge app
- `git diff --check`
- Aristotle architecture implementation review: approved with no findings

## Series

This is step 1 of 6 in `.plan/active/setup-aware-plugin-management`. Frozen PR #510 remains source material only and will not be merged or cherry-picked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep attach-only plugins resident so they don’t auto-suspend after idle. In OpenCode attach mode (`--opencode-no-auto-start`), we now enforce an effective idle timeout of 0 without changing saved settings.

- **New Features**
  - Added `PluginResidencyPolicy` (transient | resident) to `sesori_plugin_interface`; default is transient.
  - `OpenCodePluginDescriptor` maps `--opencode-no-auto-start` to resident.
  - `BridgeRuntimeRunner` passes residency to `PluginLifecycleService`, which yields effective timeout 0 for resident plugins while leaving persisted timeouts untouched.
  - Added debug logs for generation start/stop and idle-suspension outcomes.
  - Updated tests and planning docs: new `.plan/active/setup-aware-plugin-management` (six-step series) and lifecycle plan/tracker updates, including the “one open PR and one local successor” delivery rule (this is step 1/6).

- **Refactors**
  - Centralized OpenCode CLI config keys into `_OpenCodeConfigKey` to remove string literals across validation/probing/runtime mapping.

<sup>Written for commit 8f76915b1bec1fe735cd282d109fe3c71334b4fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

