### PR TITLE
[setup-aware-harness-settings] feat(bridge): declare harness management capabilities [step 7/8]

### DIFF
--- a/.plan/active/setup-aware-harness-settings/PLAN.md
+++ b/.plan/active/setup-aware-harness-settings/PLAN.md
@@ -908,11 +908,10 @@ enum PluginManagementCapability {
 }
 ```
 
-The transport field is non-null with a conservative empty legacy default and a
-dated compatibility comment: an older bridge that cannot declare control safety
-must not cause a newer app to expose process controls. The UI explains that the
-connected bridge must be updated when capability data is unavailable. Unknown
-enum values degrade as unsupported. Do not infer capability from
+The transport field is required and has no default. This capability contract and
+its controls ship together before either exists in production, so there is no
+released peer payload to preserve between internal implementation slices.
+Unknown enum values degrade as unsupported. Do not infer capability from
 `idleTimeoutMins <= 0`: that value also truthfully represents a managed plugin
 configured never to idle.
 
@@ -938,6 +937,8 @@ authoritative:
 - enable, disable, and restart reject plugins without `lifecycle` support;
 - setup refresh rejects plugins without `setupRefresh` support;
 - per-plugin timeout set/clear rejects plugins without `idleTimeout` support;
+- automatic idle suspension requires both `lifecycle` and `idleTimeout`
+  support, checked before scheduling and again before stopping;
 - apply-all updates the bridge default and only clears/applies per-plugin
   timeout state for capable plugins;
 - unsupported operations return a typed non-forceable conflict and never touch
@@ -955,8 +956,8 @@ Production files:
 
 ### Verification
 
-- Shared JSON covers declared capabilities, unknown values, and omitted legacy
-  payloads degrading to no controls.
+- Shared JSON covers declared capabilities, unknown values, and rejection of a
+  missing required capability field.
 - Interface tests cover the default declaration without importing shared; each
   concrete descriptor is updated in lockstep.
 - Descriptor and bridge-service tests prove no-auto-start OpenCode publishes no

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -163,8 +163,13 @@
   capabilities. The bridge rejects unsupported lifecycle and per-plugin timeout
   operations before runtime or settings effects, returns typed non-forceable
   conflicts, and apply-all updates the global default while clearing overrides
-  only for timeout-capable plugins. Full shared (340), plugin interface (147),
-  OpenCode (398), and bridge app (2160) suites pass; fatal analysis is clean in
+  only for timeout-capable plugins. Review follow-up made the immutable
+  registration snapshot authoritative for both published controls and command
+  authorization. Startup now removes lifecycle-uncontrollable plugins from a
+  stale persisted disabled set, so externally managed OpenCode cannot become
+  permanently unroutable after changing launch mode. Full shared (340), plugin
+  interface (147), OpenCode (398), bridge app (2163), and module_core (696)
+  suites pass; fatal analysis is clean in
   those packages, Codex, Cursor, module_core, mobile, desktop, and
   module_desktop_core. Architecture review approved the Layer-0 independence,
   bridge mapping/enforcement, and required capability contract. PR review also

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -3,8 +3,8 @@
 ## Current State
 
 - **Implementation base:** `origin/main` at `075951cb` after Step 6/8 merged
-- **Series state:** Step 7/8 management capabilities implemented and verified
-- **Next action:** deliver and monitor the Step 7/8 PR
+- **Series state:** Step 7/8 PR #594 open; management capabilities implemented and verified
+- **Next action:** monitor and settle PR #594
 
 ## Delivery
 
@@ -16,7 +16,7 @@
 | [x] | Step 4/7 — harness logos | `setup-aware-harness-settings-branding` | PR #590 merged as `99670e08`; simplified to use existing plugin IDs |
 | [x] | Step 5/7 — Harnesses overview and state contract | `setup-aware-harness-settings-overview` | PR #592 merged as `1b0f9874`; combined simulator E2E passed |
 | [x] | Step 6/8 — management actions | `setup-aware-harness-settings-state` | PR #593 merged as `075951cb`; estimate 650-800 changed lines |
-| [ ] | Step 7/8 — management capabilities | `setup-aware-harness-settings-capabilities` | ready for PR; estimate 650-850 changed lines |
+| [ ] | Step 7/8 — management capabilities | `setup-aware-harness-settings-capabilities` | PR #594 open; estimate 650-850 changed lines |
 | [ ] | Step 8/8 — management controls | `setup-aware-harness-settings-controls` | planned; estimate 800-1,000 changed lines |
 
 ## Source Material

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -165,9 +165,10 @@
   conflicts, and apply-all updates the global default while clearing overrides
   only for timeout-capable plugins. Review follow-up made the immutable
   registration snapshot authoritative for both published controls and command
-  authorization. Startup now removes lifecycle-uncontrollable plugins from a
-  stale persisted disabled set, so externally managed OpenCode cannot become
-  permanently unroutable after changing launch mode. Full shared (340), plugin
+  authorization. Startup now rejects a persisted disabled state for a plugin
+  without lifecycle control with an actionable config command, preserving
+  `plugins.disabled` as the authoritative policy without silently making a
+  rejected startup mutate it. Full shared (340), plugin
   interface (147), OpenCode (398), bridge app (2163), and module_core (696)
   suites pass; fatal analysis is clean in
   those packages, Codex, Cursor, module_core, mobile, desktop, and

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -156,8 +156,9 @@
   owns the controls UI. Historical merged PR title suffixes remain `/7`.
 - Step 7/8 (2026-07-27): added independent backend-neutral capability enums to
   the plugin interface and shared wire contract, with `bridge/app` owning the
-  mapping. Omitted legacy capability data fails closed to an empty set and
-  future values decode to `unknown`. OpenCode no-auto-start declares setup
+  mapping. The capability field is required with no default because it and the
+  controls ship together before production; future values decode to `unknown`.
+  OpenCode no-auto-start declares setup
   refresh only; managed OpenCode, Codex, and Cursor retain all default
   capabilities. The bridge rejects unsupported lifecycle and per-plugin timeout
   operations before runtime or settings effects, returns typed non-forceable
@@ -166,4 +167,7 @@
   OpenCode (398), and bridge app (2160) suites pass; fatal analysis is clean in
   those packages, Codex, Cursor, module_core, mobile, desktop, and
   module_desktop_core. Architecture review approved the Layer-0 independence,
-  bridge mapping/enforcement, and conservative compatibility behavior.
+  bridge mapping/enforcement, and required capability contract. PR review also
+  required idle suspension to check lifecycle plus timeout capabilities before
+  scheduling and stopping, and corrected new private helpers to required named
+  parameters.

--- a/.plan/active/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/active/setup-aware-harness-settings/TRACKER.md
@@ -2,9 +2,9 @@
 
 ## Current State
 
-- **Implementation base:** `origin/main` at `1b0f9874` after Step 5/7 merged
-- **Series state:** Step 6/8 PR #593 open; management actions implemented and verified
-- **Next action:** monitor and settle PR #593
+- **Implementation base:** `origin/main` at `075951cb` after Step 6/8 merged
+- **Series state:** Step 7/8 management capabilities implemented and verified
+- **Next action:** deliver and monitor the Step 7/8 PR
 
 ## Delivery
 
@@ -15,8 +15,8 @@
 | [x] | Step 3/7 — synchronization service | `setup-aware-harness-settings-service` | PR #589 merged as `6fe69d5a`; 1,095 changed lines (estimate 550-700, race-matrix test overage) |
 | [x] | Step 4/7 — harness logos | `setup-aware-harness-settings-branding` | PR #590 merged as `99670e08`; simplified to use existing plugin IDs |
 | [x] | Step 5/7 — Harnesses overview and state contract | `setup-aware-harness-settings-overview` | PR #592 merged as `1b0f9874`; combined simulator E2E passed |
-| [ ] | Step 6/8 — management actions | `setup-aware-harness-settings-state` | PR #593 open; estimate 650-800 changed lines |
-| [ ] | Step 7/8 — management capabilities | `setup-aware-harness-settings-capabilities` | planned; estimate 650-850 changed lines |
+| [x] | Step 6/8 — management actions | `setup-aware-harness-settings-state` | PR #593 merged as `075951cb`; estimate 650-800 changed lines |
+| [ ] | Step 7/8 — management capabilities | `setup-aware-harness-settings-capabilities` | ready for PR; estimate 650-850 changed lines |
 | [ ] | Step 8/8 — management controls | `setup-aware-harness-settings-controls` | planned; estimate 800-1,000 changed lines |
 
 ## Source Material
@@ -154,3 +154,16 @@
   effective timeout value. Because that cross-layer contract and enforcement is
   not tiny, the user approved expanding the series to eight PRs; Step 8/8 now
   owns the controls UI. Historical merged PR title suffixes remain `/7`.
+- Step 7/8 (2026-07-27): added independent backend-neutral capability enums to
+  the plugin interface and shared wire contract, with `bridge/app` owning the
+  mapping. Omitted legacy capability data fails closed to an empty set and
+  future values decode to `unknown`. OpenCode no-auto-start declares setup
+  refresh only; managed OpenCode, Codex, and Cursor retain all default
+  capabilities. The bridge rejects unsupported lifecycle and per-plugin timeout
+  operations before runtime or settings effects, returns typed non-forceable
+  conflicts, and apply-all updates the global default while clearing overrides
+  only for timeout-capable plugins. Full shared (340), plugin interface (147),
+  OpenCode (398), and bridge app (2160) suites pass; fatal analysis is clean in
+  those packages, Codex, Cursor, module_core, mobile, desktop, and
+  module_desktop_core. Architecture review approved the Layer-0 independence,
+  bridge mapping/enforcement, and conservative compatibility behavior.

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -649,19 +649,27 @@ class BridgeRuntimeRunner {
             ],
           );
       pluginLifecycleService = activePluginLifecycleService;
-      final disabledPluginIds = await activePluginLifecycleService.reconcileUncontrollableDisabledPlugins(
+      final uncontrollableDisabledPluginIds = activePluginLifecycleService.uncontrollableDisabledPluginIds(
         disabledPluginIds: bridgeSettings.plugins.disabledPluginIds,
       );
+      if (uncontrollableDisabledPluginIds.isNotEmpty) {
+        final pluginIds = uncontrollableDisabledPluginIds.toList()..sort();
+        Console.error(
+          "Cannot start because plugins without lifecycle control are disabled: ${pluginIds.join(', ')}. "
+          "Enable each plugin with `sesori-bridge config plugins enable <plugin-id>`.",
+        );
+        return 1;
+      }
       final eligiblePluginIds = {
         for (final descriptor in knownPlugins)
-          if (!disabledPluginIds.contains(descriptor.id)) descriptor.id,
+          if (!bridgeSettings.plugins.isDisabled(pluginId: descriptor.id)) descriptor.id,
       };
       final setupById = await lifecycleRepository.inspect(
         pluginIds: eligiblePluginIds,
         markUnselectedNotInspected: true,
       );
       final startupPolicy = activePluginLifecycleService.initialize(
-        disabledPluginIds: disabledPluginIds,
+        disabledPluginIds: bridgeSettings.plugins.disabledPluginIds,
         setupById: setupById,
       );
       for (final importPluginId in options.importPluginIds) {

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -644,6 +644,7 @@ class BridgeRuntimeRunner {
                   id: descriptor.id,
                   displayName: descriptor.displayName,
                   residencyPolicy: descriptor.residencyPolicy(config: pluginConfigs[descriptor.id]!),
+                  managementCapabilities: descriptor.managementCapabilities(config: pluginConfigs[descriptor.id]!),
                 ),
             ],
           );

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -649,16 +649,19 @@ class BridgeRuntimeRunner {
             ],
           );
       pluginLifecycleService = activePluginLifecycleService;
+      final disabledPluginIds = await activePluginLifecycleService.reconcileUncontrollableDisabledPlugins(
+        disabledPluginIds: bridgeSettings.plugins.disabledPluginIds,
+      );
       final eligiblePluginIds = {
         for (final descriptor in knownPlugins)
-          if (!bridgeSettings.plugins.isDisabled(pluginId: descriptor.id)) descriptor.id,
+          if (!disabledPluginIds.contains(descriptor.id)) descriptor.id,
       };
       final setupById = await lifecycleRepository.inspect(
         pluginIds: eligiblePluginIds,
         markUnselectedNotInspected: true,
       );
       final startupPolicy = activePluginLifecycleService.initialize(
-        disabledPluginIds: bridgeSettings.plugins.disabledPluginIds,
+        disabledPluginIds: disabledPluginIds,
         setupById: setupById,
       );
       for (final importPluginId in options.importPluginIds) {

--- a/bridge/app/lib/src/routing/patch_plugin_idle_timeout_handler.dart
+++ b/bridge/app/lib/src/routing/patch_plugin_idle_timeout_handler.dart
@@ -1,3 +1,5 @@
+import "dart:convert";
+
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../bridge/routing/request_handler.dart";
@@ -27,6 +29,13 @@ class PatchPluginIdleTimeoutHandler
       return await _lifecycleService.updateIdleTimeout(request: body);
     } on PluginManagementPluginNotFoundException {
       throw buildErrorResponse(request, 404, "plugin not found");
+    } on PluginManagementConflictException catch (error) {
+      throw RelayResponse(
+        id: request.id,
+        status: 409,
+        headers: const {"content-type": "application/json"},
+        body: jsonEncode(error.conflict.toJson()),
+      );
     } on PluginManagementMutationOutcomeUncertainException {
       throw buildErrorResponse(request, 503, "plugin mutation outcome is uncertain");
     }

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -312,7 +312,7 @@ class PluginLifecycleService {
       final plugins = switch (request) {
         PluginIdleTimeoutApplyAllRequest(:final idleTimeoutMins) => current.plugins.withDefaultIdleTimeout(
           idleTimeoutMins: idleTimeoutMins,
-          clearOverridePluginIds: _pluginIdsSupporting(PluginControlCapability.idleTimeout),
+          clearOverridePluginIds: _pluginIdsSupporting(capability: PluginControlCapability.idleTimeout),
         ),
         PluginIdleTimeoutSetOverrideRequest(:final pluginId, :final idleTimeoutMins) =>
           current.plugins.withPluginIdleTimeout(pluginId: pluginId, idleTimeoutMins: idleTimeoutMins),
@@ -722,19 +722,20 @@ class PluginLifecycleService {
       idleTimeoutMins: _effectiveIdleTimeoutMins(plugin.id),
       hasIdleTimeoutOverride: settings.plugins.settingsByPluginId[plugin.id]?.idleTimeoutMins != null,
       managementCapabilities: {
-        for (final capability in plugin.managementCapabilities) _mapManagementCapability(capability),
+        for (final capability in plugin.managementCapabilities) _mapManagementCapability(capability: capability),
       },
       actionHint: setup.actionHint ?? _managementActionHint(snapshot.state),
     );
   }
 
-  PluginManagementCapability _mapManagementCapability(PluginControlCapability capability) => switch (capability) {
-    PluginControlCapability.lifecycle => PluginManagementCapability.lifecycle,
-    PluginControlCapability.setupRefresh => PluginManagementCapability.setupRefresh,
-    PluginControlCapability.idleTimeout => PluginManagementCapability.idleTimeout,
-  };
+  PluginManagementCapability _mapManagementCapability({required PluginControlCapability capability}) =>
+      switch (capability) {
+        PluginControlCapability.lifecycle => PluginManagementCapability.lifecycle,
+        PluginControlCapability.setupRefresh => PluginManagementCapability.setupRefresh,
+        PluginControlCapability.idleTimeout => PluginManagementCapability.idleTimeout,
+      };
 
-  Set<String> _pluginIdsSupporting(PluginControlCapability capability) {
+  Set<String> _pluginIdsSupporting({required PluginControlCapability capability}) {
     final capabilitiesById = _managementCapabilitiesById;
     if (capabilitiesById == null) throw StateError("Plugins have not been registered.");
     return {
@@ -744,9 +745,7 @@ class PluginLifecycleService {
   }
 
   void _requireManagementCapability({required String pluginId, required PluginControlCapability capability}) {
-    final capabilitiesById = _managementCapabilitiesById;
-    if (capabilitiesById == null) throw StateError("Plugins have not been registered.");
-    if (capabilitiesById[pluginId]?.contains(capability) ?? false) return;
+    if (_supportsManagementCapability(pluginId: pluginId, capability: capability)) return;
     throw PluginManagementConflictException(
       PluginLifecycleConflict(
         pluginId: pluginId,
@@ -754,6 +753,23 @@ class PluginLifecycleService {
         current: _managementRowForPluginId(pluginId),
       ),
     );
+  }
+
+  bool _supportsManagementCapability({required String pluginId, required PluginControlCapability capability}) {
+    final capabilitiesById = _managementCapabilitiesById;
+    if (capabilitiesById == null) throw StateError("Plugins have not been registered.");
+    return capabilitiesById[pluginId]?.contains(capability) ?? false;
+  }
+
+  bool _supportsIdleSuspension({required String pluginId}) {
+    return _supportsManagementCapability(
+          pluginId: pluginId,
+          capability: PluginControlCapability.lifecycle,
+        ) &&
+        _supportsManagementCapability(
+          pluginId: pluginId,
+          capability: PluginControlCapability.idleTimeout,
+        );
   }
 
   PluginManagementMetadata _managementRowForPluginId(String pluginId) {
@@ -912,7 +928,7 @@ class PluginLifecycleService {
     _idleTimers.keys.where((pluginId) => !currentIds.contains(pluginId)).toList().forEach(_cancelIdleTimer);
     for (final snapshot in snapshots) {
       final timeoutMins = _effectiveIdleTimeoutMins(snapshot.pluginId);
-      if (timeoutMins <= 0 || !_isIdleCandidate(snapshot)) {
+      if (!_supportsIdleSuspension(pluginId: snapshot.pluginId) || timeoutMins <= 0 || !_isIdleCandidate(snapshot)) {
         _cancelIdleTimer(snapshot.pluginId);
         continue;
       }
@@ -959,6 +975,7 @@ class PluginLifecycleService {
   }) async {
     if (_disposing || !identical(_idleTimers[pluginId]?.timer, timer)) return;
     _idleTimers.remove(pluginId);
+    if (!_supportsIdleSuspension(pluginId: pluginId)) return;
     final snapshot = _lifecycleRepository.snapshot.where((entry) => entry.pluginId == pluginId).firstOrNull;
     final timeoutMins = _effectiveIdleTimeoutMins(pluginId);
     if (snapshot == null || timeoutMins <= 0 || !_isIdleCandidate(snapshot)) return;

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -103,26 +103,13 @@ class PluginLifecycleService {
     });
   }
 
-  Future<Set<String>> reconcileUncontrollableDisabledPlugins({required Set<String> disabledPluginIds}) async {
+  Set<String> uncontrollableDisabledPluginIds({required Set<String> disabledPluginIds}) {
     if (_eligiblePluginIds != null) throw StateError("Plugin lifecycle is already initialized.");
-    final uncontrollableDisabledPluginIds = disabledPluginIds.intersection(
-      _pluginIdsWithout(capability: PluginControlCapability.lifecycle),
+    return Set<String>.unmodifiable(
+      disabledPluginIds.intersection(
+        _pluginIdsWithout(capability: PluginControlCapability.lifecycle),
+      ),
     );
-    if (uncontrollableDisabledPluginIds.isEmpty) {
-      return Set<String>.unmodifiable(disabledPluginIds);
-    }
-
-    final current = await _bridgeSettingsRepository.loadSettings();
-    var plugins = current.plugins;
-    for (final pluginId in uncontrollableDisabledPluginIds) {
-      plugins = plugins.withPluginDisabled(pluginId: pluginId, disabled: false);
-    }
-    await _bridgeSettingsRepository.saveSettings(settings: current.copyWith(plugins: plugins));
-    Log.w(
-      "Re-enabled plugins that cannot be lifecycle-managed: "
-      "${(uncontrollableDisabledPluginIds.toList()..sort()).join(', ')}",
-    );
-    return Set<String>.unmodifiable(disabledPluginIds.difference(uncontrollableDisabledPluginIds));
   }
 
   PluginStartupPolicy initialize({

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -103,6 +103,28 @@ class PluginLifecycleService {
     });
   }
 
+  Future<Set<String>> reconcileUncontrollableDisabledPlugins({required Set<String> disabledPluginIds}) async {
+    if (_eligiblePluginIds != null) throw StateError("Plugin lifecycle is already initialized.");
+    final uncontrollableDisabledPluginIds = disabledPluginIds.intersection(
+      _pluginIdsWithout(capability: PluginControlCapability.lifecycle),
+    );
+    if (uncontrollableDisabledPluginIds.isEmpty) {
+      return Set<String>.unmodifiable(disabledPluginIds);
+    }
+
+    final current = await _bridgeSettingsRepository.loadSettings();
+    var plugins = current.plugins;
+    for (final pluginId in uncontrollableDisabledPluginIds) {
+      plugins = plugins.withPluginDisabled(pluginId: pluginId, disabled: false);
+    }
+    await _bridgeSettingsRepository.saveSettings(settings: current.copyWith(plugins: plugins));
+    Log.w(
+      "Re-enabled plugins that cannot be lifecycle-managed: "
+      "${(uncontrollableDisabledPluginIds.toList()..sort()).join(', ')}",
+    );
+    return Set<String>.unmodifiable(disabledPluginIds.difference(uncontrollableDisabledPluginIds));
+  }
+
   PluginStartupPolicy initialize({
     required Set<String> disabledPluginIds,
     required Map<String, PluginSetupStatus> setupById,
@@ -722,7 +744,8 @@ class PluginLifecycleService {
       idleTimeoutMins: _effectiveIdleTimeoutMins(plugin.id),
       hasIdleTimeoutOverride: settings.plugins.settingsByPluginId[plugin.id]?.idleTimeoutMins != null,
       managementCapabilities: {
-        for (final capability in plugin.managementCapabilities) _mapManagementCapability(capability: capability),
+        for (final capability in _managementCapabilitiesForPluginId(pluginId: plugin.id))
+          _mapManagementCapability(capability: capability),
       },
       actionHint: setup.actionHint ?? _managementActionHint(snapshot.state),
     );
@@ -744,6 +767,21 @@ class PluginLifecycleService {
     };
   }
 
+  Set<String> _pluginIdsWithout({required PluginControlCapability capability}) {
+    final capabilitiesById = _managementCapabilitiesById;
+    if (capabilitiesById == null) throw StateError("Plugins have not been registered.");
+    return {
+      for (final MapEntry(key: pluginId, value: capabilities) in capabilitiesById.entries)
+        if (!capabilities.contains(capability)) pluginId,
+    };
+  }
+
+  Set<PluginControlCapability> _managementCapabilitiesForPluginId({required String pluginId}) {
+    final capabilitiesById = _managementCapabilitiesById;
+    if (capabilitiesById == null) throw StateError("Plugins have not been registered.");
+    return capabilitiesById[pluginId] ?? (throw StateError('Plugin "$pluginId" is not registered.'));
+  }
+
   void _requireManagementCapability({required String pluginId, required PluginControlCapability capability}) {
     if (_supportsManagementCapability(pluginId: pluginId, capability: capability)) return;
     throw PluginManagementConflictException(
@@ -756,9 +794,7 @@ class PluginLifecycleService {
   }
 
   bool _supportsManagementCapability({required String pluginId, required PluginControlCapability capability}) {
-    final capabilitiesById = _managementCapabilitiesById;
-    if (capabilitiesById == null) throw StateError("Plugins have not been registered.");
-    return capabilitiesById[pluginId]?.contains(capability) ?? false;
+    return _managementCapabilitiesForPluginId(pluginId: pluginId).contains(capability);
   }
 
   bool _supportsIdleSuspension({required String pluginId}) {

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -23,7 +23,12 @@ typedef PluginCompositionView = ({
   Map<String, PluginProjectOwnership> projectOwnershipById,
 });
 
-typedef RegisteredPluginMetadata = ({String id, String displayName, PluginResidencyPolicy residencyPolicy});
+typedef RegisteredPluginMetadata = ({
+  String id,
+  String displayName,
+  PluginResidencyPolicy residencyPolicy,
+  Set<PluginControlCapability> managementCapabilities,
+});
 
 typedef PluginStartupPolicy = ({
   List<String> eligiblePluginIds,
@@ -59,6 +64,7 @@ class PluginLifecycleService {
   List<RegisteredPluginMetadata>? _registeredPlugins;
   Set<String>? _knownPluginIds;
   Map<String, PluginResidencyPolicy>? _residencyPolicyById;
+  Map<String, Set<PluginControlCapability>>? _managementCapabilitiesById;
   List<String>? _eligiblePluginIds;
   Set<String> _startAllowedPluginIds = {};
   Map<String, PluginMetadata> _metadataById = <String, PluginMetadata>{};
@@ -91,6 +97,9 @@ class PluginLifecycleService {
     _knownPluginIds = Set<String>.unmodifiable(ids);
     _residencyPolicyById = Map<String, PluginResidencyPolicy>.unmodifiable({
       for (final plugin in plugins) plugin.id: plugin.residencyPolicy,
+    });
+    _managementCapabilitiesById = Map<String, Set<PluginControlCapability>>.unmodifiable({
+      for (final plugin in plugins) plugin.id: Set<PluginControlCapability>.unmodifiable(plugin.managementCapabilities),
     });
   }
 
@@ -242,6 +251,15 @@ class PluginLifecycleService {
       throw StateError("Plugin management snapshot is not ready.");
     }
     _requireBridgeId();
+    _requireManagementCapability(
+      pluginId: pluginId,
+      capability: switch (request) {
+        PluginLifecycleEnableRequest() ||
+        PluginLifecycleDisableRequest() ||
+        PluginLifecycleRestartRequest() => PluginControlCapability.lifecycle,
+        PluginLifecycleRefreshRequest() => PluginControlCapability.setupRefresh,
+      },
+    );
     final active = _activePluginCommands[pluginId];
     if (active != null) {
       if (active.request == request) return active.completer.future;
@@ -278,13 +296,23 @@ class PluginLifecycleService {
         }
     }
     _requireBridgeId();
+    switch (request) {
+      case PluginIdleTimeoutApplyAllRequest():
+        break;
+      case PluginIdleTimeoutSetOverrideRequest(:final pluginId) ||
+          PluginIdleTimeoutClearOverrideRequest(:final pluginId):
+        _requireManagementCapability(
+          pluginId: pluginId,
+          capability: PluginControlCapability.idleTimeout,
+        );
+    }
     return _withSettingsMutationTail(() async {
       _requireBridgeId();
       final current = await _bridgeSettingsRepository.loadSettings();
       final plugins = switch (request) {
         PluginIdleTimeoutApplyAllRequest(:final idleTimeoutMins) => current.plugins.withDefaultIdleTimeout(
           idleTimeoutMins: idleTimeoutMins,
-          clearOverridePluginIds: knownPluginIds,
+          clearOverridePluginIds: _pluginIdsSupporting(PluginControlCapability.idleTimeout),
         ),
         PluginIdleTimeoutSetOverrideRequest(:final pluginId, :final idleTimeoutMins) =>
           current.plugins.withPluginIdleTimeout(pluginId: pluginId, idleTimeoutMins: idleTimeoutMins),
@@ -693,7 +721,38 @@ class PluginLifecycleService {
       workState: _mapWorkState(snapshot.workState),
       idleTimeoutMins: _effectiveIdleTimeoutMins(plugin.id),
       hasIdleTimeoutOverride: settings.plugins.settingsByPluginId[plugin.id]?.idleTimeoutMins != null,
+      managementCapabilities: {
+        for (final capability in plugin.managementCapabilities) _mapManagementCapability(capability),
+      },
       actionHint: setup.actionHint ?? _managementActionHint(snapshot.state),
+    );
+  }
+
+  PluginManagementCapability _mapManagementCapability(PluginControlCapability capability) => switch (capability) {
+    PluginControlCapability.lifecycle => PluginManagementCapability.lifecycle,
+    PluginControlCapability.setupRefresh => PluginManagementCapability.setupRefresh,
+    PluginControlCapability.idleTimeout => PluginManagementCapability.idleTimeout,
+  };
+
+  Set<String> _pluginIdsSupporting(PluginControlCapability capability) {
+    final capabilitiesById = _managementCapabilitiesById;
+    if (capabilitiesById == null) throw StateError("Plugins have not been registered.");
+    return {
+      for (final MapEntry(key: pluginId, value: capabilities) in capabilitiesById.entries)
+        if (capabilities.contains(capability)) pluginId,
+    };
+  }
+
+  void _requireManagementCapability({required String pluginId, required PluginControlCapability capability}) {
+    final capabilitiesById = _managementCapabilitiesById;
+    if (capabilitiesById == null) throw StateError("Plugins have not been registered.");
+    if (capabilitiesById[pluginId]?.contains(capability) ?? false) return;
+    throw PluginManagementConflictException(
+      PluginLifecycleConflict(
+        pluginId: pluginId,
+        reasons: const [PluginLifecycleConflictReason.unsupported],
+        current: _managementRowForPluginId(pluginId),
+      ),
     );
   }
 

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -36,7 +36,12 @@ void main() {
           )
           ..registerPlugins(
             plugins: const [
-              (id: "opencode", displayName: "OpenCode", residencyPolicy: PluginResidencyPolicy.transient),
+              (
+                id: "opencode",
+                displayName: "OpenCode",
+                residencyPolicy: PluginResidencyPolicy.transient,
+                managementCapabilities: defaultManagementCapabilities,
+              ),
             ],
           )
           ..initialize(

--- a/bridge/app/test/bridge/routing/get_plugin_management_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_plugin_management_handler_test.dart
@@ -49,6 +49,11 @@ const _response = PluginManagementResponse(
       workState: PluginManagementWorkState.unknown,
       idleTimeoutMins: 10,
       hasIdleTimeoutOverride: false,
+      managementCapabilities: {
+        PluginManagementCapability.lifecycle,
+        PluginManagementCapability.setupRefresh,
+        PluginManagementCapability.idleTimeout,
+      },
       actionHint: null,
     ),
   ],

--- a/bridge/app/test/bridge/routing/get_plugin_setup_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_plugin_setup_handler_test.dart
@@ -31,8 +31,18 @@ void main() {
             )
             ..registerPlugins(
               plugins: const [
-                (id: "ready", displayName: "Ready", residencyPolicy: PluginResidencyPolicy.transient),
-                (id: "blocked", displayName: "Blocked", residencyPolicy: PluginResidencyPolicy.transient),
+                (
+                  id: "ready",
+                  displayName: "Ready",
+                  residencyPolicy: PluginResidencyPolicy.transient,
+                  managementCapabilities: defaultManagementCapabilities,
+                ),
+                (
+                  id: "blocked",
+                  displayName: "Blocked",
+                  residencyPolicy: PluginResidencyPolicy.transient,
+                  managementCapabilities: defaultManagementCapabilities,
+                ),
               ],
             )
             ..initialize(

--- a/bridge/app/test/bridge/routing/patch_plugin_idle_timeout_handler_test.dart
+++ b/bridge/app/test/bridge/routing/patch_plugin_idle_timeout_handler_test.dart
@@ -40,6 +40,31 @@ void main() {
     );
   });
 
+  test("PatchPluginIdleTimeoutHandler returns unsupported updates as a typed 409 conflict", () async {
+    final service = _FakePluginLifecycleService()
+      ..error = const PluginManagementConflictException(_unsupportedConflict);
+
+    final response = await buildHandler(service: service).handleInternal(
+      makeRequest(
+        "PATCH",
+        "/plugin/idle-timeout",
+        body: jsonEncode(
+          const PluginIdleTimeoutUpdateRequest.setOverride(pluginId: "one", idleTimeoutMins: 30).toJson(),
+        ),
+      ),
+      pathParams: const {},
+      queryParams: const {},
+      fragment: null,
+    );
+
+    expect(response.status, 409);
+    expect(response.headers, containsPair("content-type", "application/json"));
+    expect(
+      PluginLifecycleConflict.fromJson(jsonDecodeMap(response.body!)),
+      _unsupportedConflict,
+    );
+  });
+
   test("PatchPluginIdleTimeoutHandler maps invalid, unknown, uncertain, and failed writes", () async {
     final service = _FakePluginLifecycleService();
     final handler = buildHandler(service: service);
@@ -101,6 +126,27 @@ const _response = PluginManagementResponse(
   defaultPluginId: "one",
   defaultIdleTimeoutMins: 30,
   plugins: [],
+);
+
+const _unsupportedPlugin = PluginManagementMetadata(
+  setup: PluginSetupMetadata(
+    id: "one",
+    displayName: "One",
+    state: PluginSetupState.ready,
+    actionHint: null,
+  ),
+  runtimeState: PluginRuntimeState.dormant,
+  workState: PluginManagementWorkState.idle,
+  idleTimeoutMins: 10,
+  hasIdleTimeoutOverride: false,
+  managementCapabilities: {PluginManagementCapability.setupRefresh},
+  actionHint: null,
+);
+
+const _unsupportedConflict = PluginLifecycleConflict(
+  pluginId: "one",
+  reasons: [PluginLifecycleConflictReason.unsupported],
+  current: _unsupportedPlugin,
 );
 
 class _FakePluginLifecycleService implements PluginLifecycleService {

--- a/bridge/app/test/bridge/routing/post_plugin_lifecycle_command_handler_test.dart
+++ b/bridge/app/test/bridge/routing/post_plugin_lifecycle_command_handler_test.dart
@@ -94,6 +94,11 @@ const _plugin = PluginManagementMetadata(
   workState: PluginManagementWorkState.idle,
   idleTimeoutMins: 10,
   hasIdleTimeoutOverride: false,
+  managementCapabilities: {
+    PluginManagementCapability.lifecycle,
+    PluginManagementCapability.setupRefresh,
+    PluginManagementCapability.idleTimeout,
+  },
   actionHint: null,
 );
 

--- a/bridge/app/test/helpers/plugin_lifecycle_test_support.dart
+++ b/bridge/app/test/helpers/plugin_lifecycle_test_support.dart
@@ -11,6 +11,12 @@ import "test_helpers.dart";
 
 final Expando<PluginRuntime> _runtimes = Expando<PluginRuntime>();
 
+const defaultManagementCapabilities = <PluginControlCapability>{
+  PluginControlCapability.lifecycle,
+  PluginControlCapability.setupRefresh,
+  PluginControlCapability.idleTimeout,
+};
+
 Future<PluginLifecycleService> createSinglePluginLifecycleService({
   required BridgePluginApi plugin,
 }) {
@@ -32,7 +38,12 @@ Future<PluginLifecycleService> createPluginLifecycleService({
         ..registerPlugins(
           plugins: [
             for (final plugin in plugins)
-              (id: plugin.id, displayName: plugin.id, residencyPolicy: PluginResidencyPolicy.transient),
+              (
+                id: plugin.id,
+                displayName: plugin.id,
+                residencyPolicy: PluginResidencyPolicy.transient,
+                managementCapabilities: defaultManagementCapabilities,
+              ),
           ],
         )
         ..initialize(

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -745,6 +745,28 @@ void main() {
     expect(timerScheduler.timers, isEmpty);
   });
 
+  test("idle suspension requires lifecycle and idle-timeout capabilities", () async {
+    final repository = _IdleLifecycleRepository();
+    final settingsRepository = _MutableBridgeSettingsRepository(settings: const BridgeSettings());
+    final timerScheduler = _ControllablePluginIdleTimerScheduler();
+    final service = _singleIdleService(
+      lifecycleRepository: repository,
+      settingsRepository: settingsRepository,
+      timerScheduler: timerScheduler,
+      residencyPolicy: PluginResidencyPolicy.transient,
+      managementCapabilities: const {PluginControlCapability.setupRefresh},
+    );
+    addTearDown(() async {
+      await service.dispose();
+      await repository.dispose();
+    });
+
+    repository.publish(workState: PluginWorkState.idle, leaseCount: 0);
+
+    expect(timerScheduler.timers, isEmpty);
+    expect(repository.stopCalls, isZero);
+  });
+
   test("unsupported lifecycle commands fail before runtime or settings effects", () async {
     final repository = _CommandLifecycleRepository(
       inspectionResult: const PluginSetupReady(),

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -331,7 +331,7 @@ void main() {
     );
   });
 
-  test("re-enables disabled plugins that cannot be lifecycle-managed", () async {
+  test("reports disabled plugins that cannot be lifecycle-managed", () {
     final runtime = createRegisteredTestPluginRuntime(pluginIds: const ["external", "managed"]);
     addTearDown(runtime.dispose);
     final settingsRepository = _MutableBridgeSettingsRepository(
@@ -364,12 +364,15 @@ void main() {
         );
     addTearDown(service.dispose);
 
-    final disabledPluginIds = await service.reconcileUncontrollableDisabledPlugins(
+    final disabledPluginIds = service.uncontrollableDisabledPluginIds(
       disabledPluginIds: settingsRepository.currentSettings.plugins.disabledPluginIds,
     );
 
-    expect(disabledPluginIds, const {"managed", "future-plugin"});
-    expect(settingsRepository.currentSettings.plugins.disabledPluginIds, const {"managed", "future-plugin"});
+    expect(disabledPluginIds, const {"external"});
+    expect(
+      settingsRepository.currentSettings.plugins.disabledPluginIds,
+      const {"external", "managed", "future-plugin"},
+    );
   });
 
   test("management snapshot tokens publish only externally visible changes", () async {

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -301,6 +301,77 @@ void main() {
     );
   });
 
+  test("management snapshot uses the immutable capability registration snapshot", () {
+    final repository = _CommandLifecycleRepository(
+      inspectionResult: const PluginSetupReady(),
+      inspectionGate: null,
+      startFailureMessage: null,
+    );
+    final capabilities = <PluginControlCapability>{PluginControlCapability.setupRefresh};
+    final service = _commandService(
+      repository: repository,
+      settingsRepository: null,
+      managementCapabilities: capabilities,
+    );
+    capabilities
+      ..clear()
+      ..add(PluginControlCapability.lifecycle);
+    service.initialize(
+      disabledPluginIds: const {},
+      setupById: const {"one": PluginSetupReady()},
+    );
+    addTearDown(() async {
+      await service.dispose();
+      await repository.dispose();
+    });
+
+    expect(
+      service.managementSnapshot.plugins.single.managementCapabilities,
+      const {PluginManagementCapability.setupRefresh},
+    );
+  });
+
+  test("re-enables disabled plugins that cannot be lifecycle-managed", () async {
+    final runtime = createRegisteredTestPluginRuntime(pluginIds: const ["external", "managed"]);
+    addTearDown(runtime.dispose);
+    final settingsRepository = _MutableBridgeSettingsRepository(
+      settings: const BridgeSettings(
+        plugins: BridgePluginSettings(disabledPluginIds: {"external", "managed", "future-plugin"}),
+      ),
+    );
+    final service =
+        PluginLifecycleService(
+          lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
+          preferredDefaultPluginId: legacyMissingPluginId,
+          bridgeSettingsRepository: settingsRepository,
+          idleTimerScheduler: const PluginIdleTimerScheduler(),
+          bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
+        )..registerPlugins(
+          plugins: const [
+            (
+              id: "external",
+              displayName: "External",
+              residencyPolicy: PluginResidencyPolicy.resident,
+              managementCapabilities: {PluginControlCapability.setupRefresh},
+            ),
+            (
+              id: "managed",
+              displayName: "Managed",
+              residencyPolicy: PluginResidencyPolicy.transient,
+              managementCapabilities: defaultManagementCapabilities,
+            ),
+          ],
+        );
+    addTearDown(service.dispose);
+
+    final disabledPluginIds = await service.reconcileUncontrollableDisabledPlugins(
+      disabledPluginIds: settingsRepository.currentSettings.plugins.disabledPluginIds,
+    );
+
+    expect(disabledPluginIds, const {"managed", "future-plugin"});
+    expect(settingsRepository.currentSettings.plugins.disabledPluginIds, const {"managed", "future-plugin"});
+  });
+
   test("management snapshot tokens publish only externally visible changes", () async {
     final runtime = createRegisteredTestPluginRuntime(pluginIds: const ["alpha"]);
     final service =

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -21,9 +21,24 @@ void main() {
     final service = _service(
       runtime: runtime,
       plugins: const [
-        (id: "zeta", displayName: "Zeta", residencyPolicy: PluginResidencyPolicy.transient),
-        (id: "beta", displayName: "Beta", residencyPolicy: PluginResidencyPolicy.transient),
-        (id: "alpha", displayName: "Alpha", residencyPolicy: PluginResidencyPolicy.transient),
+        (
+          id: "zeta",
+          displayName: "Zeta",
+          residencyPolicy: PluginResidencyPolicy.transient,
+          managementCapabilities: defaultManagementCapabilities,
+        ),
+        (
+          id: "beta",
+          displayName: "Beta",
+          residencyPolicy: PluginResidencyPolicy.transient,
+          managementCapabilities: defaultManagementCapabilities,
+        ),
+        (
+          id: "alpha",
+          displayName: "Alpha",
+          residencyPolicy: PluginResidencyPolicy.transient,
+          managementCapabilities: defaultManagementCapabilities,
+        ),
       ],
     );
     addTearDown(service.dispose);
@@ -53,8 +68,18 @@ void main() {
     final service = _service(
       runtime: runtime,
       plugins: const [
-        (id: "alpha", displayName: "Alpha", residencyPolicy: PluginResidencyPolicy.transient),
-        (id: "opencode", displayName: "OpenCode", residencyPolicy: PluginResidencyPolicy.transient),
+        (
+          id: "alpha",
+          displayName: "Alpha",
+          residencyPolicy: PluginResidencyPolicy.transient,
+          managementCapabilities: defaultManagementCapabilities,
+        ),
+        (
+          id: "opencode",
+          displayName: "OpenCode",
+          residencyPolicy: PluginResidencyPolicy.transient,
+          managementCapabilities: defaultManagementCapabilities,
+        ),
       ],
     );
     addTearDown(service.dispose);
@@ -82,8 +107,18 @@ void main() {
     final service = _service(
       runtime: runtime,
       plugins: const [
-        (id: "opencode", displayName: "OpenCode", residencyPolicy: PluginResidencyPolicy.transient),
-        (id: "alpha", displayName: "Alpha", residencyPolicy: PluginResidencyPolicy.transient),
+        (
+          id: "opencode",
+          displayName: "OpenCode",
+          residencyPolicy: PluginResidencyPolicy.transient,
+          managementCapabilities: defaultManagementCapabilities,
+        ),
+        (
+          id: "alpha",
+          displayName: "Alpha",
+          residencyPolicy: PluginResidencyPolicy.transient,
+          managementCapabilities: defaultManagementCapabilities,
+        ),
       ],
     );
     addTearDown(service.dispose);
@@ -105,8 +140,18 @@ void main() {
     final service = _service(
       runtime: runtime,
       plugins: const [
-        (id: "opencode", displayName: "OpenCode", residencyPolicy: PluginResidencyPolicy.transient),
-        (id: "cursor", displayName: "Cursor", residencyPolicy: PluginResidencyPolicy.transient),
+        (
+          id: "opencode",
+          displayName: "OpenCode",
+          residencyPolicy: PluginResidencyPolicy.transient,
+          managementCapabilities: defaultManagementCapabilities,
+        ),
+        (
+          id: "cursor",
+          displayName: "Cursor",
+          residencyPolicy: PluginResidencyPolicy.transient,
+          managementCapabilities: defaultManagementCapabilities,
+        ),
       ],
     );
     addTearDown(service.dispose);
@@ -161,9 +206,24 @@ void main() {
           )
           ..registerPlugins(
             plugins: const [
-              (id: "opencode", displayName: "OpenCode", residencyPolicy: PluginResidencyPolicy.resident),
-              (id: "alpha", displayName: "Alpha", residencyPolicy: PluginResidencyPolicy.transient),
-              (id: "beta", displayName: "Beta", residencyPolicy: PluginResidencyPolicy.transient),
+              (
+                id: "opencode",
+                displayName: "OpenCode",
+                residencyPolicy: PluginResidencyPolicy.resident,
+                managementCapabilities: defaultManagementCapabilities,
+              ),
+              (
+                id: "alpha",
+                displayName: "Alpha",
+                residencyPolicy: PluginResidencyPolicy.transient,
+                managementCapabilities: defaultManagementCapabilities,
+              ),
+              (
+                id: "beta",
+                displayName: "Beta",
+                residencyPolicy: PluginResidencyPolicy.transient,
+                managementCapabilities: defaultManagementCapabilities,
+              ),
             ],
           )
           ..initialize(
@@ -215,13 +275,44 @@ void main() {
     expect(runtime.activePluginIds, isEmpty);
   });
 
+  test("management snapshot publishes each plugin's declared capabilities", () {
+    final repository = _CommandLifecycleRepository(
+      inspectionResult: const PluginSetupReady(),
+      inspectionGate: null,
+      startFailureMessage: null,
+    );
+    final service =
+        _commandService(
+          repository: repository,
+          settingsRepository: null,
+          managementCapabilities: const {PluginControlCapability.setupRefresh},
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"one": PluginSetupReady()},
+        );
+    addTearDown(() async {
+      await service.dispose();
+      await repository.dispose();
+    });
+
+    expect(
+      service.managementSnapshot.plugins.single.managementCapabilities,
+      const {PluginManagementCapability.setupRefresh},
+    );
+  });
+
   test("management snapshot tokens publish only externally visible changes", () async {
     final runtime = createRegisteredTestPluginRuntime(pluginIds: const ["alpha"]);
     final service =
         _service(
           runtime: runtime,
           plugins: const [
-            (id: "alpha", displayName: "Alpha", residencyPolicy: PluginResidencyPolicy.transient),
+            (
+              id: "alpha",
+              displayName: "Alpha",
+              residencyPolicy: PluginResidencyPolicy.transient,
+              managementCapabilities: defaultManagementCapabilities,
+            ),
           ],
         )..initialize(
           disabledPluginIds: const {},
@@ -277,8 +368,18 @@ void main() {
         _service(
           runtime: runtime,
           plugins: const [
-            (id: "alpha", displayName: "Alpha", residencyPolicy: PluginResidencyPolicy.transient),
-            (id: "beta", displayName: "Beta", residencyPolicy: PluginResidencyPolicy.transient),
+            (
+              id: "alpha",
+              displayName: "Alpha",
+              residencyPolicy: PluginResidencyPolicy.transient,
+              managementCapabilities: defaultManagementCapabilities,
+            ),
+            (
+              id: "beta",
+              displayName: "Beta",
+              residencyPolicy: PluginResidencyPolicy.transient,
+              managementCapabilities: defaultManagementCapabilities,
+            ),
           ],
         )..initialize(
           disabledPluginIds: const {},
@@ -316,6 +417,119 @@ void main() {
     expect(snapshotTokens, hasLength(3));
     expect(service.managementSnapshot.snapshotToken, snapshotTokens.last);
     expect({initialToken, ...snapshotTokens}, hasLength(4));
+  });
+
+  test("unsupported per-plugin timeout updates fail before settings or runtime effects", () async {
+    final repository = _IdleLifecycleRepository();
+    final settingsRepository = _MutableBridgeSettingsRepository(
+      settings: const BridgeSettings(
+        plugins: BridgePluginSettings(
+          settingsByPluginId: {
+            "one": PluginLifecycleSettings(idleTimeoutMins: 15),
+          },
+        ),
+      ),
+    );
+    final timerScheduler = _ControllablePluginIdleTimerScheduler();
+    final service = _singleIdleService(
+      lifecycleRepository: repository,
+      settingsRepository: settingsRepository,
+      timerScheduler: timerScheduler,
+      residencyPolicy: PluginResidencyPolicy.transient,
+      managementCapabilities: const {PluginControlCapability.setupRefresh},
+    );
+    addTearDown(() async {
+      await service.dispose();
+      await repository.dispose();
+    });
+    final unsupportedConflict = isA<PluginManagementConflictException>()
+        .having((error) => error.conflict.pluginId, "pluginId", "one")
+        .having(
+          (error) => error.conflict.reasons,
+          "reasons",
+          const [PluginLifecycleConflictReason.unsupported],
+        );
+
+    for (final request in const <PluginIdleTimeoutUpdateRequest>[
+      PluginIdleTimeoutUpdateRequest.setOverride(pluginId: "one", idleTimeoutMins: 45),
+      PluginIdleTimeoutUpdateRequest.clearOverride(pluginId: "one"),
+    ]) {
+      await expectLater(
+        Future<PluginManagementResponse>.sync(
+          () => service.updateIdleTimeout(request: request),
+        ),
+        throwsA(unsupportedConflict),
+      );
+    }
+
+    expect(settingsRepository.loadCalls, isZero);
+    expect(settingsRepository.settings.plugins.settingsByPluginId["one"]?.idleTimeoutMins, 15);
+    expect(timerScheduler.timers, isEmpty);
+    expect(repository.stopCalls, isZero);
+  });
+
+  test("apply-all updates the default and clears only timeout-capable overrides", () async {
+    final runtime = createRegisteredTestPluginRuntime(pluginIds: const ["managed", "external"]);
+    final settingsRepository = _MutableBridgeSettingsRepository(
+      settings: const BridgeSettings(
+        plugins: BridgePluginSettings(
+          defaults: PluginLifecycleSettings(idleTimeoutMins: 10),
+          settingsByPluginId: {
+            "managed": PluginLifecycleSettings(idleTimeoutMins: 20),
+            "external": PluginLifecycleSettings(idleTimeoutMins: 25),
+          },
+        ),
+      ),
+    );
+    final service =
+        PluginLifecycleService(
+            lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
+            preferredDefaultPluginId: legacyMissingPluginId,
+            bridgeSettingsRepository: settingsRepository,
+            idleTimerScheduler: const PluginIdleTimerScheduler(),
+            bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
+          )
+          ..registerPlugins(
+            plugins: const [
+              (
+                id: "managed",
+                displayName: "Managed",
+                residencyPolicy: PluginResidencyPolicy.transient,
+                managementCapabilities: {PluginControlCapability.idleTimeout},
+              ),
+              (
+                id: "external",
+                displayName: "External",
+                residencyPolicy: PluginResidencyPolicy.transient,
+                managementCapabilities: {PluginControlCapability.setupRefresh},
+              ),
+            ],
+          )
+          ..initialize(
+            disabledPluginIds: const {},
+            setupById: const {
+              "managed": PluginSetupReady(),
+              "external": PluginSetupReady(),
+            },
+          );
+    addTearDown(() async {
+      await service.dispose();
+      await runtime.dispose();
+    });
+
+    final response = await service.updateIdleTimeout(
+      request: const PluginIdleTimeoutUpdateRequest.applyAll(idleTimeoutMins: 30),
+    );
+    final responseById = {for (final plugin in response.plugins) plugin.setup.id: plugin};
+
+    expect(response.defaultIdleTimeoutMins, 30);
+    expect(settingsRepository.settings.plugins.defaults.idleTimeoutMins, 30);
+    expect(settingsRepository.settings.plugins.settingsByPluginId, isNot(contains("managed")));
+    expect(settingsRepository.settings.plugins.settingsByPluginId["external"]?.idleTimeoutMins, 25);
+    expect(responseById["managed"]?.idleTimeoutMins, 30);
+    expect(responseById["managed"]?.hasIdleTimeoutOverride, isFalse);
+    expect(responseById["external"]?.idleTimeoutMins, 25);
+    expect(responseById["external"]?.hasIdleTimeoutOverride, isTrue);
   });
 
   test("idle timeout writes serialize and preserve unknown plugin settings", () async {
@@ -397,7 +611,12 @@ void main() {
           )
           ..registerPlugins(
             plugins: const [
-              (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
+              (
+                id: "one",
+                displayName: "One",
+                residencyPolicy: PluginResidencyPolicy.transient,
+                managementCapabilities: defaultManagementCapabilities,
+              ),
             ],
           )
           ..initialize(
@@ -526,6 +745,88 @@ void main() {
     expect(timerScheduler.timers, isEmpty);
   });
 
+  test("unsupported lifecycle commands fail before runtime or settings effects", () async {
+    final repository = _CommandLifecycleRepository(
+      inspectionResult: const PluginSetupReady(),
+      inspectionGate: null,
+      startFailureMessage: null,
+    );
+    final settingsRepository = _MutableBridgeSettingsRepository(settings: const BridgeSettings());
+    final service =
+        _commandService(
+          repository: repository,
+          settingsRepository: settingsRepository,
+          managementCapabilities: const {PluginControlCapability.setupRefresh},
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"one": PluginSetupReady()},
+        );
+    addTearDown(() async {
+      await service.dispose();
+      await repository.dispose();
+    });
+    final unsupportedConflict = isA<PluginManagementConflictException>().having(
+      (error) => error.conflict.reasons,
+      "reasons",
+      const [PluginLifecycleConflictReason.unsupported],
+    );
+
+    for (final request in const <PluginLifecycleCommandRequest>[
+      PluginLifecycleCommandRequest.enable(),
+      PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe),
+      PluginLifecycleCommandRequest.restart(mode: PluginStopMode.force),
+    ]) {
+      await expectLater(
+        Future<PluginManagementResponse>.sync(
+          () => service.command(pluginId: "one", request: request),
+        ),
+        throwsA(unsupportedConflict),
+      );
+    }
+
+    expect(repository.inspectCalls, isZero);
+    expect(repository.startCalls, isZero);
+    expect(repository.restartCalls, isZero);
+    expect(repository.prepareDisableCalls, isZero);
+    expect(repository.snapshot.single.state, PluginRuntimeState.dormant);
+    expect(settingsRepository.loadCalls, isZero);
+    expect(settingsRepository.settings, const BridgeSettings());
+  });
+
+  test("setup refresh remains allowed without lifecycle capability", () async {
+    final repository = _CommandLifecycleRepository(
+      inspectionResult: const PluginSetupReady(),
+      inspectionGate: null,
+      startFailureMessage: null,
+    );
+    final settingsRepository = _MutableBridgeSettingsRepository(settings: const BridgeSettings());
+    final service =
+        _commandService(
+          repository: repository,
+          settingsRepository: settingsRepository,
+          managementCapabilities: const {PluginControlCapability.setupRefresh},
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"one": PluginSetupRuntimeMissing(actionHint: "Install")},
+        );
+    addTearDown(() async {
+      await service.dispose();
+      await repository.dispose();
+    });
+
+    final response = await service.command(
+      pluginId: "one",
+      request: const PluginLifecycleCommandRequest.refresh(),
+    );
+
+    expect(repository.inspectCalls, 1);
+    expect(repository.startCalls, isZero);
+    expect(repository.restartCalls, isZero);
+    expect(repository.prepareDisableCalls, isZero);
+    expect(settingsRepository.loadCalls, isZero);
+    expect(response.plugins.single.setup.state, PluginSetupState.ready);
+  });
+
   test("disable commits durable eligibility and equal commands join", () async {
     final runtime = createRegisteredTestPluginRuntime(pluginIds: const ["one"]);
     final settingsRepository = _MutableBridgeSettingsRepository(settings: const BridgeSettings())
@@ -540,7 +841,12 @@ void main() {
           )
           ..registerPlugins(
             plugins: const [
-              (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
+              (
+                id: "one",
+                displayName: "One",
+                residencyPolicy: PluginResidencyPolicy.transient,
+                managementCapabilities: defaultManagementCapabilities,
+              ),
             ],
           )
           ..initialize(
@@ -588,7 +894,12 @@ void main() {
           )
           ..registerPlugins(
             plugins: const [
-              (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
+              (
+                id: "one",
+                displayName: "One",
+                residencyPolicy: PluginResidencyPolicy.transient,
+                managementCapabilities: defaultManagementCapabilities,
+              ),
             ],
           )
           ..initialize(
@@ -638,7 +949,12 @@ void main() {
           )
           ..registerPlugins(
             plugins: const [
-              (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
+              (
+                id: "one",
+                displayName: "One",
+                residencyPolicy: PluginResidencyPolicy.transient,
+                managementCapabilities: defaultManagementCapabilities,
+              ),
             ],
           )
           ..initialize(
@@ -675,7 +991,12 @@ void main() {
           )
           ..registerPlugins(
             plugins: const [
-              (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
+              (
+                id: "one",
+                displayName: "One",
+                residencyPolicy: PluginResidencyPolicy.transient,
+                managementCapabilities: defaultManagementCapabilities,
+              ),
             ],
           )
           ..initialize(
@@ -964,8 +1285,18 @@ void main() {
     final service = _service(
       runtime: runtime,
       plugins: const [
-        (id: "beta", displayName: "Beta", residencyPolicy: PluginResidencyPolicy.transient),
-        (id: "alpha", displayName: "Alpha", residencyPolicy: PluginResidencyPolicy.transient),
+        (
+          id: "beta",
+          displayName: "Beta",
+          residencyPolicy: PluginResidencyPolicy.transient,
+          managementCapabilities: defaultManagementCapabilities,
+        ),
+        (
+          id: "alpha",
+          displayName: "Alpha",
+          residencyPolicy: PluginResidencyPolicy.transient,
+          managementCapabilities: defaultManagementCapabilities,
+        ),
       ],
     );
     addTearDown(service.dispose);
@@ -1003,7 +1334,12 @@ void main() {
     final service = _service(
       runtime: runtime,
       plugins: const [
-        (id: "alpha", displayName: "Alpha", residencyPolicy: PluginResidencyPolicy.transient),
+        (
+          id: "alpha",
+          displayName: "Alpha",
+          residencyPolicy: PluginResidencyPolicy.transient,
+          managementCapabilities: defaultManagementCapabilities,
+        ),
       ],
     );
     addTearDown(service.dispose);
@@ -1026,7 +1362,12 @@ void main() {
           bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
         )..registerPlugins(
           plugins: const [
-            (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
+            (
+              id: "one",
+              displayName: "One",
+              residencyPolicy: PluginResidencyPolicy.transient,
+              managementCapabilities: defaultManagementCapabilities,
+            ),
           ],
         );
     addTearDown(service.dispose);
@@ -1052,7 +1393,12 @@ void main() {
           bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
         )..registerPlugins(
           plugins: const [
-            (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
+            (
+              id: "one",
+              displayName: "One",
+              residencyPolicy: PluginResidencyPolicy.transient,
+              managementCapabilities: defaultManagementCapabilities,
+            ),
           ],
         );
     addTearDown(service.dispose);
@@ -1095,7 +1441,12 @@ void main() {
           bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
         )..registerPlugins(
           plugins: const [
-            (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
+            (
+              id: "one",
+              displayName: "One",
+              residencyPolicy: PluginResidencyPolicy.transient,
+              managementCapabilities: defaultManagementCapabilities,
+            ),
           ],
         );
     addTearDown(service.dispose);
@@ -1133,7 +1484,12 @@ void main() {
           bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
         )..registerPlugins(
           plugins: const [
-            (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.resident),
+            (
+              id: "one",
+              displayName: "One",
+              residencyPolicy: PluginResidencyPolicy.resident,
+              managementCapabilities: defaultManagementCapabilities,
+            ),
           ],
         );
     addTearDown(service.dispose);
@@ -1169,6 +1525,7 @@ PluginLifecycleService _singleIdleService({
   required BridgeSettingsRepository settingsRepository,
   required PluginIdleTimerScheduler timerScheduler,
   required PluginResidencyPolicy residencyPolicy,
+  Set<PluginControlCapability> managementCapabilities = defaultManagementCapabilities,
 }) {
   return PluginLifecycleService(
       lifecycleRepository: lifecycleRepository,
@@ -1178,7 +1535,14 @@ PluginLifecycleService _singleIdleService({
       bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
     )
     ..registerPlugins(
-      plugins: [(id: "one", displayName: "One", residencyPolicy: residencyPolicy)],
+      plugins: [
+        (
+          id: "one",
+          displayName: "One",
+          residencyPolicy: residencyPolicy,
+          managementCapabilities: managementCapabilities,
+        ),
+      ],
     )
     ..initialize(
       disabledPluginIds: const {},
@@ -1189,6 +1553,7 @@ PluginLifecycleService _singleIdleService({
 PluginLifecycleService _commandService({
   required PluginLifecycleRepository repository,
   required BridgeSettingsRepository? settingsRepository,
+  Set<PluginControlCapability> managementCapabilities = defaultManagementCapabilities,
 }) {
   return PluginLifecycleService(
     lifecycleRepository: repository,
@@ -1197,8 +1562,13 @@ PluginLifecycleService _commandService({
     idleTimerScheduler: const PluginIdleTimerScheduler(),
     bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
   )..registerPlugins(
-    plugins: const [
-      (id: "one", displayName: "One", residencyPolicy: PluginResidencyPolicy.transient),
+    plugins: [
+      (
+        id: "one",
+        displayName: "One",
+        residencyPolicy: PluginResidencyPolicy.transient,
+        managementCapabilities: managementCapabilities,
+      ),
     ],
   );
 }
@@ -1397,6 +1767,7 @@ class _CommandLifecycleRepository implements PluginLifecycleRepository {
   int inspectCalls = 0;
   int startCalls = 0;
   int restartCalls = 0;
+  int prepareDisableCalls = 0;
 
   @override
   List<PluginLifecycleSnapshot> get snapshot => [_current];
@@ -1474,6 +1845,7 @@ class _CommandLifecycleRepository implements PluginLifecycleRepository {
     required String pluginId,
     required PluginStopIntent intent,
   }) async {
+    prepareDisableCalls++;
     _current = _copySnapshot(
       setup: _current.setup,
       accessGate: PluginRuntimeAccessGate.draining,

--- a/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
+++ b/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
@@ -11,6 +11,7 @@ export "src/lifecycle/bridge_plugin.dart";
 export "src/lifecycle/bridge_plugin_descriptor.dart";
 export "src/lifecycle/plugin_authentication_required_exception.dart";
 export "src/lifecycle/plugin_config.dart";
+export "src/lifecycle/plugin_control_capability.dart";
 export "src/lifecycle/plugin_diagnostics.dart";
 export "src/lifecycle/plugin_option.dart";
 export "src/lifecycle/plugin_project_ownership.dart";

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin_descriptor.dart
@@ -4,6 +4,7 @@ import "../host/host_process_service.dart";
 import "../host/plugin_host.dart";
 import "bridge_plugin.dart";
 import "plugin_config.dart";
+import "plugin_control_capability.dart";
 import "plugin_option.dart";
 import "plugin_project_ownership.dart";
 import "plugin_residency_policy.dart";
@@ -57,6 +58,19 @@ abstract class BridgePluginDescriptor {
   /// default applies the bridge's configured timeout.
   PluginResidencyPolicy residencyPolicy({required PluginConfig config}) {
     return PluginResidencyPolicy.transient;
+  }
+
+  /// Declares the management operations Sesori may perform under [config].
+  ///
+  /// This is independent from residency: a managed plugin may be configured
+  /// never to idle, while an externally managed plugin may still support setup
+  /// inspection. The default supports every bridge-owned operation.
+  Set<PluginControlCapability> managementCapabilities({required PluginConfig config}) {
+    return const {
+      PluginControlCapability.lifecycle,
+      PluginControlCapability.setupRefresh,
+      PluginControlCapability.idleTimeout,
+    };
   }
 
   /// Inspects whether this plugin's runtime and authentication are already set

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_control_capability.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_control_capability.dart
@@ -1,0 +1,12 @@
+/// Operations that Sesori may perform for a plugin under its current
+/// configuration.
+enum PluginControlCapability {
+  /// Enable, disable, and restart the plugin runtime.
+  lifecycle,
+
+  /// Re-run setup inspection and reconnect when appropriate.
+  setupRefresh,
+
+  /// Configure idle timeout defaults or per-plugin overrides.
+  idleTimeout,
+}

--- a/bridge/sesori_plugin_interface/test/lifecycle/bridge_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_interface/test/lifecycle/bridge_plugin_descriptor_test.dart
@@ -24,6 +24,19 @@ void main() {
       );
     });
 
+    test('supports every management capability by default', () {
+      const descriptor = _MinimalDescriptor();
+
+      expect(
+        descriptor.managementCapabilities(config: const PluginConfig.empty()),
+        const {
+          PluginControlCapability.lifecycle,
+          PluginControlCapability.setupRefresh,
+          PluginControlCapability.idleTimeout,
+        },
+      );
+    });
+
     test('a descriptor can reject configuration with PluginConfigException', () {
       const descriptor = _ValidatingDescriptor();
       const config = PluginConfig(values: {'no-auto-start': true, 'port': null});

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
@@ -266,6 +266,14 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
   }
 
   @override
+  Set<PluginControlCapability> managementCapabilities({required PluginConfig config}) {
+    if (config.flag(_OpenCodeConfigKey.noAutoStart)) {
+      return const {PluginControlCapability.setupRefresh};
+    }
+    return super.managementCapabilities(config: config);
+  }
+
+  @override
   Future<PluginSetupStatus> inspectSetup({
     required PluginConfig config,
     required HostProcessService processes,

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_test.dart
@@ -52,6 +52,28 @@ void main() {
       );
     });
 
+    test("allows only setup refresh in --no-auto-start mode", () {
+      expect(
+        descriptor.managementCapabilities(
+          config: const PluginConfig(values: {"no-auto-start": true}),
+        ),
+        const {PluginControlCapability.setupRefresh},
+      );
+    });
+
+    test("allows every management capability in managed mode", () {
+      expect(
+        descriptor.managementCapabilities(
+          config: const PluginConfig(values: {"no-auto-start": false}),
+        ),
+        const {
+          PluginControlCapability.lifecycle,
+          PluginControlCapability.setupRefresh,
+          PluginControlCapability.idleTimeout,
+        },
+      );
+    });
+
     test("validateConfig requires --port when --no-auto-start is set", () {
       expect(
         () => descriptor.validateConfig(

--- a/client/app/test/features/settings/harnesses_settings_screen_test.dart
+++ b/client/app/test/features/settings/harnesses_settings_screen_test.dart
@@ -32,6 +32,11 @@ const _response = PluginManagementResponse(
       workState: PluginManagementWorkState.idle,
       idleTimeoutMins: 10,
       hasIdleTimeoutOverride: false,
+      managementCapabilities: {
+        PluginManagementCapability.lifecycle,
+        PluginManagementCapability.setupRefresh,
+        PluginManagementCapability.idleTimeout,
+      },
       actionHint: null,
     ),
     PluginManagementMetadata(
@@ -45,6 +50,11 @@ const _response = PluginManagementResponse(
       workState: PluginManagementWorkState.unknown,
       idleTimeoutMins: 20,
       hasIdleTimeoutOverride: true,
+      managementCapabilities: {
+        PluginManagementCapability.lifecycle,
+        PluginManagementCapability.setupRefresh,
+        PluginManagementCapability.idleTimeout,
+      },
       actionHint: "Future guidance.",
     ),
   ],

--- a/client/module_core/test/api/plugin_api_test.dart
+++ b/client/module_core/test/api/plugin_api_test.dart
@@ -156,6 +156,7 @@ const _managementJson = {
       "workState": "idle",
       "idleTimeoutMins": 30,
       "hasIdleTimeoutOverride": false,
+      "managementCapabilities": ["lifecycle", "setupRefresh", "idleTimeout"],
     },
   ],
 };

--- a/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
+++ b/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
@@ -451,6 +451,11 @@ PluginLifecycleConflict _conflict(List<PluginLifecycleConflictReason> reasons) {
       workState: PluginManagementWorkState.idle,
       idleTimeoutMins: 10,
       hasIdleTimeoutOverride: false,
+      managementCapabilities: {
+        PluginManagementCapability.lifecycle,
+        PluginManagementCapability.setupRefresh,
+        PluginManagementCapability.idleTimeout,
+      },
       actionHint: null,
     ),
   );

--- a/client/module_core/test/repositories/plugin_repository_test.dart
+++ b/client/module_core/test/repositories/plugin_repository_test.dart
@@ -307,6 +307,11 @@ const _managementPlugin = PluginManagementMetadata(
   workState: PluginManagementWorkState.busy,
   idleTimeoutMins: 30,
   hasIdleTimeoutOverride: false,
+  managementCapabilities: {
+    PluginManagementCapability.lifecycle,
+    PluginManagementCapability.setupRefresh,
+    PluginManagementCapability.idleTimeout,
+  },
   actionHint: null,
 );
 
@@ -327,5 +332,6 @@ const _conflictJson = {
     "workState": "busy",
     "idleTimeoutMins": 30,
     "hasIdleTimeoutOverride": false,
+    "managementCapabilities": ["lifecycle", "setupRefresh", "idleTimeout"],
   },
 };

--- a/client/module_core/test/services/plugin_management_service_test.dart
+++ b/client/module_core/test/services/plugin_management_service_test.dart
@@ -538,6 +538,7 @@ void main() {
         const [],
         const [PluginLifecycleConflictReason.transitioning],
         const [PluginLifecycleConflictReason.notEnabled],
+        const [PluginLifecycleConflictReason.unsupported],
         const [PluginLifecycleConflictReason.unknown],
         const [PluginLifecycleConflictReason.busy, PluginLifecycleConflictReason.unknown],
       ]) {

--- a/client/module_core/test/services/plugin_management_service_test.dart
+++ b/client/module_core/test/services/plugin_management_service_test.dart
@@ -617,6 +617,11 @@ PluginLifecycleConflict _conflict(List<PluginLifecycleConflictReason> reasons) {
       workState: PluginManagementWorkState.idle,
       idleTimeoutMins: 10,
       hasIdleTimeoutOverride: false,
+      managementCapabilities: {
+        PluginManagementCapability.lifecycle,
+        PluginManagementCapability.setupRefresh,
+        PluginManagementCapability.idleTimeout,
+      },
       actionHint: null,
     ),
   );

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.dart
@@ -56,13 +56,8 @@ sealed class PluginManagementMetadata with _$PluginManagementMetadata {
     @JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) required PluginManagementWorkState workState,
     required int idleTimeoutMins,
     required bool hasIdleTimeoutOverride,
-    // COMPATIBILITY 2026-07-27 (v1.7.0): Older bridge payloads cannot declare
-    // whether management operations are safe. Empty fails closed so newer
-    // clients do not expose controls for an externally managed runtime. Remove
-    // this default and make the field required when those bridges are unsupported.
-    @Default(<PluginManagementCapability>{})
     @JsonKey(unknownEnumValue: PluginManagementCapability.unknown)
-    Set<PluginManagementCapability> managementCapabilities,
+    required Set<PluginManagementCapability> managementCapabilities,
     required String? actionHint,
   }) = _PluginManagementMetadata;
 

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.dart
@@ -42,9 +42,11 @@ enum PluginRuntimeState {
 
 enum PluginManagementWorkState { idle, busy, unknown }
 
+enum PluginManagementCapability { lifecycle, setupRefresh, idleTimeout, unknown }
+
 enum PluginStopMode { safe, force }
 
-enum PluginLifecycleConflictReason { inFlight, busy, workStateUnknown, transitioning, notEnabled, unknown }
+enum PluginLifecycleConflictReason { inFlight, busy, workStateUnknown, transitioning, notEnabled, unsupported, unknown }
 
 @Freezed(fromJson: true, toJson: true)
 sealed class PluginManagementMetadata with _$PluginManagementMetadata {
@@ -54,6 +56,13 @@ sealed class PluginManagementMetadata with _$PluginManagementMetadata {
     @JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) required PluginManagementWorkState workState,
     required int idleTimeoutMins,
     required bool hasIdleTimeoutOverride,
+    // COMPATIBILITY 2026-07-27 (v1.7.0): Older bridge payloads cannot declare
+    // whether management operations are safe. Empty fails closed so newer
+    // clients do not expose controls for an externally managed runtime. Remove
+    // this default and make the field required when those bridges are unsupported.
+    @Default(<PluginManagementCapability>{})
+    @JsonKey(unknownEnumValue: PluginManagementCapability.unknown)
+    Set<PluginManagementCapability> managementCapabilities,
     required String? actionHint,
   }) = _PluginManagementMetadata;
 

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.freezed.dart
@@ -15,7 +15,11 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$PluginManagementMetadata {
 
- PluginSetupMetadata get setup;@JsonKey(unknownEnumValue: PluginRuntimeState.unknown) PluginRuntimeState get runtimeState;@JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) PluginManagementWorkState get workState; int get idleTimeoutMins; bool get hasIdleTimeoutOverride; String? get actionHint;
+ PluginSetupMetadata get setup;@JsonKey(unknownEnumValue: PluginRuntimeState.unknown) PluginRuntimeState get runtimeState;@JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) PluginManagementWorkState get workState; int get idleTimeoutMins; bool get hasIdleTimeoutOverride;// COMPATIBILITY 2026-07-27 (v1.7.0): Older bridge payloads cannot declare
+// whether management operations are safe. Empty fails closed so newer
+// clients do not expose controls for an externally managed runtime. Remove
+// this default and make the field required when those bridges are unsupported.
+@JsonKey(unknownEnumValue: PluginManagementCapability.unknown) Set<PluginManagementCapability> get managementCapabilities; String? get actionHint;
 /// Create a copy of PluginManagementMetadata
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +32,16 @@ $PluginManagementMetadataCopyWith<PluginManagementMetadata> get copyWith => _$Pl
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginManagementMetadata&&(identical(other.setup, setup) || other.setup == setup)&&(identical(other.runtimeState, runtimeState) || other.runtimeState == runtimeState)&&(identical(other.workState, workState) || other.workState == workState)&&(identical(other.idleTimeoutMins, idleTimeoutMins) || other.idleTimeoutMins == idleTimeoutMins)&&(identical(other.hasIdleTimeoutOverride, hasIdleTimeoutOverride) || other.hasIdleTimeoutOverride == hasIdleTimeoutOverride)&&(identical(other.actionHint, actionHint) || other.actionHint == actionHint));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginManagementMetadata&&(identical(other.setup, setup) || other.setup == setup)&&(identical(other.runtimeState, runtimeState) || other.runtimeState == runtimeState)&&(identical(other.workState, workState) || other.workState == workState)&&(identical(other.idleTimeoutMins, idleTimeoutMins) || other.idleTimeoutMins == idleTimeoutMins)&&(identical(other.hasIdleTimeoutOverride, hasIdleTimeoutOverride) || other.hasIdleTimeoutOverride == hasIdleTimeoutOverride)&&const DeepCollectionEquality().equals(other.managementCapabilities, managementCapabilities)&&(identical(other.actionHint, actionHint) || other.actionHint == actionHint));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,setup,runtimeState,workState,idleTimeoutMins,hasIdleTimeoutOverride,actionHint);
+int get hashCode => Object.hash(runtimeType,setup,runtimeState,workState,idleTimeoutMins,hasIdleTimeoutOverride,const DeepCollectionEquality().hash(managementCapabilities),actionHint);
 
 @override
 String toString() {
-  return 'PluginManagementMetadata(setup: $setup, runtimeState: $runtimeState, workState: $workState, idleTimeoutMins: $idleTimeoutMins, hasIdleTimeoutOverride: $hasIdleTimeoutOverride, actionHint: $actionHint)';
+  return 'PluginManagementMetadata(setup: $setup, runtimeState: $runtimeState, workState: $workState, idleTimeoutMins: $idleTimeoutMins, hasIdleTimeoutOverride: $hasIdleTimeoutOverride, managementCapabilities: $managementCapabilities, actionHint: $actionHint)';
 }
 
 
@@ -48,7 +52,7 @@ abstract mixin class $PluginManagementMetadataCopyWith<$Res>  {
   factory $PluginManagementMetadataCopyWith(PluginManagementMetadata value, $Res Function(PluginManagementMetadata) _then) = _$PluginManagementMetadataCopyWithImpl;
 @useResult
 $Res call({
- PluginSetupMetadata setup,@JsonKey(unknownEnumValue: PluginRuntimeState.unknown) PluginRuntimeState runtimeState,@JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) PluginManagementWorkState workState, int idleTimeoutMins, bool hasIdleTimeoutOverride, String? actionHint
+ PluginSetupMetadata setup,@JsonKey(unknownEnumValue: PluginRuntimeState.unknown) PluginRuntimeState runtimeState,@JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) PluginManagementWorkState workState, int idleTimeoutMins, bool hasIdleTimeoutOverride,@JsonKey(unknownEnumValue: PluginManagementCapability.unknown) Set<PluginManagementCapability> managementCapabilities, String? actionHint
 });
 
 
@@ -65,14 +69,15 @@ class _$PluginManagementMetadataCopyWithImpl<$Res>
 
 /// Create a copy of PluginManagementMetadata
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? setup = null,Object? runtimeState = null,Object? workState = null,Object? idleTimeoutMins = null,Object? hasIdleTimeoutOverride = null,Object? actionHint = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? setup = null,Object? runtimeState = null,Object? workState = null,Object? idleTimeoutMins = null,Object? hasIdleTimeoutOverride = null,Object? managementCapabilities = null,Object? actionHint = freezed,}) {
   return _then(_self.copyWith(
 setup: null == setup ? _self.setup : setup // ignore: cast_nullable_to_non_nullable
 as PluginSetupMetadata,runtimeState: null == runtimeState ? _self.runtimeState : runtimeState // ignore: cast_nullable_to_non_nullable
 as PluginRuntimeState,workState: null == workState ? _self.workState : workState // ignore: cast_nullable_to_non_nullable
 as PluginManagementWorkState,idleTimeoutMins: null == idleTimeoutMins ? _self.idleTimeoutMins : idleTimeoutMins // ignore: cast_nullable_to_non_nullable
 as int,hasIdleTimeoutOverride: null == hasIdleTimeoutOverride ? _self.hasIdleTimeoutOverride : hasIdleTimeoutOverride // ignore: cast_nullable_to_non_nullable
-as bool,actionHint: freezed == actionHint ? _self.actionHint : actionHint // ignore: cast_nullable_to_non_nullable
+as bool,managementCapabilities: null == managementCapabilities ? _self.managementCapabilities : managementCapabilities // ignore: cast_nullable_to_non_nullable
+as Set<PluginManagementCapability>,actionHint: freezed == actionHint ? _self.actionHint : actionHint // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }
@@ -94,7 +99,7 @@ $PluginSetupMetadataCopyWith<$Res> get setup {
 @JsonSerializable()
 
 class _PluginManagementMetadata implements PluginManagementMetadata {
-  const _PluginManagementMetadata({required this.setup, @JsonKey(unknownEnumValue: PluginRuntimeState.unknown) required this.runtimeState, @JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) required this.workState, required this.idleTimeoutMins, required this.hasIdleTimeoutOverride, required this.actionHint});
+  const _PluginManagementMetadata({required this.setup, @JsonKey(unknownEnumValue: PluginRuntimeState.unknown) required this.runtimeState, @JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) required this.workState, required this.idleTimeoutMins, required this.hasIdleTimeoutOverride, @JsonKey(unknownEnumValue: PluginManagementCapability.unknown) final  Set<PluginManagementCapability> managementCapabilities = const <PluginManagementCapability>{}, required this.actionHint}): _managementCapabilities = managementCapabilities;
   factory _PluginManagementMetadata.fromJson(Map<String, dynamic> json) => _$PluginManagementMetadataFromJson(json);
 
 @override final  PluginSetupMetadata setup;
@@ -102,6 +107,21 @@ class _PluginManagementMetadata implements PluginManagementMetadata {
 @override@JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) final  PluginManagementWorkState workState;
 @override final  int idleTimeoutMins;
 @override final  bool hasIdleTimeoutOverride;
+// COMPATIBILITY 2026-07-27 (v1.7.0): Older bridge payloads cannot declare
+// whether management operations are safe. Empty fails closed so newer
+// clients do not expose controls for an externally managed runtime. Remove
+// this default and make the field required when those bridges are unsupported.
+ final  Set<PluginManagementCapability> _managementCapabilities;
+// COMPATIBILITY 2026-07-27 (v1.7.0): Older bridge payloads cannot declare
+// whether management operations are safe. Empty fails closed so newer
+// clients do not expose controls for an externally managed runtime. Remove
+// this default and make the field required when those bridges are unsupported.
+@override@JsonKey(unknownEnumValue: PluginManagementCapability.unknown) Set<PluginManagementCapability> get managementCapabilities {
+  if (_managementCapabilities is EqualUnmodifiableSetView) return _managementCapabilities;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableSetView(_managementCapabilities);
+}
+
 @override final  String? actionHint;
 
 /// Create a copy of PluginManagementMetadata
@@ -117,16 +137,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginManagementMetadata&&(identical(other.setup, setup) || other.setup == setup)&&(identical(other.runtimeState, runtimeState) || other.runtimeState == runtimeState)&&(identical(other.workState, workState) || other.workState == workState)&&(identical(other.idleTimeoutMins, idleTimeoutMins) || other.idleTimeoutMins == idleTimeoutMins)&&(identical(other.hasIdleTimeoutOverride, hasIdleTimeoutOverride) || other.hasIdleTimeoutOverride == hasIdleTimeoutOverride)&&(identical(other.actionHint, actionHint) || other.actionHint == actionHint));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginManagementMetadata&&(identical(other.setup, setup) || other.setup == setup)&&(identical(other.runtimeState, runtimeState) || other.runtimeState == runtimeState)&&(identical(other.workState, workState) || other.workState == workState)&&(identical(other.idleTimeoutMins, idleTimeoutMins) || other.idleTimeoutMins == idleTimeoutMins)&&(identical(other.hasIdleTimeoutOverride, hasIdleTimeoutOverride) || other.hasIdleTimeoutOverride == hasIdleTimeoutOverride)&&const DeepCollectionEquality().equals(other._managementCapabilities, _managementCapabilities)&&(identical(other.actionHint, actionHint) || other.actionHint == actionHint));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,setup,runtimeState,workState,idleTimeoutMins,hasIdleTimeoutOverride,actionHint);
+int get hashCode => Object.hash(runtimeType,setup,runtimeState,workState,idleTimeoutMins,hasIdleTimeoutOverride,const DeepCollectionEquality().hash(_managementCapabilities),actionHint);
 
 @override
 String toString() {
-  return 'PluginManagementMetadata(setup: $setup, runtimeState: $runtimeState, workState: $workState, idleTimeoutMins: $idleTimeoutMins, hasIdleTimeoutOverride: $hasIdleTimeoutOverride, actionHint: $actionHint)';
+  return 'PluginManagementMetadata(setup: $setup, runtimeState: $runtimeState, workState: $workState, idleTimeoutMins: $idleTimeoutMins, hasIdleTimeoutOverride: $hasIdleTimeoutOverride, managementCapabilities: $managementCapabilities, actionHint: $actionHint)';
 }
 
 
@@ -137,7 +157,7 @@ abstract mixin class _$PluginManagementMetadataCopyWith<$Res> implements $Plugin
   factory _$PluginManagementMetadataCopyWith(_PluginManagementMetadata value, $Res Function(_PluginManagementMetadata) _then) = __$PluginManagementMetadataCopyWithImpl;
 @override @useResult
 $Res call({
- PluginSetupMetadata setup,@JsonKey(unknownEnumValue: PluginRuntimeState.unknown) PluginRuntimeState runtimeState,@JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) PluginManagementWorkState workState, int idleTimeoutMins, bool hasIdleTimeoutOverride, String? actionHint
+ PluginSetupMetadata setup,@JsonKey(unknownEnumValue: PluginRuntimeState.unknown) PluginRuntimeState runtimeState,@JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) PluginManagementWorkState workState, int idleTimeoutMins, bool hasIdleTimeoutOverride,@JsonKey(unknownEnumValue: PluginManagementCapability.unknown) Set<PluginManagementCapability> managementCapabilities, String? actionHint
 });
 
 
@@ -154,14 +174,15 @@ class __$PluginManagementMetadataCopyWithImpl<$Res>
 
 /// Create a copy of PluginManagementMetadata
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? setup = null,Object? runtimeState = null,Object? workState = null,Object? idleTimeoutMins = null,Object? hasIdleTimeoutOverride = null,Object? actionHint = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? setup = null,Object? runtimeState = null,Object? workState = null,Object? idleTimeoutMins = null,Object? hasIdleTimeoutOverride = null,Object? managementCapabilities = null,Object? actionHint = freezed,}) {
   return _then(_PluginManagementMetadata(
 setup: null == setup ? _self.setup : setup // ignore: cast_nullable_to_non_nullable
 as PluginSetupMetadata,runtimeState: null == runtimeState ? _self.runtimeState : runtimeState // ignore: cast_nullable_to_non_nullable
 as PluginRuntimeState,workState: null == workState ? _self.workState : workState // ignore: cast_nullable_to_non_nullable
 as PluginManagementWorkState,idleTimeoutMins: null == idleTimeoutMins ? _self.idleTimeoutMins : idleTimeoutMins // ignore: cast_nullable_to_non_nullable
 as int,hasIdleTimeoutOverride: null == hasIdleTimeoutOverride ? _self.hasIdleTimeoutOverride : hasIdleTimeoutOverride // ignore: cast_nullable_to_non_nullable
-as bool,actionHint: freezed == actionHint ? _self.actionHint : actionHint // ignore: cast_nullable_to_non_nullable
+as bool,managementCapabilities: null == managementCapabilities ? _self._managementCapabilities : managementCapabilities // ignore: cast_nullable_to_non_nullable
+as Set<PluginManagementCapability>,actionHint: freezed == actionHint ? _self.actionHint : actionHint // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.freezed.dart
@@ -15,11 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$PluginManagementMetadata {
 
- PluginSetupMetadata get setup;@JsonKey(unknownEnumValue: PluginRuntimeState.unknown) PluginRuntimeState get runtimeState;@JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) PluginManagementWorkState get workState; int get idleTimeoutMins; bool get hasIdleTimeoutOverride;// COMPATIBILITY 2026-07-27 (v1.7.0): Older bridge payloads cannot declare
-// whether management operations are safe. Empty fails closed so newer
-// clients do not expose controls for an externally managed runtime. Remove
-// this default and make the field required when those bridges are unsupported.
-@JsonKey(unknownEnumValue: PluginManagementCapability.unknown) Set<PluginManagementCapability> get managementCapabilities; String? get actionHint;
+ PluginSetupMetadata get setup;@JsonKey(unknownEnumValue: PluginRuntimeState.unknown) PluginRuntimeState get runtimeState;@JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) PluginManagementWorkState get workState; int get idleTimeoutMins; bool get hasIdleTimeoutOverride;@JsonKey(unknownEnumValue: PluginManagementCapability.unknown) Set<PluginManagementCapability> get managementCapabilities; String? get actionHint;
 /// Create a copy of PluginManagementMetadata
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -99,7 +95,7 @@ $PluginSetupMetadataCopyWith<$Res> get setup {
 @JsonSerializable()
 
 class _PluginManagementMetadata implements PluginManagementMetadata {
-  const _PluginManagementMetadata({required this.setup, @JsonKey(unknownEnumValue: PluginRuntimeState.unknown) required this.runtimeState, @JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) required this.workState, required this.idleTimeoutMins, required this.hasIdleTimeoutOverride, @JsonKey(unknownEnumValue: PluginManagementCapability.unknown) final  Set<PluginManagementCapability> managementCapabilities = const <PluginManagementCapability>{}, required this.actionHint}): _managementCapabilities = managementCapabilities;
+  const _PluginManagementMetadata({required this.setup, @JsonKey(unknownEnumValue: PluginRuntimeState.unknown) required this.runtimeState, @JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) required this.workState, required this.idleTimeoutMins, required this.hasIdleTimeoutOverride, @JsonKey(unknownEnumValue: PluginManagementCapability.unknown) required final  Set<PluginManagementCapability> managementCapabilities, required this.actionHint}): _managementCapabilities = managementCapabilities;
   factory _PluginManagementMetadata.fromJson(Map<String, dynamic> json) => _$PluginManagementMetadataFromJson(json);
 
 @override final  PluginSetupMetadata setup;
@@ -107,15 +103,7 @@ class _PluginManagementMetadata implements PluginManagementMetadata {
 @override@JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) final  PluginManagementWorkState workState;
 @override final  int idleTimeoutMins;
 @override final  bool hasIdleTimeoutOverride;
-// COMPATIBILITY 2026-07-27 (v1.7.0): Older bridge payloads cannot declare
-// whether management operations are safe. Empty fails closed so newer
-// clients do not expose controls for an externally managed runtime. Remove
-// this default and make the field required when those bridges are unsupported.
  final  Set<PluginManagementCapability> _managementCapabilities;
-// COMPATIBILITY 2026-07-27 (v1.7.0): Older bridge payloads cannot declare
-// whether management operations are safe. Empty fails closed so newer
-// clients do not expose controls for an externally managed runtime. Remove
-// this default and make the field required when those bridges are unsupported.
 @override@JsonKey(unknownEnumValue: PluginManagementCapability.unknown) Set<PluginManagementCapability> get managementCapabilities {
   if (_managementCapabilities is EqualUnmodifiableSetView) return _managementCapabilities;
   // ignore: implicit_dynamic_type

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.g.dart
@@ -23,17 +23,15 @@ _PluginManagementMetadata _$PluginManagementMetadataFromJson(Map json) =>
       ),
       idleTimeoutMins: (json['idleTimeoutMins'] as num).toInt(),
       hasIdleTimeoutOverride: json['hasIdleTimeoutOverride'] as bool,
-      managementCapabilities:
-          (json['managementCapabilities'] as List<dynamic>?)
-              ?.map(
-                (e) => $enumDecode(
-                  _$PluginManagementCapabilityEnumMap,
-                  e,
-                  unknownValue: PluginManagementCapability.unknown,
-                ),
-              )
-              .toSet() ??
-          const <PluginManagementCapability>{},
+      managementCapabilities: (json['managementCapabilities'] as List<dynamic>)
+          .map(
+            (e) => $enumDecode(
+              _$PluginManagementCapabilityEnumMap,
+              e,
+              unknownValue: PluginManagementCapability.unknown,
+            ),
+          )
+          .toSet(),
       actionHint: json['actionHint'] as String?,
     );
 

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.g.dart
@@ -23,6 +23,17 @@ _PluginManagementMetadata _$PluginManagementMetadataFromJson(Map json) =>
       ),
       idleTimeoutMins: (json['idleTimeoutMins'] as num).toInt(),
       hasIdleTimeoutOverride: json['hasIdleTimeoutOverride'] as bool,
+      managementCapabilities:
+          (json['managementCapabilities'] as List<dynamic>?)
+              ?.map(
+                (e) => $enumDecode(
+                  _$PluginManagementCapabilityEnumMap,
+                  e,
+                  unknownValue: PluginManagementCapability.unknown,
+                ),
+              )
+              .toSet() ??
+          const <PluginManagementCapability>{},
       actionHint: json['actionHint'] as String?,
     );
 
@@ -34,6 +45,9 @@ Map<String, dynamic> _$PluginManagementMetadataToJson(
   'workState': _$PluginManagementWorkStateEnumMap[instance.workState]!,
   'idleTimeoutMins': instance.idleTimeoutMins,
   'hasIdleTimeoutOverride': instance.hasIdleTimeoutOverride,
+  'managementCapabilities': instance.managementCapabilities
+      .map((e) => _$PluginManagementCapabilityEnumMap[e]!)
+      .toList(),
   'actionHint': ?instance.actionHint,
 };
 
@@ -53,6 +67,13 @@ const _$PluginManagementWorkStateEnumMap = {
   PluginManagementWorkState.idle: 'idle',
   PluginManagementWorkState.busy: 'busy',
   PluginManagementWorkState.unknown: 'unknown',
+};
+
+const _$PluginManagementCapabilityEnumMap = {
+  PluginManagementCapability.lifecycle: 'lifecycle',
+  PluginManagementCapability.setupRefresh: 'setupRefresh',
+  PluginManagementCapability.idleTimeout: 'idleTimeout',
+  PluginManagementCapability.unknown: 'unknown',
 };
 
 _PluginManagementResponse _$PluginManagementResponseFromJson(Map json) =>
@@ -202,5 +223,6 @@ const _$PluginLifecycleConflictReasonEnumMap = {
   PluginLifecycleConflictReason.workStateUnknown: 'workStateUnknown',
   PluginLifecycleConflictReason.transitioning: 'transitioning',
   PluginLifecycleConflictReason.notEnabled: 'notEnabled',
+  PluginLifecycleConflictReason.unsupported: 'unsupported',
   PluginLifecycleConflictReason.unknown: 'unknown',
 };

--- a/shared/sesori_shared/test/models/plugin_management_contract_test.dart
+++ b/shared/sesori_shared/test/models/plugin_management_contract_test.dart
@@ -71,12 +71,12 @@ void main() {
     );
   });
 
-  test("omitted management capabilities decode to empty", () {
+  test("management capabilities are required", () {
     final json = plugin.toJson()..remove("managementCapabilities");
 
     expect(
-      PluginManagementMetadata.fromJson(json).managementCapabilities,
-      isEmpty,
+      () => PluginManagementMetadata.fromJson(json),
+      throwsA(anything),
     );
   });
 

--- a/shared/sesori_shared/test/models/plugin_management_contract_test.dart
+++ b/shared/sesori_shared/test/models/plugin_management_contract_test.dart
@@ -13,6 +13,11 @@ void main() {
     workState: PluginManagementWorkState.idle,
     idleTimeoutMins: 0,
     hasIdleTimeoutOverride: true,
+    managementCapabilities: {
+      PluginManagementCapability.lifecycle,
+      PluginManagementCapability.setupRefresh,
+      PluginManagementCapability.idleTimeout,
+    },
     actionHint: null,
   );
 
@@ -36,7 +41,14 @@ void main() {
     );
     expect(
       pluginJson.keys,
-      unorderedEquals(["setup", "runtimeState", "workState", "idleTimeoutMins", "hasIdleTimeoutOverride"]),
+      unorderedEquals([
+        "setup",
+        "runtimeState",
+        "workState",
+        "idleTimeoutMins",
+        "hasIdleTimeoutOverride",
+        "managementCapabilities",
+      ]),
     );
     expect(json["snapshotToken"], "snapshot-token");
     expect(json["bridgeId"], "br_abc12345");
@@ -44,6 +56,37 @@ void main() {
     expect(pluginJson, isNot(contains("isDefault")));
     expect(json, isNot(contains("authority")));
     expect(json, isNot(contains("order")));
+  });
+
+  test("declared management capabilities round-trip", () {
+    final json = plugin.toJson();
+
+    expect(
+      json["managementCapabilities"],
+      unorderedEquals(["lifecycle", "setupRefresh", "idleTimeout"]),
+    );
+    expect(
+      PluginManagementMetadata.fromJson(json).managementCapabilities,
+      plugin.managementCapabilities,
+    );
+  });
+
+  test("omitted management capabilities decode to empty", () {
+    final json = plugin.toJson()..remove("managementCapabilities");
+
+    expect(
+      PluginManagementMetadata.fromJson(json).managementCapabilities,
+      isEmpty,
+    );
+  });
+
+  test("future management capabilities decode to unknown", () {
+    final json = plugin.toJson()..["managementCapabilities"] = ["lifecycle", "futureCapability"];
+
+    expect(
+      PluginManagementMetadata.fromJson(json).managementCapabilities,
+      {PluginManagementCapability.lifecycle, PluginManagementCapability.unknown},
+    );
   });
 
   test("older management responses decode without a snapshot token", () {
@@ -146,9 +189,10 @@ void main() {
 
     const conflict = PluginLifecycleConflict(
       pluginId: "opencode",
-      reasons: [PluginLifecycleConflictReason.busy],
+      reasons: [PluginLifecycleConflictReason.unsupported],
       current: plugin,
     );
+    expect(conflict.toJson()["reasons"], ["unsupported"]);
     expect(PluginLifecycleConflict.fromJson(conflict.toJson()), conflict);
   });
 


### PR DESCRIPTION
## Summary

- add independent backend-neutral management capability enums to the plugin interface and shared wire contract, mapped only in `bridge/app`
- require capability data on every management row because the contract and controls ship together before production
- declare setup-refresh-only management for OpenCode `--opencode-no-auto-start`, while managed plugins retain lifecycle, setup refresh, and idle-timeout support
- enforce capabilities authoritatively before runtime or settings effects and return typed non-forceable conflicts for unsupported operations
- require lifecycle plus idle-timeout capability before scheduling or executing automatic idle suspension
- keep apply-all timeout updates global while clearing per-plugin overrides only for timeout-capable harnesses

## Verification

- shared full suite: 340 tests
- plugin interface full suite: 147 tests
- OpenCode full suite: 398 tests
- bridge app full suite: 2,160 tests
- focused module-core management service: 22 tests
- fatal analysis clean in shared, plugin interface, OpenCode, Codex, Cursor, bridge app, module_core, mobile, desktop, and module_desktop_core
- Aristotle implementation review approved

## Series

Step 7 of 8 in `.plan/active/setup-aware-harness-settings`. Step 8 consumes
these declared capabilities in the Harnesses controls UI.
