### PR TITLE
Redesign the bridge-disconnected projects state

### DIFF
--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -145,6 +145,7 @@ class _ConnectBridgeChecklist extends StatelessWidget {
             stepHeader: _InfoLabel(
               title: "1. ${loc.projectsOnboardingInstallStepTitle}",
               info: loc.projectsOnboardingInstallStepInfo,
+              centered: false,
             ),
           ),
         ),
@@ -158,6 +159,7 @@ class _ConnectBridgeChecklist extends StatelessWidget {
               _InfoLabel(
                 title: "2. ${loc.projectsOnboardingStartStepTitle}",
                 info: loc.projectsOnboardingStartStepInfo,
+                centered: false,
               ),
               const SizedBox(height: PregoSpacing.md),
               const _CommandBoxFrame(
@@ -226,7 +228,7 @@ class _WhyBridgeButton extends StatelessWidget {
 /// on the bridge-offline view. Tapping the icon opens a [PregoInfoPopover]
 /// (glass on iOS, flat/`cue` on Android) anchored to it, showing [info].
 class _InfoLabel extends StatelessWidget {
-  const _InfoLabel({required this.title, required this.info, this.centered = false});
+  const _InfoLabel({required this.title, required this.info, required this.centered});
 
   final String title;
   final String info;
@@ -246,11 +248,18 @@ class _InfoLabel extends StatelessWidget {
       children: [
         // The info icon's 40px tap target holds its 12px glyph against its
         // start, leaving 24px of dead space at the end. An equal gap in front
-        // centres what the user actually sees rather than the hit box.
+        // centres what the user actually sees rather than the hit box — and
+        // keeps it centred once the title grows wide enough to claim the whole
+        // row, where the spacer becomes the leading margin matching the glyph's
+        // trailing one.
         if (centered) const SizedBox(width: 24),
         Flexible(
           child: Text(
             title,
+            // A title too long for one line (long locale, large text scale)
+            // wraps; centre those lines so the block still reads as centred
+            // rather than ragged against the leading edge.
+            textAlign: centered ? TextAlign.center : TextAlign.start,
             style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textPrimary),
           ),
         ),

--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -222,21 +222,32 @@ class _WhyBridgeButton extends StatelessWidget {
 }
 
 /// A command-box label with a trailing "ⓘ" info popover — e.g. "1. Install the
-/// bridge ⓘ" on the connect onboarding or "Start your bridge ⓘ" on the
-/// bridge-offline view. Tapping the icon opens a [PregoInfoPopover] (glass on
-/// iOS, flat/`cue` on Android) anchored to it, showing [info].
+/// bridge ⓘ" on the connect onboarding or "Make sure the Bridge is running ⓘ"
+/// on the bridge-offline view. Tapping the icon opens a [PregoInfoPopover]
+/// (glass on iOS, flat/`cue` on Android) anchored to it, showing [info].
 class _InfoLabel extends StatelessWidget {
-  const _InfoLabel({required this.title, required this.info});
+  const _InfoLabel({required this.title, required this.info, this.centered = false});
 
   final String title;
   final String info;
+
+  /// Centres the label + icon pair instead of aligning it to the start. The
+  /// numbered onboarding steps sit above a full-width box and read as a list,
+  /// so they stay start-aligned; the bridge-offline label heads a centred
+  /// composition.
+  final bool centered;
 
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
     final prego = context.prego;
     return Row(
+      mainAxisAlignment: centered ? MainAxisAlignment.center : MainAxisAlignment.start,
       children: [
+        // The info icon's 40px tap target holds its 12px glyph against its
+        // start, leaving 24px of dead space at the end. An equal gap in front
+        // centres what the user actually sees rather than the hit box.
+        if (centered) const SizedBox(width: 24),
         Flexible(
           child: Text(
             title,

--- a/client/app/lib/features/project_list/project_list_screen.dart
+++ b/client/app/lib/features/project_list/project_list_screen.dart
@@ -120,31 +120,25 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
     final loc = context.loc;
     final state = context.watch<ProjectListCubit>().state;
     final isRefreshing = state is ProjectListLoaded && state.isRefreshing;
-    // The connect-your-computer onboarding (no bridge ever registered, none
-    // connected) trades the collapsing large title for the compact
-    // back-leading block, whose subtitle row reports the connection the body
-    // is waiting on. Its body is a fixed setup checklist with nothing to
-    // scroll a large title away against, and the design gives the waiting
-    // status the bar's second line. Every other state keeps the large title.
-    final isConnectOnboarding = state is ProjectListBridgeDisconnected && !state.hasRegisteredBridges;
+    // Both disconnected surfaces — the connect-your-computer onboarding and the
+    // bridge-offline recovery view — trade the collapsing large title for the
+    // compact back-leading block, whose subtitle row reports the connection the
+    // body is about. Their bodies are fixed setup flows with nothing to scroll a
+    // large title away against, and the design gives that connection status the
+    // bar's second line. Every other state keeps the large title.
+    final disconnected = state is ProjectListBridgeDisconnected ? state : null;
     final floatingAction = _floatingAction(context: context, state: state);
 
     return PregoGlassScaffold(
       title: loc.projectListTitle,
-      titleMode: isConnectOnboarding
+      titleMode: disconnected != null
           ? PregoTopNavigationTitleMode.backLeading
           : PregoTopNavigationTitleMode.collapsing,
       // With no back button leading it, the block is the page's own title, so
       // it takes the design's prominent weight rather than the muted one the
       // sessions bar uses beside its back button.
       leadingTitleEmphasis: PregoNavLeadingTitleEmphasis.prominent,
-      subtitle: isConnectOnboarding
-          ? PregoNavSubtitle(
-              text: loc.projectsOnboardingWaitingForBridge,
-              icon: TablerRegular.broadcast_off,
-              status: PregoNavStatus.error,
-            )
-          : null,
+      subtitle: disconnected == null ? null : _disconnectedSubtitle(context: context, state: disconnected),
       // A loaded list hosts the top-nav connection banner; the loading and
       // bridge-disconnected states own their messaging full-screen (setup
       // onboarding or the "turn on your bridge" design), so they suppress it.
@@ -163,6 +157,33 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
       floatingActionAlignment: floatingAction.alignment,
       onRefresh: _refreshFor(context: context, state: state),
       slivers: _buildContentSlivers(context: context, state: state, isRefreshing: isRefreshing),
+    );
+  }
+
+  /// The bar's subtitle row on a disconnected Projects screen, naming what the
+  /// body is about in a single `text-xs` line under the title. Both variants
+  /// carry the error dot: on these screens, not being connected *is* the page.
+  ///
+  /// Before any bridge is registered there is no machine to name, so the row
+  /// reports what the setup checklist is waiting for. Once one is registered
+  /// the row names the machine the app is trying to reach — the body's own
+  /// status line says how long it has been gone. Null while that lookup has no
+  /// answer: the body already carries the disconnected caption, and repeating
+  /// it in the bar would name nothing the page doesn't already say.
+  Widget? _disconnectedSubtitle({required BuildContext context, required ProjectListBridgeDisconnected state}) {
+    if (!state.hasRegisteredBridges) {
+      return PregoNavSubtitle(
+        text: context.loc.projectsOnboardingWaitingForBridge,
+        icon: TablerRegular.broadcast_off,
+        status: PregoNavStatus.error,
+      );
+    }
+    final bridge = state.bridges.firstOrNull;
+    if (bridge == null) return null;
+    return PregoNavSubtitle(
+      text: bridge.name,
+      icon: TablerRegular.device_laptop,
+      status: PregoNavStatus.error,
     );
   }
 

--- a/client/app/lib/features/project_list/widgets/bridge_offline_view.dart
+++ b/client/app/lib/features/project_list/widgets/bridge_offline_view.dart
@@ -17,8 +17,8 @@ part of "../project_list_screen.dart";
 ///
 /// A body, not a page: it is hosted in the project list's own page scroll (see
 /// [ProjectListScreen]) so the expanded install commands scroll under a fixed
-/// bar. Centred while it fits the viewport; the enclosing sliver grows past it
-/// once it doesn't.
+/// bar. Anchored to the top of that page at the design's offset; the enclosing
+/// sliver grows past the viewport once the body outgrows it.
 class _BridgeOfflineView extends StatefulWidget {
   const _BridgeOfflineView({required this.bridges});
 
@@ -46,9 +46,13 @@ class _BridgeOfflineViewState extends State<_BridgeOfflineView> {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: PregoSpacing.xl),
       child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
+          // Figma hangs the graphic 90px below the bar. Off the spacing scale,
+          // so it is written out. Anchored rather than centred: the composition
+          // reads from the top down, and centring would move the graphic as the
+          // install-commands disclosure grows the body beneath it.
+          const SizedBox(height: 90),
           const ExcludeSemantics(child: Center(child: ConnectionGraphic.connectionOff())),
           const SizedBox(height: PregoSpacing.lg),
           // The machine identity leads: the graphic already says "not
@@ -125,9 +129,8 @@ class _BridgeOfflineViewState extends State<_BridgeOfflineView> {
                   SizedBox(height: PregoSpacing.lg),
                   _InstallCommandBoxes(surface: OnboardingSurface.bridgeOffline),
                   // Bottom breathing room so the last install box can be
-                  // scrolled clear of the "Need help?" button pinned in the
-                  // bottom-right corner. Inside the disclosure so the collapsed
-                  // body keeps its exact vertical centring.
+                  // scrolled clear of the "Need help?" button floating at the
+                  // bottom of the page.
                   SizedBox(height: PregoSpacing.x6l),
                 ],
               ),

--- a/client/app/lib/features/project_list/widgets/bridge_offline_view.dart
+++ b/client/app/lib/features/project_list/widgets/bridge_offline_view.dart
@@ -2,19 +2,23 @@ part of "../project_list_screen.dart";
 
 /// Shown when the account has a bridge registered but none is connected — the
 /// user already completed setup, so instead of the install onboarding they are
-/// asked to reconnect. Mirrors the Figma "bridge disconnected" state: the
-/// connection graphic with a "Disconnected" status caption and the machine
-/// name of the bridge being reached, a "Reconnect" CTA, the always-visible
-/// "Start your bridge" command, a "Why is this needed?" explainer, and an
-/// expandable "Install commands" disclosure at the end for when the bridge
-/// needs to be (re)installed. The "Need help?" support menu ([_NeedHelpMenu])
-/// is not part of this scroll flow — it rides the scaffold's floating-action
-/// slot.
+/// asked to bring the bridge back up. Mirrors the Figma "bridge disconnected"
+/// state (node 2325:48309): the connection graphic over the machine name of
+/// the bridge being reached and a "Disconnected · <last seen>" status line,
+/// then the always-visible start-the-bridge command, a "Why is this needed?"
+/// explainer, and an expandable "Install commands" disclosure at the end for
+/// when the bridge needs to be (re)installed. The "Need help?" support menu
+/// ([_NeedHelpMenu]) is not part of this scroll flow — it rides the scaffold's
+/// floating-action slot.
+///
+/// There is no reconnect button: reconnecting is what the page already does on
+/// its own and on pull-to-refresh, so the design spends the space on the
+/// command the user actually has to run.
 ///
 /// A body, not a page: it is hosted in the project list's own page scroll (see
-/// [ProjectListScreen]) so the large title collapses into the bar as the
-/// expanded install commands scroll. Centred while it fits the viewport; the
-/// enclosing sliver grows past it once it doesn't.
+/// [ProjectListScreen]) so the expanded install commands scroll under a fixed
+/// bar. Centred while it fits the viewport; the enclosing sliver grows past it
+/// once it doesn't.
 class _BridgeOfflineView extends StatefulWidget {
   const _BridgeOfflineView({required this.bridges});
 
@@ -29,28 +33,15 @@ class _BridgeOfflineView extends StatefulWidget {
 }
 
 class _BridgeOfflineViewState extends State<_BridgeOfflineView> {
-  /// True while a [reconnectBridge] attempt is in flight, so the Reconnect
-  /// button can show its spinner. Reset in a `finally` guarded by `mounted`
-  /// since a successful reconnect emits a new state that unmounts this view.
-  bool _reconnecting = false;
-
   /// Whether the "Install commands" disclosure is expanded.
   bool _showInstallCommands = false;
-
-  Future<void> _reconnect() async {
-    if (_reconnecting) return;
-    setState(() => _reconnecting = true);
-    try {
-      await context.read<ProjectListCubit>().reconnectBridge();
-    } finally {
-      if (mounted) setState(() => _reconnecting = false);
-    }
-  }
 
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
     final prego = context.prego;
+    final bridge = widget.bridges.firstOrNull;
+    final lastSeenAt = bridge?.lastSeenAt;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: PregoSpacing.xl),
@@ -60,52 +51,32 @@ class _BridgeOfflineViewState extends State<_BridgeOfflineView> {
         children: [
           const ExcludeSemantics(child: Center(child: ConnectionGraphic.connectionOff())),
           const SizedBox(height: PregoSpacing.lg),
-          // "Disconnected ⊗" status caption: the crossed circle reads as part
-          // of the caption, mirroring the check on the onboarding's connected
-          // status line. Merged so screen readers announce it as one unit.
-          MergeSemantics(
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Flexible(
-                  child: Text(
-                    loc.projectsBridgeOfflineDisconnected,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textPrimary),
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsetsDirectional.only(start: PregoSpacing.xs),
-                  child: Icon(
-                    TablerRegular.circle_x,
-                    size: 14,
-                    color: prego.colors.textTertiary,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          if (widget.bridges.isNotEmpty) ...[
+          // The machine identity leads: the graphic already says "not
+          // connected", so the open question is which machine is unreachable.
+          // The status line answers the follow-up underneath it.
+          if (bridge != null) ...[
+            Center(child: _MachineNameRow(name: bridge.name)),
             const SizedBox(height: PregoSpacing.xxs),
-            Center(child: _MachineNameRow(name: widget.bridges.first.name)),
           ],
-          const SizedBox(height: PregoSpacing.x5l),
-          PregoButtonsSolid(
-            label: loc.projectsBridgeOfflineReconnect,
-            hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
-            size: PregoButtonsSolidSize.xl,
-            leadingIcon: TablerRegular.rotate_clockwise,
-            fullWidth: true,
-            isLoading: _reconnecting,
-            onPressed: _reconnect,
+          Text(
+            lastSeenAt == null
+                ? loc.projectsBridgeOfflineDisconnected
+                // How long the bridge has been gone separates "I just closed
+                // the laptop lid" from "this has been down for days". Refreshed
+                // by the screen's minute ticker.
+                : loc.projectsBridgeOfflineDisconnectedSince(
+                    context.formatTimestamp(lastSeenAt.millisecondsSinceEpoch),
+                  ),
+            textAlign: TextAlign.center,
+            style: prego.textTheme.textXs.regular.copyWith(color: prego.colors.textSecondary),
           ),
+          const SizedBox(height: PregoSpacing.x5l),
           // Always visible: the bridge is already installed here, so the common
           // recovery is to (re)start it rather than reinstall.
-          const SizedBox(height: PregoSpacing.xl),
           _InfoLabel(
             title: loc.projectsBridgeOfflineStartBridge,
             info: loc.projectsBridgeOfflineStartBridgeInfo,
+            centered: true,
           ),
           const SizedBox(height: PregoSpacing.md),
           const _CommandBoxFrame(
@@ -168,11 +139,13 @@ class _BridgeOfflineViewState extends State<_BridgeOfflineView> {
   }
 }
 
-/// The machine identity row under the "Disconnected" caption: a laptop glyph
-/// and the machine name of the bridge being reached (the hostname the bridge
-/// registered with the auth server). A static, non-interactive label — the
-/// account runs a single bridge at a time, so there is nothing to act on
-/// here.
+/// The machine identity row naming the bridge being reached (the hostname the
+/// bridge registered with the auth server), shown beside a laptop glyph. A
+/// static, non-interactive label — the account runs a single bridge at a time,
+/// so there is nothing to act on here.
+///
+/// Reads in `text-primary`: it is the headline of the offline body, with the
+/// status line beneath it as the quiet second read.
 class _MachineNameRow extends StatelessWidget {
   const _MachineNameRow({required this.name});
 
@@ -182,6 +155,7 @@ class _MachineNameRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
+    final color = prego.colors.textPrimary;
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -189,7 +163,7 @@ class _MachineNameRow extends StatelessWidget {
           width: 20,
           height: 20,
           child: Center(
-            child: Icon(TablerRegular.device_laptop, size: 12, color: prego.colors.textSecondary),
+            child: Icon(TablerRegular.device_laptop, size: 12, color: color),
           ),
         ),
         Flexible(
@@ -197,7 +171,7 @@ class _MachineNameRow extends StatelessWidget {
             name,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
-            style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textSecondary),
+            style: prego.textTheme.textSm.regular.copyWith(color: color),
           ),
         ),
       ],

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -114,20 +114,29 @@
   },
   "projectsBridgeOfflineDisconnected": "Disconnected",
   "@projectsBridgeOfflineDisconnected": {
-    "description": "Status caption under the connection graphic on the bridge-offline Projects screen, rendered with a trailing crossed-circle icon."
+    "description": "Status caption under the machine name on the bridge-offline Projects screen, used when the bridge has never reported a last-seen time."
   },
-  "projectsBridgeOfflineReconnect": "Reconnect",
+  "projectsBridgeOfflineDisconnectedSince": "Disconnected · {lastSeen}",
+  "@projectsBridgeOfflineDisconnectedSince": {
+    "description": "Status caption under the machine name on the bridge-offline Projects screen, pairing the disconnected state with how long ago the bridge was last seen, e.g. 'Disconnected · 5 hours ago'.",
+    "placeholders": {
+      "lastSeen": {
+        "type": "String",
+        "example": "5 hours ago"
+      }
+    }
+  },
   "projectsBridgeOfflineInstallCommands": "Install commands",
   "@projectsBridgeOfflineInstallCommands": {
     "description": "Label for the disclosure on the bridge-offline Projects screen that expands to reveal the bridge install commands."
   },
-  "projectsBridgeOfflineStartBridge": "Start your bridge",
+  "projectsBridgeOfflineStartBridge": "Make sure the Bridge is running",
   "@projectsBridgeOfflineStartBridge": {
     "description": "Label above the command box on the bridge-offline Projects screen that shows the command to start an already-installed bridge; carries a trailing info icon."
   },
   "projectsBridgeOfflineStartBridgeInfo": "Leave it running while you use Sesori from your phone.",
   "@projectsBridgeOfflineStartBridgeInfo": {
-    "description": "Popover text explaining the 'Start your bridge' command on the bridge-offline Projects screen, opened from the info icon next to that label. Kept in the same untitled single-sentence style as the onboarding step popovers."
+    "description": "Popover text explaining the start-the-bridge command on the bridge-offline Projects screen, opened from the info icon next to that label. Kept in the same untitled single-sentence style as the onboarding step popovers."
   },
   "connectionLostTitle": "Connection Lost",
   "connectionLostReconnect": "Reconnect",

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -118,11 +118,11 @@
   },
   "projectsBridgeOfflineDisconnectedSince": "Disconnected · {lastSeen}",
   "@projectsBridgeOfflineDisconnectedSince": {
-    "description": "Status caption under the machine name on the bridge-offline Projects screen, pairing the disconnected state with how long ago the bridge was last seen, e.g. 'Disconnected · 5 hours ago'.",
+    "description": "Status caption under the machine name on the bridge-offline Projects screen, pairing the disconnected state with when the bridge was last seen, e.g. 'Disconnected · 5h ago'. The placeholder is already-formatted text from the app's shared relative-time vocabulary (the same one the project rows use), which is compact for recent instants and becomes a plain date past the relative window.",
     "placeholders": {
       "lastSeen": {
         "type": "String",
-        "example": "5 hours ago"
+        "example": "5h ago"
       }
     }
   },

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -319,17 +319,17 @@ abstract class AppLocalizations {
   /// **'More information'**
   String get projectsOnboardingStepInfoSemantics;
 
-  /// Status caption under the connection graphic on the bridge-offline Projects screen, rendered with a trailing crossed-circle icon.
+  /// Status caption under the machine name on the bridge-offline Projects screen, used when the bridge has never reported a last-seen time.
   ///
   /// In en, this message translates to:
   /// **'Disconnected'**
   String get projectsBridgeOfflineDisconnected;
 
-  /// No description provided for @projectsBridgeOfflineReconnect.
+  /// Status caption under the machine name on the bridge-offline Projects screen, pairing the disconnected state with how long ago the bridge was last seen, e.g. 'Disconnected · 5 hours ago'.
   ///
   /// In en, this message translates to:
-  /// **'Reconnect'**
-  String get projectsBridgeOfflineReconnect;
+  /// **'Disconnected · {lastSeen}'**
+  String projectsBridgeOfflineDisconnectedSince(String lastSeen);
 
   /// Label for the disclosure on the bridge-offline Projects screen that expands to reveal the bridge install commands.
   ///
@@ -340,10 +340,10 @@ abstract class AppLocalizations {
   /// Label above the command box on the bridge-offline Projects screen that shows the command to start an already-installed bridge; carries a trailing info icon.
   ///
   /// In en, this message translates to:
-  /// **'Start your bridge'**
+  /// **'Make sure the Bridge is running'**
   String get projectsBridgeOfflineStartBridge;
 
-  /// Popover text explaining the 'Start your bridge' command on the bridge-offline Projects screen, opened from the info icon next to that label. Kept in the same untitled single-sentence style as the onboarding step popovers.
+  /// Popover text explaining the start-the-bridge command on the bridge-offline Projects screen, opened from the info icon next to that label. Kept in the same untitled single-sentence style as the onboarding step popovers.
   ///
   /// In en, this message translates to:
   /// **'Leave it running while you use Sesori from your phone.'**

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -325,7 +325,7 @@ abstract class AppLocalizations {
   /// **'Disconnected'**
   String get projectsBridgeOfflineDisconnected;
 
-  /// Status caption under the machine name on the bridge-offline Projects screen, pairing the disconnected state with how long ago the bridge was last seen, e.g. 'Disconnected · 5 hours ago'.
+  /// Status caption under the machine name on the bridge-offline Projects screen, pairing the disconnected state with when the bridge was last seen, e.g. 'Disconnected · 5h ago'. The placeholder is already-formatted text from the app's shared relative-time vocabulary (the same one the project rows use), which is compact for recent instants and becomes a plain date past the relative window.
   ///
   /// In en, this message translates to:
   /// **'Disconnected · {lastSeen}'**

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -134,13 +134,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectsBridgeOfflineDisconnected => 'Disconnected';
 
   @override
-  String get projectsBridgeOfflineReconnect => 'Reconnect';
+  String projectsBridgeOfflineDisconnectedSince(String lastSeen) {
+    return 'Disconnected · $lastSeen';
+  }
 
   @override
   String get projectsBridgeOfflineInstallCommands => 'Install commands';
 
   @override
-  String get projectsBridgeOfflineStartBridge => 'Start your bridge';
+  String get projectsBridgeOfflineStartBridge => 'Make sure the Bridge is running';
 
   @override
   String get projectsBridgeOfflineStartBridgeInfo => 'Leave it running while you use Sesori from your phone.';

--- a/client/app/test/features/project_list/bridge_offline_view_test.dart
+++ b/client/app/test/features/project_list/bridge_offline_view_test.dart
@@ -15,9 +15,9 @@ import "../../helpers/test_helpers.dart";
 
 // ---------------------------------------------------------------------------
 // Behaviour guards for the redesigned bridge-offline recovery view: the
-// machine-name row fed from the account's registered bridges, the
-// "Start your bridge" info popover, and the install-commands disclosure that
-// now closes the body.
+// machine-name row fed from the account's registered bridges, the status line
+// reporting how long that bridge has been gone, the start-the-bridge info
+// popover, and the install-commands disclosure that closes the body.
 //
 // Pumps the real [ProjectListScreen] (its cubit is built from getIt, so every
 // dependency is registered as a mock below) driven into the bridge-offline
@@ -113,28 +113,36 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    expect(find.text("Disconnected"), findsOneWidget);
+    expect(find.text("Make sure the Bridge is running"), findsOneWidget);
     addTearDown(() => tester.pumpWidget(const SizedBox.shrink()));
   }
 
   group("machine-name row", () {
-    testWidgets("names the most recently seen registered bridge", (tester) async {
+    testWidgets("names the most recently seen registered bridge, above the status line", (tester) async {
       when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer(
         (_) async => [_bridge(id: "a", name: "Macbook-Pro.local", lastSeenAt: DateTime.utc(2026, 7, 1))],
       );
 
       await pumpScreen(tester);
 
-      expect(find.text("Macbook-Pro.local"), findsOneWidget);
+      // Once in the body, once as the top bar's subtitle.
+      expect(find.text("Macbook-Pro.local"), findsNWidgets(2));
+      final bodyName = find.descendant(
+        of: find.byType(CustomScrollView),
+        matching: find.text("Macbook-Pro.local"),
+      );
+      final status = find.textContaining("Disconnected");
+      expect(tester.getTopLeft(bodyName).dy, lessThan(tester.getTopLeft(status).dy));
     });
 
     testWidgets("is hidden when the registered bridges could not be fetched", (tester) async {
       await pumpScreen(tester);
 
       expect(find.byIcon(TablerRegular.device_laptop), findsNothing);
-      // The recovery view itself still renders in full.
-      expect(find.text("Reconnect"), findsOneWidget);
-      expect(find.text("Start your bridge"), findsOneWidget);
+      // The recovery view itself still renders in full, and with no last-seen
+      // time to report the status line falls back to the bare caption.
+      expect(find.text("Disconnected"), findsOneWidget);
+      expect(find.text("Install commands"), findsOneWidget);
     });
 
     testWidgets("is a static label: only the most recent machine, tapping does nothing", (tester) async {
@@ -148,21 +156,38 @@ void main() {
       await pumpScreen(tester);
 
       // One bridge at a time: stale extra registrations are never listed.
-      expect(find.text("Macbook-Pro.local"), findsOneWidget);
       expect(find.text("work-desktop"), findsNothing);
 
       // Not tappable — no menu or sheet opens off the row.
-      await tester.tap(find.text("Macbook-Pro.local"));
+      await tester.tap(find.text("Macbook-Pro.local").first);
       await tester.pumpAndSettle();
-      expect(find.text("Macbook-Pro.local"), findsOneWidget);
       expect(find.text("work-desktop"), findsNothing);
     });
   });
 
-  testWidgets("the Start-your-bridge info icon opens its explainer popover", (tester) async {
+  testWidgets("the status line reports how long the bridge has been gone", (tester) async {
+    when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer(
+      (_) async => [
+        _bridge(
+          id: "a",
+          name: "Macbook-Pro.local",
+          lastSeenAt: DateTime.now().subtract(const Duration(hours: 5)),
+        ),
+      ],
+    );
+
     await pumpScreen(tester);
 
-    // The "Start your bridge" label owns the only info trigger on this view.
+    // Relative wording follows the app's shared timestamp vocabulary ("5h
+    // ago"), the same one the project tiles use.
+    expect(find.text("Disconnected · 5h ago"), findsOneWidget);
+  });
+
+  testWidgets("the start-the-bridge info icon opens its explainer popover", (tester) async {
+    await pumpScreen(tester);
+
+    // The "Make sure the Bridge is running" label owns the only info trigger
+    // on this view.
     await tester.tap(find.bySemanticsLabel("More information"));
     await tester.pumpAndSettle();
 
@@ -175,12 +200,12 @@ void main() {
   testWidgets("the install-commands disclosure closes the body and expands in place", (tester) async {
     await pumpScreen(tester);
 
-    // End-of-body ordering: Reconnect → run box → explainer → disclosure.
-    final reconnectY = tester.getTopLeft(find.text("Reconnect")).dy;
-    final runBoxY = tester.getTopLeft(find.text("Start your bridge")).dy;
+    // End-of-body ordering: run box → explainer → disclosure. No reconnect
+    // button: the page reconnects on its own and on pull-to-refresh.
+    expect(find.text("Reconnect"), findsNothing);
+    final runBoxY = tester.getTopLeft(find.text("Make sure the Bridge is running")).dy;
     final whyY = tester.getTopLeft(find.text("Why is this needed?")).dy;
     final disclosureY = tester.getTopLeft(find.text("Install commands")).dy;
-    expect(reconnectY, lessThan(runBoxY));
     expect(runBoxY, lessThan(whyY));
     expect(whyY, lessThan(disclosureY));
 

--- a/client/app/test/features/project_list/project_list_collapsing_title_test.dart
+++ b/client/app/test/features/project_list/project_list_collapsing_title_test.dart
@@ -14,10 +14,14 @@ import "../../helpers/test_helpers.dart";
 
 /// The two disconnected Projects states — the connect-your-computer onboarding
 /// and the bridge-offline view — used to own an inner scroll view, which forced
-/// the page scroll off and left the large title pinned while the body moved
-/// underneath it. They are bodies now, hosted in the scaffold's page scroll, so
-/// the title scrolls away with the content and collapses into the top nav bar
-/// exactly as it does on the loaded project list.
+/// the page scroll off and left the bar's title pinned while the body moved
+/// underneath it. They are bodies now, hosted in the scaffold's page scroll.
+///
+/// Both trade the loaded list's collapsing large title for the compact
+/// back-leading block, whose subtitle reports the connection the body is about:
+/// what the setup checklist is waiting for, or the machine the offline view is
+/// trying to reach. So neither page has a large title to scroll away, and the
+/// bar stays put while its body scrolls.
 void main() {
   const config = ServerConnectionConfig(relayHost: "relay.example.com", authToken: "test-token");
   const health = HealthResponse(healthy: true, version: "0.1.200", filesystemAccessDegraded: null);
@@ -61,14 +65,19 @@ void main() {
     await getIt.reset();
   });
 
-  Future<void> pumpScreen(WidgetTester tester, {required bool hasRegisteredBridges}) async {
+  Future<void> pumpScreen(
+    WidgetTester tester, {
+    required bool hasRegisteredBridges,
+    List<BridgeSummary> bridges = const [],
+    double viewportHeight = 500,
+  }) async {
     when(() => mockRegisteredBridgesService.hasRegisteredBridges()).thenAnswer((_) async => hasRegisteredBridges);
-    when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer((_) async => const []);
-    // A phone-width viewport, deliberately short so both bodies overflow it.
+    when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer((_) async => bridges);
+    // A phone-width viewport, deliberately short so the body overflows it.
     // Overflow is the precondition for the behaviour under test: a body that
-    // fits leaves the page with no scroll extent, and a large title with
-    // nothing to scroll against correctly stays put.
-    tester.view.physicalSize = const Size(393, 500);
+    // fits leaves the page with no scroll extent, and a bar with nothing to
+    // scroll against correctly stays put.
+    tester.view.physicalSize = Size(393, viewportHeight);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.reset);
 
@@ -96,40 +105,54 @@ void main() {
     skipOffstage: false,
   );
 
-  /// The alpha the large title is painted with: 1 while fully shown, 0 once it
-  /// has collapsed into the bar.
-  double largeTitleAlpha(WidgetTester tester, String title) => tester.widget<Text>(largeTitle(title)).style!.color!.a;
-
   /// Drags the page up past [PregoTopNavigation.collapseDistance].
   Future<void> scrollPageUp(WidgetTester tester) async {
     await tester.drag(find.byType(CustomScrollView), const Offset(0, -180), warnIfMissed: false);
     await tester.pumpAndSettle();
   }
 
-  testWidgets("the bridge-offline body scrolls the page, collapsing the large title", (tester) async {
-    await pumpScreen(tester, hasRegisteredBridges: true);
-    expect(find.text("Disconnected"), findsOneWidget);
+  testWidgets("the bridge-offline body scrolls under a back-leading bar naming the machine", (tester) async {
+    await pumpScreen(
+      tester,
+      hasRegisteredBridges: true,
+      bridges: [
+        BridgeSummary(
+          id: "a",
+          name: "Macbook-Pro.local",
+          platform: "macos",
+          addedAt: DateTime.utc(2026),
+          lastSeenAt: DateTime.utc(2026, 7),
+        ),
+      ],
+      // Taller than the collapsed offline body, which is what makes expanding
+      // the disclosure — below — the thing that pushes it past the viewport. A
+      // shorter viewport would bury the disclosure button under the floating
+      // "Need help?" pill, leaving nothing to tap.
+      viewportHeight: 600,
+    );
     // A single scroll view for the whole page — the body no longer nests one.
     expect(find.byType(CustomScrollView), findsOneWidget);
     expect(find.byType(SingleChildScrollView), findsNothing);
 
+    // The bar carries the page title over the machine the body is trying to
+    // reach, so there is no large title in the scroll view to collapse.
+    expect(find.byType(PregoNavLeadingTitle), findsOneWidget);
+    expect(largeTitle("Projects"), findsNothing);
+    expect(find.text("Projects"), findsOneWidget);
+    expect(find.byIcon(TablerRegular.device_laptop), findsNWidgets(2));
+    expect(find.text("Macbook-Pro.local"), findsNWidgets(2));
+
     // Expanding the install commands (the disclosure at the end of the body)
-    // grows the body past the viewport, which is when the title must travel
-    // with the content. The button may itself sit below the short viewport, so
-    // scroll it into view first, then return to the top for a clean baseline.
-    await tester.scrollUntilVisible(find.text("Install commands", skipOffstage: false), 100);
+    // grows the body past the viewport; the body then scrolls under a bar that
+    // stays put.
     await tester.tap(find.text("Install commands"));
     await tester.pumpAndSettle();
-    await tester.drag(find.byType(CustomScrollView), const Offset(0, 600), warnIfMissed: false);
-    await tester.pumpAndSettle();
 
-    final titleBefore = tester.getTopLeft(largeTitle("Projects")).dy;
-    expect(largeTitleAlpha(tester, "Projects"), closeTo(1, 0.001));
-
+    final barBefore = tester.getTopLeft(find.byType(PregoNavLeadingTitle));
+    final bodyBefore = tester.getTopLeft(find.text("Make sure the Bridge is running")).dy;
     await scrollPageUp(tester);
-
-    expect(tester.getTopLeft(largeTitle("Projects")).dy, lessThan(titleBefore));
-    expect(largeTitleAlpha(tester, "Projects"), closeTo(0, 0.001));
+    expect(tester.getTopLeft(find.text("Make sure the Bridge is running")).dy, lessThan(bodyBefore));
+    expect(tester.getTopLeft(find.byType(PregoNavLeadingTitle)), barBefore);
   });
 
   testWidgets("the connect onboarding hosts a back-leading bar instead of a large title", (tester) async {

--- a/client/app/test/features/project_list/project_list_collapsing_title_test.dart
+++ b/client/app/test/features/project_list/project_list_collapsing_title_test.dart
@@ -69,7 +69,6 @@ void main() {
     WidgetTester tester, {
     required bool hasRegisteredBridges,
     List<BridgeSummary> bridges = const [],
-    double viewportHeight = 500,
   }) async {
     when(() => mockRegisteredBridgesService.hasRegisteredBridges()).thenAnswer((_) async => hasRegisteredBridges);
     when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer((_) async => bridges);
@@ -77,7 +76,7 @@ void main() {
     // Overflow is the precondition for the behaviour under test: a body that
     // fits leaves the page with no scroll extent, and a bar with nothing to
     // scroll against correctly stays put.
-    tester.view.physicalSize = Size(393, viewportHeight);
+    tester.view.physicalSize = const Size(393, 500);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.reset);
 
@@ -124,11 +123,6 @@ void main() {
           lastSeenAt: DateTime.utc(2026, 7),
         ),
       ],
-      // Taller than the collapsed offline body, which is what makes expanding
-      // the disclosure — below — the thing that pushes it past the viewport. A
-      // shorter viewport would bury the disclosure button under the floating
-      // "Need help?" pill, leaving nothing to tap.
-      viewportHeight: 600,
     );
     // A single scroll view for the whole page — the body no longer nests one.
     expect(find.byType(CustomScrollView), findsOneWidget);
@@ -142,12 +136,7 @@ void main() {
     expect(find.byIcon(TablerRegular.device_laptop), findsNWidgets(2));
     expect(find.text("Macbook-Pro.local"), findsNWidgets(2));
 
-    // Expanding the install commands (the disclosure at the end of the body)
-    // grows the body past the viewport; the body then scrolls under a bar that
-    // stays put.
-    await tester.tap(find.text("Install commands"));
-    await tester.pumpAndSettle();
-
+    // The body scrolls under a bar that stays put.
     final barBefore = tester.getTopLeft(find.byType(PregoNavLeadingTitle));
     final bodyBefore = tester.getTopLeft(find.text("Make sure the Bridge is running")).dy;
     await scrollPageUp(tester);


### PR DESCRIPTION
Brings the bridge-offline empty Projects state up to the latest Figma
([node 2325:48309](https://www.figma.com/design/NILKXLD9cwuWHhLnGqPqeJ/Sesori?node-id=2325-48309&m=dev)).

## What changed

**Body** (`widgets/bridge_offline_view.dart`)

- The machine identity now leads: the machine name moves above the status line in
  `text-primary`, with `Disconnected · <last seen>` beneath it in `text-xs`. The
  relative time comes from the bridge's `lastSeenAt` and is refreshed by the
  screen's existing minute ticker; with no last-seen time it falls back to the
  bare "Disconnected" caption.
- **Reconnect button removed.** The design has none, and the page already
  reconnects on its own and on pull-to-refresh — `reconnectBridge` is still wired
  to the refresh control.
- The command label is now "Make sure the Bridge is running", centred over its
  box. The centred variant of `_InfoLabel` balances the info icon's 40px tap
  target so the visible text, not the hit box, is what gets centred.
- The body is anchored 90px below the bar (the Figma offset) instead of being
  vertically centred, so the graphic also holds still as the install-commands
  disclosure grows the body beneath it.

**Top navigation** (`project_list_screen.dart`)

The state now uses the same back-leading bar the connect onboarding already had:
the "Projects" title over a subtitle naming the machine being reached, with the
error dot. Per direction, no avatar. When the bridge lookup has not produced a
name, the subtitle is omitted rather than repeating the body's caption.

## Deviations from the Figma

1. **No chevron on the machine name** (bar or body). The design draws one, but
   there is no bridge picker — `getRegisteredBridges` is only ever read for its
   most recent entry, so the chevron would open nothing. The identical chevron in
   the nav subtitle was already dropped when the connect onboarding was built.
2. **"5h ago", not "5 hours ago".** That is `formatTimestamp`, the app's shared
   relative-time vocabulary (same as the project tiles).

## Follow-up worth a look

With the body top-anchored, there is now a wide gap between "Install commands"
and the "Need help?" pill, which rides the scaffold's bottom-pinned
floating-action slot. The Figma places it 40px below "Install commands" with the
empty space at the bottom of the screen instead. Moving it into the body flow
would also affect the connect-onboarding screen that shares that slot, so it is
left out of this PR.

## Verification

- `flutter analyze lib test` clean; the 82 `project_list` tests pass.
- Verified live on the iPhone 17 Pro Max simulator against a genuinely offline
  bridge.
- Tests updated: `bridge_offline_view_test` (last-seen status line, ordering
  without Reconnect, machine row above the status line) and
  `project_list_collapsing_title_test` (the offline page asserts a fixed
  back-leading bar instead of a collapsing large title).

https://claude.ai/code/session_01PtnYj21TVUvRSDSAXyUhgH

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the Projects screen for a disconnected Bridge to match the latest Figma. Leads with the machine identity, shows a clear last-seen status, aligns the top nav with onboarding, and removes the Reconnect button.

- **Refactors**
  - Machine name now appears above the status line. Status shows “Disconnected · <last seen>” and updates every minute; falls back to “Disconnected”.
  - Command renamed to “Make sure the Bridge is running” and centered; `_InfoLabel` now requires a `centered` parameter and centers wrapped lines when `centered: true`.
  - Body anchored 90px below the bar so the graphic stays fixed when “Install commands” expands.
  - Top nav uses the back-leading layout with an error dot and a subtitle: “waiting for bridge” before any registration, otherwise the machine name; no avatar or chevron.
  - L10n updates: added the last-seen caption and corrected the placeholder example; updated strings. Tests cover the new layout and behaviors.

<sup>Written for commit 3b0071cd652b32779859a5989ce571dc5f6d6e2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

