### PR TITLE
feat(bridge): show phone connection wait indicator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,10 @@ eagerly "just in case."
 - Never hand-edit generated files. Change their source and run the generator.
 - Create and update GitHub PR bodies with real multiline Markdown through
   `--body-file` or stdin; never pass escaped `\n` text.
+- Assume the user will not inspect local-only changes unless they explicitly say
+  they will. Once a task is complete and ready for code review or implementation
+  testing, commit, push, and open a PR by default. Leave changes local only when
+  the user explicitly requests that.
 - When splitting any task across multiple PRs, title every PR
   `[<slug>] <description> [step <x>/<y>]`. For planned work, `<slug>` is the
   plan directory name under `.plan`; otherwise choose one stable, lowercase

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -614,6 +614,7 @@ class OrchestratorSession {
   /// to abandon a response instead of awaiting an OpenCode HTTP call that has
   /// outlived the relay session.
   final Completer<void> _shutdownCompleter = Completer<void>();
+  final Completer<void> _firstPhoneConnectedCompleter = Completer<void>();
 
   OrchestratorSession._({
     required this.config,
@@ -709,6 +710,10 @@ class OrchestratorSession {
   /// track bandwidth (e.g. with [BandwidthTracker]).
   Stream<int> get bytesSent => _bytesSentController.stream;
   Stream<SesoriSseEvent> get localWireEvents => _localWireEventsController.stream;
+
+  /// Completes after the first phone finishes key exchange or resume and can
+  /// send encrypted bridge traffic.
+  Future<void> get firstPhoneConnected => _firstPhoneConnectedCompleter.future;
   RequestRouter get router => _router;
   Future<void> drainRoutedMutations() => _sessionMutationDispatcher.drain();
 
@@ -1643,8 +1648,7 @@ class OrchestratorSession {
             throw Exception("send ready for connId $connID: $e");
           }
 
-          activePhones[connID] = true;
-          Log.d("phone $connID is now active");
+          _markPhoneConnected(connID: connID, activePhones: activePhones);
           break processMessage;
         }
 
@@ -1724,11 +1728,19 @@ class OrchestratorSession {
             throw Exception("send resume ack for connId $connID: $e");
           }
 
-          activePhones[connID] = true;
+          _markPhoneConnected(connID: connID, activePhones: activePhones);
         }
       }
       hasMessage = await iterator.moveNext();
     }
+  }
+
+  void _markPhoneConnected({required int connID, required Map<int, bool> activePhones}) {
+    activePhones[connID] = true;
+    if (!_firstPhoneConnectedCompleter.isCompleted) {
+      _firstPhoneConnectedCompleter.complete();
+    }
+    Log.d("phone $connID is now active");
   }
 
   Future<void> _handleDecryptedMessage(int connID, List<int> decrypted) async {

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -43,6 +43,7 @@ import "../../control/bridge_control_message_dispatcher.dart";
 import "../../control/control_channel_loss_listener.dart";
 import "../../control/control_provision_notifier.dart";
 import "../../control/control_status_notifier.dart";
+import "../../foundation/app_connection_wait_indicator.dart";
 import "../../foundation/app_onboarding_formatter.dart";
 import "../../foundation/control_channel_client.dart";
 import "../../listeners/catalog_import_console_listener.dart";
@@ -159,6 +160,8 @@ enum SupervisedExitCode {
   /// The process exit code reported to the GUI supervisor.
   final int code;
 }
+
+enum _PhoneConnectionWaitOutcome { connected, sessionStopped }
 
 Future<int> runBridgeApp({
   required BridgeCliOptions options,
@@ -871,6 +874,11 @@ class BridgeRuntimeRunner {
             ]);
             if (decision == AppClientOnboardingDecision.prompt) {
               _presentAppOnboardingPrompt(environment: environment);
+              await _waitForFirstPhoneConnection(
+                firstPhoneConnected: activeRuntime.session.firstPhoneConnected,
+                sessionRun: sessionRun,
+                environment: environment,
+              );
             }
           }
           await sessionRun;
@@ -965,6 +973,29 @@ class BridgeRuntimeRunner {
     Console.message("");
     Console.message(AppOnboardingFormatter(out: io.stdout, environment: environment).formatDestination());
     Console.message("");
+  }
+
+  static Future<void> _waitForFirstPhoneConnection({
+    required Future<void> firstPhoneConnected,
+    required Future<void> sessionRun,
+    required Map<String, String> environment,
+  }) async {
+    final indicator = AppConnectionWaitIndicator(
+      out: io.stdout,
+      environment: environment,
+      frameInterval: const Duration(milliseconds: 80),
+    );
+    var connected = false;
+    indicator.start();
+    try {
+      final outcome = await Future.any<_PhoneConnectionWaitOutcome>([
+        sessionRun.then((_) => _PhoneConnectionWaitOutcome.sessionStopped),
+        firstPhoneConnected.then((_) => _PhoneConnectionWaitOutcome.connected),
+      ]);
+      connected = outcome == _PhoneConnectionWaitOutcome.connected;
+    } finally {
+      indicator.stop(connected: connected);
+    }
   }
 
   /// Whether [url] is an acceptable supervised control-channel endpoint: a

--- a/bridge/app/lib/src/foundation/app_connection_wait_indicator.dart
+++ b/bridge/app/lib/src/foundation/app_connection_wait_indicator.dart
@@ -2,7 +2,7 @@ import "dart:async";
 import "dart:io";
 
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
-    show TerminalColorValidator, TerminalGlyphValidator;
+    show Log, TerminalColorValidator, TerminalGlyphValidator;
 
 /// Renders the post-onboarding wait for the first usable phone connection.
 ///
@@ -25,6 +25,7 @@ class AppConnectionWaitIndicator {
   static const String connectedMessage = "Sesori connected on your phone.";
   static const List<String> _unicodeFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
   static const List<String> _asciiFrames = ["|", "/", "-", r"\"];
+  static const int _animatedLineWidth = waitingMessage.length + 2;
 
   final Stdout _out;
   final Duration _frameInterval;
@@ -45,11 +46,12 @@ class AppConnectionWaitIndicator {
     _started = true;
 
     if (!_animated) {
-      _write("$staticWaitingMessage\n");
+      _write(text: "$staticWaitingMessage\n");
       return;
     }
 
     _drawFrame();
+    if (_writeFailed || _stopped) return;
     _timer = Timer.periodic(_frameInterval, (_) => _drawFrame());
   }
 
@@ -60,11 +62,11 @@ class AppConnectionWaitIndicator {
     _timer?.cancel();
 
     if (_drewAnimatedLine) {
-      _write("\r\x1b[2K");
+      _write(text: "\r\x1b[2K");
     }
     if (connected) {
       final prefix = _unicode ? "✓ " : "";
-      _write("$prefix$connectedMessage\n");
+      _write(text: "$prefix$connectedMessage\n");
     }
   }
 
@@ -73,19 +75,20 @@ class AppConnectionWaitIndicator {
     final frames = _unicode ? _unicodeFrames : _asciiFrames;
     final frame = frames[_frameIndex % frames.length];
     _frameIndex += 1;
-    if (_write("\r$frame $waitingMessage")) {
+    if (_write(text: "\r$frame $waitingMessage")) {
       _drewAnimatedLine = true;
     }
   }
 
-  bool _write(String text) {
+  bool _write({required String text}) {
     if (_writeFailed) return false;
     try {
       _out.write(text);
       return true;
-    } on Object {
+    } on Object catch (error, stackTrace) {
       _writeFailed = true;
       _timer?.cancel();
+      Log.w("Disabling the phone connection indicator after stdout failed", error, stackTrace);
       return false;
     }
   }
@@ -95,7 +98,7 @@ class AppConnectionWaitIndicator {
       return false;
     }
     try {
-      return out.hasTerminal;
+      return out.hasTerminal && out.terminalColumns >= _animatedLineWidth;
     } on Object {
       return false;
     }

--- a/bridge/app/lib/src/foundation/app_connection_wait_indicator.dart
+++ b/bridge/app/lib/src/foundation/app_connection_wait_indicator.dart
@@ -1,0 +1,103 @@
+import "dart:async";
+import "dart:io";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
+    show TerminalColorValidator, TerminalGlyphValidator;
+
+/// Renders the post-onboarding wait for the first usable phone connection.
+///
+/// Interactive capable terminals receive an in-place spinner. Redirected or
+/// limited terminals receive one static status line instead, so the bridge's
+/// state remains understandable without ANSI cursor control.
+class AppConnectionWaitIndicator {
+  AppConnectionWaitIndicator({
+    required Stdout out,
+    required Map<String, String> environment,
+    required Duration frameInterval,
+  }) : _out = out,
+       _frameInterval = frameInterval,
+       _unicode = TerminalGlyphValidator.isSupported(environment: environment),
+       _animated = _canAnimate(out: out, environment: environment);
+
+  static const String waitingMessage = "Waiting for Sesori on your phone to connect";
+  static const String staticWaitingMessage =
+      "Waiting for Sesori on your phone to connect. The bridge is already running.";
+  static const String connectedMessage = "Sesori connected on your phone.";
+  static const List<String> _unicodeFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+  static const List<String> _asciiFrames = ["|", "/", "-", r"\"];
+
+  final Stdout _out;
+  final Duration _frameInterval;
+  final bool _unicode;
+  final bool _animated;
+
+  Timer? _timer;
+  int _frameIndex = 0;
+  bool _started = false;
+  bool _stopped = false;
+  bool _drewAnimatedLine = false;
+  bool _writeFailed = false;
+
+  void start() {
+    if (_started) {
+      throw StateError("App connection wait indicator has already started");
+    }
+    _started = true;
+
+    if (!_animated) {
+      _write("$staticWaitingMessage\n");
+      return;
+    }
+
+    _drawFrame();
+    _timer = Timer.periodic(_frameInterval, (_) => _drawFrame());
+  }
+
+  /// Stops animation and optionally replaces the waiting state with success.
+  void stop({required bool connected}) {
+    if (!_started || _stopped) return;
+    _stopped = true;
+    _timer?.cancel();
+
+    if (_drewAnimatedLine) {
+      _write("\r\x1b[2K");
+    }
+    if (connected) {
+      final prefix = _unicode ? "✓ " : "";
+      _write("$prefix$connectedMessage\n");
+    }
+  }
+
+  void _drawFrame() {
+    if (_stopped || _writeFailed) return;
+    final frames = _unicode ? _unicodeFrames : _asciiFrames;
+    final frame = frames[_frameIndex % frames.length];
+    _frameIndex += 1;
+    if (_write("\r$frame $waitingMessage")) {
+      _drewAnimatedLine = true;
+    }
+  }
+
+  bool _write(String text) {
+    if (_writeFailed) return false;
+    try {
+      _out.write(text);
+      return true;
+    } on Object {
+      _writeFailed = true;
+      _timer?.cancel();
+      return false;
+    }
+  }
+
+  static bool _canAnimate({required Stdout out, required Map<String, String> environment}) {
+    if (!TerminalColorValidator.isSupported(out: out, environment: environment)) {
+      return false;
+    }
+    try {
+      return out.hasTerminal;
+    } on Object {
+      return false;
+    }
+  }
+}

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -63,6 +63,14 @@ void main() {
       final secondMessages = StreamIterator<dynamic>(secondSocket);
       expect(await secondMessages.moveNext(), isTrue);
       final authMessage = jsonDecodeMap(secondMessages.current as String);
+      final firstPhoneConnected = harness.session.firstPhoneConnected;
+
+      secondSocket.add(jsonEncode({"type": "phone_connected", "connId": 7}));
+      final rawSocketActivatedPhone = await Future.any<bool>([
+        firstPhoneConnected.then((_) => true),
+        Future<bool>.delayed(const Duration(milliseconds: 100), () => false),
+      ]);
+      expect(rawSocketActivatedPhone, isFalse);
 
       final phoneKeyPair = await RelayCryptoService().generateKeyPair();
       final phonePublicKey = await phoneKeyPair.extractPublicKey();
@@ -79,6 +87,7 @@ void main() {
       final response = secondMessages.current;
       expect(response, isA<List<int>>());
       expect((response as List<int>).sublist(0, 2), equals(const [0, 7]));
+      await firstPhoneConnected.timeout(const Duration(seconds: 2));
       await secondMessages.cancel();
 
       expect(repository.registeredBridgeIds, equals([null]), reason: "registration is memoized per process");

--- a/bridge/app/test/foundation/app_connection_wait_indicator_test.dart
+++ b/bridge/app/test/foundation/app_connection_wait_indicator_test.dart
@@ -1,0 +1,144 @@
+import "dart:io";
+
+import "package:fake_async/fake_async.dart";
+import "package:sesori_bridge/src/foundation/app_connection_wait_indicator.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("AppConnectionWaitIndicator", () {
+    test("animates in place and replaces the wait with success", () {
+      final out = _CapturingStdout(hasTerminal: true, supportsAnsiEscapes: true);
+
+      fakeAsync((async) {
+        final indicator = AppConnectionWaitIndicator(
+          out: out,
+          environment: const {"LANG": "en_US.UTF-8"},
+          frameInterval: const Duration(milliseconds: 80),
+        );
+
+        indicator.start();
+        async.elapse(const Duration(milliseconds: 240));
+        indicator.stop(connected: true);
+      });
+
+      expect("\r".allMatches(out.written).length, greaterThanOrEqualTo(4));
+      expect(out.written, contains("⠋ ${AppConnectionWaitIndicator.waitingMessage}"));
+      expect(out.written, contains("\r\x1b[2K"));
+      expect(out.written, endsWith("✓ ${AppConnectionWaitIndicator.connectedMessage}\n"));
+      expect(out.written, isNot(contains(AppConnectionWaitIndicator.staticWaitingMessage)));
+    });
+
+    test("uses static ASCII status on a dumb terminal", () {
+      final out = _CapturingStdout(hasTerminal: true, supportsAnsiEscapes: true);
+
+      fakeAsync((async) {
+        final indicator = AppConnectionWaitIndicator(
+          out: out,
+          environment: const {"TERM": "dumb", "LANG": "en_US.UTF-8"},
+          frameInterval: const Duration(milliseconds: 80),
+        );
+
+        indicator.start();
+        async.elapse(const Duration(seconds: 1));
+        indicator.stop(connected: true);
+      });
+
+      expect(
+        out.written,
+        "${AppConnectionWaitIndicator.staticWaitingMessage}\n"
+        "${AppConnectionWaitIndicator.connectedMessage}\n",
+      );
+      expect(out.written, isNot(contains("\r")));
+    });
+
+    test("uses ASCII animation when unicode glyphs are unavailable", () {
+      final out = _CapturingStdout(hasTerminal: true, supportsAnsiEscapes: true);
+
+      fakeAsync((async) {
+        final indicator = AppConnectionWaitIndicator(
+          out: out,
+          environment: const {"LANG": "C"},
+          frameInterval: const Duration(milliseconds: 80),
+        );
+
+        indicator.start();
+        async.elapse(const Duration(milliseconds: 80));
+        indicator.stop(connected: true);
+      });
+
+      expect(out.written, contains("\r| ${AppConnectionWaitIndicator.waitingMessage}"));
+      expect(out.written, contains("\r/ ${AppConnectionWaitIndicator.waitingMessage}"));
+      expect(out.written, endsWith("${AppConnectionWaitIndicator.connectedMessage}\n"));
+      expect(out.written, isNot(contains("✓")));
+    });
+
+    test("clears animation without success when the session stops", () {
+      final out = _CapturingStdout(hasTerminal: true, supportsAnsiEscapes: true);
+
+      fakeAsync((_) {
+        final indicator = AppConnectionWaitIndicator(
+          out: out,
+          environment: const {"LANG": "en_US.UTF-8"},
+          frameInterval: const Duration(milliseconds: 80),
+        );
+
+        indicator.start();
+        indicator.stop(connected: false);
+      });
+
+      expect(out.written, endsWith("\r\x1b[2K"));
+      expect(out.written, isNot(contains(AppConnectionWaitIndicator.connectedMessage)));
+    });
+
+    test("tolerates a broken output stream", () {
+      final out = _ThrowingStdout();
+      final indicator = AppConnectionWaitIndicator(
+        out: out,
+        environment: const {"LANG": "en_US.UTF-8"},
+        frameInterval: const Duration(milliseconds: 80),
+      );
+
+      expect(indicator.start, returnsNormally);
+      expect(() => indicator.stop(connected: true), returnsNormally);
+      expect(out.writeCalls, equals(1));
+    });
+  });
+}
+
+class _CapturingStdout implements Stdout {
+  _CapturingStdout({required this.hasTerminal, required this.supportsAnsiEscapes});
+
+  @override
+  final bool hasTerminal;
+
+  @override
+  final bool supportsAnsiEscapes;
+
+  final StringBuffer _buffer = StringBuffer();
+  String get written => _buffer.toString();
+
+  @override
+  void write(Object? object) => _buffer.write(object);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _ThrowingStdout implements Stdout {
+  int writeCalls = 0;
+
+  @override
+  bool get hasTerminal => true;
+
+  @override
+  bool get supportsAnsiEscapes => true;
+
+  @override
+  void write(Object? object) {
+    writeCalls += 1;
+    throw const StdoutException("broken pipe");
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/foundation/app_connection_wait_indicator_test.dart
+++ b/bridge/app/test/foundation/app_connection_wait_indicator_test.dart
@@ -7,7 +7,11 @@ import "package:test/test.dart";
 void main() {
   group("AppConnectionWaitIndicator", () {
     test("animates in place and replaces the wait with success", () {
-      final out = _CapturingStdout(hasTerminal: true, supportsAnsiEscapes: true);
+      final out = _CapturingStdout(
+        hasTerminal: true,
+        supportsAnsiEscapes: true,
+        terminalColumns: 80,
+      );
 
       fakeAsync((async) {
         final indicator = AppConnectionWaitIndicator(
@@ -29,7 +33,11 @@ void main() {
     });
 
     test("uses static ASCII status on a dumb terminal", () {
-      final out = _CapturingStdout(hasTerminal: true, supportsAnsiEscapes: true);
+      final out = _CapturingStdout(
+        hasTerminal: true,
+        supportsAnsiEscapes: true,
+        terminalColumns: 80,
+      );
 
       fakeAsync((async) {
         final indicator = AppConnectionWaitIndicator(
@@ -52,7 +60,11 @@ void main() {
     });
 
     test("uses ASCII animation when unicode glyphs are unavailable", () {
-      final out = _CapturingStdout(hasTerminal: true, supportsAnsiEscapes: true);
+      final out = _CapturingStdout(
+        hasTerminal: true,
+        supportsAnsiEscapes: true,
+        terminalColumns: 80,
+      );
 
       fakeAsync((async) {
         final indicator = AppConnectionWaitIndicator(
@@ -73,7 +85,11 @@ void main() {
     });
 
     test("clears animation without success when the session stops", () {
-      final out = _CapturingStdout(hasTerminal: true, supportsAnsiEscapes: true);
+      final out = _CapturingStdout(
+        hasTerminal: true,
+        supportsAnsiEscapes: true,
+        terminalColumns: 80,
+      );
 
       fakeAsync((_) {
         final indicator = AppConnectionWaitIndicator(
@@ -90,29 +106,64 @@ void main() {
       expect(out.written, isNot(contains(AppConnectionWaitIndicator.connectedMessage)));
     });
 
-    test("tolerates a broken output stream", () {
-      final out = _ThrowingStdout();
-      final indicator = AppConnectionWaitIndicator(
-        out: out,
-        environment: const {"LANG": "en_US.UTF-8"},
-        frameInterval: const Duration(milliseconds: 80),
+    test("uses static status when the animated line would wrap", () {
+      final out = _CapturingStdout(
+        hasTerminal: true,
+        supportsAnsiEscapes: true,
+        terminalColumns: AppConnectionWaitIndicator.waitingMessage.length + 1,
       );
 
-      expect(indicator.start, returnsNormally);
-      expect(() => indicator.stop(connected: true), returnsNormally);
+      fakeAsync((async) {
+        final indicator = AppConnectionWaitIndicator(
+          out: out,
+          environment: const {"LANG": "en_US.UTF-8"},
+          frameInterval: const Duration(milliseconds: 80),
+        );
+
+        indicator.start();
+        async.elapse(const Duration(seconds: 1));
+        indicator.stop(connected: false);
+      });
+
+      expect(out.written, "${AppConnectionWaitIndicator.staticWaitingMessage}\n");
+      expect(out.written, isNot(contains("\r")));
+    });
+
+    test("does not retain a timer after the initial write fails", () {
+      final out = _ThrowingStdout();
+
+      fakeAsync((async) {
+        final indicator = AppConnectionWaitIndicator(
+          out: out,
+          environment: const {"LANG": "en_US.UTF-8"},
+          frameInterval: const Duration(milliseconds: 80),
+        );
+
+        expect(indicator.start, returnsNormally);
+        expect(async.periodicTimerCount, 0);
+        expect(() => indicator.stop(connected: true), returnsNormally);
+      });
+
       expect(out.writeCalls, equals(1));
     });
   });
 }
 
 class _CapturingStdout implements Stdout {
-  _CapturingStdout({required this.hasTerminal, required this.supportsAnsiEscapes});
+  _CapturingStdout({
+    required this.hasTerminal,
+    required this.supportsAnsiEscapes,
+    required this.terminalColumns,
+  });
 
   @override
   final bool hasTerminal;
 
   @override
   final bool supportsAnsiEscapes;
+
+  @override
+  final int terminalColumns;
 
   final StringBuffer _buffer = StringBuffer();
   String get written => _buffer.toString();
@@ -132,6 +183,9 @@ class _ThrowingStdout implements Stdout {
 
   @override
   bool get supportsAnsiEscapes => true;
+
+  @override
+  int get terminalColumns => 80;
 
   @override
   void write(Object? object) {


### PR DESCRIPTION
## Summary

- show an in-place post-QR spinner while waiting for Sesori on the user's phone to become usable
- fall back to a static, non-ANSI status that makes clear the bridge is already running
- replace the waiting line with `Sesori connected on your phone.` after successful key exchange or resume
- stop and clear the indicator when the bridge session ends, without delaying relay serving or shutdown
- document that completed work defaults to PR delivery because users do not inspect local-only changes unless explicitly stated

The connection signal intentionally ignores the relay's raw `phone_connected` control frame. It completes only after the phone receives a key-exchange `ready` response or a `resume_ack`, when encrypted bridge traffic is usable.

## Verification

- `dart test test/foundation/app_connection_wait_indicator_test.dart test/bridge/orchestrator_registration_test.dart test/bridge/runtime/bridge_runtime_runner_test.dart test/bridge/orchestrator_error_recovery_test.dart`
- `dart analyze --fatal-infos`
- architecture implementation review approved before and after rebasing onto current `main`
- `git diff --check`

## Delivery

- Base: `ecd75b6c`
- Changed lines: 309

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a wait indicator after onboarding until the phone is actually usable, then replaces it on success or clears it on shutdown. Improves CLI UX on interactive, redirected, and narrow terminals.

- **New Features**
  - Spinner on capable terminals; static status on non-ANSI, redirected, or narrow output.
  - Connection completes only after key exchange `ready` or `resume_ack` (ignores raw `phone_connected`).
  - Replaces the wait with "Sesori connected on your phone." on success; clears on session stop.
  - Adds `firstPhoneConnected` to the orchestrator and uses it in the runtime to drive the indicator.
  - Hardened: disables itself on stdout write failures to avoid lingering timers; tests cover animation, fallbacks, shutdown, and broken streams. `AGENTS.md` notes PR-by-default delivery.

<sup>Written for commit 0507da21c0e96c5e42e1adc8c4902eb81f6ef66f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

