### PR TITLE
[user-analytics] Add analytics plan, practice docs, and BigQuery views [step 1/4]

### DIFF
--- a/.opencode/skills/add-analytics/SKILL.md
+++ b/.opencode/skills/add-analytics/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: add-analytics
+description: Guidelines for adding analytics events to the Sesori app. Use when adding new user-facing features, evaluating whether an event is worth tracking, or designing event parameters. Covers the event taxonomy, hook points, BigQuery view updates, and the decision framework for what to track.
+---
+
+# add-analytics
+
+How to add analytics events to the Sesori mobile app.
+
+## Decision framework: is this event worth tracking?
+
+Ask these questions in order. If any answer is "no", skip the event.
+
+1. **Does it answer a product question?** ("How many users use voice?" not "How many times was this button tapped?")
+2. **Would it appear in an investor update?** (Activation rate, DAU, retention, feature adoption)
+3. **Would it change a product decision?** (If the metric moved, would you do something differently?)
+4. **Is it actionable?** (Can you tie it to a funnel step, retention cohort, or feature?)
+
+If all 4 are "yes", add the event. If any is "no", don't.
+
+## Event naming
+
+- GA4 event name: `snake_case`, letters/digits/underscores only, max 40 chars
+- Use a verb or verb_phrase: `login_completed`, `message_sent`, `diff_viewed`
+- Prefix with the domain when ambiguous: `bridge_connected` not just `connected`
+- The `@FreezedUnionValue` annotation pins the wire name — never change it after release
+
+## Parameters
+
+- Max 25 parameters per event (GA4 limit)
+- Parameter names: `snake_case`, max 40 chars
+- Use enums for closed sets (e.g., `AuthProvider`, `MessageSource`) — never free-form strings
+- Use `String` for open-ended values (e.g., `pluginId`)
+- Register custom parameters in GA4 console → Admin → Custom Definitions for them to appear in the GA4 UI (they appear in BigQuery automatically)
+
+## Where to add the hook
+
+| Event type | Hook location | Example |
+|-----------|---------------|---------|
+| User intent (tap, submit) | Cubit method entry | `loginStarted` in `LoginCubit.loginWithProvider()` |
+| Confirmed outcome | Cubit method after success | `loginCompleted` on `LoginSuccess` emit |
+| Reactive transition | Dedicated Layer-4 listener subscribing to a service stream | `BridgeConnectionAnalyticsListener` subscribes to `ConnectionService.status` |
+| Screen navigation | Dedicated Layer-4 listener subscribing to `RouteSource` | `AnalyticsRouteListener` subscribes to `GoRouterRouteSource.currentRouteStream` |
+| Flutter-only capability outcome | UI call site after the capability returns | `voiceTranscriptionCompleted` in `PromptInput._stopAndTranscribe()` |
+
+**Prefer cubit hooks or dedicated listeners over modifying services.** Never add
+analytics calls to Layer-0 transport (`ConnectionService`, `RelayClient`) or to
+app-shell capability services (`VoiceTranscriptionService`). If a stream
+transition needs tracking, create a small listener class in `module_core` that
+subscribes to the stream and delegates to `AnalyticsReporter`.
+
+## Architecture rules
+
+- `AnalyticsReporter` and `AnalyticsEvent` live in `module_core/lib/src/platform/` — they are a Layer-0 seam, same as `UrlLauncher` and `RouteSource`.
+- The concrete implementation (`FirebaseAnalyticsReporter`) stays in the product shell (`client/app`) and is registered during phase-1 DI, before `configureCoreDependencies`.
+- `module_core` never registers the implementation. Desktop registers a `NoOpAnalyticsReporter` during its phase-1 DI.
+- Stream-driven events use dedicated Layer-4 listeners in `module_core/lib/src/services/`, not modifications to Layer-0 services.
+
+## Step-by-step checklist
+
+1. [ ] Add the event case to `module_core/lib/src/platform/analytics_event.dart`
+2. [ ] Add any new enums to the same file (with `@JsonValue` wire names)
+3. [ ] Run `dart run build_runner build --delete-conflicting-outputs` in `module_core/`
+4. [ ] Add `AnalyticsReporter` parameter to the cubit/service constructor
+5. [ ] Add `getIt<AnalyticsReporter>()` to the `BlocProvider(create:)` closure (both mobile and desktop if the cubit is shared)
+6. [ ] Log the event at the correct hook point (see table above)
+7. [ ] Add/update tests: verify the event fires on success, doesn't fire on failure
+8. [ ] Run `dart analyze` in touched modules
+9. [ ] Run `dart test` (module_core) and/or `flutter test` (app)
+10. [ ] If the event adds a new dimension, update `docs/analytics/bigquery_views.sql` with a view that uses it
+11. [ ] Register the new parameter in GA4 console → Admin → Custom Definitions
+
+## What NOT to track
+
+- **Sensitive data**: No message content, file paths, code snippets, or PII beyond the hashed user ID
+- **High-frequency events**: No per-keystroke, per-frame, or per-scroll events (GA4 quotas)
+- **Redundant events**: If `session_created` already implies `project_selected`, don't add both
+- **Debug/diagnostic events**: Use Crashlytics or logs, not analytics
+
+## BigQuery view updates
+
+When adding an event that enables a new investor metric, add a corresponding view to `docs/analytics/bigquery_views.sql`. Follow the existing naming convention: `v_<metric_name>`.
+
+## Existing event taxonomy
+
+See `module_core/lib/src/platform/analytics_event.dart` for the complete, auditable list of all tracked events. This file is the single source of truth.

--- a/.plan/active/user-analytics/PLAN.md
+++ b/.plan/active/user-analytics/PLAN.md
@@ -1,0 +1,375 @@
+# User Analytics Expansion Plan
+
+**Slug:** `user-analytics`
+**Goal:** Instrument the mobile app with a full activation-funnel + engagement event taxonomy, add GoRouter screen-view tracking, set up BigQuery views for investor metrics, and codify analytics practices in AGENTS.md + a new skill.
+**Branch:** `user-analytics-plan` (worktree)
+**PR strategy:** Multiple PRs, each titled `[user-analytics] <description> [step <x>/<y>]`
+
+---
+
+**Architecture review:** Passed after corrections (Aristotle). Key corrections applied:
+- `AnalyticsReporter`/`AnalyticsEvent` live in `module_core/lib/src/platform/` (Layer-0 seam, same as `UrlLauncher`/`RouteSource`), not an unclassified `reporting/` directory.
+- `FirebaseAnalyticsReporter` stays in `client/app` and is registered during mobile phase-1 DI; `module_core` never registers the implementation.
+- Desktop registers a `NoOpAnalyticsReporter` during its phase-1 DI; all desktop `BlocProvider` call sites for shared cubits are updated.
+- `bridgeConnected` is reported by a dedicated `BridgeConnectionAnalyticsListener` (Layer 4), not by `ConnectionService` (Layer 0 transport).
+- `voiceTranscriptionCompleted` fires from the `PromptInput` call site, not from `VoiceTranscriptionService`.
+- Route tracking uses `AnalyticsRouteListener` (Layer 4, in `module_core`), not `AnalyticsRouteObserver` in the app shell.
+
+---
+
+## Current State
+
+- Firebase Analytics wired in `client/app` only (mobile, iOS/Android/macOS targets).
+- `AnalyticsReporter` interface + `AnalyticsEvent` sealed union in `client/app/lib/core/analytics/`.
+- `FirebaseAnalyticsReporter` implements the interface, forwards to `FirebaseAnalytics.logEvent()`.
+- `AnalyticsUserIdTracker` syncs SHA-256-hashed `AuthUser.id` to Firebase `setUserId`.
+- **Only 7 events tracked** — all onboarding UI interactions (install command copies, support link taps, "why bridge" explainer).
+- No login, connection, session, message, screen-view, or activation events.
+- Desktop app has **no analytics** (deferred per user decision).
+- `GoRouterRouteSource` in `client/app/lib/core/platform/go_router_route_source.dart` already emits `AppRouteDef?` on every route change — the hook for screen-view tracking.
+
+## Decisions (confirmed with user)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | `first_assistant_message` dedup | BigQuery `MIN(event_timestamp)` per user — no client-side flag |
+| 2 | `message_sent` source param | Yes — `source: typed \| voice` to track voice-first adoption over time |
+| 3 | Screen-view tracking | Yes — via `GoRouterRouteSource.currentRouteStream` → typed route names |
+| 4 | Desktop analytics | Deferred to follow-up phase |
+| 5 | Login provider | Parameter on events (`provider: github \| google \| apple \| email`), not separate events |
+| 6 | AGENTS.md update | Add analytics-as-recurring-practice guidance |
+| 7 | New skill | `.opencode/skills/add-analytics/` with event-design guidelines |
+
+---
+
+## PR Breakdown
+
+### PR 1: `[user-analytics] Add analytics plan, practice docs, and BigQuery views [step 1/4]`
+
+Already implemented on the `user-analytics-plan` branch:
+
+- `.plan/active/user-analytics/PLAN.md` — this plan
+- `.opencode/skills/add-analytics/SKILL.md` — analytics event-design skill
+- `docs/analytics/bigquery_views.sql` — 9 BigQuery views (DAU, retention, funnel, voice adoption, etc.)
+- `AGENTS.md` — new "Analytics" section making event consideration a recurring practice
+
+Docs/instruction changes only — no Dart/Flutter suites needed.
+
+---
+
+### PR 2: `[user-analytics] Move analytics seam to module_core [step 2/4]`
+
+Move `AnalyticsReporter` interface and `AnalyticsEvent` union from `client/app` to `client/module_core` so cubits and services (pure Dart) can log events without importing Flutter.
+
+**Changes:**
+
+1. Move `client/app/lib/core/analytics/analytics_reporter.dart` → `client/module_core/lib/src/platform/analytics_reporter.dart`
+2. Move `client/app/lib/core/analytics/analytics_event.dart` → `client/module_core/lib/src/platform/analytics_event.dart`
+3. Regenerate freezed files (`analytics_event.freezed.dart`, `analytics_event.g.dart`) via `build_runner` in `module_core`
+4. Export new files from `module_core/lib/sesori_dart_core.dart`
+5. Update `FirebaseAnalyticsReporter` import in `client/app/lib/core/analytics/firebase_analytics_reporter.dart` to import from `sesori_dart_core`
+6. Update `AnalyticsUserIdTracker` import similarly
+7. Update all existing call sites (`onboarding_view.dart`, test helpers) to import from `sesori_dart_core` instead of local analytics files
+8. **No DI registration change in `module_core`** — `FirebaseAnalyticsReporter` stays in `client/app` and is registered during mobile phase-1 DI (before `configureCoreDependencies`), same as today. `module_core` only defines the interface; the shell owns the implementation.
+9. **Desktop no-op registration** — Register a `NoOpAnalyticsReporter` in `client/desktop` during desktop phase-1 DI so shared cubits that require `AnalyticsReporter` can resolve it. Update all desktop `BlocProvider(create:)` call sites for shared cubits (`LoginCubit`, `ProjectListCubit`, `NewSessionCubit`, `SessionDetailCubit`, `SessionListCubit`, `DiffCubit`) to pass `getIt<AnalyticsReporter>()`.
+
+**Why `platform/`:** `AnalyticsReporter` is a shell-implemented platform seam — the same Layer-0 classification as `UrlLauncher`, `RouteSource`, `DeepLinkSource`, and `LifecycleSource` which already live in `module_core/lib/src/platform/`. The `AnalyticsEvent` union is the typed contract that both the interface and its consumers share, so it lives alongside the reporter.
+
+**Why this shape:** `FailureReporter` precedent — interface in shared code, implementation in the app shell. Cubits in `module_core` already depend on `FailureReporter` (from `sesori_shared`); `AnalyticsReporter` follows the same pattern but lives in `module_core` since it's client-only.
+
+**Files touched:** ~12 (2 moved, 2 regenerated, 6 import updates, 1 new NoOp, 1 desktop DI update)
+
+**Verification:**
+- `dart pub get` exits 0 from `client/`
+- `dart analyze` exits 0 in `module_core/`, `app/`, and `desktop/`
+- `cd app && flutter test` passes
+- `cd module_core && dart test` passes
+- `cd desktop && flutter test` passes
+
+---
+
+### PR 3: `[user-analytics] Add activation funnel + engagement events [step 3/4]`
+
+Add all new `AnalyticsEvent` union cases and hook them into cubits/services.
+
+#### New events
+
+**Auth:**
+```dart
+@FreezedUnionValue("login_started")
+const factory AnalyticsEvent.loginStarted({required AuthProvider provider}) = LoginStarted;
+
+@FreezedUnionValue("login_completed")
+const factory AnalyticsEvent.loginCompleted({required AuthProvider provider}) = LoginCompleted;
+
+@FreezedUnionValue("login_failed")
+const factory AnalyticsEvent.loginFailed({required AuthProvider provider}) = LoginFailed;
+```
+
+**Connection / Activation:**
+```dart
+@FreezedUnionValue("bridge_connected")
+const factory AnalyticsEvent.bridgeConnected() = BridgeConnected;
+
+@FreezedUnionValue("project_discovered")
+const factory AnalyticsEvent.projectDiscovered() = ProjectDiscovered;
+
+@FreezedUnionValue("session_created")
+const factory AnalyticsEvent.sessionCreated({required String pluginId}) = SessionCreated;
+
+@FreezedUnionValue("first_assistant_message")
+const factory AnalyticsEvent.firstAssistantMessage() = FirstAssistantMessage;
+```
+
+**Engagement:**
+```dart
+@FreezedUnionValue("message_sent")
+const factory AnalyticsEvent.messageSent({required MessageSource source}) = MessageSent;
+
+@FreezedUnionValue("voice_transcription_completed")
+const factory AnalyticsEvent.voiceTranscriptionCompleted() = VoiceTranscriptionCompleted;
+
+@FreezedUnionValue("diff_viewed")
+const factory AnalyticsEvent.diffViewed() = DiffViewed;
+
+@FreezedUnionValue("permission_replied")
+const factory AnalyticsEvent.permissionReplied({required PermissionReply reply}) = PermissionReplied;
+
+@FreezedUnionValue("session_archived")
+const factory AnalyticsEvent.sessionArchived() = SessionArchived;
+
+@FreezedUnionValue("session_deleted")
+const factory AnalyticsEvent.sessionDeleted() = SessionDeleted;
+
+@FreezedUnionValue("session_renamed")
+const factory AnalyticsEvent.sessionRenamed() = SessionRenamed;
+
+@FreezedUnionValue("project_created")
+const factory AnalyticsEvent.projectCreated() = ProjectCreated;
+```
+
+**New enums:**
+```dart
+enum MessageSource {
+  @JsonValue("typed") typed,
+  @JsonValue("voice") voice,
+}
+
+enum AuthProvider {  // already exists in module_auth — reuse, don't redefine
+  github, google, apple, email,
+}
+```
+
+#### Hook points (file → method → event)
+
+| File | Method | Event | Notes |
+|------|--------|-------|-------|
+| `module_core/lib/src/cubits/login/login_cubit.dart` | `loginWithProvider()` | `loginStarted(provider)` | At entry |
+| `module_core/lib/src/cubits/login/login_cubit.dart` | `loginWithProvider()` | `loginCompleted(provider)` | On `LoginSuccess` emit |
+| `module_core/lib/src/cubits/login/login_cubit.dart` | `loginWithProvider()` | `loginFailed(provider)` | On `LoginFailed` emit |
+| `module_core/lib/src/cubits/login/login_cubit.dart` | `loginWithApple()` | Same 3 events with `AuthProvider.apple` | |
+| `module_core/lib/src/cubits/login/login_cubit.dart` | `loginWithEmail()` | Same 3 events with `AuthProvider.email` | |
+| `module_core/lib/src/services/bridge_connection_analytics_listener.dart` (new) | Listens to `ConnectionService.status` stream | `bridgeConnected()` | Fire once per non-connected → connected transition. Layer-4 listener, not transport. |
+| `module_core/lib/src/cubits/project_list/project_list_cubit.dart` | `discoverProject()` | `projectDiscovered()` | On success |
+| `module_core/lib/src/cubits/project_list/project_list_cubit.dart` | `createProject()` / `createDirectory()` | `projectCreated()` | On success |
+| `module_core/lib/src/cubits/new_session/new_session_cubit.dart` | `createSession()` | `sessionCreated(pluginId)` | On `NewSessionCreated` emit |
+| `module_core/lib/src/cubits/session_detail/session_detail_cubit.dart` | `_onMessageUpdated()` | `firstAssistantMessage()` | Only when `message is MessageAssistant` and it's a new message (not an update to existing) |
+| `module_core/lib/src/cubits/session_detail/session_detail_cubit.dart` | `sendMessage()` | `messageSent(source)` | On success (not error/requeue). Track `source` param — requires threading origin through `QueuedSessionSubmission` |
+| `module_core/lib/src/cubits/session_detail/session_detail_cubit.dart` | `_drainQueuedMessages()` | `messageSent(source)` | Same — when queued send succeeds |
+| `module_core/lib/src/cubits/session_detail/session_detail_cubit.dart` | `replyToPermission()` | `permissionReplied(reply)` | On success |
+| `module_core/lib/src/cubits/session_list/session_list_cubit.dart` | `archiveSession()` | `sessionArchived()` | On success |
+| `module_core/lib/src/cubits/session_list/session_list_cubit.dart` | `deleteSession()` | `sessionDeleted()` | On success |
+| `module_core/lib/src/cubits/session_list/session_list_cubit.dart` | `renameSession()` | `sessionRenamed()` | On success |
+| `module_core/lib/src/cubits/session_diffs/diff_cubit.dart` | `_fetchAndEmit()` | `diffViewed()` | On `DiffLoaded` emit (first load per mount) |
+| `client/app/lib/features/session_detail/widgets/prompt_input.dart` | `_stopAndTranscribe()` | `voiceTranscriptionCompleted()` | On success (transcript returned). Fired from the UI call site, not from `VoiceTranscriptionService` — keeps the app-shell service free of analytics decisions. |
+
+#### Voice source threading
+
+`messageSent(source)` requires knowing whether the message text originated from voice. The approach:
+
+1. `PromptInput._stopAndTranscribe()` already sets the transcribed text into the input controller. Add a flag `_lastInputWasVoice` that is set to `true` after transcription and cleared on any manual text edit.
+2. When `PromptInput._handleSend()` calls `SessionDetailCubit.sendMessage()`, pass the source.
+3. `sendMessage()` stores the source in `QueuedSessionSubmission` (add a `source` field) so queued sends retain their origin.
+4. Both `sendMessage()` and `_drainQueuedMessages()` log `messageSent(source)` with the stored source.
+
+**Changes to `QueuedSessionSubmission`:** Add `required MessageSource source` field (defaults to `MessageSource.typed` for backward compat during migration, but make it required since we control all call sites).
+
+#### Cubit constructor changes
+
+Each cubit that logs events gains a new required `AnalyticsReporter analyticsReporter` parameter. Call sites in `BlocProvider(create:)` closures add `getIt<AnalyticsReporter>()`.
+
+Cubits affected: `LoginCubit`, `ProjectListCubit`, `NewSessionCubit`, `SessionDetailCubit`, `SessionListCubit`, `DiffCubit`.
+
+Services affected: None — `bridgeConnected` moves to a new `BridgeConnectionAnalyticsListener` (Layer 4), and `voiceTranscriptionCompleted` fires from the UI call site.
+
+**New Layer-4 listener:**
+
+`BridgeConnectionAnalyticsListener` in `module_core/lib/src/services/bridge_connection_analytics_listener.dart`:
+
+```dart
+class BridgeConnectionAnalyticsListener {
+  final AnalyticsReporter _reporter;
+  final ConnectionService _connectionService;
+  StreamSubscription<ConnectionStatus>? _subscription;
+  bool _wasConnected = false;
+
+  BridgeConnectionAnalyticsListener({
+    required AnalyticsReporter reporter,
+    required ConnectionService connectionService,
+  }) : _reporter = reporter, _connectionService = connectionService {
+    _subscription = _connectionService.status.listen(_onStatusChanged);
+  }
+
+  void _onStatusChanged(ConnectionStatus status) {
+    final isConnected = status is ConnectionConnected;
+    if (isConnected && !_wasConnected) {
+      unawaited(_reporter.logEvent(event: const AnalyticsEvent.bridgeConnected()));
+    }
+    _wasConnected = isConnected;
+  }
+
+  void dispose() => _subscription?.cancel();
+}
+```
+
+Instantiated in `main.dart` alongside `AnalyticsUserIdTracker`, passing `getIt<AnalyticsReporter>()` and `getIt<ConnectionService>()`. Mobile only — desktop does not instantiate this listener.
+
+**Verification:**
+- `dart analyze` exits 0 in `module_core/` and `app/`
+- `cd module_core && dart test` passes (add tests for new event logging in cubit tests)
+- `cd app && flutter test` passes (update onboarding analytics test, add connected_empty_view test if needed)
+- Existing analytics events still fire correctly (no regressions)
+
+---
+
+### PR 4: `[user-analytics] Add screen-view tracking [step 4/4]`
+
+Create `AnalyticsRouteListener` in `module_core/lib/src/services/analytics_route_listener.dart`:
+
+```dart
+class AnalyticsRouteListener {
+  final AnalyticsReporter _reporter;
+  final RouteSource _routeSource;
+  StreamSubscription<AppRouteDef?>? _subscription;
+  AppRouteDef? _lastLoggedRoute;
+
+  AnalyticsRouteListener({
+    required AnalyticsReporter reporter,
+    required RouteSource routeSource,
+  }) : _reporter = reporter, _routeSource = routeSource {
+    _subscription = _routeSource.currentRouteStream.listen(_onRouteChanged);
+  }
+
+  void _onRouteChanged(AppRouteDef? route) {
+    if (route == null || route == _lastLoggedRoute) return;
+    _lastLoggedRoute = route;
+    unawaited(_reporter.logEvent(
+      event: AnalyticsEvent.screenViewed(screen: route.name),
+    ));
+  }
+
+  void dispose() => _subscription?.cancel();
+}
+```
+
+Pure Dart — no Flutter dependency. The `RouteSource` interface and `AppRouteDef` enum are already in `module_core`, so this listener lives there. Only its construction and app-lifetime ownership belong in `client/app/main.dart`.
+
+**New event:**
+```dart
+@FreezedUnionValue("screen_view")
+const factory AnalyticsEvent.screenViewed({required String screen}) = ScreenViewed;
+```
+
+Note: GA4 reserves `screen_view` as an automatic event name, but since we're logging it manually with our own parameter (`screen` instead of `firebase_screen`), it will appear as a custom event. This is intentional — GA4's automatic screen tracking doesn't work with `go_router`.
+
+**Wire-up:** Instantiate in `main.dart` alongside `AnalyticsUserIdTracker`, passing `getIt<AnalyticsReporter>()` and `getIt<RouteSource>()`. Mobile only.
+
+**Verification:**
+- `dart analyze` exits 0 in `module_core/` and `app/`
+- `cd module_core && dart test` passes (add `AnalyticsRouteListener` tests)
+- `cd app && flutter test` passes
+
+---
+
+## BigQuery Console Setup Checklist (manual, one-time)
+
+The SQL views live in `docs/analytics/bigquery_views.sql` (delivered in PR 1). To activate:
+
+1. [ ] Open Firebase Console → Project Settings → Integrations → BigQuery
+2. [ ] Click "Link" → choose BigQuery project and region (match your GCP project)
+3. [ ] Enable "Daily export" (free tier: 10GB storage, 1TB queries/month)
+4. [ ] Wait 24h for first export (or use streaming export for real-time)
+5. [ ] Note the dataset name (format: `analytics_<project_number>`)
+6. [ ] Run the SQL from `docs/analytics/bigquery_views.sql` (replace `<project>` and `<dataset>`)
+7. [ ] In GA4 console → Admin → Custom Definitions → register custom dimensions:
+   - `provider` (event-scoped)
+   - `source` (event-scoped)
+   - `screen` (event-scoped)
+   - `reply` (event-scoped)
+   - `pluginId` (event-scoped)
+   - `surface` (event-scoped)
+   - `method` (event-scoped)
+   - `os` (event-scoped)
+   - `channel` (event-scoped)
+8. [ ] Optional: Create a Looker Studio dashboard connected to BigQuery for live investor metrics
+
+---
+
+## Event Taxonomy Summary
+
+| Event | Parameters | Funnel stage | Investor metric |
+|-------|-----------|--------------|-----------------|
+| `first_open` | — (automatic) | Install | New users |
+| `session_start` | — (automatic) | Engagement | DAU/WAU/MAU |
+| `screen_view` | `screen` | Engagement | Navigation patterns |
+| `login_started` | `provider` | Acquisition | Provider mix |
+| `login_completed` | `provider` | Activation step 1 | Signup rate |
+| `login_failed` | `provider` | Activation step 1 (drop) | Auth friction |
+| `bridge_connected` | — | Activation step 2 | Bridge setup rate |
+| `project_discovered` | — | Activation step 3 | Project setup rate |
+| `project_created` | — | Activation step 3 (alt) | Project creation |
+| `session_created` | `pluginId` | Activation step 4 | First usage |
+| `first_assistant_message` | — | **Aha moment** | **Activation rate** |
+| `message_sent` | `source` | Engagement | Daily usage, voice adoption |
+| `voice_transcription_completed` | — | Engagement | Voice feature adoption |
+| `diff_viewed` | — | Engagement | Review behavior |
+| `permission_replied` | `reply` | Engagement | AI control patterns |
+| `session_archived` | — | Engagement | Session management |
+| `session_deleted` | — | Engagement | Session cleanup |
+| `session_renamed` | — | Engagement | Session organization |
+| `onboarding_need_help_opened` | `surface` | Onboarding | Support-seeking |
+| `onboarding_support_link_opened` | `channel`, `surface` | Onboarding | Support channel mix |
+| `onboarding_why_bridge_opened` | `surface` | Onboarding | Education engagement |
+| `bridge_install_command_copied` | `method`, `os`, `surface` | Onboarding | Install intent |
+| `bridge_install_command_shared` | `method`, `os`, `surface` | Onboarding | Install intent |
+| `bridge_run_command_copied` | `surface` | Onboarding | Run intent |
+| `bridge_run_command_shared` | `surface` | Onboarding | Run intent |
+
+**Total: 23 events** (7 existing + 16 new)
+
+---
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| `first_assistant_message` fires on history load (not live) | Only fire when `_onMessageUpdated` receives a **new** `MessageAssistant` (index < 0 in existing list), not an update to an existing message |
+| `messageSent` double-fires from both `sendMessage()` and `_drainQueuedMessages()` | Fire only on success path; if `sendMessage` enqueues, the event fires when `_drainQueuedMessages` succeeds, not on enqueue |
+| `bridgeConnected` fires on every reconnect (noisy) | `BridgeConnectionAnalyticsListener` tracks `_wasConnected` and only fires on non-connected → connected transitions, not on steady-state replays |
+| `screen_view` floods GA4 with duplicate events | `AnalyticsRouteListener` deduplicates consecutive identical routes |
+| Freezed regeneration breaks existing events | The `@FreezedUnionValue` annotations pin wire names; regenerated code is identical for unchanged cases |
+| GA4 custom parameter limits | Max 25 params/event, max 50 custom dimensions — we're well under |
+| BigQuery costs | Free tier: 10GB storage, 1TB queries/month. Our volume is negligible. |
+
+---
+
+## What We're NOT Doing (and why)
+
+| Skipped | Reason |
+|---------|--------|
+| Desktop analytics | Desktop app has no Firebase setup; bridge supervision still in progress. Follow-up phase. |
+| Client-side `first_assistant_message` dedup flag | BigQuery `MIN(event_timestamp)` per user handles dedup. No client state to sync. |
+| Bridge-side analytics | Bridge is a CLI tool; no analytics infrastructure. Relay-level metrics would need server work. |
+| Crashlytics → BigQuery | Crashlytics is error reporting, not product analytics. Separate concern. |
+| Session duration tracking | GA4 `session_start` + `session_end` (automatic) already provides this. |
+| Custom user properties (e.g., "primary_provider") | Adds complexity without clear investor value. Can derive from event parameters. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,18 @@ eagerly "just in case."
   approve it. Prefer a dedicated PR without unrelated functionality changes
   when practical.
 
+## Analytics
+
+When adding a user-facing action or feature, consider whether an analytics
+event is warranted. The goal is to track the activation funnel, engagement
+depth, and feature adoption — not every tap. Ask: "Would this metric change a
+product decision or appear in an investor update?" If yes, add it. If no, skip
+it.
+
+New events go in `module_core/lib/src/platform/analytics_event.dart` as a new
+`AnalyticsEvent` union case. See `.opencode/skills/add-analytics/SKILL.md` for
+the full event-design checklist.
+
 ## Repeated Pitfalls
 
 - Do not solve speculative edge cases with broad locks, registries, lifecycle

--- a/docs/analytics/bigquery_views.sql
+++ b/docs/analytics/bigquery_views.sql
@@ -1,0 +1,213 @@
+-- =============================================================================
+-- Sesori Analytics — BigQuery Views
+-- =============================================================================
+--
+-- Prerequisites:
+--   1. Firebase Console → Project Settings → Integrations → BigQuery → Link
+--   2. Enable daily export (free tier: 10GB storage, 1TB queries/month)
+--   3. Note the dataset ID (format: analytics_<project_number>)
+--   4. Replace `<project>` and `<dataset>` below with your values
+--
+-- After creating views, register custom dimensions in GA4 console:
+--   Admin → Custom Definitions → Add:
+--     - provider (event-scoped)
+--     - source (event-scoped)
+--     - screen (event-scoped)
+--     - reply (event-scoped)
+--     - pluginId (event-scoped)
+--     - surface (event-scoped)
+--     - method (event-scoped)
+--     - os (event-scoped)
+--     - channel (event-scoped)
+-- =============================================================================
+
+
+-- =============================================================================
+-- 1. Daily Active Users (DAU) + New Users
+-- =============================================================================
+CREATE OR REPLACE VIEW `<project>.<dataset>.v_dau` AS
+SELECT
+  event_date,
+  COUNT(DISTINCT user_pseudo_id) AS dau,
+  COUNT(DISTINCT IF(event_name = 'first_open', user_pseudo_id, NULL)) AS new_users
+FROM `<project>.<dataset>.events_*`
+WHERE event_name IN ('session_start', 'first_open')
+  AND _TABLE_SUFFIX >= FORMAT_DATE('%Y%m%d', DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY))
+GROUP BY event_date
+ORDER BY event_date;
+
+
+-- =============================================================================
+-- 2. Weekly Active Users (WAU) + Stickiness (DAU/WAU ratio)
+-- =============================================================================
+CREATE OR REPLACE VIEW `<project>.<dataset>.v_wau_stickiness` AS
+WITH daily AS (
+  SELECT
+    event_date,
+    COUNT(DISTINCT user_pseudo_id) AS dau
+  FROM `<project>.<dataset>.events_*`
+  WHERE event_name = 'session_start'
+  GROUP BY event_date
+),
+weekly AS (
+  SELECT
+    event_date,
+    COUNT(DISTINCT user_pseudo_id) AS wau
+  FROM `<project>.<dataset>.events_*`
+  WHERE event_name = 'session_start'
+    AND event_date >= FORMAT_DATE('%Y%m%d', DATE_SUB(PARSE_DATE('%Y%m%d', event_date), INTERVAL 6 DAY))
+  GROUP BY event_date
+)
+SELECT
+  d.event_date,
+  d.dau,
+  w.wau,
+  SAFE_DIVIDE(d.dau, w.wau) AS stickiness_ratio
+FROM daily d
+JOIN weekly w ON d.event_date = w.event_date
+ORDER BY d.event_date;
+
+
+-- =============================================================================
+-- 3. Activation Funnel
+-- =============================================================================
+CREATE OR REPLACE VIEW `<project>.<dataset>.v_activation_funnel` AS
+WITH funnel_events AS (
+  SELECT
+    user_pseudo_id,
+    event_name,
+    event_timestamp,
+    (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'provider') AS provider
+  FROM `<project>.<dataset>.events_*`
+  WHERE event_name IN (
+    'first_open',
+    'login_started',
+    'login_completed',
+    'bridge_connected',
+    'project_discovered',
+    'session_created',
+    'first_assistant_message'
+  )
+)
+SELECT
+  event_name AS funnel_step,
+  COUNT(DISTINCT user_pseudo_id) AS users_reached,
+  ROUND(COUNT(DISTINCT user_pseudo_id) * 100.0 /
+    FIRST_VALUE(COUNT(DISTINCT user_pseudo_id)) OVER (ORDER BY COUNT(DISTINCT user_pseudo_id) DESC), 1) AS pct_of_top
+FROM funnel_events
+GROUP BY event_name
+ORDER BY users_reached DESC;
+
+
+-- =============================================================================
+-- 4. Time to Activation (login → first AI reply, in hours)
+-- =============================================================================
+CREATE OR REPLACE VIEW `<project>.<dataset>.v_time_to_activation` AS
+SELECT
+  user_pseudo_id,
+  MIN(IF(event_name = 'login_completed', event_timestamp, NULL)) AS login_ts,
+  MIN(IF(event_name = 'first_assistant_message', event_timestamp, NULL)) AS aha_ts,
+  TIMESTAMP_DIFF(
+    MIN(IF(event_name = 'first_assistant_message', event_timestamp, NULL)),
+    MIN(IF(event_name = 'login_completed', event_timestamp, NULL)),
+    MINUTE
+  ) / 60.0 AS hours_to_activation
+FROM `<project>.<dataset>.events_*`
+WHERE event_name IN ('login_completed', 'first_assistant_message')
+GROUP BY user_pseudo_id
+HAVING aha_ts IS NOT NULL
+ORDER BY hours_to_activation;
+
+
+-- =============================================================================
+-- 5. Weekly Cohort Retention
+-- =============================================================================
+CREATE OR REPLACE VIEW `<project>.<dataset>.v_weekly_retention` AS
+WITH first_seen AS (
+  SELECT
+    user_pseudo_id,
+    MIN(PARSE_DATE('%Y%m%d', event_date)) AS cohort_date
+  FROM `<project>.<dataset>.events_*`
+  WHERE event_name = 'first_open'
+  GROUP BY user_pseudo_id
+),
+activity AS (
+  SELECT DISTINCT
+    user_pseudo_id,
+    PARSE_DATE('%Y%m%d', event_date) AS active_date
+  FROM `<project>.<dataset>.events_*`
+  WHERE event_name = 'session_start'
+)
+SELECT
+  DATE_TRUNC(f.cohort_date, WEEK) AS cohort_week,
+  COUNT(DISTINCT f.user_pseudo_id) AS cohort_size,
+  COUNT(DISTINCT IF(DATE_DIFF(a.active_date, f.cohort_date, DAY) BETWEEN 0 AND 6, f.user_pseudo_id, NULL)) AS week_0,
+  COUNT(DISTINCT IF(DATE_DIFF(a.active_date, f.cohort_date, DAY) BETWEEN 7 AND 13, f.user_pseudo_id, NULL)) AS week_1,
+  COUNT(DISTINCT IF(DATE_DIFF(a.active_date, f.cohort_date, DAY) BETWEEN 14 AND 27, f.user_pseudo_id, NULL)) AS week_2,
+  COUNT(DISTINCT IF(DATE_DIFF(a.active_date, f.cohort_date, DAY) BETWEEN 28 AND 55, f.user_pseudo_id, NULL)) AS week_4
+FROM first_seen f
+LEFT JOIN activity a ON f.user_pseudo_id = a.user_pseudo_id
+GROUP BY cohort_week
+ORDER BY cohort_week;
+
+
+-- =============================================================================
+-- 6. Voice Adoption (weekly voice vs typed message volume)
+-- =============================================================================
+CREATE OR REPLACE VIEW `<project>.<dataset>.v_voice_adoption` AS
+SELECT
+  DATE_TRUNC(PARSE_DATE('%Y%m%d', event_date), WEEK) AS week,
+  (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'source') AS source,
+  COUNT(*) AS message_count,
+  COUNT(DISTINCT user_pseudo_id) AS unique_users
+FROM `<project>.<dataset>.events_*`
+WHERE event_name = 'message_sent'
+GROUP BY week, source
+ORDER BY week, source;
+
+
+-- =============================================================================
+-- 7. Screen Popularity (top screens by views)
+-- =============================================================================
+CREATE OR REPLACE VIEW `<project>.<dataset>.v_screen_popularity` AS
+SELECT
+  (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'screen') AS screen_name,
+  COUNT(*) AS view_count,
+  COUNT(DISTINCT user_pseudo_id) AS unique_viewers
+FROM `<project>.<dataset>.events_*`
+WHERE event_name = 'screen_view'
+GROUP BY screen_name
+ORDER BY view_count DESC;
+
+
+-- =============================================================================
+-- 8. Permission Reply Distribution (always vs once vs reject)
+-- =============================================================================
+CREATE OR REPLACE VIEW `<project>.<dataset>.v_permission_replies` AS
+SELECT
+  (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'reply') AS reply_type,
+  COUNT(*) AS count,
+  COUNT(DISTINCT user_pseudo_id) AS unique_users
+FROM `<project>.<dataset>.events_*`
+WHERE event_name = 'permission_replied'
+GROUP BY reply_type
+ORDER BY count DESC;
+
+
+-- =============================================================================
+-- 9. Login Provider Breakdown
+-- =============================================================================
+CREATE OR REPLACE VIEW `<project>.<dataset>.v_login_providers` AS
+SELECT
+  (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'provider') AS provider,
+  COUNT(IF(event_name = 'login_started', 1, NULL)) AS started,
+  COUNT(IF(event_name = 'login_completed', 1, NULL)) AS completed,
+  COUNT(IF(event_name = 'login_failed', 1, NULL)) AS failed,
+  ROUND(SAFE_DIVIDE(
+    COUNT(IF(event_name = 'login_completed', 1, NULL)),
+    COUNT(IF(event_name = 'login_started', 1, NULL))
+  ) * 100, 1) AS success_rate_pct
+FROM `<project>.<dataset>.events_*`
+WHERE event_name IN ('login_started', 'login_completed', 'login_failed')
+GROUP BY provider
+ORDER BY started DESC;


### PR DESCRIPTION
## What

Analytics expansion plan + practice docs + BigQuery views. This is step 1 of 4 — docs only, no code changes.

## Changes

- **`.plan/active/user-analytics/PLAN.md`** — Full 4-PR implementation plan covering:
  - 16 new analytics events (auth, activation funnel, engagement, voice adoption)
  - Event taxonomy with exact hook points in cubits/services
  - BigQuery console setup checklist
  - Risk mitigations and architecture decisions
- **`.opencode/skills/add-analytics/SKILL.md`** — Reusable skill for adding analytics events:
  - Decision framework (is this event worth tracking?)
  - Event naming and parameter conventions
  - Hook-point table (where to add events by type)
  - Architecture rules (Layer-0 seam, no analytics in transport services)
  - Step-by-step checklist
- **`docs/analytics/bigquery_views.sql`** — 9 BigQuery views for investor metrics:
  - DAU / new users
  - WAU + stickiness ratio
  - Activation funnel (install → first AI reply)
  - Time to activation
  - Weekly cohort retention
  - Voice adoption (typed vs voice messages)
  - Screen popularity
  - Permission reply distribution
  - Login provider breakdown
- **`AGENTS.md`** — New "Analytics" section making event consideration a recurring practice when adding features

## Architecture review

Plan reviewed and corrected by Aristotle. Key corrections applied:
- `AnalyticsReporter`/`AnalyticsEvent` → `module_core/lib/src/platform/` (Layer-0 seam)
- `FirebaseAnalyticsReporter` stays in `client/app`, registered in phase-1 DI
- Desktop gets `NoOpAnalyticsReporter` for shared cubit compatibility
- `bridgeConnected` uses a dedicated `BridgeConnectionAnalyticsListener` (Layer 4), not `ConnectionService`
- `voiceTranscriptionCompleted` fires from the UI call site, not from `VoiceTranscriptionService`
- Route tracking uses `AnalyticsRouteListener` (Layer 4, in `module_core`)

## Next steps (planned PRs)

- **Step 2/4**: Move analytics seam to `module_core` (interface + event union)
- **Step 3/4**: Add 16 new events + hook into cubits/services
- **Step 4/4**: Add screen-view tracking via `GoRouterRouteSource`

## Verification

Docs/instruction changes only — no Dart/Flutter suites needed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a documented analytics plan and practice docs, plus 9 BigQuery views for core investor metrics. Docs-only; no app code changes.

- **New Features**
  - `.plan/active/user-analytics/PLAN.md`: 4-step rollout; 16 new events; exact hook points; GA4/BigQuery setup; risks and decisions.
  - `.opencode/skills/add-analytics/SKILL.md`: decision framework, naming/params, hook locations, architecture rules, and a step-by-step checklist.
  - `docs/analytics/bigquery_views.sql`: DAU/new users, WAU/stickiness, activation funnel, time to activation, weekly retention, voice adoption, screen popularity, permission replies, and login provider breakdown.
  - `AGENTS.md`: new Analytics section to make event consideration a recurring practice.

<sup>Written for commit 35af3d4448b8329bd8227c2db8e5191812800fdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

