### PR TITLE
fix(cursor): refresh session recency after turns

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -123,6 +123,30 @@ class AcpEventMapper {
     }
   }
 
+  /// Advances session recency for accepted outbound work. ACP agents do not
+  /// consistently emit a timestamp-bearing `session_info_update`, so the
+  /// plugin supplies its acceptance time while preserving strict monotonicity.
+  BridgeSseSessionUpdated mapSessionActivity({
+    required String sessionId,
+    required int updatedAtMs,
+  }) {
+    final snapshot = _sessionSnapshots[sessionId];
+    final previousUpdatedMs = snapshot?.updatedMs ?? snapshot?.createdMs;
+    final nextUpdatedMs = previousUpdatedMs == null || updatedAtMs > previousUpdatedMs
+        ? updatedAtMs
+        : previousUpdatedMs + 1;
+    setSessionSnapshot(
+      sessionId: sessionId,
+      title: null,
+      createdMs: null,
+      updatedMs: nextUpdatedMs,
+    );
+    return BridgeSseSessionUpdated(
+      info: _sessionUpdate(sessionId).toJson(),
+      titleChanged: false,
+    );
+  }
+
   /// Per-session project directory (an ACP project id *is* its `cwd`). The
   /// plugin records it so `session_info_update` (title) events are filed under
   /// the session's real project, not the launch [launchDirectory]. The mobile

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -758,6 +758,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     // Acceptance gate: an unreachable agent fails the send itself; the turn
     // re-resolves the client at dispatch time (see [_runTurn]).
     await _connectedClient();
+    _recordSessionActivity(sessionId);
     eventMapper.mapSentPrompt(sessionId: sessionId, parts: parts).forEach(_eventBuffer.add);
     _enqueueTurn(
       sessionId: sessionId,
@@ -785,6 +786,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     final visibleBody = userVisibleArguments == null ? "/$command" : "/$command $userVisibleArguments";
     // Acceptance gate — see [sendPrompt].
     await _connectedClient();
+    _recordSessionActivity(sessionId);
     eventMapper
         .mapSentPrompt(
           sessionId: sessionId,
@@ -797,6 +799,15 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       model: model,
       variant: variant,
       agent: agent,
+    );
+  }
+
+  void _recordSessionActivity(String sessionId) {
+    _eventBuffer.add(
+      eventMapper.mapSessionActivity(
+        sessionId: sessionId,
+        updatedAtMs: DateTime.now().millisecondsSinceEpoch,
+      ),
     );
   }
 

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -605,6 +605,39 @@ void main() {
       expect(session.time?.updated, 3000);
     });
 
+    test("accepted activity advances recency and stale backend timestamps cannot regress it", () {
+      mapper.setSessionSnapshot(
+        sessionId: "s1",
+        title: "Existing title",
+        createdMs: 1000,
+        updatedMs: 2000,
+      );
+
+      final activity = mapper.mapSessionActivity(sessionId: "s1", updatedAtMs: 2000);
+      final activeSession = shared.Session.fromJson(activity.info);
+      expect(activity.titleChanged, isFalse);
+      expect(activeSession.title, "Existing title");
+      expect(activeSession.time, const shared.SessionTime(created: 1000, updated: 2001, archived: null));
+
+      final staleEvents = mapper.map(
+        update({
+          "sessionUpdate": "session_info_update",
+          "updatedAt": 1500,
+        }),
+      );
+      final staleSession = shared.Session.fromJson(staleEvents.whereType<BridgeSseSessionUpdated>().single.info);
+      expect(staleSession.time?.updated, 2001);
+
+      final newerEvents = mapper.map(
+        update({
+          "sessionUpdate": "session_info_update",
+          "updatedAt": 3000,
+        }),
+      );
+      final newerSession = shared.Session.fromJson(newerEvents.whereType<BridgeSseSessionUpdated>().single.info);
+      expect(newerSession.time?.updated, 3000);
+    });
+
     test("session_info_update without a title or timestamp emits nothing", () {
       final events = mapper.map(update({
         "sessionUpdate": "session_info_update",

--- a/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
@@ -1,6 +1,7 @@
 import "package:acp_plugin/acp_plugin.dart";
 import "package:acp_plugin/acp_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" show Session;
 import "package:test/test.dart";
 
 /// Exercises [AcpPlugin.getActiveSessionsSummary] — the activity feed the
@@ -92,6 +93,11 @@ void main() {
         model: null,
       );
       await waitForFrame("session/prompt");
+
+      final recencyUpdate = emitted.whereType<BridgeSseSessionUpdated>().single;
+      final updatedSession = Session.fromJson(recencyUpdate.info);
+      expect(recencyUpdate.titleChanged, isFalse);
+      expect(updatedSession.time?.updated, greaterThan(updatedSession.time!.created));
 
       final running = plugin.getActiveSessionsSummary();
       expect(running, hasLength(1));


### PR DESCRIPTION
## Summary

- advance ACP session recency when an outbound prompt or command is accepted, covering Cursor agents that omit timestamp-bearing `session_info_update` notifications
- emit the existing backend-neutral `session.updated` event so bridge persistence and connected session lists receive the newer timestamp immediately
- preserve strict monotonicity against same-millisecond activity and stale backend timestamps while allowing later authoritative timestamps to advance the snapshot

## Validation

- `bridge/sesori_plugin_acp`: analyzer clean; 152 tests passed
- `bridge/sesori_plugin_cursor`: analyzer clean; 95 tests passed
- iPhone 17 simulator on iOS 26.5 against the source bridge and production relay: continued the existing `CURSOR E2E OK` session without a timestamp notification
- durable `updated` advanced from `1785022633782` to `1785057103351`; the row moved to the top as `just now`, and reopening detail reloaded the exact `CURSOR LIST FRESHNESS FIX OK.` turn

Closes #575


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advances session recency when a prompt or command is accepted, so Cursor sessions stay fresh even if agents don’t send timestamp updates. Emits a backend‑neutral session.updated with a strictly monotonic updatedAt to update persistence and connected session lists immediately.

<sup>Written for commit 7c0e972d24471ba4ae06e95cd7e0c6c8d12c0178. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

