### PR TITLE
Fix relay handshake recovery after network changes

### DIFF
--- a/bridge/app/lib/src/bridge/key_exchange.dart
+++ b/bridge/app/lib/src/bridge/key_exchange.dart
@@ -4,24 +4,15 @@ import "package:sesori_shared/sesori_shared.dart";
 
 class KeyExchangeManager {
   final List<int> _roomKey;
-  final Map<int, bool> _pendingExchanges = <int, bool>{};
   final RelayCryptoService _cryptoService;
 
   KeyExchangeManager(List<int> roomKey, {RelayCryptoService? cryptoService})
     : _roomKey = List<int>.from(roomKey),
       _cryptoService = cryptoService ?? RelayCryptoService();
 
-  void startExchange(int connID) {
-    _pendingExchanges.remove(connID);
-    _pendingExchanges[connID] = true;
-  }
-
-  Future<List<int>> handleKeyExchange(int connID, RelayKeyExchange message) async {
-    final isPending = _pendingExchanges[connID] ?? false;
-    if (!isPending) {
-      throw StateError("no pending exchange for connID $connID");
-    }
-
+  /// The key-exchange frame is the initiation signal. The relay does not send
+  /// `phone_connected` snapshots when a bridge joins phones already online.
+  Future<List<int>> handleKeyExchange({required RelayKeyExchange message}) async {
     final bridgeKeyPair = await _cryptoService.generateKeyPair();
     final bridgePublicKey = await bridgeKeyPair.extractPublicKey();
     final bridgePublicKeyBytes = bridgePublicKey.bytes;
@@ -48,11 +39,6 @@ class KeyExchangeManager {
     final encryptor = _cryptoService.createSessionEncryptor(ephemeralKey);
     final encryptedFrame = await frame(readyJSON, encryptor: encryptor);
 
-    _pendingExchanges.remove(connID);
     return [...bridgePublicKeyBytes, ...encryptedFrame];
-  }
-
-  void removeExchange(int connID) {
-    _pendingExchanges.remove(connID);
   }
 }

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -1476,14 +1476,8 @@ class OrchestratorSession {
         switch (type) {
           case "phone_connected":
             Log.v("phone_connected connID=$connID");
-            try {
-              kxManager.startExchange(connID);
-            } catch (e) {
-              Log.e("failed to start exchange for connId $connID: $e");
-            }
           case "phone_disconnected":
             Log.v("phone_disconnected connID=$connID");
-            kxManager.removeExchange(connID);
             activePhones.remove(connID);
             _sseManager.removeSubscriber(connID);
             _sessionViewTracker.releaseConnection(connID: connID);
@@ -1526,7 +1520,7 @@ class OrchestratorSession {
 
         List<int> encrypted;
         try {
-          encrypted = await kxManager.handleKeyExchange(connID, relayMessage);
+          encrypted = await kxManager.handleKeyExchange(message: relayMessage);
           Log.d("key exchange OK, sending ready to connID=$connID");
         } catch (e) {
           Log.e("failed key exchange for connId $connID: $e");

--- a/bridge/app/test/bridge/key_exchange_test.dart
+++ b/bridge/app/test/bridge/key_exchange_test.dart
@@ -16,9 +16,6 @@ void main() {
 
       roomKey[0] ^= 0xFF;
 
-      const connID = 1;
-      manager.startExchange(connID);
-
       final crypto = RelayCryptoService();
       final phoneKp = await crypto.generateKeyPair();
       final phonePub = await phoneKp.extractPublicKey();
@@ -29,7 +26,7 @@ void main() {
               )
               as RelayKeyExchange;
 
-      final response = await manager.handleKeyExchange(connID, kxMsg);
+      final response = await manager.handleKeyExchange(message: kxMsg);
       final ready = await _decryptReady(response, phoneKp);
       final decodedRoomKey = base64Url.decode(
         base64Url.normalize(ready.roomKey),
@@ -40,8 +37,6 @@ void main() {
 
     test("handleKeyExchange round-trip returns prefixed framed data", () async {
       final manager = KeyExchangeManager(makeRoomKey());
-      const connID = 1;
-      manager.startExchange(connID);
 
       final crypto = RelayCryptoService();
       final phoneKp = await crypto.generateKeyPair();
@@ -52,7 +47,7 @@ void main() {
               )
               as RelayKeyExchange;
 
-      final encrypted = await manager.handleKeyExchange(connID, kxMsg);
+      final encrypted = await manager.handleKeyExchange(message: kxMsg);
 
       const x25519PubKeyLen = 32;
       const protocolVersionLen = 1;
@@ -64,7 +59,7 @@ void main() {
       expect(encrypted[x25519PubKeyLen], equals(protocolVersion));
     });
 
-    test("handleKeyExchange throws when no exchange is pending", () async {
+    test("key exchange starts without a preceding phone_connected event", () async {
       final manager = KeyExchangeManager(makeRoomKey());
 
       final crypto = RelayCryptoService();
@@ -76,19 +71,16 @@ void main() {
               )
               as RelayKeyExchange;
 
-      expect(
-        () => manager.handleKeyExchange(1, kxMsg),
-        throwsA(isA<StateError>()),
-      );
+      final response = await manager.handleKeyExchange(message: kxMsg);
+
+      expect(response, isNotEmpty);
     });
 
     test("supports concurrent exchanges", () async {
       final manager = KeyExchangeManager(makeRoomKey());
       const connIDs = [1, 2, 3];
 
-      connIDs.forEach(manager.startExchange);
-
-      final futures = connIDs.map((connID) async {
+      final futures = connIDs.map((_) async {
         final crypto = RelayCryptoService();
         final phoneKp = await crypto.generateKeyPair();
         final phonePub = await phoneKp.extractPublicKey();
@@ -98,7 +90,7 @@ void main() {
                 )
                 as RelayKeyExchange;
 
-        final result = await manager.handleKeyExchange(connID, kxMsg);
+        final result = await manager.handleKeyExchange(message: kxMsg);
         return result;
       });
 
@@ -108,15 +100,10 @@ void main() {
       }
     });
 
-    test(
-      "startExchange twice for same connID replaces stale pending exchange",
-      () async {
-        final manager = KeyExchangeManager(makeRoomKey());
-        const connID = 42;
+    test("supports repeated exchanges", () async {
+      final manager = KeyExchangeManager(makeRoomKey());
 
-        manager.startExchange(connID);
-        manager.startExchange(connID);
-
+      Future<List<int>> exchange() async {
         final crypto = RelayCryptoService();
         final phoneKp = await crypto.generateKeyPair();
         final phonePub = await phoneKp.extractPublicKey();
@@ -125,32 +112,11 @@ void main() {
                   publicKey: base64Url.encode(phonePub.bytes).replaceAll("=", ""),
                 )
                 as RelayKeyExchange;
+        return manager.handleKeyExchange(message: kxMsg);
+      }
 
-        final result = await manager.handleKeyExchange(connID, kxMsg);
-        expect(result, isNotEmpty);
-      },
-    );
-
-    test("removeExchange clears pending exchange", () async {
-      final manager = KeyExchangeManager(makeRoomKey());
-      const connID = 10;
-
-      manager.startExchange(connID);
-      manager.removeExchange(connID);
-
-      final crypto = RelayCryptoService();
-      final phoneKp = await crypto.generateKeyPair();
-      final phonePub = await phoneKp.extractPublicKey();
-      final kxMsg =
-          RelayMessage.keyExchange(
-                publicKey: base64Url.encode(phonePub.bytes).replaceAll("=", ""),
-              )
-              as RelayKeyExchange;
-
-      expect(
-        () => manager.handleKeyExchange(connID, kxMsg),
-        throwsA(isA<StateError>()),
-      );
+      expect(await exchange(), isNotEmpty);
+      expect(await exchange(), isNotEmpty);
     });
   });
 }

--- a/client/app/test/capabilities/relay/relay_client_test.dart
+++ b/client/app/test/capabilities/relay/relay_client_test.dart
@@ -56,6 +56,7 @@ void main() {
         relayHost: "relay.example.com",
         cryptoService: RelayCryptoService(),
         roomKeyStorage: MockRoomKeyStorage(),
+        authToken: null,
       );
 
       expect(client.connectionState, equals(RelayClientConnectionState.disconnected));
@@ -66,6 +67,7 @@ void main() {
         relayHost: "relay.example.com",
         cryptoService: RelayCryptoService(),
         roomKeyStorage: MockRoomKeyStorage(),
+        authToken: null,
       );
 
       expect(client.isConnected, isFalse);
@@ -76,6 +78,7 @@ void main() {
         relayHost: "relay.example.com",
         cryptoService: RelayCryptoService(),
         roomKeyStorage: MockRoomKeyStorage(),
+        authToken: null,
       );
 
       expect(client.lastCloseCode, isNull);

--- a/client/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/client/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -3,6 +3,7 @@ import "dart:convert";
 import "dart:typed_data";
 
 import "package:cryptography/cryptography.dart";
+import "package:meta/meta.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:web_socket_channel/web_socket_channel.dart";
 
@@ -23,6 +24,7 @@ class RelayClient {
 
   final RelayCryptoService _cryptoService;
   final RoomKeyStorage _roomKeyStorage;
+  final WebSocketChannel Function(Uri uri) _channelConnector;
 
   WebSocketChannel? _channel;
   StreamSubscription<void>? _channelSubscription;
@@ -31,6 +33,8 @@ class RelayClient {
   final Map<String, Completer<RelayResponse>> _pendingRequests = {};
   StreamController<RelaySseEvent>? _sseController;
   Completer<Uint8List>? _firstBinaryMessage;
+  List<int>? _pendingHandshakeFrame;
+  BridgeStatus? _lastBridgeStatus;
 
   final StreamController<BridgeStatus> _bridgeStatusController = StreamController<BridgeStatus>.broadcast();
   final StreamController<void> _socketClosedController = StreamController<void>.broadcast();
@@ -47,12 +51,42 @@ class RelayClient {
   int? get lastCloseCode => _lastCloseCode;
 
   RelayClient({
+    required String relayHost,
+    required RelayCryptoService cryptoService,
+    required RoomKeyStorage roomKeyStorage,
+    required String? authToken,
+  }) : this._(
+         relayHost: relayHost,
+         cryptoService: cryptoService,
+         roomKeyStorage: roomKeyStorage,
+         authToken: authToken,
+         channelConnector: WebSocketChannel.connect,
+       );
+
+  @visibleForTesting
+  RelayClient.withChannelConnector({
+    required String relayHost,
+    required RelayCryptoService cryptoService,
+    required RoomKeyStorage roomKeyStorage,
+    required String? authToken,
+    required WebSocketChannel Function(Uri uri) channelConnector,
+  }) : this._(
+         relayHost: relayHost,
+         cryptoService: cryptoService,
+         roomKeyStorage: roomKeyStorage,
+         authToken: authToken,
+         channelConnector: channelConnector,
+       );
+
+  RelayClient._({
     required this.relayHost,
     required RelayCryptoService cryptoService,
     required RoomKeyStorage roomKeyStorage,
-    this.authToken,
+    required this.authToken,
+    required WebSocketChannel Function(Uri uri) channelConnector,
   }) : _cryptoService = cryptoService,
-       _roomKeyStorage = roomKeyStorage;
+       _roomKeyStorage = roomKeyStorage,
+       _channelConnector = channelConnector;
 
   RelayClientConnectionState get connectionState => _connectionState;
 
@@ -60,8 +94,7 @@ class RelayClient {
   /// While the socket is held open with no bridge present (the bridge-absent
   /// park), there is no session encryptor, so this stays false and callers
   /// (e.g. RelayHttpApiClient) must not route requests through it.
-  bool get isConnected =>
-      _connectionState == RelayClientConnectionState.connected && _sessionEncryptor != null;
+  bool get isConnected => _connectionState == RelayClientConnectionState.connected && _sessionEncryptor != null;
   bool get didResume => _didResume;
 
   /// Stream of bridge online/offline events sent as text control frames by the relay.
@@ -93,10 +126,12 @@ class RelayClient {
     _connectionState = RelayClientConnectionState.connecting;
     _didResume = false;
     _lastCloseCode = null;
+    _pendingHandshakeFrame = null;
+    _lastBridgeStatus = null;
     final uri = Uri.parse("wss://$relayHost/ws");
 
     try {
-      _channel = WebSocketChannel.connect(uri);
+      _channel = _channelConnector(uri);
       final channel = _channel;
       if (channel == null) {
         throw StateError("Failed to create relay WebSocket channel");
@@ -113,6 +148,7 @@ class RelayClient {
             (data) {},
             onError: (Object error, StackTrace stackTrace) {
               loge("Relay socket stream error", error, stackTrace);
+              _pendingHandshakeFrame = null;
               final firstBinaryMessage = _firstBinaryMessage;
               if (firstBinaryMessage != null && !firstBinaryMessage.isCompleted) {
                 firstBinaryMessage.completeError(error, stackTrace);
@@ -186,6 +222,7 @@ class RelayClient {
       // armed would let a later bridge_disconnected or socket-close complete an
       // unobserved future, surfacing as an uncaught async error.
       _firstBinaryMessage = null;
+      _pendingHandshakeFrame = null;
       logd("Relay connected but bridge is offline — holding socket open");
       return;
     } catch (error, stackTrace) {
@@ -254,6 +291,7 @@ class RelayClient {
       // and let connect() resolve into the bridge-absent outcome.
       rethrow;
     } catch (error, stackTrace) {
+      _pendingHandshakeFrame = null;
       loge("Resume failed, clearing room key and falling back to DH key exchange", error, stackTrace);
       await _roomKeyStorage.clearRoomKey();
       return false;
@@ -278,7 +316,9 @@ class RelayClient {
     // Key exchange is sent as a binary frame (UTF-8 JSON bytes).
     // Text frames from phones are silently dropped by the relay phone handler.
     final keyExchange = RelayMessage.keyExchange(publicKey: encodedPublicKey);
-    channel.sink.add(utf8.encode(jsonEncode(keyExchange.toJson())));
+    final keyExchangeFrame = utf8.encode(jsonEncode(keyExchange.toJson()));
+    _pendingHandshakeFrame = keyExchangeFrame;
+    channel.sink.add(keyExchangeFrame);
 
     final firstEncryptedMessage = await completer.future.timeout(
       const Duration(seconds: 15),
@@ -432,6 +472,7 @@ class RelayClient {
     final encryptor = _sessionEncryptor;
     if (encryptor == null) {
       if (_firstBinaryMessage case final completer? when !completer.isCompleted) {
+        _pendingHandshakeFrame = null;
         completer.complete(bytes);
       } else {
         logw("Received extra binary frame before relay key exchange completion");
@@ -477,6 +518,7 @@ class RelayClient {
 
     final firstBinaryMessage = _firstBinaryMessage;
     if (firstBinaryMessage != null && !firstBinaryMessage.isCompleted) {
+      _pendingHandshakeFrame = null;
       firstBinaryMessage.completeError(
         StateError("Relay socket closed before key exchange (code=$closeCode)"),
       );
@@ -510,6 +552,18 @@ class RelayClient {
     channel.sink.add(payload);
   }
 
+  void _replayPendingHandshakeFrame() {
+    final channel = _channel;
+    final frame = _pendingHandshakeFrame;
+    final response = _firstBinaryMessage;
+    if (_disposed || channel == null || frame == null || response == null || response.isCompleted) {
+      return;
+    }
+
+    channel.sink.add(frame);
+    logd("Relay bridge changed during handshake; resent pending handshake frame");
+  }
+
   /// Sends an encrypted message using the provided [encryptor] instead of
   /// [_sessionEncryptor]. Used during handshake before the session is established.
   // ignore: no_slop_linter/prefer_required_named_parameters, private handshake helper mirrors call sites
@@ -525,6 +579,7 @@ class RelayClient {
     final jsonBytes = utf8.encode(jsonEncode(message.toJson()));
     final encryptedBytes = await encryptor.encrypt(jsonBytes);
     final payload = Uint8List.fromList([_messageVersion, ...encryptedBytes]);
+    _pendingHandshakeFrame = payload;
     channel.sink.add(payload);
   }
 
@@ -582,6 +637,8 @@ class RelayClient {
       loge("Failed to close relay socket channel", error, stackTrace);
     }
     _firstBinaryMessage = null;
+    _pendingHandshakeFrame = null;
+    _lastBridgeStatus = null;
   }
 
   Future<void> _closeSseController() async {
@@ -635,14 +692,24 @@ class RelayClient {
       switch (type) {
         case RelayProtocol.typeBridgeConnected:
           logd("Relay: bridge came online");
+          // The first status describes the bridge present when this phone
+          // joined. A later online status is a new bridge relay connection, so
+          // replay any handshake frame that the prior connection may have lost.
+          final hadKnownBridgeStatus = _lastBridgeStatus != null;
+          _lastBridgeStatus = BridgeStatus.online;
+          if (hadKnownBridgeStatus) {
+            _replayPendingHandshakeFrame();
+          }
           _bridgeStatusController.add(BridgeStatus.online);
         case RelayProtocol.typeBridgeDisconnected:
           logd("Relay: bridge went offline");
+          _lastBridgeStatus = BridgeStatus.offline;
           final firstBinaryMessage = _firstBinaryMessage;
           if (firstBinaryMessage != null && !firstBinaryMessage.isCompleted) {
             // Bridge absent during the handshake. Signal a distinct, non-fatal
             // outcome so connect() keeps the socket open and waits for a later
             // bridge_connected instead of tearing the socket down.
+            _pendingHandshakeFrame = null;
             firstBinaryMessage.completeError(const _BridgeOfflineDuringHandshake());
           }
           _bridgeStatusController.add(BridgeStatus.offline);

--- a/client/module_core/test/capabilities/relay/relay_client_handshake_replay_test.dart
+++ b/client/module_core/test/capabilities/relay/relay_client_handshake_replay_test.dart
@@ -1,0 +1,131 @@
+import "dart:async";
+import "dart:convert";
+import "dart:typed_data";
+
+import "package:cryptography/cryptography.dart";
+import "package:mocktail/mocktail.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+import "package:web_socket_channel/web_socket_channel.dart";
+
+class _MockRoomKeyStorage extends Mock implements RoomKeyStorage {}
+
+void main() {
+  test("replays resume when the bridge reconnects during handshake", () async {
+    final roomKey = Uint8List.fromList(List<int>.generate(32, (index) => index));
+    final roomKeyStorage = _MockRoomKeyStorage();
+    when(roomKeyStorage.getRoomKey).thenAnswer((_) async => roomKey);
+    final socket = _FakeWebSocket();
+    final client = RelayClient.withChannelConnector(
+      relayHost: "relay.example.com",
+      cryptoService: RelayCryptoService(),
+      roomKeyStorage: roomKeyStorage,
+      authToken: null,
+      channelConnector: (_) => socket.channel,
+    );
+    final outgoing = StreamIterator<Object?>(socket.outgoing);
+    addTearDown(() async {
+      await outgoing.cancel();
+      await client.disconnect();
+      await socket.close();
+    });
+
+    final firstFrameReady = outgoing.moveNext();
+    final connectFuture = client.connect();
+    expect(await firstFrameReady.timeout(const Duration(seconds: 1)), isTrue);
+    final firstFrame = Uint8List.fromList(outgoing.current! as List<int>);
+
+    socket.serverSink.add('{"type":"${RelayProtocol.typeBridgeConnected}"}');
+    await Future<void>.delayed(Duration.zero);
+
+    final replayReady = outgoing.moveNext();
+    socket.serverSink.add('{"type":"${RelayProtocol.typeBridgeConnected}"}');
+    expect(await replayReady.timeout(const Duration(seconds: 1)), isTrue);
+    final replayedFrame = Uint8List.fromList(outgoing.current! as List<int>);
+    expect(replayedFrame, firstFrame);
+
+    final encryptor = RelayCryptoService().createSessionEncryptor(SecretKey(roomKey));
+    final resumeAck = await frame(
+      utf8.encode(jsonEncode(const RelayMessage.resumeAck().toJson())),
+      encryptor: encryptor,
+    );
+    socket.serverSink.add(resumeAck);
+
+    await connectFuture.timeout(const Duration(seconds: 1));
+    expect(client.isConnected, isTrue);
+    expect(client.didResume, isTrue);
+    verifyNever(roomKeyStorage.clearRoomKey);
+  });
+}
+
+class _FakeWebSocket {
+  _FakeWebSocket()
+    : _clientToServer = StreamController<Object?>.broadcast(),
+      _serverToClient = StreamController<Object?>.broadcast() {
+    channel = _StubChannel(
+      stream: _serverToClient.stream,
+      sink: _SinkAdapter(_clientToServer),
+    );
+  }
+
+  final StreamController<Object?> _clientToServer;
+  final StreamController<Object?> _serverToClient;
+  late final WebSocketChannel channel;
+
+  Stream<Object?> get outgoing => _clientToServer.stream;
+  Sink<Object?> get serverSink => _serverToClient.sink;
+
+  Future<void> close() async {
+    if (!_serverToClient.isClosed) await _serverToClient.close();
+    if (!_clientToServer.isClosed) await _clientToServer.close();
+  }
+}
+
+class _StubChannel implements WebSocketChannel {
+  _StubChannel({required this.stream, required this.sink});
+
+  @override
+  final Stream<dynamic> stream;
+
+  @override
+  final WebSocketSink sink;
+
+  @override
+  int? get closeCode => null;
+
+  @override
+  String? get closeReason => null;
+
+  @override
+  String? get protocol => null;
+
+  @override
+  Future<void> get ready => Future<void>.value();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _SinkAdapter implements WebSocketSink {
+  _SinkAdapter(this._controller);
+
+  final StreamController<Object?> _controller;
+
+  @override
+  void add(Object? data) => _controller.add(data);
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) => _controller.addError(error, stackTrace);
+
+  @override
+  Future<void> addStream(Stream<Object?> stream) => _controller.addStream(stream);
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) async {
+    if (!_controller.isClosed) await _controller.close();
+  }
+
+  @override
+  Future<void> get done => _controller.done;
+}


### PR DESCRIPTION
## Summary

- replay the client's in-flight resume or DH frame when the relay announces a new bridge connection during the handshake
- let the authenticated `key_exchange` frame initiate DH without requiring a preceding `phone_connected` control frame
- add regression coverage for the observed double-`bridge_connected` sequence and for bridge reconnects with pre-existing phone sockets

## Root Cause

During a VPN or network transition, the phone could join while the relay still held the bridge's old socket. Its resume frame was routed to that dead connection. When the bridge reconnected, the relay sent another `bridge_connected` event to the phone but did not replay `phone_connected` to the bridge for the existing phone socket.

The client therefore waited the full 15-second resume timeout before falling back to DH. The bridge then rejected that DH frame because its pending-exchange state had never been armed, causing another 15-second timeout and a second client reconnect.

The client now replays the pending handshake frame on the later bridge connection epoch, allowing same-room-key resume to complete immediately. If rekeying is necessary, the bridge treats the DH frame itself as the initiation signal, which matches the relay's routing contract.

## Verification

- `dart test` in `client/module_core` (621 tests)
- `dart test` in `bridge/app` (2146 tests)
- `dart analyze` in `client/module_core`, `client/app`, and `client/desktop`
- `dart analyze --fatal-infos` in `bridge/app`
- focused Flutter relay tests in `client/app`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes relay handshake recovery during VPN/network changes by replaying in-flight resume/DH frames and allowing DH to start from the `key_exchange` frame. This removes 15s timeouts and double reconnects.

- **Bug Fixes**
  - Client stores and resends the pending handshake frame when a new `bridge_connected` arrives during handshake.
  - Bridge treats `key_exchange` as the initiation signal and drops the pending-exchange state; no prior `phone_connected` required.
  - Added regression tests for double `bridge_connected`, bridge reconnects with existing phone sockets, and handshake replay.

- **Migration**
  - `RelayClient` now requires `authToken` (nullable). Pass `authToken: null` where unauthenticated.

<sup>Written for commit 3f26be345971c3154ff3d382d9777640cb8d546c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

