### PR TITLE
fix(app): auto-close question/permission modals resolved on another device

### DIFF
--- a/client/app/lib/features/session_detail/widgets/permission_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/permission_modal.dart
@@ -104,10 +104,12 @@ class _PermissionModalState extends State<PermissionModal> {
   void initState() {
     super.initState();
     // Pops this sheet's own route when the request leaves the pending list,
-    // e.g. answered on another device. `_dismiss` is idempotent, so a local
-    // reply already popping the sheet can't be doubled here.
+    // e.g. answered on another device. Route-driven dismissals (barrier tap,
+    // swipe-down) bypass `_dismiss`, so while the route is no longer
+    // current — exiting — a pop here would remove the page underneath.
     _pendingSub = widget.isPendingStream.listen((isPending) {
-      if (isPending) return;
+      if (isPending || !mounted) return;
+      if (ModalRoute.of(context)?.isCurrent != true) return;
       if (!_dismissed) widget.onResolvedRemotely();
       _dismiss();
     });

--- a/client/app/lib/features/session_detail/widgets/permission_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/permission_modal.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:math" as math;
 
 import "package:flutter/material.dart";
@@ -15,7 +16,7 @@ import "../../../core/widgets/markdown_styles.dart";
 ///
 /// Displays the tool name and description, and offers three actions:
 /// reject, allow once, or always allow.
-class PermissionModal extends StatelessWidget {
+class PermissionModal extends StatefulWidget {
   final SesoriPermissionAsked permission;
   final void Function({
     required String requestId,
@@ -23,6 +24,11 @@ class PermissionModal extends StatelessWidget {
     required PermissionReply reply,
   })
   onReply;
+
+  /// Emits whether this request is still pending. When it reports `false`
+  /// (answered on another device), the sheet dismisses itself instead of
+  /// lingering as a stale modal — without firing a reply.
+  final Stream<bool> isPendingStream;
 
   /// Status-bar inset captured from the presenting context. The modal route
   /// (`useSafeArea: false`) strips the top inset from BOTH `padding` and
@@ -34,6 +40,7 @@ class PermissionModal extends StatelessWidget {
     super.key,
     required this.permission,
     required this.onReply,
+    required this.isPendingStream,
     required this.topInset,
   });
 
@@ -51,6 +58,7 @@ class PermissionModal extends StatelessWidget {
       required PermissionReply reply,
     })
     onReply,
+    required Stream<bool> isPendingStream,
   }) {
     // Capture before presenting: inside the route the top inset reads as 0.
     final topInset = MediaQuery.paddingOf(context).top;
@@ -64,16 +72,41 @@ class PermissionModal extends StatelessWidget {
       builder: (_) => PermissionModal(
         permission: permission,
         onReply: onReply,
+        isPendingStream: isPendingStream,
         topInset: topInset,
       ),
     );
   }
 
+  @override
+  State<PermissionModal> createState() => _PermissionModalState();
+}
+
+class _PermissionModalState extends State<PermissionModal> {
+  StreamSubscription<bool>? _pendingSub;
+
+  @override
+  void initState() {
+    super.initState();
+    // Pops this sheet's own route when the request leaves the pending list,
+    // e.g. answered on another device. A local reply pops the sheet first,
+    // disposing this state and cancelling the subscription, so no double-pop.
+    _pendingSub = widget.isPendingStream.listen((isPending) {
+      if (!isPending && mounted) context.pop();
+    });
+  }
+
+  @override
+  void dispose() {
+    _pendingSub?.cancel();
+    super.dispose();
+  }
+
   void _reply(BuildContext context, {required PermissionReply reply}) {
     context.pop();
-    onReply(
-      requestId: permission.requestID,
-      sessionId: permission.sessionID,
+    widget.onReply(
+      requestId: widget.permission.requestID,
+      sessionId: widget.permission.sessionID,
       reply: reply,
     );
   }
@@ -89,11 +122,11 @@ class PermissionModal extends StatelessWidget {
     // Cap the body just under the sheet's own cap: a long description then
     // scrolls inside its Flexible slot while the action row stays pinned,
     // instead of pushing the (blocking) actions below the fold.
-    final maxBody = screenHeight - topInset - PregoBottomSheet.contentTopInset - bottomInset;
+    final maxBody = screenHeight - widget.topInset - PregoBottomSheet.contentTopInset - bottomInset;
 
     return PregoBottomSheet(
       title: context.loc.diffPermissionRequestTitle,
-      topInset: topInset,
+      topInset: widget.topInset,
       // Closing the sheet answers the assistant: the X rejects, matching the
       // explicit reject button.
       onClose: () => _reply(context, reply: PermissionReply.reject),
@@ -142,7 +175,7 @@ class PermissionModal extends StatelessWidget {
                             SizedBox(width: prego.spacing.md),
                             Expanded(
                               child: Text(
-                                permission.tool,
+                                widget.permission.tool,
                                 style: prego.textTheme.textSm.bold.monospace,
                                 maxLines: 1,
                                 overflow: TextOverflow.ellipsis,
@@ -169,7 +202,7 @@ class PermissionModal extends StatelessWidget {
                           children: [
                             Expanded(
                               child: MarkdownBody(
-                                data: permission.description,
+                                data: widget.permission.description,
                                 selectable: true,
                                 onTapLink: handleMarkdownLinkTap,
                                 styleSheet:
@@ -189,7 +222,7 @@ class PermissionModal extends StatelessWidget {
                             ),
                             SizedBox(width: prego.spacing.xs),
                             CopyIconButton(
-                              text: permission.description,
+                              text: widget.permission.description,
                               tooltip: context.loc.sessionDetailCopy,
                             ),
                           ],

--- a/client/app/lib/features/session_detail/widgets/permission_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/permission_modal.dart
@@ -30,6 +30,11 @@ class PermissionModal extends StatefulWidget {
   /// lingering as a stale modal — without firing a reply.
   final Stream<bool> isPendingStream;
 
+  /// Called when the sheet self-dismisses because the request was resolved
+  /// on another device, so the presenter can chain the next pending prompt
+  /// the way a local reply would.
+  final VoidCallback onResolvedRemotely;
+
   /// Status-bar inset captured from the presenting context. The modal route
   /// (`useSafeArea: false`) strips the top inset from BOTH `padding` and
   /// `viewPadding` in the sheet's own MediaQuery, so it must be measured
@@ -41,6 +46,7 @@ class PermissionModal extends StatefulWidget {
     required this.permission,
     required this.onReply,
     required this.isPendingStream,
+    required this.onResolvedRemotely,
     required this.topInset,
   });
 
@@ -59,6 +65,7 @@ class PermissionModal extends StatefulWidget {
     })
     onReply,
     required Stream<bool> isPendingStream,
+    required VoidCallback onResolvedRemotely,
   }) {
     // Capture before presenting: inside the route the top inset reads as 0.
     final topInset = MediaQuery.paddingOf(context).top;
@@ -73,6 +80,7 @@ class PermissionModal extends StatefulWidget {
         permission: permission,
         onReply: onReply,
         isPendingStream: isPendingStream,
+        onResolvedRemotely: onResolvedRemotely,
         topInset: topInset,
       ),
     );
@@ -99,7 +107,9 @@ class _PermissionModalState extends State<PermissionModal> {
     // e.g. answered on another device. `_dismiss` is idempotent, so a local
     // reply already popping the sheet can't be doubled here.
     _pendingSub = widget.isPendingStream.listen((isPending) {
-      if (!isPending) _dismiss();
+      if (isPending) return;
+      if (!_dismissed) widget.onResolvedRemotely();
+      _dismiss();
     });
   }
 
@@ -116,6 +126,9 @@ class _PermissionModalState extends State<PermissionModal> {
   }
 
   void _reply({required PermissionReply reply}) {
+    // A remote resolution already dismissed this sheet; a tap landing during
+    // the exit animation must not send a stale reply.
+    if (_dismissed) return;
     _dismiss();
     widget.onReply(
       requestId: widget.permission.requestID,

--- a/client/app/lib/features/session_detail/widgets/permission_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/permission_modal.dart
@@ -30,6 +30,10 @@ class PermissionModal extends StatefulWidget {
   /// lingering as a stale modal — without firing a reply.
   final Stream<bool> isPendingStream;
 
+  /// Reads the latest pending status after the stream subscription is active,
+  /// so a resolution cannot be missed between presentation and subscription.
+  final bool Function() isPendingNow;
+
   /// Called when the sheet self-dismisses because the request was resolved
   /// on another device, so the presenter can chain the next pending prompt
   /// the way a local reply would.
@@ -46,6 +50,7 @@ class PermissionModal extends StatefulWidget {
     required this.permission,
     required this.onReply,
     required this.isPendingStream,
+    required this.isPendingNow,
     required this.onResolvedRemotely,
     required this.topInset,
   });
@@ -65,6 +70,7 @@ class PermissionModal extends StatefulWidget {
     })
     onReply,
     required Stream<bool> isPendingStream,
+    required bool Function() isPendingNow,
     required VoidCallback onResolvedRemotely,
   }) {
     // Capture before presenting: inside the route the top inset reads as 0.
@@ -80,6 +86,7 @@ class PermissionModal extends StatefulWidget {
         permission: permission,
         onReply: onReply,
         isPendingStream: isPendingStream,
+        isPendingNow: isPendingNow,
         onResolvedRemotely: onResolvedRemotely,
         topInset: topInset,
       ),
@@ -101,18 +108,29 @@ class _PermissionModalState extends State<PermissionModal> {
   bool _dismissed = false;
 
   @override
-  void initState() {
-    super.initState();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_pendingSub != null) return;
+
     // Pops this sheet's own route when the request leaves the pending list,
     // e.g. answered on another device. Route-driven dismissals (barrier tap,
     // swipe-down) bypass `_dismiss`, so while the route is no longer
     // current — exiting — a pop here would remove the page underneath.
-    _pendingSub = widget.isPendingStream.listen((isPending) {
-      if (isPending || !mounted) return;
-      if (ModalRoute.of(context)?.isCurrent != true) return;
-      if (!_dismissed) widget.onResolvedRemotely();
-      _dismiss();
+    _pendingSub = widget.isPendingStream.listen(_onPendingChanged);
+
+    // Subscribe first, then read the latest state. Any change between these
+    // operations is either observed by the stream or reflected by this read.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _onPendingChanged(widget.isPendingNow());
     });
+  }
+
+  void _onPendingChanged(bool isPending) {
+    if (isPending || !mounted) return;
+    if (ModalRoute.of(context)?.isCurrent != true) return;
+    if (_dismissed) return;
+    _dismiss();
+    widget.onResolvedRemotely();
   }
 
   @override
@@ -130,7 +148,7 @@ class _PermissionModalState extends State<PermissionModal> {
   void _reply({required PermissionReply reply}) {
     // A remote resolution already dismissed this sheet; a tap landing during
     // the exit animation must not send a stale reply.
-    if (_dismissed) return;
+    if (_dismissed || ModalRoute.of(context)?.isCurrent != true) return;
     _dismiss();
     widget.onReply(
       requestId: widget.permission.requestID,

--- a/client/app/lib/features/session_detail/widgets/permission_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/permission_modal.dart
@@ -85,14 +85,21 @@ class PermissionModal extends StatefulWidget {
 class _PermissionModalState extends State<PermissionModal> {
   StreamSubscription<bool>? _pendingSub;
 
+  /// Guards against a double pop: a local reply pops the sheet and the
+  /// cubit's optimistic resolution then reports `false` on
+  /// [PermissionModal.isPendingStream] while this state is still mounted
+  /// during the exit animation — a second pop would remove the page
+  /// underneath.
+  bool _dismissed = false;
+
   @override
   void initState() {
     super.initState();
     // Pops this sheet's own route when the request leaves the pending list,
-    // e.g. answered on another device. A local reply pops the sheet first,
-    // disposing this state and cancelling the subscription, so no double-pop.
+    // e.g. answered on another device. `_dismiss` is idempotent, so a local
+    // reply already popping the sheet can't be doubled here.
     _pendingSub = widget.isPendingStream.listen((isPending) {
-      if (!isPending && mounted) context.pop();
+      if (!isPending) _dismiss();
     });
   }
 
@@ -102,8 +109,14 @@ class _PermissionModalState extends State<PermissionModal> {
     super.dispose();
   }
 
-  void _reply(BuildContext context, {required PermissionReply reply}) {
+  void _dismiss() {
+    if (_dismissed) return;
+    _dismissed = true;
     context.pop();
+  }
+
+  void _reply({required PermissionReply reply}) {
+    _dismiss();
     widget.onReply(
       requestId: widget.permission.requestID,
       sessionId: widget.permission.sessionID,
@@ -129,7 +142,7 @@ class _PermissionModalState extends State<PermissionModal> {
       topInset: widget.topInset,
       // Closing the sheet answers the assistant: the X rejects, matching the
       // explicit reject button.
-      onClose: () => _reply(context, reply: PermissionReply.reject),
+      onClose: () => _reply(reply: PermissionReply.reject),
       child: ConstrainedBox(
         constraints: BoxConstraints(maxHeight: math.max(maxBody, screenHeight * 0.3)),
         child: Column(
@@ -244,21 +257,21 @@ class _PermissionModalState extends State<PermissionModal> {
                       foregroundColor: prego.colors.fgErrorPrimary,
                       side: BorderSide(color: prego.colors.fgErrorPrimary),
                     ),
-                    onPressed: () => _reply(context, reply: PermissionReply.reject),
+                    onPressed: () => _reply(reply: PermissionReply.reject),
                     child: Text(context.loc.diffPermissionReject),
                   ),
                 ),
                 const SizedBox(width: 8),
                 Expanded(
                   child: OutlinedButton(
-                    onPressed: () => _reply(context, reply: PermissionReply.once),
+                    onPressed: () => _reply(reply: PermissionReply.once),
                     child: Text(context.loc.diffPermissionOnce),
                   ),
                 ),
                 const SizedBox(width: 8),
                 Expanded(
                   child: FilledButton(
-                    onPressed: () => _reply(context, reply: PermissionReply.always),
+                    onPressed: () => _reply(reply: PermissionReply.always),
                     child: Text(context.loc.diffPermissionAlwaysAllow),
                   ),
                 ),

--- a/client/app/lib/features/session_detail/widgets/question_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/question_modal.dart
@@ -123,10 +123,12 @@ class _QuestionModalState extends State<QuestionModal> {
     _customFocus.addListener(_onCustomFocusChanged);
     _customController.addListener(_onCustomTextChanged);
     // Pops this sheet's own route when the request leaves the pending list,
-    // e.g. answered on another device. `_dismissModal` is idempotent, so a
-    // local answer already popping the sheet can't be doubled here.
+    // e.g. answered on another device. Route-driven dismissals (barrier tap,
+    // swipe-down) bypass `_dismissModal`, so while the route is no longer
+    // current — exiting — a pop here would remove the page underneath.
     _pendingSub = widget.isPendingStream.listen((isPending) {
-      if (isPending) return;
+      if (isPending || !mounted) return;
+      if (ModalRoute.of(context)?.isCurrent != true) return;
       if (!_dismissed) widget.onResolvedRemotely();
       _dismissModal();
     });

--- a/client/app/lib/features/session_detail/widgets/question_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/question_modal.dart
@@ -25,6 +25,11 @@ class QuestionModal extends StatefulWidget {
   /// instead of lingering as a stale modal.
   final Stream<bool> isPendingStream;
 
+  /// Called when the sheet self-dismisses because the request was resolved
+  /// on another device, so the presenter can chain the next pending prompt
+  /// the way a local answer would.
+  final VoidCallback onResolvedRemotely;
+
   /// Status-bar inset captured from the presenting context. The modal route
   /// (`useSafeArea: false`) strips the top inset from BOTH `padding` and
   /// `viewPadding` in the sheet's own MediaQuery, so it must be measured
@@ -37,6 +42,7 @@ class QuestionModal extends StatefulWidget {
     required this.onReply,
     required this.onReject,
     required this.isPendingStream,
+    required this.onResolvedRemotely,
     required this.topInset,
   });
 
@@ -52,6 +58,7 @@ class QuestionModal extends StatefulWidget {
     required void Function(String requestId, List<ReplyAnswer> answers) onReply,
     required void Function(String requestId) onReject,
     required Stream<bool> isPendingStream,
+    required VoidCallback onResolvedRemotely,
   }) {
     // Capture before presenting: inside the route the top inset reads as 0.
     final topInset = MediaQuery.paddingOf(context).top;
@@ -67,6 +74,7 @@ class QuestionModal extends StatefulWidget {
         onReply: onReply,
         onReject: onReject,
         isPendingStream: isPendingStream,
+        onResolvedRemotely: onResolvedRemotely,
         topInset: topInset,
       ),
     );
@@ -118,7 +126,9 @@ class _QuestionModalState extends State<QuestionModal> {
     // e.g. answered on another device. `_dismissModal` is idempotent, so a
     // local answer already popping the sheet can't be doubled here.
     _pendingSub = widget.isPendingStream.listen((isPending) {
-      if (!isPending) _dismissModal();
+      if (isPending) return;
+      if (!_dismissed) widget.onResolvedRemotely();
+      _dismissModal();
     });
   }
 
@@ -201,6 +211,9 @@ class _QuestionModalState extends State<QuestionModal> {
   /// Collects the current answer and either advances to the next question
   /// or submits all answers if this is the last one.
   void _onProceed() {
+    // A remote resolution already dismissed this sheet; a tap landing during
+    // the exit animation must not send a stale answer.
+    if (_dismissed) return;
     // Build the answer for the current question.
     final answer = _selectedLabels.toList();
     if (_hasSelectedCustomAnswer) {
@@ -226,6 +239,7 @@ class _QuestionModalState extends State<QuestionModal> {
   }
 
   void _onReject() {
+    if (_dismissed) return;
     widget.onReject(widget.question.id);
     _dismissModal();
   }

--- a/client/app/lib/features/session_detail/widgets/question_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/question_modal.dart
@@ -25,6 +25,10 @@ class QuestionModal extends StatefulWidget {
   /// instead of lingering as a stale modal.
   final Stream<bool> isPendingStream;
 
+  /// Reads the latest pending status after the stream subscription is active,
+  /// so a resolution cannot be missed between presentation and subscription.
+  final bool Function() isPendingNow;
+
   /// Called when the sheet self-dismisses because the request was resolved
   /// on another device, so the presenter can chain the next pending prompt
   /// the way a local answer would.
@@ -42,6 +46,7 @@ class QuestionModal extends StatefulWidget {
     required this.onReply,
     required this.onReject,
     required this.isPendingStream,
+    required this.isPendingNow,
     required this.onResolvedRemotely,
     required this.topInset,
   });
@@ -58,6 +63,7 @@ class QuestionModal extends StatefulWidget {
     required void Function(String requestId, List<ReplyAnswer> answers) onReply,
     required void Function(String requestId) onReject,
     required Stream<bool> isPendingStream,
+    required bool Function() isPendingNow,
     required VoidCallback onResolvedRemotely,
   }) {
     // Capture before presenting: inside the route the top inset reads as 0.
@@ -74,6 +80,7 @@ class QuestionModal extends StatefulWidget {
         onReply: onReply,
         onReject: onReject,
         isPendingStream: isPendingStream,
+        isPendingNow: isPendingNow,
         onResolvedRemotely: onResolvedRemotely,
         topInset: topInset,
       ),
@@ -122,16 +129,32 @@ class _QuestionModalState extends State<QuestionModal> {
     super.initState();
     _customFocus.addListener(_onCustomFocusChanged);
     _customController.addListener(_onCustomTextChanged);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_pendingSub != null) return;
+
     // Pops this sheet's own route when the request leaves the pending list,
     // e.g. answered on another device. Route-driven dismissals (barrier tap,
     // swipe-down) bypass `_dismissModal`, so while the route is no longer
     // current — exiting — a pop here would remove the page underneath.
-    _pendingSub = widget.isPendingStream.listen((isPending) {
-      if (isPending || !mounted) return;
-      if (ModalRoute.of(context)?.isCurrent != true) return;
-      if (!_dismissed) widget.onResolvedRemotely();
-      _dismissModal();
+    _pendingSub = widget.isPendingStream.listen(_onPendingChanged);
+
+    // Subscribe first, then read the latest state. Any change between these
+    // operations is either observed by the stream or reflected by this read.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _onPendingChanged(widget.isPendingNow());
     });
+  }
+
+  void _onPendingChanged(bool isPending) {
+    if (isPending || !mounted) return;
+    if (ModalRoute.of(context)?.isCurrent != true) return;
+    if (_dismissed) return;
+    _dismissModal();
+    widget.onResolvedRemotely();
   }
 
   @override
@@ -215,7 +238,7 @@ class _QuestionModalState extends State<QuestionModal> {
   void _onProceed() {
     // A remote resolution already dismissed this sheet; a tap landing during
     // the exit animation must not send a stale answer.
-    if (_dismissed) return;
+    if (_dismissed || ModalRoute.of(context)?.isCurrent != true) return;
     // Build the answer for the current question.
     final answer = _selectedLabels.toList();
     if (_hasSelectedCustomAnswer) {
@@ -227,8 +250,8 @@ class _QuestionModalState extends State<QuestionModal> {
 
     if (_isLastQuestion) {
       // All questions answered — submit.
-      widget.onReply(widget.question.id, _collectedAnswers);
       _dismissModal();
+      widget.onReply(widget.question.id, _collectedAnswers);
     } else {
       // Advance to next question — reset selection state.
       setState(() {
@@ -241,9 +264,9 @@ class _QuestionModalState extends State<QuestionModal> {
   }
 
   void _onReject() {
-    if (_dismissed) return;
-    widget.onReject(widget.question.id);
+    if (_dismissed || ModalRoute.of(context)?.isCurrent != true) return;
     _dismissModal();
+    widget.onReject(widget.question.id);
   }
 
   // ---------------------------------------------------------------------------

--- a/client/app/lib/features/session_detail/widgets/question_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/question_modal.dart
@@ -91,7 +91,15 @@ class _QuestionModalState extends State<QuestionModal> {
   final Set<String> _selectedLabels = {};
   bool _customSelected = false;
 
+  /// Guards against a double pop: a local answer pops the sheet and the
+  /// cubit's optimistic resolution then reports `false` on
+  /// [QuestionModal.isPendingStream] while this state is still mounted during
+  /// the exit animation — a second pop would remove the page underneath.
+  bool _dismissed = false;
+
   void _dismissModal() {
+    if (_dismissed) return;
+    _dismissed = true;
     context.pop();
   }
 
@@ -107,10 +115,10 @@ class _QuestionModalState extends State<QuestionModal> {
     _customFocus.addListener(_onCustomFocusChanged);
     _customController.addListener(_onCustomTextChanged);
     // Pops this sheet's own route when the request leaves the pending list,
-    // e.g. answered on another device. A local answer pops the sheet first,
-    // disposing this state and cancelling the subscription, so no double-pop.
+    // e.g. answered on another device. `_dismissModal` is idempotent, so a
+    // local answer already popping the sheet can't be doubled here.
     _pendingSub = widget.isPendingStream.listen((isPending) {
-      if (!isPending && mounted) _dismissModal();
+      if (!isPending) _dismissModal();
     });
   }
 

--- a/client/app/lib/features/session_detail/widgets/question_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/question_modal.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:math" as math;
 
 import "package:flutter/material.dart";
@@ -19,6 +20,11 @@ class QuestionModal extends StatefulWidget {
   final void Function(String requestId, List<ReplyAnswer> answers) onReply;
   final void Function(String requestId) onReject;
 
+  /// Emits whether this request is still pending. When it reports `false`
+  /// (answered or rejected on another device), the sheet dismisses itself
+  /// instead of lingering as a stale modal.
+  final Stream<bool> isPendingStream;
+
   /// Status-bar inset captured from the presenting context. The modal route
   /// (`useSafeArea: false`) strips the top inset from BOTH `padding` and
   /// `viewPadding` in the sheet's own MediaQuery, so it must be measured
@@ -30,6 +36,7 @@ class QuestionModal extends StatefulWidget {
     required this.question,
     required this.onReply,
     required this.onReject,
+    required this.isPendingStream,
     required this.topInset,
   });
 
@@ -44,6 +51,7 @@ class QuestionModal extends StatefulWidget {
     required SesoriQuestionAsked question,
     required void Function(String requestId, List<ReplyAnswer> answers) onReply,
     required void Function(String requestId) onReject,
+    required Stream<bool> isPendingStream,
   }) {
     // Capture before presenting: inside the route the top inset reads as 0.
     final topInset = MediaQuery.paddingOf(context).top;
@@ -58,6 +66,7 @@ class QuestionModal extends StatefulWidget {
         question: question,
         onReply: onReply,
         onReject: onReject,
+        isPendingStream: isPendingStream,
         topInset: topInset,
       ),
     );
@@ -70,6 +79,7 @@ class QuestionModal extends StatefulWidget {
 class _QuestionModalState extends State<QuestionModal> {
   final TextEditingController _customController = TextEditingController();
   final FocusNode _customFocus = FocusNode();
+  StreamSubscription<bool>? _pendingSub;
 
   /// Index of the question currently being displayed.
   int _currentIndex = 0;
@@ -96,10 +106,17 @@ class _QuestionModalState extends State<QuestionModal> {
     super.initState();
     _customFocus.addListener(_onCustomFocusChanged);
     _customController.addListener(_onCustomTextChanged);
+    // Pops this sheet's own route when the request leaves the pending list,
+    // e.g. answered on another device. A local answer pops the sheet first,
+    // disposing this state and cancelling the subscription, so no double-pop.
+    _pendingSub = widget.isPendingStream.listen((isPending) {
+      if (!isPending && mounted) _dismissModal();
+    });
   }
 
   @override
   void dispose() {
+    _pendingSub?.cancel();
     _customFocus.dispose();
     _customController.dispose();
     super.dispose();

--- a/client/app/lib/features/session_detail/widgets/session_detail_body.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_body.dart
@@ -204,6 +204,7 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
         cubit: cubit,
         isPending: (state) => state.pendingQuestions.any((q) => q.id == question.id),
       ),
+      onResolvedRemotely: _scheduleNextQuestionModal,
       onReply: (requestId, answers) async {
         final success = await context.read<SessionDetailCubit>().replyToQuestion(
           requestId: requestId,
@@ -234,6 +235,7 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
         cubit: cubit,
         isPending: (state) => state.pendingPermissions.any((p) => p.requestID == permission.requestID),
       ),
+      onResolvedRemotely: _scheduleNextPermissionModal,
       onReply:
           ({
             required String requestId,

--- a/client/app/lib/features/session_detail/widgets/session_detail_body.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_body.dart
@@ -200,7 +200,10 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
     QuestionModal.show(
       context,
       question: question,
-      isPendingStream: _isPendingStream(cubit.stream, (state) => state.pendingQuestions.any((q) => q.id == question.id)),
+      isPendingStream: _isPendingStream(
+        cubit: cubit,
+        isPending: (state) => state.pendingQuestions.any((q) => q.id == question.id),
+      ),
       onReply: (requestId, answers) async {
         final success = await context.read<SessionDetailCubit>().replyToQuestion(
           requestId: requestId,
@@ -228,8 +231,8 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
       context,
       permission: permission,
       isPendingStream: _isPendingStream(
-        cubit.stream,
-        (state) => state.pendingPermissions.any((p) => p.requestID == permission.requestID),
+        cubit: cubit,
+        isPending: (state) => state.pendingPermissions.any((p) => p.requestID == permission.requestID),
       ),
       onReply:
           ({
@@ -251,11 +254,23 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
 
   /// Maps cubit state to "request still pending" for an open sheet: `true`
   /// while the request is in the loaded pending list. A non-loaded state keeps
-  /// the sheet open rather than dismissing on a transient reload.
-  Stream<bool> _isPendingStream(
-    Stream<SessionDetailState> states,
-    bool Function(SessionDetailLoaded state) isPending,
-  ) => states.map((state) => state is! SessionDetailLoaded || isPending(state)).distinct();
+  /// the sheet open rather than dismissing on a transient reload. Seeded with
+  /// the current state so a resolution that races the sheet's presentation
+  /// (e.g. the `_scheduleModal` delay) is not missed.
+  Stream<bool> _isPendingStream({
+    required SessionDetailCubit cubit,
+    required bool Function(SessionDetailLoaded state) isPending,
+  }) async* {
+    bool toIsPending(SessionDetailState state) => state is! SessionDetailLoaded || isPending(state);
+    var last = toIsPending(cubit.state);
+    yield last;
+    await for (final state in cubit.stream) {
+      final pending = toIsPending(state);
+      if (pending == last) continue;
+      last = pending;
+      yield pending;
+    }
+  }
 
   void _scheduleNextQuestionModal() {
     final state = context.read<SessionDetailCubit>().state;

--- a/client/app/lib/features/session_detail/widgets/session_detail_body.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_body.dart
@@ -195,10 +195,12 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
 
   void _showQuestionModal(SesoriQuestionAsked question) {
     if (!_isCurrentPage) return;
-    context.read<SessionDetailCubit>().clearNotifications();
+    final cubit = context.read<SessionDetailCubit>();
+    cubit.clearNotifications();
     QuestionModal.show(
       context,
       question: question,
+      isPendingStream: _isPendingStream(cubit.stream, (state) => state.pendingQuestions.any((q) => q.id == question.id)),
       onReply: (requestId, answers) async {
         final success = await context.read<SessionDetailCubit>().replyToQuestion(
           requestId: requestId,
@@ -220,10 +222,15 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
 
   void _showPermissionModal(SesoriPermissionAsked permission) {
     if (!_isCurrentPage) return;
-    context.read<SessionDetailCubit>().clearNotifications();
+    final cubit = context.read<SessionDetailCubit>();
+    cubit.clearNotifications();
     PermissionModal.show(
       context,
       permission: permission,
+      isPendingStream: _isPendingStream(
+        cubit.stream,
+        (state) => state.pendingPermissions.any((p) => p.requestID == permission.requestID),
+      ),
       onReply:
           ({
             required String requestId,
@@ -241,6 +248,14 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
           },
     );
   }
+
+  /// Maps cubit state to "request still pending" for an open sheet: `true`
+  /// while the request is in the loaded pending list. A non-loaded state keeps
+  /// the sheet open rather than dismissing on a transient reload.
+  Stream<bool> _isPendingStream(
+    Stream<SessionDetailState> states,
+    bool Function(SessionDetailLoaded state) isPending,
+  ) => states.map((state) => state is! SessionDetailLoaded || isPending(state)).distinct();
 
   void _scheduleNextQuestionModal() {
     final state = context.read<SessionDetailCubit>().state;

--- a/client/app/lib/features/session_detail/widgets/session_detail_body.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_body.dart
@@ -196,14 +196,20 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
   void _showQuestionModal(SesoriQuestionAsked question) {
     if (!_isCurrentPage) return;
     final cubit = context.read<SessionDetailCubit>();
+    bool isPendingNow() {
+      final state = cubit.state;
+      return state is! SessionDetailLoaded || state.pendingQuestions.any((q) => q.id == question.id);
+    }
+
+    // A queued presentation may run after this question was already resolved.
+    final state = cubit.state;
+    if (state is! SessionDetailLoaded || !state.pendingQuestions.any((q) => q.id == question.id)) return;
     cubit.clearNotifications();
     QuestionModal.show(
       context,
       question: question,
-      isPendingStream: _isPendingStream(
-        cubit: cubit,
-        isPending: (state) => state.pendingQuestions.any((q) => q.id == question.id),
-      ),
+      isPendingStream: cubit.stream.map((_) => isPendingNow()).distinct(),
+      isPendingNow: isPendingNow,
       onResolvedRemotely: _scheduleNextQuestionModal,
       onReply: (requestId, answers) async {
         final success = await context.read<SessionDetailCubit>().replyToQuestion(
@@ -227,14 +233,22 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
   void _showPermissionModal(SesoriPermissionAsked permission) {
     if (!_isCurrentPage) return;
     final cubit = context.read<SessionDetailCubit>();
+    bool isPendingNow() {
+      final state = cubit.state;
+      return state is! SessionDetailLoaded || state.pendingPermissions.any((p) => p.requestID == permission.requestID);
+    }
+
+    // A queued presentation may run after this permission was already resolved.
+    final state = cubit.state;
+    if (state is! SessionDetailLoaded || !state.pendingPermissions.any((p) => p.requestID == permission.requestID)) {
+      return;
+    }
     cubit.clearNotifications();
     PermissionModal.show(
       context,
       permission: permission,
-      isPendingStream: _isPendingStream(
-        cubit: cubit,
-        isPending: (state) => state.pendingPermissions.any((p) => p.requestID == permission.requestID),
-      ),
+      isPendingStream: cubit.stream.map((_) => isPendingNow()).distinct(),
+      isPendingNow: isPendingNow,
       onResolvedRemotely: _scheduleNextPermissionModal,
       onReply:
           ({
@@ -252,26 +266,6 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
             _scheduleNextPermissionModal();
           },
     );
-  }
-
-  /// Maps cubit state to "request still pending" for an open sheet: `true`
-  /// while the request is in the loaded pending list. A non-loaded state keeps
-  /// the sheet open rather than dismissing on a transient reload. Seeded with
-  /// the current state so a resolution that races the sheet's presentation
-  /// (e.g. the `_scheduleModal` delay) is not missed.
-  Stream<bool> _isPendingStream({
-    required SessionDetailCubit cubit,
-    required bool Function(SessionDetailLoaded state) isPending,
-  }) async* {
-    bool toIsPending(SessionDetailState state) => state is! SessionDetailLoaded || isPending(state);
-    var last = toIsPending(cubit.state);
-    yield last;
-    await for (final state in cubit.stream) {
-      final pending = toIsPending(state);
-      if (pending == last) continue;
-      last = pending;
-      yield pending;
-    }
   }
 
   void _scheduleNextQuestionModal() {

--- a/client/app/test/features/session_detail/widgets/permission_modal_test.dart
+++ b/client/app/test/features/session_detail/widgets/permission_modal_test.dart
@@ -157,6 +157,28 @@ void main() {
     expect(capture.reply, isNull);
   });
 
+  testWidgets("a local reply racing the resolved signal pops only the sheet", (tester) async {
+    final capture = _ReplyCapture();
+    final isPending = StreamController<bool>();
+    addTearDown(isPending.close);
+    final router = _createRouter(permission: _permission, capture: capture, isPendingStream: isPending.stream);
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openPermissionModal(tester);
+
+    // Replying resolves the request optimistically: the `false` emission
+    // arrives while the sheet is still mounted in its exit animation. The
+    // listener must not pop a second time (that would remove the page).
+    await tester.tap(find.text("Once"));
+    isPending.add(false);
+    await tester.pumpAndSettle();
+
+    expect(capture.reply, PermissionReply.once);
+    expect(find.text("bash"), findsNothing);
+    expect(find.byKey(const Key("open-permission-modal")), findsOneWidget);
+  });
+
   testWidgets("keeps actions visible for a long request detail", (tester) async {
     final capture = _ReplyCapture();
     final permission = _permission.copyWith(

--- a/client/app/test/features/session_detail/widgets/permission_modal_test.dart
+++ b/client/app/test/features/session_detail/widgets/permission_modal_test.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:flutter/material.dart";
 import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
 import "package:flutter_test/flutter_test.dart";
@@ -37,6 +39,7 @@ class _ReplyCapture {
 GoRouter _createRouter({
   required SesoriPermissionAsked permission,
   required _ReplyCapture capture,
+  required Stream<bool> isPendingStream,
 }) {
   return GoRouter(
     routes: [
@@ -52,6 +55,7 @@ GoRouter _createRouter({
                     context,
                     permission: permission,
                     onReply: capture.onReply,
+                    isPendingStream: isPendingStream,
                   );
                 },
                 child: const Text("Open permission modal"),
@@ -82,7 +86,7 @@ Future<void> _openPermissionModal(WidgetTester tester) async {
 void main() {
   testWidgets("groups the tool and highlighted request detail in one card", (tester) async {
     final capture = _ReplyCapture();
-    final router = _createRouter(permission: _permission, capture: capture);
+    final router = _createRouter(permission: _permission, capture: capture, isPendingStream: const Stream<bool>.empty());
     addTearDown(router.dispose);
 
     await tester.pumpWidget(_buildApp(router: router));
@@ -120,7 +124,7 @@ void main() {
   ]) {
     testWidgets("forwards the ${replyCase.label.toLowerCase()} reply", (tester) async {
       final capture = _ReplyCapture();
-      final router = _createRouter(permission: _permission, capture: capture);
+      final router = _createRouter(permission: _permission, capture: capture, isPendingStream: const Stream<bool>.empty());
       addTearDown(router.dispose);
 
       await tester.pumpWidget(_buildApp(router: router));
@@ -134,12 +138,31 @@ void main() {
     });
   }
 
+  testWidgets("dismisses itself without replying when resolved on another device", (tester) async {
+    final capture = _ReplyCapture();
+    final isPending = StreamController<bool>();
+    addTearDown(isPending.close);
+    final router = _createRouter(permission: _permission, capture: capture, isPendingStream: isPending.stream);
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openPermissionModal(tester);
+    expect(find.text("bash"), findsOneWidget);
+
+    isPending.add(false);
+    await tester.pumpAndSettle();
+
+    expect(find.text("bash"), findsNothing);
+    expect(capture.requestId, isNull);
+    expect(capture.reply, isNull);
+  });
+
   testWidgets("keeps actions visible for a long request detail", (tester) async {
     final capture = _ReplyCapture();
     final permission = _permission.copyWith(
       description: List.filled(80, "echo a long permission request").join("\n"),
     );
-    final router = _createRouter(permission: permission, capture: capture);
+    final router = _createRouter(permission: permission, capture: capture, isPendingStream: const Stream<bool>.empty());
     addTearDown(router.dispose);
 
     await tester.pumpWidget(_buildApp(router: router));

--- a/client/app/test/features/session_detail/widgets/permission_modal_test.dart
+++ b/client/app/test/features/session_detail/widgets/permission_modal_test.dart
@@ -40,6 +40,7 @@ GoRouter _createRouter({
   required SesoriPermissionAsked permission,
   required _ReplyCapture capture,
   required Stream<bool> isPendingStream,
+  required VoidCallback onResolvedRemotely,
 }) {
   return GoRouter(
     routes: [
@@ -56,6 +57,7 @@ GoRouter _createRouter({
                     permission: permission,
                     onReply: capture.onReply,
                     isPendingStream: isPendingStream,
+                    onResolvedRemotely: onResolvedRemotely,
                   );
                 },
                 child: const Text("Open permission modal"),
@@ -86,7 +88,7 @@ Future<void> _openPermissionModal(WidgetTester tester) async {
 void main() {
   testWidgets("groups the tool and highlighted request detail in one card", (tester) async {
     final capture = _ReplyCapture();
-    final router = _createRouter(permission: _permission, capture: capture, isPendingStream: const Stream<bool>.empty());
+    final router = _createRouter(permission: _permission, capture: capture, isPendingStream: const Stream<bool>.empty(), onResolvedRemotely: () {});
     addTearDown(router.dispose);
 
     await tester.pumpWidget(_buildApp(router: router));
@@ -124,7 +126,7 @@ void main() {
   ]) {
     testWidgets("forwards the ${replyCase.label.toLowerCase()} reply", (tester) async {
       final capture = _ReplyCapture();
-      final router = _createRouter(permission: _permission, capture: capture, isPendingStream: const Stream<bool>.empty());
+      final router = _createRouter(permission: _permission, capture: capture, isPendingStream: const Stream<bool>.empty(), onResolvedRemotely: () {});
       addTearDown(router.dispose);
 
       await tester.pumpWidget(_buildApp(router: router));
@@ -141,8 +143,14 @@ void main() {
   testWidgets("dismisses itself without replying when resolved on another device", (tester) async {
     final capture = _ReplyCapture();
     final isPending = StreamController<bool>();
+    var remoteDismissals = 0;
     addTearDown(isPending.close);
-    final router = _createRouter(permission: _permission, capture: capture, isPendingStream: isPending.stream);
+    final router = _createRouter(
+      permission: _permission,
+      capture: capture,
+      isPendingStream: isPending.stream,
+      onResolvedRemotely: () => remoteDismissals++,
+    );
     addTearDown(router.dispose);
 
     await tester.pumpWidget(_buildApp(router: router));
@@ -155,13 +163,20 @@ void main() {
     expect(find.text("bash"), findsNothing);
     expect(capture.requestId, isNull);
     expect(capture.reply, isNull);
+    expect(remoteDismissals, 1);
   });
 
   testWidgets("a local reply racing the resolved signal pops only the sheet", (tester) async {
     final capture = _ReplyCapture();
     final isPending = StreamController<bool>();
+    var remoteDismissals = 0;
     addTearDown(isPending.close);
-    final router = _createRouter(permission: _permission, capture: capture, isPendingStream: isPending.stream);
+    final router = _createRouter(
+      permission: _permission,
+      capture: capture,
+      isPendingStream: isPending.stream,
+      onResolvedRemotely: () => remoteDismissals++,
+    );
     addTearDown(router.dispose);
 
     await tester.pumpWidget(_buildApp(router: router));
@@ -177,6 +192,32 @@ void main() {
     expect(capture.reply, PermissionReply.once);
     expect(find.text("bash"), findsNothing);
     expect(find.byKey(const Key("open-permission-modal")), findsOneWidget);
+    expect(remoteDismissals, 0);
+  });
+
+  testWidgets("ignores replies tapped during the exit animation after a remote resolution", (tester) async {
+    final capture = _ReplyCapture();
+    final isPending = StreamController<bool>();
+    addTearDown(isPending.close);
+    final router = _createRouter(
+      permission: _permission,
+      capture: capture,
+      isPendingStream: isPending.stream,
+      onResolvedRemotely: () {},
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openPermissionModal(tester);
+
+    isPending.add(false);
+    // Mid exit animation: the buttons are still on screen and tappable, but
+    // the request is already resolved — no reply may be sent.
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tap(find.text("Once"), warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    expect(capture.reply, isNull);
   });
 
   testWidgets("keeps actions visible for a long request detail", (tester) async {
@@ -184,7 +225,7 @@ void main() {
     final permission = _permission.copyWith(
       description: List.filled(80, "echo a long permission request").join("\n"),
     );
-    final router = _createRouter(permission: permission, capture: capture, isPendingStream: const Stream<bool>.empty());
+    final router = _createRouter(permission: permission, capture: capture, isPendingStream: const Stream<bool>.empty(), onResolvedRemotely: () {});
     addTearDown(router.dispose);
 
     await tester.pumpWidget(_buildApp(router: router));

--- a/client/app/test/features/session_detail/widgets/permission_modal_test.dart
+++ b/client/app/test/features/session_detail/widgets/permission_modal_test.dart
@@ -41,6 +41,7 @@ GoRouter _createRouter({
   required _ReplyCapture capture,
   required Stream<bool> isPendingStream,
   required VoidCallback onResolvedRemotely,
+  bool Function()? isPendingNow,
 }) {
   return GoRouter(
     routes: [
@@ -57,6 +58,7 @@ GoRouter _createRouter({
                     permission: permission,
                     onReply: capture.onReply,
                     isPendingStream: isPendingStream,
+                    isPendingNow: isPendingNow ?? () => true,
                     onResolvedRemotely: onResolvedRemotely,
                   );
                 },
@@ -88,7 +90,12 @@ Future<void> _openPermissionModal(WidgetTester tester) async {
 void main() {
   testWidgets("groups the tool and highlighted request detail in one card", (tester) async {
     final capture = _ReplyCapture();
-    final router = _createRouter(permission: _permission, capture: capture, isPendingStream: const Stream<bool>.empty(), onResolvedRemotely: () {});
+    final router = _createRouter(
+      permission: _permission,
+      capture: capture,
+      isPendingStream: const Stream<bool>.empty(),
+      onResolvedRemotely: () {},
+    );
     addTearDown(router.dispose);
 
     await tester.pumpWidget(_buildApp(router: router));
@@ -126,7 +133,12 @@ void main() {
   ]) {
     testWidgets("forwards the ${replyCase.label.toLowerCase()} reply", (tester) async {
       final capture = _ReplyCapture();
-      final router = _createRouter(permission: _permission, capture: capture, isPendingStream: const Stream<bool>.empty(), onResolvedRemotely: () {});
+      final router = _createRouter(
+        permission: _permission,
+        capture: capture,
+        isPendingStream: const Stream<bool>.empty(),
+        onResolvedRemotely: () {},
+      );
       addTearDown(router.dispose);
 
       await tester.pumpWidget(_buildApp(router: router));
@@ -252,7 +264,12 @@ void main() {
     final permission = _permission.copyWith(
       description: List.filled(80, "echo a long permission request").join("\n"),
     );
-    final router = _createRouter(permission: permission, capture: capture, isPendingStream: const Stream<bool>.empty(), onResolvedRemotely: () {});
+    final router = _createRouter(
+      permission: permission,
+      capture: capture,
+      isPendingStream: const Stream<bool>.empty(),
+      onResolvedRemotely: () {},
+    );
     addTearDown(router.dispose);
 
     await tester.pumpWidget(_buildApp(router: router));

--- a/client/app/test/features/session_detail/widgets/permission_modal_test.dart
+++ b/client/app/test/features/session_detail/widgets/permission_modal_test.dart
@@ -220,6 +220,33 @@ void main() {
     expect(capture.reply, isNull);
   });
 
+  testWidgets("ignores the resolved signal while exiting from a barrier dismissal", (tester) async {
+    final capture = _ReplyCapture();
+    final isPending = StreamController<bool>();
+    var remoteDismissals = 0;
+    addTearDown(isPending.close);
+    final router = _createRouter(
+      permission: _permission,
+      capture: capture,
+      isPendingStream: isPending.stream,
+      onResolvedRemotely: () => remoteDismissals++,
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openPermissionModal(tester);
+
+    // Barrier tap pops the route without going through the modal's dismiss
+    // path; a resolution landing mid-exit-animation must not pop the page.
+    await tester.tapAt(const Offset(200, 50));
+    await tester.pump(const Duration(milliseconds: 50));
+    isPending.add(false);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key("open-permission-modal")), findsOneWidget);
+    expect(remoteDismissals, 0);
+  });
+
   testWidgets("keeps actions visible for a long request detail", (tester) async {
     final capture = _ReplyCapture();
     final permission = _permission.copyWith(

--- a/client/app/test/features/session_detail/widgets/question_modal_test.dart
+++ b/client/app/test/features/session_detail/widgets/question_modal_test.dart
@@ -430,4 +430,40 @@ void main() {
     expect(capture.requestId, isNull);
     expect(capture.answers, isNull);
   });
+
+  testWidgets("a local answer racing the resolved signal pops only the sheet", (tester) async {
+    final capture = _ReplyCapture();
+    final isPending = StreamController<bool>();
+    addTearDown(isPending.close);
+    final router = _createRouter(
+      question: _questionAsked(
+        questions: const [
+          QuestionInfo(
+            question: "Choose a release channel",
+            header: "Release channel",
+            options: [QuestionOption(label: "Stable", description: "Release to everyone")],
+          ),
+        ],
+      ),
+      capture: capture,
+      isPendingStream: isPending.stream,
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openQuestionModal(tester);
+
+    // Answering resolves the request optimistically: the `false` emission
+    // arrives while the sheet is still mounted in its exit animation. The
+    // listener must not pop a second time (that would remove the page).
+    await tester.tap(find.text("Stable"));
+    await tester.pump();
+    await tester.tap(find.text("Submit"));
+    isPending.add(false);
+    await tester.pumpAndSettle();
+
+    expect(capture.requestId, "question-1");
+    expect(find.text("Choose a release channel"), findsNothing);
+    expect(find.byKey(const Key("open-question-modal")), findsOneWidget);
+  });
 }

--- a/client/app/test/features/session_detail/widgets/question_modal_test.dart
+++ b/client/app/test/features/session_detail/widgets/question_modal_test.dart
@@ -22,6 +22,7 @@ GoRouter _createRouter({
   required SesoriQuestionAsked question,
   required _ReplyCapture capture,
   required Stream<bool> isPendingStream,
+  required VoidCallback onResolvedRemotely,
 }) {
   return GoRouter(
     routes: [
@@ -39,6 +40,7 @@ GoRouter _createRouter({
                     onReply: capture.onReply,
                     onReject: (_) {},
                     isPendingStream: isPendingStream,
+                    onResolvedRemotely: onResolvedRemotely,
                   );
                 },
                 child: const Text("Open question modal"),
@@ -95,6 +97,7 @@ void main() {
       ),
       capture: capture,
       isPendingStream: const Stream<bool>.empty(),
+      onResolvedRemotely: () {},
     );
     addTearDown(router.dispose);
 
@@ -133,6 +136,7 @@ void main() {
       ),
       capture: capture,
       isPendingStream: const Stream<bool>.empty(),
+      onResolvedRemotely: () {},
     );
     addTearDown(router.dispose);
 
@@ -170,6 +174,7 @@ void main() {
       ),
       capture: capture,
       isPendingStream: const Stream<bool>.empty(),
+      onResolvedRemotely: () {},
     );
     addTearDown(router.dispose);
 
@@ -207,6 +212,7 @@ void main() {
       ),
       capture: capture,
       isPendingStream: const Stream<bool>.empty(),
+      onResolvedRemotely: () {},
     );
     addTearDown(router.dispose);
 
@@ -248,6 +254,7 @@ void main() {
       ),
       capture: capture,
       isPendingStream: const Stream<bool>.empty(),
+      onResolvedRemotely: () {},
     );
     addTearDown(router.dispose);
 
@@ -287,6 +294,7 @@ void main() {
       ),
       capture: capture,
       isPendingStream: const Stream<bool>.empty(),
+      onResolvedRemotely: () {},
     );
     addTearDown(router.dispose);
 
@@ -326,6 +334,7 @@ void main() {
       ),
       capture: capture,
       isPendingStream: const Stream<bool>.empty(),
+      onResolvedRemotely: () {},
     );
     addTearDown(router.dispose);
 
@@ -368,6 +377,7 @@ void main() {
       ),
       capture: capture,
       isPendingStream: const Stream<bool>.empty(),
+      onResolvedRemotely: () {},
     );
     addTearDown(router.dispose);
 
@@ -403,6 +413,7 @@ void main() {
   testWidgets("dismisses itself without replying when resolved on another device", (tester) async {
     final capture = _ReplyCapture();
     final isPending = StreamController<bool>();
+    var remoteDismissals = 0;
     addTearDown(isPending.close);
     final router = _createRouter(
       question: _questionAsked(
@@ -416,6 +427,7 @@ void main() {
       ),
       capture: capture,
       isPendingStream: isPending.stream,
+      onResolvedRemotely: () => remoteDismissals++,
     );
     addTearDown(router.dispose);
 
@@ -429,11 +441,13 @@ void main() {
     expect(find.text("Choose a release channel"), findsNothing);
     expect(capture.requestId, isNull);
     expect(capture.answers, isNull);
+    expect(remoteDismissals, 1);
   });
 
   testWidgets("a local answer racing the resolved signal pops only the sheet", (tester) async {
     final capture = _ReplyCapture();
     final isPending = StreamController<bool>();
+    var remoteDismissals = 0;
     addTearDown(isPending.close);
     final router = _createRouter(
       question: _questionAsked(
@@ -447,6 +461,7 @@ void main() {
       ),
       capture: capture,
       isPendingStream: isPending.stream,
+      onResolvedRemotely: () => remoteDismissals++,
     );
     addTearDown(router.dispose);
 
@@ -465,5 +480,41 @@ void main() {
     expect(capture.requestId, "question-1");
     expect(find.text("Choose a release channel"), findsNothing);
     expect(find.byKey(const Key("open-question-modal")), findsOneWidget);
+    expect(remoteDismissals, 0);
+  });
+
+  testWidgets("ignores actions tapped during the exit animation after a remote resolution", (tester) async {
+    final capture = _ReplyCapture();
+    final isPending = StreamController<bool>();
+    addTearDown(isPending.close);
+    final router = _createRouter(
+      question: _questionAsked(
+        questions: const [
+          QuestionInfo(
+            question: "Choose a release channel",
+            header: "Release channel",
+            options: [QuestionOption(label: "Stable", description: "Release to everyone")],
+          ),
+        ],
+      ),
+      capture: capture,
+      isPendingStream: isPending.stream,
+      onResolvedRemotely: () {},
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openQuestionModal(tester);
+
+    isPending.add(false);
+    // Mid exit animation: the buttons are still on screen and tappable, but
+    // the request is already resolved — no answer may be sent.
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tap(find.text("Stable"), warnIfMissed: false);
+    await tester.tap(find.text("Submit"), warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    expect(capture.requestId, isNull);
+    expect(capture.answers, isNull);
   });
 }

--- a/client/app/test/features/session_detail/widgets/question_modal_test.dart
+++ b/client/app/test/features/session_detail/widgets/question_modal_test.dart
@@ -23,6 +23,7 @@ GoRouter _createRouter({
   required _ReplyCapture capture,
   required Stream<bool> isPendingStream,
   required VoidCallback onResolvedRemotely,
+  bool Function()? isPendingNow,
 }) {
   return GoRouter(
     routes: [
@@ -40,6 +41,7 @@ GoRouter _createRouter({
                     onReply: capture.onReply,
                     onReject: (_) {},
                     isPendingStream: isPendingStream,
+                    isPendingNow: isPendingNow ?? () => true,
                     onResolvedRemotely: onResolvedRemotely,
                   );
                 },
@@ -401,16 +403,16 @@ void main() {
     await tester.tap(find.byType(FilledButton).last);
     await tester.pumpAndSettle();
 
-      expect(
-        capture.answers,
-        [
-          const ReplyAnswer(values: ["Mobile", "Also notify QA"]),
-          const ReplyAnswer(values: ["Gradual"]),
-        ],
-      );
-    });
+    expect(
+      capture.answers,
+      [
+        const ReplyAnswer(values: ["Mobile", "Also notify QA"]),
+        const ReplyAnswer(values: ["Gradual"]),
+      ],
+    );
+  });
 
-  testWidgets("dismisses itself without replying when resolved on another device", (tester) async {
+  testWidgets("dismisses itself when already resolved before the sheet subscribes", (tester) async {
     final capture = _ReplyCapture();
     final isPending = StreamController<bool>();
     var remoteDismissals = 0;
@@ -427,16 +429,13 @@ void main() {
       ),
       capture: capture,
       isPendingStream: isPending.stream,
+      isPendingNow: () => false,
       onResolvedRemotely: () => remoteDismissals++,
     );
     addTearDown(router.dispose);
 
     await tester.pumpWidget(_buildApp(router: router));
     await _openQuestionModal(tester);
-    expect(find.text("Choose a release channel"), findsOneWidget);
-
-    isPending.add(false);
-    await tester.pumpAndSettle();
 
     expect(find.text("Choose a release channel"), findsNothing);
     expect(capture.requestId, isNull);

--- a/client/app/test/features/session_detail/widgets/question_modal_test.dart
+++ b/client/app/test/features/session_detail/widgets/question_modal_test.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:go_router/go_router.dart";
@@ -19,6 +21,7 @@ class _ReplyCapture {
 GoRouter _createRouter({
   required SesoriQuestionAsked question,
   required _ReplyCapture capture,
+  required Stream<bool> isPendingStream,
 }) {
   return GoRouter(
     routes: [
@@ -35,6 +38,7 @@ GoRouter _createRouter({
                     question: question,
                     onReply: capture.onReply,
                     onReject: (_) {},
+                    isPendingStream: isPendingStream,
                   );
                 },
                 child: const Text("Open question modal"),
@@ -90,6 +94,7 @@ void main() {
         ],
       ),
       capture: capture,
+      isPendingStream: const Stream<bool>.empty(),
     );
     addTearDown(router.dispose);
 
@@ -127,6 +132,7 @@ void main() {
         ],
       ),
       capture: capture,
+      isPendingStream: const Stream<bool>.empty(),
     );
     addTearDown(router.dispose);
 
@@ -163,6 +169,7 @@ void main() {
         ],
       ),
       capture: capture,
+      isPendingStream: const Stream<bool>.empty(),
     );
     addTearDown(router.dispose);
 
@@ -199,6 +206,7 @@ void main() {
         ],
       ),
       capture: capture,
+      isPendingStream: const Stream<bool>.empty(),
     );
     addTearDown(router.dispose);
 
@@ -239,6 +247,7 @@ void main() {
         ],
       ),
       capture: capture,
+      isPendingStream: const Stream<bool>.empty(),
     );
     addTearDown(router.dispose);
 
@@ -277,6 +286,7 @@ void main() {
         ],
       ),
       capture: capture,
+      isPendingStream: const Stream<bool>.empty(),
     );
     addTearDown(router.dispose);
 
@@ -315,6 +325,7 @@ void main() {
         ],
       ),
       capture: capture,
+      isPendingStream: const Stream<bool>.empty(),
     );
     addTearDown(router.dispose);
 
@@ -356,6 +367,7 @@ void main() {
         ],
       ),
       capture: capture,
+      isPendingStream: const Stream<bool>.empty(),
     );
     addTearDown(router.dispose);
 
@@ -379,12 +391,43 @@ void main() {
     await tester.tap(find.byType(FilledButton).last);
     await tester.pumpAndSettle();
 
-    expect(
-      capture.answers,
-      [
-        const ReplyAnswer(values: ["Mobile", "Also notify QA"]),
-        const ReplyAnswer(values: ["Gradual"]),
-      ],
+      expect(
+        capture.answers,
+        [
+          const ReplyAnswer(values: ["Mobile", "Also notify QA"]),
+          const ReplyAnswer(values: ["Gradual"]),
+        ],
+      );
+    });
+
+  testWidgets("dismisses itself without replying when resolved on another device", (tester) async {
+    final capture = _ReplyCapture();
+    final isPending = StreamController<bool>();
+    addTearDown(isPending.close);
+    final router = _createRouter(
+      question: _questionAsked(
+        questions: const [
+          QuestionInfo(
+            question: "Choose a release channel",
+            header: "Release channel",
+            options: [QuestionOption(label: "Stable", description: "Release to everyone")],
+          ),
+        ],
+      ),
+      capture: capture,
+      isPendingStream: isPending.stream,
     );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openQuestionModal(tester);
+    expect(find.text("Choose a release channel"), findsOneWidget);
+
+    isPending.add(false);
+    await tester.pumpAndSettle();
+
+    expect(find.text("Choose a release channel"), findsNothing);
+    expect(capture.requestId, isNull);
+    expect(capture.answers, isNull);
   });
 }

--- a/client/app/test/features/session_detail/widgets/question_modal_test.dart
+++ b/client/app/test/features/session_detail/widgets/question_modal_test.dart
@@ -517,4 +517,39 @@ void main() {
     expect(capture.requestId, isNull);
     expect(capture.answers, isNull);
   });
+
+  testWidgets("ignores the resolved signal while exiting from a barrier dismissal", (tester) async {
+    final capture = _ReplyCapture();
+    final isPending = StreamController<bool>();
+    var remoteDismissals = 0;
+    addTearDown(isPending.close);
+    final router = _createRouter(
+      question: _questionAsked(
+        questions: const [
+          QuestionInfo(
+            question: "Choose a release channel",
+            header: "Release channel",
+            options: [QuestionOption(label: "Stable", description: "Release to everyone")],
+          ),
+        ],
+      ),
+      capture: capture,
+      isPendingStream: isPending.stream,
+      onResolvedRemotely: () => remoteDismissals++,
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openQuestionModal(tester);
+
+    // Barrier tap pops the route without going through the modal's dismiss
+    // path; a resolution landing mid-exit-animation must not pop the page.
+    await tester.tapAt(const Offset(200, 50));
+    await tester.pump(const Duration(milliseconds: 50));
+    isPending.add(false);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key("open-question-modal")), findsOneWidget);
+    expect(remoteDismissals, 0);
+  });
 }

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -314,6 +314,72 @@ void main() {
     expect(find.text("Choose a release channel"), findsOneWidget);
   });
 
+  testWidgets("closes an open question modal when the question is resolved on another device", (tester) async {
+    final questionController = StreamController<SesoriQuestionAsked>.broadcast();
+    final stateController = StreamController<SessionDetailState>.broadcast();
+    addTearDown(questionController.close);
+    addTearDown(stateController.close);
+    var state = _loadedState(pendingQuestions: const [], pendingPermissions: const []);
+    when(() => cubit.state).thenAnswer((_) => state);
+    when(() => cubit.stream).thenAnswer((_) => stateController.stream);
+    when(() => cubit.questionStream).thenAnswer((_) => questionController.stream);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    state = state.copyWith(pendingQuestions: const [_question]);
+    questionController.add(_question);
+    await tester.pumpAndSettle();
+    expect(find.text("Choose a release channel"), findsOneWidget);
+
+    // The bridge broadcasts question.replied to every connected device; the
+    // cubit drops it from pending without any local answer.
+    state = state.copyWith(pendingQuestions: const []);
+    stateController.add(state);
+    await tester.pumpAndSettle();
+
+    expect(find.text("Choose a release channel"), findsNothing);
+    verifyNever(
+      () => cubit.replyToQuestion(
+        requestId: any(named: "requestId"),
+        sessionId: any(named: "sessionId"),
+        answers: any(named: "answers"),
+      ),
+    );
+  });
+
+  testWidgets("closes an open permission modal when the permission is resolved on another device", (tester) async {
+    final permissionController = StreamController<SesoriPermissionAsked>.broadcast();
+    final stateController = StreamController<SessionDetailState>.broadcast();
+    addTearDown(permissionController.close);
+    addTearDown(stateController.close);
+    var state = _loadedState(pendingQuestions: const [], pendingPermissions: const []);
+    when(() => cubit.state).thenAnswer((_) => state);
+    when(() => cubit.stream).thenAnswer((_) => stateController.stream);
+    when(() => cubit.permissionStream).thenAnswer((_) => permissionController.stream);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    state = state.copyWith(pendingPermissions: const [_permission]);
+    permissionController.add(_permission);
+    await tester.pumpAndSettle();
+    expect(find.text("write_release_notes"), findsOneWidget);
+
+    state = state.copyWith(pendingPermissions: const []);
+    stateController.add(state);
+    await tester.pumpAndSettle();
+
+    expect(find.text("write_release_notes"), findsNothing);
+    verifyNever(
+      () => cubit.replyToPermission(
+        requestId: any(named: "requestId"),
+        sessionId: any(named: "sessionId"),
+        reply: PermissionReply.once,
+      ),
+    );
+  });
+
   // Only the input row is grouped with the text field via a TextFieldTapRegion,
   // so tapping the send button does not fire the field's default `onTapOutside`
   // (which unfocuses and dismisses the keyboard) — without the region, send

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -112,6 +112,19 @@ const _permission = SesoriPermissionAsked(
   description: "Allow writing the release notes",
 );
 
+const _question2 = SesoriQuestionAsked(
+  id: "question-2",
+  sessionID: "session-1",
+  displaySessionId: null,
+  questions: [
+    QuestionInfo(
+      question: "Pick a rollout percentage",
+      header: "Rollout",
+      options: [QuestionOption(label: "10%", description: "Start small")],
+    ),
+  ],
+);
+
 void main() {
   late MockSessionDetailCubit cubit;
   late MockVoiceTranscriptionService voiceTranscriptionService;
@@ -378,6 +391,39 @@ void main() {
         reply: PermissionReply.once,
       ),
     );
+  });
+
+  testWidgets("presents the next queued question after a remote resolution closes the active one", (tester) async {
+    final questionController = StreamController<SesoriQuestionAsked>.broadcast();
+    final stateController = StreamController<SessionDetailState>.broadcast();
+    addTearDown(questionController.close);
+    addTearDown(stateController.close);
+    var state = _loadedState(pendingQuestions: const [], pendingPermissions: const []);
+    when(() => cubit.state).thenAnswer((_) => state);
+    when(() => cubit.stream).thenAnswer((_) => stateController.stream);
+    when(() => cubit.questionStream).thenAnswer((_) => questionController.stream);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    // Two questions pending; only the first auto-opens (the second's auto-show
+    // is suppressed while the sheet is up, as in the real flow).
+    state = state.copyWith(pendingQuestions: const [_question, _question2]);
+    questionController.add(_question);
+    await tester.pumpAndSettle();
+    expect(find.text("Choose a release channel"), findsOneWidget);
+    expect(find.text("Pick a rollout percentage"), findsNothing);
+
+    // The first question is answered on another device: it leaves the pending
+    // list, its sheet self-dismisses, and the queued question is presented.
+    state = state.copyWith(pendingQuestions: const [_question2]);
+    stateController.add(state);
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pumpAndSettle();
+
+    expect(find.text("Choose a release channel"), findsNothing);
+    expect(find.text("Pick a rollout percentage"), findsOneWidget);
   });
 
   // Only the input row is grouped with the text field via a TextFieldTapRegion,

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -348,8 +348,17 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
               streamingText: streamingText,
               sessionStatus: refreshedSessionStatus,
               retryErrorMessage: retryMessage,
-              pendingQuestions: _mapPendingQuestions(snapshot.pendingQuestions),
-              pendingPermissions: _mapPendingPermissions(snapshot.pendingPermissions),
+              // A null pending list means its refetch failed; keep the
+              // previous state so still-open requests are not mistaken for
+              // remotely resolved.
+              pendingQuestions: switch (snapshot.pendingQuestions) {
+                final pending? => _mapPendingQuestions(pending),
+                null => latest.pendingQuestions,
+              },
+              pendingPermissions: switch (snapshot.pendingPermissions) {
+                final pending? => _mapPendingPermissions(pending),
+                null => latest.pendingPermissions,
+              },
               agent: latestAssistant?.agent,
               assistantAgentModel: assistantAgentModel,
               children: refreshedChildSessions,
@@ -522,16 +531,26 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
       SesoriSessionUpdated(:final info) => info.parentID == _sessionId,
       // Permission/question events for a descendant (sub-agent) session that
       // surfaces on this session must be buffered so they replay after load.
-      SesoriPermissionAsked(:final sessionID, :final displaySessionId) =>
-        _surfacesChildRequestHere(sessionID: sessionID, displaySessionId: displaySessionId),
-      SesoriPermissionReplied(:final sessionID, :final displaySessionId) =>
-        _surfacesChildRequestHere(sessionID: sessionID, displaySessionId: displaySessionId),
-      SesoriQuestionAsked(:final sessionID, :final displaySessionId) =>
-        _surfacesChildRequestHere(sessionID: sessionID, displaySessionId: displaySessionId),
-      SesoriQuestionReplied(:final sessionID, :final displaySessionId) =>
-        _surfacesChildRequestHere(sessionID: sessionID, displaySessionId: displaySessionId),
-      SesoriQuestionRejected(:final sessionID, :final displaySessionId) =>
-        _surfacesChildRequestHere(sessionID: sessionID, displaySessionId: displaySessionId),
+      SesoriPermissionAsked(:final sessionID, :final displaySessionId) => _surfacesChildRequestHere(
+        sessionID: sessionID,
+        displaySessionId: displaySessionId,
+      ),
+      SesoriPermissionReplied(:final sessionID, :final displaySessionId) => _surfacesChildRequestHere(
+        sessionID: sessionID,
+        displaySessionId: displaySessionId,
+      ),
+      SesoriQuestionAsked(:final sessionID, :final displaySessionId) => _surfacesChildRequestHere(
+        sessionID: sessionID,
+        displaySessionId: displaySessionId,
+      ),
+      SesoriQuestionReplied(:final sessionID, :final displaySessionId) => _surfacesChildRequestHere(
+        sessionID: sessionID,
+        displaySessionId: displaySessionId,
+      ),
+      SesoriQuestionRejected(:final sessionID, :final displaySessionId) => _surfacesChildRequestHere(
+        sessionID: sessionID,
+        displaySessionId: displaySessionId,
+      ),
       // Definitively irrelevant high-volume events.
       SesoriServerConnected() ||
       SesoriServerHeartbeat() ||
@@ -1446,8 +1465,8 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
       streamingText: const {},
       sessionStatus: initialSessionStatus,
       retryErrorMessage: initialRetryMessage,
-      pendingQuestions: _mapPendingQuestions(snapshot.pendingQuestions),
-      pendingPermissions: _mapPendingPermissions(snapshot.pendingPermissions),
+      pendingQuestions: _mapPendingQuestions(snapshot.pendingQuestions ?? const []),
+      pendingPermissions: _mapPendingPermissions(snapshot.pendingPermissions ?? const []),
       sessionTitle: snapshot.canonicalSessionTitle,
       agent: latestAssistant?.agent,
       assistantAgentModel: assistantAgentModel,

--- a/client/module_core/lib/src/services/session_detail_load_service.dart
+++ b/client/module_core/lib/src/services/session_detail_load_service.dart
@@ -85,13 +85,23 @@ class SessionDetailLoadService {
         ErrorResponse(:final error) => throw error,
       };
 
+      // A failed pending fetch yields null (not an empty list) so callers can
+      // preserve the previous pending state: an open question/permission is
+      // still awaiting an answer on the bridge and must not be treated as
+      // resolved just because the refetch failed.
       final pendingQuestions = switch (questionsResponse) {
         SuccessResponse(:final data) => data.data,
-        ErrorResponse() => <PendingQuestion>[],
+        ErrorResponse(:final error) => () {
+          logw("Failed to load pending questions", error);
+          return null;
+        }(),
       };
       final pendingPermissions = switch (permissionsResponse) {
         SuccessResponse(:final data) => data.data,
-        ErrorResponse() => <PendingPermission>[],
+        ErrorResponse(:final error) => () {
+          logw("Failed to load pending permissions", error);
+          return null;
+        }(),
       };
       final childSessions = switch (childrenResponse) {
         SuccessResponse(:final data) => data.items,
@@ -195,8 +205,14 @@ class SessionDetailLoadService {
 class SessionDetailSnapshot {
   final String? projectId;
   final List<MessageWithParts> messages;
-  final List<PendingQuestion> pendingQuestions;
-  final List<PendingPermission> pendingPermissions;
+
+  /// Null when the pending-questions fetch failed — the previous pending
+  /// state should be preserved rather than treated as "all resolved".
+  final List<PendingQuestion>? pendingQuestions;
+
+  /// Null when the pending-permissions fetch failed — the previous pending
+  /// state should be preserved rather than treated as "all resolved".
+  final List<PendingPermission>? pendingPermissions;
   final List<Session> childSessions;
   final Map<String, SessionStatus> statuses;
   final List<AgentInfo?> agents;

--- a/client/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
@@ -287,8 +287,18 @@ void main() {
       verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getSessionStatuses()).called(1);
-      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: "plugin-1")).called(1);
-      verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: "plugin-1")).called(1);
+      verify(
+        () => mockSessionService.listAgents(
+          projectId: any(named: "projectId"),
+          pluginId: "plugin-1",
+        ),
+      ).called(1);
+      verify(
+        () => mockSessionService.listProviders(
+          projectId: any(named: "projectId"),
+          pluginId: "plugin-1",
+        ),
+      ).called(1);
     });
 
     test("non-loaded state buffers permission events and replays after loaded", () async {
@@ -483,6 +493,78 @@ void main() {
       // Reject targets the owning child session, not the open root.
       verify(() => mockSessionService.rejectQuestion(requestId: "q-child", sessionId: "child-1")).called(1);
     });
+
+    test("silent refresh preserves pending prompts when pending fetches fail", () async {
+      final cubit = _buildCubit(
+        sessionId: sessionId,
+        projectId: "project-1",
+        connectionService: mockConnectionService,
+        loadService: loadService,
+        promptDispatcher: promptDispatcher,
+        notificationCanceller: mockNotificationCanceller,
+        permissionRepository: mockPermissionRepository,
+        failureReporter: mockFailureReporter,
+      );
+      addTearDown(cubit.close);
+      await _awaitLoaded(cubit);
+
+      const question = SesoriQuestionAsked(
+        id: "question-1",
+        sessionID: sessionId,
+        displaySessionId: null,
+        questions: [],
+      );
+      const permission = SesoriPermissionAsked(
+        requestID: "permission-1",
+        sessionID: sessionId,
+        displaySessionId: null,
+        tool: "bash",
+        description: "Run tests",
+      );
+      sessionEvents
+        ..add(question)
+        ..add(permission);
+      await _waitUntil(
+        condition: () {
+          final state = cubit.state;
+          return state is SessionDetailLoaded &&
+              state.pendingQuestions.contains(question) &&
+              state.pendingPermissions.contains(permission);
+        },
+      );
+
+      final questionsFetch = Completer<ApiResponse<PendingQuestionResponse>>();
+      final permissionsFetch = Completer<ApiResponse<PendingPermissionResponse>>();
+      when(
+        () => mockSessionService.getPendingQuestions(sessionId: any(named: "sessionId")),
+      ).thenAnswer((_) => questionsFetch.future);
+      when(
+        () => mockSessionService.getPendingPermissions(sessionId: any(named: "sessionId")),
+      ).thenAnswer((_) => permissionsFetch.future);
+
+      globalEvents.add(
+        SseEvent(data: const SesoriSseEvent.sessionsUpdated(projectID: "project-1")),
+      );
+      await _waitUntil(
+        condition: () => switch (cubit.state) {
+          SessionDetailLoaded(:final isRefreshing) => isRefreshing,
+          SessionDetailLoading() || SessionDetailFailed() => false,
+        },
+      );
+
+      questionsFetch.complete(ApiResponse.error(ApiError.generic()));
+      permissionsFetch.complete(ApiResponse.error(ApiError.generic()));
+      await _waitUntil(
+        condition: () => switch (cubit.state) {
+          SessionDetailLoaded(:final isRefreshing) => !isRefreshing,
+          SessionDetailLoading() || SessionDetailFailed() => false,
+        },
+      );
+
+      final state = cubit.state as SessionDetailLoaded;
+      expect(state.pendingQuestions, [question]);
+      expect(state.pendingPermissions, [permission]);
+    });
   });
 }
 
@@ -613,4 +695,12 @@ Future<void> _awaitLoaded(SessionDetailCubit cubit) async {
     await Future<void>.delayed(const Duration(milliseconds: 1));
   }
   fail("Timed out waiting for SessionDetailLoaded; current state: ${cubit.state}");
+}
+
+Future<void> _waitUntil({required bool Function() condition}) async {
+  for (var i = 0; i < 100; i++) {
+    if (condition()) return;
+    await Future<void>.delayed(const Duration(milliseconds: 2));
+  }
+  fail("Timed out waiting for condition");
 }

--- a/client/module_core/test/services/session_detail_load_service_test.dart
+++ b/client/module_core/test/services/session_detail_load_service_test.dart
@@ -64,6 +64,24 @@ void main() {
       verifyNever(() => projectRepository.findSessionContext(sessionId: any(named: "sessionId")));
     });
 
+    test("pending fetch failures remain indeterminate in the snapshot", () async {
+      connectionStatus.add(connectedStatus);
+      _stubRepositorySnapshot(repository: repository);
+      when(
+        () => repository.getPendingQuestions(sessionId: "session-1"),
+      ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
+      when(
+        () => repository.getPendingPermissions(sessionId: "session-1"),
+      ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
+
+      final result = await service.load(sessionId: "session-1", projectId: "project-1");
+
+      expect(result, isA<SessionDetailLoadResultLoaded>());
+      final snapshot = (result as SessionDetailLoadResultLoaded).snapshot;
+      expect(snapshot.pendingQuestions, isNull);
+      expect(snapshot.pendingPermissions, isNull);
+    });
+
     test("load gives the route project id precedence over session metadata", () async {
       connectionStatus.add(connectedStatus);
       _stubRepositorySnapshot(repository: repository);


### PR DESCRIPTION
## Problem

With the same session open on two devices, a question/permission request correctly shows on both. Answering on one device removed it from pending state everywhere, but an already-open sheet on the other device remained stale and could later submit against an already-resolved request.

## Fix

The existing pending lists remain the authoritative UI state: live `question.replied` / `question.rejected` / `permission.replied` events remove requests immediately, while a successful pending snapshot reconciles devices that missed a live event while disconnected.

- `SessionDetailBody` passes each sheet a per-request pending stream plus a current-state read. The sheet subscribes first, then reads current state, so no resolution can be lost during presentation. Delayed queued presentation also rechecks pending state before opening.
- `QuestionModal` and `PermissionModal` dismiss their own route when the request leaves pending state, without sending another reply. Dismissal is idempotent, local actions mark the sheet dismissed before dispatch, and route-exit guards prevent popping the session page underneath. Remote dismissal chains the next queued prompt like a local answer.
- Pending endpoint failures are no longer treated as authoritative empty snapshots. `SessionDetailSnapshot` uses `null` for an indeterminate pending fetch; silent refresh preserves the prior list, while a successful empty response still means all requests are resolved. Initial load maps indeterminate pending fields to empty because there is no prior state.

## Verification

- `dart analyze .` in `client/app`: pass
- `dart analyze .` in `client/module_core`: pass
- 31 focused Flutter widget tests across the question modal, permission modal, and session-detail body suites: pass
- 22 focused core tests across the load service and session-detail cubit suites: pass
- Architecture review of the partial snapshot contract and cross-layer flow: approved
