### PR TITLE
[setup-aware-harness-settings] feat(client): add harness management actions [step 6/8]

### DIFF
--- a/.plan/active/setup-aware-harness-settings/PLAN.md
+++ b/.plan/active/setup-aware-harness-settings/PLAN.md
@@ -812,6 +812,7 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
   });
   Future<void> clearIdleTimeoutOverride({required String pluginId});
   Future<void> confirmForce();
+  void dismissForceConfirmation();
   void dismissActionError();
   void dismissRefreshError();
 
@@ -953,7 +954,8 @@ Force confirmation:
 - Trigger only when cubit state exposes an allowed pending disable/restart.
 - Explicitly state that active work may be interrupted. Current main's #576
   reconciles sessions after forced disable, but the warning remains required.
-- Cancel leaves the original state.
+- Cancel dismisses the pending confirmation and returns the action lifecycle to
+  idle without sending a force request.
 - Confirm sends exactly one force command and never schedules a retry.
 
 Add remaining user-facing copy to `app_en.arb` and regenerate localization.

--- a/.plan/active/setup-aware-harness-settings/PLAN.md
+++ b/.plan/active/setup-aware-harness-settings/PLAN.md
@@ -20,7 +20,7 @@ mergeable history: no replacement branch rebases, merges, or cherry-picks it.
 ## Goal
 
 Deliver the mobile Harnesses settings surface and per-bridge harness preference
-in seven independently reviewable PRs. Each slice compiles and verifies against
+in eight independently reviewable PRs. Each slice compiles and verifies against
 its base, exposes no placeholder user surface, and leaves no temporary public
 contract that a later slice must break.
 
@@ -34,6 +34,10 @@ presentation-facing copy use Harnesses.
 - Backend-specific behavior stays in its owning bridge plugin descriptor. Shared
   transport and clients consume backend-neutral contracts; Prego resolves an
   opaque presentation logo key without using plugin IDs as behavioral state.
+- Lifecycle controls are capability-gated. In particular, OpenCode attach mode
+  (`--opencode-no-auto-start`) is externally managed: Sesori must not offer or
+  execute enable, disable, or restart for it. Clients never infer this from the
+  plugin ID, runtime state, residency, or a non-positive timeout.
 - Layering remains Foundation -> API -> Repository -> Service -> Consumer.
   Cubits never call APIs and are never registered in DI.
 - Additive nullable wire fields must decode from older peers and must be omitted
@@ -66,13 +70,17 @@ presentation-facing copy use Harnesses.
 | 3/7 | `setup-aware-harness-settings-service` | `[setup-aware-harness-settings] feat(client): synchronize harness management [step 3/7]` | 550-700 | Replay, coalescing, reconnect, and mutation fencing. |
 | 4/7 | `setup-aware-harness-settings-branding` | `[setup-aware-harness-settings] feat(prego): render harness logos [step 4/7]` | 750-900 | Descriptor-to-Prego brand key flow plus chooser rendering. |
 | 5/7 | `setup-aware-harness-settings-overview` | `[setup-aware-harness-settings] feat(app): add harness settings overview [step 5/7]` | 1,100-1,300 | Notifications-style read-only Harnesses page, final state contract, and settings entry. |
-| 6/7 | `setup-aware-harness-settings-state` | `[setup-aware-harness-settings] feat(client): add harness management actions [step 6/7]` | 650-800 | Mutation cubit behavior over service-owned validation and force policy. |
-| 7/7 | `setup-aware-harness-settings-controls` | `[setup-aware-harness-settings] feat(app): add harness management controls [step 7/7]` | 800-1,000 | Management controls page with safe/force and timeout flows. |
+| 6/8 | `setup-aware-harness-settings-state` | `[setup-aware-harness-settings] feat(client): add harness management actions [step 6/8]` | 650-800 | Mutation cubit behavior over service-owned validation and force policy. |
+| 7/8 | `setup-aware-harness-settings-capabilities` | `[setup-aware-harness-settings] feat(bridge): declare harness management capabilities [step 7/8]` | 650-850 | Backend-neutral capability declaration, transport, and authoritative bridge enforcement. |
+| 8/8 | `setup-aware-harness-settings-controls` | `[setup-aware-harness-settings] feat(app): add harness management controls [step 8/8]` | 800-1,000 | Management controls page with capability-gated safe/force and timeout flows. |
 
 Steps 2 and 3 are functionally independent from Step 1, but the series still
 runs sequentially. Step 5 expects the Step 3 snapshot contract and the Step 4
-logo primitive. Steps 6 and 7 complete the control surface; no management
-mutation is exposed before Step 7.
+logo primitive. The series expanded from seven to eight slices after Steps 1-5
+merged, when product clarification required a cross-layer externally-managed
+capability contract. Their historical `/7` PR title suffixes remain unchanged;
+Steps 6-8 use the final `/8` total. Steps 6-8 complete the control surface; no
+management mutation is exposed before Step 8.
 
 ## Step 1/7: Per-Bridge Harness Preference
 
@@ -789,7 +797,7 @@ Production files:
 - Localization generation, focused module-core and Flutter tests, and fatal
   analysis in module_core, mobile, and desktop.
 
-## Step 6/7: Management Cubit Actions
+## Step 6/8: Management Cubit Actions
 
 ### Scope
 
@@ -883,9 +891,90 @@ Production files:
 - Focused service/cubit tests, module-core fatal analysis, and mobile/desktop
   fatal analysis.
 
-## Step 7/7: Harness Management Controls Page
+## Step 7/8: Management Capability Contract And Enforcement
 
 ### Scope
+
+First add the backend-neutral management capability contract needed by the
+controls. `PluginManagementMetadata` carries a closed set of independently
+supported operations rather than an OpenCode-specific flag:
+
+```dart
+enum PluginManagementCapability {
+  lifecycle,
+  setupRefresh,
+  idleTimeout,
+  unknown,
+}
+```
+
+The transport field is non-null with a conservative empty legacy default and a
+dated compatibility comment: an older bridge that cannot declare control safety
+must not cause a newer app to expose process controls. The UI explains that the
+connected bridge must be updated when capability data is unavailable. Unknown
+enum values degrade as unsupported. Do not infer capability from
+`idleTimeoutMins <= 0`: that value also truthfully represents a managed plugin
+configured never to idle.
+
+The plugin interface independently defines its Layer-0 enum and descriptor
+method; it never imports `sesori_shared`:
+
+```dart
+enum PluginControlCapability { lifecycle, setupRefresh, idleTimeout }
+
+Set<PluginControlCapability> managementCapabilities({
+  required PluginConfig config,
+});
+```
+
+The wire-facing `PluginManagementCapability` remains independently defined in
+`sesori_shared`. Existing descriptors default to all three interface
+capabilities. The OpenCode descriptor omits lifecycle and idle-timeout
+capabilities in no-auto-start attach mode while retaining setup refresh.
+`bridge/app` maps the interface enum to the shared enum during composition and
+publication; neither Layer-0 package depends on the other. The bridge remains
+authoritative:
+
+- enable, disable, and restart reject plugins without `lifecycle` support;
+- setup refresh rejects plugins without `setupRefresh` support;
+- per-plugin timeout set/clear rejects plugins without `idleTimeout` support;
+- apply-all updates the bridge default and only clears/applies per-plugin
+  timeout state for capable plugins;
+- unsupported operations return a typed non-forceable conflict and never touch
+  process state or persisted per-plugin settings.
+
+Production files:
+
+- `shared/sesori_shared/lib/src/models/sesori/plugin_management.dart` and
+  generated companions for the additive wire capability contract
+- `bridge/sesori_plugin_interface/` for the independent descriptor capability
+  enum and declaration
+- registered plugin descriptors and `bridge/app` composition mapping
+- `bridge/app/lib/src/services/plugin_lifecycle_service.dart` for authoritative
+  capability publication and command/settings enforcement
+
+### Verification
+
+- Shared JSON covers declared capabilities, unknown values, and omitted legacy
+  payloads degrading to no controls.
+- Interface tests cover the default declaration without importing shared; each
+  concrete descriptor is updated in lockstep.
+- Descriptor and bridge-service tests prove no-auto-start OpenCode publishes no
+  lifecycle/timeout capability, setup refresh remains explicit, unsupported
+  commands never touch runtime state, and unsupported timeout writes never
+  mutate settings.
+- Managed plugins retain every existing command and timeout flow; apply-all
+  skips externally managed harness settings while updating the bridge default.
+
+## Step 8/8: Harness Management Controls Page
+
+### Scope
+
+Step 8 renders only controls declared by the snapshot. An externally managed
+harness remains visible with setup/runtime/work context and copy explaining that
+its process is managed outside Sesori. Setup refresh remains available when its
+separate capability is declared. No client layer recognizes OpenCode or
+`no-auto-start`.
 
 Add the second typed route:
 
@@ -970,6 +1059,9 @@ Production files:
 
 ### Verification
 
+- Mobile tests prove controls follow capabilities and never infer external
+  management from plugin identity, runtime state, residency, or timeout value.
+
 - Route encode/decode, router registration, overview-to-management navigation,
   back, and close behavior.
 - Every loading/unsupported/failure/ready state.
@@ -1037,7 +1129,7 @@ persisted disable/timeout/preference/session state altered.
 | After Step 1/7 | Connect through the normal app flow, open `random stuff`, verify each per-bridge harness choice persists across app reopen and falls back after a saved harness becomes unavailable. Restore the written preference afterward. Keep the omitted-`bridgeId` case in wire/service contract tests unless a real older-peer fixture is explicitly available; this repository's Step 1 bridge always emits the ID, so it cannot honestly exercise that path. |
 | After Step 5/7 | Explicitly resolve the Step 3 service through the app's integration path, then verify initial snapshot load, reconnect/replay-loss refresh, management SSE invalidation, and identity-scoped retained snapshots against the real bridge. Open Settings, verify the Harnesses row is immediately below Notifications with the same grouped-row style, open the page, and verify logos, statuses, default badge, refresh, retained snapshot after refresh failure, unsupported state if an older bridge is available, and Notifications-style close behavior. |
 | After Step 4/7 | Verify the new-session chooser renders the real OpenCode, Codex, and Cursor logos. Keep generic-logo verification in widget/contract tests unless an integration fixture can honestly return a null or unknown key; the normal three-descriptor bridge cannot produce that case. |
-| After Step 7/7 | In `random stuff`, exercise safe enable/disable/restart/setup-refresh, busy-conflict copy, explicit force confirmation, timeout apply-all/override/clear, persistence across bridge restart, and session creation from the resulting harness state. Verify current-main forced-disable session reconciliation remains visible, then restore the pre-E2E durable state. |
+| After Step 8/8 | In `random stuff`, exercise safe enable/disable/restart/setup-refresh, busy-conflict copy, explicit force confirmation, timeout apply-all/override/clear, persistence across bridge restart, and session creation from the resulting harness state. Run OpenCode once in no-auto-start attach mode and verify lifecycle/timeout controls are absent while declared setup refresh remains available. Verify current-main forced-disable session reconciliation remains visible, then restore the pre-E2E durable state. |
 
 Stop the temporary E2E bridge after verification and restore any deliberately
 stopped pre-existing bridge. Do not kill an unrelated user bridge; identify

--- a/.plan/active/setup-aware-harness-settings/PLAN.md
+++ b/.plan/active/setup-aware-harness-settings/PLAN.md
@@ -746,6 +746,10 @@ Prego tokens only. The ready state contains one read-only card per harness:
 - `PregoBrandLogo` in the leading slot.
 - display name and Default badge.
 - setup, runtime, work, and effective timeout rows.
+- effective timeout values at or below zero render as `No timeout` with
+  always-running guidance; they never render as zero minutes or claim to use
+  the bridge default, because a resident harness may override the default
+  operationally without a persisted per-harness timeout override.
 - action hint/setup guidance when present.
 - forward-compatible unknown setup/runtime/work values render readable copy
   and never crash.

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -3,7 +3,7 @@
 ## Current State
 
 - **Implementation base:** `origin/main` at `1b0f9874` after Step 5/7 merged
-- **Series state:** Step 6/7 PR #593 open; management actions implemented and verified
+- **Series state:** Step 6/8 PR #593 open; management actions implemented and verified
 - **Next action:** monitor and settle PR #593
 
 ## Delivery
@@ -15,8 +15,9 @@
 | [x] | Step 3/7 — synchronization service | `setup-aware-harness-settings-service` | PR #589 merged as `6fe69d5a`; 1,095 changed lines (estimate 550-700, race-matrix test overage) |
 | [x] | Step 4/7 — harness logos | `setup-aware-harness-settings-branding` | PR #590 merged as `99670e08`; simplified to use existing plugin IDs |
 | [x] | Step 5/7 — Harnesses overview and state contract | `setup-aware-harness-settings-overview` | PR #592 merged as `1b0f9874`; combined simulator E2E passed |
-| [ ] | Step 6/7 — management actions | `setup-aware-harness-settings-state` | PR #593 open; estimate 650-800 changed lines |
-| [ ] | Step 7/7 — management controls | `setup-aware-harness-settings-controls` | planned; estimate 800-1,000 changed lines |
+| [ ] | Step 6/8 — management actions | `setup-aware-harness-settings-state` | PR #593 open; estimate 650-800 changed lines |
+| [ ] | Step 7/8 — management capabilities | `setup-aware-harness-settings-capabilities` | planned; estimate 650-850 changed lines |
+| [ ] | Step 8/8 — management controls | `setup-aware-harness-settings-controls` | planned; estimate 800-1,000 changed lines |
 
 ## Source Material
 
@@ -130,7 +131,7 @@
   bridge cannot escape through replay. Full module_core (686) and focused tests
   pass; module_core, mobile, and desktop analysis is clean; architecture review
   approved the lifecycle ownership and publication fencing.
-- Step 6/7 (2026-07-27): extended the existing cubit over the final nested
+- Step 6/8 (2026-07-27): extended the existing cubit over the final nested
   sealed state contract with exact enable, safe-disable, safe-restart, setup
   refresh, apply-all timeout, per-harness override, clear-override, and explicit
   force-confirmation flows. Timeout parsing and forceability remain service
@@ -145,3 +146,11 @@
   review approved the service/cubit lifecycle ownership and boundaries. PR
   review added explicit force-confirmation dismissal so cancel returns the
   action lifecycle to idle and cannot leave all subsequent controls blocked.
+- Step 7/8 requirement clarification (2026-07-27): OpenCode attached with
+  `--opencode-no-auto-start` is externally managed and cannot be lifecycle- or
+  idle-timeout-controlled by Sesori. Step 7 will add an explicit backend-neutral
+  capability set from plugin descriptor through bridge enforcement and shared
+  transport to UI gating; it will not infer this mode from plugin ID or the
+  effective timeout value. Because that cross-layer contract and enforcement is
+  not tiny, the user approved expanding the series to eight PRs; Step 8/8 now
+  owns the controls UI. Historical merged PR title suffixes remain `/7`.

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -3,8 +3,8 @@
 ## Current State
 
 - **Implementation base:** `origin/main` at `1b0f9874` after Step 5/7 merged
-- **Series state:** Step 6/7 management actions implemented and verified
-- **Next action:** deliver and monitor the Step 6/7 PR
+- **Series state:** Step 6/7 PR #593 open; management actions implemented and verified
+- **Next action:** monitor and settle PR #593
 
 ## Delivery
 
@@ -15,7 +15,7 @@
 | [x] | Step 3/7 — synchronization service | `setup-aware-harness-settings-service` | PR #589 merged as `6fe69d5a`; 1,095 changed lines (estimate 550-700, race-matrix test overage) |
 | [x] | Step 4/7 — harness logos | `setup-aware-harness-settings-branding` | PR #590 merged as `99670e08`; simplified to use existing plugin IDs |
 | [x] | Step 5/7 — Harnesses overview and state contract | `setup-aware-harness-settings-overview` | PR #592 merged as `1b0f9874`; combined simulator E2E passed |
-| [ ] | Step 6/7 — management actions | `setup-aware-harness-settings-state` | ready for PR; estimate 650-800 changed lines |
+| [ ] | Step 6/7 — management actions | `setup-aware-harness-settings-state` | PR #593 open; estimate 650-800 changed lines |
 | [ ] | Step 7/7 — management controls | `setup-aware-harness-settings-controls` | planned; estimate 800-1,000 changed lines |
 
 ## Source Material

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -3,8 +3,8 @@
 ## Current State
 
 - **Implementation base:** `origin/main` at `1b0f9874` after Step 5/7 merged
-- **Series state:** Step 6/7 branch started from the merged Step 5 contract
-- **Next action:** implement and deliver Step 6/7 management actions
+- **Series state:** Step 6/7 management actions implemented and verified
+- **Next action:** deliver and monitor the Step 6/7 PR
 
 ## Delivery
 
@@ -15,7 +15,7 @@
 | [x] | Step 3/7 — synchronization service | `setup-aware-harness-settings-service` | PR #589 merged as `6fe69d5a`; 1,095 changed lines (estimate 550-700, race-matrix test overage) |
 | [x] | Step 4/7 — harness logos | `setup-aware-harness-settings-branding` | PR #590 merged as `99670e08`; simplified to use existing plugin IDs |
 | [x] | Step 5/7 — Harnesses overview and state contract | `setup-aware-harness-settings-overview` | PR #592 merged as `1b0f9874`; combined simulator E2E passed |
-| [ ] | Step 6/7 — management actions | `setup-aware-harness-settings-state` | active; estimate 650-800 changed lines |
+| [ ] | Step 6/7 — management actions | `setup-aware-harness-settings-state` | ready for PR; estimate 650-800 changed lines |
 | [ ] | Step 7/7 — management controls | `setup-aware-harness-settings-controls` | planned; estimate 800-1,000 changed lines |
 
 ## Source Material
@@ -130,3 +130,16 @@
   bridge cannot escape through replay. Full module_core (686) and focused tests
   pass; module_core, mobile, and desktop analysis is clean; architecture review
   approved the lifecycle ownership and publication fencing.
+- Step 6/7 (2026-07-27): extended the existing cubit over the final nested
+  sealed state contract with exact enable, safe-disable, safe-restart, setup
+  refresh, apply-all timeout, per-harness override, clear-override, and explicit
+  force-confirmation flows. Timeout parsing and forceability remain service
+  policy; the cubit preserves action state across successful/failed refresh
+  publications, fences late completions after deliberate state transitions,
+  and maps uncertain outcomes explicitly. The Harnesses overview now renders
+  effective timeout values at or below zero as `No timeout` with always-running
+  guidance instead of zero minutes or a false bridge-default attribution. Root
+  agent guidance now requires sealed variants with only their valid non-nullable
+  fields. Full module_core (695), 53 focused mobile tests, and analysis in
+  module_core, mobile, desktop, and module_desktop_core pass. Architecture
+  review approved the service/cubit lifecycle ownership and boundaries.

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -142,4 +142,6 @@
   agent guidance now requires sealed variants with only their valid non-nullable
   fields. Full module_core (695), 53 focused mobile tests, and analysis in
   module_core, mobile, desktop, and module_desktop_core pass. Architecture
-  review approved the service/cubit lifecycle ownership and boundaries.
+  review approved the service/cubit lifecycle ownership and boundaries. PR
+  review added explicit force-confirmation dismissal so cancel returns the
+  action lifecycle to idle and cannot leave all subsequent controls blocked.

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -2,9 +2,9 @@
 
 ## Current State
 
-- **Implementation base:** `origin/main` at `99670e08` after Step 4/7 merged
-- **Series state:** Step 5/7 PR #592 review fix verified; combined simulator E2E passed
-- **Next action:** merge PR #592, then begin Step 6/7
+- **Implementation base:** `origin/main` at `1b0f9874` after Step 5/7 merged
+- **Series state:** Step 6/7 branch started from the merged Step 5 contract
+- **Next action:** implement and deliver Step 6/7 management actions
 
 ## Delivery
 
@@ -14,8 +14,8 @@
 | [x] | Step 2/7 — management transport | `setup-aware-harness-settings-transport` | PR #583 merged as `ecd75b6c`; ~660 changed lines (estimate 300-400, test-driven overage) |
 | [x] | Step 3/7 — synchronization service | `setup-aware-harness-settings-service` | PR #589 merged as `6fe69d5a`; 1,095 changed lines (estimate 550-700, race-matrix test overage) |
 | [x] | Step 4/7 — harness logos | `setup-aware-harness-settings-branding` | PR #590 merged as `99670e08`; simplified to use existing plugin IDs |
-| [ ] | Step 5/7 — Harnesses overview and state contract | `setup-aware-harness-settings-overview` | PR #592 ready; 1,735 initial changed lines (estimate 1,100-1,300, generated state/localization overage) |
-| [ ] | Step 6/7 — management actions | `setup-aware-harness-settings-state` | planned; estimate 650-800 changed lines |
+| [x] | Step 5/7 — Harnesses overview and state contract | `setup-aware-harness-settings-overview` | PR #592 merged as `1b0f9874`; combined simulator E2E passed |
+| [ ] | Step 6/7 — management actions | `setup-aware-harness-settings-state` | active; estimate 650-800 changed lines |
 | [ ] | Step 7/7 — management controls | `setup-aware-harness-settings-controls` | planned; estimate 800-1,000 changed lines |
 
 ## Source Material

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,11 @@ eagerly "just in case."
 - Use enums for simple closed scalar sets and sealed classes for variants that
   carry different data or behavior. Parse external strings at the boundary;
   never use magic strings for domain state or decisions.
+- Make impossible state combinations unrepresentable. When variants have
+  different valid data, give each sealed variant only its required non-nullable
+  fields instead of flattening them into nullable coordination fields, booleans,
+  or sentinel values. Model independent state machines as separate sealed types
+  and compose their non-null instances.
 - Never use an empty string to represent missing data. Use `null` when absence
   is meaningful; do not avoid nullability when it accurately models the domain.
 - Bridge code must resolve the user home directory with

--- a/client/app/lib/features/settings/harnesses_settings_screen.dart
+++ b/client/app/lib/features/settings/harnesses_settings_screen.dart
@@ -207,6 +207,7 @@ class _HarnessCard extends StatelessWidget {
     final loc = context.loc;
     final pluginId = plugin.setup.id;
     final actionHint = plugin.actionHint ?? plugin.setup.actionHint;
+    final hasNoIdleTimeout = plugin.idleTimeoutMins <= 0;
 
     return PregoGroupedRows(
       key: Key("harnesses_card_$pluginId"),
@@ -242,9 +243,15 @@ class _HarnessCard extends StatelessWidget {
         PregoGroupedRow(
           title: Text(loc.harnessesEffectiveIdleTimeout),
           subtitle: Text(
-            plugin.hasIdleTimeoutOverride ? loc.harnessesCustomIdleTimeout : loc.harnessesUsesDefaultIdleTimeout,
+            hasNoIdleTimeout
+                ? loc.harnessesNoIdleTimeoutDescription
+                : plugin.hasIdleTimeoutOverride
+                ? loc.harnessesCustomIdleTimeout
+                : loc.harnessesUsesDefaultIdleTimeout,
           ),
-          trailing: Text(loc.harnessesIdleTimeoutMinutes(plugin.idleTimeoutMins)),
+          trailing: Text(
+            hasNoIdleTimeout ? loc.harnessesNoIdleTimeout : loc.harnessesIdleTimeoutMinutes(plugin.idleTimeoutMins),
+          ),
           isLast: true,
         ),
       ],

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -169,6 +169,8 @@
   "harnessesEffectiveIdleTimeout": "Idle timeout",
   "harnessesCustomIdleTimeout": "Custom for this harness",
   "harnessesUsesDefaultIdleTimeout": "Uses the bridge default",
+  "harnessesNoIdleTimeout": "No timeout",
+  "harnessesNoIdleTimeoutDescription": "This harness stays running",
   "harnessesIdleTimeoutMinutes": "{minutes} min",
   "@harnessesIdleTimeoutMinutes": {
     "placeholders": {

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -529,6 +529,18 @@ abstract class AppLocalizations {
   /// **'Uses the bridge default'**
   String get harnessesUsesDefaultIdleTimeout;
 
+  /// No description provided for @harnessesNoIdleTimeout.
+  ///
+  /// In en, this message translates to:
+  /// **'No timeout'**
+  String get harnessesNoIdleTimeout;
+
+  /// No description provided for @harnessesNoIdleTimeoutDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'This harness stays running'**
+  String get harnessesNoIdleTimeoutDescription;
+
   /// No description provided for @harnessesIdleTimeoutMinutes.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -238,6 +238,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get harnessesUsesDefaultIdleTimeout => 'Uses the bridge default';
 
   @override
+  String get harnessesNoIdleTimeout => 'No timeout';
+
+  @override
+  String get harnessesNoIdleTimeoutDescription => 'This harness stays running';
+
+  @override
   String harnessesIdleTimeoutMinutes(int minutes) {
     return '$minutes min';
   }

--- a/client/app/test/features/settings/harnesses_settings_screen_test.dart
+++ b/client/app/test/features/settings/harnesses_settings_screen_test.dart
@@ -159,6 +159,29 @@ void main() {
     expect(find.text("The connected bridge hasn't registered any coding harnesses."), findsOneWidget);
   });
 
+  testWidgets("zero and negative idle timeouts mean the harness stays running", (tester) async {
+    snapshots.add(
+      PluginManagementLoadResult.supported(
+        response: _response.copyWith(
+          plugins: [
+            _response.plugins[0].copyWith(idleTimeoutMins: 0, hasIdleTimeoutOverride: false),
+            _response.plugins[1].copyWith(idleTimeoutMins: -5, hasIdleTimeoutOverride: false),
+          ],
+        ),
+        refreshError: null,
+      ),
+    );
+
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+
+    expect(find.text("No timeout"), findsNWidgets(2));
+    expect(find.text("This harness stays running"), findsNWidgets(2));
+    expect(find.text("Uses the bridge default"), findsNothing);
+    expect(find.text("0 min"), findsNothing);
+    expect(find.text("-5 min"), findsNothing);
+  });
+
   testWidgets("ready refresh failure keeps the snapshot visible and can be dismissed", (tester) async {
     snapshots.add(
       PluginManagementLoadResult.supported(

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
@@ -1,6 +1,7 @@
 import "dart:async";
 
 import "package:bloc/bloc.dart";
+import "package:sesori_shared/sesori_shared.dart";
 
 import "../../repositories/models/plugin_management_result.dart";
 import "../../services/plugin_management_service.dart";
@@ -15,8 +16,78 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
 
   final PluginManagementService _service;
   late final StreamSubscription<PluginManagementLoadResult> _snapshotSubscription;
+  int _actionGeneration = 0;
 
   Future<void> refresh() => _service.refresh();
+
+  Future<void> enable({required String pluginId}) => _runCommand(
+    pluginId: pluginId,
+    request: const PluginLifecycleCommandRequest.enable(),
+    forceAction: null,
+    replacePendingConfirmation: false,
+  );
+
+  Future<void> disable({required String pluginId}) => _runCommand(
+    pluginId: pluginId,
+    request: const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe),
+    forceAction: PluginManagementForceAction.disable,
+    replacePendingConfirmation: false,
+  );
+
+  Future<void> restart({required String pluginId}) => _runCommand(
+    pluginId: pluginId,
+    request: const PluginLifecycleCommandRequest.restart(mode: PluginStopMode.safe),
+    forceAction: PluginManagementForceAction.restart,
+    replacePendingConfirmation: false,
+  );
+
+  Future<void> refreshSetup({required String pluginId}) => _runCommand(
+    pluginId: pluginId,
+    request: const PluginLifecycleCommandRequest.refresh(),
+    forceAction: null,
+    replacePendingConfirmation: false,
+  );
+
+  Future<void> applyIdleTimeoutToAll({required String input}) => _runTimeoutPlan(
+    target: const PluginManagementActionTarget.allHarnesses(),
+    plan: _service.planApplyAllIdleTimeout(input: input),
+  );
+
+  Future<void> setIdleTimeoutOverride({required String pluginId, required String input}) => _runTimeoutPlan(
+    target: PluginManagementActionTarget.harness(pluginId: pluginId),
+    plan: _service.planSetIdleTimeoutOverride(pluginId: pluginId, input: input),
+  );
+
+  Future<void> clearIdleTimeoutOverride({required String pluginId}) => _runTimeoutPlan(
+    target: PluginManagementActionTarget.harness(pluginId: pluginId),
+    plan: _service.planClearIdleTimeoutOverride(pluginId: pluginId),
+  );
+
+  Future<void> confirmForce() async {
+    final current = state;
+    final pending = switch (current) {
+      PluginManagementReady(action: final PluginManagementActionForceConfirmationRequired pending) => pending,
+      PluginManagementReady() ||
+      PluginManagementLoading() ||
+      PluginManagementUnsupported() ||
+      PluginManagementFailure() => null,
+    };
+    if (pending == null) return;
+    await _runCommand(
+      pluginId: pending.pluginId,
+      request: pending.request,
+      forceAction: null,
+      replacePendingConfirmation: true,
+    );
+  }
+
+  void dismissActionError() {
+    if (isClosed) return;
+    final current = state;
+    if (current is! PluginManagementReady || current.action is! PluginManagementActionFailed) return;
+    _actionGeneration++;
+    emit(current.copyWith(action: const PluginManagementActionState.idle()));
+  }
 
   void dismissRefreshError() {
     if (isClosed) return;
@@ -25,12 +96,167 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
     emit(current.copyWith(refresh: const PluginManagementRefreshState.idle()));
   }
 
+  Future<void> _runCommand({
+    required String pluginId,
+    required PluginLifecycleCommandRequest request,
+    required PluginManagementForceAction? forceAction,
+    required bool replacePendingConfirmation,
+  }) async {
+    final target = PluginManagementActionTarget.harness(pluginId: pluginId);
+    final generation = _beginAction(target: target, replacePendingConfirmation: replacePendingConfirmation);
+    if (generation == null) return;
+
+    final result = await _service.command(pluginId: pluginId, request: request);
+    if (!_canFinishAction(generation: generation)) return;
+
+    switch (result) {
+      case PluginManagementMutationResultSuccess():
+        _finishAction(generation: generation, action: const PluginManagementActionState.idle());
+      case PluginManagementMutationResultNotFound():
+        _finishAction(
+          generation: generation,
+          action: PluginManagementActionState.failed(
+            target: target,
+            error: const PluginManagementActionError.notFound(),
+          ),
+        );
+      case PluginManagementMutationResultConflict(:final conflict):
+        final actionState = switch (forceAction) {
+          final forceAction? => switch (_service.assessForce(conflict: conflict, action: forceAction)) {
+            PluginManagementForceAssessmentRequiresConfirmation(:final request) =>
+              PluginManagementActionState.forceConfirmationRequired(
+                pluginId: pluginId,
+                action: forceAction,
+                conflict: conflict,
+                request: request,
+              ),
+            PluginManagementForceAssessmentNotForceable() => PluginManagementActionState.failed(
+              target: target,
+              error: PluginManagementActionError.conflict(conflict: conflict),
+            ),
+          },
+          null => PluginManagementActionState.failed(
+            target: target,
+            error: PluginManagementActionError.conflict(conflict: conflict),
+          ),
+        };
+        _finishAction(generation: generation, action: actionState);
+      case PluginManagementMutationResultUncertain():
+        _finishAction(
+          generation: generation,
+          action: PluginManagementActionState.failed(
+            target: target,
+            error: const PluginManagementActionError.uncertain(),
+          ),
+        );
+      case PluginManagementMutationResultFailure(:final error):
+        _finishAction(
+          generation: generation,
+          action: PluginManagementActionState.failed(
+            target: target,
+            error: PluginManagementActionError.request(error: error),
+          ),
+        );
+    }
+  }
+
+  Future<void> _runTimeoutPlan({
+    required PluginManagementActionTarget target,
+    required PluginManagementCommandPlan plan,
+  }) async {
+    switch (plan) {
+      case PluginManagementCommandPlanInvalidInput():
+        _emitImmediateFailure(
+          target: target,
+          error: const PluginManagementActionError.invalidIdleTimeout(),
+        );
+      case PluginManagementCommandPlanRequest(:final request):
+        final generation = _beginAction(target: target, replacePendingConfirmation: false);
+        if (generation == null) return;
+        final result = await _service.updateIdleTimeout(request: request);
+        if (!_canFinishAction(generation: generation)) return;
+        final action = switch (result) {
+          PluginManagementMutationResultSuccess() => const PluginManagementActionState.idle(),
+          PluginManagementMutationResultNotFound() => PluginManagementActionState.failed(
+            target: target,
+            error: const PluginManagementActionError.notFound(),
+          ),
+          PluginManagementMutationResultConflict(:final conflict) => PluginManagementActionState.failed(
+            target: target,
+            error: PluginManagementActionError.conflict(conflict: conflict),
+          ),
+          PluginManagementMutationResultUncertain() => PluginManagementActionState.failed(
+            target: target,
+            error: const PluginManagementActionError.uncertain(),
+          ),
+          PluginManagementMutationResultFailure(:final error) => PluginManagementActionState.failed(
+            target: target,
+            error: PluginManagementActionError.request(error: error),
+          ),
+        };
+        _finishAction(generation: generation, action: action);
+    }
+  }
+
+  int? _beginAction({
+    required PluginManagementActionTarget target,
+    required bool replacePendingConfirmation,
+  }) {
+    if (isClosed) return null;
+    final current = state;
+    if (current is! PluginManagementReady) return null;
+    final canBegin =
+        current.action is PluginManagementActionIdle ||
+        current.action is PluginManagementActionFailed ||
+        (replacePendingConfirmation && current.action is PluginManagementActionForceConfirmationRequired);
+    if (!canBegin) return null;
+    final generation = ++_actionGeneration;
+    emit(current.copyWith(action: PluginManagementActionState.inProgress(target: target)));
+    return generation;
+  }
+
+  bool _canFinishAction({required int generation}) {
+    return !isClosed && generation == _actionGeneration && state is PluginManagementReady;
+  }
+
+  void _finishAction({required int generation, required PluginManagementActionState action}) {
+    if (isClosed || generation != _actionGeneration) return;
+    final current = state;
+    if (current is! PluginManagementReady) return;
+    emit(current.copyWith(action: action));
+  }
+
+  void _emitImmediateFailure({
+    required PluginManagementActionTarget target,
+    required PluginManagementActionError error,
+  }) {
+    if (isClosed) return;
+    final current = state;
+    if (current is! PluginManagementReady ||
+        (current.action is! PluginManagementActionIdle && current.action is! PluginManagementActionFailed)) {
+      return;
+    }
+    _actionGeneration++;
+    emit(
+      current.copyWith(
+        action: PluginManagementActionState.failed(target: target, error: error),
+      ),
+    );
+  }
+
   void _onSnapshot({required PluginManagementLoadResult snapshot}) {
     if (isClosed) return;
     switch (snapshot) {
       case PluginManagementLoadResultLoading():
+        _actionGeneration++;
         emit(const PluginManagementState.loading());
       case PluginManagementLoadResultSupported(:final response, :final refreshError):
+        final action = switch (state) {
+          PluginManagementReady(:final action) => action,
+          PluginManagementLoading() ||
+          PluginManagementUnsupported() ||
+          PluginManagementFailure() => const PluginManagementActionState.idle(),
+        };
         emit(
           PluginManagementState.ready(
             response: response,
@@ -38,12 +264,14 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
               final error? => PluginManagementRefreshState.failed(error: error),
               null => const PluginManagementRefreshState.idle(),
             },
-            action: const PluginManagementActionState.idle(),
+            action: action,
           ),
         );
       case PluginManagementLoadResultUnsupported():
+        _actionGeneration++;
         emit(const PluginManagementState.unsupported());
       case PluginManagementLoadResultFailure(:final error):
+        _actionGeneration++;
         emit(PluginManagementState.failure(error: error));
     }
   }

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
@@ -81,6 +81,16 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
     );
   }
 
+  void dismissForceConfirmation() {
+    if (isClosed) return;
+    final current = state;
+    if (current is! PluginManagementReady || current.action is! PluginManagementActionForceConfirmationRequired) {
+      return;
+    }
+    _actionGeneration++;
+    emit(current.copyWith(action: const PluginManagementActionState.idle()));
+  }
+
   void dismissActionError() {
     if (isClosed) return;
     final current = state;

--- a/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
+++ b/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
@@ -26,11 +26,25 @@ void main() {
   late BehaviorSubject<PluginManagementLoadResult> snapshots;
   late PluginManagementCubit cubit;
 
+  setUpAll(() {
+    registerFallbackValue(const PluginLifecycleCommandRequest.enable());
+    registerFallbackValue(const PluginIdleTimeoutUpdateRequest.applyAll(idleTimeoutMins: 1));
+  });
+
   setUp(() {
     service = _MockPluginManagementService();
     snapshots = BehaviorSubject();
     when(() => service.snapshots).thenAnswer((_) => snapshots.stream);
     when(() => service.refresh()).thenAnswer((_) async {});
+    when(
+      () => service.command(
+        pluginId: any(named: "pluginId"),
+        request: any(named: "request"),
+      ),
+    ).thenAnswer((_) async => const PluginManagementMutationResult.success(response: _response));
+    when(
+      () => service.updateIdleTimeout(request: any(named: "request")),
+    ).thenAnswer((_) async => const PluginManagementMutationResult.success(response: _response));
     cubit = PluginManagementCubit(service: service);
   });
 
@@ -112,4 +126,303 @@ void main() {
 
     expect(cubit.dismissRefreshError, returnsNormally);
   });
+
+  group("actions", () {
+    setUp(() async {
+      snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+      await _settle();
+    });
+
+    test("constructs every lifecycle command exactly", () async {
+      await cubit.enable(pluginId: "one");
+      await cubit.disable(pluginId: "two");
+      await cubit.restart(pluginId: "three");
+      await cubit.refreshSetup(pluginId: "four");
+
+      verify(
+        () => service.command(
+          pluginId: "one",
+          request: const PluginLifecycleCommandRequest.enable(),
+        ),
+      ).called(1);
+      verify(
+        () => service.command(
+          pluginId: "two",
+          request: const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe),
+        ),
+      ).called(1);
+      verify(
+        () => service.command(
+          pluginId: "three",
+          request: const PluginLifecycleCommandRequest.restart(mode: PluginStopMode.safe),
+        ),
+      ).called(1);
+      verify(
+        () => service.command(
+          pluginId: "four",
+          request: const PluginLifecycleCommandRequest.refresh(),
+        ),
+      ).called(1);
+      expect((cubit.state as PluginManagementReady).action, const PluginManagementActionState.idle());
+    });
+
+    test("executes service-owned timeout plans including zero and negative values", () async {
+      when(
+        () => service.planApplyAllIdleTimeout(input: " -5 "),
+      ).thenReturn(
+        const PluginManagementCommandPlan.request(
+          request: PluginIdleTimeoutUpdateRequest.applyAll(idleTimeoutMins: -5),
+        ),
+      );
+      when(
+        () => service.planSetIdleTimeoutOverride(pluginId: "one", input: "0"),
+      ).thenReturn(
+        const PluginManagementCommandPlan.request(
+          request: PluginIdleTimeoutUpdateRequest.setOverride(pluginId: "one", idleTimeoutMins: 0),
+        ),
+      );
+      when(
+        () => service.planClearIdleTimeoutOverride(pluginId: "one"),
+      ).thenReturn(
+        const PluginManagementCommandPlan.request(
+          request: PluginIdleTimeoutUpdateRequest.clearOverride(pluginId: "one"),
+        ),
+      );
+
+      await cubit.applyIdleTimeoutToAll(input: " -5 ");
+      await cubit.setIdleTimeoutOverride(pluginId: "one", input: "0");
+      await cubit.clearIdleTimeoutOverride(pluginId: "one");
+
+      verify(
+        () => service.updateIdleTimeout(
+          request: const PluginIdleTimeoutUpdateRequest.applyAll(idleTimeoutMins: -5),
+        ),
+      ).called(1);
+      verify(
+        () => service.updateIdleTimeout(
+          request: const PluginIdleTimeoutUpdateRequest.setOverride(pluginId: "one", idleTimeoutMins: 0),
+        ),
+      ).called(1);
+      verify(
+        () => service.updateIdleTimeout(
+          request: const PluginIdleTimeoutUpdateRequest.clearOverride(pluginId: "one"),
+        ),
+      ).called(1);
+    });
+
+    test("maps invalid timeout plans without dispatching", () async {
+      when(
+        () => service.planApplyAllIdleTimeout(input: "not a number"),
+      ).thenReturn(const PluginManagementCommandPlan.invalidInput());
+
+      await cubit.applyIdleTimeoutToAll(input: "not a number");
+
+      expect(
+        (cubit.state as PluginManagementReady).action,
+        const PluginManagementActionState.failed(
+          target: PluginManagementActionTarget.allHarnesses(),
+          error: PluginManagementActionError.invalidIdleTimeout(),
+        ),
+      );
+      verifyNever(() => service.updateIdleTimeout(request: any(named: "request")));
+    });
+
+    test("safe conflict requires one explicit force confirmation", () async {
+      final conflict = _conflict(const [PluginLifecycleConflictReason.busy]);
+      when(
+        () => service.command(
+          pluginId: "one",
+          request: const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe),
+        ),
+      ).thenAnswer((_) async => PluginManagementMutationResult.conflict(conflict: conflict));
+      when(
+        () => service.assessForce(conflict: conflict, action: PluginManagementForceAction.disable),
+      ).thenReturn(
+        const PluginManagementForceAssessment.requiresConfirmation(
+          request: PluginLifecycleCommandRequest.disable(mode: PluginStopMode.force),
+        ),
+      );
+
+      await cubit.disable(pluginId: "one");
+
+      expect(
+        (cubit.state as PluginManagementReady).action,
+        PluginManagementActionState.forceConfirmationRequired(
+          pluginId: "one",
+          action: PluginManagementForceAction.disable,
+          conflict: conflict,
+          request: const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.force),
+        ),
+      );
+      verifyNever(
+        () => service.command(
+          pluginId: "one",
+          request: const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.force),
+        ),
+      );
+
+      await cubit.confirmForce();
+
+      verify(
+        () => service.command(
+          pluginId: "one",
+          request: const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.force),
+        ),
+      ).called(1);
+      expect((cubit.state as PluginManagementReady).action, const PluginManagementActionState.idle());
+    });
+
+    test("maps a non-forceable conflict to an explicit action error", () async {
+      final conflict = _conflict(const [PluginLifecycleConflictReason.unknown]);
+      when(
+        () => service.command(
+          pluginId: "one",
+          request: const PluginLifecycleCommandRequest.restart(mode: PluginStopMode.safe),
+        ),
+      ).thenAnswer((_) async => PluginManagementMutationResult.conflict(conflict: conflict));
+      when(
+        () => service.assessForce(conflict: conflict, action: PluginManagementForceAction.restart),
+      ).thenReturn(const PluginManagementForceAssessment.notForceable());
+
+      await cubit.restart(pluginId: "one");
+
+      expect(
+        (cubit.state as PluginManagementReady).action,
+        PluginManagementActionState.failed(
+          target: const PluginManagementActionTarget.harness(pluginId: "one"),
+          error: PluginManagementActionError.conflict(conflict: conflict),
+        ),
+      );
+    });
+
+    test("maps uncertain mutations and dismisses their explicit error", () async {
+      when(
+        () => service.command(
+          pluginId: "one",
+          request: const PluginLifecycleCommandRequest.enable(),
+        ),
+      ).thenAnswer((_) async => const PluginManagementMutationResult.uncertain());
+
+      await cubit.enable(pluginId: "one");
+      expect(
+        (cubit.state as PluginManagementReady).action,
+        const PluginManagementActionState.failed(
+          target: PluginManagementActionTarget.harness(pluginId: "one"),
+          error: PluginManagementActionError.uncertain(),
+        ),
+      );
+
+      cubit.dismissActionError();
+      expect((cubit.state as PluginManagementReady).action, const PluginManagementActionState.idle());
+    });
+
+    test("preserves an in-flight action across successful and failed refresh publications", () async {
+      final command = Completer<PluginManagementMutationResult>();
+      when(
+        () => service.command(
+          pluginId: "one",
+          request: const PluginLifecycleCommandRequest.enable(),
+        ),
+      ).thenAnswer((_) => command.future);
+
+      final action = cubit.enable(pluginId: "one");
+      const target = PluginManagementActionTarget.harness(pluginId: "one");
+      expect(
+        (cubit.state as PluginManagementReady).action,
+        const PluginManagementActionState.inProgress(target: target),
+      );
+
+      snapshots.add(
+        PluginManagementLoadResult.supported(
+          response: _response.copyWith(snapshotToken: "successful-refresh"),
+          refreshError: null,
+        ),
+      );
+      await _settle();
+      expect(
+        (cubit.state as PluginManagementReady).action,
+        const PluginManagementActionState.inProgress(target: target),
+      );
+
+      snapshots.add(
+        PluginManagementLoadResult.supported(
+          response: _response.copyWith(snapshotToken: "refresh"),
+          refreshError: ApiError.generic(),
+        ),
+      );
+      await _settle();
+      final refreshed = cubit.state as PluginManagementReady;
+      expect(refreshed.action, const PluginManagementActionState.inProgress(target: target));
+      expect(refreshed.refresh, isA<PluginManagementRefreshFailed>());
+
+      command.complete(const PluginManagementMutationResult.success(response: _response));
+      await action;
+      expect((cubit.state as PluginManagementReady).action, const PluginManagementActionState.idle());
+    });
+
+    test("preserves pending force confirmation across refresh", () async {
+      final conflict = _conflict(const [PluginLifecycleConflictReason.inFlight]);
+      when(
+        () => service.command(
+          pluginId: "one",
+          request: const PluginLifecycleCommandRequest.restart(mode: PluginStopMode.safe),
+        ),
+      ).thenAnswer((_) async => PluginManagementMutationResult.conflict(conflict: conflict));
+      when(
+        () => service.assessForce(conflict: conflict, action: PluginManagementForceAction.restart),
+      ).thenReturn(
+        const PluginManagementForceAssessment.requiresConfirmation(
+          request: PluginLifecycleCommandRequest.restart(mode: PluginStopMode.force),
+        ),
+      );
+      await cubit.restart(pluginId: "one");
+      final pending = (cubit.state as PluginManagementReady).action;
+
+      snapshots.add(
+        PluginManagementLoadResult.supported(
+          response: _response.copyWith(snapshotToken: "refresh"),
+          refreshError: null,
+        ),
+      );
+      await _settle();
+
+      expect((cubit.state as PluginManagementReady).action, pending);
+    });
+
+    test("does not emit after closing during an action", () async {
+      final command = Completer<PluginManagementMutationResult>();
+      when(
+        () => service.command(
+          pluginId: "one",
+          request: const PluginLifecycleCommandRequest.enable(),
+        ),
+      ).thenAnswer((_) => command.future);
+      final action = cubit.enable(pluginId: "one");
+
+      await cubit.close();
+      command.complete(const PluginManagementMutationResult.success(response: _response));
+
+      await expectLater(action, completes);
+    });
+  });
+}
+
+PluginLifecycleConflict _conflict(List<PluginLifecycleConflictReason> reasons) {
+  return PluginLifecycleConflict(
+    pluginId: "one",
+    reasons: reasons,
+    current: const PluginManagementMetadata(
+      setup: PluginSetupMetadata(
+        id: "one",
+        displayName: "One",
+        state: PluginSetupState.ready,
+        actionHint: null,
+      ),
+      runtimeState: PluginRuntimeState.dormant,
+      workState: PluginManagementWorkState.idle,
+      idleTimeoutMins: 10,
+      hasIdleTimeoutOverride: false,
+      actionHint: null,
+    ),
+  );
 }

--- a/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
+++ b/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
@@ -272,6 +272,35 @@ void main() {
       expect((cubit.state as PluginManagementReady).action, const PluginManagementActionState.idle());
     });
 
+    test("dismissing force confirmation allows another action", () async {
+      final conflict = _conflict(const [PluginLifecycleConflictReason.busy]);
+      when(
+        () => service.command(
+          pluginId: "one",
+          request: const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe),
+        ),
+      ).thenAnswer((_) async => PluginManagementMutationResult.conflict(conflict: conflict));
+      when(
+        () => service.assessForce(conflict: conflict, action: PluginManagementForceAction.disable),
+      ).thenReturn(
+        const PluginManagementForceAssessment.requiresConfirmation(
+          request: PluginLifecycleCommandRequest.disable(mode: PluginStopMode.force),
+        ),
+      );
+      await cubit.disable(pluginId: "one");
+
+      cubit.dismissForceConfirmation();
+      await cubit.enable(pluginId: "two");
+
+      expect((cubit.state as PluginManagementReady).action, const PluginManagementActionState.idle());
+      verify(
+        () => service.command(
+          pluginId: "two",
+          request: const PluginLifecycleCommandRequest.enable(),
+        ),
+      ).called(1);
+    });
+
     test("maps a non-forceable conflict to an explicit action error", () async {
       final conflict = _conflict(const [PluginLifecycleConflictReason.unknown]);
       when(


### PR DESCRIPTION
## Summary

- extend `PluginManagementCubit` with typed enable, disable, restart, setup refresh, and idle-timeout actions
- keep timeout parsing and forceability policy in `PluginManagementService`, with safe-first lifecycle commands and one explicit force confirmation
- preserve independent sealed refresh/action state across replayed snapshots and fence late action completions after bridge/state transitions
- render effective timeout values at or below zero as **No timeout** with always-running guidance instead of `0 min` or an incorrect bridge-default attribution
- document the project rule that sealed variants carry only their valid required non-nullable fields

## Verification

- `dart test` in `client/module_core` — 695 tests passed
- `dart analyze` in `client/module_core`
- `dart analyze` in `client/app`
- focused mobile settings/routing tests — 53 tests passed
- `dart analyze` in `client/desktop`
- `dart analyze` in `client/module_desktop_core`
- Aristotle implementation review approved

## Series

Step 6 of 8 in `.plan/active/setup-aware-harness-settings`. The series expanded
after product clarification required a separate backend-neutral capability and
bridge-enforcement slice before the controls UI.
