### PR TITLE
fix(bridge): clarify optional GitHub CLI status

### DIFF
--- a/bridge/app/lib/src/bridge/api/gh_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/gh_cli_api.dart
@@ -24,22 +24,21 @@ class GhCliApi {
       _reportAvailabilityFailure(
         message:
             "GitHub CLI (gh) is installed but unusable: 'gh --version' exited with code ${result.exitCode}. "
-            "GitHub pull request and CI status sync is disabled; local worktree diffs do not require gh.",
+            "GitHub pull request and CI status sync is disabled.",
       );
       return false;
     } on ProcessException {
       _reportAvailabilityFailure(
         message:
             "GitHub CLI (gh) is not installed or is unavailable on PATH. "
-            "GitHub pull request and CI status sync is disabled; local worktree diffs do not require gh.",
+            "GitHub pull request and CI status sync is disabled.",
       );
       return false;
     } on Object catch (error, stackTrace) {
       if (!_availabilityFailureReported) {
         _availabilityFailureReported = true;
         Log.w(
-          "GitHub CLI availability check failed. GitHub pull request and CI status sync is disabled; "
-          "local worktree diffs do not require gh.",
+          "GitHub CLI availability check failed. GitHub pull request and CI status sync is disabled.",
           error,
           stackTrace,
         );
@@ -64,15 +63,14 @@ class GhCliApi {
       _reportAvailabilityFailure(
         message:
             "GitHub CLI (gh) is not installed or is unavailable on PATH. "
-            "GitHub pull request and CI status sync is disabled; local worktree diffs do not require gh.",
+            "GitHub pull request and CI status sync is disabled.",
       );
       return false;
     } on Object catch (error, stackTrace) {
       if (!_authenticationFailureReported) {
         _authenticationFailureReported = true;
         Log.w(
-          "GitHub CLI authentication check failed. GitHub pull request and CI status sync is disabled; "
-          "local worktree diffs do not require gh.",
+          "GitHub CLI authentication check failed. GitHub pull request and CI status sync is disabled.",
           error,
           stackTrace,
         );
@@ -92,7 +90,7 @@ class GhCliApi {
     _authenticationFailureReported = true;
     Log.i(
       "GitHub CLI (gh) is not authenticated for github.com. Run 'gh auth login' or set GH_TOKEN/GITHUB_TOKEN "
-      "to enable GitHub pull request and CI status sync. Local worktree diffs do not require gh.",
+      "to enable GitHub pull request and CI status sync.",
     );
   }
 

--- a/bridge/app/lib/src/bridge/api/gh_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/gh_cli_api.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:io";
 
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart" show jsonDecodeListMap, jsonDecodeMap;
@@ -8,27 +9,91 @@ import "gh_pull_request.dart";
 
 class GhCliApi {
   final ProcessRunner _processRunner;
+  bool _availabilityFailureReported = false;
+  bool _authenticationFailureReported = false;
 
   GhCliApi({required ProcessRunner processRunner}) : _processRunner = processRunner;
 
   Future<bool> isAvailable() async {
     try {
       final result = await _processRunner.run("gh", const ["--version"]);
-      return result.exitCode == 0;
-    } on Object catch (e) {
-      Log.w("[GhCli] gh --version failed: $e");
+      if (result.exitCode == 0) {
+        _availabilityFailureReported = false;
+        return true;
+      }
+      _reportAvailabilityFailure(
+        message:
+            "GitHub CLI (gh) is installed but unusable: 'gh --version' exited with code ${result.exitCode}. "
+            "GitHub pull request and CI status sync is disabled; local worktree diffs do not require gh.",
+      );
+      return false;
+    } on ProcessException {
+      _reportAvailabilityFailure(
+        message:
+            "GitHub CLI (gh) is not installed or is unavailable on PATH. "
+            "GitHub pull request and CI status sync is disabled; local worktree diffs do not require gh.",
+      );
+      return false;
+    } on Object catch (error, stackTrace) {
+      if (!_availabilityFailureReported) {
+        _availabilityFailureReported = true;
+        Log.w(
+          "GitHub CLI availability check failed. GitHub pull request and CI status sync is disabled; "
+          "local worktree diffs do not require gh.",
+          error,
+          stackTrace,
+        );
+      }
       return false;
     }
   }
 
   Future<bool> isAuthenticated() async {
     try {
-      final result = await _processRunner.run("gh", const ["auth", "status"]);
-      return result.exitCode == 0;
-    } on Object catch (e) {
-      Log.w("[GhCli] gh auth status failed: $e");
+      final result = await _processRunner.run(
+        "gh",
+        const ["auth", "status", "--hostname", "github.com"],
+      );
+      if (result.exitCode == 0) {
+        _authenticationFailureReported = false;
+        return true;
+      }
+      _reportAuthenticationFailure();
+      return false;
+    } on ProcessException {
+      _reportAvailabilityFailure(
+        message:
+            "GitHub CLI (gh) is not installed or is unavailable on PATH. "
+            "GitHub pull request and CI status sync is disabled; local worktree diffs do not require gh.",
+      );
+      return false;
+    } on Object catch (error, stackTrace) {
+      if (!_authenticationFailureReported) {
+        _authenticationFailureReported = true;
+        Log.w(
+          "GitHub CLI authentication check failed. GitHub pull request and CI status sync is disabled; "
+          "local worktree diffs do not require gh.",
+          error,
+          stackTrace,
+        );
+      }
       return false;
     }
+  }
+
+  void _reportAvailabilityFailure({required String message}) {
+    if (_availabilityFailureReported) return;
+    _availabilityFailureReported = true;
+    Log.i(message);
+  }
+
+  void _reportAuthenticationFailure() {
+    if (_authenticationFailureReported) return;
+    _authenticationFailureReported = true;
+    Log.i(
+      "GitHub CLI (gh) is not authenticated for github.com. Run 'gh auth login' or set GH_TOKEN/GITHUB_TOKEN "
+      "to enable GitHub pull request and CI status sync. Local worktree diffs do not require gh.",
+    );
   }
 
   Future<List<GhPullRequest>> listOpenPrs({required String workingDirectory}) async {

--- a/bridge/app/lib/src/bridge/api/gh_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/gh_cli_api.dart
@@ -1,7 +1,6 @@
-import "dart:async";
 import "dart:io";
 
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Console;
 import "package:sesori_shared/sesori_shared.dart" show jsonDecodeListMap, jsonDecodeMap;
 
 import "../foundation/process_runner.dart";
@@ -34,16 +33,6 @@ class GhCliApi {
             "GitHub pull request and CI status sync is disabled.",
       );
       return false;
-    } on Object catch (error, stackTrace) {
-      if (!_availabilityFailureReported) {
-        _availabilityFailureReported = true;
-        Log.w(
-          "GitHub CLI availability check failed. GitHub pull request and CI status sync is disabled.",
-          error,
-          stackTrace,
-        );
-      }
-      return false;
     }
   }
 
@@ -66,29 +55,19 @@ class GhCliApi {
             "GitHub pull request and CI status sync is disabled.",
       );
       return false;
-    } on Object catch (error, stackTrace) {
-      if (!_authenticationFailureReported) {
-        _authenticationFailureReported = true;
-        Log.w(
-          "GitHub CLI authentication check failed. GitHub pull request and CI status sync is disabled.",
-          error,
-          stackTrace,
-        );
-      }
-      return false;
     }
   }
 
   void _reportAvailabilityFailure({required String message}) {
     if (_availabilityFailureReported) return;
     _availabilityFailureReported = true;
-    Log.i(message);
+    Console.warning(message);
   }
 
   void _reportAuthenticationFailure() {
     if (_authenticationFailureReported) return;
     _authenticationFailureReported = true;
-    Log.i(
+    Console.warning(
       "GitHub CLI (gh) is not authenticated for github.com. Run 'gh auth login' or set GH_TOKEN/GITHUB_TOKEN "
       "to enable GitHub pull request and CI status sync.",
     );

--- a/bridge/app/test/bridge/api/gh_cli_api_test.dart
+++ b/bridge/app/test/bridge/api/gh_cli_api_test.dart
@@ -5,7 +5,6 @@ import "dart:io";
 import "package:sesori_bridge/src/bridge/api/gh_cli_api.dart";
 import "package:sesori_bridge/src/bridge/api/gh_pull_request.dart";
 import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log, LogLevel;
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -39,12 +38,10 @@ void main() {
       expect(isAvailable, isFalse);
     });
 
-    test("returns false on timeout", () async {
+    test("propagates timeout", () async {
       processRunner.enqueueError(error: TimeoutException("timed out"));
 
-      final isAvailable = await service.isAvailable();
-
-      expect(isAvailable, isFalse);
+      await expectLater(service.isAvailable(), throwsA(isA<TimeoutException>()));
     });
 
     test("returns false on ProcessException", () async {
@@ -59,9 +56,6 @@ void main() {
 
     test("reports a missing optional gh installation only once", () async {
       final stderrLines = <String>[];
-      final previousLogLevel = Log.level;
-      addTearDown(() => Log.level = previousLogLevel);
-      Log.level = LogLevel.info;
       processRunner
         ..enqueueError(
           error: const ProcessException("gh", <String>["--version"], "No such file or directory", 2),
@@ -122,11 +116,14 @@ void main() {
       expect(isAuthenticated, isFalse);
     });
 
+    test("propagates timeout", () async {
+      processRunner.enqueueError(error: TimeoutException("timed out"));
+
+      await expectLater(service.isAuthenticated(), throwsA(isA<TimeoutException>()));
+    });
+
     test("reports unauthenticated gh with actionable options only once", () async {
       final stderrLines = <String>[];
-      final previousLogLevel = Log.level;
-      addTearDown(() => Log.level = previousLogLevel);
-      Log.level = LogLevel.info;
       processRunner
         ..enqueueResult(result: _fail(exitCode: 1))
         ..enqueueResult(result: _fail(exitCode: 1));

--- a/bridge/app/test/bridge/api/gh_cli_api_test.dart
+++ b/bridge/app/test/bridge/api/gh_cli_api_test.dart
@@ -84,7 +84,7 @@ void main() {
         allOf(
           contains("GitHub CLI (gh) is not installed or is unavailable on PATH"),
           contains("GitHub pull request and CI status sync is disabled"),
-          contains("local worktree diffs do not require gh"),
+          isNot(contains("worktree")),
           isNot(contains("ProcessException")),
         ),
       );
@@ -146,7 +146,7 @@ void main() {
           contains("GitHub CLI (gh) is not authenticated for github.com"),
           contains("gh auth login"),
           contains("GH_TOKEN/GITHUB_TOKEN"),
-          contains("Local worktree diffs do not require gh"),
+          isNot(contains("worktree")),
         ),
       );
     });

--- a/bridge/app/test/bridge/api/gh_cli_api_test.dart
+++ b/bridge/app/test/bridge/api/gh_cli_api_test.dart
@@ -5,6 +5,7 @@ import "dart:io";
 import "package:sesori_bridge/src/bridge/api/gh_cli_api.dart";
 import "package:sesori_bridge/src/bridge/api/gh_pull_request.dart";
 import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log, LogLevel;
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -55,6 +56,39 @@ void main() {
 
       expect(isAvailable, isFalse);
     });
+
+    test("reports a missing optional gh installation only once", () async {
+      final stderrLines = <String>[];
+      final previousLogLevel = Log.level;
+      addTearDown(() => Log.level = previousLogLevel);
+      Log.level = LogLevel.info;
+      processRunner
+        ..enqueueError(
+          error: const ProcessException("gh", <String>["--version"], "No such file or directory", 2),
+        )
+        ..enqueueError(
+          error: const ProcessException("gh", <String>["--version"], "No such file or directory", 2),
+        );
+
+      await IOOverrides.runZoned(
+        () async {
+          expect(await service.isAvailable(), isFalse);
+          expect(await service.isAvailable(), isFalse);
+        },
+        stderr: () => _CapturingStdout(stderrLines),
+      );
+
+      expect(stderrLines, hasLength(1));
+      expect(
+        stderrLines.single,
+        allOf(
+          contains("GitHub CLI (gh) is not installed or is unavailable on PATH"),
+          contains("GitHub pull request and CI status sync is disabled"),
+          contains("local worktree diffs do not require gh"),
+          isNot(contains("ProcessException")),
+        ),
+      );
+    });
   });
 
   group("GhCliApi.isAuthenticated", () {
@@ -74,7 +108,10 @@ void main() {
       expect(isAuthenticated, isTrue);
       expect(processRunner.invocations, hasLength(1));
       expect(processRunner.invocations.first.command, equals("gh"));
-      expect(processRunner.invocations.first.arguments, equals(["auth", "status"]));
+      expect(
+        processRunner.invocations.first.arguments,
+        equals(["auth", "status", "--hostname", "github.com"]),
+      );
     });
 
     test("returns false on non-zero exit code", () async {
@@ -83,6 +120,35 @@ void main() {
       final isAuthenticated = await service.isAuthenticated();
 
       expect(isAuthenticated, isFalse);
+    });
+
+    test("reports unauthenticated gh with actionable options only once", () async {
+      final stderrLines = <String>[];
+      final previousLogLevel = Log.level;
+      addTearDown(() => Log.level = previousLogLevel);
+      Log.level = LogLevel.info;
+      processRunner
+        ..enqueueResult(result: _fail(exitCode: 1))
+        ..enqueueResult(result: _fail(exitCode: 1));
+
+      await IOOverrides.runZoned(
+        () async {
+          expect(await service.isAuthenticated(), isFalse);
+          expect(await service.isAuthenticated(), isFalse);
+        },
+        stderr: () => _CapturingStdout(stderrLines),
+      );
+
+      expect(stderrLines, hasLength(1));
+      expect(
+        stderrLines.single,
+        allOf(
+          contains("GitHub CLI (gh) is not authenticated for github.com"),
+          contains("gh auth login"),
+          contains("GH_TOKEN/GITHUB_TOKEN"),
+          contains("Local worktree diffs do not require gh"),
+        ),
+      );
     });
   });
 
@@ -373,4 +439,21 @@ class _FakeProcessRunner implements ProcessRunner {
     }
     throw output;
   }
+}
+
+class _CapturingStdout implements Stdout {
+  final List<String> lines;
+
+  _CapturingStdout(this.lines);
+
+  @override
+  bool get supportsAnsiEscapes => false;
+
+  @override
+  void writeln([Object? object = ""]) {
+    lines.add(object.toString());
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/docs/SETUP_HEADLESS_VM.md
+++ b/docs/SETUP_HEADLESS_VM.md
@@ -31,36 +31,13 @@ status to sessions. Git worktrees and local file diffs use `git` directly and
 do not require `gh`, so you can skip this step if you do not need GitHub status
 sync.
 
-```bash
-(type -p wget >/dev/null || (sudo apt update && sudo apt install wget -y)) \
-	&& sudo mkdir -p -m 755 /etc/apt/keyrings \
-	&& out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-	&& cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-	&& sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-	&& sudo mkdir -p -m 755 /etc/apt/sources.list.d \
-	&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-	&& sudo apt update \
-	&& sudo apt install gh -y
-```
+Follow the official [GitHub CLI installation instructions](https://cli.github.com/).
 
 To enable GitHub status sync, authenticate as the same OS user that will run
 `sesori-bridge` (`root` in the service below):
 
 ```bash
 gh auth login
-```
-
-For token authentication, a shell export will not be inherited by systemd.
-Create a root-only environment file instead (the service definition below
-loads it when present):
-
-```bash
-install -m 600 /dev/null /etc/sesori-bridge.env
-nano /etc/sesori-bridge.env
-```
-
-```ini
-GH_TOKEN=replace-with-token
 ```
 
 ---
@@ -182,7 +159,6 @@ After=opencode.service
 Requires=opencode.service
 
 [Service]
-EnvironmentFile=-/etc/sesori-bridge.env
 ExecStart=/root/.local/bin/sesori-bridge --opencode-no-auto-start --opencode-port 9921 --log-level debug
 Restart=always
 RestartSec=3
@@ -190,6 +166,32 @@ User=root
 
 [Install]
 WantedBy=multi-user.target
+```
+
+### Optional: Token authentication for `gh`
+
+Skip this subsection if you ran `gh auth login` in step 4. It is needed only
+when you choose to authenticate GitHub CLI with `GH_TOKEN` or `GITHUB_TOKEN`
+instead of stored `gh` credentials.
+
+Systemd does not inherit variables exported in an SSH shell. Create a root-only
+environment file:
+
+```bash
+install -m 600 /dev/null /etc/sesori-bridge.env
+nano /etc/sesori-bridge.env
+```
+
+Add your token:
+
+```ini
+GH_TOKEN=replace-with-token
+```
+
+Then add this line under `[Service]` in `sesori-bridge.service`:
+
+```ini
+EnvironmentFile=/etc/sesori-bridge.env
 ```
 
 Enable + start:

--- a/docs/SETUP_HEADLESS_VM.md
+++ b/docs/SETUP_HEADLESS_VM.md
@@ -50,8 +50,18 @@ To enable GitHub status sync, authenticate as the same OS user that will run
 gh auth login
 ```
 
-An inherited `GH_TOKEN` or `GITHUB_TOKEN` environment variable can be used
-instead of stored `gh` credentials.
+For token authentication, a shell export will not be inherited by systemd.
+Create a root-only environment file instead (the service definition below
+loads it when present):
+
+```bash
+install -m 600 /dev/null /etc/sesori-bridge.env
+nano /etc/sesori-bridge.env
+```
+
+```ini
+GH_TOKEN=replace-with-token
+```
 
 ---
 
@@ -172,6 +182,7 @@ After=opencode.service
 Requires=opencode.service
 
 [Service]
+EnvironmentFile=-/etc/sesori-bridge.env
 ExecStart=/root/.local/bin/sesori-bridge --opencode-no-auto-start --opencode-port 9921 --log-level debug
 Restart=always
 RestartSec=3

--- a/docs/SETUP_HEADLESS_VM.md
+++ b/docs/SETUP_HEADLESS_VM.md
@@ -24,7 +24,12 @@ apt install git -y
 
 ---
 
-## 4. Install GitHub CLI (`gh`)
+## 4. (Optional) Install GitHub CLI (`gh`)
+
+Sesori uses `gh` only to add GitHub pull request, CI, review, and mergeability
+status to sessions. Git worktrees and local file diffs use `git` directly and
+do not require `gh`, so you can skip this step if you do not need GitHub status
+sync.
 
 ```bash
 (type -p wget >/dev/null || (sudo apt update && sudo apt install wget -y)) \
@@ -37,6 +42,16 @@ apt install git -y
 	&& sudo apt update \
 	&& sudo apt install gh -y
 ```
+
+To enable GitHub status sync, authenticate as the same OS user that will run
+`sesori-bridge` (`root` in the service below):
+
+```bash
+gh auth login
+```
+
+An inherited `GH_TOKEN` or `GITHUB_TOKEN` environment variable can be used
+instead of stored `gh` credentials.
 
 ---
 


### PR DESCRIPTION
## Summary

- report a missing GitHub CLI as an optional capability limitation instead of a raw `ProcessException`
- emit missing and unauthenticated notices only once until the capability recovers
- explain that `gh` only enables GitHub PR/CI status sync and is not used for local worktree diffs
- scope authentication checks to `github.com` and document `gh auth login` plus token-based authentication

## Investigation

The session diff endpoint uses local `git` commands and filesystem reads only. The `gh --version` probe is triggered independently by opportunistic PR metadata refreshes when sessions are loaded, which made the two actions appear related in #562.

Managed download is deliberately deferred: installing a portable `gh` binary would not provide credentials, while replacing `gh` requires a separate local GitHub OAuth/token lifecycle. The current external CLI keeps GitHub credentials local and remains optional.

## Verification

- `dart test test/bridge/api/gh_cli_api_test.dart`
- `dart analyze --fatal-infos`

Fixes #356
Related to #562

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that GitHub CLI (`gh`) is optional and shows clear, one-time warnings for PR/CI status sync. Docs now explain when and how to install/authenticate `gh`; timeouts propagate, and local `git` worktree diffs remain unaffected.

- **Bug Fixes**
  - Report missing or unusable `gh` once with scoped console warnings; no raw errors.
  - Scope auth checks to `github.com` and guide `gh auth login` or `GH_TOKEN`/`GITHUB_TOKEN`; docs mark `gh` as optional, point to official install, note authenticating as the `sesori-bridge` user, and show systemd `EnvironmentFile` token setup.
  - Propagate timeouts from `gh` availability/auth checks.

<sup>Written for commit 6f72d339a59c0a4a41c5c7a72829fd96064db60e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

