### PR TITLE
[bridge-ready-onboarding] fix(bridge): start relay before mobile onboarding [step 2/2]

### DIFF
--- a/.plan/active/bridge-ready-onboarding/TRACKER.md
+++ b/.plan/active/bridge-ready-onboarding/TRACKER.md
@@ -2,12 +2,12 @@
 
 ## Plan State
 
-- **Status:** Step 1 merged; Step 2 implemented and verified locally
+- **Status:** Step 1 merged; Step 2 PR in review
 - **Plan slug:** `bridge-ready-onboarding`
 - **Implementation base:** `origin/main` at
   `235caf8e2cb73a5607ae8dcb662d7eb6e85dd3b1`
 - **Plan PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/580
-- **Implementation state:** Step 2 ready for commit/delivery
+- **Implementation state:** Step 2 PR: https://github.com/sesori-ai/sesori_apps_monorepo/pull/587
 
 ## Plan Review
 
@@ -22,7 +22,7 @@
 | Done | Step | Branch | Exact PR title | Changed-line budget | State |
 |---|---|---|---|---:|---|
 | [x] | 1/2 | `bridge-setup-ux-assessment` | `[bridge-ready-onboarding] refactor(bridge): separate session startup from serving [step 1/2]` | 650-950; reassess at 1,300; maximum 1,500 | [PR #585](https://github.com/sesori-ai/sesori_apps_monorepo/pull/585) merged |
-| [ ] | 2/2 | `bridge-setup-ux-assessment` | `[bridge-ready-onboarding] fix(bridge): start relay before mobile onboarding [step 2/2]` | 450-750; reassess at 1,300; maximum 1,500 | Implemented and verified locally |
+| [ ] | 2/2 | `bridge-setup-ux-assessment` | `[bridge-ready-onboarding] fix(bridge): start relay before mobile onboarding [step 2/2]` | 450-750; reassess at 1,300; maximum 1,500 | [PR #587](https://github.com/sesori-ai/sesori_apps_monorepo/pull/587) in review |
 
 ## Execution Rules
 
@@ -40,7 +40,7 @@
 
 ## Current Pointer
 
-- **Next action:** commit and publish Step 2.
+- **Next action:** monitor Step 2 CI and review.
 
 ## Step 1 Verification
 
@@ -61,6 +61,9 @@
 
 ## Findings And Plan Deltas
 
+- **2026-07-27 — Step 2 delivery:** Opened implementation PR
+  [#587](https://github.com/sesori-ai/sesori_apps_monorepo/pull/587) and started
+  CI/review monitoring.
 - **2026-07-27 — Step 2 implementation:** Replaced the notification-registration
   gate with one finite, presentation-free immediate status decision; removed the
   long-poll `wait` contract; started preparation concurrently with relay startup;

--- a/.plan/active/bridge-ready-onboarding/TRACKER.md
+++ b/.plan/active/bridge-ready-onboarding/TRACKER.md
@@ -2,12 +2,12 @@
 
 ## Plan State
 
-- **Status:** plan merged; Step 1 PR in review
+- **Status:** Step 1 merged; Step 2 implemented and verified locally
 - **Plan slug:** `bridge-ready-onboarding`
 - **Implementation base:** `origin/main` at
-  `f87b4c6603c682b4606a57010a41d3cab4d96ddd`
+  `235caf8e2cb73a5607ae8dcb662d7eb6e85dd3b1`
 - **Plan PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/580
-- **Implementation state:** Step 1 PR: https://github.com/sesori-ai/sesori_apps_monorepo/pull/585
+- **Implementation state:** Step 2 ready for commit/delivery
 
 ## Plan Review
 
@@ -21,8 +21,8 @@
 
 | Done | Step | Branch | Exact PR title | Changed-line budget | State |
 |---|---|---|---|---:|---|
-| [ ] | 1/2 | `bridge-setup-ux-assessment` | `[bridge-ready-onboarding] refactor(bridge): separate session startup from serving [step 1/2]` | 650-950; reassess at 1,300; maximum 1,500 | [PR #585](https://github.com/sesori-ai/sesori_apps_monorepo/pull/585) in review |
-| [ ] | 2/2 | `bridge-ready-onboarding-relay-first` | `[bridge-ready-onboarding] fix(bridge): start relay before mobile onboarding [step 2/2]` | 450-750; reassess at 1,300; maximum 1,500 | Blocked on Step 1 merge |
+| [x] | 1/2 | `bridge-setup-ux-assessment` | `[bridge-ready-onboarding] refactor(bridge): separate session startup from serving [step 1/2]` | 650-950; reassess at 1,300; maximum 1,500 | [PR #585](https://github.com/sesori-ai/sesori_apps_monorepo/pull/585) merged |
+| [ ] | 2/2 | `bridge-setup-ux-assessment` | `[bridge-ready-onboarding] fix(bridge): start relay before mobile onboarding [step 2/2]` | 450-750; reassess at 1,300; maximum 1,500 | Implemented and verified locally |
 
 ## Execution Rules
 
@@ -40,8 +40,7 @@
 
 ## Current Pointer
 
-- **Next action:** monitor Step 1 CI and review; Step 2 remains blocked until
-  Step 1 merges.
+- **Next action:** commit and publish Step 2.
 
 ## Step 1 Verification
 
@@ -52,8 +51,24 @@
 - `aristotle-impl-review` approved the implementation on its second pass after
   the cancelled-startup path was fixed to preserve supervised exit sentinels.
 
+## Step 2 Verification
+
+- Focused onboarding service, status repository/API, runner guard, registration,
+  and lifecycle tests pass.
+- `dart analyze --fatal-infos` passes from `bridge/app`.
+- `aristotle-impl-review` approved the relay-first onboarding data flow and
+  composition-root lifecycle sequencing.
+
 ## Findings And Plan Deltas
 
+- **2026-07-27 — Step 2 implementation:** Replaced the notification-registration
+  gate with one finite, presentation-free immediate status decision; removed the
+  long-poll `wait` contract; started preparation concurrently with relay startup;
+  and moved ready-state QR/link presentation into the runner after session
+  readiness. The existing user-directed worktree branch was reused.
+- **2026-07-27 — Step 1 merge:** Implementation PR
+  [#585](https://github.com/sesori-ai/sesori_apps_monorepo/pull/585) merged and
+  became the Step 2 base.
 - **2026-07-27 — Step 1 delivery:** Opened implementation PR
   [#585](https://github.com/sesori-ai/sesori_apps_monorepo/pull/585) and started
   CI/review monitoring.

--- a/.plan/completed/bridge-ready-onboarding/PLAN.md
+++ b/.plan/completed/bridge-ready-onboarding/PLAN.md
@@ -3,13 +3,17 @@
 ## Status
 
 - **Plan slug:** `bridge-ready-onboarding`
-- **Status:** architecture review corrections applied; in review on plan PR
-  [#580](https://github.com/sesori-ai/sesori_apps_monorepo/pull/580)
+- **Status:** complete; plan PR
+  [#580](https://github.com/sesori-ai/sesori_apps_monorepo/pull/580) and
+  implementation PRs
+  [#585](https://github.com/sesori-ai/sesori_apps_monorepo/pull/585) and
+  [#587](https://github.com/sesori-ai/sesori_apps_monorepo/pull/587) merged
 - **Plan date:** 2026-07-26
+- **Completion date:** 2026-07-27
 - **Implementation base:** `origin/main` at
   `f8c71eb78987aa8c64e397e8e8e3bb72eefa0692`
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
-- **Delivery:** two sequential bridge-only PRs
+- **Delivery:** two sequential bridge-only PRs, both merged
 
 ## Goal
 

--- a/.plan/completed/bridge-ready-onboarding/TRACKER.md
+++ b/.plan/completed/bridge-ready-onboarding/TRACKER.md
@@ -2,12 +2,13 @@
 
 ## Plan State
 
-- **Status:** Step 1 merged; Step 2 PR in review
+- **Status:** Complete; Step 1 and Step 2 merged
 - **Plan slug:** `bridge-ready-onboarding`
-- **Implementation base:** `origin/main` at
+- **Step 2 base:** `origin/main` at
   `235caf8e2cb73a5607ae8dcb662d7eb6e85dd3b1`
 - **Plan PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/580
-- **Implementation state:** Step 2 PR: https://github.com/sesori-ai/sesori_apps_monorepo/pull/587
+- **Implementation state:** complete; final PR
+  [#587](https://github.com/sesori-ai/sesori_apps_monorepo/pull/587) merged
 
 ## Plan Review
 
@@ -15,14 +16,15 @@
   directly; revised plan not re-reviewed
 - **Reviewer:** `aristotle-plan-review`
 - **Date:** 2026-07-26
-- **Reviewed scope:** `.plan/active/bridge-ready-onboarding/`
+- **Reviewed scope at review time:** `.plan/active/bridge-ready-onboarding/`
+  (now archived here)
 
 ## Delivery Steps
 
 | Done | Step | Branch | Exact PR title | Changed-line budget | State |
 |---|---|---|---|---:|---|
 | [x] | 1/2 | `bridge-setup-ux-assessment` | `[bridge-ready-onboarding] refactor(bridge): separate session startup from serving [step 1/2]` | 650-950; reassess at 1,300; maximum 1,500 | [PR #585](https://github.com/sesori-ai/sesori_apps_monorepo/pull/585) merged |
-| [ ] | 2/2 | `bridge-setup-ux-assessment` | `[bridge-ready-onboarding] fix(bridge): start relay before mobile onboarding [step 2/2]` | 450-750; reassess at 1,300; maximum 1,500 | [PR #587](https://github.com/sesori-ai/sesori_apps_monorepo/pull/587) in review |
+| [x] | 2/2 | `bridge-setup-ux-assessment` | `[bridge-ready-onboarding] fix(bridge): start relay before mobile onboarding [step 2/2]` | 450-750; reassess at 1,300; maximum 1,500 | [PR #587](https://github.com/sesori-ai/sesori_apps_monorepo/pull/587) merged |
 
 ## Execution Rules
 
@@ -40,7 +42,7 @@
 
 ## Current Pointer
 
-- **Next action:** monitor Step 2 CI and review.
+- **Next action:** None; the two-PR series is complete.
 
 ## Step 1 Verification
 
@@ -61,6 +63,10 @@
 
 ## Findings And Plan Deltas
 
+- **2026-07-27 — Plan completion:** Final implementation PR
+  [#587](https://github.com/sesori-ai/sesori_apps_monorepo/pull/587) merged. Both
+  delivery steps are complete, and the plan moved from `.plan/active` to
+  `.plan/completed` in the final PR.
 - **2026-07-27 — Step 2 delivery:** Opened implementation PR
   [#587](https://github.com/sesori-ai/sesori_apps_monorepo/pull/587) and started
   CI/review monitoring.

--- a/bridge/app/lib/src/api/sesori_server_api.dart
+++ b/bridge/app/lib/src/api/sesori_server_api.dart
@@ -33,12 +33,8 @@ class SesoriServerApi {
   final http.Client _client;
   final Duration _requestDeadline;
 
-  Future<AppClientStatusResponse> getAppClientStatus({
-    required String accessToken,
-    required bool wait,
-  }) async {
-    final endpoint = Uri.parse("$_authBackendUrl/auth/app-clients/status");
-    final uri = wait ? endpoint.replace(queryParameters: const {"wait": "true"}) : endpoint;
+  Future<AppClientStatusResponse> getAppClientStatus({required String accessToken}) async {
+    final uri = Uri.parse("$_authBackendUrl/auth/app-clients/status");
     final abortCompleter = Completer<void>();
     final deadlineTimer = Timer(_requestDeadline, abortCompleter.complete);
     final request = http.AbortableRequest("GET", uri, abortTrigger: abortCompleter.future)

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -520,8 +520,7 @@ class BridgeRuntimeRunner {
       // token service is the access-token provider + refresher, pulling tokens
       // from the GUI over the loopback channel. Standalone keeps the
       // TokenManager, which refreshes against the auth server with the locally
-      // stored refresh token (no GUI exists to ask). Build it before interactive
-      // app onboarding so an unbounded wait can refresh its access token.
+      // stored refresh token (no GUI exists to ask).
       final String authAccessToken;
       final AccessTokenProvider accessTokenProvider;
       final TokenRefresher tokenRefresher;
@@ -688,30 +687,6 @@ class BridgeRuntimeRunner {
       activePluginLifecycleService.applyAvailability(
         availablePluginIds: availableDescriptors.map((descriptor) => descriptor.id).toSet(),
       );
-      final runAppOnboarding = shouldRunAppOnboarding(
-        isSupervised: options.isSupervised,
-        isInteractive: terminalPromptApi.isInteractive,
-      );
-      if (runAppOnboarding) {
-        await AppClientOnboardingService(
-          statusRepository: AppClientStatusRepository(
-            api: SesoriServerApi(
-              authBackendUrl: options.authBackendUrl,
-              client: httpClient,
-              requestDeadline: SesoriServerApi.defaultRequestDeadline,
-            ),
-          ),
-          stateRepository: AppOnboardingStateRepository(
-            storage: AppOnboardingStateStorage(
-              directoryPath: appOnboardingStateDirectoryPath(
-                dataDirectory: options.dataDirectory,
-              ),
-            ),
-          ),
-          formatter: AppOnboardingFormatter(out: io.stdout, environment: environment),
-          tokenRefresher: tokenRefresher,
-        ).run(accessToken: authAccessToken, authBackendUrl: options.authBackendUrl);
-      }
       // If this bridge was spawned by a restart, wait for the predecessor to
       // exit before single-live-bridge enforcement so the handoff is clean.
       final predecessorPidRaw = environment[sesoriRestartPredecessorPidEnvVar];
@@ -899,11 +874,45 @@ class BridgeRuntimeRunner {
       shutdownCoordinator.add(disposable: updateLifecycle.dispose);
       updateLifecycle.start();
 
+      final Future<AppClientOnboardingDecision>? onboardingPreparation;
+      if (shouldRunAppOnboarding(
+        isSupervised: options.isSupervised,
+        isInteractive: terminalPromptApi.isInteractive,
+      )) {
+        onboardingPreparation = AppClientOnboardingService(
+          statusRepository: AppClientStatusRepository(
+            api: SesoriServerApi(
+              authBackendUrl: options.authBackendUrl,
+              client: httpClient,
+              requestDeadline: SesoriServerApi.defaultRequestDeadline,
+            ),
+          ),
+          stateRepository: AppOnboardingStateRepository(
+            storage: AppOnboardingStateStorage(
+              directoryPath: appOnboardingStateDirectoryPath(
+                dataDirectory: options.dataDirectory,
+              ),
+            ),
+          ),
+        ).prepare(accessToken: authAccessToken, authBackendUrl: options.authBackendUrl);
+      } else {
+        onboardingPreparation = null;
+      }
+
       try {
         final sessionStart = activeRuntime.session.start();
         sessionRun = activeRuntime.session.waitUntilStopped();
         final startResult = await sessionStart;
         if (startResult == OrchestratorSessionStartResult.ready) {
+          if (onboardingPreparation case final preparation?) {
+            final decision = await Future.any<AppClientOnboardingDecision>([
+              sessionRun.then((_) => AppClientOnboardingDecision.skip),
+              preparation,
+            ]);
+            if (decision == AppClientOnboardingDecision.prompt) {
+              _presentAppOnboardingPrompt(environment: environment);
+            }
+          }
           await sessionRun;
         }
       } finally {
@@ -985,6 +994,18 @@ class BridgeRuntimeRunner {
     required bool isSupervised,
     required bool isInteractive,
   }) => !isSupervised && isInteractive;
+
+  static void _presentAppOnboardingPrompt({required Map<String, String> environment}) {
+    Console.message("");
+    Console.message("Your Sesori bridge is running");
+    Console.message("");
+    Console.message(
+      "Install or open Sesori using the QR code or link below, then sign in with this same account.",
+    );
+    Console.message("");
+    Console.message(AppOnboardingFormatter(out: io.stdout, environment: environment).formatDestination());
+    Console.message("");
+  }
 
   /// Whether [url] is an acceptable supervised control-channel endpoint: a
   /// loopback host over ws/wss. The GUI hosts the control channel on loopback,

--- a/bridge/app/lib/src/repositories/app_client_status_repository.dart
+++ b/bridge/app/lib/src/repositories/app_client_status_repository.dart
@@ -24,12 +24,9 @@ class AppClientStatusRepository {
 
   final SesoriServerApi _api;
 
-  Future<AppClientStatusResult> getStatus({
-    required String accessToken,
-    required bool wait,
-  }) async {
+  Future<AppClientStatusResult> getStatus({required String accessToken}) async {
     try {
-      final response = await _api.getAppClientStatus(accessToken: accessToken, wait: wait);
+      final response = await _api.getAppClientStatus(accessToken: accessToken);
       return response.registered ? const AppClientRegistered() : const AppClientAbsent();
     } on SesoriServerApiException catch (error, stackTrace) {
       if (error.statusCode == 404 || error.statusCode == 405) {

--- a/bridge/app/lib/src/services/app_client_onboarding_service.dart
+++ b/bridge/app/lib/src/services/app_client_onboarding_service.dart
@@ -1,108 +1,51 @@
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Console, Log;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart" show parseJwtUserId;
 
-import "../auth/token_refresher.dart";
-import "../foundation/app_onboarding_formatter.dart";
 import "../repositories/app_client_status_repository.dart";
 import "../repositories/app_onboarding_state_repository.dart";
+
+enum AppClientOnboardingDecision { skip, prompt }
 
 class AppClientOnboardingService {
   AppClientOnboardingService({
     required AppClientStatusRepository statusRepository,
     required AppOnboardingStateRepository stateRepository,
-    required AppOnboardingFormatter formatter,
-    required TokenRefresher tokenRefresher,
   }) : _statusRepository = statusRepository,
-       _stateRepository = stateRepository,
-       _formatter = formatter,
-       _tokenRefresher = tokenRefresher;
-
-  static const Duration _failureRetryDelay = Duration(seconds: 5);
+       _stateRepository = stateRepository;
 
   final AppClientStatusRepository _statusRepository;
   final AppOnboardingStateRepository _stateRepository;
-  final AppOnboardingFormatter _formatter;
-  final TokenRefresher _tokenRefresher;
 
-  Future<void> run({required String accessToken, required String authBackendUrl}) async {
+  Future<AppClientOnboardingDecision> prepare({
+    required String accessToken,
+    required String authBackendUrl,
+  }) async {
     final userId = parseJwtUserId(accessToken);
     if (userId == null) {
       Log.w("Skipping app onboarding check: access token has no readable userId claim");
-      return;
+      return AppClientOnboardingDecision.skip;
     }
 
     final marker = await _stateRepository.lookup(authBackendUrl: authBackendUrl, userId: userId);
     switch (marker) {
       case AppOnboardingStatePresent():
-        return;
+        return AppClientOnboardingDecision.skip;
       case AppOnboardingStateAbsent():
         break;
       case AppOnboardingStateReadFailed(:final error, :final stackTrace):
         Log.w("Could not read app onboarding state; checking registration anyway", error, stackTrace);
     }
 
-    final immediate = await _statusRepository.getStatus(accessToken: accessToken, wait: false);
+    final immediate = await _statusRepository.getStatus(accessToken: accessToken);
     switch (immediate) {
       case AppClientRegistered():
         await _markCompleted(authBackendUrl: authBackendUrl, userId: userId);
-        return;
+        return AppClientOnboardingDecision.skip;
       case AppClientStatusUnavailable(:final error, :final stackTrace):
         Log.w("Could not check Sesori app registration; continuing bridge startup", error, stackTrace);
-        return;
+        return AppClientOnboardingDecision.skip;
       case AppClientAbsent():
-        break;
-    }
-
-    Console.message("");
-    Console.message("Connect the Sesori mobile app to continue");
-    Console.message("");
-    Console.message(
-      "Use the QR code or link below to install or open Sesori, then sign in with this same account.",
-    );
-    Console.message("");
-    Console.message(_formatter.formatDestination());
-    Console.message("");
-    Console.message("Waiting for the Sesori mobile app to connect...");
-    Console.message("Bridge startup is paused and will continue automatically once connected.");
-
-    var waitFailureReported = false;
-    while (true) {
-      final String pollingAccessToken;
-      try {
-        pollingAccessToken = await _tokenRefresher.getAccessToken();
-      } on Object catch (error, stackTrace) {
-        if (!waitFailureReported) {
-          Log.w(
-            "Could not refresh authentication while waiting for the Sesori app; retrying",
-            error,
-            stackTrace,
-          );
-          waitFailureReported = true;
-        }
-        await Future<void>.delayed(_failureRetryDelay);
-        continue;
-      }
-
-      final waited = await _statusRepository.getStatus(accessToken: pollingAccessToken, wait: true);
-      switch (waited) {
-        case AppClientRegistered():
-          await _markCompleted(authBackendUrl: authBackendUrl, userId: userId);
-          Console.message("");
-          Console.message("Sesori mobile app connected. Continuing bridge startup.");
-          return;
-        case AppClientAbsent():
-          waitFailureReported = false;
-        case AppClientStatusUnavailable(:final error, :final stackTrace):
-          if (!waitFailureReported) {
-            Log.w(
-              "Could not check Sesori app registration; bridge startup remains paused and the check will retry",
-              error,
-              stackTrace,
-            );
-            waitFailureReported = true;
-          }
-          await Future<void>.delayed(_failureRetryDelay);
-      }
+        return AppClientOnboardingDecision.prompt;
     }
   }
 

--- a/bridge/app/lib/src/services/app_client_onboarding_service.dart
+++ b/bridge/app/lib/src/services/app_client_onboarding_service.dart
@@ -20,6 +20,18 @@ class AppClientOnboardingService {
     required String accessToken,
     required String authBackendUrl,
   }) async {
+    try {
+      return await _prepare(accessToken: accessToken, authBackendUrl: authBackendUrl);
+    } on Object catch (error, stackTrace) {
+      Log.w("Could not prepare Sesori app onboarding; continuing bridge startup", error, stackTrace);
+      return AppClientOnboardingDecision.skip;
+    }
+  }
+
+  Future<AppClientOnboardingDecision> _prepare({
+    required String accessToken,
+    required String authBackendUrl,
+  }) async {
     final userId = parseJwtUserId(accessToken);
     if (userId == null) {
       Log.w("Skipping app onboarding check: access token has no readable userId claim");

--- a/bridge/app/test/api/sesori_server_api_test.dart
+++ b/bridge/app/test/api/sesori_server_api_test.dart
@@ -19,29 +19,12 @@ void main() {
         requestDeadline: const Duration(seconds: 1),
       );
 
-      final response = await api.getAppClientStatus(accessToken: "secret-token", wait: false);
+      final response = await api.getAppClientStatus(accessToken: "secret-token");
 
       expect(response.registered, isTrue);
       expect(request.method, equals("GET"));
       expect(request.url, equals(Uri.parse("https://auth.example.test/auth/app-clients/status")));
       expect(request.headers["Authorization"], equals("Bearer secret-token"));
-    });
-
-    test("adds only wait=true for the long-poll request", () async {
-      late Uri requestUri;
-      final api = SesoriServerApi(
-        authBackendUrl: "https://auth.example.test",
-        client: MockClient((request) async {
-          requestUri = request.url;
-          return http.Response('{"registered":false}', 200);
-        }),
-        requestDeadline: const Duration(seconds: 1),
-      );
-
-      final response = await api.getAppClientStatus(accessToken: "token", wait: true);
-
-      expect(response.registered, isFalse);
-      expect(requestUri, equals(Uri.parse("https://auth.example.test/auth/app-clients/status?wait=true")));
     });
 
     test("rejects non-200 status and malformed response models", () async {
@@ -57,11 +40,11 @@ void main() {
       );
 
       await expectLater(
-        statusApi.getAppClientStatus(accessToken: "token", wait: false),
+        statusApi.getAppClientStatus(accessToken: "token"),
         throwsA(isA<SesoriServerApiException>().having((error) => error.statusCode, "statusCode", 503)),
       );
       await expectLater(
-        malformedApi.getAppClientStatus(accessToken: "token", wait: false),
+        malformedApi.getAppClientStatus(accessToken: "token"),
         throwsA(isA<TypeError>()),
       );
     });
@@ -75,7 +58,7 @@ void main() {
       );
 
       await expectLater(
-        api.getAppClientStatus(accessToken: "token", wait: false),
+        api.getAppClientStatus(accessToken: "token"),
         throwsA(isA<http.RequestAbortedException>()),
       );
       expect(client.abortObserved, isTrue);
@@ -89,7 +72,7 @@ void main() {
         requestDeadline: const Duration(milliseconds: 5),
       );
 
-      await api.getAppClientStatus(accessToken: "token", wait: false);
+      await api.getAppClientStatus(accessToken: "token");
       await Future<void>.delayed(const Duration(milliseconds: 20));
 
       expect(client.abortObserved, isFalse);

--- a/bridge/app/test/repositories/app_client_status_repository_test.dart
+++ b/bridge/app/test/repositories/app_client_status_repository_test.dart
@@ -10,11 +10,11 @@ void main() {
       final repository = AppClientStatusRepository(api: api);
 
       api.response = const AppClientStatusResponse(registered: true);
-      expect(await repository.getStatus(accessToken: "token", wait: false), isA<AppClientRegistered>());
+      expect(await repository.getStatus(accessToken: "token"), isA<AppClientRegistered>());
 
       api.response = const AppClientStatusResponse(registered: false);
-      expect(await repository.getStatus(accessToken: "token", wait: true), isA<AppClientAbsent>());
-      expect(api.waitValues, equals([false, true]));
+      expect(await repository.getStatus(accessToken: "token"), isA<AppClientAbsent>());
+      expect(api.accessTokens, equals(["token", "token"]));
     });
 
     test("maps legacy endpoint omission statuses to unavailable", () async {
@@ -26,7 +26,7 @@ void main() {
           );
         final result = await AppClientStatusRepository(
           api: api,
-        ).getStatus(accessToken: "token", wait: false);
+        ).getStatus(accessToken: "token");
 
         expect(result, isA<AppClientStatusUnavailable>());
       }
@@ -38,7 +38,7 @@ void main() {
 
       final result = await AppClientStatusRepository(
         api: api,
-      ).getStatus(accessToken: "token", wait: false);
+      ).getStatus(accessToken: "token");
 
       expect(result, isA<AppClientStatusUnavailable>());
       expect((result as AppClientStatusUnavailable).error, same(error));
@@ -49,11 +49,11 @@ void main() {
 class _FakeSesoriServerApi implements SesoriServerApi {
   AppClientStatusResponse response = const AppClientStatusResponse(registered: false);
   Object? error;
-  final List<bool> waitValues = [];
+  final List<String> accessTokens = [];
 
   @override
-  Future<AppClientStatusResponse> getAppClientStatus({required String accessToken, required bool wait}) async {
-    waitValues.add(wait);
+  Future<AppClientStatusResponse> getAppClientStatus({required String accessToken}) async {
+    accessTokens.add(accessToken);
     if (error != null) throw error!;
     return response;
   }

--- a/bridge/app/test/services/app_client_onboarding_service_test.dart
+++ b/bridge/app/test/services/app_client_onboarding_service_test.dart
@@ -1,9 +1,6 @@
 import "dart:convert";
 import "dart:io";
 
-import "package:fake_async/fake_async.dart";
-import "package:sesori_bridge/src/auth/token_refresher.dart";
-import "package:sesori_bridge/src/foundation/app_onboarding_formatter.dart";
 import "package:sesori_bridge/src/repositories/app_client_status_repository.dart";
 import "package:sesori_bridge/src/repositories/app_onboarding_state_repository.dart";
 import "package:sesori_bridge/src/services/app_client_onboarding_service.dart";
@@ -15,19 +12,15 @@ void main() {
     late _FakeAppClientStatusRepository statusRepository;
     late _FakeAppOnboardingStateRepository stateRepository;
     late AppClientOnboardingService service;
-    late _FakeTokenRefresher tokenRefresher;
     late _CapturingStdout stdoutCapture;
     late _CapturingStdout stderrCapture;
 
     setUp(() {
       statusRepository = _FakeAppClientStatusRepository();
       stateRepository = _FakeAppOnboardingStateRepository();
-      tokenRefresher = _FakeTokenRefresher(accessToken: _token(userId: "user-a"));
       service = AppClientOnboardingService(
         statusRepository: statusRepository,
         stateRepository: stateRepository,
-        formatter: _StubAppOnboardingFormatter(),
-        tokenRefresher: tokenRefresher,
       );
       stdoutCapture = _CapturingStdout();
       stderrCapture = _CapturingStdout();
@@ -38,49 +31,52 @@ void main() {
       Log.level = LogLevel.info;
     });
 
-    test("matching marker performs no request and emits no output", () async {
+    test("matching marker skips without a request or output", () async {
       stateRepository.lookupResult = const AppOnboardingStatePresent();
 
-      await _runCaptured(
-        () => service.run(
-          accessToken: _token(userId: "user-a"),
-          authBackendUrl: "https://auth.test",
-        ),
+      final decision = await _prepareCaptured(
+        service: service,
+        accessToken: _token(userId: "user-a"),
         out: stdoutCapture,
         err: stderrCapture,
       );
 
-      expect(statusRepository.waitValues, isEmpty);
+      expect(decision, AppClientOnboardingDecision.skip);
+      expect(statusRepository.accessTokens, isEmpty);
       expect(stateRepository.markCalls, equals(0));
       expect(stdoutCapture.lines, isEmpty);
       expect(stderrCapture.lines, isEmpty);
     });
 
-    test("missing JWT userId warns and performs no marker or status request", () async {
-      await _runCaptured(
-        () => service.run(accessToken: _token(userId: null), authBackendUrl: "https://auth.test"),
+    test("missing JWT userId warns and skips all state and status work", () async {
+      final decision = await _prepareCaptured(
+        service: service,
+        accessToken: _token(userId: null),
         out: stdoutCapture,
         err: stderrCapture,
       );
 
+      expect(decision, AppClientOnboardingDecision.skip);
       expect(stateRepository.lookupCalls, equals(0));
-      expect(statusRepository.waitValues, isEmpty);
+      expect(statusRepository.accessTokens, isEmpty);
+      expect(stdoutCapture.lines, isEmpty);
       expect(stderrCapture.lines, hasLength(1));
     });
 
-    test("immediate registration marks the pair and continues silently", () async {
+    test("immediate registration marks the pair and skips silently", () async {
       statusRepository.results.add(const AppClientRegistered());
+      final accessToken = _token(userId: "user-a");
 
-      await _runCaptured(
-        () => service.run(
-          accessToken: _token(userId: "user-a"),
-          authBackendUrl: "https://auth.test/",
-        ),
+      final decision = await _prepareCaptured(
+        service: service,
+        accessToken: accessToken,
+        authBackendUrl: "https://auth.test/",
         out: stdoutCapture,
         err: stderrCapture,
       );
 
-      expect(statusRepository.waitValues, equals([false]));
+      expect(decision, AppClientOnboardingDecision.skip);
+      expect(statusRepository.accessTokens, equals([accessToken]));
       expect(stateRepository.markCalls, equals(1));
       expect(stateRepository.lastAuthBackendUrl, equals("https://auth.test/"));
       expect(stateRepository.lastUserId, equals("user-a"));
@@ -88,83 +84,25 @@ void main() {
       expect(stderrCapture.lines, isEmpty);
     });
 
-    test("confirmed absence shows guidance and polls until registration", () async {
-      tokenRefresher.accessToken = "refreshed-token";
-      statusRepository.results
-        ..add(const AppClientAbsent())
-        ..add(const AppClientAbsent())
-        ..add(const AppClientAbsent())
-        ..add(const AppClientRegistered());
+    test("confirmed absence returns prompt after exactly one silent status request", () async {
+      statusRepository.results.add(const AppClientAbsent());
+      final accessToken = _token(userId: "user-a");
 
-      await _runCaptured(
-        () => service.run(
-          accessToken: _token(userId: "user-a"),
-          authBackendUrl: "https://auth.test",
-        ),
+      final decision = await _prepareCaptured(
+        service: service,
+        accessToken: accessToken,
         out: stdoutCapture,
         err: stderrCapture,
       );
 
-      expect(statusRepository.waitValues, equals([false, true, true, true]));
-      expect(statusRepository.accessTokens, [
-        _token(userId: "user-a"),
-        "refreshed-token",
-        "refreshed-token",
-        "refreshed-token",
-      ]);
-      expect(stateRepository.markCalls, equals(1));
-      expect(stdoutCapture.lines, [
-        "",
-        "Connect the Sesori mobile app to continue",
-        "",
-        "Use the QR code or link below to install or open Sesori, then sign in with this same account.",
-        "",
-        AppOnboardingFormatter.appUrl,
-        "",
-        "Waiting for the Sesori mobile app to connect...",
-        "Bridge startup is paused and will continue automatically once connected.",
-        "",
-        "Sesori mobile app connected. Continuing bridge startup.",
-      ]);
+      expect(decision, AppClientOnboardingDecision.prompt);
+      expect(statusRepository.accessTokens, equals([accessToken]));
+      expect(stateRepository.markCalls, equals(0));
+      expect(stdoutCapture.lines, isEmpty);
+      expect(stderrCapture.lines, isEmpty);
     });
 
-    test("wait failure keeps startup paused and retries", () {
-      statusRepository.results
-        ..add(const AppClientAbsent())
-        ..add(
-          const AppClientStatusUnavailable(
-            error: FormatException("offline"),
-            stackTrace: StackTrace.empty,
-          ),
-        )
-        ..add(const AppClientRegistered());
-
-      fakeAsync((async) {
-        var completed = false;
-        _runCaptured(
-          () => service.run(
-            accessToken: _token(userId: "user-a"),
-            authBackendUrl: "https://auth.test",
-          ),
-          out: stdoutCapture,
-          err: stderrCapture,
-        ).then((_) => completed = true);
-
-        async.flushMicrotasks();
-        expect(statusRepository.waitValues, equals([false, true]));
-        expect(completed, isFalse);
-
-        async.elapse(const Duration(seconds: 5));
-        async.flushMicrotasks();
-        expect(statusRepository.waitValues, equals([false, true, true]));
-        expect(completed, isTrue);
-      });
-
-      expect(stateRepository.markCalls, equals(1));
-      expect(stderrCapture.lines, hasLength(1));
-    });
-
-    test("marker read failure warns but a confirmed status still attempts the write", () async {
+    test("marker read failure warns but confirmed registration still writes", () async {
       const readError = FileSystemException("cannot read marker");
       stateRepository.lookupResult = const AppOnboardingStateReadFailed(
         error: readError,
@@ -172,63 +110,69 @@ void main() {
       );
       statusRepository.results.add(const AppClientRegistered());
 
-      await _runCaptured(
-        () => service.run(
-          accessToken: _token(userId: "user-a"),
-          authBackendUrl: "https://auth.test",
-        ),
+      final decision = await _prepareCaptured(
+        service: service,
+        accessToken: _token(userId: "user-a"),
         out: stdoutCapture,
         err: stderrCapture,
       );
 
+      expect(decision, AppClientOnboardingDecision.skip);
       expect(stateRepository.markCalls, equals(1));
+      expect(stdoutCapture.lines, isEmpty);
       expect(stderrCapture.lines, hasLength(1));
     });
 
-    test("remote failure warns once and does not retry or mark", () async {
+    test("status failure warns and skips without retrying or marking", () async {
       statusRepository.results.add(
         const AppClientStatusUnavailable(error: FormatException("offline"), stackTrace: StackTrace.empty),
       );
 
-      await _runCaptured(
-        () => service.run(
-          accessToken: _token(userId: "user-a"),
-          authBackendUrl: "https://auth.test",
-        ),
+      final decision = await _prepareCaptured(
+        service: service,
+        accessToken: _token(userId: "user-a"),
         out: stdoutCapture,
         err: stderrCapture,
       );
 
-      expect(statusRepository.waitValues, equals([false]));
+      expect(decision, AppClientOnboardingDecision.skip);
+      expect(statusRepository.accessTokens, hasLength(1));
       expect(stateRepository.markCalls, equals(0));
+      expect(stdoutCapture.lines, isEmpty);
       expect(stderrCapture.lines, hasLength(1));
     });
 
-    test("marker write failure warns and startup continues", () async {
+    test("marker write failure remains observable and non-fatal", () async {
       stateRepository.markError = const FileSystemException("disk full");
       statusRepository.results.add(const AppClientRegistered());
 
-      await _runCaptured(
-        () => service.run(
-          accessToken: _token(userId: "user-a"),
-          authBackendUrl: "https://auth.test",
-        ),
+      final decision = await _prepareCaptured(
+        service: service,
+        accessToken: _token(userId: "user-a"),
         out: stdoutCapture,
         err: stderrCapture,
       );
 
+      expect(decision, AppClientOnboardingDecision.skip);
       expect(stateRepository.markCalls, equals(1));
+      expect(stdoutCapture.lines, isEmpty);
       expect(stderrCapture.lines, hasLength(1));
     });
   });
 }
 
-Future<void> _runCaptured(
-  Future<void> Function() operation, {
+Future<AppClientOnboardingDecision> _prepareCaptured({
+  required AppClientOnboardingService service,
+  required String accessToken,
+  String authBackendUrl = "https://auth.test",
   required _CapturingStdout out,
   required _CapturingStdout err,
 }) {
-  return IOOverrides.runZoned(operation, stdout: () => out, stderr: () => err);
+  return IOOverrides.runZoned(
+    () => service.prepare(accessToken: accessToken, authBackendUrl: authBackendUrl),
+    stdout: () => out,
+    stderr: () => err,
+  );
 }
 
 String _token({required String? userId}) {
@@ -238,24 +182,13 @@ String _token({required String? userId}) {
 
 class _FakeAppClientStatusRepository implements AppClientStatusRepository {
   final List<AppClientStatusResult> results = [];
-  final List<bool> waitValues = [];
   final List<String> accessTokens = [];
 
   @override
-  Future<AppClientStatusResult> getStatus({required String accessToken, required bool wait}) async {
+  Future<AppClientStatusResult> getStatus({required String accessToken}) async {
     accessTokens.add(accessToken);
-    waitValues.add(wait);
     return results.removeAt(0);
   }
-}
-
-class _FakeTokenRefresher implements TokenRefresher {
-  _FakeTokenRefresher({required this.accessToken});
-
-  String accessToken;
-
-  @override
-  Future<String> getAccessToken({bool forceRefresh = false}) async => accessToken;
 }
 
 class _FakeAppOnboardingStateRepository implements AppOnboardingStateRepository {
@@ -284,11 +217,6 @@ class _FakeAppOnboardingStateRepository implements AppOnboardingStateRepository 
   Future<void> clearAll() {
     throw UnimplementedError("not used by onboarding service");
   }
-}
-
-class _StubAppOnboardingFormatter implements AppOnboardingFormatter {
-  @override
-  String formatDestination() => AppOnboardingFormatter.appUrl;
 }
 
 class _CapturingStdout implements Stdout {

--- a/bridge/app/test/services/app_client_onboarding_service_test.dart
+++ b/bridge/app/test/services/app_client_onboarding_service_test.dart
@@ -142,6 +142,22 @@ void main() {
       expect(stderrCapture.lines, hasLength(1));
     });
 
+    test("unexpected preparation failure warns and skips", () async {
+      statusRepository.error = StateError("unexpected status failure");
+
+      final decision = await _prepareCaptured(
+        service: service,
+        accessToken: _token(userId: "user-a"),
+        out: stdoutCapture,
+        err: stderrCapture,
+      );
+
+      expect(decision, AppClientOnboardingDecision.skip);
+      expect(stateRepository.markCalls, equals(0));
+      expect(stdoutCapture.lines, isEmpty);
+      expect(stderrCapture.lines, hasLength(1));
+    });
+
     test("marker write failure remains observable and non-fatal", () async {
       stateRepository.markError = const FileSystemException("disk full");
       statusRepository.results.add(const AppClientRegistered());
@@ -183,10 +199,12 @@ String _token({required String? userId}) {
 class _FakeAppClientStatusRepository implements AppClientStatusRepository {
   final List<AppClientStatusResult> results = [];
   final List<String> accessTokens = [];
+  Object? error;
 
   @override
   Future<AppClientStatusResult> getStatus({required String accessToken}) async {
     accessTokens.add(accessToken);
+    if (error != null) throw error!;
     return results.removeAt(0);
   }
 }


### PR DESCRIPTION
## Summary

- replace the notification-registration startup gate with one finite, presentation-free app-status decision
- remove the internal long-poll `wait` contract, `wait=true` query, token-refresh polling, and retry timer
- start onboarding preparation without awaiting it before relay session startup
- render revised QR/link guidance only after local relay readiness, while letting lifecycle completion suppress stale prompts
- preserve marker compatibility, the 35-second request abort, and supervised/non-interactive behavior
- archive the completed `bridge-ready-onboarding` plan and record this final PR as merged so the post-merge documentation is already final

The bridge is now already registered, relay-connected, authenticated, and serving its inbound stream before a missing-app prompt is shown. Push-token registration is no longer required for bridge availability.

## Verification

- `dart test test/services/app_client_onboarding_service_test.dart test/repositories/app_client_status_repository_test.dart test/api/sesori_server_api_test.dart test/bridge/runtime/bridge_runtime_runner_test.dart test/bridge/orchestrator_registration_test.dart test/bridge/orchestrator_error_recovery_test.dart`
- `dart test test/services/app_client_onboarding_service_test.dart` after review hardening
- `dart analyze --fatal-infos`
- architecture implementation review approved
- `git diff --check`

## Delivery

- Plan: #580
- Step 1: #585
- Plan slug: `bridge-ready-onboarding`
- Step: 2/2
- Base: `235caf8e2cb73a5607ae8dcb662d7eb6e85dd3b1`
- Changed lines: 494, below the 1,500-line maximum
