### PR TITLE
fix(client): ignore unknown SSE event types

### DIFF
--- a/client/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/client/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -3,6 +3,7 @@ import "dart:convert";
 import "dart:math";
 
 import "package:injectable/injectable.dart";
+import "package:json_annotation/json_annotation.dart" show CheckedFromJsonException;
 import "package:meta/meta.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
@@ -565,6 +566,13 @@ class ConnectionService {
       try {
         eventData = SesoriSseEvent.fromJson(merged);
       } catch (e, st) {
+        // Freezed uses this exception shape only for an unknown top-level union.
+        // Malformed fields in known variants carry an inner error and remain reportable.
+        if (e is CheckedFromJsonException && _isUnknownSseEventType(error: e, type: typeValue)) {
+          logt("Ignoring unknown SSE event type: $typeValue", e, st);
+          return;
+        }
+
         loge("Failed to parse SSE event payload", e, st);
         _failureReporter.recordFailure(
           error: e,
@@ -587,6 +595,15 @@ class ConnectionService {
       loge("Failed to parse SSE frame", e, st);
     }
   }
+
+  bool _isUnknownSseEventType({
+    required CheckedFromJsonException error,
+    required String type,
+  }) =>
+      error.className == "SesoriSseEvent" &&
+      error.key == "type" &&
+      error.innerError == null &&
+      error.map["type"] == type;
 
   /// Tears down the active relay client, coalescing concurrent callers so an
   /// eager teardown (e.g. on resume) and the reconnect path's own teardown share

--- a/client/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/client/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -569,7 +569,7 @@ class ConnectionService {
         // Freezed uses this exception shape only for an unknown top-level union.
         // Malformed fields in known variants carry an inner error and remain reportable.
         if (e is CheckedFromJsonException && _isUnknownSseEventType(error: e, type: typeValue)) {
-          logt("Ignoring unknown SSE event type: $typeValue", e, st);
+          logw("Ignoring unknown SSE event type: $typeValue", e, st);
           return;
         }
 

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -247,7 +247,7 @@ class SessionListCubit extends Cubit<SessionListState> {
   void _onSessionCreated(Session session) {
     // Only add root sessions that belong to this project.
     if (session.parentID != null) {
-      logd("[SessionList] session.created ignored id=${session.id} reason=child");
+      logt("[SessionList] session.created ignored id=${session.id} reason=child");
       return;
     }
     if (session.projectID != _projectId) {
@@ -285,7 +285,7 @@ class SessionListCubit extends Cubit<SessionListState> {
 
     if (index < 0) {
       // Session was unarchived (or created elsewhere) — add it if it belongs here.
-      logd("[SessionList] session.updated not_found id=${session.id} action=add_via_created");
+      logt("[SessionList] session.updated not_found id=${session.id} action=add_via_created");
       _onSessionCreated(session);
       return;
     }

--- a/client/module_core/test/capabilities/server_connection/connection_service_sse_test.dart
+++ b/client/module_core/test/capabilities/server_connection/connection_service_sse_test.dart
@@ -117,7 +117,7 @@ void main() {
 
     test("ignores an unknown event type without reporting and continues", () async {
       final previousLogLevel = logLevel;
-      setLogLevel(LogLevel.trace);
+      setLogLevel(LogLevel.warning);
       addTearDown(() => setLogLevel(previousLogLevel));
 
       final logs = <String>[];

--- a/client/module_core/test/capabilities/server_connection/connection_service_sse_test.dart
+++ b/client/module_core/test/capabilities/server_connection/connection_service_sse_test.dart
@@ -1,0 +1,224 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:mocktail/mocktail.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_dart_core/src/capabilities/relay/relay_client.dart";
+import "package:sesori_dart_core/src/capabilities/relay/room_key_storage.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/connection_service.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/server_connection_config.dart";
+import "package:sesori_dart_core/src/logging/logging.dart";
+import "package:sesori_dart_core/src/platform/lifecycle_source.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+class _MockRelayCryptoService extends Mock implements RelayCryptoService {}
+
+class _MockRoomKeyStorage extends Mock implements RoomKeyStorage {}
+
+class _MockAuthTokenProvider extends Mock implements AuthTokenProvider {}
+
+class _MockAuthSession extends Mock implements AuthSession {}
+
+class _MockLifecycleSource extends Mock implements LifecycleSource {}
+
+class _MockFailureReporter extends Mock implements FailureReporter {}
+
+class _MockRelayClient extends Mock implements RelayClient {}
+
+class _TestRelayClientFactory extends RelayClientFactory {
+  final RelayClient _client;
+
+  _TestRelayClientFactory({required RelayClient client}) : _client = client;
+
+  @override
+  RelayClient call({
+    required String relayHost,
+    required RelayCryptoService cryptoService,
+    required RoomKeyStorage roomKeyStorage,
+    required String? authToken,
+  }) => _client;
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(StackTrace.empty);
+    registerFallbackValue(
+      const RelayRequest(
+        id: "fallback",
+        method: "GET",
+        path: "/health",
+        headers: {},
+        body: null,
+      ),
+    );
+  });
+
+  group("ConnectionService SSE parsing", () {
+    late BehaviorSubject<LifecycleState> lifecycleController;
+    late BehaviorSubject<AuthState> authStateController;
+    late StreamController<RelaySseEvent> sseController;
+    late _MockFailureReporter failureReporter;
+    late ConnectionService service;
+
+    const config = ServerConnectionConfig(
+      relayHost: "relay.example.com",
+      authToken: "token",
+    );
+    const health = HealthResponse(healthy: true, version: "1.0.0", filesystemAccessDegraded: null);
+
+    setUp(() {
+      lifecycleController = BehaviorSubject<LifecycleState>.seeded(LifecycleState.resumed);
+      authStateController = BehaviorSubject<AuthState>.seeded(const AuthState.initial());
+      sseController = StreamController<RelaySseEvent>.broadcast();
+
+      final lifecycleSource = _MockLifecycleSource();
+      final authSession = _MockAuthSession();
+      failureReporter = _MockFailureReporter();
+      final relayClient = _MockRelayClient();
+
+      when(() => lifecycleSource.lifecycleStateStream).thenAnswer((_) => lifecycleController.stream);
+      when(() => authSession.authStateStream).thenAnswer((_) => authStateController.stream);
+      when(relayClient.connect).thenAnswer((_) async {});
+      when(() => relayClient.didResume).thenReturn(false);
+      when(() => relayClient.isConnected).thenReturn(true);
+      when(() => relayClient.connectionState).thenReturn(RelayClientConnectionState.connected);
+      when(() => relayClient.sendRequest(any())).thenAnswer(
+        (_) async => RelayResponse(
+          id: "health",
+          status: 200,
+          body: jsonEncode(health.toJson()),
+          headers: const {},
+        ),
+      );
+      when(() => relayClient.subscribeSse(any())).thenAnswer((_) => sseController.stream);
+      when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
+      when(relayClient.disconnect).thenAnswer((_) async {});
+
+      service = ConnectionService(
+        _MockRelayCryptoService(),
+        _MockRoomKeyStorage(),
+        _MockAuthTokenProvider(),
+        authSession,
+        lifecycleSource,
+        failureReporter,
+        relayClientFactory: _TestRelayClientFactory(client: relayClient),
+      );
+    });
+
+    tearDown(() async {
+      service.dispose();
+      await Future<void>.delayed(Duration.zero);
+      await sseController.close();
+      await lifecycleController.close();
+      await authStateController.close();
+    });
+
+    test("ignores an unknown event type without reporting and continues", () async {
+      final previousLogLevel = logLevel;
+      setLogLevel(LogLevel.trace);
+      addTearDown(() => setLogLevel(previousLogLevel));
+
+      final logs = <String>[];
+      final unknownEventLogged = Completer<void>();
+
+      await runZoned(
+        () async {
+          final result = await service.connect(config);
+          expect(result, isA<SuccessResponse<HealthResponse>>());
+
+          final nextKnownEvent = service.events.first;
+          sseController.add(
+            RelaySseEvent(
+              data: jsonEncode({
+                "payload": {
+                  "type": "plugin.future.changed",
+                  "properties": {"snapshotToken": "future-token"},
+                },
+              }),
+            ),
+          );
+          await unknownEventLogged.future.timeout(const Duration(seconds: 1));
+
+          verifyNever(
+            () => failureReporter.recordFailure(
+              error: any(named: "error"),
+              stackTrace: any(named: "stackTrace"),
+              uniqueIdentifier: any(named: "uniqueIdentifier"),
+              fatal: any(named: "fatal"),
+              reason: any(named: "reason"),
+              information: any(named: "information"),
+            ),
+          );
+
+          sseController.add(
+            RelaySseEvent(
+              data: jsonEncode({
+                "payload": {"type": "server.heartbeat", "properties": <String, Object?>{}},
+              }),
+            ),
+          );
+
+          final event = await nextKnownEvent.timeout(const Duration(seconds: 1));
+          expect(event.data, isA<SesoriServerHeartbeat>());
+        },
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            logs.add(line);
+            if (line.contains("Ignoring unknown SSE event type: plugin.future.changed") &&
+                !unknownEventLogged.isCompleted) {
+              unknownEventLogged.complete();
+            }
+          },
+        ),
+      );
+
+      expect(logs, contains(contains("Ignoring unknown SSE event type: plugin.future.changed")));
+    });
+
+    test("still reports a malformed payload for a known event type", () async {
+      final previousLogLevel = logLevel;
+      setLogLevel(LogLevel.none);
+      addTearDown(() => setLogLevel(previousLogLevel));
+
+      final failureReported = Completer<void>();
+      when(
+        () => failureReporter.recordFailure(
+          error: any(named: "error"),
+          stackTrace: any(named: "stackTrace"),
+          uniqueIdentifier: any(named: "uniqueIdentifier"),
+          fatal: any(named: "fatal"),
+          reason: any(named: "reason"),
+          information: any(named: "information"),
+        ),
+      ).thenAnswer((_) {
+        failureReported.complete();
+        return Future<void>.value();
+      });
+
+      final result = await service.connect(config);
+      expect(result, isA<SuccessResponse<HealthResponse>>());
+
+      sseController.add(
+        RelaySseEvent(
+          data: jsonEncode({
+            "payload": {"type": "plugin.management.changed", "properties": <String, Object?>{}},
+          }),
+        ),
+      );
+      await failureReported.future.timeout(const Duration(seconds: 1));
+
+      verify(
+        () => failureReporter.recordFailure(
+          error: any(named: "error"),
+          stackTrace: any(named: "stackTrace"),
+          uniqueIdentifier: "sse_parse_failure:plugin.management.changed",
+          fatal: false,
+          reason: "Unknown or malformed SSE event type: plugin.management.changed",
+          information: any(named: "information"),
+        ),
+      ).called(1);
+    });
+  });
+}

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
@@ -23,8 +23,8 @@ sealed class SesoriSessionEvent {}
 /// Typed representation of all known SSE event payloads.
 ///
 /// Uses Freezed [unionKey] on the `"type"` field to auto-deserialize from JSON.
-/// Unknown event types cause [fromJson] to throw — callers should catch and
-/// report via [FailureReporter.recordFailure].
+/// Unknown event types cause [fromJson] to throw so transport callers can skip
+/// events introduced by newer peers without hiding malformed known payloads.
 @Freezed(unionKey: "type", fromJson: true, toJson: true)
 sealed class SesoriSseEvent with _$SesoriSseEvent {
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- treat unknown top-level SSE union types as forward-compatible events and skip them with a warning without reporting to Crashlytics
- continue reporting malformed payloads for known SSE event types
- move common child-session and missing-update reconciliation messages from debug to trace

## Testing

- `dart test test/capabilities/server_connection/connection_service_sse_test.dart`
- `dart test test/cubits/session_list/session_list_cubit_test.dart`
- `dart analyze` (`client/module_core`)
- `dart analyze` (`shared/sesori_shared`)
- `dart analyze` (`client/app`)
