### PR TITLE
fix(bridge): reconcile sessions after forced plugin disable

### DIFF
--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -1049,7 +1049,7 @@ class OrchestratorSession {
             !_pluginRuntime.isCurrentEvent(
               pluginId: source.pluginId,
               generation: generation,
-              event: source.event,
+              allowDuringStop: source.allowDuringStop,
             )) {
           return;
         }
@@ -1066,6 +1066,7 @@ class OrchestratorSession {
     final pluginId = source.pluginId;
     final generation = source.generation;
     final sourcedEvent = source.event;
+    final allowDuringStop = source.allowDuringStop;
     final terminalHandoff = sourcedEvent is BridgeSseTerminalHandoff;
     final event = switch (sourcedEvent) {
       BridgeSseTerminalHandoff(:final event) => event,
@@ -1073,7 +1074,11 @@ class OrchestratorSession {
     };
     try {
       if (generation != null &&
-          !_pluginRuntime.isCurrentEvent(pluginId: pluginId, generation: generation, event: sourcedEvent)) {
+          !_pluginRuntime.isCurrentEvent(
+            pluginId: pluginId,
+            generation: generation,
+            allowDuringStop: allowDuringStop,
+          )) {
         return;
       }
       Log.v("[sse] plugin event arrived: ${event.runtimeType}");
@@ -1109,7 +1114,11 @@ class OrchestratorSession {
       final refreshProjectsSummary = event is BridgeSseProjectUpdated || event is BridgeSseSessionDeleted;
       final sesoriEvent = event is BridgeSseProjectUpdated ? null : _mapper.map(event);
       if (generation != null &&
-          !_pluginRuntime.isCurrentEvent(pluginId: pluginId, generation: generation, event: sourcedEvent)) {
+          !_pluginRuntime.isCurrentEvent(
+            pluginId: pluginId,
+            generation: generation,
+            allowDuringStop: allowDuringStop,
+          )) {
         return;
       }
       if (sesoriEvent != null) {
@@ -1117,7 +1126,7 @@ class OrchestratorSession {
           event: sesoriEvent,
           pluginId: pluginId,
           generation: generation,
-          allowDuringStop: terminalHandoff,
+          allowDuringStop: allowDuringStop,
         );
       } else if (!refreshProjectsSummary) {
         Log.v("[sse] mapping returned null — event dropped");
@@ -1127,13 +1136,17 @@ class OrchestratorSession {
       // after delivering session.deleted so clients observe deletion first.
       if (refreshProjectsSummary) {
         if (generation != null &&
-            !_pluginRuntime.isCurrentEvent(pluginId: pluginId, generation: generation, event: sourcedEvent)) {
+            !_pluginRuntime.isCurrentEvent(
+              pluginId: pluginId,
+              generation: generation,
+              allowDuringStop: allowDuringStop,
+            )) {
           return;
         }
         await _buildAndDeliverProjectsSummaryInOrder(
           pluginId: pluginId,
           generation: generation,
-          allowDuringStop: terminalHandoff,
+          allowDuringStop: allowDuringStop,
         );
       }
     } catch (e, st) {
@@ -1222,9 +1235,11 @@ class OrchestratorSession {
   }) {
     if (generation == null) return true;
     if (pluginId == null) return false;
-    return allowDuringStop
-        ? _pluginRuntime.isCurrentEventGeneration(pluginId: pluginId, generation: generation)
-        : _pluginRuntime.isCurrentGeneration(pluginId: pluginId, generation: generation);
+    return _pluginRuntime.isCurrentEvent(
+      pluginId: pluginId,
+      generation: generation,
+      allowDuringStop: allowDuringStop,
+    );
   }
 
   void _enqueueWireEvent(SesoriSseEvent event) {

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -1046,14 +1046,17 @@ class OrchestratorSession {
       try {
         final generation = source.generation;
         if (generation != null &&
-            !_pluginRuntime.isCurrentGeneration(
+            !_pluginRuntime.isCurrentEvent(
               pluginId: source.pluginId,
               generation: generation,
+              event: source.event,
             )) {
           return;
         }
         await _processPluginEvent(source);
       } finally {
+        final consumed = source.terminalHandoffConsumed;
+        if (consumed != null && !consumed.isCompleted) consumed.complete();
         release.complete();
       }
     }();
@@ -1062,9 +1065,15 @@ class OrchestratorSession {
   Future<void> _processPluginEvent(NormalizedSourcedBridgeEvent source) async {
     final pluginId = source.pluginId;
     final generation = source.generation;
-    final event = source.event;
+    final sourcedEvent = source.event;
+    final terminalHandoff = sourcedEvent is BridgeSseTerminalHandoff;
+    final event = switch (sourcedEvent) {
+      BridgeSseTerminalHandoff(:final event) => event,
+      _ => sourcedEvent,
+    };
     try {
-      if (generation != null && !_pluginRuntime.isCurrentGeneration(pluginId: pluginId, generation: generation)) {
+      if (generation != null &&
+          !_pluginRuntime.isCurrentEvent(pluginId: pluginId, generation: generation, event: sourcedEvent)) {
         return;
       }
       Log.v("[sse] plugin event arrived: ${event.runtimeType}");
@@ -1093,13 +1102,14 @@ class OrchestratorSession {
         if (config.yolo) await _permissionAutoApprovalService.approvePending();
       }
 
-      if (config.yolo && event is BridgeSseProjectUpdated) {
+      if (config.yolo && event is BridgeSseProjectUpdated && !terminalHandoff) {
         await _permissionAutoApprovalService.approvePending();
       }
 
       final refreshProjectsSummary = event is BridgeSseProjectUpdated || event is BridgeSseSessionDeleted;
       final sesoriEvent = event is BridgeSseProjectUpdated ? null : _mapper.map(event);
-      if (generation != null && !_pluginRuntime.isCurrentGeneration(pluginId: pluginId, generation: generation)) {
+      if (generation != null &&
+          !_pluginRuntime.isCurrentEvent(pluginId: pluginId, generation: generation, event: sourcedEvent)) {
         return;
       }
       if (sesoriEvent != null) {
@@ -1107,6 +1117,7 @@ class OrchestratorSession {
           event: sesoriEvent,
           pluginId: pluginId,
           generation: generation,
+          allowDuringStop: terminalHandoff,
         );
       } else if (!refreshProjectsSummary) {
         Log.v("[sse] mapping returned null — event dropped");
@@ -1115,12 +1126,14 @@ class OrchestratorSession {
       // Both trigger types mean activity changed. Rebuild from repository data
       // after delivering session.deleted so clients observe deletion first.
       if (refreshProjectsSummary) {
-        if (generation != null && !_pluginRuntime.isCurrentGeneration(pluginId: pluginId, generation: generation)) {
+        if (generation != null &&
+            !_pluginRuntime.isCurrentEvent(pluginId: pluginId, generation: generation, event: sourcedEvent)) {
           return;
         }
         await _buildAndDeliverProjectsSummaryInOrder(
           pluginId: pluginId,
           generation: generation,
+          allowDuringStop: terminalHandoff,
         );
       }
     } catch (e, st) {
@@ -1144,8 +1157,9 @@ class OrchestratorSession {
     required SesoriSseEvent event,
     required String? pluginId,
     required int? generation,
+    required bool allowDuringStop,
   }) async {
-    if (!_isCurrentSource(pluginId: pluginId, generation: generation)) return;
+    if (!_isCurrentSource(pluginId: pluginId, generation: generation, allowDuringStop: allowDuringStop)) return;
     Log.v(
       "[sse] mapped to: ${event.runtimeType} — enqueuing (subscribers: ${_sseManager.subscriberCount})",
     );
@@ -1158,7 +1172,7 @@ class OrchestratorSession {
     if (event is SesoriSessionCreated) {
       await _routeUnseenActivity(event);
     }
-    if (!_isCurrentSource(pluginId: pluginId, generation: generation)) return;
+    if (!_isCurrentSource(pluginId: pluginId, generation: generation, allowDuringStop: allowDuringStop)) return;
     _enqueueWireEvent(event);
     if (event is! SesoriSessionCreated) {
       try {
@@ -1177,6 +1191,7 @@ class OrchestratorSession {
   Future<void> _buildAndDeliverProjectsSummaryInOrder({
     required String? pluginId,
     required int? generation,
+    required bool allowDuringStop,
   }) {
     final previous = _projectsSummaryTail;
     final release = Completer<void>();
@@ -1184,13 +1199,14 @@ class OrchestratorSession {
     return () async {
       await previous;
       try {
-        if (!_isCurrentSource(pluginId: pluginId, generation: generation)) return;
+        if (!_isCurrentSource(pluginId: pluginId, generation: generation, allowDuringStop: allowDuringStop)) return;
         final summary = await _buildProjectsSummary();
         if (summary != null) {
           await _deliverSseEvent(
             event: summary,
             pluginId: pluginId,
             generation: generation,
+            allowDuringStop: allowDuringStop,
           );
         }
       } finally {
@@ -1199,13 +1215,16 @@ class OrchestratorSession {
     }();
   }
 
-  bool _isCurrentSource({required String? pluginId, required int? generation}) {
+  bool _isCurrentSource({
+    required String? pluginId,
+    required int? generation,
+    required bool allowDuringStop,
+  }) {
     if (generation == null) return true;
-    return pluginId != null &&
-        _pluginRuntime.isCurrentGeneration(
-          pluginId: pluginId,
-          generation: generation,
-        );
+    if (pluginId == null) return false;
+    return allowDuringStop
+        ? _pluginRuntime.isCurrentEventGeneration(pluginId: pluginId, generation: generation)
+        : _pluginRuntime.isCurrentGeneration(pluginId: pluginId, generation: generation);
   }
 
   void _enqueueWireEvent(SesoriSseEvent event) {

--- a/bridge/app/lib/src/bridge/repositories/mappers/session_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/repositories/mappers/session_event_mapper.dart
@@ -6,6 +6,7 @@ class SessionEventMapper {
 
   Session? sessionInfo({required BridgeSseEvent event}) {
     return switch (event) {
+      BridgeSseTerminalHandoff(:final event) => sessionInfo(event: event),
       BridgeSseSessionCreated(:final info) ||
       BridgeSseSessionUpdated(:final info) ||
       BridgeSseSessionDeleted(:final info) => Session.fromJson(info),
@@ -19,6 +20,7 @@ class SessionEventMapper {
       return {session.id, ?session.parentID};
     }
     return switch (event) {
+      BridgeSseTerminalHandoff(:final event) => backendSessionIds(event: event),
       BridgeSseSessionsUpdated(:final sessionID) ||
       BridgeSseSessionDiff(:final sessionID) ||
       BridgeSseSessionCompacted(:final sessionID) ||
@@ -64,8 +66,9 @@ class SessionEventMapper {
       BridgeSseTuiToastShow() ||
       BridgeSseWorktreeReady() ||
       BridgeSseWorktreeFailed() => const <String>{},
-      BridgeSseSessionCreated() || BridgeSseSessionUpdated() || BridgeSseSessionDeleted() =>
-        throw StateError("session event parsing unexpectedly returned no session"),
+      BridgeSseSessionCreated() ||
+      BridgeSseSessionUpdated() ||
+      BridgeSseSessionDeleted() => throw StateError("session event parsing unexpectedly returned no session"),
     };
   }
 
@@ -90,6 +93,13 @@ class SessionEventMapper {
     }
 
     return switch (event) {
+      BridgeSseTerminalHandoff(:final event) => switch (map(
+        event: event,
+        sessionIdsByBackendId: sessionIdsByBackendId,
+      )) {
+        final mappedEvent? => BridgeSseTerminalHandoff(event: mappedEvent),
+        null => null,
+      },
       BridgeSseSessionCreated(:final info) => switch (mappedSession(info)) {
         final session? => BridgeSseSessionCreated(info: session.toJson()),
         null => null,
@@ -129,16 +139,17 @@ class SessionEventMapper {
         final sessionId? => BridgeSseSessionIdle(sessionID: sessionId),
         null => null,
       },
-      BridgeSseCommandExecuted(:final name, :final sessionID, :final arguments, :final messageID) =>
-        switch (mapped(sessionID)) {
-          final sessionId? => BridgeSseCommandExecuted(
-            name: name,
-            sessionID: sessionId,
-            arguments: arguments,
-            messageID: messageID,
-          ),
-          null => null,
-        },
+      BridgeSseCommandExecuted(:final name, :final sessionID, :final arguments, :final messageID) => switch (mapped(
+        sessionID,
+      )) {
+        final sessionId? => BridgeSseCommandExecuted(
+          name: name,
+          sessionID: sessionId,
+          arguments: arguments,
+          messageID: messageID,
+        ),
+        null => null,
+      },
       BridgeSseMessageUpdated(:final info) => switch (Message.fromJson(info)) {
         final message => switch (mapped(message.sessionID)) {
           final sessionId? => BridgeSseMessageUpdated(info: message.copyWith(sessionID: sessionId).toJson()),
@@ -164,15 +175,14 @@ class SessionEventMapper {
           ),
           null => null,
         },
-      BridgeSseMessagePartRemoved(:final sessionID, :final messageID, :final partID) =>
-        switch (mapped(sessionID)) {
-          final sessionId? => BridgeSseMessagePartRemoved(
-            sessionID: sessionId,
-            messageID: messageID,
-            partID: partID,
-          ),
-          null => null,
-        },
+      BridgeSseMessagePartRemoved(:final sessionID, :final messageID, :final partID) => switch (mapped(sessionID)) {
+        final sessionId? => BridgeSseMessagePartRemoved(
+          sessionID: sessionId,
+          messageID: messageID,
+          partID: partID,
+        ),
+        null => null,
+      },
       BridgeSsePermissionAsked(
         :final requestID,
         :final sessionID,
@@ -191,48 +201,56 @@ class SessionEventMapper {
             ),
           _ => null,
         },
-      BridgeSsePermissionReplied(:final requestID, :final sessionID, :final displaySessionId, :final reply) =>
-        switch ((mapped(sessionID), mappedOptional(displaySessionId))) {
-          (final sessionId?, final displayId) when displaySessionId == null || displayId != null =>
-            BridgeSsePermissionReplied(
-              requestID: requestID,
-              sessionID: sessionId,
-              displaySessionId: displayId,
-              reply: reply,
-            ),
-          _ => null,
-        },
-      BridgeSseQuestionAsked(:final id, :final sessionID, :final displaySessionId, :final questions) =>
-        switch ((mapped(sessionID), mappedOptional(displaySessionId))) {
-          (final sessionId?, final displayId) when displaySessionId == null || displayId != null =>
-            BridgeSseQuestionAsked(
-              id: id,
-              sessionID: sessionId,
-              displaySessionId: displayId,
-              questions: questions,
-            ),
-          _ => null,
-        },
-      BridgeSseQuestionReplied(:final requestID, :final sessionID, :final displaySessionId) =>
-        switch ((mapped(sessionID), mappedOptional(displaySessionId))) {
-          (final sessionId?, final displayId) when displaySessionId == null || displayId != null =>
-            BridgeSseQuestionReplied(
-              requestID: requestID,
-              sessionID: sessionId,
-              displaySessionId: displayId,
-            ),
-          _ => null,
-        },
-      BridgeSseQuestionRejected(:final requestID, :final sessionID, :final displaySessionId) =>
-        switch ((mapped(sessionID), mappedOptional(displaySessionId))) {
-          (final sessionId?, final displayId) when displaySessionId == null || displayId != null =>
-            BridgeSseQuestionRejected(
-              requestID: requestID,
-              sessionID: sessionId,
-              displaySessionId: displayId,
-            ),
-          _ => null,
-        },
+      BridgeSsePermissionReplied(:final requestID, :final sessionID, :final displaySessionId, :final reply) => switch ((
+        mapped(sessionID),
+        mappedOptional(displaySessionId),
+      )) {
+        (final sessionId?, final displayId) when displaySessionId == null || displayId != null =>
+          BridgeSsePermissionReplied(
+            requestID: requestID,
+            sessionID: sessionId,
+            displaySessionId: displayId,
+            reply: reply,
+          ),
+        _ => null,
+      },
+      BridgeSseQuestionAsked(:final id, :final sessionID, :final displaySessionId, :final questions) => switch ((
+        mapped(sessionID),
+        mappedOptional(displaySessionId),
+      )) {
+        (final sessionId?, final displayId) when displaySessionId == null || displayId != null =>
+          BridgeSseQuestionAsked(
+            id: id,
+            sessionID: sessionId,
+            displaySessionId: displayId,
+            questions: questions,
+          ),
+        _ => null,
+      },
+      BridgeSseQuestionReplied(:final requestID, :final sessionID, :final displaySessionId) => switch ((
+        mapped(sessionID),
+        mappedOptional(displaySessionId),
+      )) {
+        (final sessionId?, final displayId) when displaySessionId == null || displayId != null =>
+          BridgeSseQuestionReplied(
+            requestID: requestID,
+            sessionID: sessionId,
+            displaySessionId: displayId,
+          ),
+        _ => null,
+      },
+      BridgeSseQuestionRejected(:final requestID, :final sessionID, :final displaySessionId) => switch ((
+        mapped(sessionID),
+        mappedOptional(displaySessionId),
+      )) {
+        (final sessionId?, final displayId) when displaySessionId == null || displayId != null =>
+          BridgeSseQuestionRejected(
+            requestID: requestID,
+            sessionID: sessionId,
+            displaySessionId: displayId,
+          ),
+        _ => null,
+      },
       BridgeSseTodoUpdated(:final sessionID) => switch (mapped(sessionID)) {
         final sessionId? => BridgeSseTodoUpdated(sessionID: sessionId),
         null => null,

--- a/bridge/app/lib/src/bridge/runtime/plugin_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_runtime.dart
@@ -58,6 +58,7 @@ typedef SourcedPluginRuntimeEvent = ({
   String pluginId,
   int generation,
   BridgeSseEvent event,
+  bool allowDuringStop,
   Completer<void>? terminalHandoffConsumed,
 });
 typedef SourcedPluginProvisionProgress = ({String pluginId, RuntimeProvisionProgress event});
@@ -457,9 +458,8 @@ class PluginRuntime {
     return slot != null && slot.generation == generation && _isRoutable(slot);
   }
 
-  /// Captured backend events stay valid while their generation is stopping.
-  /// Cancelling its event subscription prevents new arrivals; a successor
-  /// generation then fences any older event still queued for normalization.
+  /// Runtime-authorized stop events stay valid while their generation exists.
+  /// A successor generation fences any older event still queued for delivery.
   bool isCurrentEventGeneration({required String pluginId, required int generation}) {
     final slot = _slots[pluginId];
     return slot != null && slot.generation == generation;
@@ -468,10 +468,10 @@ class PluginRuntime {
   bool isCurrentEvent({
     required String pluginId,
     required int generation,
-    required BridgeSseEvent event,
+    required bool allowDuringStop,
   }) {
     return isCurrentGeneration(pluginId: pluginId, generation: generation) ||
-        (event is BridgeSseTerminalHandoff && isCurrentEventGeneration(pluginId: pluginId, generation: generation));
+        (allowDuringStop && isCurrentEventGeneration(pluginId: pluginId, generation: generation));
   }
 
   void requireCurrentGeneration({
@@ -1017,16 +1017,27 @@ class PluginRuntime {
     final plugin = slot.plugin;
     if (intent == PluginStopIntent.force && plugin != null) {
       final budgetElapsed = Stopwatch()..start();
+      final activeSessionIds = _snapshotActiveSessionIds(slot: slot, plugin: plugin);
       final barrierDrained = await _drainForcedStopBarrier(
         slot: slot,
         budgetElapsed: budgetElapsed,
       );
-      if (barrierDrained && plugin.currentWorkState != PluginWorkState.idle) {
-        await _interruptActiveWork(
-          slot: slot,
-          plugin: plugin,
-          budgetElapsed: budgetElapsed,
-        );
+      if (barrierDrained) {
+        if (plugin.currentWorkState == PluginWorkState.idle) {
+          await _emitTerminalHandoff(
+            slot: slot,
+            sessionIds: activeSessionIds,
+            emitProjectSentinel: activeSessionIds.isNotEmpty,
+            budgetElapsed: budgetElapsed,
+          );
+        } else {
+          await _interruptActiveWork(
+            slot: slot,
+            plugin: plugin,
+            activeSessionIds: activeSessionIds,
+            budgetElapsed: budgetElapsed,
+          );
+        }
       }
     } else {
       await _waitForDurableCommits(slot);
@@ -1048,33 +1059,79 @@ class PluginRuntime {
     if (cleanupError != null) Error.throwWithStackTrace(cleanupError, cleanupStackTrace!);
   }
 
+  Set<String> _snapshotActiveSessionIds({
+    required _PluginRuntimeSlot slot,
+    required BridgePlugin plugin,
+  }) {
+    try {
+      return {
+        for (final summary in plugin.api.getActiveSessionsSummary())
+          for (final session in summary.activeSessions) ...[
+            session.id,
+            ...session.childSessionIds,
+          ],
+      };
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        'Plugin "${slot.registration.descriptor.id}" active-session snapshot failed before forced stop',
+        error,
+        stackTrace,
+      );
+      return const {};
+    }
+  }
+
   Future<void> _interruptActiveWork({
     required _PluginRuntimeSlot slot,
     required BridgePlugin plugin,
+    required Set<String> activeSessionIds,
     required Stopwatch budgetElapsed,
   }) async {
     final pluginId = slot.registration.descriptor.id;
     final Set<String> interruptedSessionIds;
+    slot.allowPendingInputResolutionsDuringStop = true;
     try {
       final remaining = _remainingShutdownBudget(budgetElapsed: budgetElapsed);
       interruptedSessionIds = await plugin.interruptActiveWork(budget: remaining).timeout(remaining);
+      // Plugin event streams are asynchronous. Let cancellation resolutions
+      // already emitted by the completed interruption reach the runtime before
+      // the final handoff sentinel is enqueued.
+      await Future<void>.delayed(Duration.zero);
     } on Object catch (error, stackTrace) {
       Log.w('Plugin "$pluginId" could not quiesce active work before forced stop', error, stackTrace);
       return;
+    } finally {
+      slot.allowPendingInputResolutionsDuringStop = false;
     }
+    await _emitTerminalHandoff(
+      slot: slot,
+      sessionIds: {...activeSessionIds, ...interruptedSessionIds},
+      emitProjectSentinel: true,
+      budgetElapsed: budgetElapsed,
+    );
+  }
+
+  Future<void> _emitTerminalHandoff({
+    required _PluginRuntimeSlot slot,
+    required Set<String> sessionIds,
+    required bool emitProjectSentinel,
+    required Stopwatch budgetElapsed,
+  }) async {
+    final pluginId = slot.registration.descriptor.id;
     final generation = slot.generation;
     if (generation == null || _backendEventsSubject.isClosed) return;
-    for (final sessionId in interruptedSessionIds.toList()..sort()) {
+    for (final sessionId in sessionIds.toList()..sort()) {
       _backendEventsSubject.add((
         pluginId: pluginId,
         generation: generation,
         event: BridgeSseTerminalHandoff(
           event: BridgeSseSessionIdle(sessionID: sessionId),
         ),
+        allowDuringStop: true,
         terminalHandoffConsumed: null,
       ));
     }
-    if (interruptedSessionIds.isNotEmpty) {
+    if (emitProjectSentinel) {
       final consumed = Completer<void>();
       _backendEventsSubject.add((
         pluginId: pluginId,
@@ -1082,6 +1139,7 @@ class PluginRuntime {
         event: const BridgeSseTerminalHandoff(
           event: BridgeSseProjectUpdated(),
         ),
+        allowDuringStop: true,
         terminalHandoffConsumed: consumed,
       ));
       try {
@@ -1332,6 +1390,7 @@ class PluginRuntime {
               pluginId: pluginId,
               generation: generation,
               event: event,
+              allowDuringStop: slot.allowPendingInputResolutionsDuringStop && _isPendingInputResolution(event),
               terminalHandoffConsumed: null,
             ));
           }
@@ -1586,6 +1645,12 @@ class PluginRuntime {
     await Future.wait([for (final cancel in cancellations) cancel()]);
   }
 
+  bool _isPendingInputResolution(BridgeSseEvent event) {
+    return event is BridgeSsePermissionReplied ||
+        event is BridgeSseQuestionReplied ||
+        event is BridgeSseQuestionRejected;
+  }
+
   Future<void> _cancelGenerationSubscriptions(_PluginRuntimeSlot slot) async {
     final subscriptions = [slot.statusSubscription, slot.workSubscription, slot.eventSubscription];
     slot
@@ -1716,6 +1781,7 @@ class _PluginRuntimeSlot {
   StreamSubscription<PluginWorkState>? workSubscription;
   // ignore: cancel_subscriptions - generation ownership cancels these in PluginRuntime.
   StreamSubscription<BridgeSseEvent>? eventSubscription;
+  bool allowPendingInputResolutionsDuringStop = false;
   final Set<Future<void> Function()> operationStreamCancellations = <Future<void> Function()>{};
 }
 

--- a/bridge/app/lib/src/bridge/runtime/plugin_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_runtime.dart
@@ -54,7 +54,12 @@ class PluginRuntimeSnapshot {
   final PluginRuntimeTransition transition;
 }
 
-typedef SourcedPluginRuntimeEvent = ({String pluginId, int generation, BridgeSseEvent event});
+typedef SourcedPluginRuntimeEvent = ({
+  String pluginId,
+  int generation,
+  BridgeSseEvent event,
+  Completer<void>? terminalHandoffConsumed,
+});
 typedef SourcedPluginProvisionProgress = ({String pluginId, RuntimeProvisionProgress event});
 
 sealed class PluginRuntimeCommandResult {
@@ -450,6 +455,23 @@ class PluginRuntime {
   bool isCurrentGeneration({required String pluginId, required int generation}) {
     final slot = _slots[pluginId];
     return slot != null && slot.generation == generation && _isRoutable(slot);
+  }
+
+  /// Captured backend events stay valid while their generation is stopping.
+  /// Cancelling its event subscription prevents new arrivals; a successor
+  /// generation then fences any older event still queued for normalization.
+  bool isCurrentEventGeneration({required String pluginId, required int generation}) {
+    final slot = _slots[pluginId];
+    return slot != null && slot.generation == generation;
+  }
+
+  bool isCurrentEvent({
+    required String pluginId,
+    required int generation,
+    required BridgeSseEvent event,
+  }) {
+    return isCurrentGeneration(pluginId: pluginId, generation: generation) ||
+        (event is BridgeSseTerminalHandoff && isCurrentEventGeneration(pluginId: pluginId, generation: generation));
   }
 
   void requireCurrentGeneration({
@@ -992,8 +1014,23 @@ class PluginRuntime {
       startStackTrace = stackTrace;
     }
     await slot.cleanupFuture;
-    await _waitForDurableCommits(slot);
     final plugin = slot.plugin;
+    if (intent == PluginStopIntent.force && plugin != null) {
+      final budgetElapsed = Stopwatch()..start();
+      final barrierDrained = await _drainForcedStopBarrier(
+        slot: slot,
+        budgetElapsed: budgetElapsed,
+      );
+      if (barrierDrained && plugin.currentWorkState != PluginWorkState.idle) {
+        await _interruptActiveWork(
+          slot: slot,
+          plugin: plugin,
+          budgetElapsed: budgetElapsed,
+        );
+      }
+    } else {
+      await _waitForDurableCommits(slot);
+    }
     slot
       ..plugin = null
       ..state = PluginRuntimeState.stopping
@@ -1009,6 +1046,74 @@ class PluginRuntime {
     }
     if (startError != null) Error.throwWithStackTrace(startError, startStackTrace!);
     if (cleanupError != null) Error.throwWithStackTrace(cleanupError, cleanupStackTrace!);
+  }
+
+  Future<void> _interruptActiveWork({
+    required _PluginRuntimeSlot slot,
+    required BridgePlugin plugin,
+    required Stopwatch budgetElapsed,
+  }) async {
+    final pluginId = slot.registration.descriptor.id;
+    final Set<String> interruptedSessionIds;
+    try {
+      final remaining = _remainingShutdownBudget(budgetElapsed: budgetElapsed);
+      interruptedSessionIds = await plugin.interruptActiveWork(budget: remaining).timeout(remaining);
+    } on Object catch (error, stackTrace) {
+      Log.w('Plugin "$pluginId" could not quiesce active work before forced stop', error, stackTrace);
+      return;
+    }
+    final generation = slot.generation;
+    if (generation == null || _backendEventsSubject.isClosed) return;
+    for (final sessionId in interruptedSessionIds.toList()..sort()) {
+      _backendEventsSubject.add((
+        pluginId: pluginId,
+        generation: generation,
+        event: BridgeSseTerminalHandoff(
+          event: BridgeSseSessionIdle(sessionID: sessionId),
+        ),
+        terminalHandoffConsumed: null,
+      ));
+    }
+    if (interruptedSessionIds.isNotEmpty) {
+      final consumed = Completer<void>();
+      _backendEventsSubject.add((
+        pluginId: pluginId,
+        generation: generation,
+        event: const BridgeSseTerminalHandoff(
+          event: BridgeSseProjectUpdated(),
+        ),
+        terminalHandoffConsumed: consumed,
+      ));
+      try {
+        await consumed.future.timeout(_remainingShutdownBudget(budgetElapsed: budgetElapsed));
+      } on Object catch (error, stackTrace) {
+        Log.w('Plugin "$pluginId" terminal handoff was not consumed before forced stop', error, stackTrace);
+      }
+    }
+  }
+
+  Future<bool> _drainForcedStopBarrier({
+    required _PluginRuntimeSlot slot,
+    required Stopwatch budgetElapsed,
+  }) async {
+    final pluginId = slot.registration.descriptor.id;
+    try {
+      await _cancelOperationStreams(slot).timeout(_remainingShutdownBudget(budgetElapsed: budgetElapsed));
+      await _waitForLeaseDrain(slot).timeout(_remainingShutdownBudget(budgetElapsed: budgetElapsed));
+      await _waitForDurableCommits(slot).timeout(_remainingShutdownBudget(budgetElapsed: budgetElapsed));
+      return true;
+    } on Object catch (error, stackTrace) {
+      Log.w('Plugin "$pluginId" still had in-flight operations at forced stop', error, stackTrace);
+      return false;
+    }
+  }
+
+  Duration _remainingShutdownBudget({required Stopwatch budgetElapsed}) {
+    final remaining = _shutdownBudget - budgetElapsed.elapsed;
+    if (remaining <= Duration.zero) {
+      throw TimeoutException("Plugin forced-stop budget elapsed");
+    }
+    return remaining;
   }
 
   Future<_PluginLease> _acquire({
@@ -1223,7 +1328,12 @@ class PluginRuntime {
       slot.eventSubscription = started.api.events.listen(
         (event) {
           if (slot.generation == generation && !_backendEventsSubject.isClosed) {
-            _backendEventsSubject.add((pluginId: pluginId, generation: generation, event: event));
+            _backendEventsSubject.add((
+              pluginId: pluginId,
+              generation: generation,
+              event: event,
+              terminalHandoffConsumed: null,
+            ));
           }
         },
         onError: (Object error, StackTrace stackTrace) {

--- a/bridge/app/lib/src/bridge/services/session_event_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/services/session_event_dispatcher.dart
@@ -6,8 +6,17 @@ import "package:sesori_shared/sesori_shared.dart";
 import "../repositories/session_repository.dart";
 import "session_event_service.dart";
 
-typedef NormalizedSourcedBridgeEvent = ({String pluginId, int? generation, BridgeSseEvent event});
-typedef _DispatchEvent = ({int? generation, BridgeSseEvent event});
+typedef NormalizedSourcedBridgeEvent = ({
+  String pluginId,
+  int? generation,
+  BridgeSseEvent event,
+  Completer<void>? terminalHandoffConsumed,
+});
+typedef _DispatchEvent = ({
+  int? generation,
+  BridgeSseEvent event,
+  Completer<void>? terminalHandoffConsumed,
+});
 
 class SessionEventDispatcher {
   final SessionEventService _sessionEventService;
@@ -33,13 +42,23 @@ class SessionEventDispatcher {
     );
   }
 
-  Future<void> dispatchPluginEvent({required SourcedBridgeEvent source}) {
+  Future<void> dispatchPluginEvent({
+    required SourcedBridgeEvent source,
+    required Completer<void>? terminalHandoffConsumed,
+  }) {
     return _dispatch(
       pluginId: source.pluginId,
-      operation: () async => [
-        for (final event in await _sessionEventService.normalize(source: source))
-          (generation: source.generation, event: event),
-      ],
+      operation: () async {
+        final events = await _sessionEventService.normalize(source: source);
+        return [
+          for (var index = 0; index < events.length; index++)
+            (
+              generation: source.generation,
+              event: events[index],
+              terminalHandoffConsumed: index == events.length - 1 ? terminalHandoffConsumed : null,
+            ),
+        ];
+      },
     );
   }
 
@@ -48,7 +67,7 @@ class SessionEventDispatcher {
       pluginId: commit.pluginId,
       operation: () async => [
         for (final output in await _sessionEventService.handleBindingsCommitted(commit: commit))
-          (generation: output.generation, event: output.event),
+          (generation: output.generation, event: output.event, terminalHandoffConsumed: null),
       ],
     );
   }
@@ -56,7 +75,13 @@ class SessionEventDispatcher {
   Future<void> dispatchDeletedSession({required Session session}) {
     return _dispatch(
       pluginId: session.pluginId,
-      operation: () async => [(generation: null, event: BridgeSseSessionDeleted(info: session.toJson()))],
+      operation: () async => [
+        (
+          generation: null,
+          event: BridgeSseSessionDeleted(info: session.toJson()),
+          terminalHandoffConsumed: null,
+        ),
+      ],
     );
   }
 
@@ -88,13 +113,19 @@ class SessionEventDispatcher {
           final event = output.event;
           if (await _sessionEventService.canPublish(event: event)) {
             if (generation != null &&
-                !_sessionEventService.isCurrentGeneration(
+                !_sessionEventService.isCurrentEvent(
                   pluginId: pluginId,
                   generation: generation,
+                  event: event,
                 )) {
               continue;
             }
-            _eventsController.add((pluginId: pluginId, generation: generation, event: event));
+            _eventsController.add((
+              pluginId: pluginId,
+              generation: generation,
+              event: event,
+              terminalHandoffConsumed: output.terminalHandoffConsumed,
+            ));
           }
         }
       } on Object catch (error, stackTrace) {

--- a/bridge/app/lib/src/bridge/services/session_event_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/services/session_event_dispatcher.dart
@@ -10,11 +10,13 @@ typedef NormalizedSourcedBridgeEvent = ({
   String pluginId,
   int? generation,
   BridgeSseEvent event,
+  bool allowDuringStop,
   Completer<void>? terminalHandoffConsumed,
 });
 typedef _DispatchEvent = ({
   int? generation,
   BridgeSseEvent event,
+  bool allowDuringStop,
   Completer<void>? terminalHandoffConsumed,
 });
 
@@ -44,17 +46,22 @@ class SessionEventDispatcher {
 
   Future<void> dispatchPluginEvent({
     required SourcedBridgeEvent source,
+    required bool allowDuringStop,
     required Completer<void>? terminalHandoffConsumed,
   }) {
     return _dispatch(
       pluginId: source.pluginId,
       operation: () async {
-        final events = await _sessionEventService.normalize(source: source);
+        final events = await _sessionEventService.normalize(
+          source: source,
+          allowDuringStop: allowDuringStop,
+        );
         return [
           for (var index = 0; index < events.length; index++)
             (
               generation: source.generation,
               event: events[index],
+              allowDuringStop: allowDuringStop,
               terminalHandoffConsumed: index == events.length - 1 ? terminalHandoffConsumed : null,
             ),
         ];
@@ -67,7 +74,12 @@ class SessionEventDispatcher {
       pluginId: commit.pluginId,
       operation: () async => [
         for (final output in await _sessionEventService.handleBindingsCommitted(commit: commit))
-          (generation: output.generation, event: output.event, terminalHandoffConsumed: null),
+          (
+            generation: output.generation,
+            event: output.event,
+            allowDuringStop: false,
+            terminalHandoffConsumed: null,
+          ),
       ],
     );
   }
@@ -79,6 +91,7 @@ class SessionEventDispatcher {
         (
           generation: null,
           event: BridgeSseSessionDeleted(info: session.toJson()),
+          allowDuringStop: false,
           terminalHandoffConsumed: null,
         ),
       ],
@@ -116,7 +129,7 @@ class SessionEventDispatcher {
                 !_sessionEventService.isCurrentEvent(
                   pluginId: pluginId,
                   generation: generation,
-                  event: event,
+                  allowDuringStop: output.allowDuringStop,
                 )) {
               continue;
             }
@@ -124,6 +137,7 @@ class SessionEventDispatcher {
               pluginId: pluginId,
               generation: generation,
               event: event,
+              allowDuringStop: output.allowDuringStop,
               terminalHandoffConsumed: output.terminalHandoffConsumed,
             ));
           }

--- a/bridge/app/lib/src/bridge/services/session_event_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_event_service.dart
@@ -58,13 +58,17 @@ class SessionEventService {
     required SourcedBridgeEvent source,
     required bool drainPending,
   }) async {
-    if (!isCurrentGeneration(pluginId: source.pluginId, generation: source.generation)) {
+    if (!isCurrentEvent(pluginId: source.pluginId, generation: source.generation, event: source.event)) {
       return const [];
     }
     try {
       return await _normalize(source: source, drainPending: drainPending);
     } on Object catch (error, stackTrace) {
-      if (!isCurrentGeneration(pluginId: source.pluginId, generation: source.generation)) {
+      if (_eventMapper.sessionInfo(event: source.event) != null &&
+          !isCurrentGeneration(pluginId: source.pluginId, generation: source.generation)) {
+        return const [];
+      }
+      if (!isCurrentEvent(pluginId: source.pluginId, generation: source.generation, event: source.event)) {
         return const [];
       }
       Log.w("[sse] failed to normalize ${source.event.runtimeType}", error, stackTrace);
@@ -88,6 +92,14 @@ class SessionEventService {
     return _pluginRuntime.isCurrentGeneration(pluginId: pluginId, generation: generation);
   }
 
+  bool isCurrentEvent({
+    required String pluginId,
+    required int generation,
+    required BridgeSseEvent event,
+  }) {
+    return _pluginRuntime.isCurrentEvent(pluginId: pluginId, generation: generation, event: event);
+  }
+
   Future<List<BridgeSseEvent>> _normalize({
     required SourcedBridgeEvent source,
     required bool drainPending,
@@ -99,6 +111,9 @@ class SessionEventService {
       return [
         ?await _translate(source: source),
       ];
+    }
+    if (!isCurrentGeneration(pluginId: source.pluginId, generation: source.generation)) {
+      return const [];
     }
 
     final projection = await _projectSession(source: source, observed: observed);
@@ -348,7 +363,7 @@ class SessionEventService {
       pluginId: source.pluginId,
       backendSessionIds: backendSessionIds.toList(growable: false),
     );
-    if (!isCurrentGeneration(pluginId: source.pluginId, generation: source.generation)) return null;
+    if (!isCurrentEvent(pluginId: source.pluginId, generation: source.generation, event: source.event)) return null;
     if (bindings.length != backendSessionIds.length) {
       final missingBackendSessionIds = backendSessionIds.where((id) => !bindings.containsKey(id)).toList();
       if (missingBackendSessionIds.isNotEmpty &&
@@ -379,7 +394,7 @@ class SessionEventService {
         for (final entry in bindings.entries) entry.key: entry.value.id,
       },
     );
-    if (!isCurrentGeneration(pluginId: source.pluginId, generation: source.generation)) return null;
+    if (!isCurrentEvent(pluginId: source.pluginId, generation: source.generation, event: source.event)) return null;
     if (translated == null) return null;
 
     final translatedSession = _eventMapper.sessionInfo(event: translated);
@@ -414,9 +429,9 @@ class SessionEventService {
     required Session session,
     required bool titleChanged,
   }) async {
-    if (!isCurrentGeneration(pluginId: source.pluginId, generation: source.generation)) return null;
+    if (!isCurrentEvent(pluginId: source.pluginId, generation: source.generation, event: source.event)) return null;
     final catalogSession = await _sessionRepository.getCatalogSession(sessionId: session.id);
-    if (!isCurrentGeneration(pluginId: source.pluginId, generation: source.generation)) return null;
+    if (!isCurrentEvent(pluginId: source.pluginId, generation: source.generation, event: source.event)) return null;
     if (catalogSession == null) return null;
     return BridgeSseSessionUpdated(info: catalogSession.toJson(), titleChanged: titleChanged);
   }

--- a/bridge/app/lib/src/bridge/services/session_event_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_event_service.dart
@@ -50,25 +50,45 @@ class SessionEventService {
     );
   }
 
-  Future<List<BridgeSseEvent>> normalize({required SourcedBridgeEvent source}) async {
-    return _normalizeGuarded(source: source, drainPending: true);
+  Future<List<BridgeSseEvent>> normalize({
+    required SourcedBridgeEvent source,
+    required bool allowDuringStop,
+  }) async {
+    return _normalizeGuarded(
+      source: source,
+      allowDuringStop: allowDuringStop,
+      drainPending: true,
+    );
   }
 
   Future<List<BridgeSseEvent>> _normalizeGuarded({
     required SourcedBridgeEvent source,
+    required bool allowDuringStop,
     required bool drainPending,
   }) async {
-    if (!isCurrentEvent(pluginId: source.pluginId, generation: source.generation, event: source.event)) {
+    if (!isCurrentEvent(
+      pluginId: source.pluginId,
+      generation: source.generation,
+      allowDuringStop: allowDuringStop,
+    )) {
       return const [];
     }
     try {
-      return await _normalize(source: source, drainPending: drainPending);
+      return await _normalize(
+        source: source,
+        allowDuringStop: allowDuringStop,
+        drainPending: drainPending,
+      );
     } on Object catch (error, stackTrace) {
-      if (_eventMapper.sessionInfo(event: source.event) != null &&
+      if (_isSessionPayloadEvent(source.event) &&
           !isCurrentGeneration(pluginId: source.pluginId, generation: source.generation)) {
         return const [];
       }
-      if (!isCurrentEvent(pluginId: source.pluginId, generation: source.generation, event: source.event)) {
+      if (!isCurrentEvent(
+        pluginId: source.pluginId,
+        generation: source.generation,
+        allowDuringStop: allowDuringStop,
+      )) {
         return const [];
       }
       Log.w("[sse] failed to normalize ${source.event.runtimeType}", error, stackTrace);
@@ -95,13 +115,18 @@ class SessionEventService {
   bool isCurrentEvent({
     required String pluginId,
     required int generation,
-    required BridgeSseEvent event,
+    required bool allowDuringStop,
   }) {
-    return _pluginRuntime.isCurrentEvent(pluginId: pluginId, generation: generation, event: event);
+    return _pluginRuntime.isCurrentEvent(
+      pluginId: pluginId,
+      generation: generation,
+      allowDuringStop: allowDuringStop,
+    );
   }
 
   Future<List<BridgeSseEvent>> _normalize({
     required SourcedBridgeEvent source,
+    required bool allowDuringStop,
     required bool drainPending,
   }) async {
     if (source.event is BridgeSseSessionDeleted) return const [];
@@ -109,7 +134,7 @@ class SessionEventService {
     final observed = _eventMapper.sessionInfo(event: source.event);
     if (observed == null) {
       return [
-        ?await _translate(source: source),
+        ?await _translate(source: source, allowDuringStop: allowDuringStop),
       ];
     }
     if (!isCurrentGeneration(pluginId: source.pluginId, generation: source.generation)) {
@@ -118,7 +143,7 @@ class SessionEventService {
 
     final projection = await _projectSession(source: source, observed: observed);
     if (projection == null) return const [];
-    final normalized = await _translate(source: source);
+    final normalized = await _translate(source: source, allowDuringStop: allowDuringStop);
     final output = <BridgeSseEvent>[
       if (projection.inserted && source.event is! BridgeSseSessionCreated)
         ?await _createdEvent(sessionId: projection.binding.id),
@@ -328,6 +353,7 @@ class SessionEventService {
           projectionUpdatedAt: pending.projectionUpdatedAt,
           event: pending.event,
         ),
+        allowDuringStop: false,
         drainPending: false,
       );
       output.addAll([
@@ -357,13 +383,22 @@ class SessionEventService {
     );
   }
 
-  Future<BridgeSseEvent?> _translate({required SourcedBridgeEvent source}) async {
+  Future<BridgeSseEvent?> _translate({
+    required SourcedBridgeEvent source,
+    required bool allowDuringStop,
+  }) async {
     final backendSessionIds = _eventMapper.backendSessionIds(event: source.event);
     final bindings = await _sessionRepository.getStoredSessionsByBackendIds(
       pluginId: source.pluginId,
       backendSessionIds: backendSessionIds.toList(growable: false),
     );
-    if (!isCurrentEvent(pluginId: source.pluginId, generation: source.generation, event: source.event)) return null;
+    if (!isCurrentEvent(
+      pluginId: source.pluginId,
+      generation: source.generation,
+      allowDuringStop: allowDuringStop,
+    )) {
+      return null;
+    }
     if (bindings.length != backendSessionIds.length) {
       final missingBackendSessionIds = backendSessionIds.where((id) => !bindings.containsKey(id)).toList();
       if (missingBackendSessionIds.isNotEmpty &&
@@ -394,7 +429,13 @@ class SessionEventService {
         for (final entry in bindings.entries) entry.key: entry.value.id,
       },
     );
-    if (!isCurrentEvent(pluginId: source.pluginId, generation: source.generation, event: source.event)) return null;
+    if (!isCurrentEvent(
+      pluginId: source.pluginId,
+      generation: source.generation,
+      allowDuringStop: allowDuringStop,
+    )) {
+      return null;
+    }
     if (translated == null) return null;
 
     final translatedSession = _eventMapper.sessionInfo(event: translated);
@@ -411,6 +452,7 @@ class SessionEventService {
           source: source,
           session: session,
           titleChanged: titleChanged,
+          allowDuringStop: allowDuringStop,
         ),
         null => null,
       },
@@ -428,10 +470,23 @@ class SessionEventService {
     required SourcedBridgeEvent source,
     required Session session,
     required bool titleChanged,
+    required bool allowDuringStop,
   }) async {
-    if (!isCurrentEvent(pluginId: source.pluginId, generation: source.generation, event: source.event)) return null;
+    if (!isCurrentEvent(
+      pluginId: source.pluginId,
+      generation: source.generation,
+      allowDuringStop: allowDuringStop,
+    )) {
+      return null;
+    }
     final catalogSession = await _sessionRepository.getCatalogSession(sessionId: session.id);
-    if (!isCurrentEvent(pluginId: source.pluginId, generation: source.generation, event: source.event)) return null;
+    if (!isCurrentEvent(
+      pluginId: source.pluginId,
+      generation: source.generation,
+      allowDuringStop: allowDuringStop,
+    )) {
+      return null;
+    }
     if (catalogSession == null) return null;
     return BridgeSseSessionUpdated(info: catalogSession.toJson(), titleChanged: titleChanged);
   }
@@ -445,5 +500,13 @@ class SessionEventService {
   Future<BridgeSseEvent?> _createdEvent({required String sessionId}) async {
     final session = await _sessionRepository.getCatalogSession(sessionId: sessionId);
     return session == null ? null : BridgeSseSessionCreated(info: session.toJson());
+  }
+
+  bool _isSessionPayloadEvent(BridgeSseEvent event) {
+    return switch (event) {
+      BridgeSseTerminalHandoff(:final event) => _isSessionPayloadEvent(event),
+      BridgeSseSessionCreated() || BridgeSseSessionUpdated() || BridgeSseSessionDeleted() => true,
+      _ => false,
+    };
   }
 }

--- a/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
@@ -20,6 +20,7 @@ class BridgeEventMapper {
   SesoriSseEvent? map(BridgeSseEvent event) {
     try {
       return switch (event) {
+        BridgeSseTerminalHandoff() => throw StateError("terminal handoff must be unwrapped by Orchestrator"),
         BridgeSseServerConnected() => null,
         BridgeSseServerHeartbeat() => null,
         BridgeSseServerInstanceDisposed() => null,

--- a/bridge/app/lib/src/listeners/plugin_event_listener.dart
+++ b/bridge/app/lib/src/listeners/plugin_event_listener.dart
@@ -27,6 +27,7 @@ class PluginEventListener {
         unawaited(
           _dispatcher.dispatchPluginEvent(
             source: source,
+            allowDuringStop: event.allowDuringStop,
             terminalHandoffConsumed: event.terminalHandoffConsumed,
           ),
         );

--- a/bridge/app/lib/src/listeners/plugin_event_listener.dart
+++ b/bridge/app/lib/src/listeners/plugin_event_listener.dart
@@ -24,7 +24,12 @@ class PluginEventListener {
           generation: event.generation,
           event: event.event,
         );
-        unawaited(_dispatcher.dispatchPluginEvent(source: source));
+        unawaited(
+          _dispatcher.dispatchPluginEvent(
+            source: source,
+            terminalHandoffConsumed: event.terminalHandoffConsumed,
+          ),
+        );
       },
       onError: _dispatcher.addSourceError,
     );

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -121,6 +121,42 @@ void main() {
     await runFuture.timeout(const Duration(seconds: 5));
   });
 
+  test("a stopping generation delivers terminal handoff events only", () async {
+    final relayServer = await TestRelayServer.start();
+    final harness = await _OrchestratorHarness.create(
+      pluginIds: const ["one"],
+      relayUrl: "ws://127.0.0.1:${relayServer.port}",
+    );
+    addTearDown(() async {
+      await harness.close();
+      await relayServer.close();
+    });
+    final runFuture = harness.composition.session.run();
+    unawaited(runFuture.catchError((_) {}));
+    await relayServer.nextClient();
+    await harness.activatePlugins();
+    final pluginRuntime = runtimeForLifecycleService(service: harness.lifecycleService) as TestPluginRuntime;
+    final events = <SesoriSseEvent>[];
+    final subscription = harness.composition.session.localWireEvents.listen(events.add);
+    addTearDown(subscription.cancel);
+    pluginRuntime.generationCurrent = false;
+    final terminalHandoffConsumed = Completer<void>();
+    pluginRuntime.terminalHandoffConsumed = terminalHandoffConsumed;
+
+    harness.plugins.single.emitEvent(const BridgeSseVcsBranchUpdated());
+    harness.plugins.single.emitEvent(
+      const BridgeSseTerminalHandoff(event: BridgeSseProjectUpdated()),
+    );
+
+    await terminalHandoffConsumed.future.timeout(const Duration(seconds: 2));
+    expect(events.whereType<SesoriProjectsSummary>(), hasLength(1));
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(events.whereType<SesoriVcsBranchUpdated>(), isEmpty);
+
+    await harness.composition.session.cancel();
+    await runFuture.timeout(const Duration(seconds: 5));
+  });
+
   test("post-normalization work is concurrent across plugins and ordered within each plugin", () async {
     final relayServer = await TestRelayServer.start();
     final harness = await _OrchestratorHarness.create(
@@ -437,11 +473,11 @@ class _OrchestratorHarness {
     }
 
     final ready = Completer<void>();
-    final subscription = composition.session.localWireEvents
-        .where((event) => event is SesoriVcsBranchUpdated)
-        .listen((_) {
-          if (!ready.isCompleted) ready.complete();
-        });
+    final subscription = composition.session.localWireEvents.where((event) => event is SesoriVcsBranchUpdated).listen((
+      _,
+    ) {
+      if (!ready.isCompleted) ready.complete();
+    });
     try {
       for (var attempt = 0; attempt < 200 && !ready.isCompleted; attempt++) {
         plugins.first.emitEvent(const BridgeSseVcsBranchUpdated());

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -121,7 +121,7 @@ void main() {
     await runFuture.timeout(const Duration(seconds: 5));
   });
 
-  test("a stopping generation delivers terminal handoff events only", () async {
+  test("a plugin wrapper cannot spoof the stop fence and runtime handoff is consumed after delivery", () async {
     final relayServer = await TestRelayServer.start();
     final harness = await _OrchestratorHarness.create(
       pluginIds: const ["one"],
@@ -141,17 +141,24 @@ void main() {
     addTearDown(subscription.cancel);
     pluginRuntime.generationCurrent = false;
     final terminalHandoffConsumed = Completer<void>();
-    pluginRuntime.terminalHandoffConsumed = terminalHandoffConsumed;
 
     harness.plugins.single.emitEvent(const BridgeSseVcsBranchUpdated());
     harness.plugins.single.emitEvent(
       const BridgeSseTerminalHandoff(event: BridgeSseProjectUpdated()),
     );
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(events.whereType<SesoriProjectsSummary>(), isEmpty);
+    expect(events.whereType<SesoriVcsBranchUpdated>(), isEmpty);
+
+    pluginRuntime.emitRuntimeEvent(
+      pluginId: "one",
+      event: const BridgeSseTerminalHandoff(event: BridgeSseProjectUpdated()),
+      allowDuringStop: true,
+      terminalHandoffConsumed: terminalHandoffConsumed,
+    );
 
     await terminalHandoffConsumed.future.timeout(const Duration(seconds: 2));
     expect(events.whereType<SesoriProjectsSummary>(), hasLength(1));
-    await Future<void>.delayed(const Duration(milliseconds: 50));
-    expect(events.whereType<SesoriVcsBranchUpdated>(), isEmpty);
 
     await harness.composition.session.cancel();
     await runFuture.timeout(const Duration(seconds: 5));

--- a/bridge/app/test/bridge/runtime/plugin_generation_factory_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_generation_factory_test.dart
@@ -450,6 +450,9 @@ class _FakeBridgePlugin implements BridgePlugin {
   }
 
   @override
+  Future<Set<String>> interruptActiveWork({required Duration budget}) async => const {};
+
+  @override
   Future<void> shutdown({required Duration? budget}) async {}
 }
 

--- a/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
@@ -409,6 +409,110 @@ void main() {
     expect(runtime.snapshot.single.state, PluginRuntimeState.active);
   });
 
+  test("a force stop interrupts active sessions before retiring the generation", () async {
+    final api = _FakeApi();
+    late _FakePlugin plugin;
+    final factory = _FakeGenerationFactory(
+      startGate: Future<void>.value(),
+      pluginFactory: (_) => plugin = _FakePlugin(api: api),
+    );
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.start(pluginId: "one");
+    plugin.workStates.add(PluginWorkState.busy);
+    await _waitUntil(() => runtime.snapshot.single.workState == PluginWorkState.busy);
+    final events = <SourcedPluginRuntimeEvent>[];
+    final eventSubscription = runtime.backendEvents.listen((event) {
+      events.add(event);
+      final consumed = event.terminalHandoffConsumed;
+      if (consumed != null && !consumed.isCompleted) consumed.complete();
+    });
+    plugin.interruptActiveWorkHandler = (budget) async {
+      plugin.workStates.add(PluginWorkState.idle);
+      return {"busy", "retry"};
+    };
+
+    final result = await runtime.stop(pluginId: "one", intent: PluginStopIntent.force);
+
+    expect(result, isA<PluginRuntimeCommandApplied>());
+    expect(plugin.interruptActiveWorkCount, 1);
+    final handoffEvents = events.map((event) => (event.event as BridgeSseTerminalHandoff).event).toList();
+    expect(
+      handoffEvents.whereType<BridgeSseSessionIdle>().map((event) => event.sessionID),
+      unorderedEquals(["busy", "retry"]),
+    );
+    expect(handoffEvents.whereType<BridgeSseProjectUpdated>(), hasLength(1));
+    expect(runtime.isCurrentGeneration(pluginId: "one", generation: 1), isFalse);
+    expect(runtime.isCurrentEventGeneration(pluginId: "one", generation: 1), isTrue);
+    expect(
+      runtime.isCurrentEvent(
+        pluginId: "one",
+        generation: 1,
+        event: const BridgeSseTerminalHandoff(
+          event: BridgeSseSessionIdle(sessionID: "busy"),
+        ),
+      ),
+      isTrue,
+    );
+    expect(
+      runtime.isCurrentEvent(
+        pluginId: "one",
+        generation: 1,
+        event: const BridgeSsePermissionAsked(
+          requestID: "stale",
+          sessionID: "busy",
+          displaySessionId: "busy",
+          tool: "shell",
+          description: "stale permission",
+        ),
+      ),
+      isFalse,
+    );
+
+    await runtime.start(pluginId: "one");
+    expect(runtime.isCurrentEventGeneration(pluginId: "one", generation: 1), isFalse);
+    await eventSubscription.cancel();
+  });
+
+  test("a force restart waits for terminal handoff consumption before starting its successor", () async {
+    late _FakePlugin firstPlugin;
+    final factory = _FakeGenerationFactory(
+      startGate: Future<void>.value(),
+      pluginFactory: (generation) {
+        final plugin = _FakePlugin(api: _FakeApi());
+        if (generation == 1) firstPlugin = plugin;
+        return plugin;
+      },
+    );
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.start(pluginId: "one");
+    firstPlugin.workStates.add(PluginWorkState.busy);
+    await _waitUntil(() => runtime.snapshot.single.workState == PluginWorkState.busy);
+    firstPlugin.interruptActiveWorkHandler = (_) async {
+      firstPlugin.workStates.add(PluginWorkState.idle);
+      return {"busy"};
+    };
+    final terminalHandoff = Completer<SourcedPluginRuntimeEvent>();
+    final subscription = runtime.backendEvents.listen((event) {
+      if (event.terminalHandoffConsumed != null && !terminalHandoff.isCompleted) {
+        terminalHandoff.complete(event);
+      }
+    });
+
+    final restarting = runtime.restart(pluginId: "one", intent: PluginStopIntent.force);
+    final handoff = await terminalHandoff.future.timeout(const Duration(seconds: 1));
+
+    expect(factory.startCount, 1);
+    expect(runtime.snapshot.single.transition, PluginRuntimeTransition.restarting);
+    handoff.terminalHandoffConsumed!.complete();
+    expect(await restarting, isA<PluginRuntimeCommandApplied>());
+    expect(factory.startCount, 2);
+    expect(runtime.snapshot.single.generation, 2);
+
+    await subscription.cancel();
+  });
+
   test("prepare disable fences starts until rollback restores access", () async {
     final factory = _FakeGenerationFactory(startGate: Future<void>.value());
     final runtime = _runtime(factory: factory);
@@ -687,7 +791,7 @@ void main() {
     await disposing;
   });
 
-  test("a force stop fences an operation that completes after shutdown", () async {
+  test("a force stop drains a pre-fence operation before retiring the generation", () async {
     final operationGate = Completer<void>();
     final factory = _FakeGenerationFactory(startGate: Future<void>.value());
     final runtime = _runtime(factory: factory);
@@ -700,10 +804,14 @@ void main() {
     );
     await _waitUntil(() => runtime.snapshot.single.leaseCount == 1);
 
-    expect(
-      await runtime.stop(pluginId: "one", intent: PluginStopIntent.force),
-      isA<PluginRuntimeCommandApplied>(),
-    );
+    var stopCompleted = false;
+    final stopping = runtime.stop(pluginId: "one", intent: PluginStopIntent.force).whenComplete(() {
+      stopCompleted = true;
+    });
+    await _waitUntil(() => runtime.snapshot.single.transition == PluginRuntimeTransition.stopping);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(stopCompleted, isFalse);
     operationGate.complete();
 
     await expectLater(
@@ -716,6 +824,7 @@ void main() {
         ),
       ),
     );
+    expect(await stopping, isA<PluginRuntimeCommandApplied>());
     expect(runtime.snapshot.single.state, PluginRuntimeState.dormant);
   });
 
@@ -1189,6 +1298,8 @@ class _FakePlugin implements BridgePlugin {
   Future<void>? _shutdownFuture;
   int shutdownInvocationCount = 0;
   int shutdownCount = 0;
+  int interruptActiveWorkCount = 0;
+  Future<Set<String>> Function(Duration budget)? interruptActiveWorkHandler;
 
   @override
   final _FakeApi api;
@@ -1207,6 +1318,12 @@ class _FakePlugin implements BridgePlugin {
 
   @override
   PluginDiagnostics describe() => const PluginDiagnostics(pluginId: "one", endpoint: null, details: {});
+
+  @override
+  Future<Set<String>> interruptActiveWork({required Duration budget}) async {
+    interruptActiveWorkCount++;
+    return await interruptActiveWorkHandler?.call(budget) ?? const {};
+  }
 
   @override
   Future<void> shutdown({required Duration? budget}) {

--- a/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
@@ -410,7 +410,20 @@ void main() {
   });
 
   test("a force stop interrupts active sessions before retiring the generation", () async {
-    final api = _FakeApi();
+    final api = _FakeApi(
+      activeSessionsSummary: const [
+        PluginProjectActivitySummary(
+          id: "project",
+          activeSessions: [
+            PluginActiveSession(
+              id: "snapshot",
+              mainAgentRunning: true,
+              childSessionIds: ["snapshot-child"],
+            ),
+          ],
+        ),
+      ],
+    );
     late _FakePlugin plugin;
     final factory = _FakeGenerationFactory(
       startGate: Future<void>.value(),
@@ -436,10 +449,16 @@ void main() {
 
     expect(result, isA<PluginRuntimeCommandApplied>());
     expect(plugin.interruptActiveWorkCount, 1);
+    expect(
+      events,
+      everyElement(
+        isA<SourcedPluginRuntimeEvent>().having((event) => event.allowDuringStop, "allowDuringStop", isTrue),
+      ),
+    );
     final handoffEvents = events.map((event) => (event.event as BridgeSseTerminalHandoff).event).toList();
     expect(
       handoffEvents.whereType<BridgeSseSessionIdle>().map((event) => event.sessionID),
-      unorderedEquals(["busy", "retry"]),
+      unorderedEquals(["snapshot", "snapshot-child", "busy", "retry"]),
     );
     expect(handoffEvents.whereType<BridgeSseProjectUpdated>(), hasLength(1));
     expect(runtime.isCurrentGeneration(pluginId: "one", generation: 1), isFalse);
@@ -448,9 +467,7 @@ void main() {
       runtime.isCurrentEvent(
         pluginId: "one",
         generation: 1,
-        event: const BridgeSseTerminalHandoff(
-          event: BridgeSseSessionIdle(sessionID: "busy"),
-        ),
+        allowDuringStop: true,
       ),
       isTrue,
     );
@@ -458,19 +475,242 @@ void main() {
       runtime.isCurrentEvent(
         pluginId: "one",
         generation: 1,
-        event: const BridgeSsePermissionAsked(
-          requestID: "stale",
-          sessionID: "busy",
-          displaySessionId: "busy",
-          tool: "shell",
-          description: "stale permission",
-        ),
+        allowDuringStop: false,
       ),
       isFalse,
     );
 
     await runtime.start(pluginId: "one");
     expect(runtime.isCurrentEventGeneration(pluginId: "one", generation: 1), isFalse);
+    await eventSubscription.cancel();
+  });
+
+  test("a failed interruption does not synthesize idle handoff", () async {
+    final api = _FakeApi(
+      activeSessionsSummary: const [
+        PluginProjectActivitySummary(
+          id: "project",
+          activeSessions: [PluginActiveSession(id: "busy", mainAgentRunning: true)],
+        ),
+      ],
+    );
+    late _FakePlugin plugin;
+    final factory = _FakeGenerationFactory(
+      startGate: Future<void>.value(),
+      pluginFactory: (_) => plugin = _FakePlugin(api: api),
+    );
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.start(pluginId: "one");
+    plugin.workStates.add(PluginWorkState.busy);
+    await _waitUntil(() => runtime.snapshot.single.workState == PluginWorkState.busy);
+    final events = <SourcedPluginRuntimeEvent>[];
+    final eventSubscription = runtime.backendEvents.listen(events.add);
+    plugin.interruptActiveWorkHandler = (_) => Future.error(StateError("cannot quiesce"));
+
+    expect(
+      await runtime.stop(pluginId: "one", intent: PluginStopIntent.force),
+      isA<PluginRuntimeCommandApplied>(),
+    );
+
+    expect(plugin.interruptActiveWorkCount, 1);
+    expect(events, isEmpty);
+    await eventSubscription.cancel();
+  });
+
+  test("a force stop reconciles the pre-barrier snapshot when work naturally becomes idle", () async {
+    final api = _FakeApi(
+      activeSessionsSummary: const [
+        PluginProjectActivitySummary(
+          id: "project",
+          activeSessions: [
+            PluginActiveSession(
+              id: "root",
+              mainAgentRunning: true,
+              childSessionIds: ["child"],
+            ),
+          ],
+        ),
+      ],
+    );
+    late _FakePlugin plugin;
+    final factory = _FakeGenerationFactory(
+      startGate: Future<void>.value(),
+      pluginFactory: (_) => plugin = _FakePlugin(api: api),
+    );
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.start(pluginId: "one");
+    plugin.workStates.add(PluginWorkState.busy);
+    await _waitUntil(() => runtime.snapshot.single.workState == PluginWorkState.busy);
+    final operationStarted = Completer<void>();
+    final operationGate = Completer<void>();
+    final operation = runtime.use<void>(
+      pluginId: "one",
+      operation: _TestOperation.use,
+      body: (_) async {
+        operationStarted.complete();
+        await operationGate.future;
+      },
+    );
+    final operationCompletion = expectLater(operation, throwsA(isA<PluginOperationException>()));
+    await operationStarted.future;
+    final events = <SourcedPluginRuntimeEvent>[];
+    final eventSubscription = runtime.backendEvents.listen((event) {
+      events.add(event);
+      final consumed = event.terminalHandoffConsumed;
+      if (consumed != null && !consumed.isCompleted) consumed.complete();
+    });
+
+    final stopping = runtime.stop(pluginId: "one", intent: PluginStopIntent.force);
+    await _waitUntil(() => api.getActiveSessionsSummaryCount == 1);
+    plugin.workStates.add(PluginWorkState.idle);
+    operationGate.complete();
+    await operationCompletion;
+
+    expect(await stopping, isA<PluginRuntimeCommandApplied>());
+    expect(plugin.interruptActiveWorkCount, 0);
+    final handoffEvents = events.map((event) => (event.event as BridgeSseTerminalHandoff).event).toList();
+    expect(
+      handoffEvents.whereType<BridgeSseSessionIdle>().map((event) => event.sessionID),
+      unorderedEquals(["root", "child"]),
+    );
+    expect(handoffEvents.last, isA<BridgeSseProjectUpdated>());
+    expect(events.last.terminalHandoffConsumed, isNotNull);
+
+    await eventSubscription.cancel();
+  });
+
+  test("only pending-input resolutions emitted during interruption are authorized", () async {
+    final api = _FakeApi();
+    late _FakePlugin plugin;
+    final factory = _FakeGenerationFactory(
+      startGate: Future<void>.value(),
+      pluginFactory: (_) => plugin = _FakePlugin(api: api),
+    );
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.start(pluginId: "one");
+    final events = <SourcedPluginRuntimeEvent>[];
+    final sentinelArrived = Completer<SourcedPluginRuntimeEvent>();
+    final eventSubscription = runtime.backendEvents.listen((event) {
+      events.add(event);
+      if (event.terminalHandoffConsumed != null && !sentinelArrived.isCompleted) {
+        sentinelArrived.complete(event);
+      }
+    });
+    api.eventsController.add(
+      const BridgeSsePermissionReplied(
+        requestID: "before",
+        sessionID: "busy",
+        displaySessionId: "busy",
+        reply: "reject",
+      ),
+    );
+    await _waitUntil(() => events.isNotEmpty);
+    plugin.workStates.add(PluginWorkState.busy);
+    await _waitUntil(() => runtime.snapshot.single.workState == PluginWorkState.busy);
+    plugin.interruptActiveWorkHandler = (_) async {
+      api.eventsController
+        ..add(
+          const BridgeSsePermissionAsked(
+            requestID: "ask",
+            sessionID: "busy",
+            displaySessionId: "busy",
+            tool: "shell",
+            description: "must remain fenced",
+          ),
+        )
+        ..add(
+          const BridgeSsePermissionReplied(
+            requestID: "permission",
+            sessionID: "busy",
+            displaySessionId: "busy",
+            reply: "reject",
+          ),
+        )
+        ..add(
+          const BridgeSseQuestionReplied(
+            requestID: "question-replied",
+            sessionID: "busy",
+            displaySessionId: "busy",
+          ),
+        )
+        ..add(
+          const BridgeSseTerminalHandoff(
+            event: BridgeSsePermissionReplied(
+              requestID: "spoofed",
+              sessionID: "busy",
+              displaySessionId: "busy",
+              reply: "reject",
+            ),
+          ),
+        );
+      scheduleMicrotask(
+        () => api.eventsController.add(
+          const BridgeSseQuestionRejected(
+            requestID: "question-rejected",
+            sessionID: "busy",
+            displaySessionId: "busy",
+          ),
+        ),
+      );
+      plugin.workStates.add(PluginWorkState.idle);
+      return const <String>{};
+    };
+
+    final stopping = runtime.stop(pluginId: "one", intent: PluginStopIntent.force);
+    final sentinel = await sentinelArrived.future.timeout(const Duration(seconds: 1));
+    expect(
+      (sentinel.event as BridgeSseTerminalHandoff).event,
+      isA<BridgeSseProjectUpdated>(),
+    );
+    expect(
+      events.indexOf(sentinel),
+      greaterThan(events.lastIndexWhere((event) => event.event is BridgeSseQuestionRejected)),
+    );
+    api.eventsController.add(
+      const BridgeSsePermissionReplied(
+        requestID: "after",
+        sessionID: "busy",
+        displaySessionId: "busy",
+        reply: "reject",
+      ),
+    );
+    await _waitUntil(
+      () => events.where((event) => event.event is BridgeSsePermissionReplied).length == 3,
+    );
+    sentinel.terminalHandoffConsumed!.complete();
+    expect(await stopping, isA<PluginRuntimeCommandApplied>());
+
+    expect(
+      events.where((event) => event.event is BridgeSsePermissionReplied).map((event) => event.allowDuringStop),
+      [false, true, false],
+    );
+    expect(
+      events.singleWhere((event) => event.event is BridgeSsePermissionAsked).allowDuringStop,
+      isFalse,
+    );
+    expect(
+      events.singleWhere((event) => event.event is BridgeSseQuestionReplied).allowDuringStop,
+      isTrue,
+    );
+    expect(
+      events.singleWhere((event) => event.event is BridgeSseQuestionRejected).allowDuringStop,
+      isTrue,
+    );
+    expect(
+      events
+          .singleWhere(
+            (event) =>
+                event.event is BridgeSseTerminalHandoff &&
+                (event.event as BridgeSseTerminalHandoff).event is BridgeSsePermissionReplied,
+          )
+          .allowDuringStop,
+      isFalse,
+    );
+    expect(sentinel.allowDuringStop, isTrue);
+
     await eventSubscription.cancel();
   });
 
@@ -1343,17 +1583,29 @@ class _FakePlugin implements BridgePlugin {
 }
 
 class _FakeApi extends NativeProjectsPluginApi {
-  _FakeApi({this.id = "one", this.closeEventsOnDispose = false});
+  _FakeApi({
+    this.id = "one",
+    this.closeEventsOnDispose = false,
+    this.activeSessionsSummary = const [],
+  });
 
   final StreamController<BridgeSseEvent> eventsController = StreamController.broadcast();
   final bool closeEventsOnDispose;
+  final List<PluginProjectActivitySummary> activeSessionsSummary;
   int disposeCount = 0;
+  int getActiveSessionsSummaryCount = 0;
 
   @override
   final String id;
 
   @override
   Stream<BridgeSseEvent> get events => eventsController.stream;
+
+  @override
+  List<PluginProjectActivitySummary> getActiveSessionsSummary() {
+    getActiveSessionsSummaryCount++;
+    return activeSessionsSummary;
+  }
 
   @override
   Future<void> dispose() async {

--- a/bridge/app/test/bridge/services/session_event_dispatcher_test.dart
+++ b/bridge/app/test/bridge/services/session_event_dispatcher_test.dart
@@ -31,7 +31,10 @@ void main() {
       ),
     );
 
-    final createdDispatch = dispatcher.dispatchPluginEvent(source: source);
+    final createdDispatch = dispatcher.dispatchPluginEvent(
+      source: source,
+      terminalHandoffConsumed: null,
+    );
     service.createdIsPublishable = false;
     final deletedDispatch = dispatcher.dispatchDeletedSession(
       session: const Session(
@@ -74,13 +77,39 @@ void main() {
       ),
     );
 
-    final dispatch = dispatcher.dispatchPluginEvent(source: source);
+    final dispatch = dispatcher.dispatchPluginEvent(
+      source: source,
+      terminalHandoffConsumed: null,
+    );
     service.generationCurrent = false;
     normalizeGate.complete();
     await dispatch;
 
     expect(output, isEmpty);
     await subscription.cancel();
+    await dispatcher.dispose();
+  });
+
+  test("forwards terminal handoff consumption with the final normalized event", () async {
+    final service = _GatedSessionEventService(normalizeGate: Future<void>.value());
+    final dispatcher = SessionEventDispatcher(sessionEventService: service);
+    final outputFuture = dispatcher.events.first;
+    final consumed = Completer<void>();
+    final source = service.captureSource(
+      pluginId: "plugin",
+      generation: 1,
+      event: const BridgeSseTerminalHandoff(
+        event: BridgeSseProjectUpdated(),
+      ),
+    );
+
+    await dispatcher.dispatchPluginEvent(
+      source: source,
+      terminalHandoffConsumed: consumed,
+    );
+
+    final output = await outputFuture;
+    expect(output.terminalHandoffConsumed, same(consumed));
     await dispatcher.dispose();
   });
 
@@ -154,6 +183,15 @@ class _GatedSessionEventService implements SessionEventService {
 
   @override
   bool isCurrentGeneration({required String pluginId, required int generation}) {
+    return generationCurrent && generation == currentGeneration;
+  }
+
+  @override
+  bool isCurrentEvent({
+    required String pluginId,
+    required int generation,
+    required BridgeSseEvent event,
+  }) {
     return generationCurrent && generation == currentGeneration;
   }
 

--- a/bridge/app/test/bridge/services/session_event_dispatcher_test.dart
+++ b/bridge/app/test/bridge/services/session_event_dispatcher_test.dart
@@ -33,6 +33,7 @@ void main() {
 
     final createdDispatch = dispatcher.dispatchPluginEvent(
       source: source,
+      allowDuringStop: false,
       terminalHandoffConsumed: null,
     );
     service.createdIsPublishable = false;
@@ -79,6 +80,7 @@ void main() {
 
     final dispatch = dispatcher.dispatchPluginEvent(
       source: source,
+      allowDuringStop: false,
       terminalHandoffConsumed: null,
     );
     service.generationCurrent = false;
@@ -90,8 +92,8 @@ void main() {
     await dispatcher.dispose();
   });
 
-  test("forwards terminal handoff consumption with the final normalized event", () async {
-    final service = _GatedSessionEventService(normalizeGate: Future<void>.value());
+  test("forwards stop authorization and handoff consumption with the final normalized event", () async {
+    final service = _GatedSessionEventService(normalizeGate: Future<void>.value())..generationCurrent = false;
     final dispatcher = SessionEventDispatcher(sessionEventService: service);
     final outputFuture = dispatcher.events.first;
     final consumed = Completer<void>();
@@ -105,10 +107,12 @@ void main() {
 
     await dispatcher.dispatchPluginEvent(
       source: source,
+      allowDuringStop: true,
       terminalHandoffConsumed: consumed,
     );
 
     final output = await outputFuture;
+    expect(output.allowDuringStop, isTrue);
     expect(output.terminalHandoffConsumed, same(consumed));
     await dispatcher.dispose();
   });
@@ -161,6 +165,7 @@ class _GatedSessionEventService implements SessionEventService {
   final Future<void> _normalizeGate;
   bool createdIsPublishable = true;
   bool generationCurrent = true;
+  bool eventGenerationCurrent = true;
   int currentGeneration = 1;
   List<NormalizedRuntimeEvent> bindingOutputs = const [];
 
@@ -176,7 +181,10 @@ class _GatedSessionEventService implements SessionEventService {
   }
 
   @override
-  Future<List<BridgeSseEvent>> normalize({required SourcedBridgeEvent source}) async {
+  Future<List<BridgeSseEvent>> normalize({
+    required SourcedBridgeEvent source,
+    required bool allowDuringStop,
+  }) async {
     await _normalizeGate;
     return [source.event];
   }
@@ -190,9 +198,9 @@ class _GatedSessionEventService implements SessionEventService {
   bool isCurrentEvent({
     required String pluginId,
     required int generation,
-    required BridgeSseEvent event,
+    required bool allowDuringStop,
   }) {
-    return generationCurrent && generation == currentGeneration;
+    return generation == currentGeneration && (generationCurrent || (allowDuringStop && eventGenerationCurrent));
   }
 
   @override

--- a/bridge/app/test/bridge/services/session_event_service_test.dart
+++ b/bridge/app/test/bridge/services/session_event_service_test.dart
@@ -59,6 +59,7 @@ void main() {
 
     test("drops unknown roots without discovering projects and preserves backend-deleted history", () async {
       final unknown = await service.normalize(
+        allowDuringStop: false,
         source: (
           pluginId: plugin.id,
           generation: 1,
@@ -91,6 +92,7 @@ void main() {
         backendSessionId: "backend-root",
       );
       final deleted = await service.normalize(
+        allowDuringStop: false,
         source: (
           pluginId: plugin.id,
           generation: 1,
@@ -117,7 +119,7 @@ void main() {
       );
     });
 
-    test("publishes a terminal event captured before its generation stopped routing", () async {
+    test("only runtime-authorized terminal provenance passes a stopped generation fence", () async {
       await _insertRoot(
         database: database,
         pluginId: plugin.id,
@@ -126,7 +128,8 @@ void main() {
       );
       pluginRuntime.generationCurrent = false;
 
-      final output = await service.normalize(
+      final spoofed = await service.normalize(
+        allowDuringStop: false,
         source: (
           pluginId: plugin.id,
           generation: 1,
@@ -137,6 +140,18 @@ void main() {
         ),
       );
 
+      expect(spoofed, isEmpty);
+      final output = await service.normalize(
+        allowDuringStop: true,
+        source: (
+          pluginId: plugin.id,
+          generation: 1,
+          projectionUpdatedAt: 2,
+          event: const BridgeSseTerminalHandoff(
+            event: BridgeSseSessionIdle(sessionID: "backend-root"),
+          ),
+        ),
+      );
       expect(output, hasLength(1));
       expect(output.single, isA<BridgeSseTerminalHandoff>());
       expect(
@@ -145,10 +160,11 @@ void main() {
       );
       expect(
         await service.normalize(
+          allowDuringStop: false,
           source: (
             pluginId: plugin.id,
             generation: 1,
-            projectionUpdatedAt: 2,
+            projectionUpdatedAt: 3,
             event: const BridgeSsePermissionAsked(
               requestID: "stale",
               sessionID: "backend-root",
@@ -161,13 +177,32 @@ void main() {
         isEmpty,
       );
 
+      final resolution = await service.normalize(
+        allowDuringStop: true,
+        source: (
+          pluginId: plugin.id,
+          generation: 1,
+          projectionUpdatedAt: 4,
+          event: const BridgeSsePermissionReplied(
+            requestID: "cancelled",
+            sessionID: "backend-root",
+            displaySessionId: "backend-root",
+            reply: "reject",
+          ),
+        ),
+      );
+      final replied = resolution.single as BridgeSsePermissionReplied;
+      expect(replied.sessionID, "stable-root");
+      expect(replied.displaySessionId, "stable-root");
+
       pluginRuntime.eventGenerationCurrent = false;
       expect(
         await service.normalize(
+          allowDuringStop: true,
           source: (
             pluginId: plugin.id,
             generation: 1,
-            projectionUpdatedAt: 3,
+            projectionUpdatedAt: 5,
             event: const BridgeSseTerminalHandoff(
               event: BridgeSseSessionIdle(sessionID: "backend-root"),
             ),
@@ -175,6 +210,24 @@ void main() {
         ),
         isEmpty,
       );
+    });
+
+    test("malformed current-generation session payload fails soft and reports once", () async {
+      final output = await service.normalize(
+        allowDuringStop: false,
+        source: (
+          pluginId: plugin.id,
+          generation: 1,
+          projectionUpdatedAt: 1,
+          event: const BridgeSseSessionUpdated(
+            info: {"id": 1},
+            titleChanged: false,
+          ),
+        ),
+      );
+
+      expect(output, isEmpty);
+      expect(failureReporter.recordedIdentifiers, ["bridge.sse.session_event"]);
     });
 
     test("recursively drains out-of-order descendants under a durable same-plugin parent", () async {
@@ -186,6 +239,7 @@ void main() {
       );
 
       final grandchildOutput = await service.normalize(
+        allowDuringStop: false,
         source: (
           pluginId: plugin.id,
           generation: 1,
@@ -204,6 +258,7 @@ void main() {
       expect(eventTracker.length, 1);
 
       final output = await service.normalize(
+        allowDuringStop: false,
         source: (
           pluginId: plugin.id,
           generation: 1,
@@ -247,6 +302,7 @@ void main() {
       );
 
       final output = await service.normalize(
+        allowDuringStop: false,
         source: (
           pluginId: plugin.id,
           generation: 1,
@@ -283,6 +339,7 @@ void main() {
       );
 
       final output = await service.normalize(
+        allowDuringStop: false,
         source: (
           pluginId: plugin.id,
           generation: 1,
@@ -322,6 +379,7 @@ void main() {
       );
 
       final output = await service.normalize(
+        allowDuringStop: false,
         source: (
           pluginId: plugin.id,
           generation: 1,
@@ -354,6 +412,7 @@ void main() {
       );
 
       final output = await service.normalize(
+        allowDuringStop: false,
         source: (
           pluginId: plugin.id,
           generation: 1,
@@ -388,6 +447,7 @@ void main() {
         backendSessionId: "backend-root",
       );
       final created = await service.normalize(
+        allowDuringStop: false,
         source: (
           pluginId: plugin.id,
           generation: 1,
@@ -405,6 +465,7 @@ void main() {
       final child = Session.fromJson((created.single as BridgeSseSessionCreated).info);
 
       final output = await service.normalize(
+        allowDuringStop: false,
         source: (
           pluginId: plugin.id,
           generation: 1,
@@ -440,6 +501,7 @@ void main() {
       );
 
       final output = await service.normalize(
+        allowDuringStop: false,
         source: (
           pluginId: plugin.id,
           generation: 1,
@@ -477,12 +539,14 @@ void main() {
 
       expect(
         await service.normalize(
+          allowDuringStop: false,
           source: (pluginId: plugin.id, generation: 1, projectionUpdatedAt: 10, event: rootEvent),
         ),
         isEmpty,
       );
       expect(
         await service.normalize(
+          allowDuringStop: false,
           source: (pluginId: plugin.id, generation: 1, projectionUpdatedAt: 11, event: childEvent),
         ),
         isEmpty,
@@ -556,6 +620,7 @@ void main() {
       for (final (index, event) in [created, message, part, status].indexed) {
         expect(
           await service.normalize(
+            allowDuringStop: false,
             source: (
               pluginId: plugin.id,
               generation: 1,
@@ -631,12 +696,14 @@ void main() {
 
       expect(
         await service.normalize(
+          allowDuringStop: false,
           source: (pluginId: plugin.id, generation: 1, projectionUpdatedAt: 12, event: created),
         ),
         isEmpty,
       );
       expect(
         await service.normalize(
+          allowDuringStop: false,
           source: (pluginId: plugin.id, generation: 1, projectionUpdatedAt: 13, event: updated),
         ),
         isEmpty,
@@ -683,6 +750,7 @@ void main() {
 
       expect(
         await service.normalize(
+          allowDuringStop: false,
           source: (pluginId: plugin.id, generation: 1, projectionUpdatedAt: 12, event: created),
         ),
         isEmpty,
@@ -690,6 +758,7 @@ void main() {
       pluginRuntime.currentGeneration = 2;
       expect(
         await service.normalize(
+          allowDuringStop: false,
           source: (pluginId: plugin.id, generation: 2, projectionUpdatedAt: 13, event: updated),
         ),
         isEmpty,
@@ -752,24 +821,28 @@ void main() {
 
       expect(
         await service.normalize(
+          allowDuringStop: false,
           source: (pluginId: plugin.id, generation: 1, projectionUpdatedAt: 20, event: rootEvent),
         ),
         isEmpty,
       );
       expect(
         await service.normalize(
+          allowDuringStop: false,
           source: (pluginId: plugin.id, generation: 1, projectionUpdatedAt: 21, event: childEvent),
         ),
         isEmpty,
       );
       expect(
         await service.normalize(
+          allowDuringStop: false,
           source: (pluginId: plugin.id, generation: 1, projectionUpdatedAt: 22, event: rootPermissionEvent),
         ),
         isEmpty,
       );
       expect(
         await service.normalize(
+          allowDuringStop: false,
           source: (pluginId: plugin.id, generation: 1, projectionUpdatedAt: 23, event: childPermissionEvent),
         ),
         isEmpty,
@@ -837,6 +910,7 @@ void main() {
       for (var index = 0; index < events.length; index++) {
         expect(
           await service.normalize(
+            allowDuringStop: false,
             source: (
               pluginId: plugin.id,
               generation: 1,
@@ -890,6 +964,7 @@ void main() {
       );
 
       final output = await service.normalize(
+        allowDuringStop: false,
         source: (
           pluginId: plugin.id,
           generation: 1,
@@ -930,6 +1005,7 @@ void main() {
       sessionDao.gateNextProjectionTransaction();
 
       final normalization = service.normalize(
+        allowDuringStop: false,
         source: (
           pluginId: plugin.id,
           generation: 1,
@@ -970,6 +1046,7 @@ void main() {
       sessionDao.gateNextProjectionTransaction();
 
       final normalization = service.normalize(
+        allowDuringStop: false,
         source: (
           pluginId: plugin.id,
           generation: 1,
@@ -1009,6 +1086,7 @@ void main() {
       sessionDao.gateNextProjectionTransaction();
 
       final update = service.normalize(
+        allowDuringStop: false,
         source: (
           pluginId: plugin.id,
           generation: 1,
@@ -1037,6 +1115,7 @@ void main() {
 
       sessionDao.gateNextProjectionTransaction();
       final childCreation = service.normalize(
+        allowDuringStop: false,
         source: (
           pluginId: plugin.id,
           generation: 1,

--- a/bridge/app/test/bridge/services/session_event_service_test.dart
+++ b/bridge/app/test/bridge/services/session_event_service_test.dart
@@ -117,6 +117,66 @@ void main() {
       );
     });
 
+    test("publishes a terminal event captured before its generation stopped routing", () async {
+      await _insertRoot(
+        database: database,
+        pluginId: plugin.id,
+        sessionId: "stable-root",
+        backendSessionId: "backend-root",
+      );
+      pluginRuntime.generationCurrent = false;
+
+      final output = await service.normalize(
+        source: (
+          pluginId: plugin.id,
+          generation: 1,
+          projectionUpdatedAt: 1,
+          event: const BridgeSseTerminalHandoff(
+            event: BridgeSseSessionIdle(sessionID: "backend-root"),
+          ),
+        ),
+      );
+
+      expect(output, hasLength(1));
+      expect(output.single, isA<BridgeSseTerminalHandoff>());
+      expect(
+        ((output.single as BridgeSseTerminalHandoff).event as BridgeSseSessionIdle).sessionID,
+        "stable-root",
+      );
+      expect(
+        await service.normalize(
+          source: (
+            pluginId: plugin.id,
+            generation: 1,
+            projectionUpdatedAt: 2,
+            event: const BridgeSsePermissionAsked(
+              requestID: "stale",
+              sessionID: "backend-root",
+              displaySessionId: "backend-root",
+              tool: "shell",
+              description: "stale permission",
+            ),
+          ),
+        ),
+        isEmpty,
+      );
+
+      pluginRuntime.eventGenerationCurrent = false;
+      expect(
+        await service.normalize(
+          source: (
+            pluginId: plugin.id,
+            generation: 1,
+            projectionUpdatedAt: 3,
+            event: const BridgeSseTerminalHandoff(
+              event: BridgeSseSessionIdle(sessionID: "backend-root"),
+            ),
+          ),
+        ),
+        isEmpty,
+      );
+    });
+
     test("recursively drains out-of-order descendants under a durable same-plugin parent", () async {
       await _insertRoot(
         database: database,

--- a/bridge/app/test/helpers/plugin_runtime_test_support.dart
+++ b/bridge/app/test/helpers/plugin_runtime_test_support.dart
@@ -56,7 +56,9 @@ class TestPluginRuntime extends PluginRuntime {
   final Map<String, PluginRuntimeTransition> _transitions = {};
   final StreamController<List<PluginRuntimeSnapshot>> _snapshotChanges = StreamController.broadcast(sync: true);
   bool generationCurrent = true;
+  bool eventGenerationCurrent = true;
   int currentGeneration = 1;
+  Completer<void>? terminalHandoffConsumed;
 
   @override
   Set<String> get activePluginIds => Set<String>.unmodifiable(_plugins.keys);
@@ -70,6 +72,21 @@ class TestPluginRuntime extends PluginRuntime {
   @override
   bool isCurrentGeneration({required String pluginId, required int generation}) {
     return generationCurrent && generation == currentGeneration && _plugins.containsKey(pluginId);
+  }
+
+  @override
+  bool isCurrentEventGeneration({required String pluginId, required int generation}) {
+    return eventGenerationCurrent && generation == currentGeneration && _plugins.containsKey(pluginId);
+  }
+
+  @override
+  bool isCurrentEvent({
+    required String pluginId,
+    required int generation,
+    required BridgeSseEvent event,
+  }) {
+    return isCurrentGeneration(pluginId: pluginId, generation: generation) ||
+        (event is BridgeSseTerminalHandoff && isCurrentEventGeneration(pluginId: pluginId, generation: generation));
   }
 
   @override
@@ -113,7 +130,14 @@ class TestPluginRuntime extends PluginRuntime {
   Stream<SourcedPluginRuntimeEvent> get backendEvents {
     return Rx.merge([
       for (final plugin in _plugins.values)
-        plugin.events.map((event) => (pluginId: plugin.id, generation: currentGeneration, event: event)),
+        plugin.events.map(
+          (event) => (
+            pluginId: plugin.id,
+            generation: currentGeneration,
+            event: event,
+            terminalHandoffConsumed: event is BridgeSseTerminalHandoff ? terminalHandoffConsumed : null,
+          ),
+        ),
     ]);
   }
 
@@ -224,6 +248,16 @@ class _AlwaysCurrentTestPluginRuntime extends TestPluginRuntime {
 
   @override
   bool isCurrentGeneration({required String pluginId, required int generation}) => generation == 1;
+
+  @override
+  bool isCurrentEventGeneration({required String pluginId, required int generation}) => generation == 1;
+
+  @override
+  bool isCurrentEvent({
+    required String pluginId,
+    required int generation,
+    required BridgeSseEvent event,
+  }) => generation == 1;
 }
 
 class _UnusedGenerationFactory implements PluginGenerationFactory {

--- a/bridge/app/test/helpers/plugin_runtime_test_support.dart
+++ b/bridge/app/test/helpers/plugin_runtime_test_support.dart
@@ -55,10 +55,10 @@ class TestPluginRuntime extends PluginRuntime {
   final Map<String, PluginRuntimeState> _states = {};
   final Map<String, PluginRuntimeTransition> _transitions = {};
   final StreamController<List<PluginRuntimeSnapshot>> _snapshotChanges = StreamController.broadcast(sync: true);
+  final StreamController<SourcedPluginRuntimeEvent> _runtimeEvents = StreamController.broadcast(sync: true);
   bool generationCurrent = true;
   bool eventGenerationCurrent = true;
   int currentGeneration = 1;
-  Completer<void>? terminalHandoffConsumed;
 
   @override
   Set<String> get activePluginIds => Set<String>.unmodifiable(_plugins.keys);
@@ -83,10 +83,10 @@ class TestPluginRuntime extends PluginRuntime {
   bool isCurrentEvent({
     required String pluginId,
     required int generation,
-    required BridgeSseEvent event,
+    required bool allowDuringStop,
   }) {
     return isCurrentGeneration(pluginId: pluginId, generation: generation) ||
-        (event is BridgeSseTerminalHandoff && isCurrentEventGeneration(pluginId: pluginId, generation: generation));
+        (allowDuringStop && isCurrentEventGeneration(pluginId: pluginId, generation: generation));
   }
 
   @override
@@ -135,10 +135,27 @@ class TestPluginRuntime extends PluginRuntime {
             pluginId: plugin.id,
             generation: currentGeneration,
             event: event,
-            terminalHandoffConsumed: event is BridgeSseTerminalHandoff ? terminalHandoffConsumed : null,
+            allowDuringStop: false,
+            terminalHandoffConsumed: null,
           ),
         ),
+      _runtimeEvents.stream,
     ]);
+  }
+
+  void emitRuntimeEvent({
+    required String pluginId,
+    required BridgeSseEvent event,
+    required bool allowDuringStop,
+    required Completer<void>? terminalHandoffConsumed,
+  }) {
+    _runtimeEvents.add((
+      pluginId: pluginId,
+      generation: currentGeneration,
+      event: event,
+      allowDuringStop: allowDuringStop,
+      terminalHandoffConsumed: terminalHandoffConsumed,
+    ));
   }
 
   @override
@@ -151,6 +168,7 @@ class TestPluginRuntime extends PluginRuntime {
 
   @override
   Future<void> dispose() async {
+    if (!_runtimeEvents.isClosed) await _runtimeEvents.close();
     if (!_snapshotChanges.isClosed) await _snapshotChanges.close();
   }
 
@@ -256,7 +274,7 @@ class _AlwaysCurrentTestPluginRuntime extends TestPluginRuntime {
   bool isCurrentEvent({
     required String pluginId,
     required int generation,
-    required BridgeSseEvent event,
+    required bool allowDuringStop,
   }) => generation == 1;
 }
 

--- a/bridge/app/test/listeners/plugin_event_listener_test.dart
+++ b/bridge/app/test/listeners/plugin_event_listener_test.dart
@@ -18,9 +18,20 @@ void main() {
         dispatcher: dispatcher,
       );
       listener.start();
+      final terminalHandoffConsumed = Completer<void>();
 
-      source.add((pluginId: "plugin-a", generation: 1, event: const BridgeSseSessionDiff(sessionID: "first")));
-      source.add((pluginId: "plugin-a", generation: 1, event: const BridgeSseProjectUpdated()));
+      source.add((
+        pluginId: "plugin-a",
+        generation: 1,
+        event: const BridgeSseSessionDiff(sessionID: "first"),
+        terminalHandoffConsumed: null,
+      ));
+      source.add((
+        pluginId: "plugin-a",
+        generation: 1,
+        event: const BridgeSseProjectUpdated(),
+        terminalHandoffConsumed: terminalHandoffConsumed,
+      ));
       await Future<void>.delayed(Duration.zero);
 
       expect(dispatcher.captured.map((source) => source.event.runtimeType), [
@@ -28,6 +39,7 @@ void main() {
         BridgeSseProjectUpdated,
       ]);
       expect(dispatcher.dispatched, hasLength(2));
+      expect(dispatcher.terminalHandoffConsumptions, [null, terminalHandoffConsumed]);
 
       firstGate.complete();
       await dispatcher.dispatched.last;
@@ -62,6 +74,7 @@ class _RecordingSessionEventDispatcher implements SessionEventDispatcher {
   final Future<void> _firstGate;
   final List<SourcedBridgeEvent> captured = [];
   final List<Future<void>> dispatched = [];
+  final List<Completer<void>?> terminalHandoffConsumptions = [];
 
   _RecordingSessionEventDispatcher({required Future<void> firstGate}) : _firstGate = firstGate;
 
@@ -82,9 +95,13 @@ class _RecordingSessionEventDispatcher implements SessionEventDispatcher {
   }
 
   @override
-  Future<void> dispatchPluginEvent({required SourcedBridgeEvent source}) {
+  Future<void> dispatchPluginEvent({
+    required SourcedBridgeEvent source,
+    required Completer<void>? terminalHandoffConsumed,
+  }) {
     final future = dispatched.isEmpty ? _firstGate : Future<void>.value();
     dispatched.add(future);
+    terminalHandoffConsumptions.add(terminalHandoffConsumed);
     return future;
   }
 

--- a/bridge/app/test/listeners/plugin_event_listener_test.dart
+++ b/bridge/app/test/listeners/plugin_event_listener_test.dart
@@ -24,12 +24,14 @@ void main() {
         pluginId: "plugin-a",
         generation: 1,
         event: const BridgeSseSessionDiff(sessionID: "first"),
+        allowDuringStop: false,
         terminalHandoffConsumed: null,
       ));
       source.add((
         pluginId: "plugin-a",
         generation: 1,
         event: const BridgeSseProjectUpdated(),
+        allowDuringStop: true,
         terminalHandoffConsumed: terminalHandoffConsumed,
       ));
       await Future<void>.delayed(Duration.zero);
@@ -39,6 +41,7 @@ void main() {
         BridgeSseProjectUpdated,
       ]);
       expect(dispatcher.dispatched, hasLength(2));
+      expect(dispatcher.allowDuringStopValues, [false, true]);
       expect(dispatcher.terminalHandoffConsumptions, [null, terminalHandoffConsumed]);
 
       firstGate.complete();
@@ -74,6 +77,7 @@ class _RecordingSessionEventDispatcher implements SessionEventDispatcher {
   final Future<void> _firstGate;
   final List<SourcedBridgeEvent> captured = [];
   final List<Future<void>> dispatched = [];
+  final List<bool> allowDuringStopValues = [];
   final List<Completer<void>?> terminalHandoffConsumptions = [];
 
   _RecordingSessionEventDispatcher({required Future<void> firstGate}) : _firstGate = firstGate;
@@ -97,10 +101,12 @@ class _RecordingSessionEventDispatcher implements SessionEventDispatcher {
   @override
   Future<void> dispatchPluginEvent({
     required SourcedBridgeEvent source,
+    required bool allowDuringStop,
     required Completer<void>? terminalHandoffConsumed,
   }) {
     final future = dispatched.isEmpty ? _firstGate : Future<void>.value();
     dispatched.add(future);
+    allowDuringStopValues.add(allowDuringStop);
     terminalHandoffConsumptions.add(terminalHandoffConsumed);
     return future;
   }

--- a/bridge/app/tool/benchmarks/benchmark_plugin_runtime.dart
+++ b/bridge/app/tool/benchmarks/benchmark_plugin_runtime.dart
@@ -60,7 +60,14 @@ class BenchmarkPluginRuntime extends PluginRuntime {
   @override
   Stream<SourcedPluginRuntimeEvent> get backendEvents => Rx.merge([
     for (final plugin in _plugins.values)
-      plugin.events.map((event) => (pluginId: plugin.id, generation: 1, event: event)),
+      plugin.events.map(
+        (event) => (
+          pluginId: plugin.id,
+          generation: 1,
+          event: event,
+          terminalHandoffConsumed: null,
+        ),
+      ),
   ]);
 
   @override

--- a/bridge/app/tool/benchmarks/benchmark_plugin_runtime.dart
+++ b/bridge/app/tool/benchmarks/benchmark_plugin_runtime.dart
@@ -65,6 +65,7 @@ class BenchmarkPluginRuntime extends PluginRuntime {
           pluginId: plugin.id,
           generation: 1,
           event: event,
+          allowDuringStop: false,
           terminalHandoffConsumed: null,
         ),
       ),

--- a/bridge/app/tool/benchmarks/catalog_import_event_soak.dart
+++ b/bridge/app/tool/benchmarks/catalog_import_event_soak.dart
@@ -556,7 +556,10 @@ class _CatalogImportEventSoak {
         titleChanged: false,
       ),
     );
-    final normalized = await eventService.normalize(source: source);
+    final normalized = await eventService.normalize(
+      source: source,
+      allowDuringStop: false,
+    );
     if (normalized.length != 1) {
       throw StateError("known-session input produced ${normalized.length} translated events; expected one");
     }

--- a/bridge/app/tool/benchmarks/event_projection_benchmark.dart
+++ b/bridge/app/tool/benchmarks/event_projection_benchmark.dart
@@ -254,6 +254,7 @@ class _EventProjectionBenchmark {
     required int updatedAt,
   }) async {
     final output = await service.normalize(
+      allowDuringStop: false,
       source: service.captureSource(
         pluginId: _pluginId,
         generation: 1,

--- a/bridge/app/tool/benchmarks/multi_plugin_startup_benchmark.dart
+++ b/bridge/app/tool/benchmarks/multi_plugin_startup_benchmark.dart
@@ -330,6 +330,9 @@ class _FakePlugin implements BridgePlugin {
   PluginDiagnostics describe() => PluginDiagnostics(pluginId: _api.id, endpoint: null, details: const {});
 
   @override
+  Future<Set<String>> interruptActiveWork({required Duration budget}) async => const {};
+
+  @override
   Future<void> shutdown({required Duration? budget}) => _shutdownFuture ??= Future.wait([
     _statusController.close(),
     _api.dispose(),

--- a/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
@@ -210,6 +210,8 @@ class AcpApprovalRegistry {
 
   bool get hasAnyPendingInput => _pending.isNotEmpty;
 
+  Set<String> get pendingSessionIds => Set<String>.unmodifiable(_pending.values.map((entry) => entry.sessionId));
+
   /// Resolves every pending approval for [sessionId] as cancelled — used when
   /// a turn is aborted. ACP still requires the client to answer an in-flight
   /// permission/question request, so this responds to the agent (unblocking

--- a/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
@@ -73,8 +73,7 @@ class AcpApprovalRegistry {
     return AcpApprovalRegistry(
       emit: emit,
       respond: (id, result) => client.respondToServerRequest(id: id, result: result),
-      respondError: (id, code, message) =>
-          client.respondToServerRequestWithError(id: id, code: code, message: message),
+      respondError: (id, code, message) => client.respondToServerRequestWithError(id: id, code: code, message: message),
       idGenerator: idGenerator,
       activeSessionResolver: activeSessionResolver,
     );
@@ -104,8 +103,7 @@ class AcpApprovalRegistry {
   void respond(Object acpId, Object? result) => _respond(acpId, result);
 
   /// Respond to a server request with a JSON-RPC error.
-  void respondError(Object acpId, int code, String message) =>
-      _respondError(acpId, code, message);
+  void respondError(Object acpId, int code, String message) => _respondError(acpId, code, message);
 
   /// Generates the next stable bridge request id (`br-N`).
   String generateBridgeId() {
@@ -199,14 +197,12 @@ class AcpApprovalRegistry {
         .toList(growable: false);
   }
 
-  String? sessionIdFor(String bridgeRequestId) =>
-      _pending[bridgeRequestId]?.sessionId;
+  String? sessionIdFor(String bridgeRequestId) => _pending[bridgeRequestId]?.sessionId;
 
   /// Whether [sessionId] is blocked awaiting user input — a pending permission
   /// ask or question. Both kinds count, mirroring the OpenCode tracker's
   /// "awaiting input" notion (see `_rootHasPendingInput`).
-  bool hasPendingInput(String sessionId) =>
-      _pending.values.any((e) => e.sessionId == sessionId);
+  bool hasPendingInput(String sessionId) => _pending.values.any((e) => e.sessionId == sessionId);
 
   bool get hasAnyPendingInput => _pending.isNotEmpty;
 
@@ -290,8 +286,7 @@ class AcpApprovalRegistry {
   bool replyQuestion(String bridgeRequestId, List<List<String>> answers) {
     final entry = _pending.remove(bridgeRequestId);
     if (entry == null || entry.kind != _PendingKind.question) return false;
-    final payload = entry.replyBuilder?.call(answers) ??
-        {"answers": answers.map((row) => row.toList()).toList()};
+    final payload = entry.replyBuilder?.call(answers) ?? {"answers": answers.map((row) => row.toList()).toList()};
     _respond(entry.acpId, payload);
     _emit(
       BridgeSseQuestionReplied(
@@ -410,10 +405,7 @@ class AcpApprovalRegistry {
   List<Map<String, dynamic>> _optionsFrom(Map<String, dynamic> params) {
     final raw = params["options"];
     if (raw is! List) return const [];
-    return raw
-        .whereType<Map<dynamic, dynamic>>()
-        .map((m) => m.cast<String, dynamic>())
-        .toList(growable: false);
+    return raw.whereType<Map<dynamic, dynamic>>().map((m) => m.cast<String, dynamic>()).toList(growable: false);
   }
 
   String? _selectOptionId(

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -779,9 +779,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     required ({String providerID, String modelID})? model,
   }) async {
     final backendCommand = commandForDispatch(command: command);
-    final body = arguments.isEmpty
-        ? "/$backendCommand"
-        : "/$backendCommand $arguments";
+    final body = arguments.isEmpty ? "/$backendCommand" : "/$backendCommand $arguments";
     final visibleBody = userVisibleArguments == null ? "/$command" : "/$command $userVisibleArguments";
     // Acceptance gate — see [sendPrompt].
     await _connectedClient();
@@ -1168,6 +1166,24 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     // turn was blocked on; otherwise the agent keeps waiting on that JSON-RPC
     // request and the phone shows a stale prompt.
     _approvalRegistry?.cancelForSession(sessionId);
+  }
+
+  Future<Set<String>> interruptActiveWork({required Duration budget}) {
+    return () async {
+      final activeSessionIds = <String>{
+        for (final summary in getActiveSessionsSummary())
+          for (final session in summary.activeSessions) ...[session.id, ...session.childSessionIds],
+      };
+      if (activeSessionIds.isEmpty) return const <String>{};
+
+      await Future.wait([
+        for (final sessionId in activeSessionIds) abortSession(sessionId: sessionId),
+      ]);
+      if (currentWorkState != PluginWorkState.idle) {
+        await workState.firstWhere((state) => state == PluginWorkState.idle);
+      }
+      return Set<String>.unmodifiable(activeSessionIds);
+    }().timeout(budget);
   }
 
   @override

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1173,6 +1173,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       final activeSessionIds = <String>{
         for (final summary in getActiveSessionsSummary())
           for (final session in summary.activeSessions) ...[session.id, ...session.childSessionIds],
+        ...?_approvalRegistry?.pendingSessionIds,
       };
       if (activeSessionIds.isEmpty) return const <String>{};
 

--- a/bridge/sesori_plugin_acp/lib/src/runtime/acp_bridge_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/runtime/acp_bridge_plugin.dart
@@ -59,6 +59,11 @@ class AcpBridgePlugin with SteadyPluginLifecycle implements BridgePlugin {
     );
   }
 
+  @override
+  Future<Set<String>> interruptActiveWork({required Duration budget}) {
+    return _plugin.interruptActiveWork(budget: budget);
+  }
+
   /// Eagerly establishes the ACP connection within [budget] so the agent is
   /// spawned and the `initialize` handshake done before the first mobile
   /// request, and the reported status reflects reality.

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -356,6 +356,40 @@ void main() {
       expect(emitted.whereType<BridgeSseSessionIdle>(), hasLength(1));
     });
 
+    test("forced interruption cancels pending input for an untracked session", () async {
+      await connect();
+      const sessionId = "untracked-session";
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 501,
+        "method": "session/request_permission",
+        "params": {
+          "sessionId": sessionId,
+          "toolCall": {"toolCallId": "tc-501", "title": "Run", "kind": "execute"},
+          "options": [
+            {"optionId": "allow", "name": "Allow", "kind": "allow_once"},
+          ],
+        },
+      });
+      await pump();
+      expect(plugin.currentWorkState, PluginWorkState.busy);
+      expect(await plugin.getPendingPermissions(sessionId: sessionId), hasLength(1));
+      emitted.clear();
+
+      final interrupted = await plugin.interruptActiveWork(
+        budget: const Duration(seconds: 1),
+      );
+
+      final cancel = frames("session/cancel").single;
+      expect((cancel["params"] as Map)["sessionId"], sessionId);
+      expect(await plugin.getPendingPermissions(sessionId: sessionId), isEmpty);
+      final clearingEvent = emitted.whereType<BridgeSsePermissionReplied>().single;
+      expect(clearingEvent.sessionID, sessionId);
+      expect(clearingEvent.reply, PluginPermissionReply.reject.name);
+      expect(interrupted, {sessionId});
+      expect(plugin.currentWorkState, PluginWorkState.idle);
+    });
+
     test("an abort landing during turn selection still drops the turn", () async {
       final gated = _GatedSelectionPlugin(
         id: "acp",

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -335,6 +335,27 @@ void main() {
       expect(plugin.getActiveSessionsSummary(), isEmpty);
     });
 
+    test("forced interruption waits for ACP history to quiesce", () async {
+      await connect();
+      final sessionId = await createSession(cwd, "s1");
+      await sendPrompt(sessionId, "long task");
+      final prompt = await waitForFrame("session/prompt");
+      var interruptionCompleted = false;
+
+      final interruption = plugin
+          .interruptActiveWork(budget: const Duration(seconds: 1))
+          .whenComplete(() => interruptionCompleted = true);
+      await waitForFrame("session/cancel");
+      await pump();
+      expect(interruptionCompleted, isFalse);
+
+      respondTo(prompt, {"stopReason": "cancelled"});
+
+      expect(await interruption, {sessionId});
+      expect(plugin.currentWorkState, PluginWorkState.idle);
+      expect(emitted.whereType<BridgeSseSessionIdle>(), hasLength(1));
+    });
+
     test("an abort landing during turn selection still drops the turn", () async {
       final gated = _GatedSelectionPlugin(
         id: "acp",

--- a/bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart
@@ -54,7 +54,7 @@ class CodexAppServerApi {
     );
   }
 
-  Future<void> startTurn({
+  Future<CodexThreadEnvelopeDto> startTurn({
     required String threadId,
     required List<CodexTurnInputDto> input,
     required String? model,
@@ -84,7 +84,8 @@ class CodexAppServerApi {
         ),
       ).toJson();
     }
-    await _client.request(method: "turn/start", params: params);
+    final result = await _client.request(method: "turn/start", params: params);
+    return _decodeResponse(result: result, operation: "turn/start");
   }
 
   Future<void> compactThread({required String threadId}) async {

--- a/bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart
@@ -5,6 +5,7 @@ import "../models/codex_collaboration_mode.dart";
 import "models/codex_collaboration_mode_dto.dart";
 import "models/codex_skill_dto.dart";
 import "models/codex_thread_dto.dart";
+import "models/codex_turn_dto.dart";
 import "models/codex_turn_input_dto.dart";
 
 /// Layer-1 typed boundary for migrated Codex app-server operations.
@@ -54,7 +55,7 @@ class CodexAppServerApi {
     );
   }
 
-  Future<CodexThreadEnvelopeDto> startTurn({
+  Future<CodexTurnStartResponseDto> startTurn({
     required String threadId,
     required List<CodexTurnInputDto> input,
     required String? model,
@@ -85,7 +86,13 @@ class CodexAppServerApi {
       ).toJson();
     }
     final result = await _client.request(method: "turn/start", params: params);
-    return _decodeResponse(result: result, operation: "turn/start");
+    if (result is! Map) {
+      throw StateError(
+        "expected a Codex turn response object from turn/start, got "
+        "${result.runtimeType}",
+      );
+    }
+    return CodexTurnStartResponseDto.fromJson(result.cast<String, dynamic>());
   }
 
   Future<void> compactThread({required String threadId}) async {

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.dart
@@ -7,7 +7,6 @@ part "codex_thread_dto.g.dart";
 sealed class CodexThreadEnvelopeDto with _$CodexThreadEnvelopeDto {
   const factory CodexThreadEnvelopeDto({
     required CodexThreadDto? thread,
-    required String? turnId,
     required String? model,
     required String? modelProvider,
     required String? cwd,

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.dart
@@ -7,6 +7,7 @@ part "codex_thread_dto.g.dart";
 sealed class CodexThreadEnvelopeDto with _$CodexThreadEnvelopeDto {
   const factory CodexThreadEnvelopeDto({
     required CodexThreadDto? thread,
+    required String? turnId,
     required String? model,
     required String? modelProvider,
     required String? cwd,

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$CodexThreadEnvelopeDto {
 
- CodexThreadDto? get thread; String? get turnId; String? get model; String? get modelProvider; String? get cwd;
+ CodexThreadDto? get thread; String? get model; String? get modelProvider; String? get cwd;
 /// Create a copy of CodexThreadEnvelopeDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,16 +26,16 @@ $CodexThreadEnvelopeDtoCopyWith<CodexThreadEnvelopeDto> get copyWith => _$CodexT
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadEnvelopeDto&&(identical(other.thread, thread) || other.thread == thread)&&(identical(other.turnId, turnId) || other.turnId == turnId)&&(identical(other.model, model) || other.model == model)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.cwd, cwd) || other.cwd == cwd));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadEnvelopeDto&&(identical(other.thread, thread) || other.thread == thread)&&(identical(other.model, model) || other.model == model)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.cwd, cwd) || other.cwd == cwd));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,thread,turnId,model,modelProvider,cwd);
+int get hashCode => Object.hash(runtimeType,thread,model,modelProvider,cwd);
 
 @override
 String toString() {
-  return 'CodexThreadEnvelopeDto(thread: $thread, turnId: $turnId, model: $model, modelProvider: $modelProvider, cwd: $cwd)';
+  return 'CodexThreadEnvelopeDto(thread: $thread, model: $model, modelProvider: $modelProvider, cwd: $cwd)';
 }
 
 
@@ -46,7 +46,7 @@ abstract mixin class $CodexThreadEnvelopeDtoCopyWith<$Res>  {
   factory $CodexThreadEnvelopeDtoCopyWith(CodexThreadEnvelopeDto value, $Res Function(CodexThreadEnvelopeDto) _then) = _$CodexThreadEnvelopeDtoCopyWithImpl;
 @useResult
 $Res call({
- CodexThreadDto? thread, String? turnId, String? model, String? modelProvider, String? cwd
+ CodexThreadDto? thread, String? model, String? modelProvider, String? cwd
 });
 
 
@@ -63,11 +63,10 @@ class _$CodexThreadEnvelopeDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexThreadEnvelopeDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? thread = freezed,Object? turnId = freezed,Object? model = freezed,Object? modelProvider = freezed,Object? cwd = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? thread = freezed,Object? model = freezed,Object? modelProvider = freezed,Object? cwd = freezed,}) {
   return _then(_self.copyWith(
 thread: freezed == thread ? _self.thread : thread // ignore: cast_nullable_to_non_nullable
-as CodexThreadDto?,turnId: freezed == turnId ? _self.turnId : turnId // ignore: cast_nullable_to_non_nullable
-as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
+as CodexThreadDto?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
 as String?,modelProvider: freezed == modelProvider ? _self.modelProvider : modelProvider // ignore: cast_nullable_to_non_nullable
 as String?,cwd: freezed == cwd ? _self.cwd : cwd // ignore: cast_nullable_to_non_nullable
 as String?,
@@ -94,11 +93,10 @@ $CodexThreadDtoCopyWith<$Res>? get thread {
 @JsonSerializable(createToJson: false)
 
 class _CodexThreadEnvelopeDto implements CodexThreadEnvelopeDto {
-  const _CodexThreadEnvelopeDto({required this.thread, required this.turnId, required this.model, required this.modelProvider, required this.cwd});
+  const _CodexThreadEnvelopeDto({required this.thread, required this.model, required this.modelProvider, required this.cwd});
   factory _CodexThreadEnvelopeDto.fromJson(Map<String, dynamic> json) => _$CodexThreadEnvelopeDtoFromJson(json);
 
 @override final  CodexThreadDto? thread;
-@override final  String? turnId;
 @override final  String? model;
 @override final  String? modelProvider;
 @override final  String? cwd;
@@ -113,16 +111,16 @@ _$CodexThreadEnvelopeDtoCopyWith<_CodexThreadEnvelopeDto> get copyWith => __$Cod
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexThreadEnvelopeDto&&(identical(other.thread, thread) || other.thread == thread)&&(identical(other.turnId, turnId) || other.turnId == turnId)&&(identical(other.model, model) || other.model == model)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.cwd, cwd) || other.cwd == cwd));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexThreadEnvelopeDto&&(identical(other.thread, thread) || other.thread == thread)&&(identical(other.model, model) || other.model == model)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.cwd, cwd) || other.cwd == cwd));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,thread,turnId,model,modelProvider,cwd);
+int get hashCode => Object.hash(runtimeType,thread,model,modelProvider,cwd);
 
 @override
 String toString() {
-  return 'CodexThreadEnvelopeDto(thread: $thread, turnId: $turnId, model: $model, modelProvider: $modelProvider, cwd: $cwd)';
+  return 'CodexThreadEnvelopeDto(thread: $thread, model: $model, modelProvider: $modelProvider, cwd: $cwd)';
 }
 
 
@@ -133,7 +131,7 @@ abstract mixin class _$CodexThreadEnvelopeDtoCopyWith<$Res> implements $CodexThr
   factory _$CodexThreadEnvelopeDtoCopyWith(_CodexThreadEnvelopeDto value, $Res Function(_CodexThreadEnvelopeDto) _then) = __$CodexThreadEnvelopeDtoCopyWithImpl;
 @override @useResult
 $Res call({
- CodexThreadDto? thread, String? turnId, String? model, String? modelProvider, String? cwd
+ CodexThreadDto? thread, String? model, String? modelProvider, String? cwd
 });
 
 
@@ -150,11 +148,10 @@ class __$CodexThreadEnvelopeDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexThreadEnvelopeDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? thread = freezed,Object? turnId = freezed,Object? model = freezed,Object? modelProvider = freezed,Object? cwd = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? thread = freezed,Object? model = freezed,Object? modelProvider = freezed,Object? cwd = freezed,}) {
   return _then(_CodexThreadEnvelopeDto(
 thread: freezed == thread ? _self.thread : thread // ignore: cast_nullable_to_non_nullable
-as CodexThreadDto?,turnId: freezed == turnId ? _self.turnId : turnId // ignore: cast_nullable_to_non_nullable
-as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
+as CodexThreadDto?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
 as String?,modelProvider: freezed == modelProvider ? _self.modelProvider : modelProvider // ignore: cast_nullable_to_non_nullable
 as String?,cwd: freezed == cwd ? _self.cwd : cwd // ignore: cast_nullable_to_non_nullable
 as String?,

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$CodexThreadEnvelopeDto {
 
- CodexThreadDto? get thread; String? get model; String? get modelProvider; String? get cwd;
+ CodexThreadDto? get thread; String? get turnId; String? get model; String? get modelProvider; String? get cwd;
 /// Create a copy of CodexThreadEnvelopeDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,16 +26,16 @@ $CodexThreadEnvelopeDtoCopyWith<CodexThreadEnvelopeDto> get copyWith => _$CodexT
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadEnvelopeDto&&(identical(other.thread, thread) || other.thread == thread)&&(identical(other.model, model) || other.model == model)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.cwd, cwd) || other.cwd == cwd));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadEnvelopeDto&&(identical(other.thread, thread) || other.thread == thread)&&(identical(other.turnId, turnId) || other.turnId == turnId)&&(identical(other.model, model) || other.model == model)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.cwd, cwd) || other.cwd == cwd));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,thread,model,modelProvider,cwd);
+int get hashCode => Object.hash(runtimeType,thread,turnId,model,modelProvider,cwd);
 
 @override
 String toString() {
-  return 'CodexThreadEnvelopeDto(thread: $thread, model: $model, modelProvider: $modelProvider, cwd: $cwd)';
+  return 'CodexThreadEnvelopeDto(thread: $thread, turnId: $turnId, model: $model, modelProvider: $modelProvider, cwd: $cwd)';
 }
 
 
@@ -46,7 +46,7 @@ abstract mixin class $CodexThreadEnvelopeDtoCopyWith<$Res>  {
   factory $CodexThreadEnvelopeDtoCopyWith(CodexThreadEnvelopeDto value, $Res Function(CodexThreadEnvelopeDto) _then) = _$CodexThreadEnvelopeDtoCopyWithImpl;
 @useResult
 $Res call({
- CodexThreadDto? thread, String? model, String? modelProvider, String? cwd
+ CodexThreadDto? thread, String? turnId, String? model, String? modelProvider, String? cwd
 });
 
 
@@ -63,10 +63,11 @@ class _$CodexThreadEnvelopeDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexThreadEnvelopeDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? thread = freezed,Object? model = freezed,Object? modelProvider = freezed,Object? cwd = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? thread = freezed,Object? turnId = freezed,Object? model = freezed,Object? modelProvider = freezed,Object? cwd = freezed,}) {
   return _then(_self.copyWith(
 thread: freezed == thread ? _self.thread : thread // ignore: cast_nullable_to_non_nullable
-as CodexThreadDto?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
+as CodexThreadDto?,turnId: freezed == turnId ? _self.turnId : turnId // ignore: cast_nullable_to_non_nullable
+as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
 as String?,modelProvider: freezed == modelProvider ? _self.modelProvider : modelProvider // ignore: cast_nullable_to_non_nullable
 as String?,cwd: freezed == cwd ? _self.cwd : cwd // ignore: cast_nullable_to_non_nullable
 as String?,
@@ -93,10 +94,11 @@ $CodexThreadDtoCopyWith<$Res>? get thread {
 @JsonSerializable(createToJson: false)
 
 class _CodexThreadEnvelopeDto implements CodexThreadEnvelopeDto {
-  const _CodexThreadEnvelopeDto({required this.thread, required this.model, required this.modelProvider, required this.cwd});
+  const _CodexThreadEnvelopeDto({required this.thread, required this.turnId, required this.model, required this.modelProvider, required this.cwd});
   factory _CodexThreadEnvelopeDto.fromJson(Map<String, dynamic> json) => _$CodexThreadEnvelopeDtoFromJson(json);
 
 @override final  CodexThreadDto? thread;
+@override final  String? turnId;
 @override final  String? model;
 @override final  String? modelProvider;
 @override final  String? cwd;
@@ -111,16 +113,16 @@ _$CodexThreadEnvelopeDtoCopyWith<_CodexThreadEnvelopeDto> get copyWith => __$Cod
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexThreadEnvelopeDto&&(identical(other.thread, thread) || other.thread == thread)&&(identical(other.model, model) || other.model == model)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.cwd, cwd) || other.cwd == cwd));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexThreadEnvelopeDto&&(identical(other.thread, thread) || other.thread == thread)&&(identical(other.turnId, turnId) || other.turnId == turnId)&&(identical(other.model, model) || other.model == model)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.cwd, cwd) || other.cwd == cwd));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,thread,model,modelProvider,cwd);
+int get hashCode => Object.hash(runtimeType,thread,turnId,model,modelProvider,cwd);
 
 @override
 String toString() {
-  return 'CodexThreadEnvelopeDto(thread: $thread, model: $model, modelProvider: $modelProvider, cwd: $cwd)';
+  return 'CodexThreadEnvelopeDto(thread: $thread, turnId: $turnId, model: $model, modelProvider: $modelProvider, cwd: $cwd)';
 }
 
 
@@ -131,7 +133,7 @@ abstract mixin class _$CodexThreadEnvelopeDtoCopyWith<$Res> implements $CodexThr
   factory _$CodexThreadEnvelopeDtoCopyWith(_CodexThreadEnvelopeDto value, $Res Function(_CodexThreadEnvelopeDto) _then) = __$CodexThreadEnvelopeDtoCopyWithImpl;
 @override @useResult
 $Res call({
- CodexThreadDto? thread, String? model, String? modelProvider, String? cwd
+ CodexThreadDto? thread, String? turnId, String? model, String? modelProvider, String? cwd
 });
 
 
@@ -148,10 +150,11 @@ class __$CodexThreadEnvelopeDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexThreadEnvelopeDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? thread = freezed,Object? model = freezed,Object? modelProvider = freezed,Object? cwd = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? thread = freezed,Object? turnId = freezed,Object? model = freezed,Object? modelProvider = freezed,Object? cwd = freezed,}) {
   return _then(_CodexThreadEnvelopeDto(
 thread: freezed == thread ? _self.thread : thread // ignore: cast_nullable_to_non_nullable
-as CodexThreadDto?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
+as CodexThreadDto?,turnId: freezed == turnId ? _self.turnId : turnId // ignore: cast_nullable_to_non_nullable
+as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
 as String?,modelProvider: freezed == modelProvider ? _self.modelProvider : modelProvider // ignore: cast_nullable_to_non_nullable
 as String?,cwd: freezed == cwd ? _self.cwd : cwd // ignore: cast_nullable_to_non_nullable
 as String?,

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.g.dart
@@ -13,6 +13,7 @@ _CodexThreadEnvelopeDto _$CodexThreadEnvelopeDtoFromJson(Map json) =>
           : CodexThreadDto.fromJson(
               Map<String, dynamic>.from(json['thread'] as Map),
             ),
+      turnId: json['turnId'] as String?,
       model: json['model'] as String?,
       modelProvider: json['modelProvider'] as String?,
       cwd: json['cwd'] as String?,

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.g.dart
@@ -13,7 +13,6 @@ _CodexThreadEnvelopeDto _$CodexThreadEnvelopeDtoFromJson(Map json) =>
           : CodexThreadDto.fromJson(
               Map<String, dynamic>.from(json['thread'] as Map),
             ),
-      turnId: json['turnId'] as String?,
       model: json['model'] as String?,
       modelProvider: json['modelProvider'] as String?,
       cwd: json['cwd'] as String?,

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_turn_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_turn_dto.dart
@@ -1,0 +1,22 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "codex_turn_dto.freezed.dart";
+part "codex_turn_dto.g.dart";
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CodexTurnStartResponseDto with _$CodexTurnStartResponseDto {
+  const factory CodexTurnStartResponseDto({
+    required CodexTurnDto? turn,
+  }) = _CodexTurnStartResponseDto;
+
+  factory CodexTurnStartResponseDto.fromJson(Map<String, dynamic> json) => _$CodexTurnStartResponseDtoFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CodexTurnDto with _$CodexTurnDto {
+  const factory CodexTurnDto({
+    required String? id,
+  }) = _CodexTurnDto;
+
+  factory CodexTurnDto.fromJson(Map<String, dynamic> json) => _$CodexTurnDtoFromJson(json);
+}

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_turn_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_turn_dto.freezed.dart
@@ -1,0 +1,296 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'codex_turn_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$CodexTurnStartResponseDto {
+
+ CodexTurnDto? get turn;
+/// Create a copy of CodexTurnStartResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexTurnStartResponseDtoCopyWith<CodexTurnStartResponseDto> get copyWith => _$CodexTurnStartResponseDtoCopyWithImpl<CodexTurnStartResponseDto>(this as CodexTurnStartResponseDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexTurnStartResponseDto&&(identical(other.turn, turn) || other.turn == turn));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,turn);
+
+@override
+String toString() {
+  return 'CodexTurnStartResponseDto(turn: $turn)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexTurnStartResponseDtoCopyWith<$Res>  {
+  factory $CodexTurnStartResponseDtoCopyWith(CodexTurnStartResponseDto value, $Res Function(CodexTurnStartResponseDto) _then) = _$CodexTurnStartResponseDtoCopyWithImpl;
+@useResult
+$Res call({
+ CodexTurnDto? turn
+});
+
+
+$CodexTurnDtoCopyWith<$Res>? get turn;
+
+}
+/// @nodoc
+class _$CodexTurnStartResponseDtoCopyWithImpl<$Res>
+    implements $CodexTurnStartResponseDtoCopyWith<$Res> {
+  _$CodexTurnStartResponseDtoCopyWithImpl(this._self, this._then);
+
+  final CodexTurnStartResponseDto _self;
+  final $Res Function(CodexTurnStartResponseDto) _then;
+
+/// Create a copy of CodexTurnStartResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? turn = freezed,}) {
+  return _then(_self.copyWith(
+turn: freezed == turn ? _self.turn : turn // ignore: cast_nullable_to_non_nullable
+as CodexTurnDto?,
+  ));
+}
+/// Create a copy of CodexTurnStartResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CodexTurnDtoCopyWith<$Res>? get turn {
+    if (_self.turn == null) {
+    return null;
+  }
+
+  return $CodexTurnDtoCopyWith<$Res>(_self.turn!, (value) {
+    return _then(_self.copyWith(turn: value));
+  });
+}
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexTurnStartResponseDto implements CodexTurnStartResponseDto {
+  const _CodexTurnStartResponseDto({required this.turn});
+  factory _CodexTurnStartResponseDto.fromJson(Map<String, dynamic> json) => _$CodexTurnStartResponseDtoFromJson(json);
+
+@override final  CodexTurnDto? turn;
+
+/// Create a copy of CodexTurnStartResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexTurnStartResponseDtoCopyWith<_CodexTurnStartResponseDto> get copyWith => __$CodexTurnStartResponseDtoCopyWithImpl<_CodexTurnStartResponseDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexTurnStartResponseDto&&(identical(other.turn, turn) || other.turn == turn));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,turn);
+
+@override
+String toString() {
+  return 'CodexTurnStartResponseDto(turn: $turn)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexTurnStartResponseDtoCopyWith<$Res> implements $CodexTurnStartResponseDtoCopyWith<$Res> {
+  factory _$CodexTurnStartResponseDtoCopyWith(_CodexTurnStartResponseDto value, $Res Function(_CodexTurnStartResponseDto) _then) = __$CodexTurnStartResponseDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ CodexTurnDto? turn
+});
+
+
+@override $CodexTurnDtoCopyWith<$Res>? get turn;
+
+}
+/// @nodoc
+class __$CodexTurnStartResponseDtoCopyWithImpl<$Res>
+    implements _$CodexTurnStartResponseDtoCopyWith<$Res> {
+  __$CodexTurnStartResponseDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexTurnStartResponseDto _self;
+  final $Res Function(_CodexTurnStartResponseDto) _then;
+
+/// Create a copy of CodexTurnStartResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? turn = freezed,}) {
+  return _then(_CodexTurnStartResponseDto(
+turn: freezed == turn ? _self.turn : turn // ignore: cast_nullable_to_non_nullable
+as CodexTurnDto?,
+  ));
+}
+
+/// Create a copy of CodexTurnStartResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CodexTurnDtoCopyWith<$Res>? get turn {
+    if (_self.turn == null) {
+    return null;
+  }
+
+  return $CodexTurnDtoCopyWith<$Res>(_self.turn!, (value) {
+    return _then(_self.copyWith(turn: value));
+  });
+}
+}
+
+
+/// @nodoc
+mixin _$CodexTurnDto {
+
+ String? get id;
+/// Create a copy of CodexTurnDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexTurnDtoCopyWith<CodexTurnDto> get copyWith => _$CodexTurnDtoCopyWithImpl<CodexTurnDto>(this as CodexTurnDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexTurnDto&&(identical(other.id, id) || other.id == id));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id);
+
+@override
+String toString() {
+  return 'CodexTurnDto(id: $id)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexTurnDtoCopyWith<$Res>  {
+  factory $CodexTurnDtoCopyWith(CodexTurnDto value, $Res Function(CodexTurnDto) _then) = _$CodexTurnDtoCopyWithImpl;
+@useResult
+$Res call({
+ String? id
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexTurnDtoCopyWithImpl<$Res>
+    implements $CodexTurnDtoCopyWith<$Res> {
+  _$CodexTurnDtoCopyWithImpl(this._self, this._then);
+
+  final CodexTurnDto _self;
+  final $Res Function(CodexTurnDto) _then;
+
+/// Create a copy of CodexTurnDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,}) {
+  return _then(_self.copyWith(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexTurnDto implements CodexTurnDto {
+  const _CodexTurnDto({required this.id});
+  factory _CodexTurnDto.fromJson(Map<String, dynamic> json) => _$CodexTurnDtoFromJson(json);
+
+@override final  String? id;
+
+/// Create a copy of CodexTurnDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexTurnDtoCopyWith<_CodexTurnDto> get copyWith => __$CodexTurnDtoCopyWithImpl<_CodexTurnDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexTurnDto&&(identical(other.id, id) || other.id == id));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id);
+
+@override
+String toString() {
+  return 'CodexTurnDto(id: $id)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexTurnDtoCopyWith<$Res> implements $CodexTurnDtoCopyWith<$Res> {
+  factory _$CodexTurnDtoCopyWith(_CodexTurnDto value, $Res Function(_CodexTurnDto) _then) = __$CodexTurnDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String? id
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexTurnDtoCopyWithImpl<$Res>
+    implements _$CodexTurnDtoCopyWith<$Res> {
+  __$CodexTurnDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexTurnDto _self;
+  final $Res Function(_CodexTurnDto) _then;
+
+/// Create a copy of CodexTurnDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,}) {
+  return _then(_CodexTurnDto(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_turn_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_turn_dto.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'codex_turn_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_CodexTurnStartResponseDto _$CodexTurnStartResponseDtoFromJson(Map json) =>
+    _CodexTurnStartResponseDto(
+      turn: json['turn'] == null
+          ? null
+          : CodexTurnDto.fromJson(
+              Map<String, dynamic>.from(json['turn'] as Map),
+            ),
+    );
+
+_CodexTurnDto _$CodexTurnDtoFromJson(Map json) =>
+    _CodexTurnDto(id: json['id'] as String?);

--- a/bridge/sesori_plugin_codex/lib/src/approval_registry.dart
+++ b/bridge/sesori_plugin_codex/lib/src/approval_registry.dart
@@ -85,8 +85,7 @@ enum _PendingKind { permission, question }
 /// Per-request reply functions injected at construction time so the
 /// registry stays decoupled from [CodexAppServerClient].
 typedef ApprovalResponder = void Function(Object id, Object? result);
-typedef ApprovalErrorResponder =
-    void Function(Object id, int code, String message);
+typedef ApprovalErrorResponder = void Function(Object id, int code, String message);
 
 /// Routes codex server-originated approval requests to the bridge SSE
 /// stream and answers them when the bridge consumer replies.
@@ -189,13 +188,15 @@ class ApprovalRegistry {
 
   /// Returns the session id for a pending request, or null if the id is
   /// unknown.
-  String? sessionIdFor(String bridgeRequestId) =>
-      _pending[bridgeRequestId]?.sessionId;
+  String? sessionIdFor(String bridgeRequestId) => _pending[bridgeRequestId]?.sessionId;
 
-  bool hasPendingInput(String sessionId) =>
-      _pending.values.any((entry) => entry.sessionId == sessionId);
+  bool hasPendingInput(String sessionId) => _pending.values.any((entry) => entry.sessionId == sessionId);
 
   bool get hasAnyPendingInput => _pending.isNotEmpty;
+
+  Set<String> get pendingSessionIds => Set<String>.unmodifiable(
+    _pending.values.map((entry) => entry.sessionId),
+  );
 
   void cancelForSession(String sessionId) {
     final entries = _pending.values.where((entry) => entry.sessionId == sessionId).toList(growable: false);
@@ -381,8 +382,7 @@ class ApprovalRegistry {
   /// `PermissionAsked` event and the pending-permission snapshot so the two
   /// never drift.
   String _permissionDescriptionFor(_PendingApproval entry) =>
-      (entry.params["reason"] as String?) ??
-      _descriptionFallback(entry.method, entry.params);
+      (entry.params["reason"] as String?) ?? _descriptionFallback(entry.method, entry.params);
 
   /// Builds the JSON-RPC result payload for a permission reply, keyed by the
   /// request's wire method:

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -340,6 +340,7 @@ class CodexPlugin implements CodexManagedApi {
       _eventMapper.mapThreadStarted(thread).forEach(_eventBuffer.add);
       return;
     }
+    if (_isSupersededTurnLifecycleNotification(notification)) return;
     final threadId = notification.params["threadId"] as String?;
     if (notification.method == "turn/started" && threadId != null) {
       // Calls initiated through this plugin start tailing before turn/start.
@@ -354,6 +355,7 @@ class CodexPlugin implements CodexManagedApi {
             _eventMapper.isIdleThreadStatus(notification.params["status"]));
     if (terminalHistory && threadId != null) {
       await _rolloutTailer.finish(sessionId: threadId);
+      if (_isSupersededTurnLifecycleNotification(notification)) return;
     }
     // Keep work state busy until the terminal rollout drain has emitted its
     // final tool updates. Forced runtime teardown waits for this transition
@@ -432,6 +434,37 @@ class CodexPlugin implements CodexManagedApi {
     );
   }
 
+  bool _isSupersededTurnLifecycleNotification(
+    CodexServerNotification notification,
+  ) {
+    final threadId = notification.params["threadId"] as String?;
+    if (threadId == null) return false;
+    final tracksTurnIdentity = switch (notification.method) {
+      "turn/started" || "turn/completed" || "error" || "thread/status/changed" => true,
+      _ => false,
+    };
+    if (!tracksTurnIdentity) return false;
+
+    final activeTurnId = _activeTurnByThread[threadId];
+    final notificationTurnId = _notificationTurnId(notification.params);
+    if (activeTurnId != null && notificationTurnId != null && activeTurnId != notificationTurnId) {
+      return true;
+    }
+    return notification.method == "thread/status/changed" &&
+        _eventMapper.isIdleThreadStatus(notification.params["status"]) &&
+        notificationTurnId == null &&
+        (activeTurnId != null || _provisionalAcceptedTurnThreadIds.contains(threadId));
+  }
+
+  String? _notificationTurnId(Map<String, dynamic> params) {
+    final turn = params["turn"];
+    Object? value = turn is Map ? turn["id"] : null;
+    value ??= params["turnId"];
+    if (value is! String) return null;
+    final trimmed = value.trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
+
   bool _maintainBookkeeping(CodexServerNotification notification) {
     final params = notification.params;
     final threadId = params["threadId"] as String?;
@@ -439,8 +472,7 @@ class CodexPlugin implements CodexManagedApi {
       case "turn/started":
         if (threadId == null) return false;
         if (!_recordAuthoritativeTurnEvidence(threadId)) return false;
-        final turn = (params["turn"] as Map?)?.cast<String, dynamic>();
-        final turnId = turn?["id"] as String?;
+        final turnId = _notificationTurnId(params);
         if (turnId != null) _activeTurnByThread[threadId] = turnId;
         return _setSessionStatus(threadId, const PluginSessionStatus.busy());
       case "turn/completed":
@@ -654,9 +686,13 @@ class CodexPlugin implements CodexManagedApi {
       if (resolvedModel != null) {
         _eventMapper.setThreadModel(sessionId, resolvedModel);
       }
-      if (!_deletedThreadIds.contains(sessionId) &&
-          (_turnEvidenceRevisionByThread[sessionId] ?? 0) == evidenceRevision) {
-        _provisionalAcceptedTurnThreadIds.add(sessionId);
+      final turnId = dispatch.turnId;
+      if (turnId != null) {
+        _recordAcceptedTurn(
+          threadId: sessionId,
+          turnId: turnId,
+          evidenceRevision: evidenceRevision,
+        );
       }
       _syncWorkState();
     } on Object {
@@ -759,16 +795,31 @@ class CodexPlugin implements CodexManagedApi {
       if (resolvedModel != null) {
         _eventMapper.setThreadModel(threadId, resolvedModel);
       }
-      if (!_deletedThreadIds.contains(threadId) && (_turnEvidenceRevisionByThread[threadId] ?? 0) == evidenceRevision) {
-        final turnId = dispatch.turnId;
-        if (turnId != null) _activeTurnByThread[threadId] = turnId;
-        _provisionalAcceptedTurnThreadIds.add(threadId);
+      final turnId = dispatch.turnId;
+      if (turnId != null) {
+        _recordAcceptedTurn(
+          threadId: threadId,
+          turnId: turnId,
+          evidenceRevision: evidenceRevision,
+        );
       }
       _syncWorkState();
     } on Object {
       _rolloutTailer.stop(sessionId: threadId);
       rethrow;
     }
+  }
+
+  void _recordAcceptedTurn({
+    required String threadId,
+    required String turnId,
+    required int evidenceRevision,
+  }) {
+    if (_deletedThreadIds.contains(threadId) || (_turnEvidenceRevisionByThread[threadId] ?? 0) != evidenceRevision) {
+      return;
+    }
+    _activeTurnByThread[threadId] = turnId;
+    _provisionalAcceptedTurnThreadIds.add(threadId);
   }
 
   bool _recordAuthoritativeTurnEvidence(String threadId) {

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -346,18 +346,24 @@ class CodexPlugin implements CodexManagedApi {
       // This fallback covers a turn started by another app-server client.
       _rolloutTailer.start(sessionId: threadId);
     }
-    final activityChanged = _maintainBookkeeping(notification);
-    if (notification.method == "turn/completed" && threadId != null) {
+    final terminalHistory =
+        notification.method == "turn/completed" ||
+        notification.method == "error" ||
+        notification.method == "thread/closed" ||
+        (notification.method == "thread/status/changed" &&
+            _eventMapper.isIdleThreadStatus(notification.params["status"]));
+    if (terminalHistory && threadId != null) {
       await _rolloutTailer.finish(sessionId: threadId);
     }
+    // Keep work state busy until the terminal rollout drain has emitted its
+    // final tool updates. Forced runtime teardown waits for this transition
+    // before disconnecting the generation's event stream.
+    final activityChanged = _maintainBookkeeping(notification);
     _eventMapper.map(notification).forEach(_eventBuffer.add);
     if (notification.method == "item/completed" && threadId != null) {
       // The app-server item is provisional; a rollout output written for the
       // same call id immediately enriches it with executor metadata.
       _rolloutTailer.drain(sessionId: threadId);
-    }
-    if (threadId != null && (notification.method == "error" || notification.method == "thread/closed")) {
-      _rolloutTailer.stop(sessionId: threadId);
     }
     if (threadId != null &&
         (notification.method == "turn/completed" ||
@@ -452,11 +458,11 @@ class CodexPlugin implements CodexManagedApi {
       case "thread/status/changed":
         if (threadId == null) return false;
         if (!_recordAuthoritativeTurnEvidence(threadId)) return false;
+        final idle = _eventMapper.isIdleThreadStatus(params["status"]);
+        if (idle) _activeTurnByThread.remove(threadId);
         return _setSessionStatus(
           threadId,
-          _eventMapper.isIdleThreadStatus(params["status"])
-              ? const PluginSessionStatus.idle()
-              : const PluginSessionStatus.busy(),
+          idle ? const PluginSessionStatus.idle() : const PluginSessionStatus.busy(),
         );
       case "thread/closed":
         if (threadId == null) return false;
@@ -661,10 +667,17 @@ class CodexPlugin implements CodexManagedApi {
 
   @override
   Future<void> abortSession({required String sessionId}) async {
+    _approvalRegistry?.cancelForSession(sessionId);
     final turnId = _activeTurnByThread[sessionId];
-    if (turnId == null) return;
+    if (turnId == null) {
+      _syncWorkState();
+      return;
+    }
     final client = _client;
-    if (client == null) return;
+    if (client == null) {
+      _syncWorkState();
+      return;
+    }
     try {
       await client.request(
         method: "turn/interrupt",
@@ -676,7 +689,31 @@ class CodexPlugin implements CodexManagedApi {
       if (error.code != -32602) rethrow;
     } finally {
       _activeTurnByThread.remove(sessionId);
+      _syncWorkState();
     }
+  }
+
+  @override
+  Future<Set<String>> interruptActiveWork({required Duration budget}) {
+    return () async {
+      final activeSessionIds = <String>{
+        ..._provisionalAcceptedTurnThreadIds,
+        ..._activeTurnByThread.keys,
+        for (final entry in _sessionStatuses.entries)
+          if (_isActiveStatus(entry.value)) entry.key,
+        ...?_approvalRegistry?.pendingSessionIds,
+      };
+      if (activeSessionIds.isEmpty) return const <String>{};
+
+      await Future.wait([
+        for (final sessionId in activeSessionIds) abortSession(sessionId: sessionId),
+      ]);
+      await _notificationWork;
+      if (currentWorkState != PluginWorkState.idle) {
+        await workState.firstWhere((state) => state == PluginWorkState.idle);
+      }
+      return Set<String>.unmodifiable(activeSessionIds);
+    }().timeout(budget);
   }
 
   Future<void> _startTurn({
@@ -723,6 +760,8 @@ class CodexPlugin implements CodexManagedApi {
         _eventMapper.setThreadModel(threadId, resolvedModel);
       }
       if (!_deletedThreadIds.contains(threadId) && (_turnEvidenceRevisionByThread[threadId] ?? 0) == evidenceRevision) {
+        final turnId = dispatch.turnId;
+        if (turnId != null) _activeTurnByThread[threadId] = turnId;
         _provisionalAcceptedTurnThreadIds.add(threadId);
       }
       _syncWorkState();

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_thread_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_thread_repository.dart
@@ -84,7 +84,11 @@ class CodexThreadRepository {
         collaborationMode: collaborationMode,
       ),
     );
-    return response.turnId;
+    final turnId = _usefulText(response.turn?.id);
+    if (turnId == null) {
+      throw StateError("turn/start response missing turn.id");
+    }
+    return turnId;
   }
 
   Future<void> compactThread({required String threadId}) => _request(

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_thread_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_thread_repository.dart
@@ -65,7 +65,7 @@ class CodexThreadRepository {
     return _mapRequired(dto: dto, operation: "thread/resume");
   }
 
-  Future<bool> startTurn({
+  Future<String?> startTurn({
     required String threadId,
     required List<PluginPromptPart> parts,
     required String? model,
@@ -73,8 +73,8 @@ class CodexThreadRepository {
     required CodexCollaborationMode? collaborationMode,
   }) async {
     final input = parts.map(_mapTurnInput).whereType<CodexTurnInputDto>().toList();
-    if (input.isEmpty) return false;
-    await _request(
+    if (input.isEmpty) return null;
+    final response = await _request(
       operation: "turn/start",
       request: () => _appServerApi.startTurn(
         threadId: threadId,
@@ -84,7 +84,7 @@ class CodexThreadRepository {
         collaborationMode: collaborationMode,
       ),
     );
-    return true;
+    return response.turnId;
   }
 
   Future<void> compactThread({required String threadId}) => _request(

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_bridge_plugin.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_bridge_plugin.dart
@@ -66,6 +66,11 @@ class CodexBridgePlugin implements BridgePlugin {
     );
   }
 
+  @override
+  Future<Set<String>> interruptActiveWork({required Duration budget}) {
+    return api.interruptActiveWork(budget: budget);
+  }
+
   /// Stops the plugin in order: disarm the monitor (so the child's deliberate
   /// exit is never mistaken for a crash), tear down the api, then stop the owned
   /// `codex app-server` process (when this bridge owns one). Idempotent —

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_managed_api.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_managed_api.dart
@@ -15,6 +15,8 @@ abstract interface class CodexManagedApi implements BridgeDerivedProjectsPluginA
   Stream<PluginWorkState> get workState;
   PluginWorkState get currentWorkState;
 
+  Future<Set<String>> interruptActiveWork({required Duration budget});
+
   /// Opens the WebSocket transport, performs the `initialize` handshake, and
   /// starts pumping `codex app-server` notifications into [BridgePluginApi.events].
   ///

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
@@ -179,7 +179,7 @@ class CodexSessionService {
     }
   }
 
-  Future<({CodexThreadRecord? resumedThread, String? resolvedModel})> sendCommand({
+  Future<({CodexThreadRecord? resumedThread, String? resolvedModel, String? turnId})> sendCommand({
     required String threadId,
     required String command,
     required String arguments,
@@ -198,8 +198,9 @@ class CodexSessionService {
       collaborationMode: collaborationMode,
     );
     var turnEffort = effort ?? turnMode?.defaultReasoningEffort;
+    String? turnId;
     try {
-      await _dispatchCommand(
+      turnId = await _dispatchCommand(
         threadId: threadId,
         command: command,
         arguments: arguments,
@@ -219,7 +220,7 @@ class CodexSessionService {
         collaborationMode: collaborationMode,
       );
       turnEffort = effort ?? turnMode?.defaultReasoningEffort;
-      await _dispatchCommand(
+      turnId = await _dispatchCommand(
         threadId: threadId,
         command: command,
         arguments: arguments,
@@ -234,10 +235,11 @@ class CodexSessionService {
     return (
       resumedThread: resumed,
       resolvedModel: command == compactionCommandName ? null : turnModel,
+      turnId: turnId,
     );
   }
 
-  Future<void> _dispatchCommand({
+  Future<String?> _dispatchCommand({
     required String threadId,
     required String command,
     required String arguments,
@@ -247,10 +249,10 @@ class CodexSessionService {
   }) async {
     if (command == compactionCommandName) {
       await _connectedThreadRepository.compactThread(threadId: threadId);
-      return;
+      return null;
     }
     final invocation = arguments.isEmpty ? "\$$command" : "\$$command $arguments";
-    await _connectedThreadRepository.startTurn(
+    return _connectedThreadRepository.startTurn(
       threadId: threadId,
       parts: [PluginPromptPart.text(text: invocation)],
       model: model,

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
@@ -113,7 +113,7 @@ class CodexSessionService {
     return thread;
   }
 
-  Future<({CodexThreadRecord? resumedThread, String? resolvedModel, bool started})> startTurn({
+  Future<({CodexThreadRecord? resumedThread, String? resolvedModel, String? turnId, bool started})> startTurn({
     required String threadId,
     required List<PluginPromptPart> parts,
     required String? model,
@@ -132,20 +132,21 @@ class CodexSessionService {
     );
     var turnEffort = effort ?? turnMode?.defaultReasoningEffort;
     try {
-      final started = await _connectedThreadRepository.startTurn(
+      final turnId = await _connectedThreadRepository.startTurn(
         threadId: threadId,
         parts: parts,
         model: turnModel,
         effort: turnEffort,
         collaborationMode: turnMode,
       );
-      if (started) {
+      if (turnId != null) {
         _rememberThreadModel(threadId: threadId, model: turnModel);
       }
       return (
         resumedThread: resumed,
         resolvedModel: turnModel,
-        started: started,
+        turnId: turnId,
+        started: turnId != null,
       );
     } on CodexThreadNotFoundException {
       resumed = await resumeThreadIfNeeded(threadId: threadId, force: true);
@@ -159,20 +160,21 @@ class CodexSessionService {
         collaborationMode: collaborationMode,
       );
       turnEffort = effort ?? turnMode?.defaultReasoningEffort;
-      final started = await _connectedThreadRepository.startTurn(
+      final turnId = await _connectedThreadRepository.startTurn(
         threadId: threadId,
         parts: parts,
         model: turnModel,
         effort: turnEffort,
         collaborationMode: turnMode,
       );
-      if (started) {
+      if (turnId != null) {
         _rememberThreadModel(threadId: threadId, model: turnModel);
       }
       return (
         resumedThread: resumed,
         resolvedModel: turnModel,
-        started: started,
+        turnId: turnId,
+        started: turnId != null,
       );
     }
   }

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -619,7 +619,7 @@ void main() {
         agent: null,
         model: null,
       );
-      await Future<void>.delayed(Duration.zero);
+      await plugin.workState.firstWhere((state) => state == PluginWorkState.idle).timeout(const Duration(seconds: 1));
 
       expect(plugin.currentWorkState, PluginWorkState.idle);
     });
@@ -853,6 +853,112 @@ void main() {
       final params = fake.sentParamsFor("turn/interrupt");
       expect(params["threadId"], equals("t-1"));
       expect(params["turnId"], equals("u-active"));
+    });
+
+    test("forced interruption includes an accepted turn before turn/started arrives", () async {
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "thread": {"id": "t-force", "cwd": "/work/sample"},
+          },
+        ),
+        const _Response(result: {"turnId": "u-force"}),
+        const _Response(result: null),
+      ]);
+      await plugin.sendPrompt(
+        sessionId: "t-force",
+        parts: const [PluginPromptPart.text(text: "long task")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      var interruptionCompleted = false;
+
+      final interruption = plugin
+          .interruptActiveWork(budget: const Duration(seconds: 2))
+          .whenComplete(() => interruptionCompleted = true);
+      for (var attempt = 0; attempt < 100 && !fake.sentMethods.contains("turn/interrupt"); attempt++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(fake.sentMethods, contains("turn/interrupt"));
+      expect(interruptionCompleted, isFalse);
+
+      fake.pushNotification("turn/completed", {
+        "threadId": "t-force",
+        "turn": {"id": "u-force"},
+      });
+
+      expect(await interruption, {"t-force"});
+      expect(plugin.currentWorkState, PluginWorkState.idle);
+    });
+
+    test("error waits for terminal rollout history before reporting idle", () async {
+      const sessionId = "019a0000-1111-2222-3333-bbbbbbbbbbbb";
+      final rollout = File(
+        p.join(
+          codexHome.path,
+          "sessions/2026/07/23/"
+          "rollout-2026-07-23T08-00-00-$sessionId.jsonl",
+        ),
+      )..createSync(recursive: true);
+      rollout.writeAsStringSync(
+        "${jsonEncode({
+          "timestamp": "2026-07-23T08:00:00Z",
+          "type": "session_meta",
+          "payload": {
+            "id": sessionId,
+            "timestamp": "2026-07-23T08:00:00Z",
+            "cwd": "/work/sample",
+            "model_provider": "openai",
+            "cli_version": "0.144.1",
+          },
+        })}\n",
+      );
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "thread": {"id": sessionId},
+          },
+        ),
+        const _Response(result: {"turnId": "u-error"}),
+      ]);
+      final events = <BridgeSseEvent>[];
+      final subscription = plugin.events.listen(events.add);
+      addTearDown(subscription.cancel);
+      await plugin.sendPrompt(
+        sessionId: sessionId,
+        parts: const [PluginPromptPart.text(text: "run a tool")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final record = jsonEncode(
+        _toolCall(
+          id: "fc-error",
+          callId: "call-error",
+          name: "exec_command",
+          arguments: '{"cmd":"sleep 1"}',
+        ),
+      );
+      final split = record.length ~/ 2;
+      rollout.writeAsStringSync(record.substring(0, split), mode: FileMode.append);
+
+      final idle = plugin.workState.firstWhere((state) => state == PluginWorkState.idle);
+      fake.pushNotification("error", {
+        "threadId": sessionId,
+        "error": {"message": "turn failed"},
+      });
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      expect(plugin.currentWorkState, PluginWorkState.busy);
+
+      rollout.writeAsStringSync("${record.substring(split)}\n", mode: FileMode.append);
+      await idle.timeout(const Duration(seconds: 1));
+      expect(
+        events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part.messageID),
+        contains("call-error"),
+      );
     });
 
     test("notification stream is mapped into bridge events", () async {

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -92,7 +92,11 @@ void main() {
             },
           },
         ),
-        const _Response(result: {"turnId": "u-1"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-1"},
+          },
+        ),
       ]);
 
       final session = await plugin.createSession(
@@ -146,7 +150,11 @@ void main() {
             "model": "gpt-5.4",
           },
         ),
-        const _Response(result: {"turnId": "u-skill"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-skill"},
+          },
+        ),
         const _Response(result: {}),
       ]);
 
@@ -207,7 +215,11 @@ void main() {
             },
           },
         ),
-        const _Response(result: {"turnId": "u-1"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-1"},
+          },
+        ),
       ]);
       // codex can emit a cwd-less notification while turn/start is still in
       // flight and before any rollout exists on disk — the thread directory
@@ -295,7 +307,11 @@ void main() {
             "thread": {"id": "t-empty-rollout"},
           },
         ),
-        const _Response(result: {"turnId": "u-1"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-1"},
+          },
+        ),
         emptyRolloutResponse,
         emptyRolloutResponse,
         emptyRolloutResponse,
@@ -385,7 +401,11 @@ void main() {
             "thread": {"id": "t-existing"},
           },
         ),
-        const _Response(result: {"turnId": "u-1"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-1"},
+          },
+        ),
       ]);
 
       await plugin.sendPrompt(
@@ -413,7 +433,11 @@ void main() {
             "thread": {"id": "t-default-mode"},
           },
         ),
-        const _Response(result: {"turnId": "u-default"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-default"},
+          },
+        ),
       ]);
 
       await plugin.sendPrompt(
@@ -483,7 +507,11 @@ void main() {
             "thread": {"id": sessionId, "modelProvider": "openai"},
           },
         ),
-        const _Response(result: {"turnId": "u-resolved"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-resolved"},
+          },
+        ),
       ]);
       final events = <BridgeSseEvent>[];
       final subscription = resolvedPlugin.events.listen(events.add);
@@ -520,7 +548,11 @@ void main() {
             "thread": {"id": "t-command"},
           },
         ),
-        const _Response(result: {"turnId": "u-command"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-command"},
+          },
+        ),
       ]);
 
       await plugin.sendCommand(
@@ -534,6 +566,55 @@ void main() {
       );
 
       expect(plugin.currentWorkState, PluginWorkState.busy);
+    });
+
+    test("forced interruption includes an accepted command before turn/started arrives", () async {
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "thread": {"id": "t-command-force"},
+          },
+        ),
+        const _Response(
+          result: {
+            "turn": {"id": "u-command-force"},
+          },
+        ),
+        const _Response(result: null),
+      ]);
+      await plugin.sendCommand(
+        sessionId: "t-command-force",
+        command: "review",
+        arguments: "recent changes",
+        userVisibleArguments: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      var interruptionCompleted = false;
+
+      final interruption = plugin
+          .interruptActiveWork(budget: const Duration(seconds: 2))
+          .whenComplete(() => interruptionCompleted = true);
+      for (var attempt = 0; attempt < 100 && !fake.sentMethods.contains("turn/interrupt"); attempt++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      expect(fake.sentMethods, contains("turn/interrupt"));
+      expect(fake.sentParamsFor("turn/interrupt"), {
+        "threadId": "t-command-force",
+        "turnId": "u-command-force",
+      });
+      expect(interruptionCompleted, isFalse);
+
+      fake.pushNotification("turn/completed", {
+        "threadId": "t-command-force",
+        "turn": {"id": "u-command-force"},
+      });
+
+      expect(await interruption, {"t-command-force"});
+      expect(plugin.currentWorkState, PluginWorkState.idle);
     });
 
     test("turn/start rejection does not mark the plugin busy", () async {
@@ -571,7 +652,11 @@ void main() {
             "thread": {"id": "t-delayed"},
           },
         ),
-        const _Response(result: {"turnId": "u-delayed"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-delayed"},
+          },
+        ),
       ]);
 
       await plugin.sendPrompt(
@@ -604,7 +689,11 @@ void main() {
             "thread": {"id": "t-early-complete"},
           },
         ),
-        const _Response(result: {"turnId": "u-early-complete"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-early-complete"},
+          },
+        ),
       ]);
       fake.onRequest = (method) {
         if (method == "turn/start") {
@@ -651,7 +740,14 @@ void main() {
       await turnStarted.future;
       await plugin.deleteSession("t-deleted");
 
-      fake.respondToHeld("turn/start", const _Response(result: {"turnId": "u-deleted"}));
+      fake.respondToHeld(
+        "turn/start",
+        const _Response(
+          result: {
+            "turn": {"id": "u-deleted"},
+          },
+        ),
+      );
       await send;
       expect(plugin.currentWorkState, PluginWorkState.idle);
 
@@ -661,7 +757,11 @@ void main() {
             "thread": {"id": "t-deleted"},
           },
         ),
-        const _Response(result: {"turnId": "u-recreated"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-recreated"},
+          },
+        ),
       ]);
       await plugin.createSession(
         directory: "/work/sample",
@@ -697,45 +797,39 @@ void main() {
       expect(fake.serverResponseFor(99)["result"], {"decision": "decline"});
     });
 
-    for (final terminalNotification in ["error", "thread/status/changed"]) {
-      test("$terminalNotification clears provisional busy", () async {
-        fake.respondInOrder([
-          const _Response(result: _initOk),
-          const _Response(
-            result: {
-              "thread": {"id": "t-terminal"},
-            },
-          ),
-          const _Response(result: {"turnId": "u-terminal"}),
-        ]);
+    test("error clears provisional busy", () async {
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "thread": {"id": "t-terminal"},
+          },
+        ),
+        const _Response(
+          result: {
+            "turn": {"id": "u-terminal"},
+          },
+        ),
+      ]);
 
-        await plugin.sendPrompt(
-          sessionId: "t-terminal",
-          parts: const [PluginPromptPart.text(text: "go on")],
-          variant: null,
-          agent: null,
-          model: null,
-        );
-        expect(plugin.currentWorkState, PluginWorkState.busy);
+      await plugin.sendPrompt(
+        sessionId: "t-terminal",
+        parts: const [PluginPromptPart.text(text: "go on")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      expect(plugin.currentWorkState, PluginWorkState.busy);
 
-        final idle = plugin.workState.firstWhere((state) => state == PluginWorkState.idle);
-        fake.pushNotification(
-          terminalNotification,
-          terminalNotification == "error"
-              ? {
-                  "threadId": "t-terminal",
-                  "error": {"message": "turn failed"},
-                }
-              : {
-                  "threadId": "t-terminal",
-                  "status": {"type": "idle"},
-                },
-        );
-
-        await idle.timeout(const Duration(seconds: 1));
-        expect(plugin.currentWorkState, PluginWorkState.idle);
+      final idle = plugin.workState.firstWhere((state) => state == PluginWorkState.idle);
+      fake.pushNotification("error", {
+        "threadId": "t-terminal",
+        "error": {"message": "turn failed"},
       });
-    }
+
+      await idle.timeout(const Duration(seconds: 1));
+      expect(plugin.currentWorkState, PluginWorkState.idle);
+    });
 
     test("sendPrompt does not re-resume a thread created in this run", () async {
       // createSession (no parts) loads the thread; a follow-up turn must reuse
@@ -747,7 +841,11 @@ void main() {
             "thread": {"id": "t-fresh"},
           },
         ),
-        const _Response(result: {"turnId": "u-1"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-1"},
+          },
+        ),
       ]);
 
       await plugin.createSession(
@@ -789,7 +887,11 @@ void main() {
             "thread": {"id": "t-dropped"},
           },
         ),
-        const _Response(result: {"turnId": "u-2"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-2"},
+          },
+        ),
       ]);
 
       // createSession with no parts marks t-dropped as loaded.
@@ -827,7 +929,11 @@ void main() {
             "thread": {"id": "t-1"},
           },
         ),
-        const _Response(result: {"turnId": "u-active"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-active"},
+          },
+        ),
         const _Response(result: null),
       ]);
 
@@ -863,7 +969,11 @@ void main() {
             "thread": {"id": "t-force", "cwd": "/work/sample"},
           },
         ),
-        const _Response(result: {"turnId": "u-force"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-force"},
+          },
+        ),
         const _Response(result: null),
       ]);
       await plugin.sendPrompt(
@@ -891,6 +1001,111 @@ void main() {
 
       expect(await interruption, {"t-force"});
       expect(plugin.currentWorkState, PluginWorkState.idle);
+    });
+
+    test("delayed prior terminal notifications preserve a newer accepted turn", () async {
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "thread": {"id": "t-overlap", "cwd": "/work/sample"},
+          },
+        ),
+        const _Response(
+          result: {
+            "turn": {"id": "u-prior"},
+          },
+        ),
+      ]);
+      await plugin.sendPrompt(
+        sessionId: "t-overlap",
+        parts: const [PluginPromptPart.text(text: "first task")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final firstIdle = plugin.workState.firstWhere((state) => state == PluginWorkState.idle);
+      fake.pushNotification("turn/completed", {
+        "threadId": "t-overlap",
+        "turn": {"id": "u-prior"},
+      });
+      await firstIdle.timeout(const Duration(seconds: 1));
+
+      fake.respondInOrder([
+        const _Response(
+          result: {
+            "turn": {"id": "u-current"},
+          },
+        ),
+        const _Response(result: null),
+      ]);
+      await plugin.sendPrompt(
+        sessionId: "t-overlap",
+        parts: const [PluginPromptPart.text(text: "second task")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      expect(plugin.currentWorkState, PluginWorkState.busy);
+
+      fake.pushNotification("turn/completed", {
+        "threadId": "t-overlap",
+        "turn": {"id": "u-prior"},
+      });
+      fake.pushNotification("thread/status/changed", {
+        "threadId": "t-overlap",
+        "status": {"type": "idle"},
+      });
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(plugin.currentWorkState, PluginWorkState.busy);
+      final interruption = plugin.interruptActiveWork(budget: const Duration(seconds: 2));
+      for (var attempt = 0; attempt < 100 && !fake.sentMethods.contains("turn/interrupt"); attempt++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(fake.sentParamsFor("turn/interrupt"), {
+        "threadId": "t-overlap",
+        "turnId": "u-current",
+      });
+
+      fake.pushNotification("turn/completed", {
+        "threadId": "t-overlap",
+        "turn": {"id": "u-current"},
+      });
+      expect(await interruption, {"t-overlap"});
+    });
+
+    test("turn/start rejects a whitespace-only nested turn id", () async {
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "thread": {"id": "t-whitespace"},
+          },
+        ),
+        const _Response(
+          result: {
+            "turn": {"id": "   "},
+          },
+        ),
+      ]);
+
+      await expectLater(
+        plugin.sendPrompt(
+          sessionId: "t-whitespace",
+          parts: const [PluginPromptPart.text(text: "continue")],
+          variant: null,
+          agent: null,
+          model: null,
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            "message",
+            "turn/start response missing turn.id",
+          ),
+        ),
+      );
     });
 
     test("error waits for terminal rollout history before reporting idle", () async {
@@ -922,7 +1137,11 @@ void main() {
             "thread": {"id": sessionId},
           },
         ),
-        const _Response(result: {"turnId": "u-error"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-error"},
+          },
+        ),
       ]);
       final events = <BridgeSseEvent>[];
       final subscription = plugin.events.listen(events.add);
@@ -1064,7 +1283,11 @@ void main() {
             "thread": {"id": sessionId},
           },
         ),
-        const _Response(result: {"turnId": "u-live"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-live"},
+          },
+        ),
       ]);
       final events = <BridgeSseEvent>[];
       final subscription = plugin.events.listen(events.add);
@@ -1417,7 +1640,11 @@ void main() {
             "thread": {"id": "t-effort"},
           },
         ),
-        const _Response(result: {"turnId": "u-1"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-1"},
+          },
+        ),
       ]);
 
       await plugin.sendPrompt(
@@ -1448,7 +1675,11 @@ void main() {
             "thread": {"id": "t-default"},
           },
         ),
-        const _Response(result: {"turnId": "u-1"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-1"},
+          },
+        ),
       ]);
 
       await plugin.sendPrompt(
@@ -1471,7 +1702,11 @@ void main() {
             "thread": {"id": "t-new"},
           },
         ),
-        const _Response(result: {"turnId": "u-1"}),
+        const _Response(
+          result: {
+            "turn": {"id": "u-1"},
+          },
+        ),
       ]);
 
       await plugin.createSession(

--- a/bridge/sesori_plugin_codex/test/codex_session_service_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_session_service_test.dart
@@ -172,7 +172,7 @@ class _StubThreadRepository extends CodexThreadRepository {
   }
 
   @override
-  Future<bool> startTurn({
+  Future<String?> startTurn({
     required String threadId,
     required List<PluginPromptPart> parts,
     required String? model,
@@ -182,7 +182,7 @@ class _StubThreadRepository extends CodexThreadRepository {
     lastParts = parts;
     lastModel = model;
     lastEffort = effort;
-    return true;
+    return "turn";
   }
 
   @override

--- a/bridge/sesori_plugin_codex/test/codex_session_service_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_session_service_test.dart
@@ -86,7 +86,7 @@ void main() {
       skillRepository: _StubSkillRepository(),
     );
 
-    await service.sendCommand(
+    final dispatched = await service.sendCommand(
       threadId: "thread-id",
       command: "review",
       arguments: "staged changes",
@@ -99,8 +99,9 @@ void main() {
     expect(input.text, r"$review staged changes");
     expect(threadRepository.lastModel, "gpt-5.6");
     expect(threadRepository.lastEffort, "high");
+    expect(dispatched.turnId, "turn");
 
-    await service.sendCommand(
+    final compacted = await service.sendCommand(
       threadId: "thread-id",
       command: "compact",
       arguments: "",
@@ -109,6 +110,7 @@ void main() {
       collaborationMode: null,
     );
     expect(threadRepository.compactCount, 1);
+    expect(compacted.turnId, isNull);
   });
 }
 

--- a/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
@@ -5,6 +5,14 @@ sealed class BridgeSseEvent {
   const BridgeSseEvent();
 }
 
+/// Runtime-owned provenance for reconciliation emitted during a forced stop.
+/// Plugin implementations emit ordinary events; only the generation runtime
+/// wraps events after `BridgePlugin.interruptActiveWork` has quiesced history.
+class BridgeSseTerminalHandoff extends BridgeSseEvent {
+  final BridgeSseEvent event;
+  const BridgeSseTerminalHandoff({required this.event});
+}
+
 class BridgeSseServerConnected extends BridgeSseEvent {
   const BridgeSseServerConnected();
 }

--- a/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
@@ -5,9 +5,11 @@ sealed class BridgeSseEvent {
   const BridgeSseEvent();
 }
 
-/// Runtime-owned provenance for reconciliation emitted during a forced stop.
-/// Plugin implementations emit ordinary events; only the generation runtime
-/// wraps events after `BridgePlugin.interruptActiveWork` has quiesced history.
+/// Mapping provenance for reconciliation synthesized during a forced stop.
+///
+/// This wrapper carries no stop-fence authority. The generation runtime owns
+/// that authorization separately, so a plugin-emitted wrapper remains an
+/// ordinary fenced event.
 class BridgeSseTerminalHandoff extends BridgeSseEvent {
   final BridgeSseEvent event;
   const BridgeSseTerminalHandoff({required this.event});

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin.dart
@@ -46,6 +46,15 @@ abstract class BridgePlugin {
   /// Cheap, synchronous, side-effect-free diagnostics (endpoint, version).
   PluginDiagnostics describe();
 
+  /// Interrupts every active backend session before a forced generation stop.
+  ///
+  /// The runtime has already fenced new acquisitions and drained pre-fence
+  /// operations when this is called.
+  /// Implementations must wait until interrupted history is reloadable and
+  /// return only backend session IDs that are no longer busy or retrying.
+  /// [budget] bounds the complete interruption and quiescence operation.
+  Future<Set<String>> interruptActiveWork({required Duration budget});
+
   /// Stops the plugin in order: api teardown, then any managed runtime,
   /// releasing everything `start()` acquired.
   ///

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/steady_plugin_lifecycle.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/steady_plugin_lifecycle.dart
@@ -13,8 +13,8 @@ import "plugin_work_state.dart";
 /// and remote-server archetypes whose "lifecycle" is just connectivity.
 ///
 /// Mixing this in implements `status`, `currentStatus`, and `shutdown()`;
-/// the plugin only supplies `api`, `describe()`, and (optionally)
-/// [onShutdown]:
+/// the plugin supplies `api`, `describe()`, `interruptActiveWork()`, and
+/// (optionally) [onShutdown]:
 ///
 /// ```dart
 /// class RemotePlugin with SteadyPluginLifecycle implements BridgePlugin {
@@ -24,6 +24,9 @@ import "plugin_work_state.dart";
 ///   @override
 ///   PluginDiagnostics describe() =>
 ///       PluginDiagnostics(pluginId: api.id, endpoint: _url, details: const {});
+///
+///   @override
+///   Future<Set<String>> interruptActiveWork({required Duration budget}) async => const {};
 ///
 ///   @override
 ///   Future<void> onShutdown({required Duration? budget}) => _api.dispose();

--- a/bridge/sesori_plugin_interface/test/lifecycle/steady_plugin_lifecycle_test.dart
+++ b/bridge/sesori_plugin_interface/test/lifecycle/steady_plugin_lifecycle_test.dart
@@ -246,6 +246,9 @@ class _SteadyPlugin with SteadyPluginLifecycle {
   PluginDiagnostics describe() => const PluginDiagnostics(pluginId: 'steady-test', endpoint: null, details: {});
 
   @override
+  Future<Set<String>> interruptActiveWork({required Duration budget}) async => const {};
+
+  @override
   Future<void> onShutdown({required Duration? budget}) async {
     onShutdownCalls++;
     lastBudget = budget;

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -135,8 +135,7 @@ class ActiveSessionTracker {
     // status baseline. A later acceptance must not be cleared by an older idle
     // response that happens to complete after the command was accepted.
     _provisionalAcceptedTurnRevisionBySession.removeWhere(
-      (sessionId, revision) =>
-          revision <= acceptedTurnBaselineRevision && allStatuses.containsKey(sessionId),
+      (sessionId, revision) => revision <= acceptedTurnBaselineRevision && allStatuses.containsKey(sessionId),
     );
 
     _sessionStatuses
@@ -337,6 +336,15 @@ class ActiveSessionTracker {
   }
 
   bool get hasAcceptedTurnEvidence => _provisionalAcceptedTurnRevisionBySession.isNotEmpty;
+
+  Set<String> get interruptibleSessionIds => Set<String>.unmodifiable({
+    ..._sessionStatuses.keys,
+    ..._provisionalAcceptedTurnRevisionBySession.keys,
+    for (final entry in _pendingQuestions.entries)
+      if (entry.value.isNotEmpty) entry.key,
+    for (final entry in _pendingPermissions.entries)
+      if (entry.value.isNotEmpty) entry.key,
+  });
 
   void populatePendingQuestions({
     required List<QuestionRequest> questions,

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -420,6 +420,22 @@ class OpenCodePlugin implements OpenCodeManagedApi {
   }
 
   @override
+  Future<Set<String>> interruptActiveWork({required Duration budget}) {
+    return () async {
+      final activeSessionIds = _service.tracker.interruptibleSessionIds;
+      if (activeSessionIds.isEmpty) return const <String>{};
+
+      await Future.wait([
+        for (final sessionId in activeSessionIds) abortSession(sessionId: sessionId),
+      ]);
+      if (currentWorkState != PluginWorkState.idle) {
+        await workState.firstWhere((state) => state == PluginWorkState.idle);
+      }
+      return Set<String>.unmodifiable(activeSessionIds);
+    }().timeout(budget);
+  }
+
+  @override
   Future<List<PluginAgent>> getAgents({required String projectId}) {
     return _call(() => _service.getAgents(projectId: projectId));
   }

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_bridge_plugin.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_bridge_plugin.dart
@@ -154,6 +154,11 @@ class OpenCodeBridgePlugin implements BridgePlugin {
     );
   }
 
+  @override
+  Future<Set<String>> interruptActiveWork({required Duration budget}) {
+    return api.interruptActiveWork(budget: budget);
+  }
+
   /// Stops the plugin in order: disarm the monitor (so the child's deliberate
   /// exit is never mistaken for a crash), tear down the api, then stop the owned
   /// `opencode serve` process (when this bridge owns one). Idempotent — repeated

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_managed_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_managed_api.dart
@@ -12,6 +12,8 @@ abstract interface class OpenCodeManagedApi implements NativeProjectsPluginApi {
   Stream<PluginWorkState> get workState;
   PluginWorkState get currentWorkState;
 
+  Future<Set<String>> interruptActiveWork({required Duration budget});
+
   /// Hydrates the session tracker from the server and starts the SSE stream.
   ///
   /// Idempotent: repeated calls share a single in-flight cold-start. Rethrows a

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -507,6 +507,62 @@ void main() {
       );
     });
 
+    test("forced interruption includes an accepted prompt before busy SSE arrives", () async {
+      final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
+      addTearDown(plugin.dispose);
+      await server.waitForSseConnection();
+      final initialProjectUpdated = Completer<void>();
+      final idleEvent = Completer<void>();
+      final subscription = plugin.events.listen((event) {
+        if (event is BridgeSseProjectUpdated && !initialProjectUpdated.isCompleted) {
+          initialProjectUpdated.complete();
+        }
+        if (event is BridgeSseSessionStatus &&
+            event.sessionID == "s-root" &&
+            event.status["type"] == "idle" &&
+            !idleEvent.isCompleted) {
+          idleEvent.complete();
+        }
+      });
+      addTearDown(subscription.cancel);
+      await initialProjectUpdated.future;
+      await plugin.sendPrompt(
+        sessionId: "s-root",
+        parts: const [PluginPromptPart.text(text: "long task")],
+        agent: null,
+        variant: null,
+        model: null,
+      );
+      expect(plugin.currentWorkState, PluginWorkState.busy);
+
+      var completed = false;
+      final interruption = plugin.interruptActiveWork(budget: const Duration(seconds: 2)).then((sessionIds) {
+        completed = true;
+        return sessionIds;
+      });
+      expect(await server.waitForAbort(), "s-root");
+      expect(completed, isFalse);
+
+      await server.emitRawSse(
+        jsonEncode({
+          "directory": "/repo",
+          "payload": {
+            "type": "session.status",
+            "properties": {
+              "sessionID": "s-root",
+              "status": {"type": "idle"},
+            },
+          },
+        }),
+      );
+      await idleEvent.future.timeout(const Duration(seconds: 1));
+      final interrupted = await interruption;
+
+      expect(interrupted, {"s-root"});
+      expect(server.abortedSessionIds, ["s-root"]);
+      expect(plugin.currentWorkState, PluginWorkState.idle);
+    });
+
     test("unknown and malformed SSE frames are ignored without emitting bridge events", () async {
       final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
       await server.waitForSseConnection();
@@ -872,6 +928,11 @@ class _FakeOpenCodeServer {
   int promptStatusCode = HttpStatus.ok;
   int commandStatusCode = HttpStatus.ok;
   bool acceptSseConnections = true;
+  final List<String> abortedSessionIds = [];
+  final Completer<String> _firstAbort = Completer<String>();
+  final Map<String, Map<String, dynamic>> sessionStatuses = {
+    "s-root": {"type": "idle"},
+  };
 
   /// Extra sessions appended to the `GET /session` response, so tests can
   /// stage sessions in directories the fixed fixtures don't cover.
@@ -966,9 +1027,7 @@ class _FakeOpenCodeServer {
       }
 
       if (request.method == "GET" && path == "/session/status") {
-        await _sendJson(request.response, {
-          "s-root": {"type": "idle"},
-        });
+        await _sendJson(request.response, sessionStatuses);
         return;
       }
 
@@ -1056,6 +1115,18 @@ class _FakeOpenCodeServer {
           return;
         }
         await _sendJson(request.response, true);
+        return;
+      }
+
+      final abortMatch = RegExp(r"^/session/([^/]+)/abort$").firstMatch(path);
+      if (abortMatch != null && request.method == "POST") {
+        final sessionId = abortMatch.group(1)!;
+        abortedSessionIds.add(sessionId);
+        sessionStatuses[sessionId] = {"type": "idle"};
+        await _sendJson(request.response, true);
+        if (!_firstAbort.isCompleted) {
+          _firstAbort.complete(sessionId);
+        }
         return;
       }
 
@@ -1681,6 +1752,7 @@ class _FakeOpenCodeServer {
         request.response.headers.contentType = ContentType("text", "event-stream");
         request.response.headers.set("cache-control", "no-cache");
         request.response.headers.set("connection", "keep-alive");
+        request.response.bufferOutput = false;
         request.response.write(": connected\n\n");
         await request.response.flush();
         _sseClients.add(request.response);
@@ -1702,6 +1774,8 @@ class _FakeOpenCodeServer {
   }
 
   Future<void> waitForSseConnection() => _firstSseClient.future;
+
+  Future<String> waitForAbort() => _firstAbort.future;
 
   Future<void> emitRawSse(String data) async {
     final futures = <Future<void>>[];


### PR DESCRIPTION
## Summary

- drain pre-fence operations, leases, and durable commits before interrupting a forced plugin stop
- wait for backend interruption and reloadable terminal history, then carry a runtime-owned terminal handoff through ordered client delivery before retiring the generation
- reconcile backend-specific active work across OpenCode accepted prompts and pending input, Codex provisional turns and rollout drains, and ACP/Cursor cancellation settlement

## Validation

- `bridge/app`: analyzer clean; 2,143 tests passed
- `bridge/sesori_plugin_interface`: analyzer clean; 150 tests passed
- `bridge/sesori_plugin_opencode`: analyzer clean; 404 tests passed
- `bridge/sesori_plugin_codex`: analyzer clean; 193 tests passed
- `bridge/sesori_plugin_acp`: analyzer clean; 152 tests passed
- iPhone 17 simulator on iOS 26.5 against the source bridge and production relay: started a Codex `sleep 120` turn, confirmed management reported `busy`, and force-disabled Codex
- the connected session immediately lost its active Stop state and Running list badge; after re-enabling and reopening, the interrupted tool rendered `Done` with `aborted by user after 23.1s`

Closes #573

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale busy sessions after a forced plugin disable and adds stop-fence authorization so only runtime-issued terminal handoffs pass; clients settle to idle before the generation retires. Applies across `sesori_plugin_opencode`, `sesori_plugin_codex`, and `sesori_plugin_acp`.

- **Bug Fixes**
  - Runtime: on forced stop, drain ops/leases/commits, call `BridgePlugin.interruptActiveWork`, then emit `BridgeSseTerminalHandoff` and wait for its consumption before retiring/restarting
  - Ordering: only runtime-authorized terminal handoff events are delivered during stop; plugin wrappers cannot spoof the fence
  - Orchestrator/dispatcher: unwrap terminal handoff, propagate stop authorization, and forward a “handoff consumed” signal to gate teardown
  - Mapping/service: add `isCurrentEvent` checks and session mapping for terminal handoff; `BridgeEventMapper` rejects unwrapped handoffs; ignore stale events from stopped generations
  - Codex: capture `turnId`, ignore superseded lifecycle notifications, include provisional/active turns and pending approvals in interruption, wait for rollout drains before idle; `startTurn` now returns `CodexTurnStartResponseDto` with `turn.id`
  - OpenCode/ACP: interrupt active and pending work (including accepted prompts and pending input), then wait until `workState` is idle
  - Small utilities: ACP approval registry formatting cleanup; OpenCode tracker exposes interruptible session IDs

- **Migration**
  - Implement `BridgePlugin.interruptActiveWork({required Duration budget})` in custom plugins to support graceful forced stops

<sup>Written for commit 6e7aed929344dba7515b6af1d01fc41479ec49e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

