### PR TITLE
fix(opencode): show automatic compaction messages

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/message_part_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/message_part_mapper.dart
@@ -22,9 +22,9 @@ import "models/openapi/tool_state_running.g.dart";
 class MessagePartMapper {
   const MessagePartMapper();
 
-  // OpenCode omits the original text from manual compaction parts, so restore
-  // the built-in command that produced the part for display in clients.
-  static const String _manualCompactionCommandText = "/compact";
+  // OpenCode emits compaction as a user message without text, so restore the
+  // equivalent built-in command for both manual and automatic compaction.
+  static const String _compactionCommandText = "/compact";
 
   /// Maps a generated [Part] union to the plugin-facing [PluginMessagePart].
   ///
@@ -64,12 +64,12 @@ class MessagePartMapper {
     FilePart() => _part(raw.id, raw.sessionID, raw.messageID, PluginMessagePartType.file),
     SnapshotPart() => _part(raw.id, raw.sessionID, raw.messageID, PluginMessagePartType.snapshot),
     PatchPart() => _part(raw.id, raw.sessionID, raw.messageID, PluginMessagePartType.patch),
-    CompactionPart(:final auto) => _part(
+    CompactionPart() => _part(
       raw.id,
       raw.sessionID,
       raw.messageID,
-      auto ? PluginMessagePartType.compaction : PluginMessagePartType.text,
-      text: auto ? null : _manualCompactionCommandText,
+      PluginMessagePartType.text,
+      text: _compactionCommandText,
     ),
     StepStartPart() => _part(raw.id, raw.sessionID, raw.messageID, PluginMessagePartType.stepStart),
     StepFinishPart() => _part(raw.id, raw.sessionID, raw.messageID, PluginMessagePartType.stepFinish),

--- a/bridge/sesori_plugin_opencode/test/message_part_mapper_test.dart
+++ b/bridge/sesori_plugin_opencode/test/message_part_mapper_test.dart
@@ -23,7 +23,7 @@ void main() {
     expect(part.type.isVisible, isTrue);
   });
 
-  test("keeps automatic compaction hidden", () {
+  test("maps automatic compaction to visible command text", () {
     final part = mapper.mapPart(
       const CompactionPart(
         id: "part-1",
@@ -35,8 +35,8 @@ void main() {
       ),
     );
 
-    expect(part.type, equals(PluginMessagePartType.compaction));
-    expect(part.text, isNull);
-    expect(part.type.isVisible, isFalse);
+    expect(part.type, equals(PluginMessagePartType.text));
+    expect(part.text, equals("/compact"));
+    expect(part.type.isVisible, isTrue);
   });
 }

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -384,17 +384,17 @@ void main() {
       );
     });
 
-    test("getSessionMessages filters patch and automatic compaction parts", () async {
+    test("getSessionMessages shows automatic compaction user messages", () async {
       final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
 
       final messages = await plugin.getSessionMessages("ses-new-parts-filter");
 
       expect(messages, hasLength(2));
       final parts = messages.last.parts;
-      expect(
-        parts.map((part) => part.type).toList(),
-        equals([PluginMessagePartType.text]),
-      );
+      expect(messages.last.info, isA<PluginMessageUser>());
+      expect(parts, hasLength(1));
+      expect(parts.single.type, equals(PluginMessagePartType.text));
+      expect(parts.single.text, equals("/compact"));
     });
 
     test("getSessionMessages agent part carries agentName", () async {
@@ -1525,46 +1525,20 @@ class _FakeOpenCodeServer {
           },
           {
             "info": {
-              "role": "assistant",
+              "role": "user",
               "id": "m-npf",
               "sessionID": "ses-new-parts-filter",
-              "parentID": "m-npf-user",
-              "modelID": "gpt",
-              "providerID": "openai",
-              "mode": "primary",
               "agent": "build",
-              "path": {"cwd": "/repo", "root": "/repo"},
-              "cost": 0,
-              "tokens": {
-                "input": 0,
-                "output": 0,
-                "reasoning": 0,
-                "cache": {"read": 0, "write": 0},
-              },
+              "model": {"providerID": "openai", "modelID": "gpt"},
               "time": {"created": 123},
             },
             "parts": [
-              {
-                "id": "p-patch",
-                "sessionID": "ses-new-parts-filter",
-                "messageID": "m-npf",
-                "type": "patch",
-                "hash": "abc123",
-                "files": <String>[],
-              },
               {
                 "id": "p-compaction",
                 "sessionID": "ses-new-parts-filter",
                 "messageID": "m-npf",
                 "type": "compaction",
                 "auto": true,
-              },
-              {
-                "id": "p-text",
-                "sessionID": "ses-new-parts-filter",
-                "messageID": "m-npf",
-                "type": "text",
-                "text": "done",
               },
             ],
           },


### PR DESCRIPTION
## Summary
- render automatic OpenCode compaction user messages as visible `/compact` text
- preserve the existing manual compaction display behavior
- cover the real automatic-compaction-only user message shape in plugin tests

## Root cause
OpenCode emits automatic compaction as a user message containing a compaction part without text. The mapper classified automatic parts as hidden, so downstream filtering left an empty user message bubble.

## Verification
- `dart test test/message_part_mapper_test.dart test/opencode_plugin_impl_test.dart`
- `dart analyze --fatal-infos`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows automatic OpenCode compaction user messages as visible "/compact" text to prevent empty user bubbles, while keeping manual compaction display unchanged.

- **Bug Fixes**
  - Map all `CompactionPart`s to `PluginMessagePartType.text` with "/compact", removing auto/manual branching that hid automatic compaction.
  - Update tests to cover the automatic-compaction-only user message shape and assert visibility.

<sup>Written for commit 9576e59874de3217b8b3fda2959d6a4927ad059c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

