### PR TITLE
docs: add user analytics implementation plan

### DIFF
--- a/.opencode/skills/add-analytics/SKILL.md
+++ b/.opencode/skills/add-analytics/SKILL.md
@@ -64,6 +64,9 @@ PR after updating all in-repository consumers in lockstep.
 
 Never use a widget tap as a proxy when a confirmed outcome exists. Never emit a
 success event when an operation is queued, merely attempted, or later requeued.
+Capture product-event occurrence time at that authoritative seam before any
+preference deferral; a later Firebase emission timestamp must not move funnel or
+retention timing.
 
 ## Screen reporting
 
@@ -88,7 +91,8 @@ success event when an operation is queued, merely attempted, or later requeued.
 - Do not rename a released wire value. Add a schema version when semantics must
   change.
 - `input_mode=voice_assisted` means a successful transcript contributed to the
-  submitted composer value; it never means the final text was unedited.
+  submitted composer value; it never means the final text was unedited. Preserve
+  that bounded origin with any restored composer draft.
 
 ## Identity and privacy
 

--- a/.opencode/skills/add-analytics/SKILL.md
+++ b/.opencode/skills/add-analytics/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: add-analytics
+description: Design or add Sesori product analytics. Use when adding a user-facing feature, deciding whether an event is valuable, changing analytics identity/privacy, instrumenting an outcome, or adding BigQuery/Looker metrics. Covers authoritative hook points, layered delivery, bounded event design, GoRouter screen reporting, voice/login exceptions, and warehouse verification.
+---
+
+# add-analytics
+
+Design analytics that answer a product question without creating misleading or
+sensitive data.
+
+## Before adding an event
+
+An event is worthwhile only when all of these are concrete:
+
+1. **Decision:** What product decision or investor metric changes if this moves?
+2. **Meaning:** Is it an intent, confirmed outcome, state transition, or view?
+3. **Authority:** Which business success/failure seam proves it happened?
+4. **Population:** Is the unit an account, installation, or action? Never mix
+   those denominators under one label.
+5. **Privacy:** Can every parameter be a bounded enum/boolean or explicitly
+   approved scalar without code, content, paths, identity, or entity IDs?
+6. **Reporting:** Which curated model/view consumes it, and how are coverage,
+   maturity, freshness, and deduplication handled?
+
+If the answer is only “this button was tapped,” skip it unless that tap is the
+only honest signal for a defined funnel step.
+
+## Current and planned seams
+
+Until `.plan/active/user-analytics/` step 3 lands, the existing event union is
+`client/app/lib/core/analytics/analytics_event.dart` and the mobile shell owns
+`AnalyticsReporter`. Do not pretend the planned core files already exist or
+partially introduce the new architecture outside the series.
+
+After step 3 lands, the source of truth is the closed models under
+`client/module_core/lib/src/foundation/models/product_analytics/`, with
+repository delivery/preference records under `repositories/models/` and service
+state under `services/models/`:
+
+- Consumers call `ProductAnalyticsService` for authenticated account-linked
+  events.
+- The three approved pre-auth login events call
+  `InstallationAnalyticsService`; they are account-less and preference-exempt
+  by explicit product decision.
+- Delivery flows `Client (Foundation) -> API -> Repository -> Service ->
+  Consumer`. Cubits/widgets/listeners never hold `AnalyticsClient` or
+  `AnalyticsApi` directly.
+- Mobile implements `AnalyticsClient` with Firebase; desktop uses a no-op
+  adapter until desktop analytics has its own approved scope.
+
+Remove this transitional “until step 3” paragraph in the step-3 implementation
+PR after updating all in-repository consumers in lockstep.
+
+## Choose the authoritative hook
+
+| Event meaning | Correct seam | Example |
+| --- | --- | --- |
+| Confirmed outcome | Success branch after repository/service response | Message accepted, session created |
+| Failure diagnostic | Explicit typed failure branch | Session creation failed |
+| Reactive state | Dedicated listener or bounded transition guard | Bridge/screen state |
+| Screen | `GoRouterRouteSource` -> exhaustive `AnalyticsScreen` mapping | `product_screen_viewed` |
+| Flutter-only capability | UI call site after capability succeeds, calling Layer-3 service | Voice transcription completed |
+| Pre-auth login | `LoginCubit` terminal state through `InstallationAnalyticsService` | Timeout by provider |
+
+Never use a widget tap as a proxy when a confirmed outcome exists. Never emit a
+success event when an operation is queued, merely attempted, or later requeued.
+
+## Screen reporting
+
+- `GoRouterRouteSource.currentRouteStream` is the sole screen source.
+- Map every `AppRouteDef` exhaustively to a pinned `AnalyticsScreen`; never send
+  concrete paths, project/session IDs, or Dart enum names as implicit wire
+  values.
+- Disable Firebase automatic screen reporting on Android and Firebase-enabled
+  Apple targets.
+- Emit canonical account-linked `product_screen_viewed`, then let the Firebase
+  adapter best-effort mirror the same pinned name through `logScreenView`.
+- Curated account metrics use only `product_screen_viewed`; standard
+  `screen_view` is diagnostic. Test one custom + one native event per changed
+  GoRouter route and no automatic duplicate.
+
+## Parameters and naming
+
+- Event/parameter names: pinned `snake_case`, max 40 characters.
+- Use enums for closed values and explicit converters/mappings for existing
+  sealed types. Do not assume a domain type is an enum.
+- Max 25 parameters per GA4 event; fewer is better.
+- Do not rename a released wire value. Add a schema version when semantics must
+  change.
+- `input_mode=voice_assisted` means a successful transcript contributed to the
+  submitted composer value; it never means the final text was unedited.
+
+## Identity and privacy
+
+Never report:
+
+- prompt, response, transcript, code, reasoning, or tool content;
+- file/repository/project/session/branch/worktree names or paths;
+- raw or hashed project/session/bridge/device/notification IDs;
+- OAuth identity, username, email, provider user ID, IP/geography, or raw error
+  text;
+- coding provider/model/agent/tool/command names unless a later approved plan
+  changes the privacy contract.
+
+Account-linked events use only the pseudonymous custom `user_key` produced in
+the repository. Never set Firebase global `user_id` for the new design.
+Installation login events carry no `user_key` or attempt ID and may not be
+extended beyond their approved provider/failure enums without a new decision.
+
+## Implementation checklist
+
+1. Add a closed event variant and pinned parameter enums to the active source of
+   truth.
+2. Identify the authoritative success/failure/transition seam.
+3. Route through the correct Layer-3 service; update every mobile/desktop
+   constructor consumer in lockstep.
+4. Keep product behavior independent: analytics is best-effort, failure-isolated,
+   and never changes product success.
+5. Generate source outputs; never hand-edit generated files.
+6. Test exact wire names/parameters, success-only emission, failure/no-op paths,
+   deduplication, and absence of sensitive values.
+7. Add/update versioned BigQuery transforms and fixture `ASSERT`s. Account
+   metrics use `user_key` plus the eligible auth snapshot; installation events
+   aggregate without persisting `user_pseudo_id`.
+8. Show complete periods, denominators, cohort maturity, coverage, and freshness.
+9. Run analyze/tests for every touched module and affected downstream shell.
+
+## Do not create raw-export dashboards
+
+Investor and product dashboards read authorized aggregate reporting views, not
+ad-hoc views over raw `events_*`. Raw GA4 timestamps are integer microseconds;
+users/installations/accounts differ; rolling WAU needs a real seven-day range;
+and retention requires matured, fixed windows. Encode those contracts in curated
+SQL with fixture assertions rather than dashboard formulas.

--- a/.plan/active/user-analytics/PLAN.md
+++ b/.plan/active/user-analytics/PLAN.md
@@ -238,6 +238,8 @@ clear the hash persisted by current releases. It runs immediately after Firebase
 initialization and before custom sources. Vendor automatic initialization can
 precede that supported reset, so the plan treats possible pre-clear automatic
 rows as legacy raw data rather than promising an impossible zero-width window.
+If clear fails, classify/disclose that whole process as potentially legacy-
+keyed; disabling only custom events is not described as stopping automatic data.
 
 The core service combines installation-local intent with the server preference:
 
@@ -259,11 +261,15 @@ The core service combines installation-local intent with the server preference:
 - Server success stores synchronized disabled. Failure preserves the pending
   record and surfaces “disabled on this device; account sync pending”; retry is
   allowed only after post-splash readiness or explicit user action.
-- Enable keeps custom sharing inactive until server success and synchronized
-  local persistence.
+- Enable first persists inactive `pendingEnable`, then keeps custom sharing
+  inactive through server success until synchronized local persistence. A final
+  local write failure remains a truthful pending-finalization state across
+  restart, never a displayed failure followed by silent activation.
 - Logout/account loss never deletes a pending disable. The logout flow attempts
   one authenticated sync before credentials are cleared; if it fails, it
   preserves the record and requires reauthentication to finish server sync.
+  Every preference operation has a 10-second deadline, so it cannot hold logout
+  or the foreground reconciliation slot indefinitely.
 
 The setting is not advertised as a universal Firebase or legacy-client kill
 switch. It immediately controls Sesori-defined custom events on this
@@ -337,23 +343,25 @@ mixed `src/analytics/` bucket. The concrete dependency direction is:
 | `AnalyticsEvent`, bounded enums, `AnalyticsScreen`, `AnalyticsDeliveryResult`, `ProductAnalyticsPreference`, `ProductAnalyticsState`, `CampaignCode`, and persisted record variants under `module_core/lib/src/models/product_analytics/` | Domain models; no SDK/Flutter dependencies | Closed event/screen/preference/state values. `AnalyticsScreen` is independent of routing; `AnalyticsRouteListener` performs the exhaustive `AppRouteDef -> AnalyticsScreen` mapping. Delivery is `acceptedBySdk`, `deferredUntilPreference`, or `failed`, never an untruthful “reported” boolean. Campaign completion is account-scoped; the in-memory pending activation variant carries only one typed message-success event and its auth generation. |
 | `AnalyticsClient` in `module_core/lib/src/platform/analytics_client.dart` | Foundation external-sink capability | Typed `logEvent({required AnalyticsEvent event, required String userKey})`. The key is already pseudonymous and is serialized as the custom `user_key` event parameter, never global SDK identity. Methods throw SDK failures; they accept no arbitrary map/name or raw account ID. |
 | `AnalyticsApi` in `module_core/lib/src/api/analytics_api.dart` | Layer 1; constructor requires `AnalyticsClient` | Thin API over the external client. It is the only core class that invokes the platform sink. |
-| `ProductAnalyticsPreferenceApi` in `module_core/lib/src/api/product_analytics_preference_api.dart` | Layer 1; constructor requires `AuthenticatedHttpApiClient` | Calls authenticated GET/PUT `/product-analytics/preference`, serializes the closed enum, parses external strings at the boundary, and returns explicit success/failure. It does not mutate auth state. |
+| `ProductAnalyticsPreferenceApi` in `module_core/lib/src/api/product_analytics_preference_api.dart` | Layer 1; constructor requires `AuthenticatedHttpApiClient` | Calls authenticated GET/PUT `/product-analytics/preference` under a fixed 10-second operation deadline, serializes the closed enum, parses external strings at the boundary, and returns explicit success/timeout/failure. It does not mutate auth state; late transport completion is detached and cannot complete the bounded operation twice. |
 | `ProductAnalyticsPreferenceStorage` and `CampaignAttributionStorage` in `module_core/lib/src/storage/` | Layer 1 storage; each constructor requires `SecureStorage` | Read/write/delete only their closed persisted records. They do not reconcile accounts, call APIs, hash IDs, or emit analytics. |
 | `ProductAnalyticsRepository` in `module_core/lib/src/repositories/product_analytics_repository.dart` | Layer 2; constructor requires `AnalyticsApi` | Converts raw authenticated user ID to lowercase SHA-256, passes only the pseudonymous key downward, and maps API exceptions to explicit `AnalyticsDeliveryResult` without redundant logging. It adds `schema_version=1` through the typed event serialization contract. |
-| `ProductAnalyticsPreferenceRepository` in `module_core/lib/src/repositories/product_analytics_preference_repository.dart` | Layer 2; requires `ProductAnalyticsPreferenceApi` and `ProductAnalyticsPreferenceStorage` | Fetch/update server preference, scope local records to one account, persist only `synced(userId, preference)` or `pendingDisable(userId)`, and expose explicit results. Enable is never persisted pending. |
-| `CampaignAttributionRepository` in `module_core/lib/src/repositories/campaign_attribution_repository.dart` | Layer 2; requires `CampaignAttributionStorage` | Enforces a 24-hour pending TTL and persists either pre-auth `pending(code, capturedAt)` or `acceptedBySdk(userId, code, completedAt)`. Completion deduplicates only that account; any later valid pre-auth capture after logout replaces the completed record with pending before the next account is known. Absence genuinely means no campaign. It never stores a full URI/UTM text. |
+| `ProductAnalyticsPreferenceRepository` in `module_core/lib/src/repositories/product_analytics_preference_repository.dart` | Layer 2; requires `ProductAnalyticsPreferenceApi` and `ProductAnalyticsPreferenceStorage` | Fetch/update server preference, scope local records to one account, and persist only `synced(userId, preference)`, `pendingDisable(userId)`, or `pendingEnable(userId)`. `pendingEnable` is an inactive write-ahead/finalization state, never permission to emit. |
+| `CampaignAttributionRepository` in `module_core/lib/src/repositories/campaign_attribution_repository.dart` | Layer 2; requires `CampaignAttributionStorage` | Enforces a 24-hour TTL and persists pre-auth `pendingUnbound(code, capturedAt)`, post-attempt `pendingRetry(userId, code, capturedAt)`, or `acceptedBySdk(userId, code, completedAt)`. The first authenticated attempt binds any failure to that user; another account can never consume it. Any later valid pre-auth capture after logout replaces completed/failed state before the next account is known. Absence genuinely means no campaign. It never stores a full URI/UTM text. |
 | `ProductAnalyticsService` in `module_core/lib/src/services/product_analytics_service.dart` | Layer 3, `@lazySingleton`; requires `AuthSession` (read-only), existing `LifecycleSource`, `ProductAnalyticsRepository`, and `ProductAnalyticsPreferenceRepository` | Sole owner of preference/custom-event lifecycle and Consumer `logEvent`. Exposes a replaying state stream plus `start`, `markPostSplashReady`, `setPreference`, `retryPendingDisable`, and `dispose`. It performs no network work until readiness, revalidates while foregrounded, serializes reconciliation per auth generation, and sends no custom event unless active. While preference is unknown, it may retain exactly one bounded activation-candidate event for the current generation; all other inactive events remain unbuffered. |
-| `CampaignAttributionService` in `module_core/lib/src/services/campaign_attribution_service.dart` | Layer 3, `@lazySingleton`; requires read-only `AuthSession`, `CampaignAttributionRepository`, and `ProductAnalyticsService` | Captures a validated first touch and attempts the event only on an active transition/start. It marks account-scoped `acceptedBySdk` only when the service returns that typed result; failure leaves `pending` for a later lifecycle attempt without a timer loop. |
+| `CampaignAttributionService` in `module_core/lib/src/services/campaign_attribution_service.dart` | Layer 3, `@lazySingleton`; requires read-only `AuthSession`, `CampaignAttributionRepository`, and `ProductAnalyticsService` | Holds at most one bounded URI classification while auth restoration is unknown. It persists pre-auth first touch only after restoration conclusively yields unauthenticated, discards it if authenticated, and attempts only when the bound/current account matches. SDK failure changes unbound pending to account-bound retry; accepted state is also account-scoped. |
 | `AnalyticsRouteListener` in `module_core/lib/src/listeners/analytics_route_listener.dart` | Consumer/listener, `@lazySingleton`; requires `RouteSource` and `ProductAnalyticsService` | Owns route subscription, maps `AppRouteDef` exhaustively to `AnalyticsScreen`, signals readiness on the first non-splash route, and reports stable screens only while active. It never passes a route model/path to Foundation. |
 | `CampaignAttributionListener` in `module_core/lib/src/listeners/campaign_attribution_listener.dart` | Consumer/listener, `@lazySingleton`; requires `DeepLinkSource` and `CampaignAttributionService` | Replaces the obsolete app `DeepLinkService`, owns the one URI subscription, validates only approved `sesori.com/link` campaign codes, and ignores all other/legacy callback URIs without logging complete values. |
 | `NotificationOpenAnalyticsListener` in `module_core/lib/src/listeners/notification_open_analytics_listener.dart` | Consumer/listener, `@lazySingleton`; requires the bounded notification-open source and `ProductAnalyticsService` | Buffers at most the one validated cold-start open until preference reconciliation, emits it only if the same account becomes active, and drops it on disable, logout/account switch, or process-lifetime timeout. No entity ID enters the buffer. |
 | `ProductAnalyticsPreferenceCubit` in `module_core/lib/src/cubits/product_analytics_preference/` | Consumer; constructor requires `ProductAnalyticsService` | Subscribes to service state and exposes toggle/retry intents. Mobile Settings constructs it; it is not in DI. |
 | `FirebaseAnalyticsClient` in `app/lib/core/platform/firebase_analytics_client.dart` | Thin mobile Foundation adapter, `@LazySingleton(as: AnalyticsClient)`; requires `FirebaseAnalytics` | Serializes only typed custom events plus `schema_version` and `user_key`, and throws failures upward. It never applies global identity/collection overrides and contains no route/campaign/preference/hash business logic. Firebase-disabled environments use the existing no-op SDK object. |
-| `FirebaseAnalyticsIdentityMigration` in `app/lib/core/platform/firebase_analytics_identity_migration.dart` | Mobile-only pre-core bootstrap helper; requires `FirebaseAnalytics` | Immediately after Firebase initialization and before DI/listeners, awaits `setUserId(id: null)` to clear the hash persisted by prior releases. It does nothing else to consent/collection. Failure leaves the process custom-event adapter disabled and retries next launch. Keep this cleanup through minimum-supported-version adoption plus the 90-day raw window, then remove it explicitly. |
+| `FirebaseAnalyticsIdentityMigration` in `app/lib/core/platform/firebase_analytics_identity_migration.dart` | Mobile-only pre-core bootstrap helper; requires `FirebaseAnalytics` | Immediately after Firebase initialization and before DI/listeners, awaits `setUserId(id: null)` to clear the hash persisted by prior releases. It does nothing else to consent/collection. Failure leaves the process custom-event adapter disabled and retries next launch; because automatic collection cannot then be safely reconfigured without another persisted override, the **entire failed process** is classified/disclosed as potentially legacy-keyed and remains covered by recurring legacy deletion. Keep this cleanup through minimum-supported-version adoption plus the 90-day raw window, then remove it explicitly. |
 | `NoOpAnalyticsClient` in `desktop/lib/core/platform/no_op_analytics_client.dart` | Desktop phase-1 Foundation adapter | Satisfies shared core DI and accepts operations without collection. No desktop listeners are started. |
 
-`AnalyticsScreen` pins snake-case wire values for login, projects, settings and
-its subpages, sessions, new session, session detail, and session diffs. Screen
+`AnalyticsScreen` pins snake-case wire values for login, projects, approved
+settings groupings, sessions, new session, session detail, and session diffs.
+`settingsHarnesses` and `settingsHarnessManagement` both map to generic
+`settings`; they never produce harness-specific wire values. Screen
 activity is the Sesori custom `product_screen_viewed` event rather than Firebase
 `screen_view`, so the custom-event gate and `user_key` always apply. The
 route listener's exhaustive switch also handles splash explicitly (readiness
@@ -391,7 +399,10 @@ listener exists yet. A native automatic startup event can still occur between
 vendor SDK initialization and this earliest supported reset; treat any such
 legacy-keyed row as restricted raw legacy data, exclude automatic events from
 behavioral models, cover it through the legacy `USER_ID` deletion path, and do
-not claim that upgrade retroactively removes it.
+not claim that upgrade retroactively removes it. If the clear fails, this legacy
+classification applies to every automatic event for that whole process—not only
+startup—while all custom events remain disabled. Recurring deletion sweeps keep
+submitting the legacy user key; do not claim automatic collection was stopped.
 
 ### Preference and lifecycle data flow
 
@@ -406,12 +417,14 @@ then may the service fetch/reconcile for the currently authenticated account.
 If login is still unauthenticated, it waits for the later auth emission. Thus
 `restoreLocalSession()` cannot trigger a splash-time network request.
 
-**Reconciliation:** A same-account local `pendingDisable` keeps custom sharing off
-and PUTs disabled after readiness. Otherwise the repository GETs the server
-preference; returned disabled stays off, while returned enabled in a release
-build allows `ProductAnalyticsRepository` to hash the account ID for each typed
-event. Debug/profile/unsupported builds retain the desired preference but
-publish `ProductAnalyticsState.inactive(buildUnsupported)`.
+**Reconciliation:** A same-account local `pendingDisable` keeps custom sharing
+off and PUTs disabled after readiness. `pendingEnable` also stays inactive: GET
+disabled returns to synchronized disabled; GET enabled must first finalize
+synchronized enabled storage before event acceptance. Otherwise the repository
+GETs the server preference; returned disabled stays off, while returned enabled
+in a release build allows `ProductAnalyticsRepository` to hash the account ID
+for each typed event. Debug/profile/unsupported builds retain the desired
+preference but publish `ProductAnalyticsState.inactive(buildUnsupported)`.
 
 Every auth emission/account switch/logout increments a monotonically increasing
 service generation. Each GET, PUT, persistence operation, and scheduled refresh
@@ -424,7 +437,11 @@ within one generation. After initial readiness the service refreshes on each
 time while continuously resumed. A returned disabled value synchronously marks
 the current generation inactive before any follow-up persistence await. Network
 failure preserves the honest prior local state and last-successful-check time;
-the UI makes the conditional online propagation bound explicit.
+the UI makes the conditional online propagation bound explicit. Every preference
+GET/PUT has the API's 10-second operation deadline. Timeout releases the sole
+reconciliation slot and advances no state; generation checks ignore any detached
+late completion. Disable intent remains durable, so neither logout nor future
+15-minute checks can be held indefinitely by one request.
 
 **Schema exposure and first-message deferral:** On each process's first active
 transition, the service attempts `analytics_schema_ready` before later buffered
@@ -447,34 +464,44 @@ surfaces unsaved failure unless the server confirms disabled. Retry occurs only
 from Settings or a later post-splash lifecycle, never from a timer or splash
 auth emission.
 
-**Enable:** Custom sharing remains off while the preference repository PUTs
-enabled. Only server success followed by synchronized local persistence allows
-the analytics repository to hash/send. Failed enable remains disabled and is
-not persisted for automatic future activation.
+**Enable:** Custom sharing remains off. The first awaited operation writes
+`pendingEnable(userId)`; if that write fails, no server PUT occurs. The service
+then PUTs enabled under the bounded deadline and, on success, must persist
+synchronized enabled before activation. If final persistence fails,
+`pendingEnable` remains durable and the UI reports “enabled on account; local
+finalization pending,” not failure; restart/retry stays inactive until final
+storage succeeds. PUT failure/timeout also remains inactive and requires
+explicit retry/cancellation, or a later reconciliation that confirms server
+enabled and successfully finalizes local storage. The UI always says pending,
+not failed, until one of those outcomes; no later activation contradicts the
+displayed result.
 
 **Logout/account switch:** Before explicit logout clears credentials, the auth
 consumer asks the service to attempt one pending disable sync. Regardless of
 success it immediately suppresses custom events. Failure must not block logout:
 the encrypted pending record remains scoped by raw ID and is retried after that
 account reauthenticates; it never applies to another account. Unexpected token
-loss preserves the same record. No path claims or requests a Firebase-wide data
-reset.
+loss preserves the same record. The attempt is bounded by the 10-second API
+deadline, after which logout clears credentials and continues. No path claims or
+requests a Firebase-wide data reset.
 
 **Screen flow:** The route listener retains the latest `AnalyticsScreen` while
 inactive. Inactive-to-active emits `product_screen_viewed` once; later changed
 screen enums emit once. Foundation sees neither `AppRouteDef` nor a concrete URI.
 
-**Campaign flow:** The campaign listener converts only an approved URI received
-while unauthenticated to `CampaignCode`; authenticated/post-signup opens are
-ignored. The service/repository stores first touch plus capture time before auth
-and expires it after 24 hours. On active state it attempts
+**Campaign flow:** During splash/session restoration, authenticated state is
+`unknown`, not unauthenticated. The listener may hold one validated bounded code
+in memory, but stores nothing until restoration resolves: authenticated drops
+it; conclusively unauthenticated stores `pendingUnbound(code, capturedAt)`.
+Authenticated/post-signup opens are ignored. On active state it attempts
 `campaign_attributed`. `acceptedBySdk` is persisted only from the typed accepted
 result as `acceptedBySdk(userId, code, completedAt)` and deduplicates only that
 account. Any later valid pre-auth link after logout replaces prior completion
 with pending before the next account is known; if account B then signs up, A's
 completion cannot consume B's first touch. If A logs back in instead, the
-warehouse age/earliest rules make the extra attempt harmless. A failed result
-leaves pending, with at most one attempt per active lifecycle; BigQuery accepts
+warehouse age/earliest rules make the extra attempt harmless. The first failed
+SDK attempt converts unbound state to `pendingRetry(userId, ...)`; only that same
+current account may retry, and account switch discards it. BigQuery accepts
 attribution only when the account is at most 24 hours old at event time and
 selects the earliest eligible event. Existing
 accounts opening campaign links before login therefore remain unattributed.
@@ -495,7 +522,7 @@ Existing wire names remain unchanged. Add only the following initial events:
 | --- | --- | --- | --- |
 | `analytics_schema_ready` | The process first becomes active for an authenticated account under schema v1 | none beyond shared schema/key | Per-account instrumentation-capable exposure; never activity |
 | `project_inventory_loaded` | The first successful empty inventory and the first successful non-empty inventory in a cubit lifetime | `inventory_state=empty/non_empty` | First project available from earliest non-empty; empty is onboarding friction |
-| `session_activity_viewed` | The first successful empty snapshot and the first successful non-empty snapshot in a cubit lifetime | `activity_state=empty/non_empty` | Meaningful monitoring from earliest non-empty; empty is diagnostic only |
+| `session_activity_viewed` | The first successful empty snapshot in a cubit lifetime, and at most one successful non-empty snapshot per UTC date while that session detail is visible/foregrounded | `activity_state=empty/non_empty` | Earliest non-empty is the monitoring milestone; dated non-empty events support WAU/retention without SSE inflation |
 | `session_message_sent` | Existing-session send returns success, including a queued send that later succeeds | `submission_kind=text/command` | Full activation, control activity |
 | `session_created_with_message` | `createSessionWithMessage` returns success | `submission_kind`, `workspace_kind=project/dedicated_worktree` | Full activation, remote creation, worktrees |
 | `session_creation_failed` | That creation returns an explicit failure | `failure_reason` from bounded `RemoteFailureReason`, `workspace_kind` | Creation friction; never activation |
@@ -521,8 +548,8 @@ an additional `session_message_sent`.
 - `ProductAnalyticsService`: schema-ready exposure on first active transition.
 - `ProjectListCubit`: first successful empty and first successful non-empty
   inventory states.
-- `SessionDetailCubit._loadMessages`: first successful empty and first
-  successful non-empty activity states.
+- `SessionDetailCubit._loadMessages` plus its existing lifecycle handling: first
+  empty diagnostic and one visible/foreground non-empty activity per UTC date.
 - `SessionDetailCubit.sendMessage` and `_drainQueuedMessages`: accepted
   existing-session messages.
 - `NewSessionCubit.createSession`: accepted created session/message and bounded
@@ -550,7 +577,7 @@ merely to avoid updating tests.
 | Owner change | Exact flow and deduplication |
 | --- | --- |
 | `ProjectListCubit` | Add required `ProductAnalyticsService` and retain the bounded inventory states already emitted in that cubit lifetime. Emit the first successful `empty` once and the first later/same-lifecycle `non_empty` once; refreshes never repeat either classification. The warehouse milestone uses only earliest non-empty. |
-| `SessionDetailCubit` view | Add required product analytics service and retain the bounded activity states already emitted. Initial empty may emit once; a later non-empty transition from refresh/SSE emits once and is not suppressed by the earlier empty diagnostic. Repeated snapshots in either state do not emit. |
+| `SessionDetailCubit` view | Add required product analytics service. Retain one lifetime empty-diagnostic guard plus the last UTC date for which visible/foreground non-empty activity was emitted. Initial or later empty emits once; the first successful non-empty load/refresh/SSE on each UTC date emits once while the route is visible and lifecycle resumed. Background events emit nothing; resume reload can emit for a new date. This preserves earliest monitoring while supporting later WAU/retention without per-SSE counts. |
 | `SessionDetailCubit` send paths | Direct `sendMessage` and `_drainQueuedMessages` call one private `_reportAcceptedSubmission` only on `SuccessResponse`. The queued item retains only text/command for sending; analytics derives text/command without reading content. Error/requeue emits nothing, and each dequeued successful item reports once. |
 | `NewSessionCubit` | Add required product analytics service. Capture workspace/submission classifications before awaiting. `SuccessResponse` makes one `session_created_with_message` call; `ErrorResponse` emits only bounded `session_creation_failed`. It never also emits the existing-session event. |
 | `SessionDetailCubit` question/permission/abort | Report after each existing method's success branch. Question answers/rejections carry no answer data; permission maps the existing `PermissionReply` enum; abort reports only after every root/active-child response succeeds. |
@@ -843,9 +870,11 @@ not weaken the written privacy boundary to fit an unchecked property.
 
 1. **`events_flattened`**: flatten only catalogued Sesori custom events/parameters
    from GA4, use `event_timestamp` in UTC, require schema version and non-null
-   custom `user_key`, and retain Firebase platform/app version/build. Exclude
-   internal/test keys, but deliberately do **not** join the current auth snapshot
-   here. Raw bundle/install fields may be used transiently to discard
+   custom `user_key`, and retain Firebase platform/app version/build. Anti-join
+   both active internal/test keys and the permanent deletion-exclusion keys on
+   every build/recomputation, but deliberately do **not** join the time-varying
+   current auth eligibility snapshot here. Raw bundle/install fields may be used
+   transiently to discard
    byte-identical export duplicates but are not selected into the table. This
    recoverable 90-day fact layer prevents a transient auth-export outage from
    permanently discarding otherwise eligible events.
@@ -933,8 +962,13 @@ only three days.
   suppression operation, verifies preference disabled plus
   `productAnalyticsExportSuppressedAt`, and only then adds `user_key` to a
   restricted deletion-exclusion control. It deletes matching auth-private/
-  curated/reporting rows and rebuilds identifier-free setup cohorts; the source
-  tombstone prevents the next daily export from restoring either contribution.
+  curated/reporting rows and rebuilds identifier-free setup cohorts. It does not
+  declare warehouse completion until an auth export with
+  `runCutoff >= productAnalyticsExportSuppressedAt` has published, then performs
+  one final delete/rebuild and verifies the key/contribution remains absent.
+  Thus an export staged before the tombstone may finish, but cannot restore data
+  after the verified tombstone-aware run/final cleanup; no broad cross-system
+  lock is required.
 - From the still-retained raw window, resolve only `user_pseudo_id` values whose
   installation emitted a matching keyed custom event and submit GA4 User
   Deletion API requests as app-instance IDs. Also submit the hashed key as legacy
@@ -944,9 +978,18 @@ only three days.
   deletion request; do not claim otherwise. Its unlinked GA4 data is governed by
   the verified two-month upstream retention. State this limit in the privacy
   notice/deletion response rather than creating a persistent account-device map.
+- Keep deletion-exclusion tombstones permanent and run a daily upstream deletion
+  sweep over newly landed raw partitions. For every tombstoned key it discovers
+  newly uploaded keyed installation IDs (including events queued while a
+  supported client was offline), resubmits GA app-instance deletion, deletes any
+  matching warehouse rows, and always submits the legacy `USER_ID` while that
+  migration window remains possible. The request can report source/warehouse
+  deletion plus recurring enforcement installed, but must not promise that an
+  offline client's future upload can never transiently reach restricted raw.
   Record request IDs/completion without raw account/install IDs. Test the API
-  credential, request format, source non-repopulation, aggregate rebuild, and a
-  non-production deletion before rollout.
+  credential, request format, in-flight export ordering, delayed offline upload,
+  flattened anti-join/non-repopulation, aggregate rebuild, and a non-production
+  deletion before rollout.
 
 ## Looker Studio
 
@@ -1044,13 +1087,14 @@ directory name.
   disclosure updates.
 - Test API parsing, layer wiring, fail-closed custom events during splash,
   post-splash fetch, pending-disable storage as the first awaited operation,
-  storage failure, crash/restart pending recovery, legacy-ID clear success/
-  failure ordering before custom sources, logout sync failure/account-switch
-  preservation,
-  enable-after-server success, delayed GET/PUT/storage completions across rapid
-  login/logout/account switches, foreground/15-minute refresh propagation,
-  debug suppression, core identity hash, route-to-screen mapping, event wire
-  pins, and mobile/desktop DI.
+  storage failure, crash/restart pending recovery, pending-enable write-ahead/
+  finalization failure, 10-second timeout releasing logout/reconciliation,
+  legacy-ID clear success/failure ordering and whole-process disclosure, logout
+  sync failure/account-switch preservation, enable-after-server success, delayed
+  GET/PUT/storage completions across rapid login/logout/account switches,
+  foreground/15-minute refresh propagation, harness routes mapping only to
+  generic settings, debug suppression, core identity hash, route-to-screen
+  mapping, event wire pins, and mobile/desktop DI.
 - Release only after both auth PRs are deployed. Once users can opt out, this
   custom-event lifecycle becomes a non-rollback privacy floor: subsequent
   client fixes must preserve it or suppress all Sesori custom events.
@@ -1067,22 +1111,24 @@ directory name.
   non-blocking.
 - Buffer only the first activation-candidate outcome while same-generation
   preference is unknown, then emit on active or drop on disabled/auth change;
-  report first empty and first later non-empty inventory/activity/diff states
-  separately.
+  report first empty/non-empty transitions for milestones and at most one
+  visible non-empty session activity per UTC date for WAU/retention.
 - Preserve bounded notification category/event type through open dispatch and
   classify push/local plus cold/warm; buffer the single cold-start open until
   same-account preference resolution and drop it on disable/logout/timeout.
 - Add core campaign Storage -> repository -> service -> deep-link listener,
-  24-hour pre-auth capture/attribution rules, typed SDK-acceptance result, and
-  remove the obsolete app `DeepLinkService` and full URI logging.
+  auth-restoration hold, 24-hour pre-auth capture/attribution rules, account-
+  bound failed retry, typed SDK-acceptance result, and remove the obsolete app
+  `DeepLinkService` and full URI logging.
 - Regenerate only source-generated outputs.
 - Add focused tests that failures/taps/queued-only operations do not activate,
   each successful message path makes one service call, new-session success is not
   double counted, sensitive inputs cannot enter parameter maps, notification
   classification and first-message deferral survive preference resolution,
-  empty-to-non-empty transitions report once, post-signup/old-account links
-  cannot become acquisition, account A completion cannot consume account B's
-  first touch, and campaign values are bounded.
+  empty-to-non-empty transitions report once, resumed/later-date monitoring can
+  report again without SSE inflation, auth-unknown links wait for restoration,
+  post-signup/old-account links cannot become acquisition, and account A failed/
+  completed state cannot consume account B's first touch.
 
 ### PR 5/5 — Warehouse models and dashboards
 
@@ -1100,6 +1146,9 @@ directory name.
 - Schedule the auth export and three-day event recomputation, then reconcile
   source counts and freshness; verify stale auth snapshots abort publication and
   recovery backfills the missed window.
+- Apply deletion exclusion in flattened facts, schedule the recurring upstream
+  tombstone sweep, and require a tombstone-aware auth export plus final cleanup
+  before declaring warehouse deletion complete.
 - Build and permission the seven-page Looker report.
 - Run a release-build smoke test through account -> bridge -> project -> message
   and verify the event, auth join, full activation, complete-day table, and
@@ -1114,7 +1163,7 @@ directory name.
 | Before 1/5 | Existing clients/events continue. Firebase daily export should be linked only through the controlled day-zero sequence so its non-retroactive clock starts safely. | Complete restricted-project IAM, daily-only link, raw expiration/settings verification, and record `raw_export_start_at`. | Unlinking loses future export and is not a useful rollback; stop rollout and correct IAM/expiration/location before derived datasets or new instrumentation. |
 | After 1/5 | Dedicated GET/PUT preference endpoints work; old clients are unaffected because auth responses did not change. New users always write preference; old documents read as enabled during migration. | Deploy write-first web code to all serving instances, verify new writes, run/re-run backfill, and record zero missing. | Roll back before any opt-out client release if necessary. The added field is ignored by old code; do not remove it. Re-run backfill after returning to step 1. |
 | After 2/5 | Preference schema is required and export command/job image is deployable but unscheduled. Existing clients remain unaffected. | Require recorded zero-missing evidence from step 1; deploy enforcement; smoke-test account creation and endpoints; deploy job disabled. | Roll back web/job to step 1, whose honest missing-field default can read every document. Stop any job; published tables stay at last good state. |
-| After 3/5 | Mobile clears the prior global Firebase user ID before custom sources, can disable/enable Sesori custom events on this installation, and syncs its server reporting/supported-client preference; existing custom events and stable screens obey the lifecycle; Firebase automatic install events retain the separately disclosed property behavior; desktop remains no-op. | Both auth endpoints/schema must be live. If legacy-ID clear fails, custom events stay disabled for that process; if preference is unavailable, GET/enable fails closed and disable remains local pending without blocking logout. | **Forward-fix only after public release.** Preserve both legacy-ID cleanup and local custom-event gating through their declared floors. For a severe defect, suppress all custom events; do not claim control over legacy/automatic events. Server preference data is never rolled back. |
+| After 3/5 | Mobile clears the prior global Firebase user ID before custom sources, can disable/enable Sesori custom events on this installation, and syncs its server reporting/supported-client preference; existing custom events and stable screens obey the lifecycle; Firebase automatic install events retain the separately disclosed property behavior; desktop remains no-op. | Both auth endpoints/schema must be live. If legacy-ID clear fails, custom events stay disabled and all automatic events for that process are classified as potentially legacy-keyed; if preference is unavailable, GET/enable fails closed and disable remains local pending without blocking logout. | **Forward-fix only after public release.** Preserve both legacy-ID cleanup and local custom-event gating through their declared floors. For a severe defect, suppress all custom events; do not claim automatic collection stopped on clear failure or that legacy behavior is controlled. Server preference data is never rolled back. |
 | After 4/5 | New activation/engagement events accumulate in GA4 raw export. Product operations remain unchanged if Firebase is unavailable. | Step 3 custom-key/preference/schema lifecycle must be released. BigQuery needs no GA4 custom-dimension registration. | Forward-fix the app while retaining step-3 privacy behavior; event-specific defects may be disabled/removed. Missing future event names yield null/zero data, not product failure. |
 | After 5/5 | Auth job, curated models, authorized reporting views, and Looker provide the complete metric contract. | Create same-location datasets/IAM; deploy SQL/tests; schedule auth export; validate its first publish; schedule event transforms; then connect Looker. | Pause schedules/job and revert reporting views/dashboard sources to last known-good SQL. Raw GA4 and prior auth published tables remain; app behavior is unaffected. |
 
@@ -1141,7 +1190,9 @@ the separately released app.
   custom-event sharing on for convenience.
 - Seed the current release's global Firebase user ID, upgrade to the new build,
   and verify null-clear completes before any custom source starts; force clear
-  failure and verify custom events remain disabled while product startup works.
+  failure and verify custom events remain disabled while product startup works,
+  then verify the runbook classifies the whole process's automatic rows as
+  potentially legacy-keyed rather than claiming collection stopped.
 
 ### Auth server
 
@@ -1159,8 +1210,9 @@ the separately released app.
   inclusion, failed/queued exclusion, deferred first-message selection, timely
   per-account schema exposure, legacy-without-exposure exclusion, 7-day cohort
   maturity, W1/W4 boundaries, internal/disabled/suppressed filtering before
-  aggregates, the 24-hour campaign rule, unknown campaign, stale-auth-snapshot
-  publication abort/recovery, and late-event replacement.
+  aggregates, deletion exclusion in flattened recomputation, daily monitoring
+  activity without SSE duplication, the 24-hour campaign rule, unknown campaign,
+  stale-auth-snapshot publication abort/recovery, and late-event replacement.
 - Reconcile GA4 custom event counts -> flattened events -> daily activity ->
   reporting totals for at least three complete days.
 - Verify auth export credentials cannot write controls/curated/reporting, Looker
@@ -1169,8 +1221,10 @@ the separately released app.
 - Verify raw ACL/default expiration and GA4 two-month retention before data
   acceptance, then complete one non-production GA User Deletion API exercise
   through auth-source tombstone, warehouse suppression/deletion, aggregate
-  rebuild/non-repopulation, and upstream request status. Verify the deletion
-  response states the automatic-only never-keyed installation limit.
+  rebuild/non-repopulation after an in-flight pre-tombstone export, delayed
+  offline-client upload plus recurring sweep, and upstream request status.
+  Verify the deletion response states both the transient future-upload and
+  automatic-only never-keyed installation limits.
 
 ## Rollout And Two-Month Readiness
 
@@ -1216,8 +1270,13 @@ no cohort has matured.
   and never claim account-wide enforcement without minimum-version controls.
 - **Legacy global identity on upgrade:** clear it at earliest post-Firebase
   bootstrap before custom sources and keep the migration for the raw-retention
-  window. Automatic events before that supported reset remain restricted legacy
-  raw data and are never represented as fully preventable.
+  window. Automatic events before a successful reset—or for the whole process
+  when reset fails—remain restricted legacy raw data and are never represented
+  as fully preventable.
+- **Offline upload after deletion:** permanent source/control tombstones,
+  flattened anti-join, and daily upstream resweeps prevent durable reporting and
+  repeatedly delete newly discovered keyed installs; the response remains
+  honest that a later upload may transiently enter restricted vendor/raw data.
 - **Privacy rollback floor:** after the opt-out release, use forward fixes that
   preserve local pending-disable/custom-event gating or suppress all custom
   events; never republish old startup emission as rollback.
@@ -1245,15 +1304,18 @@ The work is complete when:
 - A production release makes one analytics emission attempt per confirmed
   first-message success path with a pseudonymous custom `user_key`, immediately
   honors installation-local disable/re-enable semantics, preserves pending
-  server sync across logout/restart, defers the first same-generation message
-  while preference is unknown, clears legacy global identity before custom
-  sources, and never claims to control legacy or automatic events; duplicate
-  delivery cannot change the earliest activation.
+  disable/enable sync across logout/restart, bounds preference operations,
+  defers the first same-generation message while preference is unknown, clears
+  legacy global identity before custom sources, and never claims to control
+  legacy or automatic events; duplicate delivery cannot change activation.
 - The auth job publishes validated eligible milestones and external-account
   setup cohorts without raw identity or internal/deletion-suppressed accounts.
 - BigQuery derives the metric contract above from versioned SQL, passes fixture
   assertions, survives stale auth snapshots without permanent event loss, and
   remains fresh after recovery/late data.
+- Privacy deletion remains excluded from flattened/reporting rebuilds, survives
+  an in-flight old auth export, and has recurring upstream enforcement for later
+  keyed uploads with its unavoidable transient/never-keyed limits disclosed.
 - Looker exposes only aggregate authorized views and shows complete-period,
   denominator, coverage, maturity, and freshness labels.
 - The executive page can truthfully report new accounts, setup, full

--- a/.plan/active/user-analytics/PLAN.md
+++ b/.plan/active/user-analytics/PLAN.md
@@ -59,6 +59,7 @@ silently compared with a mature one.
 | Bridge registered | First bridge registration (`ActivationState.bridgeSetupAt`) | Auth server |
 | Project available | First successful project inventory containing at least one project after instrumentation starts | App event |
 | Legacy session signal | First accepted `/sessions/generate-metadata` request (`ActivationState.firstSessionAt`) | Auth server |
+| Analytics-ready exposure | Earliest schema-v1 `analytics_schema_ready` or other accepted schema-v1 custom event, provided it occurs within 24 hours of account creation | App event |
 | Full activation | Earliest successful `session_message_sent` or `session_created_with_message` | App event |
 
 `mobileSetupAt` is **not** “mobile setup”: it proves notification registration.
@@ -71,16 +72,19 @@ Behavioral milestones cannot be backfilled before the new event release. Store
 two timestamps: `raw_export_start_at` when Firebase export begins and
 `behavioral_schema_v1_start_at` only after the production app version has
 successfully exported the new event schema. Restrict activation/retention
-cohorts to accounts created on or after the behavioral timestamp. Historical
-server milestones may still support honestly labeled setup trends.
+cohorts to accounts created on or after the behavioral timestamp **and** with
+per-account analytics-ready exposure no later than 24 hours after creation.
+Calendar eligibility alone is insufficient because a newly created account can
+still run a legacy binary. Historical server milestones may still support
+honestly labeled setup trends.
 
 ### Headline metrics
 
 | Metric | Exact definition |
 | --- | --- |
-| Weekly new accounts | All auth accounts created during the complete week. This comes from aggregate server export and is not reduced by product-analytics opt-out. |
+| Weekly new accounts | Non-internal, non-deletion-suppressed auth accounts created during the complete week. This comes from aggregate server export and is not reduced by ordinary product-analytics opt-out. |
 | 7-day bridge setup conversion | Accounts whose first bridge registration is within 7 x 24 hours of account creation, divided by accounts at least 7 days old in the cohort. |
-| 7-day full activation conversion | Analytics-eligible accounts whose full activation is within 7 x 24 hours of account creation, divided by measurable accounts at least 7 days old and created on/after `behavioral_schema_v1_start_at`. Show behavioral coverage beside it; do not extrapolate to disabled/legacy accounts. |
+| 7-day full activation conversion | Analytics-eligible accounts whose full activation is within 7 x 24 hours of account creation, divided by accounts at least 7 days old, created on/after `behavioral_schema_v1_start_at`, and observed on schema v1 within 24 hours of creation. Show both schema-exposure and preference coverage; accounts lacking timely exposure are unmeasurable, not non-activations. |
 | Time to activation | P50 and P75 of `full_activation_at - account_created_at` among activated measurable accounts. |
 | Meaningful WAU | Distinct users with a non-empty session activity view or a confirmed control event in the complete week. A screen view/app open never qualifies. |
 | Controller WAU | Distinct users with a successful message, question answer/rejection, permission answer, session abort, or session creation with message. |
@@ -158,7 +162,8 @@ server milestones may still support honestly labeled setup trends.
   Firebase in mobile and by a no-op adapter on unsupported products.
 - Authenticated custom-event key lifecycle, release-build custom-event sharing,
   stable screen views, campaign attribution, and the outcome events below.
-- A daily privacy-safe auth export and aggregate all-account setup cohorts.
+- A daily privacy-safe auth export and aggregate external-account setup cohorts
+  after internal/deletion suppression.
 - Versioned BigQuery DDL/transforms/tests and Looker Studio dashboards.
 - Internal/test-user exclusion, retention, access, cost, and data-quality
   controls.
@@ -188,11 +193,11 @@ server milestones may still support honestly labeled setup trends.
 
 | Repository/workspace | Production paths and layer | Change | Downstream impact |
 | --- | --- | --- | --- |
-| `sesori_auth_server` | `src/types/product-analytics.ts` (domain enum), `src/models/{documents,api,product-analytics-export}.ts` (persisted/API/export contracts), `src/repositories/{user-repo,activation-state-repo,product-analytics-export-repo}.ts` (data access/aggregation), `src/services/{product-analytics-preference-service,product-analytics-export-service}.ts` (business logic), `src/clients/bigquery-product-analytics-client.ts` and `src/api/product-analytics-export-api.ts` (external sink layers), `src/routes/product-analytics.ts` (HTTP boundary), `src/scripts/{backfill-product-analytics-preference,export-product-analytics,product-analytics-export-config}.ts` (separate command composition) | Persist preference behind a dedicated service, expose GET/PUT endpoints, and export privacy-safe data. | Existing auth responses and clients remain unchanged. The web process constructs only the preference service; it never constructs export/BigQuery classes. |
+| `sesori_auth_server` | `src/types/product-analytics.ts` (domain enum), `src/models/{documents,api,product-analytics-export}.ts` (persisted/API/export contracts), `src/repositories/{user-repo,activation-state-repo,product-analytics-export-repo,product-analytics-control-repo}.ts` (data access/aggregation), `src/services/{product-analytics-preference-service,product-analytics-export-service}.ts` (business logic), `src/clients/bigquery-product-analytics-client.ts` and `src/api/product-analytics-export-api.ts` (external sink layers), `src/routes/product-analytics.ts` (HTTP boundary), `src/scripts/{backfill-product-analytics-preference,suppress-product-analytics-export,export-product-analytics,product-analytics-export-config}.ts` (separate command composition) | Persist preference/privacy-suppression state behind a dedicated service, expose GET/PUT endpoints, and export privacy-safe data after source/internal exclusion. | Existing auth responses and clients remain unchanged. The web process constructs only the preference service; it never constructs export/BigQuery classes. |
 | `shared/sesori_shared` | No production change | Keep `AuthUser` authentication-only; do not add a product preference to the shared auth/persisted contract. | No bridge/shared migration or compatibility default is introduced. |
 | `client/module_auth` | No production change | Continue to own tokens, OAuth, auth state, and `AuthenticatedHttpApiClient` only. | `module_core` observes `AuthSession` read-only and injects `AuthenticatedHttpApiClient` into its own Layer-1 preference API. |
 | `client/module_core` | `lib/src/models/product_analytics/`, `lib/src/platform/analytics_client.dart`, `lib/src/api/{analytics_api,product_analytics_preference_api}.dart`, `lib/src/storage/{product_analytics_preference_storage,campaign_attribution_storage}.dart`, `lib/src/repositories/{product_analytics,product_analytics_preference,campaign_attribution}_repository.dart`, `lib/src/services/{product_analytics,campaign_attribution}_service.dart`, `lib/src/listeners/{analytics_route,campaign_attribution,notification_open_analytics}_listener.dart`, `lib/src/cubits/product_analytics_preference/`, existing project/session/diff cubits and notification dispatcher, DI/barrel/generated files | Expose architectural layers explicitly; own preference HTTP/persistence, pseudonymous hashing, route/campaign/notification lifecycle, Settings state, and authoritative business-outcome emission. | Mobile supplies only the Firebase platform client. Desktop supplies a no-op client. Cubit constructor call sites/tests update in lockstep. |
-| `client/app` | `lib/core/platform/firebase_analytics_client.dart`, `lib/core/di/`, `lib/features/{settings,project_list,new_session,session_detail,session_diffs}/`, `lib/l10n/`, `lib/main.dart`, iOS/Android analytics defaults | Implement the thin Firebase SDK adapter, start core services/listeners, render preference UI, and inject services into core consumers. | Existing app event sources move to core; `AnalyticsUserIdTracker` and obsolete app `DeepLinkService` are removed. No global Firebase `user_id` or runtime collection override is added. No new voice logic is added. |
+| `client/app` | `lib/core/platform/{firebase_analytics_client,firebase_analytics_identity_migration}.dart`, `lib/core/di/`, `lib/features/{settings,project_list,new_session,session_detail,session_diffs}/`, `lib/l10n/`, `lib/main.dart`, iOS/Android analytics defaults | Clear legacy global identity at earliest post-Firebase bootstrap, implement the thin custom-event adapter, start core services/listeners, render preference UI, and inject services into core consumers. | Existing app event sources move to core; `AnalyticsUserIdTracker` and obsolete app `DeepLinkService` are removed. The only global Firebase `user_id` call sets null for migration; no account key or runtime collection override is added. No new voice logic is added. |
 | `client/desktop` | `lib/core/platform/no_op_analytics_client.dart`, DI generated file | Satisfy the shared core platform capability without collecting desktop analytics. | No desktop product events or UI are added. Analyze/test verifies core DI remains resolvable. |
 | `client/module_desktop_core` | No planned production edit; tests/build are downstream validation | Continue unchanged. | Shared core DI/downstream validation only. |
 | `bridge/app` | No planned production or contract edit | Remain outside product analytics. | No additional bridge validation beyond normal CI is caused by this plan. |
@@ -225,8 +230,14 @@ and are disclosed separately; they never define product activity. Every
 Sesori-defined custom event instead carries the pseudonymous `user_key` as a
 typed parameter, and `ProductAnalyticsService` refuses to create those events
 unless the local/server gate is active. This avoids a cold-start race with a
-persisted Firebase enable override and prevents automatic startup events from
-inheriting an account key.
+persisted Firebase enable override and prevents the new design from assigning
+an account key to automatic events.
+
+The one compatibility exception is an earliest-bootstrap `setUserId(null)` to
+clear the hash persisted by current releases. It runs immediately after Firebase
+initialization and before custom sources. Vendor automatic initialization can
+precede that supported reset, so the plan treats possible pre-clear automatic
+rows as legacy raw data rather than promising an impossible zero-width window.
 
 The core service combines installation-local intent with the server preference:
 
@@ -323,21 +334,22 @@ mixed `src/analytics/` bucket. The concrete dependency direction is:
 
 | Class/file | Layer and constructor collaborators | Responsibility and lifecycle |
 | --- | --- | --- |
-| `AnalyticsEvent`, bounded enums, `AnalyticsScreen`, `AnalyticsDeliveryResult`, `ProductAnalyticsPreference`, `ProductAnalyticsState`, `CampaignCode`, and persisted record variants under `module_core/lib/src/models/product_analytics/` | Domain models; no SDK/Flutter dependencies | Closed event/screen/preference/state values. `AnalyticsScreen` is independent of routing; `AnalyticsRouteListener` performs the exhaustive `AppRouteDef -> AnalyticsScreen` mapping. Delivery is `acceptedBySdk` or `failed`, never an untruthful “reported” boolean. |
+| `AnalyticsEvent`, bounded enums, `AnalyticsScreen`, `AnalyticsDeliveryResult`, `ProductAnalyticsPreference`, `ProductAnalyticsState`, `CampaignCode`, and persisted record variants under `module_core/lib/src/models/product_analytics/` | Domain models; no SDK/Flutter dependencies | Closed event/screen/preference/state values. `AnalyticsScreen` is independent of routing; `AnalyticsRouteListener` performs the exhaustive `AppRouteDef -> AnalyticsScreen` mapping. Delivery is `acceptedBySdk`, `deferredUntilPreference`, or `failed`, never an untruthful “reported” boolean. Campaign completion is account-scoped; the in-memory pending activation variant carries only one typed message-success event and its auth generation. |
 | `AnalyticsClient` in `module_core/lib/src/platform/analytics_client.dart` | Foundation external-sink capability | Typed `logEvent({required AnalyticsEvent event, required String userKey})`. The key is already pseudonymous and is serialized as the custom `user_key` event parameter, never global SDK identity. Methods throw SDK failures; they accept no arbitrary map/name or raw account ID. |
 | `AnalyticsApi` in `module_core/lib/src/api/analytics_api.dart` | Layer 1; constructor requires `AnalyticsClient` | Thin API over the external client. It is the only core class that invokes the platform sink. |
 | `ProductAnalyticsPreferenceApi` in `module_core/lib/src/api/product_analytics_preference_api.dart` | Layer 1; constructor requires `AuthenticatedHttpApiClient` | Calls authenticated GET/PUT `/product-analytics/preference`, serializes the closed enum, parses external strings at the boundary, and returns explicit success/failure. It does not mutate auth state. |
 | `ProductAnalyticsPreferenceStorage` and `CampaignAttributionStorage` in `module_core/lib/src/storage/` | Layer 1 storage; each constructor requires `SecureStorage` | Read/write/delete only their closed persisted records. They do not reconcile accounts, call APIs, hash IDs, or emit analytics. |
 | `ProductAnalyticsRepository` in `module_core/lib/src/repositories/product_analytics_repository.dart` | Layer 2; constructor requires `AnalyticsApi` | Converts raw authenticated user ID to lowercase SHA-256, passes only the pseudonymous key downward, and maps API exceptions to explicit `AnalyticsDeliveryResult` without redundant logging. It adds `schema_version=1` through the typed event serialization contract. |
 | `ProductAnalyticsPreferenceRepository` in `module_core/lib/src/repositories/product_analytics_preference_repository.dart` | Layer 2; requires `ProductAnalyticsPreferenceApi` and `ProductAnalyticsPreferenceStorage` | Fetch/update server preference, scope local records to one account, persist only `synced(userId, preference)` or `pendingDisable(userId)`, and expose explicit results. Enable is never persisted pending. |
-| `CampaignAttributionRepository` in `module_core/lib/src/repositories/campaign_attribution_repository.dart` | Layer 2; requires `CampaignAttributionStorage` | Enforces first touch and a 24-hour pending TTL, and persists `pending(code, capturedAt)` or `acceptedBySdk(code)`. Absence genuinely means no campaign. It never stores a full URI/UTM text. |
-| `ProductAnalyticsService` in `module_core/lib/src/services/product_analytics_service.dart` | Layer 3, `@lazySingleton`; requires `AuthSession` (read-only), existing `LifecycleSource`, `ProductAnalyticsRepository`, and `ProductAnalyticsPreferenceRepository` | Sole owner of preference/custom-event lifecycle and Consumer `logEvent`. Exposes a replaying state stream plus `start`, `markPostSplashReady`, `setPreference`, `retryPendingDisable`, and `dispose`. It performs no network work until readiness, revalidates while foregrounded, serializes reconciliation per auth generation, and sends no custom event unless active. |
-| `CampaignAttributionService` in `module_core/lib/src/services/campaign_attribution_service.dart` | Layer 3, `@lazySingleton`; requires `CampaignAttributionRepository` and `ProductAnalyticsService` | Captures a validated first touch and attempts the event only on an active transition/start. It marks `acceptedBySdk` only when the service returns that typed result; failure leaves `pending` for a later lifecycle attempt without a timer loop. |
+| `CampaignAttributionRepository` in `module_core/lib/src/repositories/campaign_attribution_repository.dart` | Layer 2; requires `CampaignAttributionStorage` | Enforces a 24-hour pending TTL and persists either pre-auth `pending(code, capturedAt)` or `acceptedBySdk(userId, code, completedAt)`. Completion deduplicates only that account; any later valid pre-auth capture after logout replaces the completed record with pending before the next account is known. Absence genuinely means no campaign. It never stores a full URI/UTM text. |
+| `ProductAnalyticsService` in `module_core/lib/src/services/product_analytics_service.dart` | Layer 3, `@lazySingleton`; requires `AuthSession` (read-only), existing `LifecycleSource`, `ProductAnalyticsRepository`, and `ProductAnalyticsPreferenceRepository` | Sole owner of preference/custom-event lifecycle and Consumer `logEvent`. Exposes a replaying state stream plus `start`, `markPostSplashReady`, `setPreference`, `retryPendingDisable`, and `dispose`. It performs no network work until readiness, revalidates while foregrounded, serializes reconciliation per auth generation, and sends no custom event unless active. While preference is unknown, it may retain exactly one bounded activation-candidate event for the current generation; all other inactive events remain unbuffered. |
+| `CampaignAttributionService` in `module_core/lib/src/services/campaign_attribution_service.dart` | Layer 3, `@lazySingleton`; requires read-only `AuthSession`, `CampaignAttributionRepository`, and `ProductAnalyticsService` | Captures a validated first touch and attempts the event only on an active transition/start. It marks account-scoped `acceptedBySdk` only when the service returns that typed result; failure leaves `pending` for a later lifecycle attempt without a timer loop. |
 | `AnalyticsRouteListener` in `module_core/lib/src/listeners/analytics_route_listener.dart` | Consumer/listener, `@lazySingleton`; requires `RouteSource` and `ProductAnalyticsService` | Owns route subscription, maps `AppRouteDef` exhaustively to `AnalyticsScreen`, signals readiness on the first non-splash route, and reports stable screens only while active. It never passes a route model/path to Foundation. |
 | `CampaignAttributionListener` in `module_core/lib/src/listeners/campaign_attribution_listener.dart` | Consumer/listener, `@lazySingleton`; requires `DeepLinkSource` and `CampaignAttributionService` | Replaces the obsolete app `DeepLinkService`, owns the one URI subscription, validates only approved `sesori.com/link` campaign codes, and ignores all other/legacy callback URIs without logging complete values. |
 | `NotificationOpenAnalyticsListener` in `module_core/lib/src/listeners/notification_open_analytics_listener.dart` | Consumer/listener, `@lazySingleton`; requires the bounded notification-open source and `ProductAnalyticsService` | Buffers at most the one validated cold-start open until preference reconciliation, emits it only if the same account becomes active, and drops it on disable, logout/account switch, or process-lifetime timeout. No entity ID enters the buffer. |
 | `ProductAnalyticsPreferenceCubit` in `module_core/lib/src/cubits/product_analytics_preference/` | Consumer; constructor requires `ProductAnalyticsService` | Subscribes to service state and exposes toggle/retry intents. Mobile Settings constructs it; it is not in DI. |
 | `FirebaseAnalyticsClient` in `app/lib/core/platform/firebase_analytics_client.dart` | Thin mobile Foundation adapter, `@LazySingleton(as: AnalyticsClient)`; requires `FirebaseAnalytics` | Serializes only typed custom events plus `schema_version` and `user_key`, and throws failures upward. It never applies global identity/collection overrides and contains no route/campaign/preference/hash business logic. Firebase-disabled environments use the existing no-op SDK object. |
+| `FirebaseAnalyticsIdentityMigration` in `app/lib/core/platform/firebase_analytics_identity_migration.dart` | Mobile-only pre-core bootstrap helper; requires `FirebaseAnalytics` | Immediately after Firebase initialization and before DI/listeners, awaits `setUserId(id: null)` to clear the hash persisted by prior releases. It does nothing else to consent/collection. Failure leaves the process custom-event adapter disabled and retries next launch. Keep this cleanup through minimum-supported-version adoption plus the 90-day raw window, then remove it explicitly. |
 | `NoOpAnalyticsClient` in `desktop/lib/core/platform/no_op_analytics_client.dart` | Desktop phase-1 Foundation adapter | Satisfies shared core DI and accepts operations without collection. No desktop listeners are started. |
 
 `AnalyticsScreen` pins snake-case wire values for login, projects, settings and
@@ -350,9 +362,9 @@ cannot silently omit its analytics mapping.
 
 The client API may return SDK acceptance, not delivery to Google's backend.
 That distinction is sufficient for truthful local campaign state and must remain
-explicit in names/docs. Normal outcome consumers may ignore a failed result,
-but the result remains explicit to callers; analytics cannot alter product
-success.
+explicit in names/docs. `ProductAnalyticsService` itself owns the sole deferred
+first-message variant; ordinary outcome consumers may ignore delivery results,
+but the result remains explicit and analytics cannot alter product success.
 
 ### DI and process lifecycle
 
@@ -372,6 +384,14 @@ success.
 5. Cubits remain constructed in `BlocProvider` and receive
    `getIt<ProductAnalyticsService>()` explicitly. Existing mobile-only
    onboarding widgets call the same service rather than the Foundation client.
+
+Before mobile phase 1, `main()` initializes Firebase and awaits
+`FirebaseAnalyticsIdentityMigration`. No Sesori custom event source or core
+listener exists yet. A native automatic startup event can still occur between
+vendor SDK initialization and this earliest supported reset; treat any such
+legacy-keyed row as restricted raw legacy data, exclude automatic events from
+behavioral models, cover it through the legacy `USER_ID` deletion path, and do
+not claim that upgrade retroactively removes it.
 
 ### Preference and lifecycle data flow
 
@@ -406,6 +426,17 @@ the current generation inactive before any follow-up persistence await. Network
 failure preserves the honest prior local state and last-successful-check time;
 the UI makes the conditional online propagation bound explicit.
 
+**Schema exposure and first-message deferral:** On each process's first active
+transition, the service attempts `analytics_schema_ready` before later buffered
+work. Warehouse exposure is the earliest accepted schema-v1 event of any name,
+so an outcome event also proves capability if readiness delivery fails. If a
+confirmed `session_message_sent` or `session_created_with_message` occurs while
+the same generation is preference-unknown (and not locally disabled),
+`logEvent` retains only the first typed candidate in memory and returns
+`deferredUntilPreference`. Active resolution emits it once; disabled resolution,
+logout/account switch, or generation change drops it. No prompt/message content
+or session identifier enters the buffer, and no other outcome event is queued.
+
 **Disable:** The cubit calls `ProductAnalyticsService.setPreference(disabled)`.
 The service immediately publishes inactive, then first durably persists
 `pendingDisable(userId)` before any subsequent await, then calls the preference
@@ -438,9 +469,14 @@ while unauthenticated to `CampaignCode`; authenticated/post-signup opens are
 ignored. The service/repository stores first touch plus capture time before auth
 and expires it after 24 hours. On active state it attempts
 `campaign_attributed`. `acceptedBySdk` is persisted only from the typed accepted
-result. A failed result leaves pending, with at most one attempt per active
-lifecycle; BigQuery accepts attribution only when the account is at most 24
-hours old at event time and selects the earliest eligible event. Existing
+result as `acceptedBySdk(userId, code, completedAt)` and deduplicates only that
+account. Any later valid pre-auth link after logout replaces prior completion
+with pending before the next account is known; if account B then signs up, A's
+completion cannot consume B's first touch. If A logs back in instead, the
+warehouse age/earliest rules make the extra attempt harmless. A failed result
+leaves pending, with at most one attempt per active lifecycle; BigQuery accepts
+attribution only when the account is at most 24 hours old at event time and
+selects the earliest eligible event. Existing
 accounts opening campaign links before login therefore remain unattributed.
 
 **Cold notification flow:** The notification dispatcher first performs its
@@ -457,8 +493,9 @@ Existing wire names remain unchanged. Add only the following initial events:
 
 | Event | Emit only when | Bounded parameters | Reporting use |
 | --- | --- | --- | --- |
-| `project_inventory_loaded` | Initial project inventory succeeds | `inventory_state=empty/non_empty` | First project available, onboarding friction |
-| `session_activity_viewed` | A session snapshot successfully loads for the first time in a cubit lifetime | `activity_state=empty/non_empty` | Meaningful monitoring when non-empty |
+| `analytics_schema_ready` | The process first becomes active for an authenticated account under schema v1 | none beyond shared schema/key | Per-account instrumentation-capable exposure; never activity |
+| `project_inventory_loaded` | The first successful empty inventory and the first successful non-empty inventory in a cubit lifetime | `inventory_state=empty/non_empty` | First project available from earliest non-empty; empty is onboarding friction |
+| `session_activity_viewed` | The first successful empty snapshot and the first successful non-empty snapshot in a cubit lifetime | `activity_state=empty/non_empty` | Meaningful monitoring from earliest non-empty; empty is diagnostic only |
 | `session_message_sent` | Existing-session send returns success, including a queued send that later succeeds | `submission_kind=text/command` | Full activation, control activity |
 | `session_created_with_message` | `createSessionWithMessage` returns success | `submission_kind`, `workspace_kind=project/dedicated_worktree` | Full activation, remote creation, worktrees |
 | `session_creation_failed` | That creation returns an explicit failure | `failure_reason` from bounded `RemoteFailureReason`, `workspace_kind` | Creation friction; never activation |
@@ -466,7 +503,7 @@ Existing wire names remain unchanged. Add only the following initial events:
 | `session_question_rejected` | Question rejection returns success | none | Remote interventions |
 | `session_permission_answered` | Permission reply returns success | `decision=once/always/reject` | Remote interventions |
 | `session_abort_succeeded` | Root and active-child abort requests all return success | none | Remote interventions |
-| `session_diff_viewed` | Initial diff fetch succeeds | `change_state=empty/non_empty` | Diff adoption; meaningful only when non-empty |
+| `session_diff_viewed` | The first successful empty diff and the first successful non-empty diff in a cubit lifetime | `change_state=empty/non_empty` | Diff adoption from earliest non-empty; empty is diagnostic only |
 | `notification_opened` | A valid notification is dispatched after authentication | `source=push/local`, `launch_context=cold/warm`, bounded `category`, bounded `event_type` | Notification engagement |
 | `campaign_attributed` | A pre-auth first-touch code captured in the prior 24 hours receives an SDK-accepted attempt for an authenticated custom-sharing-enabled install | `campaign_code` only | Acquisition coverage and cohorts; warehouse also requires account age <= 24 hours and earliest eligible event wins |
 | `product_screen_viewed` | `RouteSource` emits a changed non-null `AppRouteDef` while custom sharing is active | stable `screen` enum only | Navigation/friction, never meaningful activity |
@@ -481,15 +518,19 @@ an additional `session_message_sent`.
 
 ### Authoritative emission seams
 
-- `ProjectListCubit`: successful initial inventory.
-- `SessionDetailCubit._loadMessages`: first successful activity view.
+- `ProductAnalyticsService`: schema-ready exposure on first active transition.
+- `ProjectListCubit`: first successful empty and first successful non-empty
+  inventory states.
+- `SessionDetailCubit._loadMessages`: first successful empty and first
+  successful non-empty activity states.
 - `SessionDetailCubit.sendMessage` and `_drainQueuedMessages`: accepted
   existing-session messages.
 - `NewSessionCubit.createSession`: accepted created session/message and bounded
   creation failure.
 - `SessionDetailCubit.replyToQuestion`, `rejectQuestion`,
   `replyToPermission`, and `abort`: successful control outcomes.
-- `DiffCubit._fetchAndEmit`: first successful diff load.
+- `DiffCubit._fetchAndEmit`: first successful empty and first successful
+  non-empty diff states.
 - `NotificationOpenDispatcher`: valid push/local cold/warm dispatch. Extend the
   internal open request to preserve existing bounded notification category and
   event type, but never an entity identifier in analytics.
@@ -508,12 +549,12 @@ merely to avoid updating tests.
 
 | Owner change | Exact flow and deduplication |
 | --- | --- |
-| `ProjectListCubit` | Add required `ProductAnalyticsService`. After the initial `ProjectListService` load returns a successful inventory, emit `project_inventory_loaded` once for that cubit lifetime with only empty/non-empty. Refreshes do not repeatedly report the same inventory. |
-| `SessionDetailCubit` view | Add required product analytics service and a `_hasReportedInitialView` guard. The first successful snapshot after initial load/wait/reconnect emits one activity-view event based only on bounded activity state; reload/SSE refresh does not. |
+| `ProjectListCubit` | Add required `ProductAnalyticsService` and retain the bounded inventory states already emitted in that cubit lifetime. Emit the first successful `empty` once and the first later/same-lifecycle `non_empty` once; refreshes never repeat either classification. The warehouse milestone uses only earliest non-empty. |
+| `SessionDetailCubit` view | Add required product analytics service and retain the bounded activity states already emitted. Initial empty may emit once; a later non-empty transition from refresh/SSE emits once and is not suppressed by the earlier empty diagnostic. Repeated snapshots in either state do not emit. |
 | `SessionDetailCubit` send paths | Direct `sendMessage` and `_drainQueuedMessages` call one private `_reportAcceptedSubmission` only on `SuccessResponse`. The queued item retains only text/command for sending; analytics derives text/command without reading content. Error/requeue emits nothing, and each dequeued successful item reports once. |
 | `NewSessionCubit` | Add required product analytics service. Capture workspace/submission classifications before awaiting. `SuccessResponse` makes one `session_created_with_message` call; `ErrorResponse` emits only bounded `session_creation_failed`. It never also emits the existing-session event. |
 | `SessionDetailCubit` question/permission/abort | Report after each existing method's success branch. Question answers/rejections carry no answer data; permission maps the existing `PermissionReply` enum; abort reports only after every root/active-child response succeeds. |
-| `DiffCubit` | Add required product analytics service and `_hasReportedInitialDiff` guard. First successful fetch emits empty/non-empty; SSE refreshes and retries after an already successful first fetch do not. |
+| `DiffCubit` | Add required product analytics service and retain reported change states. Emit first empty and first later non-empty once each; only non-empty defines adoption, and SSE refreshes do not repeat either state. |
 | `NotificationOpenRequest` / `NotificationOpenDispatcher` / `NotificationOpenAnalyticsListener` | Extend the internal request with required bounded category/event type already present in `NotificationData`. Push/local adapters provide `unknown` for legacy local payload omissions. Dispatcher publishes bounded source/cold-warm/category/event-type metadata after validated route dispatch, never project/session/title. The listener applies the one-event cold-start buffer and preference/account rules above before calling product analytics. |
 | Screen constructors/tests | `ProjectListScreen`, `NewSessionScreen`, `SessionDetailScreen`, and `SessionDiffsScreen` pass the phase-3 product analytics service from GetIt into required cubit constructors. Core tests inject a mock/recording service and assert event count/shape. |
 
@@ -563,15 +604,23 @@ export work to request handlers or the long-running auth process.
   `$set` only where either is missing and reports/validates counts. After the
   write-first version is live and backfill reaches zero missing documents, the
   next PR removes both decode defaults and enforces both fields as required.
+  It also permits genuinely absent `productAnalyticsExportSuppressedAt`; a
+  privacy-deletion workflow sets that timestamp, so no default/backfill exists.
 - `src/models/api.ts` defines Zod-validated GET/PUT preference replies/body only;
   it does not modify `UserProfile` or auth token/login contracts.
 - `UserRepository.updateProductAnalyticsPreference(userId, preference)` owns one
   atomic Mongo update of value and server timestamp;
   `findProductAnalyticsPreference` reads them with temporary migration defaults
   only in the write-first release.
+- `UserRepository.suppressProductAnalyticsExport(userId, suppressedAt)`
+  atomically sets preference disabled, updates its timestamp, and sets the
+  permanent export-suppression tombstone before any warehouse deletion. GET
+  remains disabled and PUT enabled returns an explicit conflict for suppressed
+  accounts; ordinary opt-out never sets this tombstone.
 - `ProductAnalyticsPreferenceService` in
   `src/services/product-analytics-preference-service.ts` requires only
-  `UserRepository` and owns get/update business operations.
+  `UserRepository` and owns get/update plus permanent export-suppression
+  business operations.
 - `src/routes/product-analytics.ts` adds authenticated
   `GET /product-analytics/preference` and
   `PUT /product-analytics/preference`; PUT body is
@@ -581,19 +630,25 @@ export work to request handlers or the long-running auth process.
   `src/index.ts` register/construct this service without changing `AuthService`.
 - The Dart client owns this contract in core
   `ProductAnalyticsPreferenceApi`; `AuthManager`/`AuthSession` are unchanged.
+- `src/scripts/suppress-product-analytics-export.ts` is the isolated privacy-
+  operator composition root. It reads a verified raw account ID from protected
+  stdin (never argv/logs), invokes the service suppression operation, verifies
+  disabled+tombstoned state, prints only the external privacy request ID/status,
+  and closes Mongo. There is no public suppression route.
 
 ### Export classes and composition
 
 | Class/file | Constructor dependencies and layer | Responsibility |
 | --- | --- | --- |
-| `UserRepository` additions in `src/repositories/user-repo.ts` | Existing `MongoDbAccessor` | `findProductAnalyticsExportBatch({afterUserId, batchLimit, createdAtOrBefore})` returns string user ID, creation time, preference, and preference-update time in deterministic ObjectId order. `findPreferenceChanges({after, atOrBefore})` supports the final conservative exclusion pass; no Mongo `ObjectId` leaves the repository. |
+| `UserRepository` additions in `src/repositories/user-repo.ts` | Existing `MongoDbAccessor` | `findProductAnalyticsExportBatch({afterUserId, batchLimit, createdAtOrBefore})` returns string user ID, creation time, preference/update time, and optional export-suppression time in deterministic ObjectId order. `findPreferenceChanges({after, atOrBefore})` supports the final conservative exclusion pass; no Mongo `ObjectId` leaves the repository. |
 | `ActivationStateRepository.findByUserIds` in `src/repositories/activation-state-repo.ts` | Existing Mongo collection | Requires `runCutoff`, batch-loads only the four milestone fields for one user page, and projects each milestone to null when its timestamp is later than that cutoff. It returns a map keyed by string user ID and exposes no reminder fields. |
 | `ProductAnalyticsExportRow` / `ProductAnalyticsSetupCohortRow` in `src/models/product-analytics-export.ts` | Plain internal models | Make BigQuery row shapes closed and prevent external-sink calls with auth/OAuth/bridge documents. |
-| `BigQueryProductAnalyticsClient` in `src/clients/bigquery-product-analytics-client.ts` | Foundation external client; requires `@google-cloud/bigquery` `BigQuery`, project ID, auth-export dataset ID, and location | Thin SDK operations for creating expiring tables, inserting typed safe rows, and executing parameterized queries/transactions **inside that one dataset only**. It never receives raw IDs/Mongo documents, control-dataset identifiers, or export semantics. |
-| `ProductAnalyticsExportApi` in `src/api/product-analytics-export-api.ts` | Layer 1; requires `BigQueryProductAnalyticsClient` | Defines the external BigQuery operations used by this product area and maps SDK responses/errors; no pagination, aggregation, or publication policy. |
+| `BigQueryProductAnalyticsClient` in `src/clients/bigquery-product-analytics-client.ts` | Foundation external client; requires `@google-cloud/bigquery` `BigQuery`, project ID, auth-export dataset ID, one fully qualified authorized internal-exclusion view, and location | Thin SDK operations for creating/inserting/querying **inside the auth-export dataset only**, plus one typed read of active `user_key` values from the authorized view. It exposes no controls write/DDL method and never receives raw IDs/Mongo documents or export semantics. |
+| `ProductAnalyticsExportApi` in `src/api/product-analytics-export-api.ts` | Layer 1; requires `BigQueryProductAnalyticsClient` | Defines external auth-dataset operations and read-only active-exclusion retrieval, and maps SDK responses/errors; no pagination, aggregation, or publication policy. |
 | `ProductAnalyticsExportRepository` in `src/repositories/product-analytics-export-repo.ts` | Layer 2; requires `ProductAnalyticsExportApi` | Owns a run's staging-table lifecycle, safe-row batching, validation queries, and atomic two-target promotion. The service never calls the client/API directly. |
-| `ProductAnalyticsExportService` in `src/services/product-analytics-export-service.ts` | Layer 3; requires `UserRepository`, `ActivationStateRepository`, and `ProductAnalyticsExportRepository` | Owns cutoff pagination, SHA-256 transformation, enabled-user filtering, weekly all-account accumulation, reconciliation inputs, and repository promotion. `run({ runCutoff }: { runCutoff: Date })` receives one immutable cutoff. |
-| `product-analytics-export-config.ts` in `src/scripts/` | Zod over process environment | Validates only job concerns: Mongo connection/database, GCP project, auth-export dataset, location, and bounded batch size. It cannot configure control/curated/reporting datasets, does not import the web server's full OAuth/FCM configuration, and accepts no service-account JSON key. |
+| `ProductAnalyticsControlRepository` in `src/repositories/product-analytics-control-repo.ts` | Layer 2; requires `ProductAnalyticsExportApi` | Loads and validates the bounded active internal-user key set from the one authorized view. It cannot write controls or auth export tables. |
+| `ProductAnalyticsExportService` in `src/services/product-analytics-export-service.ts` | Layer 3; requires `UserRepository`, `ActivationStateRepository`, `ProductAnalyticsControlRepository`, and `ProductAnalyticsExportRepository` | Owns cutoff pagination, SHA-256 transformation, suppression/internal filtering before all counters, enabled-user filtering, weekly external-account accumulation, reconciliation inputs, and repository promotion. `run({ runCutoff }: { runCutoff: Date })` receives one immutable cutoff. |
+| `product-analytics-export-config.ts` in `src/scripts/` | Zod over process environment | Validates only job concerns: Mongo connection/database, GCP project, auth-export dataset, authorized exclusion-view name, location, and bounded batch/exclusion-set size. It cannot configure control writes or curated/reporting datasets, does not import the web server's full OAuth/FCM configuration, and accepts no service-account JSON key. |
 | `export-product-analytics.ts` in `src/scripts/` | Command composition root | Constructs Mongo repositories, ADC BigQuery client, export API/repository/service; invokes one run, awaits jobs, and closes Mongo in `finally`. It is compiled into the production image and run as `node dist/scripts/export-product-analytics.js`; `src/index.ts` does not import it. |
 
 The web server constructs the dedicated preference service but never constructs
@@ -615,26 +670,34 @@ historical preference values while ensuring pagination timing cannot admit a
 post-cutoff enable/disable. The job writes two products through temporary tables
 before an atomic replace/merge:
 
-1. `private.auth_user_milestones`: only accounts whose optional product
-   analytics preference is enabled; fields are `user_key`,
+1. `auth_private.auth_user_milestones`: only enabled accounts that are neither
+   internally excluded nor source-suppressed; fields are `user_key`,
    `account_created_at`, `notification_registered_at`,
    `bridge_registered_at`, `legacy_first_metadata_request_at`, and
    `exported_at`.
-2. `private.auth_weekly_setup_cohorts`: identifier-free all-account cohort
-   totals, including total accounts, enabled-account coverage, notification and
-   bridge registration within 1/7/30 days, and the legacy signal. This supports
-   honest account/setup totals without exposing opted-out user rows.
+2. `auth_private.auth_weekly_setup_cohorts`: identifier-free external-account
+   cohort totals after internal and source-deletion suppression, including total
+   accounts, enabled-account coverage, notification and bridge registration
+   within 1/7/30 days, and the legacy signal. Ordinary opted-out accounts remain
+   in these aggregate setup totals without exposing keyed rows.
 
 Never export provider identity or reminder scheduling/sent timestamps. Replace
-the eligible-user snapshot each run so currently disabled accounts no longer
-join behavioral reports. Keep raw all-account rows inside Mongo; only aggregate
-cohorts leave the auth boundary.
+the eligible-user snapshot and rebuild setup cohorts each run so currently
+disabled/suppressed accounts no longer join behavioral reports and suppression
+can remove prior aggregate contribution. Keep raw account rows inside Mongo;
+only filtered aggregate cohorts leave the auth boundary.
 
-For each page, the service builds a user-ID-to-activation-state map in memory,
-updates weekly counters for every account, and creates a pseudonymous row only
-when preference is enabled. It hashes before invoking the export repository,
-then drops the raw page before requesting the next. Run-scoped staging tables contain only
-hashed/aggregate rows, expire within 24 hours, and are invisible to reporting.
+At run start, the service loads the active internal `user_key` set and records
+its control-view update/cutoff in run metadata. Missing, stale, malformed, or
+over-limit control output aborts the run before source pagination; it never
+falls back to an empty exclusion set. For each page it builds a user-
+ID-to-activation-state map, hashes each raw user ID in memory, and first skips a
+row entirely when source-suppressed or present in the internal set. Only then
+does it update weekly counters; it creates a keyed milestone row only when the
+remaining account preference is enabled. This also excludes opted-out internal
+accounts before irreversible aggregation. It drops raw IDs/page hashes before
+requesting the next page. Run-scoped staging tables contain only hashed/
+aggregate rows, expire within 24 hours, and are invisible to reporting.
 After all pages and checks succeed, one BigQuery multi-statement transaction
 deletes/inserts both published targets from staging; a failure rolls back both,
 leaving the prior snapshot/cohorts visible. Cleanup is best-effort because table
@@ -647,6 +710,8 @@ Job acceptance checks before promotion:
 - milestone ordering and timestamp types are valid without assuming setup
   occurs in a fixed order;
 - exported enabled count reconciles with aggregate coverage count;
+- internal/suppressed source counts reconcile with exclusions before weekly
+  aggregation, and neither class appears in keyed or aggregate outputs;
 - source and staging row counts are recorded without raw IDs;
 - a partial/failed run leaves the previous published tables intact.
 - milestones written after `runCutoff` and preferences changed before
@@ -655,9 +720,10 @@ Job acceptance checks before promotion:
 
 Use Application Default Credentials, Secret Manager for Mongo access, and an
 export service account limited to BigQuery Job User plus Data Editor on
-`sesori_analytics_auth_private` only. It has no role on raw, controls, curated,
-or reporting datasets and cannot write campaign/exclusion/config control
-tables. A separate scheduled-transform identity has read-only access to raw,
+`sesori_analytics_auth_private` plus table-level Data Viewer on the one
+authorized active-internal-exclusion view. It has no controls dataset write/DDL
+role and no role on raw, curated, or reporting datasets, so it cannot mutate
+campaign/exclusion/config tables. A separate scheduled-transform identity has read-only access to raw,
 auth-private, and controls plus write access to curated; the deployment identity
 alone owns schemas/IAM/control-table writes. The auth web runtime receives no
 BigQuery role.
@@ -703,7 +769,7 @@ property/project IDs:
 | --- | --- | --- |
 | `analytics_<property_id>` | Raw restricted | Firebase-managed GA4 daily tables |
 | `sesori_analytics_auth_private` | Security/analytics admins, auth export job; transform identity read-only | Auth eligible-user snapshot/staging and aggregate setup cohorts only |
-| `sesori_analytics_controls` | Security/analytics admins and deployment identity; transform identity read-only | Campaign registry, internal-user exclusions, dual measurement timestamps, export freshness policy |
+| `sesori_analytics_controls` | Security/analytics admins and deployment identity; transform identity read-only; auth-export identity can read only an authorized active-exclusion view | Campaign registry, internal-user exclusions, dual measurement timestamps, export freshness policy |
 | `sesori_analytics_curated` | Analytics engineers | Flattened allowlisted events, daily user activity, user milestones, scheduled intermediate tables |
 | `sesori_analytics_reporting` | Looker service account/product leadership | Identifier-free authorized views and dashboard tables |
 
@@ -785,11 +851,15 @@ not weaken the written privacy boundary to fit an unchecked property.
    permanently discarding otherwise eligible events.
 2. **`user_activity_daily`**: one row per user/date with monitor, control,
    message, notification, diff, and feature flags/counts.
-3. **`user_milestones`**: auth timestamps plus earliest project availability,
-   full activation, monitor activity, and feature milestones. Full activation
-   is the minimum of the two successful message event names only.
-4. **`activation_cohorts`**: account-cohort denominators, 1/7/30-day milestone
-   flags, times to milestone, cohort maturity, and behavioral coverage.
+3. **`user_milestones`**: auth timestamps plus earliest schema-v1 exposure,
+   project availability, full activation, monitor activity, and feature
+   milestones. Full activation is the minimum of the two successful message
+   event names only; `analytics_schema_ready_at` is the earliest schema-v1 event
+   of any name.
+4. **`activation_cohorts`**: account-cohort denominators only when schema-v1
+   exposure occurs within 24 hours of account creation, plus 1/7/30-day
+   milestone flags, times to milestone, cohort maturity, and separate
+   preference/schema coverage.
 5. **`retention_cohorts`**: activation-anchored W1/W4 eligibility and activity.
 6. **`acquisition_first_touch`**: earliest strict custom campaign code or
    approved automatic store/source class per eligible user, provided the event
@@ -849,8 +919,8 @@ only three days.
   for 14 months initially; retain identifier-free weekly aggregates longer only
   after privacy approval.
 - Keep the current eligible auth snapshot rather than historical copies with
-  user keys. A disabled account disappears from joinable reporting on the next
-  successful export.
+  user keys. A disabled or source-suppressed account disappears from joinable
+  reporting on the next successful export.
 - Restrict raw/private datasets; give Looker and routine viewers access only to
   reporting views. Do not expose `user_key` in Looker fields, extracts, or URLs.
 - Maintain internal/test exclusions as hashes in a restricted table with owner,
@@ -859,16 +929,24 @@ only three days.
   the approved minimum users; totals retain sample sizes.
 - Configure dataset/table expiration, scheduled-query byte limits, billing
   alerts, and a monthly cost check before dashboard sharing.
-- Implement a privacy-request runbook/job that first adds the `user_key` to a
-  restricted deletion-exclusion control so scheduled transforms cannot
-  repopulate it, then deletes matching auth-private/curated/reporting rows. From
-  the still-retained raw window it resolves only matching Firebase
-  `user_pseudo_id` values transiently and submits GA4 User Deletion API requests
-  as app-instance IDs; it also submits the hashed key as legacy GA `USER_ID` for
-  data produced before this design removed global `user_id`. Record request IDs
-  and completion status without raw account/install IDs. The two-month GA
-  retention plus 90-day raw window is the operating deadline; test the API
-  credential, request format, and a non-production deletion before rollout.
+- Implement a privacy-request runbook/job that first calls the auth-source
+  suppression operation, verifies preference disabled plus
+  `productAnalyticsExportSuppressedAt`, and only then adds `user_key` to a
+  restricted deletion-exclusion control. It deletes matching auth-private/
+  curated/reporting rows and rebuilds identifier-free setup cohorts; the source
+  tombstone prevents the next daily export from restoring either contribution.
+- From the still-retained raw window, resolve only `user_pseudo_id` values whose
+  installation emitted a matching keyed custom event and submit GA4 User
+  Deletion API requests as app-instance IDs. Also submit the hashed key as legacy
+  GA `USER_ID` for data produced before this design removed global `user_id`.
+  An automatic-only installation that disabled before ever emitting a keyed
+  event has no account link by design and cannot be targeted by an account-based
+  deletion request; do not claim otherwise. Its unlinked GA4 data is governed by
+  the verified two-month upstream retention. State this limit in the privacy
+  notice/deletion response rather than creating a persistent account-device map.
+  Record request IDs/completion without raw account/install IDs. Test the API
+  credential, request format, source non-repopulation, aggregate rebuild, and a
+  non-production deletion before rollout.
 
 ## Looker Studio
 
@@ -906,10 +984,11 @@ directory name.
 
 **Repository:** `sesori_auth_server`
 
-- Add the persisted enum and temporarily default missing Mongo fields to the
-  honest prior value (`enabled`) at decode/read boundaries.
-- Make every new `UserRepository.create` write the field before exposing GET/PUT
-  preference behavior.
+- Add the persisted enum/value-update timestamp, temporarily default missing
+  fields to honest prior values at decode/read boundaries, and add genuinely
+  nullable `productAnalyticsExportSuppressedAt` without a default.
+- Make every new `UserRepository.create` write preference plus update timestamp
+  before exposing GET/PUT preference behavior.
 - Add the dedicated repository-backed preference service and authenticated
   product-analytics routes; leave all auth profiles/tokens untouched.
 - Add the idempotent backfill/count command.
@@ -927,14 +1006,16 @@ directory name.
 
 - Remove the temporary missing-field default and make the Mongo model required;
   add a startup/test assertion that fixture creation always supplies it.
-- Add BigQuery Client -> export API -> export repository -> export service,
-  isolated job config/composition, package dependency, and production image
-  command.
+- Add BigQuery Client -> export API -> export/control repositories -> export
+  service, source suppression operation/command, isolated job config/composition,
+  package dependency, and production image command.
 - Publish the eligible pseudonymous snapshot and identifier-free weekly setup
-  cohorts through staging/validation/transactional promotion.
+  cohorts through staging/validation/transactional promotion, excluding source-
+  suppressed and active internal keys before keyed rows or aggregate counters.
 - Test hashing golden vector, opt-out filtering, aggregate reconciliation,
   pagination cutoff, milestones/preferences changing on already-read and future
   pages, conservative preference exclusion, staging cleanup, rerun idempotency,
+  source/internal suppression before aggregation, tombstone non-repopulation,
   and failed-run safety.
 - Deploy web enforcement only after step-1 zero-missing evidence. Deploy the job
   definition disabled; schedule it in PR 5 after private datasets/IAM exist.
@@ -950,19 +1031,22 @@ directory name.
   Settings cubit. `module_auth` and shared `AuthUser` remain unchanged.
 - Move the existing seven-event contract into core models and route existing
   onboarding UI calls through `ProductAnalyticsService`.
-- Implement only the thin `FirebaseAnalyticsClient` and desktop no-op adapter in
-  product shells; add pure-Dart `crypto` to `module_core` and keep SHA-256,
-  route mapping, state, and lifecycle in core.
-- Remove `AnalyticsUserIdTracker`, never set Firebase global `user_id` or its
+- Implement the thin `FirebaseAnalyticsClient`, pre-core legacy-identity cleanup,
+  and desktop no-op adapter in product shells; add pure-Dart `crypto` to
+  `module_core` and keep SHA-256, route mapping, state, and lifecycle in core.
+- Remove `AnalyticsUserIdTracker`, clear its persisted global Firebase user ID
+  immediately after Firebase initialization, never set another account key or
   persisted collection override, gate every Sesori custom event to post-splash
-  authenticated enabled release builds, and add custom stable-screen reporting.
+  authenticated enabled release builds, and add schema-ready/custom stable-
+  screen reporting.
 - Add the Settings toggle, explanatory/localized copy, pending/error behavior,
   explicit installation/automatic-event limitations, and privacy/legal/store-
   disclosure updates.
 - Test API parsing, layer wiring, fail-closed custom events during splash,
   post-splash fetch, pending-disable storage as the first awaited operation,
-  storage failure, crash/restart
-  pending recovery, logout sync failure/account switch preservation,
+  storage failure, crash/restart pending recovery, legacy-ID clear success/
+  failure ordering before custom sources, logout sync failure/account-switch
+  preservation,
   enable-after-server success, delayed GET/PUT/storage completions across rapid
   login/logout/account switches, foreground/15-minute refresh propagation,
   debug suppression, core identity hash, route-to-screen mapping, event wire
@@ -981,6 +1065,10 @@ directory name.
 - Instrument the authoritative core/app seams listed above, including both
   direct and queued message success, while keeping analytics best-effort and
   non-blocking.
+- Buffer only the first activation-candidate outcome while same-generation
+  preference is unknown, then emit on active or drop on disabled/auth change;
+  report first empty and first later non-empty inventory/activity/diff states
+  separately.
 - Preserve bounded notification category/event type through open dispatch and
   classify push/local plus cold/warm; buffer the single cold-start open until
   same-account preference resolution and drop it on disable/logout/timeout.
@@ -991,8 +1079,10 @@ directory name.
 - Add focused tests that failures/taps/queued-only operations do not activate,
   each successful message path makes one service call, new-session success is not
   double counted, sensitive inputs cannot enter parameter maps, notification
-  classification survives preference resolution, post-signup/old-account links
-  cannot become acquisition, and campaign values are bounded.
+  classification and first-message deferral survive preference resolution,
+  empty-to-non-empty transitions report once, post-signup/old-account links
+  cannot become acquisition, account A completion cannot consume account B's
+  first touch, and campaign values are bounded.
 
 ### PR 5/5 — Warehouse models and dashboards
 
@@ -1003,9 +1093,10 @@ directory name.
 - Add `tool/product_analytics/` data contract, parameterized deployment tool,
   DDL, transforms, fixture assertions, scheduled-query definitions, and runbook.
 - Create auth-private/controls/curated/reporting datasets in the raw GA4
-  location; keep export-job write access confined to auth-private; configure
-  IAM, expiration, budget alerts, campaign registry, exclusions, upstream GA4
-  retention/deletion, and separate raw/behavioral start timestamps.
+  location; keep export-job write access confined to auth-private and grant only
+  authorized-view reads for internal exclusion; configure IAM, expiration,
+  budget alerts, campaign registry, source/control exclusions, upstream GA4
+  retention/deletion limits, and separate raw/behavioral start timestamps.
 - Schedule the auth export and three-day event recomputation, then reconcile
   source counts and freshness; verify stale auth snapshots abort publication and
   recovery backfills the missed window.
@@ -1023,7 +1114,7 @@ directory name.
 | Before 1/5 | Existing clients/events continue. Firebase daily export should be linked only through the controlled day-zero sequence so its non-retroactive clock starts safely. | Complete restricted-project IAM, daily-only link, raw expiration/settings verification, and record `raw_export_start_at`. | Unlinking loses future export and is not a useful rollback; stop rollout and correct IAM/expiration/location before derived datasets or new instrumentation. |
 | After 1/5 | Dedicated GET/PUT preference endpoints work; old clients are unaffected because auth responses did not change. New users always write preference; old documents read as enabled during migration. | Deploy write-first web code to all serving instances, verify new writes, run/re-run backfill, and record zero missing. | Roll back before any opt-out client release if necessary. The added field is ignored by old code; do not remove it. Re-run backfill after returning to step 1. |
 | After 2/5 | Preference schema is required and export command/job image is deployable but unscheduled. Existing clients remain unaffected. | Require recorded zero-missing evidence from step 1; deploy enforcement; smoke-test account creation and endpoints; deploy job disabled. | Roll back web/job to step 1, whose honest missing-field default can read every document. Stop any job; published tables stay at last good state. |
-| After 3/5 | Mobile can disable/enable Sesori custom events on this installation and sync its server reporting/supported-client preference; existing custom events and stable screens obey the lifecycle; Firebase automatic install events retain the separately disclosed property behavior; desktop remains no-op. | Both auth endpoints/schema must be live. If unavailable, GET/enable fails closed for custom events and disable remains local pending without blocking logout. | **Forward-fix only after public release.** Never republish a client that emits custom events before readiness or ignores local disabled intent. For a severe defect, suppress all custom events; do not claim control over legacy/automatic events. Server preference data is never rolled back. |
+| After 3/5 | Mobile clears the prior global Firebase user ID before custom sources, can disable/enable Sesori custom events on this installation, and syncs its server reporting/supported-client preference; existing custom events and stable screens obey the lifecycle; Firebase automatic install events retain the separately disclosed property behavior; desktop remains no-op. | Both auth endpoints/schema must be live. If legacy-ID clear fails, custom events stay disabled for that process; if preference is unavailable, GET/enable fails closed and disable remains local pending without blocking logout. | **Forward-fix only after public release.** Preserve both legacy-ID cleanup and local custom-event gating through their declared floors. For a severe defect, suppress all custom events; do not claim control over legacy/automatic events. Server preference data is never rolled back. |
 | After 4/5 | New activation/engagement events accumulate in GA4 raw export. Product operations remain unchanged if Firebase is unavailable. | Step 3 custom-key/preference/schema lifecycle must be released. BigQuery needs no GA4 custom-dimension registration. | Forward-fix the app while retaining step-3 privacy behavior; event-specific defects may be disabled/removed. Missing future event names yield null/zero data, not product failure. |
 | After 5/5 | Auth job, curated models, authorized reporting views, and Looker provide the complete metric contract. | Create same-location datasets/IAM; deploy SQL/tests; schedule auth export; validate its first publish; schedule event transforms; then connect Looker. | Pause schedules/job and revert reporting views/dashboard sources to last known-good SQL. Raw GA4 and prior auth published tables remain; app behavior is unaffected. |
 
@@ -1048,24 +1139,28 @@ the separately released app.
 - Inspect a release-build Firebase DebugView/BigQuery sample using synthetic
   content and verify no forbidden field/value appears. Do not turn normal debug
   custom-event sharing on for convenience.
+- Seed the current release's global Firebase user ID, upgrade to the new build,
+  and verify null-clear completes before any custom source starts; force clear
+  failure and verify custom events remain disabled while product startup works.
 
 ### Auth server
 
 - `npm run build`, `npm run lint`, `npm run format:check`, and focused Node test
   suites; run the full DB-backed tests when MongoDB is available.
 - Run export dry-run/staging against synthetic accounts including enabled,
-  disabled, no activation state, out-of-order milestones, and page-boundary
-  cases.
+  disabled, internal enabled/disabled, source-suppressed, no activation state,
+  out-of-order milestones, and page-boundary cases.
 - Compare published aggregate totals to direct Mongo aggregate counts without
   exporting raw comparison rows.
 
 ### BigQuery and Looker
 
 - Dry-run every deployed query and run fixture `ASSERT`s for activation event
-  inclusion, failed/queued exclusion, earliest-message selection, 7-day cohort
-  maturity, W1/W4 boundaries, internal/disabled filtering, the 24-hour campaign
-  rule, unknown campaign, stale-auth-snapshot publication abort/recovery, and
-  late-event replacement.
+  inclusion, failed/queued exclusion, deferred first-message selection, timely
+  per-account schema exposure, legacy-without-exposure exclusion, 7-day cohort
+  maturity, W1/W4 boundaries, internal/disabled/suppressed filtering before
+  aggregates, the 24-hour campaign rule, unknown campaign, stale-auth-snapshot
+  publication abort/recovery, and late-event replacement.
 - Reconcile GA4 custom event counts -> flattened events -> daily activity ->
   reporting totals for at least three complete days.
 - Verify auth export credentials cannot write controls/curated/reporting, Looker
@@ -1073,7 +1168,9 @@ the separately released app.
   sample-size/partial-period labels.
 - Verify raw ACL/default expiration and GA4 two-month retention before data
   acceptance, then complete one non-production GA User Deletion API exercise
-  through warehouse suppression/deletion and upstream request status.
+  through auth-source tombstone, warehouse suppression/deletion, aggregate
+  rebuild/non-repopulation, and upstream request status. Verify the deletion
+  response states the automatic-only never-keyed installation limit.
 
 ## Rollout And Two-Month Readiness
 
@@ -1106,6 +1203,9 @@ no cohort has matured.
   excludes a restricted internal-user list; monitor app version/schema mix.
 - **Opt-out bias:** show eligible coverage with every behavioral funnel and do
   not extrapolate activation/retention to all accounts.
+- **Legacy denominator bias:** require timely per-account schema-v1 exposure;
+  global rollout time or server default-enabled state alone never makes an
+  account measurable.
 - **Cross-repository deployment mismatch:** deploy write-first server behavior,
   backfill/verify, then enforce, and only then release the client. Preference
   GET/PUT failure is fail-closed; auth profiles remain unchanged.
@@ -1114,6 +1214,10 @@ no cohort has matured.
   custom-event toggle. Narrow UI/legal promises accordingly, use current
   preference only for supported-client custom events and reporting eligibility,
   and never claim account-wide enforcement without minimum-version controls.
+- **Legacy global identity on upgrade:** clear it at earliest post-Firebase
+  bootstrap before custom sources and keep the migration for the raw-retention
+  window. Automatic events before that supported reset remain restricted legacy
+  raw data and are never represented as fully preventable.
 - **Privacy rollback floor:** after the opt-out release, use forward fixes that
   preserve local pending-disable/custom-event gating or suppress all custom
   events; never republish old startup emission as rollback.
@@ -1141,10 +1245,12 @@ The work is complete when:
 - A production release makes one analytics emission attempt per confirmed
   first-message success path with a pseudonymous custom `user_key`, immediately
   honors installation-local disable/re-enable semantics, preserves pending
-  server sync across logout/restart, and never claims to control legacy or
-  automatic events; duplicate delivery cannot change the earliest activation.
-- The auth job publishes validated eligible milestones and all-account setup
-  cohorts without raw identity.
+  server sync across logout/restart, defers the first same-generation message
+  while preference is unknown, clears legacy global identity before custom
+  sources, and never claims to control legacy or automatic events; duplicate
+  delivery cannot change the earliest activation.
+- The auth job publishes validated eligible milestones and external-account
+  setup cohorts without raw identity or internal/deletion-suppressed accounts.
 - BigQuery derives the metric contract above from versioned SQL, passes fixture
   assertions, survives stale auth snapshots without permanent event loss, and
   remains fresh after recovery/late data.

--- a/.plan/active/user-analytics/PLAN.md
+++ b/.plan/active/user-analytics/PLAN.md
@@ -33,9 +33,11 @@ Revenue metrics are out of scope because Sesori is currently free.
    permission/question, or creating an empty session does not.
 2. The implementation spans the apps monorepo, the Sesori auth server,
    Firebase/GA4, BigQuery, and Looker Studio.
-3. Optional product-interaction analytics is enabled by default for an account
-   after its authenticated preference is known. Users receive an account-wide
-   opt-out in Settings.
+3. Optional Sesori-defined product-interaction events are enabled by default
+   after the authenticated server preference is known. Settings disables them
+   immediately on this installation and synchronizes a reporting/supported-
+   client preference to the server. It does not claim to stop Firebase's
+   automatic install-level events or already-installed legacy binaries.
 4. Acquisition work starts with campaign links and automatic store/Firebase
    attribution. No onboarding survey is added in this scope.
 5. Looker Studio is the reporting surface; it reads aggregate authorized views,
@@ -66,9 +68,11 @@ Reporting aliases both fields to their factual meanings and never substitutes
 the legacy signal for full activation.
 
 Behavioral milestones cannot be backfilled before the new event release. Store
-an instrumentation start timestamp and restrict activation/retention cohorts to
-accounts created on or after it. Historical server milestones may still support
-honestly labeled setup trends.
+two timestamps: `raw_export_start_at` when Firebase export begins and
+`behavioral_schema_v1_start_at` only after the production app version has
+successfully exported the new event schema. Restrict activation/retention
+cohorts to accounts created on or after the behavioral timestamp. Historical
+server milestones may still support honestly labeled setup trends.
 
 ### Headline metrics
 
@@ -76,7 +80,7 @@ honestly labeled setup trends.
 | --- | --- |
 | Weekly new accounts | All auth accounts created during the complete week. This comes from aggregate server export and is not reduced by product-analytics opt-out. |
 | 7-day bridge setup conversion | Accounts whose first bridge registration is within 7 x 24 hours of account creation, divided by accounts at least 7 days old in the cohort. |
-| 7-day full activation conversion | Analytics-enabled accounts whose full activation is within 7 x 24 hours of account creation, divided by measurable accounts at least 7 days old and created after instrumentation start. Show behavioral coverage beside it; do not extrapolate to opted-out accounts. |
+| 7-day full activation conversion | Analytics-eligible accounts whose full activation is within 7 x 24 hours of account creation, divided by measurable accounts at least 7 days old and created on/after `behavioral_schema_v1_start_at`. Show behavioral coverage beside it; do not extrapolate to disabled/legacy accounts. |
 | Time to activation | P50 and P75 of `full_activation_at - account_created_at` among activated measurable accounts. |
 | Meaningful WAU | Distinct users with a non-empty session activity view or a confirmed control event in the complete week. A screen view/app open never qualifies. |
 | Controller WAU | Distinct users with a successful message, question answer/rejection, permission answer, session abort, or session creation with message. |
@@ -146,12 +150,14 @@ honestly labeled setup trends.
 
 ### In scope
 
-- Immediate Firebase/GA4 -> BigQuery linking and a recorded measurement start.
-- Account-wide optional product-analytics preference and mobile Settings UI.
+- Immediate Firebase/GA4 -> BigQuery linking with raw controls and a recorded
+  raw-export start; record the separate behavioral start at production rollout.
+- Installation-enforced optional custom product-analytics preference, mobile
+  Settings UI, and a server preference for reporting/supported clients.
 - A surface-neutral typed analytics contract in `module_core`, implemented by
   Firebase in mobile and by a no-op adapter on unsupported products.
-- Authenticated identity lifecycle, release-build collection, stable screen
-  views, campaign attribution, and the outcome events below.
+- Authenticated custom-event key lifecycle, release-build custom-event sharing,
+  stable screen views, campaign attribution, and the outcome events below.
 - A daily privacy-safe auth export and aggregate all-account setup cohorts.
 - Versioned BigQuery DDL/transforms/tests and Looker Studio dashboards.
 - Internal/test-user exclusion, retention, access, cost, and data-quality
@@ -185,8 +191,8 @@ honestly labeled setup trends.
 | `sesori_auth_server` | `src/types/product-analytics.ts` (domain enum), `src/models/{documents,api,product-analytics-export}.ts` (persisted/API/export contracts), `src/repositories/{user-repo,activation-state-repo,product-analytics-export-repo}.ts` (data access/aggregation), `src/services/{product-analytics-preference-service,product-analytics-export-service}.ts` (business logic), `src/clients/bigquery-product-analytics-client.ts` and `src/api/product-analytics-export-api.ts` (external sink layers), `src/routes/product-analytics.ts` (HTTP boundary), `src/scripts/{backfill-product-analytics-preference,export-product-analytics,product-analytics-export-config}.ts` (separate command composition) | Persist preference behind a dedicated service, expose GET/PUT endpoints, and export privacy-safe data. | Existing auth responses and clients remain unchanged. The web process constructs only the preference service; it never constructs export/BigQuery classes. |
 | `shared/sesori_shared` | No production change | Keep `AuthUser` authentication-only; do not add a product preference to the shared auth/persisted contract. | No bridge/shared migration or compatibility default is introduced. |
 | `client/module_auth` | No production change | Continue to own tokens, OAuth, auth state, and `AuthenticatedHttpApiClient` only. | `module_core` observes `AuthSession` read-only and injects `AuthenticatedHttpApiClient` into its own Layer-1 preference API. |
-| `client/module_core` | `lib/src/models/product_analytics/`, `lib/src/platform/analytics_client.dart`, `lib/src/api/{analytics_api,product_analytics_preference_api}.dart`, `lib/src/storage/{product_analytics_preference_storage,campaign_attribution_storage}.dart`, `lib/src/repositories/{product_analytics,product_analytics_preference,campaign_attribution}_repository.dart`, `lib/src/services/{product_analytics,campaign_attribution}_service.dart`, `lib/src/listeners/{analytics_route,campaign_attribution}_listener.dart`, `lib/src/cubits/product_analytics_preference/`, existing project/session/diff cubits and notification dispatcher, DI/barrel/generated files | Expose architectural layers explicitly; own preference HTTP/persistence, pseudonymous hashing, route/campaign lifecycle, Settings state, and authoritative business-outcome emission. | Mobile supplies only the Firebase platform client. Desktop supplies a no-op client. Cubit constructor call sites/tests update in lockstep. |
-| `client/app` | `lib/core/platform/firebase_analytics_client.dart`, `lib/core/di/`, `lib/features/{settings,project_list,new_session,session_detail,session_diffs}/`, `lib/l10n/`, `lib/main.dart`, iOS/Android analytics defaults | Implement the thin Firebase SDK adapter, start core services/listeners, render preference UI, and inject services into core consumers. | Existing app event sources move to core; `AnalyticsUserIdTracker` and obsolete app `DeepLinkService` are removed. No new voice logic is added. |
+| `client/module_core` | `lib/src/models/product_analytics/`, `lib/src/platform/analytics_client.dart`, `lib/src/api/{analytics_api,product_analytics_preference_api}.dart`, `lib/src/storage/{product_analytics_preference_storage,campaign_attribution_storage}.dart`, `lib/src/repositories/{product_analytics,product_analytics_preference,campaign_attribution}_repository.dart`, `lib/src/services/{product_analytics,campaign_attribution}_service.dart`, `lib/src/listeners/{analytics_route,campaign_attribution,notification_open_analytics}_listener.dart`, `lib/src/cubits/product_analytics_preference/`, existing project/session/diff cubits and notification dispatcher, DI/barrel/generated files | Expose architectural layers explicitly; own preference HTTP/persistence, pseudonymous hashing, route/campaign/notification lifecycle, Settings state, and authoritative business-outcome emission. | Mobile supplies only the Firebase platform client. Desktop supplies a no-op client. Cubit constructor call sites/tests update in lockstep. |
+| `client/app` | `lib/core/platform/firebase_analytics_client.dart`, `lib/core/di/`, `lib/features/{settings,project_list,new_session,session_detail,session_diffs}/`, `lib/l10n/`, `lib/main.dart`, iOS/Android analytics defaults | Implement the thin Firebase SDK adapter, start core services/listeners, render preference UI, and inject services into core consumers. | Existing app event sources move to core; `AnalyticsUserIdTracker` and obsolete app `DeepLinkService` are removed. No global Firebase `user_id` or runtime collection override is added. No new voice logic is added. |
 | `client/desktop` | `lib/core/platform/no_op_analytics_client.dart`, DI generated file | Satisfy the shared core platform capability without collecting desktop analytics. | No desktop product events or UI are added. Analyze/test verifies core DI remains resolvable. |
 | `client/module_desktop_core` | No planned production edit; tests/build are downstream validation | Continue unchanged. | Shared core DI/downstream validation only. |
 | `bridge/app` | No planned production or contract edit | Remain outside product analytics. | No additional bridge validation beyond normal CI is caused by this plan. |
@@ -212,42 +218,74 @@ pending update may start only after an explicit non-splash readiness signal or
 a Settings action—never as a side effect of `restoreLocalSession()` during
 splash.
 
-The mobile app starts Firebase Analytics collection **disabled in native
-configuration**. A core `ProductAnalyticsService` combines the locally persisted
-preference/sync intent with the authenticated server preference:
+Do not use Firebase's persisted `setAnalyticsCollectionEnabled` override or
+global `setUserId` as the preference mechanism. Firebase automatic install-level
+events remain governed by the privacy-minimized property/native configuration
+and are disclosed separately; they never define product activity. Every
+Sesori-defined custom event instead carries the pseudonymous `user_key` as a
+typed parameter, and `ProductAnalyticsService` refuses to create those events
+unless the local/server gate is active. This avoids a cold-start race with a
+persisted Firebase enable override and prevents automatic startup events from
+inheriting an account key.
 
-- Unknown, unauthenticated, debug/profile, or disabled state keeps collection
-  off and `user_id` clear.
-- After post-splash readiness, an authenticated account fetches the server
-  preference. Only a returned enabled value in a release build sets the
-  pseudonymous user ID, grants analytics/functionality storage, and enables
-  collection; a local cached enabled value alone never enables a new run.
-- Disabling turns collection off immediately, denies analytics storage, clears
-  identity, resets queued/local analytics data, persists a pending disable if
-  the server is unavailable, and retries only after post-splash readiness or an
-  explicit user retry.
-- Enabling waits for a successful server update before collection starts.
-- Logout disables collection until another authenticated preference is known.
+The core service combines installation-local intent with the server preference:
+
+- Unknown, unauthenticated, debug/profile, locally disabled, or server-disabled
+  state suppresses all Sesori-defined custom events.
+- After post-splash readiness, an authenticated installation fetches the server
+  preference. Only returned enabled in a release build activates custom event
+  sharing; a local cached enabled value alone never activates a new run.
+- Disable synchronously transitions the service to inactive, then makes durable
+  `pendingDisable(userId)` its **first awaited operation**, before any SDK/network
+  work, and only then PUTs disabled. A crash after that write leaves recoverable
+  local intent; no SDK disable/reset call is required for custom-event
+  enforcement.
+- A local storage read error keeps custom events inactive rather than treating
+  missing state as enabled. If the write-ahead write fails, the process remains
+  inactive and still attempts the authenticated server disable, but the UI does
+  not report saved success unless either durable local intent or server disabled
+  is confirmed; a double failure requires explicit retry.
+- Server success stores synchronized disabled. Failure preserves the pending
+  record and surfaces “disabled on this device; account sync pending”; retry is
+  allowed only after post-splash readiness or explicit user action.
+- Enable keeps custom sharing inactive until server success and synchronized
+  local persistence.
+- Logout/account loss never deletes a pending disable. The logout flow attempts
+  one authenticated sync before credentials are cleared; if it fails, it
+  preserves the record and requires reauthentication to finish server sync.
+
+The setting is not advertised as a universal Firebase or legacy-client kill
+switch. It immediately controls Sesori-defined custom events on this
+installation; the server preference suppresses reporting and is honored by
+analytics-capable releases. Already-installed older binaries can continue their
+previous Firebase behavior until upgraded/retired, so account-wide wording is
+forbidden unless a future minimum-version enforcement mechanism makes it true.
+Supported clients re-read the preference on every foreground transition and at
+most every 15 minutes while continuously foregrounded. Thus a remote change is
+applied by the next successful check (within 15 minutes when online), not
+instantaneously; offline and legacy limitations must remain explicit in copy.
 
 Model preference and synchronization status as separate sealed states; do not
 flatten “disabled”, “unknown”, “pending sync”, and “failed” into nullable flags.
-The Settings copy must say that optional pseudonymous feature interactions are
-controlled by the toggle, list the prohibited content categories, and explain
-that account/bridge records required to operate Sesori remain outside this
-optional collection. Product/privacy counsel must approve the final text and
-store disclosures before release.
+The Settings copy must say “Share pseudonymous product usage from this device,”
+list the prohibited content categories, identify the pending server-sync state,
+and explain that Firebase automatic install-level events plus account/bridge
+records required to operate Sesori are not controlled by this switch. Product/
+privacy counsel must approve the final text and store disclosures before
+release.
 
 ### Pseudonymous join key
 
 Continue using lowercase hex SHA-256 over the UTF-8 auth user ID. Implement the
 same algorithm in TypeScript and in the core `ProductAnalyticsRepository`, and
 pin both repositories to one documented golden test vector. The mobile Firebase
-adapter receives only the resulting value; it never receives a raw account ID.
+adapter receives the resulting value only inside typed custom event envelopes;
+it never receives a raw account ID and never sets Firebase's global `user_id`.
 Raw user IDs are permitted only in auth/core process memory and
 the auth database/existing encrypted local auth or preference storage; they must
 not reach Firebase, BigQuery, logs, SQL assets, or dashboard URLs.
 
-The deterministic hash allows cross-device and auth-to-GA4 joins but remains
+The deterministic custom `user_key` allows cross-device and auth-to-GA4 joins but remains
 pseudonymous personal data. Documentation and access controls must call it that.
 
 ### Allowed dimensions
@@ -286,25 +324,28 @@ mixed `src/analytics/` bucket. The concrete dependency direction is:
 | Class/file | Layer and constructor collaborators | Responsibility and lifecycle |
 | --- | --- | --- |
 | `AnalyticsEvent`, bounded enums, `AnalyticsScreen`, `AnalyticsDeliveryResult`, `ProductAnalyticsPreference`, `ProductAnalyticsState`, `CampaignCode`, and persisted record variants under `module_core/lib/src/models/product_analytics/` | Domain models; no SDK/Flutter dependencies | Closed event/screen/preference/state values. `AnalyticsScreen` is independent of routing; `AnalyticsRouteListener` performs the exhaustive `AppRouteDef -> AnalyticsScreen` mapping. Delivery is `acceptedBySdk` or `failed`, never an untruthful “reported” boolean. |
-| `AnalyticsClient` in `module_core/lib/src/platform/analytics_client.dart` | Foundation external-sink capability | Typed `logEvent`, `logScreenView`, `enable({required String userKey})`, and `disable({required bool resetData})`. The key is already pseudonymous. Methods throw SDK failures; they accept no arbitrary map/name or raw account ID. |
+| `AnalyticsClient` in `module_core/lib/src/platform/analytics_client.dart` | Foundation external-sink capability | Typed `logEvent({required AnalyticsEvent event, required String userKey})`. The key is already pseudonymous and is serialized as the custom `user_key` event parameter, never global SDK identity. Methods throw SDK failures; they accept no arbitrary map/name or raw account ID. |
 | `AnalyticsApi` in `module_core/lib/src/api/analytics_api.dart` | Layer 1; constructor requires `AnalyticsClient` | Thin API over the external client. It is the only core class that invokes the platform sink. |
 | `ProductAnalyticsPreferenceApi` in `module_core/lib/src/api/product_analytics_preference_api.dart` | Layer 1; constructor requires `AuthenticatedHttpApiClient` | Calls authenticated GET/PUT `/product-analytics/preference`, serializes the closed enum, parses external strings at the boundary, and returns explicit success/failure. It does not mutate auth state. |
 | `ProductAnalyticsPreferenceStorage` and `CampaignAttributionStorage` in `module_core/lib/src/storage/` | Layer 1 storage; each constructor requires `SecureStorage` | Read/write/delete only their closed persisted records. They do not reconcile accounts, call APIs, hash IDs, or emit analytics. |
 | `ProductAnalyticsRepository` in `module_core/lib/src/repositories/product_analytics_repository.dart` | Layer 2; constructor requires `AnalyticsApi` | Converts raw authenticated user ID to lowercase SHA-256, passes only the pseudonymous key downward, and maps API exceptions to explicit `AnalyticsDeliveryResult` without redundant logging. It adds `schema_version=1` through the typed event serialization contract. |
 | `ProductAnalyticsPreferenceRepository` in `module_core/lib/src/repositories/product_analytics_preference_repository.dart` | Layer 2; requires `ProductAnalyticsPreferenceApi` and `ProductAnalyticsPreferenceStorage` | Fetch/update server preference, scope local records to one account, persist only `synced(userId, preference)` or `pendingDisable(userId)`, and expose explicit results. Enable is never persisted pending. |
-| `CampaignAttributionRepository` in `module_core/lib/src/repositories/campaign_attribution_repository.dart` | Layer 2; requires `CampaignAttributionStorage` | Enforces first touch and persists `pending(code)` or `acceptedBySdk(code)`. Absence genuinely means no campaign. It never stores a full URI/UTM text. |
-| `ProductAnalyticsService` in `module_core/lib/src/services/product_analytics_service.dart` | Layer 3, `@lazySingleton`; requires `AuthSession` (read-only), `ProductAnalyticsRepository`, and `ProductAnalyticsPreferenceRepository` | Sole owner of preference/collection lifecycle and Consumer methods `logEvent`/`logScreenView`. Exposes a replaying state stream plus `start`, `markPostSplashReady`, `setPreference`, `retryPendingDisable`, and `dispose`. It performs no network work until readiness. |
+| `CampaignAttributionRepository` in `module_core/lib/src/repositories/campaign_attribution_repository.dart` | Layer 2; requires `CampaignAttributionStorage` | Enforces first touch and a 24-hour pending TTL, and persists `pending(code, capturedAt)` or `acceptedBySdk(code)`. Absence genuinely means no campaign. It never stores a full URI/UTM text. |
+| `ProductAnalyticsService` in `module_core/lib/src/services/product_analytics_service.dart` | Layer 3, `@lazySingleton`; requires `AuthSession` (read-only), existing `LifecycleSource`, `ProductAnalyticsRepository`, and `ProductAnalyticsPreferenceRepository` | Sole owner of preference/custom-event lifecycle and Consumer `logEvent`. Exposes a replaying state stream plus `start`, `markPostSplashReady`, `setPreference`, `retryPendingDisable`, and `dispose`. It performs no network work until readiness, revalidates while foregrounded, serializes reconciliation per auth generation, and sends no custom event unless active. |
 | `CampaignAttributionService` in `module_core/lib/src/services/campaign_attribution_service.dart` | Layer 3, `@lazySingleton`; requires `CampaignAttributionRepository` and `ProductAnalyticsService` | Captures a validated first touch and attempts the event only on an active transition/start. It marks `acceptedBySdk` only when the service returns that typed result; failure leaves `pending` for a later lifecycle attempt without a timer loop. |
 | `AnalyticsRouteListener` in `module_core/lib/src/listeners/analytics_route_listener.dart` | Consumer/listener, `@lazySingleton`; requires `RouteSource` and `ProductAnalyticsService` | Owns route subscription, maps `AppRouteDef` exhaustively to `AnalyticsScreen`, signals readiness on the first non-splash route, and reports stable screens only while active. It never passes a route model/path to Foundation. |
 | `CampaignAttributionListener` in `module_core/lib/src/listeners/campaign_attribution_listener.dart` | Consumer/listener, `@lazySingleton`; requires `DeepLinkSource` and `CampaignAttributionService` | Replaces the obsolete app `DeepLinkService`, owns the one URI subscription, validates only approved `sesori.com/link` campaign codes, and ignores all other/legacy callback URIs without logging complete values. |
+| `NotificationOpenAnalyticsListener` in `module_core/lib/src/listeners/notification_open_analytics_listener.dart` | Consumer/listener, `@lazySingleton`; requires the bounded notification-open source and `ProductAnalyticsService` | Buffers at most the one validated cold-start open until preference reconciliation, emits it only if the same account becomes active, and drops it on disable, logout/account switch, or process-lifetime timeout. No entity ID enters the buffer. |
 | `ProductAnalyticsPreferenceCubit` in `module_core/lib/src/cubits/product_analytics_preference/` | Consumer; constructor requires `ProductAnalyticsService` | Subscribes to service state and exposes toggle/retry intents. Mobile Settings constructs it; it is not in DI. |
-| `FirebaseAnalyticsClient` in `app/lib/core/platform/firebase_analytics_client.dart` | Thin mobile Foundation adapter, `@LazySingleton(as: AnalyticsClient)`; requires `FirebaseAnalytics` | Serializes typed events/screens, applies consent/collection/identity SDK calls, and throws failures upward. It receives an already hashed key and contains no route/campaign/preference/hash business logic. Firebase-disabled environments use the existing no-op SDK object. |
+| `FirebaseAnalyticsClient` in `app/lib/core/platform/firebase_analytics_client.dart` | Thin mobile Foundation adapter, `@LazySingleton(as: AnalyticsClient)`; requires `FirebaseAnalytics` | Serializes only typed custom events plus `schema_version` and `user_key`, and throws failures upward. It never applies global identity/collection overrides and contains no route/campaign/preference/hash business logic. Firebase-disabled environments use the existing no-op SDK object. |
 | `NoOpAnalyticsClient` in `desktop/lib/core/platform/no_op_analytics_client.dart` | Desktop phase-1 Foundation adapter | Satisfies shared core DI and accepts operations without collection. No desktop listeners are started. |
 
 `AnalyticsScreen` pins snake-case wire values for login, projects, settings and
-its subpages, sessions, new session, session detail, and session diffs. The
+its subpages, sessions, new session, session detail, and session diffs. Screen
+activity is the Sesori custom `product_screen_viewed` event rather than Firebase
+`screen_view`, so the custom-event gate and `user_key` always apply. The
 route listener's exhaustive switch also handles splash explicitly (readiness
-only, no report while collection is inactive), so adding an `AppRouteDef`
+only, no report while custom sharing is inactive), so adding an `AppRouteDef`
 cannot silently omit its analytics mapping.
 
 The client API may return SDK acceptance, not delivery to Google's backend.
@@ -320,11 +361,12 @@ success.
 2. Auth phase 2 registers `AuthSession` and `AuthenticatedHttpApiClient` without
    any analytics-specific method.
 3. Core phase 3 registers both APIs, both Storage classes, three repositories,
-   two services, and two listeners. Dependencies therefore resolve only
+   two services, and three listeners. Dependencies therefore resolve only
    downward through the declared layers.
 4. Mobile bootstrap awaits `ProductAnalyticsService.start()`, then starts
-   `CampaignAttributionService`, `AnalyticsRouteListener`, and
-   `CampaignAttributionListener` for process lifetime. Their dispose methods are
+   `CampaignAttributionService`, `AnalyticsRouteListener`,
+   `CampaignAttributionListener`, and `NotificationOpenAnalyticsListener` for
+   process lifetime. Their dispose methods are
    owned by GetIt/test teardown. Starting them on the initial splash route
    performs local reads/subscriptions only.
 5. Cubits remain constructed in `BlocProvider` and receive
@@ -333,50 +375,81 @@ success.
 
 ### Preference and lifecycle data flow
 
-**Startup and readiness:** Native iOS/Android defaults deny analytics storage
-and disable collection. `ProductAnalyticsService.start()` calls repository
-disable with `resetData: false`, reads only local pending state, and subscribes
-to `AuthSession.authStateStream`; it never validates auth or calls the
-preference API. `AnalyticsRouteListener` sees initial `splash` but does not mark
+**Startup and readiness:** Firebase retains its privacy-minimized automatic
+event configuration, but custom reporting starts inactive.
+`ProductAnalyticsService.start()` reads only local pending state and subscribes
+to `AuthSession.authStateStream`; it never validates auth, calls the preference
+API, sets global Firebase identity, or changes SDK collection state.
+`AnalyticsRouteListener` sees initial `splash` but does not mark
 readiness. On the first non-splash route it calls `markPostSplashReady()`. Only
 then may the service fetch/reconcile for the currently authenticated account.
 If login is still unauthenticated, it waits for the later auth emission. Thus
 `restoreLocalSession()` cannot trigger a splash-time network request.
 
-**Reconciliation:** A same-account local `pendingDisable` keeps collection off
+**Reconciliation:** A same-account local `pendingDisable` keeps custom sharing off
 and PUTs disabled after readiness. Otherwise the repository GETs the server
 preference; returned disabled stays off, while returned enabled in a release
-build asks `ProductAnalyticsRepository` to hash the account ID and enable the
-SDK. Debug/profile/unsupported builds retain the desired preference but publish
-`AnalyticsCollectionState.inactive(buildUnsupported)`.
+build allows `ProductAnalyticsRepository` to hash the account ID for each typed
+event. Debug/profile/unsupported builds retain the desired preference but
+publish `ProductAnalyticsState.inactive(buildUnsupported)`.
+
+Every auth emission/account switch/logout increments a monotonically increasing
+service generation. Each GET, PUT, persistence operation, and scheduled refresh
+captures `(generation, userId)`; after every await and immediately before any
+state transition/event acceptance it verifies both still match current auth.
+Stale completions may finish only their account-scoped storage/server operation;
+they cannot activate another generation. Reconciliations are non-overlapping
+within one generation. After initial readiness the service refreshes on each
+`LifecycleState.resumed` transition and schedules one 15-minute recheck at a
+time while continuously resumed. A returned disabled value synchronously marks
+the current generation inactive before any follow-up persistence await. Network
+failure preserves the honest prior local state and last-successful-check time;
+the UI makes the conditional online propagation bound explicit.
 
 **Disable:** The cubit calls `ProductAnalyticsService.setPreference(disabled)`.
-The service first disables/resets the SDK through the analytics repository,
-then persists `pendingDisable(userId)`, then calls the preference repository
-PUT. Success stores synchronized disabled; failure remains pending and exposes
-generic retry state. Retry occurs only from Settings or a later post-splash
-lifecycle, never from a timer or splash auth emission.
+The service immediately publishes inactive, then first durably persists
+`pendingDisable(userId)` before any subsequent await, then calls the preference
+repository PUT. Success stores synchronized disabled; network failure remains
+pending and exposes the truthful local-disabled/server-sync-pending state. A
+storage-write failure keeps in-memory suppression, attempts server disable, and
+surfaces unsaved failure unless the server confirms disabled. Retry occurs only
+from Settings or a later post-splash lifecycle, never from a timer or splash
+auth emission.
 
-**Enable:** Collection remains off while the preference repository PUTs
+**Enable:** Custom sharing remains off while the preference repository PUTs
 enabled. Only server success followed by synchronized local persistence allows
-the analytics repository to hash/enable. Failed enable remains disabled and is
+the analytics repository to hash/send. Failed enable remains disabled and is
 not persisted for automatic future activation.
 
-**Logout/account switch:** Any unauthenticated state disables without reset,
-clears SDK identity, and publishes unauthenticated. Local records are scoped by
-raw ID inside encrypted storage and never apply to another account. Explicit
-opt-out is the only path requesting SDK data reset.
+**Logout/account switch:** Before explicit logout clears credentials, the auth
+consumer asks the service to attempt one pending disable sync. Regardless of
+success it immediately suppresses custom events. Failure must not block logout:
+the encrypted pending record remains scoped by raw ID and is retried after that
+account reauthenticates; it never applies to another account. Unexpected token
+loss preserves the same record. No path claims or requests a Firebase-wide data
+reset.
 
 **Screen flow:** The route listener retains the latest `AnalyticsScreen` while
-inactive. Inactive-to-active emits that screen once; later changed screen enums
-emit once. Foundation sees neither `AppRouteDef` nor a concrete URI.
+inactive. Inactive-to-active emits `product_screen_viewed` once; later changed
+screen enums emit once. Foundation sees neither `AppRouteDef` nor a concrete URI.
 
-**Campaign flow:** The campaign listener converts only an approved URI to
-`CampaignCode`; the service/repository stores first touch before auth. On active
-state it attempts `campaign_attributed`. `acceptedBySdk` is persisted only from
-the typed accepted result. A failed result leaves pending, with at most one
-attempt per active lifecycle; BigQuery selects the earliest event if a crash
-between SDK acceptance and local persistence causes a duplicate.
+**Campaign flow:** The campaign listener converts only an approved URI received
+while unauthenticated to `CampaignCode`; authenticated/post-signup opens are
+ignored. The service/repository stores first touch plus capture time before auth
+and expires it after 24 hours. On active state it attempts
+`campaign_attributed`. `acceptedBySdk` is persisted only from the typed accepted
+result. A failed result leaves pending, with at most one attempt per active
+lifecycle; BigQuery accepts attribution only when the account is at most 24
+hours old at event time and selects the earliest eligible event. Existing
+accounts opening campaign links before login therefore remain unattributed.
+
+**Cold notification flow:** The notification dispatcher first performs its
+normal validated navigation dispatch and publishes only bounded analytics
+metadata. The analytics listener buffers at most that one cold-start open while
+preference is unknown. It emits after same-account active reconciliation; it
+drops the buffer on disabled, logout/account switch, or if reconciliation does
+not complete during that process. Warm opens while active emit immediately;
+inactive warm opens are not retained.
 
 ### Outcome event catalog
 
@@ -395,8 +468,8 @@ Existing wire names remain unchanged. Add only the following initial events:
 | `session_abort_succeeded` | Root and active-child abort requests all return success | none | Remote interventions |
 | `session_diff_viewed` | Initial diff fetch succeeds | `change_state=empty/non_empty` | Diff adoption; meaningful only when non-empty |
 | `notification_opened` | A valid notification is dispatched after authentication | `source=push/local`, `launch_context=cold/warm`, bounded `category`, bounded `event_type` | Notification engagement |
-| `campaign_attributed` | The first valid campaign code receives an SDK-accepted attempt for an authenticated analytics-enabled account/install | `campaign_code` only | Acquisition coverage and cohorts; earliest event wins |
-| Firebase `screen_view` | `RouteSource` emits a changed non-null `AppRouteDef` | stable enum name only | Navigation/friction, never meaningful activity |
+| `campaign_attributed` | A pre-auth first-touch code captured in the prior 24 hours receives an SDK-accepted attempt for an authenticated custom-sharing-enabled install | `campaign_code` only | Acquisition coverage and cohorts; warehouse also requires account age <= 24 hours and earliest eligible event wins |
+| `product_screen_viewed` | `RouteSource` emits a changed non-null `AppRouteDef` while custom sharing is active | stable `screen` enum only | Navigation/friction, never meaningful activity |
 
 For `session_activity_viewed`, `non_empty` means there is at least one message,
 pending question/permission, or an active/retrying status.
@@ -441,7 +514,7 @@ merely to avoid updating tests.
 | `NewSessionCubit` | Add required product analytics service. Capture workspace/submission classifications before awaiting. `SuccessResponse` makes one `session_created_with_message` call; `ErrorResponse` emits only bounded `session_creation_failed`. It never also emits the existing-session event. |
 | `SessionDetailCubit` question/permission/abort | Report after each existing method's success branch. Question answers/rejections carry no answer data; permission maps the existing `PermissionReply` enum; abort reports only after every root/active-child response succeeds. |
 | `DiffCubit` | Add required product analytics service and `_hasReportedInitialDiff` guard. First successful fetch emits empty/non-empty; SSE refreshes and retries after an already successful first fetch do not. |
-| `NotificationOpenRequest` / `NotificationOpenDispatcher` | Extend the internal request with required bounded category/event type already present in `NotificationData`. Push/local adapters provide `unknown` for legacy local payload omissions. Add required product analytics service to the injectable dispatcher; `_dispatch` reports source and cold/warm context after authentication and route dispatch, never project/session/title. |
+| `NotificationOpenRequest` / `NotificationOpenDispatcher` / `NotificationOpenAnalyticsListener` | Extend the internal request with required bounded category/event type already present in `NotificationData`. Push/local adapters provide `unknown` for legacy local payload omissions. Dispatcher publishes bounded source/cold-warm/category/event-type metadata after validated route dispatch, never project/session/title. The listener applies the one-event cold-start buffer and preference/account rules above before calling product analytics. |
 | Screen constructors/tests | `ProjectListScreen`, `NewSessionScreen`, `SessionDetailScreen`, and `SessionDiffsScreen` pass the phase-3 product analytics service from GetIt into required cubit constructors. Core tests inject a mock/recording service and assert event count/shape. |
 
 ## Campaign Attribution
@@ -456,9 +529,12 @@ runbook that generates:
   reporting; and
 - the same code in installed-app universal/app links.
 
-Core stores the first valid code locally and attempts it only after an
-authenticated enabled analytics identity exists, retaining pending state until
-the SDK accepts an attempt. BigQuery's restricted
+Core stores the first valid pre-auth code plus capture time locally, expires it
+after 24 hours, and attempts it only after authenticated custom-event sharing
+becomes active, retaining pending state until the SDK accepts an attempt.
+BigQuery independently requires the event to occur no later than 24 hours after
+account creation, so a campaign opened by an established account never becomes
+acquisition. The restricted
 `campaign_registry` maps code to source, medium, campaign display name, and
 active dates. Do not accept or emit arbitrary UTM text from an inbound URI.
 
@@ -480,17 +556,19 @@ export work to request handlers or the long-running auth process.
 - `src/types/product-analytics.ts` defines the string-valued
   `ProductAnalyticsPreference.Enabled/Disabled` enum and its Zod schema.
 - `src/models/documents.ts` initially adds
-  `productAnalyticsPreference` with an honest decode default of `Enabled` for
-  existing Mongo documents, while `UserRepository.create` always writes the
-  field. `src/scripts/backfill-product-analytics-preference.ts` performs an
-  idempotent `$set` only where missing and reports/validates counts. After the
+  `productAnalyticsPreference` plus `productAnalyticsPreferenceUpdatedAt` with
+  an honest decode default of enabled/account creation time for existing Mongo
+  documents, while `UserRepository.create` always writes both fields.
+  `src/scripts/backfill-product-analytics-preference.ts` performs an idempotent
+  `$set` only where either is missing and reports/validates counts. After the
   write-first version is live and backfill reaches zero missing documents, the
-  next PR removes the decode default and enforces the field as required.
+  next PR removes both decode defaults and enforces both fields as required.
 - `src/models/api.ts` defines Zod-validated GET/PUT preference replies/body only;
   it does not modify `UserProfile` or auth token/login contracts.
-- `UserRepository.updateProductAnalyticsPreference(userId, preference)` owns
-  the Mongo update; `findProductAnalyticsPreference` reads it with the temporary
-  migration default only in the write-first release.
+- `UserRepository.updateProductAnalyticsPreference(userId, preference)` owns one
+  atomic Mongo update of value and server timestamp;
+  `findProductAnalyticsPreference` reads them with temporary migration defaults
+  only in the write-first release.
 - `ProductAnalyticsPreferenceService` in
   `src/services/product-analytics-preference-service.ts` requires only
   `UserRepository` and owns get/update business operations.
@@ -508,14 +586,14 @@ export work to request handlers or the long-running auth process.
 
 | Class/file | Constructor dependencies and layer | Responsibility |
 | --- | --- | --- |
-| `UserRepository` additions in `src/repositories/user-repo.ts` | Existing `MongoDbAccessor` | `findProductAnalyticsExportBatch({afterUserId, batchLimit, createdAtOrBefore})` returns string user ID, creation time, and preference in deterministic ObjectId order; no Mongo `ObjectId` leaves the repository. |
-| `ActivationStateRepository.findByUserIds` in `src/repositories/activation-state-repo.ts` | Existing Mongo collection | Batch-loads only the four milestone fields for one user page and returns a map keyed by string user ID. It does not expose reminder fields to the export service. |
+| `UserRepository` additions in `src/repositories/user-repo.ts` | Existing `MongoDbAccessor` | `findProductAnalyticsExportBatch({afterUserId, batchLimit, createdAtOrBefore})` returns string user ID, creation time, preference, and preference-update time in deterministic ObjectId order. `findPreferenceChanges({after, atOrBefore})` supports the final conservative exclusion pass; no Mongo `ObjectId` leaves the repository. |
+| `ActivationStateRepository.findByUserIds` in `src/repositories/activation-state-repo.ts` | Existing Mongo collection | Requires `runCutoff`, batch-loads only the four milestone fields for one user page, and projects each milestone to null when its timestamp is later than that cutoff. It returns a map keyed by string user ID and exposes no reminder fields. |
 | `ProductAnalyticsExportRow` / `ProductAnalyticsSetupCohortRow` in `src/models/product-analytics-export.ts` | Plain internal models | Make BigQuery row shapes closed and prevent external-sink calls with auth/OAuth/bridge documents. |
-| `BigQueryProductAnalyticsClient` in `src/clients/bigquery-product-analytics-client.ts` | Foundation external client; requires `@google-cloud/bigquery` `BigQuery`, project ID, private dataset ID, and location | Thin SDK operations for creating expiring tables, inserting typed safe rows, and executing parameterized queries/transactions. It never receives raw IDs/Mongo documents or decides export semantics. |
+| `BigQueryProductAnalyticsClient` in `src/clients/bigquery-product-analytics-client.ts` | Foundation external client; requires `@google-cloud/bigquery` `BigQuery`, project ID, auth-export dataset ID, and location | Thin SDK operations for creating expiring tables, inserting typed safe rows, and executing parameterized queries/transactions **inside that one dataset only**. It never receives raw IDs/Mongo documents, control-dataset identifiers, or export semantics. |
 | `ProductAnalyticsExportApi` in `src/api/product-analytics-export-api.ts` | Layer 1; requires `BigQueryProductAnalyticsClient` | Defines the external BigQuery operations used by this product area and maps SDK responses/errors; no pagination, aggregation, or publication policy. |
 | `ProductAnalyticsExportRepository` in `src/repositories/product-analytics-export-repo.ts` | Layer 2; requires `ProductAnalyticsExportApi` | Owns a run's staging-table lifecycle, safe-row batching, validation queries, and atomic two-target promotion. The service never calls the client/API directly. |
 | `ProductAnalyticsExportService` in `src/services/product-analytics-export-service.ts` | Layer 3; requires `UserRepository`, `ActivationStateRepository`, and `ProductAnalyticsExportRepository` | Owns cutoff pagination, SHA-256 transformation, enabled-user filtering, weekly all-account accumulation, reconciliation inputs, and repository promotion. `run({ runCutoff }: { runCutoff: Date })` receives one immutable cutoff. |
-| `product-analytics-export-config.ts` in `src/scripts/` | Zod over process environment | Validates only job concerns: Mongo connection/database, GCP project, private dataset, location, and bounded batch size. It does not import the web server's full OAuth/FCM configuration or accept a service-account JSON key. |
+| `product-analytics-export-config.ts` in `src/scripts/` | Zod over process environment | Validates only job concerns: Mongo connection/database, GCP project, auth-export dataset, location, and bounded batch size. It cannot configure control/curated/reporting datasets, does not import the web server's full OAuth/FCM configuration, and accepts no service-account JSON key. |
 | `export-product-analytics.ts` in `src/scripts/` | Command composition root | Constructs Mongo repositories, ADC BigQuery client, export API/repository/service; invokes one run, awaits jobs, and closes Mongo in `finally`. It is compiled into the production image and run as `node dist/scripts/export-product-analytics.js`; `src/index.ts` does not import it. |
 
 The web server constructs the dedicated preference service but never constructs
@@ -523,9 +601,19 @@ The web server constructs the dedicated preference service but never constructs
 built image with a command override, so auth HTTP availability and latency
 cannot depend on BigQuery.
 
-The job takes a fixed run cutoff, pages users deterministically, batch-loads
-activation states, and writes two products through temporary tables before an
-atomic replace/merge:
+The job takes a fixed `runCutoff`, pages only users created by then, and
+batch-loads activation states with the same cutoff so later milestone writes
+are always null regardless of which page observes them. Preference updates are
+privacy-conservative: rows whose `productAnalyticsPreferenceUpdatedAt` is after
+`runCutoff` are never eligible in that run. Immediately before promotion the
+service captures `preferenceScanCutoff`, queries all preference changes in
+`(runCutoff, preferenceScanCutoff]`, removes those keys from staging/eligible
+coverage, and validates none remain. A preference update after that second
+cutoff belongs to the next run; a disable still disappears from reporting on
+that next successful export. This explicit rule avoids reconstructing unknown
+historical preference values while ensuring pagination timing cannot admit a
+post-cutoff enable/disable. The job writes two products through temporary tables
+before an atomic replace/merge:
 
 1. `private.auth_user_milestones`: only accounts whose optional product
    analytics preference is enabled; fields are `user_key`,
@@ -561,10 +649,18 @@ Job acceptance checks before promotion:
 - exported enabled count reconciles with aggregate coverage count;
 - source and staging row counts are recorded without raw IDs;
 - a partial/failed run leaves the previous published tables intact.
+- milestones written after `runCutoff` and preferences changed before
+  `preferenceScanCutoff` remain excluded regardless of the page on which the
+  concurrent write occurs.
 
-Use Application Default Credentials, Secret Manager for Mongo access, and a
-service account limited to BigQuery Job User plus Data Editor on the private
-staging/target datasets. The auth web runtime receives no BigQuery role.
+Use Application Default Credentials, Secret Manager for Mongo access, and an
+export service account limited to BigQuery Job User plus Data Editor on
+`sesori_analytics_auth_private` only. It has no role on raw, controls, curated,
+or reporting datasets and cannot write campaign/exclusion/config control
+tables. A separate scheduled-transform identity has read-only access to raw,
+auth-private, and controls plus write access to curated; the deployment identity
+alone owns schemas/IAM/control-table writes. The auth web runtime receives no
+BigQuery role.
 
 ## BigQuery Design
 
@@ -574,15 +670,29 @@ Do this before waiting for application PRs because Firebase export is not
 retroactive:
 
 1. Confirm the Firebase project is `sesori-ai`, identify the GA4 property ID,
-   billing status, property timezone, and existing BigQuery link.
-2. If not linked, enable daily Analytics export. Streaming/intraday export is
-   optional and not needed for the initial complete-day/week dashboards.
+   billing status, property timezone, current GA retention/deletion posture, and
+   existing BigQuery link. If already linked, audit and remediate every existing
+   raw table before any dashboard or application rollout.
+2. Before creating a new link, put the sink in a dedicated/restricted GCP
+   project: remove broad project dataset-reader roles, establish the approved
+   admin and scheduled-query identities, and prepare automation that applies a
+   90-day default table expiration plus dataset ACL immediately when GA creates
+   `analytics_<property_id>`. Enable **daily only**, not streaming/intraday, so
+   those controls can be verified before the first daily table lands. If a table
+   appears before verification, stop rollout, apply expiration to it explicitly,
+   and treat the miss as a privacy preflight failure.
 3. Record the immutable raw dataset location. If no location exists, choose the
    privacy/operations-approved location (prefer EU when compatible); every
    derived dataset must use the same location.
-4. Record `measurement_start_at`, owner, service accounts, and dashboard access
-   group in the restricted deployment configuration.
-5. Verify one existing custom event reaches `analytics_<property_id>.events_*`.
+4. Configure GA4 event/user-data retention to two months, disable Google Signals,
+   ad personalization, ad storage/user-data features, and verify Firebase native
+   advertising identifiers remain disabled before collecting production data.
+5. Record `raw_export_start_at` only when the first controlled daily export is
+   verified. Record `behavioral_schema_v1_start_at` separately only after the
+   released event schema is observed in export. Also record owner, identities,
+   deletion-job owner, and dashboard access group in restricted configuration.
+6. Verify one existing event reaches `analytics_<property_id>.events_*`, then
+   verify the new custom schema before setting its behavioral timestamp.
 
 ### Datasets
 
@@ -592,7 +702,8 @@ property/project IDs:
 | Dataset | Access | Contents |
 | --- | --- | --- |
 | `analytics_<property_id>` | Raw restricted | Firebase-managed GA4 daily tables |
-| `sesori_analytics_private` | Security/analytics admins and export job | Auth eligible-user snapshot, aggregate setup cohorts, campaign registry, internal-user exclusions, measurement config |
+| `sesori_analytics_auth_private` | Security/analytics admins, auth export job; transform identity read-only | Auth eligible-user snapshot/staging and aggregate setup cohorts only |
+| `sesori_analytics_controls` | Security/analytics admins and deployment identity; transform identity read-only | Campaign registry, internal-user exclusions, dual measurement timestamps, export freshness policy |
 | `sesori_analytics_curated` | Analytics engineers | Flattened allowlisted events, daily user activity, user milestones, scheduled intermediate tables |
 | `sesori_analytics_reporting` | Looker service account/product leadership | Identifier-free authorized views and dashboard tables |
 
@@ -603,8 +714,8 @@ runbook. Never commit service-account material or live internal user keys.
 
 The initial file ownership is fixed:
 
-- `tool/product_analytics/deploy.dart` validates named project, location, raw
-  dataset, private/curated/reporting dataset, and measurement-start arguments;
+- `tool/product_analytics/deploy.dart` validates named project, location, raw,
+  auth-private/controls/curated/reporting datasets, and both start timestamps;
   renders identifier placeholders from the checked-in SQL; and invokes `bq`
   non-interactively with the explicit location. It does not perform `gcloud`
   login or read key files.
@@ -651,9 +762,9 @@ These vendor fields change the controls and disclosure, not the event contract:
   bundle sequence, stream ID, or arbitrary traffic-source strings;
 - curated acquisition maps only a strict Sesori campaign code/registry match or
   a small approved source class; unmatched raw traffic text becomes `unknown`;
-- Firebase automatic events are excluded except stable `screen_view` and a
-  transient `first_open`/traffic-source projection in the acquisition model;
-  app opens never define activity;
+- Firebase automatic events are excluded from behavioral facts. Only a
+  transient `first_open`/traffic-source projection may participate in the
+  acquisition model; app/screen opens never define activity;
 - the privacy notice must disclose Firebase's pseudonymous install/device and
   approximate-location processing even though those fields are discarded from
   Sesori reporting.
@@ -664,15 +775,14 @@ not weaken the written privacy boundary to fit an unchecked property.
 
 ### Curated models
 
-1. **`events_flattened`**: flatten only catalogued events/parameters from GA4,
-   use `event_timestamp` in UTC, require schema version for Sesori custom
-   events, and retain Firebase platform/app version/build. Permit Firebase
-   `screen_view` only when its screen name is in `AnalyticsScreen` and its app
-   version is at/after instrumentation start. Exclude null `user_id`,
-   internal/test keys, and users absent from the current eligible auth snapshot
-   before downstream behavioral reporting. Raw bundle/install fields may be
-   used transiently to discard byte-identical export duplicates but are not
-   selected into the table.
+1. **`events_flattened`**: flatten only catalogued Sesori custom events/parameters
+   from GA4, use `event_timestamp` in UTC, require schema version and non-null
+   custom `user_key`, and retain Firebase platform/app version/build. Exclude
+   internal/test keys, but deliberately do **not** join the current auth snapshot
+   here. Raw bundle/install fields may be used transiently to discard
+   byte-identical export duplicates but are not selected into the table. This
+   recoverable 90-day fact layer prevents a transient auth-export outage from
+   permanently discarding otherwise eligible events.
 2. **`user_activity_daily`**: one row per user/date with monitor, control,
    message, notification, diff, and feature flags/counts.
 3. **`user_milestones`**: auth timestamps plus earliest project availability,
@@ -682,7 +792,8 @@ not weaken the written privacy boundary to fit an unchecked property.
    flags, times to milestone, cohort maturity, and behavioral coverage.
 5. **`retention_cohorts`**: activation-anchored W1/W4 eligibility and activity.
 6. **`acquisition_first_touch`**: earliest strict custom campaign code or
-   approved automatic store/source class per eligible user. It uses raw
+   approved automatic store/source class per eligible user, provided the event
+   occurs no later than 24 hours after account creation. It uses raw
    install/traffic fields only inside the scheduled query, persists no
    `user_pseudo_id` or arbitrary source text, and labels unmatched values
    `unknown`.
@@ -697,6 +808,20 @@ snapshot and anti-joins the current internal exclusion table. Therefore a
 disable or newly added internal exclusion takes effect after the next auth
 export/report refresh even when an older curated partition exists; those gates
 are not applied only at the historical partition's original build time.
+
+The auth export atomically publishes snapshot metadata (`run_id`, immutable
+source cutoff, completion time, eligible/source counts) with its tables. Before
+any eligible user-level transform writes or replaces output, BigQuery `ASSERT`s
+that the latest successful snapshot is no more than 36 hours old and its
+reconciliation checks passed. A stale/missing/partial snapshot aborts before
+mutation and leaves the previous reporting tables plus an explicit stale status
+visible; it never publishes an empty day. `events_flattened` can continue
+ingesting recoverable custom facts without that join. Once auth export recovers,
+the user-level schedules recompute from the first date after the last
+successfully published reporting watermark through the current three-day late-
+arrival window (bounded by the 90-day recoverable retention) before advancing
+freshness. Thus a week-long outage backfills the whole missed week rather than
+only three days.
 
 ### Reporting views
 
@@ -734,8 +859,16 @@ are not applied only at the historical partition's original build time.
   the approved minimum users; totals retain sample sizes.
 - Configure dataset/table expiration, scheduled-query byte limits, billing
   alerts, and a monthly cost check before dashboard sharing.
-- Document a privacy-request runbook for suppressing a user key from curated
-  reporting and deleting warehouse rows when policy requires it.
+- Implement a privacy-request runbook/job that first adds the `user_key` to a
+  restricted deletion-exclusion control so scheduled transforms cannot
+  repopulate it, then deletes matching auth-private/curated/reporting rows. From
+  the still-retained raw window it resolves only matching Firebase
+  `user_pseudo_id` values transiently and submits GA4 User Deletion API requests
+  as app-instance IDs; it also submits the hashed key as legacy GA `USER_ID` for
+  data produced before this design removed global `user_id`. Record request IDs
+  and completion status without raw account/install IDs. The two-month GA
+  retention plus 90-day raw window is the operating deadline; test the API
+  credential, request format, and a non-production deletion before rollout.
 
 ## Looker Studio
 
@@ -800,7 +933,9 @@ directory name.
 - Publish the eligible pseudonymous snapshot and identifier-free weekly setup
   cohorts through staging/validation/transactional promotion.
 - Test hashing golden vector, opt-out filtering, aggregate reconciliation,
-  pagination cutoff, staging cleanup, rerun idempotency, and failed-run safety.
+  pagination cutoff, milestones/preferences changing on already-read and future
+  pages, conservative preference exclusion, staging cleanup, rerun idempotency,
+  and failed-run safety.
 - Deploy web enforcement only after step-1 zero-missing evidence. Deploy the job
   definition disabled; schedule it in PR 5 after private datasets/IAM exist.
 
@@ -818,18 +953,23 @@ directory name.
 - Implement only the thin `FirebaseAnalyticsClient` and desktop no-op adapter in
   product shells; add pure-Dart `crypto` to `module_core` and keep SHA-256,
   route mapping, state, and lifecycle in core.
-- Make native Analytics default-off, remove `AnalyticsUserIdTracker`, gate
-  collection to post-splash authenticated enabled release builds, and add
-  stable `AnalyticsScreen` reporting.
+- Remove `AnalyticsUserIdTracker`, never set Firebase global `user_id` or its
+  persisted collection override, gate every Sesori custom event to post-splash
+  authenticated enabled release builds, and add custom stable-screen reporting.
 - Add the Settings toggle, explanatory/localized copy, pending/error behavior,
-  and privacy/legal/store-disclosure updates.
-- Test API parsing, layer wiring, fail-closed splash, post-splash fetch, local
-  pending disable, disable/reset/logout/account switch, enable-after-server
-  success, debug suppression, core identity hash, route-to-screen mapping,
-  event wire pins, and Firebase-enabled/disabled/desktop DI.
+  explicit installation/automatic-event limitations, and privacy/legal/store-
+  disclosure updates.
+- Test API parsing, layer wiring, fail-closed custom events during splash,
+  post-splash fetch, pending-disable storage as the first awaited operation,
+  storage failure, crash/restart
+  pending recovery, logout sync failure/account switch preservation,
+  enable-after-server success, delayed GET/PUT/storage completions across rapid
+  login/logout/account switches, foreground/15-minute refresh propagation,
+  debug suppression, core identity hash, route-to-screen mapping, event wire
+  pins, and mobile/desktop DI.
 - Release only after both auth PRs are deployed. Once users can opt out, this
-  lifecycle becomes a non-rollback privacy floor: subsequent client fixes must
-  preserve it or disable all collection.
+  custom-event lifecycle becomes a non-rollback privacy floor: subsequent
+  client fixes must preserve it or suppress all Sesori custom events.
 
 ### PR 4/5 — Outcome and campaign instrumentation
 
@@ -842,15 +982,17 @@ directory name.
   direct and queued message success, while keeping analytics best-effort and
   non-blocking.
 - Preserve bounded notification category/event type through open dispatch and
-  classify push/local plus cold/warm.
+  classify push/local plus cold/warm; buffer the single cold-start open until
+  same-account preference resolution and drop it on disable/logout/timeout.
 - Add core campaign Storage -> repository -> service -> deep-link listener,
-  typed SDK-acceptance result, and remove the obsolete app `DeepLinkService` and
-  full URI logging.
+  24-hour pre-auth capture/attribution rules, typed SDK-acceptance result, and
+  remove the obsolete app `DeepLinkService` and full URI logging.
 - Regenerate only source-generated outputs.
 - Add focused tests that failures/taps/queued-only operations do not activate,
   each successful message path makes one service call, new-session success is not
   double counted, sensitive inputs cannot enter parameter maps, notification
-  classification survives, and campaign values are bounded.
+  classification survives preference resolution, post-signup/old-account links
+  cannot become acquisition, and campaign values are bounded.
 
 ### PR 5/5 — Warehouse models and dashboards
 
@@ -860,11 +1002,13 @@ directory name.
 
 - Add `tool/product_analytics/` data contract, parameterized deployment tool,
   DDL, transforms, fixture assertions, scheduled-query definitions, and runbook.
-- Create private/curated/reporting datasets in the raw GA4 location; configure
-  IAM, expiration, budget alerts, campaign registry, internal exclusions, and
-  measurement start.
+- Create auth-private/controls/curated/reporting datasets in the raw GA4
+  location; keep export-job write access confined to auth-private; configure
+  IAM, expiration, budget alerts, campaign registry, exclusions, upstream GA4
+  retention/deletion, and separate raw/behavioral start timestamps.
 - Schedule the auth export and three-day event recomputation, then reconcile
-  source counts and freshness.
+  source counts and freshness; verify stale auth snapshots abort publication and
+  recovery backfills the missed window.
 - Build and permission the seven-page Looker report.
 - Run a release-build smoke test through account -> bridge -> project -> message
   and verify the event, auth join, full activation, complete-day table, and
@@ -876,11 +1020,11 @@ directory name.
 
 | State | Independently usable behavior | Deployment prerequisites/order | Rollback boundary |
 | --- | --- | --- | --- |
-| Before 1/5 | Existing clients/events continue. Firebase daily export should already be linked so its non-retroactive clock has started. | Complete BigQuery day-zero preflight only. | Unlinking loses future export and is not a useful rollback; correct IAM/location before derived datasets. |
+| Before 1/5 | Existing clients/events continue. Firebase daily export should be linked only through the controlled day-zero sequence so its non-retroactive clock starts safely. | Complete restricted-project IAM, daily-only link, raw expiration/settings verification, and record `raw_export_start_at`. | Unlinking loses future export and is not a useful rollback; stop rollout and correct IAM/expiration/location before derived datasets or new instrumentation. |
 | After 1/5 | Dedicated GET/PUT preference endpoints work; old clients are unaffected because auth responses did not change. New users always write preference; old documents read as enabled during migration. | Deploy write-first web code to all serving instances, verify new writes, run/re-run backfill, and record zero missing. | Roll back before any opt-out client release if necessary. The added field is ignored by old code; do not remove it. Re-run backfill after returning to step 1. |
 | After 2/5 | Preference schema is required and export command/job image is deployable but unscheduled. Existing clients remain unaffected. | Require recorded zero-missing evidence from step 1; deploy enforcement; smoke-test account creation and endpoints; deploy job disabled. | Roll back web/job to step 1, whose honest missing-field default can read every document. Stop any job; published tables stay at last good state. |
-| After 3/5 | Mobile can opt out/in; existing seven events and stable screens obey lifecycle; desktop remains no-op. No activation event is needed for app correctness. | Both auth endpoints/schema must be live. If unavailable, GET/enable fails closed and disable remains local pending. | **Forward-fix only after public release.** Never republish a pre-step-3 client that grants analytics at startup and ignores account preference. For a severe defect, hotfix while retaining the preference/readiness layers, or remotely/release-disable all analytics collection. Server preference data is never rolled back. |
-| After 4/5 | New activation/engagement events accumulate in GA4 raw export. Product operations remain unchanged if Firebase is unavailable. | Step 3 identity/consent/schema must be released. BigQuery needs no GA4 custom-dimension registration. | Forward-fix the app while retaining step-3 privacy behavior; event-specific defects may be disabled/removed. Missing future event names yield null/zero data, not product failure. |
+| After 3/5 | Mobile can disable/enable Sesori custom events on this installation and sync its server reporting/supported-client preference; existing custom events and stable screens obey the lifecycle; Firebase automatic install events retain the separately disclosed property behavior; desktop remains no-op. | Both auth endpoints/schema must be live. If unavailable, GET/enable fails closed for custom events and disable remains local pending without blocking logout. | **Forward-fix only after public release.** Never republish a client that emits custom events before readiness or ignores local disabled intent. For a severe defect, suppress all custom events; do not claim control over legacy/automatic events. Server preference data is never rolled back. |
+| After 4/5 | New activation/engagement events accumulate in GA4 raw export. Product operations remain unchanged if Firebase is unavailable. | Step 3 custom-key/preference/schema lifecycle must be released. BigQuery needs no GA4 custom-dimension registration. | Forward-fix the app while retaining step-3 privacy behavior; event-specific defects may be disabled/removed. Missing future event names yield null/zero data, not product failure. |
 | After 5/5 | Auth job, curated models, authorized reporting views, and Looker provide the complete metric contract. | Create same-location datasets/IAM; deploy SQL/tests; schedule auth export; validate its first publish; schedule event transforms; then connect Looker. | Pause schedules/job and revert reporting views/dashboard sources to last known-good SQL. Raw GA4 and prior auth published tables remain; app behavior is unaffected. |
 
 There is no `AuthUser` compatibility field, alternate endpoint, optional
@@ -903,7 +1047,7 @@ the separately released app.
   changes affect desktop.
 - Inspect a release-build Firebase DebugView/BigQuery sample using synthetic
   content and verify no forbidden field/value appears. Do not turn normal debug
-  collection back on for convenience.
+  custom-event sharing on for convenience.
 
 ### Auth server
 
@@ -919,23 +1063,30 @@ the separately released app.
 
 - Dry-run every deployed query and run fixture `ASSERT`s for activation event
   inclusion, failed/queued exclusion, earliest-message selection, 7-day cohort
-  maturity, W1/W4 boundaries, internal/disabled filtering, unknown campaign,
-  and late-event replacement.
+  maturity, W1/W4 boundaries, internal/disabled filtering, the 24-hour campaign
+  rule, unknown campaign, stale-auth-snapshot publication abort/recovery, and
+  late-event replacement.
 - Reconcile GA4 custom event counts -> flattened events -> daily activity ->
   reporting totals for at least three complete days.
-- Verify Looker credentials cannot query raw/private datasets or expose user
-  keys, and verify sample-size/partial-period labels.
+- Verify auth export credentials cannot write controls/curated/reporting, Looker
+  credentials cannot query raw/private datasets or expose user keys, and verify
+  sample-size/partial-period labels.
+- Verify raw ACL/default expiration and GA4 two-month retention before data
+  acceptance, then complete one non-production GA User Deletion API exercise
+  through warehouse suppression/deletion and upstream request status.
 
 ## Rollout And Two-Month Readiness
 
-1. **Day 0:** Link Firebase to BigQuery and record the measurement start; this
-   cannot be recovered later.
+1. **Day 0:** Establish restricted project IAM, link daily Firebase export,
+   verify raw ACL/90-day expiration before the first table, and record
+   `raw_export_start_at`; this data cannot be recovered later.
 2. **Week 1:** Land/deploy write-first auth preference, run/verify backfill,
    then land enforcement/export.
 3. **Weeks 1-2:** Land the client foundation and ship its fail-closed opt-out
    release.
 4. **Weeks 2-3:** Land instrumentation and ship the mobile release as early as
-   store review permits.
+   store review permits; set `behavioral_schema_v1_start_at` only after its
+   schema appears in controlled raw export.
 5. **Weeks 3-4:** Deploy warehouse models, run data QA, and build Looker.
 6. **Weeks 4-8:** Monitor data-quality alerts weekly, correct only demonstrated
    schema/metric defects, and let cohorts mature.
@@ -948,19 +1099,24 @@ no cohort has matured.
 
 ## Risks And Mitigations
 
-- **No retroactive behavioral data:** link/export and ship early; label the
-  measurement start and do not backfill full activation from metadata requests.
-- **Developer/internal pollution:** collection is release-only and reporting
+- **No retroactive behavioral data:** link/export and ship early; label raw and
+  behavioral starts separately and do not backfill full activation from
+  metadata requests.
+- **Developer/internal pollution:** custom events are release-only and reporting
   excludes a restricted internal-user list; monitor app version/schema mix.
 - **Opt-out bias:** show eligible coverage with every behavioral funnel and do
   not extrapolate activation/retention to all accounts.
 - **Cross-repository deployment mismatch:** deploy write-first server behavior,
   backfill/verify, then enforce, and only then release the client. Preference
   GET/PUT failure is fail-closed; auth profiles remain unchanged.
-- **Privacy rollback floor:** a pre-opt-out mobile binary can grant collection
-  regardless of server preference. After the opt-out release, use forward fixes
-  that preserve the lifecycle or disable all collection; never republish the
-  old startup behavior as rollback.
+- **Legacy/automatic-event limitation:** a pre-opt-out binary can continue its
+  prior Firebase behavior, and Firebase automatic install events are outside the
+  custom-event toggle. Narrow UI/legal promises accordingly, use current
+  preference only for supported-client custom events and reporting eligibility,
+  and never claim account-wide enforcement without minimum-version controls.
+- **Privacy rollback floor:** after the opt-out release, use forward fixes that
+  preserve local pending-disable/custom-event gating or suppress all custom
+  events; never republish old startup emission as rollback.
 - **Analytics affecting product behavior:** all reports are best-effort,
   unawaited after confirmed outcomes, and failure-isolated.
 - **High-cardinality or sensitive leakage:** closed event variants, bounded
@@ -969,6 +1125,9 @@ no cohort has matured.
   never relabel unknown as organic.
 - **Late/incomplete GA4 exports:** recompute recent partitions and show freshness
   plus complete-period defaults.
+- **Auth-export outage:** keep flattened facts independent, assert a fresh
+  completed snapshot before user-level publication, retain last-good reporting,
+  and backfill the recent raw window after recovery.
 - **Small-cohort investor overstatement:** show denominators, maturity, and
   thresholded segments; keep directional W4 claims explicitly directional.
 - **Cloud location/hosting uncertainty:** discover before dataset creation;
@@ -980,13 +1139,15 @@ no cohort has matured.
 The work is complete when:
 
 - A production release makes one analytics emission attempt per confirmed
-  first-message success path with a pseudonymous authenticated ID and honors
-  account-wide disable/re-enable; duplicate delivery cannot change the earliest
-  full-activation milestone.
+  first-message success path with a pseudonymous custom `user_key`, immediately
+  honors installation-local disable/re-enable semantics, preserves pending
+  server sync across logout/restart, and never claims to control legacy or
+  automatic events; duplicate delivery cannot change the earliest activation.
 - The auth job publishes validated eligible milestones and all-account setup
   cohorts without raw identity.
 - BigQuery derives the metric contract above from versioned SQL, passes fixture
-  assertions, and remains fresh after late data.
+  assertions, survives stale auth snapshots without permanent event loss, and
+  remains fresh after recovery/late data.
 - Looker exposes only aggregate authorized views and shows complete-period,
   denominator, coverage, maturity, and freshness labels.
 - The executive page can truthfully report new accounts, setup, full

--- a/.plan/active/user-analytics/PLAN.md
+++ b/.plan/active/user-analytics/PLAN.md
@@ -45,7 +45,10 @@ Revenue metrics are out of scope because Sesori is currently free.
    They carry no `user_key`, attempt identifier, OAuth identity, or payload,
    remain release-only, follow the upstream two-month retention, and are
    disclosed as installation-level operational analytics outside the product-
-   interaction toggle.
+   interaction toggle. Because they intentionally retain no account/install
+   mapping, internal/test release traffic cannot be removed reliably; reports
+   label that limitation and keep login conversion out of investor headline
+   metrics.
 5. `GoRouterRouteSource` is the authoritative screen source. Automatic Firebase
    screen reporting is disabled, and the typed route listener maps each
    `AppRouteDef` to a pinned `AnalyticsScreen`. The Firebase adapter mirrors that
@@ -78,7 +81,8 @@ silently compared with a mature one.
 | Bridge registered | First bridge registration (`ActivationState.bridgeSetupAt`) | Auth server |
 | Project available | First successful project inventory containing at least one project after instrumentation starts | App event |
 | Legacy session signal | First accepted `/sessions/generate-metadata` request (`ActivationState.firstSessionAt`) | Auth server |
-| Analytics-ready exposure | Earliest schema-v1 `analytics_schema_ready` or other accepted account-linked schema-v1 product event, provided it occurs within 24 hours of account creation | App event |
+| Foundation analytics exposure | Earliest schema-v1 `analytics_schema_ready` or other accepted account-linked foundation event | App event; diagnostic coverage only |
+| Activation-capable exposure | Earliest `analytics_activation_ready(activation_schema_version=1)` or accepted full-activation outcome, provided it occurs within 24 hours of account creation | App event from the outcome-instrumentation release |
 | Full activation | Earliest successful `session_message_sent` or `session_created_with_message` | App event |
 
 `mobileSetupAt` is **not** “mobile setup”: it proves notification registration.
@@ -89,8 +93,8 @@ the legacy signal for full activation.
 
 Behavioral milestones cannot be backfilled before the new event release. Store
 two timestamps: `raw_export_start_at` when Firebase export begins and
-`behavioral_schema_v1_start_at` only after the production app version has
-successfully exported the new account-linked product-event schema. Restrict activation/retention
+`behavioral_schema_v1_start_at` only after the production outcome-instrumentation
+version has successfully exported `analytics_activation_ready`. Restrict activation/retention
 cohorts to accounts created on or after the behavioral timestamp **and** with
 per-account analytics-ready exposure no later than 24 hours after creation.
 Calendar eligibility alone is insufficient because a newly created account can
@@ -103,7 +107,7 @@ honestly labeled setup trends.
 | --- | --- |
 | Weekly new accounts | Non-internal, non-deletion-suppressed auth accounts created during the complete week. This comes from aggregate server export and is not reduced by ordinary product-analytics opt-out. |
 | 7-day bridge setup conversion | Accounts whose first bridge registration is within 7 x 24 hours of account creation, divided by accounts at least 7 days old in the cohort. |
-| 7-day full activation conversion | Analytics-eligible accounts whose full activation is within 7 x 24 hours of account creation, divided by accounts at least 7 days old, created on/after `behavioral_schema_v1_start_at`, and observed on schema v1 within 24 hours of creation. Show both schema-exposure and preference coverage; accounts lacking timely exposure are unmeasurable, not non-activations. |
+| 7-day full activation conversion | Analytics-eligible accounts whose full activation is within 7 x 24 hours of account creation, divided by accounts at least 7 days old, created on/after `behavioral_schema_v1_start_at`, and observed on activation schema v1 within 24 hours of creation. Foundation-only exposure never qualifies. Show activation-capability and preference coverage; accounts lacking timely capability are unmeasurable, not non-activations. |
 | Time to activation | P50 and P75 of `full_activation_at - account_created_at` among activated measurable accounts. |
 | Meaningful WAU | Distinct users with a non-empty session activity view or a confirmed control event in the complete week. A screen view/app open never qualifies. |
 | Controller WAU | Distinct users with a successful message, question answer/rejection, permission answer, session abort, or session creation with message. |
@@ -123,8 +127,8 @@ honestly labeled setup trends.
 - Dedicated-worktree share among successful remotely created sessions.
 - Weekly users and successful-message share using voice-assisted input.
 - Pre-auth login starts, completions, failures/timeouts, and completion rate by
-  pinned provider; these are installation-level diagnostics, not account funnel
-  milestones.
+  pinned provider; these are installation-level diagnostics that may include
+  internal/test release traffic, not account funnel milestones/headline metrics.
 - Screen popularity and navigation sequences from the exhaustive GoRouter-to-
   `AnalyticsScreen` mapping. Account-level reporting uses
   `product_screen_viewed`; Firebase-native `screen_view` is diagnostic only.
@@ -138,6 +142,10 @@ honestly labeled setup trends.
 - `client/app` has Firebase Analytics; desktop and bridge do not.
 - `client/app/lib/core/analytics/analytics_event.dart` is a Freezed closed event
   union with seven onboarding/support/install events.
+- Several existing call sites emit outcome-worded events before the platform
+  operation: support link before launcher success and copy/share before
+  clipboard/share handoff. Migration must correct those seams rather than merely
+  move the same tap proxies into the new service.
 - `FirebaseAnalyticsReporter` serializes that union and best-effort logs it.
 - `AnalyticsUserIdTracker` sends SHA-256 of `AuthUser.id` as Firebase
   `user_id`. This identifier is pseudonymous, not anonymous.
@@ -187,8 +195,9 @@ honestly labeled setup trends.
 - A daily privacy-safe auth export and aggregate external-account setup cohorts
   after internal/deletion suppression.
 - Versioned BigQuery DDL/transforms/tests and Looker Studio dashboards.
-- Internal/test-user exclusion, retention, access, cost, and data-quality
-  controls.
+- Internal/test-user exclusion for all account-linked/keyed reporting, plus an
+  explicit non-excludable internal/test limitation on account-less login
+  diagnostics; retention, access, cost, and data-quality controls.
 
 ### Out of scope
 
@@ -221,7 +230,7 @@ honestly labeled setup trends.
 | `shared/sesori_shared` | No production change | Keep `AuthUser` authentication-only; do not add a product preference to the shared auth/persisted contract. | No bridge/shared migration or compatibility default is introduced. |
 | `client/module_auth` | Existing HTTP client interfaces/implementations/tests | Add named-parameter JSON `PUT` support to `SafeApiClient`, `HttpApiClient`, and `AuthenticatedHttpApiClient`; keep tokens, OAuth, and auth state otherwise unchanged. | `module_core` injects the authenticated client into its Layer-1 preference API; no wrong-verb workaround or compatibility path is introduced. |
 | `client/module_core` | `lib/src/foundation/{models/product_analytics/,platform/analytics_client.dart}`, `lib/src/api/{analytics_api,product_analytics_preference_api.dart,storage/product_analytics_preference_storage.dart}`, `lib/src/repositories/{models/,product_analytics,installation_analytics,product_analytics_preference}_repository.dart`, `lib/src/services/{models/,product_analytics,installation_analytics}_service.dart`, `lib/src/routing/{analytics_route,session_activity_analytics}_listener.dart`, `lib/src/cubits/{product_analytics_preference,settings}/`, existing login/project/session/diff cubits, DI/barrel/generated files | Mirror the declared layers explicitly; own preference HTTP/persistence, pseudonymous hashing, bounded account-less login telemetry, route/visibility lifecycle, pre-logout orchestration, Settings state, and authoritative business-outcome emission. | Mobile supplies the Firebase client plus immutable runtime capability. Desktop supplies no-op/disabled Foundation adapters. Cubit constructor call sites/tests update in lockstep. |
-| `client/app` | `lib/core/platform/{firebase_analytics_client,firebase_analytics_identity_migration}.dart`, `lib/core/di/`, `lib/features/{settings,project_list,new_session,session_detail,session_diffs}/`, composer widgets/callbacks, `lib/l10n/`, `lib/main.dart`, iOS/macOS/Android analytics defaults | Clear legacy global identity at earliest post-Firebase bootstrap, pass its immutable capability into phase-1 DI, implement the thin Firebase adapter, disable automatic screen reporting, mirror GoRouter-derived screens through `logScreenView`, report successful content-free transcription completion, start core services/listeners, render preference UI, and inject services into core consumers. | Existing app event sources move to core; `AnalyticsUserIdTracker` is removed. The only global Firebase `user_id` call sets null for migration; no account key or runtime collection override is added. Existing `DeepLinkService` remains unchanged because campaign work is deferred. |
+| `client/app` | `lib/core/platform/{firebase_analytics_client,firebase_analytics_identity_migration}.dart`, `lib/core/di/`, `lib/features/{login,settings,project_list,new_session,session_detail,session_diffs}/`, composer widgets/callbacks, `lib/l10n/`, `lib/main.dart`, iOS/macOS/Android analytics defaults | Clear legacy global identity at earliest post-Firebase bootstrap, pass its immutable capability into phase-1 DI, implement the thin Firebase adapter, disable automatic screen reporting, mirror GoRouter-derived screens through `logScreenView`, begin Apple analytics before the native authorization sheet, report successful content-free transcription completion, start core services/listeners, render preference UI, and inject services into core consumers. | Existing app event sources move to core; `AnalyticsUserIdTracker` is removed. The only global Firebase `user_id` call sets null for migration; no account key or runtime collection override is added. Existing `DeepLinkService` remains unchanged because campaign work is deferred. |
 | `client/desktop` | `lib/core/platform/no_op_analytics_client.dart`, DI generated file | Satisfy the shared core platform capability without collecting desktop analytics. | No desktop product events or UI are added. Analyze/test verifies core DI remains resolvable. |
 | `client/module_desktop_core` | No planned production edit; tests/build are downstream validation | Continue unchanged. | Shared core DI/downstream validation only. |
 | `bridge/app` | No planned production or contract edit | Remain outside product analytics. | No additional bridge validation beyond normal CI is caused by this plan. |
@@ -391,8 +400,8 @@ mixed `src/analytics/` bucket. The concrete dependency direction is:
 | `ProductAnalyticsRepository` in `module_core/lib/src/repositories/product_analytics_repository.dart` | Layer 2; constructor requires `AnalyticsApi` | Converts raw authenticated user ID to lowercase SHA-256, passes only the pseudonymous key downward, and maps API exceptions to explicit `AnalyticsDeliveryResult` without redundant logging. It adds `schema_version=1` through the typed event serialization contract. |
 | `InstallationAnalyticsRepository` in `module_core/lib/src/repositories/installation_analytics_repository.dart` | Layer 2; constructor requires `AnalyticsApi` | Sends only `InstallationAnalyticsEvent`, adds the installation schema version, and maps SDK failures to explicit delivery results. It has no auth/user/preference dependency and cannot receive a `user_key`. |
 | `ProductAnalyticsPreferenceRepository` in `module_core/lib/src/repositories/product_analytics_preference_repository.dart` | Layer 2; requires `ProductAnalyticsPreferenceApi` and `ProductAnalyticsPreferenceStorage` | Fetch/update server preference, scope local records to one account, and persist only versioned `synced`, `pendingDisable`, or `pendingEnable` records. Every PUT uses the last observed revision plus stable operation ID. Conflict on disable triggers one bounded GET/retry against the new revision; conflict on enable remains inactive and returns explicit refresh-required state so an older enable cannot automatically override a newer disable. `pendingEnable` is never permission to emit. |
-| `ProductAnalyticsState` and its independent preference/synchronization variants under `module_core/lib/src/services/models/` | Layer-3 service state | Represents active/inactive/pending/failure truth without nullable coordination fields; it is not part of the Foundation sink contract. |
-| `ProductAnalyticsService` in `module_core/lib/src/services/product_analytics_service.dart` | Layer 3, `@lazySingleton`; requires immutable `AnalyticsRuntimeCapability`, read-only `AuthSession`, `ProductAnalyticsRepository`, and `ProductAnalyticsPreferenceRepository` | Sole owner of preference/custom-event lifecycle and Consumer `logEvent`. Exposes a replaying state stream plus `start`, `markPostSplashReady`, explicit `refreshPreference`, `setPreference`, `retryPendingDisable`, bounded `prepareForLogout`, and `dispose`. It performs one server read per post-readiness auth generation plus explicit Settings refresh/actions—no lifecycle timer/polling—and sends no product event unless active. While preference is unknown, it may retain exactly one bounded activation-candidate event for the current generation; all other inactive events remain unbuffered. |
+| `ProductAnalyticsState`, independent preference/synchronization variants, and closed fixed-capacity `DeferredProductAnalyticsCandidates` under `module_core/lib/src/services/models/` | Layer-3 service state | Represents active/inactive/pending/failure truth plus only activation/project-available/diff-adoption deferred slots without nullable coordination fields or a generic queue; it is not part of the Foundation sink contract. |
+| `ProductAnalyticsService` in `module_core/lib/src/services/product_analytics_service.dart` | Layer 3, `@lazySingleton`; requires immutable `AnalyticsRuntimeCapability`, read-only `AuthSession`, `ProductAnalyticsRepository`, and `ProductAnalyticsPreferenceRepository` | Sole owner of preference/custom-event lifecycle and Consumer `logEvent`. Exposes a replaying state stream plus `start`, `markPostSplashReady`, explicit `refreshPreference`, `setPreference`, `retryPendingDisable`, bounded `prepareForLogout`, and `dispose`. It performs one server read per post-readiness auth generation plus explicit Settings refresh/actions—no lifecycle timer/polling—and sends no product event unless active. While same-generation preference is unknown, a closed fixed-capacity deferred model may retain one activation candidate, first non-empty project availability, and first non-empty diff adoption; there is no generic event queue. |
 | `InstallationAnalyticsService` in `module_core/lib/src/services/installation_analytics_service.dart` | Layer 3, `@lazySingleton`; requires immutable `AnalyticsRuntimeCapability` and `InstallationAnalyticsRepository` | Accepts only typed login-attempt lifecycle methods, maps the sealed auth provider exhaustively to `AnalyticsLoginProvider`, classifies timeout versus bounded authentication/launch failure, and reports best-effort. It has no account/preference state, buffers nothing, and remains inactive in debug/profile/unsupported builds or when legacy-ID cleanup failed. |
 | `AnalyticsRouteListener` in `module_core/lib/src/routing/analytics_route_listener.dart` | Layer-4 routing listener, `@lazySingleton`; requires `RouteSource` and `ProductAnalyticsService` | Owns route subscription, maps `AppRouteDef` exhaustively to `AnalyticsScreen`, signals readiness on the first non-splash route, and reports stable screens only while active. It never passes a route model/path to Foundation. |
 | `SessionActivityAnalyticsListener` in `module_core/lib/src/routing/session_activity_analytics_listener.dart` | Layer-4 route-aware listener; constructed/owned by `SessionDetailScreen`, requires its `SessionDetailCubit`, `RouteSource`, `LifecycleSource`, and `ProductAnalyticsService` | Combines bounded loaded-state classification with actual `sessionDetail` route visibility and resumed lifecycle. It emits first empty once and non-empty at most once per UTC date only while the detail route is topmost; nested diffs/background SSE cannot create false monitoring activity. |
@@ -420,10 +429,10 @@ carry no `user_key`. Adding an `AppRouteDef` therefore cannot silently omit or
 rename its analytics mapping.
 
 The client API may return SDK acceptance, not delivery to Google's backend.
-That distinction remains explicit in names/docs. `ProductAnalyticsService`
-itself owns the sole deferred
-first-message variant; ordinary outcome consumers may ignore delivery results,
-but the result remains explicit and analytics cannot alter product success.
+That distinction remains explicit in names/docs. Product analytics owns only the
+closed deferred candidates listed above; ordinary outcome consumers may ignore
+delivery results, but the result remains explicit and analytics cannot alter
+product success.
 
 ### DI and process lifecycle
 
@@ -505,16 +514,25 @@ reconciliation slot and advances no state; a stable operation ID plus server
 revision compare-and-set makes detached late mutation completion idempotent and
 unable to overwrite a newer revision.
 
-**Schema exposure and first-message deferral:** On each process's first active
-transition, the service attempts `analytics_schema_ready` before later buffered
-work. Warehouse exposure is the earliest accepted schema-v1 event of any name,
-so an outcome event also proves capability if readiness delivery fails. If a
-confirmed `session_message_sent` or `session_created_with_message` occurs while
-the same generation is preference-unknown (and not locally disabled),
-`logEvent` retains only the first typed candidate in memory and returns
-`deferredUntilPreference`. Active resolution emits it once; disabled resolution,
-logout/account switch, or generation change drops it. No prompt/message content
-or session identifier enters the buffer, and no other outcome event is queued.
+**Capability exposure and bounded deferral:** On each process's first active
+transition, the foundation release attempts `analytics_schema_ready`. The later
+outcome release additionally attempts
+`analytics_activation_ready(activation_schema_version=1)` before buffered work.
+Only the latter readiness event or an accepted full-activation outcome proves
+activation capability; an old foundation-only binary remains unmeasurable.
+While the same generation is preference-unknown (and not locally disabled), the
+service may return `deferredUntilPreference` and retain only the closed
+activation/project-available/diff-adoption candidates. Active resolution emits
+each retained semantic once; disabled resolution, logout/account switch, or
+generation change drops them. No prompt/message content, project/session ID, or
+unbounded event enters this fixed model. Empty diagnostics are not buffered.
+
+`SessionActivityAnalyticsListener` separately retains at most one non-empty
+candidate for the current UTC date. It advances its date guard only after
+`acceptedBySdk`; while preference is unknown it waits for active state and
+revalidates that the session-detail route is still topmost/resumed before
+retrying. It drops the candidate on date change, route exit, disable, or auth
+generation change, so delayed preference cannot fabricate monitoring activity.
 
 **Disable:** The cubit calls `ProductAnalyticsService.setPreference(disabled)`.
 The service immediately publishes inactive, then first durably persists
@@ -563,7 +581,12 @@ without duplicate framework-generated names. Foundation sees neither
 
 **Pre-auth login flow:** `LoginCubit` reports a started event only after a valid
 provider intent is accepted, then exactly one completed or failed terminal event
-for that attempt. OAuth polling timeout maps to bounded `timeout`; launch,
+for that attempt. Apple is the exception to Cubit-owned platform execution: the
+mobile call site first calls typed `LoginCubit.beginAppleLoginAttempt()` before
+opening `SignInWithApple.getAppleIDCredential`; native cancellation/failure calls
+the Cubit's terminal failure method, while a credential continues the already-
+started attempt through its server login method without a second start. OAuth
+polling timeout maps to bounded `timeout`; native cancellation, launch,
 authentication, and unknown failures remain separate closed values only where
 the current state distinguishes them. No exception text, OAuth user, account
 key, or random attempt ID is emitted. Installation events are not buffered or
@@ -587,7 +610,8 @@ linked product events:
 
 | Event | Emit only when | Bounded parameters | Reporting use |
 | --- | --- | --- | --- |
-| `analytics_schema_ready` | The process first becomes active for an authenticated account under schema v1 | none beyond shared schema/key | Per-account instrumentation-capable exposure; never activity |
+| `analytics_schema_ready` | The foundation process first becomes active for an authenticated account | none beyond shared schema/key | Foundation deployment/preference coverage only; never activation capability/activity |
+| `analytics_activation_ready` | An outcome-instrumented process first becomes active | `activation_schema_version=1` | Per-account activation-capable exposure; never activity |
 | `project_inventory_loaded` | The first successful empty inventory and the first successful non-empty inventory in a cubit lifetime | `inventory_state=empty/non_empty` | First project available from earliest non-empty; empty is onboarding friction |
 | `session_activity_viewed` | The first successful empty snapshot in a cubit lifetime, and at most one successful non-empty snapshot per UTC date while that session detail is visible/foregrounded | `activity_state=empty/non_empty` | Earliest non-empty is the monitoring milestone; dated non-empty events support WAU/retention without SSE inflation |
 | `session_message_sent` | Existing-session send returns success, including a queued send that later succeeds | `submission_kind=text/command`, `input_mode=typed/voice_assisted` | Full activation, control activity, voice-assisted share |
@@ -617,7 +641,7 @@ The separate account-less installation event catalog contains exactly:
 | --- | --- | --- | --- |
 | `login_attempt_started` | A valid GitHub/Google/Apple/email login flow begins | `provider` from `AnalyticsLoginProvider` | Provider demand and attempt denominator |
 | `login_attempt_completed` | That flow reaches `LoginSuccess` | `provider` | Provider completion count/rate |
-| `login_attempt_failed` | That flow reaches failure or timeout | `provider`, `failure_kind=authentication/launch/timeout/unknown` | Bounded pre-auth friction |
+| `login_attempt_failed` | That flow reaches failure, native cancellation, or timeout | `provider`, `failure_kind=authentication/launch/cancelled/timeout/unknown` | Bounded pre-auth friction |
 
 These three events carry no `user_key`, attempt ID, or auth payload and are never
 used as account creation or activation evidence.
@@ -625,8 +649,9 @@ used as account creation or activation evidence.
 ### Authoritative emission seams
 
 - `ProductAnalyticsService`: schema-ready exposure on first active transition.
-- `LoginCubit`: account-less started/completed/failed outcomes, including the
-  distinct OAuth timeout terminal state, through `InstallationAnalyticsService`.
+- `LoginCubit` plus the Apple mobile entry call site: account-less started/
+  completed/failed outcomes, including native cancellation and the distinct
+  OAuth timeout terminal state, through `InstallationAnalyticsService`.
 - `ProjectListCubit`: first successful empty and first successful non-empty
   inventory states.
 - `SessionActivityAnalyticsListener` combining `SessionDetailCubit` state,
@@ -638,7 +663,9 @@ used as account creation or activation evidence.
 - Mobile composer transcription success call sites: content-free completion and
   voice-assisted input classification through the Layer-3 service.
 - `SessionDetailCubit.replyToQuestion`, `rejectQuestion`,
-  `replyToPermission`, and `abort`: successful control outcomes.
+  `replyToPermission`, and `abort`: successful control outcomes. Permission reply
+  must first correct the current fallthrough by pattern-matching its
+  `ApiResponse`; `ErrorResponse` is false/failure and never an analytics success.
 - `DiffCubit._fetchAndEmit`: first successful empty and first successful
   non-empty diff states.
 - `AnalyticsRouteListener` over `GoRouterRouteSource`: exhaustive stable screen
@@ -655,14 +682,14 @@ merely to avoid updating tests.
 
 | Owner change | Exact flow and deduplication |
 | --- | --- |
-| `ProjectListCubit` | Add required `ProductAnalyticsService` and retain the bounded inventory states already emitted in that cubit lifetime. Emit the first successful `empty` once and the first later/same-lifecycle `non_empty` once; refreshes never repeat either classification. The warehouse milestone uses only earliest non-empty. |
-| `SessionActivityAnalyticsListener` | `SessionDetailScreen` constructs it with the screen-owned cubit plus `RouteSource`, `LifecycleSource`, and product analytics service. It retains one lifetime empty-diagnostic guard plus the last UTC date emitted. Initial/later empty emits once; the first successful non-empty state on each UTC date emits only while `AppRouteDef.sessionDetail` is current and lifecycle resumed. Background or nested-diffs SSE emits nothing; returning to detail may emit only if the UTC-date guard permits. |
-| `LoginCubit` | Add required `InstallationAnalyticsService`. Each provider/email method maps the sealed provider exhaustively, reports one start after input validation, and reports exactly one terminal completion/failure; OAuth timeout is a failed terminal outcome. Desktop resolves the same calls through its no-op client. |
+| `ProjectListCubit` | Add required `ProductAnalyticsService`. Empty diagnostic advances only after SDK acceptance and is not buffered. First non-empty is submitted to the service's fixed project-available slot while preference is unknown; the cubit consumes its lifetime guard only after `acceptedBySdk` or `deferredUntilPreference`, because the service owns that deferred semantic. Refreshes never repeat an accepted/deferred classification. The warehouse milestone uses only earliest non-empty. |
+| `SessionActivityAnalyticsListener` | `SessionDetailScreen` constructs it with the screen-owned cubit plus `RouteSource`, `LifecycleSource`, and product analytics service. It retains one lifetime accepted empty-diagnostic guard plus the last UTC date accepted. Initial/later empty retries until accepted while visible/active. A non-empty current-date candidate waits locally through preference-unknown and is retried only after active-state plus route/lifecycle revalidation; the date guard advances only on `acceptedBySdk`. Background/nested-diffs SSE, disable, route exit, auth change, or date expiry drops the pending candidate. |
+| `LoginCubit` / Apple mobile call site | Add required `InstallationAnalyticsService`. GitHub/Google/email methods map the sealed provider exhaustively, report one start after input validation, and report exactly one terminal completion/failure; OAuth timeout is failed. For Apple, add explicit begin/credential-success/native-failure Cubit intents: the UI invokes begin before the native sheet, then exactly one credential continuation or cancelled/failure terminal call. Desktop resolves shared methods through its no-op client. |
 | `SessionDetailCubit` send paths | Direct `sendMessage` and `_drainQueuedMessages` call one private `_reportAcceptedSubmission` only on `SuccessResponse`. The queued item retains its existing text/command plus the closed input-mode enum; analytics derives text/command classification without reading content. Error/requeue emits nothing, and each dequeued successful item reports once. |
 | `NewSessionCubit` | Add required product analytics service and required input-mode argument on creation. Capture workspace/submission/input classifications before awaiting. `SuccessResponse` makes one `session_created_with_message` call; `ErrorResponse` emits only bounded `session_creation_failed`. It never also emits the existing-session event. |
 | Mobile composer call sites | After `stopAndTranscribe()` returns a non-empty transcript, report `voice_transcription_completed`, mark input `voice_assisted`, and pass the enum to existing/new-session submit methods. Manual edits do not erase contribution; clearing/resetting the composer does. Product behavior does not await analytics delivery. |
-| `SessionDetailCubit` question/permission/abort | Report after each existing method's success branch. Question answers/rejections carry no answer data; permission maps the existing `PermissionReply` enum; abort reports only after every root/active-child response succeeds. |
-| `DiffCubit` | Add required product analytics service and retain reported change states. Emit first empty and first later non-empty once each; only non-empty defines adoption, and SSE refreshes do not repeat either state. |
+| `SessionDetailCubit` question/permission/abort | Report after each verified success branch. Question answers/rejections carry no answer data. Change `replyToPermission` to pattern-match `SuccessResponse`/`ErrorResponse` instead of treating every non-throwing response as true; only success maps the existing `PermissionReply` enum and reports. Abort reports only after every root/active-child response succeeds. |
+| `DiffCubit` | Add required product analytics service. Empty diagnostic advances only after SDK acceptance and is not buffered. First non-empty may occupy the service's fixed diff-adoption slot while preference is unknown; consume its guard only after accepted/deferred result. Only non-empty defines adoption, and SSE refreshes do not repeat accepted/deferred state. |
 | `AnalyticsRouteListener` / `FirebaseAnalyticsClient` | Listener maps every `AppRouteDef` to pinned `AnalyticsScreen`, deduplicates unchanged routes, and reports only after product analytics activates. The adapter logs canonical `product_screen_viewed`, then best-effort calls `logScreenView` with the same name. Native automatic screen reporting is disabled and standard rows are excluded from account-level models. |
 | Screen constructors/tests | `ProjectListScreen`, `NewSessionScreen`, `SessionDetailScreen`, and `SessionDiffsScreen` pass the phase-3 product analytics service from GetIt into required cubit constructors. `SessionDetailScreen` also owns/disposes `SessionActivityAnalyticsListener`. Core tests inject recording services/routes/lifecycle and assert event count/shape. |
 
@@ -860,10 +887,10 @@ only raw-ID-to-`user_key` handoff, and raw account ID never crosses it.
 | Class/file | Layer/dependencies | Responsibility |
 | --- | --- | --- |
 | `bigquery_privacy_deletion_client.dart` and `ga_user_deletion_client.dart` | Foundation clients | Typed BigQuery operations within allowlisted datasets and typed GA User Deletion API submission; no orchestration or raw account ID. |
-| `privacy_deletion_api.dart` | Layer 1; requires both clients | Loads pending auth-private targets, upserts only the deletion-exclusion control, discovers currently linkable installation IDs from retained keyed raw rows, deletes matching warehouse rows, submits app-instance/legacy-user deletion, rebuilds aggregates, and updates target status through typed operations. |
+| `privacy_deletion_api.dart` | Layer 1; requires both clients | Loads pending auth-private targets for request processing; upserts/reads the permanent deletion-exclusion control; range-joins newly landed keyed raw rows against **all** permanent tombstones for sweeps; discovers currently linkable installation IDs, deletes matching warehouse rows, submits app-instance/legacy-user deletion, rebuilds aggregates, and updates target status through typed operations. |
 | `privacy_deletion_repository.dart` | Layer 2; requires API | Owns idempotent request status, target validation, run checkpoints, tombstone-aware auth-export cutoff checks, and explicit result mapping. It never persists discovered installation IDs. |
 | `privacy_deletion_service.dart` | Layer 3; requires repository | Orchestrates exclusion-before-delete, waits for a successful auth export with `runCutoff >= suppressedAt`, performs final delete/rebuild/verification, and marks the request complete or retryable. |
-| `run_privacy_deletion.dart` / `sweep_privacy_deletions.dart` | Manual and scheduled composition roots | Construct with ADC/config, process one request or all pending/recent targets, return only aggregate status, and close clients. The daily sweep revisits incomplete targets and future **keyed** uploads only. |
+| `run_privacy_deletion.dart` / `sweep_privacy_deletions.dart` | Manual and scheduled composition roots | Construct with ADC/config, process one request or the newly landed raw-partition window, return only aggregate status, and close clients. The daily sweep joins that window against every permanent deletion-exclusion tombstone regardless of target completion/age, while acting only on future **keyed** uploads. |
 
 Use a dedicated deletion service account with BigQuery Job User, read of the
 restricted auth target/raw datasets, write only to the deletion-exclusion
@@ -906,11 +933,12 @@ retroactive:
    advertising identifiers remain disabled before collecting production data.
 5. Record `raw_export_start_at` only when the first controlled daily export is
    verified. Record `behavioral_schema_v1_start_at` separately only after the
-   released event schema is observed in export. Also record owner, identities,
-   deletion-job owner, and dashboard access group in restricted configuration.
+   outcome release's `analytics_activation_ready` is observed in export. Also
+   record owner, identities, deletion-job owner, and dashboard access group in
+   restricted configuration.
 6. Verify one existing event reaches `analytics_<property_id>.events_*`, then
-   verify the new account-linked product schema before setting its behavioral
-   timestamp. Installation-login schema does not qualify.
+   verify activation schema v1 before setting its behavioral timestamp.
+   Foundation or installation-login schema does not qualify.
 
 ### Datasets
 
@@ -1008,18 +1036,23 @@ not weaken the written privacy boundary to fit an unchecked property.
    account-less login events by platform, app version, pinned provider, and
    bounded failure kind. It scans raw rows but never persists
    `user_pseudo_id`, joins to an account, or contributes to account metrics.
+   Because that privacy boundary prevents after-the-fact internal exclusion, the
+   model/report carries `includes_internal_test_traffic=true` and is diagnostic
+   only.
 3. **`user_activity_daily`**: one row per user/date with monitor, control,
    message, voice-assisted, transcription, diff, screen, and feature
    flags/counts.
-4. **`user_milestones`**: auth timestamps plus earliest schema-v1 exposure,
+4. **`user_milestones`**: auth timestamps plus earliest foundation and
+   activation-capable exposure,
    project availability, full activation, monitor activity, and feature
    milestones. Full activation is the minimum of the two successful message
-   event names only; `analytics_schema_ready_at` is the earliest schema-v1 event
-   of any name.
-5. **`activation_cohorts`**: account-cohort denominators only when schema-v1
-   exposure occurs within 24 hours of account creation, plus 1/7/30-day
-   milestone flags, times to milestone, cohort maturity, and separate
-   preference/schema coverage.
+   event names only; `analytics_schema_ready_at` is diagnostic, while
+   `activation_capable_at` is the earliest activation-ready event or activation
+   outcome.
+5. **`activation_cohorts`**: account-cohort denominators only when activation-
+   capable schema-v1 exposure occurs within 24 hours of account creation, plus
+   1/7/30-day milestone flags, times to milestone, cohort maturity, and separate
+   preference/foundation/activation-capability coverage.
 6. **`retention_cohorts`**: activation-anchored W1/W4 eligibility and activity.
 
 Materialize partitioned daily/intermediate tables where repeated Looker scans
@@ -1061,7 +1094,8 @@ only three days.
   adoption.
 - `installation_login_funnel`: identifier-free started/completed/failed counts
   and completion rates by pinned provider/app version, explicitly labeled as
-  installation-level and never joined to account activation.
+  installation-level, potentially including internal/test release traffic, and
+  never joined to account activation or the investor snapshot.
 - `screen_usage`: account-level unique users/views by pinned
   `AnalyticsScreen`, sourced only from `product_screen_viewed`; standard
   Firebase screen rows are excluded.
@@ -1212,6 +1246,12 @@ directory name.
   JSON transport surface for PUT.
 - Move the existing seven-event contract into core models and route existing
   onboarding UI calls through `ProductAnalyticsService`.
+- Preserve existing wire names but make their semantics truthful: report support
+  link only after `UrlLauncher` confirms launch (update `openExternalLink` to
+  expose the boolean result), command copy only after awaited clipboard success,
+  share only after the native share API confirms a non-error handoff, and menu/
+  explainer open only after presentation. Failed/unavailable platform actions
+  emit nothing; tests cover each failure.
 - Update root analytics guidance and `.opencode/skills/add-analytics/SKILL.md`
   in the same PR: remove their transitional current-shell note and make the new
   core models/services the sole source of truth.
@@ -1260,9 +1300,16 @@ directory name.
 **Repository:** apps monorepo
 
 - Add the event catalog variants and bounded enum serialization.
+- Add `analytics_activation_ready(activation_schema_version=1)` to this outcome
+  release and emit it on first active transition. PR-3
+  `analytics_schema_ready` remains foundation diagnostics only; set
+  `behavioral_schema_v1_start_at` and admit activation cohorts only after this
+  PR-4 capability appears in production export.
 - Instrument `LoginCubit` through `InstallationAnalyticsService` with one start
   and one terminal completion/failure (including timeout) per valid attempt;
-  events remain account-less and carry only pinned provider/failure enums.
+  events remain account-less and carry only pinned provider/failure enums. Add
+  the mobile Apple begin/failure intents before/after the native authorization
+  sheet so cancellation/launch failures share the same honest denominator.
 - Instrument the authoritative core/app seams listed above, including both
   direct and queued message success, while keeping analytics best-effort and
   non-blocking.
@@ -1276,12 +1323,17 @@ directory name.
 - Regenerate only source-generated outputs.
 - Add focused tests that failures/taps/queued-only operations do not activate,
   each successful message path makes one service call, new-session success is not
-  double counted, sensitive inputs cannot enter parameter maps, first-message
+  double counted, a non-throwing permission `ErrorResponse` returns failure and
+  emits no success, sensitive inputs cannot enter parameter maps, bounded
+  milestone candidates survive preference-unknown without consuming guards,
+  activation-ready exposure excludes foundation-only binaries, first-message
   deferral survives preference resolution,
   empty-to-non-empty transitions report once, resumed/later-date monitoring can
   report again without SSE inflation, voice-assisted origin survives queueing
   without transcript data, and login timeout/failure makes one bounded terminal
-  installation event without an account key.
+  installation event without an account key. Widget tests verify Apple start is
+  emitted before opening the native sheet and cancellation/failure terminates
+  that attempt without calling the Cubit start twice.
 
 ### PR 5/5 — Warehouse models and dashboards
 
@@ -1371,7 +1423,8 @@ the separately released app.
 
 - Dry-run every deployed query and run fixture `ASSERT`s for activation event
   inclusion, failed/queued exclusion, deferred first-message selection, timely
-  per-account schema exposure, legacy-without-exposure exclusion, 7-day cohort
+  per-account activation-capable exposure, foundation-only/legacy exclusion,
+  7-day cohort
   maturity, W1/W4 boundaries, internal/disabled/suppressed filtering before
   aggregates, deletion exclusion in flattened recomputation, daily monitoring
   activity without SSE duplication, typed/voice-assisted classification,
@@ -1401,7 +1454,7 @@ the separately released app.
    release.
 4. **Weeks 2-3:** Land instrumentation and ship the mobile release as early as
    store review permits; set `behavioral_schema_v1_start_at` only after its
-   schema appears in controlled raw export.
+   `analytics_activation_ready` capability appears in controlled raw export.
 5. **Weeks 3-4:** Deploy warehouse models, run data QA, and build Looker.
 6. **Weeks 4-8:** Monitor data-quality alerts weekly, correct only demonstrated
    schema/metric defects, and let cohorts mature.
@@ -1420,13 +1473,15 @@ extensions only through versioned schema/model changes.
 - **No retroactive behavioral data:** link/export and ship early; label raw and
   behavioral starts separately and do not backfill full activation from
   metadata requests.
-- **Developer/internal pollution:** custom events are release-only and reporting
-  excludes a restricted internal-user list; monitor app version/schema mix.
+- **Developer/internal pollution:** custom events are release-only and account-
+  linked reporting excludes a restricted internal-user list; the separately
+  labeled login diagnostic cannot apply that exclusion. Monitor app version/
+  schema mix and keep login out of headlines.
 - **Opt-out bias:** show eligible coverage with every behavioral funnel and do
   not extrapolate activation/retention to all accounts.
-- **Legacy denominator bias:** require timely per-account schema-v1 exposure;
-  global rollout time or server default-enabled state alone never makes an
-  account measurable.
+- **Legacy/foundation-only denominator bias:** require timely per-account
+  activation-capable exposure; foundation readiness, global rollout time, or
+  server default-enabled state alone never makes an account measurable.
 - **Cross-repository deployment mismatch:** deploy write-first server behavior,
   backfill/verify, then enforce, and only then release the client. Preference
   GET/PUT failure is fail-closed; auth profiles remain unchanged.
@@ -1454,8 +1509,9 @@ extensions only through versioned schema/model changes.
 - **High-cardinality or sensitive leakage:** closed event variants, bounded
   enums, raw-ID prohibition, wire-pin tests, and allowlisted SQL.
 - **Misleading login conversion:** label pre-auth login metrics as installation-
-  level aggregates, never join them to account creation/activation, and do not
-  infer unique people from attempts or `user_pseudo_id`.
+  level aggregates that may include internal/test release traffic, keep them out
+  of investor headlines, never join them to account creation/activation, and do
+  not infer unique people from attempts or `user_pseudo_id`.
 - **Incorrect screen names/duplicates:** disable Firebase automatic screen
   reporting, map GoRouter routes exhaustively to pinned screen values, mirror
   those through `logScreenView`, and use only the custom event in account-level

--- a/.plan/active/user-analytics/PLAN.md
+++ b/.plan/active/user-analytics/PLAN.md
@@ -227,7 +227,7 @@ honestly labeled setup trends.
 
 | Repository/workspace | Production paths and layer | Change | Downstream impact |
 | --- | --- | --- | --- |
-| `sesori_auth_server` | `src/types/product-analytics.ts` (domain enum), `src/models/{documents,api,product-analytics-export}.ts` (persisted/API/export/deletion-target contracts), `src/repositories/{user-repo,activation-state-repo,product-analytics-export-repo,product-analytics-control-repo,product-analytics-deletion-target-repo}.ts`, `src/services/{product-analytics-preference-service,product-analytics-export-service,product-analytics-deletion-service}.ts`, `src/clients/bigquery-product-analytics-client.ts` and `src/api/product-analytics-export-api.ts`, `src/routes/product-analytics.ts`, `src/scripts/{backfill-product-analytics-preference,suppress-product-analytics-export,export-product-analytics,product-analytics-export-config}.ts` | Persist revisioned preference/privacy-suppression state behind dedicated services, expose GET/PUT endpoints, export privacy-safe data after source/internal exclusion, and hand tombstoned deletion targets to restricted auth-private storage. | Existing auth profile/token responses remain unchanged. The web process constructs only the preference service; export/deletion BigQuery classes exist only in isolated command composition. |
+| `sesori_auth_server` | `src/types/product-analytics.ts` (domain enum), `src/models/{documents,api,product-analytics-export}.ts` (persisted/API/export/deletion-target contracts), `src/repositories/{user-repo,activation-state-repo,product-analytics-export-repo,product-analytics-control-repo,product-analytics-deletion-target-repo}.ts`, `src/services/{product-analytics-preference-service,product-analytics-export-service,product-analytics-deletion-service}.ts`, separate `src/clients/{bigquery-product-analytics-client,bigquery-product-analytics-deletion-target-client}.ts` and `src/api/{product-analytics-export-api,product-analytics-deletion-target-api}.ts`, `src/routes/product-analytics.ts`, `src/scripts/{backfill-product-analytics-preference,suppress-product-analytics-export,export-product-analytics,product-analytics-export-config}.ts` | Persist revisioned preference/privacy-suppression state behind dedicated services, expose GET/PUT endpoints, export privacy-safe data after source/internal exclusion, and hand tombstoned deletion targets to a separately permissioned privacy-private dataset. | Existing auth profile/token responses remain unchanged. The web process constructs only the preference service; export/deletion BigQuery classes and identities remain isolated from each other and exist only in command composition. |
 | `shared/sesori_shared` | No production change | Keep `AuthUser` authentication-only; do not add a product preference to the shared auth/persisted contract. | No bridge/shared migration or compatibility default is introduced. |
 | `client/module_auth` | Existing HTTP client interfaces/implementations/tests | Add named-parameter JSON `PUT` support to `SafeApiClient`, `HttpApiClient`, and `AuthenticatedHttpApiClient`; keep tokens, OAuth, and auth state otherwise unchanged. | `module_core` injects the authenticated client into its Layer-1 preference API; no wrong-verb workaround or compatibility path is introduced. |
 | `client/module_core` | `lib/src/foundation/{models/product_analytics/,platform/analytics_client.dart}`, `lib/src/api/{analytics_api,product_analytics_preference_api.dart,storage/product_analytics_preference_storage.dart}`, `lib/src/repositories/{models/,product_analytics,installation_analytics,product_analytics_preference}_repository.dart`, `lib/src/services/{models/,product_analytics,installation_analytics}_service.dart`, existing `services/draft_store.dart` plus typed composer-draft model, `lib/src/routing/{analytics_route,session_activity_analytics}_listener.dart`, `lib/src/cubits/{product_analytics_preference,settings}/`, existing login/project/session/diff cubits, DI/barrel/generated files | Mirror the declared layers explicitly; own preference HTTP/persistence, pseudonymous hashing, bounded account-less login telemetry, typed draft/input-origin restoration, route/visibility lifecycle, pre-logout orchestration, Settings state, and authoritative business-outcome emission. | Mobile supplies the Firebase client plus immutable runtime capability. Desktop supplies no-op/disabled Foundation adapters. Cubit constructor call sites/tests update in lockstep. |
@@ -406,14 +406,14 @@ mixed `src/analytics/` bucket. The concrete dependency direction is:
 | `ProductAnalyticsRepository` in `module_core/lib/src/repositories/product_analytics_repository.dart` | Layer 2; constructor requires `AnalyticsApi` | Converts raw authenticated user ID to lowercase SHA-256, passes only the pseudonymous key downward, and maps API exceptions to explicit `AnalyticsDeliveryResult` without redundant logging. It adds `schema_version=1` through the typed event serialization contract. |
 | `InstallationAnalyticsRepository` in `module_core/lib/src/repositories/installation_analytics_repository.dart` | Layer 2; constructor requires `AnalyticsApi` | Sends only `InstallationAnalyticsEvent`, adds the installation schema version, and maps SDK failures to explicit delivery results. It has no auth/user/preference dependency and cannot receive a `user_key`. |
 | `ProductAnalyticsPreferenceRepository` in `module_core/lib/src/repositories/product_analytics_preference_repository.dart` | Layer 2; requires `ProductAnalyticsPreferenceApi` and `ProductAnalyticsPreferenceStorage` | Fetch/update server preference, scope local records to one account, and persist only versioned `synced`, `pendingDisable`, or `pendingEnable` records. Every PUT uses the last observed revision plus stable operation ID. Conflict on disable triggers one bounded GET/retry against the new revision; conflict on enable remains inactive and returns explicit refresh-required state so an older enable cannot automatically override a newer disable. `pendingEnable` is never permission to emit. |
-| `ProductAnalyticsState`, independent preference/synchronization variants, and closed fixed-capacity `DeferredProductAnalyticsCandidates` under `module_core/lib/src/services/models/` | Layer-3 service state | Represents active/inactive/pending/failure truth plus only activation/project-available/diff-adoption deferred slots without nullable coordination fields or a generic queue; it is not part of the Foundation sink contract. |
-| `ProductAnalyticsService` in `module_core/lib/src/services/product_analytics_service.dart` | Layer 3, `@lazySingleton`; requires immutable `AnalyticsRuntimeCapability`, read-only `AuthSession`, `ProductAnalyticsRepository`, and `ProductAnalyticsPreferenceRepository` | Sole owner of preference/custom-event lifecycle and Consumer `logEvent`. Exposes a replaying state stream plus `start`, `markPostSplashReady`, explicit `refreshPreference`, `setPreference`, `retryPendingDisable`, bounded `prepareForLogout`, and `dispose`. It performs one server read per post-readiness auth generation plus explicit Settings refresh/actions—no lifecycle timer/polling—and sends no product event unless active. While same-generation preference is unknown, a closed fixed-capacity deferred model may retain one activation candidate, first non-empty project availability, and first non-empty diff adoption; there is no generic event queue. |
+| `ProductAnalyticsState`, independent preference/synchronization variants, and closed fixed-capacity `DeferredProductAnalyticsCandidates` under `module_core/lib/src/services/models/` | Layer-3 service state | Represents active/inactive/pending/failure truth plus only activation/project-available/diff-adoption/current-date-session-activity deferred slots without nullable coordination fields or a generic queue; it is not part of the Foundation sink contract. |
+| `ProductAnalyticsService` in `module_core/lib/src/services/product_analytics_service.dart` | Layer 3, `@lazySingleton`; requires immutable `AnalyticsRuntimeCapability`, read-only `AuthSession`, `ProductAnalyticsRepository`, and `ProductAnalyticsPreferenceRepository` | Sole owner of preference/custom-event lifecycle and Consumer `logEvent`. Exposes a replaying state stream plus `start`, `markPostSplashReady`, explicit `refreshPreference`, `setPreference`, `retryPendingDisable`, bounded `prepareForLogout`, and `dispose`. It performs one server read per post-readiness auth generation plus explicit Settings refresh/actions—no lifecycle timer/polling—and sends no product event unless active. While same-generation preference is unknown, a closed fixed-capacity deferred model may retain one activation candidate, first non-empty project availability, first non-empty diff adoption, and one authoritative session-activity occurrence; there is no generic event queue. |
 | `InstallationAnalyticsService` in `module_core/lib/src/services/installation_analytics_service.dart` | Layer 3, `@lazySingleton`; requires immutable `AnalyticsRuntimeCapability` and `InstallationAnalyticsRepository` | Accepts only typed login-attempt lifecycle methods, maps the sealed auth provider exhaustively to `AnalyticsLoginProvider`, classifies timeout versus bounded authentication/launch failure, and reports best-effort. It has no account/preference state, buffers nothing, and remains inactive in debug/profile/unsupported builds or when legacy-ID cleanup failed. |
 | `AnalyticsRouteListener` in `module_core/lib/src/routing/analytics_route_listener.dart` | Layer-4 routing listener, `@lazySingleton`; requires `RouteSource` and `ProductAnalyticsService` | Owns route subscription, maps `AppRouteDef` exhaustively to `AnalyticsScreen`, signals readiness on the first non-splash route, and reports stable screens only while active. It never passes a route model/path to Foundation. |
 | `SessionActivityAnalyticsListener` in `module_core/lib/src/routing/session_activity_analytics_listener.dart` | Layer-4 route-aware listener; constructed/owned by `SessionDetailScreen`, requires its `SessionDetailCubit`, `RouteSource`, `LifecycleSource`, and `ProductAnalyticsService` | Combines bounded loaded-state classification with actual `sessionDetail` route visibility and resumed lifecycle. It emits first empty once and non-empty at most once per UTC date only while the detail route is topmost; nested diffs/background SSE cannot create false monitoring activity. |
 | `ProductAnalyticsPreferenceCubit` in `module_core/lib/src/cubits/product_analytics_preference/` | Consumer; constructor requires `ProductAnalyticsService` | Subscribes to service state and exposes toggle/retry intents. Mobile Settings constructs it; it is not in DI. |
 | `FirebaseAnalyticsClient` in `app/lib/core/platform/firebase_analytics_client.dart` | Thin mobile Foundation adapter, `@LazySingleton(as: AnalyticsClient)`; requires `FirebaseAnalytics` and immutable `AnalyticsRuntimeCapability` | Rejects all operations unless capability is enabled, serializes only typed product/installation events plus their permitted shared fields, and throws canonical-event failures upward. For `product_screen_viewed`, after the canonical custom event is accepted it also best-effort calls `FirebaseAnalytics.logScreenView` with the same pinned screen name and stable `GoRouter` screen class; mirror failure is logged but does not rewrite canonical delivery. It never applies global identity/collection overrides and contains no route/preference/hash business logic. Firebase-disabled environments use the no-op client plus disabled capability. |
-| `FirebaseAnalyticsIdentityMigration` in `app/lib/core/platform/firebase_analytics_identity_migration.dart` | Mobile-only pre-phase-1 bootstrap helper; constructed directly with `FirebaseAnalytics.instance` after Firebase initialization | Awaits `setUserId(id: null)` and returns immutable `AnalyticsRuntimeCapability.enabled` or `.disabled(legacyIdentityClearFailed)`. `main` passes that value into phase-1 dependency configuration; the Firebase client and both services require the same instance. Failure deterministically disables all custom events and retries next launch; because automatic collection cannot then be safely reconfigured without another persisted override, the **entire failed process** is classified/disclosed as potentially legacy-keyed and remains covered by recurring legacy deletion. Keep this cleanup through minimum-supported-version adoption plus the 90-day raw window, then remove it explicitly. |
+| `FirebaseAnalyticsIdentityMigration` in `app/lib/core/platform/firebase_analytics_identity_migration.dart` | Mobile-only reusable pre-DI helper; constructed directly with `FirebaseAnalytics.instance` after Firebase initialization in foreground `main` and the FCM background entry point | Awaits `setUserId(id: null)`. Foreground returns immutable `AnalyticsRuntimeCapability.enabled` or `.disabled(legacyIdentityClearFailed)` for phase-1 DI. The background handler runs the same idempotent clear immediately after its independent `Firebase.initializeApp` and before handler work; failure logs and ends/classifies that whole background execution as potentially legacy-keyed. Automatic initialization can still precede either clear, so recurring legacy deletion covers that unavoidable window. Keep both calls through minimum-supported-version adoption plus the 90-day raw window, then remove explicitly. |
 | `NoOpAnalyticsClient` in `desktop/lib/core/platform/no_op_analytics_client.dart` | Desktop phase-1 Foundation adapter | Satisfies shared core DI and accepts operations without collection. No desktop listeners are started. |
 
 `AnalyticsScreen` pins snake-case wire values for login, projects, approved
@@ -479,6 +479,13 @@ classification applies to every automatic event for that whole process—not onl
 startup—while all custom events remain disabled. Recurring deletion sweeps keep
 submitting the legacy user key; do not claim automatic collection was stopped.
 
+The `@pragma("vm:entry-point")` FCM background handler independently initializes
+Firebase, then awaits the same migration helper before doing any message work.
+It never constructs core DI or emits custom analytics. Clear failure is logged
+and the handler returns; automatic events that may precede/follow a failed clear
+are classified as legacy-keyed for that background execution and covered by the
+same deletion/retention disclosure.
+
 ### Preference and lifecycle data flow
 
 **Startup and readiness:** Firebase retains its privacy-minimized automatic
@@ -520,15 +527,15 @@ reconciliation slot and advances no state; a stable operation ID plus server
 revision compare-and-set makes detached late mutation completion idempotent and
 unable to overwrite a newer revision.
 
-**Capability exposure and bounded deferral:** On each process's first active
-transition, the foundation release attempts `analytics_schema_ready`. The later
-outcome release additionally attempts
+**Capability exposure and bounded deferral:** On each authenticated generation's
+first active transition, the foundation release attempts
+`analytics_schema_ready`. The later outcome release additionally attempts
 `analytics_activation_ready(activation_schema_version=1)` before buffered work.
 Only the latter readiness event or an accepted full-activation outcome proves
 activation capability; an old foundation-only binary remains unmeasurable.
 While the same generation is preference-unknown (and not locally disabled), the
 service may return `deferredUntilPreference` and retain only the closed
-activation/project-available/diff-adoption candidates. Active resolution emits
+activation/project-available/diff-adoption/session-activity candidates. Active resolution emits
 each retained semantic once; disabled resolution, logout/account switch, or
 generation change drops them. No prompt/message content, project/session ID, or
 unbounded event enters this fixed model. Each candidate retains its typed
@@ -536,13 +543,19 @@ unbounded event enters this fixed model. Each candidate retains its typed
 move activation eligibility, latency, project availability, or adoption time.
 Empty diagnostics are not buffered.
 
-`SessionActivityAnalyticsListener` separately retains at most one non-empty
-candidate for the current UTC date. It advances its date guard only after
-`acceptedBySdk`; while preference is unknown it waits for active state and
-revalidates that the session-detail route is still topmost/resumed before
-retrying the original envelope/occurrence time. It drops the candidate on date
-change, route exit, disable, or auth
-generation change, so delayed preference cannot fabricate monitoring activity.
+Readiness guards live in generation-scoped service state, not a process-global
+boolean. Logout/account switch clears them; account B in the same process emits
+its own foundation/activation readiness even when it never activates, preventing
+success-conditioned cohort eligibility.
+
+`SessionActivityAnalyticsListener` creates the candidate only while the detail
+route is topmost/resumed, then submits its original envelope/occurrence time to
+the service's fixed slot. It advances its date guard after `acceptedBySdk` or
+`deferredUntilPreference`; once deferred, the already-authoritative view remains
+valid across route exit or UTC rollover and the service emits it when the same
+generation becomes enabled. Disable or auth generation change drops it. This
+preserves brief real views without allowing background/nested-route state to
+create candidates.
 
 **Disable:** The cubit calls `ProductAnalyticsService.setPreference(disabled)`.
 The service immediately publishes inactive, then first durably persists
@@ -635,8 +648,8 @@ it. Account-less login events are immediate and do not add this field.
 
 | Event | Emit only when | Bounded parameters | Reporting use |
 | --- | --- | --- | --- |
-| `analytics_schema_ready` | The foundation process first becomes active for an authenticated account | none beyond shared schema/key | Foundation deployment/preference coverage only; never activation capability/activity |
-| `analytics_activation_ready` | An outcome-instrumented process first becomes active | `activation_schema_version=1` | Per-account activation-capable exposure; never activity |
+| `analytics_schema_ready` | The foundation becomes active once per authenticated generation | none beyond shared schema/key | Per-account foundation deployment/preference coverage only; never activation capability/activity |
+| `analytics_activation_ready` | An outcome-instrumented build becomes active once per authenticated generation | `activation_schema_version=1` | Per-account activation-capable exposure including unsuccessful accounts; never activity |
 | `project_inventory_loaded` | The first successful empty inventory and the first successful non-empty inventory in a cubit lifetime | `inventory_state=empty/non_empty` | First project available from earliest non-empty; empty is onboarding friction |
 | `session_activity_viewed` | The first successful empty snapshot in a cubit lifetime, and at most one successful non-empty snapshot per UTC date while that session detail is visible/foregrounded | `activity_state=empty/non_empty` | Earliest non-empty is the monitoring milestone; dated non-empty events support WAU/retention without SSE inflation |
 | `session_message_sent` | Existing-session send returns success, including a queued send that later succeeds | `submission_kind=text/command`, `input_mode=typed/voice_assisted` | Full activation, control activity, voice-assisted share |
@@ -708,7 +721,7 @@ merely to avoid updating tests.
 | Owner change | Exact flow and deduplication |
 | --- | --- |
 | `ProjectListCubit` | Add required `ProductAnalyticsService`. Empty diagnostic advances only after SDK acceptance and is not buffered. First non-empty is submitted to the service's fixed project-available slot while preference is unknown; the cubit consumes its lifetime guard only after `acceptedBySdk` or `deferredUntilPreference`, because the service owns that deferred semantic. Refreshes never repeat an accepted/deferred classification. The warehouse milestone uses only earliest non-empty. |
-| `SessionActivityAnalyticsListener` | `SessionDetailScreen` constructs it with the screen-owned cubit plus `RouteSource`, `LifecycleSource`, and product analytics service. It retains one lifetime accepted empty-diagnostic guard plus the last UTC date accepted. Initial/later empty retries until accepted while visible/active. A non-empty current-date candidate waits locally through preference-unknown and is retried only after active-state plus route/lifecycle revalidation; the date guard advances only on `acceptedBySdk`. Background/nested-diffs SSE, disable, route exit, auth change, or date expiry drops the pending candidate. |
+| `SessionActivityAnalyticsListener` | `SessionDetailScreen` constructs it with the screen-owned cubit plus `RouteSource`, `LifecycleSource`, and product analytics service. It retains one accepted empty-diagnostic guard plus the last UTC date accepted/deferred. Initial/later empty retries until accepted while visible/active. It creates non-empty only while detail is topmost/resumed, then advances the date guard after accepted/deferred result; the service owns deferred delivery across route/date changes for the same generation. Background/nested-diffs SSE never creates a candidate; disable/auth change drops service-held state. |
 | `LoginCubit` / Apple mobile call site | Add required `InstallationAnalyticsService` and one closed `ActiveLoginAnalyticsAttempt`. GitHub/Google/email methods map the sealed provider exhaustively, report one start after input validation, and report exactly one terminal completion/failure; interrupted OAuth polling retains provider through `_onAppResumed`, and timeout is failed. For Apple, add explicit begin/credential-success/native-failure Cubit intents: the UI invokes begin before the native sheet, then exactly one credential continuation or cancelled/failure terminal call. Desktop resolves shared methods through its no-op client. |
 | `SessionDetailCubit` send paths | Direct `sendMessage` and `_drainQueuedMessages` call one private `_reportAcceptedSubmission` only on `SuccessResponse`. The queued item retains its existing text/command plus the closed input-mode enum; analytics derives text/command classification without reading content. Error/requeue emits nothing, and each dequeued successful item reports once. |
 | `NewSessionCubit` | Add required product analytics service and required input-mode argument on creation. Capture workspace/submission/input classifications before awaiting. `SuccessResponse` makes one `session_created_with_message` call; `ErrorResponse` emits only bounded `session_creation_failed`. It never also emits the existing-session event. |
@@ -882,8 +895,8 @@ Use Application Default Credentials, Secret Manager for Mongo access, and an
 export service account limited to BigQuery Job User plus Data Editor on
 `sesori_analytics_auth_private` plus table-level Data Viewer on the one
 authorized permanent-internal-exclusion view. It has no controls dataset write/DDL
-role and no role on raw, curated, or reporting datasets, so it cannot mutate
-exclusion/config tables. A separate scheduled-transform identity has read-only access to raw,
+role and no role on privacy-private, raw, curated, or reporting datasets, so it
+cannot mutate deletion targets, exclusions, or config. A separate scheduled-transform identity has read-only access to raw,
 auth-private, and controls plus write access to curated; the deployment identity
 alone owns schemas/IAM/control-table writes. The auth web runtime receives no
 BigQuery role.
@@ -898,12 +911,13 @@ handler and never an informal sequence of console queries.
 | Class/file | Layer/dependencies | Responsibility |
 | --- | --- | --- |
 | `ProductAnalyticsDeletionTarget` in `src/models/product-analytics-export.ts` | Closed internal model | Contains only external privacy request ID, lowercase `user_key`, source tombstone time, and status; no raw account ID. |
-| `ProductAnalyticsDeletionTargetRepository` in `src/repositories/product-analytics-deletion-target-repo.ts` | Layer 2; requires `ProductAnalyticsExportApi` scoped to `auth_private` | Idempotently upserts the restricted deletion target and reads status. It cannot access controls/raw/curated/reporting. |
+| `BigQueryProductAnalyticsDeletionTargetClient` / `ProductAnalyticsDeletionTargetApi` | Foundation/Layer 1; scoped only to `privacy_private.product_analytics_deletion_targets` | Typed target upsert/read/status operations. It cannot access export-owned auth-private tables, controls, raw, curated, or reporting. |
+| `ProductAnalyticsDeletionTargetRepository` in `src/repositories/product-analytics-deletion-target-repo.ts` | Layer 2; requires `ProductAnalyticsDeletionTargetApi` | Idempotently upserts the restricted deletion target and reads status; it never reuses the export API/client. |
 | `ProductAnalyticsDeletionService` in `src/services/product-analytics-deletion-service.ts` | Layer 3; requires `ProductAnalyticsPreferenceService` and deletion-target repository | Receives raw account ID only in protected process memory, atomically source-tombstones/disables first, hashes with the pinned golden algorithm, writes the restricted target, drops raw ID/key locals, and returns only request ID/status. A target-write failure leaves the source tombstone intact and is safely retryable. |
-| `src/scripts/suppress-product-analytics-export.ts` | Protected command composition root | Reads verified raw account ID from stdin and external request ID from a protected input channel, constructs Mongo plus auth-private client/API/repository/service, invokes once, prints only request ID/status, and closes both clients in `finally`. |
+| `src/scripts/suppress-product-analytics-export.ts` | Protected command composition root | Reads verified raw account ID from stdin and external request ID from a protected input channel, constructs Mongo plus the privacy-private target client/API/repository/service, invokes once, prints only request ID/status, and closes both clients in `finally`. |
 
 The script identity has Mongo suppression access plus append/update/read status
-only on `auth_private.product_analytics_deletion_targets`; it cannot query GA4
+only on `privacy_private.product_analytics_deletion_targets`; it cannot query GA4
 raw data or mutate controls/curated/reporting. The restricted target table is the
 only raw-ID-to-`user_key` handoff, and raw account ID never crosses it.
 
@@ -912,14 +926,14 @@ only raw-ID-to-`user_key` handoff, and raw account ID never crosses it.
 | Class/file | Layer/dependencies | Responsibility |
 | --- | --- | --- |
 | `bigquery_privacy_deletion_client.dart` and `ga_user_deletion_client.dart` | Foundation clients | Typed BigQuery operations within allowlisted datasets and typed GA User Deletion API submission; no orchestration or raw account ID. |
-| `privacy_deletion_api.dart` | Layer 1; requires both clients | Loads pending auth-private targets for request processing; upserts/reads the permanent deletion-exclusion control; range-joins newly landed keyed raw rows against **all** permanent tombstones for sweeps; discovers currently linkable installation IDs, deletes matching warehouse rows, submits app-instance/legacy-user deletion, rebuilds aggregates, and updates target status through typed operations. |
+| `privacy_deletion_api.dart` | Layer 1; requires both clients | Loads pending privacy-private targets for request processing; upserts/reads the permanent deletion-exclusion control; range-joins the overlapping raw window against **all** permanent tombstones for sweeps; discovers currently linkable installation IDs, deletes matching warehouse rows, submits app-instance/legacy-user deletion, rebuilds aggregates, and updates target status through typed operations. |
 | `privacy_deletion_repository.dart` | Layer 2; requires API | Owns idempotent request status, target validation, run checkpoints, tombstone-aware auth-export cutoff checks, and explicit result mapping. It never persists discovered installation IDs. |
 | `privacy_deletion_service.dart` | Layer 3; requires repository | Orchestrates exclusion-before-delete, waits for a successful auth export with `runCutoff >= suppressedAt`, performs final delete/rebuild/verification, and marks the request complete or retryable. |
-| `run_privacy_deletion.dart` / `sweep_privacy_deletions.dart` | Manual and scheduled composition roots | Construct with ADC/config, process one request or the newly landed raw-partition window, return only aggregate status, and close clients. The daily sweep joins that window against every permanent deletion-exclusion tombstone regardless of target completion/age, while acting only on future **keyed** uploads. |
+| `run_privacy_deletion.dart` / `sweep_privacy_deletions.dart` | Manual and scheduled composition roots | Construct with ADC/config, process one request or a checkpointed raw-partition range, return only aggregate status, and close clients. Each daily sweep starts from the earlier of the last-success watermark continuation and the latest three UTC event dates, matching GA4 late-arrival recomputation; it joins every scanned version against all permanent deletion tombstones regardless of target completion/age. Submission/deletion is idempotent and acts only on future **keyed** uploads. |
 
 Use a dedicated deletion service account with BigQuery Job User, read of the
-restricted auth target/raw datasets, write only to the deletion-exclusion
-control and target status, delete/rebuild permission on auth-private/curated/
+restricted privacy-target/raw datasets, write only to the deletion-exclusion
+control and privacy-target status, delete/rebuild permission on auth-private/curated/
 reporting (and matching retained raw rows), plus the minimum GA deletion API
 role. It has no Mongo access and no general controls/deployment role. Secret
 Manager/ADC supply credentials; no service-account key enters Git.
@@ -976,7 +990,8 @@ property/project IDs:
 | --- | --- | --- |
 | `analytics_<property_id>` | Raw restricted | Firebase-managed GA4 daily tables |
 | `sesori_analytics_auth_private` | Security/analytics admins, auth export job; transform identity read-only | Auth eligible-user snapshot/staging and aggregate setup cohorts only |
-| `sesori_analytics_controls` | Security/analytics admins and deployment identity; transform identity read-only; auth-export identity can read only an authorized active-exclusion view | Internal-user and deletion exclusions, dual measurement timestamps, export freshness policy |
+| `sesori_analytics_privacy_private` | Security/privacy admins, auth suppression command limited writer, deletion job | Product-analytics deletion targets/status only; auth export identity has no access |
+| `sesori_analytics_controls` | Security/analytics admins and deployment identity; transform identity read-only; auth-export identity can read only an authorized permanent-internal-exclusion view | Internal-user and deletion exclusions, dual measurement timestamps, export freshness policy |
 | `sesori_analytics_curated` | Analytics engineers | Flattened allowlisted events, daily user activity, user milestones, scheduled intermediate tables |
 | `sesori_analytics_reporting` | Looker service account/product leadership | Identifier-free authorized views and dashboard tables |
 
@@ -988,7 +1003,8 @@ runbook. Never commit service-account material or live internal user keys.
 The initial file ownership is fixed:
 
 - `tool/product_analytics/deploy.dart` validates named project, location, raw,
-  auth-private/controls/curated/reporting datasets, and both start timestamps;
+  auth-private/privacy-private/controls/curated/reporting datasets, and both
+  start timestamps;
   renders identifier placeholders from the checked-in SQL; and invokes `bq`
   non-interactively with the explicit location. It does not perform `gcloud`
   login or read key files.
@@ -1176,7 +1192,8 @@ only three days.
   expiration. State both limits in the privacy notice/deletion response rather
   than creating a persistent account-device map.
 - Keep deletion-exclusion tombstones permanent and run a daily upstream deletion
-  sweep over newly landed raw partitions. For every tombstoned key it discovers
+  sweep over a checkpointed range with at least a three-UTC-date overlap for
+  mutable GA4 late arrivals. For every tombstoned key it discovers
   future keyed installation IDs (including product events queued while a
   supported client was offline), it resubmits GA app-instance deletion, deletes
   matching warehouse rows, and submits the legacy `USER_ID` while that migration
@@ -1187,8 +1204,9 @@ only three days.
   **keyed-upload** enforcement, never indefinite automatic-event enforcement.
   Record request IDs/completion without raw account/install IDs.
   Test the layered deletion command, IAM, request format, in-flight export
-  ordering, delayed keyed upload, flattened anti-join/non-repopulation,
-  aggregate rebuild, and a non-production deletion before rollout.
+  ordering, delayed keyed upload appended to an already-swept partition,
+  watermark-gap recovery, flattened anti-join/non-repopulation, aggregate
+  rebuild, and a non-production deletion before rollout.
 
 ## Looker Studio
 
@@ -1317,7 +1335,8 @@ directory name.
   finalization failure, revision conflict/idempotent operation handling,
   timed-out old enable unable to overwrite newer disable, 10-second timeout
   releasing logout/reconciliation,
-  legacy-ID clear success/failure ordering and whole-process disclosure, logout
+  foreground and FCM-background legacy-ID clear success/failure ordering and
+  whole-execution disclosure, logout
   sync failure/account-switch preservation, `SettingsCubit` pre-logout ordering,
   enable-after-server success, delayed
   GET/PUT/storage completions across rapid login/logout/account switches,
@@ -1386,7 +1405,7 @@ directory name.
 
 - Add `tool/product_analytics/` data contract, parameterized deployment tool,
   DDL, transforms, fixture assertions, scheduled-query definitions, and runbook.
-- Create auth-private/controls/curated/reporting datasets in the raw GA4
+- Create auth-private/privacy-private/controls/curated/reporting datasets in the raw GA4
   location; keep export-job write access confined to auth-private and grant only
   authorized-view reads for internal exclusion; configure IAM, expiration,
   budget alerts, source/control exclusions, upstream GA4
@@ -1398,7 +1417,8 @@ directory name.
   tombstone sweep using the declared Foundation/API/Repository/Service command
   architecture, and require a tombstone-aware auth export plus final cleanup
   before declaring warehouse deletion complete. The sweep covers future keyed
-  uploads only and persists no account-install mapping.
+  uploads only, rescans the mutable three-date late-arrival window plus any
+  watermark gap, and persists no account-install mapping.
 - Build and permission the three-page initial Looker report with freshness,
   coverage, maturity, voice, login, and GoRouter screen panels.
 - Run a release-build smoke test through account -> bridge -> project -> message
@@ -1484,7 +1504,8 @@ the separately released app.
   acceptance, then complete one non-production GA User Deletion API exercise
   through auth-source tombstone, warehouse suppression/deletion, aggregate
   rebuild/non-repopulation after an in-flight pre-tombstone export, delayed
-  offline-client upload plus recurring sweep, and upstream request status.
+  offline-client upload into a previously swept mutable partition plus
+  overlapping recurring sweep, and upstream request status.
   Verify the deletion response states transient future-upload/keyed-only sweep
   limits and, for automatic-only/never-keyed data, both two-month upstream GA
   retention and 90-day restricted BigQuery raw expiration.

--- a/.plan/active/user-analytics/PLAN.md
+++ b/.plan/active/user-analytics/PLAN.md
@@ -1,7 +1,7 @@
 # User Analytics
 
-**Status:** Revised after rejected architecture review; valid findings applied,
-not re-reviewed
+**Status:** Latest considerable revision rejected by architecture review; valid
+findings and current PR feedback applied directly, not re-reviewed
 
 **Plan slug:** `user-analytics`
 
@@ -9,8 +9,8 @@ not re-reviewed
 
 ## Goal
 
-Give Sesori a privacy-safe product analytics system that can answer, within the
-next two months:
+Give Sesori a durable, privacy-safe product analytics system. The first
+trustworthy reporting release should answer within the next two months:
 
 - Are new accounts growing?
 - Do users complete bridge setup and reach product value?
@@ -18,7 +18,8 @@ next two months:
 - Which remote-control and differentiating features create engagement?
 - Where do onboarding and core actions fail?
 
-The system must produce reproducible BigQuery metrics and restricted Looker
+The system remains the product's analytics foundation after that fundraising
+window. It must produce reproducible BigQuery metrics and restricted Looker
 Studio dashboards without exporting source code, prompts, transcripts, paths,
 project/session names, raw entity identifiers, or unbounded backend data.
 
@@ -38,10 +39,28 @@ Revenue metrics are out of scope because Sesori is currently free.
    immediately on this installation and synchronizes a reporting/supported-
    client preference to the server. It does not claim to stop Firebase's
    automatic install-level events or already-installed legacy binaries.
-4. Acquisition work starts with campaign links and automatic store/Firebase
-   attribution. No onboarding survey is added in this scope.
-5. Looker Studio is the reporting surface; it reads aggregate authorized views,
+4. Three bounded pre-auth login-funnel events are an explicit exception to the
+   authenticated product-event preference: started, completed, and failed
+   attempts carry only a pinned login-provider enum plus a bounded failure kind.
+   They carry no `user_key`, attempt identifier, OAuth identity, or payload,
+   remain release-only, follow the upstream two-month retention, and are
+   disclosed as installation-level operational analytics outside the product-
+   interaction toggle.
+5. `GoRouterRouteSource` is the authoritative screen source. Automatic Firebase
+   screen reporting is disabled, and the typed route listener maps each
+   `AppRouteDef` to a pinned `AnalyticsScreen`. The Firebase adapter mirrors that
+   same transition through `logScreenView` for correct native Firebase screen
+   reporting while the account-linked custom `product_screen_viewed` event
+   remains the canonical BigQuery fact.
+6. Voice-first adoption is part of the initial metric contract: successful
+   sends classify `input_mode=typed/voice_assisted`, and successful
+   transcription completion emits one content-free event.
+7. Looker Studio is the reporting surface; it reads aggregate authorized views,
    not raw event or per-user tables.
+8. Campaign attribution, notification open-to-action conversion, and expanded
+   dashboard pages are durable follow-up extensions, not part of the fixed
+   first implementation series. Deferral does not discard them after the
+   fundraising window.
 
 ## Metric Contract
 
@@ -59,7 +78,7 @@ silently compared with a mature one.
 | Bridge registered | First bridge registration (`ActivationState.bridgeSetupAt`) | Auth server |
 | Project available | First successful project inventory containing at least one project after instrumentation starts | App event |
 | Legacy session signal | First accepted `/sessions/generate-metadata` request (`ActivationState.firstSessionAt`) | Auth server |
-| Analytics-ready exposure | Earliest schema-v1 `analytics_schema_ready` or other accepted schema-v1 custom event, provided it occurs within 24 hours of account creation | App event |
+| Analytics-ready exposure | Earliest schema-v1 `analytics_schema_ready` or other accepted account-linked schema-v1 product event, provided it occurs within 24 hours of account creation | App event |
 | Full activation | Earliest successful `session_message_sent` or `session_created_with_message` | App event |
 
 `mobileSetupAt` is **not** “mobile setup”: it proves notification registration.
@@ -71,7 +90,7 @@ the legacy signal for full activation.
 Behavioral milestones cannot be backfilled before the new event release. Store
 two timestamps: `raw_export_start_at` when Firebase export begins and
 `behavioral_schema_v1_start_at` only after the production app version has
-successfully exported the new event schema. Restrict activation/retention
+successfully exported the new account-linked product-event schema. Restrict activation/retention
 cohorts to accounts created on or after the behavioral timestamp **and** with
 per-account analytics-ready exposure no later than 24 hours after creation.
 Calendar eligibility alone is insufficient because a newly created account can
@@ -102,12 +121,14 @@ honestly labeled setup trends.
 - First-message activation split by existing-session versus remotely created
   session.
 - Dedicated-worktree share among successful remotely created sessions.
+- Weekly users and successful-message share using voice-assisted input.
+- Pre-auth login starts, completions, failures/timeouts, and completion rate by
+  pinned provider; these are installation-level diagnostics, not account funnel
+  milestones.
+- Screen popularity and navigation sequences from the exhaustive GoRouter-to-
+  `AnalyticsScreen` mapping. Account-level reporting uses
+  `product_screen_viewed`; Firebase-native `screen_view` is diagnostic only.
 - Diff-review users, question/permission interventions, and aborts.
-- Notification open-to-meaningful-action conversion within 30 minutes for the
-  same user. This is intentionally an open-to-action metric, not a delivery or
-  click-through rate; there is no delivery denominator in this scope.
-- Campaign-attributed accounts, known-attribution coverage, and activation by
-  campaign. Unknown attribution remains `unknown`, never “organic”.
 - Onboarding support/install interactions already present in the event schema.
 
 ## Current Behavior
@@ -161,7 +182,8 @@ honestly labeled setup trends.
 - A surface-neutral typed analytics contract in `module_core`, implemented by
   Firebase in mobile and by a no-op adapter on unsupported products.
 - Authenticated custom-event key lifecycle, release-build custom-event sharing,
-  stable screen views, campaign attribution, and the outcome events below.
+  GoRouter-backed Firebase/custom screen views, bounded pre-auth login events,
+  voice-first adoption, and the outcome events below.
 - A daily privacy-safe auth export and aggregate external-account setup cohorts
   after internal/deletion suppression.
 - Versioned BigQuery DDL/transforms/tests and Looker Studio dashboards.
@@ -180,10 +202,12 @@ honestly labeled setup trends.
   attribution SDKs.
 - Backend/harness adoption. Plugin identity remains behind the plugin boundary
   and is not classified into a client analytics dimension.
-- Voice interaction analytics. The current orchestration lives in the mobile
-  shell; instrument it only after a separately approved migration behind core
-  platform/API/repository/service boundaries. Auth-server aggregate
-  transcription usage is not added merely as a substitute.
+- Campaign attribution and campaign link persistence in the first release.
+- Notification open-to-action conversion in the first release. Existing
+  notification behavior remains unchanged.
+- More than the initial three Looker pages. Additional feature, acquisition,
+  product-quality, and data-quality pages may be added after the core pipeline
+  is stable; the underlying bounded feature/data-quality facts remain durable.
 - A “How did you hear about us?” prompt.
 - Predictive scoring, experimentation infrastructure, revenue analytics, or a
   general-purpose event bus.
@@ -193,15 +217,15 @@ honestly labeled setup trends.
 
 | Repository/workspace | Production paths and layer | Change | Downstream impact |
 | --- | --- | --- | --- |
-| `sesori_auth_server` | `src/types/product-analytics.ts` (domain enum), `src/models/{documents,api,product-analytics-export}.ts` (persisted/API/export contracts), `src/repositories/{user-repo,activation-state-repo,product-analytics-export-repo,product-analytics-control-repo}.ts` (data access/aggregation), `src/services/{product-analytics-preference-service,product-analytics-export-service}.ts` (business logic), `src/clients/bigquery-product-analytics-client.ts` and `src/api/product-analytics-export-api.ts` (external sink layers), `src/routes/product-analytics.ts` (HTTP boundary), `src/scripts/{backfill-product-analytics-preference,suppress-product-analytics-export,export-product-analytics,product-analytics-export-config}.ts` (separate command composition) | Persist preference/privacy-suppression state behind a dedicated service, expose GET/PUT endpoints, and export privacy-safe data after source/internal exclusion. | Existing auth responses and clients remain unchanged. The web process constructs only the preference service; it never constructs export/BigQuery classes. |
+| `sesori_auth_server` | `src/types/product-analytics.ts` (domain enum), `src/models/{documents,api,product-analytics-export}.ts` (persisted/API/export/deletion-target contracts), `src/repositories/{user-repo,activation-state-repo,product-analytics-export-repo,product-analytics-control-repo,product-analytics-deletion-target-repo}.ts`, `src/services/{product-analytics-preference-service,product-analytics-export-service,product-analytics-deletion-service}.ts`, `src/clients/bigquery-product-analytics-client.ts` and `src/api/product-analytics-export-api.ts`, `src/routes/product-analytics.ts`, `src/scripts/{backfill-product-analytics-preference,suppress-product-analytics-export,export-product-analytics,product-analytics-export-config}.ts` | Persist revisioned preference/privacy-suppression state behind dedicated services, expose GET/PUT endpoints, export privacy-safe data after source/internal exclusion, and hand tombstoned deletion targets to restricted auth-private storage. | Existing auth profile/token responses remain unchanged. The web process constructs only the preference service; export/deletion BigQuery classes exist only in isolated command composition. |
 | `shared/sesori_shared` | No production change | Keep `AuthUser` authentication-only; do not add a product preference to the shared auth/persisted contract. | No bridge/shared migration or compatibility default is introduced. |
-| `client/module_auth` | No production change | Continue to own tokens, OAuth, auth state, and `AuthenticatedHttpApiClient` only. | `module_core` observes `AuthSession` read-only and injects `AuthenticatedHttpApiClient` into its own Layer-1 preference API. |
-| `client/module_core` | `lib/src/models/product_analytics/`, `lib/src/platform/analytics_client.dart`, `lib/src/api/{analytics_api,product_analytics_preference_api}.dart`, `lib/src/storage/{product_analytics_preference_storage,campaign_attribution_storage}.dart`, `lib/src/repositories/{product_analytics,product_analytics_preference,campaign_attribution}_repository.dart`, `lib/src/services/{product_analytics,campaign_attribution}_service.dart`, `lib/src/listeners/{analytics_route,campaign_attribution,notification_open_analytics}_listener.dart`, `lib/src/cubits/product_analytics_preference/`, existing project/session/diff cubits and notification dispatcher, DI/barrel/generated files | Expose architectural layers explicitly; own preference HTTP/persistence, pseudonymous hashing, route/campaign/notification lifecycle, Settings state, and authoritative business-outcome emission. | Mobile supplies only the Firebase platform client. Desktop supplies a no-op client. Cubit constructor call sites/tests update in lockstep. |
-| `client/app` | `lib/core/platform/{firebase_analytics_client,firebase_analytics_identity_migration}.dart`, `lib/core/di/`, `lib/features/{settings,project_list,new_session,session_detail,session_diffs}/`, `lib/l10n/`, `lib/main.dart`, iOS/Android analytics defaults | Clear legacy global identity at earliest post-Firebase bootstrap, implement the thin custom-event adapter, start core services/listeners, render preference UI, and inject services into core consumers. | Existing app event sources move to core; `AnalyticsUserIdTracker` and obsolete app `DeepLinkService` are removed. The only global Firebase `user_id` call sets null for migration; no account key or runtime collection override is added. No new voice logic is added. |
+| `client/module_auth` | Existing HTTP client interfaces/implementations/tests | Add named-parameter JSON `PUT` support to `SafeApiClient`, `HttpApiClient`, and `AuthenticatedHttpApiClient`; keep tokens, OAuth, and auth state otherwise unchanged. | `module_core` injects the authenticated client into its Layer-1 preference API; no wrong-verb workaround or compatibility path is introduced. |
+| `client/module_core` | `lib/src/foundation/{models/product_analytics/,platform/analytics_client.dart}`, `lib/src/api/{analytics_api,product_analytics_preference_api.dart,storage/product_analytics_preference_storage.dart}`, `lib/src/repositories/{models/,product_analytics,installation_analytics,product_analytics_preference}_repository.dart`, `lib/src/services/{models/,product_analytics,installation_analytics}_service.dart`, `lib/src/routing/{analytics_route,session_activity_analytics}_listener.dart`, `lib/src/cubits/{product_analytics_preference,settings}/`, existing login/project/session/diff cubits, DI/barrel/generated files | Mirror the declared layers explicitly; own preference HTTP/persistence, pseudonymous hashing, bounded account-less login telemetry, route/visibility lifecycle, pre-logout orchestration, Settings state, and authoritative business-outcome emission. | Mobile supplies the Firebase client plus immutable runtime capability. Desktop supplies no-op/disabled Foundation adapters. Cubit constructor call sites/tests update in lockstep. |
+| `client/app` | `lib/core/platform/{firebase_analytics_client,firebase_analytics_identity_migration}.dart`, `lib/core/di/`, `lib/features/{settings,project_list,new_session,session_detail,session_diffs}/`, composer widgets/callbacks, `lib/l10n/`, `lib/main.dart`, iOS/macOS/Android analytics defaults | Clear legacy global identity at earliest post-Firebase bootstrap, pass its immutable capability into phase-1 DI, implement the thin Firebase adapter, disable automatic screen reporting, mirror GoRouter-derived screens through `logScreenView`, report successful content-free transcription completion, start core services/listeners, render preference UI, and inject services into core consumers. | Existing app event sources move to core; `AnalyticsUserIdTracker` is removed. The only global Firebase `user_id` call sets null for migration; no account key or runtime collection override is added. Existing `DeepLinkService` remains unchanged because campaign work is deferred. |
 | `client/desktop` | `lib/core/platform/no_op_analytics_client.dart`, DI generated file | Satisfy the shared core platform capability without collecting desktop analytics. | No desktop product events or UI are added. Analyze/test verifies core DI remains resolvable. |
 | `client/module_desktop_core` | No planned production edit; tests/build are downstream validation | Continue unchanged. | Shared core DI/downstream validation only. |
 | `bridge/app` | No planned production or contract edit | Remain outside product analytics. | No additional bridge validation beyond normal CI is caused by this plan. |
-| Apps monorepo tooling | `tool/product_analytics/` (deployment tooling/SQL/runbook) | Version BigQuery DDL, transforms, assertions, and dashboard contract. | Cloud deployment supplies property/project/location; no credentials or live exclusion values enter Git. |
+| Apps monorepo tooling | `tool/product_analytics/` (deployment tooling/SQL/runbook plus `privacy_deletion/` layered command flow) | Version BigQuery DDL, transforms, assertions, dashboard contract, deletion exclusion/upstream submission, and recurring keyed-upload sweep. | Cloud deployment supplies property/project/location and ADC identities; no credentials or live identifiers enter Git. |
 
 ## Privacy And Identity Contract
 
@@ -227,11 +251,21 @@ Do not use Firebase's persisted `setAnalyticsCollectionEnabled` override or
 global `setUserId` as the preference mechanism. Firebase automatic install-level
 events remain governed by the privacy-minimized property/native configuration
 and are disclosed separately; they never define product activity. Every
-Sesori-defined custom event instead carries the pseudonymous `user_key` as a
+authenticated Sesori product event carries the pseudonymous `user_key` as a
 typed parameter, and `ProductAnalyticsService` refuses to create those events
 unless the local/server gate is active. This avoids a cold-start race with a
 persisted Firebase enable override and prevents the new design from assigning
 an account key to automatic events.
+
+The only custom-event exception is the pre-auth login funnel. Its three closed
+event variants carry no `user_key` and no identifier other than Firebase's
+vendor-managed installation identifier, are emitted only by
+`InstallationAnalyticsService` in release builds, and are excluded from
+account-level curated facts. They are not controlled by the authenticated
+product-interaction preference because no account preference is available yet.
+Privacy/Settings copy must disclose this narrowly bounded operational telemetry;
+new pre-auth exceptions require a separate product/privacy decision and may not
+be added by extending a generic map API.
 
 The one compatibility exception is an earliest-bootstrap `setUserId(null)` to
 clear the hash persisted by current releases. It runs immediately after Firebase
@@ -241,10 +275,13 @@ rows as legacy raw data rather than promising an impossible zero-width window.
 If clear fails, classify/disclose that whole process as potentially legacy-
 keyed; disabling only custom events is not described as stopping automatic data.
 
-The core service combines installation-local intent with the server preference:
+The product analytics service combines installation-local intent with the server
+preference:
 
 - Unknown, unauthenticated, debug/profile, locally disabled, or server-disabled
-  state suppresses all Sesori-defined custom events.
+  state suppresses all authenticated Sesori product events. The separate,
+  account-less login variants remain governed by their release-only installation
+  service contract above.
 - After post-splash readiness, an authenticated installation fetches the server
   preference. Only returned enabled in a release build activates custom event
   sharing; a local cached enabled value alone never activates a new run.
@@ -253,7 +290,7 @@ The core service combines installation-local intent with the server preference:
   work, and only then PUTs disabled. A crash after that write leaves recoverable
   local intent; no SDK disable/reset call is required for custom-event
   enforcement.
-- A local storage read error keeps custom events inactive rather than treating
+- A local storage read error keeps account-linked product events inactive rather than treating
   missing state as enabled. If the write-ahead write fails, the process remains
   inactive and still attempts the authenticated server disable, but the UI does
   not report saved success unless either durable local intent or server disabled
@@ -269,27 +306,30 @@ The core service combines installation-local intent with the server preference:
   one authenticated sync before credentials are cleared; if it fails, it
   preserves the record and requires reauthentication to finish server sync.
   Every preference operation has a 10-second deadline, so it cannot hold logout
-  or the foreground reconciliation slot indefinitely.
+  or the reconciliation slot indefinitely.
 
 The setting is not advertised as a universal Firebase or legacy-client kill
-switch. It immediately controls Sesori-defined custom events on this
+switch. It immediately controls authenticated Sesori product events on this
 installation; the server preference suppresses reporting and is honored by
-analytics-capable releases. Already-installed older binaries can continue their
-previous Firebase behavior until upgraded/retired, so account-wide wording is
-forbidden unless a future minimum-version enforcement mechanism makes it true.
-Supported clients re-read the preference on every foreground transition and at
-most every 15 minutes while continuously foregrounded. Thus a remote change is
-applied by the next successful check (within 15 minutes when online), not
-instantaneously; offline and legacy limitations must remain explicit in copy.
+analytics-capable releases. It does not control the disclosed, account-less
+login-funnel events or Firebase automatic install-level events. Already-
+installed older binaries can continue their previous Firebase behavior until
+upgraded/retired, so account-wide wording is forbidden unless a future minimum-
+version enforcement mechanism makes it true.
+Supported clients read once after post-splash readiness for each authenticated
+generation and on explicit Settings refresh/actions. Thus a remote change is
+applied on next process/auth establishment or an explicit online Settings
+refresh, not instantaneously; offline and legacy limitations must remain
+explicit in copy.
 
 Model preference and synchronization status as separate sealed states; do not
 flatten “disabled”, “unknown”, “pending sync”, and “failed” into nullable flags.
 The Settings copy must say “Share pseudonymous product usage from this device,”
 list the prohibited content categories, identify the pending server-sync state,
-and explain that Firebase automatic install-level events plus account/bridge
-records required to operate Sesori are not controlled by this switch. Product/
-privacy counsel must approve the final text and store disclosures before
-release.
+and explain that Firebase automatic install-level events, the bounded pre-auth
+login funnel, plus account/bridge records required to operate Sesori are not
+controlled by this switch. Product/privacy counsel must approve the final text
+and store disclosures before release.
 
 ### Pseudonymous join key
 
@@ -310,10 +350,8 @@ pseudonymous personal data. Documentation and access controls must call it that.
 - Event schema version.
 - Stable screen enum.
 - Platform and app version/build supplied by Firebase.
-- Bounded onboarding, notification, interaction, and failure enums.
-- Strict opaque campaign code (lowercase ASCII letters/digits plus `_`/`-`,
-  maximum 32 characters) mapped to human labels only in a restricted BigQuery
-  registry.
+- Bounded onboarding, interaction, voice-input, login-provider, login-failure,
+  and product-failure enums.
 
 ### Prohibited dimensions
 
@@ -322,6 +360,10 @@ text, reasoning, filenames/paths, repository/project/session/branch/worktree
 names, provider/model/agent/tool/command names, raw error text/status payloads,
 OAuth identity, email, IP/geography, or raw/hashed project/session/bridge/device
 IDs. The event union should make these fields impossible to pass.
+
+Here “provider” in the prohibited list means a coding/model provider. The
+separate `AnalyticsLoginProvider` enum is allowed and pins only
+`github/google/apple/email`; it never carries provider user identity.
 
 This prohibition governs Sesori-defined event parameters and every curated or
 reporting model. It does not falsely claim that the vendor-managed raw GA4
@@ -340,62 +382,80 @@ mixed `src/analytics/` bucket. The concrete dependency direction is:
 
 | Class/file | Layer and constructor collaborators | Responsibility and lifecycle |
 | --- | --- | --- |
-| `AnalyticsEvent`, bounded enums, `AnalyticsScreen`, `AnalyticsDeliveryResult`, `ProductAnalyticsPreference`, `ProductAnalyticsState`, `CampaignCode`, and persisted record variants under `module_core/lib/src/models/product_analytics/` | Domain models; no SDK/Flutter dependencies | Closed event/screen/preference/state values. `AnalyticsScreen` is independent of routing; `AnalyticsRouteListener` performs the exhaustive `AppRouteDef -> AnalyticsScreen` mapping. Delivery is `acceptedBySdk`, `deferredUntilPreference`, or `failed`, never an untruthful “reported” boolean. Campaign completion is account-scoped; the in-memory pending activation variant carries only one typed message-success event and its auth generation. |
-| `AnalyticsClient` in `module_core/lib/src/platform/analytics_client.dart` | Foundation external-sink capability | Typed `logEvent({required AnalyticsEvent event, required String userKey})`. The key is already pseudonymous and is serialized as the custom `user_key` event parameter, never global SDK identity. Methods throw SDK failures; they accept no arbitrary map/name or raw account ID. |
-| `AnalyticsApi` in `module_core/lib/src/api/analytics_api.dart` | Layer 1; constructor requires `AnalyticsClient` | Thin API over the external client. It is the only core class that invokes the platform sink. |
-| `ProductAnalyticsPreferenceApi` in `module_core/lib/src/api/product_analytics_preference_api.dart` | Layer 1; constructor requires `AuthenticatedHttpApiClient` | Calls authenticated GET/PUT `/product-analytics/preference` under a fixed 10-second operation deadline, serializes the closed enum, parses external strings at the boundary, and returns explicit success/timeout/failure. It does not mutate auth state; late transport completion is detached and cannot complete the bounded operation twice. |
-| `ProductAnalyticsPreferenceStorage` and `CampaignAttributionStorage` in `module_core/lib/src/storage/` | Layer 1 storage; each constructor requires `SecureStorage` | Read/write/delete only their closed persisted records. They do not reconcile accounts, call APIs, hash IDs, or emit analytics. |
+| `ProductAnalyticsEvent`, `InstallationAnalyticsEvent`, `AnalyticsScreen`, `AnalyticsInputMode`, pinned event enums, and immutable `AnalyticsRuntimeCapability` under `module_core/lib/src/foundation/models/product_analytics/` | Foundation contracts; no SDK/Flutter dependencies | Separate closed account-linked and account-less sink contracts. `AnalyticsScreen` is independent of routing; `AnalyticsRouteListener` performs the exhaustive `AppRouteDef -> AnalyticsScreen` mapping. `AnalyticsLoginProvider` is independently pinned and exhaustively mapped from the sealed auth provider. Runtime capability is `enabled` or a closed disabled reason and is produced before phase-1 DI. |
+| `AnalyticsClient` in `module_core/lib/src/foundation/platform/analytics_client.dart` | Foundation external-sink capability | Typed `logProductEvent({required ProductAnalyticsEvent event, required String userKey})` and `logInstallationEvent({required InstallationAnalyticsEvent event})`. Methods throw SDK failures and accept no arbitrary map/name or raw account ID. Only the product method can receive the already-pseudonymous key. |
+| `AnalyticsApi` in `module_core/lib/src/api/analytics_api.dart` | Layer 1; constructor requires `AnalyticsClient` | Thin typed API over both external-client operations. It is the only core class that invokes the platform sink. |
+| `ProductAnalyticsPreferenceApi` in `module_core/lib/src/api/product_analytics_preference_api.dart` | Layer 1; constructor requires `AuthenticatedHttpApiClient` | Calls authenticated GET/PUT `/product-analytics/preference` under a fixed 10-second operation deadline. GET parses `{preference, revision}`; PUT requires `{preference, expectedRevision, operationId}` and parses success/conflict. It serializes closed values, parses external strings at the boundary, and returns explicit success/conflict/timeout/failure. A timed-out transport may finish, but server compare-and-set prevents it from overwriting a newer committed revision. |
+| `ProductAnalyticsPreferenceStorage` in `module_core/lib/src/api/storage/` | Layer 1 data source; constructor requires `SecureStorage` | Reads/writes/deletes only closed preference synchronization records. It does not reconcile accounts, call APIs, hash IDs, or emit analytics. |
+| `AnalyticsDeliveryResult`, `ProductAnalyticsPreference`, versioned synchronized/pending preference records, and explicit repository results under `module_core/lib/src/repositories/models/` | Layer-2 contracts | Delivery is `acceptedBySdk`, `deferredUntilPreference`, or `failed`, never an untruthful “reported” boolean. Preference records carry the last server revision required for ordered compare-and-set updates. |
 | `ProductAnalyticsRepository` in `module_core/lib/src/repositories/product_analytics_repository.dart` | Layer 2; constructor requires `AnalyticsApi` | Converts raw authenticated user ID to lowercase SHA-256, passes only the pseudonymous key downward, and maps API exceptions to explicit `AnalyticsDeliveryResult` without redundant logging. It adds `schema_version=1` through the typed event serialization contract. |
-| `ProductAnalyticsPreferenceRepository` in `module_core/lib/src/repositories/product_analytics_preference_repository.dart` | Layer 2; requires `ProductAnalyticsPreferenceApi` and `ProductAnalyticsPreferenceStorage` | Fetch/update server preference, scope local records to one account, and persist only `synced(userId, preference)`, `pendingDisable(userId)`, or `pendingEnable(userId)`. `pendingEnable` is an inactive write-ahead/finalization state, never permission to emit. |
-| `CampaignAttributionRepository` in `module_core/lib/src/repositories/campaign_attribution_repository.dart` | Layer 2; requires `CampaignAttributionStorage` | Enforces a 24-hour TTL and persists pre-auth `pendingUnbound(code, capturedAt)`, post-attempt `pendingRetry(userId, code, capturedAt)`, or `acceptedBySdk(userId, code, completedAt)`. The first authenticated attempt binds any failure to that user; another account can never consume it. Any later valid pre-auth capture after logout replaces completed/failed state before the next account is known. Absence genuinely means no campaign. It never stores a full URI/UTM text. |
-| `ProductAnalyticsService` in `module_core/lib/src/services/product_analytics_service.dart` | Layer 3, `@lazySingleton`; requires `AuthSession` (read-only), existing `LifecycleSource`, `ProductAnalyticsRepository`, and `ProductAnalyticsPreferenceRepository` | Sole owner of preference/custom-event lifecycle and Consumer `logEvent`. Exposes a replaying state stream plus `start`, `markPostSplashReady`, `setPreference`, `retryPendingDisable`, and `dispose`. It performs no network work until readiness, revalidates while foregrounded, serializes reconciliation per auth generation, and sends no custom event unless active. While preference is unknown, it may retain exactly one bounded activation-candidate event for the current generation; all other inactive events remain unbuffered. |
-| `CampaignAttributionService` in `module_core/lib/src/services/campaign_attribution_service.dart` | Layer 3, `@lazySingleton`; requires read-only `AuthSession`, `CampaignAttributionRepository`, and `ProductAnalyticsService` | Holds at most one bounded URI classification while auth restoration is unknown. It persists pre-auth first touch only after restoration conclusively yields unauthenticated, discards it if authenticated, and attempts only when the bound/current account matches. SDK failure changes unbound pending to account-bound retry; accepted state is also account-scoped. |
-| `AnalyticsRouteListener` in `module_core/lib/src/listeners/analytics_route_listener.dart` | Consumer/listener, `@lazySingleton`; requires `RouteSource` and `ProductAnalyticsService` | Owns route subscription, maps `AppRouteDef` exhaustively to `AnalyticsScreen`, signals readiness on the first non-splash route, and reports stable screens only while active. It never passes a route model/path to Foundation. |
-| `CampaignAttributionListener` in `module_core/lib/src/listeners/campaign_attribution_listener.dart` | Consumer/listener, `@lazySingleton`; requires `DeepLinkSource` and `CampaignAttributionService` | Replaces the obsolete app `DeepLinkService`, owns the one URI subscription, validates only approved `sesori.com/link` campaign codes, and ignores all other/legacy callback URIs without logging complete values. |
-| `NotificationOpenAnalyticsListener` in `module_core/lib/src/listeners/notification_open_analytics_listener.dart` | Consumer/listener, `@lazySingleton`; requires the bounded notification-open source and `ProductAnalyticsService` | Buffers at most the one validated cold-start open until preference reconciliation, emits it only if the same account becomes active, and drops it on disable, logout/account switch, or process-lifetime timeout. No entity ID enters the buffer. |
+| `InstallationAnalyticsRepository` in `module_core/lib/src/repositories/installation_analytics_repository.dart` | Layer 2; constructor requires `AnalyticsApi` | Sends only `InstallationAnalyticsEvent`, adds the installation schema version, and maps SDK failures to explicit delivery results. It has no auth/user/preference dependency and cannot receive a `user_key`. |
+| `ProductAnalyticsPreferenceRepository` in `module_core/lib/src/repositories/product_analytics_preference_repository.dart` | Layer 2; requires `ProductAnalyticsPreferenceApi` and `ProductAnalyticsPreferenceStorage` | Fetch/update server preference, scope local records to one account, and persist only versioned `synced`, `pendingDisable`, or `pendingEnable` records. Every PUT uses the last observed revision plus stable operation ID. Conflict on disable triggers one bounded GET/retry against the new revision; conflict on enable remains inactive and returns explicit refresh-required state so an older enable cannot automatically override a newer disable. `pendingEnable` is never permission to emit. |
+| `ProductAnalyticsState` and its independent preference/synchronization variants under `module_core/lib/src/services/models/` | Layer-3 service state | Represents active/inactive/pending/failure truth without nullable coordination fields; it is not part of the Foundation sink contract. |
+| `ProductAnalyticsService` in `module_core/lib/src/services/product_analytics_service.dart` | Layer 3, `@lazySingleton`; requires immutable `AnalyticsRuntimeCapability`, read-only `AuthSession`, `ProductAnalyticsRepository`, and `ProductAnalyticsPreferenceRepository` | Sole owner of preference/custom-event lifecycle and Consumer `logEvent`. Exposes a replaying state stream plus `start`, `markPostSplashReady`, explicit `refreshPreference`, `setPreference`, `retryPendingDisable`, bounded `prepareForLogout`, and `dispose`. It performs one server read per post-readiness auth generation plus explicit Settings refresh/actions—no lifecycle timer/polling—and sends no product event unless active. While preference is unknown, it may retain exactly one bounded activation-candidate event for the current generation; all other inactive events remain unbuffered. |
+| `InstallationAnalyticsService` in `module_core/lib/src/services/installation_analytics_service.dart` | Layer 3, `@lazySingleton`; requires immutable `AnalyticsRuntimeCapability` and `InstallationAnalyticsRepository` | Accepts only typed login-attempt lifecycle methods, maps the sealed auth provider exhaustively to `AnalyticsLoginProvider`, classifies timeout versus bounded authentication/launch failure, and reports best-effort. It has no account/preference state, buffers nothing, and remains inactive in debug/profile/unsupported builds or when legacy-ID cleanup failed. |
+| `AnalyticsRouteListener` in `module_core/lib/src/routing/analytics_route_listener.dart` | Layer-4 routing listener, `@lazySingleton`; requires `RouteSource` and `ProductAnalyticsService` | Owns route subscription, maps `AppRouteDef` exhaustively to `AnalyticsScreen`, signals readiness on the first non-splash route, and reports stable screens only while active. It never passes a route model/path to Foundation. |
+| `SessionActivityAnalyticsListener` in `module_core/lib/src/routing/session_activity_analytics_listener.dart` | Layer-4 route-aware listener; constructed/owned by `SessionDetailScreen`, requires its `SessionDetailCubit`, `RouteSource`, `LifecycleSource`, and `ProductAnalyticsService` | Combines bounded loaded-state classification with actual `sessionDetail` route visibility and resumed lifecycle. It emits first empty once and non-empty at most once per UTC date only while the detail route is topmost; nested diffs/background SSE cannot create false monitoring activity. |
 | `ProductAnalyticsPreferenceCubit` in `module_core/lib/src/cubits/product_analytics_preference/` | Consumer; constructor requires `ProductAnalyticsService` | Subscribes to service state and exposes toggle/retry intents. Mobile Settings constructs it; it is not in DI. |
-| `FirebaseAnalyticsClient` in `app/lib/core/platform/firebase_analytics_client.dart` | Thin mobile Foundation adapter, `@LazySingleton(as: AnalyticsClient)`; requires `FirebaseAnalytics` | Serializes only typed custom events plus `schema_version` and `user_key`, and throws failures upward. It never applies global identity/collection overrides and contains no route/campaign/preference/hash business logic. Firebase-disabled environments use the existing no-op SDK object. |
-| `FirebaseAnalyticsIdentityMigration` in `app/lib/core/platform/firebase_analytics_identity_migration.dart` | Mobile-only pre-core bootstrap helper; requires `FirebaseAnalytics` | Immediately after Firebase initialization and before DI/listeners, awaits `setUserId(id: null)` to clear the hash persisted by prior releases. It does nothing else to consent/collection. Failure leaves the process custom-event adapter disabled and retries next launch; because automatic collection cannot then be safely reconfigured without another persisted override, the **entire failed process** is classified/disclosed as potentially legacy-keyed and remains covered by recurring legacy deletion. Keep this cleanup through minimum-supported-version adoption plus the 90-day raw window, then remove it explicitly. |
+| `FirebaseAnalyticsClient` in `app/lib/core/platform/firebase_analytics_client.dart` | Thin mobile Foundation adapter, `@LazySingleton(as: AnalyticsClient)`; requires `FirebaseAnalytics` and immutable `AnalyticsRuntimeCapability` | Rejects all operations unless capability is enabled, serializes only typed product/installation events plus their permitted shared fields, and throws canonical-event failures upward. For `product_screen_viewed`, after the canonical custom event is accepted it also best-effort calls `FirebaseAnalytics.logScreenView` with the same pinned screen name and stable `GoRouter` screen class; mirror failure is logged but does not rewrite canonical delivery. It never applies global identity/collection overrides and contains no route/preference/hash business logic. Firebase-disabled environments use the no-op client plus disabled capability. |
+| `FirebaseAnalyticsIdentityMigration` in `app/lib/core/platform/firebase_analytics_identity_migration.dart` | Mobile-only pre-phase-1 bootstrap helper; constructed directly with `FirebaseAnalytics.instance` after Firebase initialization | Awaits `setUserId(id: null)` and returns immutable `AnalyticsRuntimeCapability.enabled` or `.disabled(legacyIdentityClearFailed)`. `main` passes that value into phase-1 dependency configuration; the Firebase client and both services require the same instance. Failure deterministically disables all custom events and retries next launch; because automatic collection cannot then be safely reconfigured without another persisted override, the **entire failed process** is classified/disclosed as potentially legacy-keyed and remains covered by recurring legacy deletion. Keep this cleanup through minimum-supported-version adoption plus the 90-day raw window, then remove it explicitly. |
 | `NoOpAnalyticsClient` in `desktop/lib/core/platform/no_op_analytics_client.dart` | Desktop phase-1 Foundation adapter | Satisfies shared core DI and accepts operations without collection. No desktop listeners are started. |
 
 `AnalyticsScreen` pins snake-case wire values for login, projects, approved
 settings groupings, sessions, new session, session detail, and session diffs.
 `settingsHarnesses` and `settingsHarnessManagement` both map to generic
-`settings`; they never produce harness-specific wire values. Screen
-activity is the Sesori custom `product_screen_viewed` event rather than Firebase
-`screen_view`, so the custom-event gate and `user_key` always apply. The
-route listener's exhaustive switch also handles splash explicitly (readiness
-only, no report while custom sharing is inactive), so adding an `AppRouteDef`
-cannot silently omit its analytics mapping.
+`settings`; they never produce harness-specific wire values. Disable Firebase's
+automatic screen reporter in Android metadata and each Firebase-enabled Apple
+target so Navigator/Flutter internals cannot emit duplicate or incorrect names.
+Use `google_analytics_automatic_screen_reporting_enabled=false` in Android
+metadata and `FirebaseAutomaticScreenReportingEnabled=false` in each relevant
+Apple `Info.plist`; verify the runtime result in DebugView instead of assuming
+the source setting took effect.
+`GoRouterRouteSource.currentRouteStream` is the sole route source; the listener's
+exhaustive switch handles splash explicitly (readiness only), reports the
+account-linked custom `product_screen_viewed`, and causes the adapter to mirror
+the same pinned name through standard Firebase `logScreenView`. Curated facts
+use only `product_screen_viewed`; standard `screen_view` rows are diagnostic and
+carry no `user_key`. Adding an `AppRouteDef` therefore cannot silently omit or
+rename its analytics mapping.
 
 The client API may return SDK acceptance, not delivery to Google's backend.
-That distinction is sufficient for truthful local campaign state and must remain
-explicit in names/docs. `ProductAnalyticsService` itself owns the sole deferred
+That distinction remains explicit in names/docs. `ProductAnalyticsService`
+itself owns the sole deferred
 first-message variant; ordinary outcome consumers may ignore delivery results,
 but the result remains explicit and analytics cannot alter product success.
 
 ### DI and process lifecycle
 
-1. Mobile/desktop phase 1 registers `AnalyticsClient` (Firebase or no-op) plus
-   existing `SecureStorage`, `RouteSource`, and `DeepLinkSource` adapters.
-2. Auth phase 2 registers `AuthSession` and `AuthenticatedHttpApiClient` without
-   any analytics-specific method.
-3. Core phase 3 registers both APIs, both Storage classes, three repositories,
-   two services, and three listeners. Dependencies therefore resolve only
+1. Before mobile phase 1, `main` produces one immutable
+   `AnalyticsRuntimeCapability` from the awaited legacy-ID cleanup. Mobile phase
+   1 registers that exact instance plus `AnalyticsClient`, `SecureStorage`, and
+   `RouteSource`; desktop registers disabled capability plus no-op client.
+   Existing deep-link wiring remains unrelated because campaign attribution is
+   deferred.
+2. Auth phase 2 registers `AuthSession` and the internal HTTP clients, including
+   the new JSON PUT operation used by the core preference API.
+3. Core phase 3 registers both APIs, preference Storage, three repositories,
+   two services, and the route listener. Dependencies therefore resolve only
    downward through the declared layers.
 4. Mobile bootstrap awaits `ProductAnalyticsService.start()`, then starts
-   `CampaignAttributionService`, `AnalyticsRouteListener`,
-   `CampaignAttributionListener`, and `NotificationOpenAnalyticsListener` for
-   process lifetime. Their dispose methods are
-   owned by GetIt/test teardown. Starting them on the initial splash route
-   performs local reads/subscriptions only.
+   `AnalyticsRouteListener` for process lifetime. Disposal is owned by GetIt/test
+   teardown. Starting on the initial splash route performs only local reads and
+   subscription work.
 5. Cubits remain constructed in `BlocProvider` and receive
-   `getIt<ProductAnalyticsService>()` explicitly. Existing mobile-only
-   onboarding widgets call the same service rather than the Foundation client.
+   `getIt<ProductAnalyticsService>()` explicitly. `LoginCubit` additionally
+   receives `InstallationAnalyticsService`; desktop resolves the same service
+   through its no-op client. `SettingsCubit` requires
+   `ProductAnalyticsService` and owns pre-logout preparation. The session-detail
+   screen constructs/disposes its route-aware activity listener alongside its
+   cubit. Existing mobile-only onboarding/composer widgets call the appropriate
+   Layer-3 service rather than the Foundation client.
 
-Before mobile phase 1, `main()` initializes Firebase and awaits
-`FirebaseAnalyticsIdentityMigration`. No Sesori custom event source or core
-listener exists yet. A native automatic startup event can still occur between
+Before mobile phase 1, `main()` initializes Firebase, constructs
+`FirebaseAnalyticsIdentityMigration` directly with `FirebaseAnalytics.instance`,
+awaits it, and passes the returned immutable capability into
+`configureDependencies`. No Sesori custom event source or core listener exists
+yet. A native automatic startup event can still occur between
 vendor SDK initialization and this earliest supported reset; treat any such
 legacy-keyed row as restricted raw legacy data, exclude automatic events from
 behavioral models, cover it through the legacy `USER_ID` deletion path, and do
@@ -418,30 +478,32 @@ If login is still unauthenticated, it waits for the later auth emission. Thus
 `restoreLocalSession()` cannot trigger a splash-time network request.
 
 **Reconciliation:** A same-account local `pendingDisable` keeps custom sharing
-off and PUTs disabled after readiness. `pendingEnable` also stays inactive: GET
-disabled returns to synchronized disabled; GET enabled must first finalize
-synchronized enabled storage before event acceptance. Otherwise the repository
-GETs the server preference; returned disabled stays off, while returned enabled
-in a release build allows `ProductAnalyticsRepository` to hash the account ID
-for each typed event. Debug/profile/unsupported builds retain the desired
-preference but publish `ProductAnalyticsState.inactive(buildUnsupported)`.
+off and PUTs disabled after readiness using its last revision; conflict performs
+one bounded GET/retry. `pendingEnable` also stays inactive: GET disabled returns
+to synchronized disabled; GET enabled must first finalize synchronized enabled
+storage before event acceptance. Otherwise the repository GETs the server
+preference once for each post-readiness auth generation; returned disabled stays
+off, while returned enabled in a capable release build allows
+`ProductAnalyticsRepository` to hash the account ID for each typed event.
+Disabled runtime capability/debug/profile/unsupported builds retain the desired
+preference but publish the matching inactive reason.
 
 Every auth emission/account switch/logout increments a monotonically increasing
-service generation. Each GET, PUT, persistence operation, and scheduled refresh
-captures `(generation, userId)`; after every await and immediately before any
+service generation. Each GET, PUT, and persistence operation captures
+`(generation, userId)`; after every await and immediately before any
 state transition/event acceptance it verifies both still match current auth.
 Stale completions may finish only their account-scoped storage/server operation;
 they cannot activate another generation. Reconciliations are non-overlapping
-within one generation. After initial readiness the service refreshes on each
-`LifecycleState.resumed` transition and schedules one 15-minute recheck at a
-time while continuously resumed. A returned disabled value synchronously marks
-the current generation inactive before any follow-up persistence await. Network
+within one generation. There is no foreground polling or timer. A later server
+change is observed on the next auth generation/process start or an explicit
+Settings refresh/action. A returned disabled value synchronously marks the
+current generation inactive before any follow-up persistence await. Network
 failure preserves the honest prior local state and last-successful-check time;
-the UI makes the conditional online propagation bound explicit. Every preference
+the UI makes this explicit propagation contract visible. Every preference
 GET/PUT has the API's 10-second operation deadline. Timeout releases the sole
-reconciliation slot and advances no state; generation checks ignore any detached
-late completion. Disable intent remains durable, so neither logout nor future
-15-minute checks can be held indefinitely by one request.
+reconciliation slot and advances no state; a stable operation ID plus server
+revision compare-and-set makes detached late mutation completion idempotent and
+unable to overwrite a newer revision.
 
 **Schema exposure and first-message deferral:** On each process's first active
 transition, the service attempts `analytics_schema_ready` before later buffered
@@ -460,9 +522,9 @@ The service immediately publishes inactive, then first durably persists
 repository PUT. Success stores synchronized disabled; network failure remains
 pending and exposes the truthful local-disabled/server-sync-pending state. A
 storage-write failure keeps in-memory suppression, attempts server disable, and
-surfaces unsaved failure unless the server confirms disabled. Retry occurs only
-from Settings or a later post-splash lifecycle, never from a timer or splash
-auth emission.
+  surfaces unsaved failure unless the server confirms disabled. Retry occurs only
+  from explicit Settings action or the next post-readiness auth generation,
+  never from a timer or lifecycle polling.
 
 **Enable:** Custom sharing remains off. The first awaited operation writes
 `pendingEnable(userId)`; if that write fails, no server PUT occurs. The service
@@ -476,64 +538,68 @@ enabled and successfully finalizes local storage. The UI always says pending,
 not failed, until one of those outcomes; no later activation contradicts the
 displayed result.
 
-**Logout/account switch:** Before explicit logout clears credentials, the auth
-consumer asks the service to attempt one pending disable sync. Regardless of
-success it immediately suppresses custom events. Failure must not block logout:
+**Logout/account switch:** `SettingsCubit.logout()` first awaits
+`ProductAnalyticsService.prepareForLogout()`, which immediately suppresses the
+current generation and makes one bounded pending-disable sync attempt while the
+authenticated client still has credentials. It then performs existing
+notification unregistration and finally calls
+`AuthSession.logoutCurrentDevice()`. The analytics method is best-effort and
+never throws into or blocks the logout flow beyond its operation deadline. On failure,
 the encrypted pending record remains scoped by raw ID and is retried after that
 account reauthenticates; it never applies to another account. Unexpected token
 loss preserves the same record. The attempt is bounded by the 10-second API
 deadline, after which logout clears credentials and continues. No path claims or
 requests a Firebase-wide data reset.
 
-**Screen flow:** The route listener retains the latest `AnalyticsScreen` while
-inactive. Inactive-to-active emits `product_screen_viewed` once; later changed
-screen enums emit once. Foundation sees neither `AppRouteDef` nor a concrete URI.
+**Screen flow:** `GoRouterRouteSource` resolves the actual router configuration
+to `AppRouteDef`; no Navigator runtime-type or URL with entity IDs is used. The
+route listener retains the latest `AnalyticsScreen` while inactive. Inactive-to-
+active emits `product_screen_viewed` once; later changed screen enums emit once.
+The Firebase adapter also mirrors each accepted custom screen event through
+`logScreenView` using the same pinned name. Automatic Firebase screen reporting
+is disabled, so DebugView/GA4 screen reports identify the real GoRouter screen
+without duplicate framework-generated names. Foundation sees neither
+`AppRouteDef` nor a concrete URI.
 
-**Campaign flow:** During splash/session restoration, authenticated state is
-`unknown`, not unauthenticated. The listener may hold one validated bounded code
-in memory, but stores nothing until restoration resolves: authenticated drops
-it; conclusively unauthenticated stores `pendingUnbound(code, capturedAt)`.
-Authenticated/post-signup opens are ignored. On active state it attempts
-`campaign_attributed`. `acceptedBySdk` is persisted only from the typed accepted
-result as `acceptedBySdk(userId, code, completedAt)` and deduplicates only that
-account. Any later valid pre-auth link after logout replaces prior completion
-with pending before the next account is known; if account B then signs up, A's
-completion cannot consume B's first touch. If A logs back in instead, the
-warehouse age/earliest rules make the extra attempt harmless. The first failed
-SDK attempt converts unbound state to `pendingRetry(userId, ...)`; only that same
-current account may retry, and account switch discards it. BigQuery accepts
-attribution only when the account is at most 24 hours old at event time and
-selects the earliest eligible event. Existing
-accounts opening campaign links before login therefore remain unattributed.
+**Pre-auth login flow:** `LoginCubit` reports a started event only after a valid
+provider intent is accepted, then exactly one completed or failed terminal event
+for that attempt. OAuth polling timeout maps to bounded `timeout`; launch,
+authentication, and unknown failures remain separate closed values only where
+the current state distinguishes them. No exception text, OAuth user, account
+key, or random attempt ID is emitted. Installation events are not buffered or
+joined to later accounts; BigQuery reports aggregate provider completion rates
+and excludes them from account-level funnel/retention tables.
 
-**Cold notification flow:** The notification dispatcher first performs its
-normal validated navigation dispatch and publishes only bounded analytics
-metadata. The analytics listener buffers at most that one cold-start open while
-preference is unknown. It emits after same-account active reconciliation; it
-drops the buffer on disabled, logout/account switch, or if reconciliation does
-not complete during that process. Warm opens while active emit immediately;
-inactive warm opens are not retained.
+**Voice flow:** A successful non-empty transcription sets the composer input
+classification to `voice_assisted` and emits one content-free
+`voice_transcription_completed` through `ProductAnalyticsService`. The flag
+remains voice-assisted through subsequent manual edits, resets when the composer
+is cleared/reset, and is captured with the submission. Existing-session queued
+items retain only the enum alongside their existing content/command; successful
+send is reported later with that enum. New-session creation threads the same
+enum into its successful outcome. No transcript, duration, audio metadata, or
+text length is emitted.
 
 ### Outcome event catalog
 
-Existing wire names remain unchanged. Add only the following initial events:
+Existing wire names remain unchanged. Add only the following initial account-
+linked product events:
 
 | Event | Emit only when | Bounded parameters | Reporting use |
 | --- | --- | --- | --- |
 | `analytics_schema_ready` | The process first becomes active for an authenticated account under schema v1 | none beyond shared schema/key | Per-account instrumentation-capable exposure; never activity |
 | `project_inventory_loaded` | The first successful empty inventory and the first successful non-empty inventory in a cubit lifetime | `inventory_state=empty/non_empty` | First project available from earliest non-empty; empty is onboarding friction |
 | `session_activity_viewed` | The first successful empty snapshot in a cubit lifetime, and at most one successful non-empty snapshot per UTC date while that session detail is visible/foregrounded | `activity_state=empty/non_empty` | Earliest non-empty is the monitoring milestone; dated non-empty events support WAU/retention without SSE inflation |
-| `session_message_sent` | Existing-session send returns success, including a queued send that later succeeds | `submission_kind=text/command` | Full activation, control activity |
-| `session_created_with_message` | `createSessionWithMessage` returns success | `submission_kind`, `workspace_kind=project/dedicated_worktree` | Full activation, remote creation, worktrees |
+| `session_message_sent` | Existing-session send returns success, including a queued send that later succeeds | `submission_kind=text/command`, `input_mode=typed/voice_assisted` | Full activation, control activity, voice-assisted share |
+| `session_created_with_message` | `createSessionWithMessage` returns success | `submission_kind`, `input_mode`, `workspace_kind=project/dedicated_worktree` | Full activation, remote creation, worktrees, voice-assisted share |
 | `session_creation_failed` | That creation returns an explicit failure | `failure_reason` from bounded `RemoteFailureReason`, `workspace_kind` | Creation friction; never activation |
+| `voice_transcription_completed` | A successful non-empty transcription is applied to a composer | none | Voice feature adoption; never contains transcript/audio metadata |
 | `session_question_answered` | Question reply returns success | none | Remote interventions |
 | `session_question_rejected` | Question rejection returns success | none | Remote interventions |
 | `session_permission_answered` | Permission reply returns success | `decision=once/always/reject` | Remote interventions |
 | `session_abort_succeeded` | Root and active-child abort requests all return success | none | Remote interventions |
 | `session_diff_viewed` | The first successful empty diff and the first successful non-empty diff in a cubit lifetime | `change_state=empty/non_empty` | Diff adoption from earliest non-empty; empty is diagnostic only |
-| `notification_opened` | A valid notification is dispatched after authentication | `source=push/local`, `launch_context=cold/warm`, bounded `category`, bounded `event_type` | Notification engagement |
-| `campaign_attributed` | A pre-auth first-touch code captured in the prior 24 hours receives an SDK-accepted attempt for an authenticated custom-sharing-enabled install | `campaign_code` only | Acquisition coverage and cohorts; warehouse also requires account age <= 24 hours and earliest eligible event wins |
-| `product_screen_viewed` | `RouteSource` emits a changed non-null `AppRouteDef` while custom sharing is active | stable `screen` enum only | Navigation/friction, never meaningful activity |
+| `product_screen_viewed` | `RouteSource` emits a changed non-null `AppRouteDef` while custom sharing is active | stable `screen` enum only | Canonical account-level navigation/friction; adapter mirrors Firebase-native screen reporting, never meaningful activity |
 
 For `session_activity_viewed`, `non_empty` means there is at least one message,
 pending question/permission, or an active/retrying status.
@@ -541,29 +607,42 @@ pending question/permission, or an active/retrying status.
 The send events fire after repository success, never on a tap or queue insert.
 The direct-send and queue-drain paths must call the same helper so retries do not
 double count. New-session success emits one `session_created_with_message`, not
-an additional `session_message_sent`.
+an additional `session_message_sent`. A command-only submission always uses
+`input_mode=typed`; `voice_assisted` means a successful transcript contributed
+to the submitted composer value, not that the final text was unedited.
+
+The separate account-less installation event catalog contains exactly:
+
+| Event | Emit only when | Bounded parameters | Reporting use |
+| --- | --- | --- | --- |
+| `login_attempt_started` | A valid GitHub/Google/Apple/email login flow begins | `provider` from `AnalyticsLoginProvider` | Provider demand and attempt denominator |
+| `login_attempt_completed` | That flow reaches `LoginSuccess` | `provider` | Provider completion count/rate |
+| `login_attempt_failed` | That flow reaches failure or timeout | `provider`, `failure_kind=authentication/launch/timeout/unknown` | Bounded pre-auth friction |
+
+These three events carry no `user_key`, attempt ID, or auth payload and are never
+used as account creation or activation evidence.
 
 ### Authoritative emission seams
 
 - `ProductAnalyticsService`: schema-ready exposure on first active transition.
+- `LoginCubit`: account-less started/completed/failed outcomes, including the
+  distinct OAuth timeout terminal state, through `InstallationAnalyticsService`.
 - `ProjectListCubit`: first successful empty and first successful non-empty
   inventory states.
-- `SessionDetailCubit._loadMessages` plus its existing lifecycle handling: first
-  empty diagnostic and one visible/foreground non-empty activity per UTC date.
+- `SessionActivityAnalyticsListener` combining `SessionDetailCubit` state,
+  `RouteSource`, and `LifecycleSource`: first empty diagnostic and one actually
+  visible/foreground non-empty activity per UTC date.
 - `SessionDetailCubit.sendMessage` and `_drainQueuedMessages`: accepted
-  existing-session messages.
+  existing-session messages with the captured input-mode enum.
 - `NewSessionCubit.createSession`: accepted created session/message and bounded
-  creation failure.
+- Mobile composer transcription success call sites: content-free completion and
+  voice-assisted input classification through the Layer-3 service.
 - `SessionDetailCubit.replyToQuestion`, `rejectQuestion`,
   `replyToPermission`, and `abort`: successful control outcomes.
 - `DiffCubit._fetchAndEmit`: first successful empty and first successful
   non-empty diff states.
-- `NotificationOpenDispatcher`: valid push/local cold/warm dispatch. Extend the
-  internal open request to preserve existing bounded notification category and
-  event type, but never an entity identifier in analytics.
-- `GoRouterRouteSource`: stable screen names.
-- `CampaignAttributionListener`: replace `DeepLinkService` as the sole URI
-  listener, parse only strict campaign links, and never log complete URIs.
+- `AnalyticsRouteListener` over `GoRouterRouteSource`: exhaustive stable screen
+  names for both the canonical custom event and Firebase-native mirror.
 
 Every changed cubit/service receives `ProductAnalyticsService` through required
 constructor injection. The service reaches the platform sink only through
@@ -577,40 +656,32 @@ merely to avoid updating tests.
 | Owner change | Exact flow and deduplication |
 | --- | --- |
 | `ProjectListCubit` | Add required `ProductAnalyticsService` and retain the bounded inventory states already emitted in that cubit lifetime. Emit the first successful `empty` once and the first later/same-lifecycle `non_empty` once; refreshes never repeat either classification. The warehouse milestone uses only earliest non-empty. |
-| `SessionDetailCubit` view | Add required product analytics service. Retain one lifetime empty-diagnostic guard plus the last UTC date for which visible/foreground non-empty activity was emitted. Initial or later empty emits once; the first successful non-empty load/refresh/SSE on each UTC date emits once while the route is visible and lifecycle resumed. Background events emit nothing; resume reload can emit for a new date. This preserves earliest monitoring while supporting later WAU/retention without per-SSE counts. |
-| `SessionDetailCubit` send paths | Direct `sendMessage` and `_drainQueuedMessages` call one private `_reportAcceptedSubmission` only on `SuccessResponse`. The queued item retains only text/command for sending; analytics derives text/command without reading content. Error/requeue emits nothing, and each dequeued successful item reports once. |
-| `NewSessionCubit` | Add required product analytics service. Capture workspace/submission classifications before awaiting. `SuccessResponse` makes one `session_created_with_message` call; `ErrorResponse` emits only bounded `session_creation_failed`. It never also emits the existing-session event. |
+| `SessionActivityAnalyticsListener` | `SessionDetailScreen` constructs it with the screen-owned cubit plus `RouteSource`, `LifecycleSource`, and product analytics service. It retains one lifetime empty-diagnostic guard plus the last UTC date emitted. Initial/later empty emits once; the first successful non-empty state on each UTC date emits only while `AppRouteDef.sessionDetail` is current and lifecycle resumed. Background or nested-diffs SSE emits nothing; returning to detail may emit only if the UTC-date guard permits. |
+| `LoginCubit` | Add required `InstallationAnalyticsService`. Each provider/email method maps the sealed provider exhaustively, reports one start after input validation, and reports exactly one terminal completion/failure; OAuth timeout is a failed terminal outcome. Desktop resolves the same calls through its no-op client. |
+| `SessionDetailCubit` send paths | Direct `sendMessage` and `_drainQueuedMessages` call one private `_reportAcceptedSubmission` only on `SuccessResponse`. The queued item retains its existing text/command plus the closed input-mode enum; analytics derives text/command classification without reading content. Error/requeue emits nothing, and each dequeued successful item reports once. |
+| `NewSessionCubit` | Add required product analytics service and required input-mode argument on creation. Capture workspace/submission/input classifications before awaiting. `SuccessResponse` makes one `session_created_with_message` call; `ErrorResponse` emits only bounded `session_creation_failed`. It never also emits the existing-session event. |
+| Mobile composer call sites | After `stopAndTranscribe()` returns a non-empty transcript, report `voice_transcription_completed`, mark input `voice_assisted`, and pass the enum to existing/new-session submit methods. Manual edits do not erase contribution; clearing/resetting the composer does. Product behavior does not await analytics delivery. |
 | `SessionDetailCubit` question/permission/abort | Report after each existing method's success branch. Question answers/rejections carry no answer data; permission maps the existing `PermissionReply` enum; abort reports only after every root/active-child response succeeds. |
 | `DiffCubit` | Add required product analytics service and retain reported change states. Emit first empty and first later non-empty once each; only non-empty defines adoption, and SSE refreshes do not repeat either state. |
-| `NotificationOpenRequest` / `NotificationOpenDispatcher` / `NotificationOpenAnalyticsListener` | Extend the internal request with required bounded category/event type already present in `NotificationData`. Push/local adapters provide `unknown` for legacy local payload omissions. Dispatcher publishes bounded source/cold-warm/category/event-type metadata after validated route dispatch, never project/session/title. The listener applies the one-event cold-start buffer and preference/account rules above before calling product analytics. |
-| Screen constructors/tests | `ProjectListScreen`, `NewSessionScreen`, `SessionDetailScreen`, and `SessionDiffsScreen` pass the phase-3 product analytics service from GetIt into required cubit constructors. Core tests inject a mock/recording service and assert event count/shape. |
+| `AnalyticsRouteListener` / `FirebaseAnalyticsClient` | Listener maps every `AppRouteDef` to pinned `AnalyticsScreen`, deduplicates unchanged routes, and reports only after product analytics activates. The adapter logs canonical `product_screen_viewed`, then best-effort calls `logScreenView` with the same name. Native automatic screen reporting is disabled and standard rows are excluded from account-level models. |
+| Screen constructors/tests | `ProjectListScreen`, `NewSessionScreen`, `SessionDetailScreen`, and `SessionDiffsScreen` pass the phase-3 product analytics service from GetIt into required cubit constructors. `SessionDetailScreen` also owns/disposes `SessionActivityAnalyticsListener`. Core tests inject recording services/routes/lifecycle and assert event count/shape. |
 
-## Campaign Attribution
+## Deferred Extensions
 
-Use `https://sesori.com/link/...` campaign links, which the current Android App
-Link and iOS associated-domain configuration already accepts. Define a link
-runbook that generates:
+Campaign attribution and notification open-to-action conversion remain useful
+future additions after the core identity, preference, activation, retention,
+voice, login, and screen pipeline is stable. They are not silently discarded:
 
-- a strict opaque campaign code;
-- Google Play URL/referrer UTM values for automatic Firebase attribution;
-- Apple App Store campaign/provider tokens for App Store Connect aggregate
-  reporting; and
-- the same code in installed-app universal/app links.
-
-Core stores the first valid pre-auth code plus capture time locally, expires it
-after 24 hours, and attempts it only after authenticated custom-event sharing
-becomes active, retaining pending state until the SDK accepts an attempt.
-BigQuery independently requires the event to occur no later than 24 hours after
-account creation, so a campaign opened by an established account never becomes
-acquisition. The restricted
-`campaign_registry` maps code to source, medium, campaign display name, and
-active dates. Do not accept or emit arbitrary UTM text from an inbound URI.
-
-Firebase/Play and App Store attribution have different identity and deferred
-deep-link limits. The dashboard reports “known attribution coverage” and keeps
-unknown separate; it must not claim that cross-platform attribution is
-complete. App Store Connect aggregate data remains a separately labeled source
-unless a privacy-reviewed join becomes available later.
+- Campaign work may later add strict opaque campaign codes, store attribution,
+  pre-auth capture with a bounded TTL, a restricted registry, and honest known-
+  attribution coverage. It must not replace `DeepLinkService` or add persistence
+  in the initial series.
+- Notification work may later preserve bounded source/category/event type and
+  measure open-to-meaningful-action conversion. It must not claim delivery or
+  click-through rates without a delivery denominator.
+- Any follow-up must reuse the typed Client -> API -> Repository -> Service ->
+  Consumer path and go through the normal architecture-plan review. It may not
+  broaden the initial event union with arbitrary strings or identifiers.
 
 ## Auth Export
 
@@ -624,24 +695,31 @@ export work to request handlers or the long-running auth process.
 - `src/types/product-analytics.ts` defines the string-valued
   `ProductAnalyticsPreference.Enabled/Disabled` enum and its Zod schema.
 - `src/models/documents.ts` initially adds
-  `productAnalyticsPreference` plus `productAnalyticsPreferenceUpdatedAt` with
-  an honest decode default of enabled/account creation time for existing Mongo
-  documents, while `UserRepository.create` always writes both fields.
+  `productAnalyticsPreference`, `productAnalyticsPreferenceUpdatedAt`, integer
+  `productAnalyticsPreferenceRevision`, and genuinely nullable
+  `productAnalyticsPreferenceLastOperationId`. Existing documents receive honest
+  temporary decode defaults of enabled/account creation time/revision 1, while
+  `UserRepository.create` always writes the first three fields and null last ID.
   `src/scripts/backfill-product-analytics-preference.ts` performs an idempotent
-  `$set` only where either is missing and reports/validates counts. After the
+  `$set` only where required fields are missing and reports/validates counts.
+  After the
   write-first version is live and backfill reaches zero missing documents, the
-  next PR removes both decode defaults and enforces both fields as required.
+  next PR removes all required-field decode defaults and enforces preference,
+  update time, and revision as required.
   It also permits genuinely absent `productAnalyticsExportSuppressedAt`; a
   privacy-deletion workflow sets that timestamp, so no default/backfill exists.
 - `src/models/api.ts` defines Zod-validated GET/PUT preference replies/body only;
   it does not modify `UserProfile` or auth token/login contracts.
-- `UserRepository.updateProductAnalyticsPreference(userId, preference)` owns one
-  atomic Mongo update of value and server timestamp;
-  `findProductAnalyticsPreference` reads them with temporary migration defaults
-  only in the write-first release.
+- `UserRepository.updateProductAnalyticsPreference` owns one atomic compare-and-
+  set by `(userId, expectedRevision)`: it updates value/server timestamp/last
+  operation ID and increments revision. Repeating the same operation ID returns
+  the already-committed result; a different stale revision returns conflict.
+  `findProductAnalyticsPreference` reads versioned state with temporary
+  migration defaults only in the write-first release.
 - `UserRepository.suppressProductAnalyticsExport(userId, suppressedAt)`
   atomically sets preference disabled, updates its timestamp, and sets the
-  permanent export-suppression tombstone before any warehouse deletion. GET
+  permanent export-suppression tombstone while incrementing preference revision
+  before any warehouse deletion. GET
   remains disabled and PUT enabled returns an explicit conflict for suppressed
   accounts; ordinary opt-out never sets this tombstone.
 - `ProductAnalyticsPreferenceService` in
@@ -651,17 +729,20 @@ export work to request handlers or the long-running auth process.
 - `src/routes/product-analytics.ts` adds authenticated
   `GET /product-analytics/preference` and
   `PUT /product-analytics/preference`; PUT body is
-  `{ "preference": "enabled" | "disabled" }` and both reply with
-  `{ "preference": ... }`. The existing auth middleware supplies the user; the
+  `{ "preference": "enabled" | "disabled", "expectedRevision": number,
+  "operationId": uuid }`; success replies with `{ "preference": ...,
+  "revision": number }` and stale revision returns an explicit conflict with
+  current versioned state. The existing auth middleware supplies the user; the
   route validates and delegates to the dedicated service. `src/server.ts` and
   `src/index.ts` register/construct this service without changing `AuthService`.
 - The Dart client owns this contract in core
   `ProductAnalyticsPreferenceApi`; `AuthManager`/`AuthSession` are unchanged.
 - `src/scripts/suppress-product-analytics-export.ts` is the isolated privacy-
   operator composition root. It reads a verified raw account ID from protected
-  stdin (never argv/logs), invokes the service suppression operation, verifies
-  disabled+tombstoned state, prints only the external privacy request ID/status,
-  and closes Mongo. There is no public suppression route.
+  stdin (never argv/logs), constructs the deletion service described below,
+  verifies disabled+tombstoned state plus restricted target handoff, prints only
+  the external privacy request ID/status, and closes Mongo/BigQuery clients.
+  There is no public suppression route.
 
 ### Export classes and composition
 
@@ -750,10 +831,53 @@ export service account limited to BigQuery Job User plus Data Editor on
 `sesori_analytics_auth_private` plus table-level Data Viewer on the one
 authorized active-internal-exclusion view. It has no controls dataset write/DDL
 role and no role on raw, curated, or reporting datasets, so it cannot mutate
-campaign/exclusion/config tables. A separate scheduled-transform identity has read-only access to raw,
+exclusion/config tables. A separate scheduled-transform identity has read-only access to raw,
 auth-private, and controls plus write access to curated; the deployment identity
 alone owns schemas/IAM/control-table writes. The auth web runtime receives no
 BigQuery role.
+
+### Privacy deletion executable architecture
+
+Deletion is an isolated cross-repository command flow, never a web request
+handler and never an informal sequence of console queries.
+
+**Auth-source handoff (`sesori_auth_server`):**
+
+| Class/file | Layer/dependencies | Responsibility |
+| --- | --- | --- |
+| `ProductAnalyticsDeletionTarget` in `src/models/product-analytics-export.ts` | Closed internal model | Contains only external privacy request ID, lowercase `user_key`, source tombstone time, and status; no raw account ID. |
+| `ProductAnalyticsDeletionTargetRepository` in `src/repositories/product-analytics-deletion-target-repo.ts` | Layer 2; requires `ProductAnalyticsExportApi` scoped to `auth_private` | Idempotently upserts the restricted deletion target and reads status. It cannot access controls/raw/curated/reporting. |
+| `ProductAnalyticsDeletionService` in `src/services/product-analytics-deletion-service.ts` | Layer 3; requires `ProductAnalyticsPreferenceService` and deletion-target repository | Receives raw account ID only in protected process memory, atomically source-tombstones/disables first, hashes with the pinned golden algorithm, writes the restricted target, drops raw ID/key locals, and returns only request ID/status. A target-write failure leaves the source tombstone intact and is safely retryable. |
+| `src/scripts/suppress-product-analytics-export.ts` | Protected command composition root | Reads verified raw account ID from stdin and external request ID from a protected input channel, constructs Mongo plus auth-private client/API/repository/service, invokes once, prints only request ID/status, and closes both clients in `finally`. |
+
+The script identity has Mongo suppression access plus append/update/read status
+only on `auth_private.product_analytics_deletion_targets`; it cannot query GA4
+raw data or mutate controls/curated/reporting. The restricted target table is the
+only raw-ID-to-`user_key` handoff, and raw account ID never crosses it.
+
+**Warehouse/upstream deletion (`tool/product_analytics/privacy_deletion/`):**
+
+| Class/file | Layer/dependencies | Responsibility |
+| --- | --- | --- |
+| `bigquery_privacy_deletion_client.dart` and `ga_user_deletion_client.dart` | Foundation clients | Typed BigQuery operations within allowlisted datasets and typed GA User Deletion API submission; no orchestration or raw account ID. |
+| `privacy_deletion_api.dart` | Layer 1; requires both clients | Loads pending auth-private targets, upserts only the deletion-exclusion control, discovers currently linkable installation IDs from retained keyed raw rows, deletes matching warehouse rows, submits app-instance/legacy-user deletion, rebuilds aggregates, and updates target status through typed operations. |
+| `privacy_deletion_repository.dart` | Layer 2; requires API | Owns idempotent request status, target validation, run checkpoints, tombstone-aware auth-export cutoff checks, and explicit result mapping. It never persists discovered installation IDs. |
+| `privacy_deletion_service.dart` | Layer 3; requires repository | Orchestrates exclusion-before-delete, waits for a successful auth export with `runCutoff >= suppressedAt`, performs final delete/rebuild/verification, and marks the request complete or retryable. |
+| `run_privacy_deletion.dart` / `sweep_privacy_deletions.dart` | Manual and scheduled composition roots | Construct with ADC/config, process one request or all pending/recent targets, return only aggregate status, and close clients. The daily sweep revisits incomplete targets and future **keyed** uploads only. |
+
+Use a dedicated deletion service account with BigQuery Job User, read of the
+restricted auth target/raw datasets, write only to the deletion-exclusion
+control and target status, delete/rebuild permission on auth-private/curated/
+reporting (and matching retained raw rows), plus the minimum GA deletion API
+role. It has no Mongo access and no general controls/deployment role. Secret
+Manager/ADC supply credentials; no service-account key enters Git.
+
+No persistent account-to-installation map is created. Once currently linkable
+app-instance IDs are submitted and raw keyed rows are deleted/expired, later
+automatic-only events cannot be associated with the account. Recurring sweeps
+therefore promise enforcement only for future keyed uploads; automatic-only
+future rows remain under upstream two-month retention. Privacy responses must
+state that limit instead of claiming indefinite automatic-event deletion.
 
 ## BigQuery Design
 
@@ -785,7 +909,8 @@ retroactive:
    released event schema is observed in export. Also record owner, identities,
    deletion-job owner, and dashboard access group in restricted configuration.
 6. Verify one existing event reaches `analytics_<property_id>.events_*`, then
-   verify the new custom schema before setting its behavioral timestamp.
+   verify the new account-linked product schema before setting its behavioral
+   timestamp. Installation-login schema does not qualify.
 
 ### Datasets
 
@@ -796,7 +921,7 @@ property/project IDs:
 | --- | --- | --- |
 | `analytics_<property_id>` | Raw restricted | Firebase-managed GA4 daily tables |
 | `sesori_analytics_auth_private` | Security/analytics admins, auth export job; transform identity read-only | Auth eligible-user snapshot/staging and aggregate setup cohorts only |
-| `sesori_analytics_controls` | Security/analytics admins and deployment identity; transform identity read-only; auth-export identity can read only an authorized active-exclusion view | Campaign registry, internal-user exclusions, dual measurement timestamps, export freshness policy |
+| `sesori_analytics_controls` | Security/analytics admins and deployment identity; transform identity read-only; auth-export identity can read only an authorized active-exclusion view | Internal-user and deletion exclusions, dual measurement timestamps, export freshness policy |
 | `sesori_analytics_curated` | Analytics engineers | Flattened allowlisted events, daily user activity, user milestones, scheduled intermediate tables |
 | `sesori_analytics_reporting` | Looker service account/product leadership | Identifier-free authorized views and dashboard tables |
 
@@ -813,9 +938,9 @@ The initial file ownership is fixed:
   non-interactively with the explicit location. It does not perform `gcloud`
   login or read key files.
 - `tool/product_analytics/sql/00_datasets.sql` creates/configures derived
-  datasets and reference tables; `10_events_flattened.sql`,
-  `20_user_activity_daily.sql`, `25_acquisition_first_touch.sql`,
-  `30_user_milestones.sql`,
+   datasets and reference tables; `10_events_flattened.sql`,
+   `15_installation_login_daily.sql`, `20_user_activity_daily.sql`,
+   `30_user_milestones.sql`,
   `40_activation_retention.sql`, and `50_reporting_views.sql` own the dependency
   order described below.
 - `tool/product_analytics/sql/schedules.json` is a credential-free manifest of
@@ -853,11 +978,11 @@ These vendor fields change the controls and disclosure, not the event contract:
 - `events_flattened` deliberately does **not** select `user_pseudo_id`, GA
   session ID, device brand/model, geo, user properties, advertising/vendor IDs,
   bundle sequence, stream ID, or arbitrary traffic-source strings;
-- curated acquisition maps only a strict Sesori campaign code/registry match or
-  a small approved source class; unmatched raw traffic text becomes `unknown`;
-- Firebase automatic events are excluded from behavioral facts. Only a
-  transient `first_open`/traffic-source projection may participate in the
-  acquisition model; app/screen opens never define activity;
+- Firebase automatic events and native `screen_view` mirrors are excluded from
+  behavioral facts. App/screen opens never define activity;
+- account-less login events are aggregated directly to daily
+  date/platform/app-version/provider/failure totals; `user_pseudo_id` is never
+  selected into a curated or reporting table;
 - the privacy notice must disclose Firebase's pseudonymous install/device and
   approximate-location processing even though those fields are discarded from
   Sesori reporting.
@@ -868,9 +993,10 @@ not weaken the written privacy boundary to fit an unchecked property.
 
 ### Curated models
 
-1. **`events_flattened`**: flatten only catalogued Sesori custom events/parameters
-   from GA4, use `event_timestamp` in UTC, require schema version and non-null
-   custom `user_key`, and retain Firebase platform/app version/build. Anti-join
+1. **`events_flattened`**: flatten only catalogued account-linked Sesori product
+   events/parameters from GA4, use `event_timestamp` in UTC, require schema
+   version and non-null custom `user_key`, and retain Firebase platform/app
+   version/build. Anti-join
    both active internal/test keys and the permanent deletion-exclusion keys on
    every build/recomputation, but deliberately do **not** join the time-varying
    current auth eligibility snapshot here. Raw bundle/install fields may be used
@@ -878,24 +1004,23 @@ not weaken the written privacy boundary to fit an unchecked property.
    byte-identical export duplicates but are not selected into the table. This
    recoverable 90-day fact layer prevents a transient auth-export outage from
    permanently discarding otherwise eligible events.
-2. **`user_activity_daily`**: one row per user/date with monitor, control,
-   message, notification, diff, and feature flags/counts.
-3. **`user_milestones`**: auth timestamps plus earliest schema-v1 exposure,
+2. **`installation_login_daily`**: identifier-free daily counts of the three
+   account-less login events by platform, app version, pinned provider, and
+   bounded failure kind. It scans raw rows but never persists
+   `user_pseudo_id`, joins to an account, or contributes to account metrics.
+3. **`user_activity_daily`**: one row per user/date with monitor, control,
+   message, voice-assisted, transcription, diff, screen, and feature
+   flags/counts.
+4. **`user_milestones`**: auth timestamps plus earliest schema-v1 exposure,
    project availability, full activation, monitor activity, and feature
    milestones. Full activation is the minimum of the two successful message
    event names only; `analytics_schema_ready_at` is the earliest schema-v1 event
    of any name.
-4. **`activation_cohorts`**: account-cohort denominators only when schema-v1
+5. **`activation_cohorts`**: account-cohort denominators only when schema-v1
    exposure occurs within 24 hours of account creation, plus 1/7/30-day
    milestone flags, times to milestone, cohort maturity, and separate
    preference/schema coverage.
-5. **`retention_cohorts`**: activation-anchored W1/W4 eligibility and activity.
-6. **`acquisition_first_touch`**: earliest strict custom campaign code or
-   approved automatic store/source class per eligible user, provided the event
-   occurs no later than 24 hours after account creation. It uses raw
-   install/traffic fields only inside the scheduled query, persists no
-   `user_pseudo_id` or arbitrary source text, and labels unmatched values
-   `unknown`.
+6. **`retention_cohorts`**: activation-anchored W1/W4 eligibility and activity.
 
 Materialize partitioned daily/intermediate tables where repeated Looker scans
 would be expensive; cluster event facts by event name/user key. Scheduled
@@ -932,11 +1057,14 @@ only three days.
   1/7/30-day cohorts and notification registration beside the main path.
 - `retention`: W1/W4 cohorts with eligible denominators.
 - `feature_adoption`: worktree, diff, question/permission, abort, and
-  remote-created-session adoption.
-- `notification_engagement`: opens and 30-minute open-to-action conversion by
-  bounded category/event type.
-- `acquisition_performance`: known coverage, accounts, activation, and
-  retention by registered campaign; suppress small segmented cells.
+  remote-created-session, voice-transcription, and voice-assisted-message
+  adoption.
+- `installation_login_funnel`: identifier-free started/completed/failed counts
+  and completion rates by pinned provider/app version, explicitly labeled as
+  installation-level and never joined to account activation.
+- `screen_usage`: account-level unique users/views by pinned
+  `AnalyticsScreen`, sourced only from `product_screen_viewed`; standard
+  Firebase screen rows are excluded.
 - `onboarding_friction`: empty project/session states, bounded creation
   failures, and existing support/install interactions.
 - `data_quality`: event freshness, schema/app versions, null identity, unknown
@@ -954,8 +1082,6 @@ only three days.
   reporting views. Do not expose `user_key` in Looker fields, extracts, or URLs.
 - Maintain internal/test exclusions as hashes in a restricted table with owner,
   reason, and optional expiry. Never put the list in Git.
-- Apply campaign segmentation suppression when a cell has fewer than
-  the approved minimum users; totals retain sample sizes.
 - Configure dataset/table expiration, scheduled-query byte limits, billing
   alerts, and a monthly cost check before dashboard sharing.
 - Implement a privacy-request runbook/job that first calls the auth-source
@@ -980,34 +1106,37 @@ only three days.
   notice/deletion response rather than creating a persistent account-device map.
 - Keep deletion-exclusion tombstones permanent and run a daily upstream deletion
   sweep over newly landed raw partitions. For every tombstoned key it discovers
-  newly uploaded keyed installation IDs (including events queued while a
-  supported client was offline), resubmits GA app-instance deletion, deletes any
-  matching warehouse rows, and always submits the legacy `USER_ID` while that
-  migration window remains possible. The request can report source/warehouse
-  deletion plus recurring enforcement installed, but must not promise that an
-  offline client's future upload can never transiently reach restricted raw.
-  Record request IDs/completion without raw account/install IDs. Test the API
-  credential, request format, in-flight export ordering, delayed offline upload,
-  flattened anti-join/non-repopulation, aggregate rebuild, and a non-production
-  deletion before rollout.
+  future keyed installation IDs (including product events queued while a
+  supported client was offline), it resubmits GA app-instance deletion, deletes
+  matching warehouse rows, and submits the legacy `USER_ID` while that migration
+  window remains possible. It persists no install mapping, so later automatic-
+  only events after the last keyed row cannot be associated and remain governed
+  by upstream two-month retention. The request reports source/warehouse deletion
+  plus recurring **keyed-upload** enforcement, never indefinite automatic-event
+  enforcement. Record request IDs/completion without raw account/install IDs.
+  Test the layered deletion command, IAM, request format, in-flight export
+  ordering, delayed keyed upload, flattened anti-join/non-repopulation,
+  aggregate rebuild, and a non-production deletion before rollout.
 
 ## Looker Studio
 
-Create one restricted report backed only by `sesori_analytics_reporting`:
+Create one restricted initial report backed only by
+`sesori_analytics_reporting`:
 
 1. **Executive snapshot** — headline scorecards, complete-week trends,
    activation funnel, W1/W4 retention, sample size, behavioral coverage, and
    last refresh.
 2. **Activation** — cohort funnel and time-to-step distributions; optional
-   notification registration is visually separate.
+   notification registration is visually separate, and the account-less login
+   funnel is a clearly separated diagnostic panel.
 3. **Retention and engagement** — cohort heatmap, meaningful/controller WAU,
-   active days, interventions, and message depth.
-4. **Feature adoption** — worktree/diff/remote interaction trends.
-5. **Acquisition** — known-attribution coverage and thresholded campaign
-   quality; unknown remains explicit.
-6. **Product quality** — onboarding states and bounded failures.
-7. **Data quality** — freshness, coverage, exclusions, versions, and incomplete
-   cohorts so a broken pipeline cannot look like declining usage.
+   active days, interventions, message depth, voice adoption, feature adoption,
+   and screen usage.
+
+Each page includes a compact freshness/coverage/maturity strip backed by the
+`data_quality` view so a broken pipeline cannot look like declining usage.
+Additional dedicated feature, acquisition, product-quality, and data-quality
+pages are deferred extensions rather than deleted requirements.
 
 Default every page to complete periods. Allow a clearly marked live-period
 filter for operators, but never use live partial values in exported investor
@@ -1030,13 +1159,16 @@ directory name.
 - Add the persisted enum/value-update timestamp, temporarily default missing
   fields to honest prior values at decode/read boundaries, and add genuinely
   nullable `productAnalyticsExportSuppressedAt` without a default.
-- Make every new `UserRepository.create` write preference plus update timestamp
-  before exposing GET/PUT preference behavior.
+- Make every new `UserRepository.create` write preference, update timestamp,
+  revision, and nullable last-operation ID before exposing GET/PUT preference
+  behavior.
 - Add the dedicated repository-backed preference service and authenticated
   product-analytics routes; leave all auth profiles/tokens untouched.
 - Add the idempotent backfill/count command.
 - Test auth/validation, new-user writes, missing-document default, concurrent
-  updates, and unchanged OAuth/password/refresh responses.
+  compare-and-set updates, duplicate operation idempotency, stale revision
+  conflict (including late older enable after newer disable), and unchanged
+  OAuth/password/refresh responses.
 - Deploy this version fully, verify every new user writes the field, then run
   backfill until repeated validation reports zero missing. PR 2 cannot merge or
   deploy before that evidence is recorded.
@@ -1047,10 +1179,11 @@ directory name.
 
 **Repository:** `sesori_auth_server`
 
-- Remove the temporary missing-field default and make the Mongo model required;
+- Remove the temporary required-field defaults and make the Mongo model required;
   add a startup/test assertion that fixture creation always supplies it.
 - Add BigQuery Client -> export API -> export/control repositories -> export
-  service, source suppression operation/command, isolated job config/composition,
+  service; add deletion-target repository/service plus source suppression/
+  restricted-target handoff command; add isolated job config/composition,
   package dependency, and production image command.
 - Publish the eligible pseudonymous snapshot and identifier-free weekly setup
   cohorts through staging/validation/transactional promotion, excluding source-
@@ -1069,66 +1202,86 @@ directory name.
 
 **Repository:** apps monorepo
 
+- Add JSON PUT to `SafeApiClient`, `HttpApiClient`, and
+  `AuthenticatedHttpApiClient` in `module_auth`, including auth/header/error/
+  timeout tests; use it for the revisioned preference endpoint.
 - Add the explicitly layered core models, Analytics Client/API/repository,
-  preference API/Storage/repository/service, route listener/readiness gate, and
-  Settings cubit. `module_auth` and shared `AuthUser` remain unchanged.
+  product/installation repositories and services, preference API/Storage/
+  repository/service, route listener/readiness gate, and Settings cubit.
+  Shared `AuthUser` remains unchanged; `module_auth` changes only its internal
+  JSON transport surface for PUT.
 - Move the existing seven-event contract into core models and route existing
   onboarding UI calls through `ProductAnalyticsService`.
+- Update root analytics guidance and `.opencode/skills/add-analytics/SKILL.md`
+  in the same PR: remove their transitional current-shell note and make the new
+  core models/services the sole source of truth.
 - Implement the thin `FirebaseAnalyticsClient`, pre-core legacy-identity cleanup,
   and desktop no-op adapter in product shells; add pure-Dart `crypto` to
   `module_core` and keep SHA-256, route mapping, state, and lifecycle in core.
+- Disable automatic Firebase screen reporting in Android and every Firebase-
+  enabled Apple target. Drive screens only from
+  `GoRouterRouteSource.currentRouteStream`, map exhaustively to pinned
+  `AnalyticsScreen`, emit canonical `product_screen_viewed`, and mirror the same
+  name through `FirebaseAnalytics.logScreenView`; never derive names from
+  Navigator runtime classes or concrete paths.
 - Remove `AnalyticsUserIdTracker`, clear its persisted global Firebase user ID
   immediately after Firebase initialization, never set another account key or
-  persisted collection override, gate every Sesori custom event to post-splash
-  authenticated enabled release builds, and add schema-ready/custom stable-
-  screen reporting.
+  persisted collection override, gate every account-linked Sesori product event
+  to post-splash authenticated enabled release builds, while allowing only the separately
+  typed, release-only, account-less login catalog; add schema-ready and stable
+  GoRouter-backed screen reporting.
 - Add the Settings toggle, explanatory/localized copy, pending/error behavior,
-  explicit installation/automatic-event limitations, and privacy/legal/store-
-  disclosure updates.
-- Test API parsing, layer wiring, fail-closed custom events during splash,
+  explicit installation/login-funnel/automatic-event limitations, and privacy/
+  legal/store-disclosure updates.
+- Test API parsing, layer wiring, fail-closed account-linked events during splash,
   post-splash fetch, pending-disable storage as the first awaited operation,
   storage failure, crash/restart pending recovery, pending-enable write-ahead/
-  finalization failure, 10-second timeout releasing logout/reconciliation,
+  finalization failure, revision conflict/idempotent operation handling,
+  timed-out old enable unable to overwrite newer disable, 10-second timeout
+  releasing logout/reconciliation,
   legacy-ID clear success/failure ordering and whole-process disclosure, logout
-  sync failure/account-switch preservation, enable-after-server success, delayed
+  sync failure/account-switch preservation, `SettingsCubit` pre-logout ordering,
+  enable-after-server success, delayed
   GET/PUT/storage completions across rapid login/logout/account switches,
-  foreground/15-minute refresh propagation, harness routes mapping only to
+  one-read-per-auth-generation plus explicit Settings refresh, harness routes mapping only to
   generic settings, debug suppression, core identity hash, route-to-screen
-  mapping, event wire pins, and mobile/desktop DI.
+  mapping, disabled automatic screen reporting, one Firebase-native screen
+  mirror per changed GoRouter route, product/installation event separation,
+  event wire pins, and mobile/desktop DI.
 - Release only after both auth PRs are deployed. Once users can opt out, this
-  custom-event lifecycle becomes a non-rollback privacy floor: subsequent
-  client fixes must preserve it or suppress all Sesori custom events.
+  account-linked custom-event lifecycle becomes a non-rollback privacy floor:
+  subsequent client fixes must preserve it or suppress all account-linked
+  Sesori product events.
 
-### PR 4/5 — Outcome and campaign instrumentation
+### PR 4/5 — Outcome, voice, and login instrumentation
 
 **Title:** `[user-analytics] Instrument activation and engagement outcomes [step 4/5]`
 
 **Repository:** apps monorepo
 
 - Add the event catalog variants and bounded enum serialization.
+- Instrument `LoginCubit` through `InstallationAnalyticsService` with one start
+  and one terminal completion/failure (including timeout) per valid attempt;
+  events remain account-less and carry only pinned provider/failure enums.
 - Instrument the authoritative core/app seams listed above, including both
   direct and queued message success, while keeping analytics best-effort and
   non-blocking.
+- Thread `input_mode=typed/voice_assisted` through existing/new-session sends and
+  queued submissions, and report content-free successful transcription from the
+  mobile composer call site.
 - Buffer only the first activation-candidate outcome while same-generation
   preference is unknown, then emit on active or drop on disabled/auth change;
   report first empty/non-empty transitions for milestones and at most one
   visible non-empty session activity per UTC date for WAU/retention.
-- Preserve bounded notification category/event type through open dispatch and
-  classify push/local plus cold/warm; buffer the single cold-start open until
-  same-account preference resolution and drop it on disable/logout/timeout.
-- Add core campaign Storage -> repository -> service -> deep-link listener,
-  auth-restoration hold, 24-hour pre-auth capture/attribution rules, account-
-  bound failed retry, typed SDK-acceptance result, and remove the obsolete app
-  `DeepLinkService` and full URI logging.
 - Regenerate only source-generated outputs.
 - Add focused tests that failures/taps/queued-only operations do not activate,
   each successful message path makes one service call, new-session success is not
-  double counted, sensitive inputs cannot enter parameter maps, notification
-  classification and first-message deferral survive preference resolution,
+  double counted, sensitive inputs cannot enter parameter maps, first-message
+  deferral survives preference resolution,
   empty-to-non-empty transitions report once, resumed/later-date monitoring can
-  report again without SSE inflation, auth-unknown links wait for restoration,
-  post-signup/old-account links cannot become acquisition, and account A failed/
-  completed state cannot consume account B's first touch.
+  report again without SSE inflation, voice-assisted origin survives queueing
+  without transcript data, and login timeout/failure makes one bounded terminal
+  installation event without an account key.
 
 ### PR 5/5 — Warehouse models and dashboards
 
@@ -1141,15 +1294,18 @@ directory name.
 - Create auth-private/controls/curated/reporting datasets in the raw GA4
   location; keep export-job write access confined to auth-private and grant only
   authorized-view reads for internal exclusion; configure IAM, expiration,
-  budget alerts, campaign registry, source/control exclusions, upstream GA4
+  budget alerts, source/control exclusions, upstream GA4
   retention/deletion limits, and separate raw/behavioral start timestamps.
 - Schedule the auth export and three-day event recomputation, then reconcile
   source counts and freshness; verify stale auth snapshots abort publication and
   recovery backfills the missed window.
 - Apply deletion exclusion in flattened facts, schedule the recurring upstream
-  tombstone sweep, and require a tombstone-aware auth export plus final cleanup
-  before declaring warehouse deletion complete.
-- Build and permission the seven-page Looker report.
+  tombstone sweep using the declared Foundation/API/Repository/Service command
+  architecture, and require a tombstone-aware auth export plus final cleanup
+  before declaring warehouse deletion complete. The sweep covers future keyed
+  uploads only and persists no account-install mapping.
+- Build and permission the three-page initial Looker report with freshness,
+  coverage, maturity, voice, login, and GoRouter screen panels.
 - Run a release-build smoke test through account -> bridge -> project -> message
   and verify the event, auth join, full activation, complete-day table, and
   reporting view without inspecting sensitive payloads.
@@ -1163,7 +1319,7 @@ directory name.
 | Before 1/5 | Existing clients/events continue. Firebase daily export should be linked only through the controlled day-zero sequence so its non-retroactive clock starts safely. | Complete restricted-project IAM, daily-only link, raw expiration/settings verification, and record `raw_export_start_at`. | Unlinking loses future export and is not a useful rollback; stop rollout and correct IAM/expiration/location before derived datasets or new instrumentation. |
 | After 1/5 | Dedicated GET/PUT preference endpoints work; old clients are unaffected because auth responses did not change. New users always write preference; old documents read as enabled during migration. | Deploy write-first web code to all serving instances, verify new writes, run/re-run backfill, and record zero missing. | Roll back before any opt-out client release if necessary. The added field is ignored by old code; do not remove it. Re-run backfill after returning to step 1. |
 | After 2/5 | Preference schema is required and export command/job image is deployable but unscheduled. Existing clients remain unaffected. | Require recorded zero-missing evidence from step 1; deploy enforcement; smoke-test account creation and endpoints; deploy job disabled. | Roll back web/job to step 1, whose honest missing-field default can read every document. Stop any job; published tables stay at last good state. |
-| After 3/5 | Mobile clears the prior global Firebase user ID before custom sources, can disable/enable Sesori custom events on this installation, and syncs its server reporting/supported-client preference; existing custom events and stable screens obey the lifecycle; Firebase automatic install events retain the separately disclosed property behavior; desktop remains no-op. | Both auth endpoints/schema must be live. If legacy-ID clear fails, custom events stay disabled and all automatic events for that process are classified as potentially legacy-keyed; if preference is unavailable, GET/enable fails closed and disable remains local pending without blocking logout. | **Forward-fix only after public release.** Preserve both legacy-ID cleanup and local custom-event gating through their declared floors. For a severe defect, suppress all custom events; do not claim automatic collection stopped on clear failure or that legacy behavior is controlled. Server preference data is never rolled back. |
+| After 3/5 | Mobile clears the prior global Firebase user ID before custom sources, can disable/enable account-linked Sesori product events on this installation, and syncs its server reporting/supported-client preference; existing product events and GoRouter-backed screens obey the lifecycle; only the bounded account-less login catalog plus Firebase automatic install events retain the separately disclosed installation behavior; desktop remains no-op. | Both auth endpoints/schema must be live. If legacy-ID clear fails, all custom events stay disabled and all automatic events for that process are classified as potentially legacy-keyed; if preference is unavailable, account-linked events fail closed and disable remains local pending without blocking logout. | **Forward-fix only after public release.** Preserve both legacy-ID cleanup and local product-event gating through their declared floors. For a severe defect, suppress all custom events; do not claim automatic collection stopped on clear failure or that legacy behavior is controlled. Server preference data is never rolled back. |
 | After 4/5 | New activation/engagement events accumulate in GA4 raw export. Product operations remain unchanged if Firebase is unavailable. | Step 3 custom-key/preference/schema lifecycle must be released. BigQuery needs no GA4 custom-dimension registration. | Forward-fix the app while retaining step-3 privacy behavior; event-specific defects may be disabled/removed. Missing future event names yield null/zero data, not product failure. |
 | After 5/5 | Auth job, curated models, authorized reporting views, and Looker provide the complete metric contract. | Create same-location datasets/IAM; deploy SQL/tests; schedule auth export; validate its first publish; schedule event transforms; then connect Looker. | Pause schedules/job and revert reporting views/dashboard sources to last known-good SQL. Raw GA4 and prior auth published tables remain; app behavior is unaffected. |
 
@@ -1179,6 +1335,8 @@ the separately released app.
 
 - Run code generation after changing Freezed/Injectable sources; never edit
   generated files manually.
+- `dart test` and `dart analyze` in `client/module_auth` for the new PUT transport
+  method and authenticated delegation.
 - `dart test` and `dart analyze` in `client/module_core`; add API/repository/
   service/listener/cubit tests with fake platform clients/storage.
 - `flutter test` and `dart analyze` in `client/app`.
@@ -1188,6 +1346,11 @@ the separately released app.
 - Inspect a release-build Firebase DebugView/BigQuery sample using synthetic
   content and verify no forbidden field/value appears. Do not turn normal debug
   custom-event sharing on for convenience.
+- Navigate every `AppRouteDef` through GoRouter and verify exactly one canonical
+  `product_screen_viewed` plus one Firebase-native `screen_view` mirror with the
+  same pinned name, no concrete route parameters, and no automatic duplicate.
+- Verify login events carry no `user_key`/attempt identifier and voice events
+  carry no transcript, audio metadata, duration, or text-derived value.
 - Seed the current release's global Firebase user ID, upgrade to the new build,
   and verify null-clear completes before any custom source starts; force clear
   failure and verify custom events remain disabled while product startup works,
@@ -1211,7 +1374,8 @@ the separately released app.
   per-account schema exposure, legacy-without-exposure exclusion, 7-day cohort
   maturity, W1/W4 boundaries, internal/disabled/suppressed filtering before
   aggregates, deletion exclusion in flattened recomputation, daily monitoring
-  activity without SSE duplication, the 24-hour campaign rule, unknown campaign,
+  activity without SSE duplication, typed/voice-assisted classification,
+  identifier-free login aggregation, custom-screen-only account reporting,
   stale-auth-snapshot publication abort/recovery, and late-event replacement.
 - Reconcile GA4 custom event counts -> flattened events -> daily activity ->
   reporting totals for at least three complete days.
@@ -1226,7 +1390,7 @@ the separately released app.
   Verify the deletion response states both the transient future-upload and
   automatic-only never-keyed installation limits.
 
-## Rollout And Two-Month Readiness
+## First Release And Ongoing Operation
 
 1. **Day 0:** Establish restricted project IAM, link daily Firebase export,
    verify raw ACL/90-day expiration before the first table, and record
@@ -1246,7 +1410,10 @@ W1 retention becomes available after two weeks of production behavior. W4
 requires at least 35 days after a user's activation to close the full 28-34 day
 window; any release delay directly reduces the W4 sample available by the
 two-month deadline. Show the cohort size and use null—not a fabricated zero—if
-no cohort has matured.
+no cohort has matured. The deadline is the first investor-ready readout, not the
+end of the system: keep the same metric definitions, schedules, privacy controls,
+and data-quality monitoring in ongoing product operation, and add deferred
+extensions only through versioned schema/model changes.
 
 ## Risks And Mitigations
 
@@ -1265,9 +1432,11 @@ no cohort has matured.
   GET/PUT failure is fail-closed; auth profiles remain unchanged.
 - **Legacy/automatic-event limitation:** a pre-opt-out binary can continue its
   prior Firebase behavior, and Firebase automatic install events are outside the
-  custom-event toggle. Narrow UI/legal promises accordingly, use current
-  preference only for supported-client custom events and reporting eligibility,
-  and never claim account-wide enforcement without minimum-version controls.
+  custom-event toggle. The bounded pre-auth login catalog is also outside the
+  authenticated product-event toggle by explicit decision. Narrow UI/legal
+  promises accordingly, use current preference only for supported-client
+  account-linked events and reporting eligibility, and never claim account-wide
+  enforcement without minimum-version controls.
 - **Legacy global identity on upgrade:** clear it at earliest post-Firebase
   bootstrap before custom sources and keep the migration for the raw-retention
   window. Automatic events before a successful reset—or for the whole process
@@ -1278,14 +1447,19 @@ no cohort has matured.
   repeatedly delete newly discovered keyed installs; the response remains
   honest that a later upload may transiently enter restricted vendor/raw data.
 - **Privacy rollback floor:** after the opt-out release, use forward fixes that
-  preserve local pending-disable/custom-event gating or suppress all custom
-  events; never republish old startup emission as rollback.
+  preserve local pending-disable/product-event gating or suppress all account-
+  linked product events; never republish old startup emission as rollback.
 - **Analytics affecting product behavior:** all reports are best-effort,
   unawaited after confirmed outcomes, and failure-isolated.
 - **High-cardinality or sensitive leakage:** closed event variants, bounded
-  enums/campaign codes, raw-ID prohibition, wire-pin tests, and allowlisted SQL.
-- **Misleading acquisition:** label known coverage and platform limitations;
-  never relabel unknown as organic.
+  enums, raw-ID prohibition, wire-pin tests, and allowlisted SQL.
+- **Misleading login conversion:** label pre-auth login metrics as installation-
+  level aggregates, never join them to account creation/activation, and do not
+  infer unique people from attempts or `user_pseudo_id`.
+- **Incorrect screen names/duplicates:** disable Firebase automatic screen
+  reporting, map GoRouter routes exhaustively to pinned screen values, mirror
+  those through `logScreenView`, and use only the custom event in account-level
+  reporting.
 - **Late/incomplete GA4 exports:** recompute recent partitions and show freshness
   plus complete-period defaults.
 - **Auth-export outage:** keep flattened facts independent, assert a fresh
@@ -1308,6 +1482,11 @@ The work is complete when:
   defers the first same-generation message while preference is unknown, clears
   legacy global identity before custom sources, and never claims to control
   legacy or automatic events; duplicate delivery cannot change activation.
+- The same release reports typed versus voice-assisted successful submissions
+  and content-free transcription completion, reports bounded account-less login
+  attempt outcomes without account/attempt identity, and derives every screen
+  name from GoRouter with one canonical custom event plus one matching Firebase-
+  native mirror and no automatic duplicate.
 - The auth job publishes validated eligible milestones and external-account
   setup cohorts without raw identity or internal/deletion-suppressed accounts.
 - BigQuery derives the metric contract above from versioned SQL, passes fixture

--- a/.plan/active/user-analytics/PLAN.md
+++ b/.plan/active/user-analytics/PLAN.md
@@ -43,7 +43,8 @@ Revenue metrics are out of scope because Sesori is currently free.
    authenticated product-event preference: started, completed, and failed
    attempts carry only a pinned login-provider enum plus a bounded failure kind.
    They carry no `user_key`, attempt identifier, OAuth identity, or payload,
-   remain release-only, follow the upstream two-month retention, and are
+   remain release-only, follow two-month upstream GA retention plus the
+   restricted 90-day exported-raw expiration, and are
    disclosed as installation-level operational analytics outside the product-
    interaction toggle. Because they intentionally retain no account/install
    mapping, internal/test release traffic cannot be removed reliably; reports
@@ -229,7 +230,7 @@ honestly labeled setup trends.
 | `sesori_auth_server` | `src/types/product-analytics.ts` (domain enum), `src/models/{documents,api,product-analytics-export}.ts` (persisted/API/export/deletion-target contracts), `src/repositories/{user-repo,activation-state-repo,product-analytics-export-repo,product-analytics-control-repo,product-analytics-deletion-target-repo}.ts`, `src/services/{product-analytics-preference-service,product-analytics-export-service,product-analytics-deletion-service}.ts`, `src/clients/bigquery-product-analytics-client.ts` and `src/api/product-analytics-export-api.ts`, `src/routes/product-analytics.ts`, `src/scripts/{backfill-product-analytics-preference,suppress-product-analytics-export,export-product-analytics,product-analytics-export-config}.ts` | Persist revisioned preference/privacy-suppression state behind dedicated services, expose GET/PUT endpoints, export privacy-safe data after source/internal exclusion, and hand tombstoned deletion targets to restricted auth-private storage. | Existing auth profile/token responses remain unchanged. The web process constructs only the preference service; export/deletion BigQuery classes exist only in isolated command composition. |
 | `shared/sesori_shared` | No production change | Keep `AuthUser` authentication-only; do not add a product preference to the shared auth/persisted contract. | No bridge/shared migration or compatibility default is introduced. |
 | `client/module_auth` | Existing HTTP client interfaces/implementations/tests | Add named-parameter JSON `PUT` support to `SafeApiClient`, `HttpApiClient`, and `AuthenticatedHttpApiClient`; keep tokens, OAuth, and auth state otherwise unchanged. | `module_core` injects the authenticated client into its Layer-1 preference API; no wrong-verb workaround or compatibility path is introduced. |
-| `client/module_core` | `lib/src/foundation/{models/product_analytics/,platform/analytics_client.dart}`, `lib/src/api/{analytics_api,product_analytics_preference_api.dart,storage/product_analytics_preference_storage.dart}`, `lib/src/repositories/{models/,product_analytics,installation_analytics,product_analytics_preference}_repository.dart`, `lib/src/services/{models/,product_analytics,installation_analytics}_service.dart`, `lib/src/routing/{analytics_route,session_activity_analytics}_listener.dart`, `lib/src/cubits/{product_analytics_preference,settings}/`, existing login/project/session/diff cubits, DI/barrel/generated files | Mirror the declared layers explicitly; own preference HTTP/persistence, pseudonymous hashing, bounded account-less login telemetry, route/visibility lifecycle, pre-logout orchestration, Settings state, and authoritative business-outcome emission. | Mobile supplies the Firebase client plus immutable runtime capability. Desktop supplies no-op/disabled Foundation adapters. Cubit constructor call sites/tests update in lockstep. |
+| `client/module_core` | `lib/src/foundation/{models/product_analytics/,platform/analytics_client.dart}`, `lib/src/api/{analytics_api,product_analytics_preference_api.dart,storage/product_analytics_preference_storage.dart}`, `lib/src/repositories/{models/,product_analytics,installation_analytics,product_analytics_preference}_repository.dart`, `lib/src/services/{models/,product_analytics,installation_analytics}_service.dart`, existing `services/draft_store.dart` plus typed composer-draft model, `lib/src/routing/{analytics_route,session_activity_analytics}_listener.dart`, `lib/src/cubits/{product_analytics_preference,settings}/`, existing login/project/session/diff cubits, DI/barrel/generated files | Mirror the declared layers explicitly; own preference HTTP/persistence, pseudonymous hashing, bounded account-less login telemetry, typed draft/input-origin restoration, route/visibility lifecycle, pre-logout orchestration, Settings state, and authoritative business-outcome emission. | Mobile supplies the Firebase client plus immutable runtime capability. Desktop supplies no-op/disabled Foundation adapters. Cubit constructor call sites/tests update in lockstep. |
 | `client/app` | `lib/core/platform/{firebase_analytics_client,firebase_analytics_identity_migration}.dart`, `lib/core/di/`, `lib/features/{login,settings,project_list,new_session,session_detail,session_diffs}/`, composer widgets/callbacks, `lib/l10n/`, `lib/main.dart`, iOS/macOS/Android analytics defaults | Clear legacy global identity at earliest post-Firebase bootstrap, pass its immutable capability into phase-1 DI, implement the thin Firebase adapter, disable automatic screen reporting, mirror GoRouter-derived screens through `logScreenView`, begin Apple analytics before the native authorization sheet, report successful content-free transcription completion, start core services/listeners, render preference UI, and inject services into core consumers. | Existing app event sources move to core; `AnalyticsUserIdTracker` is removed. The only global Firebase `user_id` call sets null for migration; no account key or runtime collection override is added. Existing `DeepLinkService` remains unchanged because campaign work is deferred. |
 | `client/desktop` | `lib/core/platform/no_op_analytics_client.dart`, DI generated file | Satisfy the shared core platform capability without collecting desktop analytics. | No desktop product events or UI are added. Analyze/test verifies core DI remains resolvable. |
 | `client/module_desktop_core` | No planned production edit; tests/build are downstream validation | Continue unchanged. | Shared core DI/downstream validation only. |
@@ -337,8 +338,10 @@ The Settings copy must say “Share pseudonymous product usage from this device,
 list the prohibited content categories, identify the pending server-sync state,
 and explain that Firebase automatic install-level events, the bounded pre-auth
 login funnel, plus account/bridge records required to operate Sesori are not
-controlled by this switch. Product/privacy counsel must approve the final text
-and store disclosures before release.
+controlled by this switch. Privacy/deletion disclosures distinguish GA's two-
+month upstream retention from the restricted exported BigQuery raw copy's 90-day
+expiration. Product/privacy counsel must approve the final text and store
+disclosures before release.
 
 ### Pseudonymous join key
 
@@ -357,6 +360,9 @@ pseudonymous personal data. Documentation and access controls must call it that.
 ### Allowed dimensions
 
 - Event schema version.
+- Account-linked product `occurred_at_micros`, captured at the authoritative
+  seam and used only as validated warehouse time—not registered as a GA custom
+  dimension.
 - Stable screen enum.
 - Platform and app version/build supplied by Firebase.
 - Bounded onboarding, interaction, voice-input, login-provider, login-failure,
@@ -391,8 +397,8 @@ mixed `src/analytics/` bucket. The concrete dependency direction is:
 
 | Class/file | Layer and constructor collaborators | Responsibility and lifecycle |
 | --- | --- | --- |
-| `ProductAnalyticsEvent`, `InstallationAnalyticsEvent`, `AnalyticsScreen`, `AnalyticsInputMode`, pinned event enums, and immutable `AnalyticsRuntimeCapability` under `module_core/lib/src/foundation/models/product_analytics/` | Foundation contracts; no SDK/Flutter dependencies | Separate closed account-linked and account-less sink contracts. `AnalyticsScreen` is independent of routing; `AnalyticsRouteListener` performs the exhaustive `AppRouteDef -> AnalyticsScreen` mapping. `AnalyticsLoginProvider` is independently pinned and exhaustively mapped from the sealed auth provider. Runtime capability is `enabled` or a closed disabled reason and is produced before phase-1 DI. |
-| `AnalyticsClient` in `module_core/lib/src/foundation/platform/analytics_client.dart` | Foundation external-sink capability | Typed `logProductEvent({required ProductAnalyticsEvent event, required String userKey})` and `logInstallationEvent({required InstallationAnalyticsEvent event})`. Methods throw SDK failures and accept no arbitrary map/name or raw account ID. Only the product method can receive the already-pseudonymous key. |
+| `ProductAnalyticsEvent`, typed `ProductAnalyticsEnvelope(event, occurredAtUtc)`, `InstallationAnalyticsEvent`, `AnalyticsScreen`, `AnalyticsInputMode`, pinned event enums, and immutable `AnalyticsRuntimeCapability` under `module_core/lib/src/foundation/models/product_analytics/` | Foundation contracts; no SDK/Flutter dependencies | Separate closed account-linked and account-less sink contracts. Every product outcome captures occurrence time at its authoritative seam before analytics work; deferred candidates retain the envelope. `AnalyticsScreen` is independent of routing; `AnalyticsRouteListener` performs the exhaustive `AppRouteDef -> AnalyticsScreen` mapping. `AnalyticsLoginProvider` is independently pinned and exhaustively mapped from the sealed auth provider. Runtime capability is `enabled` or a closed disabled reason and is produced before phase-1 DI. |
+| `AnalyticsClient` in `module_core/lib/src/foundation/platform/analytics_client.dart` | Foundation external-sink capability | Typed `logProductEvent({required ProductAnalyticsEnvelope envelope, required String userKey})` and `logInstallationEvent({required InstallationAnalyticsEvent event})`. Product serialization adds `occurred_at_micros`; methods throw SDK failures and accept no arbitrary map/name or raw account ID. Only the product method can receive the already-pseudonymous key. |
 | `AnalyticsApi` in `module_core/lib/src/api/analytics_api.dart` | Layer 1; constructor requires `AnalyticsClient` | Thin typed API over both external-client operations. It is the only core class that invokes the platform sink. |
 | `ProductAnalyticsPreferenceApi` in `module_core/lib/src/api/product_analytics_preference_api.dart` | Layer 1; constructor requires `AuthenticatedHttpApiClient` | Calls authenticated GET/PUT `/product-analytics/preference` under a fixed 10-second operation deadline. GET parses `{preference, revision}`; PUT requires `{preference, expectedRevision, operationId}` and parses success/conflict. It serializes closed values, parses external strings at the boundary, and returns explicit success/conflict/timeout/failure. A timed-out transport may finish, but server compare-and-set prevents it from overwriting a newer committed revision. |
 | `ProductAnalyticsPreferenceStorage` in `module_core/lib/src/api/storage/` | Layer 1 data source; constructor requires `SecureStorage` | Reads/writes/deletes only closed preference synchronization records. It does not reconcile accounts, call APIs, hash IDs, or emit analytics. |
@@ -525,21 +531,25 @@ service may return `deferredUntilPreference` and retain only the closed
 activation/project-available/diff-adoption candidates. Active resolution emits
 each retained semantic once; disabled resolution, logout/account switch, or
 generation change drops them. No prompt/message content, project/session ID, or
-unbounded event enters this fixed model. Empty diagnostics are not buffered.
+unbounded event enters this fixed model. Each candidate retains its typed
+`occurredAtUtc`, captured before analytics invocation, so later emission cannot
+move activation eligibility, latency, project availability, or adoption time.
+Empty diagnostics are not buffered.
 
 `SessionActivityAnalyticsListener` separately retains at most one non-empty
 candidate for the current UTC date. It advances its date guard only after
 `acceptedBySdk`; while preference is unknown it waits for active state and
 revalidates that the session-detail route is still topmost/resumed before
-retrying. It drops the candidate on date change, route exit, disable, or auth
+retrying the original envelope/occurrence time. It drops the candidate on date
+change, route exit, disable, or auth
 generation change, so delayed preference cannot fabricate monitoring activity.
 
 **Disable:** The cubit calls `ProductAnalyticsService.setPreference(disabled)`.
 The service immediately publishes inactive, then first durably persists
 `pendingDisable(userId)` before any subsequent await, then calls the preference
 repository PUT. Success stores synchronized disabled; network failure remains
-pending and exposes the truthful local-disabled/server-sync-pending state. A
-storage-write failure keeps in-memory suppression, attempts server disable, and
+  pending and exposes the truthful local-disabled/server-sync-pending state. A
+  storage-write failure keeps in-memory suppression, attempts server disable, and
   surfaces unsaved failure unless the server confirms disabled. Retry occurs only
   from explicit Settings action or the next post-readiness auth generation,
   never from a timer or lifecycle polling.
@@ -593,6 +603,13 @@ key, or random attempt ID is emitted. Installation events are not buffered or
 joined to later accounts; BigQuery reports aggregate provider completion rates
 and excludes them from account-level funnel/retention tables.
 
+`LoginCubit` retains one closed in-memory `ActiveLoginAnalyticsAttempt(provider,
+terminalReported)` independently from transient UI states. OAuth poll
+interruption/backgrounding does not clear it; `_onAppResumed` uses that provider
+for the eventual completion/failure and then clears it. Logout/cubit close or a
+new validated attempt clears/replaces it without emitting a fabricated terminal
+event. The context is never persisted or sent as an identifier.
+
 **Voice flow:** A successful non-empty transcription sets the composer input
 classification to `voice_assisted` and emits one content-free
 `voice_transcription_completed` through `ProductAnalyticsService`. The flag
@@ -600,13 +617,21 @@ remains voice-assisted through subsequent manual edits, resets when the composer
 is cleared/reset, and is captured with the submission. Existing-session queued
 items retain only the enum alongside their existing content/command; successful
 send is reported later with that enum. New-session creation threads the same
-enum into its successful outcome. No transcript, duration, audio metadata, or
-text length is emitted.
+enum into its successful outcome. Change in-memory `DraftStore` from raw string
+values to typed `ComposerDraft(text, inputMode)` for both session and
+`new-session:<projectId>` keys, so navigation/disposal/restoration preserves
+voice contribution. Whitespace clear removes the whole draft/origin. No
+transcript, duration, audio metadata, or text length is emitted or persisted.
 
 ### Outcome event catalog
 
 Existing wire names remain unchanged. Add only the following initial account-
 linked product events:
+
+Every account-linked row uses `ProductAnalyticsEnvelope` and therefore includes
+shared `occurred_at_micros` captured at the authoritative seam. It is transport/
+warehouse metadata, not a GA custom dimension; deferred delivery never rewrites
+it. Account-less login events are immediate and do not add this field.
 
 | Event | Emit only when | Bounded parameters | Reporting use |
 | --- | --- | --- | --- |
@@ -684,10 +709,10 @@ merely to avoid updating tests.
 | --- | --- |
 | `ProjectListCubit` | Add required `ProductAnalyticsService`. Empty diagnostic advances only after SDK acceptance and is not buffered. First non-empty is submitted to the service's fixed project-available slot while preference is unknown; the cubit consumes its lifetime guard only after `acceptedBySdk` or `deferredUntilPreference`, because the service owns that deferred semantic. Refreshes never repeat an accepted/deferred classification. The warehouse milestone uses only earliest non-empty. |
 | `SessionActivityAnalyticsListener` | `SessionDetailScreen` constructs it with the screen-owned cubit plus `RouteSource`, `LifecycleSource`, and product analytics service. It retains one lifetime accepted empty-diagnostic guard plus the last UTC date accepted. Initial/later empty retries until accepted while visible/active. A non-empty current-date candidate waits locally through preference-unknown and is retried only after active-state plus route/lifecycle revalidation; the date guard advances only on `acceptedBySdk`. Background/nested-diffs SSE, disable, route exit, auth change, or date expiry drops the pending candidate. |
-| `LoginCubit` / Apple mobile call site | Add required `InstallationAnalyticsService`. GitHub/Google/email methods map the sealed provider exhaustively, report one start after input validation, and report exactly one terminal completion/failure; OAuth timeout is failed. For Apple, add explicit begin/credential-success/native-failure Cubit intents: the UI invokes begin before the native sheet, then exactly one credential continuation or cancelled/failure terminal call. Desktop resolves shared methods through its no-op client. |
+| `LoginCubit` / Apple mobile call site | Add required `InstallationAnalyticsService` and one closed `ActiveLoginAnalyticsAttempt`. GitHub/Google/email methods map the sealed provider exhaustively, report one start after input validation, and report exactly one terminal completion/failure; interrupted OAuth polling retains provider through `_onAppResumed`, and timeout is failed. For Apple, add explicit begin/credential-success/native-failure Cubit intents: the UI invokes begin before the native sheet, then exactly one credential continuation or cancelled/failure terminal call. Desktop resolves shared methods through its no-op client. |
 | `SessionDetailCubit` send paths | Direct `sendMessage` and `_drainQueuedMessages` call one private `_reportAcceptedSubmission` only on `SuccessResponse`. The queued item retains its existing text/command plus the closed input-mode enum; analytics derives text/command classification without reading content. Error/requeue emits nothing, and each dequeued successful item reports once. |
 | `NewSessionCubit` | Add required product analytics service and required input-mode argument on creation. Capture workspace/submission/input classifications before awaiting. `SuccessResponse` makes one `session_created_with_message` call; `ErrorResponse` emits only bounded `session_creation_failed`. It never also emits the existing-session event. |
-| Mobile composer call sites | After `stopAndTranscribe()` returns a non-empty transcript, report `voice_transcription_completed`, mark input `voice_assisted`, and pass the enum to existing/new-session submit methods. Manual edits do not erase contribution; clearing/resetting the composer does. Product behavior does not await analytics delivery. |
+| Mobile composer call sites / `DraftStore` | After `stopAndTranscribe()` returns a non-empty transcript, report `voice_transcription_completed`, mark input `voice_assisted`, and pass the enum to existing/new-session submit methods. Replace draft strings with typed `ComposerDraft` so dispose/restore for either key preserves the enum. Manual edits do not erase contribution; clearing/resetting the composer removes text+origin. Product behavior does not await analytics delivery. |
 | `SessionDetailCubit` question/permission/abort | Report after each verified success branch. Question answers/rejections carry no answer data. Change `replyToPermission` to pattern-match `SuccessResponse`/`ErrorResponse` instead of treating every non-throwing response as true; only success maps the existing `PermissionReply` enum and reports. Abort reports only after every root/active-child response succeeds. |
 | `DiffCubit` | Add required product analytics service. Empty diagnostic advances only after SDK acceptance and is not buffered. First non-empty may occupy the service's fixed diff-adoption slot while preference is unknown; consume its guard only after accepted/deferred result. Only non-empty defines adoption, and SSE refreshes do not repeat accepted/deferred state. |
 | `AnalyticsRouteListener` / `FirebaseAnalyticsClient` | Listener maps every `AppRouteDef` to pinned `AnalyticsScreen`, deduplicates unchanged routes, and reports only after product analytics activates. The adapter logs canonical `product_screen_viewed`, then best-effort calls `logScreenView` with the same name. Native automatic screen reporting is disabled and standard rows are excluded from account-level models. |
@@ -781,7 +806,7 @@ export work to request handlers or the long-running auth process.
 | `BigQueryProductAnalyticsClient` in `src/clients/bigquery-product-analytics-client.ts` | Foundation external client; requires `@google-cloud/bigquery` `BigQuery`, project ID, auth-export dataset ID, one fully qualified authorized internal-exclusion view, and location | Thin SDK operations for creating/inserting/querying **inside the auth-export dataset only**, plus one typed read of active `user_key` values from the authorized view. It exposes no controls write/DDL method and never receives raw IDs/Mongo documents or export semantics. |
 | `ProductAnalyticsExportApi` in `src/api/product-analytics-export-api.ts` | Layer 1; requires `BigQueryProductAnalyticsClient` | Defines external auth-dataset operations and read-only active-exclusion retrieval, and maps SDK responses/errors; no pagination, aggregation, or publication policy. |
 | `ProductAnalyticsExportRepository` in `src/repositories/product-analytics-export-repo.ts` | Layer 2; requires `ProductAnalyticsExportApi` | Owns a run's staging-table lifecycle, safe-row batching, validation queries, and atomic two-target promotion. The service never calls the client/API directly. |
-| `ProductAnalyticsControlRepository` in `src/repositories/product-analytics-control-repo.ts` | Layer 2; requires `ProductAnalyticsExportApi` | Loads and validates the bounded active internal-user key set from the one authorized view. It cannot write controls or auth export tables. |
+| `ProductAnalyticsControlRepository` in `src/repositories/product-analytics-control-repo.ts` | Layer 2; requires `ProductAnalyticsExportApi` | Loads and validates the bounded permanent internal/test-user key set from the one authorized view. It cannot write controls or auth export tables. |
 | `ProductAnalyticsExportService` in `src/services/product-analytics-export-service.ts` | Layer 3; requires `UserRepository`, `ActivationStateRepository`, `ProductAnalyticsControlRepository`, and `ProductAnalyticsExportRepository` | Owns cutoff pagination, SHA-256 transformation, suppression/internal filtering before all counters, enabled-user filtering, weekly external-account accumulation, reconciliation inputs, and repository promotion. `run({ runCutoff }: { runCutoff: Date })` receives one immutable cutoff. |
 | `product-analytics-export-config.ts` in `src/scripts/` | Zod over process environment | Validates only job concerns: Mongo connection/database, GCP project, auth-export dataset, authorized exclusion-view name, location, and bounded batch/exclusion-set size. It cannot configure control writes or curated/reporting datasets, does not import the web server's full OAuth/FCM configuration, and accepts no service-account JSON key. |
 | `export-product-analytics.ts` in `src/scripts/` | Command composition root | Constructs Mongo repositories, ADC BigQuery client, export API/repository/service; invokes one run, awaits jobs, and closes Mongo in `finally`. It is compiled into the production image and run as `node dist/scripts/export-product-analytics.js`; `src/index.ts` does not import it. |
@@ -822,7 +847,7 @@ disabled/suppressed accounts no longer join behavioral reports and suppression
 can remove prior aggregate contribution. Keep raw account rows inside Mongo;
 only filtered aggregate cohorts leave the auth boundary.
 
-At run start, the service loads the active internal `user_key` set and records
+At run start, the service loads the permanent internal/test `user_key` set and records
 its control-view update/cutoff in run metadata. Missing, stale, malformed, or
 over-limit control output aborts the run before source pagination; it never
 falls back to an empty exclusion set. For each page it builds a user-
@@ -856,7 +881,7 @@ Job acceptance checks before promotion:
 Use Application Default Credentials, Secret Manager for Mongo access, and an
 export service account limited to BigQuery Job User plus Data Editor on
 `sesori_analytics_auth_private` plus table-level Data Viewer on the one
-authorized active-internal-exclusion view. It has no controls dataset write/DDL
+authorized permanent-internal-exclusion view. It has no controls dataset write/DDL
 role and no role on raw, curated, or reporting datasets, so it cannot mutate
 exclusion/config tables. A separate scheduled-transform identity has read-only access to raw,
 auth-private, and controls plus write access to curated; the deployment identity
@@ -903,8 +928,10 @@ No persistent account-to-installation map is created. Once currently linkable
 app-instance IDs are submitted and raw keyed rows are deleted/expired, later
 automatic-only events cannot be associated with the account. Recurring sweeps
 therefore promise enforcement only for future keyed uploads; automatic-only
-future rows remain under upstream two-month retention. Privacy responses must
-state that limit instead of claiming indefinite automatic-event deletion.
+future rows remain under upstream two-month retention and may remain in the
+already-exported restricted BigQuery raw copy until its 90-day expiration.
+Privacy responses must state both limits instead of claiming indefinite
+automatic-event deletion.
 
 ## BigQuery Design
 
@@ -1022,10 +1049,16 @@ not weaken the written privacy boundary to fit an unchecked property.
 ### Curated models
 
 1. **`events_flattened`**: flatten only catalogued account-linked Sesori product
-   events/parameters from GA4, use `event_timestamp` in UTC, require schema
-   version and non-null custom `user_key`, and retain Firebase platform/app
-   version/build. Anti-join
-   both active internal/test keys and the permanent deletion-exclusion keys on
+   events/parameters from GA4, preserve export `event_timestamp` as
+   `emitted_at` via `TIMESTAMP_MICROS(event_timestamp)`, parse required integer
+   `occurred_at_micros` the same way as `occurred_at`,
+   require schema version and non-null custom `user_key`, and retain Firebase
+   platform/app version/build. Reject occurrence later than emitted time beyond
+   the documented clock-skew allowance. User-milestone/cohort joins additionally
+   require occurrence no earlier than account creation beyond that allowance;
+   invalid timing remains a data-quality count and is excluded from time-bound
+   metrics rather than silently falling back to emission. Anti-join
+   both permanent internal/test keys and the permanent deletion-exclusion keys on
    every build/recomputation, but deliberately do **not** join the time-varying
    current auth eligibility snapshot here. Raw bundle/install fields may be used
    transiently to discard
@@ -1061,7 +1094,7 @@ queries recompute at least the last three UTC event dates because GA4 daily
 exports can receive late events. Reporting uses only completed recomputations,
 and data-quality views expose source/export/query freshness.
 Every user-level reporting build also inner-joins the **current** eligible auth
-snapshot and anti-joins the current internal exclusion table. Therefore a
+snapshot and anti-joins the permanent internal exclusion table. Therefore a
 disable or newly added internal exclusion takes effect after the next auth
 export/report refresh even when an older curated partition exists; those gates
 are not applied only at the historical partition's original build time.
@@ -1114,8 +1147,10 @@ only three days.
   reporting on the next successful export.
 - Restrict raw/private datasets; give Looker and routine viewers access only to
   reporting views. Do not expose `user_key` in Looker fields, extracts, or URLs.
-- Maintain internal/test exclusions as hashes in a restricted table with owner,
-  reason, and optional expiry. Never put the list in Git.
+- Maintain internal/test exclusions as permanent hashes in a restricted table
+  with owner and reason. Accounts ever used for internal/test activity remain
+  excluded from all historical/future account metrics; do not expire a row and
+  retroactively reintroduce its history. Never put the list in Git.
 - Configure dataset/table expiration, scheduled-query byte limits, billing
   alerts, and a monthly cost check before dashboard sharing.
 - Implement a privacy-request runbook/job that first calls the auth-source
@@ -1136,8 +1171,10 @@ only three days.
   An automatic-only installation that disabled before ever emitting a keyed
   event has no account link by design and cannot be targeted by an account-based
   deletion request; do not claim otherwise. Its unlinked GA4 data is governed by
-  the verified two-month upstream retention. State this limit in the privacy
-  notice/deletion response rather than creating a persistent account-device map.
+  verified two-month upstream retention, while rows already exported to the
+  restricted BigQuery raw dataset may remain until the separate 90-day table
+  expiration. State both limits in the privacy notice/deletion response rather
+  than creating a persistent account-device map.
 - Keep deletion-exclusion tombstones permanent and run a daily upstream deletion
   sweep over newly landed raw partitions. For every tombstoned key it discovers
   future keyed installation IDs (including product events queued while a
@@ -1145,9 +1182,10 @@ only three days.
   matching warehouse rows, and submits the legacy `USER_ID` while that migration
   window remains possible. It persists no install mapping, so later automatic-
   only events after the last keyed row cannot be associated and remain governed
-  by upstream two-month retention. The request reports source/warehouse deletion
-  plus recurring **keyed-upload** enforcement, never indefinite automatic-event
-  enforcement. Record request IDs/completion without raw account/install IDs.
+  by upstream two-month retention and the restricted exported-raw 90-day
+  expiration. The request reports source/warehouse deletion plus recurring
+  **keyed-upload** enforcement, never indefinite automatic-event enforcement.
+  Record request IDs/completion without raw account/install IDs.
   Test the layered deletion command, IAM, request format, in-flight export
   ordering, delayed keyed upload, flattened anti-join/non-repopulation,
   aggregate rebuild, and a non-production deletion before rollout.
@@ -1221,7 +1259,7 @@ directory name.
   package dependency, and production image command.
 - Publish the eligible pseudonymous snapshot and identifier-free weekly setup
   cohorts through staging/validation/transactional promotion, excluding source-
-  suppressed and active internal keys before keyed rows or aggregate counters.
+  suppressed and permanent internal keys before keyed rows or aggregate counters.
 - Test hashing golden vector, opt-out filtering, aggregate reconciliation,
   pagination cutoff, milestones/preferences changing on already-read and future
   pages, conservative preference exclusion, staging cleanup, rerun idempotency,
@@ -1314,24 +1352,29 @@ directory name.
   direct and queued message success, while keeping analytics best-effort and
   non-blocking.
 - Thread `input_mode=typed/voice_assisted` through existing/new-session sends and
-  queued submissions, and report content-free successful transcription from the
-  mobile composer call site.
-- Buffer only the first activation-candidate outcome while same-generation
-  preference is unknown, then emit on active or drop on disabled/auth change;
-  report first empty/non-empty transitions for milestones and at most one
-  visible non-empty session activity per UTC date for WAU/retention.
+  queued submissions; store typed text+input mode in `DraftStore` across composer
+  disposal/restoration; and report content-free successful transcription from
+  the mobile composer call site.
+- Retain only the fixed activation/project-available/diff-adoption candidates
+  while same-generation preference is unknown, preserving their occurrence
+  times; keep one route-visible current-date session-activity candidate locally;
+  then emit on active or drop under the declared disabled/auth/route/date rules.
 - Regenerate only source-generated outputs.
 - Add focused tests that failures/taps/queued-only operations do not activate,
   each successful message path makes one service call, new-session success is not
   double counted, a non-throwing permission `ErrorResponse` returns failure and
   emits no success, sensitive inputs cannot enter parameter maps, bounded
   milestone candidates survive preference-unknown without consuming guards,
+  deferred envelopes preserve authoritative occurrence time and invalid clock
+  values are excluded from time-bound warehouse metrics,
   activation-ready exposure excludes foundation-only binaries, first-message
   deferral survives preference resolution,
   empty-to-non-empty transitions report once, resumed/later-date monitoring can
   report again without SSE inflation, voice-assisted origin survives queueing
-  without transcript data, and login timeout/failure makes one bounded terminal
-  installation event without an account key. Widget tests verify Apple start is
+  and both existing/new-session draft restoration without transcript data,
+  interrupted/resumed OAuth retains its provider, and login timeout/failure
+  makes one bounded terminal installation event without an account key. Widget
+  tests verify Apple start is
   emitted before opening the native sheet and cancellation/failure terminates
   that attempt without calling the Cubit start twice.
 
@@ -1428,6 +1471,8 @@ the separately released app.
   maturity, W1/W4 boundaries, internal/disabled/suppressed filtering before
   aggregates, deletion exclusion in flattened recomputation, daily monitoring
   activity without SSE duplication, typed/voice-assisted classification,
+  deferred occurrence-time preservation, clock-skew rejection, and occurrence-
+  based activation/retention anchors,
   identifier-free login aggregation, custom-screen-only account reporting,
   stale-auth-snapshot publication abort/recovery, and late-event replacement.
 - Reconcile GA4 custom event counts -> flattened events -> daily activity ->
@@ -1440,8 +1485,9 @@ the separately released app.
   through auth-source tombstone, warehouse suppression/deletion, aggregate
   rebuild/non-repopulation after an in-flight pre-tombstone export, delayed
   offline-client upload plus recurring sweep, and upstream request status.
-  Verify the deletion response states both the transient future-upload and
-  automatic-only never-keyed installation limits.
+  Verify the deletion response states transient future-upload/keyed-only sweep
+  limits and, for automatic-only/never-keyed data, both two-month upstream GA
+  retention and 90-day restricted BigQuery raw expiration.
 
 ## First Release And Ongoing Operation
 
@@ -1550,7 +1596,8 @@ The work is complete when:
   remains fresh after recovery/late data.
 - Privacy deletion remains excluded from flattened/reporting rebuilds, survives
   an in-flight old auth export, and has recurring upstream enforcement for later
-  keyed uploads with its unavoidable transient/never-keyed limits disclosed.
+  keyed uploads with its unavoidable transient/never-keyed limits and distinct
+  two-month upstream/90-day exported-raw retention disclosed.
 - Looker exposes only aggregate authorized views and shows complete-period,
   denominator, coverage, maturity, and freshness labels.
 - The executive page can truthfully report new accounts, setup, full

--- a/.plan/active/user-analytics/PLAN.md
+++ b/.plan/active/user-analytics/PLAN.md
@@ -1,0 +1,994 @@
+# User Analytics
+
+**Status:** Revised after rejected architecture review; valid findings applied,
+not re-reviewed
+
+**Plan slug:** `user-analytics`
+
+**Created:** 2026-07-28
+
+## Goal
+
+Give Sesori a privacy-safe product analytics system that can answer, within the
+next two months:
+
+- Are new accounts growing?
+- Do users complete bridge setup and reach product value?
+- Do activated users return and use Sesori repeatedly?
+- Which remote-control and differentiating features create engagement?
+- Where do onboarding and core actions fail?
+
+The system must produce reproducible BigQuery metrics and restricted Looker
+Studio dashboards without exporting source code, prompts, transcripts, paths,
+project/session names, raw entity identifiers, or unbounded backend data.
+
+Revenue metrics are out of scope because Sesori is currently free.
+
+## Product Decisions
+
+1. **Full activation is the first successfully accepted user-authored message
+   to any coding session.** Both sending to an existing session and creating a
+   session with an initial message qualify. A command submission qualifies;
+   tapping Send, queueing offline, merely opening a session, answering a
+   permission/question, or creating an empty session does not.
+2. The implementation spans the apps monorepo, the Sesori auth server,
+   Firebase/GA4, BigQuery, and Looker Studio.
+3. Optional product-interaction analytics is enabled by default for an account
+   after its authenticated preference is known. Users receive an account-wide
+   opt-out in Settings.
+4. Acquisition work starts with campaign links and automatic store/Firebase
+   attribution. No onboarding survey is added in this scope.
+5. Looker Studio is the reporting surface; it reads aggregate authorized views,
+   not raw event or per-user tables.
+
+## Metric Contract
+
+All reporting uses UTC. Weekly metrics use complete Monday-Sunday weeks unless
+the dashboard explicitly labels a live partial week. Every rate displays its
+numerator, denominator, and cohort maturity; an incomplete cohort must never be
+silently compared with a mature one.
+
+### Canonical milestones
+
+| Milestone | Definition | Source |
+| --- | --- | --- |
+| Account created | `users.createdAt` | Auth server |
+| Notifications registered | First device-token registration (`ActivationState.mobileSetupAt`) | Auth server |
+| Bridge registered | First bridge registration (`ActivationState.bridgeSetupAt`) | Auth server |
+| Project available | First successful project inventory containing at least one project after instrumentation starts | App event |
+| Legacy session signal | First accepted `/sessions/generate-metadata` request (`ActivationState.firstSessionAt`) | Auth server |
+| Full activation | Earliest successful `session_message_sent` or `session_created_with_message` | App event |
+
+`mobileSetupAt` is **not** “mobile setup”: it proves notification registration.
+`firstSessionAt` is **not** full activation: it is recorded before downstream
+session creation completes and does not prove that the user sent a message.
+Reporting aliases both fields to their factual meanings and never substitutes
+the legacy signal for full activation.
+
+Behavioral milestones cannot be backfilled before the new event release. Store
+an instrumentation start timestamp and restrict activation/retention cohorts to
+accounts created on or after it. Historical server milestones may still support
+honestly labeled setup trends.
+
+### Headline metrics
+
+| Metric | Exact definition |
+| --- | --- |
+| Weekly new accounts | All auth accounts created during the complete week. This comes from aggregate server export and is not reduced by product-analytics opt-out. |
+| 7-day bridge setup conversion | Accounts whose first bridge registration is within 7 x 24 hours of account creation, divided by accounts at least 7 days old in the cohort. |
+| 7-day full activation conversion | Analytics-enabled accounts whose full activation is within 7 x 24 hours of account creation, divided by measurable accounts at least 7 days old and created after instrumentation start. Show behavioral coverage beside it; do not extrapolate to opted-out accounts. |
+| Time to activation | P50 and P75 of `full_activation_at - account_created_at` among activated measurable accounts. |
+| Meaningful WAU | Distinct users with a non-empty session activity view or a confirmed control event in the complete week. A screen view/app open never qualifies. |
+| Controller WAU | Distinct users with a successful message, question answer/rejection, permission answer, session abort, or session creation with message. |
+| W1 retention | Activated users with meaningful activity 7-13 days after their activation timestamp, divided by users whose full W1 window has elapsed. |
+| W4 retention | Activated users with meaningful activity 28-34 days after activation, divided by users whose full W4 window has elapsed. |
+| Active days per WAU | P50/P75 distinct UTC meaningful-activity dates per meaningful user in each complete week. |
+| Remote interventions per controller | Successful control events divided by Controller WAU. Keep message counts and other control actions separately visible. |
+| Four-week WAU growth | `(latest complete week meaningful WAU / meaningful WAU four complete weeks earlier) - 1`; return null when either sample is unavailable, not zero. |
+
+### Diagnostic and differentiation metrics
+
+- Setup funnel: account created -> bridge registered -> project available ->
+  full activation. Notification registration is a side-adoption metric, not a
+  required step.
+- First-message activation split by existing-session versus remotely created
+  session.
+- Dedicated-worktree share among successful remotely created sessions.
+- Diff-review users, question/permission interventions, and aborts.
+- Notification open-to-meaningful-action conversion within 30 minutes for the
+  same user. This is intentionally an open-to-action metric, not a delivery or
+  click-through rate; there is no delivery denominator in this scope.
+- Campaign-attributed accounts, known-attribution coverage, and activation by
+  campaign. Unknown attribution remains `unknown`, never “organic”.
+- Onboarding support/install interactions already present in the event schema.
+
+## Current Behavior
+
+### Apps monorepo
+
+- `client/app` has Firebase Analytics; desktop and bridge do not.
+- `client/app/lib/core/analytics/analytics_event.dart` is a Freezed closed event
+  union with seven onboarding/support/install events.
+- `FirebaseAnalyticsReporter` serializes that union and best-effort logs it.
+- `AnalyticsUserIdTracker` sends SHA-256 of `AuthUser.id` as Firebase
+  `user_id`. This identifier is pseudonymous, not anonymous.
+- Ad storage, ad user data, ad personalization, ad-network registration, IDFV,
+  and Android AD_ID are disabled. Analytics storage is currently granted at
+  startup, with no user preference.
+- Analytics currently runs in developer builds, and screens are not explicitly
+  tracked.
+- Stable route names are already available through
+  `RouteSource.currentRouteStream` and `AppRouteDef`; route paths with project
+  or session IDs do not need to be logged.
+- Confirmed message/session/question/permission/diff outcomes live in
+  `module_core`, while the analytics contract currently lives in the mobile
+  shell. The contract must move down to a backend-neutral core boundary so
+  cubits can report authoritative outcomes without widget-tap proxies.
+
+### Auth server
+
+- `User.createdAt` and one `ActivationState` per user already persist the
+  available setup timestamps.
+- Activation reconciliation/backfill already preserves earliest evidence.
+- No BigQuery export or product-analytics preference exists.
+- The server is a separate TypeScript repository and must never send Mongo
+  ObjectIds, OAuth identifiers, usernames, email addresses, bridge IDs, device
+  tokens, or IP data to BigQuery.
+
+### Cloud/reporting
+
+- No BigQuery SQL, reporting datasets, dashboard definitions, or data-quality
+  checks are versioned in the apps monorepo.
+- Whether Firebase is already linked to BigQuery, its property ID/location,
+  billing state, and current Looker assets cannot be established from source.
+
+## Scope
+
+### In scope
+
+- Immediate Firebase/GA4 -> BigQuery linking and a recorded measurement start.
+- Account-wide optional product-analytics preference and mobile Settings UI.
+- A surface-neutral typed analytics contract in `module_core`, implemented by
+  Firebase in mobile and by a no-op adapter on unsupported products.
+- Authenticated identity lifecycle, release-build collection, stable screen
+  views, campaign attribution, and the outcome events below.
+- A daily privacy-safe auth export and aggregate all-account setup cohorts.
+- Versioned BigQuery DDL/transforms/tests and Looker Studio dashboards.
+- Internal/test-user exclusion, retention, access, cost, and data-quality
+  controls.
+
+### Out of scope
+
+- Desktop or bridge product-interaction analytics.
+- Prompt/transcript/tool/model/agent/command-name analytics.
+- Sesori-defined raw project, session, bridge, device, repository, account, or
+  notification identifiers—even hashed per-entity identifiers. Firebase's
+  unavoidable raw app-install identifier is confined as documented below.
+- FCM delivery export, delivery-rate claims, session-level notification
+  correlation, heatmaps, session replay, ad attribution, or third-party mobile
+  attribution SDKs.
+- Backend/harness adoption. Plugin identity remains behind the plugin boundary
+  and is not classified into a client analytics dimension.
+- Voice interaction analytics. The current orchestration lives in the mobile
+  shell; instrument it only after a separately approved migration behind core
+  platform/API/repository/service boundaries. Auth-server aggregate
+  transcription usage is not added merely as a substitute.
+- A “How did you hear about us?” prompt.
+- Predictive scoring, experimentation infrastructure, revenue analytics, or a
+  general-purpose event bus.
+- Pretending historical metadata requests are historical full activations.
+
+### Touched repositories and workspaces
+
+| Repository/workspace | Production paths and layer | Change | Downstream impact |
+| --- | --- | --- | --- |
+| `sesori_auth_server` | `src/types/product-analytics.ts` (domain enum), `src/models/{documents,api,product-analytics-export}.ts` (persisted/API/export contracts), `src/repositories/{user-repo,activation-state-repo,product-analytics-export-repo}.ts` (data access/aggregation), `src/services/{product-analytics-preference-service,product-analytics-export-service}.ts` (business logic), `src/clients/bigquery-product-analytics-client.ts` and `src/api/product-analytics-export-api.ts` (external sink layers), `src/routes/product-analytics.ts` (HTTP boundary), `src/scripts/{backfill-product-analytics-preference,export-product-analytics,product-analytics-export-config}.ts` (separate command composition) | Persist preference behind a dedicated service, expose GET/PUT endpoints, and export privacy-safe data. | Existing auth responses and clients remain unchanged. The web process constructs only the preference service; it never constructs export/BigQuery classes. |
+| `shared/sesori_shared` | No production change | Keep `AuthUser` authentication-only; do not add a product preference to the shared auth/persisted contract. | No bridge/shared migration or compatibility default is introduced. |
+| `client/module_auth` | No production change | Continue to own tokens, OAuth, auth state, and `AuthenticatedHttpApiClient` only. | `module_core` observes `AuthSession` read-only and injects `AuthenticatedHttpApiClient` into its own Layer-1 preference API. |
+| `client/module_core` | `lib/src/models/product_analytics/`, `lib/src/platform/analytics_client.dart`, `lib/src/api/{analytics_api,product_analytics_preference_api}.dart`, `lib/src/storage/{product_analytics_preference_storage,campaign_attribution_storage}.dart`, `lib/src/repositories/{product_analytics,product_analytics_preference,campaign_attribution}_repository.dart`, `lib/src/services/{product_analytics,campaign_attribution}_service.dart`, `lib/src/listeners/{analytics_route,campaign_attribution}_listener.dart`, `lib/src/cubits/product_analytics_preference/`, existing project/session/diff cubits and notification dispatcher, DI/barrel/generated files | Expose architectural layers explicitly; own preference HTTP/persistence, pseudonymous hashing, route/campaign lifecycle, Settings state, and authoritative business-outcome emission. | Mobile supplies only the Firebase platform client. Desktop supplies a no-op client. Cubit constructor call sites/tests update in lockstep. |
+| `client/app` | `lib/core/platform/firebase_analytics_client.dart`, `lib/core/di/`, `lib/features/{settings,project_list,new_session,session_detail,session_diffs}/`, `lib/l10n/`, `lib/main.dart`, iOS/Android analytics defaults | Implement the thin Firebase SDK adapter, start core services/listeners, render preference UI, and inject services into core consumers. | Existing app event sources move to core; `AnalyticsUserIdTracker` and obsolete app `DeepLinkService` are removed. No new voice logic is added. |
+| `client/desktop` | `lib/core/platform/no_op_analytics_client.dart`, DI generated file | Satisfy the shared core platform capability without collecting desktop analytics. | No desktop product events or UI are added. Analyze/test verifies core DI remains resolvable. |
+| `client/module_desktop_core` | No planned production edit; tests/build are downstream validation | Continue unchanged. | Shared core DI/downstream validation only. |
+| `bridge/app` | No planned production or contract edit | Remain outside product analytics. | No additional bridge validation beyond normal CI is caused by this plan. |
+| Apps monorepo tooling | `tool/product_analytics/` (deployment tooling/SQL/runbook) | Version BigQuery DDL, transforms, assertions, and dashboard contract. | Cloud deployment supplies property/project/location; no credentials or live exclusion values enter Git. |
+
+## Privacy And Identity Contract
+
+### Account preference
+
+Define the same closed wire values (`enabled`, `disabled`) at the two language
+boundaries, but do **not** add the preference to `AuthUser`, `AuthSession`, JWTs,
+or auth login/refresh responses. It is product state, not authentication state.
+The auth server persists it on `User`, exposes dedicated authenticated GET/PUT
+product-analytics endpoints through a dedicated preference service, and writes
+`enabled` for every new account. Existing accounts are backfilled to the honest
+prior behavior before the server schema becomes non-null/enforced.
+
+In the client, a `module_core` Layer-1 preference API uses the already exported
+`AuthenticatedHttpApiClient`; its repository combines the server operation with
+encrypted local pending-disable storage. `AuthSession` is observed only for the
+authenticated user ID and logout/account-switch lifecycle. A server fetch or
+pending update may start only after an explicit non-splash readiness signal or
+a Settings action—never as a side effect of `restoreLocalSession()` during
+splash.
+
+The mobile app starts Firebase Analytics collection **disabled in native
+configuration**. A core `ProductAnalyticsService` combines the locally persisted
+preference/sync intent with the authenticated server preference:
+
+- Unknown, unauthenticated, debug/profile, or disabled state keeps collection
+  off and `user_id` clear.
+- After post-splash readiness, an authenticated account fetches the server
+  preference. Only a returned enabled value in a release build sets the
+  pseudonymous user ID, grants analytics/functionality storage, and enables
+  collection; a local cached enabled value alone never enables a new run.
+- Disabling turns collection off immediately, denies analytics storage, clears
+  identity, resets queued/local analytics data, persists a pending disable if
+  the server is unavailable, and retries only after post-splash readiness or an
+  explicit user retry.
+- Enabling waits for a successful server update before collection starts.
+- Logout disables collection until another authenticated preference is known.
+
+Model preference and synchronization status as separate sealed states; do not
+flatten “disabled”, “unknown”, “pending sync”, and “failed” into nullable flags.
+The Settings copy must say that optional pseudonymous feature interactions are
+controlled by the toggle, list the prohibited content categories, and explain
+that account/bridge records required to operate Sesori remain outside this
+optional collection. Product/privacy counsel must approve the final text and
+store disclosures before release.
+
+### Pseudonymous join key
+
+Continue using lowercase hex SHA-256 over the UTF-8 auth user ID. Implement the
+same algorithm in TypeScript and in the core `ProductAnalyticsRepository`, and
+pin both repositories to one documented golden test vector. The mobile Firebase
+adapter receives only the resulting value; it never receives a raw account ID.
+Raw user IDs are permitted only in auth/core process memory and
+the auth database/existing encrypted local auth or preference storage; they must
+not reach Firebase, BigQuery, logs, SQL assets, or dashboard URLs.
+
+The deterministic hash allows cross-device and auth-to-GA4 joins but remains
+pseudonymous personal data. Documentation and access controls must call it that.
+
+### Allowed dimensions
+
+- Event schema version.
+- Stable screen enum.
+- Platform and app version/build supplied by Firebase.
+- Bounded onboarding, notification, interaction, and failure enums.
+- Strict opaque campaign code (lowercase ASCII letters/digits plus `_`/`-`,
+  maximum 32 characters) mapped to human labels only in a restricted BigQuery
+  registry.
+
+### Prohibited dimensions
+
+Do not add fields capable of carrying code, prompts, responses, transcript
+text, reasoning, filenames/paths, repository/project/session/branch/worktree
+names, provider/model/agent/tool/command names, raw error text/status payloads,
+OAuth identity, email, IP/geography, or raw/hashed project/session/bridge/device
+IDs. The event union should make these fields impossible to pass.
+
+This prohibition governs Sesori-defined event parameters and every curated or
+reporting model. It does not falsely claim that the vendor-managed raw GA4
+schema lacks installation/device metadata; that unavoidable boundary is
+documented and restricted below.
+
+## Client Architecture
+
+### Layered ownership
+
+Move the existing event union out of the Flutter shell, but do not create a
+mixed `src/analytics/` bucket. The concrete dependency direction is:
+
+`AnalyticsClient (Foundation) -> AnalyticsApi / *Storage (Layer 1) ->
+*Repository (Layer 2) -> *Service (Layer 3) -> Listener/Cubit/UI (Consumer)`.
+
+| Class/file | Layer and constructor collaborators | Responsibility and lifecycle |
+| --- | --- | --- |
+| `AnalyticsEvent`, bounded enums, `AnalyticsScreen`, `AnalyticsDeliveryResult`, `ProductAnalyticsPreference`, `ProductAnalyticsState`, `CampaignCode`, and persisted record variants under `module_core/lib/src/models/product_analytics/` | Domain models; no SDK/Flutter dependencies | Closed event/screen/preference/state values. `AnalyticsScreen` is independent of routing; `AnalyticsRouteListener` performs the exhaustive `AppRouteDef -> AnalyticsScreen` mapping. Delivery is `acceptedBySdk` or `failed`, never an untruthful “reported” boolean. |
+| `AnalyticsClient` in `module_core/lib/src/platform/analytics_client.dart` | Foundation external-sink capability | Typed `logEvent`, `logScreenView`, `enable({required String userKey})`, and `disable({required bool resetData})`. The key is already pseudonymous. Methods throw SDK failures; they accept no arbitrary map/name or raw account ID. |
+| `AnalyticsApi` in `module_core/lib/src/api/analytics_api.dart` | Layer 1; constructor requires `AnalyticsClient` | Thin API over the external client. It is the only core class that invokes the platform sink. |
+| `ProductAnalyticsPreferenceApi` in `module_core/lib/src/api/product_analytics_preference_api.dart` | Layer 1; constructor requires `AuthenticatedHttpApiClient` | Calls authenticated GET/PUT `/product-analytics/preference`, serializes the closed enum, parses external strings at the boundary, and returns explicit success/failure. It does not mutate auth state. |
+| `ProductAnalyticsPreferenceStorage` and `CampaignAttributionStorage` in `module_core/lib/src/storage/` | Layer 1 storage; each constructor requires `SecureStorage` | Read/write/delete only their closed persisted records. They do not reconcile accounts, call APIs, hash IDs, or emit analytics. |
+| `ProductAnalyticsRepository` in `module_core/lib/src/repositories/product_analytics_repository.dart` | Layer 2; constructor requires `AnalyticsApi` | Converts raw authenticated user ID to lowercase SHA-256, passes only the pseudonymous key downward, and maps API exceptions to explicit `AnalyticsDeliveryResult` without redundant logging. It adds `schema_version=1` through the typed event serialization contract. |
+| `ProductAnalyticsPreferenceRepository` in `module_core/lib/src/repositories/product_analytics_preference_repository.dart` | Layer 2; requires `ProductAnalyticsPreferenceApi` and `ProductAnalyticsPreferenceStorage` | Fetch/update server preference, scope local records to one account, persist only `synced(userId, preference)` or `pendingDisable(userId)`, and expose explicit results. Enable is never persisted pending. |
+| `CampaignAttributionRepository` in `module_core/lib/src/repositories/campaign_attribution_repository.dart` | Layer 2; requires `CampaignAttributionStorage` | Enforces first touch and persists `pending(code)` or `acceptedBySdk(code)`. Absence genuinely means no campaign. It never stores a full URI/UTM text. |
+| `ProductAnalyticsService` in `module_core/lib/src/services/product_analytics_service.dart` | Layer 3, `@lazySingleton`; requires `AuthSession` (read-only), `ProductAnalyticsRepository`, and `ProductAnalyticsPreferenceRepository` | Sole owner of preference/collection lifecycle and Consumer methods `logEvent`/`logScreenView`. Exposes a replaying state stream plus `start`, `markPostSplashReady`, `setPreference`, `retryPendingDisable`, and `dispose`. It performs no network work until readiness. |
+| `CampaignAttributionService` in `module_core/lib/src/services/campaign_attribution_service.dart` | Layer 3, `@lazySingleton`; requires `CampaignAttributionRepository` and `ProductAnalyticsService` | Captures a validated first touch and attempts the event only on an active transition/start. It marks `acceptedBySdk` only when the service returns that typed result; failure leaves `pending` for a later lifecycle attempt without a timer loop. |
+| `AnalyticsRouteListener` in `module_core/lib/src/listeners/analytics_route_listener.dart` | Consumer/listener, `@lazySingleton`; requires `RouteSource` and `ProductAnalyticsService` | Owns route subscription, maps `AppRouteDef` exhaustively to `AnalyticsScreen`, signals readiness on the first non-splash route, and reports stable screens only while active. It never passes a route model/path to Foundation. |
+| `CampaignAttributionListener` in `module_core/lib/src/listeners/campaign_attribution_listener.dart` | Consumer/listener, `@lazySingleton`; requires `DeepLinkSource` and `CampaignAttributionService` | Replaces the obsolete app `DeepLinkService`, owns the one URI subscription, validates only approved `sesori.com/link` campaign codes, and ignores all other/legacy callback URIs without logging complete values. |
+| `ProductAnalyticsPreferenceCubit` in `module_core/lib/src/cubits/product_analytics_preference/` | Consumer; constructor requires `ProductAnalyticsService` | Subscribes to service state and exposes toggle/retry intents. Mobile Settings constructs it; it is not in DI. |
+| `FirebaseAnalyticsClient` in `app/lib/core/platform/firebase_analytics_client.dart` | Thin mobile Foundation adapter, `@LazySingleton(as: AnalyticsClient)`; requires `FirebaseAnalytics` | Serializes typed events/screens, applies consent/collection/identity SDK calls, and throws failures upward. It receives an already hashed key and contains no route/campaign/preference/hash business logic. Firebase-disabled environments use the existing no-op SDK object. |
+| `NoOpAnalyticsClient` in `desktop/lib/core/platform/no_op_analytics_client.dart` | Desktop phase-1 Foundation adapter | Satisfies shared core DI and accepts operations without collection. No desktop listeners are started. |
+
+`AnalyticsScreen` pins snake-case wire values for login, projects, settings and
+its subpages, sessions, new session, session detail, and session diffs. The
+route listener's exhaustive switch also handles splash explicitly (readiness
+only, no report while collection is inactive), so adding an `AppRouteDef`
+cannot silently omit its analytics mapping.
+
+The client API may return SDK acceptance, not delivery to Google's backend.
+That distinction is sufficient for truthful local campaign state and must remain
+explicit in names/docs. Normal outcome consumers may ignore a failed result,
+but the result remains explicit to callers; analytics cannot alter product
+success.
+
+### DI and process lifecycle
+
+1. Mobile/desktop phase 1 registers `AnalyticsClient` (Firebase or no-op) plus
+   existing `SecureStorage`, `RouteSource`, and `DeepLinkSource` adapters.
+2. Auth phase 2 registers `AuthSession` and `AuthenticatedHttpApiClient` without
+   any analytics-specific method.
+3. Core phase 3 registers both APIs, both Storage classes, three repositories,
+   two services, and two listeners. Dependencies therefore resolve only
+   downward through the declared layers.
+4. Mobile bootstrap awaits `ProductAnalyticsService.start()`, then starts
+   `CampaignAttributionService`, `AnalyticsRouteListener`, and
+   `CampaignAttributionListener` for process lifetime. Their dispose methods are
+   owned by GetIt/test teardown. Starting them on the initial splash route
+   performs local reads/subscriptions only.
+5. Cubits remain constructed in `BlocProvider` and receive
+   `getIt<ProductAnalyticsService>()` explicitly. Existing mobile-only
+   onboarding widgets call the same service rather than the Foundation client.
+
+### Preference and lifecycle data flow
+
+**Startup and readiness:** Native iOS/Android defaults deny analytics storage
+and disable collection. `ProductAnalyticsService.start()` calls repository
+disable with `resetData: false`, reads only local pending state, and subscribes
+to `AuthSession.authStateStream`; it never validates auth or calls the
+preference API. `AnalyticsRouteListener` sees initial `splash` but does not mark
+readiness. On the first non-splash route it calls `markPostSplashReady()`. Only
+then may the service fetch/reconcile for the currently authenticated account.
+If login is still unauthenticated, it waits for the later auth emission. Thus
+`restoreLocalSession()` cannot trigger a splash-time network request.
+
+**Reconciliation:** A same-account local `pendingDisable` keeps collection off
+and PUTs disabled after readiness. Otherwise the repository GETs the server
+preference; returned disabled stays off, while returned enabled in a release
+build asks `ProductAnalyticsRepository` to hash the account ID and enable the
+SDK. Debug/profile/unsupported builds retain the desired preference but publish
+`AnalyticsCollectionState.inactive(buildUnsupported)`.
+
+**Disable:** The cubit calls `ProductAnalyticsService.setPreference(disabled)`.
+The service first disables/resets the SDK through the analytics repository,
+then persists `pendingDisable(userId)`, then calls the preference repository
+PUT. Success stores synchronized disabled; failure remains pending and exposes
+generic retry state. Retry occurs only from Settings or a later post-splash
+lifecycle, never from a timer or splash auth emission.
+
+**Enable:** Collection remains off while the preference repository PUTs
+enabled. Only server success followed by synchronized local persistence allows
+the analytics repository to hash/enable. Failed enable remains disabled and is
+not persisted for automatic future activation.
+
+**Logout/account switch:** Any unauthenticated state disables without reset,
+clears SDK identity, and publishes unauthenticated. Local records are scoped by
+raw ID inside encrypted storage and never apply to another account. Explicit
+opt-out is the only path requesting SDK data reset.
+
+**Screen flow:** The route listener retains the latest `AnalyticsScreen` while
+inactive. Inactive-to-active emits that screen once; later changed screen enums
+emit once. Foundation sees neither `AppRouteDef` nor a concrete URI.
+
+**Campaign flow:** The campaign listener converts only an approved URI to
+`CampaignCode`; the service/repository stores first touch before auth. On active
+state it attempts `campaign_attributed`. `acceptedBySdk` is persisted only from
+the typed accepted result. A failed result leaves pending, with at most one
+attempt per active lifecycle; BigQuery selects the earliest event if a crash
+between SDK acceptance and local persistence causes a duplicate.
+
+### Outcome event catalog
+
+Existing wire names remain unchanged. Add only the following initial events:
+
+| Event | Emit only when | Bounded parameters | Reporting use |
+| --- | --- | --- | --- |
+| `project_inventory_loaded` | Initial project inventory succeeds | `inventory_state=empty/non_empty` | First project available, onboarding friction |
+| `session_activity_viewed` | A session snapshot successfully loads for the first time in a cubit lifetime | `activity_state=empty/non_empty` | Meaningful monitoring when non-empty |
+| `session_message_sent` | Existing-session send returns success, including a queued send that later succeeds | `submission_kind=text/command` | Full activation, control activity |
+| `session_created_with_message` | `createSessionWithMessage` returns success | `submission_kind`, `workspace_kind=project/dedicated_worktree` | Full activation, remote creation, worktrees |
+| `session_creation_failed` | That creation returns an explicit failure | `failure_reason` from bounded `RemoteFailureReason`, `workspace_kind` | Creation friction; never activation |
+| `session_question_answered` | Question reply returns success | none | Remote interventions |
+| `session_question_rejected` | Question rejection returns success | none | Remote interventions |
+| `session_permission_answered` | Permission reply returns success | `decision=once/always/reject` | Remote interventions |
+| `session_abort_succeeded` | Root and active-child abort requests all return success | none | Remote interventions |
+| `session_diff_viewed` | Initial diff fetch succeeds | `change_state=empty/non_empty` | Diff adoption; meaningful only when non-empty |
+| `notification_opened` | A valid notification is dispatched after authentication | `source=push/local`, `launch_context=cold/warm`, bounded `category`, bounded `event_type` | Notification engagement |
+| `campaign_attributed` | The first valid campaign code receives an SDK-accepted attempt for an authenticated analytics-enabled account/install | `campaign_code` only | Acquisition coverage and cohorts; earliest event wins |
+| Firebase `screen_view` | `RouteSource` emits a changed non-null `AppRouteDef` | stable enum name only | Navigation/friction, never meaningful activity |
+
+For `session_activity_viewed`, `non_empty` means there is at least one message,
+pending question/permission, or an active/retrying status.
+
+The send events fire after repository success, never on a tap or queue insert.
+The direct-send and queue-drain paths must call the same helper so retries do not
+double count. New-session success emits one `session_created_with_message`, not
+an additional `session_message_sent`.
+
+### Authoritative emission seams
+
+- `ProjectListCubit`: successful initial inventory.
+- `SessionDetailCubit._loadMessages`: first successful activity view.
+- `SessionDetailCubit.sendMessage` and `_drainQueuedMessages`: accepted
+  existing-session messages.
+- `NewSessionCubit.createSession`: accepted created session/message and bounded
+  creation failure.
+- `SessionDetailCubit.replyToQuestion`, `rejectQuestion`,
+  `replyToPermission`, and `abort`: successful control outcomes.
+- `DiffCubit._fetchAndEmit`: first successful diff load.
+- `NotificationOpenDispatcher`: valid push/local cold/warm dispatch. Extend the
+  internal open request to preserve existing bounded notification category and
+  event type, but never an entity identifier in analytics.
+- `GoRouterRouteSource`: stable screen names.
+- `CampaignAttributionListener`: replace `DeepLinkService` as the sole URI
+  listener, parse only strict campaign links, and never log complete URIs.
+
+Every changed cubit/service receives `ProductAnalyticsService` through required
+constructor injection. The service reaches the platform sink only through
+`ProductAnalyticsRepository`; consumers never hold `AnalyticsClient` or
+`AnalyticsApi`. Do not use global service location inside `module_core`, add
+optional compatibility parameters, or move success reporting to widget taps
+merely to avoid updating tests.
+
+### Outcome emission data flow
+
+| Owner change | Exact flow and deduplication |
+| --- | --- |
+| `ProjectListCubit` | Add required `ProductAnalyticsService`. After the initial `ProjectListService` load returns a successful inventory, emit `project_inventory_loaded` once for that cubit lifetime with only empty/non-empty. Refreshes do not repeatedly report the same inventory. |
+| `SessionDetailCubit` view | Add required product analytics service and a `_hasReportedInitialView` guard. The first successful snapshot after initial load/wait/reconnect emits one activity-view event based only on bounded activity state; reload/SSE refresh does not. |
+| `SessionDetailCubit` send paths | Direct `sendMessage` and `_drainQueuedMessages` call one private `_reportAcceptedSubmission` only on `SuccessResponse`. The queued item retains only text/command for sending; analytics derives text/command without reading content. Error/requeue emits nothing, and each dequeued successful item reports once. |
+| `NewSessionCubit` | Add required product analytics service. Capture workspace/submission classifications before awaiting. `SuccessResponse` makes one `session_created_with_message` call; `ErrorResponse` emits only bounded `session_creation_failed`. It never also emits the existing-session event. |
+| `SessionDetailCubit` question/permission/abort | Report after each existing method's success branch. Question answers/rejections carry no answer data; permission maps the existing `PermissionReply` enum; abort reports only after every root/active-child response succeeds. |
+| `DiffCubit` | Add required product analytics service and `_hasReportedInitialDiff` guard. First successful fetch emits empty/non-empty; SSE refreshes and retries after an already successful first fetch do not. |
+| `NotificationOpenRequest` / `NotificationOpenDispatcher` | Extend the internal request with required bounded category/event type already present in `NotificationData`. Push/local adapters provide `unknown` for legacy local payload omissions. Add required product analytics service to the injectable dispatcher; `_dispatch` reports source and cold/warm context after authentication and route dispatch, never project/session/title. |
+| Screen constructors/tests | `ProjectListScreen`, `NewSessionScreen`, `SessionDetailScreen`, and `SessionDiffsScreen` pass the phase-3 product analytics service from GetIt into required cubit constructors. Core tests inject a mock/recording service and assert event count/shape. |
+
+## Campaign Attribution
+
+Use `https://sesori.com/link/...` campaign links, which the current Android App
+Link and iOS associated-domain configuration already accepts. Define a link
+runbook that generates:
+
+- a strict opaque campaign code;
+- Google Play URL/referrer UTM values for automatic Firebase attribution;
+- Apple App Store campaign/provider tokens for App Store Connect aggregate
+  reporting; and
+- the same code in installed-app universal/app links.
+
+Core stores the first valid code locally and attempts it only after an
+authenticated enabled analytics identity exists, retaining pending state until
+the SDK accepts an attempt. BigQuery's restricted
+`campaign_registry` maps code to source, medium, campaign display name, and
+active dates. Do not accept or emit arbitrary UTM text from an inbound URI.
+
+Firebase/Play and App Store attribution have different identity and deferred
+deep-link limits. The dashboard reports “known attribution coverage” and keeps
+unknown separate; it must not claim that cross-platform attribution is
+complete. App Store Connect aggregate data remains a separately labeled source
+unless a privacy-reviewed join becomes available later.
+
+## Auth Export
+
+Implement a one-shot auth-server export command, designed to run daily as a
+least-privileged Cloud Run Job (or an equivalently isolated scheduler on the
+existing host if GCP cannot reach MongoDB). Do not add BigQuery credentials or
+export work to request handlers or the long-running auth process.
+
+### Auth preference endpoint and persistence
+
+- `src/types/product-analytics.ts` defines the string-valued
+  `ProductAnalyticsPreference.Enabled/Disabled` enum and its Zod schema.
+- `src/models/documents.ts` initially adds
+  `productAnalyticsPreference` with an honest decode default of `Enabled` for
+  existing Mongo documents, while `UserRepository.create` always writes the
+  field. `src/scripts/backfill-product-analytics-preference.ts` performs an
+  idempotent `$set` only where missing and reports/validates counts. After the
+  write-first version is live and backfill reaches zero missing documents, the
+  next PR removes the decode default and enforces the field as required.
+- `src/models/api.ts` defines Zod-validated GET/PUT preference replies/body only;
+  it does not modify `UserProfile` or auth token/login contracts.
+- `UserRepository.updateProductAnalyticsPreference(userId, preference)` owns
+  the Mongo update; `findProductAnalyticsPreference` reads it with the temporary
+  migration default only in the write-first release.
+- `ProductAnalyticsPreferenceService` in
+  `src/services/product-analytics-preference-service.ts` requires only
+  `UserRepository` and owns get/update business operations.
+- `src/routes/product-analytics.ts` adds authenticated
+  `GET /product-analytics/preference` and
+  `PUT /product-analytics/preference`; PUT body is
+  `{ "preference": "enabled" | "disabled" }` and both reply with
+  `{ "preference": ... }`. The existing auth middleware supplies the user; the
+  route validates and delegates to the dedicated service. `src/server.ts` and
+  `src/index.ts` register/construct this service without changing `AuthService`.
+- The Dart client owns this contract in core
+  `ProductAnalyticsPreferenceApi`; `AuthManager`/`AuthSession` are unchanged.
+
+### Export classes and composition
+
+| Class/file | Constructor dependencies and layer | Responsibility |
+| --- | --- | --- |
+| `UserRepository` additions in `src/repositories/user-repo.ts` | Existing `MongoDbAccessor` | `findProductAnalyticsExportBatch({afterUserId, batchLimit, createdAtOrBefore})` returns string user ID, creation time, and preference in deterministic ObjectId order; no Mongo `ObjectId` leaves the repository. |
+| `ActivationStateRepository.findByUserIds` in `src/repositories/activation-state-repo.ts` | Existing Mongo collection | Batch-loads only the four milestone fields for one user page and returns a map keyed by string user ID. It does not expose reminder fields to the export service. |
+| `ProductAnalyticsExportRow` / `ProductAnalyticsSetupCohortRow` in `src/models/product-analytics-export.ts` | Plain internal models | Make BigQuery row shapes closed and prevent external-sink calls with auth/OAuth/bridge documents. |
+| `BigQueryProductAnalyticsClient` in `src/clients/bigquery-product-analytics-client.ts` | Foundation external client; requires `@google-cloud/bigquery` `BigQuery`, project ID, private dataset ID, and location | Thin SDK operations for creating expiring tables, inserting typed safe rows, and executing parameterized queries/transactions. It never receives raw IDs/Mongo documents or decides export semantics. |
+| `ProductAnalyticsExportApi` in `src/api/product-analytics-export-api.ts` | Layer 1; requires `BigQueryProductAnalyticsClient` | Defines the external BigQuery operations used by this product area and maps SDK responses/errors; no pagination, aggregation, or publication policy. |
+| `ProductAnalyticsExportRepository` in `src/repositories/product-analytics-export-repo.ts` | Layer 2; requires `ProductAnalyticsExportApi` | Owns a run's staging-table lifecycle, safe-row batching, validation queries, and atomic two-target promotion. The service never calls the client/API directly. |
+| `ProductAnalyticsExportService` in `src/services/product-analytics-export-service.ts` | Layer 3; requires `UserRepository`, `ActivationStateRepository`, and `ProductAnalyticsExportRepository` | Owns cutoff pagination, SHA-256 transformation, enabled-user filtering, weekly all-account accumulation, reconciliation inputs, and repository promotion. `run({ runCutoff }: { runCutoff: Date })` receives one immutable cutoff. |
+| `product-analytics-export-config.ts` in `src/scripts/` | Zod over process environment | Validates only job concerns: Mongo connection/database, GCP project, private dataset, location, and bounded batch size. It does not import the web server's full OAuth/FCM configuration or accept a service-account JSON key. |
+| `export-product-analytics.ts` in `src/scripts/` | Command composition root | Constructs Mongo repositories, ADC BigQuery client, export API/repository/service; invokes one run, awaits jobs, and closes Mongo in `finally`. It is compiled into the production image and run as `node dist/scripts/export-product-analytics.js`; `src/index.ts` does not import it. |
+
+The web server constructs the dedicated preference service but never constructs
+`BigQuery` or any export API/repository/service. The scheduled job uses the same
+built image with a command override, so auth HTTP availability and latency
+cannot depend on BigQuery.
+
+The job takes a fixed run cutoff, pages users deterministically, batch-loads
+activation states, and writes two products through temporary tables before an
+atomic replace/merge:
+
+1. `private.auth_user_milestones`: only accounts whose optional product
+   analytics preference is enabled; fields are `user_key`,
+   `account_created_at`, `notification_registered_at`,
+   `bridge_registered_at`, `legacy_first_metadata_request_at`, and
+   `exported_at`.
+2. `private.auth_weekly_setup_cohorts`: identifier-free all-account cohort
+   totals, including total accounts, enabled-account coverage, notification and
+   bridge registration within 1/7/30 days, and the legacy signal. This supports
+   honest account/setup totals without exposing opted-out user rows.
+
+Never export provider identity or reminder scheduling/sent timestamps. Replace
+the eligible-user snapshot each run so currently disabled accounts no longer
+join behavioral reports. Keep raw all-account rows inside Mongo; only aggregate
+cohorts leave the auth boundary.
+
+For each page, the service builds a user-ID-to-activation-state map in memory,
+updates weekly counters for every account, and creates a pseudonymous row only
+when preference is enabled. It hashes before invoking the export repository,
+then drops the raw page before requesting the next. Run-scoped staging tables contain only
+hashed/aggregate rows, expire within 24 hours, and are invisible to reporting.
+After all pages and checks succeed, one BigQuery multi-statement transaction
+deletes/inserts both published targets from staging; a failure rolls back both,
+leaving the prior snapshot/cohorts visible. Cleanup is best-effort because table
+expiry is the final guard.
+
+Job acceptance checks before promotion:
+
+- one unique, non-null 64-character lowercase hex `user_key` per eligible
+  account;
+- milestone ordering and timestamp types are valid without assuming setup
+  occurs in a fixed order;
+- exported enabled count reconciles with aggregate coverage count;
+- source and staging row counts are recorded without raw IDs;
+- a partial/failed run leaves the previous published tables intact.
+
+Use Application Default Credentials, Secret Manager for Mongo access, and a
+service account limited to BigQuery Job User plus Data Editor on the private
+staging/target datasets. The auth web runtime receives no BigQuery role.
+
+## BigQuery Design
+
+### Day-zero setup
+
+Do this before waiting for application PRs because Firebase export is not
+retroactive:
+
+1. Confirm the Firebase project is `sesori-ai`, identify the GA4 property ID,
+   billing status, property timezone, and existing BigQuery link.
+2. If not linked, enable daily Analytics export. Streaming/intraday export is
+   optional and not needed for the initial complete-day/week dashboards.
+3. Record the immutable raw dataset location. If no location exists, choose the
+   privacy/operations-approved location (prefer EU when compatible); every
+   derived dataset must use the same location.
+4. Record `measurement_start_at`, owner, service accounts, and dashboard access
+   group in the restricted deployment configuration.
+5. Verify one existing custom event reaches `analytics_<property_id>.events_*`.
+
+### Datasets
+
+All names below are deployment defaults and remain configurable for the real
+property/project IDs:
+
+| Dataset | Access | Contents |
+| --- | --- | --- |
+| `analytics_<property_id>` | Raw restricted | Firebase-managed GA4 daily tables |
+| `sesori_analytics_private` | Security/analytics admins and export job | Auth eligible-user snapshot, aggregate setup cohorts, campaign registry, internal-user exclusions, measurement config |
+| `sesori_analytics_curated` | Analytics engineers | Flattened allowlisted events, daily user activity, user milestones, scheduled intermediate tables |
+| `sesori_analytics_reporting` | Looker service account/product leadership | Identifier-free authorized views and dashboard tables |
+
+Version deployable assets under `tool/product_analytics/`: a data dictionary,
+templated DDL and scheduled-query SQL, a small deployment command accepting
+project/GA4 dataset/location, BigQuery `ASSERT` fixture tests, and an operations
+runbook. Never commit service-account material or live internal user keys.
+
+The initial file ownership is fixed:
+
+- `tool/product_analytics/deploy.dart` validates named project, location, raw
+  dataset, private/curated/reporting dataset, and measurement-start arguments;
+  renders identifier placeholders from the checked-in SQL; and invokes `bq`
+  non-interactively with the explicit location. It does not perform `gcloud`
+  login or read key files.
+- `tool/product_analytics/sql/00_datasets.sql` creates/configures derived
+  datasets and reference tables; `10_events_flattened.sql`,
+  `20_user_activity_daily.sql`, `25_acquisition_first_touch.sql`,
+  `30_user_milestones.sql`,
+  `40_activation_retention.sql`, and `50_reporting_views.sql` own the dependency
+  order described below.
+- `tool/product_analytics/sql/schedules.json` is a credential-free manifest of
+  query file, destination, cadence, recent-date recomputation window, and max
+  bytes; the deploy command creates/updates those transfer configs only after a
+  `--apply-schedules` flag.
+- `tool/product_analytics/tests/metric_contract_assertions.sql` uses temporary
+  fixture tables and BigQuery `ASSERT`; `schema_allowlist_assertions.sql` fails
+  when curated columns/event parameters exceed the approved contract.
+- `tool/product_analytics/README.md` is the operator runbook/data dictionary;
+  `LOOKER_STUDIO.md` pins page sources, filters, formulas, access group, and
+  manual dashboard verification because Looker Studio report layout is not a
+  safely deployable repository artifact.
+
+### Vendor-managed raw GA4 boundary
+
+Firebase's BigQuery export schema unavoidably includes more than Sesori's custom
+parameters. In the restricted `analytics_<property_id>` dataset this includes
+`user_pseudo_id` (an app-install identifier), GA session identifiers, platform,
+device category/brand/model/OS fields, derived geographic fields, app metadata,
+traffic-source strings, event bundle/stream metadata, and Firebase automatic
+events. The source IP is not an exported column, but Google may derive the geo
+fields before export. With AD_ID, IDFV, ad storage, ad user data, Google Signals,
+and personalization disabled, advertising/vendor identifier fields are expected
+to be null; verify that assumption from production rows rather than relying on
+configuration alone.
+
+These vendor fields change the controls and disclosure, not the event contract:
+
+- raw GA4 access is limited to the analytics/security admin group and scheduled
+  query service account; Looker and ordinary product viewers receive none;
+- raw daily tables receive a 90-day expiration, sufficient for late-data repair
+  and the planned retention windows, while longer history comes from minimized
+  curated facts and identifier-free aggregates;
+- `events_flattened` deliberately does **not** select `user_pseudo_id`, GA
+  session ID, device brand/model, geo, user properties, advertising/vendor IDs,
+  bundle sequence, stream ID, or arbitrary traffic-source strings;
+- curated acquisition maps only a strict Sesori campaign code/registry match or
+  a small approved source class; unmatched raw traffic text becomes `unknown`;
+- Firebase automatic events are excluded except stable `screen_view` and a
+  transient `first_open`/traffic-source projection in the acquisition model;
+  app opens never define activity;
+- the privacy notice must disclose Firebase's pseudonymous install/device and
+  approximate-location processing even though those fields are discarded from
+  Sesori reporting.
+
+If the linked property cannot apply the required raw expiration or Google
+Signals/ad settings, stop dashboard rollout and resolve that cloud posture; do
+not weaken the written privacy boundary to fit an unchecked property.
+
+### Curated models
+
+1. **`events_flattened`**: flatten only catalogued events/parameters from GA4,
+   use `event_timestamp` in UTC, require schema version for Sesori custom
+   events, and retain Firebase platform/app version/build. Permit Firebase
+   `screen_view` only when its screen name is in `AnalyticsScreen` and its app
+   version is at/after instrumentation start. Exclude null `user_id`,
+   internal/test keys, and users absent from the current eligible auth snapshot
+   before downstream behavioral reporting. Raw bundle/install fields may be
+   used transiently to discard byte-identical export duplicates but are not
+   selected into the table.
+2. **`user_activity_daily`**: one row per user/date with monitor, control,
+   message, notification, diff, and feature flags/counts.
+3. **`user_milestones`**: auth timestamps plus earliest project availability,
+   full activation, monitor activity, and feature milestones. Full activation
+   is the minimum of the two successful message event names only.
+4. **`activation_cohorts`**: account-cohort denominators, 1/7/30-day milestone
+   flags, times to milestone, cohort maturity, and behavioral coverage.
+5. **`retention_cohorts`**: activation-anchored W1/W4 eligibility and activity.
+6. **`acquisition_first_touch`**: earliest strict custom campaign code or
+   approved automatic store/source class per eligible user. It uses raw
+   install/traffic fields only inside the scheduled query, persists no
+   `user_pseudo_id` or arbitrary source text, and labels unmatched values
+   `unknown`.
+
+Materialize partitioned daily/intermediate tables where repeated Looker scans
+would be expensive; cluster event facts by event name/user key. Scheduled
+queries recompute at least the last three UTC event dates because GA4 daily
+exports can receive late events. Reporting uses only completed recomputations,
+and data-quality views expose source/export/query freshness.
+Every user-level reporting build also inner-joins the **current** eligible auth
+snapshot and anti-joins the current internal exclusion table. Therefore a
+disable or newly added internal exclusion takes effect after the next auth
+export/report refresh even when an older curated partition exists; those gates
+are not applied only at the historical partition's original build time.
+
+### Reporting views
+
+- `investor_snapshot`: latest complete-week headline metrics, prior comparison,
+  sample sizes, coverage, and as-of timestamps.
+- `weekly_kpis`: new accounts, meaningful/controller WAU, growth, activity
+  depth, and activation/setup conversion.
+- `activation_funnel`: account -> bridge -> project -> message, with matured
+  1/7/30-day cohorts and notification registration beside the main path.
+- `retention`: W1/W4 cohorts with eligible denominators.
+- `feature_adoption`: worktree, diff, question/permission, abort, and
+  remote-created-session adoption.
+- `notification_engagement`: opens and 30-minute open-to-action conversion by
+  bounded category/event type.
+- `acquisition_performance`: known coverage, accounts, activation, and
+  retention by registered campaign; suppress small segmented cells.
+- `onboarding_friction`: empty project/session states, bounded creation
+  failures, and existing support/install interactions.
+- `data_quality`: event freshness, schema/app versions, null identity, unknown
+  enums, excluded internal traffic, preference coverage, and cohort maturity.
+
+### Retention, access, and cost
+
+- Keep raw GA4 tables for 90 days and minimized pseudonymous curated event data
+  for 14 months initially; retain identifier-free weekly aggregates longer only
+  after privacy approval.
+- Keep the current eligible auth snapshot rather than historical copies with
+  user keys. A disabled account disappears from joinable reporting on the next
+  successful export.
+- Restrict raw/private datasets; give Looker and routine viewers access only to
+  reporting views. Do not expose `user_key` in Looker fields, extracts, or URLs.
+- Maintain internal/test exclusions as hashes in a restricted table with owner,
+  reason, and optional expiry. Never put the list in Git.
+- Apply campaign segmentation suppression when a cell has fewer than
+  the approved minimum users; totals retain sample sizes.
+- Configure dataset/table expiration, scheduled-query byte limits, billing
+  alerts, and a monthly cost check before dashboard sharing.
+- Document a privacy-request runbook for suppressing a user key from curated
+  reporting and deleting warehouse rows when policy requires it.
+
+## Looker Studio
+
+Create one restricted report backed only by `sesori_analytics_reporting`:
+
+1. **Executive snapshot** — headline scorecards, complete-week trends,
+   activation funnel, W1/W4 retention, sample size, behavioral coverage, and
+   last refresh.
+2. **Activation** — cohort funnel and time-to-step distributions; optional
+   notification registration is visually separate.
+3. **Retention and engagement** — cohort heatmap, meaningful/controller WAU,
+   active days, interventions, and message depth.
+4. **Feature adoption** — worktree/diff/remote interaction trends.
+5. **Acquisition** — known-attribution coverage and thresholded campaign
+   quality; unknown remains explicit.
+6. **Product quality** — onboarding states and bounded failures.
+7. **Data quality** — freshness, coverage, exclusions, versions, and incomplete
+   cohorts so a broken pipeline cannot look like declining usage.
+
+Default every page to complete periods. Allow a clearly marked live-period
+filter for operators, but never use live partial values in exported investor
+screenshots.
+
+## Implementation Sequence
+
+This implementation intentionally spans five PRs. The extra auth-server slice
+is required to make the persisted-field migration write-first and race-free.
+Every implementation PR uses
+the fixed series title wrapper shown below; `user-analytics` is this plan's
+directory name.
+
+### PR 1/5 — Write-first auth preference
+
+**Title:** `[user-analytics] Add write-first analytics preference [step 1/5]`
+
+**Repository:** `sesori_auth_server`
+
+- Add the persisted enum and temporarily default missing Mongo fields to the
+  honest prior value (`enabled`) at decode/read boundaries.
+- Make every new `UserRepository.create` write the field before exposing GET/PUT
+  preference behavior.
+- Add the dedicated repository-backed preference service and authenticated
+  product-analytics routes; leave all auth profiles/tokens untouched.
+- Add the idempotent backfill/count command.
+- Test auth/validation, new-user writes, missing-document default, concurrent
+  updates, and unchanged OAuth/password/refresh responses.
+- Deploy this version fully, verify every new user writes the field, then run
+  backfill until repeated validation reports zero missing. PR 2 cannot merge or
+  deploy before that evidence is recorded.
+
+### PR 2/5 — Enforce preference and add auth export
+
+**Title:** `[user-analytics] Enforce analytics preference and add export [step 2/5]`
+
+**Repository:** `sesori_auth_server`
+
+- Remove the temporary missing-field default and make the Mongo model required;
+  add a startup/test assertion that fixture creation always supplies it.
+- Add BigQuery Client -> export API -> export repository -> export service,
+  isolated job config/composition, package dependency, and production image
+  command.
+- Publish the eligible pseudonymous snapshot and identifier-free weekly setup
+  cohorts through staging/validation/transactional promotion.
+- Test hashing golden vector, opt-out filtering, aggregate reconciliation,
+  pagination cutoff, staging cleanup, rerun idempotency, and failed-run safety.
+- Deploy web enforcement only after step-1 zero-missing evidence. Deploy the job
+  definition disabled; schedule it in PR 5 after private datasets/IAM exist.
+
+### PR 3/5 — Client analytics foundation and preference
+
+**Title:** `[user-analytics] Add client analytics foundation and opt-out [step 3/5]`
+
+**Repository:** apps monorepo
+
+- Add the explicitly layered core models, Analytics Client/API/repository,
+  preference API/Storage/repository/service, route listener/readiness gate, and
+  Settings cubit. `module_auth` and shared `AuthUser` remain unchanged.
+- Move the existing seven-event contract into core models and route existing
+  onboarding UI calls through `ProductAnalyticsService`.
+- Implement only the thin `FirebaseAnalyticsClient` and desktop no-op adapter in
+  product shells; add pure-Dart `crypto` to `module_core` and keep SHA-256,
+  route mapping, state, and lifecycle in core.
+- Make native Analytics default-off, remove `AnalyticsUserIdTracker`, gate
+  collection to post-splash authenticated enabled release builds, and add
+  stable `AnalyticsScreen` reporting.
+- Add the Settings toggle, explanatory/localized copy, pending/error behavior,
+  and privacy/legal/store-disclosure updates.
+- Test API parsing, layer wiring, fail-closed splash, post-splash fetch, local
+  pending disable, disable/reset/logout/account switch, enable-after-server
+  success, debug suppression, core identity hash, route-to-screen mapping,
+  event wire pins, and Firebase-enabled/disabled/desktop DI.
+- Release only after both auth PRs are deployed. Once users can opt out, this
+  lifecycle becomes a non-rollback privacy floor: subsequent client fixes must
+  preserve it or disable all collection.
+
+### PR 4/5 — Outcome and campaign instrumentation
+
+**Title:** `[user-analytics] Instrument activation and engagement outcomes [step 4/5]`
+
+**Repository:** apps monorepo
+
+- Add the event catalog variants and bounded enum serialization.
+- Instrument the authoritative core/app seams listed above, including both
+  direct and queued message success, while keeping analytics best-effort and
+  non-blocking.
+- Preserve bounded notification category/event type through open dispatch and
+  classify push/local plus cold/warm.
+- Add core campaign Storage -> repository -> service -> deep-link listener,
+  typed SDK-acceptance result, and remove the obsolete app `DeepLinkService` and
+  full URI logging.
+- Regenerate only source-generated outputs.
+- Add focused tests that failures/taps/queued-only operations do not activate,
+  each successful message path makes one service call, new-session success is not
+  double counted, sensitive inputs cannot enter parameter maps, notification
+  classification survives, and campaign values are bounded.
+
+### PR 5/5 — Warehouse models and dashboards
+
+**Title:** `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]`
+
+**Repository:** apps monorepo plus cloud deployment
+
+- Add `tool/product_analytics/` data contract, parameterized deployment tool,
+  DDL, transforms, fixture assertions, scheduled-query definitions, and runbook.
+- Create private/curated/reporting datasets in the raw GA4 location; configure
+  IAM, expiration, budget alerts, campaign registry, internal exclusions, and
+  measurement start.
+- Schedule the auth export and three-day event recomputation, then reconcile
+  source counts and freshness.
+- Build and permission the seven-page Looker report.
+- Run a release-build smoke test through account -> bridge -> project -> message
+  and verify the event, auth join, full activation, complete-day table, and
+  reporting view without inspecting sensitive payloads.
+- Record dashboard owner, refresh schedule, metric definitions, and rollback/
+  incident steps in the runbook.
+
+### Deployability, compatibility, and rollback by step
+
+| State | Independently usable behavior | Deployment prerequisites/order | Rollback boundary |
+| --- | --- | --- | --- |
+| Before 1/5 | Existing clients/events continue. Firebase daily export should already be linked so its non-retroactive clock has started. | Complete BigQuery day-zero preflight only. | Unlinking loses future export and is not a useful rollback; correct IAM/location before derived datasets. |
+| After 1/5 | Dedicated GET/PUT preference endpoints work; old clients are unaffected because auth responses did not change. New users always write preference; old documents read as enabled during migration. | Deploy write-first web code to all serving instances, verify new writes, run/re-run backfill, and record zero missing. | Roll back before any opt-out client release if necessary. The added field is ignored by old code; do not remove it. Re-run backfill after returning to step 1. |
+| After 2/5 | Preference schema is required and export command/job image is deployable but unscheduled. Existing clients remain unaffected. | Require recorded zero-missing evidence from step 1; deploy enforcement; smoke-test account creation and endpoints; deploy job disabled. | Roll back web/job to step 1, whose honest missing-field default can read every document. Stop any job; published tables stay at last good state. |
+| After 3/5 | Mobile can opt out/in; existing seven events and stable screens obey lifecycle; desktop remains no-op. No activation event is needed for app correctness. | Both auth endpoints/schema must be live. If unavailable, GET/enable fails closed and disable remains local pending. | **Forward-fix only after public release.** Never republish a pre-step-3 client that grants analytics at startup and ignores account preference. For a severe defect, hotfix while retaining the preference/readiness layers, or remotely/release-disable all analytics collection. Server preference data is never rolled back. |
+| After 4/5 | New activation/engagement events accumulate in GA4 raw export. Product operations remain unchanged if Firebase is unavailable. | Step 3 identity/consent/schema must be released. BigQuery needs no GA4 custom-dimension registration. | Forward-fix the app while retaining step-3 privacy behavior; event-specific defects may be disabled/removed. Missing future event names yield null/zero data, not product failure. |
+| After 5/5 | Auth job, curated models, authorized reporting views, and Looker provide the complete metric contract. | Create same-location datasets/IAM; deploy SQL/tests; schedule auth export; validate its first publish; schedule event transforms; then connect Looker. | Pause schedules/job and revert reporting views/dashboard sources to last known-good SQL. Raw GA4 and prior auth published tables remain; app behavior is unaffected. |
+
+There is no `AuthUser` compatibility field, alternate endpoint, optional
+internal constructor parameter, dual event name, or product behavior in
+`module_auth`. Server write-first/backfill/enforce ordering handles persistence;
+client fail-closed behavior plus a declared forward-fix privacy floor handles
+the separately released app.
+
+## Verification
+
+### Apps monorepo
+
+- Run code generation after changing Freezed/Injectable sources; never edit
+  generated files manually.
+- `dart test` and `dart analyze` in `client/module_core`; add API/repository/
+  service/listener/cubit tests with fake platform clients/storage.
+- `flutter test` and `dart analyze` in `client/app`.
+- `dart test`/`dart analyze` in `client/module_desktop_core` and
+  `flutter test`/`dart analyze` in `client/desktop` when shared DI/constructor
+  changes affect desktop.
+- Inspect a release-build Firebase DebugView/BigQuery sample using synthetic
+  content and verify no forbidden field/value appears. Do not turn normal debug
+  collection back on for convenience.
+
+### Auth server
+
+- `npm run build`, `npm run lint`, `npm run format:check`, and focused Node test
+  suites; run the full DB-backed tests when MongoDB is available.
+- Run export dry-run/staging against synthetic accounts including enabled,
+  disabled, no activation state, out-of-order milestones, and page-boundary
+  cases.
+- Compare published aggregate totals to direct Mongo aggregate counts without
+  exporting raw comparison rows.
+
+### BigQuery and Looker
+
+- Dry-run every deployed query and run fixture `ASSERT`s for activation event
+  inclusion, failed/queued exclusion, earliest-message selection, 7-day cohort
+  maturity, W1/W4 boundaries, internal/disabled filtering, unknown campaign,
+  and late-event replacement.
+- Reconcile GA4 custom event counts -> flattened events -> daily activity ->
+  reporting totals for at least three complete days.
+- Verify Looker credentials cannot query raw/private datasets or expose user
+  keys, and verify sample-size/partial-period labels.
+
+## Rollout And Two-Month Readiness
+
+1. **Day 0:** Link Firebase to BigQuery and record the measurement start; this
+   cannot be recovered later.
+2. **Week 1:** Land/deploy write-first auth preference, run/verify backfill,
+   then land enforcement/export.
+3. **Weeks 1-2:** Land the client foundation and ship its fail-closed opt-out
+   release.
+4. **Weeks 2-3:** Land instrumentation and ship the mobile release as early as
+   store review permits.
+5. **Weeks 3-4:** Deploy warehouse models, run data QA, and build Looker.
+6. **Weeks 4-8:** Monitor data-quality alerts weekly, correct only demonstrated
+   schema/metric defects, and let cohorts mature.
+
+W1 retention becomes available after two weeks of production behavior. W4
+requires at least 35 days after a user's activation to close the full 28-34 day
+window; any release delay directly reduces the W4 sample available by the
+two-month deadline. Show the cohort size and use null—not a fabricated zero—if
+no cohort has matured.
+
+## Risks And Mitigations
+
+- **No retroactive behavioral data:** link/export and ship early; label the
+  measurement start and do not backfill full activation from metadata requests.
+- **Developer/internal pollution:** collection is release-only and reporting
+  excludes a restricted internal-user list; monitor app version/schema mix.
+- **Opt-out bias:** show eligible coverage with every behavioral funnel and do
+  not extrapolate activation/retention to all accounts.
+- **Cross-repository deployment mismatch:** deploy write-first server behavior,
+  backfill/verify, then enforce, and only then release the client. Preference
+  GET/PUT failure is fail-closed; auth profiles remain unchanged.
+- **Privacy rollback floor:** a pre-opt-out mobile binary can grant collection
+  regardless of server preference. After the opt-out release, use forward fixes
+  that preserve the lifecycle or disable all collection; never republish the
+  old startup behavior as rollback.
+- **Analytics affecting product behavior:** all reports are best-effort,
+  unawaited after confirmed outcomes, and failure-isolated.
+- **High-cardinality or sensitive leakage:** closed event variants, bounded
+  enums/campaign codes, raw-ID prohibition, wire-pin tests, and allowlisted SQL.
+- **Misleading acquisition:** label known coverage and platform limitations;
+  never relabel unknown as organic.
+- **Late/incomplete GA4 exports:** recompute recent partitions and show freshness
+  plus complete-period defaults.
+- **Small-cohort investor overstatement:** show denominators, maturity, and
+  thresholded segments; keep directional W4 claims explicitly directional.
+- **Cloud location/hosting uncertainty:** discover before dataset creation;
+  colocate all BigQuery data and use an isolated scheduler that can securely
+  reach MongoDB rather than coupling export to auth requests.
+
+## Completion Criteria
+
+The work is complete when:
+
+- A production release makes one analytics emission attempt per confirmed
+  first-message success path with a pseudonymous authenticated ID and honors
+  account-wide disable/re-enable; duplicate delivery cannot change the earliest
+  full-activation milestone.
+- The auth job publishes validated eligible milestones and all-account setup
+  cohorts without raw identity.
+- BigQuery derives the metric contract above from versioned SQL, passes fixture
+  assertions, and remains fresh after late data.
+- Looker exposes only aggregate authorized views and shows complete-period,
+  denominator, coverage, maturity, and freshness labels.
+- The executive page can truthfully report new accounts, setup, full
+  activation, WAU/growth, W1/W4 retention when mature, activity depth, and the
+  selected feature-adoption metrics without manual spreadsheet logic.

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -77,6 +77,11 @@
   persist voice-assisted origin in typed in-memory drafts; disclose both two-
   month upstream and 90-day exported-raw retention; and make internal/test
   exclusions permanent so rebuilds never resurrect historical traffic.
+- [x] Apply valid latest findings: clear legacy Firebase identity in foreground
+  and FCM-background execution; scope readiness to each authenticated generation;
+  service-own already-observed deferred session activity; isolate deletion
+  targets from auth-export access; and overlap deletion sweeps across mutable
+  late-arrival partitions plus watermark gaps.
 - [ ] Confirm cloud preflight facts: Firebase/GA4 BigQuery link, property ID,
   billing, dataset location, existing raw tables/IAM/expiration, GA4 retention/
   deletion configuration, scheduler connectivity, and dashboard access group.
@@ -101,7 +106,7 @@ step count across both repositories.
 | 2/5 | `sesori_auth_server` | `[user-analytics] Enforce analytics preference and add export [step 2/5]` | Not started | Step 1 deployed and repeated backfill validation at zero missing |
 | 3/5 | apps monorepo | `[user-analytics] Add client analytics foundation and opt-out [step 3/5]` | Not started | Steps 1-2 endpoints/schema deployed |
 | 4/5 | apps monorepo | `[user-analytics] Instrument activation and engagement outcomes [step 4/5]` | Not started | Step 3 released |
-| 5/5 | apps monorepo + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | Not started | Steps 2 and 4, controlled Firebase export, split auth-private/control IAM |
+| 5/5 | apps monorepo + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | Not started | Steps 2 and 4, controlled Firebase export, split auth-private/privacy-private/control IAM |
 
 ## Release Evidence
 

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -6,11 +6,12 @@
   milestones, and reporting constraints.
 - [x] Agree that first successfully accepted user-authored message is full
   activation.
-- [x] Agree on cross-repository scope, default-on optional analytics with an
-  in-app opt-out, campaign links first, and Looker Studio. The reviewed design
-  narrows the enforceable promise to installation-local Sesori custom events,
-  server reporting/supported-client synchronization, and explicitly disclosed
-  legacy/Firebase-automatic-event limits.
+- [x] Agree on cross-repository scope, default-on optional authenticated product
+  analytics with an in-app opt-out, a narrowly exempt/disclosed account-less
+  login funnel, and Looker Studio. The design narrows the enforceable preference
+  promise to account-linked Sesori product events, server reporting/supported-
+  client synchronization, and explicitly disclosed login/legacy/Firebase-
+  automatic-event limits.
 - [x] First architecture pre-review rejected the draft as too vague about
   workspace/class/DI ownership, auth export composition, data flow,
   compatibility/rollback, and unavoidable GA4 raw fields.
@@ -21,9 +22,9 @@
   splash networking, migration race, and unsafe rollback.
 - [x] Apply those valid findings directly: explicit Client/API/Storage/
   Repository/Service/Listener layers, core preference API and lifecycle,
-  dedicated server service, core hashing/route/campaign behavior, no harness or
-  voice events, SDK-acceptance result, post-splash readiness, write-first split,
-  and forward-fix privacy floor. Per review rules, these corrections were not
+  dedicated server service, core hashing/route behavior, no harness event,
+  SDK-acceptance result, post-splash readiness, write-first split, and forward-
+  fix privacy floor. Per review rules, these corrections were not
   sent for a third approval pass; do not describe the revised plan as reviewer-
   approved.
 - [x] Apply valid automated PR findings: write-ahead local disable and logout
@@ -41,6 +42,29 @@
   preference deadlines, durable pending enable, repeatable daily monitoring,
   whole-process legacy-ID-clear failure disclosure, deletion anti-join/recurring
   sweeps, and tombstone-aware export completion.
+- [x] Compare the alternate plan and both PR review sets. Retain this plan's
+  account-level identity, privacy, layering, curated warehouse, and authoritative
+  activation seams; reject the alternate raw GA4 SQL after verified WAU,
+  timestamp, cohort, identity, provider, and screen-schema defects.
+- [x] Apply later product decisions: keep the foundation durable beyond the
+  two-month readout; add bounded voice-assisted and pre-auth login metrics;
+  explicitly drive Firebase screen reporting from GoRouter with automatic
+  screen collection disabled; defer campaign attribution, notification
+  conversion, and dedicated dashboard pages beyond the initial three-page
+  report without discarding them from future work.
+- [x] Review the considerable revised plan. The reviewer rejected its missing
+  pre-logout owner, underspecified deletion command, preference polling,
+  undeclared runtime-capability DI, and non-mirrored layer directories. Apply
+  those valid findings directly: `SettingsCubit -> prepareForLogout`, concrete
+  layered deletion commands/IAM, one read per auth generation plus explicit
+  Settings refresh, immutable pre-phase-1 capability injected everywhere, and
+  Foundation/API/Repository/Service/Layer-4 paths. Per review rules, do not claim
+  the corrected version was re-reviewed/approved.
+- [x] Apply valid current PR findings: add internal JSON PUT support; add server
+  revision compare-and-set/idempotency so timed-out older enable cannot overwrite
+  newer disable; move monitoring activity to a route-visible listener; defer the
+  obsolete notification finding with its feature; and narrow recurring upstream
+  deletion to future keyed uploads without a persistent account-install map.
 - [ ] Confirm cloud preflight facts: Firebase/GA4 BigQuery link, property ID,
   billing, dataset location, existing raw tables/IAM/expiration, GA4 retention/
   deletion configuration, scheduler connectivity, and dashboard access group.
@@ -51,7 +75,8 @@
   only** BigQuery export; apply/verify raw dataset ACL and 90-day expiration
   before the first daily table and record exact UTC `raw_export_start_at`.
   Export is not retroactive. Record `behavioral_schema_v1_start_at` separately
-  only after the production custom schema appears.
+  only after the production account-linked product schema appears; account-less
+  login events do not qualify.
 
 ## Implementation Series
 
@@ -73,21 +98,29 @@ step count across both repositories.
 - [ ] Auth export staging validation reconciled and daily schedule enabled.
 - [ ] Mobile analytics release available to production users.
 - [ ] Local disable survives restart/logout, delayed stale auth work cannot
-  reactivate another account, and supported online foreground clients observe a
-  remote preference change within the declared 15-minute bound.
+  reactivate another account, and clients observe remote preference changes on
+  next auth generation/process start or explicit online Settings refresh without
+  polling.
 - [ ] Upgrade clears legacy Firebase global identity before custom sources, and
   forced clear failure suppresses custom events without blocking the product or
   pretending the process's automatic events lost legacy identity.
 - [ ] First production full-activation event joins its auth milestone row and a
   timely per-account schema-v1 exposure; preference-unknown first message is
   deferred rather than lost.
+- [ ] Typed/voice-assisted successful messages and content-free transcription
+  completions appear without transcript/audio-derived data; account-less login
+  aggregates contain only pinned provider/failure dimensions and no user key.
+- [ ] Every GoRouter route maps to the pinned screen enum and produces one
+  canonical custom screen event plus one matching Firebase-native mirror, with
+  automatic screen reporting disabled and no concrete route identifiers.
 - [ ] Three complete event days reconcile through reporting models.
 - [ ] Stale auth snapshot abort/recovery and GA4 upstream deletion drills pass,
   including in-flight export ordering, delayed offline upload/recurring sweep,
-  flattened non-repopulation, aggregate rebuild, and explicit transient/
-  automatic-only never-keyed coverage limits.
-- [ ] Looker permissions, complete-period defaults, sample sizes, coverage,
-  cohort maturity, and freshness verified.
+  flattened non-repopulation, aggregate rebuild, and explicit transient/future-
+  automatic-only/never-keyed coverage limits; recurring enforcement is claimed
+  only for future keyed uploads.
+- [ ] Three-page Looker permissions, complete-period defaults, sample sizes,
+  coverage, cohort maturity, and freshness verified.
 - [ ] First W1 cohort matured and reviewed.
 - [ ] First W4 cohort matured and reviewed, or dashboard truthfully shows no
   mature cohort yet.

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -36,6 +36,11 @@
   campaign completion, internal exclusion before auth aggregation, source
   deletion tombstones, honest never-keyed deletion limits, and earliest upgrade
   clearing of legacy Firebase global identity.
+- [x] Apply materially valid third-round findings: auth-bound campaign retries,
+  auth-restoration link classification, generic harness screen mapping, bounded
+  preference deadlines, durable pending enable, repeatable daily monitoring,
+  whole-process legacy-ID-clear failure disclosure, deletion anti-join/recurring
+  sweeps, and tombstone-aware export completion.
 - [ ] Confirm cloud preflight facts: Firebase/GA4 BigQuery link, property ID,
   billing, dataset location, existing raw tables/IAM/expiration, GA4 retention/
   deletion configuration, scheduler connectivity, and dashboard access group.
@@ -71,13 +76,15 @@ step count across both repositories.
   reactivate another account, and supported online foreground clients observe a
   remote preference change within the declared 15-minute bound.
 - [ ] Upgrade clears legacy Firebase global identity before custom sources, and
-  forced clear failure suppresses custom events without blocking the product.
+  forced clear failure suppresses custom events without blocking the product or
+  pretending the process's automatic events lost legacy identity.
 - [ ] First production full-activation event joins its auth milestone row and a
   timely per-account schema-v1 exposure; preference-unknown first message is
   deferred rather than lost.
 - [ ] Three complete event days reconcile through reporting models.
 - [ ] Stale auth snapshot abort/recovery and GA4 upstream deletion drills pass,
-  including auth-source non-repopulation, aggregate rebuild, and explicit
+  including in-flight export ordering, delayed offline upload/recurring sweep,
+  flattened non-repopulation, aggregate rebuild, and explicit transient/
   automatic-only never-keyed coverage limits.
 - [ ] Looker permissions, complete-period defaults, sample sizes, coverage,
   cohort maturity, and freshness verified.

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -32,7 +32,7 @@
   cold-open buffering, strict campaign window, immutable export cutoffs,
   split auth/control IAM, dual start timestamps, outage-recoverable transforms,
   day-zero raw controls, and upstream GA4 retention/deletion.
-- [x] Apply valid second-round findings: timely per-account schema exposure,
+- [x] Apply valid second-round findings: timely per-account foundation exposure,
   bounded first-message deferral, empty-to-non-empty milestones, account-scoped
   campaign completion, internal exclusion before auth aggregation, source
   deletion tombstones, honest never-keyed deletion limits, and earliest upgrade
@@ -65,6 +65,13 @@
   newer disable; move monitoring activity to a route-visible listener; defer the
   obsolete notification finding with its feature; and narrow recurring upstream
   deletion to future keyed uploads without a persistent account-install map.
+- [x] Apply valid follow-up findings: retain fixed measurement-critical
+  candidates until preference resolves without prematurely consuming guards;
+  verify permission `ApiResponse` before success; sweep all permanent deletion
+  tombstones for newly landed keyed rows; label account-less login diagnostics
+  as including non-excludable internal/test traffic; move existing onboarding
+  events to confirmed platform outcomes; add PR-4 activation-capable readiness;
+  and begin Apple login analytics before the native authorization sheet.
 - [ ] Confirm cloud preflight facts: Firebase/GA4 BigQuery link, property ID,
   billing, dataset location, existing raw tables/IAM/expiration, GA4 retention/
   deletion configuration, scheduler connectivity, and dashboard access group.
@@ -75,8 +82,8 @@
   only** BigQuery export; apply/verify raw dataset ACL and 90-day expiration
   before the first daily table and record exact UTC `raw_export_start_at`.
   Export is not retroactive. Record `behavioral_schema_v1_start_at` separately
-  only after the production account-linked product schema appears; account-less
-  login events do not qualify.
+  only after production `analytics_activation_ready` appears; foundation-only
+  and account-less login events do not qualify.
 
 ## Implementation Series
 
@@ -105,8 +112,9 @@ step count across both repositories.
   forced clear failure suppresses custom events without blocking the product or
   pretending the process's automatic events lost legacy identity.
 - [ ] First production full-activation event joins its auth milestone row and a
-  timely per-account schema-v1 exposure; preference-unknown first message is
-  deferred rather than lost.
+  timely per-account `analytics_activation_ready` exposure from the outcome
+  release; foundation-only binaries remain unmeasurable and preference-unknown
+  first message is deferred rather than lost.
 - [ ] Typed/voice-assisted successful messages and content-free transcription
   completions appear without transcript/audio-derived data; account-less login
   aggregates contain only pinned provider/failure dimensions and no user key.

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -6,8 +6,11 @@
   milestones, and reporting constraints.
 - [x] Agree that first successfully accepted user-authored message is full
   activation.
-- [x] Agree on cross-repository scope, default-on account opt-out, campaign
-  links first, and Looker Studio.
+- [x] Agree on cross-repository scope, default-on optional analytics with an
+  in-app opt-out, campaign links first, and Looker Studio. The reviewed design
+  narrows the enforceable promise to installation-local Sesori custom events,
+  server reporting/supported-client synchronization, and explicitly disclosed
+  legacy/Firebase-automatic-event limits.
 - [x] First architecture pre-review rejected the draft as too vague about
   workspace/class/DI ownership, auth export composition, data flow,
   compatibility/rollback, and unavoidable GA4 raw fields.
@@ -23,14 +26,22 @@
   and forward-fix privacy floor. Per review rules, these corrections were not
   sent for a third approval pass; do not describe the revised plan as reviewer-
   approved.
+- [x] Apply valid automated PR findings: write-ahead local disable and logout
+  retry preservation, generation-safe/foreground preference reconciliation,
+  cold-open buffering, strict campaign window, immutable export cutoffs,
+  split auth/control IAM, dual start timestamps, outage-recoverable transforms,
+  day-zero raw controls, and upstream GA4 retention/deletion.
 - [ ] Confirm cloud preflight facts: Firebase/GA4 BigQuery link, property ID,
-  billing, dataset location, measurement start, scheduler connectivity, and
-  dashboard access group.
+  billing, dataset location, existing raw tables/IAM/expiration, GA4 retention/
+  deletion configuration, scheduler connectivity, and dashboard access group.
 
 ## Immediate Operational Action
 
-- [ ] Enable or verify Firebase daily BigQuery export now; record the exact UTC
-  measurement start. Export is not retroactive.
+- [ ] Establish restricted project IAM, then enable or verify Firebase **daily-
+  only** BigQuery export; apply/verify raw dataset ACL and 90-day expiration
+  before the first daily table and record exact UTC `raw_export_start_at`.
+  Export is not retroactive. Record `behavioral_schema_v1_start_at` separately
+  only after the production custom schema appears.
 
 ## Implementation Series
 
@@ -43,7 +54,7 @@ step count across both repositories.
 | 2/5 | `sesori_auth_server` | `[user-analytics] Enforce analytics preference and add export [step 2/5]` | Not started | Step 1 deployed and repeated backfill validation at zero missing |
 | 3/5 | apps monorepo | `[user-analytics] Add client analytics foundation and opt-out [step 3/5]` | Not started | Steps 1-2 endpoints/schema deployed |
 | 4/5 | apps monorepo | `[user-analytics] Instrument activation and engagement outcomes [step 4/5]` | Not started | Step 3 released |
-| 5/5 | apps monorepo + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | Not started | Steps 2 and 4, Firebase export, private dataset/IAM |
+| 5/5 | apps monorepo + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | Not started | Steps 2 and 4, controlled Firebase export, split auth-private/control IAM |
 
 ## Release Evidence
 
@@ -51,8 +62,12 @@ step count across both repositories.
   zero missing; required-field enforcement deployed.
 - [ ] Auth export staging validation reconciled and daily schedule enabled.
 - [ ] Mobile analytics release available to production users.
+- [ ] Local disable survives restart/logout, delayed stale auth work cannot
+  reactivate another account, and supported online foreground clients observe a
+  remote preference change within the declared 15-minute bound.
 - [ ] First production full-activation event joined to its auth milestone row.
 - [ ] Three complete event days reconcile through reporting models.
+- [ ] Stale auth snapshot abort/recovery and GA4 upstream deletion drills pass.
 - [ ] Looker permissions, complete-period defaults, sample sizes, coverage,
   cohort maturity, and freshness verified.
 - [ ] First W1 cohort matured and reviewed.

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -1,0 +1,60 @@
+# User Analytics Tracker
+
+## Plan State
+
+- [x] Audit current analytics, product journeys, identity, privacy, auth
+  milestones, and reporting constraints.
+- [x] Agree that first successfully accepted user-authored message is full
+  activation.
+- [x] Agree on cross-repository scope, default-on account opt-out, campaign
+  links first, and Looker Studio.
+- [x] First architecture pre-review rejected the draft as too vague about
+  workspace/class/DI ownership, auth export composition, data flow,
+  compatibility/rollback, and unavoidable GA4 raw fields.
+- [x] Clarify those six areas directly in `PLAN.md`.
+- [x] Run the one permitted second review. It passed the detail gate but
+  rejected the architecture for upward/layer-skipping dependencies, auth/shell
+  ownership leakage, backend classification, untruthful campaign persistence,
+  splash networking, migration race, and unsafe rollback.
+- [x] Apply those valid findings directly: explicit Client/API/Storage/
+  Repository/Service/Listener layers, core preference API and lifecycle,
+  dedicated server service, core hashing/route/campaign behavior, no harness or
+  voice events, SDK-acceptance result, post-splash readiness, write-first split,
+  and forward-fix privacy floor. Per review rules, these corrections were not
+  sent for a third approval pass; do not describe the revised plan as reviewer-
+  approved.
+- [ ] Confirm cloud preflight facts: Firebase/GA4 BigQuery link, property ID,
+  billing, dataset location, measurement start, scheduler connectivity, and
+  dashboard access group.
+
+## Immediate Operational Action
+
+- [ ] Enable or verify Firebase daily BigQuery export now; record the exact UTC
+  measurement start. Export is not retroactive.
+
+## Implementation Series
+
+The total is fixed at five implementation PRs. Titles must retain this slug and
+step count across both repositories.
+
+| Step | Repository | Required title | Status | Depends on |
+| --- | --- | --- | --- | --- |
+| 1/5 | `sesori_auth_server` | `[user-analytics] Add write-first analytics preference [step 1/5]` | Not started | Deploy before backfill; Firebase export preflight is independent |
+| 2/5 | `sesori_auth_server` | `[user-analytics] Enforce analytics preference and add export [step 2/5]` | Not started | Step 1 deployed and repeated backfill validation at zero missing |
+| 3/5 | apps monorepo | `[user-analytics] Add client analytics foundation and opt-out [step 3/5]` | Not started | Steps 1-2 endpoints/schema deployed |
+| 4/5 | apps monorepo | `[user-analytics] Instrument activation and engagement outcomes [step 4/5]` | Not started | Step 3 released |
+| 5/5 | apps monorepo + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | Not started | Steps 2 and 4, Firebase export, private dataset/IAM |
+
+## Release Evidence
+
+- [ ] Write-first auth preference endpoint deployed; backfill repeatedly reports
+  zero missing; required-field enforcement deployed.
+- [ ] Auth export staging validation reconciled and daily schedule enabled.
+- [ ] Mobile analytics release available to production users.
+- [ ] First production full-activation event joined to its auth milestone row.
+- [ ] Three complete event days reconcile through reporting models.
+- [ ] Looker permissions, complete-period defaults, sample sizes, coverage,
+  cohort maturity, and freshness verified.
+- [ ] First W1 cohort matured and reviewed.
+- [ ] First W4 cohort matured and reviewed, or dashboard truthfully shows no
+  mature cohort yet.

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -72,6 +72,11 @@
   as including non-excludable internal/test traffic; move existing onboarding
   events to confirmed platform outcomes; add PR-4 activation-capable readiness;
   and begin Apple login analytics before the native authorization sheet.
+- [x] Apply valid next-round findings: preserve authoritative occurrence time
+  through deferred delivery; retain OAuth provider across interruption/resume;
+  persist voice-assisted origin in typed in-memory drafts; disclose both two-
+  month upstream and 90-day exported-raw retention; and make internal/test
+  exclusions permanent so rebuilds never resurrect historical traffic.
 - [ ] Confirm cloud preflight facts: Firebase/GA4 BigQuery link, property ID,
   billing, dataset location, existing raw tables/IAM/expiration, GA4 retention/
   deletion configuration, scheduler connectivity, and dashboard access group.
@@ -126,7 +131,8 @@ step count across both repositories.
   including in-flight export ordering, delayed offline upload/recurring sweep,
   flattened non-repopulation, aggregate rebuild, and explicit transient/future-
   automatic-only/never-keyed coverage limits; recurring enforcement is claimed
-  only for future keyed uploads.
+  only for future keyed uploads, and responses distinguish two-month upstream
+  retention from 90-day restricted exported-raw expiration.
 - [ ] Three-page Looker permissions, complete-period defaults, sample sizes,
   coverage, cohort maturity, and freshness verified.
 - [ ] First W1 cohort matured and reviewed.

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -31,6 +31,11 @@
   cold-open buffering, strict campaign window, immutable export cutoffs,
   split auth/control IAM, dual start timestamps, outage-recoverable transforms,
   day-zero raw controls, and upstream GA4 retention/deletion.
+- [x] Apply valid second-round findings: timely per-account schema exposure,
+  bounded first-message deferral, empty-to-non-empty milestones, account-scoped
+  campaign completion, internal exclusion before auth aggregation, source
+  deletion tombstones, honest never-keyed deletion limits, and earliest upgrade
+  clearing of legacy Firebase global identity.
 - [ ] Confirm cloud preflight facts: Firebase/GA4 BigQuery link, property ID,
   billing, dataset location, existing raw tables/IAM/expiration, GA4 retention/
   deletion configuration, scheduler connectivity, and dashboard access group.
@@ -65,9 +70,15 @@ step count across both repositories.
 - [ ] Local disable survives restart/logout, delayed stale auth work cannot
   reactivate another account, and supported online foreground clients observe a
   remote preference change within the declared 15-minute bound.
-- [ ] First production full-activation event joined to its auth milestone row.
+- [ ] Upgrade clears legacy Firebase global identity before custom sources, and
+  forced clear failure suppresses custom events without blocking the product.
+- [ ] First production full-activation event joins its auth milestone row and a
+  timely per-account schema-v1 exposure; preference-unknown first message is
+  deferred rather than lost.
 - [ ] Three complete event days reconcile through reporting models.
-- [ ] Stale auth snapshot abort/recovery and GA4 upstream deletion drills pass.
+- [ ] Stale auth snapshot abort/recovery and GA4 upstream deletion drills pass,
+  including auth-source non-repopulation, aggregate rebuild, and explicit
+  automatic-only never-keyed coverage limits.
 - [ ] Looker permissions, complete-period defaults, sample sizes, coverage,
   cohort maturity, and freshness verified.
 - [ ] First W1 cohort matured and reviewed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,22 @@ eagerly "just in case."
 - A recovered failure that continues must remain observable. Do not add a
   redundant log when the error is rethrown or returned as an explicit failure.
 
+## Analytics
+
+- When adding a user-facing feature or action, consider whether analytics would
+  answer a product decision, activation/retention question, or feature-adoption
+  question. Do not track every tap. Load
+  `.opencode/skills/add-analytics/SKILL.md` for the event-design, privacy,
+  architecture, and reporting checklist.
+- Instrument the authoritative outcome rather than a UI proxy, use closed
+  bounded parameters, and never report source code, prompts, transcripts,
+  paths, names, raw error text, or raw/hashed entity identifiers.
+- Until `.plan/active/user-analytics/` step 3 lands, the existing event union is
+  `client/app/lib/core/analytics/analytics_event.dart`. The step-3 PR moves the
+  source of truth to core product-analytics models and must remove this
+  transitional sentence while updating every consumer in lockstep; do not point
+  contributors at files that do not yet exist.
+
 ## Verification And Review
 
 - For localized production changes, run directly relevant tests and analyze the


### PR DESCRIPTION
## Summary

- add the canonical durable cross-repository product analytics plan and tracker
- define full activation as the first successfully accepted user-authored session message
- preserve account-level identity, opt-out, deletion, curated BigQuery, and authorized reporting controls beyond the first two-month readout
- add bounded voice-assisted adoption and account-less login-funnel metrics
- fix Firebase screen reporting by making GoRouter the sole screen source, disabling automatic screen collection, and mirroring pinned names through `logScreenView`
- add the reusable `add-analytics` skill and recurring `AGENTS.md` guidance

## Initial implementation scope

- five ordered implementation PRs across the auth server, apps monorepo, and cloud reporting
- revisioned/idempotent server preference updates and internal JSON PUT support
- fail-closed account-linked product events with a narrow, disclosed pre-auth login exception
- authoritative activation/engagement outcomes, voice input mode, route-visible activity, and stable screen reporting
- auth milestones plus curated activation, retention, engagement, login, voice, and screen models
- a restricted three-page initial Looker report with freshness, coverage, denominator, and cohort-maturity labels

Campaign attribution, notification open-to-action conversion, and dedicated dashboard pages beyond the initial three are explicitly deferred extensions, not discarded future requirements.

## Privacy and architecture

- delivery follows `Foundation Client -> API -> Repository -> Service -> Consumer`
- account events use a pseudonymous custom `user_key`; Firebase global `user_id` is cleared and not reused
- installation login events carry no account/attempt identity and never enter account-level models
- preference propagation uses one read per auth generation plus explicit Settings refresh—no polling
- privacy deletion has concrete auth handoff and layered command/job ownership, while recurring upstream claims are narrowed honestly to future keyed uploads

## Architecture review note

The latest considerable revision was architecture-reviewed and rejected for five concrete gaps: pre-logout ownership, deletion executable ownership, preference polling, runtime-capability DI, and layer-directory mirroring. Those valid findings were applied directly. Per repository rules, the corrected version was not re-reviewed and this PR does not claim approval.

## Verification

- `git diff --check`
- no Dart/Flutter/Node suites run because this PR changes plans, instructions, and a skill only

## Immediate operational follow-up

Verify or enable restricted Firebase daily BigQuery export and record exact UTC `raw_export_start_at`; export is not retroactive. Record `behavioral_schema_v1_start_at` only after the account-linked product schema is observed.
