### PR TITLE
fix(client): prevent relay failures from appearing as fatal crashes

### DIFF
--- a/client/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/client/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -101,11 +101,10 @@ class RelayClient {
         throw StateError("Failed to create relay WebSocket channel");
       }
       unawaited(
-        channel.sink.done.catchError((Object error) {
-          logw("WebSocket sink closed with error (suppressed): ${error.toString()}");
+        channel.sink.done.catchError((Object error, StackTrace stackTrace) {
+          logw("WebSocket sink closed with error (suppressed)", error, stackTrace);
         }),
       );
-      _firstBinaryMessage = Completer<Uint8List>();
 
       _channelSubscription = channel.stream
           .asyncMap(_onSocketMessage)
@@ -121,6 +120,10 @@ class RelayClient {
             },
             onDone: _onSocketDone,
           );
+      // Upgrade failures reach both the stream and `ready`: subscribe first to
+      // drain channel closure, then await `ready` so this connect call owns the error.
+      await channel.ready;
+      _firstBinaryMessage = Completer<Uint8List>();
 
       // Auth token is sent before E2EE is established. This is intentional:
       // the relay requires a valid JWT to authenticate the WebSocket connection

--- a/client/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/client/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -41,6 +41,7 @@ class RelayClient {
 
   static const int _messageVersion = 0x01;
   static const Duration _handshakeTimeout = Duration(seconds: 15);
+  static const Duration _channelCloseTimeout = Duration(seconds: 3);
   static const Duration _requestTimeout = Duration(seconds: 30);
   int? _lastCloseCode;
   int? get lastCloseCode => _lastCloseCode;
@@ -122,7 +123,14 @@ class RelayClient {
           );
       // Upgrade failures reach both the stream and `ready`: subscribe first to
       // drain channel closure, then await `ready` so this connect call owns the error.
-      await channel.ready;
+      await channel.ready.timeout(
+        _handshakeTimeout,
+        onTimeout: () => throw TimeoutException(
+          "Timed out waiting for relay WebSocket upgrade",
+          _handshakeTimeout,
+        ),
+      );
+      if (_disposed) return;
       _firstBinaryMessage = Completer<Uint8List>();
 
       // Auth token is sent before E2EE is established. This is intentional:
@@ -181,6 +189,7 @@ class RelayClient {
       logd("Relay connected but bridge is offline — holding socket open");
       return;
     } catch (error, stackTrace) {
+      if (_disposed) return;
       loge("Failed to connect relay client", error, stackTrace);
       await _teardownChannelOnly();
       _connectionState = RelayClientConnectionState.disconnected;
@@ -559,12 +568,19 @@ class RelayClient {
     }
     _channelSubscription = null;
 
+    final channel = _channel;
+    _channel = null;
     try {
-      await _channel?.sink.close();
+      await channel?.sink.close().timeout(
+        _channelCloseTimeout,
+        onTimeout: () => throw TimeoutException(
+          "Timed out closing relay WebSocket channel",
+          _channelCloseTimeout,
+        ),
+      );
     } catch (error, stackTrace) {
       loge("Failed to close relay socket channel", error, stackTrace);
     }
-    _channel = null;
     _firstBinaryMessage = null;
   }
 

--- a/client/module_core/test/capabilities/relay/relay_client_connection_error_test.dart
+++ b/client/module_core/test/capabilities/relay/relay_client_connection_error_test.dart
@@ -1,0 +1,34 @@
+import "dart:async";
+
+import "package:mocktail/mocktail.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+import "package:web_socket_channel/web_socket_channel.dart";
+
+class _MockRoomKeyStorage extends Mock implements RoomKeyStorage {}
+
+void main() {
+  test("failed WebSocket handshake does not escape as an uncaught async error", () async {
+    final roomKeyStorage = _MockRoomKeyStorage();
+    when(roomKeyStorage.getRoomKey).thenAnswer((_) async => null);
+    final client = RelayClient(
+      relayHost: "127.0.0.1:0",
+      cryptoService: RelayCryptoService(),
+      roomKeyStorage: roomKeyStorage,
+      authToken: null,
+    );
+    final uncaughtErrors = <Object>[];
+
+    await runZonedGuarded(
+      () async {
+        await expectLater(client.connect(), throwsA(isA<WebSocketChannelException>()));
+        await client.disconnect();
+        await Future<void>.delayed(Duration.zero);
+      },
+      (error, stackTrace) => uncaughtErrors.add(error),
+    );
+
+    expect(uncaughtErrors, isEmpty);
+  });
+}

--- a/client/module_core/test/capabilities/relay/relay_client_connection_error_test.dart
+++ b/client/module_core/test/capabilities/relay/relay_client_connection_error_test.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:io";
 
 import "package:mocktail/mocktail.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
@@ -30,5 +31,38 @@ void main() {
     );
 
     expect(uncaughtErrors, isEmpty);
+  });
+
+  test("disconnect during a stalled WebSocket upgrade does not leave connect pending", () async {
+    final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    final acceptedSocket = Completer<Socket>();
+    final serverSubscription = server.listen((socket) {
+      if (acceptedSocket.isCompleted) {
+        socket.destroy();
+      } else {
+        acceptedSocket.complete(socket);
+      }
+    });
+    final roomKeyStorage = _MockRoomKeyStorage();
+    when(roomKeyStorage.getRoomKey).thenAnswer((_) async => null);
+    final client = RelayClient(
+      relayHost: "127.0.0.1:${server.port}",
+      cryptoService: RelayCryptoService(),
+      roomKeyStorage: roomKeyStorage,
+      authToken: null,
+    );
+    final connectFuture = client.connect();
+    final socket = await acceptedSocket.future.timeout(const Duration(seconds: 2));
+
+    try {
+      await client.disconnect().timeout(const Duration(seconds: 4));
+      socket.destroy();
+      await connectFuture.timeout(const Duration(seconds: 2));
+    } finally {
+      socket.destroy();
+      await serverSubscription.cancel();
+      await server.close();
+      await connectFuture.catchError((Object _) {}).timeout(const Duration(seconds: 2), onTimeout: () {});
+    }
   });
 }


### PR DESCRIPTION
## Summary

- await `WebSocketChannel.ready` so failed relay upgrades remain owned by `RelayClient.connect()`
- arm the E2EE handshake only after transport readiness and preserve structured sink error context
- add a regression test proving connection failures do not escape as uncaught async errors

## Root cause

`web_socket_channel` exposes connection failures through both the channel stream and a separate `ready` future. The stream error was handled, but `ready` was never awaited, so the same failure reached `PlatformDispatcher.onError` and was recorded by Crashlytics with `fatal: true` even though the connection service recovered normally.

The global Crashlytics handler remains unchanged, preserving fatal reporting for genuinely uncaught application errors.

## Testing

- `dart test` in `client/module_core`
- `dart analyze` in `client/module_core`
- `flutter test` in `client/app`
- `dart analyze` in `client/app`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent relay WebSocket upgrade failures from being reported as fatal crashes, and bound the connection lifecycle so disconnects don’t hang. We now await `WebSocketChannel.ready` so connection errors stay inside `RelayClient.connect()`.

- **Bug Fixes**
  - Subscribe to the channel stream before awaiting `WebSocketChannel.ready`; await with a handshake timeout so upgrade errors are contained.
  - Defer E2EE handshake until transport is ready; log sink errors with error and stack trace; guard early returns when `_disposed`.
  - Add `_channelCloseTimeout` to bound socket close and ensure `disconnect()` resolves even if the upgrade stalls; add tests for handshake errors not escaping and for disconnect during a stalled upgrade.

<sup>Written for commit 8877cb523524c6a2dc47dd058d02da908d91bbd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

