### PR TITLE
fix(bridge): avoid cleanup timeout after relay rejection

### DIFF
--- a/bridge/app/lib/src/bridge/relay_client.dart
+++ b/bridge/app/lib/src/bridge/relay_client.dart
@@ -283,6 +283,18 @@ class RelayClient {
     required String failureMessage,
   }) async {
     try {
+      await channel.ready.timeout(timeout);
+    } on TimeoutException catch (error, stackTrace) {
+      Log.w(timeoutMessage, error, stackTrace);
+      return;
+    } on Object {
+      // web_socket_channel never attaches its outbound sink when the upgrade
+      // fails, so sink.close() cannot complete. The failed ready future is the
+      // terminal signal; pending attempts have also force-closed HttpClient.
+      return;
+    }
+
+    try {
       await channel.sink.close().timeout(timeout);
     } on TimeoutException catch (error, stackTrace) {
       Log.w(timeoutMessage, error, stackTrace);

--- a/bridge/app/test/bridge/client_test.dart
+++ b/bridge/app/test/bridge/client_test.dart
@@ -310,6 +310,34 @@ void main() {
       expect((states[1] as RelayDisconnected).closeCode, isNull);
     });
 
+    test("rejected upgrade does not wait for unopened channel cleanup", () async {
+      final server = await HttpServer.bind("127.0.0.1", 0);
+      server.listen((request) {
+        request.response.statusCode = HttpStatus.tooManyRequests;
+        unawaited(request.response.close());
+      });
+      addTearDown(() => server.close(force: true));
+
+      final client = RelayClient(
+        relayURL: "ws://127.0.0.1:${server.port}",
+        accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
+      );
+      final stopwatch = Stopwatch()..start();
+
+      await expectLater(
+        client.connect(),
+        throwsA(
+          predicate<Object>(
+            (error) => error.toString().contains("429"),
+          ),
+        ),
+      );
+      stopwatch.stop();
+
+      expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 750)));
+    });
+
     test("reconnect after a remote drop emits connecting then connected again", () async {
       final server = await TestRelayServer.start();
       addTearDown(server.close);

--- a/bridge/app/test/bridge/client_test.dart
+++ b/bridge/app/test/bridge/client_test.dart
@@ -335,7 +335,10 @@ void main() {
       );
       stopwatch.stop();
 
-      expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 750)));
+      // The regression adds a full one-second cleanup timeout after the local
+      // server has already rejected the upgrade. Allow CI scheduling slack
+      // while still requiring completion before that timeout can elapse.
+      expect(stopwatch.elapsed, lessThan(const Duration(seconds: 1)));
     });
 
     test("reconnect after a remote drop emits connecting then connected again", () async {


### PR DESCRIPTION
## Summary

- wait for WebSocket readiness before attempting the close handshake
- treat a rejected or failed upgrade as terminal after the pending HTTP client is closed
- cover an HTTP 429 upgrade rejection without the extra cleanup timeout

## Root cause

`web_socket_channel` does not attach its outbound sink when the WebSocket upgrade future fails. Calling `sink.close()` in that state waits on a `done` future that cannot complete, producing a misleading cleanup timeout after the original connection error.

This change preserves the original relay rejection and removes only the secondary timeout. It does not alter relay rate-limit policy.

## Testing

- `dart test test/bridge/client_test.dart`
- `dart analyze --fatal-infos`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a misleading cleanup timeout when the relay rejects or fails the WebSocket upgrade. Preserves the original error (e.g., HTTP 429) and avoids waiting on a close handshake that can’t complete.

- **Bug Fixes**
  - Wait for `channel.ready` with a timeout before calling `sink.close()`.
  - Treat failed or rejected upgrades as terminal per `web_socket_channel`; skip the close handshake when the sink isn’t attached.
  - Cover HTTP 429 upgrade rejections with a timing test to ensure no extra cleanup delay.

<sup>Written for commit cc175c83f2bde4561a1bb6116be6d37543ffa672. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

