### PR TITLE
fix(bridge): refresh base branch before worktree creation

### DIFF
--- a/bridge/app/lib/src/bridge/api/git_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/git_cli_api.dart
@@ -191,8 +191,12 @@ class GitCliApi {
     required String projectPath,
     required String branchName,
   }) async {
+    if (branchName.contains("*")) {
+      throw ArgumentError.value(branchName, "branchName", "must name one exact branch");
+    }
     final arguments = [
       "fetch",
+      "--no-write-fetch-head",
       "--no-tags",
       "--no-recurse-submodules",
       "origin",
@@ -203,6 +207,7 @@ class GitCliApi {
       arguments,
       workingDirectory: projectPath,
       timeout: const Duration(seconds: 30),
+      environment: const {"GIT_TERMINAL_PROMPT": "0"},
     );
     if (result.exitCode != 0) {
       throw ProcessException(

--- a/bridge/app/lib/src/bridge/api/git_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/git_cli_api.dart
@@ -187,6 +187,23 @@ class GitCliApi {
     return commit.isEmpty ? null : commit;
   }
 
+  Future<bool> fetchOriginBranch({
+    required String projectPath,
+    required String branchName,
+  }) async {
+    final result = await runGit(
+      projectPath: projectPath,
+      arguments: [
+        "fetch",
+        "--no-tags",
+        "--no-recurse-submodules",
+        "origin",
+        "+refs/heads/$branchName:refs/remotes/origin/$branchName",
+      ],
+    );
+    return result.exitCode == 0;
+  }
+
   Future<ProcessResult> verifyRevision({
     required String projectPath,
     required String revision,

--- a/bridge/app/lib/src/bridge/api/git_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/git_cli_api.dart
@@ -198,9 +198,11 @@ class GitCliApi {
       "origin",
       "+refs/heads/$branchName:refs/remotes/origin/$branchName",
     ];
-    final result = await runGit(
-      projectPath: projectPath,
-      arguments: arguments,
+    final result = await _processRunner.run(
+      "git",
+      arguments,
+      workingDirectory: projectPath,
+      timeout: const Duration(seconds: 30),
     );
     if (result.exitCode != 0) {
       throw ProcessException(

--- a/bridge/app/lib/src/bridge/api/git_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/git_cli_api.dart
@@ -187,21 +187,29 @@ class GitCliApi {
     return commit.isEmpty ? null : commit;
   }
 
-  Future<bool> fetchOriginBranch({
+  Future<void> fetchOriginBranch({
     required String projectPath,
     required String branchName,
   }) async {
+    final arguments = [
+      "fetch",
+      "--no-tags",
+      "--no-recurse-submodules",
+      "origin",
+      "+refs/heads/$branchName:refs/remotes/origin/$branchName",
+    ];
     final result = await runGit(
       projectPath: projectPath,
-      arguments: [
-        "fetch",
-        "--no-tags",
-        "--no-recurse-submodules",
-        "origin",
-        "+refs/heads/$branchName:refs/remotes/origin/$branchName",
-      ],
+      arguments: arguments,
     );
-    return result.exitCode == 0;
+    if (result.exitCode != 0) {
+      throw ProcessException(
+        "git",
+        arguments,
+        result.stderr.toString(),
+        result.exitCode,
+      );
+    }
   }
 
   Future<ProcessResult> verifyRevision({

--- a/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
@@ -109,6 +109,7 @@ class WorktreeRepository {
   Future<({String baseBranch, String baseCommit, String startPoint})?> resolveBaseBranchAndCommit({
     required String projectId,
     required String projectPath,
+    required bool refreshOrigin,
   }) async {
     try {
       final storedBranch = await _projectsDao.getBaseBranch(projectId: projectId);
@@ -116,6 +117,24 @@ class WorktreeRepository {
         projectPath: projectPath,
         storedBranch: storedBranch,
       );
+
+      if (refreshOrigin) {
+        try {
+          final fetched = await _gitApi.fetchOriginBranch(
+            projectPath: projectPath,
+            branchName: baseBranch,
+          );
+          if (!fetched) {
+            Log.w("[WorktreeRepository] failed to refresh origin/$baseBranch; using existing refs");
+          }
+        } on Object catch (error, stackTrace) {
+          Log.w(
+            "[WorktreeRepository] failed to refresh origin/$baseBranch; using existing refs",
+            error,
+            stackTrace,
+          );
+        }
+      }
 
       final localCommit = await _gitApi.resolveCommit(
         projectPath: projectPath,

--- a/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
@@ -1,3 +1,6 @@
+import "dart:async";
+import "dart:io";
+
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
 import "../../api/database/daos/projects_dao.dart";
@@ -120,14 +123,17 @@ class WorktreeRepository {
 
       if (refreshOrigin) {
         try {
-          final fetched = await _gitApi.fetchOriginBranch(
+          await _gitApi.fetchOriginBranch(
             projectPath: projectPath,
             branchName: baseBranch,
           );
-          if (!fetched) {
-            Log.w("[WorktreeRepository] failed to refresh origin/$baseBranch; using existing refs");
-          }
-        } on Object catch (error, stackTrace) {
+        } on ProcessException catch (error, stackTrace) {
+          Log.w(
+            "[WorktreeRepository] failed to refresh origin/$baseBranch; using existing refs",
+            error,
+            stackTrace,
+          );
+        } on TimeoutException catch (error, stackTrace) {
           Log.w(
             "[WorktreeRepository] failed to refresh origin/$baseBranch; using existing refs",
             error,

--- a/bridge/app/lib/src/bridge/services/worktree_service.dart
+++ b/bridge/app/lib/src/bridge/services/worktree_service.dart
@@ -74,6 +74,7 @@ class WorktreeService {
     final baseBranchAndCommit = await _worktreeRepository.resolveBaseBranchAndCommit(
       projectId: projectId,
       projectPath: projectPath,
+      refreshOrigin: true,
     );
     if (baseBranchAndCommit == null) {
       Log.w(
@@ -166,6 +167,7 @@ class WorktreeService {
     return _worktreeRepository.resolveBaseBranchAndCommit(
       projectId: projectId,
       projectPath: await _worktreeRepository.resolveProjectPath(projectId: projectId),
+      refreshOrigin: false,
     );
   }
 

--- a/bridge/app/test/bridge/worktree_service_git_test.dart
+++ b/bridge/app/test/bridge/worktree_service_git_test.dart
@@ -247,6 +247,7 @@ void main() {
         processRunner.invocations.single.arguments,
         equals([
           "fetch",
+          "--no-write-fetch-head",
           "--no-tags",
           "--no-recurse-submodules",
           "origin",
@@ -255,6 +256,22 @@ void main() {
       );
       expect(processRunner.invocations.single.workingDirectory, equals("/repo/project"));
       expect(processRunner.invocations.single.timeout, const Duration(seconds: 30));
+      expect(
+        processRunner.invocations.single.environment,
+        const {"GIT_TERMINAL_PROMPT": "0"},
+      );
+    });
+
+    test("fetchOriginBranch rejects a wildcard branch without running git", () async {
+      await expectLater(
+        () => service.fetchOriginBranch(
+          projectPath: "/repo/project",
+          branchName: "release/*",
+        ),
+        throwsArgumentError,
+      );
+
+      expect(processRunner.invocations, isEmpty);
     });
 
     test("fetchOriginBranch throws ProcessException when git fails", () async {
@@ -440,12 +457,14 @@ class _Invocation {
   final List<String> arguments;
   final String? workingDirectory;
   final Duration timeout;
+  final Map<String, String>? environment;
 
   const _Invocation({
     required this.command,
     required this.arguments,
     required this.workingDirectory,
     required this.timeout,
+    required this.environment,
   });
 }
 
@@ -486,6 +505,7 @@ class _FakeProcessRunner implements ProcessRunner {
         arguments: List<String>.from(arguments),
         workingDirectory: workingDirectory,
         timeout: timeout,
+        environment: environment,
       ),
     );
 

--- a/bridge/app/test/bridge/worktree_service_git_test.dart
+++ b/bridge/app/test/bridge/worktree_service_git_test.dart
@@ -254,6 +254,7 @@ void main() {
         ]),
       );
       expect(processRunner.invocations.single.workingDirectory, equals("/repo/project"));
+      expect(processRunner.invocations.single.timeout, const Duration(seconds: 30));
     });
 
     test("fetchOriginBranch throws ProcessException when git fails", () async {
@@ -438,11 +439,13 @@ class _Invocation {
   final String command;
   final List<String> arguments;
   final String? workingDirectory;
+  final Duration timeout;
 
   const _Invocation({
     required this.command,
     required this.arguments,
     required this.workingDirectory,
+    required this.timeout,
   });
 }
 
@@ -482,6 +485,7 @@ class _FakeProcessRunner implements ProcessRunner {
         command: executable,
         arguments: List<String>.from(arguments),
         workingDirectory: workingDirectory,
+        timeout: timeout,
       ),
     );
 

--- a/bridge/app/test/bridge/worktree_service_git_test.dart
+++ b/bridge/app/test/bridge/worktree_service_git_test.dart
@@ -237,12 +237,11 @@ void main() {
     test("fetchOriginBranch refreshes only the selected origin branch", () async {
       processRunner.enqueue(result: _processResult(exitCode: 0));
 
-      final result = await service.fetchOriginBranch(
+      await service.fetchOriginBranch(
         projectPath: "/repo/project",
         branchName: "main",
       );
 
-      expect(result, isTrue);
       expect(processRunner.invocations, hasLength(1));
       expect(
         processRunner.invocations.single.arguments,
@@ -257,15 +256,20 @@ void main() {
       expect(processRunner.invocations.single.workingDirectory, equals("/repo/project"));
     });
 
-    test("fetchOriginBranch reports fetch failure", () async {
+    test("fetchOriginBranch throws ProcessException when git fails", () async {
       processRunner.enqueue(result: _processResult(exitCode: 1, stderr: "offline"));
 
-      final result = await service.fetchOriginBranch(
-        projectPath: "/repo/project",
-        branchName: "main",
+      await expectLater(
+        () => service.fetchOriginBranch(
+          projectPath: "/repo/project",
+          branchName: "main",
+        ),
+        throwsA(
+          isA<ProcessException>()
+              .having((error) => error.errorCode, "errorCode", 1)
+              .having((error) => error.message, "message", "offline"),
+        ),
       );
-
-      expect(result, isFalse);
     });
 
     group("inspectWorktreeSafety", () {

--- a/bridge/app/test/bridge/worktree_service_git_test.dart
+++ b/bridge/app/test/bridge/worktree_service_git_test.dart
@@ -234,6 +234,40 @@ void main() {
       expect(processRunner.invocations.single.workingDirectory, equals("/repo/project"));
     });
 
+    test("fetchOriginBranch refreshes only the selected origin branch", () async {
+      processRunner.enqueue(result: _processResult(exitCode: 0));
+
+      final result = await service.fetchOriginBranch(
+        projectPath: "/repo/project",
+        branchName: "main",
+      );
+
+      expect(result, isTrue);
+      expect(processRunner.invocations, hasLength(1));
+      expect(
+        processRunner.invocations.single.arguments,
+        equals([
+          "fetch",
+          "--no-tags",
+          "--no-recurse-submodules",
+          "origin",
+          "+refs/heads/main:refs/remotes/origin/main",
+        ]),
+      );
+      expect(processRunner.invocations.single.workingDirectory, equals("/repo/project"));
+    });
+
+    test("fetchOriginBranch reports fetch failure", () async {
+      processRunner.enqueue(result: _processResult(exitCode: 1, stderr: "offline"));
+
+      final result = await service.fetchOriginBranch(
+        projectPath: "/repo/project",
+        branchName: "main",
+      );
+
+      expect(result, isFalse);
+    });
+
     group("inspectWorktreeSafety", () {
       late Directory tempDir;
 

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -573,6 +573,7 @@ void main() {
         processRunner.invocations[2].arguments,
         equals([
           "fetch",
+          "--no-write-fetch-head",
           "--no-tags",
           "--no-recurse-submodules",
           "origin",

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -708,6 +708,26 @@ void main() {
       expect(worktreeAddArgs.last, equals("main"));
     });
 
+    test("unexpected fetch error aborts worktree creation", () async {
+      processRunner.enqueue(result: _ok()); // rev-parse HEAD
+      processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n")); // symbolic-ref
+      processRunner.enqueueError(error: StateError("broken process runner")); // fetch
+      // These would let creation succeed if the unexpected error were swallowed.
+      processRunner.enqueue(result: _ok(stdout: "local111\n"));
+      processRunner.enqueue(result: _fail(exitCode: 128));
+      processRunner.enqueue(result: _ok(stdout: ""));
+      processRunner.enqueue(result: _ok());
+
+      final result = await service.prepareWorktreeForSession(
+        projectId: _projectId,
+        parentSessionId: null,
+      );
+
+      expect(result, isA<WorktreeFallback>());
+      expect((result as WorktreeFallback).reason, equals("failed to resolve base branch/commit"));
+      expect(processRunner.invocations, hasLength(3));
+    });
+
     test("merge-base fails: worktree starts from origin ref", () async {
       // rev-parse HEAD → ok
       processRunner.enqueue(result: _ok());
@@ -1117,10 +1137,14 @@ class _FakeProcessRunner implements ProcessRunner {
   }
 
   final List<_Invocation> invocations = <_Invocation>[];
-  final List<ProcessResult> _queue = <ProcessResult>[];
+  final List<Object> _queue = <Object>[];
 
   void enqueue({required ProcessResult result}) {
     _queue.add(result);
+  }
+
+  void enqueueError({required Object error}) {
+    _queue.add(error);
   }
 
   @override
@@ -1143,7 +1167,11 @@ class _FakeProcessRunner implements ProcessRunner {
       throw StateError("No ProcessResult queued for: $executable $arguments");
     }
 
-    return _queue.removeAt(0);
+    final next = _queue.removeAt(0);
+    if (next is ProcessResult) {
+      return next;
+    }
+    throw next;
   }
 }
 

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -56,6 +56,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // git symbolic-ref refs/remotes/origin/HEAD → "refs/remotes/origin/main"
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // git fetch origin/main → unavailable; continue with existing refs
+      processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
       // git rev-parse origin/main → no remote tracking branch
@@ -97,6 +99,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // git symbolic-ref refs/remotes/origin/HEAD → "refs/remotes/origin/main"
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // git fetch origin/main → unavailable; continue with existing refs
+      processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
       // git rev-parse origin/main → no remote tracking branch
@@ -157,6 +161,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // git symbolic-ref refs/remotes/origin/HEAD → "refs/remotes/origin/main"
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // git fetch origin/main → unavailable; continue with existing refs
+      processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
       // git rev-parse origin/main → no remote tracking branch
@@ -224,6 +230,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // fetch origin/main → unavailable; continue with existing refs
+      processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
       // git rev-parse origin/main → no remote tracking branch
@@ -263,6 +271,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // fetch origin/main → unavailable; continue with existing refs
+      processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
       // git rev-parse origin/main → no remote tracking branch
@@ -300,6 +310,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // branch --list develop → non-empty (exists)
       processRunner.enqueue(result: _ok(stdout: "  develop\n"));
+      // fetch origin/develop → unavailable; continue with existing refs
+      processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse develop → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "deadbeef1234\n"));
       // git rev-parse origin/develop → no remote tracking branch
@@ -347,6 +359,8 @@ void main() {
       processRunner.enqueue(result: _ok(stdout: ""));
       // symbolic-ref refs/remotes/origin/HEAD → "refs/remotes/origin/main"
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // fetch origin/main → unavailable; continue with existing refs
+      processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
       // git rev-parse origin/main → no remote tracking branch
@@ -378,6 +392,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // fetch origin/main → unavailable; continue with existing refs
+      processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
       // git rev-parse origin/main → no remote tracking branch
@@ -406,6 +422,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // fetch origin/main → unavailable; continue with existing refs
+      processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
       // git rev-parse origin/main → no remote tracking branch
@@ -433,6 +451,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // fetch origin/main → unavailable; continue with existing refs
+      processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
       // git rev-parse origin/main → no remote tracking branch
@@ -462,6 +482,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // fetch origin/main → unavailable; continue with existing refs
+      processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
       // git rev-parse origin/main → no remote tracking branch
@@ -519,14 +541,16 @@ void main() {
     // Origin comparison scenarios
     // -----------------------------------------------------------------------
 
-    test("origin ahead: worktree starts from origin ref", () async {
+    test("freshly fetched origin ahead: worktree starts from origin ref", () async {
       // rev-parse HEAD → ok
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // fetch origin/main → refreshes the stale remote-tracking ref
+      processRunner.enqueue(result: _ok());
       // rev-parse main → local commit
       processRunner.enqueue(result: _ok(stdout: "local111\n"));
-      // rev-parse origin/main → origin commit (different)
+      // rev-parse origin/main → newly fetched origin commit
       processRunner.enqueue(result: _ok(stdout: "origin222\n"));
       // merge-base --is-ancestor origin222 local111 → exit 1 (origin NOT ancestor of local)
       processRunner.enqueue(result: _fail(exitCode: 1));
@@ -545,6 +569,17 @@ void main() {
       expect(success.baseBranch, equals("origin/main"));
       expect(success.baseCommit, equals("origin222"));
 
+      expect(
+        processRunner.invocations[2].arguments,
+        equals([
+          "fetch",
+          "--no-tags",
+          "--no-recurse-submodules",
+          "origin",
+          "+refs/heads/main:refs/remotes/origin/main",
+        ]),
+      );
+
       // Verify worktree add used "origin/main" as start point
       final worktreeAddArgs = processRunner.invocations.last.arguments;
       expect(worktreeAddArgs.last, equals("origin/main"));
@@ -555,6 +590,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // fetch origin/main → success
+      processRunner.enqueue(result: _ok());
       // rev-parse main → local commit
       processRunner.enqueue(result: _ok(stdout: "local111\n"));
       // rev-parse origin/main → origin commit (different)
@@ -586,6 +623,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // fetch origin/main → success
+      processRunner.enqueue(result: _ok());
       // rev-parse main → local commit
       processRunner.enqueue(result: _ok(stdout: "samecommit\n"));
       // rev-parse origin/main → same commit
@@ -614,6 +653,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // fetch origin/main → success
+      processRunner.enqueue(result: _ok());
       // rev-parse main → local commit
       processRunner.enqueue(result: _ok(stdout: "diverged-local\n"));
       // rev-parse origin/main → origin commit
@@ -643,6 +684,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // fetch origin/main → unavailable; continue with existing refs
+      processRunner.enqueue(result: _fail(exitCode: 1));
       // rev-parse main → local commit
       processRunner.enqueue(result: _ok(stdout: "local111\n"));
       // rev-parse origin/main → fail (no remote tracking branch)
@@ -670,6 +713,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // fetch origin/main → success
+      processRunner.enqueue(result: _ok());
       // rev-parse main → local commit
       processRunner.enqueue(result: _ok(stdout: "local111\n"));
       // rev-parse origin/main → origin commit (different)


### PR DESCRIPTION
## Summary
- fetch the selected `origin/<baseBranch>` immediately before resolving a dedicated worktree's start point
- retain local-only and offline behavior by logging fetch failures and falling back to existing refs
- cover the targeted fetch command and freshly advanced origin branch scenario

## Testing
- `dart test test/bridge/worktree_service_git_test.dart test/bridge/worktree_service_test.dart`
- `dart analyze --fatal-infos`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh the remote base branch before choosing a worktree start point so new worktrees start from the latest `origin/<baseBranch>`. Fetch failures (git error or timeout) are logged and we use existing refs; unexpected errors abort.

- **Bug Fixes**
  - Added a targeted `git fetch` for the base branch with a 30s timeout and `GIT_TERMINAL_PROMPT=0`; used only during worktree creation, not preview.
  - Rejected wildcard branch names and used a precise refspec to refresh only that branch.
  - Expanded tests for fetch args/env/timeout, wildcard rejection, the freshly advanced origin case, and the abort-on-unexpected-error path.

<sup>Written for commit 63e8695113a713ad1012fbc504fd6400f6d829c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

