### PR TITLE
[bridge-ready-onboarding] refactor(bridge): separate session startup from serving [step 1/2]

### DIFF
--- a/.plan/active/bridge-ready-onboarding/TRACKER.md
+++ b/.plan/active/bridge-ready-onboarding/TRACKER.md
@@ -2,12 +2,12 @@
 
 ## Plan State
 
-- **Status:** plan merged; Step 1 implemented and verified locally
+- **Status:** plan merged; Step 1 PR in review
 - **Plan slug:** `bridge-ready-onboarding`
 - **Implementation base:** `origin/main` at
   `f87b4c6603c682b4606a57010a41d3cab4d96ddd`
 - **Plan PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/580
-- **Implementation state:** Step 1 ready for commit/delivery; no implementation PR opened
+- **Implementation state:** Step 1 PR: https://github.com/sesori-ai/sesori_apps_monorepo/pull/585
 
 ## Plan Review
 
@@ -21,7 +21,7 @@
 
 | Done | Step | Branch | Exact PR title | Changed-line budget | State |
 |---|---|---|---|---:|---|
-| [ ] | 1/2 | `bridge-setup-ux-assessment` | `[bridge-ready-onboarding] refactor(bridge): separate session startup from serving [step 1/2]` | 650-950; reassess at 1,300; maximum 1,500 | Implemented and verified locally |
+| [ ] | 1/2 | `bridge-setup-ux-assessment` | `[bridge-ready-onboarding] refactor(bridge): separate session startup from serving [step 1/2]` | 650-950; reassess at 1,300; maximum 1,500 | [PR #585](https://github.com/sesori-ai/sesori_apps_monorepo/pull/585) in review |
 | [ ] | 2/2 | `bridge-ready-onboarding-relay-first` | `[bridge-ready-onboarding] fix(bridge): start relay before mobile onboarding [step 2/2]` | 450-750; reassess at 1,300; maximum 1,500 | Blocked on Step 1 merge |
 
 ## Execution Rules
@@ -40,8 +40,8 @@
 
 ## Current Pointer
 
-- **Next action:** commit and publish Step 1 when requested; Step 2 remains
-  blocked until Step 1 merges.
+- **Next action:** monitor Step 1 CI and review; Step 2 remains blocked until
+  Step 1 merges.
 
 ## Step 1 Verification
 
@@ -54,6 +54,9 @@
 
 ## Findings And Plan Deltas
 
+- **2026-07-27 — Step 1 delivery:** Opened implementation PR
+  [#585](https://github.com/sesori-ai/sesori_apps_monorepo/pull/585) and started
+  CI/review monitoring.
 - **2026-07-27 — Step 1 implementation:** Replaced the session `run` contract
   with one-shot startup/readiness and lifecycle-wait operations, added pending
   WebSocket handshake ownership/cancellation, armed a fresh relay iterator for

--- a/.plan/active/bridge-ready-onboarding/TRACKER.md
+++ b/.plan/active/bridge-ready-onboarding/TRACKER.md
@@ -2,12 +2,12 @@
 
 ## Plan State
 
-- **Status:** architecture review corrections applied; plan PR in review
+- **Status:** plan merged; Step 1 implemented and verified locally
 - **Plan slug:** `bridge-ready-onboarding`
 - **Implementation base:** `origin/main` at
-  `f8c71eb78987aa8c64e397e8e8e3bb72eefa0692`
+  `f87b4c6603c682b4606a57010a41d3cab4d96ddd`
 - **Plan PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/580
-- **Implementation state:** not started
+- **Implementation state:** Step 1 ready for commit/delivery; no implementation PR opened
 
 ## Plan Review
 
@@ -21,7 +21,7 @@
 
 | Done | Step | Branch | Exact PR title | Changed-line budget | State |
 |---|---|---|---|---:|---|
-| [ ] | 1/2 | `bridge-ready-onboarding-session-lifecycle` | `[bridge-ready-onboarding] refactor(bridge): separate session startup from serving [step 1/2]` | 650-950; reassess at 1,300; maximum 1,500 | Not started |
+| [ ] | 1/2 | `bridge-setup-ux-assessment` | `[bridge-ready-onboarding] refactor(bridge): separate session startup from serving [step 1/2]` | 650-950; reassess at 1,300; maximum 1,500 | Implemented and verified locally |
 | [ ] | 2/2 | `bridge-ready-onboarding-relay-first` | `[bridge-ready-onboarding] fix(bridge): start relay before mobile onboarding [step 2/2]` | 450-750; reassess at 1,300; maximum 1,500 | Blocked on Step 1 merge |
 
 ## Execution Rules
@@ -40,11 +40,30 @@
 
 ## Current Pointer
 
-- **Next action:** merge the plan PR, then create Step 1 from current
-  `origin/main` and pin its actual base SHA in the PR body.
+- **Next action:** commit and publish Step 1 when requested; Step 2 remains
+  blocked until Step 1 merges.
+
+## Step 1 Verification
+
+- Focused lifecycle, registration, reconnect, relay-client, event, and debug
+  server tests pass.
+- `dart test test/bridge/runtime/bridge_runtime_runner_test.dart` passes.
+- `dart analyze --fatal-infos` passes from `bridge/app`.
+- `aristotle-impl-review` approved the implementation on its second pass after
+  the cancelled-startup path was fixed to preserve supervised exit sentinels.
 
 ## Findings And Plan Deltas
 
+- **2026-07-27 — Step 1 implementation:** Replaced the session `run` contract
+  with one-shot startup/readiness and lifecycle-wait operations, added pending
+  WebSocket handshake ownership/cancellation, armed a fresh relay iterator for
+  every connection, migrated all in-repository callers, and added focused
+  lifecycle/reconnect coverage. The user-directed existing worktree branch was
+  used instead of creating the planned Step 1 branch.
+- **2026-07-27 — Step 1 implementation review:** The first pass found that an
+  early cancelled-startup return could bypass supervised restart sentinel
+  finalization. The runner now finalizes typed exit state before returning; the
+  second review approved the implementation.
 - **2026-07-26 — Follow-up PR feedback:** Added `RelayClient` pending-handshake
   ownership/cancellation to Step 1 so shutdown cannot wait for the 15-second
   connect timeout or allow late channel promotion/auth; clarified that Step 2

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -543,10 +543,12 @@ bool _gitPathExists({required String gitPath}) {
   return FileSystemEntity.typeSync(gitPath) != FileSystemEntityType.notFound;
 }
 
+enum OrchestratorSessionStartResult { ready, cancelled }
+
 /// A running bridge session with immutable runtime state.
 ///
-/// Created by [Orchestrator.create]. Call [run] to start the relay loop
-/// and [cancel] to shut down gracefully.
+/// Created by [Orchestrator.create]. Call [start] once, capture
+/// [waitUntilStopped] immediately, and use [cancel] to shut down gracefully.
 class OrchestratorSession {
   final BridgeConfig config;
   final RelayClient _client;
@@ -589,6 +591,7 @@ class OrchestratorSession {
   final Map<String, Future<void>> _pluginEventProcessingTails = <String, Future<void>>{};
   Future<void> _projectsSummaryTail = Future<void>.value();
   final Random _backoffJitter = Random();
+  Future<void>? _lifecycleFuture;
 
   bool _cancelled = false;
   Object? _beginShutdownError;
@@ -709,18 +712,83 @@ class OrchestratorSession {
   RequestRouter get router => _router;
   Future<void> drainRoutedMutations() => _sessionMutationDispatcher.drain();
 
-  Future<void> run() async {
+  Future<OrchestratorSessionStartResult> start() {
+    if (_lifecycleFuture != null) {
+      return Future.error(StateError("OrchestratorSession has already started"), StackTrace.current);
+    }
+
+    final readiness = Completer<OrchestratorSessionStartResult>();
+    final lifecycleFuture = Future<void>.microtask(
+      () => _runLifecycle(readiness: readiness),
+    );
+    _lifecycleFuture = lifecycleFuture;
+    lifecycleFuture.ignore();
+    return readiness.future;
+  }
+
+  Future<void> waitUntilStopped() {
+    final lifecycleFuture = _lifecycleFuture;
+    if (lifecycleFuture == null) {
+      return Future.error(StateError("OrchestratorSession has not started"), StackTrace.current);
+    }
+    return lifecycleFuture;
+  }
+
+  Future<void> _runLifecycle({
+    required Completer<OrchestratorSessionStartResult> readiness,
+  }) async {
+    Object? firstError;
+    StackTrace? firstStackTrace;
+
+    try {
+      await _startAndServe(readiness: readiness);
+    } on Object catch (error, stackTrace) {
+      if (!_cancelled) {
+        firstError = error;
+        firstStackTrace = stackTrace;
+      }
+    }
+
+    try {
+      await _teardown();
+    } on Object catch (error, stackTrace) {
+      firstError ??= error;
+      firstStackTrace ??= stackTrace;
+    }
+
+    if (!readiness.isCompleted) {
+      if (_cancelled) {
+        readiness.complete(OrchestratorSessionStartResult.cancelled);
+      } else {
+        final error = firstError ?? StateError("OrchestratorSession stopped before becoming ready");
+        final stackTrace = firstStackTrace ?? StackTrace.current;
+        firstError = error;
+        firstStackTrace = stackTrace;
+        readiness.completeError(error, stackTrace);
+      }
+    }
+
+    if (firstError case final error?) {
+      Error.throwWithStackTrace(error, firstStackTrace ?? StackTrace.current);
+    }
+  }
+
+  Future<void> _startAndServe({
+    required Completer<OrchestratorSessionStartResult> readiness,
+  }) async {
     final kxManager = KeyExchangeManager(_roomKey);
     final activePhones = <int, bool>{};
 
     Log.d("registering bridge with auth server...");
     await _bridgeRegistrationService.ensureRegistered();
     Log.d("bridge registered");
+    if (_cancelled) return;
 
     try {
       Log.d("connecting to relay...");
       await _client.connect();
       Log.d("relay connected");
+      if (_cancelled) return;
 
       _sessionAbortService.abortStartedSessions
           .listen(_completionListener.markSessionAbortPending)
@@ -815,152 +883,184 @@ class OrchestratorSession {
     Console.message("Relay:  ${config.relayURL}");
     Console.message("Waiting for relay events...");
 
-    try {
-      while (!_cancelled) {
+    await _serveRelayConnections(
+      readiness: readiness,
+      kxManager: kxManager,
+      activePhones: activePhones,
+    );
+  }
+
+  Future<void> _teardown() async {
+    final teardownSw = Stopwatch()..start();
+    Object? firstTeardownError = _beginShutdownError;
+    StackTrace? firstTeardownStackTrace = _beginShutdownStackTrace;
+
+    Future<void> attempt(FutureOr<void> Function() action) async {
+      try {
+        await action();
+      } on Object catch (error, stackTrace) {
+        firstTeardownError ??= error;
+        firstTeardownStackTrace ??= stackTrace;
+      }
+    }
+
+    final sinceCancelMs = _cancelRequestedAt == null
+        ? null
+        : DateTime.now().difference(_cancelRequestedAt!).inMilliseconds;
+    Log.i("Disconnecting...");
+    Log.d(
+      "[shutdown] session teardown begin "
+      "(${sinceCancelMs == null ? "no cancel timestamp" : "${sinceCancelMs}ms since cancel()"}"
+      "${_inFlightRequestLabel == null ? "" : ", in-flight request: $_inFlightRequestLabel"})",
+    );
+    await Future.wait([
+      attempt(_subscriptions.cancel),
+      attempt(_promptDefaultsSubscriptions.cancel),
+      attempt(_catalogImportSubscriptions.cancel),
+    ]);
+    Log.v("[shutdown] subscriptions cancelled (+${teardownSw.elapsedMilliseconds}ms)");
+    await attempt(() async {
+      await Future.wait(_pluginEventProcessingTails.values);
+    });
+    Log.v("[shutdown] plugin event processing drained (+${teardownSw.elapsedMilliseconds}ms)");
+    await attempt(_sessionPromptService.dispose);
+    await Future.wait([
+      for (final listener in _pluginEventListeners) attempt(listener.dispose),
+      attempt(_sessionBindingCommitListener.dispose),
+      attempt(_sessionDeletionListener.dispose),
+    ]);
+    await attempt(_sessionEventDispatcher.dispose);
+    await attempt(_permissionAutoApprovalService.dispose);
+    await attempt(_sessionMutationDispatcher.dispose);
+    await attempt(_projectActivityService.dispose);
+    Log.v("[shutdown] project activity service disposed (+${teardownSw.elapsedMilliseconds}ms)");
+    await attempt(_sessionAbortService.dispose);
+    Log.v("[shutdown] session abort service disposed (+${teardownSw.elapsedMilliseconds}ms)");
+    await attempt(_completionListener.dispose);
+    Log.v("[shutdown] completion listener disposed (+${teardownSw.elapsedMilliseconds}ms)");
+    await attempt(_maintenanceListener.dispose);
+    await attempt(_prSyncService.dispose);
+    Log.v("[shutdown] maintenance + pr-sync listeners disposed (+${teardownSw.elapsedMilliseconds}ms)");
+    // Plugin teardown is owned by BridgePlugin.shutdown(), run as the
+    // shutdown coordinator's ordered step — the deprecated direct
+    // api.dispose() call is gone since the descriptor flip.
+    Log.v("stopping sse manager...");
+    await attempt(_sseManager.stop);
+    Log.v("sse manager stopped (+${teardownSw.elapsedMilliseconds}ms)");
+    Log.v("disposing push notification service...");
+    await attempt(_pushDispatcher.dispose);
+    Log.v("push notification service disposed (+${teardownSw.elapsedMilliseconds}ms)");
+    await Future.wait([
+      attempt(_localWireEventsController.close),
+      attempt(_bytesSentController.close),
+    ]);
+    await attempt(() async {
+      Log.v("closing relay client...");
+      await _client.close();
+      Log.v("relay client closed (+${teardownSw.elapsedMilliseconds}ms)");
+    });
+    Log.d("[shutdown] session teardown complete (${teardownSw.elapsedMilliseconds}ms total)");
+    if (firstTeardownError != null) {
+      Error.throwWithStackTrace(firstTeardownError!, firstTeardownStackTrace!);
+    }
+  }
+
+  Future<void> _serveRelayConnections({
+    required Completer<OrchestratorSessionStartResult> readiness,
+    required KeyExchangeManager kxManager,
+    required Map<int, bool> activePhones,
+  }) async {
+    while (!_cancelled) {
+      final iterator = StreamIterator<RelayClientMessage>(_client.read());
+      final firstRead = iterator.moveNext();
+      if (!readiness.isCompleted) {
+        readiness.complete(OrchestratorSessionStartResult.ready);
+      }
+
+      try {
         try {
-          await _runRelayLoop(_roomKey, kxManager, activePhones);
-        } catch (e) {
-          if (_cancelled) break;
-          Log.w("relay loop ended: $e");
-        }
-
-        if (_cancelled) {
-          break;
-        }
-
-        Log.w("Relay connection lost. Reconnecting...");
-        _sseManager.orphanAll();
-        activePhones.clear();
-        // Every phone connection died with the relay link; drop their view
-        // declarations so no session stays "watched" by a ghost connection.
-        // Phones re-assert their current view on reconnect.
-        _sessionViewTracker.clearAll();
-
-        if (_client.closeCode == RelayCloseCodes.bridgeRevoked) {
-          Log.w("Relay reports this bridge as revoked — re-registering with a fresh bridge id");
-          await _bridgeRegistrationService.handleBridgeRevoked();
-        }
-
-        // Another bridge on this account took the single relay slot. Reconnect
-        // only on a long backoff so two always-on bridges don't tight-loop
-        // kicking each other (ADR A22); headless/VM failover is preserved
-        // because we still retry, just slowly. The GUI is told separately via
-        // ControlStatusNotifier (it observes the same replaced-close on the
-        // connection-state stream); this loop owns only the backoff policy.
-        final takenOver = RelayCloseCodes.isBridgeReplaced(
-          closeCode: _client.closeCode,
-          closeReason: _client.closeReason,
-        );
-        if (takenOver) {
-          Console.warning(
-            "Another bridge for this account has taken over the relay connection. "
-            "Retrying on a long backoff — stop the other bridge to reclaim this slot.",
+          await _runRelayLoop(
+            iterator: iterator,
+            firstRead: firstRead,
+            roomKey: _roomKey,
+            kxManager: kxManager,
+            activePhones: activePhones,
           );
-        }
-
-        var backoff = _initialBackoff(takenOver: takenOver);
-        while (!_cancelled) {
-          await _backoffDelay(backoff);
-          if (_cancelled) {
-            return;
-          }
-
-          // Don't reconnect without a usable token: in supervised mode a
-          // signed-out / mid-login GUI yields no token, and reconnecting would
-          // re-authenticate the relay from a stale cached token. Back off and
-          // retry — a later refresh (or a token_update push) recovers.
-          if (!await _refreshAccessToken()) {
-            Log.w("No access token available — deferring reconnect (retrying in $backoff)");
-            backoff = _nextBackoff(backoff, takenOver: takenOver);
-            continue;
-          }
-
-          try {
-            await _bridgeRegistrationService.ensureRegistered();
-            await _client.reconnect();
-          } catch (e) {
-            Log.w("Reconnect failed: $e (retrying in $backoff)");
-            backoff = _nextBackoff(backoff, takenOver: takenOver);
-            continue;
-          }
-
-          backoff = _initialBackoff(takenOver: takenOver);
-          Log.i("Reconnected to relay");
-          break;
-        }
-      }
-    } finally {
-      final teardownSw = Stopwatch()..start();
-      Object? firstTeardownError = _beginShutdownError;
-      StackTrace? firstTeardownStackTrace = _beginShutdownStackTrace;
-
-      Future<void> attempt(FutureOr<void> Function() action) async {
-        try {
-          await action();
         } on Object catch (error, stackTrace) {
-          firstTeardownError ??= error;
-          firstTeardownStackTrace ??= stackTrace;
+          if (_cancelled) break;
+          Log.w("relay loop ended", error, stackTrace);
+        }
+      } finally {
+        try {
+          await iterator.cancel();
+        } on Object catch (error, stackTrace) {
+          Log.w("Failed to cancel relay read iterator", error, stackTrace);
         }
       }
 
-      final sinceCancelMs = _cancelRequestedAt == null
-          ? null
-          : DateTime.now().difference(_cancelRequestedAt!).inMilliseconds;
-      Log.i("Disconnecting...");
-      Log.d(
-        "[shutdown] session teardown begin "
-        "(${sinceCancelMs == null ? "no cancel timestamp" : "${sinceCancelMs}ms since cancel()"}"
-        "${_inFlightRequestLabel == null ? "" : ", in-flight request: $_inFlightRequestLabel"})",
+      if (_cancelled) {
+        break;
+      }
+
+      Log.w("Relay connection lost. Reconnecting...");
+      _sseManager.orphanAll();
+      activePhones.clear();
+      // Every phone connection died with the relay link; drop their view
+      // declarations so no session stays "watched" by a ghost connection.
+      // Phones re-assert their current view on reconnect.
+      _sessionViewTracker.clearAll();
+
+      if (_client.closeCode == RelayCloseCodes.bridgeRevoked) {
+        Log.w("Relay reports this bridge as revoked — re-registering with a fresh bridge id");
+        await _bridgeRegistrationService.handleBridgeRevoked();
+      }
+
+      // Another bridge on this account took the single relay slot. Reconnect
+      // only on a long backoff so two always-on bridges don't tight-loop
+      // kicking each other (ADR A22); headless/VM failover is preserved
+      // because we still retry, just slowly. The GUI is told separately via
+      // ControlStatusNotifier (it observes the same replaced-close on the
+      // connection-state stream); this loop owns only the backoff policy.
+      final takenOver = RelayCloseCodes.isBridgeReplaced(
+        closeCode: _client.closeCode,
+        closeReason: _client.closeReason,
       );
-      await Future.wait([
-        attempt(_subscriptions.cancel),
-        attempt(_promptDefaultsSubscriptions.cancel),
-        attempt(_catalogImportSubscriptions.cancel),
-      ]);
-      Log.v("[shutdown] subscriptions cancelled (+${teardownSw.elapsedMilliseconds}ms)");
-      await attempt(() async {
-        await Future.wait(_pluginEventProcessingTails.values);
-      });
-      Log.v("[shutdown] plugin event processing drained (+${teardownSw.elapsedMilliseconds}ms)");
-      await attempt(_sessionPromptService.dispose);
-      await Future.wait([
-        for (final listener in _pluginEventListeners) attempt(listener.dispose),
-        attempt(_sessionBindingCommitListener.dispose),
-        attempt(_sessionDeletionListener.dispose),
-      ]);
-      await attempt(_sessionEventDispatcher.dispose);
-      await attempt(_permissionAutoApprovalService.dispose);
-      await attempt(_sessionMutationDispatcher.dispose);
-      await attempt(_projectActivityService.dispose);
-      Log.v("[shutdown] project activity service disposed (+${teardownSw.elapsedMilliseconds}ms)");
-      await attempt(_sessionAbortService.dispose);
-      Log.v("[shutdown] session abort service disposed (+${teardownSw.elapsedMilliseconds}ms)");
-      await attempt(_completionListener.dispose);
-      Log.v("[shutdown] completion listener disposed (+${teardownSw.elapsedMilliseconds}ms)");
-      await attempt(_maintenanceListener.dispose);
-      await attempt(_prSyncService.dispose);
-      Log.v("[shutdown] maintenance + pr-sync listeners disposed (+${teardownSw.elapsedMilliseconds}ms)");
-      // Plugin teardown is owned by BridgePlugin.shutdown(), run as the
-      // shutdown coordinator's ordered step — the deprecated direct
-      // api.dispose() call is gone since the descriptor flip.
-      Log.v("stopping sse manager...");
-      await attempt(_sseManager.stop);
-      Log.v("sse manager stopped (+${teardownSw.elapsedMilliseconds}ms)");
-      Log.v("disposing push notification service...");
-      await attempt(_pushDispatcher.dispose);
-      Log.v("push notification service disposed (+${teardownSw.elapsedMilliseconds}ms)");
-      await Future.wait([
-        attempt(_localWireEventsController.close),
-        attempt(_bytesSentController.close),
-      ]);
-      await attempt(() async {
-        Log.v("closing relay client...");
-        await _client.close();
-        Log.v("relay client closed (+${teardownSw.elapsedMilliseconds}ms)");
-      });
-      Log.d("[shutdown] session teardown complete (${teardownSw.elapsedMilliseconds}ms total)");
-      if (firstTeardownError != null) {
-        Error.throwWithStackTrace(firstTeardownError!, firstTeardownStackTrace!);
+      if (takenOver) {
+        Console.warning(
+          "Another bridge for this account has taken over the relay connection. "
+          "Retrying on a long backoff — stop the other bridge to reclaim this slot.",
+        );
+      }
+
+      var backoff = _initialBackoff(takenOver: takenOver);
+      while (!_cancelled) {
+        await _backoffDelay(backoff);
+        if (_cancelled) {
+          return;
+        }
+
+        // Don't reconnect without a usable token: in supervised mode a
+        // signed-out / mid-login GUI yields no token, and reconnecting would
+        // re-authenticate the relay from a stale cached token. Back off and
+        // retry — a later refresh (or a token_update push) recovers.
+        if (!await _refreshAccessToken()) {
+          Log.w("No access token available — deferring reconnect (retrying in $backoff)");
+          backoff = _nextBackoff(backoff, takenOver: takenOver);
+          continue;
+        }
+
+        try {
+          await _bridgeRegistrationService.ensureRegistered();
+          await _client.reconnect();
+        } on Object catch (error, stackTrace) {
+          Log.w("Reconnect failed (retrying in $backoff)", error, stackTrace);
+          backoff = _nextBackoff(backoff, takenOver: takenOver);
+          continue;
+        }
+
+        backoff = _initialBackoff(takenOver: takenOver);
+        Log.i("Reconnected to relay");
+        break;
       }
     }
   }
@@ -1420,7 +1520,7 @@ class OrchestratorSession {
   /// Live re-auth trigger: the token provider emitted a token for a different
   /// auth identity while the relay was connected, so the open socket is still
   /// authenticated as the old identity. Closing the relay ends the active read
-  /// loop, after which [run]'s reconnect block force-pulls the new token and
+  /// loop, after which the serving loop's reconnect block force-pulls the new token and
   /// reconnects — the same path a relay-side drop drives. No-op once cancelled
   /// so a token emit during shutdown can't fight teardown.
   Future<void> _reauthenticateRelay() async {
@@ -1444,182 +1544,190 @@ class OrchestratorSession {
     }
   }
 
-  Future<void> _runRelayLoop(
-    List<int> roomKey,
-    KeyExchangeManager kxManager,
-    Map<int, bool> activePhones,
-  ) async {
-    await for (final msg in _client.read()) {
-      if (_cancelled) {
-        return;
-      }
-
-      Log.v("relay msg: isText=${msg.isText} len=${msg.data.length}");
-
-      if (msg.isText) {
-        Map<String, dynamic> control;
-        try {
-          control = jsonDecodeMap(utf8.decode(msg.data));
-        } catch (e) {
-          Log.e("failed to parse control message: $e");
-          continue;
+  Future<void> _runRelayLoop({
+    required StreamIterator<RelayClientMessage> iterator,
+    required Future<bool> firstRead,
+    required List<int> roomKey,
+    required KeyExchangeManager kxManager,
+    required Map<int, bool> activePhones,
+  }) async {
+    var hasMessage = await firstRead;
+    while (hasMessage) {
+      processMessage:
+      {
+        final msg = iterator.current;
+        if (_cancelled) {
+          return;
         }
 
-        final type = control["type"] as String?;
-        final connID = control["connId"] as int?;
-        Log.v("control: type=$type connID=$connID");
-        if (type == null || connID == null) {
-          Log.v("dropping control: null type or connID");
-          continue;
-        }
+        Log.v("relay msg: isText=${msg.isText} len=${msg.data.length}");
 
-        switch (type) {
-          case "phone_connected":
-            Log.v("phone_connected connID=$connID");
-          case "phone_disconnected":
-            Log.v("phone_disconnected connID=$connID");
-            activePhones.remove(connID);
-            _sseManager.removeSubscriber(connID);
-            _sessionViewTracker.releaseConnection(connID: connID);
-        }
-        continue;
-      }
-
-      if (msg.data.length < 2) {
-        Log.v("binary too short: ${msg.data.length}");
-        continue;
-      }
-
-      final connID = ByteData.sublistView(msg.data).getUint16(0, Endian.big);
-      final payload = msg.data.sublist(2);
-      if (payload.isEmpty) {
-        Log.v("empty payload for connID=$connID");
-        continue;
-      }
-
-      Log.v("binary: connID=$connID payloadLen=${payload.length} firstByte=0x${payload[0].toRadixString(16)}");
-
-      if (payload[0] == RelayProtocol.jsonStartByte) {
-        Log.v("JSON message (key exchange?)");
-        RelayMessage relayMessage;
-        try {
-          relayMessage = RelayMessage.fromJson(
-            jsonDecodeMap(utf8.decode(payload)),
-          );
-        } catch (e) {
-          Log.v("failed to parse relay JSON: $e");
-          continue;
-        }
-
-        Log.v("parsed: ${relayMessage.runtimeType}");
-
-        if (relayMessage is! RelayKeyExchange) {
-          Log.v("not a key exchange, skipping");
-          continue;
-        }
-
-        List<int> encrypted;
-        try {
-          encrypted = await kxManager.handleKeyExchange(message: relayMessage);
-          Log.d("key exchange OK, sending ready to connID=$connID");
-        } catch (e) {
-          Log.e("failed key exchange for connId $connID: $e");
-          continue;
-        }
-
-        try {
-          _client.send(connID, encrypted);
-          Log.d("ready sent to connID=$connID");
-        } catch (e) {
-          if (_cancelled) {
-            throw StateError("cancelled");
-          }
-          throw Exception("send ready for connId $connID: $e");
-        }
-
-        activePhones[connID] = true;
-        Log.d("phone $connID is now active");
-        continue;
-      }
-
-      Log.v(
-        "checking protocolVersion: payload[0]=0x${payload[0].toRadixString(16)} expected=0x${protocolVersion.toRadixString(16)}",
-      );
-      if (payload[0] == protocolVersion) {
-        final encryptor = RelayCryptoService().createSessionEncryptor(
-          SecretKey(List<int>.from(roomKey)),
-        );
-
-        List<int>? decrypted;
-        Object? decryptError;
-        try {
-          decrypted = await unframe(payload, encryptor: encryptor);
-        } catch (e) {
-          decryptError = e;
-        }
-
-        if (activePhones[connID] == true) {
-          if (decryptError != null || decrypted == null) {
-            Log.v(
-              "failed to decrypt from connId $connID: $decryptError",
-            );
-            continue;
-          }
-          Log.v("decrypted OK from connID=$connID, handling...");
-          await _handleDecryptedMessage(connID, decrypted);
-          Log.v("handled message from connID=$connID");
-          continue;
-        }
-
-        if (decryptError != null || decrypted == null) {
-          Log.v("not active, decrypt failed for connID=$connID: $decryptError — sending rekeyRequired");
-          final rekeyRequired = jsonEncode(
-            const RelayMessage.rekeyRequired().toJson(),
-          );
+        if (msg.isText) {
+          Map<String, dynamic> control;
           try {
-            _client.send(connID, utf8.encode(rekeyRequired));
-          } catch (_) {
+            control = jsonDecodeMap(utf8.decode(msg.data));
+          } catch (e) {
+            Log.e("failed to parse control message: $e");
+            break processMessage;
+          }
+
+          final type = control["type"] as String?;
+          final connID = control["connId"] as int?;
+          Log.v("control: type=$type connID=$connID");
+          if (type == null || connID == null) {
+            Log.v("dropping control: null type or connID");
+            break processMessage;
+          }
+
+          switch (type) {
+            case "phone_connected":
+              Log.v("phone_connected connID=$connID");
+            case "phone_disconnected":
+              Log.v("phone_disconnected connID=$connID");
+              activePhones.remove(connID);
+              _sseManager.removeSubscriber(connID);
+              _sessionViewTracker.releaseConnection(connID: connID);
+          }
+          break processMessage;
+        }
+
+        if (msg.data.length < 2) {
+          Log.v("binary too short: ${msg.data.length}");
+          break processMessage;
+        }
+
+        final connID = ByteData.sublistView(msg.data).getUint16(0, Endian.big);
+        final payload = msg.data.sublist(2);
+        if (payload.isEmpty) {
+          Log.v("empty payload for connID=$connID");
+          break processMessage;
+        }
+
+        Log.v("binary: connID=$connID payloadLen=${payload.length} firstByte=0x${payload[0].toRadixString(16)}");
+
+        if (payload[0] == RelayProtocol.jsonStartByte) {
+          Log.v("JSON message (key exchange?)");
+          RelayMessage relayMessage;
+          try {
+            relayMessage = RelayMessage.fromJson(
+              jsonDecodeMap(utf8.decode(payload)),
+            );
+          } catch (e) {
+            Log.v("failed to parse relay JSON: $e");
+            break processMessage;
+          }
+
+          Log.v("parsed: ${relayMessage.runtimeType}");
+
+          if (relayMessage is! RelayKeyExchange) {
+            Log.v("not a key exchange, skipping");
+            break processMessage;
+          }
+
+          List<int> encrypted;
+          try {
+            encrypted = await kxManager.handleKeyExchange(message: relayMessage);
+            Log.d("key exchange OK, sending ready to connID=$connID");
+          } catch (e) {
+            Log.e("failed key exchange for connId $connID: $e");
+            break processMessage;
+          }
+
+          try {
+            _client.send(connID, encrypted);
+            Log.d("ready sent to connID=$connID");
+          } catch (e) {
             if (_cancelled) {
               throw StateError("cancelled");
             }
+            throw Exception("send ready for connId $connID: $e");
           }
-          continue;
+
+          activePhones[connID] = true;
+          Log.d("phone $connID is now active");
+          break processMessage;
         }
 
-        RelayMessage parsedMessage;
-        try {
-          parsedMessage = RelayMessage.fromJson(
-            jsonDecodeMap(utf8.decode(decrypted)),
-          );
-        } catch (_) {
-          continue;
-        }
-
-        if (parsedMessage is! RelayResume) {
-          continue;
-        }
-
-        final ackJSON = utf8.encode(
-          jsonEncode(const RelayMessage.resumeAck().toJson()),
+        Log.v(
+          "checking protocolVersion: payload[0]=0x${payload[0].toRadixString(16)} expected=0x${protocolVersion.toRadixString(16)}",
         );
-        List<int> encryptedAck;
-        try {
-          encryptedAck = await frame(ackJSON, encryptor: encryptor);
-        } catch (_) {
-          continue;
-        }
+        if (payload[0] == protocolVersion) {
+          final encryptor = RelayCryptoService().createSessionEncryptor(
+            SecretKey(List<int>.from(roomKey)),
+          );
 
-        try {
-          _client.send(connID, encryptedAck);
-        } catch (e) {
-          if (_cancelled) {
-            throw StateError("cancelled");
+          List<int>? decrypted;
+          Object? decryptError;
+          try {
+            decrypted = await unframe(payload, encryptor: encryptor);
+          } catch (e) {
+            decryptError = e;
           }
-          throw Exception("send resume ack for connId $connID: $e");
-        }
 
-        activePhones[connID] = true;
+          if (activePhones[connID] == true) {
+            if (decryptError != null || decrypted == null) {
+              Log.v(
+                "failed to decrypt from connId $connID: $decryptError",
+              );
+              break processMessage;
+            }
+            Log.v("decrypted OK from connID=$connID, handling...");
+            await _handleDecryptedMessage(connID, decrypted);
+            Log.v("handled message from connID=$connID");
+            break processMessage;
+          }
+
+          if (decryptError != null || decrypted == null) {
+            Log.v("not active, decrypt failed for connID=$connID: $decryptError — sending rekeyRequired");
+            final rekeyRequired = jsonEncode(
+              const RelayMessage.rekeyRequired().toJson(),
+            );
+            try {
+              _client.send(connID, utf8.encode(rekeyRequired));
+            } catch (_) {
+              if (_cancelled) {
+                throw StateError("cancelled");
+              }
+            }
+            break processMessage;
+          }
+
+          RelayMessage parsedMessage;
+          try {
+            parsedMessage = RelayMessage.fromJson(
+              jsonDecodeMap(utf8.decode(decrypted)),
+            );
+          } catch (_) {
+            break processMessage;
+          }
+
+          if (parsedMessage is! RelayResume) {
+            break processMessage;
+          }
+
+          final ackJSON = utf8.encode(
+            jsonEncode(const RelayMessage.resumeAck().toJson()),
+          );
+          List<int> encryptedAck;
+          try {
+            encryptedAck = await frame(ackJSON, encryptor: encryptor);
+          } catch (_) {
+            break processMessage;
+          }
+
+          try {
+            _client.send(connID, encryptedAck);
+          } catch (e) {
+            if (_cancelled) {
+              throw StateError("cancelled");
+            }
+            throw Exception("send resume ack for connId $connID: $e");
+          }
+
+          activePhones[connID] = true;
+        }
       }
+      hasMessage = await iterator.moveNext();
     }
   }
 

--- a/bridge/app/lib/src/bridge/relay_client.dart
+++ b/bridge/app/lib/src/bridge/relay_client.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 import "dart:convert";
+import "dart:io" show HttpClient;
 import "dart:typed_data";
 
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
@@ -60,8 +61,8 @@ class RelayClient {
   final BridgeIdProvider _bridgeIdProvider;
   final Duration _pingInterval;
   final Duration _connectTimeout;
-  final StreamController<RelayConnectionState> _connectionState =
-      StreamController<RelayConnectionState>.broadcast();
+  final StreamController<RelayConnectionState> _connectionState = StreamController<RelayConnectionState>.broadcast();
+  _RelayConnectionAttempt? _pendingConnection;
   IOWebSocketChannel? _channel;
   String? _lastAuthedToken;
 
@@ -112,26 +113,43 @@ class RelayClient {
     // throwing parse must not leave observers stuck on a connecting state
     // that never resolves to a terminal one.
     final wsURL = _buildWebSocketURL(_relayURL);
+    if (_pendingConnection != null || _channel != null) {
+      throw StateError("Relay connection already exists or is in progress");
+    }
     _connectionState.add(const RelayConnecting());
+    final httpClient = HttpClient();
     final channel = IOWebSocketChannel.connect(
       wsURL,
       pingInterval: _pingInterval,
+      customClient: httpClient,
     );
+    final attempt = _RelayConnectionAttempt(channel: channel, httpClient: httpClient);
+    _pendingConnection = attempt;
 
     try {
       await channel.ready.timeout(_connectTimeout);
-    } catch (e) {
-      _connectionState.add(const RelayDisconnected(closeCode: null, closeReason: null));
-      // Clean up the channel if connection fails or times out to prevent
-      // zombie WebSocket connections from lingering.
-      try {
-        await channel.sink.close().timeout(const Duration(seconds: 1));
-      } catch (closeError) {
-        Log.w("Failed to clean up WebSocket channel: $closeError");
+    } on Object catch (error, stackTrace) {
+      // A detached attempt belongs to deliberate close(); only a still-owned
+      // failure reports disconnected and cleans up here.
+      if (identical(_pendingConnection, attempt)) {
+        _pendingConnection = null;
+        _connectionState.add(const RelayDisconnected(closeCode: null, closeReason: null));
+        httpClient.close(force: true);
+        await _closeChannel(
+          channel: channel,
+          timeout: const Duration(seconds: 1),
+          timeoutMessage: "WebSocket cleanup timed out after connect failure",
+          failureMessage: "Failed to clean up WebSocket channel after connect failure",
+        );
       }
-      rethrow;
+      Error.throwWithStackTrace(error, stackTrace);
     }
 
+    if (!identical(_pendingConnection, attempt)) {
+      throw StateError("Relay connect was cancelled");
+    }
+    _pendingConnection = null;
+    httpClient.close();
     _channel = channel;
     _watchChannelDone(channel);
     _connectionState.add(const RelayConnected());
@@ -235,17 +253,41 @@ class RelayClient {
   }
 
   Future<void> close() async {
+    final pendingConnection = _pendingConnection;
+    _pendingConnection = null;
+    pendingConnection?.httpClient.close(force: true);
     final channel = _channel;
     _channel = null;
-    if (channel == null) {
-      return;
-    }
+    await Future.wait([
+      if (pendingConnection != null)
+        _closeChannel(
+          channel: pendingConnection.channel,
+          timeout: const Duration(seconds: 3),
+          timeoutMessage: "Pending WebSocket close timed out — connection abandoned",
+          failureMessage: "Pending WebSocket close failed — connection abandoned",
+        ),
+      if (channel != null)
+        _closeChannel(
+          channel: channel,
+          timeout: const Duration(seconds: 3),
+          timeoutMessage: "WebSocket close handshake timed out — connection abandoned",
+          failureMessage: "WebSocket close failed — connection abandoned",
+        ),
+    ]);
+  }
+
+  Future<void> _closeChannel({
+    required IOWebSocketChannel channel,
+    required Duration timeout,
+    required String timeoutMessage,
+    required String failureMessage,
+  }) async {
     try {
-      await channel.sink.close().timeout(const Duration(seconds: 3));
-    } on TimeoutException {
-      Log.w("WebSocket close handshake timed out — connection abandoned");
-    } catch (e) {
-      Log.w("WebSocket close failed: $e — connection abandoned");
+      await channel.sink.close().timeout(timeout);
+    } on TimeoutException catch (error, stackTrace) {
+      Log.w(timeoutMessage, error, stackTrace);
+    } on Object catch (error, stackTrace) {
+      Log.w(failureMessage, error, stackTrace);
     }
   }
 
@@ -257,4 +299,11 @@ class RelayClient {
     final wsPath = trimmedPath.isEmpty ? "/ws" : "$trimmedPath/ws";
     return relayURI.replace(path: wsPath).toString();
   }
+}
+
+final class _RelayConnectionAttempt {
+  const _RelayConnectionAttempt({required this.channel, required this.httpClient});
+
+  final IOWebSocketChannel channel;
+  final HttpClient httpClient;
 }

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -900,13 +900,17 @@ class BridgeRuntimeRunner {
       updateLifecycle.start();
 
       try {
-        sessionRun = activeRuntime.session.run();
-        await sessionRun;
+        final sessionStart = activeRuntime.session.start();
+        sessionRun = activeRuntime.session.waitUntilStopped();
+        final startResult = await sessionStart;
+        if (startResult == OrchestratorSessionStartResult.ready) {
+          await sessionRun;
+        }
       } finally {
         // A supervised phone-triggered restart handed the session off by exiting
         // rather than spawning a successor; resolve the GUI-respawn sentinel here
-        // (in a finally) so it survives even if a teardown await in run()/cancel()
-        // throws — otherwise the error path below would return a crash code and
+        // (in a finally) so it survives even if session teardown throws —
+        // otherwise the error path below would return a crash code and
         // the GUI would back off instead of respawning. `restartService` is only
         // in scope inside this try, hence resolving into the outer-scoped local.
         // Assigned before the outer `finally`'s shutdown runs, so a hung-shutdown
@@ -915,10 +919,7 @@ class BridgeRuntimeRunner {
           requestedSupervisedExit = SupervisedExitCode.restart;
         }
       }
-      if (requestedSupervisedExit == SupervisedExitCode.restart) {
-        return SupervisedExitCode.restart.code;
-      }
-      return 0;
+      return requestedSupervisedExit?.code ?? 0;
     } on PluginStartAbortedException {
       if (startAbortController.isAborted) {
         Log.i("Plugin start aborted as requested.");

--- a/bridge/app/test/bridge/client_test.dart
+++ b/bridge/app/test/bridge/client_test.dart
@@ -246,6 +246,48 @@ void main() {
       expect(states.whereType<RelayDisconnected>(), isEmpty);
     });
 
+    test("close promptly cancels a pending WebSocket handshake without late promotion", () async {
+      final rawServer = await ServerSocket.bind("127.0.0.1", 0);
+      final accepted = Completer<Socket>();
+      Socket? acceptedSocket;
+      rawServer.listen((socket) {
+        if (accepted.isCompleted) {
+          socket.destroy();
+          return;
+        }
+        acceptedSocket = socket;
+        accepted.complete(socket);
+      });
+      addTearDown(() async {
+        acceptedSocket?.destroy();
+        await rawServer.close();
+      });
+
+      final client = RelayClient(
+        relayURL: "ws://127.0.0.1:${rawServer.port}",
+        accessTokenProvider: FakeAccessTokenProvider("jwt-token"),
+        bridgeIdProvider: FakeBridgeIdProvider("br_abc12345"),
+        connectTimeout: const Duration(seconds: 30),
+      );
+      final states = <RelayConnectionState>[];
+      client.connectionState.listen(states.add);
+
+      final connectFuture = client.connect();
+      connectFuture.ignore();
+      await accepted.future.timeout(const Duration(seconds: 2));
+
+      final stopwatch = Stopwatch()..start();
+      await client.close().timeout(const Duration(seconds: 5));
+      stopwatch.stop();
+
+      await expectLater(connectFuture, throwsA(anything));
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(stopwatch.elapsed, lessThan(const Duration(seconds: 5)));
+      expect(states.whereType<RelayConnected>(), isEmpty);
+      expect(states.whereType<RelayDisconnected>(), isEmpty);
+      expect(() => client.send(1, const [1]), throwsA(isA<StateError>()));
+    });
+
     test("failed connect emits disconnected with no close code", () async {
       // A TCP server that accepts but never completes the WebSocket upgrade.
       final rawServer = await ServerSocket.bind("127.0.0.1", 0);

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -74,8 +74,8 @@ Future<_DebugServerHarness> _createDebugServerHarness({
     restartService: effectiveRestartService,
     composition: composition,
   );
-  final runFuture = composition.session.run();
-  unawaited(runFuture.catchError((_) {}));
+  final running = await startTestOrchestratorSession(session: composition.session);
+  final runFuture = running.stopped;
   await relayServer.nextClient();
   await activateTestPlugin(service: lifecycleService, pluginId: plugin.id);
   if (plugin case final _SubscriptionAwarePlugin subscriptionAware) {

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -98,8 +98,8 @@ void main() {
       await relayServer.close();
     });
 
-    final runFuture = harness.composition.session.run();
-    unawaited(runFuture.catchError((_) {}));
+    final running = await startTestOrchestratorSession(session: harness.composition.session);
+    final runFuture = running.stopped;
     await relayServer.nextClient();
     await harness.activatePlugins();
     final before = [for (final plugin in harness.plugins) plugin.getProjectsCallCount];
@@ -131,8 +131,8 @@ void main() {
       await harness.close();
       await relayServer.close();
     });
-    final runFuture = harness.composition.session.run();
-    unawaited(runFuture.catchError((_) {}));
+    final running = await startTestOrchestratorSession(session: harness.composition.session);
+    final runFuture = running.stopped;
     await relayServer.nextClient();
     await harness.activatePlugins();
     final pluginRuntime = runtimeForLifecycleService(service: harness.lifecycleService) as TestPluginRuntime;
@@ -175,8 +175,8 @@ void main() {
       await relayServer.close();
     });
 
-    final runFuture = harness.composition.session.run();
-    unawaited(runFuture.catchError((_) {}));
+    final running = await startTestOrchestratorSession(session: harness.composition.session);
+    final runFuture = running.stopped;
     await relayServer.nextClient();
     await harness.activatePlugins();
 
@@ -234,8 +234,8 @@ void main() {
       await relayServer.close();
     });
 
-    final runFuture = harness.composition.session.run();
-    unawaited(runFuture.catchError((_) {}));
+    final running = await startTestOrchestratorSession(session: harness.composition.session);
+    final runFuture = running.stopped;
     await relayServer.nextClient();
     await harness.activatePlugins();
     final subscribed = harness.composition.session.localWireEvents.firstWhere(
@@ -328,8 +328,8 @@ void main() {
       await relayServer.close();
     });
 
-    final runFuture = harness.composition.session.run();
-    unawaited(runFuture.catchError((_) {}));
+    final running = await startTestOrchestratorSession(session: harness.composition.session);
+    final runFuture = running.stopped;
     await relayServer.nextClient();
     await harness.activatePlugins();
 

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:io";
 
 import "package:http/http.dart" as http;
 import "package:sesori_bridge/src/api/database/database.dart";
@@ -18,9 +19,10 @@ import "../helpers/plugin_runtime_test_support.dart";
 import "../helpers/restart_test_support.dart";
 import "../helpers/test_database.dart";
 import "../helpers/test_helpers.dart";
+import "routing/routing_test_helpers.dart";
 
 void main() {
-  test("zero-plugin composition keeps the relay session online", () async {
+  test("zero-plugin composition becomes ready without an inbound relay frame", () async {
     final relayServer = await TestRelayServer.start();
     final database = createTestDatabase();
     final pluginRuntime = createRegisteredTestPluginRuntime(pluginIds: const ["opencode"]);
@@ -70,7 +72,8 @@ void main() {
       filesystemAccessOk: true,
       statusNotifier: null,
     ).create();
-    final runFuture = composition.session.run();
+    final running = await startTestOrchestratorSession(session: composition.session);
+    final runFuture = running.stopped;
 
     try {
       await relayServer.nextClient();
@@ -87,6 +90,80 @@ void main() {
       await database.close();
       await relayServer.close();
     }
+  });
+
+  test("shutdown during the initial relay handshake returns cancelled promptly", () async {
+    final rawServer = await ServerSocket.bind("127.0.0.1", 0);
+    final accepted = Completer<Socket>();
+    Socket? acceptedSocket;
+    rawServer.listen((socket) {
+      if (accepted.isCompleted) {
+        socket.destroy();
+        return;
+      }
+      acceptedSocket = socket;
+      accepted.complete(socket);
+    });
+    addTearDown(() async {
+      acceptedSocket?.destroy();
+      await rawServer.close();
+    });
+
+    final database = createTestDatabase();
+    addTearDown(database.close);
+    final plugin = FakeBridgePlugin();
+    final lifecycleService = await createSinglePluginLifecycleService(plugin: plugin);
+    addTearDown(lifecycleService.dispose);
+    final httpClient = http.Client();
+    addTearDown(httpClient.close);
+    final relayClient = RelayClient(
+      relayURL: "ws://127.0.0.1:${rawServer.port}",
+      accessTokenProvider: FakeAccessTokenProvider(""),
+      bridgeIdProvider: FakeBridgeIdProvider(),
+      connectTimeout: const Duration(seconds: 30),
+    );
+    final session = Orchestrator(
+      config: BridgeConfig(
+        relayURL: "ws://127.0.0.1:${rawServer.port}",
+        authBackendURL: "http://127.0.0.1:8080",
+        sseReplayWindow: const Duration(minutes: 1),
+        yolo: false,
+      ),
+      client: relayClient,
+      legacyMissingPluginId: plugin.id,
+      pluginLifecycleService: lifecycleService,
+      pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
+      database: database,
+      httpClient: httpClient,
+      processRunner: ProcessRunner(),
+      accessTokenProvider: FakeAccessTokenProvider(""),
+      tokenRefresher: _FakeTokenRefresher(),
+      bridgeRegistrationService: createFakeBridgeRegistrationService(),
+      failureReporter: FakeFailureReporter(),
+      restartService: buildTestRestartService(),
+      filesystemAccessOk: true,
+      statusNotifier: null,
+    ).create().session;
+
+    final startFuture = session.start();
+    final stopped = session.waitUntilStopped();
+    stopped.ignore();
+    addTearDown(() async {
+      await session.cancel();
+      await stopped.timeout(const Duration(seconds: 5));
+    });
+    await accepted.future.timeout(const Duration(seconds: 2));
+
+    final stopwatch = Stopwatch()..start();
+    await session.cancel().timeout(const Duration(seconds: 5));
+    expect(
+      await startFuture.timeout(const Duration(seconds: 5)),
+      OrchestratorSessionStartResult.cancelled,
+    );
+    await stopped.timeout(const Duration(seconds: 5));
+    stopwatch.stop();
+
+    expect(stopwatch.elapsed, lessThan(const Duration(seconds: 5)));
   });
 
   group("OrchestratorSession SSE error recovery", () {
@@ -120,7 +197,17 @@ void main() {
 
       final session = orchestrator.create().session;
 
-      await expectLater(session.run(), throwsA(isA<Exception>()));
+      await expectLater(session.waitUntilStopped(), throwsA(isA<StateError>()));
+      final localWireEventsDone = session.localWireEvents.drain<void>();
+      final startFuture = session.start();
+      final stopped = session.waitUntilStopped();
+      stopped.ignore();
+      expect(identical(stopped, session.waitUntilStopped()), isTrue);
+
+      await expectLater(startFuture, throwsA(isA<Exception>()));
+      await expectLater(stopped, throwsA(isA<Exception>()));
+      await expectLater(localWireEventsDone, completes);
+      await expectLater(session.start(), throwsA(isA<StateError>()));
 
       expect(plugin.subscribeCount, equals(0));
 
@@ -224,7 +311,8 @@ class _TestHarness {
     );
 
     final session = orchestrator.create().session;
-    final runFuture = session.run();
+    final running = await startTestOrchestratorSession(session: session);
+    final runFuture = running.stopped;
 
     await relayServer.nextClient();
 

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:convert";
 import "dart:io";
 
 import "package:http/http.dart" as http;
@@ -21,12 +22,13 @@ import "routing/routing_test_helpers.dart";
 
 void main() {
   group("OrchestratorSession bridge registration", () {
-    test("startup registration failure fails the run without connecting to the relay", () async {
+    test("startup registration failure fails startup and lifecycle without connecting to the relay", () async {
       final repository = FakeBridgeRegistrationRepository()
         ..registerError = BridgeRegistrationException(statusCode: 500, body: "boom");
       final harness = await _RegistrationHarness.start(repository: repository);
       addTearDown(harness.close);
 
+      await expectLater(harness.startFuture, throwsA(isA<BridgeRegistrationException>()));
       await expectLater(harness.runFuture, throwsA(isA<BridgeRegistrationException>()));
 
       expect(repository.registeredBridgeIds, equals([null]));
@@ -48,7 +50,7 @@ void main() {
       expect(authMessage["bridgeId"], equals("br_first001"));
     });
 
-    test("normal disconnect reconnects without re-registering", () async {
+    test("normal disconnect reconnects with a fresh inbound relay iterator", () async {
       final repository = FakeBridgeRegistrationRepository()..nextBridgeId = "br_first001";
       final harness = await _RegistrationHarness.start(repository: repository);
       addTearDown(harness.close);
@@ -58,7 +60,26 @@ void main() {
       await firstSocket.close();
 
       final secondSocket = await harness.relayServer.nextClient();
-      final authMessage = await _firstTextMessage(secondSocket);
+      final secondMessages = StreamIterator<dynamic>(secondSocket);
+      expect(await secondMessages.moveNext(), isTrue);
+      final authMessage = jsonDecodeMap(secondMessages.current as String);
+
+      final phoneKeyPair = await RelayCryptoService().generateKeyPair();
+      final phonePublicKey = await phoneKeyPair.extractPublicKey();
+      final keyExchange = RelayMessage.keyExchange(
+        publicKey: base64Url.encode(phonePublicKey.bytes).replaceAll("=", ""),
+      );
+      secondSocket.add(<int>[
+        0,
+        7,
+        ...utf8.encode(jsonEncode(keyExchange.toJson())),
+      ]);
+
+      expect(await secondMessages.moveNext(), isTrue);
+      final response = secondMessages.current;
+      expect(response, isA<List<int>>());
+      expect((response as List<int>).sublist(0, 2), equals(const [0, 7]));
+      await secondMessages.cancel();
 
       expect(repository.registeredBridgeIds, equals([null]), reason: "registration is memoized per process");
       expect(authMessage["bridgeId"], equals("br_first001"));
@@ -171,7 +192,7 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 200));
 
       // A SIGTERM-style cancel must wake the loop immediately, not wait out the
-      // 2+ minute backoff. run() should return well within a few seconds.
+      // 2+ minute backoff. The lifecycle should stop well within a few seconds.
       final sw = Stopwatch()..start();
       await harness.session.cancel();
       await harness.runFuture.timeout(const Duration(seconds: 10));
@@ -222,6 +243,7 @@ class _RegistrationHarness {
   final FakeBridgePlugin plugin;
   final FakeBridgeIdStorage bridgeIdStorage;
   final OrchestratorSession session;
+  final Future<OrchestratorSessionStartResult> startFuture;
   final Future<void> runFuture;
   final _CountingRelayServer relayServer;
   final AppDatabase database;
@@ -232,6 +254,7 @@ class _RegistrationHarness {
     required this.plugin,
     required this.bridgeIdStorage,
     required this.session,
+    required this.startFuture,
     required this.runFuture,
     required this.relayServer,
     required this.database,
@@ -284,15 +307,16 @@ class _RegistrationHarness {
     );
 
     final session = orchestrator.create().session;
-    // Surface run() failures through [runFuture] without triggering an
-    // unhandled async error when a test only awaits it via expectLater later.
-    final runFuture = session.run();
-    unawaited(runFuture.catchError((_) {}));
+    final startFuture = session.start();
+    final runFuture = session.waitUntilStopped();
+    startFuture.ignore();
+    runFuture.ignore();
 
     return _RegistrationHarness._(
       plugin: plugin,
       bridgeIdStorage: bridgeIdStorage,
       session: session,
+      startFuture: startFuture,
       runFuture: runFuture,
       relayServer: relayServer,
       database: database,
@@ -304,9 +328,14 @@ class _RegistrationHarness {
   Future<void> close() async {
     await session.cancel();
     try {
+      await startFuture.timeout(const Duration(seconds: 10));
+    } on Object {
+      // Startup may have already completed with the error under test.
+    }
+    try {
       await runFuture.timeout(const Duration(seconds: 10));
     } on Object {
-      // run() may have already completed with the error under test.
+      // The lifecycle may have already completed with the error under test.
     }
     await lifecycleService.dispose();
     httpClient.close();

--- a/bridge/app/test/bridge/orchestrator_token_reauth_test.dart
+++ b/bridge/app/test/bridge/orchestrator_token_reauth_test.dart
@@ -343,8 +343,8 @@ class _ReauthHarness {
     );
 
     final session = orchestrator.create().session;
-    final runFuture = session.run();
-    unawaited(runFuture.catchError((_) {}));
+    final running = await startTestOrchestratorSession(session: session);
+    final runFuture = running.stopped;
 
     return _ReauthHarness._(
       session: session,
@@ -363,7 +363,7 @@ class _ReauthHarness {
     try {
       await runFuture.timeout(const Duration(seconds: 10));
     } on Object {
-      // run() may have already completed.
+      // The lifecycle may have already completed.
     }
     await lifecycleService.dispose();
     httpClient.close();

--- a/bridge/app/test/helpers/test_helpers.dart
+++ b/bridge/app/test/helpers/test_helpers.dart
@@ -10,6 +10,7 @@ import "package:sesori_bridge/src/auth/bridge_id_storage.dart";
 import "package:sesori_bridge/src/auth/bridge_registration_repository.dart";
 import "package:sesori_bridge/src/auth/bridge_registration_service.dart";
 import "package:sesori_bridge/src/auth/token_refresher.dart";
+import "package:sesori_bridge/src/bridge/orchestrator.dart";
 import "package:sesori_bridge/src/bridge/relay_client.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
@@ -175,6 +176,21 @@ class CapturingFailureReporter extends FakeFailureReporter {
 List<int> makeRoomKey() {
   final random = Random.secure();
   return List<int>.generate(32, (_) => random.nextInt(256));
+}
+
+Future<({Future<void> stopped})> startTestOrchestratorSession({
+  required OrchestratorSession session,
+}) async {
+  final startFuture = session.start();
+  final stopped = session.waitUntilStopped();
+  stopped.ignore();
+  final result = await startFuture;
+  if (result != OrchestratorSessionStartResult.ready) {
+    throw StateError("Test orchestrator session was cancelled before readiness");
+  }
+  return (
+    stopped: stopped,
+  );
 }
 
 Future<(HttpServer, Stream<List<int>>)> startTestRelayServer() async {


### PR DESCRIPTION
## Summary

- replace `OrchestratorSession.run()` with one-shot readiness via `start()` and lifecycle completion via `waitUntilStopped()`
- make startup, relay serving, partial-start cleanup, and teardown share one lifecycle future
- arm a fresh `StreamIterator` for each relay connection and reconnect before reporting initial readiness
- make pending WebSocket handshakes explicitly owned and promptly cancellable without late promotion or authentication
- migrate existing callers and add focused lifecycle, reconnect, and pending-handshake coverage

This is the refactor-only first step of the plan from #580. It intentionally preserves existing onboarding ordering and user-facing copy; the relay-first onboarding change remains Step 2.

## Verification

- focused bridge tests pass for registration, error recovery, event delivery, token re-authentication, debug server behavior, and `RelayClient`
- `dart test test/bridge/runtime/bridge_runtime_runner_test.dart`
- `dart analyze --fatal-infos`
- architecture implementation review approved after fixing cancelled-startup supervised-exit sequencing
- `git diff --check`

## Delivery

- Plan slug: `bridge-ready-onboarding`
- Step: 1/2
- Base: `f87b4c6603c682b4606a57010a41d3cab4d96ddd`
- Changed lines: 1,033, below the 1,500-line maximum
