### PR TITLE
[setup-aware-plugin-management] feat(bridge): invalidate plugin management snapshots [step 3/6]

### DIFF
--- a/.plan/active/setup-aware-plugin-management/PLAN.md
+++ b/.plan/active/setup-aware-plugin-management/PLAN.md
@@ -4,8 +4,9 @@
 
 - **Plan slug:** `setup-aware-plugin-management`
 - **Parent plan:** `.plan/active/setup-aware-plugin-lifecycle`
-- **Status:** redesigned from frozen PR #510; Stage 12-P01 is active
-- **Implementation base:** `origin/main` at `41e03f12`
+- **Status:** redesigned from frozen PR #510; P01-P02 merged and P03 is open as
+  PR #568
+- **Current implementation base:** `origin/main` at `19ca475a`
 - **Reference only:** PR #510, substantive commit `c4104e73`, fixture follow-up
   `bf0433b8`
 
@@ -32,7 +33,7 @@ public contract that a later slice must break.
   in lockstep and receive no compatibility shims.
 - `PluginRuntime` owns mechanics; `PluginLifecycleRepository` maps them;
   `PluginLifecycleService` owns policy, persistence sequencing, management
-  snapshots, and revisions; handlers only parse/map HTTP; `Orchestrator` alone
+  snapshots, and change tokens; handlers only parse/map HTTP; `Orchestrator` alone
   emits SSE.
 - The existing `PluginCatalogHydrationListener` remains the only automatic
   hydration trigger. Management code widens its ready-ID input rather than
@@ -51,7 +52,7 @@ public contract that a later slice must break.
 |---|---|---|---|
 | 1/6 | `setup-aware-plugin-management-resident-attach` | `[setup-aware-plugin-management] fix(bridge): keep attach-only plugins resident [step 1/6]` | Generic residency declaration, OpenCode mapping, effective timeout `0`, and start/stop diagnostics. |
 | 2/6 | `setup-aware-plugin-management-read-snapshots` | `[setup-aware-plugin-management] feat(bridge): expose plugin management snapshots [step 2/6]` | Shared read DTOs and read-only GET route. |
-| 3/6 | `setup-aware-plugin-management-invalidation` | `[setup-aware-plugin-management] feat(bridge): invalidate plugin management snapshots [step 3/6]` | Process-local revision and additive SSE invalidation. |
+| 3/6 | `setup-aware-plugin-management-invalidation` | `[setup-aware-plugin-management] feat(bridge): invalidate plugin management snapshots [step 3/6]` | Opaque snapshot tokens and additive SSE invalidation. |
 | 4/6 | `setup-aware-plugin-management-idle-timeouts` | `[setup-aware-plugin-management] feat(bridge): update plugin idle timeouts live [step 4/6]` | Typed timeout writes, settings serialization, and live timer resync. |
 | 5/6 | `setup-aware-plugin-management-disable` | `[setup-aware-plugin-management] feat(bridge): add transactional plugin disable [step 5/6]` | End-to-end safe/force disable with runtime access gates and durable commit/rollback. |
 | 6/6 | `setup-aware-plugin-management-commands` | `[setup-aware-plugin-management] feat(bridge): add remaining plugin lifecycle commands [step 6/6]` | Enable/restart/refresh, setup fencing, and dynamic default/catalog eligibility. |
@@ -122,23 +123,31 @@ Production files:
 - `bridge/app/lib/src/bridge/orchestrator.dart`
 - `bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart`
 
-## Stage 12-P03: Revision And Invalidation
+## Stage 12-P03: Snapshot Tokens And Invalidation
 
-Add `@Default(0) int revision` to `PluginManagementResponse`, with
+Add `required String? snapshotToken` to `PluginManagementResponse`, with
 `// COMPATIBILITY 2026-07-25 (v1.6.1): Stage 12-P02 and older bridge payloads
-omit revision; default to the initial process revision. Remove when those bridge
-versions are unsupported.`, and add the `plugin.management.changed` variant to
-`SesoriSseEvent`. The lifecycle service retains one plain
-`PluginManagementResponse` as its last published comparison snapshot and owns a
-broadcast `StreamController<int>` as the only management change stream. It
-compares a freshly built externally visible response with revision normalized
-away and advances/emits the process-local revision only after a materially
-changed, settled snapshot is queryable. `managementSnapshot` remains a
-synchronous GET value; there is no unused `managementSnapshots` stream.
+omit snapshotToken; null means that peer cannot identify snapshot changes. Make
+non-null when those bridge versions are unsupported.`, and add the
+`plugin.management.changed` variant to `SesoriSseEvent`. The lifecycle service
+retains one plain `PluginManagementResponse` as its last published snapshot and
+owns a broadcast `StreamController<String>` as the only management change
+stream. It generates a random 128-bit base64url token for the initial complete
+snapshot and each materially changed public snapshot. Comparison reuses the
+previous token to ignore snapshot identity, then caches the changed response
+with its new token before synchronously emitting that token.
 
-`Orchestrator.create` passes `PluginLifecycleService.managementRevisions` into
-`OrchestratorSession`. The session subscribes in its constructor, maps each
-value to `SesoriSseEvent.pluginManagementChanged(revision: revision)`, and adds
+Every externally visible runtime/setup/work transition is independently
+queryable and invalidated. One plugin's in-progress transition does not suppress
+another plugin's public change, and a transient state can never remain paired
+with an older token. `managementSnapshot` remains the cached synchronous GET
+value, so each returned token identifies exactly that returned content; there is
+no unused `managementSnapshots` stream.
+
+`Orchestrator.create` passes
+`PluginLifecycleService.managementSnapshotTokens` into `OrchestratorSession`.
+The session subscribes in its constructor, maps each value to
+`SesoriSseEvent.pluginManagementChanged(snapshotToken: snapshotToken)`, and adds
 the subscription to its existing `_subscriptions` composite. The existing
 `_subscriptions.cancel()` in `OrchestratorSession.run` disposes it before the
 lifecycle service is closed. No lower layer emits SSE.
@@ -189,10 +198,10 @@ the one-entry set/clear primitive. `BridgeSettingsRepository` remains the sole
 I/O owner; no second settings repository or writer is added.
 
 After a successful durable write, resynchronize existing timers and publish one
-new management revision if the public snapshot changed. Resident plugins still
-report and execute effective timeout `0`; their persisted overrides remain
-editable and recover when residency returns to transient. Failed writes return
-an explicit failure and do not publish success.
+new management snapshot token if the public snapshot changed. Resident plugins
+still report and execute effective timeout `0`; their persisted overrides
+remain editable and recover when residency returns to transient. Failed writes
+return an explicit failure and do not publish success.
 
 `Orchestrator.create` registers
 `PatchPluginIdleTimeoutHandler(lifecycleService: _pluginLifecycleService)` in the
@@ -383,7 +392,7 @@ logic drives a newly enabled plugin through the dynamic service validation.
   and fatal analysis; bridge lifecycle/runtime tests and fatal analysis.
 - P02: shared contract tests/codegen/fatal analysis; bridge lifecycle/handler,
   orchestrator/debug-router tests and fatal analysis.
-- P03: shared management/SSE tests/codegen/fatal analysis; bridge revision/SSE
+- P03: shared management/SSE tests/codegen/fatal analysis; bridge token/SSE
   tests; affected module-core tests and fatal analysis.
 - P04: shared request tests/codegen/fatal analysis; bridge settings,
   lifecycle, handler, and concurrency tests plus fatal analysis.

--- a/.plan/active/setup-aware-plugin-management/TRACKER.md
+++ b/.plan/active/setup-aware-plugin-management/TRACKER.md
@@ -4,8 +4,8 @@
 
 - **Base:** `origin/main` at `19ca475a`
 - **Current branch:** `setup-aware-plugin-management-invalidation`
-- **Current slice:** Stage 12-P03 / step 3 of 6, ready to open
-- **Next action:** open and monitor step 3 of 6
+- **Current slice:** Stage 12-P03 / step 3 of 6, open for review
+- **Next action:** monitor PR #568 and prepare P04 locally
 
 ## Delivery
 
@@ -13,7 +13,7 @@
 |---|---|---|---|
 | [x] | P01 — attach-only residency and diagnostics | `setup-aware-plugin-management-resident-attach` | PR #563 merged as `f8f05c33` |
 | [x] | P02 — read-only management snapshots | `setup-aware-plugin-management-read-snapshots` | PR #567 merged as `19ca475a` |
-| [x] | P03 — revision and SSE invalidation | `setup-aware-plugin-management-invalidation` | verified locally at `1940c969`; ready to open |
+| [x] | P03 — revision and SSE invalidation | `setup-aware-plugin-management-invalidation` | PR #568 open; monitoring |
 | [ ] | P04 — live idle-timeout mutations | `setup-aware-plugin-management-idle-timeouts` | waits for P03 merge |
 | [ ] | P05 — transactional plugin disable | `setup-aware-plugin-management-disable` | waits for P04 merge |
 | [ ] | P06 — remaining commands and dynamic eligibility | `setup-aware-plugin-management-commands` | waits for P05 merge |
@@ -116,6 +116,8 @@
 - Aristotle implementation review approved the complete working-tree diff with
   no architecture findings.
 - Committed locally as `1940c969` after PR #567 merged.
+- Pushed and opened PR #568 with the fixed step-3/6 series title; monitoring
+  started immediately.
 
 ## Delivery Rules
 

--- a/.plan/active/setup-aware-plugin-management/TRACKER.md
+++ b/.plan/active/setup-aware-plugin-management/TRACKER.md
@@ -2,18 +2,18 @@
 
 ## Current State
 
-- **Base:** `origin/main` at `f8f05c33`
-- **Current branch:** `setup-aware-plugin-management-read-snapshots`
-- **Current slice:** Stage 12-P02 / step 2 of 6, open for review
-- **Next action:** monitor PR #567 and prepare P03 locally
+- **Base:** `origin/main` at `19ca475a`
+- **Current branch:** `setup-aware-plugin-management-invalidation`
+- **Current slice:** Stage 12-P03 / step 3 of 6, ready to open
+- **Next action:** open and monitor step 3 of 6
 
 ## Delivery
 
 | Done | Slice | Branch | PR state |
 |---|---|---|---|
 | [x] | P01 — attach-only residency and diagnostics | `setup-aware-plugin-management-resident-attach` | PR #563 merged as `f8f05c33` |
-| [x] | P02 — read-only management snapshots | `setup-aware-plugin-management-read-snapshots` | PR #567 open; monitoring |
-| [ ] | P03 — revision and SSE invalidation | `setup-aware-plugin-management-invalidation` | waits for P02 merge |
+| [x] | P02 — read-only management snapshots | `setup-aware-plugin-management-read-snapshots` | PR #567 merged as `19ca475a` |
+| [x] | P03 — revision and SSE invalidation | `setup-aware-plugin-management-invalidation` | verified locally at `1940c969`; ready to open |
 | [ ] | P04 — live idle-timeout mutations | `setup-aware-plugin-management-idle-timeouts` | waits for P03 merge |
 | [ ] | P05 — transactional plugin disable | `setup-aware-plugin-management-disable` | waits for P04 merge |
 | [ ] | P06 — remaining commands and dynamic eligibility | `setup-aware-plugin-management-commands` | waits for P05 merge |
@@ -49,6 +49,9 @@
 - P02 architecture implementation review approved all 11 changed files with no
   findings. Shared wire ownership, lifecycle mapping, route registration, and
   the existing runner/orchestrator boundary were accepted.
+- P03 architecture implementation review approved all 17 changed files with no
+  findings. Revision ownership, settled comparison, Orchestrator SSE mapping,
+  compatibility, and client boundary handling were accepted.
 
 ## Verification Log
 
@@ -95,6 +98,24 @@
   threads may be resolved automatically.
 - Pushed and opened PR #567 with the fixed step-2/6 series title; monitoring
   started immediately.
+
+### 2026-07-25 — P03 revision and SSE invalidation
+
+- Added a backward-compatible process-local revision to management snapshots
+  and a typed `plugin.management.changed` SSE event.
+- Lifecycle publication compares only externally visible settled snapshots,
+  advances once per material change, and makes the revised GET queryable before
+  synchronous notification. OrchestratorSession remains the sole SSE owner.
+- Existing session-focused client consumers explicitly classify the event as
+  global and ignore it until management state enters the client in a later
+  slice.
+- Shared management/SSE tests passed (43), bridge lifecycle tests passed (15),
+  Orchestrator tests passed (6), and focused module_core tests passed (77).
+- Fatal analysis passed in shared, bridge app, module_core `lib`, and mobile app
+  `lib`; `git diff --check` passed.
+- Aristotle implementation review approved the complete working-tree diff with
+  no architecture findings.
+- Committed locally as `1940c969` after PR #567 merged.
 
 ## Delivery Rules
 

--- a/.plan/active/setup-aware-plugin-management/TRACKER.md
+++ b/.plan/active/setup-aware-plugin-management/TRACKER.md
@@ -5,7 +5,7 @@
 - **Base:** `origin/main` at `19ca475a`
 - **Current branch:** `setup-aware-plugin-management-invalidation`
 - **Current slice:** Stage 12-P03 / step 3 of 6, open for review
-- **Next action:** monitor PR #568 and prepare P04 locally
+- **Next action:** monitor PR #568; P04 waits for merge
 
 ## Delivery
 
@@ -13,7 +13,7 @@
 |---|---|---|---|
 | [x] | P01 — attach-only residency and diagnostics | `setup-aware-plugin-management-resident-attach` | PR #563 merged as `f8f05c33` |
 | [x] | P02 — read-only management snapshots | `setup-aware-plugin-management-read-snapshots` | PR #567 merged as `19ca475a` |
-| [x] | P03 — revision and SSE invalidation | `setup-aware-plugin-management-invalidation` | PR #568 open; monitoring |
+| [x] | P03 — snapshot tokens and SSE invalidation | `setup-aware-plugin-management-invalidation` | PR #568 open; monitoring |
 | [ ] | P04 — live idle-timeout mutations | `setup-aware-plugin-management-idle-timeouts` | waits for P03 merge |
 | [ ] | P05 — transactional plugin disable | `setup-aware-plugin-management-disable` | waits for P04 merge |
 | [ ] | P06 — remaining commands and dynamic eligibility | `setup-aware-plugin-management-commands` | waits for P05 merge |
@@ -35,7 +35,7 @@
   dynamic catalog data flow.
 - The permitted specificity recheck passed its gate and rejected two choices.
   Removed the unused replay-latest management snapshot stream; synchronous GET
-  state plus the revision stream are now the only read/change mechanisms.
+  state plus the change-token stream are now the only read/change mechanisms.
 - The other finding requested moving all pre-existing lifecycle construction
   from `BridgeRuntimeRunner` into `Orchestrator`. That considerable refactor is
   outside this management scope and would blur the current bootstrap/session
@@ -49,9 +49,14 @@
 - P02 architecture implementation review approved all 11 changed files with no
   findings. Shared wire ownership, lifecycle mapping, route registration, and
   the existing runner/orchestrator boundary were accepted.
-- P03 architecture implementation review approved all 17 changed files with no
-  findings. Revision ownership, settled comparison, Orchestrator SSE mapping,
-  compatibility, and client boundary handling were accepted.
+- The initial P03 architecture implementation review approved all 17 changed
+  files with no findings. Its revision and settled-publication design was later
+  superseded while addressing PR review; the replacement token contract and
+  publication semantics received the permitted second review.
+- The final P03 architecture implementation review approved the replacement
+  snapshot-token contract, cached snapshot/token coherence, independent
+  per-change publication, and unchanged Orchestrator SSE ownership with no
+  findings.
 
 ## Verification Log
 
@@ -99,23 +104,30 @@
 - Pushed and opened PR #567 with the fixed step-2/6 series title; monitoring
   started immediately.
 
-### 2026-07-25 — P03 revision and SSE invalidation
+### 2026-07-25 — P03 snapshot tokens and SSE invalidation
 
-- Added a backward-compatible process-local revision to management snapshots
-  and a typed `plugin.management.changed` SSE event.
-- Lifecycle publication compares only externally visible settled snapshots,
-  advances once per material change, and makes the revised GET queryable before
-  synchronous notification. OrchestratorSession remains the sole SSE owner.
+- Added a backward-compatible opaque token to management snapshots and a typed
+  `plugin.management.changed` SSE event.
+- Lifecycle publication caches each materially changed public snapshot with a
+  new random 128-bit token before synchronous notification. Transition states
+  and unrelated plugin changes publish independently, and OrchestratorSession
+  remains the sole SSE owner.
 - Existing session-focused client consumers explicitly classify the event as
   global and ignore it until management state enters the client in a later
   slice.
-- Shared management/SSE tests passed (43), bridge lifecycle tests passed (15),
-  Orchestrator tests passed (6), and focused module_core tests passed (77).
+- Shared management/SSE tests passed (43). Focused bridge lifecycle, handler,
+  and Orchestrator coverage passed, including token deduplication, transient
+  state, unrelated-plugin invalidation, and token/GET coherence. Affected
+  module_core tests passed (108).
 - Fatal analysis passed in shared, bridge app, module_core `lib`, and mobile app
   `lib`; `git diff --check` passed.
-- Aristotle implementation review approved the complete working-tree diff with
-  no architecture findings.
+- The initial Aristotle implementation review approved the revision-based
+  working-tree diff with no architecture findings. The permitted final review
+  approved the replacement snapshot-token contract and publication semantics
+  with no findings.
 - Committed locally as `1940c969` after PR #567 merged.
+- Fixed CI initialization against partial runtime snapshots in `ec79f079` by
+  waiting for complete management state before establishing the first baseline.
 - Pushed and opened PR #568 with the fixed step-3/6 series title; monitoring
   started immediately.
 

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -502,7 +502,7 @@ class Orchestrator {
       mapper: BridgeEventMapper(failureReporter: _failureReporter),
       sessionPromptService: sessionPromptService,
       catalogImportProgress: catalogImportService.progress,
-      pluginManagementRevisions: _pluginLifecycleService.managementRevisions,
+      pluginManagementSnapshotTokens: _pluginLifecycleService.managementSnapshotTokens,
       localWireEventsController: localWireEventsController,
       bytesSentController: bytesSentController,
       failureReporter: _failureReporter,
@@ -630,7 +630,7 @@ class OrchestratorSession {
     required BridgeEventMapper mapper,
     required SessionPromptService sessionPromptService,
     required Stream<CatalogImportProgress> catalogImportProgress,
-    required Stream<int> pluginManagementRevisions,
+    required Stream<String> pluginManagementSnapshotTokens,
     required StreamController<int> bytesSentController,
     required StreamController<SesoriSseEvent> localWireEventsController,
     required FailureReporter failureReporter,
@@ -680,9 +680,9 @@ class OrchestratorSession {
           _enqueueWireEvent(SesoriSseEvent.catalogImportProgress(progress: progress));
         })
         .addTo(_catalogImportSubscriptions);
-    pluginManagementRevisions
-        .listen((revision) {
-          _enqueueWireEvent(SesoriSseEvent.pluginManagementChanged(revision: revision));
+    pluginManagementSnapshotTokens
+        .listen((snapshotToken) {
+          _enqueueWireEvent(SesoriSseEvent.pluginManagementChanged(snapshotToken: snapshotToken));
         })
         .addTo(_subscriptions);
     _sessionPromptService.promptDefaultsChanges

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -502,6 +502,7 @@ class Orchestrator {
       mapper: BridgeEventMapper(failureReporter: _failureReporter),
       sessionPromptService: sessionPromptService,
       catalogImportProgress: catalogImportService.progress,
+      pluginManagementRevisions: _pluginLifecycleService.managementRevisions,
       localWireEventsController: localWireEventsController,
       bytesSentController: bytesSentController,
       failureReporter: _failureReporter,
@@ -629,6 +630,7 @@ class OrchestratorSession {
     required BridgeEventMapper mapper,
     required SessionPromptService sessionPromptService,
     required Stream<CatalogImportProgress> catalogImportProgress,
+    required Stream<int> pluginManagementRevisions,
     required StreamController<int> bytesSentController,
     required StreamController<SesoriSseEvent> localWireEventsController,
     required FailureReporter failureReporter,
@@ -678,6 +680,11 @@ class OrchestratorSession {
           _enqueueWireEvent(SesoriSseEvent.catalogImportProgress(progress: progress));
         })
         .addTo(_catalogImportSubscriptions);
+    pluginManagementRevisions
+        .listen((revision) {
+          _enqueueWireEvent(SesoriSseEvent.pluginManagementChanged(revision: revision));
+        })
+        .addTo(_subscriptions);
     _sessionPromptService.promptDefaultsChanges
         .listen((change) {
           _enqueueWireEvent(

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -56,9 +56,12 @@ class PluginLifecycleService {
   Map<String, PluginSetupStatus>? _setupById;
   BehaviorSubject<List<PluginMetadata>>? _metadataSubject;
   BehaviorSubject<List<String>>? _readyPluginIdsSubject;
+  final StreamController<int> _managementRevisionController = StreamController<int>.broadcast(sync: true);
   StreamSubscription<List<PluginLifecycleSnapshot>>? _runtimeSubscription;
   Future<void>? _disposeFuture;
   final Map<String, ({Duration duration, Timer timer})> _idleTimers = {};
+  PluginManagementResponse? _lastPublishedManagementSnapshot;
+  int _managementRevision = 0;
   bool _disposing = false;
 
   void registerPlugins({required List<RegisteredPluginMetadata> plugins}) {
@@ -129,6 +132,7 @@ class PluginLifecycleService {
     _readyPluginIdsSubject = BehaviorSubject<List<String>>.seeded(
       _buildReadyPluginIds(_lifecycleRepository.snapshot),
     );
+    _lastPublishedManagementSnapshot = _buildManagementResponse(revision: 0);
     _runtimeSubscription = _lifecycleRepository.snapshots.listen(_applyRuntimeSnapshots);
     return (
       eligiblePluginIds: eligiblePluginIds,
@@ -189,16 +193,10 @@ class PluginLifecycleService {
   }
 
   PluginManagementResponse get managementSnapshot {
-    final registeredPlugins = _registeredPlugins;
-    if (registeredPlugins == null || _setupById == null) {
+    if (_registeredPlugins == null || _setupById == null) {
       throw StateError("Plugin lifecycle has not been initialized.");
     }
-    final settings = _bridgeSettingsRepository.currentSettings;
-    return PluginManagementResponse(
-      defaultPluginId: _selectableDefaultPluginId(),
-      defaultIdleTimeoutMins: settings.plugins.defaults.idleTimeoutMins ?? defaultPluginIdleTimeoutMins,
-      plugins: [for (final plugin in registeredPlugins) _managementRow(plugin: plugin)],
-    );
+    return _buildManagementResponse(revision: _managementRevision);
   }
 
   Stream<List<PluginMetadata>> get metadataSnapshots {
@@ -212,6 +210,8 @@ class PluginLifecycleService {
     if (subject == null) throw StateError("Plugin lifecycle has not been initialized.");
     return subject.stream;
   }
+
+  Stream<int> get managementRevisions => _managementRevisionController.stream;
 
   void _applyRuntimeSnapshots(List<PluginLifecycleSnapshot> snapshots) {
     final setupById = _setupById;
@@ -238,6 +238,7 @@ class PluginLifecycleService {
     if (subject != null && !subject.isClosed) subject.add(_orderedMetadata());
     _publishReadyPluginIds(snapshots);
     _syncIdleTimers(snapshots);
+    _publishManagementIfChanged();
   }
 
   List<PluginMetadata> _orderedMetadata() {
@@ -317,6 +318,35 @@ class PluginLifecycleService {
     );
   }
 
+  PluginManagementResponse _buildManagementResponse({required int revision}) {
+    final registeredPlugins = _registeredPlugins;
+    if (registeredPlugins == null || _setupById == null) {
+      throw StateError("Plugin lifecycle has not been initialized.");
+    }
+    final settings = _bridgeSettingsRepository.currentSettings;
+    return PluginManagementResponse(
+      revision: revision,
+      defaultPluginId: _selectableDefaultPluginId(),
+      defaultIdleTimeoutMins: settings.plugins.defaults.idleTimeoutMins ?? defaultPluginIdleTimeoutMins,
+      plugins: [for (final plugin in registeredPlugins) _managementRow(plugin: plugin)],
+    );
+  }
+
+  void _publishManagementIfChanged() {
+    if (_managementRevisionController.isClosed) return;
+    if (_lifecycleRepository.snapshot.any((snapshot) => !snapshot.transitionSettled)) return;
+    final next = _buildManagementResponse(revision: 0);
+    final previous = _lastPublishedManagementSnapshot;
+    if (previous == null) {
+      _lastPublishedManagementSnapshot = next;
+      return;
+    }
+    if (previous == next) return;
+    _lastPublishedManagementSnapshot = next;
+    _managementRevision++;
+    _managementRevisionController.add(_managementRevision);
+  }
+
   shared.PluginRuntimeState _mapRuntimeState(PluginRuntimeState state) => switch (state) {
     PluginRuntimeState.disabled => shared.PluginRuntimeState.disabled,
     PluginRuntimeState.blocked => shared.PluginRuntimeState.blocked,
@@ -369,6 +399,12 @@ class PluginLifecycleService {
     }
     try {
       await _readyPluginIdsSubject?.close();
+    } on Object catch (error, stackTrace) {
+      firstError ??= error;
+      firstStackTrace ??= stackTrace;
+    }
+    try {
+      await _managementRevisionController.close();
     } on Object catch (error, stackTrace) {
       firstError ??= error;
       firstStackTrace ??= stackTrace;

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -132,7 +132,9 @@ class PluginLifecycleService {
     _readyPluginIdsSubject = BehaviorSubject<List<String>>.seeded(
       _buildReadyPluginIds(_lifecycleRepository.snapshot),
     );
-    _lastPublishedManagementSnapshot = _buildManagementResponse(revision: 0);
+    if (_hasCompleteManagementRuntimeSnapshot) {
+      _lastPublishedManagementSnapshot = _buildManagementResponse(revision: 0);
+    }
     _runtimeSubscription = _lifecycleRepository.snapshots.listen(_applyRuntimeSnapshots);
     return (
       eligiblePluginIds: eligiblePluginIds,
@@ -333,7 +335,7 @@ class PluginLifecycleService {
   }
 
   void _publishManagementIfChanged() {
-    if (_managementRevisionController.isClosed) return;
+    if (_managementRevisionController.isClosed || !_hasCompleteManagementRuntimeSnapshot) return;
     if (_lifecycleRepository.snapshot.any((snapshot) => !snapshot.transitionSettled)) return;
     final next = _buildManagementResponse(revision: 0);
     final previous = _lastPublishedManagementSnapshot;
@@ -345,6 +347,13 @@ class PluginLifecycleService {
     _lastPublishedManagementSnapshot = next;
     _managementRevision++;
     _managementRevisionController.add(_managementRevision);
+  }
+
+  bool get _hasCompleteManagementRuntimeSnapshot {
+    final registeredPlugins = _registeredPlugins;
+    if (registeredPlugins == null) return false;
+    final runtimePluginIds = _lifecycleRepository.snapshot.map((snapshot) => snapshot.pluginId).toSet();
+    return registeredPlugins.every((plugin) => runtimePluginIds.contains(plugin.id));
   }
 
   shared.PluginRuntimeState _mapRuntimeState(PluginRuntimeState state) => switch (state) {

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -1,4 +1,6 @@
 import "dart:async";
+import "dart:convert";
+import "dart:math";
 
 import "package:rxdart/rxdart.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
@@ -56,12 +58,12 @@ class PluginLifecycleService {
   Map<String, PluginSetupStatus>? _setupById;
   BehaviorSubject<List<PluginMetadata>>? _metadataSubject;
   BehaviorSubject<List<String>>? _readyPluginIdsSubject;
-  final StreamController<int> _managementRevisionController = StreamController<int>.broadcast(sync: true);
+  final StreamController<String> _managementSnapshotTokenController = StreamController<String>.broadcast(sync: true);
   StreamSubscription<List<PluginLifecycleSnapshot>>? _runtimeSubscription;
   Future<void>? _disposeFuture;
   final Map<String, ({Duration duration, Timer timer})> _idleTimers = {};
   PluginManagementResponse? _lastPublishedManagementSnapshot;
-  int _managementRevision = 0;
+  final Random _random = Random.secure();
   bool _disposing = false;
 
   void registerPlugins({required List<RegisteredPluginMetadata> plugins}) {
@@ -133,7 +135,7 @@ class PluginLifecycleService {
       _buildReadyPluginIds(_lifecycleRepository.snapshot),
     );
     if (_hasCompleteManagementRuntimeSnapshot) {
-      _lastPublishedManagementSnapshot = _buildManagementResponse(revision: 0);
+      _lastPublishedManagementSnapshot = _buildManagementResponse(snapshotToken: _newManagementSnapshotToken());
     }
     _runtimeSubscription = _lifecycleRepository.snapshots.listen(_applyRuntimeSnapshots);
     return (
@@ -198,7 +200,9 @@ class PluginLifecycleService {
     if (_registeredPlugins == null || _setupById == null) {
       throw StateError("Plugin lifecycle has not been initialized.");
     }
-    return _buildManagementResponse(revision: _managementRevision);
+    final snapshot = _lastPublishedManagementSnapshot;
+    if (snapshot == null) throw StateError("Plugin management snapshot is not ready.");
+    return snapshot;
   }
 
   Stream<List<PluginMetadata>> get metadataSnapshots {
@@ -213,7 +217,7 @@ class PluginLifecycleService {
     return subject.stream;
   }
 
-  Stream<int> get managementRevisions => _managementRevisionController.stream;
+  Stream<String> get managementSnapshotTokens => _managementSnapshotTokenController.stream;
 
   void _applyRuntimeSnapshots(List<PluginLifecycleSnapshot> snapshots) {
     final setupById = _setupById;
@@ -320,14 +324,14 @@ class PluginLifecycleService {
     );
   }
 
-  PluginManagementResponse _buildManagementResponse({required int revision}) {
+  PluginManagementResponse _buildManagementResponse({required String? snapshotToken}) {
     final registeredPlugins = _registeredPlugins;
     if (registeredPlugins == null || _setupById == null) {
       throw StateError("Plugin lifecycle has not been initialized.");
     }
     final settings = _bridgeSettingsRepository.currentSettings;
     return PluginManagementResponse(
-      revision: revision,
+      snapshotToken: snapshotToken,
       defaultPluginId: _selectableDefaultPluginId(),
       defaultIdleTimeoutMins: settings.plugins.defaults.idleTimeoutMins ?? defaultPluginIdleTimeoutMins,
       plugins: [for (final plugin in registeredPlugins) _managementRow(plugin: plugin)],
@@ -335,18 +339,22 @@ class PluginLifecycleService {
   }
 
   void _publishManagementIfChanged() {
-    if (_managementRevisionController.isClosed || !_hasCompleteManagementRuntimeSnapshot) return;
-    if (_lifecycleRepository.snapshot.any((snapshot) => !snapshot.transitionSettled)) return;
-    final next = _buildManagementResponse(revision: 0);
+    if (_managementSnapshotTokenController.isClosed || !_hasCompleteManagementRuntimeSnapshot) return;
     final previous = _lastPublishedManagementSnapshot;
     if (previous == null) {
-      _lastPublishedManagementSnapshot = next;
+      _lastPublishedManagementSnapshot = _buildManagementResponse(snapshotToken: _newManagementSnapshotToken());
       return;
     }
+    final next = _buildManagementResponse(snapshotToken: previous.snapshotToken);
     if (previous == next) return;
-    _lastPublishedManagementSnapshot = next;
-    _managementRevision++;
-    _managementRevisionController.add(_managementRevision);
+    final snapshotToken = _newManagementSnapshotToken();
+    _lastPublishedManagementSnapshot = next.copyWith(snapshotToken: snapshotToken);
+    _managementSnapshotTokenController.add(snapshotToken);
+  }
+
+  String _newManagementSnapshotToken() {
+    final bytes = List<int>.generate(16, (_) => _random.nextInt(256), growable: false);
+    return base64Url.encode(bytes).replaceAll("=", "");
   }
 
   bool get _hasCompleteManagementRuntimeSnapshot {
@@ -413,7 +421,7 @@ class PluginLifecycleService {
       firstStackTrace ??= stackTrace;
     }
     try {
-      await _managementRevisionController.close();
+      await _managementSnapshotTokenController.close();
     } on Object catch (error, stackTrace) {
       firstError ??= error;
       firstStackTrace ??= stackTrace;

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -7,12 +7,14 @@ import "package:sesori_bridge/src/bridge/models/bridge_config.dart";
 import "package:sesori_bridge/src/bridge/orchestrator.dart";
 import "package:sesori_bridge/src/bridge/relay_client.dart";
 import "package:sesori_bridge/src/bridge/runtime/bridge_runtime.dart";
+import "package:sesori_bridge/src/bridge/runtime/plugin_runtime.dart" as runtime show PluginRuntimeState;
 import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
 import "../helpers/plugin_lifecycle_test_support.dart";
+import "../helpers/plugin_runtime_test_support.dart";
 import "../helpers/restart_test_support.dart";
 import "../helpers/test_database.dart";
 import "../helpers/test_helpers.dart";
@@ -30,6 +32,22 @@ void main() {
     expect(plugins.map((plugin) => plugin.id), ["one", "two"]);
     expect(plugins.map((plugin) => plugin.isDefault), [true, false]);
     expect(plugins.map((plugin) => plugin.state), everyElement(PluginLifecycleState.ready));
+  });
+
+  test("orchestrator emits management invalidation after a settled runtime change", () async {
+    final harness = await _OrchestratorHarness.create(pluginIds: const ["one"]);
+    addTearDown(harness.close);
+    final eventFuture = harness.composition.session.localWireEvents
+        .where((event) => event is SesoriPluginManagementChanged)
+        .cast<SesoriPluginManagementChanged>()
+        .first;
+
+    final pluginRuntime = runtimeForLifecycleService(service: harness.lifecycleService) as TestPluginRuntime;
+    pluginRuntime.emitRuntimeState(pluginId: "one", state: runtime.PluginRuntimeState.degraded);
+
+    final event = await eventFuture.timeout(const Duration(seconds: 2));
+    expect(event.revision, 1);
+    expect(harness.lifecycleService.managementSnapshot.revision, event.revision);
   });
 
   test("a sourced reconnect reconciles its active plugin and local events are already mapped", () async {

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -34,7 +34,7 @@ void main() {
     expect(plugins.map((plugin) => plugin.state), everyElement(PluginLifecycleState.ready));
   });
 
-  test("orchestrator emits management invalidation after a settled runtime change", () async {
+  test("orchestrator emits management invalidation after a runtime change", () async {
     final harness = await _OrchestratorHarness.create(pluginIds: const ["one"]);
     addTearDown(harness.close);
     final eventFuture = harness.composition.session.localWireEvents
@@ -46,8 +46,8 @@ void main() {
     pluginRuntime.emitRuntimeState(pluginId: "one", state: runtime.PluginRuntimeState.degraded);
 
     final event = await eventFuture.timeout(const Duration(seconds: 2));
-    expect(event.revision, 1);
-    expect(harness.lifecycleService.managementSnapshot.revision, event.revision);
+    expect(event.snapshotToken, hasLength(22));
+    expect(harness.lifecycleService.managementSnapshot.snapshotToken, event.snapshotToken);
   });
 
   test("a sourced reconnect reconciles its active plugin and local events are already mapped", () async {

--- a/bridge/app/test/bridge/routing/get_plugin_management_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_plugin_management_handler_test.dart
@@ -31,6 +31,7 @@ void main() {
 }
 
 const _response = PluginManagementResponse(
+  snapshotToken: "snapshot-token",
   defaultPluginId: "one",
   defaultIdleTimeoutMins: 10,
   plugins: [

--- a/bridge/app/test/helpers/plugin_runtime_test_support.dart
+++ b/bridge/app/test/helpers/plugin_runtime_test_support.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:rxdart/rxdart.dart";
 import "package:sesori_bridge/src/bridge/runtime/plugin_generation_factory.dart";
 import "package:sesori_bridge/src/bridge/runtime/plugin_runtime.dart";
@@ -50,6 +52,8 @@ class TestPluginRuntime extends PluginRuntime {
 
   final Map<String, BridgePluginApi> _plugins;
   final Set<String> _eligiblePluginIds;
+  final Map<String, PluginRuntimeState> _states = {};
+  final StreamController<List<PluginRuntimeSnapshot>> _snapshotChanges = StreamController.broadcast(sync: true);
   bool generationCurrent = true;
   int currentGeneration = 1;
 
@@ -91,7 +95,13 @@ class TestPluginRuntime extends PluginRuntime {
   ];
 
   @override
-  Stream<List<PluginRuntimeSnapshot>> get snapshots => Stream.value(snapshot);
+  Stream<List<PluginRuntimeSnapshot>> get snapshots => Rx.concat([Stream.value(snapshot), _snapshotChanges.stream]);
+
+  void emitRuntimeState({required String pluginId, required PluginRuntimeState state}) {
+    if (!_plugins.containsKey(pluginId)) throw ArgumentError.value(pluginId, "pluginId", "is not registered");
+    _states[pluginId] = state;
+    _snapshotChanges.add(snapshot);
+  }
 
   @override
   Stream<SourcedPluginRuntimeEvent> get backendEvents {
@@ -110,7 +120,9 @@ class TestPluginRuntime extends PluginRuntime {
   ]);
 
   @override
-  Future<void> dispose() async {}
+  Future<void> dispose() async {
+    if (!_snapshotChanges.isClosed) await _snapshotChanges.close();
+  }
 
   @override
   Future<T> use<T>({
@@ -193,7 +205,7 @@ class TestPluginRuntime extends PluginRuntime {
       eligible: true,
       startAllowed: true,
       generation: currentGeneration,
-      state: PluginRuntimeState.active,
+      state: _states[plugin.id] ?? PluginRuntimeState.active,
       workState: PluginWorkState.idle,
       leaseCount: 0,
       transition: PluginRuntimeTransition.none,

--- a/bridge/app/test/helpers/plugin_runtime_test_support.dart
+++ b/bridge/app/test/helpers/plugin_runtime_test_support.dart
@@ -53,6 +53,7 @@ class TestPluginRuntime extends PluginRuntime {
   final Map<String, BridgePluginApi> _plugins;
   final Set<String> _eligiblePluginIds;
   final Map<String, PluginRuntimeState> _states = {};
+  final Map<String, PluginRuntimeTransition> _transitions = {};
   final StreamController<List<PluginRuntimeSnapshot>> _snapshotChanges = StreamController.broadcast(sync: true);
   bool generationCurrent = true;
   int currentGeneration = 1;
@@ -97,9 +98,14 @@ class TestPluginRuntime extends PluginRuntime {
   @override
   Stream<List<PluginRuntimeSnapshot>> get snapshots => Rx.concat([Stream.value(snapshot), _snapshotChanges.stream]);
 
-  void emitRuntimeState({required String pluginId, required PluginRuntimeState state}) {
+  void emitRuntimeState({
+    required String pluginId,
+    required PluginRuntimeState state,
+    PluginRuntimeTransition transition = PluginRuntimeTransition.none,
+  }) {
     if (!_plugins.containsKey(pluginId)) throw ArgumentError.value(pluginId, "pluginId", "is not registered");
     _states[pluginId] = state;
+    _transitions[pluginId] = transition;
     _snapshotChanges.add(snapshot);
   }
 
@@ -208,7 +214,7 @@ class TestPluginRuntime extends PluginRuntime {
       state: _states[plugin.id] ?? PluginRuntimeState.active,
       workState: PluginWorkState.idle,
       leaseCount: 0,
-      transition: PluginRuntimeTransition.none,
+      transition: _transitions[plugin.id] ?? PluginRuntimeTransition.none,
     );
   }
 }

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -242,7 +242,7 @@ void main() {
     expect(runtime.activePluginIds, isEmpty);
   });
 
-  test("management revisions publish only settled externally visible changes", () async {
+  test("management snapshot tokens publish only externally visible changes", () async {
     final runtime = createRegisteredTestPluginRuntime(pluginIds: const ["alpha"]);
     final service =
         _service(
@@ -258,23 +258,75 @@ void main() {
       await service.dispose();
       await runtime.dispose();
     });
-    final revisions = <int>[];
-    final subscription = service.managementRevisions.listen(revisions.add);
+    final snapshotTokens = <String>[];
+    final subscription = service.managementSnapshotTokens.listen(snapshotTokens.add);
     addTearDown(subscription.cancel);
 
-    expect(service.managementSnapshot.revision, 0);
+    final initialToken = service.managementSnapshot.snapshotToken;
+    expect(initialToken, isNotNull);
+    expect(initialToken, hasLength(22));
 
     service.applyAvailability(availablePluginIds: const {});
     await Future<void>.delayed(Duration.zero);
 
-    expect(revisions, [1]);
-    expect(service.managementSnapshot.revision, 1);
+    expect(snapshotTokens, hasLength(1));
+    expect(service.managementSnapshot.snapshotToken, snapshotTokens.single);
+    expect(snapshotTokens.single, isNot(initialToken));
     expect(service.managementSnapshot.plugins.single.runtimeState, shared.PluginRuntimeState.blocked);
 
     service.applyAvailability(availablePluginIds: const {});
     await Future<void>.delayed(Duration.zero);
 
-    expect(revisions, [1]);
+    expect(snapshotTokens, hasLength(1));
+  });
+
+  test("management tokens do not strand transient or unrelated plugin changes", () async {
+    final alpha = _FakePluginApi(id: "alpha");
+    final beta = _FakePluginApi(id: "beta");
+    final runtime = createTestPluginRuntime(plugins: [alpha, beta]);
+    final service =
+        _service(
+          runtime: runtime,
+          plugins: const [
+            (id: "alpha", displayName: "Alpha", residencyPolicy: PluginResidencyPolicy.transient),
+            (id: "beta", displayName: "Beta", residencyPolicy: PluginResidencyPolicy.transient),
+          ],
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"alpha": PluginSetupReady(), "beta": PluginSetupReady()},
+        );
+    addTearDown(() async {
+      await service.dispose();
+      await runtime.dispose();
+    });
+    final snapshotTokens = <String>[];
+    final subscription = service.managementSnapshotTokens.listen(snapshotTokens.add);
+    addTearDown(subscription.cancel);
+    final initialToken = service.managementSnapshot.snapshotToken;
+    await Future<void>.delayed(Duration.zero);
+
+    runtime.emitRuntimeState(
+      pluginId: "alpha",
+      state: PluginRuntimeState.starting,
+      transition: PluginRuntimeTransition.starting,
+    );
+
+    expect(service.managementSnapshot.plugins.first.runtimeState, shared.PluginRuntimeState.starting);
+    expect(snapshotTokens, hasLength(1));
+    expect(service.managementSnapshot.snapshotToken, snapshotTokens.last);
+
+    runtime.emitRuntimeState(pluginId: "beta", state: PluginRuntimeState.degraded);
+
+    expect(service.managementSnapshot.plugins.last.runtimeState, shared.PluginRuntimeState.degraded);
+    expect(snapshotTokens, hasLength(2));
+    expect(service.managementSnapshot.snapshotToken, snapshotTokens.last);
+
+    runtime.emitRuntimeState(pluginId: "alpha", state: PluginRuntimeState.active);
+
+    expect(service.managementSnapshot.plugins.first.runtimeState, shared.PluginRuntimeState.active);
+    expect(snapshotTokens, hasLength(3));
+    expect(service.managementSnapshot.snapshotToken, snapshotTokens.last);
+    expect({initialToken, ...snapshotTokens}, hasLength(4));
   });
 
   test("runtime snapshots drive selectable metadata and derived default", () async {

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -97,8 +97,7 @@ void main() {
   });
 
   test("falls back when setup-ready OpenCode is not currently selectable", () async {
-    final alpha = _FakePluginApi(id: "alpha");
-    final runtime = createTestPluginRuntime(plugins: [alpha]);
+    final runtime = createRegisteredTestPluginRuntime(pluginIds: const ["opencode", "alpha"]);
     addTearDown(runtime.dispose);
     final service = _service(
       runtime: runtime,
@@ -116,6 +115,7 @@ void main() {
         "alpha": PluginSetupReady(),
       },
     );
+    service.applyAvailability(availablePluginIds: const {"alpha"});
     await Future<void>.delayed(Duration.zero);
 
     expect(policy.defaultPluginId, "opencode");
@@ -240,6 +240,41 @@ void main() {
     expect(opencode.hasIdleTimeoutOverride, isTrue);
     expect(settingsRepository.currentSettings.plugins.idleTimeoutMinsFor(pluginId: "opencode"), 45);
     expect(runtime.activePluginIds, isEmpty);
+  });
+
+  test("management revisions publish only settled externally visible changes", () async {
+    final runtime = createRegisteredTestPluginRuntime(pluginIds: const ["alpha"]);
+    final service =
+        _service(
+          runtime: runtime,
+          plugins: const [
+            (id: "alpha", displayName: "Alpha", residencyPolicy: PluginResidencyPolicy.transient),
+          ],
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"alpha": PluginSetupReady()},
+        );
+    addTearDown(() async {
+      await service.dispose();
+      await runtime.dispose();
+    });
+    final revisions = <int>[];
+    final subscription = service.managementRevisions.listen(revisions.add);
+    addTearDown(subscription.cancel);
+
+    expect(service.managementSnapshot.revision, 0);
+
+    service.applyAvailability(availablePluginIds: const {});
+    await Future<void>.delayed(Duration.zero);
+
+    expect(revisions, [1]);
+    expect(service.managementSnapshot.revision, 1);
+    expect(service.managementSnapshot.plugins.single.runtimeState, shared.PluginRuntimeState.blocked);
+
+    service.applyAvailability(availablePluginIds: const {});
+    await Future<void>.delayed(Duration.zero);
+
+    expect(revisions, [1]);
   });
 
   test("runtime snapshots drive selectable metadata and derived default", () async {

--- a/client/module_core/lib/src/capabilities/server_connection/models/sse_event.dart
+++ b/client/module_core/lib/src/capabilities/server_connection/models/sse_event.dart
@@ -36,6 +36,7 @@ class SseEvent {
     SesoriServerInstanceDisposed() ||
     SesoriGlobalDisposed() ||
     SesoriCatalogImportProgress() ||
+    SesoriPluginManagementChanged() ||
     SesoriPtyCreated() ||
     SesoriPtyUpdated() ||
     SesoriPtyExited() ||

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -538,6 +538,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
       SesoriServerInstanceDisposed() ||
       SesoriGlobalDisposed() ||
       SesoriCatalogImportProgress() ||
+      SesoriPluginManagementChanged() ||
       SesoriSessionDeleted() ||
       SesoriSessionDiff() ||
       SesoriSessionError() ||
@@ -620,6 +621,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
             SesoriServerInstanceDisposed() ||
             SesoriGlobalDisposed() ||
             SesoriCatalogImportProgress() ||
+            SesoriPluginManagementChanged() ||
             SesoriMessageUpdated() ||
             SesoriMessageRemoved() ||
             SesoriMessagePartUpdated() ||

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -118,6 +118,7 @@ class SessionListCubit extends Cubit<SessionListState> {
             SesoriServerInstanceDisposed() ||
             SesoriGlobalDisposed() ||
             SesoriCatalogImportProgress() ||
+            SesoriPluginManagementChanged() ||
             SesoriSessionDiff() ||
             SesoriSessionError() ||
             SesoriSessionCompacted() ||

--- a/client/module_core/lib/src/services/sse_event_tracker.dart
+++ b/client/module_core/lib/src/services/sse_event_tracker.dart
@@ -104,6 +104,7 @@ class SseEventTracker with Disposable {
             SesoriServerInstanceDisposed() ||
             SesoriGlobalDisposed() ||
             SesoriCatalogImportProgress() ||
+            SesoriPluginManagementChanged() ||
             SesoriSessionDiff() ||
             SesoriSessionError() ||
             SesoriSessionCompacted() ||

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.dart
@@ -59,6 +59,10 @@ sealed class PluginManagementMetadata with _$PluginManagementMetadata {
 @Freezed(fromJson: true, toJson: true)
 sealed class PluginManagementResponse with _$PluginManagementResponse {
   const factory PluginManagementResponse({
+    // COMPATIBILITY 2026-07-25 (v1.6.1): Stage 12-P02 and older bridge payloads
+    // omit revision; default to the initial process revision. Remove when those
+    // bridge versions are unsupported.
+    @Default(0) int revision,
     required String? defaultPluginId,
     required int defaultIdleTimeoutMins,
     required List<PluginManagementMetadata> plugins,

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.dart
@@ -60,9 +60,9 @@ sealed class PluginManagementMetadata with _$PluginManagementMetadata {
 sealed class PluginManagementResponse with _$PluginManagementResponse {
   const factory PluginManagementResponse({
     // COMPATIBILITY 2026-07-25 (v1.6.1): Stage 12-P02 and older bridge payloads
-    // omit revision; default to the initial process revision. Remove when those
-    // bridge versions are unsupported.
-    @Default(0) int revision,
+    // omit snapshotToken; null means that peer cannot identify snapshot changes.
+    // Make non-null when those bridge versions are unsupported.
+    required String? snapshotToken,
     required String? defaultPluginId,
     required int defaultIdleTimeoutMins,
     required List<PluginManagementMetadata> plugins,

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.freezed.dart
@@ -182,7 +182,8 @@ $PluginSetupMetadataCopyWith<$Res> get setup {
 /// @nodoc
 mixin _$PluginManagementResponse {
 
- String? get defaultPluginId; int get defaultIdleTimeoutMins; List<PluginManagementMetadata> get plugins;
+// COMPATIBILITY 2026-07-25 (v1.6.1): Stage 12-P02 and older bridge payloads omit revision; default to the initial process revision. Remove when those bridge versions are unsupported.
+ int get revision; String? get defaultPluginId; int get defaultIdleTimeoutMins; List<PluginManagementMetadata> get plugins;
 /// Create a copy of PluginManagementResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -195,16 +196,16 @@ $PluginManagementResponseCopyWith<PluginManagementResponse> get copyWith => _$Pl
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginManagementResponse&&(identical(other.defaultPluginId, defaultPluginId) || other.defaultPluginId == defaultPluginId)&&(identical(other.defaultIdleTimeoutMins, defaultIdleTimeoutMins) || other.defaultIdleTimeoutMins == defaultIdleTimeoutMins)&&const DeepCollectionEquality().equals(other.plugins, plugins));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginManagementResponse&&(identical(other.revision, revision) || other.revision == revision)&&(identical(other.defaultPluginId, defaultPluginId) || other.defaultPluginId == defaultPluginId)&&(identical(other.defaultIdleTimeoutMins, defaultIdleTimeoutMins) || other.defaultIdleTimeoutMins == defaultIdleTimeoutMins)&&const DeepCollectionEquality().equals(other.plugins, plugins));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,defaultPluginId,defaultIdleTimeoutMins,const DeepCollectionEquality().hash(plugins));
+int get hashCode => Object.hash(runtimeType,revision,defaultPluginId,defaultIdleTimeoutMins,const DeepCollectionEquality().hash(plugins));
 
 @override
 String toString() {
-  return 'PluginManagementResponse(defaultPluginId: $defaultPluginId, defaultIdleTimeoutMins: $defaultIdleTimeoutMins, plugins: $plugins)';
+  return 'PluginManagementResponse(revision: $revision, defaultPluginId: $defaultPluginId, defaultIdleTimeoutMins: $defaultIdleTimeoutMins, plugins: $plugins)';
 }
 
 
@@ -215,7 +216,7 @@ abstract mixin class $PluginManagementResponseCopyWith<$Res>  {
   factory $PluginManagementResponseCopyWith(PluginManagementResponse value, $Res Function(PluginManagementResponse) _then) = _$PluginManagementResponseCopyWithImpl;
 @useResult
 $Res call({
- String? defaultPluginId, int defaultIdleTimeoutMins, List<PluginManagementMetadata> plugins
+ int revision, String? defaultPluginId, int defaultIdleTimeoutMins, List<PluginManagementMetadata> plugins
 });
 
 
@@ -232,9 +233,10 @@ class _$PluginManagementResponseCopyWithImpl<$Res>
 
 /// Create a copy of PluginManagementResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? defaultPluginId = freezed,Object? defaultIdleTimeoutMins = null,Object? plugins = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? revision = null,Object? defaultPluginId = freezed,Object? defaultIdleTimeoutMins = null,Object? plugins = null,}) {
   return _then(_self.copyWith(
-defaultPluginId: freezed == defaultPluginId ? _self.defaultPluginId : defaultPluginId // ignore: cast_nullable_to_non_nullable
+revision: null == revision ? _self.revision : revision // ignore: cast_nullable_to_non_nullable
+as int,defaultPluginId: freezed == defaultPluginId ? _self.defaultPluginId : defaultPluginId // ignore: cast_nullable_to_non_nullable
 as String?,defaultIdleTimeoutMins: null == defaultIdleTimeoutMins ? _self.defaultIdleTimeoutMins : defaultIdleTimeoutMins // ignore: cast_nullable_to_non_nullable
 as int,plugins: null == plugins ? _self.plugins : plugins // ignore: cast_nullable_to_non_nullable
 as List<PluginManagementMetadata>,
@@ -249,9 +251,11 @@ as List<PluginManagementMetadata>,
 @JsonSerializable()
 
 class _PluginManagementResponse implements PluginManagementResponse {
-  const _PluginManagementResponse({required this.defaultPluginId, required this.defaultIdleTimeoutMins, required final  List<PluginManagementMetadata> plugins}): _plugins = plugins;
+  const _PluginManagementResponse({this.revision = 0, required this.defaultPluginId, required this.defaultIdleTimeoutMins, required final  List<PluginManagementMetadata> plugins}): _plugins = plugins;
   factory _PluginManagementResponse.fromJson(Map<String, dynamic> json) => _$PluginManagementResponseFromJson(json);
 
+// COMPATIBILITY 2026-07-25 (v1.6.1): Stage 12-P02 and older bridge payloads omit revision; default to the initial process revision. Remove when those bridge versions are unsupported.
+@override@JsonKey() final  int revision;
 @override final  String? defaultPluginId;
 @override final  int defaultIdleTimeoutMins;
  final  List<PluginManagementMetadata> _plugins;
@@ -275,16 +279,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginManagementResponse&&(identical(other.defaultPluginId, defaultPluginId) || other.defaultPluginId == defaultPluginId)&&(identical(other.defaultIdleTimeoutMins, defaultIdleTimeoutMins) || other.defaultIdleTimeoutMins == defaultIdleTimeoutMins)&&const DeepCollectionEquality().equals(other._plugins, _plugins));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginManagementResponse&&(identical(other.revision, revision) || other.revision == revision)&&(identical(other.defaultPluginId, defaultPluginId) || other.defaultPluginId == defaultPluginId)&&(identical(other.defaultIdleTimeoutMins, defaultIdleTimeoutMins) || other.defaultIdleTimeoutMins == defaultIdleTimeoutMins)&&const DeepCollectionEquality().equals(other._plugins, _plugins));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,defaultPluginId,defaultIdleTimeoutMins,const DeepCollectionEquality().hash(_plugins));
+int get hashCode => Object.hash(runtimeType,revision,defaultPluginId,defaultIdleTimeoutMins,const DeepCollectionEquality().hash(_plugins));
 
 @override
 String toString() {
-  return 'PluginManagementResponse(defaultPluginId: $defaultPluginId, defaultIdleTimeoutMins: $defaultIdleTimeoutMins, plugins: $plugins)';
+  return 'PluginManagementResponse(revision: $revision, defaultPluginId: $defaultPluginId, defaultIdleTimeoutMins: $defaultIdleTimeoutMins, plugins: $plugins)';
 }
 
 
@@ -295,7 +299,7 @@ abstract mixin class _$PluginManagementResponseCopyWith<$Res> implements $Plugin
   factory _$PluginManagementResponseCopyWith(_PluginManagementResponse value, $Res Function(_PluginManagementResponse) _then) = __$PluginManagementResponseCopyWithImpl;
 @override @useResult
 $Res call({
- String? defaultPluginId, int defaultIdleTimeoutMins, List<PluginManagementMetadata> plugins
+ int revision, String? defaultPluginId, int defaultIdleTimeoutMins, List<PluginManagementMetadata> plugins
 });
 
 
@@ -312,9 +316,10 @@ class __$PluginManagementResponseCopyWithImpl<$Res>
 
 /// Create a copy of PluginManagementResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? defaultPluginId = freezed,Object? defaultIdleTimeoutMins = null,Object? plugins = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? revision = null,Object? defaultPluginId = freezed,Object? defaultIdleTimeoutMins = null,Object? plugins = null,}) {
   return _then(_PluginManagementResponse(
-defaultPluginId: freezed == defaultPluginId ? _self.defaultPluginId : defaultPluginId // ignore: cast_nullable_to_non_nullable
+revision: null == revision ? _self.revision : revision // ignore: cast_nullable_to_non_nullable
+as int,defaultPluginId: freezed == defaultPluginId ? _self.defaultPluginId : defaultPluginId // ignore: cast_nullable_to_non_nullable
 as String?,defaultIdleTimeoutMins: null == defaultIdleTimeoutMins ? _self.defaultIdleTimeoutMins : defaultIdleTimeoutMins // ignore: cast_nullable_to_non_nullable
 as int,plugins: null == plugins ? _self._plugins : plugins // ignore: cast_nullable_to_non_nullable
 as List<PluginManagementMetadata>,

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.freezed.dart
@@ -182,8 +182,10 @@ $PluginSetupMetadataCopyWith<$Res> get setup {
 /// @nodoc
 mixin _$PluginManagementResponse {
 
-// COMPATIBILITY 2026-07-25 (v1.6.1): Stage 12-P02 and older bridge payloads omit revision; default to the initial process revision. Remove when those bridge versions are unsupported.
- int get revision; String? get defaultPluginId; int get defaultIdleTimeoutMins; List<PluginManagementMetadata> get plugins;
+// COMPATIBILITY 2026-07-25 (v1.6.1): Stage 12-P02 and older bridge payloads
+// omit snapshotToken; null means that peer cannot identify snapshot changes.
+// Make non-null when those bridge versions are unsupported.
+ String? get snapshotToken; String? get defaultPluginId; int get defaultIdleTimeoutMins; List<PluginManagementMetadata> get plugins;
 /// Create a copy of PluginManagementResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -196,16 +198,16 @@ $PluginManagementResponseCopyWith<PluginManagementResponse> get copyWith => _$Pl
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginManagementResponse&&(identical(other.revision, revision) || other.revision == revision)&&(identical(other.defaultPluginId, defaultPluginId) || other.defaultPluginId == defaultPluginId)&&(identical(other.defaultIdleTimeoutMins, defaultIdleTimeoutMins) || other.defaultIdleTimeoutMins == defaultIdleTimeoutMins)&&const DeepCollectionEquality().equals(other.plugins, plugins));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginManagementResponse&&(identical(other.snapshotToken, snapshotToken) || other.snapshotToken == snapshotToken)&&(identical(other.defaultPluginId, defaultPluginId) || other.defaultPluginId == defaultPluginId)&&(identical(other.defaultIdleTimeoutMins, defaultIdleTimeoutMins) || other.defaultIdleTimeoutMins == defaultIdleTimeoutMins)&&const DeepCollectionEquality().equals(other.plugins, plugins));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,revision,defaultPluginId,defaultIdleTimeoutMins,const DeepCollectionEquality().hash(plugins));
+int get hashCode => Object.hash(runtimeType,snapshotToken,defaultPluginId,defaultIdleTimeoutMins,const DeepCollectionEquality().hash(plugins));
 
 @override
 String toString() {
-  return 'PluginManagementResponse(revision: $revision, defaultPluginId: $defaultPluginId, defaultIdleTimeoutMins: $defaultIdleTimeoutMins, plugins: $plugins)';
+  return 'PluginManagementResponse(snapshotToken: $snapshotToken, defaultPluginId: $defaultPluginId, defaultIdleTimeoutMins: $defaultIdleTimeoutMins, plugins: $plugins)';
 }
 
 
@@ -216,7 +218,7 @@ abstract mixin class $PluginManagementResponseCopyWith<$Res>  {
   factory $PluginManagementResponseCopyWith(PluginManagementResponse value, $Res Function(PluginManagementResponse) _then) = _$PluginManagementResponseCopyWithImpl;
 @useResult
 $Res call({
- int revision, String? defaultPluginId, int defaultIdleTimeoutMins, List<PluginManagementMetadata> plugins
+ String? snapshotToken, String? defaultPluginId, int defaultIdleTimeoutMins, List<PluginManagementMetadata> plugins
 });
 
 
@@ -233,10 +235,10 @@ class _$PluginManagementResponseCopyWithImpl<$Res>
 
 /// Create a copy of PluginManagementResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? revision = null,Object? defaultPluginId = freezed,Object? defaultIdleTimeoutMins = null,Object? plugins = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? snapshotToken = freezed,Object? defaultPluginId = freezed,Object? defaultIdleTimeoutMins = null,Object? plugins = null,}) {
   return _then(_self.copyWith(
-revision: null == revision ? _self.revision : revision // ignore: cast_nullable_to_non_nullable
-as int,defaultPluginId: freezed == defaultPluginId ? _self.defaultPluginId : defaultPluginId // ignore: cast_nullable_to_non_nullable
+snapshotToken: freezed == snapshotToken ? _self.snapshotToken : snapshotToken // ignore: cast_nullable_to_non_nullable
+as String?,defaultPluginId: freezed == defaultPluginId ? _self.defaultPluginId : defaultPluginId // ignore: cast_nullable_to_non_nullable
 as String?,defaultIdleTimeoutMins: null == defaultIdleTimeoutMins ? _self.defaultIdleTimeoutMins : defaultIdleTimeoutMins // ignore: cast_nullable_to_non_nullable
 as int,plugins: null == plugins ? _self.plugins : plugins // ignore: cast_nullable_to_non_nullable
 as List<PluginManagementMetadata>,
@@ -251,11 +253,13 @@ as List<PluginManagementMetadata>,
 @JsonSerializable()
 
 class _PluginManagementResponse implements PluginManagementResponse {
-  const _PluginManagementResponse({this.revision = 0, required this.defaultPluginId, required this.defaultIdleTimeoutMins, required final  List<PluginManagementMetadata> plugins}): _plugins = plugins;
+  const _PluginManagementResponse({required this.snapshotToken, required this.defaultPluginId, required this.defaultIdleTimeoutMins, required final  List<PluginManagementMetadata> plugins}): _plugins = plugins;
   factory _PluginManagementResponse.fromJson(Map<String, dynamic> json) => _$PluginManagementResponseFromJson(json);
 
-// COMPATIBILITY 2026-07-25 (v1.6.1): Stage 12-P02 and older bridge payloads omit revision; default to the initial process revision. Remove when those bridge versions are unsupported.
-@override@JsonKey() final  int revision;
+// COMPATIBILITY 2026-07-25 (v1.6.1): Stage 12-P02 and older bridge payloads
+// omit snapshotToken; null means that peer cannot identify snapshot changes.
+// Make non-null when those bridge versions are unsupported.
+@override final  String? snapshotToken;
 @override final  String? defaultPluginId;
 @override final  int defaultIdleTimeoutMins;
  final  List<PluginManagementMetadata> _plugins;
@@ -279,16 +283,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginManagementResponse&&(identical(other.revision, revision) || other.revision == revision)&&(identical(other.defaultPluginId, defaultPluginId) || other.defaultPluginId == defaultPluginId)&&(identical(other.defaultIdleTimeoutMins, defaultIdleTimeoutMins) || other.defaultIdleTimeoutMins == defaultIdleTimeoutMins)&&const DeepCollectionEquality().equals(other._plugins, _plugins));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginManagementResponse&&(identical(other.snapshotToken, snapshotToken) || other.snapshotToken == snapshotToken)&&(identical(other.defaultPluginId, defaultPluginId) || other.defaultPluginId == defaultPluginId)&&(identical(other.defaultIdleTimeoutMins, defaultIdleTimeoutMins) || other.defaultIdleTimeoutMins == defaultIdleTimeoutMins)&&const DeepCollectionEquality().equals(other._plugins, _plugins));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,revision,defaultPluginId,defaultIdleTimeoutMins,const DeepCollectionEquality().hash(_plugins));
+int get hashCode => Object.hash(runtimeType,snapshotToken,defaultPluginId,defaultIdleTimeoutMins,const DeepCollectionEquality().hash(_plugins));
 
 @override
 String toString() {
-  return 'PluginManagementResponse(revision: $revision, defaultPluginId: $defaultPluginId, defaultIdleTimeoutMins: $defaultIdleTimeoutMins, plugins: $plugins)';
+  return 'PluginManagementResponse(snapshotToken: $snapshotToken, defaultPluginId: $defaultPluginId, defaultIdleTimeoutMins: $defaultIdleTimeoutMins, plugins: $plugins)';
 }
 
 
@@ -299,7 +303,7 @@ abstract mixin class _$PluginManagementResponseCopyWith<$Res> implements $Plugin
   factory _$PluginManagementResponseCopyWith(_PluginManagementResponse value, $Res Function(_PluginManagementResponse) _then) = __$PluginManagementResponseCopyWithImpl;
 @override @useResult
 $Res call({
- int revision, String? defaultPluginId, int defaultIdleTimeoutMins, List<PluginManagementMetadata> plugins
+ String? snapshotToken, String? defaultPluginId, int defaultIdleTimeoutMins, List<PluginManagementMetadata> plugins
 });
 
 
@@ -316,10 +320,10 @@ class __$PluginManagementResponseCopyWithImpl<$Res>
 
 /// Create a copy of PluginManagementResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? revision = null,Object? defaultPluginId = freezed,Object? defaultIdleTimeoutMins = null,Object? plugins = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? snapshotToken = freezed,Object? defaultPluginId = freezed,Object? defaultIdleTimeoutMins = null,Object? plugins = null,}) {
   return _then(_PluginManagementResponse(
-revision: null == revision ? _self.revision : revision // ignore: cast_nullable_to_non_nullable
-as int,defaultPluginId: freezed == defaultPluginId ? _self.defaultPluginId : defaultPluginId // ignore: cast_nullable_to_non_nullable
+snapshotToken: freezed == snapshotToken ? _self.snapshotToken : snapshotToken // ignore: cast_nullable_to_non_nullable
+as String?,defaultPluginId: freezed == defaultPluginId ? _self.defaultPluginId : defaultPluginId // ignore: cast_nullable_to_non_nullable
 as String?,defaultIdleTimeoutMins: null == defaultIdleTimeoutMins ? _self.defaultIdleTimeoutMins : defaultIdleTimeoutMins // ignore: cast_nullable_to_non_nullable
 as int,plugins: null == plugins ? _self._plugins : plugins // ignore: cast_nullable_to_non_nullable
 as List<PluginManagementMetadata>,

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.g.dart
@@ -57,7 +57,7 @@ const _$PluginManagementWorkStateEnumMap = {
 
 _PluginManagementResponse _$PluginManagementResponseFromJson(Map json) =>
     _PluginManagementResponse(
-      revision: (json['revision'] as num?)?.toInt() ?? 0,
+      snapshotToken: json['snapshotToken'] as String?,
       defaultPluginId: json['defaultPluginId'] as String?,
       defaultIdleTimeoutMins: (json['defaultIdleTimeoutMins'] as num).toInt(),
       plugins: (json['plugins'] as List<dynamic>)
@@ -72,7 +72,7 @@ _PluginManagementResponse _$PluginManagementResponseFromJson(Map json) =>
 Map<String, dynamic> _$PluginManagementResponseToJson(
   _PluginManagementResponse instance,
 ) => <String, dynamic>{
-  'revision': instance.revision,
+  'snapshotToken': ?instance.snapshotToken,
   'defaultPluginId': ?instance.defaultPluginId,
   'defaultIdleTimeoutMins': instance.defaultIdleTimeoutMins,
   'plugins': instance.plugins.map((e) => e.toJson()).toList(),

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.g.dart
@@ -57,6 +57,7 @@ const _$PluginManagementWorkStateEnumMap = {
 
 _PluginManagementResponse _$PluginManagementResponseFromJson(Map json) =>
     _PluginManagementResponse(
+      revision: (json['revision'] as num?)?.toInt() ?? 0,
       defaultPluginId: json['defaultPluginId'] as String?,
       defaultIdleTimeoutMins: (json['defaultIdleTimeoutMins'] as num).toInt(),
       plugins: (json['plugins'] as List<dynamic>)
@@ -71,6 +72,7 @@ _PluginManagementResponse _$PluginManagementResponseFromJson(Map json) =>
 Map<String, dynamic> _$PluginManagementResponseToJson(
   _PluginManagementResponse instance,
 ) => <String, dynamic>{
+  'revision': instance.revision,
   'defaultPluginId': ?instance.defaultPluginId,
   'defaultIdleTimeoutMins': instance.defaultIdleTimeoutMins,
   'plugins': instance.plugins.map((e) => e.toJson()).toList(),

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
@@ -50,6 +50,11 @@ sealed class SesoriSseEvent with _$SesoriSseEvent {
     required CatalogImportProgress progress,
   }) = SesoriCatalogImportProgress;
 
+  @FreezedUnionValue("plugin.management.changed")
+  const factory SesoriSseEvent.pluginManagementChanged({
+    required int revision,
+  }) = SesoriPluginManagementChanged;
+
   // ---------------------------------------------------------------------------
   // Session — all implement SesoriSessionEvent
   // ---------------------------------------------------------------------------

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
@@ -52,7 +52,7 @@ sealed class SesoriSseEvent with _$SesoriSseEvent {
 
   @FreezedUnionValue("plugin.management.changed")
   const factory SesoriSseEvent.pluginManagementChanged({
-    required int revision,
+    required String snapshotToken,
   }) = SesoriPluginManagementChanged;
 
   // ---------------------------------------------------------------------------

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.freezed.dart
@@ -35,6 +35,10 @@ SesoriSseEvent _$SesoriSseEventFromJson(
           return SesoriCatalogImportProgress.fromJson(
             json
           );
+                case 'plugin.management.changed':
+          return SesoriPluginManagementChanged.fromJson(
+            json
+          );
                 case 'session.created':
           return SesoriSessionCreated.fromJson(
             json
@@ -509,6 +513,79 @@ class _$SesoriCatalogImportProgressCopyWithImpl<$Res>
   return _then(SesoriCatalogImportProgress(
 progress: null == progress ? _self.progress : progress // ignore: cast_nullable_to_non_nullable
 as CatalogImportProgress,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class SesoriPluginManagementChanged implements SesoriSseEvent {
+  const SesoriPluginManagementChanged({required this.revision, final  String? $type}): $type = $type ?? 'plugin.management.changed';
+  factory SesoriPluginManagementChanged.fromJson(Map<String, dynamic> json) => _$SesoriPluginManagementChangedFromJson(json);
+
+ final  int revision;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of SesoriSseEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SesoriPluginManagementChangedCopyWith<SesoriPluginManagementChanged> get copyWith => _$SesoriPluginManagementChangedCopyWithImpl<SesoriPluginManagementChanged>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SesoriPluginManagementChangedToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SesoriPluginManagementChanged&&(identical(other.revision, revision) || other.revision == revision));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,revision);
+
+@override
+String toString() {
+  return 'SesoriSseEvent.pluginManagementChanged(revision: $revision)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SesoriPluginManagementChangedCopyWith<$Res> implements $SesoriSseEventCopyWith<$Res> {
+  factory $SesoriPluginManagementChangedCopyWith(SesoriPluginManagementChanged value, $Res Function(SesoriPluginManagementChanged) _then) = _$SesoriPluginManagementChangedCopyWithImpl;
+@useResult
+$Res call({
+ int revision
+});
+
+
+
+
+}
+/// @nodoc
+class _$SesoriPluginManagementChangedCopyWithImpl<$Res>
+    implements $SesoriPluginManagementChangedCopyWith<$Res> {
+  _$SesoriPluginManagementChangedCopyWithImpl(this._self, this._then);
+
+  final SesoriPluginManagementChanged _self;
+  final $Res Function(SesoriPluginManagementChanged) _then;
+
+/// Create a copy of SesoriSseEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? revision = null,}) {
+  return _then(SesoriPluginManagementChanged(
+revision: null == revision ? _self.revision : revision // ignore: cast_nullable_to_non_nullable
+as int,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.freezed.dart
@@ -523,10 +523,10 @@ as CatalogImportProgress,
 @JsonSerializable()
 
 class SesoriPluginManagementChanged implements SesoriSseEvent {
-  const SesoriPluginManagementChanged({required this.revision, final  String? $type}): $type = $type ?? 'plugin.management.changed';
+  const SesoriPluginManagementChanged({required this.snapshotToken, final  String? $type}): $type = $type ?? 'plugin.management.changed';
   factory SesoriPluginManagementChanged.fromJson(Map<String, dynamic> json) => _$SesoriPluginManagementChangedFromJson(json);
 
- final  int revision;
+ final  String snapshotToken;
 
 @JsonKey(name: 'type')
 final String $type;
@@ -545,16 +545,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SesoriPluginManagementChanged&&(identical(other.revision, revision) || other.revision == revision));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SesoriPluginManagementChanged&&(identical(other.snapshotToken, snapshotToken) || other.snapshotToken == snapshotToken));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,revision);
+int get hashCode => Object.hash(runtimeType,snapshotToken);
 
 @override
 String toString() {
-  return 'SesoriSseEvent.pluginManagementChanged(revision: $revision)';
+  return 'SesoriSseEvent.pluginManagementChanged(snapshotToken: $snapshotToken)';
 }
 
 
@@ -565,7 +565,7 @@ abstract mixin class $SesoriPluginManagementChangedCopyWith<$Res> implements $Se
   factory $SesoriPluginManagementChangedCopyWith(SesoriPluginManagementChanged value, $Res Function(SesoriPluginManagementChanged) _then) = _$SesoriPluginManagementChangedCopyWithImpl;
 @useResult
 $Res call({
- int revision
+ String snapshotToken
 });
 
 
@@ -582,10 +582,10 @@ class _$SesoriPluginManagementChangedCopyWithImpl<$Res>
 
 /// Create a copy of SesoriSseEvent
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? revision = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? snapshotToken = null,}) {
   return _then(SesoriPluginManagementChanged(
-revision: null == revision ? _self.revision : revision // ignore: cast_nullable_to_non_nullable
-as int,
+snapshotToken: null == snapshotToken ? _self.snapshotToken : snapshotToken // ignore: cast_nullable_to_non_nullable
+as String,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.g.dart
@@ -55,6 +55,17 @@ Map<String, dynamic> _$SesoriCatalogImportProgressToJson(
   'type': instance.$type,
 };
 
+SesoriPluginManagementChanged _$SesoriPluginManagementChangedFromJson(
+  Map json,
+) => SesoriPluginManagementChanged(
+  revision: (json['revision'] as num).toInt(),
+  $type: json['type'] as String?,
+);
+
+Map<String, dynamic> _$SesoriPluginManagementChangedToJson(
+  SesoriPluginManagementChanged instance,
+) => <String, dynamic>{'revision': instance.revision, 'type': instance.$type};
+
 SesoriSessionCreated _$SesoriSessionCreatedFromJson(Map json) =>
     SesoriSessionCreated(
       info: Session.fromJson(Map<String, dynamic>.from(json['info'] as Map)),

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.g.dart
@@ -58,13 +58,16 @@ Map<String, dynamic> _$SesoriCatalogImportProgressToJson(
 SesoriPluginManagementChanged _$SesoriPluginManagementChangedFromJson(
   Map json,
 ) => SesoriPluginManagementChanged(
-  revision: (json['revision'] as num).toInt(),
+  snapshotToken: json['snapshotToken'] as String,
   $type: json['type'] as String?,
 );
 
 Map<String, dynamic> _$SesoriPluginManagementChangedToJson(
   SesoriPluginManagementChanged instance,
-) => <String, dynamic>{'revision': instance.revision, 'type': instance.$type};
+) => <String, dynamic>{
+  'snapshotToken': instance.snapshotToken,
+  'type': instance.$type,
+};
 
 SesoriSessionCreated _$SesoriSessionCreatedFromJson(Map json) =>
     SesoriSessionCreated(

--- a/shared/sesori_shared/test/models/plugin_management_contract_test.dart
+++ b/shared/sesori_shared/test/models/plugin_management_contract_test.dart
@@ -18,7 +18,7 @@ void main() {
 
   test("management response round-trips only read snapshot fields", () {
     const response = PluginManagementResponse(
-      revision: 7,
+      snapshotToken: "snapshot-token",
       defaultPluginId: "opencode",
       defaultIdleTimeoutMins: 30,
       plugins: [plugin],
@@ -29,26 +29,27 @@ void main() {
     final pluginJson = plugins!.single! as Map<String, dynamic>;
 
     expect(PluginManagementResponse.fromJson(json), response);
-    expect(json.keys, unorderedEquals(["revision", "defaultPluginId", "defaultIdleTimeoutMins", "plugins"]));
+    expect(json.keys, unorderedEquals(["snapshotToken", "defaultPluginId", "defaultIdleTimeoutMins", "plugins"]));
     expect(
       pluginJson.keys,
       unorderedEquals(["setup", "runtimeState", "workState", "idleTimeoutMins", "hasIdleTimeoutOverride"]),
     );
-    expect(json["revision"], 7);
+    expect(json["snapshotToken"], "snapshot-token");
     expect(pluginJson, isNot(contains("enabled")));
     expect(pluginJson, isNot(contains("isDefault")));
     expect(json, isNot(contains("authority")));
     expect(json, isNot(contains("order")));
   });
 
-  test("older management responses default to the initial process revision", () {
+  test("older management responses decode without a snapshot token", () {
     final json = const PluginManagementResponse(
+      snapshotToken: null,
       defaultPluginId: "opencode",
       defaultIdleTimeoutMins: 30,
       plugins: [plugin],
-    ).toJson()..remove("revision");
+    ).toJson()..remove("snapshotToken");
 
-    expect(PluginManagementResponse.fromJson(json).revision, 0);
+    expect(PluginManagementResponse.fromJson(json).snapshotToken, isNull);
   });
 
   test("future runtime and work states decode to fail-closed unknown values", () {

--- a/shared/sesori_shared/test/models/plugin_management_contract_test.dart
+++ b/shared/sesori_shared/test/models/plugin_management_contract_test.dart
@@ -18,6 +18,7 @@ void main() {
 
   test("management response round-trips only read snapshot fields", () {
     const response = PluginManagementResponse(
+      revision: 7,
       defaultPluginId: "opencode",
       defaultIdleTimeoutMins: 30,
       plugins: [plugin],
@@ -28,16 +29,26 @@ void main() {
     final pluginJson = plugins!.single! as Map<String, dynamic>;
 
     expect(PluginManagementResponse.fromJson(json), response);
-    expect(json.keys, unorderedEquals(["defaultPluginId", "defaultIdleTimeoutMins", "plugins"]));
+    expect(json.keys, unorderedEquals(["revision", "defaultPluginId", "defaultIdleTimeoutMins", "plugins"]));
     expect(
       pluginJson.keys,
       unorderedEquals(["setup", "runtimeState", "workState", "idleTimeoutMins", "hasIdleTimeoutOverride"]),
     );
-    expect(json, isNot(contains("revision")));
+    expect(json["revision"], 7);
     expect(pluginJson, isNot(contains("enabled")));
     expect(pluginJson, isNot(contains("isDefault")));
     expect(json, isNot(contains("authority")));
     expect(json, isNot(contains("order")));
+  });
+
+  test("older management responses default to the initial process revision", () {
+    final json = const PluginManagementResponse(
+      defaultPluginId: "opencode",
+      defaultIdleTimeoutMins: 30,
+      plugins: [plugin],
+    ).toJson()..remove("revision");
+
+    expect(PluginManagementResponse.fromJson(json).revision, 0);
   });
 
   test("future runtime and work states decode to fail-closed unknown values", () {

--- a/shared/sesori_shared/test/models/sesori_sse_event_test.dart
+++ b/shared/sesori_shared/test/models/sesori_sse_event_test.dart
@@ -3,12 +3,12 @@ import 'package:sesori_shared/sesori_shared.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('plugin management change round-trips its revision', () {
-    const event = SesoriSseEvent.pluginManagementChanged(revision: 4);
+  test('plugin management change round-trips its snapshot token', () {
+    const event = SesoriSseEvent.pluginManagementChanged(snapshotToken: 'snapshot-token');
 
     final json = event.toJson();
 
-    expect(json, {'type': 'plugin.management.changed', 'revision': 4});
+    expect(json, {'type': 'plugin.management.changed', 'snapshotToken': 'snapshot-token'});
     expect(SesoriSseEvent.fromJson(json), event);
   });
 

--- a/shared/sesori_shared/test/models/sesori_sse_event_test.dart
+++ b/shared/sesori_shared/test/models/sesori_sse_event_test.dart
@@ -3,6 +3,15 @@ import 'package:sesori_shared/sesori_shared.dart';
 import 'package:test/test.dart';
 
 void main() {
+  test('plugin management change round-trips its revision', () {
+    const event = SesoriSseEvent.pluginManagementChanged(revision: 4);
+
+    final json = event.toJson();
+
+    expect(json, {'type': 'plugin.management.changed', 'revision': 4});
+    expect(SesoriSseEvent.fromJson(json), event);
+  });
+
   // ---------------------------------------------------------------------------
   // Round-trip JSON compatibility
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add a backward-compatible opaque snapshot token to plugin management snapshots
- cache every materially changed public snapshot with a fresh random 128-bit base64url token before synchronous invalidation
- publish transient and unrelated-plugin changes independently while keeping SSE conversion in `OrchestratorSession`
- explicitly ignore the new global event in existing session consumers until management state enters the client

## Verification

- shared management and SSE tests (43 passed)
- focused bridge lifecycle, handler, and Orchestrator tests, including token deduplication and transient/unrelated-plugin regressions
- affected module_core SSE/session tests (108 passed)
- `dart analyze --fatal-infos` in `shared/sesori_shared` and `bridge/app`
- `flutter analyze --fatal-infos lib` in `client/module_core` and `client/app`
- `git diff --check`
- final Aristotle implementation review approved with no architecture findings

## Series

Step 3 of 6 for setup-aware plugin management. Step 2 merged in #567.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds snapshot-token invalidation for plugin management and emits `plugin.management.changed` only after a materially changed, cached snapshot is queryable. Baseline initializes only after a complete runtime snapshot; backward compatible (`snapshotToken` may be null) with no client behavior change yet.

- **New Features**
  - `PluginLifecycleService` caches the last `PluginManagementResponse`, exposes `managementSnapshotTokens`, and generates 128-bit base64url tokens; publishes a new token only when the public snapshot changes, and each token identifies exactly the current GET response.
  - `OrchestratorSession` listens to `managementSnapshotTokens` and enqueues `SesoriSseEvent.pluginManagementChanged(snapshotToken: token)`.
  - `shared/sesori_shared` adds `snapshotToken` to `PluginManagementResponse` and `SesoriSseEvent.pluginManagementChanged`; `client/module_core` treats the event as global and ignores it for now.

<sup>Written for commit e764baa2d657dda88cd26b2dbe59d9b81ccdca51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
