### PR TITLE
feat: add file/image attachment support to message parts

### DIFF
--- a/bridge/app/lib/src/bridge/plugin_to_shared_mapping.dart
+++ b/bridge/app/lib/src/bridge/plugin_to_shared_mapping.dart
@@ -77,5 +77,10 @@ extension PluginMessagePartMapping on PluginMessagePart {
     agentName: agentName,
     attempt: attempt,
     retryError: retryError,
+    mime: mime,
+    url: url,
+    path: path,
+    base64: base64,
+    filename: filename,
   );
 }

--- a/bridge/app/lib/src/bridge/plugin_to_shared_mapping.dart
+++ b/bridge/app/lib/src/bridge/plugin_to_shared_mapping.dart
@@ -79,7 +79,7 @@ extension PluginMessagePartMapping on PluginMessagePart {
     retryError: retryError,
     mime: mime,
     url: url,
-    path: path,
+    path: null, // Never send internal filesystem paths to mobile
     base64: base64,
     filename: filename,
   );

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_message.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_message.dart
@@ -38,7 +38,7 @@ enum PluginMessagePartType {
   unknown;
 
   /// Whether this part type is visible to mobile (rendered in the UI).
-  bool get isVisible => this != file && this != snapshot && this != patch && this != compaction && this != unknown;
+  bool get isVisible => this != snapshot && this != patch && this != compaction && this != unknown;
 }
 
 @freezed
@@ -70,6 +70,12 @@ sealed class PluginMessagePart with _$PluginMessagePart {
     // retry
     required int? attempt,
     required String? retryError,
+    // file
+    required String? mime,
+    required String? url,
+    required String? path,
+    required String? base64,
+    required String? filename,
   }) = _PluginMessagePart;
 }
 

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_message.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_message.dart
@@ -71,11 +71,11 @@ sealed class PluginMessagePart with _$PluginMessagePart {
     required int? attempt,
     required String? retryError,
     // file
-    required String? mime,
-    required String? url,
-    required String? path,
-    required String? base64,
-    required String? filename,
+    String? mime,
+    String? url,
+    String? path,
+    String? base64,
+    String? filename,
   }) = _PluginMessagePart;
 }
 

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_message.freezed.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_message.freezed.dart
@@ -179,7 +179,8 @@ mixin _$PluginMessagePart {
  String? get tool; PluginToolState? get state;// subtask
  String? get prompt; String? get description; String? get agent;// agent
  String? get agentName;// retry
- int? get attempt; String? get retryError;
+ int? get attempt; String? get retryError;// file
+ String? get mime; String? get url; String? get path; String? get base64; String? get filename;
 /// Create a copy of PluginMessagePart
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -192,16 +193,16 @@ $PluginMessagePartCopyWith<PluginMessagePart> get copyWith => _$PluginMessagePar
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginMessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.state, state) || other.state == state)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.agentName, agentName) || other.agentName == agentName)&&(identical(other.attempt, attempt) || other.attempt == attempt)&&(identical(other.retryError, retryError) || other.retryError == retryError));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginMessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.state, state) || other.state == state)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.agentName, agentName) || other.agentName == agentName)&&(identical(other.attempt, attempt) || other.attempt == attempt)&&(identical(other.retryError, retryError) || other.retryError == retryError)&&(identical(other.mime, mime) || other.mime == mime)&&(identical(other.url, url) || other.url == url)&&(identical(other.path, path) || other.path == path)&&(identical(other.base64, base64) || other.base64 == base64)&&(identical(other.filename, filename) || other.filename == filename));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,sessionID,messageID,type,text,tool,state,prompt,description,agent,agentName,attempt,retryError);
+int get hashCode => Object.hash(runtimeType,id,sessionID,messageID,type,text,tool,state,prompt,description,agent,agentName,attempt,retryError,mime,url,path,base64,filename);
 
 @override
 String toString() {
-  return 'PluginMessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, state: $state, prompt: $prompt, description: $description, agent: $agent, agentName: $agentName, attempt: $attempt, retryError: $retryError)';
+  return 'PluginMessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, state: $state, prompt: $prompt, description: $description, agent: $agent, agentName: $agentName, attempt: $attempt, retryError: $retryError, mime: $mime, url: $url, path: $path, base64: $base64, filename: $filename)';
 }
 
 
@@ -212,7 +213,7 @@ abstract mixin class $PluginMessagePartCopyWith<$Res>  {
   factory $PluginMessagePartCopyWith(PluginMessagePart value, $Res Function(PluginMessagePart) _then) = _$PluginMessagePartCopyWithImpl;
 @useResult
 $Res call({
- String id, String sessionID, String messageID, PluginMessagePartType type, String? text, String? tool, PluginToolState? state, String? prompt, String? description, String? agent, String? agentName, int? attempt, String? retryError
+ String id, String sessionID, String messageID, PluginMessagePartType type, String? text, String? tool, PluginToolState? state, String? prompt, String? description, String? agent, String? agentName, int? attempt, String? retryError, String? mime, String? url, String? path, String? base64, String? filename
 });
 
 
@@ -229,7 +230,7 @@ class _$PluginMessagePartCopyWithImpl<$Res>
 
 /// Create a copy of PluginMessagePart
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? state = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,Object? agentName = freezed,Object? attempt = freezed,Object? retryError = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? state = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,Object? agentName = freezed,Object? attempt = freezed,Object? retryError = freezed,Object? mime = freezed,Object? url = freezed,Object? path = freezed,Object? base64 = freezed,Object? filename = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
@@ -244,6 +245,11 @@ as String?,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullabl
 as String?,agentName: freezed == agentName ? _self.agentName : agentName // ignore: cast_nullable_to_non_nullable
 as String?,attempt: freezed == attempt ? _self.attempt : attempt // ignore: cast_nullable_to_non_nullable
 as int?,retryError: freezed == retryError ? _self.retryError : retryError // ignore: cast_nullable_to_non_nullable
+as String?,mime: freezed == mime ? _self.mime : mime // ignore: cast_nullable_to_non_nullable
+as String?,url: freezed == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String?,path: freezed == path ? _self.path : path // ignore: cast_nullable_to_non_nullable
+as String?,base64: freezed == base64 ? _self.base64 : base64 // ignore: cast_nullable_to_non_nullable
+as String?,filename: freezed == filename ? _self.filename : filename // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }
@@ -340,7 +346,7 @@ class __$PluginMessagePartCopyWithImpl<$Res>
 
 /// Create a copy of PluginMessagePart
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? state = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,Object? agentName = freezed,Object? attempt = freezed,Object? retryError = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? state = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,Object? agentName = freezed,Object? attempt = freezed,Object? retryError = freezed,Object? mime = freezed,Object? url = freezed,Object? path = freezed,Object? base64 = freezed,Object? filename = freezed,}) {
   return _then(_PluginMessagePart(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
@@ -355,6 +361,11 @@ as String?,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullabl
 as String?,agentName: freezed == agentName ? _self.agentName : agentName // ignore: cast_nullable_to_non_nullable
 as String?,attempt: freezed == attempt ? _self.attempt : attempt // ignore: cast_nullable_to_non_nullable
 as int?,retryError: freezed == retryError ? _self.retryError : retryError // ignore: cast_nullable_to_non_nullable
+as String?,mime: freezed == mime ? _self.mime : mime // ignore: cast_nullable_to_non_nullable
+as String?,url: freezed == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String?,path: freezed == path ? _self.path : path // ignore: cast_nullable_to_non_nullable
+as String?,base64: freezed == base64 ? _self.base64 : base64 // ignore: cast_nullable_to_non_nullable
+as String?,filename: freezed == filename ? _self.filename : filename // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_message.freezed.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_message.freezed.dart
@@ -274,7 +274,7 @@ $PluginToolStateCopyWith<$Res>? get state {
 @JsonSerializable(createFactory: false)
 
 class _PluginMessagePart implements PluginMessagePart {
-  const _PluginMessagePart({required this.id, required this.sessionID, required this.messageID, required this.type, required this.text, required this.tool, required this.state, required this.prompt, required this.description, required this.agent, required this.agentName, required this.attempt, required this.retryError});
+  const _PluginMessagePart({required this.id, required this.sessionID, required this.messageID, required this.type, required this.text, required this.tool, required this.state, required this.prompt, required this.description, required this.agent, required this.agentName, required this.attempt, required this.retryError, this.mime, this.url, this.path, this.base64, this.filename});
   
 
 @override final  String id;
@@ -295,6 +295,12 @@ class _PluginMessagePart implements PluginMessagePart {
 // retry
 @override final  int? attempt;
 @override final  String? retryError;
+// file
+@override final  String? mime;
+@override final  String? url;
+@override final  String? path;
+@override final  String? base64;
+@override final  String? filename;
 
 /// Create a copy of PluginMessagePart
 /// with the given fields replaced by the non-null parameter values.
@@ -309,16 +315,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginMessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.state, state) || other.state == state)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.agentName, agentName) || other.agentName == agentName)&&(identical(other.attempt, attempt) || other.attempt == attempt)&&(identical(other.retryError, retryError) || other.retryError == retryError));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginMessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.state, state) || other.state == state)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.agentName, agentName) || other.agentName == agentName)&&(identical(other.attempt, attempt) || other.attempt == attempt)&&(identical(other.retryError, retryError) || other.retryError == retryError)&&(identical(other.mime, mime) || other.mime == mime)&&(identical(other.url, url) || other.url == url)&&(identical(other.path, path) || other.path == path)&&(identical(other.base64, base64) || other.base64 == base64)&&(identical(other.filename, filename) || other.filename == filename));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,sessionID,messageID,type,text,tool,state,prompt,description,agent,agentName,attempt,retryError);
+int get hashCode => Object.hash(runtimeType,id,sessionID,messageID,type,text,tool,state,prompt,description,agent,agentName,attempt,retryError,mime,url,path,base64,filename);
 
 @override
 String toString() {
-  return 'PluginMessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, state: $state, prompt: $prompt, description: $description, agent: $agent, agentName: $agentName, attempt: $attempt, retryError: $retryError)';
+  return 'PluginMessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, state: $state, prompt: $prompt, description: $description, agent: $agent, agentName: $agentName, attempt: $attempt, retryError: $retryError, mime: $mime, url: $url, path: $path, base64: $base64, filename: $filename)';
 }
 
 
@@ -329,7 +335,7 @@ abstract mixin class _$PluginMessagePartCopyWith<$Res> implements $PluginMessage
   factory _$PluginMessagePartCopyWith(_PluginMessagePart value, $Res Function(_PluginMessagePart) _then) = __$PluginMessagePartCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String sessionID, String messageID, PluginMessagePartType type, String? text, String? tool, PluginToolState? state, String? prompt, String? description, String? agent, String? agentName, int? attempt, String? retryError
+ String id, String sessionID, String messageID, PluginMessagePartType type, String? text, String? tool, PluginToolState? state, String? prompt, String? description, String? agent, String? agentName, int? attempt, String? retryError, String? mime, String? url, String? path, String? base64, String? filename
 });
 
 

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_message.g.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_message.g.dart
@@ -28,6 +28,11 @@ Map<String, dynamic> _$PluginMessagePartToJson(_PluginMessagePart instance) =>
       'agentName': ?instance.agentName,
       'attempt': ?instance.attempt,
       'retryError': ?instance.retryError,
+      'mime': ?instance.mime,
+      'url': ?instance.url,
+      'path': ?instance.path,
+      'base64': ?instance.base64,
+      'filename': ?instance.filename,
     };
 
 const _$PluginMessagePartTypeEnumMap = {

--- a/bridge/sesori_plugin_opencode/lib/src/message_part_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/message_part_mapper.dart
@@ -62,16 +62,38 @@ class MessagePartMapper {
       attempt: raw.attempt,
       retryError: raw.error.data.message,
     ),
-    FilePart() => _part(
-      raw.id,
-      raw.sessionID,
-      raw.messageID,
-      PluginMessagePartType.file,
-      mime: raw.mime,
-      filename: raw.filename,
-      url: raw.url,
-      path: raw.source is FileSource ? (raw.source as FileSource).path : null,
-    ),
+    FilePart() {
+      String? mime = raw.mime;
+      String? url = raw.url;
+      String? base64;
+      // Normalize data: URLs into base64 so the client can render them
+      // (Image.network does not support data: or file: schemes).
+      if (url != null && url.startsWith("data:")) {
+        final parts = url.split(",");
+        if (parts.length >= 2) {
+          base64 = parts.sublist(1).join(",");
+          if (mime == null || mime.isEmpty) {
+            final header = parts[0];
+            final mimeMatch = RegExp(r"data:([^;]+)").firstMatch(header);
+            if (mimeMatch != null) {
+              mime = mimeMatch.group(1);
+            }
+          }
+          url = null; // Don't send raw data: URL, base64 is set
+        }
+      }
+      return _part(
+        raw.id,
+        raw.sessionID,
+        raw.messageID,
+        PluginMessagePartType.file,
+        mime: mime,
+        filename: raw.filename,
+        url: url,
+        path: raw.source is FileSource ? (raw.source as FileSource).path : null,
+        base64: base64,
+      );
+    },
     SnapshotPart() => _part(raw.id, raw.sessionID, raw.messageID, PluginMessagePartType.snapshot),
     PatchPart() => _part(raw.id, raw.sessionID, raw.messageID, PluginMessagePartType.patch),
     CompactionPart() => _part(

--- a/bridge/sesori_plugin_opencode/lib/src/message_part_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/message_part_mapper.dart
@@ -3,6 +3,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "models/openapi/agent_part.g.dart";
 import "models/openapi/compaction_part.g.dart";
 import "models/openapi/file_part.g.dart";
+import "models/openapi/file_source.g.dart";
 import "models/openapi/part.g.dart";
 import "models/openapi/patch_part.g.dart";
 import "models/openapi/reasoning_part.g.dart";
@@ -61,7 +62,16 @@ class MessagePartMapper {
       attempt: raw.attempt,
       retryError: raw.error.data.message,
     ),
-    FilePart() => _part(raw.id, raw.sessionID, raw.messageID, PluginMessagePartType.file),
+    FilePart() => _part(
+      raw.id,
+      raw.sessionID,
+      raw.messageID,
+      PluginMessagePartType.file,
+      mime: raw.mime,
+      filename: raw.filename,
+      url: raw.url,
+      path: raw.source is FileSource ? (raw.source as FileSource).path : null,
+    ),
     SnapshotPart() => _part(raw.id, raw.sessionID, raw.messageID, PluginMessagePartType.snapshot),
     PatchPart() => _part(raw.id, raw.sessionID, raw.messageID, PluginMessagePartType.patch),
     CompactionPart() => _part(
@@ -93,6 +103,11 @@ class MessagePartMapper {
     String? agentName,
     int? attempt,
     String? retryError,
+    String? mime,
+    String? url,
+    String? path,
+    String? base64,
+    String? filename,
   }) => PluginMessagePart(
     id: id,
     sessionID: sessionID,
@@ -107,6 +122,11 @@ class MessagePartMapper {
     agentName: agentName,
     attempt: attempt,
     retryError: retryError,
+    mime: mime,
+    url: url,
+    path: path,
+    base64: base64,
+    filename: filename,
   );
 
   /// An unrecognized part shape. Every OpenCode part carries `id`,

--- a/bridge/sesori_plugin_opencode/lib/src/message_part_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/message_part_mapper.dart
@@ -66,8 +66,8 @@ class MessagePartMapper {
       String? mime = raw.mime;
       String? url = raw.url;
       String? base64;
-      // Normalize data: URLs into base64 so the client can render them
-      // (Image.network does not support data: or file: schemes).
+      // Normalize data: URLs into base64 so the client can render images
+      // via Image.memory (Image.network does not support data: scheme).
       if (url != null && url.startsWith("data:")) {
         final parts = url.split(",");
         if (parts.length >= 2) {
@@ -79,7 +79,8 @@ class MessagePartMapper {
               mime = mimeMatch.group(1);
             }
           }
-          url = null; // Don't send raw data: URL, base64 is set
+          // Keep url as fallback for non-image types (e.g. PDF) where
+          // the client may offer a download/link action.
         }
       }
       return _part(

--- a/client/app/lib/features/session_detail/widgets/assistant_message_card.dart
+++ b/client/app/lib/features/session_detail/widgets/assistant_message_card.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "agent_part_widget.dart";
+import "file_part_widget.dart";
 import "reasoning_part_card.dart";
 import "retry_part_widget.dart";
 import "subtask_part_widget.dart";
@@ -50,6 +51,7 @@ class AssistantMessageCard extends StatelessWidget {
       MessagePartType.stepFinish,
       MessagePartType.agent,
       MessagePartType.retry,
+      MessagePartType.file,
     ].contains(part.type);
   }
 
@@ -88,7 +90,7 @@ class AssistantMessageCard extends StatelessWidget {
       ),
       MessagePartType.stepStart => const SizedBox.shrink(),
       MessagePartType.stepFinish => const SizedBox.shrink(),
-      MessagePartType.file => const SizedBox.shrink(),
+      MessagePartType.file => FilePartWidget(key: ValueKey(part.id), part: part),
       MessagePartType.snapshot => const SizedBox.shrink(),
       MessagePartType.patch => const SizedBox.shrink(),
       MessagePartType.compaction => const SizedBox.shrink(),

--- a/client/app/lib/features/session_detail/widgets/file_part_widget.dart
+++ b/client/app/lib/features/session_detail/widgets/file_part_widget.dart
@@ -1,9 +1,11 @@
 import "dart:convert";
+import "dart:typed_data";
 
 import "package:flutter/material.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/module_prego.dart";
-import "package:url_launcher/url_launcher.dart";
+import "../../../core/external_link.dart";
 
 class FilePartWidget extends StatelessWidget {
   final MessagePart part;
@@ -27,18 +29,25 @@ class FilePartWidget extends StatelessWidget {
 
   Widget _buildImage(BuildContext context, IPregoTheme prego, String? url, String? base64, String filename) {
     if (base64 != null) {
-      final bytes = base64Decode(base64);
-      return Padding(
-        padding: const EdgeInsets.symmetric(vertical: 8),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(12),
-          child: Image.memory(
-            bytes,
-            fit: BoxFit.contain,
-            errorBuilder: (_, __, ___) => Icon(Icons.broken_image, size: 48, color: prego.colors.textTertiary),
+      Uint8List? bytes;
+      try {
+        bytes = base64Decode(base64);
+      } on FormatException {
+        logw("FilePartWidget: malformed base64 for $filename");
+      }
+      if (bytes != null) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(12),
+            child: Image.memory(
+              bytes,
+              fit: BoxFit.contain,
+              errorBuilder: (_, __, ___) => Icon(Icons.broken_image, size: 48, color: prego.colors.textTertiary),
+            ),
           ),
-        ),
-      );
+        );
+      }
     }
     if (url != null) {
       return Padding(
@@ -60,7 +69,7 @@ class FilePartWidget extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
       child: GestureDetector(
-        onTap: url != null ? () => launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication) : null,
+        onTap: url != null ? () => unawaited(openExternalLink(url: Uri.parse(url))) : null,
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
           decoration: BoxDecoration(

--- a/client/app/lib/features/session_detail/widgets/file_part_widget.dart
+++ b/client/app/lib/features/session_detail/widgets/file_part_widget.dart
@@ -3,6 +3,7 @@ import "dart:convert";
 import "package:flutter/material.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/module_prego.dart";
+import "package:url_launcher/url_launcher.dart";
 
 class FilePartWidget extends StatelessWidget {
   final MessagePart part;
@@ -58,22 +59,25 @@ class FilePartWidget extends StatelessWidget {
   Widget _buildFileLink(BuildContext context, IPregoTheme prego, String filename, String? url, String mime) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-        decoration: BoxDecoration(
-          color: prego.colors.bgSurfaceSecondary,
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: Row(
-          children: [
-            Icon(Icons.insert_drive_file, size: 20, color: prego.colors.textSecondary),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Text(filename, style: prego.textTheme.textSm.regular, overflow: TextOverflow.ellipsis),
-            ),
-            if (url != null)
-              Icon(Icons.open_in_new, size: 16, color: prego.colors.textSecondary),
-          ],
+      child: GestureDetector(
+        onTap: url != null ? () => launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication) : null,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          decoration: BoxDecoration(
+            color: prego.colors.bgSurfaceSecondary,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Row(
+            children: [
+              Icon(Icons.insert_drive_file, size: 20, color: prego.colors.textSecondary),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(filename, style: prego.textTheme.textSm.regular, overflow: TextOverflow.ellipsis),
+              ),
+              if (url != null)
+                Icon(Icons.open_in_new, size: 16, color: prego.colors.textSecondary),
+            ],
+          ),
         ),
       ),
     );

--- a/client/app/lib/features/session_detail/widgets/file_part_widget.dart
+++ b/client/app/lib/features/session_detail/widgets/file_part_widget.dart
@@ -1,0 +1,81 @@
+import "dart:convert";
+
+import "package:flutter/material.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_prego/module_prego.dart";
+
+class FilePartWidget extends StatelessWidget {
+  final MessagePart part;
+
+  const FilePartWidget({super.key, required this.part});
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    final mime = part.mime ?? "";
+    final url = part.url;
+    final base64 = part.base64;
+    final filename = part.filename ?? (url != null ? url.split("/").last : "file");
+    final isImage = mime.startsWith("image/");
+
+    if (isImage) {
+      return _buildImage(context, prego, url, base64, filename);
+    }
+    return _buildFileLink(context, prego, filename, url, mime);
+  }
+
+  Widget _buildImage(BuildContext context, IPregoTheme prego, String? url, String? base64, String filename) {
+    if (base64 != null) {
+      final bytes = base64Decode(base64);
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(12),
+          child: Image.memory(
+            bytes,
+            fit: BoxFit.contain,
+            errorBuilder: (_, __, ___) => Icon(Icons.broken_image, size: 48, color: prego.colors.textTertiary),
+          ),
+        ),
+      );
+    }
+    if (url != null) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(12),
+          child: Image.network(
+            url,
+            fit: BoxFit.contain,
+            errorBuilder: (_, __, ___) => Icon(Icons.broken_image, size: 48, color: prego.colors.textTertiary),
+          ),
+        ),
+      );
+    }
+    return const SizedBox.shrink();
+  }
+
+  Widget _buildFileLink(BuildContext context, IPregoTheme prego, String filename, String? url, String mime) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        decoration: BoxDecoration(
+          color: prego.colors.bgSurfaceSecondary,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          children: [
+            Icon(Icons.insert_drive_file, size: 20, color: prego.colors.textSecondary),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(filename, style: prego.textTheme.textSm.regular, overflow: TextOverflow.ellipsis),
+            ),
+            if (url != null)
+              Icon(Icons.open_in_new, size: 16, color: prego.colors.textSecondary),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/client/app/lib/features/session_detail/widgets/file_part_widget.dart
+++ b/client/app/lib/features/session_detail/widgets/file_part_widget.dart
@@ -5,7 +5,9 @@ import "package:flutter/material.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/module_prego.dart";
+import "../../../core/extensions/build_context_x.dart";
 import "../../../core/external_link.dart";
+import "../../../l10n/app_localizations.dart";
 
 class FilePartWidget extends StatelessWidget {
   final MessagePart part;
@@ -18,16 +20,50 @@ class FilePartWidget extends StatelessWidget {
     final mime = part.mime ?? "";
     final url = part.url;
     final base64 = part.base64;
-    final filename = part.filename ?? (url != null ? url.split("/").last : "file");
+    final filename = part.filename ?? _deriveFilename(url, part.path, context);
     final isImage = mime.startsWith("image/");
 
     if (isImage) {
-      return _buildImage(context, prego, url, base64, filename);
+      return _buildImage(
+        context: context,
+        prego: prego,
+        url: url,
+        base64: base64,
+        filename: filename,
+      );
     }
-    return _buildFileLink(context, prego, filename, url, mime);
+    return _buildFileLink(
+      context: context,
+      prego: prego,
+      filename: filename,
+      url: url,
+      mime: mime,
+    );
   }
 
-  Widget _buildImage(BuildContext context, IPregoTheme prego, String? url, String? base64, String filename) {
+  static String _deriveFilename(String? url, String? path, BuildContext context) {
+    if (url != null) {
+      final segments = Uri.tryParse(url)?.pathSegments;
+      if (segments != null && segments.isNotEmpty && segments.last.isNotEmpty) {
+        return segments.last;
+      }
+    }
+    if (path != null && path.isNotEmpty) {
+      final segments = path.split(RegExp(r"[/\\]"));
+      if (segments.isNotEmpty && segments.last.isNotEmpty) {
+        return segments.last;
+      }
+    }
+    return context.loc.sessionDetailFileUnknown;
+  }
+
+  Widget _buildImage({
+    required BuildContext context,
+    required IPregoTheme prego,
+    String? url,
+    String? base64,
+    required String filename,
+  }) {
     if (base64 != null) {
       Uint8List? bytes;
       try {
@@ -37,9 +73,9 @@ class FilePartWidget extends StatelessWidget {
       }
       if (bytes != null) {
         return Padding(
-          padding: const EdgeInsets.symmetric(vertical: 8),
+          padding: EdgeInsets.symmetric(vertical: prego.spacing.md),
           child: ClipRRect(
-            borderRadius: BorderRadius.circular(12),
+            borderRadius: BorderRadius.circular(prego.radius.xl),
             child: Image.memory(
               bytes,
               fit: BoxFit.contain,
@@ -51,9 +87,9 @@ class FilePartWidget extends StatelessWidget {
     }
     if (url != null) {
       return Padding(
-        padding: const EdgeInsets.symmetric(vertical: 8),
+        padding: EdgeInsets.symmetric(vertical: prego.spacing.md),
         child: ClipRRect(
-          borderRadius: BorderRadius.circular(12),
+          borderRadius: BorderRadius.circular(prego.radius.xl),
           child: Image.network(
             url,
             fit: BoxFit.contain,
@@ -65,21 +101,27 @@ class FilePartWidget extends StatelessWidget {
     return const SizedBox.shrink();
   }
 
-  Widget _buildFileLink(BuildContext context, IPregoTheme prego, String filename, String? url, String mime) {
+  Widget _buildFileLink({
+    required BuildContext context,
+    required IPregoTheme prego,
+    required String filename,
+    String? url,
+    required String mime,
+  }) {
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4),
+      padding: EdgeInsets.symmetric(vertical: prego.spacing.xs),
       child: GestureDetector(
         onTap: url != null ? () => unawaited(openExternalLink(url: Uri.parse(url))) : null,
         child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          padding: EdgeInsets.symmetric(horizontal: prego.spacing.lg, vertical: prego.spacing.md),
           decoration: BoxDecoration(
             color: prego.colors.bgSurfaceSecondary,
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: BorderRadius.circular(prego.radius.md),
           ),
           child: Row(
             children: [
               Icon(Icons.insert_drive_file, size: 20, color: prego.colors.textSecondary),
-              const SizedBox(width: 8),
+              SizedBox(width: prego.spacing.md),
               Expanded(
                 child: Text(filename, style: prego.textTheme.textSm.regular, overflow: TextOverflow.ellipsis),
               ),

--- a/client/app/lib/features/session_detail/widgets/user_message_card.dart
+++ b/client/app/lib/features/session_detail/widgets/user_message_card.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/module_prego.dart";
+import "file_part_widget.dart";
 
 class UserMessageCard extends StatelessWidget {
   final MessageWithParts message;
@@ -14,6 +15,7 @@ class UserMessageCard extends StatelessWidget {
         .where((part) => part.type == MessagePartType.text)
         .map((part) => part.text ?? "")
         .join("\n");
+    final fileParts = message.parts.where((part) => part.type == MessagePartType.file).toList();
 
     return Align(
       alignment: .centerRight,
@@ -27,15 +29,22 @@ class UserMessageCard extends StatelessWidget {
           color: prego.colors.bgBrandPrimary,
           borderRadius: BorderRadius.circular(16),
         ),
-        // SelectionArea (not SelectableText) to match the assistant card's
-        // selection model, so text selection behaves the same on every bubble.
-        child: SelectionArea(
-          child: Text(
-            text,
-            style: prego.textTheme.textSm.regular.copyWith(
-              color: prego.colors.textBrandPrimary,
-            ),
-          ),
+        child: Column(
+          crossAxisAlignment: .end,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (fileParts.isNotEmpty)
+              ...fileParts.map((part) => FilePartWidget(key: ValueKey(part.id), part: part)),
+            if (text.isNotEmpty)
+              SelectionArea(
+                child: Text(
+                  text,
+                  style: prego.textTheme.textSm.regular.copyWith(
+                    color: prego.colors.textBrandPrimary,
+                  ),
+                ),
+              ),
+          ],
         ),
       ),
     );

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -289,6 +289,10 @@
   "sessionDetailThinking": "Thinking...",
   "sessionDetailThought": "Thought",
   "sessionDetailToolUnknown": "Tool",
+  "sessionDetailFileUnknown": "Unknown file",
+  "@sessionDetailFileUnknown": {
+    "description": "Fallback label shown for a file attachment when the filename cannot be determined."
+  },
   "sessionDetailToolPending": "Pending",
   "sessionDetailToolRunning": "Running",
   "sessionDetailToolCompleted": "Done",

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -955,6 +955,12 @@ abstract class AppLocalizations {
   /// **'Tool'**
   String get sessionDetailToolUnknown;
 
+  /// Fallback label shown for a file attachment when the filename cannot be determined.
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown file'**
+  String get sessionDetailFileUnknown;
+
   /// No description provided for @sessionDetailToolPending.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -458,6 +458,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionDetailToolUnknown => 'Tool';
 
   @override
+  String get sessionDetailFileUnknown => 'Unknown file';
+
+  @override
   String get sessionDetailToolPending => 'Pending';
 
   @override

--- a/shared/sesori_shared/lib/src/models/sesori/message_part.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_part.dart
@@ -49,11 +49,11 @@ sealed class MessagePart with _$MessagePart {
     required int? attempt,
     required String? retryError,
     // file
-    required String? mime,
-    required String? url,
-    required String? path,
-    required String? base64,
-    required String? filename,
+    String? mime,
+    String? url,
+    String? path,
+    String? base64,
+    String? filename,
   }) = _MessagePart;
 
   factory MessagePart.fromJson(Map<String, dynamic> json) => _$MessagePartFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/message_part.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_part.dart
@@ -48,6 +48,12 @@ sealed class MessagePart with _$MessagePart {
     required String? agentName,
     required int? attempt,
     required String? retryError,
+    // file
+    required String? mime,
+    required String? url,
+    required String? path,
+    required String? base64,
+    required String? filename,
   }) = _MessagePart;
 
   factory MessagePart.fromJson(Map<String, dynamic> json) => _$MessagePartFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/message_part.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_part.freezed.dart
@@ -109,7 +109,7 @@ $ToolStateCopyWith<$Res>? get state {
 @JsonSerializable()
 
 class _MessagePart implements MessagePart {
-  const _MessagePart({required this.id, required this.sessionID, required this.messageID, required this.type, required this.text, required this.tool, required this.state, required this.prompt, required this.description, required this.agent, required this.agentName, required this.attempt, required this.retryError, required this.mime, required this.url, required this.path, required this.base64, required this.filename});
+  const _MessagePart({required this.id, required this.sessionID, required this.messageID, required this.type, required this.text, required this.tool, required this.state, required this.prompt, required this.description, required this.agent, required this.agentName, required this.attempt, required this.retryError, this.mime, this.url, this.path, this.base64, this.filename});
   factory _MessagePart.fromJson(Map<String, dynamic> json) => _$MessagePartFromJson(json);
 
 @override final  String id;
@@ -125,6 +125,12 @@ class _MessagePart implements MessagePart {
 @override final  String? agentName;
 @override final  int? attempt;
 @override final  String? retryError;
+// file
+@override final  String? mime;
+@override final  String? url;
+@override final  String? path;
+@override final  String? base64;
+@override final  String? filename;
 
 /// Create a copy of MessagePart
 /// with the given fields replaced by the non-null parameter values.
@@ -159,7 +165,7 @@ abstract mixin class _$MessagePartCopyWith<$Res> implements $MessagePartCopyWith
   factory _$MessagePartCopyWith(_MessagePart value, $Res Function(_MessagePart) _then) = __$MessagePartCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String sessionID, String messageID, MessagePartType type, String? text, String? tool, ToolState? state, String? prompt, String? description, String? agent, String? agentName, int? attempt, String? retryError
+ String id, String sessionID, String messageID, MessagePartType type, String? text, String? tool, ToolState? state, String? prompt, String? description, String? agent, String? agentName, int? attempt, String? retryError, String? mime, String? url, String? path, String? base64, String? filename
 });
 
 

--- a/shared/sesori_shared/lib/src/models/sesori/message_part.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_part.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MessagePart {
 
- String get id; String get sessionID; String get messageID; MessagePartType get type; String? get text; String? get tool; ToolState? get state; String? get prompt; String? get description; String? get agent; String? get agentName; int? get attempt; String? get retryError;
+ String get id; String get sessionID; String get messageID; MessagePartType get type; String? get text; String? get tool; ToolState? get state; String? get prompt; String? get description; String? get agent; String? get agentName; int? get attempt; String? get retryError; String? get mime; String? get url; String? get path; String? get base64; String? get filename;
 /// Create a copy of MessagePart
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $MessagePartCopyWith<MessagePart> get copyWith => _$MessagePartCopyWithImpl<Mess
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.state, state) || other.state == state)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.agentName, agentName) || other.agentName == agentName)&&(identical(other.attempt, attempt) || other.attempt == attempt)&&(identical(other.retryError, retryError) || other.retryError == retryError));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.state, state) || other.state == state)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.agentName, agentName) || other.agentName == agentName)&&(identical(other.attempt, attempt) || other.attempt == attempt)&&(identical(other.retryError, retryError) || other.retryError == retryError)&&(identical(other.mime, mime) || other.mime == mime)&&(identical(other.url, url) || other.url == url)&&(identical(other.path, path) || other.path == path)&&(identical(other.base64, base64) || other.base64 == base64)&&(identical(other.filename, filename) || other.filename == filename));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,sessionID,messageID,type,text,tool,state,prompt,description,agent,agentName,attempt,retryError);
+int get hashCode => Object.hash(runtimeType,id,sessionID,messageID,type,text,tool,state,prompt,description,agent,agentName,attempt,retryError,mime,url,path,base64,filename);
 
 @override
 String toString() {
-  return 'MessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, state: $state, prompt: $prompt, description: $description, agent: $agent, agentName: $agentName, attempt: $attempt, retryError: $retryError)';
+  return 'MessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, state: $state, prompt: $prompt, description: $description, agent: $agent, agentName: $agentName, attempt: $attempt, retryError: $retryError, mime: $mime, url: $url, path: $path, base64: $base64, filename: $filename)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $MessagePartCopyWith<$Res>  {
   factory $MessagePartCopyWith(MessagePart value, $Res Function(MessagePart) _then) = _$MessagePartCopyWithImpl;
 @useResult
 $Res call({
- String id, String sessionID, String messageID, MessagePartType type, String? text, String? tool, ToolState? state, String? prompt, String? description, String? agent, String? agentName, int? attempt, String? retryError
+ String id, String sessionID, String messageID, MessagePartType type, String? text, String? tool, ToolState? state, String? prompt, String? description, String? agent, String? agentName, int? attempt, String? retryError, String? mime, String? url, String? path, String? base64, String? filename
 });
 
 
@@ -65,7 +65,7 @@ class _$MessagePartCopyWithImpl<$Res>
 
 /// Create a copy of MessagePart
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? state = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,Object? agentName = freezed,Object? attempt = freezed,Object? retryError = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? state = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,Object? agentName = freezed,Object? attempt = freezed,Object? retryError = freezed,Object? mime = freezed,Object? url = freezed,Object? path = freezed,Object? base64 = freezed,Object? filename = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
@@ -80,6 +80,11 @@ as String?,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullabl
 as String?,agentName: freezed == agentName ? _self.agentName : agentName // ignore: cast_nullable_to_non_nullable
 as String?,attempt: freezed == attempt ? _self.attempt : attempt // ignore: cast_nullable_to_non_nullable
 as int?,retryError: freezed == retryError ? _self.retryError : retryError // ignore: cast_nullable_to_non_nullable
+as String?,mime: freezed == mime ? _self.mime : mime // ignore: cast_nullable_to_non_nullable
+as String?,url: freezed == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String?,path: freezed == path ? _self.path : path // ignore: cast_nullable_to_non_nullable
+as String?,base64: freezed == base64 ? _self.base64 : base64 // ignore: cast_nullable_to_non_nullable
+as String?,filename: freezed == filename ? _self.filename : filename // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }
@@ -104,7 +109,7 @@ $ToolStateCopyWith<$Res>? get state {
 @JsonSerializable()
 
 class _MessagePart implements MessagePart {
-  const _MessagePart({required this.id, required this.sessionID, required this.messageID, required this.type, required this.text, required this.tool, required this.state, required this.prompt, required this.description, required this.agent, required this.agentName, required this.attempt, required this.retryError});
+  const _MessagePart({required this.id, required this.sessionID, required this.messageID, required this.type, required this.text, required this.tool, required this.state, required this.prompt, required this.description, required this.agent, required this.agentName, required this.attempt, required this.retryError, required this.mime, required this.url, required this.path, required this.base64, required this.filename});
   factory _MessagePart.fromJson(Map<String, dynamic> json) => _$MessagePartFromJson(json);
 
 @override final  String id;
@@ -134,16 +139,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.state, state) || other.state == state)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.agentName, agentName) || other.agentName == agentName)&&(identical(other.attempt, attempt) || other.attempt == attempt)&&(identical(other.retryError, retryError) || other.retryError == retryError));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.state, state) || other.state == state)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.agentName, agentName) || other.agentName == agentName)&&(identical(other.attempt, attempt) || other.attempt == attempt)&&(identical(other.retryError, retryError) || other.retryError == retryError)&&(identical(other.mime, mime) || other.mime == mime)&&(identical(other.url, url) || other.url == url)&&(identical(other.path, path) || other.path == path)&&(identical(other.base64, base64) || other.base64 == base64)&&(identical(other.filename, filename) || other.filename == filename));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,sessionID,messageID,type,text,tool,state,prompt,description,agent,agentName,attempt,retryError);
+int get hashCode => Object.hash(runtimeType,id,sessionID,messageID,type,text,tool,state,prompt,description,agent,agentName,attempt,retryError,mime,url,path,base64,filename);
 
 @override
 String toString() {
-  return 'MessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, state: $state, prompt: $prompt, description: $description, agent: $agent, agentName: $agentName, attempt: $attempt, retryError: $retryError)';
+  return 'MessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, state: $state, prompt: $prompt, description: $description, agent: $agent, agentName: $agentName, attempt: $attempt, retryError: $retryError, mime: $mime, url: $url, path: $path, base64: $base64, filename: $filename)';
 }
 
 
@@ -171,7 +176,7 @@ class __$MessagePartCopyWithImpl<$Res>
 
 /// Create a copy of MessagePart
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? state = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,Object? agentName = freezed,Object? attempt = freezed,Object? retryError = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? state = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,Object? agentName = freezed,Object? attempt = freezed,Object? retryError = freezed,Object? mime = freezed,Object? url = freezed,Object? path = freezed,Object? base64 = freezed,Object? filename = freezed,}) {
   return _then(_MessagePart(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
@@ -186,6 +191,11 @@ as String?,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullabl
 as String?,agentName: freezed == agentName ? _self.agentName : agentName // ignore: cast_nullable_to_non_nullable
 as String?,attempt: freezed == attempt ? _self.attempt : attempt // ignore: cast_nullable_to_non_nullable
 as int?,retryError: freezed == retryError ? _self.retryError : retryError // ignore: cast_nullable_to_non_nullable
+as String?,mime: freezed == mime ? _self.mime : mime // ignore: cast_nullable_to_non_nullable
+as String?,url: freezed == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String?,path: freezed == path ? _self.path : path // ignore: cast_nullable_to_non_nullable
+as String?,base64: freezed == base64 ? _self.base64 : base64 // ignore: cast_nullable_to_non_nullable
+as String?,filename: freezed == filename ? _self.filename : filename // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }

--- a/shared/sesori_shared/lib/src/models/sesori/message_part.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_part.g.dart
@@ -22,6 +22,11 @@ _MessagePart _$MessagePartFromJson(Map json) => _MessagePart(
   agentName: json['agentName'] as String?,
   attempt: (json['attempt'] as num?)?.toInt(),
   retryError: json['retryError'] as String?,
+  mime: json['mime'] as String?,
+  url: json['url'] as String?,
+  path: json['path'] as String?,
+  base64: json['base64'] as String?,
+  filename: json['filename'] as String?,
 );
 
 Map<String, dynamic> _$MessagePartToJson(_MessagePart instance) =>
@@ -39,6 +44,11 @@ Map<String, dynamic> _$MessagePartToJson(_MessagePart instance) =>
       'agentName': ?instance.agentName,
       'attempt': ?instance.attempt,
       'retryError': ?instance.retryError,
+      'mime': ?instance.mime,
+      'url': ?instance.url,
+      'path': ?instance.path,
+      'base64': ?instance.base64,
+      'filename': ?instance.filename,
     };
 
 const _$MessagePartTypeEnumMap = {


### PR DESCRIPTION
## Summary

Add file and image attachment support to message parts — both for rendering AI-generated images/files on mobile and for displaying user-uploaded files.

## Changes

### Plugin interface (sesori_plugin_interface)
- Added mime, url, path, base64, filename fields to PluginMessagePart
- Made file part type visible (isVisible = true)

### Shared models (sesori_shared)
- Added same file metadata fields to shared MessagePart model

### OpenCode plugin (sesori_plugin_opencode)
- Map FilePart fields (mime, filename, url, path from FileSource)

### Bridge core (app/)
- Map new file fields from plugin to shared model

### Mobile client (client/app)
- New FilePartWidget — renders images inline, file links for other types
- Assistant and user message cards show file attachments

## Notes
Generated freezed/JSON files updated manually. Run `dart run build_runner build` in affected packages to regenerate.

All new fields are nullable and backward-compatible.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add file/image attachment support to message parts so mobile can render AI media and user uploads. Includes safety and polish: make file fields optional, guard base64 decoding, strip internal paths, parse `data:` URLs for images, and open non-image files with `openExternalLink`.

- **New Features**
  - Added `mime`, `url`, `path`, `base64`, `filename` to `PluginMessagePart` and shared `MessagePart`; made `file` visible and mapped fields in `sesori_plugin_opencode` and the bridge.
  - Mobile: new `FilePartWidget`; assistant and user cards render images inline; non-image files open via links; derive filenames from `url`/`path` with a localized “Unknown file” fallback.

- **Migration**
  - Run: `dart run build_runner build` in affected packages to regenerate freezed/JSON files.

<sup>Written for commit 148dcd4a5107ff4dac6017d64c9ecaedf7883452. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

