### PR TITLE
fix(ios): upload Crashlytics dSYMs in CI

### DIFF
--- a/client/app/ios/fastlane/Fastfile
+++ b/client/app/ios/fastlane/Fastfile
@@ -359,6 +359,31 @@ platform :ios do
       output_name: "Runner.ipa"
     )
 
+    dsym_path = lane_context[SharedValues::DSYM_OUTPUT_PATH]
+    UI.user_error!("build_app did not produce a dSYM archive") \
+      if dsym_path.to_s.empty? || !File.file?(dsym_path)
+
+    # Fastlane 2.237 only auto-discovers upload-symbols from CocoaPods, but this
+    # project resolves Firebase through SwiftPM. Prefer the checkout used most
+    # recently by Xcode so local lanes also work when multiple DerivedData trees
+    # exist.
+    upload_symbols_path = Dir[
+      File.expand_path(
+        "~/Library/Developer/Xcode/DerivedData/**/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols"
+      )
+    ].max_by { |path| File.mtime(path) }
+    UI.user_error!("Firebase upload-symbols was not found in Xcode's SwiftPM checkouts") \
+      if upload_symbols_path.nil?
+
+    # Upload synchronously before distribution so TestFlight never receives a
+    # build whose exact symbols were discarded with the ephemeral CI runner.
+    sh(
+      upload_symbols_path,
+      "-gsp", File.expand_path("../Runner/GoogleService-Info.plist", __dir__),
+      "-p", "ios",
+      dsym_path
+    )
+
     # Upload to TestFlight. The "What to Test" notes are the build commit's
     # message (with a `commit: <sha>` trailer for recoverability if the matching
     # `build-<N>` git tag is ever lost). This is the TEST changelog only —


### PR DESCRIPTION
## Summary
- upload the dSYM archive produced by `build_app` before distributing the matching IPA to TestFlight
- resolve Firebase's `upload-symbols` executable from Xcode's SwiftPM checkout
- fail before TestFlight upload when dSYM generation, tool discovery, or symbol upload fails

## Verification
- `ruby -c client/app/ios/fastlane/Fastfile`
- `git diff --check`
- verified the resolved SwiftPM `upload-symbols` binary accepts zipped dSYMs with `-gsp` and `-p ios`

The signed archive and Firebase network upload will be exercised by the existing TestFlight workflow, which owns the required App Store signing credentials.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upload iOS dSYMs to Firebase Crashlytics in CI before TestFlight, so crash reports are symbolicated. Blocks distribution if dSYM generation, tool discovery, or upload fails.

- **Bug Fixes**
  - Resolve Firebase `upload-symbols` from Xcode `SwiftPM` checkout (latest DerivedData).
  - Validate dSYM output and tool presence; fail fast on generation, discovery, or upload errors.
  - Invoke `upload-symbols` with `-gsp` and `-p ios` using the produced dSYM archive.

<sup>Written for commit 9b4991ead5867baa0dceb7d09ce71f41b0fe18d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

