### PR TITLE
docs(plan): split Stage 13 Harnesses delivery

### DIFF
--- a/.plan/active/setup-aware-harness-settings/PLAN.md
+++ b/.plan/active/setup-aware-harness-settings/PLAN.md
@@ -149,6 +149,7 @@ class NewSessionPluginService {
 
   Future<ApiResponse<NewSessionPluginDiscovery>> discover({
     required String? currentSelectedPluginId,
+    required String? currentSelectionBridgeId,
   });
 
   Future<void> recordSelection({
@@ -160,15 +161,17 @@ class NewSessionPluginService {
 
 `discover` preserves the existing success/failure `ApiResponse` contract and
 owns the complete selection precedence. Current and saved selection candidates
-are considered only when the response supplies a non-null bridge identity;
-when `bridgeId` is absent, the current bridge default wins immediately so no
-selection silently crosses bridges:
+are considered only when the response supplies a non-null bridge identity. The
+current candidate must also originate from that same bridge identity; a screen
+carried across bridge A -> bridge B cannot leak A's selection into B:
 
-1. the current selection when its ID still identifies a ready or degraded
-   plugin and `bridgeId` is non-null;
+1. the current selection when its originating bridge ID equals the response
+   bridge ID and its plugin ID still identifies a ready or degraded plugin;
 2. the saved preference when its ID identifies a ready or degraded plugin and
-   `bridgeId` is non-null;
+   the response bridge ID is non-null;
 3. the current bridge default.
+
+When `bridgeId` is absent, the current bridge default wins immediately.
 
 Missing, disabled, blocked, failed, unavailable, or unknown current/saved
 plugins move to the next fallback. Secure-storage read failures are logged and
@@ -176,9 +179,10 @@ degrade to the default; write failures are logged and never block session
 creation.
 
 `NewSessionCubit` receives `NewSessionPluginService`, passes the current
-selection ID into discovery, and only maps the returned discovery result into
-composer state. It carries the discovery bridge ID and, immediately before
-submitting `createSession`, records the last submitted choice through explicit
+selection plugin ID and the bridge ID that produced that selection into
+discovery, and only maps the returned discovery result into composer state. It
+carries the latest discovery bridge ID and, immediately before submitting
+`createSession`, records the last submitted choice through explicit
 fire-and-forget `unawaited(...)`. Do not use it as a last viewed/focused
 selection.
 
@@ -209,7 +213,8 @@ Production files:
 - Focused bridge plugin-list handler and router construction tests, plus
   bridge-app fatal analysis.
 - Preference API/repository/service tests for saved, default, unroutable,
-  stale, storage-failure, and missing-`bridgeId` default-only flows.
+  stale, storage-failure, missing-`bridgeId` default-only, and bridge
+  identity-changing current-selection flows.
 - Current new-session cubit and selection tests prove the service resolves
   current/saved/default precedence while the cubit only maps state, including
   `defaultModelID`, reconnect preservation, staged command, and last-submitted
@@ -285,10 +290,14 @@ Extend `PluginRepository`:
 - HTTP 409 parses `PluginLifecycleConflict`; malformed 409 bodies map to
   explicit request failure rather than a partial conflict.
 - Successful mutation bodies remain typed `PluginManagementResponse`.
+- A 2xx mutation response whose body cannot be decoded maps to `uncertain`,
+  not ordinary failure: the bridge may have committed the mutation, and a
+  retryable-looking failure could execute it twice. The service schedules the
+  authoritative GET required to learn the outcome.
 - `uncertain` represents a mutation whose request was sent but whose outcome
-  cannot be truthfully published because the connection/service fence moved.
-  Consumers render it as an uncertain state requiring refresh, never as a
-  bridge rejection or a committed success.
+  cannot be truthfully published because the response cannot prove it or the
+  connection/service fence moved. Consumers render it as an uncertain state
+  requiring refresh, never as a bridge rejection or a committed success.
 - Existing discovery fallback behavior remains unchanged.
 
 Export the new public result surface and regenerate module-core DI if the
@@ -308,8 +317,8 @@ Production files:
 
 - API method/path/body/typed-response tests for every route.
 - Repository tests for supported, unsupported 404, mutation 404, typed 409,
-  malformed 409, uncertain result mapping, generic failure, and preserved
-  discovery fallback.
+  malformed 409, successful-status undecodable mutation body to `uncertain`,
+  generic failure, and preserved discovery fallback.
 - Module-core fatal analysis plus mobile and desktop fatal analysis.
 
 ## Step 3/7: Management Synchronization Service
@@ -476,6 +485,8 @@ Production files:
   publication races all reject superseded responses.
 - Disconnect during either request returns the required typed outcome without
   publication.
+- An undecodable successful mutation response returns `uncertain` and schedules
+  an authoritative GET without inviting an immediate duplicate retry.
 - Mutation after an intervening publication triggers authoritative GET and
   returns `uncertain` rather than unordered publication.
 - A failed first load after switching bridges never publishes the previous

--- a/.plan/active/setup-aware-harness-settings/PLAN.md
+++ b/.plan/active/setup-aware-harness-settings/PLAN.md
@@ -1,0 +1,990 @@
+# Setup-Aware Harness Settings
+
+## Status
+
+- **Plan slug:** `setup-aware-harness-settings`
+- **Parent plan:** `.plan/active/setup-aware-plugin-lifecycle`
+- **Status:** ready for implementation; no Stage 13 implementation branch has
+  started
+- **Implementation base:** current `origin/main` after Stage 12 merge
+  `6cedf5bd`, force-disable reconciliation `877f0b58`, and Cursor recency
+  `ae060c5f`
+- **Reference only:** frozen PR #511, substantive implementation commit
+  `167a3ee7`, action-preservation follow-up `bc3918cb`, head `4f07172f`
+
+This child plan owns the replacement delivery sequence for parent Stage 13. It
+inherits the parent's locked product decisions and preserves current-main
+behavior that frozen PR #511 predates. Frozen PR #511 is evidence, not
+mergeable history: no replacement branch rebases, merges, or cherry-picks it.
+
+## Goal
+
+Deliver the mobile Harnesses settings surface and per-bridge harness preference
+in seven independently reviewable PRs. Each slice compiles and verifies against
+its base, exposes no placeholder user surface, and leaves no temporary public
+contract that a later slice must break.
+
+The user-facing destination is **Harnesses**. Internal bridge, shared, API,
+repository, service, and cubit domain names remain `Plugin*`, matching the
+existing plugin lifecycle architecture. Only routes, screens, localization, and
+presentation-facing copy use Harnesses.
+
+## Locked Boundaries
+
+- Backend-specific behavior stays in its owning bridge plugin descriptor. Shared
+  transport and clients consume backend-neutral contracts; Prego resolves an
+  opaque presentation logo key without using plugin IDs as behavioral state.
+- Layering remains Foundation -> API -> Repository -> Service -> Consumer.
+  Cubits never call APIs and are never registered in DI.
+- Additive nullable wire fields must decode from older peers and must be omitted
+  when null. Add dated compatibility comments where release-reader fallback is
+  relevant.
+- Current Stage 12 routes are final: `GET /plugin/management`,
+  `POST /plugin/:id/command`, and `PATCH /plugin/idle-timeout`. Mutation
+  responses return authoritative snapshots; `snapshotToken` is opaque and
+  equality-only, never ordered.
+- `ConnectionService.currentStatus`, `status`, `events`, and
+  `dataMayBeStale` are all consumed. Refresh staleness is consumed only after a
+  supported or unsupported snapshot applies; failed or connection-blocked
+  refreshes preserve and re-arm staleness.
+- Keep one open implementation PR and one local successor built from that PR's
+  latest reviewed head. After a predecessor merges, merge updated `origin/main`
+  into the successor, reverify, then open it. Never work farther than one slice
+  ahead.
+- Changed-line estimates include additions plus deletions against the PR base,
+  including generated and mechanical lockstep output. Approximately 1,000
+  changed lines is the reviewability target, not a hard numerical gate. A simple
+  generated or mechanical excess must be named in the PR body; complex or
+  stateful work splits earlier when useful.
+
+## Delivery Sequence
+
+| Step | Branch | Exact PR title | Estimate | Review boundary |
+|---|---|---|---:|---|
+| 1/7 | `setup-aware-harness-settings-preferences` | `[setup-aware-harness-settings] feat(client): remember harnesses per bridge [step 1/7]` | 650-750 | Per-bridge last-submitted harness selection. |
+| 2/7 | `setup-aware-harness-settings-transport` | `[setup-aware-harness-settings] feat(client): add harness management transport [step 2/7]` | 300-400 | Management HTTP/repository typed results. |
+| 3/7 | `setup-aware-harness-settings-service` | `[setup-aware-harness-settings] feat(client): synchronize harness management [step 3/7]` | 550-700 | Replay, coalescing, reconnect, and mutation fencing. |
+| 4/7 | `setup-aware-harness-settings-branding` | `[setup-aware-harness-settings] feat(prego): render harness logos [step 4/7]` | 750-900 | Descriptor-to-Prego brand key flow plus chooser rendering. |
+| 5/7 | `setup-aware-harness-settings-overview` | `[setup-aware-harness-settings] feat(app): add harness settings overview [step 5/7]` | 1,100-1,300 | Notifications-style read-only Harnesses page, final state contract, and settings entry. |
+| 6/7 | `setup-aware-harness-settings-state` | `[setup-aware-harness-settings] feat(client): add harness management actions [step 6/7]` | 650-800 | Mutation cubit behavior over service-owned validation and force policy. |
+| 7/7 | `setup-aware-harness-settings-controls` | `[setup-aware-harness-settings] feat(app): add harness management controls [step 7/7]` | 800-1,000 | Management controls page with safe/force and timeout flows. |
+
+Steps 2 and 3 are functionally independent from Step 1, but the series still
+runs sequentially. Step 5 expects the Step 3 snapshot contract and the Step 4
+logo primitive. Steps 6 and 7 complete the control surface; no management
+mutation is exposed before Step 7.
+
+## Step 1/7: Per-Bridge Harness Preference
+
+### Scope
+
+Add nullable `bridgeId` to `PluginListResponse` and regenerate shared output.
+Missing or null values remain omitted from JSON.
+
+Inject the existing `BridgeIdProvider` into `GetPluginsHandler`, pass the
+current `Orchestrator`'s `_bridgeRegistrationService`, and include the current
+bridge ID in `GET /plugin`. The fallback response constructed by
+`PluginRepository` for older 404 discovery bridges sets `bridgeId: null` so
+no preference is invented.
+
+Add:
+
+```dart
+@lazySingleton
+class PluginPreferenceApi {
+  PluginPreferenceApi({required SecureStorage storage});
+
+  Future<String?> readPluginId({required String bridgeId});
+  Future<void> writePluginId({
+    required String bridgeId,
+    required String pluginId,
+  });
+}
+```
+
+The secure-storage key is
+`new_session_plugin_${Uri.encodeComponent(bridgeId)}`. Auth server bridge IDs
+are globally unique, so no account prefix is added. Revocation remints the ID
+and intentionally starts a fresh preference; stale keys have no deletion API
+because there is no concrete cleanup caller.
+
+Add:
+
+```dart
+@lazySingleton
+class PluginPreferenceRepository {
+  PluginPreferenceRepository({required PluginPreferenceApi api});
+
+  Future<String?> readPluginId({required String bridgeId});
+  Future<void> writePluginId({
+    required String bridgeId,
+    required String pluginId,
+  });
+}
+```
+
+Add:
+
+```dart
+final class NewSessionPluginDiscovery {
+  const NewSessionPluginDiscovery({
+    required this.bridgeId,
+    required this.plugins,
+    required this.selected,
+  });
+
+  final String? bridgeId;
+  final List<PluginMetadata> plugins;
+  final PluginMetadata? selected;
+}
+```
+
+```dart
+@lazySingleton
+class NewSessionPluginService {
+  NewSessionPluginService({
+    required PluginRepository pluginRepository,
+    required PluginPreferenceRepository pluginPreferenceRepository,
+  });
+
+  Future<ApiResponse<NewSessionPluginDiscovery>> discover({
+    required String? currentSelectedPluginId,
+  });
+
+  Future<void> recordSelection({
+    required String? bridgeId,
+    required PluginMetadata plugin,
+  });
+}
+```
+
+`discover` preserves the existing success/failure `ApiResponse` contract and
+owns the complete selection precedence:
+
+1. the current selection when its ID still identifies a ready or degraded
+   plugin;
+2. the saved preference when its ID identifies a ready or degraded plugin;
+3. the current bridge default.
+
+Missing, disabled, blocked, failed, unavailable, or unknown current/saved
+plugins move to the next fallback. Secure-storage read failures are logged and
+degrade to the default; write failures are logged and never block session
+creation.
+
+`NewSessionCubit` receives `NewSessionPluginService`, passes the current
+selection ID into discovery, and only maps the returned discovery result into
+composer state. It carries the discovery bridge ID and, immediately before
+submitting `createSession`, records the last submitted choice through explicit
+fire-and-forget `unawaited(...)`. Do not use it as a last viewed/focused
+selection.
+
+Preserve current `DefaultModelSelector.pickFromProvider(defaultModelID:)`,
+reconnect behavior, current plugin during refresh, staged command handling,
+generation fencing, and all new-session state variants.
+
+Production files:
+
+- `shared/sesori_shared/lib/src/models/sesori/plugin_list_response.dart` and
+  regenerated companions
+- `bridge/app/lib/src/routing/get_plugins_handler.dart`
+- `bridge/app/lib/src/bridge/orchestrator.dart`
+- `client/module_core/lib/src/api/plugin_preference_api.dart`
+- `client/module_core/lib/src/repositories/plugin_preference_repository.dart`
+- `client/module_core/lib/src/services/new_session_plugin_service.dart`
+- `client/module_core/lib/src/repositories/plugin_repository.dart` fallback
+  constructor update
+- `client/module_core/lib/src/cubits/new_session/new_session_cubit.dart`
+- `client/module_core/lib/sesori_dart_core.dart`
+- module-core DI source and regenerated `injection.config.dart`
+- `client/app/lib/features/new_session/new_session_screen.dart`
+
+### Verification
+
+- Shared code generation, missing/null/omitted `bridgeId` contract tests, and
+  `dart analyze --fatal-infos`.
+- Focused bridge plugin-list handler and router construction tests, plus
+  bridge-app fatal analysis.
+- Preference API/repository/service tests for saved, default, unroutable,
+  stale, and storage-failure flows.
+- Current new-session cubit and selection tests prove the service resolves
+  current/saved/default precedence while the cubit only maps state, including
+  `defaultModelID`, reconnect preservation, staged command, and last-submitted
+  recording semantics.
+- Focused mobile new-session tests; mobile and desktop fatal analysis.
+
+## Step 2/7: Management Transport And Repository Results
+
+### Scope
+
+Extend `PluginApi` using the current Stage 12 routes:
+
+```dart
+Future<ApiResponse<PluginManagementResponse>> getManagement();
+Future<ApiResponse<PluginManagementResponse>> command({
+  required String pluginId,
+  required PluginLifecycleCommandRequest request,
+});
+Future<ApiResponse<PluginManagementResponse>> updateIdleTimeout({
+  required PluginIdleTimeoutUpdateRequest request,
+});
+```
+
+Request bodies serialize the shared Freezed request models; no inline JSON
+maps.
+
+Add handwritten internal result models, following
+`SessionDetailLoadResult`'s pattern rather than adding roughly 500 generated
+Freezed lines for two small internal families:
+
+```dart
+sealed class PluginManagementLoadResult {
+  const PluginManagementLoadResult();
+
+  const factory PluginManagementLoadResult.supported({
+    required PluginManagementResponse response,
+  });
+  const factory PluginManagementLoadResult.unsupported();
+  const factory PluginManagementLoadResult.failure({required ApiError error});
+}
+```
+
+```dart
+sealed class PluginManagementMutationResult {
+  const PluginManagementMutationResult();
+
+  const factory PluginManagementMutationResult.success({
+    required PluginManagementResponse response,
+  });
+  const factory PluginManagementMutationResult.notFound();
+  const factory PluginManagementMutationResult.conflict({
+    required PluginLifecycleConflict conflict,
+  });
+  const factory PluginManagementMutationResult.uncertain({required ApiError error});
+  const factory PluginManagementMutationResult.failure({required ApiError error});
+}
+```
+
+Extend `PluginRepository`:
+
+- `GET /plugin/management` 404 maps to `unsupported`; other errors map to
+  explicit failure.
+- Mutation 404 maps to `notFound`.
+- HTTP 409 parses `PluginLifecycleConflict`; malformed 409 bodies map to
+  explicit request failure rather than a partial conflict.
+- Successful mutation bodies remain typed `PluginManagementResponse`.
+- `uncertain` represents a mutation whose request was sent but whose outcome
+  cannot be truthfully published because the connection/service fence moved.
+  Consumers render it as an uncertain state requiring refresh, never as a
+  bridge rejection or a committed success.
+- Existing discovery fallback behavior remains unchanged.
+
+Export the new public result surface and regenerate module-core DI if the
+repository/API registration graph changes. The management service and cubit do
+not enter this slice.
+
+Production files:
+
+- `client/module_core/lib/src/api/plugin_api.dart`
+- `client/module_core/lib/src/repositories/models/plugin_management_result.dart`
+- `client/module_core/lib/src/repositories/plugin_repository.dart`
+- `client/module_core/lib/sesori_dart_core.dart`
+- module-core DI source and regenerated `injection.config.dart` only when the
+  actual registration graph changes
+
+### Verification
+
+- API method/path/body/typed-response tests for every route.
+- Repository tests for supported, unsupported 404, mutation 404, typed 409,
+  malformed 409, uncertain result mapping, generic failure, and preserved
+  discovery fallback.
+- Module-core fatal analysis plus mobile and desktop fatal analysis.
+
+## Step 3/7: Management Synchronization Service
+
+### Scope
+
+Add:
+
+```dart
+typedef _ManagementRequestFence = ({
+  int connectionEpoch,
+  int publicationGeneration,
+  int staleGeneration,
+});
+```
+
+```dart
+@lazySingleton
+class PluginManagementService with Disposable {
+  PluginManagementService({
+    required PluginRepository pluginRepository,
+    required ConnectionService connectionService,
+  });
+
+  ValueStream<PluginManagementLoadResult> get snapshots;
+
+  Future<void> refresh();
+
+  Future<PluginManagementMutationResult> command({
+    required String pluginId,
+    required PluginLifecycleCommandRequest request,
+  });
+
+  Future<PluginManagementMutationResult> updateIdleTimeout({
+    required PluginIdleTimeoutUpdateRequest request,
+  });
+
+  PluginManagementCommandPlan planApplyAllIdleTimeout({
+    required String input,
+  });
+
+  PluginManagementCommandPlan planSetIdleTimeoutOverride({
+    required String pluginId,
+    required String input,
+  });
+
+  PluginManagementCommandPlan planClearIdleTimeoutOverride({
+    required String pluginId,
+  });
+
+  PluginManagementForceAssessment assessForce({
+    required PluginLifecycleConflict conflict,
+    required PluginManagementForceAction action,
+  });
+
+  @override
+  Future<void> onDispose();
+}
+```
+
+The timeout and force return types are small handwritten Layer-3 models in the
+service file, not wire DTOs:
+
+```dart
+sealed class PluginManagementCommandPlan {
+  const PluginManagementCommandPlan();
+
+  const factory PluginManagementCommandPlan.request({
+    required PluginIdleTimeoutUpdateRequest request,
+  });
+  const factory PluginManagementCommandPlan.invalidInput();
+}
+```
+
+```dart
+sealed class PluginManagementForceAssessment {
+  const PluginManagementForceAssessment();
+
+  const factory PluginManagementForceAssessment.requiresConfirmation({
+    required PluginLifecycleCommandRequest request,
+  });
+  const factory PluginManagementForceAssessment.notForceable();
+}
+```
+
+Constructor behavior uses one initial-connect path because current
+`ConnectionService.status` is replay-backed:
+
+```text
+read ConnectionService.currentStatus only to initialize the connection gate
+   and connection epoch
+subscribe ConnectionService.status
+subscribe ConnectionService.events
+subscribe ConnectionService.dataMayBeStale
+let the replayed status event perform the initial connected transition once
+```
+
+Do not both act on `currentStatus` and process the replayed connected event as
+a second trigger. Only `ConnectionConnected` permits management HTTP. Offline,
+reconnecting, lost, and disconnected statuses reject or defer new attempts and
+fence any in-flight attempt by connection epoch.
+
+One private publication coordinator owns every snapshot application. Both GET
+and mutation completions capture `{connectionEpoch,
+publicationGeneration, staleGeneration}` before their request and revalidate
+that entire fence immediately before publishing. Any superseded publication
+generation means another local response has already become newer; the older
+response must not publish, regardless of its opaque token. The coordinator then
+preserves/re-arms staleness and schedules or awaits one clean authoritative
+GET. Publication generation orders local client publications only; it never
+orders bridge snapshots.
+
+Refresh behavior:
+
+- Refresh triggers increment a local stale generation.
+- One coalesced refresh tail drains all triggers; no concurrent GETs.
+- A supported or unsupported response applies only under the captured
+  connection epoch, unsuperseded publication generation, and current disposal
+  state.
+- Only a successful supported/unsupported application consumes prior stale
+  generations. Failure publishes an explicit failure but preserves/re-arms
+  staleness without polling.
+- A trigger arriving while a GET is in flight schedules exactly one more drain.
+- Incoming `SesoriPluginManagementChanged` with a non-null token equal to the
+  current response token is ignored. Null or different tokens mark stale.
+- `dataMayBeStale` always marks stale.
+
+Mutation behavior:
+
+- Typed non-success results return without publishing.
+- If the connection epoch changed or the service is disposed, do not publish;
+  retain staleness and return `PluginManagementMutationResult.uncertain`.
+- If no snapshot was published since the captured fence, publish the returned
+  response.
+- If another snapshot published while the mutation was in flight, do not infer
+  order from the opaque token or publish the returned body over newer local
+  state. Mark stale, perform an authoritative GET, and return `uncertain` so
+  the caller does not claim either committed success or bridge rejection.
+- A successful mutation consumes only the staleness known at its captured
+  fence; a trigger arriving during the mutation remains stale.
+- `onDispose` cancels the connection subscriptions, awaits the active tail, and
+  closes the replay subject.
+
+Production files:
+
+- `client/module_core/lib/src/services/plugin_management_service.dart`
+- `client/module_core/lib/sesori_dart_core.dart`
+- module-core DI source and regenerated `injection.config.dart`
+
+### Verification
+
+- Constructor replay for an already-connected service performs exactly one
+  initial management GET.
+- Initial connect, reconnect, bridge-offline transition, manual refresh,
+  management SSE refresh, replay-loss refresh, equal-token suppression, and
+  disposal.
+- Two triggers while one GET runs produce one follow-up drain.
+- Failed refresh preserves staleness; next success consumes it.
+- Refresh-before-mutation, mutation-before-refresh, and refresh-after-refresh
+  publication races all reject superseded responses.
+- Disconnect during either request returns the required typed outcome without
+  publication.
+- Mutation after an intervening publication triggers authoritative GET and
+  returns `uncertain` rather than unordered publication.
+- Module-core focused tests and fatal analysis; mobile and desktop fatal
+  analysis.
+
+## Step 4/7: Backend-Neutral Harness Logos
+
+### Scope
+
+Use the existing generated Prego glyphs `VESPRSolid.opencode`,
+`VESPRSolid.codex`, and `VESPRSolid.cursor`; do not add or edit icon font
+assets or generated icon code.
+
+Add a presentation-only nullable key to the plugin interface:
+
+```dart
+abstract class BridgePluginDescriptor {
+  // Existing members...
+
+  /// Optional stable presentation key for the plugin's brand logo.
+  ///
+  /// The bridge and shared contracts treat this value as opaque. Clients map
+  /// known keys to bundled presentation assets and use a generic fallback for
+  /// null or unknown keys.
+  String? get brandLogoKey;
+}
+```
+
+Every in-repository descriptor declares intent:
+
+```dart
+OpenCodePluginDescriptor.brandLogoKey => "opencode";
+CodexPluginDescriptor.brandLogoKey => "codex";
+CursorPluginDescriptor.brandLogoKey => "cursor";
+```
+
+The values may match current IDs, but no consumer may derive the logo from the
+ID. Future or unbranded plugins return `null`.
+
+Add nullable `brandLogoKey` to shared `PluginMetadata` and
+`PluginSetupMetadata`; `PluginManagementMetadata` carries it through its
+embedded `setup`. The fields are additive, decode from missing older payloads
+as null, and are omitted when null. Include dated compatibility comments.
+
+Expand bridge-local registration metadata:
+
+```dart
+typedef RegisteredPluginMetadata = ({
+  String id,
+  String displayName,
+  String? brandLogoKey,
+  PluginResidencyPolicy residencyPolicy,
+});
+```
+
+`BridgeRuntimeRunner` copies `descriptor.brandLogoKey` alongside the existing
+display name. `PluginLifecycleService` propagates the value into discovery and
+setup/management rows. The legacy 404 discovery fallback explicitly supplies
+`brandLogoKey: "opencode"` because that branch already manufactures OpenCode
+identity.
+
+Add a non-generated Prego primitive:
+
+```dart
+class PregoBrandLogo extends StatelessWidget {
+  const PregoBrandLogo({
+    super.key,
+    required this.brandLogoKey,
+    this.size = 20,
+    this.color,
+  });
+
+  final String? brandLogoKey;
+  final double size;
+  final Color? color;
+}
+```
+
+Its private/static resolver maps exactly:
+
+```text
+"opencode" -> VESPRSolid.opencode
+"codex"    -> VESPRSolid.codex
+"cursor"   -> VESPRSolid.cursor
+other/null -> TablerRegular.plug
+```
+
+The logo is decorative; visible display-name text remains the accessible
+identity signal. Never interpret the key as a URL, asset path, font family,
+code point, capability, or behavior. Export the primitive from
+`module_prego.dart`.
+
+Update the existing new-session plugin chooser to render the declared logo in
+each option, retaining its current layout and Prego tokens. The Harnesses
+screens consume the primitive in later slices.
+
+Production files:
+
+- `bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin_descriptor.dart`
+- OpenCode, Codex, and Cursor descriptor source files
+- `bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart`
+- `bridge/app/lib/src/services/plugin_lifecycle_service.dart`
+- `shared/sesori_shared/lib/src/models/sesori/plugin_list_response.dart`
+- `shared/sesori_shared/lib/src/models/sesori/plugin_setup_response.dart`
+- regenerated shared companions
+- `client/module_core/lib/src/repositories/plugin_repository.dart`
+- `client/module_prego/lib/components/icons/prego_brand_logo.dart`
+- `client/module_prego/lib/module_prego.dart`
+- `client/app/lib/features/new_session/new_session_plugin_chooser.dart`
+
+### Verification
+
+- Descriptor contract and three concrete-key tests.
+- Bridge registration/discovery/setup/management propagation tests.
+- Shared missing/null/known/omitted-key compatibility tests and management
+  nesting coverage.
+- Prego widget tests for three mappings plus null and unknown fallback.
+- Existing chooser rendering tests.
+- Code generation, focused tests, and fatal analysis in interface, concrete
+  plugin packages, bridge app, shared, module_prego, module_core, mobile, and
+  desktop as applicable.
+
+## Step 5/7: Harnesses Overview Page
+
+### Scope
+
+Add typed routes:
+
+```dart
+AppRouteDef.settingsHarnesses("/settings/harnesses")
+const factory AppRoute.settingsHarnesses() = AppRouteSettingsHarnesses;
+```
+
+The route path is plural Harnesses even though domain models remain plugins.
+Do not use `state.extra`.
+
+Register the nested route under `/settings` beside the existing Notifications
+and Profile routes. Desktop does not add a route or screen; desktop validation
+is exhaustive compile compatibility only.
+
+In `SettingsScreen`, the existing Notifications row stops being `isLast`. Add
+the Harnesses row immediately below it in the same standalone grouped card:
+
+```dart
+PregoGroupedRow(
+  icon: TablerRegular.bell,
+  title: Text(loc.settingsNotificationsTitle),
+  trailing: const Icon(TablerRegular.chevron_right),
+  onTap: () => context.pushRoute(const AppRoute.settingsNotifications()),
+),
+PregoGroupedRow(
+  icon: TablerRegular.plug,
+  title: Text(loc.settingsHarnessesTitle),
+  trailing: const Icon(TablerRegular.chevron_right),
+  onTap: () => context.pushRoute(const AppRoute.settingsHarnesses()),
+  isLast: true,
+),
+```
+
+Preserve current Account, Appearance, Support, Legal, footer, external links,
+and close behavior.
+
+Add `HarnessesSettingsScreen`, modeled visually and structurally on
+`NotificationSettingsScreen`:
+
+```dart
+class HarnessesSettingsScreen extends StatelessWidget {
+  const HarnessesSettingsScreen({super.key});
+}
+```
+
+Construct a `PluginManagementCubit` through `BlocProvider(create:)` using
+`getIt<PluginManagementService>()`. This slice introduces the final
+`PluginManagementState` contract and its generated companion; Step 6 extends
+cubit behavior without replacing that state shape:
+
+```dart
+enum PluginManagementActionStatus { idle, inProgress }
+enum PluginManagementForceAction { disable, restart }
+```
+
+```dart
+@Freezed()
+sealed class PluginManagementActionError
+    with _$PluginManagementActionError {
+  const factory PluginManagementActionError.invalidIdleTimeout();
+  const factory PluginManagementActionError.notFound();
+  const factory PluginManagementActionError.conflict({
+    required PluginLifecycleConflict conflict,
+  });
+  const factory PluginManagementActionError.uncertain({
+    required ApiError error,
+  });
+  const factory PluginManagementActionError.request({
+    required ApiError error,
+  });
+}
+```
+
+```dart
+@Freezed()
+sealed class PluginManagementState with _$PluginManagementState {
+  const factory PluginManagementState.loading();
+  const factory PluginManagementState.unsupported();
+  const factory PluginManagementState.failure({required ApiError error});
+  const factory PluginManagementState.ready({
+    required PluginManagementResponse response,
+    required ApiError? refreshError,
+    required PluginManagementActionStatus actionStatus,
+    required String? actingPluginId,
+    required PluginManagementForceAction? pendingForceAction,
+    required PluginManagementActionError? actionError,
+  });
+}
+```
+
+The Step 5 cubit subscribes to the Step 3 replay stream, exposes `refresh()`,
+and emits ready with idle action fields. Mutation methods and controls remain
+out of this slice. A later refresh failure retains ready state with a
+dismissible `refreshError`.
+
+The scaffold matches Notifications:
+
+```dart
+PregoGlassScaffold(
+  title: loc.settingsHarnessesTitle,
+  titleMode: PregoTopNavigationTitleMode.inline,
+  banner: ConnectionBanner.maybeFor(context),
+  actions: [close-to-projects action],
+  onRefresh: cubit.refresh,
+  slivers: [...],
+)
+```
+
+Render through `SettingsSection`, `PregoGroupedRows`, `PregoGroupedRow`, and
+Prego tokens only. The ready state contains one read-only card per harness:
+
+- `PregoBrandLogo` in the leading slot.
+- display name and Default badge.
+- setup, runtime, work, and effective timeout rows.
+- action hint/setup guidance when present.
+- forward-compatible unknown setup/runtime/work values render readable copy
+  and never crash.
+
+There are no enable switches, mutation buttons, timeout dialogs, or force
+confirmations in this slice. Loading uses the existing Prego loading treatment.
+Unsupported explains that the connected bridge does not support Harnesses.
+Initial failure provides Retry. A ready-page refresh failure appears as an
+inline alert/error row while the last snapshot remains visible.
+
+Add all user-facing copy to `app_en.arb` and regenerate localization. Text is
+English-only for now.
+
+Production files:
+
+- `client/module_core/lib/src/routing/app_routes.dart`
+- `client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart`
+  for the read-only consumer defined in this slice; Step 6 extends behavior
+  without replacing the state contract
+- `client/module_core/lib/src/cubits/plugin_management/plugin_management_state.dart`
+  and its regenerated Freezed companion
+- `client/app/lib/core/routing/app_router.dart`
+- `client/app/lib/features/settings/settings_screen.dart`
+- `client/app/lib/features/settings/harnesses_settings_screen.dart`
+- `client/app/lib/l10n/app_en.arb` and regenerated localization outputs
+- route/cubit public exports as needed
+
+### Verification
+
+- Route encode/decode and router registration tests.
+- Settings landing row placement and navigation, preserving every existing
+  section.
+- Harnesses loading, unsupported, initial failure/retry, ready, known-logo,
+  generic-logo, default badge, and all setup/runtime/work unknown states.
+- Pull/manual refresh and ready-state refresh failure retention.
+- Close behavior and Notifications-style visual structure.
+- Localization generation, focused module-core and Flutter tests, and fatal
+  analysis in module_core, mobile, and desktop.
+
+## Step 6/7: Management Cubit Actions
+
+### Scope
+
+Extend the read-only cubit introduced in Step 5 into the full mutation
+consumer while retaining its final state contract:
+
+```dart
+class PluginManagementCubit extends Cubit<PluginManagementState> {
+  PluginManagementCubit({required PluginManagementService service});
+
+  Future<void> refresh();
+  Future<void> enable({required String pluginId});
+  Future<void> disable({required String pluginId});
+  Future<void> restart({required String pluginId});
+  Future<void> refreshSetup({required String pluginId});
+  Future<void> applyIdleTimeoutToAll({required String input});
+  Future<void> setIdleTimeoutOverride({
+    required String pluginId,
+    required String input,
+  });
+  Future<void> clearIdleTimeoutOverride({required String pluginId});
+  Future<void> confirmForce();
+  void dismissActionError();
+  void dismissRefreshError();
+
+  @override
+  Future<void> close();
+}
+```
+
+Command construction is exact:
+
+- enable -> `PluginLifecycleCommandRequest.enable()`
+- safe disable -> `PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe)`
+- safe restart -> `PluginLifecycleCommandRequest.restart(mode: PluginStopMode.safe)`
+- setup refresh -> `PluginLifecycleCommandRequest.refresh()`
+- force disable/restart only from `confirmForce()`
+
+Layer 3 owns domain input and policy. The cubit passes raw timeout text to the
+specific `PluginManagementService.plan*` method for apply-all or per-harness
+override and receives either a typed shared request or `invalidInput`. Clear
+override is also planned by Layer 3 so the cubit does not assemble timeout
+requests. Zero and negative integers are valid and match current resident
+semantics; only a non-integer produces the invalid outcome. On a typed
+conflict, the cubit passes the conflict and attempted action to
+`PluginManagementService.assessForce`, which owns the forceability
+classification:
+
+- Empty reason lists are not forceable.
+- Every reason must be one of `inFlight`, `busy`, or `workStateUnknown` to
+  offer force.
+- `transitioning`, `notEnabled`, or current-main `unknown` makes the conflict
+  non-forceable.
+- Force is one explicit second user action. It is never retried automatically.
+- The bridge remains authoritative; a force request can still return conflict,
+  not-found, uncertain, or failure.
+
+The cubit maps service outcomes into the Step 5 state, emits loading/action
+state, and stores the service-returned force request when confirmation is
+required. It consumes only service-published snapshots, never emits a mutation
+response independently, and never compares opaque tokens. It preserves an
+in-progress action and pending force confirmation across incoming snapshots,
+preserves ready state during a concurrent refresh failure, and clears action
+errors only on explicit dismissal, completed action, or a deliberate state
+transition. Every async gap checks `isClosed` before emitting.
+
+Production files:
+
+- `client/module_core/lib/src/services/plugin_management_service.dart` for the
+  handwritten timeout-plan and force-assessment models plus service methods
+- `client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart`
+- module-core test helpers and public exports as needed
+- no state source or generated state companion changes unless implementation
+  proves the Step 5 contract itself is wrong
+
+### Verification
+
+- Service tests cover every timeout plan and force-assessment variant.
+- Cubit tests cover every command and timeout request variant through the
+  service-owned plans.
+- Valid integer, zero, negative, whitespace, and invalid timeout input.
+- Safe-first behavior and exactly one explicit force retry.
+- Forceable and each non-forceable conflict reason, including unknown.
+- Uncertain mutation maps to its explicit presentation error without claiming
+  success or bridge rejection.
+- In-flight action plus successful refresh.
+- In-flight action plus failed refresh.
+- Pending force confirmation plus refresh.
+- Close during asynchronous action and refresh.
+- Focused service/cubit tests, module-core fatal analysis, and mobile/desktop
+  fatal analysis.
+
+## Step 7/7: Harness Management Controls Page
+
+### Scope
+
+Add the second typed route:
+
+```dart
+AppRouteDef.settingsHarnessManagement("/settings/harnesses/manage")
+const factory AppRoute.settingsHarnessManagement() =
+    AppRouteSettingsHarnessManagement;
+```
+
+Register it as another nested settings route. Add a management navigation row
+to the ready Harnesses overview:
+
+```dart
+PregoGroupedRow(
+  icon: TablerRegular.settings,
+  title: Text(loc.settingsHarnessManagementTitle),
+  trailing: const Icon(TablerRegular.chevron_right),
+  onTap: () =>
+      context.pushRoute(const AppRoute.settingsHarnessManagement()),
+  isLast: true,
+)
+```
+
+Add:
+
+```dart
+class HarnessManagementScreen extends StatelessWidget {
+  const HarnessManagementScreen({super.key});
+}
+```
+
+It creates its own `PluginManagementCubit` over the singleton
+`PluginManagementService`; replay supplies the current snapshot, so no state
+passes through `GoRouter.extra`.
+
+Use a back-leading scaffold that returns to the Harnesses overview and retains
+the close-to-projects action:
+
+```dart
+PregoGlassScaffold(
+  title: loc.settingsHarnessManagementTitle,
+  titleMode: PregoTopNavigationTitleMode.backLeading,
+  banner: ConnectionBanner.maybeFor(context),
+  onBack: () => context.pop(),
+  actions: [close-to-projects action],
+  onRefresh: cubit.refresh,
+  slivers: [...],
+)
+```
+
+Render all controls with the same grouped settings language:
+
+- Global idle timeout row and apply-all edit dialog.
+- Per-harness enable/disable switch.
+- Setup refresh action.
+- Safe restart action.
+- Per-harness timeout override dialog and clear-override row.
+- `PregoBrandLogo` and display name on each harness card.
+- Setup/runtime/work status remains visible for context.
+- Disable conflicting controls while an action is in progress.
+- Unsupported, initial failure, loading, and ready-refresh-error states use the
+  same treatment as the overview.
+
+Force confirmation:
+
+- Trigger only when cubit state exposes an allowed pending disable/restart.
+- Explicitly state that active work may be interrupted. Current main's #576
+  reconciles sessions after forced disable, but the warning remains required.
+- Cancel leaves the original state.
+- Confirm sends exactly one force command and never schedules a retry.
+
+Add remaining user-facing copy to `app_en.arb` and regenerate localization.
+
+Production files:
+
+- `client/module_core/lib/src/routing/app_routes.dart`
+- `client/app/lib/core/routing/app_router.dart`
+- `client/app/lib/features/settings/harnesses_settings_screen.dart`
+- `client/app/lib/features/settings/harness_management_screen.dart`
+- `client/app/lib/l10n/app_en.arb` and regenerated localization outputs
+
+### Verification
+
+- Route encode/decode, router registration, overview-to-management navigation,
+  back, and close behavior.
+- Every loading/unsupported/failure/ready state.
+- Global and per-harness timeout dialogs, including zero/negative/invalid
+  input.
+- Safe enable/disable/restart/setup-refresh interactions and control
+  disabling while actions run.
+- Conflict message, force confirmation cancel/confirm, and one-shot force
+  behavior.
+- Refresh failure while an action or force confirmation is pending.
+- Known and generic logos in control cards.
+- Localization generation, focused Flutter tests, module-core routing/cubit
+  tests, and mobile/desktop fatal analysis.
+
+## Risks And Compatibility
+
+| Area | Required treatment |
+|---|---|
+| Older bridge discovery | Missing `bridgeId` decodes null and disables preference persistence without failing sessions. |
+| Older clients | Additive `bridgeId` and `brandLogoKey` are ignored. |
+| Newer bridge logos | Unknown or null logo keys render the generic plug and visible display name. |
+| Logo trust boundary | `brandLogoKey` chooses bundled glyphs only; it is never a URL, path, font, or code execution input. |
+| Management 404 | Maps to an explicit unsupported page, not a fatal connection error. |
+| Snapshot ordering | Opaque tokens use equality only. Local connection/publication generations fence races. |
+| Lost SSE replay | `dataMayBeStale` always triggers management refresh. |
+| Preference timing | Persist the last submitted choice immediately before create-session request; creation failure does not roll it back. |
+| Stale preference | A saved unroutable plugin falls back to the current bridge default. |
+| Secure-storage failure | Log and degrade to default; never block new-session creation. |
+| Safe/force | Safe first, explicit one-shot force, and unknown/non-forceable reasons never show force. |
+| Current new-session behavior | Preserve Cursor `defaultModelID`, reconnect, staged command, and generation fencing. |
+| Current settings design | Preserve Account, Notifications, Appearance, Support, Legal, and footer composition. |
+| Generated files | Regenerate from source; never port generated output from frozen #511. |
+| Desktop | No desktop Harnesses route/screen; validate shared exhaustive contracts and fatal analysis only. |
+
+## Review And Verification Gates
+
+- Every architecture-bearing implementation slice receives one Aristotle
+  implementation review after relevant local verification and before delivery.
+- Run code generation only from source models.
+- Run focused tests named in each slice and fatal analysis in every changed
+  package plus required downstream consumers.
+- Do not rerun unchanged passing commands; CI supplies the full repository
+  matrix after each PR opens.
+- `git diff --check` must pass before every PR opens.
+
+## Real Simulator E2E
+
+Use the available iOS simulator with the PR build and the source bridge from
+this repository. Launch the bridge with
+`--data-dir ~/.local/share/sesori-dev` so it reuses the existing login and
+development bridge data, and use the existing `random stuff` project for
+session interactions.
+
+| Gate | Required coverage |
+|---|---|
+| After Step 1/7 | Connect through the normal app flow, open `random stuff`, verify each per-bridge harness choice persists across app reopen, falls back after a saved harness becomes unavailable, and keeps the older-bridge/no-`bridgeId` path on the bridge default without writing a preference. |
+| After Step 3/7 | Verify initial snapshot load, reconnect/replay-loss refresh, and management SSE invalidation against the real bridge. No UI assertion is required before Step 5. |
+| After Step 4/7 | Verify the new-session chooser renders the real OpenCode, Codex, and Cursor logos and a generic fallback for an unbranded/unknown harness. |
+| After Step 5/7 | Open Settings, verify the Harnesses row is immediately below Notifications with the same grouped-row style, open the page, and verify logos, statuses, default badge, refresh, unsupported state if an older bridge is available, and Notifications-style close behavior. |
+| After Step 7/7 | In `random stuff`, exercise safe enable/disable/restart/setup-refresh, busy-conflict copy, explicit force confirmation, timeout apply-all/override/clear, persistence across bridge restart, and session creation from the resulting harness state. Verify current-main forced-disable session reconciliation remains visible. |
+
+Stop the temporary E2E bridge after verification. Do not kill an unrelated
+user bridge; identify the process by the explicit development data directory
+and port before stopping it.
+
+## Completion
+
+Stage 13 completes after all seven PRs merge, the Harnesses entry and two
+pages are verified against a real bridge and simulator in `random stuff`,
+frozen PR #511 is closed as superseded, and the parent tracker records merge
+commits and verification.

--- a/.plan/active/setup-aware-harness-settings/PLAN.md
+++ b/.plan/active/setup-aware-harness-settings/PLAN.md
@@ -159,11 +159,15 @@ class NewSessionPluginService {
 ```
 
 `discover` preserves the existing success/failure `ApiResponse` contract and
-owns the complete selection precedence:
+owns the complete selection precedence. Current and saved selection candidates
+are considered only when the response supplies a non-null bridge identity;
+when `bridgeId` is absent, the current bridge default wins immediately so no
+selection silently crosses bridges:
 
 1. the current selection when its ID still identifies a ready or degraded
-   plugin;
-2. the saved preference when its ID identifies a ready or degraded plugin;
+   plugin and `bridgeId` is non-null;
+2. the saved preference when its ID identifies a ready or degraded plugin and
+   `bridgeId` is non-null;
 3. the current bridge default.
 
 Missing, disabled, blocked, failed, unavailable, or unknown current/saved
@@ -205,7 +209,7 @@ Production files:
 - Focused bridge plugin-list handler and router construction tests, plus
   bridge-app fatal analysis.
 - Preference API/repository/service tests for saved, default, unroutable,
-  stale, and storage-failure flows.
+  stale, storage-failure, and missing-`bridgeId` default-only flows.
 - Current new-session cubit and selection tests prove the service resolves
   current/saved/default precedence while the cubit only maps state, including
   `defaultModelID`, reconnect preservation, staged command, and last-submitted
@@ -242,11 +246,17 @@ sealed class PluginManagementLoadResult {
 
   const factory PluginManagementLoadResult.supported({
     required PluginManagementResponse response,
+    required ApiError? refreshError,
   });
   const factory PluginManagementLoadResult.unsupported();
   const factory PluginManagementLoadResult.failure({required ApiError error});
 }
 ```
+
+A refresh failure after a supported snapshot is replayed as `supported` with
+the retained response and a non-null `refreshError`; it does not replace the
+last usable snapshot with a bare failure. A bare `failure` remains the initial
+load state or an unsupported-bridge request failure.
 
 ```dart
 sealed class PluginManagementMutationResult {
@@ -259,7 +269,7 @@ sealed class PluginManagementMutationResult {
   const factory PluginManagementMutationResult.conflict({
     required PluginLifecycleConflict conflict,
   });
-  const factory PluginManagementMutationResult.uncertain({required ApiError error});
+  const factory PluginManagementMutationResult.uncertain();
   const factory PluginManagementMutationResult.failure({required ApiError error});
 }
 ```
@@ -372,6 +382,8 @@ sealed class PluginManagementCommandPlan {
 ```
 
 ```dart
+enum PluginManagementForceAction { disable, restart }
+
 sealed class PluginManagementForceAssessment {
   const PluginManagementForceAssessment();
 
@@ -417,7 +429,8 @@ Refresh behavior:
   connection epoch, unsuperseded publication generation, and current disposal
   state.
 - Only a successful supported/unsupported application consumes prior stale
-  generations. Failure publishes an explicit failure but preserves/re-arms
+  generations. Failure publishes `supported(refreshError:)` when a supported
+  snapshot already exists, otherwise bare `failure`; both preserve/re-arm
   staleness without polling.
 - A trigger arriving while a GET is in flight schedules exactly one more drain.
 - Incoming `SesoriPluginManagementChanged` with a non-null token equal to the
@@ -516,9 +529,9 @@ typedef RegisteredPluginMetadata = ({
 
 `BridgeRuntimeRunner` copies `descriptor.brandLogoKey` alongside the existing
 display name. `PluginLifecycleService` propagates the value into discovery and
-setup/management rows. The legacy 404 discovery fallback explicitly supplies
-`brandLogoKey: "opencode"` because that branch already manufactures OpenCode
-identity.
+setup/management rows. The legacy 404 discovery fallback supplies
+`brandLogoKey: null`; a peer that cannot declare branding renders the generic
+fallback rather than the client embedding another backend-specific key.
 
 Add a non-generated Prego primitive:
 
@@ -637,8 +650,10 @@ cubit behavior without replacing that state shape:
 
 ```dart
 enum PluginManagementActionStatus { idle, inProgress }
-enum PluginManagementForceAction { disable, restart }
 ```
+
+The Step 3 service file owns `PluginManagementForceAction`; this state imports
+that Layer-3 domain enum rather than redefining it:
 
 ```dart
 @Freezed()
@@ -649,9 +664,7 @@ sealed class PluginManagementActionError
   const factory PluginManagementActionError.conflict({
     required PluginLifecycleConflict conflict,
   });
-  const factory PluginManagementActionError.uncertain({
-    required ApiError error,
-  });
+  const factory PluginManagementActionError.uncertain();
   const factory PluginManagementActionError.request({
     required ApiError error,
   });
@@ -970,17 +983,25 @@ this repository. Launch the bridge with
 development bridge data, and use the existing `random stuff` project for
 session interactions.
 
+Before launching the E2E bridge, preflight the host for other Sesori bridge
+processes. Single-live-bridge replacement is not an acceptable implicit side
+effect: stop or wait out any unrelated bridge deliberately and record what was
+running so it can be restored afterward. Before mutations, snapshot the
+development data's plugin settings, secure preferences that this slice writes,
+and relevant `random stuff` session/catalog state. Restore those snapshots and
+clean up test sessions after verification; mandatory E2E must not leave
+persisted disable/timeout/preference/session state altered.
+
 | Gate | Required coverage |
 |---|---|
-| After Step 1/7 | Connect through the normal app flow, open `random stuff`, verify each per-bridge harness choice persists across app reopen, falls back after a saved harness becomes unavailable, and keeps the older-bridge/no-`bridgeId` path on the bridge default without writing a preference. |
-| After Step 3/7 | Verify initial snapshot load, reconnect/replay-loss refresh, and management SSE invalidation against the real bridge. No UI assertion is required before Step 5. |
-| After Step 4/7 | Verify the new-session chooser renders the real OpenCode, Codex, and Cursor logos and a generic fallback for an unbranded/unknown harness. |
-| After Step 5/7 | Open Settings, verify the Harnesses row is immediately below Notifications with the same grouped-row style, open the page, and verify logos, statuses, default badge, refresh, unsupported state if an older bridge is available, and Notifications-style close behavior. |
-| After Step 7/7 | In `random stuff`, exercise safe enable/disable/restart/setup-refresh, busy-conflict copy, explicit force confirmation, timeout apply-all/override/clear, persistence across bridge restart, and session creation from the resulting harness state. Verify current-main forced-disable session reconciliation remains visible. |
+| After Step 1/7 | Connect through the normal app flow, open `random stuff`, verify each per-bridge harness choice persists across app reopen, falls back after a saved harness becomes unavailable, and keeps the older-bridge/no-`bridgeId` path on the bridge default without writing a preference. Restore the written preference afterward. |
+| After Step 5/7 | Explicitly resolve the Step 3 service through the app's integration path, then verify initial snapshot load, reconnect/replay-loss refresh, and management SSE invalidation against the real bridge. Open Settings, verify the Harnesses row is immediately below Notifications with the same grouped-row style, open the page, and verify logos, statuses, default badge, refresh, retained snapshot after refresh failure, unsupported state if an older bridge is available, and Notifications-style close behavior. |
+| After Step 4/7 | Verify the new-session chooser renders the real OpenCode, Codex, and Cursor logos. Keep generic-logo verification in widget/contract tests unless an integration fixture can honestly return a null or unknown key; the normal three-descriptor bridge cannot produce that case. |
+| After Step 7/7 | In `random stuff`, exercise safe enable/disable/restart/setup-refresh, busy-conflict copy, explicit force confirmation, timeout apply-all/override/clear, persistence across bridge restart, and session creation from the resulting harness state. Verify current-main forced-disable session reconciliation remains visible, then restore the pre-E2E durable state. |
 
-Stop the temporary E2E bridge after verification. Do not kill an unrelated
-user bridge; identify the process by the explicit development data directory
-and port before stopping it.
+Stop the temporary E2E bridge after verification and restore any deliberately
+stopped pre-existing bridge. Do not kill an unrelated user bridge; identify
+and handle every bridge process before startup, not only after testing.
 
 ## Completion
 

--- a/.plan/active/setup-aware-harness-settings/PLAN.md
+++ b/.plan/active/setup-aware-harness-settings/PLAN.md
@@ -254,9 +254,12 @@ sealed class PluginManagementLoadResult {
 ```
 
 A refresh failure after a supported snapshot is replayed as `supported` with
-the retained response and a non-null `refreshError`; it does not replace the
-last usable snapshot with a bare failure. A bare `failure` remains the initial
-load state or an unsupported-bridge request failure.
+the retained response and a non-null `refreshError` only while the connection
+still identifies the same bridge. A bare `failure` remains the initial load
+state or an unsupported-bridge request failure. The service scopes retained
+snapshots by the connected bridge identity/config; an identity-changing
+transition clears the retained response and must never replay bridge A's
+management state while commands route to bridge B.
 
 ```dart
 sealed class PluginManagementMutationResult {
@@ -429,9 +432,10 @@ Refresh behavior:
   connection epoch, unsuperseded publication generation, and current disposal
   state.
 - Only a successful supported/unsupported application consumes prior stale
-  generations. Failure publishes `supported(refreshError:)` when a supported
-  snapshot already exists, otherwise bare `failure`; both preserve/re-arm
-  staleness without polling.
+  generations. Failure publishes `supported(refreshError:)` only when the
+  retained supported snapshot belongs to the currently connected bridge;
+  otherwise it publishes bare `failure` for the new bridge. Both paths
+  preserve/re-arm staleness without polling.
 - A trigger arriving while a GET is in flight schedules exactly one more drain.
 - Incoming `SesoriPluginManagementChanged` with a non-null token equal to the
   current response token is ignored. Null or different tokens mark stale.
@@ -463,9 +467,9 @@ Production files:
 
 - Constructor replay for an already-connected service performs exactly one
   initial management GET.
-- Initial connect, reconnect, bridge-offline transition, manual refresh,
-  management SSE refresh, replay-loss refresh, equal-token suppression, and
-  disposal.
+- Initial connect, same-bridge reconnect, identity-changing bridge transition,
+  bridge-offline transition, manual refresh, management SSE refresh,
+  replay-loss refresh, equal-token suppression, and disposal.
 - Two triggers while one GET runs produce one follow-up drain.
 - Failed refresh preserves staleness; next success consumes it.
 - Refresh-before-mutation, mutation-before-refresh, and refresh-after-refresh
@@ -474,6 +478,8 @@ Production files:
   publication.
 - Mutation after an intervening publication triggers authoritative GET and
   returns `uncertain` rather than unordered publication.
+- A failed first load after switching bridges never publishes the previous
+  bridge's retained snapshot.
 - Module-core focused tests and fatal analysis; mobile and desktop fatal
   analysis.
 

--- a/.plan/active/setup-aware-harness-settings/PLAN.md
+++ b/.plan/active/setup-aware-harness-settings/PLAN.md
@@ -225,6 +225,14 @@ Production files:
 
 ### Scope
 
+Add nullable `bridgeId` to shared `PluginManagementResponse` and regenerate its
+companions. `GetPluginManagementHandler` emits the existing
+`BridgeIdProvider.currentBridgeId` alongside the Stage 12 snapshot. The field
+is additive, decodes from older Stage 12 bridges as null, is omitted when
+null, and receives a dated compatibility comment. Mutations return the same
+identity-bearing response shape, so GET and mutation completions carry the same
+authoritative bridge identity.
+
 Extend `PluginApi` using the current Stage 12 routes:
 
 ```dart
@@ -259,12 +267,14 @@ sealed class PluginManagementLoadResult {
 ```
 
 A refresh failure after a supported snapshot is replayed as `supported` with
-the retained response and a non-null `refreshError` only while the connection
-still identifies the same bridge. A bare `failure` remains the initial load
-state or an unsupported-bridge request failure. The service scopes retained
-snapshots by the connected bridge identity/config; an identity-changing
-transition clears the retained response and must never replay bridge A's
-management state while commands route to bridge B.
+the retained response and a non-null `refreshError` only while the connected
+bridge's authoritative response identity matches the retained snapshot. A bare
+`failure` remains the initial load state or an unsupported-bridge request
+failure. `ServerConnectionConfig` is not an identity key; the service scopes
+snapshots by `PluginManagementResponse.bridgeId`, with `null` treated as one
+legacy-peer identity bucket. A different non-null ID clears the retained
+response and must never replay bridge A's management state while commands
+route to bridge B.
 
 ```dart
 sealed class PluginManagementMutationResult {
@@ -306,6 +316,9 @@ not enter this slice.
 
 Production files:
 
+- `shared/sesori_shared/lib/src/models/sesori/plugin_management.dart` and
+  regenerated companions
+- `bridge/app/lib/src/routing/get_plugin_management_handler.dart`
 - `client/module_core/lib/src/api/plugin_api.dart`
 - `client/module_core/lib/src/repositories/models/plugin_management_result.dart`
 - `client/module_core/lib/src/repositories/plugin_repository.dart`
@@ -315,6 +328,9 @@ Production files:
 
 ### Verification
 
+- Shared code generation and missing/null/known/omitted `bridgeId` management
+  compatibility tests.
+- Focused bridge management handler identity tests.
 - API method/path/body/typed-response tests for every route.
 - Repository tests for supported, unsupported 404, mutation 404, typed 409,
   malformed 409, successful-status undecodable mutation body to `uncertain`,
@@ -332,6 +348,7 @@ typedef _ManagementRequestFence = ({
   int connectionEpoch,
   int publicationGeneration,
   int staleGeneration,
+  String? bridgeId,
 });
 ```
 
@@ -425,13 +442,17 @@ fence any in-flight attempt by connection epoch.
 
 One private publication coordinator owns every snapshot application. Both GET
 and mutation completions capture `{connectionEpoch,
-publicationGeneration, staleGeneration}` before their request and revalidate
-that entire fence immediately before publishing. Any superseded publication
-generation means another local response has already become newer; the older
-response must not publish, regardless of its opaque token. The coordinator then
-preserves/re-arms staleness and schedules or awaits one clean authoritative
-GET. Publication generation orders local client publications only; it never
-orders bridge snapshots.
+publicationGeneration, staleGeneration, bridgeId}` before their request and
+revalidate that entire fence immediately before publishing. `bridgeId` comes
+from the authoritative management response; the coordinator stores it with
+each published snapshot. A response whose identity differs from the currently
+published identity clears and replaces the retained snapshot; a response whose
+identity differs from the captured request identity is fenced as superseded.
+Any superseded publication generation means another local response has already
+become newer; the older response must not publish, regardless of its opaque
+token. The coordinator then preserves/re-arms staleness and schedules or awaits
+one clean authoritative GET. Publication generation orders local client
+publications only; it never orders bridge snapshots.
 
 Refresh behavior:
 
@@ -442,9 +463,9 @@ Refresh behavior:
   state.
 - Only a successful supported/unsupported application consumes prior stale
   generations. Failure publishes `supported(refreshError:)` only when the
-  retained supported snapshot belongs to the currently connected bridge;
-  otherwise it publishes bare `failure` for the new bridge. Both paths
-  preserve/re-arm staleness without polling.
+  retained supported snapshot's `bridgeId` still belongs to the active fenced
+  identity; otherwise it publishes bare `failure` for the new bridge. Both
+  paths preserve/re-arm staleness without polling.
 - A trigger arriving while a GET is in flight schedules exactly one more drain.
 - Incoming `SesoriPluginManagementChanged` with a non-null token equal to the
   current response token is ignored. Null or different tokens mark stale.
@@ -476,9 +497,10 @@ Production files:
 
 - Constructor replay for an already-connected service performs exactly one
   initial management GET.
-- Initial connect, same-bridge reconnect, identity-changing bridge transition,
-  bridge-offline transition, manual refresh, management SSE refresh,
-  replay-loss refresh, equal-token suppression, and disposal.
+- Initial connect, same-`bridgeId` reconnect, changed-`bridgeId` transition,
+  legacy null-identity peer, bridge-offline transition, manual refresh,
+  management SSE refresh, replay-loss refresh, equal-token suppression, and
+  disposal.
 - Two triggers while one GET runs produce one follow-up drain.
 - Failed refresh preserves staleness; next success consumes it.
 - Refresh-before-mutation, mutation-before-refresh, and refresh-after-refresh
@@ -1011,8 +1033,8 @@ persisted disable/timeout/preference/session state altered.
 
 | Gate | Required coverage |
 |---|---|
-| After Step 1/7 | Connect through the normal app flow, open `random stuff`, verify each per-bridge harness choice persists across app reopen, falls back after a saved harness becomes unavailable, and keeps the older-bridge/no-`bridgeId` path on the bridge default without writing a preference. Restore the written preference afterward. |
-| After Step 5/7 | Explicitly resolve the Step 3 service through the app's integration path, then verify initial snapshot load, reconnect/replay-loss refresh, and management SSE invalidation against the real bridge. Open Settings, verify the Harnesses row is immediately below Notifications with the same grouped-row style, open the page, and verify logos, statuses, default badge, refresh, retained snapshot after refresh failure, unsupported state if an older bridge is available, and Notifications-style close behavior. |
+| After Step 1/7 | Connect through the normal app flow, open `random stuff`, verify each per-bridge harness choice persists across app reopen and falls back after a saved harness becomes unavailable. Restore the written preference afterward. Keep the omitted-`bridgeId` case in wire/service contract tests unless a real older-peer fixture is explicitly available; this repository's Step 1 bridge always emits the ID, so it cannot honestly exercise that path. |
+| After Step 5/7 | Explicitly resolve the Step 3 service through the app's integration path, then verify initial snapshot load, reconnect/replay-loss refresh, management SSE invalidation, and identity-scoped retained snapshots against the real bridge. Open Settings, verify the Harnesses row is immediately below Notifications with the same grouped-row style, open the page, and verify logos, statuses, default badge, refresh, retained snapshot after refresh failure, unsupported state if an older bridge is available, and Notifications-style close behavior. |
 | After Step 4/7 | Verify the new-session chooser renders the real OpenCode, Codex, and Cursor logos. Keep generic-logo verification in widget/contract tests unless an integration fixture can honestly return a null or unknown key; the normal three-descriptor bridge cannot produce that case. |
 | After Step 7/7 | In `random stuff`, exercise safe enable/disable/restart/setup-refresh, busy-conflict copy, explicit force confirmation, timeout apply-all/override/clear, persistence across bridge restart, and session creation from the resulting harness state. Verify current-main forced-disable session reconciliation remains visible, then restore the pre-E2E durable state. |
 

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -1,0 +1,42 @@
+# Setup-Aware Harness Settings: Tracker
+
+## Current State
+
+- **Implementation base:** current `origin/main` after Stage 12 merge `6cedf5bd`
+- **Series state:** planned; no implementation branch has started
+- **Next action:** begin Step 1/7 from current `origin/main`
+
+## Delivery
+
+| Done | Slice | Branch | PR state |
+|---|---|---|---|
+| [ ] | Step 1/7 — per-bridge harness preference | `setup-aware-harness-settings-preferences` | planned; estimate 650-750 changed lines |
+| [ ] | Step 2/7 — management transport | `setup-aware-harness-settings-transport` | planned; estimate 300-400 changed lines |
+| [ ] | Step 3/7 — synchronization service | `setup-aware-harness-settings-service` | planned; estimate 550-700 changed lines |
+| [ ] | Step 4/7 — harness logos | `setup-aware-harness-settings-branding` | planned; estimate 750-900 changed lines |
+| [ ] | Step 5/7 — Harnesses overview and state contract | `setup-aware-harness-settings-overview` | planned; estimate 1,100-1,300 changed lines |
+| [ ] | Step 6/7 — management actions | `setup-aware-harness-settings-state` | planned; estimate 650-800 changed lines |
+| [ ] | Step 7/7 — management controls | `setup-aware-harness-settings-controls` | planned; estimate 800-1,000 changed lines |
+
+## Source Material
+
+- Frozen PR #511: https://github.com/sesori-ai/sesori_apps_monorepo/pull/511
+- Substantive old commit: `167a3ee7`
+- Action-preservation follow-up: `bc3918cb`
+- Frozen head: `4f07172f`
+- Never merge, rebase, or cherry-pick the frozen branch. Reconstruct each
+  behavior against current `main` and preserve newer connection, model-default,
+  settings, and forced-disable behavior.
+
+## E2E Environment
+
+- Use the available iOS simulator for mobile Harnesses E2E.
+- Run the source bridge with `--data-dir ~/.local/share/sesori-dev` so it
+  reuses the existing login and development bridge data.
+- Use the existing `random stuff` project for session interactions and
+  management verification.
+- Do not leave a temporary E2E bridge running after verification.
+
+## Verification Log
+
+No implementation verification has run yet.

--- a/.plan/active/setup-aware-plugin-lifecycle/PLAN.md
+++ b/.plan/active/setup-aware-plugin-lifecycle/PLAN.md
@@ -119,15 +119,17 @@ available:
 
 ### Client settings
 
-- Add Plugins as a dedicated sub-page of the merged redesigned Settings screen.
+- Add Harnesses as a dedicated sub-page of the merged redesigned Settings
+  screen, with its entry immediately below Notifications.
 - The mobile shell remains thin and uses Prego settings/grouped-row primitives.
 - Shared client ownership remains API -> repository -> service -> cubit.
-- The page shows all registrations, setup/runtime/work status, eligibility,
-  effective timeout, global timeout, per-plugin override, refresh, restart, and
-  safe disable with explicit force confirmation.
-- The page does not expose runtime installation or backend login.
-- Desktop compiles against shared module-core changes but gets no plugin settings
-  UI in this plan.
+- The overview page shows all registrations, descriptor-declared logos,
+  setup/runtime/work status, eligibility, and effective timeout. A dedicated
+  management page carries global timeout, per-plugin override, refresh,
+  restart, and safe disable with explicit force confirmation.
+- The pages do not expose runtime installation or backend login.
+- Desktop compiles against shared module-core changes but gets no Harnesses
+  settings UI in this plan.
 
 ## Durable Configuration
 
@@ -469,17 +471,20 @@ small secure-storage-backed plugin preference repository. Management refresh is
 triggered by connection/reconnect and the lifecycle invalidation SSE, with one
 coalesced refresh tail and no polling.
 
-The preference repository keys a nullable last-used plugin ID by the connected
-bridge ID returned by `GET /plugin`. Layer-3 `NewSessionPluginService` combines
-plugin discovery and that preference: it prefers the saved ID only when
-routable, otherwise uses the response's derived default, and records a valid
-choice when session creation is submitted. Persistence failure is logged and
-never blocks creation. When an older bridge omits its ID, the service uses the
-bridge default and does not invent a cross-bridge key.
+The preference repository keys a nullable last-submitted plugin ID by the
+connected bridge ID returned by `GET /plugin`. Layer-3
+`NewSessionPluginService` combines plugin discovery, the current selection, and
+that preference: it resolves current routable selection, then saved routable
+selection, then the response's derived default, and records a valid choice when
+session creation is submitted. Persistence failure is logged and never blocks
+creation. When an older bridge omits its ID, the service uses the bridge
+default and does not invent a cross-bridge key.
 
-`client/app` adds a Plugins row to the redesigned Settings landing page and a
-dedicated Prego `PluginSettingsScreen`. Business decisions, command convergence,
-and force intent remain in module-core. All copy is localized.
+`client/app` adds a Harnesses row immediately below Notifications on the
+redesigned Settings landing page, a Notifications-consistent
+`HarnessesSettingsScreen`, and a dedicated `HarnessManagementScreen`. Business
+decisions, command convergence, timeout input, and force intent remain in
+module-core Layer 3. All copy is localized.
 
 The concrete client classes are:
 
@@ -495,27 +500,31 @@ The concrete client classes are:
 - Layer 2 `PluginPreferenceRepository` depends only on `PluginPreferenceApi` and
   exposes typed read/write of a nullable plugin ID.
 - Layer 3 `PluginManagementService({required PluginRepository
-  pluginRepository, required ConnectionService connectionService})` owns initial
-  GET, one coalesced refresh tail, mutation publication, and subscriptions to
-  `ConnectionService.status` and `ConnectionService.events`. Connected state and
-  `plugin.management.changed` are symmetric staleness triggers.
+  pluginRepository, required ConnectionService connectionService})` owns one
+  replay-safe initial GET, one coalesced refresh tail, fenced GET/mutation
+  publication, timeout input classification, forceability classification, and
+  subscriptions to `ConnectionService.status`, `ConnectionService.events`, and
+  `ConnectionService.dataMayBeStale`. Connected state, replay loss, and
+  `plugin.management.changed` are staleness triggers.
 - Layer 4 `PluginManagementCubit({required PluginManagementService service})`
-  owns loading/action state, integer input validation, and typed safe-to-force
-  confirmation. It calls no API directly.
+  maps Layer-3 outcomes into loading/action state and confirmation state. It
+  calls no API directly and owns no domain validation or force policy.
 - Layer 3 `NewSessionPluginService({required PluginRepository pluginRepository,
   required PluginPreferenceRepository pluginPreferenceRepository})` resolves
-  discovery plus saved/default selection and owns the observable unawaited write
-  when valid creation is submitted.
+  discovery through current-selection, saved-selection, then default precedence
+  and owns the observable unawaited write when valid creation is submitted.
 - Existing `NewSessionCubit` receives required `NewSessionPluginService`, invokes
   those use cases, and only maps results to composer state.
 
 `configureCoreDependencies` registers both APIs, both repositories, and the
-service; cubits remain `BlocProvider`-constructed. `client/app` adds
-`AppRouteDef.settingsPlugins`, `AppRoute.settingsPlugins()`, the route mapping in
-`app_router.dart`, a Plugins landing row in `settings_screen.dart`, and
-`features/settings/plugin_settings_screen.dart`. The screen resolves the service
-through DI, watches the cubit, and composes only Prego widgets and localized
-copy.
+services; cubits remain `BlocProvider`-constructed. `client/app` adds
+`AppRouteDef.settingsHarnesses`, `AppRoute.settingsHarnesses()`,
+`AppRouteDef.settingsHarnessManagement`,
+`AppRoute.settingsHarnessManagement()`, route mappings in `app_router.dart`, a
+Harnesses landing row immediately below Notifications in
+`settings_screen.dart`, `features/settings/harnesses_settings_screen.dart`, and
+`features/settings/harness_management_screen.dart`. The screens resolve services
+through DI, watch cubits, and compose only Prego widgets and localized copy.
 
 ### Concurrent management invariants
 
@@ -668,17 +677,13 @@ the listed source files and committed with their stage.
 
 ### Stage 13 / former PR #511 files
 
-This ledger is provisional source material for a dedicated Stage 13 child plan;
-it is not one PR boundary. The child plan must split the work into coherent
-approximately-1,000-line slices and record a size estimate for each slice before
-the first implementation branch starts.
-
-| Workspace | Production files/classes |
-|---|---|
-| Shared and module-core transport/persistence | Add nullable `bridgeId` to `plugin_list_response.dart`; modify `plugin_api.dart`, add `plugin_preference_api.dart`, `plugin_repository.dart`, management result models, add `plugin_preference_repository.dart`, DI source, barrel exports. |
-| Module-core orchestration/state | Add `plugin_management_service.dart`, `new_session_plugin_service.dart`, `cubits/plugin_management/*`; modify `new_session_cubit.dart`. |
-| Mobile routing/presentation | `app_routes.dart`, `app_router.dart`, `settings_screen.dart`, add `plugin_settings_screen.dart`, `app_en.arb`. |
-| Downstream | Desktop/module-core exhaustive compilation only; no desktop route or screen. |
+The concrete Stage 13 replacement delivery is owned by
+`.plan/active/setup-aware-harness-settings`. That child plan contains the
+current seven-PR sequence, exact branches/titles, file boundaries, size
+estimates, compatibility handling, and verification gates. The original frozen
+PR #511 inventory remains source material only; reconstruct behavior against
+current main rather than porting its generated output, unordered revision
+logic, old Settings screen shape, or historical plan edits.
 
 ## Delivery Stages
 
@@ -741,26 +746,27 @@ The exact branches, PR titles, merge commits, and per-slice verification are
 recorded in `.plan/completed/setup-aware-plugin-management`. Frozen PR #510 was
 closed as superseded and remains source material only.
 
-### Stage 13 / former PR #511 — redesigned mobile plugin settings
+### Stage 13 / former PR #511 — redesigned mobile Harnesses settings
 
-- module-core API -> repository -> service -> cubit and preference storage;
-- per-bridge last-used new-session choice;
-- Settings landing row and dedicated Plugins sub-page using merged Prego
-  settings primitives;
-- focused interaction, conflict/force, reconnect, and route tests.
+The concrete replacement is the seven-PR child series in
+`.plan/active/setup-aware-harness-settings`:
 
-Stage 13 begins by creating a child delivery plan that reassesses current-main
-drift from frozen PR #511, defines independently reviewable slices, and gives
-each slice an estimated changed-line range. Each PR aims for approximately
-1,000 changed lines under the sizing guardrail above. No Stage 13 implementation
-branch starts until those review and size boundaries are recorded.
+1. per-bridge last-submitted harness preference;
+2. management transport and typed repository results;
+3. reconnect/SSE/replay-safe synchronization service;
+4. descriptor-declared harness logos rendered through a backend-neutral Prego
+   primitive;
+5. Notifications-consistent read-only Harnesses page directly below the
+   Notifications settings entry;
+6. mutation cubit actions over service-owned safe/force policy;
+7. dedicated Harness management controls page.
 
-Keep one open replacement PR and one local successor built from that PR's latest
-reviewed head. After the predecessor merges, merge updated `origin/main` into
-the successor, reverify, and open it before beginning the next local slice.
-Never work farther than one slice ahead. Frozen #508-#511 remain reference
-material and are not rewritten. Stage 13 is rebuilt only after Stage 12-P06
-merges.
+The child plan records exact branches, PR titles, production files, estimates,
+wire compatibility, race handling, focused tests, and real-simulator E2E using
+`--data-dir ~/.local/share/sesori-dev` and the `random stuff` project. Keep
+one open replacement PR and one local successor built from that PR's latest
+reviewed head. Never work farther than one slice ahead. Frozen #508-#511
+remain reference material and are not rewritten.
 
 ## Verification
 

--- a/.plan/active/setup-aware-plugin-lifecycle/PLAN.md
+++ b/.plan/active/setup-aware-plugin-lifecycle/PLAN.md
@@ -549,6 +549,27 @@ copy.
   lose denylist enforcement for that run. The new bridge does not mirror legacy
   allowlists.
 
+## PR Sizing Guardrail
+
+- Plan each PR around approximately 1,000 changed lines (additions plus
+  deletions against its base). This is a reviewability target, not a hard
+  numerical gate.
+- Count generated and mechanical lockstep changes when estimating size so their
+  review cost stays visible. A PR may exceed the target when the excess is
+  simple generated output or repetitive low-risk code and the substantive
+  behavior remains one clear review boundary; document that rationale in the
+  PR body.
+- Architecture-heavy, stateful, security-sensitive, or concurrency-sensitive
+  work should split earlier when useful. Being below 1,000 lines does not make
+  a mixed or difficult diff reviewable.
+- Every child delivery plan records an estimated changed-line range for each PR.
+  Measure the actual branch diff while implementing. If substantive work is
+  trending materially beyond the target, stop and split it before opening the
+  PR rather than relying on review feedback to reduce an oversized diff.
+- Slices must still compile, pass their focused verification, and provide a
+  coherent review boundary. Do not create broken intermediate contracts or
+  artificial file-only splits merely to satisfy the target.
+
 ## Per-Stage Production File Ledger
 
 Generated Freezed/JSON/Injectable/localization companions are regenerated from
@@ -647,6 +668,11 @@ the listed source files and committed with their stage.
 
 ### Stage 13 / former PR #511 files
 
+This ledger is provisional source material for a dedicated Stage 13 child plan;
+it is not one PR boundary. The child plan must split the work into coherent
+approximately-1,000-line slices and record a size estimate for each slice before
+the first implementation branch starts.
+
 | Workspace | Production files/classes |
 |---|---|
 | Shared and module-core transport/persistence | Add nullable `bridgeId` to `plugin_list_response.dart`; modify `plugin_api.dart`, add `plugin_preference_api.dart`, `plugin_repository.dart`, management result models, add `plugin_preference_repository.dart`, DI source, barrel exports. |
@@ -722,6 +748,12 @@ closed as superseded and remains source material only.
 - Settings landing row and dedicated Plugins sub-page using merged Prego
   settings primitives;
 - focused interaction, conflict/force, reconnect, and route tests.
+
+Stage 13 begins by creating a child delivery plan that reassesses current-main
+drift from frozen PR #511, defines independently reviewable slices, and gives
+each slice an estimated changed-line range. Each PR aims for approximately
+1,000 changed lines under the sizing guardrail above. No Stage 13 implementation
+branch starts until those review and size boundaries are recorded.
 
 Keep one open replacement PR and one local successor built from that PR's latest
 reviewed head. After the predecessor merges, merge updated `origin/main` into

--- a/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
+++ b/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
@@ -334,7 +334,7 @@ run their focused verification again.
 - Added descriptor-declared opaque `brandLogoKey` transport and a Prego logo
   resolver that uses the existing OpenCode, Codex, and Cursor VESPR glyphs with
   a generic fallback.
-- Recorded per-slice estimates from 300-1,150 changed lines, including
+- Recorded per-slice estimates from 300-1,300 changed lines, including
   generated and mechanical output.
 - Required real simulator E2E with the source bridge running
   `--data-dir ~/.local/share/sesori-dev`, the existing login, and the

--- a/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
+++ b/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
@@ -4,11 +4,10 @@
 
 - **Status:** Stages 10-12 are merged; Stage 13 remains
 - **Base:** `origin/main` at Stage 12 merge `6cedf5bd`
-- **Current branch:** Stage 13 rebuild branch TBD
-- **Current stage:** Stage 13 — redesigned mobile plugin settings
-- **Next action:** reassess drift from frozen PR #511 and define the Stage 13
-  child delivery, including an estimated changed-line range for every
-  approximately-1,000-line PR slice before implementation starts
+- **Current branch:** `plan/stage-13-pr-sizing` plan update
+- **Current stage:** Stage 13 — redesigned mobile Harnesses settings
+- **Next action:** implement Step 1/7 from
+  `.plan/active/setup-aware-harness-settings` after this plan PR merges
 
 ## Frozen Oversized Stack
 
@@ -39,7 +38,7 @@ run their focused verification again.
 | [x] | Stage 11-P01D — bridge-owned projects and defaults | `setup-aware-plugin-lifecycle-project-ownership` | #550 merged as `5020c003` |
 | [x] | Stage 11-P02 — dormancy and numeric idle timeout | `setup-aware-plugin-lifecycle-dormant-runtime` | #556 merged as `41e03f12` |
 | [x] | Stage 12 — headless management | six-PR child series | #563, #567-#570, and #572 merged; recorded in `.plan/completed/setup-aware-plugin-management` |
-| [ ] | Stage 13 — redesigned mobile plugin settings | child series and branches TBD | reassess frozen #511, then define coherent ~1,000-line PR targets |
+| [ ] | Stage 13 — redesigned mobile Harnesses settings | seven-PR `setup-aware-harness-settings` child series | child plan defines exact branches/titles, file boundaries, estimates, and E2E gates |
 
 ## Locked Redesign Deltas
 
@@ -57,6 +56,12 @@ run their focused verification again.
   persisted timeout settings; OpenCode `--opencode-no-auto-start` uses it.
 - Headless management removes authority/order/serialized enabled.
 - Settings work targets the merged Prego Settings landing/sub-page architecture.
+- The user-facing settings destination is Harnesses. Internal domain names stay
+  plugins; routes, screens, localization, and copy use Harnesses.
+- The Harnesses settings row sits immediately below Notifications with the same
+  grouped-row style. Its overview page follows the Notifications page visually
+  and shows descriptor-declared harness logos through a backend-neutral Prego
+  resolver.
 - Remaining delivery aims for approximately 1,000 changed lines per PR. This is
   a reviewability target rather than a hard limit; simple generated or
   mechanical excess requires an explicit rationale, while complex work splits
@@ -319,13 +324,18 @@ run their focused verification again.
   detailed verification record moved to
   `.plan/completed/setup-aware-plugin-management`.
 
-### 2026-07-26 — Stage 13 PR sizing guardrail
+### 2026-07-26 — Stage 13 concrete Harnesses series
 
-- Added an approximately-1,000-changed-line planning target for each remaining
-  PR, with documented judgment for simple generated or mechanical excess.
-- Required the Stage 13 child plan to record per-slice changed-line estimates
-  before implementation and to split substantive work before a PR becomes
-  oversized.
-- Preserved coherent, compiling vertical slices as the primary boundary; the
-  numerical target does not justify broken intermediate contracts or
-  file-only splits.
+- Replaced the placeholder Stage 13 rebuild note with the concrete seven-PR
+  `setup-aware-harness-settings` child plan.
+- Locked the user-facing Harnesses label while retaining internal plugin domain
+  names. The settings entry goes directly below Notifications, and the overview
+  page mirrors the Notifications page's grouped-row Prego structure.
+- Added descriptor-declared opaque `brandLogoKey` transport and a Prego logo
+  resolver that uses the existing OpenCode, Codex, and Cursor VESPR glyphs with
+  a generic fallback.
+- Recorded per-slice estimates from 300-1,150 changed lines, including
+  generated and mechanical output.
+- Required real simulator E2E with the source bridge running
+  `--data-dir ~/.local/share/sesori-dev`, the existing login, and the
+  `random stuff` project; the temporary E2E bridge must be stopped afterward.

--- a/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
+++ b/.plan/active/setup-aware-plugin-lifecycle/TRACKER.md
@@ -7,7 +7,8 @@
 - **Current branch:** Stage 13 rebuild branch TBD
 - **Current stage:** Stage 13 — redesigned mobile plugin settings
 - **Next action:** reassess drift from frozen PR #511 and define the Stage 13
-  replacement delivery
+  child delivery, including an estimated changed-line range for every
+  approximately-1,000-line PR slice before implementation starts
 
 ## Frozen Oversized Stack
 
@@ -38,7 +39,7 @@ run their focused verification again.
 | [x] | Stage 11-P01D — bridge-owned projects and defaults | `setup-aware-plugin-lifecycle-project-ownership` | #550 merged as `5020c003` |
 | [x] | Stage 11-P02 — dormancy and numeric idle timeout | `setup-aware-plugin-lifecycle-dormant-runtime` | #556 merged as `41e03f12` |
 | [x] | Stage 12 — headless management | six-PR child series | #563, #567-#570, and #572 merged; recorded in `.plan/completed/setup-aware-plugin-management` |
-| [ ] | Stage 13 — redesigned mobile plugin settings | rebuild branch TBD | frozen #511 descendant |
+| [ ] | Stage 13 — redesigned mobile plugin settings | child series and branches TBD | reassess frozen #511, then define coherent ~1,000-line PR targets |
 
 ## Locked Redesign Deltas
 
@@ -56,6 +57,10 @@ run their focused verification again.
   persisted timeout settings; OpenCode `--opencode-no-auto-start` uses it.
 - Headless management removes authority/order/serialized enabled.
 - Settings work targets the merged Prego Settings landing/sub-page architecture.
+- Remaining delivery aims for approximately 1,000 changed lines per PR. This is
+  a reviewability target rather than a hard limit; simple generated or
+  mechanical excess requires an explicit rationale, while complex work splits
+  earlier when useful.
 - No compatibility machinery is retained for any contract from the superseded
   oversized stack.
 - Aggregate projects are bridge-owned and may include sessions from multiple
@@ -313,3 +318,14 @@ run their focused verification again.
 - Frozen PR #510 was closed as superseded. The completed child plan and its
   detailed verification record moved to
   `.plan/completed/setup-aware-plugin-management`.
+
+### 2026-07-26 — Stage 13 PR sizing guardrail
+
+- Added an approximately-1,000-changed-line planning target for each remaining
+  PR, with documented judgment for simple generated or mechanical excess.
+- Required the Stage 13 child plan to record per-slice changed-line estimates
+  before implementation and to split substantive work before a PR becomes
+  oversized.
+- Preserved coherent, compiling vertical slices as the primary boundary; the
+  numerical target does not justify broken intermediate contracts or
+  file-only splits.


### PR DESCRIPTION
## Summary

- add the concrete `setup-aware-harness-settings` child plan as seven ordered implementation PRs with exact branches, titles, production boundaries, dependencies, and changed-line estimates
- lock the user-facing Harnesses destination directly below Notifications, with a Notifications-consistent overview page and a separate management controls page
- define backend-neutral harness logo delivery from plugin descriptors through shared transport to the existing Prego OpenCode/Codex/Cursor glyphs and generic fallback
- require simulator E2E with the source bridge using `--data-dir ~/.local/share/sesori-dev`, the existing login, and the `random stuff` project

## Architecture review

- Architecture plan review initially rejected the draft.
- Applied all findings: Layer-3 selection precedence, replay-safe initial management load, one fenced publication coordinator, typed uncertain mutations, the final Step 5 state contract, service-owned timeout/force policy, and consistent Harnesses terminology in the parent plan.

## Validation

- `git diff --check main...HEAD`
- reviewed the complete plan and tracker diffs

No Dart or Flutter suites were run because this PR changes planning documents only.
