### PR TITLE
[setup-aware-harness-settings] feat(client): carry bridge identity in management transport [step 2/7]

### DIFF
--- a/.plan/active/setup-aware-harness-settings/PLAN.md
+++ b/.plan/active/setup-aware-harness-settings/PLAN.md
@@ -226,12 +226,13 @@ Production files:
 ### Scope
 
 Add nullable `bridgeId` to shared `PluginManagementResponse` and regenerate its
-companions. `GetPluginManagementHandler` emits the existing
-`BridgeIdProvider.currentBridgeId` alongside the Stage 12 snapshot. The field
-is additive, decodes from older Stage 12 bridges as null, is omitted when
-null, and receives a dated compatibility comment. Mutations return the same
-identity-bearing response shape, so GET and mutation completions carry the same
-authoritative bridge identity.
+companions. Compose the existing `BridgeRegistrationService` before
+`PluginLifecycleService`, inject it through `BridgeIdProvider`, and have the
+lifecycle service attach the provider's current bridge ID whenever it returns a
+Stage 12 snapshot. The field is additive, decodes from older Stage 12 bridges
+as null, is omitted when null, and receives a dated compatibility comment. GET
+and mutation handlers remain pass-through consumers of the same authoritative,
+identity-bearing service response shape.
 
 Extend `PluginApi` using the current Stage 12 routes:
 
@@ -318,7 +319,8 @@ Production files:
 
 - `shared/sesori_shared/lib/src/models/sesori/plugin_management.dart` and
   regenerated companions
-- `bridge/app/lib/src/routing/get_plugin_management_handler.dart`
+- `bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart`
+- `bridge/app/lib/src/services/plugin_lifecycle_service.dart`
 - `client/module_core/lib/src/api/plugin_api.dart`
 - `client/module_core/lib/src/repositories/models/plugin_management_result.dart`
 - `client/module_core/lib/src/repositories/plugin_repository.dart`

--- a/.plan/active/setup-aware-harness-settings/PLAN.md
+++ b/.plan/active/setup-aware-harness-settings/PLAN.md
@@ -231,7 +231,8 @@ companions. Compose the existing `BridgeRegistrationService` before
 lifecycle service cache only private identity-free management state. It builds
 the transport response when returning, requires the provider's current bridge
 ID to be non-null, and fails closed before registration rather than publishing
-an ambiguous modern snapshot. The wire field remains nullable only so newer
+an ambiguous modern snapshot or dispatching/persisting a mutation. The wire
+field remains nullable only so newer
 clients decode older Stage 12 bridges that omit it; null is omitted and receives
 a dated compatibility comment. GET and mutation handlers remain pass-through
 consumers of the same authoritative, identity-bearing service response shape.

--- a/.plan/active/setup-aware-harness-settings/PLAN.md
+++ b/.plan/active/setup-aware-harness-settings/PLAN.md
@@ -308,6 +308,8 @@ Extend `PluginRepository`:
   not ordinary failure: the bridge may have committed the mutation, and a
   retryable-looking failure could execute it twice. The service schedules the
   authoritative GET required to learn the outcome.
+- A bridge mutation that commits before its identity fence moves returns 503;
+  the repository also maps that explicit post-commit response to `uncertain`.
 - `uncertain` represents a mutation whose request was sent but whose outcome
   cannot be truthfully published because the response cannot prove it or the
   connection/service fence moved. Consumers render it as an uncertain state

--- a/.plan/active/setup-aware-harness-settings/PLAN.md
+++ b/.plan/active/setup-aware-harness-settings/PLAN.md
@@ -228,11 +228,13 @@ Production files:
 Add nullable `bridgeId` to shared `PluginManagementResponse` and regenerate its
 companions. Compose the existing `BridgeRegistrationService` before
 `PluginLifecycleService`, inject it through `BridgeIdProvider`, and have the
-lifecycle service attach the provider's current bridge ID whenever it returns a
-Stage 12 snapshot. The field is additive, decodes from older Stage 12 bridges
-as null, is omitted when null, and receives a dated compatibility comment. GET
-and mutation handlers remain pass-through consumers of the same authoritative,
-identity-bearing service response shape.
+lifecycle service cache only private identity-free management state. It builds
+the transport response when returning, requires the provider's current bridge
+ID to be non-null, and fails closed before registration rather than publishing
+an ambiguous modern snapshot. The wire field remains nullable only so newer
+clients decode older Stage 12 bridges that omit it; null is omitted and receives
+a dated compatibility comment. GET and mutation handlers remain pass-through
+consumers of the same authoritative, identity-bearing service response shape.
 
 Extend `PluginApi` using the current Stage 12 routes:
 

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -54,12 +54,13 @@
   persistence across reopen, and disable fallback with full cleanup; A-to-B
   bridge switch stays unit-tested only (single-bridge dev account).
 - Step 2/7 (2026-07-27): shared contract tests for known/null/omitted
-  `bridgeId`; full bridge suite (2148); module_core full suite (656) with new
+  `bridgeId`; full bridge suite (2148); module_core full suite (657) with new
   API route and repository mapping
   tests; mobile/desktop fatal analysis; Aristotle implementation review
   approved. Review fixes: lifecycle service caches identity-free state and
   requires the provider's current ID before reads or mutation side effects,
   including when a timeout write begins after waiting in the settings queue;
+  post-commit identity loss maps through HTTP 503 to typed `uncertain`;
   single-report malformed conflicts, named parameters, encoded command path,
   post-dispatch response loss mapped to `uncertain`.
   Confirming E2E on `cbd10948`: all three management routes carried the dev

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -54,12 +54,15 @@
   persistence across reopen, and disable fallback with full cleanup; A-to-B
   bridge switch stays unit-tested only (single-bridge dev account).
 - Step 2/7 (2026-07-27): shared contract tests for known/null/omitted
-  `bridgeId`; bridge routing suites (388) and full bridge directory (1140);
-  module_core full suite (654) with new API route and repository mapping
+  `bridgeId`; full bridge suite (2146); module_core full suite (656) with new
+  API route and repository mapping
   tests; mobile/desktop fatal analysis; Aristotle implementation review
   approved. Review fixes: lifecycle service owns bridge identity injection,
   single-report malformed conflicts, named parameters, encoded command path,
   post-dispatch response loss mapped to `uncertain`.
   Confirming E2E on `cbd10948`: all three management routes carried the dev
   bridge identity on GET and both mutation shapes; Step 1 gate rerun passed;
-  full cleanup with the E2E bridge stopped.
+  full cleanup with the E2E bridge stopped. Final service-owned identity rerun
+  on `f0c4932d` again verified the same ID on GET, command, and idle-timeout
+  responses after late registration; override cleared, Codex re-enabled, and
+  bridge stopped (one external relay 429 was retried successfully).

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -54,11 +54,12 @@
   persistence across reopen, and disable fallback with full cleanup; A-to-B
   bridge switch stays unit-tested only (single-bridge dev account).
 - Step 2/7 (2026-07-27): shared contract tests for known/null/omitted
-  `bridgeId`; full bridge suite (2147); module_core full suite (656) with new
+  `bridgeId`; full bridge suite (2148); module_core full suite (656) with new
   API route and repository mapping
   tests; mobile/desktop fatal analysis; Aristotle implementation review
   approved. Review fixes: lifecycle service caches identity-free state and
   requires the provider's current ID before reads or mutation side effects,
+  including when a timeout write begins after waiting in the settings queue;
   single-report malformed conflicts, named parameters, encoded command path,
   post-dispatch response loss mapped to `uncertain`.
   Confirming E2E on `cbd10948`: all three management routes carried the dev

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -57,4 +57,8 @@
   `bridgeId`; bridge routing suites (388) and full bridge directory (1140);
   module_core full suite (654) with new API route and repository mapping
   tests; mobile/desktop fatal analysis; Aristotle implementation review
-  approved. Confirming E2E checks follow after review settles.
+  approved. Review fixes: single-report malformed conflicts, named parameters,
+  encoded command path, post-dispatch response loss mapped to `uncertain`.
+  Confirming E2E on `cbd10948`: all three management routes carried the dev
+  bridge identity on GET and both mutation shapes; Step 1 gate rerun passed;
+  full cleanup with the E2E bridge stopped.

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -3,16 +3,16 @@
 ## Current State
 
 - **Implementation base:** current `origin/main` after Stage 12 merge `6cedf5bd`
-- **Series state:** Step 1/7 in review
-- **Next action:** wait for PR #579 review to settle, then run the confirming
-  simulator E2E pass before merge
+- **Series state:** Step 2/7 in review
+- **Next action:** wait for PR #583 review to settle, then run the confirming
+  E2E checks before merge
 
 ## Delivery
 
 | Done | Slice | Branch | PR state |
 |---|---|---|---|
-| [ ] | Step 1/7 — per-bridge harness preference | `setup-aware-harness-settings-preferences` | PR #579 in review; 729 changed lines (estimate 650-750) |
-| [ ] | Step 2/7 — management transport | `setup-aware-harness-settings-transport` | planned; estimate 300-400 changed lines |
+| [x] | Step 1/7 — per-bridge harness preference | `setup-aware-harness-settings-preferences` | PR #579 merged; 729 changed lines (estimate 650-750) |
+| [ ] | Step 2/7 — management transport | `setup-aware-harness-settings-transport` | PR #583 in review; ~590 changed lines (estimate 300-400, test-driven overage) |
 | [ ] | Step 3/7 — synchronization service | `setup-aware-harness-settings-service` | planned; estimate 550-700 changed lines |
 | [ ] | Step 4/7 — harness logos | `setup-aware-harness-settings-branding` | planned; estimate 750-900 changed lines |
 | [ ] | Step 5/7 — Harnesses overview and state contract | `setup-aware-harness-settings-overview` | planned; estimate 1,100-1,300 changed lines |
@@ -53,3 +53,8 @@
   final head `b529a8a8` re-verified restored-preference selection, Codex
   persistence across reopen, and disable fallback with full cleanup; A-to-B
   bridge switch stays unit-tested only (single-bridge dev account).
+- Step 2/7 (2026-07-27): shared contract tests for known/null/omitted
+  `bridgeId`; bridge routing suites (388) and full bridge directory (1140);
+  module_core full suite (654) with new API route and repository mapping
+  tests; mobile/desktop fatal analysis; Aristotle implementation review
+  approved. Confirming E2E checks follow after review settles.

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -58,7 +58,7 @@
   API route and repository mapping
   tests; mobile/desktop fatal analysis; Aristotle implementation review
   approved. Review fixes: lifecycle service caches identity-free state and
-  requires the provider's current ID when building responses,
+  requires the provider's current ID before reads or mutation side effects,
   single-report malformed conflicts, named parameters, encoded command path,
   post-dispatch response loss mapped to `uncertain`.
   Confirming E2E on `cbd10948`: all three management routes carried the dev

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -54,7 +54,7 @@
   persistence across reopen, and disable fallback with full cleanup; A-to-B
   bridge switch stays unit-tested only (single-bridge dev account).
 - Step 2/7 (2026-07-27): shared contract tests for known/null/omitted
-  `bridgeId`; full bridge suite (2146); module_core full suite (656) with new
+  `bridgeId`; full bridge suite (2147); module_core full suite (656) with new
   API route and repository mapping
   tests; mobile/desktop fatal analysis; Aristotle implementation review
   approved. Review fixes: lifecycle service caches identity-free state and
@@ -66,4 +66,9 @@
   full cleanup with the E2E bridge stopped. Final service-owned identity rerun
   on `f0c4932d` again verified the same ID on GET, command, and idle-timeout
   responses after late registration; override cleared, Codex re-enabled, and
-  bridge stopped (one external relay 429 was retried successfully).
+  bridge stopped (one external relay 429 was retried successfully). Final
+  mutation-guard rerun on `b0067458` verified registered GET, safe disable,
+  enable, timeout override, and timeout clear responses all carried
+  `br_qdF5_X5_LUM6zi7D`; the override was cleared, Codex re-enabled, the
+  temporary bridge stopped, and the unrelated bridge on port 7829 remained
+  untouched.

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -57,8 +57,9 @@
   `bridgeId`; bridge routing suites (388) and full bridge directory (1140);
   module_core full suite (654) with new API route and repository mapping
   tests; mobile/desktop fatal analysis; Aristotle implementation review
-  approved. Review fixes: single-report malformed conflicts, named parameters,
-  encoded command path, post-dispatch response loss mapped to `uncertain`.
+  approved. Review fixes: lifecycle service owns bridge identity injection,
+  single-report malformed conflicts, named parameters, encoded command path,
+  post-dispatch response loss mapped to `uncertain`.
   Confirming E2E on `cbd10948`: all three management routes carried the dev
   bridge identity on GET and both mutation shapes; Step 1 gate rerun passed;
   full cleanup with the E2E bridge stopped.

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -57,7 +57,8 @@
   `bridgeId`; full bridge suite (2146); module_core full suite (656) with new
   API route and repository mapping
   tests; mobile/desktop fatal analysis; Aristotle implementation review
-  approved. Review fixes: lifecycle service owns bridge identity injection,
+  approved. Review fixes: lifecycle service caches identity-free state and
+  requires the provider's current ID when building responses,
   single-report malformed conflicts, named parameters, encoded command path,
   post-dispatch response loss mapped to `uncertain`.
   Confirming E2E on `cbd10948`: all three management routes carried the dev

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -421,18 +421,9 @@ class Orchestrator {
     final router = RequestRouter(
       handlers: [
         HealthCheckHandler(healthRepository: healthRepository),
-        GetPluginManagementHandler(
-          lifecycleService: _pluginLifecycleService,
-          bridgeIdProvider: _bridgeRegistrationService,
-        ),
-        PatchPluginIdleTimeoutHandler(
-          lifecycleService: _pluginLifecycleService,
-          bridgeIdProvider: _bridgeRegistrationService,
-        ),
-        PostPluginLifecycleCommandHandler(
-          lifecycleService: _pluginLifecycleService,
-          bridgeIdProvider: _bridgeRegistrationService,
-        ),
+        GetPluginManagementHandler(lifecycleService: _pluginLifecycleService),
+        PatchPluginIdleTimeoutHandler(lifecycleService: _pluginLifecycleService),
+        PostPluginLifecycleCommandHandler(lifecycleService: _pluginLifecycleService),
         GetPluginSetupHandler(lifecycleService: _pluginLifecycleService),
         GetPluginsHandler(lifecycleService: _pluginLifecycleService, bridgeIdProvider: _bridgeRegistrationService),
         RestartBridgeHandler(restartService: _restartService),

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -421,9 +421,18 @@ class Orchestrator {
     final router = RequestRouter(
       handlers: [
         HealthCheckHandler(healthRepository: healthRepository),
-        GetPluginManagementHandler(lifecycleService: _pluginLifecycleService),
-        PatchPluginIdleTimeoutHandler(lifecycleService: _pluginLifecycleService),
-        PostPluginLifecycleCommandHandler(lifecycleService: _pluginLifecycleService),
+        GetPluginManagementHandler(
+          lifecycleService: _pluginLifecycleService,
+          bridgeIdProvider: _bridgeRegistrationService,
+        ),
+        PatchPluginIdleTimeoutHandler(
+          lifecycleService: _pluginLifecycleService,
+          bridgeIdProvider: _bridgeRegistrationService,
+        ),
+        PostPluginLifecycleCommandHandler(
+          lifecycleService: _pluginLifecycleService,
+          bridgeIdProvider: _bridgeRegistrationService,
+        ),
         GetPluginSetupHandler(lifecycleService: _pluginLifecycleService),
         GetPluginsHandler(lifecycleService: _pluginLifecycleService, bridgeIdProvider: _bridgeRegistrationService),
         RestartBridgeHandler(restartService: _restartService),

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -562,6 +562,24 @@ class BridgeRuntimeRunner {
         accessToken: authAccessToken,
       );
 
+      // Supervised mode built this early so the control dispatcher could route
+      // logout. Standalone can build it now that interactive authentication has
+      // produced its token refresher. Construct it before the lifecycle service
+      // so every management snapshot receives its authoritative bridge identity
+      // at the owning service boundary rather than at individual handlers.
+      final BridgeRegistrationService bridgeRegistrationService;
+      if (supervisedRegistrationService != null) {
+        bridgeRegistrationService = supervisedRegistrationService;
+      } else {
+        bridgeRegistrationService = _buildRegistrationService(
+          httpClient: httpClient,
+          authBackendUrl: options.authBackendUrl,
+          tokenRefresher: tokenRefresher,
+          bridgeIdStorage: bridgeIdStorage,
+        );
+        shutdownCoordinator.add(disposable: bridgeRegistrationService.dispose);
+      }
+
       final currentBridgeIdentity = await _resolveCurrentBridgeIdentity(
         processRepository: processRepository,
         currentUser: currentUser,
@@ -618,6 +636,7 @@ class BridgeRuntimeRunner {
             preferredDefaultPluginId: preferredDefaultPluginId,
             bridgeSettingsRepository: bridgeSettingsRepository,
             idleTimerScheduler: const PluginIdleTimerScheduler(),
+            bridgeIdProvider: bridgeRegistrationService,
           )..registerPlugins(
             plugins: [
               for (final descriptor in knownPlugins)
@@ -766,22 +785,6 @@ class BridgeRuntimeRunner {
       for (final pluginId in startupPolicy.eligiblePluginIds) {
         final diagnostics = activePluginRuntime.describe(pluginId: pluginId);
         if (diagnostics != null) Console.message("Target [$pluginId]: ${diagnostics.endpoint ?? pluginId}");
-      }
-
-      // Supervised mode already built this early (so the dispatcher could route
-      // the logout command); reuse that instance. Standalone builds it here, now
-      // that the interactive auth flow has produced its token refresher.
-      final BridgeRegistrationService bridgeRegistrationService;
-      if (supervisedRegistrationService != null) {
-        bridgeRegistrationService = supervisedRegistrationService;
-      } else {
-        bridgeRegistrationService = _buildRegistrationService(
-          httpClient: httpClient,
-          authBackendUrl: options.authBackendUrl,
-          tokenRefresher: tokenRefresher,
-          bridgeIdStorage: bridgeIdStorage,
-        );
-        shutdownCoordinator.add(disposable: bridgeRegistrationService.dispose);
       }
 
       // Constructed here (not inside BridgeRuntime.create) so supervised mode

--- a/bridge/app/lib/src/routing/get_plugin_management_handler.dart
+++ b/bridge/app/lib/src/routing/get_plugin_management_handler.dart
@@ -1,17 +1,14 @@
 import "package:sesori_shared/sesori_shared.dart";
 
-import "../auth/bridge_id_provider.dart";
 import "../bridge/routing/request_handler.dart";
 import "../services/plugin_lifecycle_service.dart";
 
 class GetPluginManagementHandler extends GetRequestHandler<PluginManagementResponse> {
-  GetPluginManagementHandler({required PluginLifecycleService lifecycleService, required BridgeIdProvider bridgeIdProvider})
+  GetPluginManagementHandler({required PluginLifecycleService lifecycleService})
     : _lifecycleService = lifecycleService,
-      _bridgeIdProvider = bridgeIdProvider,
       super("/plugin/management");
 
   final PluginLifecycleService _lifecycleService;
-  final BridgeIdProvider _bridgeIdProvider;
 
   @override
   Future<PluginManagementResponse> handle(
@@ -19,5 +16,5 @@ class GetPluginManagementHandler extends GetRequestHandler<PluginManagementRespo
     required Map<String, String> pathParams,
     required Map<String, String> queryParams,
     required String? fragment,
-  }) async => _lifecycleService.managementSnapshot.copyWith(bridgeId: _bridgeIdProvider.bridgeId);
+  }) async => _lifecycleService.managementSnapshot;
 }

--- a/bridge/app/lib/src/routing/get_plugin_management_handler.dart
+++ b/bridge/app/lib/src/routing/get_plugin_management_handler.dart
@@ -1,14 +1,17 @@
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../auth/bridge_id_provider.dart";
 import "../bridge/routing/request_handler.dart";
 import "../services/plugin_lifecycle_service.dart";
 
 class GetPluginManagementHandler extends GetRequestHandler<PluginManagementResponse> {
-  GetPluginManagementHandler({required PluginLifecycleService lifecycleService})
+  GetPluginManagementHandler({required PluginLifecycleService lifecycleService, required BridgeIdProvider bridgeIdProvider})
     : _lifecycleService = lifecycleService,
+      _bridgeIdProvider = bridgeIdProvider,
       super("/plugin/management");
 
   final PluginLifecycleService _lifecycleService;
+  final BridgeIdProvider _bridgeIdProvider;
 
   @override
   Future<PluginManagementResponse> handle(
@@ -16,5 +19,5 @@ class GetPluginManagementHandler extends GetRequestHandler<PluginManagementRespo
     required Map<String, String> pathParams,
     required Map<String, String> queryParams,
     required String? fragment,
-  }) async => _lifecycleService.managementSnapshot;
+  }) async => _lifecycleService.managementSnapshot.copyWith(bridgeId: _bridgeIdProvider.bridgeId);
 }

--- a/bridge/app/lib/src/routing/patch_plugin_idle_timeout_handler.dart
+++ b/bridge/app/lib/src/routing/patch_plugin_idle_timeout_handler.dart
@@ -1,16 +1,12 @@
 import "package:sesori_shared/sesori_shared.dart";
 
-import "../auth/bridge_id_provider.dart";
 import "../bridge/routing/request_handler.dart";
 import "../services/plugin_lifecycle_service.dart";
 
 class PatchPluginIdleTimeoutHandler
     extends BodyRequestHandler<PluginIdleTimeoutUpdateRequest, PluginManagementResponse> {
-  PatchPluginIdleTimeoutHandler({
-    required PluginLifecycleService lifecycleService,
-    required BridgeIdProvider bridgeIdProvider,
-  }) : _lifecycleService = lifecycleService,
-       _bridgeIdProvider = bridgeIdProvider,
+  PatchPluginIdleTimeoutHandler({required PluginLifecycleService lifecycleService})
+    : _lifecycleService = lifecycleService,
        super(
          HttpMethod.patch,
          "/plugin/idle-timeout",
@@ -18,7 +14,6 @@ class PatchPluginIdleTimeoutHandler
        );
 
   final PluginLifecycleService _lifecycleService;
-  final BridgeIdProvider _bridgeIdProvider;
 
   @override
   Future<PluginManagementResponse> handle(
@@ -29,8 +24,7 @@ class PatchPluginIdleTimeoutHandler
     required String? fragment,
   }) async {
     try {
-      final response = await _lifecycleService.updateIdleTimeout(request: body);
-      return response.copyWith(bridgeId: _bridgeIdProvider.bridgeId);
+      return await _lifecycleService.updateIdleTimeout(request: body);
     } on PluginManagementPluginNotFoundException {
       throw buildErrorResponse(request, 404, "plugin not found");
     }

--- a/bridge/app/lib/src/routing/patch_plugin_idle_timeout_handler.dart
+++ b/bridge/app/lib/src/routing/patch_plugin_idle_timeout_handler.dart
@@ -7,11 +7,11 @@ class PatchPluginIdleTimeoutHandler
     extends BodyRequestHandler<PluginIdleTimeoutUpdateRequest, PluginManagementResponse> {
   PatchPluginIdleTimeoutHandler({required PluginLifecycleService lifecycleService})
     : _lifecycleService = lifecycleService,
-       super(
-         HttpMethod.patch,
-         "/plugin/idle-timeout",
-         fromJson: PluginIdleTimeoutUpdateRequest.fromJson,
-       );
+      super(
+        HttpMethod.patch,
+        "/plugin/idle-timeout",
+        fromJson: PluginIdleTimeoutUpdateRequest.fromJson,
+      );
 
   final PluginLifecycleService _lifecycleService;
 

--- a/bridge/app/lib/src/routing/patch_plugin_idle_timeout_handler.dart
+++ b/bridge/app/lib/src/routing/patch_plugin_idle_timeout_handler.dart
@@ -1,19 +1,24 @@
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../auth/bridge_id_provider.dart";
 import "../bridge/routing/request_handler.dart";
 import "../services/plugin_lifecycle_service.dart";
 
 class PatchPluginIdleTimeoutHandler
     extends BodyRequestHandler<PluginIdleTimeoutUpdateRequest, PluginManagementResponse> {
-  PatchPluginIdleTimeoutHandler({required PluginLifecycleService lifecycleService})
-    : _lifecycleService = lifecycleService,
-      super(
-        HttpMethod.patch,
-        "/plugin/idle-timeout",
-        fromJson: PluginIdleTimeoutUpdateRequest.fromJson,
-      );
+  PatchPluginIdleTimeoutHandler({
+    required PluginLifecycleService lifecycleService,
+    required BridgeIdProvider bridgeIdProvider,
+  }) : _lifecycleService = lifecycleService,
+       _bridgeIdProvider = bridgeIdProvider,
+       super(
+         HttpMethod.patch,
+         "/plugin/idle-timeout",
+         fromJson: PluginIdleTimeoutUpdateRequest.fromJson,
+       );
 
   final PluginLifecycleService _lifecycleService;
+  final BridgeIdProvider _bridgeIdProvider;
 
   @override
   Future<PluginManagementResponse> handle(
@@ -24,7 +29,8 @@ class PatchPluginIdleTimeoutHandler
     required String? fragment,
   }) async {
     try {
-      return await _lifecycleService.updateIdleTimeout(request: body);
+      final response = await _lifecycleService.updateIdleTimeout(request: body);
+      return response.copyWith(bridgeId: _bridgeIdProvider.bridgeId);
     } on PluginManagementPluginNotFoundException {
       throw buildErrorResponse(request, 404, "plugin not found");
     }

--- a/bridge/app/lib/src/routing/patch_plugin_idle_timeout_handler.dart
+++ b/bridge/app/lib/src/routing/patch_plugin_idle_timeout_handler.dart
@@ -27,6 +27,8 @@ class PatchPluginIdleTimeoutHandler
       return await _lifecycleService.updateIdleTimeout(request: body);
     } on PluginManagementPluginNotFoundException {
       throw buildErrorResponse(request, 404, "plugin not found");
+    } on PluginManagementMutationOutcomeUncertainException {
+      throw buildErrorResponse(request, 503, "plugin mutation outcome is uncertain");
     }
   }
 }

--- a/bridge/app/lib/src/routing/post_plugin_lifecycle_command_handler.dart
+++ b/bridge/app/lib/src/routing/post_plugin_lifecycle_command_handler.dart
@@ -9,11 +9,11 @@ class PostPluginLifecycleCommandHandler
     extends BodyRequestHandler<PluginLifecycleCommandRequest, PluginManagementResponse> {
   PostPluginLifecycleCommandHandler({required PluginLifecycleService lifecycleService})
     : _lifecycleService = lifecycleService,
-       super(
-         HttpMethod.post,
-         "/plugin/:id/command",
-         fromJson: PluginLifecycleCommandRequest.fromJson,
-       );
+      super(
+        HttpMethod.post,
+        "/plugin/:id/command",
+        fromJson: PluginLifecycleCommandRequest.fromJson,
+      );
 
   final PluginLifecycleService _lifecycleService;
 

--- a/bridge/app/lib/src/routing/post_plugin_lifecycle_command_handler.dart
+++ b/bridge/app/lib/src/routing/post_plugin_lifecycle_command_handler.dart
@@ -2,17 +2,13 @@ import "dart:convert";
 
 import "package:sesori_shared/sesori_shared.dart";
 
-import "../auth/bridge_id_provider.dart";
 import "../bridge/routing/request_handler.dart";
 import "../services/plugin_lifecycle_service.dart";
 
 class PostPluginLifecycleCommandHandler
     extends BodyRequestHandler<PluginLifecycleCommandRequest, PluginManagementResponse> {
-  PostPluginLifecycleCommandHandler({
-    required PluginLifecycleService lifecycleService,
-    required BridgeIdProvider bridgeIdProvider,
-  }) : _lifecycleService = lifecycleService,
-       _bridgeIdProvider = bridgeIdProvider,
+  PostPluginLifecycleCommandHandler({required PluginLifecycleService lifecycleService})
+    : _lifecycleService = lifecycleService,
        super(
          HttpMethod.post,
          "/plugin/:id/command",
@@ -20,7 +16,6 @@ class PostPluginLifecycleCommandHandler
        );
 
   final PluginLifecycleService _lifecycleService;
-  final BridgeIdProvider _bridgeIdProvider;
 
   @override
   Future<PluginManagementResponse> handle(
@@ -33,8 +28,7 @@ class PostPluginLifecycleCommandHandler
     try {
       final pluginId = pathParams["id"];
       if (pluginId == null) throw buildErrorResponse(request, 400, "plugin id is required");
-      final response = await _lifecycleService.command(pluginId: pluginId, request: body);
-      return response.copyWith(bridgeId: _bridgeIdProvider.bridgeId);
+      return await _lifecycleService.command(pluginId: pluginId, request: body);
     } on PluginManagementPluginNotFoundException {
       throw buildErrorResponse(request, 404, "plugin not found");
     } on PluginManagementConflictException catch (error) {

--- a/bridge/app/lib/src/routing/post_plugin_lifecycle_command_handler.dart
+++ b/bridge/app/lib/src/routing/post_plugin_lifecycle_command_handler.dart
@@ -38,6 +38,8 @@ class PostPluginLifecycleCommandHandler
         headers: const {"content-type": "application/json"},
         body: jsonEncode(error.conflict.toJson()),
       );
+    } on PluginManagementMutationOutcomeUncertainException {
+      throw buildErrorResponse(request, 503, "plugin mutation outcome is uncertain");
     } on PluginManagementCommandFailedException {
       throw buildErrorResponse(request, 500, "plugin command failed");
     }

--- a/bridge/app/lib/src/routing/post_plugin_lifecycle_command_handler.dart
+++ b/bridge/app/lib/src/routing/post_plugin_lifecycle_command_handler.dart
@@ -2,20 +2,25 @@ import "dart:convert";
 
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../auth/bridge_id_provider.dart";
 import "../bridge/routing/request_handler.dart";
 import "../services/plugin_lifecycle_service.dart";
 
 class PostPluginLifecycleCommandHandler
     extends BodyRequestHandler<PluginLifecycleCommandRequest, PluginManagementResponse> {
-  PostPluginLifecycleCommandHandler({required PluginLifecycleService lifecycleService})
-    : _lifecycleService = lifecycleService,
-      super(
-        HttpMethod.post,
-        "/plugin/:id/command",
-        fromJson: PluginLifecycleCommandRequest.fromJson,
-      );
+  PostPluginLifecycleCommandHandler({
+    required PluginLifecycleService lifecycleService,
+    required BridgeIdProvider bridgeIdProvider,
+  }) : _lifecycleService = lifecycleService,
+       _bridgeIdProvider = bridgeIdProvider,
+       super(
+         HttpMethod.post,
+         "/plugin/:id/command",
+         fromJson: PluginLifecycleCommandRequest.fromJson,
+       );
 
   final PluginLifecycleService _lifecycleService;
+  final BridgeIdProvider _bridgeIdProvider;
 
   @override
   Future<PluginManagementResponse> handle(
@@ -28,7 +33,8 @@ class PostPluginLifecycleCommandHandler
     try {
       final pluginId = pathParams["id"];
       if (pluginId == null) throw buildErrorResponse(request, 400, "plugin id is required");
-      return await _lifecycleService.command(pluginId: pluginId, request: body);
+      final response = await _lifecycleService.command(pluginId: pluginId, request: body);
+      return response.copyWith(bridgeId: _bridgeIdProvider.bridgeId);
     } on PluginManagementPluginNotFoundException {
       throw buildErrorResponse(request, 404, "plugin not found");
     } on PluginManagementConflictException catch (error) {

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -191,12 +191,23 @@ class PluginLifecycleService {
   }
 
   PluginManagementResponse get managementSnapshot {
+    final snapshot = _requireManagementSnapshot();
+    return _buildManagementResponse(snapshot: snapshot, bridgeId: _requireBridgeId());
+  }
+
+  _PluginManagementSnapshot _requireManagementSnapshot() {
     if (_registeredPlugins == null || _setupById == null) {
       throw StateError("Plugin lifecycle has not been initialized.");
     }
     final snapshot = _lastPublishedManagementSnapshot;
     if (snapshot == null) throw StateError("Plugin management snapshot is not ready.");
-    final bridgeId = _requireBridgeId();
+    return snapshot;
+  }
+
+  PluginManagementResponse _buildManagementResponse({
+    required _PluginManagementSnapshot snapshot,
+    required String bridgeId,
+  }) {
     return PluginManagementResponse(
       snapshotToken: snapshot.snapshotToken,
       bridgeId: bridgeId,
@@ -204,6 +215,13 @@ class PluginLifecycleService {
       defaultIdleTimeoutMins: snapshot.defaultIdleTimeoutMins,
       plugins: snapshot.plugins,
     );
+  }
+
+  PluginManagementResponse get _managementSnapshotAfterMutation {
+    final snapshot = _requireManagementSnapshot();
+    final bridgeId = _bridgeIdProvider.bridgeId;
+    if (bridgeId == null) throw const PluginManagementMutationOutcomeUncertainException();
+    return _buildManagementResponse(snapshot: snapshot, bridgeId: bridgeId);
   }
 
   Stream<List<PluginMetadata>> get metadataSnapshots {
@@ -290,7 +308,7 @@ class PluginLifecycleService {
       await _bridgeSettingsRepository.saveSettings(settings: current.copyWith(plugins: plugins));
       _syncIdleTimers(_lifecycleRepository.snapshot);
       _publishManagementIfChanged();
-      return managementSnapshot;
+      return _managementSnapshotAfterMutation;
     });
   }
 
@@ -334,7 +352,7 @@ class PluginLifecycleService {
     _publishManagementIfChanged();
     if (failure == null) {
       try {
-        command.completer.complete(managementSnapshot);
+        command.completer.complete(_managementSnapshotAfterMutation);
       } on Object catch (error, stackTrace) {
         command.completer.completeError(error, stackTrace);
       }
@@ -990,6 +1008,10 @@ class PluginManagementCommandFailedException implements Exception {
 
   @override
   String toString() => message;
+}
+
+class PluginManagementMutationOutcomeUncertainException implements Exception {
+  const PluginManagementMutationOutcomeUncertainException();
 }
 
 class _ActivePluginCommand {

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -194,6 +194,9 @@ class PluginLifecycleService {
     }
     final snapshot = _lastPublishedManagementSnapshot;
     if (snapshot == null) throw StateError("Plugin management snapshot is not ready.");
+    // Lifecycle initialization can cache this snapshot before ensureRegistered
+    // assigns the provider's ID. Rebuild only the transport envelope here so
+    // every service response carries the provider's current identity.
     return PluginManagementResponse(
       snapshotToken: snapshot.snapshotToken,
       bridgeId: _bridgeIdProvider.bridgeId,

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -272,6 +272,7 @@ class PluginLifecycleService {
     }
     _requireBridgeId();
     return _withSettingsMutationTail(() async {
+      _requireBridgeId();
       final current = await _bridgeSettingsRepository.loadSettings();
       final plugins = switch (request) {
         PluginIdleTimeoutApplyAllRequest(:final idleTimeoutMins) => current.plugins.withDefaultIdleTimeout(
@@ -285,6 +286,7 @@ class PluginLifecycleService {
           idleTimeoutMins: null,
         ),
       };
+      _requireBridgeId();
       await _bridgeSettingsRepository.saveSettings(settings: current.copyWith(plugins: plugins));
       _syncIdleTimers(_lifecycleRepository.snapshot);
       _publishManagementIfChanged();

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -7,6 +7,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" hide PluginRuntimeState;
 import "package:sesori_shared/sesori_shared.dart" as shared show PluginRuntimeState;
 
+import "../auth/bridge_id_provider.dart";
 import "../bridge/runtime/plugin_runtime.dart";
 import "../repositories/bridge_settings.dart";
 import "../repositories/bridge_settings_repository.dart";
@@ -41,15 +42,18 @@ class PluginLifecycleService {
     required String preferredDefaultPluginId,
     required BridgeSettingsRepository bridgeSettingsRepository,
     required PluginIdleTimerScheduler idleTimerScheduler,
+    required BridgeIdProvider bridgeIdProvider,
   }) : _lifecycleRepository = lifecycleRepository,
        _preferredDefaultPluginId = preferredDefaultPluginId,
        _bridgeSettingsRepository = bridgeSettingsRepository,
-       _idleTimerScheduler = idleTimerScheduler;
+       _idleTimerScheduler = idleTimerScheduler,
+       _bridgeIdProvider = bridgeIdProvider;
 
   final PluginLifecycleRepository _lifecycleRepository;
   final String _preferredDefaultPluginId;
   final BridgeSettingsRepository _bridgeSettingsRepository;
   final PluginIdleTimerScheduler _idleTimerScheduler;
+  final BridgeIdProvider _bridgeIdProvider;
   List<RegisteredPluginMetadata>? _registeredPlugins;
   Set<String>? _knownPluginIds;
   Map<String, PluginResidencyPolicy>? _residencyPolicyById;
@@ -190,7 +194,13 @@ class PluginLifecycleService {
     }
     final snapshot = _lastPublishedManagementSnapshot;
     if (snapshot == null) throw StateError("Plugin management snapshot is not ready.");
-    return snapshot;
+    return PluginManagementResponse(
+      snapshotToken: snapshot.snapshotToken,
+      bridgeId: _bridgeIdProvider.bridgeId,
+      defaultPluginId: snapshot.defaultPluginId,
+      defaultIdleTimeoutMins: snapshot.defaultIdleTimeoutMins,
+      plugins: snapshot.plugins,
+    );
   }
 
   Stream<List<PluginMetadata>> get metadataSnapshots {
@@ -676,10 +686,7 @@ class PluginLifecycleService {
     final settings = _bridgeSettingsRepository.currentSettings;
     return PluginManagementResponse(
       snapshotToken: snapshotToken,
-      // The service builds snapshots before the bridge identity is reachable
-      // in the runtime composition order; request handlers stamp the current
-      // identity at the transport egress instead.
-      bridgeId: null,
+      bridgeId: _bridgeIdProvider.bridgeId,
       defaultPluginId: _selectableDefaultPluginId(),
       defaultIdleTimeoutMins: settings.plugins.defaults.idleTimeoutMins ?? defaultPluginIdleTimeoutMins,
       plugins: [for (final plugin in registeredPlugins) _managementRow(plugin: plugin)],

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -2,6 +2,8 @@ import "dart:async";
 import "dart:convert";
 import "dart:math";
 
+import "package:collection/collection.dart";
+import "package:meta/meta.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" hide PluginRuntimeState;
@@ -70,7 +72,7 @@ class PluginLifecycleService {
   final Map<String, _ActivePluginCommand> _activePluginCommands = {};
   final Set<String> _deferredReadyPluginIds = {};
   final Map<String, ({Duration duration, Timer timer})> _idleTimers = {};
-  PluginManagementResponse? _lastPublishedManagementSnapshot;
+  _PluginManagementSnapshot? _lastPublishedManagementSnapshot;
   final Random _random = Random.secure();
   bool _disposing = false;
 
@@ -126,7 +128,7 @@ class PluginLifecycleService {
       _buildReadyPluginIds(_lifecycleRepository.snapshot),
     );
     if (_hasCompleteManagementRuntimeSnapshot) {
-      _lastPublishedManagementSnapshot = _buildManagementResponse(snapshotToken: _newManagementSnapshotToken());
+      _lastPublishedManagementSnapshot = _buildManagementSnapshot(snapshotToken: _newManagementSnapshotToken());
     }
     _runtimeSubscription = _lifecycleRepository.snapshots.listen(_applyRuntimeSnapshots);
     return (
@@ -194,12 +196,11 @@ class PluginLifecycleService {
     }
     final snapshot = _lastPublishedManagementSnapshot;
     if (snapshot == null) throw StateError("Plugin management snapshot is not ready.");
-    // Lifecycle initialization can cache this snapshot before ensureRegistered
-    // assigns the provider's ID. Rebuild only the transport envelope here so
-    // every service response carries the provider's current identity.
+    final bridgeId = _bridgeIdProvider.bridgeId;
+    if (bridgeId == null) throw StateError("Bridge identity is not registered.");
     return PluginManagementResponse(
       snapshotToken: snapshot.snapshotToken,
-      bridgeId: _bridgeIdProvider.bridgeId,
+      bridgeId: bridgeId,
       defaultPluginId: snapshot.defaultPluginId,
       defaultIdleTimeoutMins: snapshot.defaultIdleTimeoutMins,
       plugins: snapshot.plugins,
@@ -681,15 +682,14 @@ class PluginLifecycleService {
     return _managementRow(plugin: plugin);
   }
 
-  PluginManagementResponse _buildManagementResponse({required String? snapshotToken}) {
+  _PluginManagementSnapshot _buildManagementSnapshot({required String? snapshotToken}) {
     final registeredPlugins = _registeredPlugins;
     if (registeredPlugins == null || _setupById == null) {
       throw StateError("Plugin lifecycle has not been initialized.");
     }
     final settings = _bridgeSettingsRepository.currentSettings;
-    return PluginManagementResponse(
+    return _PluginManagementSnapshot(
       snapshotToken: snapshotToken,
-      bridgeId: _bridgeIdProvider.bridgeId,
       defaultPluginId: _selectableDefaultPluginId(),
       defaultIdleTimeoutMins: settings.plugins.defaults.idleTimeoutMins ?? defaultPluginIdleTimeoutMins,
       plugins: [for (final plugin in registeredPlugins) _managementRow(plugin: plugin)],
@@ -700,13 +700,13 @@ class PluginLifecycleService {
     if (_managementSnapshotTokenController.isClosed || !_hasCompleteManagementRuntimeSnapshot) return;
     final previous = _lastPublishedManagementSnapshot;
     if (previous == null) {
-      _lastPublishedManagementSnapshot = _buildManagementResponse(snapshotToken: _newManagementSnapshotToken());
+      _lastPublishedManagementSnapshot = _buildManagementSnapshot(snapshotToken: _newManagementSnapshotToken());
       return;
     }
-    final next = _buildManagementResponse(snapshotToken: previous.snapshotToken);
+    final next = _buildManagementSnapshot(snapshotToken: previous.snapshotToken);
     if (previous == next) return;
     final snapshotToken = _newManagementSnapshotToken();
-    _lastPublishedManagementSnapshot = next.copyWith(snapshotToken: snapshotToken);
+    _lastPublishedManagementSnapshot = next.withSnapshotToken(snapshotToken: snapshotToken);
     _managementSnapshotTokenController.add(snapshotToken);
   }
 
@@ -910,6 +910,52 @@ class PluginLifecycleService {
     PluginLifecycleState.failed => "Check the bridge console and restart the bridge to retry this plugin.",
     PluginLifecycleState.ready => null,
   };
+}
+
+@immutable
+final class _PluginManagementSnapshot {
+  static const _pluginsEquality = ListEquality<PluginManagementMetadata>();
+
+  final String? snapshotToken;
+  final String? defaultPluginId;
+  final int defaultIdleTimeoutMins;
+  final List<PluginManagementMetadata> plugins;
+
+  const _PluginManagementSnapshot({
+    required this.snapshotToken,
+    required this.defaultPluginId,
+    required this.defaultIdleTimeoutMins,
+    required this.plugins,
+  });
+
+  _PluginManagementSnapshot withSnapshotToken({required String snapshotToken}) {
+    return _PluginManagementSnapshot(
+      snapshotToken: snapshotToken,
+      defaultPluginId: defaultPluginId,
+      defaultIdleTimeoutMins: defaultIdleTimeoutMins,
+      plugins: plugins,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is _PluginManagementSnapshot &&
+            snapshotToken == other.snapshotToken &&
+            defaultPluginId == other.defaultPluginId &&
+            defaultIdleTimeoutMins == other.defaultIdleTimeoutMins &&
+            _pluginsEquality.equals(plugins, other.plugins);
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(
+      snapshotToken,
+      defaultPluginId,
+      defaultIdleTimeoutMins,
+      _pluginsEquality.hash(plugins),
+    );
+  }
 }
 
 class PluginManagementPluginNotFoundException implements Exception {

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -676,6 +676,10 @@ class PluginLifecycleService {
     final settings = _bridgeSettingsRepository.currentSettings;
     return PluginManagementResponse(
       snapshotToken: snapshotToken,
+      // The service builds snapshots before the bridge identity is reachable
+      // in the runtime composition order; request handlers stamp the current
+      // identity at the transport egress instead.
+      bridgeId: null,
       defaultPluginId: _selectableDefaultPluginId(),
       defaultIdleTimeoutMins: settings.plugins.defaults.idleTimeoutMins ?? defaultPluginIdleTimeoutMins,
       plugins: [for (final plugin in registeredPlugins) _managementRow(plugin: plugin)],

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -196,8 +196,7 @@ class PluginLifecycleService {
     }
     final snapshot = _lastPublishedManagementSnapshot;
     if (snapshot == null) throw StateError("Plugin management snapshot is not ready.");
-    final bridgeId = _bridgeIdProvider.bridgeId;
-    if (bridgeId == null) throw StateError("Bridge identity is not registered.");
+    final bridgeId = _requireBridgeId();
     return PluginManagementResponse(
       snapshotToken: snapshot.snapshotToken,
       bridgeId: bridgeId,
@@ -235,6 +234,7 @@ class PluginLifecycleService {
     if (_lastPublishedManagementSnapshot == null) {
       throw StateError("Plugin management snapshot is not ready.");
     }
+    _requireBridgeId();
     final active = _activePluginCommands[pluginId];
     if (active != null) {
       if (active.request == request) return active.completer.future;
@@ -270,6 +270,7 @@ class PluginLifecycleService {
           throw PluginManagementPluginNotFoundException(pluginId);
         }
     }
+    _requireBridgeId();
     return _withSettingsMutationTail(() async {
       final current = await _bridgeSettingsRepository.loadSettings();
       final plugins = switch (request) {
@@ -330,10 +331,20 @@ class PluginLifecycleService {
     }
     _publishManagementIfChanged();
     if (failure == null) {
-      command.completer.complete(managementSnapshot);
+      try {
+        command.completer.complete(managementSnapshot);
+      } on Object catch (error, stackTrace) {
+        command.completer.completeError(error, stackTrace);
+      }
     } else {
       command.completer.completeError(failure, failureStackTrace);
     }
+  }
+
+  String _requireBridgeId() {
+    final bridgeId = _bridgeIdProvider.bridgeId;
+    if (bridgeId == null) throw StateError("Bridge identity is not registered.");
+    return bridgeId;
   }
 
   Future<void> _enable({required String pluginId, required _ActivePluginCommand command}) async {

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -30,6 +30,7 @@ void main() {
             preferredDefaultPluginId: legacyMissingPluginId,
             bridgeSettingsRepository: createTestBridgeSettingsRepository(),
             idleTimerScheduler: const PluginIdleTimerScheduler(),
+            bridgeIdProvider: FakeBridgeIdProvider(),
           )
           ..registerPlugins(
             plugins: const [

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -30,7 +30,7 @@ void main() {
             preferredDefaultPluginId: legacyMissingPluginId,
             bridgeSettingsRepository: createTestBridgeSettingsRepository(),
             idleTimerScheduler: const PluginIdleTimerScheduler(),
-            bridgeIdProvider: FakeBridgeIdProvider(),
+            bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
           )
           ..registerPlugins(
             plugins: const [

--- a/bridge/app/test/bridge/routing/get_plugin_management_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_plugin_management_handler_test.dart
@@ -3,21 +3,26 @@ import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/test_helpers.dart";
 import "routing_test_helpers.dart";
 
 void main() {
   test("handles only GET /plugin/management", () {
-    final handler = GetPluginManagementHandler(lifecycleService: _FakePluginLifecycleService());
+    final handler = GetPluginManagementHandler(
+      lifecycleService: _FakePluginLifecycleService(),
+      bridgeIdProvider: FakeBridgeIdProvider(),
+    );
 
     expect(handler.canHandle(makeRequest("GET", "/plugin/management")), isTrue);
     expect(handler.canHandle(makeRequest("POST", "/plugin/management")), isFalse);
     expect(handler.canHandle(makeRequest("GET", "/plugin/setup")), isFalse);
   });
 
-  test("returns the current lifecycle service snapshot", () async {
+  test("returns the current lifecycle service snapshot stamped with the bridge identity", () async {
     final response =
         await GetPluginManagementHandler(
           lifecycleService: _FakePluginLifecycleService(),
+          bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
         ).handleInternal(
           makeRequest("GET", "/plugin/management"),
           pathParams: const {},
@@ -26,12 +31,13 @@ void main() {
         );
 
     expect(response.status, 200);
-    expect(PluginManagementResponse.fromJson(jsonDecodeMap(response.body!)), _response);
+    expect(PluginManagementResponse.fromJson(jsonDecodeMap(response.body!)), _response.copyWith(bridgeId: "br_test1234"));
   });
 }
 
 const _response = PluginManagementResponse(
   snapshotToken: "snapshot-token",
+  bridgeId: null,
   defaultPluginId: "one",
   defaultIdleTimeoutMins: 10,
   plugins: [

--- a/bridge/app/test/bridge/routing/get_plugin_management_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_plugin_management_handler_test.dart
@@ -3,14 +3,12 @@ import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
-import "../../helpers/test_helpers.dart";
 import "routing_test_helpers.dart";
 
 void main() {
   test("handles only GET /plugin/management", () {
     final handler = GetPluginManagementHandler(
       lifecycleService: _FakePluginLifecycleService(),
-      bridgeIdProvider: FakeBridgeIdProvider(),
     );
 
     expect(handler.canHandle(makeRequest("GET", "/plugin/management")), isTrue);
@@ -18,11 +16,10 @@ void main() {
     expect(handler.canHandle(makeRequest("GET", "/plugin/setup")), isFalse);
   });
 
-  test("returns the current lifecycle service snapshot stamped with the bridge identity", () async {
+  test("returns the current lifecycle service snapshot unchanged", () async {
     final response =
         await GetPluginManagementHandler(
           lifecycleService: _FakePluginLifecycleService(),
-          bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
         ).handleInternal(
           makeRequest("GET", "/plugin/management"),
           pathParams: const {},
@@ -31,13 +28,13 @@ void main() {
         );
 
     expect(response.status, 200);
-    expect(PluginManagementResponse.fromJson(jsonDecodeMap(response.body!)), _response.copyWith(bridgeId: "br_test1234"));
+    expect(PluginManagementResponse.fromJson(jsonDecodeMap(response.body!)), _response);
   });
 }
 
 const _response = PluginManagementResponse(
   snapshotToken: "snapshot-token",
-  bridgeId: null,
+  bridgeId: "br_test1234",
   defaultPluginId: "one",
   defaultIdleTimeoutMins: 10,
   plugins: [

--- a/bridge/app/test/bridge/routing/get_plugin_setup_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_plugin_setup_handler_test.dart
@@ -27,6 +27,7 @@ void main() {
               preferredDefaultPluginId: legacyMissingPluginId,
               bridgeSettingsRepository: createTestBridgeSettingsRepository(),
               idleTimerScheduler: const PluginIdleTimerScheduler(),
+              bridgeIdProvider: FakeBridgeIdProvider(),
             )
             ..registerPlugins(
               plugins: const [

--- a/bridge/app/test/bridge/routing/get_plugin_setup_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_plugin_setup_handler_test.dart
@@ -27,7 +27,7 @@ void main() {
               preferredDefaultPluginId: legacyMissingPluginId,
               bridgeSettingsRepository: createTestBridgeSettingsRepository(),
               idleTimerScheduler: const PluginIdleTimerScheduler(),
-              bridgeIdProvider: FakeBridgeIdProvider(),
+              bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
             )
             ..registerPlugins(
               plugins: const [

--- a/bridge/app/test/bridge/routing/patch_plugin_idle_timeout_handler_test.dart
+++ b/bridge/app/test/bridge/routing/patch_plugin_idle_timeout_handler_test.dart
@@ -5,11 +5,18 @@ import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/test_helpers.dart";
 import "routing_test_helpers.dart";
 
 void main() {
+  PatchPluginIdleTimeoutHandler buildHandler(_FakePluginLifecycleService service) =>
+      PatchPluginIdleTimeoutHandler(
+        lifecycleService: service,
+        bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
+      );
+
   test("PatchPluginIdleTimeoutHandler handles only PATCH /plugin/idle-timeout", () {
-    final handler = PatchPluginIdleTimeoutHandler(lifecycleService: _FakePluginLifecycleService());
+    final handler = buildHandler(_FakePluginLifecycleService());
 
     expect(handler.canHandle(makeRequest("PATCH", "/plugin/idle-timeout")), isTrue);
     expect(handler.canHandle(makeRequest("GET", "/plugin/idle-timeout")), isFalse);
@@ -18,7 +25,7 @@ void main() {
 
   test("PatchPluginIdleTimeoutHandler returns the updated management snapshot", () async {
     final service = _FakePluginLifecycleService();
-    final response = await PatchPluginIdleTimeoutHandler(lifecycleService: service).handleInternal(
+    final response = await buildHandler(service).handleInternal(
       makeRequest(
         "PATCH",
         "/plugin/idle-timeout",
@@ -31,12 +38,15 @@ void main() {
 
     expect(response.status, 200);
     expect(service.receivedRequest, const PluginIdleTimeoutUpdateRequest.applyAll(idleTimeoutMins: 30));
-    expect(PluginManagementResponse.fromJson(jsonDecodeMap(response.body!)), _response);
+    expect(
+      PluginManagementResponse.fromJson(jsonDecodeMap(response.body!)),
+      _response.copyWith(bridgeId: "br_test1234"),
+    );
   });
 
   test("PatchPluginIdleTimeoutHandler maps invalid, unknown, and failed writes", () async {
     final service = _FakePluginLifecycleService();
-    final handler = PatchPluginIdleTimeoutHandler(lifecycleService: service);
+    final handler = buildHandler(service);
 
     final invalid = await handler.handleInternal(
       makeRequest(
@@ -79,6 +89,7 @@ void main() {
 
 const _response = PluginManagementResponse(
   snapshotToken: "snapshot-token",
+  bridgeId: null,
   defaultPluginId: "one",
   defaultIdleTimeoutMins: 30,
   plugins: [],

--- a/bridge/app/test/bridge/routing/patch_plugin_idle_timeout_handler_test.dart
+++ b/bridge/app/test/bridge/routing/patch_plugin_idle_timeout_handler_test.dart
@@ -40,7 +40,7 @@ void main() {
     );
   });
 
-  test("PatchPluginIdleTimeoutHandler maps invalid, unknown, and failed writes", () async {
+  test("PatchPluginIdleTimeoutHandler maps invalid, unknown, uncertain, and failed writes", () async {
     final service = _FakePluginLifecycleService();
     final handler = buildHandler(service: service);
 
@@ -65,6 +65,17 @@ void main() {
       queryParams: const {},
       fragment: null,
     );
+    service.error = const PluginManagementMutationOutcomeUncertainException();
+    final uncertain = await handler.handleInternal(
+      makeRequest(
+        "PATCH",
+        "/plugin/idle-timeout",
+        body: jsonEncode(const PluginIdleTimeoutUpdateRequest.clearOverride(pluginId: "one").toJson()),
+      ),
+      pathParams: const {},
+      queryParams: const {},
+      fragment: null,
+    );
     service.error = StateError("disk full");
     final failed = await handler.handleInternal(
       makeRequest(
@@ -79,6 +90,7 @@ void main() {
 
     expect(invalid.status, 400);
     expect(unknown.status, 404);
+    expect(uncertain.status, 503);
     expect(failed.status, 500);
   });
 }

--- a/bridge/app/test/bridge/routing/patch_plugin_idle_timeout_handler_test.dart
+++ b/bridge/app/test/bridge/routing/patch_plugin_idle_timeout_handler_test.dart
@@ -5,15 +5,11 @@ import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
-import "../../helpers/test_helpers.dart";
 import "routing_test_helpers.dart";
 
 void main() {
   PatchPluginIdleTimeoutHandler buildHandler({required _FakePluginLifecycleService service}) =>
-      PatchPluginIdleTimeoutHandler(
-        lifecycleService: service,
-        bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
-      );
+      PatchPluginIdleTimeoutHandler(lifecycleService: service);
 
   test("PatchPluginIdleTimeoutHandler handles only PATCH /plugin/idle-timeout", () {
     final handler = buildHandler(service: _FakePluginLifecycleService());
@@ -40,7 +36,7 @@ void main() {
     expect(service.receivedRequest, const PluginIdleTimeoutUpdateRequest.applyAll(idleTimeoutMins: 30));
     expect(
       PluginManagementResponse.fromJson(jsonDecodeMap(response.body!)),
-      _response.copyWith(bridgeId: "br_test1234"),
+      _response,
     );
   });
 
@@ -89,7 +85,7 @@ void main() {
 
 const _response = PluginManagementResponse(
   snapshotToken: "snapshot-token",
-  bridgeId: null,
+  bridgeId: "br_test1234",
   defaultPluginId: "one",
   defaultIdleTimeoutMins: 30,
   plugins: [],

--- a/bridge/app/test/bridge/routing/patch_plugin_idle_timeout_handler_test.dart
+++ b/bridge/app/test/bridge/routing/patch_plugin_idle_timeout_handler_test.dart
@@ -9,14 +9,14 @@ import "../../helpers/test_helpers.dart";
 import "routing_test_helpers.dart";
 
 void main() {
-  PatchPluginIdleTimeoutHandler buildHandler(_FakePluginLifecycleService service) =>
+  PatchPluginIdleTimeoutHandler buildHandler({required _FakePluginLifecycleService service}) =>
       PatchPluginIdleTimeoutHandler(
         lifecycleService: service,
         bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
       );
 
   test("PatchPluginIdleTimeoutHandler handles only PATCH /plugin/idle-timeout", () {
-    final handler = buildHandler(_FakePluginLifecycleService());
+    final handler = buildHandler(service: _FakePluginLifecycleService());
 
     expect(handler.canHandle(makeRequest("PATCH", "/plugin/idle-timeout")), isTrue);
     expect(handler.canHandle(makeRequest("GET", "/plugin/idle-timeout")), isFalse);
@@ -25,7 +25,7 @@ void main() {
 
   test("PatchPluginIdleTimeoutHandler returns the updated management snapshot", () async {
     final service = _FakePluginLifecycleService();
-    final response = await buildHandler(service).handleInternal(
+    final response = await buildHandler(service: service).handleInternal(
       makeRequest(
         "PATCH",
         "/plugin/idle-timeout",
@@ -46,7 +46,7 @@ void main() {
 
   test("PatchPluginIdleTimeoutHandler maps invalid, unknown, and failed writes", () async {
     final service = _FakePluginLifecycleService();
-    final handler = buildHandler(service);
+    final handler = buildHandler(service: service);
 
     final invalid = await handler.handleInternal(
       makeRequest(

--- a/bridge/app/test/bridge/routing/post_plugin_lifecycle_command_handler_test.dart
+++ b/bridge/app/test/bridge/routing/post_plugin_lifecycle_command_handler_test.dart
@@ -9,14 +9,14 @@ import "../../helpers/test_helpers.dart";
 import "routing_test_helpers.dart";
 
 void main() {
-  PostPluginLifecycleCommandHandler buildHandler(_FakePluginLifecycleService service) =>
+  PostPluginLifecycleCommandHandler buildHandler({required _FakePluginLifecycleService service}) =>
       PostPluginLifecycleCommandHandler(
         lifecycleService: service,
         bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
       );
 
   test("PostPluginLifecycleCommandHandler handles only plugin command posts", () {
-    final handler = buildHandler(_FakePluginLifecycleService());
+    final handler = buildHandler(service: _FakePluginLifecycleService());
 
     expect(handler.canHandle(makeRequest("POST", "/plugin/one/command")), isTrue);
     expect(handler.canHandle(makeRequest("GET", "/plugin/one/command")), isFalse);
@@ -25,7 +25,7 @@ void main() {
 
   test("PostPluginLifecycleCommandHandler dispatches a typed disable command", () async {
     final service = _FakePluginLifecycleService();
-    final response = await buildHandler(service).handleInternal(
+    final response = await buildHandler(service: service).handleInternal(
       makeRequest(
         "POST",
         "/plugin/one/command",
@@ -47,7 +47,7 @@ void main() {
 
   test("PostPluginLifecycleCommandHandler maps invalid, unknown, conflict, and failed commands", () async {
     final service = _FakePluginLifecycleService();
-    final handler = buildHandler(service);
+    final handler = buildHandler(service: service);
 
     final invalid = await handler.handleInternal(
       makeRequest("POST", "/plugin/one/command", body: jsonEncode(const {"type": "disable"})),

--- a/bridge/app/test/bridge/routing/post_plugin_lifecycle_command_handler_test.dart
+++ b/bridge/app/test/bridge/routing/post_plugin_lifecycle_command_handler_test.dart
@@ -5,15 +5,11 @@ import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
-import "../../helpers/test_helpers.dart";
 import "routing_test_helpers.dart";
 
 void main() {
   PostPluginLifecycleCommandHandler buildHandler({required _FakePluginLifecycleService service}) =>
-      PostPluginLifecycleCommandHandler(
-        lifecycleService: service,
-        bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
-      );
+      PostPluginLifecycleCommandHandler(lifecycleService: service);
 
   test("PostPluginLifecycleCommandHandler handles only plugin command posts", () {
     final handler = buildHandler(service: _FakePluginLifecycleService());
@@ -41,7 +37,7 @@ void main() {
     expect(service.receivedRequest, const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe));
     expect(
       PluginManagementResponse.fromJson(jsonDecodeMap(response.body!)),
-      _response.copyWith(bridgeId: "br_test1234"),
+      _response,
     );
   });
 
@@ -100,7 +96,7 @@ const _plugin = PluginManagementMetadata(
 
 const _response = PluginManagementResponse(
   snapshotToken: "snapshot-token",
-  bridgeId: null,
+  bridgeId: "br_test1234",
   defaultPluginId: "one",
   defaultIdleTimeoutMins: 10,
   plugins: [_plugin],

--- a/bridge/app/test/bridge/routing/post_plugin_lifecycle_command_handler_test.dart
+++ b/bridge/app/test/bridge/routing/post_plugin_lifecycle_command_handler_test.dart
@@ -41,7 +41,7 @@ void main() {
     );
   });
 
-  test("PostPluginLifecycleCommandHandler maps invalid, unknown, conflict, and failed commands", () async {
+  test("PostPluginLifecycleCommandHandler maps invalid, unknown, conflict, uncertain, and failed commands", () async {
     final service = _FakePluginLifecycleService();
     final handler = buildHandler(service: service);
 
@@ -55,6 +55,8 @@ void main() {
     final unknown = await _send(handler, pluginId: "missing");
     service.error = const PluginManagementConflictException(_conflict);
     final conflict = await _send(handler, pluginId: "one");
+    service.error = const PluginManagementMutationOutcomeUncertainException();
+    final uncertain = await _send(handler, pluginId: "one");
     service.error = const PluginManagementCommandFailedException("disk full");
     final failed = await _send(handler, pluginId: "one");
 
@@ -62,6 +64,7 @@ void main() {
     expect(unknown.status, 404);
     expect(conflict.status, 409);
     expect(PluginLifecycleConflict.fromJson(jsonDecodeMap(conflict.body!)), _conflict);
+    expect(uncertain.status, 503);
     expect(failed.status, 500);
     expect(failed.body, "plugin command failed");
   });

--- a/bridge/app/test/bridge/routing/post_plugin_lifecycle_command_handler_test.dart
+++ b/bridge/app/test/bridge/routing/post_plugin_lifecycle_command_handler_test.dart
@@ -5,11 +5,18 @@ import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/test_helpers.dart";
 import "routing_test_helpers.dart";
 
 void main() {
+  PostPluginLifecycleCommandHandler buildHandler(_FakePluginLifecycleService service) =>
+      PostPluginLifecycleCommandHandler(
+        lifecycleService: service,
+        bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
+      );
+
   test("PostPluginLifecycleCommandHandler handles only plugin command posts", () {
-    final handler = PostPluginLifecycleCommandHandler(lifecycleService: _FakePluginLifecycleService());
+    final handler = buildHandler(_FakePluginLifecycleService());
 
     expect(handler.canHandle(makeRequest("POST", "/plugin/one/command")), isTrue);
     expect(handler.canHandle(makeRequest("GET", "/plugin/one/command")), isFalse);
@@ -18,7 +25,7 @@ void main() {
 
   test("PostPluginLifecycleCommandHandler dispatches a typed disable command", () async {
     final service = _FakePluginLifecycleService();
-    final response = await PostPluginLifecycleCommandHandler(lifecycleService: service).handleInternal(
+    final response = await buildHandler(service).handleInternal(
       makeRequest(
         "POST",
         "/plugin/one/command",
@@ -32,12 +39,15 @@ void main() {
     expect(response.status, 200);
     expect(service.receivedPluginId, "one");
     expect(service.receivedRequest, const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe));
-    expect(PluginManagementResponse.fromJson(jsonDecodeMap(response.body!)), _response);
+    expect(
+      PluginManagementResponse.fromJson(jsonDecodeMap(response.body!)),
+      _response.copyWith(bridgeId: "br_test1234"),
+    );
   });
 
   test("PostPluginLifecycleCommandHandler maps invalid, unknown, conflict, and failed commands", () async {
     final service = _FakePluginLifecycleService();
-    final handler = PostPluginLifecycleCommandHandler(lifecycleService: service);
+    final handler = buildHandler(service);
 
     final invalid = await handler.handleInternal(
       makeRequest("POST", "/plugin/one/command", body: jsonEncode(const {"type": "disable"})),
@@ -90,6 +100,7 @@ const _plugin = PluginManagementMetadata(
 
 const _response = PluginManagementResponse(
   snapshotToken: "snapshot-token",
+  bridgeId: null,
   defaultPluginId: "one",
   defaultIdleTimeoutMins: 10,
   plugins: [_plugin],

--- a/bridge/app/test/helpers/plugin_lifecycle_test_support.dart
+++ b/bridge/app/test/helpers/plugin_lifecycle_test_support.dart
@@ -7,6 +7,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" show legacyMissingPluginId;
 
 import "plugin_runtime_test_support.dart";
+import "test_helpers.dart";
 
 final Expando<PluginRuntime> _runtimes = Expando<PluginRuntime>();
 
@@ -26,6 +27,7 @@ Future<PluginLifecycleService> createPluginLifecycleService({
           preferredDefaultPluginId: legacyMissingPluginId,
           bridgeSettingsRepository: createTestBridgeSettingsRepository(),
           idleTimerScheduler: const PluginIdleTimerScheduler(),
+          bridgeIdProvider: FakeBridgeIdProvider(),
         )
         ..registerPlugins(
           plugins: [

--- a/bridge/app/test/helpers/plugin_lifecycle_test_support.dart
+++ b/bridge/app/test/helpers/plugin_lifecycle_test_support.dart
@@ -27,7 +27,7 @@ Future<PluginLifecycleService> createPluginLifecycleService({
           preferredDefaultPluginId: legacyMissingPluginId,
           bridgeSettingsRepository: createTestBridgeSettingsRepository(),
           idleTimerScheduler: const PluginIdleTimerScheduler(),
-          bridgeIdProvider: FakeBridgeIdProvider(),
+          bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
         )
         ..registerPlugins(
           plugins: [

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -232,6 +232,20 @@ void main() {
     // management must fail closed until the authority supplies an identity,
     // then attach that current identity when returning.
     expect(() => service.managementSnapshot, throwsStateError);
+    expect(
+      () => service.command(
+        pluginId: "opencode",
+        request: const PluginLifecycleCommandRequest.refresh(),
+      ),
+      throwsStateError,
+    );
+    expect(
+      () => service.updateIdleTimeout(
+        request: const PluginIdleTimeoutUpdateRequest.applyAll(idleTimeoutMins: 60),
+      ),
+      throwsStateError,
+    );
+    expect(settingsRepository.currentSettings.plugins.defaults.idleTimeoutMins, 30);
     bridgeIdProvider.id = "br_test1234";
     final response = service.managementSnapshot;
 
@@ -600,6 +614,44 @@ void main() {
 
     settingsRepository.saveGate!.complete();
     await safe;
+  });
+
+  test("command completion surfaces identity loss after dispatch without hanging", () async {
+    final runtime = createRegisteredTestPluginRuntime(pluginIds: const ["one"]);
+    final settingsRepository = _MutableBridgeSettingsRepository(settings: const BridgeSettings())
+      ..saveGate = Completer<void>();
+    final bridgeIdProvider = FakeBridgeIdProvider("br_test1234");
+    final service =
+        PluginLifecycleService(
+            lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
+            preferredDefaultPluginId: legacyMissingPluginId,
+            bridgeSettingsRepository: settingsRepository,
+            idleTimerScheduler: const PluginIdleTimerScheduler(),
+            bridgeIdProvider: bridgeIdProvider,
+          )
+          ..registerPlugins(
+            plugins: const [
+              (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
+            ],
+          )
+          ..initialize(
+            disabledPluginIds: const {},
+            setupById: const {"one": PluginSetupReady()},
+          );
+    addTearDown(() async {
+      await service.dispose();
+      await runtime.dispose();
+    });
+
+    final response = service.command(
+      pluginId: "one",
+      request: const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe),
+    );
+    await settingsRepository.saveStarted.future;
+    bridgeIdProvider.id = null;
+    settingsRepository.saveGate!.complete();
+
+    await expectLater(response, throwsStateError);
   });
 
   test("failed disable persistence rolls runtime access back and allows retry", () async {

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -417,6 +417,49 @@ void main() {
     );
   });
 
+  test("queued idle timeout writes fail closed after bridge identity is revoked", () async {
+    final repository = _IdleLifecycleRepository();
+    addTearDown(repository.dispose);
+    final settingsRepository = _MutableBridgeSettingsRepository(settings: const BridgeSettings())
+      ..saveGate = Completer<void>();
+    final bridgeIdProvider = FakeBridgeIdProvider("br_test1234");
+    final service =
+        PluginLifecycleService(
+            lifecycleRepository: repository,
+            preferredDefaultPluginId: legacyMissingPluginId,
+            bridgeSettingsRepository: settingsRepository,
+            idleTimerScheduler: const PluginIdleTimerScheduler(),
+            bridgeIdProvider: bridgeIdProvider,
+          )
+          ..registerPlugins(
+            plugins: const [
+              (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
+            ],
+          )
+          ..initialize(
+            disabledPluginIds: const {},
+            setupById: const {"one": PluginSetupReady()},
+          );
+    addTearDown(service.dispose);
+
+    final active = service.updateIdleTimeout(
+      request: const PluginIdleTimeoutUpdateRequest.applyAll(idleTimeoutMins: 30),
+    );
+    await settingsRepository.saveStarted.future;
+    final queued = service.updateIdleTimeout(
+      request: const PluginIdleTimeoutUpdateRequest.setOverride(pluginId: "one", idleTimeoutMins: 45),
+    );
+    bridgeIdProvider.id = null;
+    final activeExpectation = expectLater(active, throwsStateError);
+    final queuedExpectation = expectLater(queued, throwsStateError);
+    settingsRepository.saveGate!.complete();
+
+    await Future.wait([activeExpectation, queuedExpectation]);
+    expect(settingsRepository.loadCalls, 1);
+    expect(settingsRepository.settings.plugins.defaults.idleTimeoutMins, 30);
+    expect(settingsRepository.settings.plugins.settingsByPluginId, isEmpty);
+  });
+
   test("successful timeout writes resync live timers while failed writes change nothing", () async {
     final repository = _IdleLifecycleRepository();
     addTearDown(repository.dispose);

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -12,6 +12,7 @@ import "package:test/test.dart";
 
 import "../helpers/plugin_lifecycle_test_support.dart";
 import "../helpers/plugin_runtime_test_support.dart";
+import "../helpers/test_helpers.dart";
 
 void main() {
   test("derives alphabetical eligibility and default from setup", () {
@@ -201,12 +202,14 @@ void main() {
         ),
       ),
     );
+    final bridgeIdProvider = FakeBridgeIdProvider();
     final service =
         PluginLifecycleService(
             lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
             preferredDefaultPluginId: legacyMissingPluginId,
             bridgeSettingsRepository: settingsRepository,
             idleTimerScheduler: const PluginIdleTimerScheduler(),
+            bridgeIdProvider: bridgeIdProvider,
           )
           ..registerPlugins(
             plugins: const [
@@ -225,8 +228,12 @@ void main() {
           );
     addTearDown(service.dispose);
 
+    // Lifecycle initialization precedes bridge registration in the runtime;
+    // the service must attach the provider's current identity when returning.
+    bridgeIdProvider.id = "br_test1234";
     final response = service.managementSnapshot;
 
+    expect(response.bridgeId, "br_test1234");
     expect(response.defaultPluginId, "opencode");
     expect(response.defaultIdleTimeoutMins, 30);
     expect(response.plugins.map((plugin) => plugin.setup.id), ["alpha", "beta", "opencode"]);
@@ -506,6 +513,7 @@ void main() {
             preferredDefaultPluginId: legacyMissingPluginId,
             bridgeSettingsRepository: settingsRepository,
             idleTimerScheduler: const PluginIdleTimerScheduler(),
+            bridgeIdProvider: FakeBridgeIdProvider(),
           )
           ..registerPlugins(
             plugins: const [
@@ -553,6 +561,7 @@ void main() {
             preferredDefaultPluginId: legacyMissingPluginId,
             bridgeSettingsRepository: settingsRepository,
             idleTimerScheduler: const PluginIdleTimerScheduler(),
+            bridgeIdProvider: FakeBridgeIdProvider(),
           )
           ..registerPlugins(
             plugins: const [
@@ -601,6 +610,7 @@ void main() {
             preferredDefaultPluginId: legacyMissingPluginId,
             bridgeSettingsRepository: settingsRepository,
             idleTimerScheduler: const PluginIdleTimerScheduler(),
+            bridgeIdProvider: FakeBridgeIdProvider(),
           )
           ..registerPlugins(
             plugins: const [
@@ -952,6 +962,7 @@ void main() {
           preferredDefaultPluginId: legacyMissingPluginId,
           bridgeSettingsRepository: createTestBridgeSettingsRepository(),
           idleTimerScheduler: const PluginIdleTimerScheduler(),
+          bridgeIdProvider: FakeBridgeIdProvider(),
         )..registerPlugins(
           plugins: const [
             (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
@@ -977,6 +988,7 @@ void main() {
           preferredDefaultPluginId: legacyMissingPluginId,
           bridgeSettingsRepository: createTestBridgeSettingsRepository(),
           idleTimerScheduler: timerScheduler,
+          bridgeIdProvider: FakeBridgeIdProvider(),
         )..registerPlugins(
           plugins: const [
             (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
@@ -1019,6 +1031,7 @@ void main() {
             ),
           ),
           idleTimerScheduler: timerScheduler,
+          bridgeIdProvider: FakeBridgeIdProvider(),
         )..registerPlugins(
           plugins: const [
             (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
@@ -1056,6 +1069,7 @@ void main() {
           preferredDefaultPluginId: legacyMissingPluginId,
           bridgeSettingsRepository: settingsRepository,
           idleTimerScheduler: timerScheduler,
+          bridgeIdProvider: FakeBridgeIdProvider(),
         )..registerPlugins(
           plugins: const [
             (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.resident),
@@ -1085,6 +1099,7 @@ PluginLifecycleService _service({
     preferredDefaultPluginId: legacyMissingPluginId,
     bridgeSettingsRepository: createTestBridgeSettingsRepository(),
     idleTimerScheduler: const PluginIdleTimerScheduler(),
+    bridgeIdProvider: FakeBridgeIdProvider(),
   )..registerPlugins(plugins: plugins);
 }
 
@@ -1099,6 +1114,7 @@ PluginLifecycleService _singleIdleService({
       preferredDefaultPluginId: legacyMissingPluginId,
       bridgeSettingsRepository: settingsRepository,
       idleTimerScheduler: timerScheduler,
+      bridgeIdProvider: FakeBridgeIdProvider(),
     )
     ..registerPlugins(
       plugins: [(id: "one", displayName: "One", residencyPolicy: residencyPolicy)],
@@ -1118,6 +1134,7 @@ PluginLifecycleService _commandService({
     preferredDefaultPluginId: legacyMissingPluginId,
     bridgeSettingsRepository: settingsRepository ?? createTestBridgeSettingsRepository(),
     idleTimerScheduler: const PluginIdleTimerScheduler(),
+    bridgeIdProvider: FakeBridgeIdProvider(),
   )..registerPlugins(
     plugins: const [
       (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -229,7 +229,9 @@ void main() {
     addTearDown(service.dispose);
 
     // Lifecycle initialization precedes bridge registration in the runtime;
-    // the service must attach the provider's current identity when returning.
+    // management must fail closed until the authority supplies an identity,
+    // then attach that current identity when returning.
+    expect(() => service.managementSnapshot, throwsStateError);
     bridgeIdProvider.id = "br_test1234";
     final response = service.managementSnapshot;
 
@@ -513,7 +515,7 @@ void main() {
             preferredDefaultPluginId: legacyMissingPluginId,
             bridgeSettingsRepository: settingsRepository,
             idleTimerScheduler: const PluginIdleTimerScheduler(),
-            bridgeIdProvider: FakeBridgeIdProvider(),
+            bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
           )
           ..registerPlugins(
             plugins: const [
@@ -561,7 +563,7 @@ void main() {
             preferredDefaultPluginId: legacyMissingPluginId,
             bridgeSettingsRepository: settingsRepository,
             idleTimerScheduler: const PluginIdleTimerScheduler(),
-            bridgeIdProvider: FakeBridgeIdProvider(),
+            bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
           )
           ..registerPlugins(
             plugins: const [
@@ -610,7 +612,7 @@ void main() {
             preferredDefaultPluginId: legacyMissingPluginId,
             bridgeSettingsRepository: settingsRepository,
             idleTimerScheduler: const PluginIdleTimerScheduler(),
-            bridgeIdProvider: FakeBridgeIdProvider(),
+            bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
           )
           ..registerPlugins(
             plugins: const [
@@ -962,7 +964,7 @@ void main() {
           preferredDefaultPluginId: legacyMissingPluginId,
           bridgeSettingsRepository: createTestBridgeSettingsRepository(),
           idleTimerScheduler: const PluginIdleTimerScheduler(),
-          bridgeIdProvider: FakeBridgeIdProvider(),
+          bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
         )..registerPlugins(
           plugins: const [
             (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
@@ -988,7 +990,7 @@ void main() {
           preferredDefaultPluginId: legacyMissingPluginId,
           bridgeSettingsRepository: createTestBridgeSettingsRepository(),
           idleTimerScheduler: timerScheduler,
-          bridgeIdProvider: FakeBridgeIdProvider(),
+          bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
         )..registerPlugins(
           plugins: const [
             (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
@@ -1031,7 +1033,7 @@ void main() {
             ),
           ),
           idleTimerScheduler: timerScheduler,
-          bridgeIdProvider: FakeBridgeIdProvider(),
+          bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
         )..registerPlugins(
           plugins: const [
             (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
@@ -1069,7 +1071,7 @@ void main() {
           preferredDefaultPluginId: legacyMissingPluginId,
           bridgeSettingsRepository: settingsRepository,
           idleTimerScheduler: timerScheduler,
-          bridgeIdProvider: FakeBridgeIdProvider(),
+          bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
         )..registerPlugins(
           plugins: const [
             (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.resident),
@@ -1099,7 +1101,7 @@ PluginLifecycleService _service({
     preferredDefaultPluginId: legacyMissingPluginId,
     bridgeSettingsRepository: createTestBridgeSettingsRepository(),
     idleTimerScheduler: const PluginIdleTimerScheduler(),
-    bridgeIdProvider: FakeBridgeIdProvider(),
+    bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
   )..registerPlugins(plugins: plugins);
 }
 
@@ -1114,7 +1116,7 @@ PluginLifecycleService _singleIdleService({
       preferredDefaultPluginId: legacyMissingPluginId,
       bridgeSettingsRepository: settingsRepository,
       idleTimerScheduler: timerScheduler,
-      bridgeIdProvider: FakeBridgeIdProvider(),
+      bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
     )
     ..registerPlugins(
       plugins: [(id: "one", displayName: "One", residencyPolicy: residencyPolicy)],
@@ -1134,7 +1136,7 @@ PluginLifecycleService _commandService({
     preferredDefaultPluginId: legacyMissingPluginId,
     bridgeSettingsRepository: settingsRepository ?? createTestBridgeSettingsRepository(),
     idleTimerScheduler: const PluginIdleTimerScheduler(),
-    bridgeIdProvider: FakeBridgeIdProvider(),
+    bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
   )..registerPlugins(
     plugins: const [
       (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -450,7 +450,7 @@ void main() {
       request: const PluginIdleTimeoutUpdateRequest.setOverride(pluginId: "one", idleTimeoutMins: 45),
     );
     bridgeIdProvider.id = null;
-    final activeExpectation = expectLater(active, throwsStateError);
+    final activeExpectation = expectLater(active, throwsA(isA<PluginManagementMutationOutcomeUncertainException>()));
     final queuedExpectation = expectLater(queued, throwsStateError);
     settingsRepository.saveGate!.complete();
 
@@ -659,7 +659,7 @@ void main() {
     await safe;
   });
 
-  test("command completion surfaces identity loss after dispatch without hanging", () async {
+  test("command completion marks identity loss after dispatch as uncertain without hanging", () async {
     final runtime = createRegisteredTestPluginRuntime(pluginIds: const ["one"]);
     final settingsRepository = _MutableBridgeSettingsRepository(settings: const BridgeSettings())
       ..saveGate = Completer<void>();
@@ -694,7 +694,7 @@ void main() {
     bridgeIdProvider.id = null;
     settingsRepository.saveGate!.complete();
 
-    await expectLater(response, throwsStateError);
+    await expectLater(response, throwsA(isA<PluginManagementMutationOutcomeUncertainException>()));
   });
 
   test("failed disable persistence rolls runtime access back and allows retry", () async {

--- a/client/module_core/lib/sesori_dart_core.dart
+++ b/client/module_core/lib/sesori_dart_core.dart
@@ -97,6 +97,7 @@ export "src/platform/url_launcher.dart";
 export "src/repositories/appearance_store.dart";
 export "src/repositories/bridge_repository.dart";
 export "src/repositories/legal_repository.dart";
+export "src/repositories/models/plugin_management_result.dart";
 export "src/repositories/models/repo_provider.dart";
 export "src/repositories/notification_preferences_repository.dart";
 export "src/repositories/notification_repository.dart";

--- a/client/module_core/lib/src/api/client/relay_http_client.dart
+++ b/client/module_core/lib/src/api/client/relay_http_client.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:convert";
 import "dart:math";
 
@@ -186,6 +187,11 @@ class RelayHttpApiClient {
         loge("Failed to parse relay response JSON", error, stackTrace);
         return ApiResponse.error(ApiError.jsonParsing(responseBody));
       }
+    } on TimeoutException catch (error) {
+      // The request may have been dispatched before the response was lost;
+      // callers (e.g. plugin mutations) must be able to treat this as an
+      // uncertain outcome instead of a retryable ordinary failure.
+      return ApiResponse.error(ApiError.dartHttpClient(error));
     } catch (error, stackTrace) {
       loge("Relay API request failed", error, stackTrace);
       return ApiResponse.error(ApiError.generic());

--- a/client/module_core/lib/src/api/client/relay_http_client.dart
+++ b/client/module_core/lib/src/api/client/relay_http_client.dart
@@ -192,6 +192,8 @@ class RelayHttpApiClient {
       // callers (e.g. plugin mutations) must be able to treat this as an
       // uncertain outcome instead of a retryable ordinary failure.
       return ApiResponse.error(ApiError.dartHttpClient(error));
+    } on RelayResponseLostException catch (error) {
+      return ApiResponse.error(ApiError.dartHttpClient(error));
     } catch (error, stackTrace) {
       loge("Relay API request failed", error, stackTrace);
       return ApiResponse.error(ApiError.generic());

--- a/client/module_core/lib/src/api/plugin_api.dart
+++ b/client/module_core/lib/src/api/plugin_api.dart
@@ -13,4 +13,29 @@ class PluginApi {
   Future<ApiResponse<PluginListResponse>> listPlugins() {
     return _client.get("/plugin", fromJson: PluginListResponse.fromJson);
   }
+
+  Future<ApiResponse<PluginManagementResponse>> getManagement() {
+    return _client.get("/plugin/management", fromJson: PluginManagementResponse.fromJson);
+  }
+
+  Future<ApiResponse<PluginManagementResponse>> command({
+    required String pluginId,
+    required PluginLifecycleCommandRequest request,
+  }) {
+    return _client.post(
+      "/plugin/$pluginId/command",
+      body: request.toJson(),
+      fromJson: PluginManagementResponse.fromJson,
+    );
+  }
+
+  Future<ApiResponse<PluginManagementResponse>> updateIdleTimeout({
+    required PluginIdleTimeoutUpdateRequest request,
+  }) {
+    return _client.patch(
+      "/plugin/idle-timeout",
+      body: request.toJson(),
+      fromJson: PluginManagementResponse.fromJson,
+    );
+  }
 }

--- a/client/module_core/lib/src/api/plugin_api.dart
+++ b/client/module_core/lib/src/api/plugin_api.dart
@@ -23,7 +23,7 @@ class PluginApi {
     required PluginLifecycleCommandRequest request,
   }) {
     return _client.post(
-      "/plugin/$pluginId/command",
+      "/plugin/${Uri.encodeComponent(pluginId)}/command",
       body: request.toJson(),
       fromJson: PluginManagementResponse.fromJson,
     );

--- a/client/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/client/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -153,7 +153,9 @@ class RelayClient {
               if (firstBinaryMessage != null && !firstBinaryMessage.isCompleted) {
                 firstBinaryMessage.completeError(error, stackTrace);
               }
-              _completeAllPendingWithError(StateError("Relay socket stream error: ${error.toString()}"));
+              _completeAllPendingWithError(
+                RelayResponseLostException(message: "Relay socket stream error: ${error.toString()}"),
+              );
             },
             onDone: _onSocketDone,
           );
@@ -447,7 +449,7 @@ class RelayClient {
     await _closeSseController();
     await _closeBridgeStatusController();
     await _closeSocketClosedController();
-    _completeAllPendingWithError(StateError("Relay disconnected"));
+    _completeAllPendingWithError(const RelayResponseLostException(message: "Relay disconnected"));
     _sessionEncryptor = null;
     _connectionState = RelayClientConnectionState.disconnected;
   }
@@ -526,7 +528,7 @@ class RelayClient {
 
     _sessionEncryptor = null;
     _connectionState = RelayClientConnectionState.disconnected;
-    _completeAllPendingWithError(StateError("Relay socket closed (code=$closeCode)"));
+    _completeAllPendingWithError(RelayResponseLostException(message: "Relay socket closed (code=$closeCode)"));
     unawaited(_teardownChannelOnly());
     unawaited(_closeSseController());
 
@@ -740,4 +742,16 @@ class RelayClient {
 /// tearing it down.
 class _BridgeOfflineDuringHandshake implements Exception {
   const _BridgeOfflineDuringHandshake();
+}
+
+/// A request frame was sent (or may have been sent) but its response can no
+/// longer arrive because the relay connection ended. Callers must treat the
+/// outcome as uncertain rather than as proof the request never executed.
+final class RelayResponseLostException implements Exception {
+  final String message;
+
+  const RelayResponseLostException({required this.message});
+
+  @override
+  String toString() => message;
 }

--- a/client/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/client/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -389,7 +389,12 @@ class RelayClient {
       );
     } catch (error, stackTrace) {
       _pendingRequests.remove(request.id);
-      loge("Failed to send relay request ${request.id}", error, stackTrace);
+      // Typed post-dispatch response losses are preserved by the transport and
+      // surfaced as an explicit uncertain outcome; the rethrow is their
+      // report, so only log genuinely unclassified failures here.
+      if (error is! TimeoutException && error is! RelayResponseLostException) {
+        loge("Failed to send relay request ${request.id}", error, stackTrace);
+      }
       rethrow;
     }
   }

--- a/client/module_core/lib/src/repositories/models/plugin_management_result.dart
+++ b/client/module_core/lib/src/repositories/models/plugin_management_result.dart
@@ -1,0 +1,84 @@
+import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+sealed class PluginManagementLoadResult {
+  const PluginManagementLoadResult();
+
+  const factory PluginManagementLoadResult.supported({
+    required PluginManagementResponse response,
+    required ApiError? refreshError,
+  }) = PluginManagementLoadResultSupported;
+
+  const factory PluginManagementLoadResult.unsupported() = PluginManagementLoadResultUnsupported;
+
+  const factory PluginManagementLoadResult.failure({required ApiError error}) = PluginManagementLoadResultFailure;
+}
+
+final class PluginManagementLoadResultSupported extends PluginManagementLoadResult {
+  final PluginManagementResponse response;
+
+  /// Non-null when this publication replays a retained snapshot after a
+  /// refresh failure against the same bridge identity.
+  final ApiError? refreshError;
+
+  const PluginManagementLoadResultSupported({required this.response, required this.refreshError});
+}
+
+final class PluginManagementLoadResultUnsupported extends PluginManagementLoadResult {
+  const PluginManagementLoadResultUnsupported();
+}
+
+final class PluginManagementLoadResultFailure extends PluginManagementLoadResult {
+  final ApiError error;
+
+  const PluginManagementLoadResultFailure({required this.error});
+}
+
+sealed class PluginManagementMutationResult {
+  const PluginManagementMutationResult();
+
+  const factory PluginManagementMutationResult.success({
+    required PluginManagementResponse response,
+  }) = PluginManagementMutationResultSuccess;
+
+  const factory PluginManagementMutationResult.notFound() = PluginManagementMutationResultNotFound;
+
+  const factory PluginManagementMutationResult.conflict({
+    required PluginLifecycleConflict conflict,
+  }) = PluginManagementMutationResultConflict;
+
+  /// The mutation request was sent but its outcome cannot be truthfully
+  /// published: the response cannot prove it or the connection/service fence
+  /// moved. Consumers render this as an uncertain state requiring refresh,
+  /// never as a bridge rejection or a committed success.
+  const factory PluginManagementMutationResult.uncertain() = PluginManagementMutationResultUncertain;
+
+  const factory PluginManagementMutationResult.failure({required ApiError error}) =
+      PluginManagementMutationResultFailure;
+}
+
+final class PluginManagementMutationResultSuccess extends PluginManagementMutationResult {
+  final PluginManagementResponse response;
+
+  const PluginManagementMutationResultSuccess({required this.response});
+}
+
+final class PluginManagementMutationResultNotFound extends PluginManagementMutationResult {
+  const PluginManagementMutationResultNotFound();
+}
+
+final class PluginManagementMutationResultConflict extends PluginManagementMutationResult {
+  final PluginLifecycleConflict conflict;
+
+  const PluginManagementMutationResultConflict({required this.conflict});
+}
+
+final class PluginManagementMutationResultUncertain extends PluginManagementMutationResult {
+  const PluginManagementMutationResultUncertain();
+}
+
+final class PluginManagementMutationResultFailure extends PluginManagementMutationResult {
+  final ApiError error;
+
+  const PluginManagementMutationResultFailure({required this.error});
+}

--- a/client/module_core/lib/src/repositories/plugin_repository.dart
+++ b/client/module_core/lib/src/repositories/plugin_repository.dart
@@ -26,7 +26,9 @@ class PluginRepository {
     required String pluginId,
     required PluginLifecycleCommandRequest request,
   }) {
-    return _mapMutation(future: _api.command(pluginId: pluginId, request: request));
+    return _mapMutation(
+      future: _api.command(pluginId: pluginId, request: request),
+    );
   }
 
   Future<PluginManagementMutationResult> updateIdleTimeout({required PluginIdleTimeoutUpdateRequest request}) {
@@ -39,8 +41,7 @@ class PluginRepository {
     return switch (await future) {
       SuccessResponse(:final data) => PluginManagementMutationResult.success(response: data),
       ErrorResponse(error: NonSuccessCodeError(errorCode: 404)) => const PluginManagementMutationResult.notFound(),
-      ErrorResponse(error: NonSuccessCodeError(errorCode: 409, rawErrorString: final body)) =>
-        _mapConflict(body: body),
+      ErrorResponse(error: NonSuccessCodeError(errorCode: 409, rawErrorString: final body)) => _mapConflict(body: body),
       // A sent mutation whose outcome cannot be proven may have committed;
       // never surface it as a retryable ordinary failure. This covers an
       // undecodable or empty 2xx body and a post-dispatch response loss.

--- a/client/module_core/lib/src/repositories/plugin_repository.dart
+++ b/client/module_core/lib/src/repositories/plugin_repository.dart
@@ -5,6 +5,7 @@ import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../api/plugin_api.dart";
+import "../capabilities/relay/relay_client.dart";
 import "models/plugin_management_result.dart";
 
 @lazySingleton
@@ -46,7 +47,7 @@ class PluginRepository {
       ErrorResponse(
         error: JsonParsingError() ||
             EmptyResponseError() ||
-            DartHttpClientError(innerError: TimeoutException()),
+            DartHttpClientError(innerError: TimeoutException() || RelayResponseLostException()),
       ) =>
         const PluginManagementMutationResult.uncertain(),
       ErrorResponse(:final error) => PluginManagementMutationResult.failure(error: error),

--- a/client/module_core/lib/src/repositories/plugin_repository.dart
+++ b/client/module_core/lib/src/repositories/plugin_repository.dart
@@ -42,6 +42,9 @@ class PluginRepository {
       SuccessResponse(:final data) => PluginManagementMutationResult.success(response: data),
       ErrorResponse(error: NonSuccessCodeError(errorCode: 404)) => const PluginManagementMutationResult.notFound(),
       ErrorResponse(error: NonSuccessCodeError(errorCode: 409, rawErrorString: final body)) => _mapConflict(body: body),
+      // Management handlers use 503 when a mutation committed but its identity
+      // fence moved before they could publish an authoritative response.
+      ErrorResponse(error: NonSuccessCodeError(errorCode: 503)) => const PluginManagementMutationResult.uncertain(),
       // A sent mutation whose outcome cannot be proven may have committed;
       // never surface it as a retryable ordinary failure. This covers an
       // undecodable or empty 2xx body and a post-dispatch response loss.

--- a/client/module_core/lib/src/repositories/plugin_repository.dart
+++ b/client/module_core/lib/src/repositories/plugin_repository.dart
@@ -3,12 +3,61 @@ import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../api/plugin_api.dart";
+import "../logging/logging.dart";
+import "models/plugin_management_result.dart";
 
 @lazySingleton
 class PluginRepository {
   final PluginApi _api;
 
   PluginRepository({required PluginApi api}) : _api = api;
+
+  Future<PluginManagementLoadResult> getManagement() async {
+    return switch (await _api.getManagement()) {
+      SuccessResponse(:final data) => PluginManagementLoadResult.supported(response: data, refreshError: null),
+      ErrorResponse(error: NonSuccessCodeError(errorCode: 404)) => const PluginManagementLoadResult.unsupported(),
+      ErrorResponse(:final error) => PluginManagementLoadResult.failure(error: error),
+    };
+  }
+
+  Future<PluginManagementMutationResult> command({
+    required String pluginId,
+    required PluginLifecycleCommandRequest request,
+  }) {
+    return _mapMutation(_api.command(pluginId: pluginId, request: request));
+  }
+
+  Future<PluginManagementMutationResult> updateIdleTimeout({required PluginIdleTimeoutUpdateRequest request}) {
+    return _mapMutation(_api.updateIdleTimeout(request: request));
+  }
+
+  Future<PluginManagementMutationResult> _mapMutation(Future<ApiResponse<PluginManagementResponse>> future) async {
+    return switch (await future) {
+      SuccessResponse(:final data) => PluginManagementMutationResult.success(response: data),
+      ErrorResponse(error: NonSuccessCodeError(errorCode: 404)) => const PluginManagementMutationResult.notFound(),
+      ErrorResponse(error: NonSuccessCodeError(errorCode: 409, rawErrorString: final body)) => _mapConflict(body),
+      // A sent mutation whose 2xx outcome cannot be proven may have committed;
+      // never surface it as a retryable ordinary failure.
+      ErrorResponse(error: JsonParsingError() || EmptyResponseError()) =>
+        const PluginManagementMutationResult.uncertain(),
+      ErrorResponse(:final error) => PluginManagementMutationResult.failure(error: error),
+    };
+  }
+
+  PluginManagementMutationResult _mapConflict(String? body) {
+    if (body != null) {
+      try {
+        return PluginManagementMutationResult.conflict(
+          conflict: PluginLifecycleConflict.fromJson(jsonDecodeMap(body)),
+        );
+      } on Object catch (error, stackTrace) {
+        logw("Plugin management: rejecting a malformed conflict body", error, stackTrace);
+      }
+    }
+    return PluginManagementMutationResult.failure(
+      error: ApiError.nonSuccessCode(errorCode: 409, rawErrorString: body),
+    );
+  }
 
   Future<ApiResponse<PluginListResponse>> listPlugins() async {
     final response = await _api.listPlugins();

--- a/client/module_core/lib/src/repositories/plugin_repository.dart
+++ b/client/module_core/lib/src/repositories/plugin_repository.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:injectable/injectable.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -38,9 +40,14 @@ class PluginRepository {
       ErrorResponse(error: NonSuccessCodeError(errorCode: 404)) => const PluginManagementMutationResult.notFound(),
       ErrorResponse(error: NonSuccessCodeError(errorCode: 409, rawErrorString: final body)) =>
         _mapConflict(body: body),
-      // A sent mutation whose 2xx outcome cannot be proven may have committed;
-      // never surface it as a retryable ordinary failure.
-      ErrorResponse(error: JsonParsingError() || EmptyResponseError()) =>
+      // A sent mutation whose outcome cannot be proven may have committed;
+      // never surface it as a retryable ordinary failure. This covers an
+      // undecodable or empty 2xx body and a post-dispatch response loss.
+      ErrorResponse(
+        error: JsonParsingError() ||
+            EmptyResponseError() ||
+            DartHttpClientError(innerError: TimeoutException()),
+      ) =>
         const PluginManagementMutationResult.uncertain(),
       ErrorResponse(:final error) => PluginManagementMutationResult.failure(error: error),
     };

--- a/client/module_core/lib/src/repositories/plugin_repository.dart
+++ b/client/module_core/lib/src/repositories/plugin_repository.dart
@@ -3,7 +3,6 @@ import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../api/plugin_api.dart";
-import "../logging/logging.dart";
 import "models/plugin_management_result.dart";
 
 @lazySingleton
@@ -24,18 +23,21 @@ class PluginRepository {
     required String pluginId,
     required PluginLifecycleCommandRequest request,
   }) {
-    return _mapMutation(_api.command(pluginId: pluginId, request: request));
+    return _mapMutation(future: _api.command(pluginId: pluginId, request: request));
   }
 
   Future<PluginManagementMutationResult> updateIdleTimeout({required PluginIdleTimeoutUpdateRequest request}) {
-    return _mapMutation(_api.updateIdleTimeout(request: request));
+    return _mapMutation(future: _api.updateIdleTimeout(request: request));
   }
 
-  Future<PluginManagementMutationResult> _mapMutation(Future<ApiResponse<PluginManagementResponse>> future) async {
+  Future<PluginManagementMutationResult> _mapMutation({
+    required Future<ApiResponse<PluginManagementResponse>> future,
+  }) async {
     return switch (await future) {
       SuccessResponse(:final data) => PluginManagementMutationResult.success(response: data),
       ErrorResponse(error: NonSuccessCodeError(errorCode: 404)) => const PluginManagementMutationResult.notFound(),
-      ErrorResponse(error: NonSuccessCodeError(errorCode: 409, rawErrorString: final body)) => _mapConflict(body),
+      ErrorResponse(error: NonSuccessCodeError(errorCode: 409, rawErrorString: final body)) =>
+        _mapConflict(body: body),
       // A sent mutation whose 2xx outcome cannot be proven may have committed;
       // never surface it as a retryable ordinary failure.
       ErrorResponse(error: JsonParsingError() || EmptyResponseError()) =>
@@ -44,14 +46,14 @@ class PluginRepository {
     };
   }
 
-  PluginManagementMutationResult _mapConflict(String? body) {
+  PluginManagementMutationResult _mapConflict({required String? body}) {
     if (body != null) {
       try {
         return PluginManagementMutationResult.conflict(
           conflict: PluginLifecycleConflict.fromJson(jsonDecodeMap(body)),
         );
-      } on Object catch (error, stackTrace) {
-        logw("Plugin management: rejecting a malformed conflict body", error, stackTrace);
+      } on Object {
+        // The typed failure below is the single observable outcome.
       }
     }
     return PluginManagementMutationResult.failure(

--- a/client/module_core/test/api/plugin_api_test.dart
+++ b/client/module_core/test/api/plugin_api_test.dart
@@ -63,4 +63,102 @@ void main() {
 
     expect(await api.listPlugins(), ApiResponse<PluginListResponse>.error(error));
   });
+
+  test("GET /plugin/management parses the typed snapshot", () async {
+    when(
+      () => client.get<PluginManagementResponse>("/plugin/management", fromJson: any(named: "fromJson")),
+    ).thenAnswer((invocation) async {
+      final fromJson =
+          invocation.namedArguments[#fromJson] as PluginManagementResponse Function(Map<String, dynamic>);
+      return ApiResponse.success(fromJson(_managementJson));
+    });
+
+    final response = await api.getManagement();
+
+    final data = (response as SuccessResponse<PluginManagementResponse>).data;
+    expect(data.bridgeId, "br_abc12345");
+    expect(data.snapshotToken, "snapshot-token");
+    expect(data.plugins.single.setup.id, "opencode");
+    verify(
+      () => client.get<PluginManagementResponse>("/plugin/management", fromJson: any(named: "fromJson")),
+    ).called(1);
+  });
+
+  test("POST /plugin/:id/command serializes the shared request model", () async {
+    when(
+      () => client.post<PluginManagementResponse>(
+        any(),
+        body: any(named: "body"),
+        fromJson: any(named: "fromJson"),
+      ),
+    ).thenAnswer((invocation) async {
+      final fromJson =
+          invocation.namedArguments[#fromJson] as PluginManagementResponse Function(Map<String, dynamic>);
+      return ApiResponse.success(fromJson(_managementJson));
+    });
+
+    final response = await api.command(
+      pluginId: "codex",
+      request: const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe),
+    );
+
+    expect(response, isA<SuccessResponse<PluginManagementResponse>>());
+    final captured = verify(
+      () => client.post<PluginManagementResponse>(
+        captureAny(),
+        body: captureAny(named: "body"),
+        fromJson: any(named: "fromJson"),
+      ),
+    ).captured;
+    expect(captured[0], "/plugin/codex/command");
+    expect(captured[1], const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe).toJson());
+  });
+
+  test("PATCH /plugin/idle-timeout serializes the shared request model", () async {
+    when(
+      () => client.patch<PluginManagementResponse>(
+        any(),
+        body: any(named: "body"),
+        fromJson: any(named: "fromJson"),
+      ),
+    ).thenAnswer((invocation) async {
+      final fromJson =
+          invocation.namedArguments[#fromJson] as PluginManagementResponse Function(Map<String, dynamic>);
+      return ApiResponse.success(fromJson(_managementJson));
+    });
+
+    final response = await api.updateIdleTimeout(
+      request: const PluginIdleTimeoutUpdateRequest.setOverride(pluginId: "codex", idleTimeoutMins: 45),
+    );
+
+    expect(response, isA<SuccessResponse<PluginManagementResponse>>());
+    final captured = verify(
+      () => client.patch<PluginManagementResponse>(
+        captureAny(),
+        body: captureAny(named: "body"),
+        fromJson: any(named: "fromJson"),
+      ),
+    ).captured;
+    expect(captured[0], "/plugin/idle-timeout");
+    expect(
+      captured[1],
+      const PluginIdleTimeoutUpdateRequest.setOverride(pluginId: "codex", idleTimeoutMins: 45).toJson(),
+    );
+  });
 }
+
+const _managementJson = {
+  "snapshotToken": "snapshot-token",
+  "bridgeId": "br_abc12345",
+  "defaultPluginId": "opencode",
+  "defaultIdleTimeoutMins": 30,
+  "plugins": [
+    {
+      "setup": {"id": "opencode", "displayName": "OpenCode", "state": "ready", "actionHint": null},
+      "runtimeState": "active",
+      "workState": "idle",
+      "idleTimeoutMins": 30,
+      "hasIdleTimeoutOverride": false,
+    },
+  ],
+};

--- a/client/module_core/test/api/plugin_api_test.dart
+++ b/client/module_core/test/api/plugin_api_test.dart
@@ -68,8 +68,7 @@ void main() {
     when(
       () => client.get<PluginManagementResponse>("/plugin/management", fromJson: any(named: "fromJson")),
     ).thenAnswer((invocation) async {
-      final fromJson =
-          invocation.namedArguments[#fromJson] as PluginManagementResponse Function(Map<String, dynamic>);
+      final fromJson = invocation.namedArguments[#fromJson] as PluginManagementResponse Function(Map<String, dynamic>);
       return ApiResponse.success(fromJson(_managementJson));
     });
 
@@ -92,8 +91,7 @@ void main() {
         fromJson: any(named: "fromJson"),
       ),
     ).thenAnswer((invocation) async {
-      final fromJson =
-          invocation.namedArguments[#fromJson] as PluginManagementResponse Function(Map<String, dynamic>);
+      final fromJson = invocation.namedArguments[#fromJson] as PluginManagementResponse Function(Map<String, dynamic>);
       return ApiResponse.success(fromJson(_managementJson));
     });
 
@@ -122,8 +120,7 @@ void main() {
         fromJson: any(named: "fromJson"),
       ),
     ).thenAnswer((invocation) async {
-      final fromJson =
-          invocation.namedArguments[#fromJson] as PluginManagementResponse Function(Map<String, dynamic>);
+      final fromJson = invocation.namedArguments[#fromJson] as PluginManagementResponse Function(Map<String, dynamic>);
       return ApiResponse.success(fromJson(_managementJson));
     });
 

--- a/client/module_core/test/repositories/plugin_repository_test.dart
+++ b/client/module_core/test/repositories/plugin_repository_test.dart
@@ -4,6 +4,7 @@ import "dart:convert";
 import "package:mocktail/mocktail.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_dart_core/src/api/plugin_api.dart";
+import "package:sesori_dart_core/src/capabilities/relay/relay_client.dart";
 import "package:sesori_dart_core/src/repositories/models/plugin_management_result.dart";
 import "package:sesori_dart_core/src/repositories/plugin_repository.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -228,6 +229,26 @@ void main() {
       ).thenAnswer(
         (_) async => ApiResponse.error(
           ApiError.dartHttpClient(TimeoutException("Relay request timed out", const Duration(seconds: 30))),
+        ),
+      );
+
+      final result = await repository.command(
+        pluginId: "codex",
+        request: const PluginLifecycleCommandRequest.restart(mode: PluginStopMode.safe),
+      );
+
+      expect(result, isA<PluginManagementMutationResultUncertain>());
+    });
+
+    test("maps a socket-close response loss to uncertain", () async {
+      when(
+        () => api.command(
+          pluginId: any(named: "pluginId"),
+          request: any(named: "request"),
+        ),
+      ).thenAnswer(
+        (_) async => ApiResponse.error(
+          ApiError.dartHttpClient(const RelayResponseLostException(message: "Relay socket closed (code=1001)")),
         ),
       );
 

--- a/client/module_core/test/repositories/plugin_repository_test.dart
+++ b/client/module_core/test/repositories/plugin_repository_test.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:convert";
 
 import "package:mocktail/mocktail.dart";
@@ -213,6 +214,26 @@ void main() {
 
       final result = await repository.updateIdleTimeout(
         request: const PluginIdleTimeoutUpdateRequest.clearOverride(pluginId: "codex"),
+      );
+
+      expect(result, isA<PluginManagementMutationResultUncertain>());
+    });
+
+    test("maps a post-dispatch response loss to uncertain", () async {
+      when(
+        () => api.command(
+          pluginId: any(named: "pluginId"),
+          request: any(named: "request"),
+        ),
+      ).thenAnswer(
+        (_) async => ApiResponse.error(
+          ApiError.dartHttpClient(TimeoutException("Relay request timed out", const Duration(seconds: 30))),
+        ),
+      );
+
+      final result = await repository.command(
+        pluginId: "codex",
+        request: const PluginLifecycleCommandRequest.restart(mode: PluginStopMode.safe),
       );
 
       expect(result, isA<PluginManagementMutationResultUncertain>());

--- a/client/module_core/test/repositories/plugin_repository_test.dart
+++ b/client/module_core/test/repositories/plugin_repository_test.dart
@@ -1,6 +1,9 @@
+import "dart:convert";
+
 import "package:mocktail/mocktail.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_dart_core/src/api/plugin_api.dart";
+import "package:sesori_dart_core/src/repositories/models/plugin_management_result.dart";
 import "package:sesori_dart_core/src/repositories/plugin_repository.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -10,6 +13,11 @@ class MockPluginApi extends Mock implements PluginApi {}
 void main() {
   late MockPluginApi api;
   late PluginRepository repository;
+
+  setUpAll(() {
+    registerFallbackValue(const PluginLifecycleCommandRequest.enable());
+    registerFallbackValue(const PluginIdleTimeoutUpdateRequest.applyAll(idleTimeoutMins: 0));
+  });
 
   setUp(() {
     api = MockPluginApi();
@@ -71,4 +79,193 @@ void main() {
 
     expect(await repository.listPlugins(), ApiResponse<PluginListResponse>.error(error));
   });
+
+  group("getManagement", () {
+    test("maps a typed snapshot to supported", () async {
+      when(api.getManagement).thenAnswer((_) async => ApiResponse.success(_managementResponse));
+
+      final result = await repository.getManagement();
+
+      expect(
+        result,
+        isA<PluginManagementLoadResultSupported>()
+            .having((r) => r.response, "response", _managementResponse)
+            .having((r) => r.refreshError, "refreshError", isNull),
+      );
+    });
+
+    test("maps an unknown management route to unsupported", () async {
+      when(api.getManagement).thenAnswer(
+        (_) async => ApiResponse.error(ApiError.nonSuccessCode(errorCode: 404, rawErrorString: null)),
+      );
+
+      expect(await repository.getManagement(), isA<PluginManagementLoadResultUnsupported>());
+    });
+
+    test("maps other errors to explicit failure", () async {
+      final error = ApiError.nonSuccessCode(errorCode: 503, rawErrorString: null);
+      when(api.getManagement).thenAnswer((_) async => ApiResponse.error(error));
+
+      expect(
+        await repository.getManagement(),
+        isA<PluginManagementLoadResultFailure>().having((r) => r.error, "error", error),
+      );
+    });
+  });
+
+  group("mutations", () {
+    test("maps a typed success body", () async {
+      when(
+        () => api.command(
+          pluginId: any(named: "pluginId"),
+          request: any(named: "request"),
+        ),
+      ).thenAnswer((_) async => ApiResponse.success(_managementResponse));
+
+      final result = await repository.command(
+        pluginId: "codex",
+        request: const PluginLifecycleCommandRequest.enable(),
+      );
+
+      expect(
+        result,
+        isA<PluginManagementMutationResultSuccess>().having((r) => r.response, "response", _managementResponse),
+      );
+    });
+
+    test("maps an unknown plugin to notFound", () async {
+      when(
+        () => api.updateIdleTimeout(request: any(named: "request")),
+      ).thenAnswer((_) async => ApiResponse.error(ApiError.nonSuccessCode(errorCode: 404, rawErrorString: null)));
+
+      final result = await repository.updateIdleTimeout(
+        request: const PluginIdleTimeoutUpdateRequest.applyAll(idleTimeoutMins: 30),
+      );
+
+      expect(result, isA<PluginManagementMutationResultNotFound>());
+    });
+
+    test("parses a typed conflict", () async {
+      when(
+        () => api.command(
+          pluginId: any(named: "pluginId"),
+          request: any(named: "request"),
+        ),
+      ).thenAnswer(
+        (_) async => ApiResponse.error(
+          ApiError.nonSuccessCode(errorCode: 409, rawErrorString: jsonEncode(_conflictJson)),
+        ),
+      );
+
+      final result = await repository.command(
+        pluginId: "codex",
+        request: const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe),
+      );
+
+      expect(
+        result,
+        isA<PluginManagementMutationResultConflict>()
+            .having((r) => r.conflict.pluginId, "pluginId", "codex")
+            .having((r) => r.conflict.reasons, "reasons", [PluginLifecycleConflictReason.busy]),
+      );
+    });
+
+    test("maps a malformed conflict body to explicit failure", () async {
+      final error = ApiError.nonSuccessCode(errorCode: 409, rawErrorString: "not json");
+      when(
+        () => api.command(
+          pluginId: any(named: "pluginId"),
+          request: any(named: "request"),
+        ),
+      ).thenAnswer((_) async => ApiResponse.error(error));
+
+      final result = await repository.command(
+        pluginId: "codex",
+        request: const PluginLifecycleCommandRequest.restart(mode: PluginStopMode.safe),
+      );
+
+      expect(
+        result,
+        isA<PluginManagementMutationResultFailure>().having((r) => r.error, "error", error),
+      );
+    });
+
+    test("maps an undecodable successful mutation body to uncertain", () async {
+      when(
+        () => api.command(
+          pluginId: any(named: "pluginId"),
+          request: any(named: "request"),
+        ),
+      ).thenAnswer((_) async => ApiResponse.error(ApiError.jsonParsing("garbage")));
+
+      final result = await repository.command(
+        pluginId: "codex",
+        request: const PluginLifecycleCommandRequest.refresh(),
+      );
+
+      expect(result, isA<PluginManagementMutationResultUncertain>());
+    });
+
+    test("maps an empty successful mutation body to uncertain", () async {
+      when(
+        () => api.updateIdleTimeout(request: any(named: "request")),
+      ).thenAnswer((_) async => ApiResponse.error(ApiError.emptyResponse()));
+
+      final result = await repository.updateIdleTimeout(
+        request: const PluginIdleTimeoutUpdateRequest.clearOverride(pluginId: "codex"),
+      );
+
+      expect(result, isA<PluginManagementMutationResultUncertain>());
+    });
+
+    test("maps generic mutation errors to explicit failure", () async {
+      final error = ApiError.generic();
+      when(
+        () => api.updateIdleTimeout(request: any(named: "request")),
+      ).thenAnswer((_) async => ApiResponse.error(error));
+
+      final result = await repository.updateIdleTimeout(
+        request: const PluginIdleTimeoutUpdateRequest.applyAll(idleTimeoutMins: 30),
+      );
+
+      expect(
+        result,
+        isA<PluginManagementMutationResultFailure>().having((r) => r.error, "error", error),
+      );
+    });
+  });
 }
+
+const _managementPlugin = PluginManagementMetadata(
+  setup: PluginSetupMetadata(
+    id: "codex",
+    displayName: "Codex",
+    state: PluginSetupState.ready,
+    actionHint: null,
+  ),
+  runtimeState: PluginRuntimeState.active,
+  workState: PluginManagementWorkState.busy,
+  idleTimeoutMins: 30,
+  hasIdleTimeoutOverride: false,
+  actionHint: null,
+);
+
+const _managementResponse = PluginManagementResponse(
+  snapshotToken: "snapshot-token",
+  bridgeId: "br_abc12345",
+  defaultPluginId: "codex",
+  defaultIdleTimeoutMins: 30,
+  plugins: [_managementPlugin],
+);
+
+const _conflictJson = {
+  "pluginId": "codex",
+  "reasons": ["busy"],
+  "current": {
+    "setup": {"id": "codex", "displayName": "Codex", "state": "ready", "actionHint": null},
+    "runtimeState": "active",
+    "workState": "busy",
+    "idleTimeoutMins": 30,
+    "hasIdleTimeoutOverride": false,
+  },
+};

--- a/client/module_core/test/repositories/plugin_repository_test.dart
+++ b/client/module_core/test/repositories/plugin_repository_test.dart
@@ -222,6 +222,22 @@ void main() {
       expect(result, isA<PluginManagementMutationResultUncertain>());
     });
 
+    test("maps a bridge-reported uncertain mutation to uncertain", () async {
+      when(
+        () => api.updateIdleTimeout(request: any(named: "request")),
+      ).thenAnswer(
+        (_) async => ApiResponse.error(
+          ApiError.nonSuccessCode(errorCode: 503, rawErrorString: "plugin mutation outcome is uncertain"),
+        ),
+      );
+
+      final result = await repository.updateIdleTimeout(
+        request: const PluginIdleTimeoutUpdateRequest.applyAll(idleTimeoutMins: 30),
+      );
+
+      expect(result, isA<PluginManagementMutationResultUncertain>());
+    });
+
     test("maps a post-dispatch response loss to uncertain", () async {
       when(
         () => api.command(

--- a/client/module_core/test/repositories/plugin_repository_test.dart
+++ b/client/module_core/test/repositories/plugin_repository_test.dart
@@ -166,9 +166,11 @@ void main() {
 
       expect(
         result,
-        isA<PluginManagementMutationResultConflict>()
-            .having((r) => r.conflict.pluginId, "pluginId", "codex")
-            .having((r) => r.conflict.reasons, "reasons", [PluginLifecycleConflictReason.busy]),
+        isA<PluginManagementMutationResultConflict>().having((r) => r.conflict.pluginId, "pluginId", "codex").having(
+          (r) => r.conflict.reasons,
+          "reasons",
+          [PluginLifecycleConflictReason.busy],
+        ),
       );
     });
 

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.dart
@@ -67,6 +67,10 @@ sealed class PluginManagementResponse with _$PluginManagementResponse {
     // omit snapshotToken; null means that peer cannot identify snapshot changes.
     // Make non-null when those bridge versions are unsupported.
     required String? snapshotToken,
+    // COMPATIBILITY 2026-07-27 (v1.7.0): Stage 12 bridge payloads omit the
+    // bridge identity; null means the peer cannot scope management snapshots
+    // to a bridge. Make non-null when those bridge versions are unsupported.
+    required String? bridgeId,
     required String? defaultPluginId,
     required int defaultIdleTimeoutMins,
     required List<PluginManagementMetadata> plugins,

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.freezed.dart
@@ -185,7 +185,10 @@ mixin _$PluginManagementResponse {
 // COMPATIBILITY 2026-07-25 (v1.6.1): Stage 12-P02 and older bridge payloads
 // omit snapshotToken; null means that peer cannot identify snapshot changes.
 // Make non-null when those bridge versions are unsupported.
- String? get snapshotToken; String? get defaultPluginId; int get defaultIdleTimeoutMins; List<PluginManagementMetadata> get plugins;
+ String? get snapshotToken;// COMPATIBILITY 2026-07-27 (v1.7.0): Stage 12 bridge payloads omit the
+// bridge identity; null means the peer cannot scope management snapshots
+// to a bridge. Make non-null when those bridge versions are unsupported.
+ String? get bridgeId; String? get defaultPluginId; int get defaultIdleTimeoutMins; List<PluginManagementMetadata> get plugins;
 /// Create a copy of PluginManagementResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -198,16 +201,16 @@ $PluginManagementResponseCopyWith<PluginManagementResponse> get copyWith => _$Pl
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginManagementResponse&&(identical(other.snapshotToken, snapshotToken) || other.snapshotToken == snapshotToken)&&(identical(other.defaultPluginId, defaultPluginId) || other.defaultPluginId == defaultPluginId)&&(identical(other.defaultIdleTimeoutMins, defaultIdleTimeoutMins) || other.defaultIdleTimeoutMins == defaultIdleTimeoutMins)&&const DeepCollectionEquality().equals(other.plugins, plugins));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginManagementResponse&&(identical(other.snapshotToken, snapshotToken) || other.snapshotToken == snapshotToken)&&(identical(other.bridgeId, bridgeId) || other.bridgeId == bridgeId)&&(identical(other.defaultPluginId, defaultPluginId) || other.defaultPluginId == defaultPluginId)&&(identical(other.defaultIdleTimeoutMins, defaultIdleTimeoutMins) || other.defaultIdleTimeoutMins == defaultIdleTimeoutMins)&&const DeepCollectionEquality().equals(other.plugins, plugins));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,snapshotToken,defaultPluginId,defaultIdleTimeoutMins,const DeepCollectionEquality().hash(plugins));
+int get hashCode => Object.hash(runtimeType,snapshotToken,bridgeId,defaultPluginId,defaultIdleTimeoutMins,const DeepCollectionEquality().hash(plugins));
 
 @override
 String toString() {
-  return 'PluginManagementResponse(snapshotToken: $snapshotToken, defaultPluginId: $defaultPluginId, defaultIdleTimeoutMins: $defaultIdleTimeoutMins, plugins: $plugins)';
+  return 'PluginManagementResponse(snapshotToken: $snapshotToken, bridgeId: $bridgeId, defaultPluginId: $defaultPluginId, defaultIdleTimeoutMins: $defaultIdleTimeoutMins, plugins: $plugins)';
 }
 
 
@@ -218,7 +221,7 @@ abstract mixin class $PluginManagementResponseCopyWith<$Res>  {
   factory $PluginManagementResponseCopyWith(PluginManagementResponse value, $Res Function(PluginManagementResponse) _then) = _$PluginManagementResponseCopyWithImpl;
 @useResult
 $Res call({
- String? snapshotToken, String? defaultPluginId, int defaultIdleTimeoutMins, List<PluginManagementMetadata> plugins
+ String? snapshotToken, String? bridgeId, String? defaultPluginId, int defaultIdleTimeoutMins, List<PluginManagementMetadata> plugins
 });
 
 
@@ -235,9 +238,10 @@ class _$PluginManagementResponseCopyWithImpl<$Res>
 
 /// Create a copy of PluginManagementResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? snapshotToken = freezed,Object? defaultPluginId = freezed,Object? defaultIdleTimeoutMins = null,Object? plugins = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? snapshotToken = freezed,Object? bridgeId = freezed,Object? defaultPluginId = freezed,Object? defaultIdleTimeoutMins = null,Object? plugins = null,}) {
   return _then(_self.copyWith(
 snapshotToken: freezed == snapshotToken ? _self.snapshotToken : snapshotToken // ignore: cast_nullable_to_non_nullable
+as String?,bridgeId: freezed == bridgeId ? _self.bridgeId : bridgeId // ignore: cast_nullable_to_non_nullable
 as String?,defaultPluginId: freezed == defaultPluginId ? _self.defaultPluginId : defaultPluginId // ignore: cast_nullable_to_non_nullable
 as String?,defaultIdleTimeoutMins: null == defaultIdleTimeoutMins ? _self.defaultIdleTimeoutMins : defaultIdleTimeoutMins // ignore: cast_nullable_to_non_nullable
 as int,plugins: null == plugins ? _self.plugins : plugins // ignore: cast_nullable_to_non_nullable
@@ -253,13 +257,17 @@ as List<PluginManagementMetadata>,
 @JsonSerializable()
 
 class _PluginManagementResponse implements PluginManagementResponse {
-  const _PluginManagementResponse({required this.snapshotToken, required this.defaultPluginId, required this.defaultIdleTimeoutMins, required final  List<PluginManagementMetadata> plugins}): _plugins = plugins;
+  const _PluginManagementResponse({required this.snapshotToken, required this.bridgeId, required this.defaultPluginId, required this.defaultIdleTimeoutMins, required final  List<PluginManagementMetadata> plugins}): _plugins = plugins;
   factory _PluginManagementResponse.fromJson(Map<String, dynamic> json) => _$PluginManagementResponseFromJson(json);
 
 // COMPATIBILITY 2026-07-25 (v1.6.1): Stage 12-P02 and older bridge payloads
 // omit snapshotToken; null means that peer cannot identify snapshot changes.
 // Make non-null when those bridge versions are unsupported.
 @override final  String? snapshotToken;
+// COMPATIBILITY 2026-07-27 (v1.7.0): Stage 12 bridge payloads omit the
+// bridge identity; null means the peer cannot scope management snapshots
+// to a bridge. Make non-null when those bridge versions are unsupported.
+@override final  String? bridgeId;
 @override final  String? defaultPluginId;
 @override final  int defaultIdleTimeoutMins;
  final  List<PluginManagementMetadata> _plugins;
@@ -283,16 +291,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginManagementResponse&&(identical(other.snapshotToken, snapshotToken) || other.snapshotToken == snapshotToken)&&(identical(other.defaultPluginId, defaultPluginId) || other.defaultPluginId == defaultPluginId)&&(identical(other.defaultIdleTimeoutMins, defaultIdleTimeoutMins) || other.defaultIdleTimeoutMins == defaultIdleTimeoutMins)&&const DeepCollectionEquality().equals(other._plugins, _plugins));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginManagementResponse&&(identical(other.snapshotToken, snapshotToken) || other.snapshotToken == snapshotToken)&&(identical(other.bridgeId, bridgeId) || other.bridgeId == bridgeId)&&(identical(other.defaultPluginId, defaultPluginId) || other.defaultPluginId == defaultPluginId)&&(identical(other.defaultIdleTimeoutMins, defaultIdleTimeoutMins) || other.defaultIdleTimeoutMins == defaultIdleTimeoutMins)&&const DeepCollectionEquality().equals(other._plugins, _plugins));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,snapshotToken,defaultPluginId,defaultIdleTimeoutMins,const DeepCollectionEquality().hash(_plugins));
+int get hashCode => Object.hash(runtimeType,snapshotToken,bridgeId,defaultPluginId,defaultIdleTimeoutMins,const DeepCollectionEquality().hash(_plugins));
 
 @override
 String toString() {
-  return 'PluginManagementResponse(snapshotToken: $snapshotToken, defaultPluginId: $defaultPluginId, defaultIdleTimeoutMins: $defaultIdleTimeoutMins, plugins: $plugins)';
+  return 'PluginManagementResponse(snapshotToken: $snapshotToken, bridgeId: $bridgeId, defaultPluginId: $defaultPluginId, defaultIdleTimeoutMins: $defaultIdleTimeoutMins, plugins: $plugins)';
 }
 
 
@@ -303,7 +311,7 @@ abstract mixin class _$PluginManagementResponseCopyWith<$Res> implements $Plugin
   factory _$PluginManagementResponseCopyWith(_PluginManagementResponse value, $Res Function(_PluginManagementResponse) _then) = __$PluginManagementResponseCopyWithImpl;
 @override @useResult
 $Res call({
- String? snapshotToken, String? defaultPluginId, int defaultIdleTimeoutMins, List<PluginManagementMetadata> plugins
+ String? snapshotToken, String? bridgeId, String? defaultPluginId, int defaultIdleTimeoutMins, List<PluginManagementMetadata> plugins
 });
 
 
@@ -320,9 +328,10 @@ class __$PluginManagementResponseCopyWithImpl<$Res>
 
 /// Create a copy of PluginManagementResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? snapshotToken = freezed,Object? defaultPluginId = freezed,Object? defaultIdleTimeoutMins = null,Object? plugins = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? snapshotToken = freezed,Object? bridgeId = freezed,Object? defaultPluginId = freezed,Object? defaultIdleTimeoutMins = null,Object? plugins = null,}) {
   return _then(_PluginManagementResponse(
 snapshotToken: freezed == snapshotToken ? _self.snapshotToken : snapshotToken // ignore: cast_nullable_to_non_nullable
+as String?,bridgeId: freezed == bridgeId ? _self.bridgeId : bridgeId // ignore: cast_nullable_to_non_nullable
 as String?,defaultPluginId: freezed == defaultPluginId ? _self.defaultPluginId : defaultPluginId // ignore: cast_nullable_to_non_nullable
 as String?,defaultIdleTimeoutMins: null == defaultIdleTimeoutMins ? _self.defaultIdleTimeoutMins : defaultIdleTimeoutMins // ignore: cast_nullable_to_non_nullable
 as int,plugins: null == plugins ? _self._plugins : plugins // ignore: cast_nullable_to_non_nullable

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.g.dart
@@ -58,6 +58,7 @@ const _$PluginManagementWorkStateEnumMap = {
 _PluginManagementResponse _$PluginManagementResponseFromJson(Map json) =>
     _PluginManagementResponse(
       snapshotToken: json['snapshotToken'] as String?,
+      bridgeId: json['bridgeId'] as String?,
       defaultPluginId: json['defaultPluginId'] as String?,
       defaultIdleTimeoutMins: (json['defaultIdleTimeoutMins'] as num).toInt(),
       plugins: (json['plugins'] as List<dynamic>)
@@ -73,6 +74,7 @@ Map<String, dynamic> _$PluginManagementResponseToJson(
   _PluginManagementResponse instance,
 ) => <String, dynamic>{
   'snapshotToken': ?instance.snapshotToken,
+  'bridgeId': ?instance.bridgeId,
   'defaultPluginId': ?instance.defaultPluginId,
   'defaultIdleTimeoutMins': instance.defaultIdleTimeoutMins,
   'plugins': instance.plugins.map((e) => e.toJson()).toList(),

--- a/shared/sesori_shared/test/models/plugin_management_contract_test.dart
+++ b/shared/sesori_shared/test/models/plugin_management_contract_test.dart
@@ -19,6 +19,7 @@ void main() {
   test("management response round-trips only read snapshot fields", () {
     const response = PluginManagementResponse(
       snapshotToken: "snapshot-token",
+      bridgeId: "br_abc12345",
       defaultPluginId: "opencode",
       defaultIdleTimeoutMins: 30,
       plugins: [plugin],
@@ -29,12 +30,16 @@ void main() {
     final pluginJson = plugins!.single! as Map<String, dynamic>;
 
     expect(PluginManagementResponse.fromJson(json), response);
-    expect(json.keys, unorderedEquals(["snapshotToken", "defaultPluginId", "defaultIdleTimeoutMins", "plugins"]));
+    expect(
+      json.keys,
+      unorderedEquals(["snapshotToken", "bridgeId", "defaultPluginId", "defaultIdleTimeoutMins", "plugins"]),
+    );
     expect(
       pluginJson.keys,
       unorderedEquals(["setup", "runtimeState", "workState", "idleTimeoutMins", "hasIdleTimeoutOverride"]),
     );
     expect(json["snapshotToken"], "snapshot-token");
+    expect(json["bridgeId"], "br_abc12345");
     expect(pluginJson, isNot(contains("enabled")));
     expect(pluginJson, isNot(contains("isDefault")));
     expect(json, isNot(contains("authority")));
@@ -44,12 +49,26 @@ void main() {
   test("older management responses decode without a snapshot token", () {
     final json = const PluginManagementResponse(
       snapshotToken: null,
+      bridgeId: null,
       defaultPluginId: "opencode",
       defaultIdleTimeoutMins: 30,
       plugins: [plugin],
     ).toJson()..remove("snapshotToken");
 
     expect(PluginManagementResponse.fromJson(json).snapshotToken, isNull);
+  });
+
+  test("management response omits a null bridge ID and decodes a missing one as null", () {
+    final json = const PluginManagementResponse(
+      snapshotToken: "snapshot-token",
+      bridgeId: null,
+      defaultPluginId: "opencode",
+      defaultIdleTimeoutMins: 30,
+      plugins: [plugin],
+    ).toJson();
+
+    expect(json, isNot(contains("bridgeId")));
+    expect(PluginManagementResponse.fromJson(json).bridgeId, isNull);
   });
 
   test("future runtime and work states decode to fail-closed unknown values", () {


### PR DESCRIPTION
## Summary

Step 2/7 of the Stage 13 Harnesses series (`.plan/active/setup-aware-harness-settings/PLAN.md`).

Carries the authoritative bridge identity through the Stage 12 management transport and introduces the client-side repository result surface for it:

- **Shared wire:** `PluginManagementResponse` gains an additive nullable `bridgeId` (omitted when null; older Stage 12 bridges decode as missing → null; dated compatibility comment).
- **Bridge:** `BridgeRegistrationService` is composed before `PluginLifecycleService` and injected through `BridgeIdProvider`. The lifecycle service caches private identity-free management state and only builds the transport response at return time. Reads and mutations fail closed before registration; mutation identity is required before dispatch or persistence, and command completion remains observable if identity disappears after dispatch. All three handlers remain pass-through consumers of the same authoritative response shape.
- **Client API:** `PluginApi` gains `getManagement`, `command`, and `updateIdleTimeout`, serializing the shared Freezed request models.
- **Client repository:** handwritten `PluginManagementLoadResult` / `PluginManagementMutationResult` (following `SessionDetailLoadResult`'s pattern) with mappings:
  - management GET 404 → `unsupported`; other errors → explicit `failure`
  - mutation 404 → `notFound`; HTTP 409 → typed `PluginLifecycleConflict`; malformed 409 → explicit failure
  - a mutation response that cannot prove the outcome (undecodable/empty 2xx, post-dispatch timeout/relay response loss, or bridge-reported post-commit identity loss via 503) → `uncertain`, never a retryable-looking failure, since the bridge may have committed
  - discovery fallback behavior unchanged

The management service and cubit arrive in Steps 3 and 6; this slice is transport + repository results only.

## Verification

- `sesori_shared`: codegen; contract tests for known/null/omitted `bridgeId`; fatal analysis.
- Bridge app: full suite (2148) + fatal analysis — lifecycle-service tests prove pre-registration reads and mutations fail closed, queued timeout writes recheck identity before persistence, command completion does not hang if identity disappears after dispatch, and the provider identity is returned after registration; handlers pass the service response through unchanged.
- `module_core`: full suite (657) + fatal analysis — API path/body/typed-response tests for all three routes; repository tests for supported, unsupported 404, mutation 404, typed/malformed 409, undecodable/empty 2xx, post-dispatch response loss, and bridge-reported post-commit identity loss → `uncertain`, generic failure, and preserved discovery fallback.
- Mobile and desktop fatal analysis clean.
- Aristotle implementation reviews: **approved**, including the final identity-ownership refactor.

Changed lines (~660) exceed the 300-400 estimate, driven by repository/API and identity-guard regression coverage; production code remains small.

## E2E

Confirming simulator E2E passed against the source dev bridge: `GET /plugin/management`, plugin command mutations, and idle-timeout mutations all carried the dev bridge ID; the Step 1 persistence gate rerun also passed. Full details and cleanup are recorded in the PR comments and tracker. The identity guards do not change registered-bridge wire behavior, and revocation while queued is covered by the full bridge suite.
