### PR TITLE
docs(plan): split bridge-ready onboarding delivery

### DIFF
--- a/.plan/active/bridge-ready-onboarding/PLAN.md
+++ b/.plan/active/bridge-ready-onboarding/PLAN.md
@@ -1,0 +1,466 @@
+# Bridge-Ready Mobile Onboarding
+
+## Status
+
+- **Plan slug:** `bridge-ready-onboarding`
+- **Status:** architecture review corrections applied; pending plan PR
+- **Plan date:** 2026-07-26
+- **Implementation base:** `origin/main` at
+  `f8c71eb78987aa8c64e397e8e8e3bb72eefa0692`
+- **Repository:** `sesori-ai/sesori_apps_monorepo`
+- **Delivery:** two sequential bridge-only PRs
+
+## Goal
+
+Make standalone interactive first setup show the mobile-app QR/link only after
+the bridge is locally ready to serve a phone through the relay. A user who
+installs or opens the app from that prompt should find an already-running
+bridge, rather than an app that reports the bridge offline while the bridge is
+still paused waiting for mobile notification registration.
+
+The implementation must also keep bridge availability independent from mobile
+push-token registration. The app-registration check remains useful for deciding
+whether the one-time prompt is needed, but it must not gate relay startup.
+
+## Success Criteria
+
+1. For a standalone interactive start that needs app onboarding, bridge
+   registration succeeds, the relay WebSocket is established, the bridge auth
+   frame is sent, startup listeners are initialized, and the first inbound relay
+   read is armed before the QR/link is rendered.
+2. The bridge can complete key exchange and serve phone traffic while the QR is
+   visible. Mobile push-token registration is not a prerequisite for relay
+   availability.
+3. If initial bridge registration, relay connection, or local serving startup
+   fails, the install/open prompt is not shown; the existing startup failure is
+   surfaced instead.
+4. A missing mobile registration produces one prompt and no long-poll or retry
+   loop. The bridge remains running whether or not the app registers a push
+   token during that process lifetime.
+5. Existing marked accounts and accounts already reporting a registered mobile
+   client remain silent. A mobile client installed during the current run is
+   recognized and marked by the immediate check on a later bridge start.
+6. Supervised and non-interactive bridge starts retain their current behavior
+   and never show the standalone app prompt.
+7. Registration ordering, reconnect/backoff behavior, relay takeover handling,
+   token re-authentication, signal-driven shutdown, and teardown error
+   propagation remain unchanged.
+8. Each implementation PR remains below 1,500 changed lines, counting additions
+   plus deletions against its PR base, including tests.
+
+## Current Behavior
+
+- `BridgeRuntimeRunner` awaits `AppClientOnboardingService.run` immediately
+  after plugin setup inspection and availability checks
+  (`bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart:691-714`).
+- When the auth server reports no app client, the service prints the generic
+  app-store QR/link and enters an unbounded loop of 30-second server long-polls,
+  refreshing auth and retrying failures every five seconds
+  (`bridge/app/lib/src/services/app_client_onboarding_service.dart:56-106`).
+- The status endpoint is backed by notification-device-token presence, not a
+  phone-to-bridge handshake
+  (`client/module_core/lib/src/services/notification_registration_service.dart:97-106`;
+  auth reference `src/services/app-client-presence-service.ts:36-50`).
+- Single-live ownership, bridge registration, `RelayClient` construction,
+  runtime composition, and `OrchestratorSession.run` all happen after that gate
+  (`bridge_runtime_runner.dart:715-904`).
+- `OrchestratorSession.run` currently combines two distinct lifecycle phases:
+  finite initial registration/connection/listener setup and the long-lived
+  relay read/reconnect/teardown loop
+  (`bridge/app/lib/src/bridge/orchestrator.dart:712-966`).
+- The phone already authenticates to the relay without a bridge, parks its
+  socket, and immediately reconnects for E2E key exchange after the relay sends
+  `bridge_connected`. No relay or client change is required for wake-up
+  (`client/module_core/lib/src/capabilities/server_connection/connection_service.dart:293-327,496-517`).
+- The displayed QR is a generic app URL with no bridge or startup-session
+  identifier (`bridge/app/lib/src/foundation/app_onboarding_formatter.dart:12`).
+
+## Locked Decisions And Boundaries
+
+- This plan changes only `bridge/app`. It adds no relay role, relay control
+  frame, auth-server endpoint, shared wire model, client connection state, or
+  mobile UI state.
+- "Ready" is an explicit local bridge guarantee: auth registration has
+  succeeded; the WebSocket connection has opened; the bridge auth frame has
+  been sent; startup subscriptions/listeners and the initial summary have been
+  initialized; and the first inbound relay read is armed. The current relay
+  protocol has no bridge-auth acknowledgement, so this plan does not claim a
+  cryptographic server acknowledgement before rendering the QR.
+- The refactor PR is standalone and preserves user-visible startup behavior. It
+  contains lifecycle separation, complete partial-start teardown ownership, and
+  lockstep test updates only. It does not move onboarding, change terminal copy,
+  or remove the app-registration wait.
+- The feature PR consumes the final lifecycle API from the refactor PR. It does
+  not reopen or broaden the lifecycle design.
+- `OrchestratorSession` remains the sole owner of relay serving, reconnect, and
+  teardown. `BridgeRuntimeRunner` sequences lifecycle phases but does not own a
+  second relay loop or duplicate teardown.
+- Sequential relay-frame handling must remain sequential. Arming the initial
+  read must not replace the current `await for` semantics with uncoordinated
+  asynchronous `listen` callbacks.
+- `AppClientOnboardingService` is preparation-only. It performs the local marker
+  lookup and one immediate status request before runtime serving starts, returns
+  a typed presentation decision, and owns no formatter or `Console` output.
+- A private `BridgeRuntimeRunner` method at the CLI composition boundary renders
+  the prompt synchronously after session startup. Do not add a one-consumer
+  presenter class. There is no background app-status task, timer, long-poll,
+  cancellation owner, or new process-lifetime service.
+- Existing endpoint-unavailable behavior remains fail-open and silent. This
+  plan does not change the released 404/405 compatibility fallback for older or
+  custom auth deployments.
+- The existing per-auth-backend/user marker remains authoritative. When a user
+  installs the app after preparation reported absence, the next immediate
+  status check writes the marker; no current-run background observer is needed.
+- Internal Dart contracts have no external consumers. Replace `run` call sites
+  in lockstep; do not retain a compatibility wrapper or deprecated alias. Step
+  2 also removes the internal status API/repository `wait` parameter and the
+  `wait=true` query branch once their only production consumer is gone.
+- The series target is 1,000 changed lines or fewer per PR. At 1,300 projected
+  changed lines, stop and reassess before implementation crosses the user's
+  1,500-line ceiling. Do not move refactoring into the feature PR to stay under
+  the first PR's estimate.
+- Keep one implementation PR open at a time. Step 2 starts from updated
+  `origin/main` after Step 1 merges; it is not opened as a stacked PR.
+
+## Delivery Sequence
+
+| Step | Branch | Exact PR title | Estimate | Review boundary |
+|---|---|---|---:|---|
+| 1/2 | `bridge-ready-onboarding-session-lifecycle` | `[bridge-ready-onboarding] refactor(bridge): separate session startup from serving [step 1/2]` | 500-800 | Standalone lifecycle refactor with no onboarding behavior change. |
+| 2/2 | `bridge-ready-onboarding-relay-first` | `[bridge-ready-onboarding] fix(bridge): start relay before mobile onboarding [step 2/2]` | 450-750 | Relay-ready prompt ordering, removal of the notification-registration gate, and deletion of the unused long-poll API variant. |
+
+"Standalone" in Step 1 means the PR is refactor-only, independently valid, and
+safe to merge without Step 2. Because it is an enabling part of this intentional
+two-PR delivery, it still uses the required series title and `[step 1/2]`
+wrapper.
+
+## Step 1/2: Separate Session Startup From Serving
+
+### Purpose
+
+Give the composition root an honest readiness boundary without mixing the UX
+change into a lifecycle refactor. Today `OrchestratorSession.run` does not return
+until shutdown, so the runner cannot both establish readiness and then render
+the prompt without launching an unowned long-lived future.
+
+### Lifecycle Contract
+
+Replace `OrchestratorSession.run` with a typed, one-shot startup operation and a
+separate wait operation:
+
+```dart
+enum OrchestratorSessionStartResult { ready, cancelled }
+
+Future<OrchestratorSessionStartResult> start();
+Future<void> waitUntilStopped();
+```
+
+`start` creates, stores, and internally observes one lifecycle future before the
+first startup operation can acquire a resource or fail. That lifecycle future
+owns startup, serving, and teardown under one `try/finally`:
+
+1. register the bridge with auth;
+2. connect `RelayClient`, which opens the socket and sends the existing bridge
+   auth frame;
+3. initialize the existing completion, maintenance, project-activity,
+   permission, plugin-event, PR, unseen, and token re-auth subscriptions;
+4. build and publish the initial project summary exactly as today;
+5. create one `StreamIterator` from `RelayClient.read()` and invoke its first
+   `moveNext()` to establish the inbound subscription; and
+6. complete the startup handshake immediately after invoking that first
+   `moveNext()`, without awaiting an inbound frame.
+
+The serving loop awaits that same pending first `moveNext()`, processes the
+current frame completely, then invokes/awaits the next `moveNext()`. This locks
+the readiness point without waiting for a phone or relay frame and preserves
+sequential frame processing. The lifecycle `finally` cancels the active
+iterator before/with the existing failure-isolated teardown. Do not replace the
+loop with uncoordinated asynchronous `listen` callbacks, and do not treat
+WebSocket opening alone as readiness.
+
+After the startup handshake returns `ready`, `waitUntilStopped` exposes that
+same internally observed lifecycle future. It continues to own:
+
+- relay frame processing and key exchange;
+- reconnect and takeover backoff;
+- bridge-revocation re-registration;
+- all existing failure-isolated teardown; and
+- propagation of the first teardown error.
+
+The lifecycle is one-shot. A second `start` fails immediately; waiting before a
+`ready` result fails immediately; repeated reads of the post-start wait future
+observe the same completion. `beginShutdown` and `cancel` remain callable by the
+existing shutdown coordinator and signal handlers and must still wake startup,
+an active normal backoff, or a takeover backoff promptly.
+
+If registration, connection, listener initialization, summary construction, or
+initial read arming fails before readiness, the lifecycle future runs complete
+partial-start teardown before `start` rethrows that failure.
+`waitUntilStopped` remains unavailable. If shutdown is requested before
+readiness, the lifecycle future tears down acquired resources, `start` returns
+`cancelled`, the runner shows no onboarding prompt, and the existing clean or
+supervised-sentinel shutdown outcome is preserved.
+
+`BridgeRuntimeRunner` adopts the new API in behavior-preserving sequence:
+
+```text
+existing app-onboarding gate
+-> session.start
+-> ready: capture wait future and await it
+-> cancelled: return through the existing clean/sentinel outcome
+```
+
+The shutdown coordinator's drain phase continues to await the captured serving
+future. The internally observed lifecycle future exists before startup can fail,
+so neither a partial-start failure nor the interval before runner capture can
+surface as an unhandled asynchronous error.
+
+### Expected Files
+
+Production:
+
+- `bridge/app/lib/src/bridge/orchestrator.dart`
+- `bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart`
+
+Lockstep tests and harnesses:
+
+- `bridge/app/test/bridge/orchestrator_registration_test.dart`
+- `bridge/app/test/bridge/orchestrator_error_recovery_test.dart`
+- `bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart`
+- `bridge/app/test/bridge/orchestrator_token_reauth_test.dart`
+- `bridge/app/test/bridge/debug_server_test.dart`
+- a focused orchestrator lifecycle test if the contract is clearer outside the
+  existing registration/error suites
+
+No new production collaborator or interface is planned. If clean ownership
+requires moving substantial pre-existing responsibilities into a new class,
+stop and update this plan rather than hiding that refactor in Step 2.
+
+### Acceptance
+
+- Existing standalone/supervised user-visible runner ordering is unchanged.
+- `start` does not complete before registration, connect/auth send, startup
+  initialization, and initial read arming.
+- Registration, initial relay, listener, summary, or read-arming failure runs
+  partial-start teardown and then throws from `start`; no waitable serving phase
+  is exposed.
+- Shutdown before readiness tears down, returns `cancelled`, and never shows a
+  prompt or becomes a startup error.
+- Key exchange and request handling work after `start` while a caller has not
+  yet awaited `waitUntilStopped`.
+- All current reconnect, revocation, takeover, token re-auth, event ordering,
+  and shutdown tests retain their behavior under the split API.
+- Every former `session.run()` production/test caller is updated in lockstep;
+  no compatibility method remains.
+
+### Verification
+
+From `bridge/app`:
+
+```bash
+dart test test/bridge/orchestrator_registration_test.dart \
+  test/bridge/orchestrator_error_recovery_test.dart \
+  test/bridge/orchestrator_emit_bridge_event_test.dart \
+  test/bridge/orchestrator_token_reauth_test.dart \
+  test/bridge/debug_server_test.dart
+dart analyze --fatal-infos
+```
+
+Run `aristotle-impl-review` against the Step 1 branch versus `main` because this
+PR changes lifecycle ownership and a production class contract.
+
+## Step 2/2: Render Onboarding After Relay Readiness
+
+### Purpose
+
+Use the lifecycle seam from Step 1 to ensure the bridge is already serving when
+the install/open prompt appears, and remove the incorrect dependency on mobile
+notification registration.
+
+### Onboarding Preparation
+
+Refactor `AppClientOnboardingService` into a finite, preparation-only decision.
+Use a concrete enum such as `AppClientOnboardingDecision { skip, prompt }`; do
+not use an empty string or nullable modern domain state. Its exact public
+operation becomes:
+
+```dart
+Future<AppClientOnboardingDecision> prepare({
+  required String accessToken,
+  required String authBackendUrl,
+});
+```
+
+Preparation preserves:
+
+- JWT `userId` parsing and warning behavior;
+- per-auth-backend/user marker lookup;
+- one immediate app-client status request;
+- immediate marker write when a registered app is already present;
+- independent marker read/write warnings; and
+- existing endpoint-unavailable compatibility behavior.
+
+Preparation removes:
+
+- `TokenRefresher` from this service;
+- `AppOnboardingFormatter` and all `Console` output from this service;
+- the unbounded polling loop;
+- the five-second retry timer; and
+- the terminal claims that startup is paused or later continuing.
+
+Remove the now-unused long-poll variant from the internal lower layers in the
+same PR: `AppClientStatusRepository.getStatus` and
+`SesoriServerApi.getAppClientStatus` become immediate-status operations without
+a `wait` parameter, and the API no longer builds a `wait=true` query.
+
+Preparation emits no QR or onboarding copy. For a `prompt` decision, a private
+`BridgeRuntimeRunner` method constructs/uses the existing formatter and writes
+the generic QR/link after the bridge session is ready and its wait future has
+been captured. Copy must state that the bridge is running and that the user
+should install/open Sesori and sign into the same account. It must not claim that
+notification registration, relay pairing, or E2E connection has already
+completed.
+
+### Runner Ordering
+
+For standalone interactive starts only:
+
+```text
+plugin inspect/availability
+-> prepare onboarding decision (finite; no prompt)
+-> ownership, diagnostics, database, and runtime composition
+-> session.start (one lifecycle future; registration + relay + listeners + first read armed)
+-> ready: capture session.waitUntilStopped for shutdown ownership
+-> synchronously render QR/link in BridgeRuntimeRunner when the decision requires it
+-> await the captured serving future
+```
+
+Supervised and non-interactive starts skip preparation/presentation and use the
+same `start -> ready/cancelled -> capture wait -> await wait` lifecycle.
+
+If session startup fails, the prompt is never rendered. If presentation itself
+throws, the existing outer runner `finally` shuts down and drains the already
+captured serving future. A `cancelled` startup result also renders no prompt and
+returns through the existing clean/sentinel outcome.
+
+### Expected Files
+
+Production:
+
+- `bridge/app/lib/src/services/app_client_onboarding_service.dart`
+- `bridge/app/lib/src/repositories/app_client_status_repository.dart`
+- `bridge/app/lib/src/api/sesori_server_api.dart`
+- `bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart`
+
+Tests:
+
+- `bridge/app/test/services/app_client_onboarding_service_test.dart`
+- `bridge/app/test/repositories/app_client_status_repository_test.dart`
+- `bridge/app/test/api/sesori_server_api_test.dart`
+- `bridge/app/test/bridge/runtime/bridge_runtime_runner_test.dart` for the
+  standalone/supervised/non-interactive decision guard
+- the Step 1 lifecycle suite for the after-start serving guarantee
+
+Do not extract a production coordinator or presenter solely to make runner
+ordering easier to mock. Verify the meaningful seams directly: lifecycle
+readiness in the orchestrator suite, output-free preparation in the onboarding
+service suite, immediate-only status API/repository behavior in their owning
+suites, and formatter/copy output at the existing CLI composition boundary.
+
+### Acceptance
+
+- Missing app registration performs exactly one immediate status request and
+  returns a prompt decision.
+- Preparing a prompt emits no stdout onboarding content.
+- The service has no formatter or `Console` dependency; the runner's private
+  presentation method emits the QR/link and revised ready-state copy.
+- The status API/repository expose no `wait` parameter and never send
+  `wait=true`.
+- Marker-present and immediate-registered paths remain silent; immediate
+  registration still writes the marker.
+- Status-unavailable and marker-failure behavior remains observable and
+  non-fatal according to the current compatibility behavior.
+- The runner starts and captures the session-serving future before prompt
+  presentation.
+- A phone can join, complete key exchange, and issue the health request while
+  the prompt is visible and without registering a notification token.
+- Signal/restart shutdown drains the same serving future and does not wait for
+  an onboarding poll or timer.
+
+### Verification
+
+From `bridge/app`:
+
+```bash
+dart test test/services/app_client_onboarding_service_test.dart \
+  test/repositories/app_client_status_repository_test.dart \
+  test/api/sesori_server_api_test.dart \
+  test/bridge/runtime/bridge_runtime_runner_test.dart \
+  test/bridge/orchestrator_registration_test.dart \
+  test/bridge/orchestrator_error_recovery_test.dart
+dart analyze --fatal-infos
+```
+
+Advisory manual check with a fresh standalone data directory/account:
+
+1. Start the bridge and confirm relay startup output precedes the QR/link.
+2. Install/open the mobile app and sign into the same account.
+3. Confirm the app reaches the bridge without a prolonged bridge-offline state.
+4. Withhold or fail push-token registration and confirm bridge relay/key-exchange
+   availability is unaffected.
+5. Restart after app registration and confirm the prompt is skipped and the
+   marker is written by the immediate status check.
+
+Run `aristotle-impl-review` against the Step 2 branch versus `main` because this
+PR changes the composition-root lifecycle trigger and onboarding data flow.
+
+## Compatibility And Security
+
+- No client/bridge transport contract changes. Old and new mobile apps continue
+  using the existing `bridge_connected`/`bridge_disconnected`, key exchange,
+  health, and SSE flows.
+- No auth or relay deployment ordering is introduced. The current auth status
+  request and bridge registration endpoints remain unchanged.
+- No source data, paths, prompt content, or startup phase is exposed to the
+  relay. The bridge still authenticates with the existing account token and
+  bridge ID.
+- The local lifecycle API updates every in-repository caller in lockstep, as
+  required for internal Dart contracts.
+- The generic QR remains account-based and contains no bridge identifier or
+  secret.
+
+## Material Risks
+
+- **Readiness overclaim:** WebSocket open plus auth-frame send is not a relay
+  acknowledgement. The plan therefore defines and tests local readiness only.
+  An exact remote "bridge accepted" acknowledgement would require a separate
+  relay protocol change and is out of scope.
+- **Lifecycle-future ownership:** Startup and serving begin before prompt
+  presentation. Step 1 creates and internally observes one lifecycle future
+  before resource acquisition, keeps startup/serving/teardown under its
+  `try/finally`, and exposes it to the runner only after readiness. Step 2
+  captures it before synchronous presentation so errors and shutdown are not
+  orphaned.
+- **Teardown drift:** Moving code across `run` can accidentally omit or duplicate
+  teardown. Step 1 keeps all teardown on the single lifecycle future and verifies
+  existing failure/reconnect/shutdown suites before any UX change.
+- **Prompt timing:** The QR appears later than today because ownership,
+  diagnostics, database composition, registration, and relay startup now finish
+  first. That delay is intentional to provide the selected ready-before-QR
+  guarantee; existing terminal startup output remains the progress signal.
+- **Marker timing:** A newly installed app is not marked during the same process
+  because background polling is removed. The next immediate startup check
+  writes the marker. This affects only whether a later prompt is skipped and
+  does not affect connectivity.
+
+## Out Of Scope
+
+- Mobile copy or visual-state changes.
+- A relay-level `bridge_starting` role or control frame.
+- Auth startup leases, bridge-status polling, or heuristic use of
+  `lastSeenAt`.
+- Eager backend-plugin startup or catalog behavior changes.
+- Desktop supervised startup UX.
+- New analytics/telemetry contracts.
+- General `Orchestrator` decomposition or cleanup unrelated to the explicit
+  start/wait lifecycle seam.

--- a/.plan/active/bridge-ready-onboarding/PLAN.md
+++ b/.plan/active/bridge-ready-onboarding/PLAN.md
@@ -61,7 +61,8 @@ whether the one-time prompt is needed, but it must not gate relay startup.
 - The status endpoint is backed by notification-device-token presence, not a
   phone-to-bridge handshake
   (`client/module_core/lib/src/services/notification_registration_service.dart:97-106`;
-  auth reference `src/services/app-client-presence-service.ts:36-50`).
+  auth-server repository `sesori-ai/sesori_auth_server` reference
+  `src/services/app-client-presence-service.ts:36-50`).
 - Single-live ownership, bridge registration, `RelayClient` construction,
   runtime composition, and `OrchestratorSession.run` all happen after that gate
   (`bridge_runtime_runner.dart:715-904`).
@@ -100,14 +101,21 @@ whether the one-time prompt is needed, but it must not gate relay startup.
   read must not replace the current `await for` semantics with uncoordinated
   asynchronous `listen` callbacks.
 - `AppClientOnboardingService` is preparation-only. It performs the local marker
-  lookup and one immediate status request before runtime serving starts, returns
-  a typed presentation decision, and owns no formatter or `Console` output.
+  lookup and one immediate status request, returns a typed presentation
+  decision, and owns no formatter or `Console` output. The runner captures that
+  finite preparation future and starts the session without awaiting it, so
+  mobile-registration infrastructure cannot gate relay readiness.
 - A private `BridgeRuntimeRunner` method at the CLI composition boundary renders
-  the prompt synchronously after session startup. Do not add a one-consumer
-  presenter class. There is no background app-status task, timer, long-poll,
-  cancellation owner, or new process-lifetime service.
-- Existing endpoint-unavailable behavior remains fail-open and silent. This
-  plan does not change the released 404/405 compatibility fallback for older or
+  the prompt synchronously only after session startup and preparation both
+  complete while the lifecycle remains active. Do not add a one-consumer
+  presenter class. The captured immediate check may overlap session startup,
+  but there is no timer, long-poll, uncaptured task, cancellation owner, or new
+  process-lifetime service.
+- Existing endpoint-unavailable behavior remains fail-open and
+  presentation-silent: it emits no onboarding `Console` prompt/success content
+  and never blocks or fails startup. It preserves the existing `Log.w`
+  diagnostic, which remains observable at the configured log level. This plan
+  does not change the released 404/405 compatibility fallback for older or
   custom auth deployments.
 - The existing per-auth-backend/user marker remains authoritative. When a user
   installs the app after preparation reported absence, the next immediate
@@ -156,9 +164,13 @@ Future<OrchestratorSessionStartResult> start();
 Future<void> waitUntilStopped();
 ```
 
-`start` creates, stores, and internally observes one lifecycle future before the
-first startup operation can acquire a resource or fail. That lifecycle future
-owns startup, serving, and teardown under one `try/finally`:
+Calling `start` synchronously creates, stores, and internally observes one
+lifecycle future before the first startup operation can acquire a resource or
+fail, then returns the separate readiness future. Before awaiting readiness, the
+runner immediately captures `waitUntilStopped`, which is available as soon as
+`start` has been invoked and exposes that same lifecycle future to the shutdown
+coordinator. That lifecycle future owns startup, serving, and teardown under one
+`try/finally`:
 
 1. register the bridge with auth;
 2. connect `RelayClient`, which opens the socket and sends the existing bridge
@@ -166,21 +178,27 @@ owns startup, serving, and teardown under one `try/finally`:
 3. initialize the existing completion, maintenance, project-activity,
    permission, plugin-event, PR, unseen, and token re-auth subscriptions;
 4. build and publish the initial project summary exactly as today;
-5. create one `StreamIterator` from `RelayClient.read()` and invoke its first
-   `moveNext()` to establish the inbound subscription; and
+5. create the initial connection's `StreamIterator` from `RelayClient.read()`
+   and invoke its first `moveNext()` to establish the inbound subscription; and
 6. complete the startup handshake immediately after invoking that first
    `moveNext()`, without awaiting an inbound frame.
 
 The serving loop awaits that same pending first `moveNext()`, processes the
 current frame completely, then invokes/awaits the next `moveNext()`. This locks
 the readiness point without waiting for a phone or relay frame and preserves
-sequential frame processing. The lifecycle `finally` cancels the active
-iterator before/with the existing failure-isolated teardown. Do not replace the
-loop with uncoordinated asynchronous `listen` callbacks, and do not treat
-WebSocket opening alone as readiness.
+sequential frame processing. Each connection owns its own iterator: when the
+stream ends, cancel that iterator before reconnecting; after every successful
+`RelayClient.reconnect()`, create a fresh iterator from the replacement
+channel, invoke its first `moveNext()`, and serve that pending read. Only the
+initial iterator completes the startup-readiness handshake. The lifecycle
+`finally` also cancels whichever iterator is currently active before/with the
+existing failure-isolated teardown. Do not replace the loop with uncoordinated
+asynchronous `listen` callbacks, continue an exhausted iterator after reconnect,
+or treat WebSocket opening alone as readiness.
 
-After the startup handshake returns `ready`, `waitUntilStopped` exposes that
-same internally observed lifecycle future. It continues to own:
+Immediately after `start` is invoked, `waitUntilStopped` exposes that same
+internally observed lifecycle future, including its pre-readiness startup and
+cleanup. It continues to own:
 
 - relay frame processing and key exchange;
 - reconnect and takeover backoff;
@@ -188,26 +206,30 @@ same internally observed lifecycle future. It continues to own:
 - all existing failure-isolated teardown; and
 - propagation of the first teardown error.
 
-The lifecycle is one-shot. A second `start` fails immediately; waiting before a
-`ready` result fails immediately; repeated reads of the post-start wait future
-observe the same completion. `beginShutdown` and `cancel` remain callable by the
-existing shutdown coordinator and signal handlers and must still wake startup,
-an active normal backoff, or a takeover backoff promptly.
+The lifecycle is one-shot. A second `start` fails immediately;
+`waitUntilStopped` before the first `start` invocation fails immediately; every
+call after that invocation observes the same lifecycle completion, including
+pre-readiness failure/cleanup. `beginShutdown` and `cancel` remain callable by
+the existing shutdown coordinator and signal handlers and must still wake
+startup, an active normal backoff, or a takeover backoff promptly.
 
 If registration, connection, listener initialization, summary construction, or
 initial read arming fails before readiness, the lifecycle future runs complete
 partial-start teardown before `start` rethrows that failure.
-`waitUntilStopped` remains unavailable. If shutdown is requested before
-readiness, the lifecycle future tears down acquired resources, `start` returns
-`cancelled`, the runner shows no onboarding prompt, and the existing clean or
-supervised-sentinel shutdown outcome is preserved.
+The already-captured wait future lets a concurrent shutdown drain that teardown
+before later phases dispose plugin/shared resources. If shutdown is requested
+before readiness, the lifecycle future tears down acquired resources, `start`
+returns `cancelled`, the runner shows no onboarding prompt, and the existing
+clean or supervised-sentinel shutdown outcome is preserved.
 
 `BridgeRuntimeRunner` adopts the new API in behavior-preserving sequence:
 
 ```text
 existing app-onboarding gate
--> session.start
--> ready: capture wait future and await it
+-> startFuture = session.start
+-> sessionRun = session.waitUntilStopped (capture before awaiting readiness)
+-> await startFuture
+-> ready: await sessionRun
 -> cancelled: return through the existing clean/sentinel outcome
 ```
 
@@ -243,12 +265,16 @@ stop and update this plan rather than hiding that refactor in Step 2.
 - `start` does not complete before registration, connect/auth send, startup
   initialization, and initial read arming.
 - Registration, initial relay, listener, summary, or read-arming failure runs
-  partial-start teardown and then throws from `start`; no waitable serving phase
-  is exposed.
+  partial-start teardown and then throws from `start`; the wait future captured
+  at start invocation observes that same lifecycle completion for coordinator
+  draining.
 - Shutdown before readiness tears down, returns `cancelled`, and never shows a
   prompt or becomes a startup error.
 - Key exchange and request handling work after `start` while a caller has not
   yet awaited `waitUntilStopped`.
+- A normal drop, token re-authentication, and every successful reconnect create
+  a fresh iterator for the replacement relay channel and process a frame from
+  it; no exhausted iterator is reused.
 - All current reconnect, revocation, takeover, token re-auth, event ordering,
   and shutdown tests retain their behavior under the split API.
 - Every former `session.run()` production/test caller is updated in lockstep;
@@ -314,13 +340,16 @@ same PR: `AppClientStatusRepository.getStatus` and
 `SesoriServerApi.getAppClientStatus` become immediate-status operations without
 a `wait` parameter, and the API no longer builds a `wait=true` query.
 
-Preparation emits no QR or onboarding copy. For a `prompt` decision, a private
+Preparation emits no QR or onboarding copy and recovers every status/marker
+failure into its typed decision after preserving the existing warning. The
+runner starts this captured preparation future and the session lifecycle without
+awaiting the status result first. For a `prompt` decision, a private
 `BridgeRuntimeRunner` method constructs/uses the existing formatter and writes
-the generic QR/link after the bridge session is ready and its wait future has
-been captured. Copy must state that the bridge is running and that the user
-should install/open Sesori and sign into the same account. It must not claim that
-notification registration, relay pairing, or E2E connection has already
-completed.
+the generic QR/link only after the bridge session is ready and its lifecycle
+future has been captured. Copy must state that the bridge is running and that
+the user should install/open Sesori and sign into the same account. It must not
+claim that notification registration, relay pairing, or E2E connection has
+already completed.
 
 ### Runner Ordering
 
@@ -328,21 +357,26 @@ For standalone interactive starts only:
 
 ```text
 plugin inspect/availability
--> prepare onboarding decision (finite; no prompt)
 -> ownership, diagnostics, database, and runtime composition
--> session.start (one lifecycle future; registration + relay + listeners + first read armed)
--> ready: capture session.waitUntilStopped for shutdown ownership
--> synchronously render QR/link in BridgeRuntimeRunner when the decision requires it
+-> capture onboarding preparation future (finite immediate check; do not await)
+-> capture startFuture = session.start and sessionRun = session.waitUntilStopped
+-> await startFuture while onboarding preparation runs concurrently
+-> ready: race/coordinate the preparation result with sessionRun
+-> preparation wins while lifecycle remains active: synchronously render the prompt decision
+-> sessionRun completes first: render no prompt and surface/preserve its outcome
 -> await the captured serving future
 ```
 
 Supervised and non-interactive starts skip preparation/presentation and use the
-same `start -> ready/cancelled -> capture wait -> await wait` lifecycle.
+same `capture start -> capture wait -> await ready/cancelled -> await wait`
+lifecycle.
 
 If session startup fails, the prompt is never rendered. If presentation itself
 throws, the existing outer runner `finally` shuts down and drains the already
 captured serving future. A `cancelled` startup result also renders no prompt and
-returns through the existing clean/sentinel outcome.
+returns through the existing clean/sentinel outcome. A slow immediate status
+request can delay only the decision to show the prompt after readiness; it can
+never delay bridge registration, relay connection, or the inbound read loop.
 
 ### Expected Files
 
@@ -372,6 +406,8 @@ suites, and formatter/copy output at the existing CLI composition boundary.
 
 - Missing app registration performs exactly one immediate status request and
   returns a prompt decision.
+- The immediate status request starts without being awaited before
+  `session.start`; its 35-second deadline cannot delay relay readiness.
 - Preparing a prompt emits no stdout onboarding content.
 - The service has no formatter or `Console` dependency; the runner's private
   presentation method emits the QR/link and revised ready-state copy.
@@ -383,6 +419,8 @@ suites, and formatter/copy output at the existing CLI composition boundary.
   non-fatal according to the current compatibility behavior.
 - The runner starts and captures the session-serving future before prompt
   presentation.
+- If the lifecycle ends while preparation is pending, no prompt is rendered and
+  the lifecycle completion remains authoritative.
 - A phone can join, complete key exchange, and issue the health request while
   the prompt is visible and without registering a notification token.
 - Signal/restart shutdown drains the same serving future and does not wait for
@@ -409,7 +447,9 @@ Advisory manual check with a fresh standalone data directory/account:
 3. Confirm the app reaches the bridge without a prolonged bridge-offline state.
 4. Withhold or fail push-token registration and confirm bridge relay/key-exchange
    availability is unaffected.
-5. Restart after app registration and confirm the prompt is skipped and the
+5. Delay/fail the immediate app-status request and confirm relay readiness is
+   established before that request completes.
+6. Restart after app registration and confirm the prompt is skipped and the
    marker is written by the immediate status check.
 
 Run `aristotle-impl-review` against the Step 2 branch versus `main` because this
@@ -439,9 +479,16 @@ PR changes the composition-root lifecycle trigger and onboarding data flow.
 - **Lifecycle-future ownership:** Startup and serving begin before prompt
   presentation. Step 1 creates and internally observes one lifecycle future
   before resource acquisition, keeps startup/serving/teardown under its
-  `try/finally`, and exposes it to the runner only after readiness. Step 2
-  captures it before synchronous presentation so errors and shutdown are not
-  orphaned.
+  `try/finally`, and exposes it to the runner immediately after `start` is
+  invoked. The runner captures it before awaiting readiness or presenting, so
+  concurrent shutdown, errors, and cleanup are never orphaned.
+- **Reconnect iterator ownership:** A read iterator is bound to one relay
+  channel. Step 1 cancels the exhausted iterator and creates/arms a fresh one
+  after every reconnect; only the initial iterator controls startup readiness.
+- **Concurrent preparation:** The one bounded immediate status request overlaps
+  session startup so it cannot gate relay readiness. The runner renders only
+  when both readiness and a prompt decision exist while the lifecycle remains
+  active; lifecycle completion suppresses a stale prompt.
 - **Teardown drift:** Moving code across `run` can accidentally omit or duplicate
   teardown. Step 1 keeps all teardown on the single lifecycle future and verifies
   existing failure/reconnect/shutdown suites before any UX change.

--- a/.plan/active/bridge-ready-onboarding/PLAN.md
+++ b/.plan/active/bridge-ready-onboarding/PLAN.md
@@ -3,7 +3,8 @@
 ## Status
 
 - **Plan slug:** `bridge-ready-onboarding`
-- **Status:** architecture review corrections applied; pending plan PR
+- **Status:** architecture review corrections applied; in review on plan PR
+  [#580](https://github.com/sesori-ai/sesori_apps_monorepo/pull/580)
 - **Plan date:** 2026-07-26
 - **Implementation base:** `origin/main` at
   `f8c71eb78987aa8c64e397e8e8e3bb72eefa0692`

--- a/.plan/active/bridge-ready-onboarding/PLAN.md
+++ b/.plan/active/bridge-ready-onboarding/PLAN.md
@@ -97,6 +97,10 @@ whether the one-time prompt is needed, but it must not gate relay startup.
 - `OrchestratorSession` remains the sole owner of relay serving, reconnect, and
   teardown. `BridgeRuntimeRunner` sequences lifecycle phases but does not own a
   second relay loop or duplicate teardown.
+- `RelayClient` owns both an in-flight connection channel and an established
+  channel. Closing/cancelling during the initial handshake must detach and close
+  the in-flight channel, and a cancelled attempt must never later promote that
+  channel or send a bridge auth frame.
 - Sequential relay-frame handling must remain sequential. Arming the initial
   read must not replace the current `await for` semantics with uncoordinated
   asynchronous `listen` callbacks.
@@ -109,8 +113,9 @@ whether the one-time prompt is needed, but it must not gate relay startup.
   the prompt synchronously only after session startup and preparation both
   complete while the lifecycle remains active. Do not add a one-consumer
   presenter class. The captured immediate check may overlap session startup,
-  but there is no timer, long-poll, uncaptured task, cancellation owner, or new
-  process-lifetime service.
+  but there is no polling/retry timer, long-poll, uncaptured task, cancellation
+  owner, or new process-lifetime service. Retain the request-local 35-second
+  deadline timer that aborts the one immediate HTTP request.
 - Existing endpoint-unavailable behavior remains fail-open and
   presentation-silent: it emits no onboarding `Console` prompt/success content
   and never blocks or fails startup. It preserves the existing `Log.w`
@@ -135,7 +140,7 @@ whether the one-time prompt is needed, but it must not gate relay startup.
 
 | Step | Branch | Exact PR title | Estimate | Review boundary |
 |---|---|---|---:|---|
-| 1/2 | `bridge-ready-onboarding-session-lifecycle` | `[bridge-ready-onboarding] refactor(bridge): separate session startup from serving [step 1/2]` | 500-800 | Standalone lifecycle refactor with no onboarding behavior change. |
+| 1/2 | `bridge-ready-onboarding-session-lifecycle` | `[bridge-ready-onboarding] refactor(bridge): separate session startup from serving [step 1/2]` | 650-950 | Standalone lifecycle and pending-connect ownership refactor with no onboarding behavior change. |
 | 2/2 | `bridge-ready-onboarding-relay-first` | `[bridge-ready-onboarding] fix(bridge): start relay before mobile onboarding [step 2/2]` | 450-750 | Relay-ready prompt ordering, removal of the notification-registration gate, and deletion of the unused long-poll API variant. |
 
 "Standalone" in Step 1 means the PR is refactor-only, independently valid, and
@@ -213,6 +218,16 @@ pre-readiness failure/cleanup. `beginShutdown` and `cancel` remain callable by
 the existing shutdown coordinator and signal handlers and must still wake
 startup, an active normal backoff, or a takeover backoff promptly.
 
+To make shutdown during initial startup real rather than timeout-bound,
+`RelayClient.connect` must publish ownership of its pending channel before
+awaiting `channel.ready`. `close`/`reconnect` atomically detach and close pending
+and established channels as applicable. After `ready`, `connect` verifies that
+the attempt still owns the pending slot before promoting it, installing the done
+watcher, emitting connected state, or sending auth. A channel cancelled during
+the handshake may complete only as the lifecycle's expected `cancelled` path;
+it must not remain unowned until the existing 15-second connect timeout or later
+authenticate after shutdown.
+
 If registration, connection, listener initialization, summary construction, or
 initial read arming fails before readiness, the lifecycle future runs complete
 partial-start teardown before `start` rethrows that failure.
@@ -243,6 +258,7 @@ surface as an unhandled asynchronous error.
 Production:
 
 - `bridge/app/lib/src/bridge/orchestrator.dart`
+- `bridge/app/lib/src/bridge/relay_client.dart`
 - `bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart`
 
 Lockstep tests and harnesses:
@@ -252,6 +268,8 @@ Lockstep tests and harnesses:
 - `bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart`
 - `bridge/app/test/bridge/orchestrator_token_reauth_test.dart`
 - `bridge/app/test/bridge/debug_server_test.dart`
+- `bridge/app/test/bridge/relay_client_test.dart` (new focused pending-connect
+  cancellation/late-promotion coverage)
 - a focused orchestrator lifecycle test if the contract is clearer outside the
   existing registration/error suites
 
@@ -270,6 +288,9 @@ stop and update this plan rather than hiding that refactor in Step 2.
   draining.
 - Shutdown before readiness tears down, returns `cancelled`, and never shows a
   prompt or becomes a startup error.
+- Shutdown during the initial WebSocket handshake closes the pending channel
+  promptly instead of waiting for the 15-second connect timeout; that channel
+  can never later become active or send auth.
 - Key exchange and request handling work after `start` while a caller has not
   yet awaited `waitUntilStopped`.
 - A normal drop, token re-authentication, and every successful reconnect create
@@ -289,7 +310,8 @@ dart test test/bridge/orchestrator_registration_test.dart \
   test/bridge/orchestrator_error_recovery_test.dart \
   test/bridge/orchestrator_emit_bridge_event_test.dart \
   test/bridge/orchestrator_token_reauth_test.dart \
-  test/bridge/debug_server_test.dart
+  test/bridge/debug_server_test.dart \
+  test/bridge/relay_client_test.dart
 dart analyze --fatal-infos
 ```
 
@@ -332,7 +354,8 @@ Preparation removes:
 - `TokenRefresher` from this service;
 - `AppOnboardingFormatter` and all `Console` output from this service;
 - the unbounded polling loop;
-- the five-second retry timer; and
+- the five-second retry timer (while preserving the request-local 35-second
+  deadline/abort timer); and
 - the terminal claims that startup is paused or later continuing.
 
 Remove the now-unused long-poll variant from the internal lower layers in the
@@ -485,6 +508,10 @@ PR changes the composition-root lifecycle trigger and onboarding data flow.
 - **Reconnect iterator ownership:** A read iterator is bound to one relay
   channel. Step 1 cancels the exhausted iterator and creates/arms a fresh one
   after every reconnect; only the initial iterator controls startup readiness.
+- **Pending-connect ownership:** The current relay client cannot close a channel
+  while `channel.ready` is pending. Step 1 makes that channel client-owned before
+  the await, closes it during cancellation, and prevents late promotion/auth so
+  shutdown does not wait for the 15-second connect timeout or orphan a socket.
 - **Concurrent preparation:** The one bounded immediate status request overlaps
   session startup so it cannot gate relay readiness. The runner renders only
   when both readiness and a prompt decision exist while the lifecycle remains

--- a/.plan/active/bridge-ready-onboarding/TRACKER.md
+++ b/.plan/active/bridge-ready-onboarding/TRACKER.md
@@ -1,0 +1,60 @@
+# Bridge-Ready Mobile Onboarding: Tracker
+
+## Plan State
+
+- **Status:** architecture review corrections applied; pending plan PR
+- **Plan slug:** `bridge-ready-onboarding`
+- **Implementation base:** `origin/main` at
+  `f8c71eb78987aa8c64e397e8e8e3bb72eefa0692`
+- **Plan PR:** pending
+- **Implementation state:** not started
+
+## Plan Review
+
+- **Verdict:** rejected with four actionable findings; all findings applied
+  directly; revised plan not re-reviewed
+- **Reviewer:** `aristotle-plan-review`
+- **Date:** 2026-07-26
+- **Reviewed scope:** `.plan/active/bridge-ready-onboarding/`
+
+## Delivery Steps
+
+| Done | Step | Branch | Exact PR title | Changed-line budget | State |
+|---|---|---|---|---:|---|
+| [ ] | 1/2 | `bridge-ready-onboarding-session-lifecycle` | `[bridge-ready-onboarding] refactor(bridge): separate session startup from serving [step 1/2]` | 500-800; reassess at 1,300; maximum 1,500 | Not started |
+| [ ] | 2/2 | `bridge-ready-onboarding-relay-first` | `[bridge-ready-onboarding] fix(bridge): start relay before mobile onboarding [step 2/2]` | 450-750; reassess at 1,300; maximum 1,500 | Blocked on Step 1 merge |
+
+## Execution Rules
+
+- Step 1 is a standalone refactor PR that preserves user-visible startup
+  behavior while making partial-start cleanup explicit. It must not contain
+  onboarding ordering or copy changes.
+- Step 2 starts from updated `origin/main` only after Step 1 merges. Do not open
+  it as a stacked PR.
+- Count additions plus deletions, including tests, against each PR base.
+- Stop and update the plan before either PR exceeds 1,500 changed lines.
+- Any newly discovered substantial refactor remains out of Step 2. Pause and
+  revise the series rather than mixing it into the feature PR.
+- Run the focused tests, strict app analyzer, and architecture implementation
+  review declared for each step before merging.
+
+## Current Pointer
+
+- **Next action:** merge the plan PR, then create Step 1 from current
+  `origin/main` and pin its actual base SHA in the PR body.
+
+## Findings And Plan Deltas
+
+- **2026-07-26 — Architecture review corrections:** Applied all four
+  `aristotle-plan-review` findings without claiming approval of the revised
+  plan: moved prompt rendering from `AppClientOnboardingService` to a private
+  runner method; made one internally observed lifecycle future own startup,
+  serving, partial-start cleanup, and teardown; fixed readiness at the
+  non-awaited first `StreamIterator.moveNext()` invocation; and added removal of
+  the now-unused status `wait` parameter/query branch to Step 2.
+- **2026-07-26 — Initial split:** Chose a two-PR sequence so the required
+  `OrchestratorSession` start/wait lifecycle refactor is independently
+  reviewable and the second PR contains only the user-visible relay-first
+  onboarding change.
+- **2026-07-26 — Line budget:** Fixed a 1,500 changed-line maximum per
+  implementation PR, with mandatory reassessment at a 1,300-line projection.

--- a/.plan/active/bridge-ready-onboarding/TRACKER.md
+++ b/.plan/active/bridge-ready-onboarding/TRACKER.md
@@ -2,11 +2,11 @@
 
 ## Plan State
 
-- **Status:** architecture review corrections applied; pending plan PR
+- **Status:** architecture review corrections applied; plan PR in review
 - **Plan slug:** `bridge-ready-onboarding`
 - **Implementation base:** `origin/main` at
   `f8c71eb78987aa8c64e397e8e8e3bb72eefa0692`
-- **Plan PR:** pending
+- **Plan PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/580
 - **Implementation state:** not started
 
 ## Plan Review
@@ -45,6 +45,9 @@
 
 ## Findings And Plan Deltas
 
+- **2026-07-26 — Plan delivery:** Opened plan PR
+  [#580](https://github.com/sesori-ai/sesori_apps_monorepo/pull/580) from the
+  dedicated `bridge-setup-ux-assessment` branch.
 - **2026-07-26 — Architecture review corrections:** Applied all four
   `aristotle-plan-review` findings without claiming approval of the revised
   plan: moved prompt rendering from `AppClientOnboardingService` to a private

--- a/.plan/active/bridge-ready-onboarding/TRACKER.md
+++ b/.plan/active/bridge-ready-onboarding/TRACKER.md
@@ -21,7 +21,7 @@
 
 | Done | Step | Branch | Exact PR title | Changed-line budget | State |
 |---|---|---|---|---:|---|
-| [ ] | 1/2 | `bridge-ready-onboarding-session-lifecycle` | `[bridge-ready-onboarding] refactor(bridge): separate session startup from serving [step 1/2]` | 500-800; reassess at 1,300; maximum 1,500 | Not started |
+| [ ] | 1/2 | `bridge-ready-onboarding-session-lifecycle` | `[bridge-ready-onboarding] refactor(bridge): separate session startup from serving [step 1/2]` | 650-950; reassess at 1,300; maximum 1,500 | Not started |
 | [ ] | 2/2 | `bridge-ready-onboarding-relay-first` | `[bridge-ready-onboarding] fix(bridge): start relay before mobile onboarding [step 2/2]` | 450-750; reassess at 1,300; maximum 1,500 | Blocked on Step 1 merge |
 
 ## Execution Rules
@@ -45,6 +45,11 @@
 
 ## Findings And Plan Deltas
 
+- **2026-07-26 — Follow-up PR feedback:** Added `RelayClient` pending-handshake
+  ownership/cancellation to Step 1 so shutdown cannot wait for the 15-second
+  connect timeout or allow late channel promotion/auth; clarified that Step 2
+  removes polling/retry timers but retains the request-local 35-second deadline
+  timer that bounds and aborts the immediate status request.
 - **2026-07-26 — PR feedback corrections:** Qualified the external auth-server
   source reference; distinguished presentation-silent compatibility recovery
   from warning-level diagnostics; required one fresh relay read iterator per

--- a/.plan/active/bridge-ready-onboarding/TRACKER.md
+++ b/.plan/active/bridge-ready-onboarding/TRACKER.md
@@ -45,6 +45,13 @@
 
 ## Findings And Plan Deltas
 
+- **2026-07-26 — PR feedback corrections:** Qualified the external auth-server
+  source reference; distinguished presentation-silent compatibility recovery
+  from warning-level diagnostics; required one fresh relay read iterator per
+  connection/reconnect; exposed the lifecycle future to the shutdown coordinator
+  immediately after `start` invocation; and made the bounded app-status
+  preparation concurrent with session startup so its 35-second deadline cannot
+  gate relay readiness.
 - **2026-07-26 — Plan delivery:** Opened plan PR
   [#580](https://github.com/sesori-ai/sesori_apps_monorepo/pull/580) from the
   dedicated `bridge-setup-ux-assessment` branch.


### PR DESCRIPTION
## Summary

- document the first-setup ordering bug and the selected ready-before-QR outcome
- split delivery into a standalone session-lifecycle refactor followed by the relay-first onboarding change
- cap each implementation PR at 1,500 changed lines, with reassessment at 1,300
- keep the implementation bridge-only, with no relay, auth, shared-wire, or mobile changes

## Planned implementation PRs

1. `[bridge-ready-onboarding] refactor(bridge): separate session startup from serving [step 1/2]`
2. `[bridge-ready-onboarding] fix(bridge): start relay before mobile onboarding [step 2/2]`

Step 1 is refactor-only and independently mergeable. Step 2 starts from `main` after Step 1 merges.

## Architecture review

`aristotle-plan-review` rejected the initial draft with four actionable findings. The plan applies all four directly:

- terminal presentation moves from the repository-backed onboarding service to the CLI composition boundary
- one internally observed lifecycle future owns startup, serving, partial-start cleanup, and teardown
- readiness is fixed at the non-awaited first `StreamIterator.moveNext()` invocation
- the now-unused internal long-poll `wait` API/query variant is removed in Step 2

The tracker records that the corrected version was not re-reviewed, so this PR does not claim reviewer approval of the revision.

## Validation

- `git diff --check origin/main...HEAD`
- documentation/plan-only change; Dart and Flutter suites were not run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a plan and tracker for relay‑ready mobile onboarding: show the mobile QR/link only after the bridge is locally ready. Updates the plan to handle startup cancellation so pending relay handshakes close promptly.

- **Refactors**
  - Split `OrchestratorSession` into `start()` (readiness) and `waitUntilStopped()` (serving); readiness = auth registered, WS open, auth frame sent, listeners initialized, first `StreamIterator.moveNext()` armed.
  - Make `RelayClient` own the pending channel before `ready`, close it on shutdown, and prevent late promotion/auth to avoid the 15s connect timeout.
  - Move QR rendering to the CLI; make `AppClientOnboardingService` preparation‑only with one immediate status check running in parallel; render only after readiness while the lifecycle is active. Step 2 removes the long‑poll `wait` query. Scope stays in `bridge/app`; add `TRACKER.md` with delivery steps and plan deltas.

<sup>Written for commit 3b9c6eef67f326188b7ec349398a0a3176f27a6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

