### PR TITLE
[setup-aware-harness-settings] feat(client): synchronize harness management [step 3/7]

### DIFF
--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -78,10 +78,14 @@
   service, a single publication coordinator, connection/publication/staleness
   fences, identity-scoped retained snapshots (including legacy null identity),
   coalesced refresh, mutation uncertainty refresh, and Layer-3 timeout/force
-  planning. Focused service suite (20) and full module_core suite (677) pass;
+  planning. Focused service suite (21) and full module_core suite (678) pass;
   module_core, mobile, and desktop fatal analysis are clean. Aristotle's first
   pass found that identity supersession did not invalidate other concurrently
   captured old-bridge requests; the fix advances the request epoch before
   forgetting identity and routes every publication through one coordinator.
-  The second pass approved. Real integration E2E remains scheduled after Step
-  5/7, when the app resolves and renders this service.
+  The second pass approved. PR review additionally fenced typed mutation
+  rejections when the connection epoch moves and corrected the remaining
+  positional private parameter. Disposal continues to await its owned,
+  transport-bounded refresh tail as required by the reviewed plan. Real
+  integration E2E remains scheduled after Step 5/7, when the app resolves and
+  renders this service.

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -2,18 +2,18 @@
 
 ## Current State
 
-- **Implementation base:** current `origin/main` after Stage 12 merge `6cedf5bd`
-- **Series state:** Step 2/7 in review
-- **Next action:** wait for PR #583 review to settle, then run the confirming
-  E2E checks before merge
+- **Implementation base:** `origin/main` at `ecd75b6c` after Step 2/7 merged
+- **Series state:** Step 3/7 implementation complete
+- **Next action:** raise the Step 3/7 synchronization-service PR and settle
+  review; the real integration E2E gate follows Step 5/7
 
 ## Delivery
 
 | Done | Slice | Branch | PR state |
 |---|---|---|---|
 | [x] | Step 1/7 — per-bridge harness preference | `setup-aware-harness-settings-preferences` | PR #579 merged; 729 changed lines (estimate 650-750) |
-| [ ] | Step 2/7 — management transport | `setup-aware-harness-settings-transport` | PR #583 in review; ~590 changed lines (estimate 300-400, test-driven overage) |
-| [ ] | Step 3/7 — synchronization service | `setup-aware-harness-settings-service` | planned; estimate 550-700 changed lines |
+| [x] | Step 2/7 — management transport | `setup-aware-harness-settings-transport` | PR #583 merged as `ecd75b6c`; ~660 changed lines (estimate 300-400, test-driven overage) |
+| [ ] | Step 3/7 — synchronization service | `setup-aware-harness-settings-service` | implementation complete; ~1,080 changed lines (estimate 550-700, race-matrix test overage) |
 | [ ] | Step 4/7 — harness logos | `setup-aware-harness-settings-branding` | planned; estimate 750-900 changed lines |
 | [ ] | Step 5/7 — Harnesses overview and state contract | `setup-aware-harness-settings-overview` | planned; estimate 1,100-1,300 changed lines |
 | [ ] | Step 6/7 — management actions | `setup-aware-harness-settings-state` | planned; estimate 650-800 changed lines |
@@ -74,3 +74,14 @@
   `br_qdF5_X5_LUM6zi7D`; the override was cleared, Codex re-enabled, the
   temporary bridge stopped, and the unrelated bridge on port 7829 remained
   untouched.
+- Step 3/7 (2026-07-27): added the replay-backed management synchronization
+  service, a single publication coordinator, connection/publication/staleness
+  fences, identity-scoped retained snapshots (including legacy null identity),
+  coalesced refresh, mutation uncertainty refresh, and Layer-3 timeout/force
+  planning. Focused service suite (20) and full module_core suite (677) pass;
+  module_core, mobile, and desktop fatal analysis are clean. Aristotle's first
+  pass found that identity supersession did not invalidate other concurrently
+  captured old-bridge requests; the fix advances the request epoch before
+  forgetting identity and routes every publication through one coordinator.
+  The second pass approved. Real integration E2E remains scheduled after Step
+  5/7, when the app resolves and renders this service.

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -3,9 +3,9 @@
 ## Current State
 
 - **Implementation base:** `origin/main` at `ecd75b6c` after Step 2/7 merged
-- **Series state:** Step 3/7 implementation complete
-- **Next action:** raise the Step 3/7 synchronization-service PR and settle
-  review; the real integration E2E gate follows Step 5/7
+- **Series state:** Step 3/7 in review
+- **Next action:** settle PR #589 review; the real integration E2E gate follows
+  Step 5/7
 
 ## Delivery
 
@@ -13,7 +13,7 @@
 |---|---|---|---|
 | [x] | Step 1/7 — per-bridge harness preference | `setup-aware-harness-settings-preferences` | PR #579 merged; 729 changed lines (estimate 650-750) |
 | [x] | Step 2/7 — management transport | `setup-aware-harness-settings-transport` | PR #583 merged as `ecd75b6c`; ~660 changed lines (estimate 300-400, test-driven overage) |
-| [ ] | Step 3/7 — synchronization service | `setup-aware-harness-settings-service` | implementation complete; ~1,080 changed lines (estimate 550-700, race-matrix test overage) |
+| [ ] | Step 3/7 — synchronization service | `setup-aware-harness-settings-service` | PR #589 in review; 1,095 changed lines (estimate 550-700, race-matrix test overage) |
 | [ ] | Step 4/7 — harness logos | `setup-aware-harness-settings-branding` | planned; estimate 750-900 changed lines |
 | [ ] | Step 5/7 — Harnesses overview and state contract | `setup-aware-harness-settings-overview` | planned; estimate 1,100-1,300 changed lines |
 | [ ] | Step 6/7 — management actions | `setup-aware-harness-settings-state` | planned; estimate 650-800 changed lines |

--- a/client/module_core/lib/sesori_dart_core.dart
+++ b/client/module_core/lib/sesori_dart_core.dart
@@ -117,6 +117,7 @@ export "src/services/models/session_activity_info.dart";
 export "src/services/new_session_plugin_service.dart";
 export "src/services/new_session_selection_tracker.dart";
 export "src/services/notification_registration_service.dart";
+export "src/services/plugin_management_service.dart";
 export "src/services/project_list_service.dart";
 export "src/services/registered_bridges_service.dart";
 export "src/services/session_detail_load_service.dart";

--- a/client/module_core/lib/src/di/injection.config.dart
+++ b/client/module_core/lib/src/di/injection.config.dart
@@ -75,6 +75,8 @@ import 'package:sesori_dart_core/src/services/new_session_selection_tracker.dart
     as _i913;
 import 'package:sesori_dart_core/src/services/notification_registration_service.dart'
     as _i659;
+import 'package:sesori_dart_core/src/services/plugin_management_service.dart'
+    as _i110;
 import 'package:sesori_dart_core/src/services/project_list_service.dart'
     as _i703;
 import 'package:sesori_dart_core/src/services/registered_bridges_service.dart'
@@ -248,6 +250,12 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i337.PluginRepository>(
       () => _i337.PluginRepository(api: gh<_i546.PluginApi>()),
+    );
+    gh.lazySingleton<_i110.PluginManagementService>(
+      () => _i110.PluginManagementService(
+        pluginRepository: gh<_i337.PluginRepository>(),
+        connectionService: gh<_i369.ConnectionService>(),
+      ),
     );
     gh.lazySingleton<_i12.SessionService>(
       () => _i12.SessionService(repository: gh<_i7.SessionRepository>()),

--- a/client/module_core/lib/src/services/plugin_management_service.dart
+++ b/client/module_core/lib/src/services/plugin_management_service.dart
@@ -228,6 +228,10 @@ class PluginManagementService with Disposable {
 
     final captured = _captureRequest(staleGeneration: _staleGeneration);
     final result = await request();
+    if (!_isConnectionFenceCurrent(captured.fence)) {
+      await _refreshAfterUncertainMutation();
+      return const PluginManagementMutationResult.uncertain();
+    }
     switch (result) {
       case PluginManagementMutationResultSuccess(:final response):
         final publication = _coordinatePublication(
@@ -314,11 +318,13 @@ class PluginManagementService with Disposable {
 
     _publicationGeneration++;
     _snapshots.add(publication);
-    if (consumeStalenessThrough != null) _consumeStalenessThrough(consumeStalenessThrough);
+    if (consumeStalenessThrough != null) {
+      _consumeStalenessThrough(generation: consumeStalenessThrough);
+    }
     return _PublicationOutcome.applied;
   }
 
-  void _consumeStalenessThrough(int generation) {
+  void _consumeStalenessThrough({required int generation}) {
     _consumedStaleGeneration = max(_consumedStaleGeneration, generation);
   }
 

--- a/client/module_core/lib/src/services/plugin_management_service.dart
+++ b/client/module_core/lib/src/services/plugin_management_service.dart
@@ -1,0 +1,408 @@
+import "dart:async";
+import "dart:math";
+
+import "package:get_it/get_it.dart";
+import "package:injectable/injectable.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../capabilities/server_connection/connection_service.dart";
+import "../capabilities/server_connection/models/connection_status.dart";
+import "../capabilities/server_connection/models/sse_event.dart";
+import "../repositories/models/plugin_management_result.dart";
+import "../repositories/plugin_repository.dart";
+
+typedef _ManagementRequestFence = ({
+  int connectionEpoch,
+  int publicationGeneration,
+  int staleGeneration,
+  String? bridgeId,
+});
+
+typedef _CapturedManagementRequest = ({
+  _ManagementRequestFence fence,
+  bool hasBridgeIdentity,
+});
+
+@lazySingleton
+class PluginManagementService with Disposable {
+  PluginManagementService({
+    required PluginRepository pluginRepository,
+    required ConnectionService connectionService,
+  }) : _pluginRepository = pluginRepository,
+       _connectionService = connectionService,
+       _connected = connectionService.currentStatus is ConnectionConnected,
+       _connectionEpoch = connectionService.currentStatus is ConnectionConnected ? 1 : 0 {
+    _subscriptions
+      ..add(_connectionService.status.listen(_onConnectionStatus))
+      ..add(_connectionService.events.listen(_onSseEvent))
+      ..add(_connectionService.dataMayBeStale.listen((_) => _markStale()));
+  }
+
+  final PluginRepository _pluginRepository;
+  final ConnectionService _connectionService;
+  final BehaviorSubject<PluginManagementLoadResult> _snapshots = BehaviorSubject();
+  final CompositeSubscription _subscriptions = CompositeSubscription();
+
+  bool _connected;
+  int _connectionEpoch;
+  bool _receivedInitialStatus = false;
+  bool _disposed = false;
+
+  int _publicationGeneration = 0;
+  int _staleGeneration = 0;
+  int _consumedStaleGeneration = 0;
+  int _lastAttemptedStaleGeneration = 0;
+  Future<void>? _refreshTail;
+
+  bool _activeBridgeIdentityKnown = false;
+  String? _activeBridgeId;
+
+  ValueStream<PluginManagementLoadResult> get snapshots => _snapshots.stream;
+
+  Future<void> refresh() {
+    _markStale();
+    return _refreshTail ?? Future<void>.value();
+  }
+
+  Future<PluginManagementMutationResult> command({
+    required String pluginId,
+    required PluginLifecycleCommandRequest request,
+  }) {
+    return _runMutation(
+      request: () => _pluginRepository.command(pluginId: pluginId, request: request),
+    );
+  }
+
+  Future<PluginManagementMutationResult> updateIdleTimeout({
+    required PluginIdleTimeoutUpdateRequest request,
+  }) {
+    return _runMutation(
+      request: () => _pluginRepository.updateIdleTimeout(request: request),
+    );
+  }
+
+  PluginManagementCommandPlan planApplyAllIdleTimeout({required String input}) {
+    final idleTimeoutMins = int.tryParse(input.trim());
+    if (idleTimeoutMins == null) return const PluginManagementCommandPlan.invalidInput();
+    return PluginManagementCommandPlan.request(
+      request: PluginIdleTimeoutUpdateRequest.applyAll(idleTimeoutMins: idleTimeoutMins),
+    );
+  }
+
+  PluginManagementCommandPlan planSetIdleTimeoutOverride({
+    required String pluginId,
+    required String input,
+  }) {
+    final idleTimeoutMins = int.tryParse(input.trim());
+    if (idleTimeoutMins == null) return const PluginManagementCommandPlan.invalidInput();
+    return PluginManagementCommandPlan.request(
+      request: PluginIdleTimeoutUpdateRequest.setOverride(
+        pluginId: pluginId,
+        idleTimeoutMins: idleTimeoutMins,
+      ),
+    );
+  }
+
+  PluginManagementCommandPlan planClearIdleTimeoutOverride({required String pluginId}) {
+    return PluginManagementCommandPlan.request(
+      request: PluginIdleTimeoutUpdateRequest.clearOverride(pluginId: pluginId),
+    );
+  }
+
+  PluginManagementForceAssessment assessForce({
+    required PluginLifecycleConflict conflict,
+    required PluginManagementForceAction action,
+  }) {
+    final reasons = conflict.reasons;
+    if (reasons.isEmpty || reasons.any((reason) => !_forceableConflictReasons.contains(reason))) {
+      return const PluginManagementForceAssessment.notForceable();
+    }
+    final request = switch (action) {
+      PluginManagementForceAction.disable => const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.force),
+      PluginManagementForceAction.restart => const PluginLifecycleCommandRequest.restart(mode: PluginStopMode.force),
+    };
+    return PluginManagementForceAssessment.requiresConfirmation(request: request);
+  }
+
+  void _onConnectionStatus(ConnectionStatus status) {
+    if (_disposed) return;
+    final nextConnected = status is ConnectionConnected;
+    if (!_receivedInitialStatus) {
+      _receivedInitialStatus = true;
+      if (nextConnected != _connected) {
+        _connectionEpoch++;
+        _connected = nextConnected;
+        _forgetActiveBridgeIdentity();
+      }
+      if (nextConnected) _markStale();
+      return;
+    }
+
+    if (nextConnected != _connected) {
+      _connectionEpoch++;
+      _connected = nextConnected;
+      _forgetActiveBridgeIdentity();
+    }
+    if (nextConnected) _markStale();
+  }
+
+  void _onSseEvent(SseEvent event) {
+    if (event.data case SesoriPluginManagementChanged(:final snapshotToken)) {
+      final currentToken = switch (_currentSnapshot) {
+        PluginManagementLoadResultSupported(:final response) => response.snapshotToken,
+        PluginManagementLoadResultUnsupported() || PluginManagementLoadResultFailure() || null => null,
+      };
+      if (snapshotToken == currentToken) return;
+      _markStale();
+    }
+  }
+
+  void _markStale() {
+    if (_disposed) return;
+    _staleGeneration++;
+    _ensureRefreshTail();
+  }
+
+  void _rearmStale() {
+    if (_disposed) return;
+    _staleGeneration++;
+  }
+
+  void _ensureRefreshTail() {
+    if (_disposed || !_connected || _refreshTail != null) return;
+    if (_consumedStaleGeneration >= _staleGeneration || _lastAttemptedStaleGeneration >= _staleGeneration) return;
+
+    final tail = _drainRefreshes();
+    _refreshTail = tail;
+    unawaited(
+      tail.whenComplete(() {
+        if (!identical(_refreshTail, tail)) return;
+        _refreshTail = null;
+        _ensureRefreshTail();
+      }),
+    );
+  }
+
+  Future<void> _drainRefreshes() async {
+    while (!_disposed && _connected && _consumedStaleGeneration < _staleGeneration) {
+      final targetGeneration = _staleGeneration;
+      if (_lastAttemptedStaleGeneration >= targetGeneration) return;
+      _lastAttemptedStaleGeneration = targetGeneration;
+
+      final outcome = await _loadAndPublish(targetGeneration: targetGeneration);
+      if (outcome == _RefreshOutcome.fenced) return;
+      if (outcome == _RefreshOutcome.failed && _staleGeneration <= targetGeneration) return;
+    }
+  }
+
+  Future<_RefreshOutcome> _loadAndPublish({required int targetGeneration}) async {
+    final captured = _captureRequest(staleGeneration: targetGeneration);
+    final result = await _pluginRepository.getManagement();
+    final publication = _coordinatePublication(
+      captured: captured,
+      candidate: result,
+      consumeStalenessThrough: switch (result) {
+        PluginManagementLoadResultSupported() || PluginManagementLoadResultUnsupported() => targetGeneration,
+        PluginManagementLoadResultFailure() => null,
+      },
+      retainSupportedOnFailure: true,
+    );
+    switch (publication) {
+      case _PublicationOutcome.applied:
+        return result is PluginManagementLoadResultFailure ? _RefreshOutcome.failed : _RefreshOutcome.applied;
+      case _PublicationOutcome.fenced:
+        return _RefreshOutcome.fenced;
+      case _PublicationOutcome.superseded || _PublicationOutcome.identitySuperseded:
+        return _RefreshOutcome.superseded;
+    }
+  }
+
+  Future<PluginManagementMutationResult> _runMutation({
+    required Future<PluginManagementMutationResult> Function() request,
+  }) async {
+    if (_disposed || !_connected) {
+      return PluginManagementMutationResult.failure(error: ApiError.generic());
+    }
+
+    final captured = _captureRequest(staleGeneration: _staleGeneration);
+    final result = await request();
+    switch (result) {
+      case PluginManagementMutationResultSuccess(:final response):
+        final publication = _coordinatePublication(
+          captured: captured,
+          candidate: PluginManagementLoadResult.supported(response: response, refreshError: null),
+          consumeStalenessThrough: captured.fence.staleGeneration,
+          retainSupportedOnFailure: false,
+        );
+        if (publication != _PublicationOutcome.applied) {
+          await _refreshAfterUncertainMutation();
+          return const PluginManagementMutationResult.uncertain();
+        }
+        return result;
+      case PluginManagementMutationResultUncertain():
+        await _refreshAfterUncertainMutation();
+        return result;
+      case PluginManagementMutationResultNotFound() ||
+          PluginManagementMutationResultConflict() ||
+          PluginManagementMutationResultFailure():
+        return result;
+    }
+  }
+
+  Future<void> _refreshAfterUncertainMutation() async {
+    _markStale();
+    await (_refreshTail ?? Future<void>.value());
+  }
+
+  _CapturedManagementRequest _captureRequest({required int staleGeneration}) {
+    return (
+      fence: (
+        connectionEpoch: _connectionEpoch,
+        publicationGeneration: _publicationGeneration,
+        staleGeneration: staleGeneration,
+        bridgeId: _activeBridgeIdentityKnown ? _activeBridgeId : null,
+      ),
+      hasBridgeIdentity: _activeBridgeIdentityKnown,
+    );
+  }
+
+  bool _isConnectionFenceCurrent(_ManagementRequestFence fence) {
+    return !_disposed && _connected && _connectionEpoch == fence.connectionEpoch;
+  }
+
+  bool _responseIdentitySupersedesRequest({
+    required PluginManagementResponse response,
+    required _CapturedManagementRequest captured,
+  }) {
+    return captured.hasBridgeIdentity && response.bridgeId != captured.fence.bridgeId;
+  }
+
+  _PublicationOutcome _coordinatePublication({
+    required _CapturedManagementRequest captured,
+    required PluginManagementLoadResult candidate,
+    required int? consumeStalenessThrough,
+    required bool retainSupportedOnFailure,
+  }) {
+    if (!_isConnectionFenceCurrent(captured.fence)) return _PublicationOutcome.fenced;
+    if (_publicationGeneration != captured.fence.publicationGeneration) {
+      _rearmStale();
+      return _PublicationOutcome.superseded;
+    }
+
+    var publication = candidate;
+    switch (candidate) {
+      case PluginManagementLoadResultSupported(:final response):
+        if (_responseIdentitySupersedesRequest(response: response, captured: captured)) {
+          _invalidateBridgeIdentityFence();
+          _rearmStale();
+          return _PublicationOutcome.identitySuperseded;
+        }
+        _activeBridgeIdentityKnown = true;
+        _activeBridgeId = response.bridgeId;
+      case PluginManagementLoadResultUnsupported():
+        _forgetActiveBridgeIdentity();
+      case PluginManagementLoadResultFailure(:final error):
+        if (retainSupportedOnFailure) {
+          final retained = _retainedSnapshotForActiveBridge;
+          if (retained != null) {
+            publication = PluginManagementLoadResult.supported(response: retained, refreshError: error);
+          }
+        }
+    }
+
+    _publicationGeneration++;
+    _snapshots.add(publication);
+    if (consumeStalenessThrough != null) _consumeStalenessThrough(consumeStalenessThrough);
+    return _PublicationOutcome.applied;
+  }
+
+  void _consumeStalenessThrough(int generation) {
+    _consumedStaleGeneration = max(_consumedStaleGeneration, generation);
+  }
+
+  PluginManagementLoadResult? get _currentSnapshot => _snapshots.hasValue ? _snapshots.value : null;
+
+  PluginManagementResponse? get _retainedSnapshotForActiveBridge {
+    if (!_activeBridgeIdentityKnown) return null;
+    return switch (_currentSnapshot) {
+      PluginManagementLoadResultSupported(:final response) when response.bridgeId == _activeBridgeId => response,
+      PluginManagementLoadResultSupported() ||
+      PluginManagementLoadResultUnsupported() ||
+      PluginManagementLoadResultFailure() ||
+      null => null,
+    };
+  }
+
+  void _forgetActiveBridgeIdentity() {
+    _activeBridgeIdentityKnown = false;
+    _activeBridgeId = null;
+  }
+
+  void _invalidateBridgeIdentityFence() {
+    _connectionEpoch++;
+    _forgetActiveBridgeIdentity();
+  }
+
+  @override
+  Future<void> onDispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await _subscriptions.dispose();
+    await _refreshTail;
+    await _snapshots.close();
+  }
+}
+
+enum _RefreshOutcome { applied, failed, superseded, fenced }
+
+enum _PublicationOutcome { applied, fenced, superseded, identitySuperseded }
+
+sealed class PluginManagementCommandPlan {
+  const PluginManagementCommandPlan();
+
+  const factory PluginManagementCommandPlan.request({
+    required PluginIdleTimeoutUpdateRequest request,
+  }) = PluginManagementCommandPlanRequest;
+
+  const factory PluginManagementCommandPlan.invalidInput() = PluginManagementCommandPlanInvalidInput;
+}
+
+final class PluginManagementCommandPlanRequest extends PluginManagementCommandPlan {
+  const PluginManagementCommandPlanRequest({required this.request});
+
+  final PluginIdleTimeoutUpdateRequest request;
+}
+
+final class PluginManagementCommandPlanInvalidInput extends PluginManagementCommandPlan {
+  const PluginManagementCommandPlanInvalidInput();
+}
+
+enum PluginManagementForceAction { disable, restart }
+
+sealed class PluginManagementForceAssessment {
+  const PluginManagementForceAssessment();
+
+  const factory PluginManagementForceAssessment.requiresConfirmation({
+    required PluginLifecycleCommandRequest request,
+  }) = PluginManagementForceAssessmentRequiresConfirmation;
+
+  const factory PluginManagementForceAssessment.notForceable() = PluginManagementForceAssessmentNotForceable;
+}
+
+final class PluginManagementForceAssessmentRequiresConfirmation extends PluginManagementForceAssessment {
+  const PluginManagementForceAssessmentRequiresConfirmation({required this.request});
+
+  final PluginLifecycleCommandRequest request;
+}
+
+final class PluginManagementForceAssessmentNotForceable extends PluginManagementForceAssessment {
+  const PluginManagementForceAssessmentNotForceable();
+}
+
+const _forceableConflictReasons = {
+  PluginLifecycleConflictReason.inFlight,
+  PluginLifecycleConflictReason.busy,
+  PluginLifecycleConflictReason.workStateUnknown,
+};

--- a/client/module_core/test/services/plugin_management_service_test.dart
+++ b/client/module_core/test/services/plugin_management_service_test.dart
@@ -1,0 +1,661 @@
+import "dart:async";
+import "dart:collection";
+
+import "package:rxdart/rxdart.dart";
+import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/connection_service.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/models/connection_status.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/models/sse_event.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/server_connection_config.dart";
+import "package:sesori_dart_core/src/repositories/models/plugin_management_result.dart";
+import "package:sesori_dart_core/src/repositories/plugin_repository.dart";
+import "package:sesori_dart_core/src/services/plugin_management_service.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("refresh synchronization", () {
+    test("already-connected construction performs exactly one replay-triggered load", () async {
+      final repository = _FakePluginRepository()..queueLoad(_supported(_response(token: "one")));
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+
+      await _waitFor(() => repository.loadCalls == 1);
+      await _waitFor(() => service.snapshots.hasValue);
+
+      expect(repository.loadCalls, 1);
+      expect(_supportedResponse(service).snapshotToken, "one");
+    });
+
+    test("disconnected construction defers its first load until connected", () async {
+      final repository = _FakePluginRepository()..queueLoad(_supported(_response(token: "connected")));
+      final connection = _FakeConnectionService(initialStatus: const ConnectionStatus.disconnected());
+      final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+
+      await _pump();
+      expect(repository.loadCalls, isZero);
+
+      connection.emitStatus(_connected);
+      await _waitFor(() => service.snapshots.hasValue);
+      expect(repository.loadCalls, 1);
+    });
+
+    test("triggers during an active load coalesce into one trailing load", () async {
+      final first = Completer<PluginManagementLoadResult>();
+      final repository = _FakePluginRepository()
+        ..queueLoad(first.future)
+        ..queueLoad(_supported(_response(token: "trailing")));
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+      await _waitFor(() => repository.loadCalls == 1);
+
+      connection
+        ..emitStale()
+        ..emitStale();
+      await _pump();
+      first.complete(_supported(_response(token: "first")));
+      await _waitFor(() => repository.loadCalls == 2);
+      await _waitFor(() => service.snapshots.hasValue && _supportedResponse(service).snapshotToken == "trailing");
+
+      expect(repository.loadCalls, 2);
+      expect(_supportedResponse(service).snapshotToken, "trailing");
+    });
+
+    test("management SSE suppresses equal tokens while replay loss always refreshes", () async {
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "same")))
+        ..queueLoad(_supported(_response(token: "changed")))
+        ..queueLoad(_supported(_response(token: "replay")));
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+      await _waitFor(() => service.snapshots.hasValue);
+
+      connection.emitManagementChanged(snapshotToken: "same");
+      await _pump();
+      expect(repository.loadCalls, 1);
+
+      connection.emitManagementChanged(snapshotToken: "different");
+      await _waitFor(() => repository.loadCalls == 2);
+      connection.emitStale();
+      await _waitFor(() => repository.loadCalls == 3);
+
+      expect(_supportedResponse(service).snapshotToken, "replay");
+    });
+
+    test("failed refresh retains same-bridge data and retries only after another trigger", () async {
+      final error = ApiError.generic();
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "initial", bridgeId: "br_a")))
+        ..queueLoad(PluginManagementLoadResult.failure(error: error))
+        ..queueLoad(_supported(_response(token: "recovered", bridgeId: "br_a")));
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+      await _waitFor(() => service.snapshots.hasValue);
+
+      await service.refresh();
+      final failedRefresh = service.snapshots.value as PluginManagementLoadResultSupported;
+      expect(failedRefresh.response.snapshotToken, "initial");
+      expect(failedRefresh.refreshError, same(error));
+      await _pump();
+      expect(repository.loadCalls, 2);
+
+      connection.emitStale();
+      await _waitFor(() => repository.loadCalls == 3);
+      expect(_supportedResponse(service).snapshotToken, "recovered");
+    });
+
+    test("first failed load after reconnect never replays the previous bridge snapshot", () async {
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "a", bridgeId: "br_a")))
+        ..queueLoad(PluginManagementLoadResult.failure(error: ApiError.generic()))
+        ..queueLoad(_supported(_response(token: "b", bridgeId: "br_b")));
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+      await _waitFor(() => service.snapshots.hasValue);
+
+      connection
+        ..emitStatus(const ConnectionStatus.connectionLost(config: _config))
+        ..emitStatus(_connected);
+      await _waitFor(() => repository.loadCalls == 2);
+
+      expect(service.snapshots.value, isA<PluginManagementLoadResultFailure>());
+      await service.refresh();
+      expect(_supportedResponse(service).bridgeId, "br_b");
+    });
+
+    test("legacy null identity is retained only within its proven connection epoch", () async {
+      final error = ApiError.generic();
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "legacy", bridgeId: null)))
+        ..queueLoad(PluginManagementLoadResult.failure(error: error))
+        ..queueLoad(PluginManagementLoadResult.failure(error: error));
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+      await _waitFor(() => service.snapshots.hasValue);
+
+      await service.refresh();
+      expect(service.snapshots.value, isA<PluginManagementLoadResultSupported>());
+
+      connection
+        ..emitStatus(const ConnectionStatus.bridgeOffline(config: _config, health: _health))
+        ..emitStatus(_connected);
+      await _waitFor(() => repository.loadCalls == 3);
+      expect(service.snapshots.value, isA<PluginManagementLoadResultFailure>());
+    });
+
+    test("an unexpected bridge identity change is confirmed by one clean load", () async {
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "a", bridgeId: "br_a")))
+        ..queueLoad(_supported(_response(token: "b1", bridgeId: "br_b")))
+        ..queueLoad(_supported(_response(token: "b2", bridgeId: "br_b")));
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+      await _waitFor(() => service.snapshots.hasValue);
+
+      connection.emitManagementChanged(snapshotToken: "b1");
+      await _waitFor(() => repository.loadCalls == 3);
+
+      expect(_supportedResponse(service).bridgeId, "br_b");
+      expect(_supportedResponse(service).snapshotToken, "b2");
+    });
+
+    test("unsupported management replaces retained supported state", () async {
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "initial")))
+        ..queueLoad(const PluginManagementLoadResult.unsupported());
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+      await _waitFor(() => service.snapshots.hasValue);
+
+      await service.refresh();
+
+      expect(service.snapshots.value, isA<PluginManagementLoadResultUnsupported>());
+    });
+  });
+
+  group("publication fencing", () {
+    test("a mutation publication supersedes an older refresh and forces a clean GET", () async {
+      final oldRefresh = Completer<PluginManagementLoadResult>();
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "initial")))
+        ..queueLoad(oldRefresh.future)
+        ..queueLoad(_supported(_response(token: "authoritative")))
+        ..queueMutation(_success(_response(token: "mutation")));
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+      await _waitFor(() => service.snapshots.hasValue);
+
+      final refresh = service.refresh();
+      await _waitFor(() => repository.loadCalls == 2);
+      final mutation = await service.command(
+        pluginId: "one",
+        request: const PluginLifecycleCommandRequest.refresh(),
+      );
+      expect(mutation, isA<PluginManagementMutationResultSuccess>());
+      oldRefresh.complete(_supported(_response(token: "old")));
+      await refresh;
+      await _waitFor(() => repository.loadCalls == 3);
+
+      expect(_supportedResponse(service).snapshotToken, "authoritative");
+    });
+
+    test("an intervening refresh makes a mutation uncertain and triggers an authoritative GET", () async {
+      final mutation = Completer<PluginManagementMutationResult>();
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "initial")))
+        ..queueLoad(_supported(_response(token: "refresh")))
+        ..queueLoad(_supported(_response(token: "authoritative")))
+        ..queueMutation(mutation.future);
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+      await _waitFor(() => service.snapshots.hasValue);
+
+      final mutationFuture = service.command(
+        pluginId: "one",
+        request: const PluginLifecycleCommandRequest.refresh(),
+      );
+      await service.refresh();
+      mutation.complete(_success(_response(token: "mutation")));
+      final result = await mutationFuture;
+
+      expect(result, isA<PluginManagementMutationResultUncertain>());
+      expect(repository.loadCalls, 3);
+      expect(_supportedResponse(service).snapshotToken, "authoritative");
+    });
+
+    test("disconnect during a mutation returns uncertain without publishing its response", () async {
+      final mutation = Completer<PluginManagementMutationResult>();
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "initial")))
+        ..queueMutation(mutation.future);
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+      await _waitFor(() => service.snapshots.hasValue);
+
+      final mutationFuture = service.command(
+        pluginId: "one",
+        request: const PluginLifecycleCommandRequest.refresh(),
+      );
+      connection.emitStatus(const ConnectionStatus.connectionLost(config: _config));
+      mutation.complete(_success(_response(token: "mutation")));
+
+      expect(await mutationFuture, isA<PluginManagementMutationResultUncertain>());
+      expect(_supportedResponse(service).snapshotToken, "initial");
+    });
+
+    test("disconnect during a refresh fences its response", () async {
+      final refresh = Completer<PluginManagementLoadResult>();
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "initial")))
+        ..queueLoad(refresh.future);
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+      await _waitFor(() => service.snapshots.hasValue);
+
+      final refreshFuture = service.refresh();
+      await _waitFor(() => repository.loadCalls == 2);
+      connection.emitStatus(const ConnectionStatus.connectionLost(config: _config));
+      await _pump();
+      refresh.complete(_supported(_response(token: "late")));
+      await refreshFuture;
+
+      expect(_supportedResponse(service).snapshotToken, "initial");
+    });
+
+    test("repository uncertain schedules a clean GET before returning", () async {
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "initial")))
+        ..queueLoad(_supported(_response(token: "authoritative")))
+        ..queueMutation(const PluginManagementMutationResult.uncertain());
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+      await _waitFor(() => service.snapshots.hasValue);
+
+      final result = await service.updateIdleTimeout(
+        request: const PluginIdleTimeoutUpdateRequest.applyAll(idleTimeoutMins: 20),
+      );
+
+      expect(result, isA<PluginManagementMutationResultUncertain>());
+      expect(repository.loadCalls, 2);
+      expect(_supportedResponse(service).snapshotToken, "authoritative");
+    });
+
+    test("a response for a different known bridge is fenced and refreshed", () async {
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "a", bridgeId: "br_a")))
+        ..queueLoad(_supported(_response(token: "a2", bridgeId: "br_a")))
+        ..queueMutation(_success(_response(token: "b", bridgeId: "br_b")));
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+      await _waitFor(() => service.snapshots.hasValue);
+
+      final result = await service.command(
+        pluginId: "one",
+        request: const PluginLifecycleCommandRequest.refresh(),
+      );
+
+      expect(result, isA<PluginManagementMutationResultUncertain>());
+      expect(_supportedResponse(service).bridgeId, "br_a");
+      expect(_supportedResponse(service).snapshotToken, "a2");
+    });
+
+    test("identity supersession fences every concurrently captured old-bridge mutation", () async {
+      final firstMutation = Completer<PluginManagementMutationResult>();
+      final secondMutation = Completer<PluginManagementMutationResult>();
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "a", bridgeId: "br_a")))
+        ..queueLoad(_supported(_response(token: "b1", bridgeId: "br_b")))
+        ..queueLoad(_supported(_response(token: "b2", bridgeId: "br_b")))
+        ..queueMutation(firstMutation.future)
+        ..queueMutation(secondMutation.future);
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+      await _waitFor(() => service.snapshots.hasValue);
+
+      final first = service.command(
+        pluginId: "one",
+        request: const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe),
+      );
+      final second = service.command(
+        pluginId: "one",
+        request: const PluginLifecycleCommandRequest.restart(mode: PluginStopMode.safe),
+      );
+      firstMutation.complete(_success(_response(token: "unexpected-b", bridgeId: "br_b")));
+      expect(await first, isA<PluginManagementMutationResultUncertain>());
+      secondMutation.complete(_success(_response(token: "late-a", bridgeId: "br_a")));
+      expect(await second, isA<PluginManagementMutationResultUncertain>());
+
+      expect(repository.loadCalls, 3);
+      expect(_supportedResponse(service).bridgeId, "br_b");
+      expect(_supportedResponse(service).snapshotToken, "b2");
+    });
+
+    test("offline mutations fail without dispatch", () async {
+      final repository = _FakePluginRepository();
+      final connection = _FakeConnectionService(initialStatus: const ConnectionStatus.disconnected());
+      final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+
+      final result = await service.command(
+        pluginId: "one",
+        request: const PluginLifecycleCommandRequest.enable(),
+      );
+
+      expect(result, isA<PluginManagementMutationResultFailure>());
+      expect(repository.mutationCalls, isZero);
+    });
+  });
+
+  group("domain planning", () {
+    late PluginManagementService service;
+    late _FakeConnectionService connection;
+
+    setUp(() {
+      connection = _FakeConnectionService(initialStatus: const ConnectionStatus.disconnected());
+      service = PluginManagementService(pluginRepository: _FakePluginRepository(), connectionService: connection);
+    });
+
+    tearDown(() async {
+      await service.onDispose();
+      await connection.dispose();
+    });
+
+    test("timeout plans accept signed integers and reject other input", () {
+      expect(
+        service.planApplyAllIdleTimeout(input: " -5 "),
+        isA<PluginManagementCommandPlanRequest>().having(
+          (plan) => plan.request,
+          "request",
+          const PluginIdleTimeoutUpdateRequest.applyAll(idleTimeoutMins: -5),
+        ),
+      );
+      expect(
+        service.planSetIdleTimeoutOverride(pluginId: "one", input: "0"),
+        isA<PluginManagementCommandPlanRequest>().having(
+          (plan) => plan.request,
+          "request",
+          const PluginIdleTimeoutUpdateRequest.setOverride(pluginId: "one", idleTimeoutMins: 0),
+        ),
+      );
+      expect(service.planApplyAllIdleTimeout(input: "1.5"), isA<PluginManagementCommandPlanInvalidInput>());
+      expect(
+        service.planClearIdleTimeoutOverride(pluginId: "one"),
+        isA<PluginManagementCommandPlanRequest>().having(
+          (plan) => plan.request,
+          "request",
+          const PluginIdleTimeoutUpdateRequest.clearOverride(pluginId: "one"),
+        ),
+      );
+    });
+
+    test("force assessment requires a non-empty set of only forceable reasons", () {
+      final forceable = service.assessForce(
+        conflict: _conflict(const [
+          PluginLifecycleConflictReason.inFlight,
+          PluginLifecycleConflictReason.busy,
+          PluginLifecycleConflictReason.workStateUnknown,
+        ]),
+        action: PluginManagementForceAction.restart,
+      );
+      expect(
+        forceable,
+        isA<PluginManagementForceAssessmentRequiresConfirmation>().having(
+          (assessment) => assessment.request,
+          "request",
+          const PluginLifecycleCommandRequest.restart(mode: PluginStopMode.force),
+        ),
+      );
+
+      for (final reasons in <List<PluginLifecycleConflictReason>>[
+        const [],
+        const [PluginLifecycleConflictReason.transitioning],
+        const [PluginLifecycleConflictReason.notEnabled],
+        const [PluginLifecycleConflictReason.unknown],
+        const [PluginLifecycleConflictReason.busy, PluginLifecycleConflictReason.unknown],
+      ]) {
+        expect(
+          service.assessForce(
+            conflict: _conflict(reasons),
+            action: PluginManagementForceAction.disable,
+          ),
+          isA<PluginManagementForceAssessmentNotForceable>(),
+        );
+      }
+    });
+  });
+
+  test("disposal cancels triggers and fences an active load", () async {
+    final activeLoad = Completer<PluginManagementLoadResult>();
+    final repository = _FakePluginRepository()..queueLoad(activeLoad.future);
+    final connection = _FakeConnectionService(initialStatus: _connected);
+    final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+    await _waitFor(() => repository.loadCalls == 1);
+
+    final snapshotsDone = expectLater(service.snapshots, emitsDone);
+    final disposal = service.onDispose();
+    activeLoad.complete(_supported(_response(token: "late")));
+    await disposal;
+    connection
+      ..emitStale()
+      ..emitManagementChanged(snapshotToken: "other")
+      ..emitStatus(_connected);
+    await _pump();
+
+    await snapshotsDone;
+    expect(repository.loadCalls, 1);
+    await connection.dispose();
+  });
+}
+
+const _config = ServerConnectionConfig(relayHost: "relay.example.com");
+const _health = HealthResponse(healthy: true, version: "test", filesystemAccessDegraded: false);
+const _connected = ConnectionStatus.connected(config: _config, health: _health);
+
+PluginManagementResponse _response({
+  required String token,
+  String? bridgeId = "br_a",
+  int timeout = 10,
+}) {
+  return PluginManagementResponse(
+    snapshotToken: token,
+    bridgeId: bridgeId,
+    defaultPluginId: "one",
+    defaultIdleTimeoutMins: timeout,
+    plugins: const [],
+  );
+}
+
+PluginManagementLoadResult _supported(PluginManagementResponse response) {
+  return PluginManagementLoadResult.supported(response: response, refreshError: null);
+}
+
+PluginManagementMutationResult _success(PluginManagementResponse response) {
+  return PluginManagementMutationResult.success(response: response);
+}
+
+PluginLifecycleConflict _conflict(List<PluginLifecycleConflictReason> reasons) {
+  return PluginLifecycleConflict(
+    pluginId: "one",
+    reasons: reasons,
+    current: const PluginManagementMetadata(
+      setup: PluginSetupMetadata(
+        id: "one",
+        displayName: "One",
+        state: PluginSetupState.ready,
+        actionHint: null,
+      ),
+      runtimeState: PluginRuntimeState.dormant,
+      workState: PluginManagementWorkState.idle,
+      idleTimeoutMins: 10,
+      hasIdleTimeoutOverride: false,
+      actionHint: null,
+    ),
+  );
+}
+
+PluginManagementResponse _supportedResponse(PluginManagementService service) {
+  return (service.snapshots.value as PluginManagementLoadResultSupported).response;
+}
+
+Future<void> _pump() => Future<void>.delayed(Duration.zero);
+
+Future<void> _waitFor(bool Function() predicate) async {
+  for (var attempt = 0; attempt < 100; attempt++) {
+    if (predicate()) return;
+    await _pump();
+  }
+  throw StateError("condition was not reached");
+}
+
+class _FakePluginRepository implements PluginRepository {
+  final Queue<Future<PluginManagementLoadResult>> _loads = Queue();
+  final Queue<Future<PluginManagementMutationResult>> _mutations = Queue();
+  int loadCalls = 0;
+  int mutationCalls = 0;
+
+  void queueLoad(FutureOr<PluginManagementLoadResult> result) {
+    _loads.add(Future<PluginManagementLoadResult>.value(result));
+  }
+
+  void queueMutation(FutureOr<PluginManagementMutationResult> result) {
+    _mutations.add(Future<PluginManagementMutationResult>.value(result));
+  }
+
+  @override
+  Future<PluginManagementLoadResult> getManagement() {
+    loadCalls++;
+    if (_loads.isEmpty) throw StateError("No queued management load");
+    return _loads.removeFirst();
+  }
+
+  @override
+  Future<PluginManagementMutationResult> command({
+    required String pluginId,
+    required PluginLifecycleCommandRequest request,
+  }) {
+    return _nextMutation();
+  }
+
+  @override
+  Future<PluginManagementMutationResult> updateIdleTimeout({
+    required PluginIdleTimeoutUpdateRequest request,
+  }) {
+    return _nextMutation();
+  }
+
+  Future<PluginManagementMutationResult> _nextMutation() {
+    mutationCalls++;
+    if (_mutations.isEmpty) throw StateError("No queued management mutation");
+    return _mutations.removeFirst();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeConnectionService implements ConnectionService {
+  _FakeConnectionService({required ConnectionStatus initialStatus}) : _statuses = BehaviorSubject.seeded(initialStatus);
+
+  final BehaviorSubject<ConnectionStatus> _statuses;
+  final StreamController<SseEvent> _events = StreamController.broadcast();
+  final StreamController<void> _stale = StreamController.broadcast();
+
+  @override
+  ConnectionStatus get currentStatus => _statuses.value;
+
+  @override
+  ValueStream<ConnectionStatus> get status => _statuses.stream;
+
+  @override
+  Stream<SseEvent> get events => _events.stream;
+
+  @override
+  Stream<void> get dataMayBeStale => _stale.stream;
+
+  void emitStatus(ConnectionStatus status) => _statuses.add(status);
+
+  void emitStale() => _stale.add(null);
+
+  void emitManagementChanged({required String snapshotToken}) {
+    _events.add(
+      SseEvent(
+        data: SesoriSseEvent.pluginManagementChanged(snapshotToken: snapshotToken),
+      ),
+    );
+  }
+
+  @override
+  Future<void> dispose() async {
+    await Future.wait([_statuses.close(), _events.close(), _stale.close()]);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/client/module_core/test/services/plugin_management_service_test.dart
+++ b/client/module_core/test/services/plugin_management_service_test.dart
@@ -291,6 +291,41 @@ void main() {
       expect(_supportedResponse(service).snapshotToken, "initial");
     });
 
+    test("a stale rejection after reconnect becomes uncertain and awaits the authoritative refresh", () async {
+      final mutation = Completer<PluginManagementMutationResult>();
+      final reconnectRefresh = Completer<PluginManagementLoadResult>();
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "initial", bridgeId: "br_a")))
+        ..queueLoad(reconnectRefresh.future)
+        ..queueLoad(_supported(_response(token: "authoritative", bridgeId: "br_b")))
+        ..queueMutation(mutation.future);
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(pluginRepository: repository, connectionService: connection);
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+      await _waitFor(() => service.snapshots.hasValue);
+
+      final mutationFuture = service.command(
+        pluginId: "one",
+        request: const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe),
+      );
+      connection
+        ..emitStatus(const ConnectionStatus.connectionLost(config: _config))
+        ..emitStatus(_connected);
+      await _waitFor(() => repository.loadCalls == 2);
+      mutation.complete(
+        PluginManagementMutationResult.conflict(conflict: _conflict(const [PluginLifecycleConflictReason.busy])),
+      );
+      await _pump();
+      reconnectRefresh.complete(_supported(_response(token: "reconnected", bridgeId: "br_b")));
+
+      expect(await mutationFuture, isA<PluginManagementMutationResultUncertain>());
+      expect(_supportedResponse(service).bridgeId, "br_b");
+      expect(_supportedResponse(service).snapshotToken, "authoritative");
+    });
+
     test("disconnect during a refresh fences its response", () async {
       final refresh = Completer<PluginManagementLoadResult>();
       final repository = _FakePluginRepository()


### PR DESCRIPTION
## Summary

Step 3/7 of the Stage 13 Harnesses series (`.plan/active/setup-aware-harness-settings/PLAN.md`). Built from latest `origin/main` after Step 2 merged as `ecd75b6c`.

Adds the Layer-3 `PluginManagementService` that owns management snapshot synchronization and domain planning:

- subscribes to replay-backed connection status, management SSE invalidations, and replay-loss staleness
- gates management HTTP on `ConnectionConnected` and fences in-flight work on disconnect/reconnect
- coalesces refresh triggers into one GET plus at most one trailing drain, preserving failed staleness without polling
- routes GET and mutation publications through one coordinator that validates connection, publication, and bridge-identity fences
- treats nullable legacy bridge identity as a proven identity bucket rather than as “unknown”
- retains same-bridge snapshots with `refreshError`, but never replays bridge A after an unproven reconnect or bridge B transition
- publishes successful mutations only when no newer local publication superseded them; otherwise refreshes authoritatively and returns `uncertain`
- advances the request epoch before forgetting a superseded bridge identity, fencing every concurrently captured old-bridge request
- owns timeout text parsing and forceability policy so later cubits remain orchestration-only
- registers and exports the service for the shared mobile/desktop integration path

## Verification

- Focused `PluginManagementService` suite: **21 passing**
  - initial connected replay and disconnected deferral
  - refresh coalescing, equal-token suppression, SSE/replay-loss triggers, failure recovery
  - same/changed/legacy-null identity behavior and unsupported state
  - refresh/mutation publication races, disconnect fencing, uncertain refresh, concurrent old-bridge mutation fencing
  - typed mutation rejections become uncertain when their captured connection fence moves
  - timeout planning, force assessment, and disposal
- Full `module_core` suite: **678 passing**
- `module_core`: `dart analyze --fatal-infos` clean
- Mobile: `dart analyze --fatal-infos` clean
- Desktop: `dart analyze --fatal-infos` clean
- Injectable code generation completed; generated DI registration included
- Aristotle implementation review: **approved** after centralizing publication and strengthening identity-fence invalidation

The ~1,100 changed lines exceed the 550-700 estimate because the deterministic race/identity test matrix is 661 lines; production service code is 408 lines.

## E2E

The plan intentionally schedules real integration E2E after Step 5/7, when the app resolves this service and renders the Harnesses overview. This service-only slice is covered through deterministic connection, SSE, identity, and publication-race tests.
