### PR TITLE
[multi-plugin-release-prep] refactor(codex): type session option discovery [step 2/6]

### DIFF
--- a/.plan/active/multi-plugin-release-prep/TRACKER.md
+++ b/.plan/active/multi-plugin-release-prep/TRACKER.md
@@ -79,7 +79,7 @@
 - Step 2/6 (2026-07-29): added typed Codex `model/list` DTO/API/repository
   ownership, moved model and collaboration-option construction into
   `CodexSessionService`, and reduced the plugin facade to route delegation.
-  Generated Freezed/JSON sources, all 203 Codex package tests, focused fatal
+  Generated Freezed/JSON sources, all 204 Codex package tests, focused fatal
   analysis, formatting, and `git diff --check` passed. Aristotle implementation
   review approved the branch-local architecture with no findings. Committed as
   `4773ddde`, pushed, and opened as PR #609.

--- a/.plan/active/multi-plugin-release-prep/TRACKER.md
+++ b/.plan/active/multi-plugin-release-prep/TRACKER.md
@@ -2,19 +2,18 @@
 
 ## Current State
 
-- **Implementation base:** `origin/main` at `9da014e2`
-- **Series state:** Step 1/6 plan PR #605 is open from
-  `multi-plugin-release-prep`
-- **Current step:** Step 1/6 — durable plan and tracker
-- **Next action:** review and merge the plan PR, then start Step 2/6 from updated
-  `origin/main`
+- **Implementation base:** `origin/main` at `fb961d16`
+- **Series state:** Step 1/6 plan PR #605 is merged; Step 2/6 is implemented
+  and locally verified on `multi-plugin-release-prep-codex-options`
+- **Current step:** Step 2/6 — typed Codex session-option discovery
+- **Next action:** commit and open the Step 2/6 PR for review
 
 ## Delivery
 
 | Done | Step | Branch | PR state |
 |---|---|---|---|
-| [ ] | Step 1/6 — plan multi-plugin release preparation | `multi-plugin-release-prep` | PR #605 open |
-| [ ] | Step 2/6 — type Codex session-option discovery | `multi-plugin-release-prep-codex-options` | Blocked on Step 1 merge |
+| [x] | Step 1/6 — plan multi-plugin release preparation | `multi-plugin-release-prep` | PR #605 merged |
+| [ ] | Step 2/6 — type Codex session-option discovery | `multi-plugin-release-prep-codex-options` | Implementation verified locally |
 | [ ] | Step 3/6 — aggregate scoped plugin options | `multi-plugin-release-prep-plugin-options` | Blocked on Step 2 merge |
 | [ ] | Step 4/6 — durable bridge cache and aggregate route | `multi-plugin-release-prep-bridge-cache` | Blocked on Step 3 merge |
 | [ ] | Step 5/6 — cached New Session client flow | `multi-plugin-release-prep-client-options` | Blocked on Step 4 merge |
@@ -75,4 +74,10 @@
 - Step 1/6 (2026-07-29): finalized the scope-aware aggregate session-options
   and single-screen Harnesses settings plan. `git diff --check` passed; no
   Dart/Flutter suites were run for this documentation-only slice. Committed as
-  `3c46773c`, pushed, and opened PR #605.
+  `3c46773c`, pushed, opened as PR #605, and merged to `main` as `fb961d16`.
+- Step 2/6 (2026-07-29): added typed Codex `model/list` DTO/API/repository
+  ownership, moved model and collaboration-option construction into
+  `CodexSessionService`, and reduced the plugin facade to route delegation.
+  Generated Freezed/JSON sources, all 201 Codex package tests, focused fatal
+  analysis, formatting, and `git diff --check` passed. Aristotle implementation
+  review approved the branch-local architecture with no findings.

--- a/.plan/active/multi-plugin-release-prep/TRACKER.md
+++ b/.plan/active/multi-plugin-release-prep/TRACKER.md
@@ -3,17 +3,18 @@
 ## Current State
 
 - **Implementation base:** `origin/main` at `fb961d16`
-- **Series state:** Step 1/6 plan PR #605 is merged; Step 2/6 is implemented
-  and locally verified on `multi-plugin-release-prep-codex-options`
+- **Series state:** Step 1/6 plan PR #605 is merged; Step 2/6 PR #609 is open
+  from `multi-plugin-release-prep-codex-options`
 - **Current step:** Step 2/6 — typed Codex session-option discovery
-- **Next action:** commit and open the Step 2/6 PR for review
+- **Next action:** review and merge PR #609, then start Step 3/6 from updated
+  `origin/main`
 
 ## Delivery
 
 | Done | Step | Branch | PR state |
 |---|---|---|---|
 | [x] | Step 1/6 — plan multi-plugin release preparation | `multi-plugin-release-prep` | PR #605 merged |
-| [ ] | Step 2/6 — type Codex session-option discovery | `multi-plugin-release-prep-codex-options` | Implementation verified locally |
+| [ ] | Step 2/6 — type Codex session-option discovery | `multi-plugin-release-prep-codex-options` | PR #609 open |
 | [ ] | Step 3/6 — aggregate scoped plugin options | `multi-plugin-release-prep-plugin-options` | Blocked on Step 2 merge |
 | [ ] | Step 4/6 — durable bridge cache and aggregate route | `multi-plugin-release-prep-bridge-cache` | Blocked on Step 3 merge |
 | [ ] | Step 5/6 — cached New Session client flow | `multi-plugin-release-prep-client-options` | Blocked on Step 4 merge |
@@ -80,4 +81,5 @@
   `CodexSessionService`, and reduced the plugin facade to route delegation.
   Generated Freezed/JSON sources, all 201 Codex package tests, focused fatal
   analysis, formatting, and `git diff --check` passed. Aristotle implementation
-  review approved the branch-local architecture with no findings.
+  review approved the branch-local architecture with no findings. Committed as
+  `4773ddde`, pushed, and opened as PR #609.

--- a/.plan/active/multi-plugin-release-prep/TRACKER.md
+++ b/.plan/active/multi-plugin-release-prep/TRACKER.md
@@ -79,7 +79,7 @@
 - Step 2/6 (2026-07-29): added typed Codex `model/list` DTO/API/repository
   ownership, moved model and collaboration-option construction into
   `CodexSessionService`, and reduced the plugin facade to route delegation.
-  Generated Freezed/JSON sources, all 201 Codex package tests, focused fatal
+  Generated Freezed/JSON sources, all 203 Codex package tests, focused fatal
   analysis, formatting, and `git diff --check` passed. Aristotle implementation
   review approved the branch-local architecture with no findings. Committed as
   `4773ddde`, pushed, and opened as PR #609.

--- a/bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart
@@ -3,6 +3,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "../codex_app_server_client.dart";
 import "../models/codex_collaboration_mode.dart";
 import "models/codex_collaboration_mode_dto.dart";
+import "models/codex_model_dto.dart";
 import "models/codex_skill_dto.dart";
 import "models/codex_thread_dto.dart";
 import "models/codex_turn_dto.dart";
@@ -51,6 +52,21 @@ class CodexAppServerApi {
       );
     }
     return CodexSkillsListResponseDto.fromJson(
+      result.cast<String, dynamic>(),
+    );
+  }
+
+  Future<CodexModelListResponseDto> listModels() async {
+    final result = await _client.request(
+      method: "model/list",
+      params: const <String, dynamic>{},
+    );
+    if (result is! Map) {
+      throw StateError(
+        "expected a Codex model response object, got ${result.runtimeType}",
+      );
+    }
+    return CodexModelListResponseDto.fromJson(
       result.cast<String, dynamic>(),
     );
   }

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_model_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_model_dto.dart
@@ -6,7 +6,7 @@ part "codex_model_dto.g.dart";
 @Freezed(fromJson: true, toJson: false)
 sealed class CodexModelListResponseDto with _$CodexModelListResponseDto {
   const factory CodexModelListResponseDto({
-    required List<CodexModelDto> data,
+    @CodexModelListConverter() required List<CodexModelDto> data,
     required String? nextCursor,
   }) = _CodexModelListResponseDto;
 
@@ -19,7 +19,7 @@ sealed class CodexModelDto with _$CodexModelDto {
     required String? id,
     required String? displayName,
     required bool? hidden,
-    required List<CodexReasoningEffortOptionDto>? supportedReasoningEfforts,
+    @CodexReasoningEffortListConverter() required List<CodexReasoningEffortOptionDto>? supportedReasoningEfforts,
     required String? defaultReasoningEffort,
     required bool? isDefault,
   }) = _CodexModelDto;
@@ -37,4 +37,51 @@ sealed class CodexReasoningEffortOptionDto with _$CodexReasoningEffortOptionDto 
   factory CodexReasoningEffortOptionDto.fromJson(
     Map<String, dynamic> json,
   ) => _$CodexReasoningEffortOptionDtoFromJson(json);
+}
+
+class CodexModelListConverter implements JsonConverter<List<CodexModelDto>, Object?> {
+  const CodexModelListConverter();
+
+  @override
+  List<CodexModelDto> fromJson(Object? json) {
+    if (json is! List) {
+      throw const FormatException("expected Codex model data to be a list");
+    }
+    return [
+      for (final entry in json)
+        if (entry is Map) CodexModelDto.fromJson(Map<String, dynamic>.from(entry)),
+    ];
+  }
+
+  @override
+  Object? toJson(List<CodexModelDto> object) {
+    throw UnsupportedError("Codex model DTOs are decode-only");
+  }
+}
+
+class CodexReasoningEffortListConverter implements JsonConverter<List<CodexReasoningEffortOptionDto>?, Object?> {
+  const CodexReasoningEffortListConverter();
+
+  @override
+  List<CodexReasoningEffortOptionDto>? fromJson(Object? json) {
+    if (json == null) return null;
+    if (json is! List) return const [];
+    return [
+      for (final entry in json)
+        if (entry is String)
+          CodexReasoningEffortOptionDto(
+            reasoningEffort: entry,
+            description: null,
+          )
+        else if (entry is Map)
+          CodexReasoningEffortOptionDto.fromJson(
+            Map<String, dynamic>.from(entry),
+          ),
+    ];
+  }
+
+  @override
+  Object? toJson(List<CodexReasoningEffortOptionDto>? object) {
+    throw UnsupportedError("Codex reasoning-effort DTOs are decode-only");
+  }
 }

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_model_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_model_dto.dart
@@ -65,7 +65,11 @@ class CodexReasoningEffortListConverter implements JsonConverter<List<CodexReaso
   @override
   List<CodexReasoningEffortOptionDto>? fromJson(Object? json) {
     if (json == null) return null;
-    if (json is! List) return const [];
+    if (json is! List) {
+      throw const FormatException(
+        "expected Codex reasoning efforts to be a list",
+      );
+    }
     return [
       for (final entry in json)
         if (entry is String)

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_model_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_model_dto.dart
@@ -1,0 +1,40 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "codex_model_dto.freezed.dart";
+part "codex_model_dto.g.dart";
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CodexModelListResponseDto with _$CodexModelListResponseDto {
+  const factory CodexModelListResponseDto({
+    required List<CodexModelDto> data,
+    required String? nextCursor,
+  }) = _CodexModelListResponseDto;
+
+  factory CodexModelListResponseDto.fromJson(Map<String, dynamic> json) => _$CodexModelListResponseDtoFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CodexModelDto with _$CodexModelDto {
+  const factory CodexModelDto({
+    required String? id,
+    required String? displayName,
+    required bool? hidden,
+    required List<CodexReasoningEffortOptionDto>? supportedReasoningEfforts,
+    required String? defaultReasoningEffort,
+    required bool? isDefault,
+  }) = _CodexModelDto;
+
+  factory CodexModelDto.fromJson(Map<String, dynamic> json) => _$CodexModelDtoFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CodexReasoningEffortOptionDto with _$CodexReasoningEffortOptionDto {
+  const factory CodexReasoningEffortOptionDto({
+    required String? reasoningEffort,
+    required String? description,
+  }) = _CodexReasoningEffortOptionDto;
+
+  factory CodexReasoningEffortOptionDto.fromJson(
+    Map<String, dynamic> json,
+  ) => _$CodexReasoningEffortOptionDtoFromJson(json);
+}

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_model_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_model_dto.freezed.dart
@@ -1,0 +1,436 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'codex_model_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$CodexModelListResponseDto {
+
+ List<CodexModelDto> get data; String? get nextCursor;
+/// Create a copy of CodexModelListResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexModelListResponseDtoCopyWith<CodexModelListResponseDto> get copyWith => _$CodexModelListResponseDtoCopyWithImpl<CodexModelListResponseDto>(this as CodexModelListResponseDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexModelListResponseDto&&const DeepCollectionEquality().equals(other.data, data)&&(identical(other.nextCursor, nextCursor) || other.nextCursor == nextCursor));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(data),nextCursor);
+
+@override
+String toString() {
+  return 'CodexModelListResponseDto(data: $data, nextCursor: $nextCursor)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexModelListResponseDtoCopyWith<$Res>  {
+  factory $CodexModelListResponseDtoCopyWith(CodexModelListResponseDto value, $Res Function(CodexModelListResponseDto) _then) = _$CodexModelListResponseDtoCopyWithImpl;
+@useResult
+$Res call({
+ List<CodexModelDto> data, String? nextCursor
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexModelListResponseDtoCopyWithImpl<$Res>
+    implements $CodexModelListResponseDtoCopyWith<$Res> {
+  _$CodexModelListResponseDtoCopyWithImpl(this._self, this._then);
+
+  final CodexModelListResponseDto _self;
+  final $Res Function(CodexModelListResponseDto) _then;
+
+/// Create a copy of CodexModelListResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? data = null,Object? nextCursor = freezed,}) {
+  return _then(_self.copyWith(
+data: null == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as List<CodexModelDto>,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexModelListResponseDto implements CodexModelListResponseDto {
+  const _CodexModelListResponseDto({required final  List<CodexModelDto> data, required this.nextCursor}): _data = data;
+  factory _CodexModelListResponseDto.fromJson(Map<String, dynamic> json) => _$CodexModelListResponseDtoFromJson(json);
+
+ final  List<CodexModelDto> _data;
+@override List<CodexModelDto> get data {
+  if (_data is EqualUnmodifiableListView) return _data;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_data);
+}
+
+@override final  String? nextCursor;
+
+/// Create a copy of CodexModelListResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexModelListResponseDtoCopyWith<_CodexModelListResponseDto> get copyWith => __$CodexModelListResponseDtoCopyWithImpl<_CodexModelListResponseDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexModelListResponseDto&&const DeepCollectionEquality().equals(other._data, _data)&&(identical(other.nextCursor, nextCursor) || other.nextCursor == nextCursor));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_data),nextCursor);
+
+@override
+String toString() {
+  return 'CodexModelListResponseDto(data: $data, nextCursor: $nextCursor)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexModelListResponseDtoCopyWith<$Res> implements $CodexModelListResponseDtoCopyWith<$Res> {
+  factory _$CodexModelListResponseDtoCopyWith(_CodexModelListResponseDto value, $Res Function(_CodexModelListResponseDto) _then) = __$CodexModelListResponseDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ List<CodexModelDto> data, String? nextCursor
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexModelListResponseDtoCopyWithImpl<$Res>
+    implements _$CodexModelListResponseDtoCopyWith<$Res> {
+  __$CodexModelListResponseDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexModelListResponseDto _self;
+  final $Res Function(_CodexModelListResponseDto) _then;
+
+/// Create a copy of CodexModelListResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? data = null,Object? nextCursor = freezed,}) {
+  return _then(_CodexModelListResponseDto(
+data: null == data ? _self._data : data // ignore: cast_nullable_to_non_nullable
+as List<CodexModelDto>,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$CodexModelDto {
+
+ String? get id; String? get displayName; bool? get hidden; List<CodexReasoningEffortOptionDto>? get supportedReasoningEfforts; String? get defaultReasoningEffort; bool? get isDefault;
+/// Create a copy of CodexModelDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexModelDtoCopyWith<CodexModelDto> get copyWith => _$CodexModelDtoCopyWithImpl<CodexModelDto>(this as CodexModelDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexModelDto&&(identical(other.id, id) || other.id == id)&&(identical(other.displayName, displayName) || other.displayName == displayName)&&(identical(other.hidden, hidden) || other.hidden == hidden)&&const DeepCollectionEquality().equals(other.supportedReasoningEfforts, supportedReasoningEfforts)&&(identical(other.defaultReasoningEffort, defaultReasoningEffort) || other.defaultReasoningEffort == defaultReasoningEffort)&&(identical(other.isDefault, isDefault) || other.isDefault == isDefault));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,displayName,hidden,const DeepCollectionEquality().hash(supportedReasoningEfforts),defaultReasoningEffort,isDefault);
+
+@override
+String toString() {
+  return 'CodexModelDto(id: $id, displayName: $displayName, hidden: $hidden, supportedReasoningEfforts: $supportedReasoningEfforts, defaultReasoningEffort: $defaultReasoningEffort, isDefault: $isDefault)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexModelDtoCopyWith<$Res>  {
+  factory $CodexModelDtoCopyWith(CodexModelDto value, $Res Function(CodexModelDto) _then) = _$CodexModelDtoCopyWithImpl;
+@useResult
+$Res call({
+ String? id, String? displayName, bool? hidden, List<CodexReasoningEffortOptionDto>? supportedReasoningEfforts, String? defaultReasoningEffort, bool? isDefault
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexModelDtoCopyWithImpl<$Res>
+    implements $CodexModelDtoCopyWith<$Res> {
+  _$CodexModelDtoCopyWithImpl(this._self, this._then);
+
+  final CodexModelDto _self;
+  final $Res Function(CodexModelDto) _then;
+
+/// Create a copy of CodexModelDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? displayName = freezed,Object? hidden = freezed,Object? supportedReasoningEfforts = freezed,Object? defaultReasoningEffort = freezed,Object? isDefault = freezed,}) {
+  return _then(_self.copyWith(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,displayName: freezed == displayName ? _self.displayName : displayName // ignore: cast_nullable_to_non_nullable
+as String?,hidden: freezed == hidden ? _self.hidden : hidden // ignore: cast_nullable_to_non_nullable
+as bool?,supportedReasoningEfforts: freezed == supportedReasoningEfforts ? _self.supportedReasoningEfforts : supportedReasoningEfforts // ignore: cast_nullable_to_non_nullable
+as List<CodexReasoningEffortOptionDto>?,defaultReasoningEffort: freezed == defaultReasoningEffort ? _self.defaultReasoningEffort : defaultReasoningEffort // ignore: cast_nullable_to_non_nullable
+as String?,isDefault: freezed == isDefault ? _self.isDefault : isDefault // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexModelDto implements CodexModelDto {
+  const _CodexModelDto({required this.id, required this.displayName, required this.hidden, required final  List<CodexReasoningEffortOptionDto>? supportedReasoningEfforts, required this.defaultReasoningEffort, required this.isDefault}): _supportedReasoningEfforts = supportedReasoningEfforts;
+  factory _CodexModelDto.fromJson(Map<String, dynamic> json) => _$CodexModelDtoFromJson(json);
+
+@override final  String? id;
+@override final  String? displayName;
+@override final  bool? hidden;
+ final  List<CodexReasoningEffortOptionDto>? _supportedReasoningEfforts;
+@override List<CodexReasoningEffortOptionDto>? get supportedReasoningEfforts {
+  final value = _supportedReasoningEfforts;
+  if (value == null) return null;
+  if (_supportedReasoningEfforts is EqualUnmodifiableListView) return _supportedReasoningEfforts;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+@override final  String? defaultReasoningEffort;
+@override final  bool? isDefault;
+
+/// Create a copy of CodexModelDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexModelDtoCopyWith<_CodexModelDto> get copyWith => __$CodexModelDtoCopyWithImpl<_CodexModelDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexModelDto&&(identical(other.id, id) || other.id == id)&&(identical(other.displayName, displayName) || other.displayName == displayName)&&(identical(other.hidden, hidden) || other.hidden == hidden)&&const DeepCollectionEquality().equals(other._supportedReasoningEfforts, _supportedReasoningEfforts)&&(identical(other.defaultReasoningEffort, defaultReasoningEffort) || other.defaultReasoningEffort == defaultReasoningEffort)&&(identical(other.isDefault, isDefault) || other.isDefault == isDefault));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,displayName,hidden,const DeepCollectionEquality().hash(_supportedReasoningEfforts),defaultReasoningEffort,isDefault);
+
+@override
+String toString() {
+  return 'CodexModelDto(id: $id, displayName: $displayName, hidden: $hidden, supportedReasoningEfforts: $supportedReasoningEfforts, defaultReasoningEffort: $defaultReasoningEffort, isDefault: $isDefault)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexModelDtoCopyWith<$Res> implements $CodexModelDtoCopyWith<$Res> {
+  factory _$CodexModelDtoCopyWith(_CodexModelDto value, $Res Function(_CodexModelDto) _then) = __$CodexModelDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String? id, String? displayName, bool? hidden, List<CodexReasoningEffortOptionDto>? supportedReasoningEfforts, String? defaultReasoningEffort, bool? isDefault
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexModelDtoCopyWithImpl<$Res>
+    implements _$CodexModelDtoCopyWith<$Res> {
+  __$CodexModelDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexModelDto _self;
+  final $Res Function(_CodexModelDto) _then;
+
+/// Create a copy of CodexModelDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? displayName = freezed,Object? hidden = freezed,Object? supportedReasoningEfforts = freezed,Object? defaultReasoningEffort = freezed,Object? isDefault = freezed,}) {
+  return _then(_CodexModelDto(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,displayName: freezed == displayName ? _self.displayName : displayName // ignore: cast_nullable_to_non_nullable
+as String?,hidden: freezed == hidden ? _self.hidden : hidden // ignore: cast_nullable_to_non_nullable
+as bool?,supportedReasoningEfforts: freezed == supportedReasoningEfforts ? _self._supportedReasoningEfforts : supportedReasoningEfforts // ignore: cast_nullable_to_non_nullable
+as List<CodexReasoningEffortOptionDto>?,defaultReasoningEffort: freezed == defaultReasoningEffort ? _self.defaultReasoningEffort : defaultReasoningEffort // ignore: cast_nullable_to_non_nullable
+as String?,isDefault: freezed == isDefault ? _self.isDefault : isDefault // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$CodexReasoningEffortOptionDto {
+
+ String? get reasoningEffort; String? get description;
+/// Create a copy of CodexReasoningEffortOptionDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexReasoningEffortOptionDtoCopyWith<CodexReasoningEffortOptionDto> get copyWith => _$CodexReasoningEffortOptionDtoCopyWithImpl<CodexReasoningEffortOptionDto>(this as CodexReasoningEffortOptionDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexReasoningEffortOptionDto&&(identical(other.reasoningEffort, reasoningEffort) || other.reasoningEffort == reasoningEffort)&&(identical(other.description, description) || other.description == description));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,reasoningEffort,description);
+
+@override
+String toString() {
+  return 'CodexReasoningEffortOptionDto(reasoningEffort: $reasoningEffort, description: $description)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexReasoningEffortOptionDtoCopyWith<$Res>  {
+  factory $CodexReasoningEffortOptionDtoCopyWith(CodexReasoningEffortOptionDto value, $Res Function(CodexReasoningEffortOptionDto) _then) = _$CodexReasoningEffortOptionDtoCopyWithImpl;
+@useResult
+$Res call({
+ String? reasoningEffort, String? description
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexReasoningEffortOptionDtoCopyWithImpl<$Res>
+    implements $CodexReasoningEffortOptionDtoCopyWith<$Res> {
+  _$CodexReasoningEffortOptionDtoCopyWithImpl(this._self, this._then);
+
+  final CodexReasoningEffortOptionDto _self;
+  final $Res Function(CodexReasoningEffortOptionDto) _then;
+
+/// Create a copy of CodexReasoningEffortOptionDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? reasoningEffort = freezed,Object? description = freezed,}) {
+  return _then(_self.copyWith(
+reasoningEffort: freezed == reasoningEffort ? _self.reasoningEffort : reasoningEffort // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexReasoningEffortOptionDto implements CodexReasoningEffortOptionDto {
+  const _CodexReasoningEffortOptionDto({required this.reasoningEffort, required this.description});
+  factory _CodexReasoningEffortOptionDto.fromJson(Map<String, dynamic> json) => _$CodexReasoningEffortOptionDtoFromJson(json);
+
+@override final  String? reasoningEffort;
+@override final  String? description;
+
+/// Create a copy of CodexReasoningEffortOptionDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexReasoningEffortOptionDtoCopyWith<_CodexReasoningEffortOptionDto> get copyWith => __$CodexReasoningEffortOptionDtoCopyWithImpl<_CodexReasoningEffortOptionDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexReasoningEffortOptionDto&&(identical(other.reasoningEffort, reasoningEffort) || other.reasoningEffort == reasoningEffort)&&(identical(other.description, description) || other.description == description));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,reasoningEffort,description);
+
+@override
+String toString() {
+  return 'CodexReasoningEffortOptionDto(reasoningEffort: $reasoningEffort, description: $description)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexReasoningEffortOptionDtoCopyWith<$Res> implements $CodexReasoningEffortOptionDtoCopyWith<$Res> {
+  factory _$CodexReasoningEffortOptionDtoCopyWith(_CodexReasoningEffortOptionDto value, $Res Function(_CodexReasoningEffortOptionDto) _then) = __$CodexReasoningEffortOptionDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String? reasoningEffort, String? description
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexReasoningEffortOptionDtoCopyWithImpl<$Res>
+    implements _$CodexReasoningEffortOptionDtoCopyWith<$Res> {
+  __$CodexReasoningEffortOptionDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexReasoningEffortOptionDto _self;
+  final $Res Function(_CodexReasoningEffortOptionDto) _then;
+
+/// Create a copy of CodexReasoningEffortOptionDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? reasoningEffort = freezed,Object? description = freezed,}) {
+  return _then(_CodexReasoningEffortOptionDto(
+reasoningEffort: freezed == reasoningEffort ? _self.reasoningEffort : reasoningEffort // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_model_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_model_dto.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$CodexModelListResponseDto {
 
- List<CodexModelDto> get data; String? get nextCursor;
+@CodexModelListConverter() List<CodexModelDto> get data; String? get nextCursor;
 /// Create a copy of CodexModelListResponseDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -46,7 +46,7 @@ abstract mixin class $CodexModelListResponseDtoCopyWith<$Res>  {
   factory $CodexModelListResponseDtoCopyWith(CodexModelListResponseDto value, $Res Function(CodexModelListResponseDto) _then) = _$CodexModelListResponseDtoCopyWithImpl;
 @useResult
 $Res call({
- List<CodexModelDto> data, String? nextCursor
+@CodexModelListConverter() List<CodexModelDto> data, String? nextCursor
 });
 
 
@@ -79,11 +79,11 @@ as String?,
 @JsonSerializable(createToJson: false)
 
 class _CodexModelListResponseDto implements CodexModelListResponseDto {
-  const _CodexModelListResponseDto({required final  List<CodexModelDto> data, required this.nextCursor}): _data = data;
+  const _CodexModelListResponseDto({@CodexModelListConverter() required final  List<CodexModelDto> data, required this.nextCursor}): _data = data;
   factory _CodexModelListResponseDto.fromJson(Map<String, dynamic> json) => _$CodexModelListResponseDtoFromJson(json);
 
  final  List<CodexModelDto> _data;
-@override List<CodexModelDto> get data {
+@override@CodexModelListConverter() List<CodexModelDto> get data {
   if (_data is EqualUnmodifiableListView) return _data;
   // ignore: implicit_dynamic_type
   return EqualUnmodifiableListView(_data);
@@ -121,7 +121,7 @@ abstract mixin class _$CodexModelListResponseDtoCopyWith<$Res> implements $Codex
   factory _$CodexModelListResponseDtoCopyWith(_CodexModelListResponseDto value, $Res Function(_CodexModelListResponseDto) _then) = __$CodexModelListResponseDtoCopyWithImpl;
 @override @useResult
 $Res call({
- List<CodexModelDto> data, String? nextCursor
+@CodexModelListConverter() List<CodexModelDto> data, String? nextCursor
 });
 
 
@@ -153,7 +153,7 @@ as String?,
 /// @nodoc
 mixin _$CodexModelDto {
 
- String? get id; String? get displayName; bool? get hidden; List<CodexReasoningEffortOptionDto>? get supportedReasoningEfforts; String? get defaultReasoningEffort; bool? get isDefault;
+ String? get id; String? get displayName; bool? get hidden;@CodexReasoningEffortListConverter() List<CodexReasoningEffortOptionDto>? get supportedReasoningEfforts; String? get defaultReasoningEffort; bool? get isDefault;
 /// Create a copy of CodexModelDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -184,7 +184,7 @@ abstract mixin class $CodexModelDtoCopyWith<$Res>  {
   factory $CodexModelDtoCopyWith(CodexModelDto value, $Res Function(CodexModelDto) _then) = _$CodexModelDtoCopyWithImpl;
 @useResult
 $Res call({
- String? id, String? displayName, bool? hidden, List<CodexReasoningEffortOptionDto>? supportedReasoningEfforts, String? defaultReasoningEffort, bool? isDefault
+ String? id, String? displayName, bool? hidden,@CodexReasoningEffortListConverter() List<CodexReasoningEffortOptionDto>? supportedReasoningEfforts, String? defaultReasoningEffort, bool? isDefault
 });
 
 
@@ -221,14 +221,14 @@ as bool?,
 @JsonSerializable(createToJson: false)
 
 class _CodexModelDto implements CodexModelDto {
-  const _CodexModelDto({required this.id, required this.displayName, required this.hidden, required final  List<CodexReasoningEffortOptionDto>? supportedReasoningEfforts, required this.defaultReasoningEffort, required this.isDefault}): _supportedReasoningEfforts = supportedReasoningEfforts;
+  const _CodexModelDto({required this.id, required this.displayName, required this.hidden, @CodexReasoningEffortListConverter() required final  List<CodexReasoningEffortOptionDto>? supportedReasoningEfforts, required this.defaultReasoningEffort, required this.isDefault}): _supportedReasoningEfforts = supportedReasoningEfforts;
   factory _CodexModelDto.fromJson(Map<String, dynamic> json) => _$CodexModelDtoFromJson(json);
 
 @override final  String? id;
 @override final  String? displayName;
 @override final  bool? hidden;
  final  List<CodexReasoningEffortOptionDto>? _supportedReasoningEfforts;
-@override List<CodexReasoningEffortOptionDto>? get supportedReasoningEfforts {
+@override@CodexReasoningEffortListConverter() List<CodexReasoningEffortOptionDto>? get supportedReasoningEfforts {
   final value = _supportedReasoningEfforts;
   if (value == null) return null;
   if (_supportedReasoningEfforts is EqualUnmodifiableListView) return _supportedReasoningEfforts;
@@ -269,7 +269,7 @@ abstract mixin class _$CodexModelDtoCopyWith<$Res> implements $CodexModelDtoCopy
   factory _$CodexModelDtoCopyWith(_CodexModelDto value, $Res Function(_CodexModelDto) _then) = __$CodexModelDtoCopyWithImpl;
 @override @useResult
 $Res call({
- String? id, String? displayName, bool? hidden, List<CodexReasoningEffortOptionDto>? supportedReasoningEfforts, String? defaultReasoningEffort, bool? isDefault
+ String? id, String? displayName, bool? hidden,@CodexReasoningEffortListConverter() List<CodexReasoningEffortOptionDto>? supportedReasoningEfforts, String? defaultReasoningEffort, bool? isDefault
 });
 
 

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_model_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_model_dto.g.dart
@@ -1,0 +1,40 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'codex_model_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_CodexModelListResponseDto _$CodexModelListResponseDtoFromJson(Map json) =>
+    _CodexModelListResponseDto(
+      data: (json['data'] as List<dynamic>)
+          .map(
+            (e) => CodexModelDto.fromJson(Map<String, dynamic>.from(e as Map)),
+          )
+          .toList(),
+      nextCursor: json['nextCursor'] as String?,
+    );
+
+_CodexModelDto _$CodexModelDtoFromJson(Map json) => _CodexModelDto(
+  id: json['id'] as String?,
+  displayName: json['displayName'] as String?,
+  hidden: json['hidden'] as bool?,
+  supportedReasoningEfforts:
+      (json['supportedReasoningEfforts'] as List<dynamic>?)
+          ?.map(
+            (e) => CodexReasoningEffortOptionDto.fromJson(
+              Map<String, dynamic>.from(e as Map),
+            ),
+          )
+          .toList(),
+  defaultReasoningEffort: json['defaultReasoningEffort'] as String?,
+  isDefault: json['isDefault'] as bool?,
+);
+
+_CodexReasoningEffortOptionDto _$CodexReasoningEffortOptionDtoFromJson(
+  Map json,
+) => _CodexReasoningEffortOptionDto(
+  reasoningEffort: json['reasoningEffort'] as String?,
+  description: json['description'] as String?,
+);

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_model_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_model_dto.g.dart
@@ -8,11 +8,7 @@ part of 'codex_model_dto.dart';
 
 _CodexModelListResponseDto _$CodexModelListResponseDtoFromJson(Map json) =>
     _CodexModelListResponseDto(
-      data: (json['data'] as List<dynamic>)
-          .map(
-            (e) => CodexModelDto.fromJson(Map<String, dynamic>.from(e as Map)),
-          )
-          .toList(),
+      data: const CodexModelListConverter().fromJson(json['data']),
       nextCursor: json['nextCursor'] as String?,
     );
 
@@ -20,14 +16,9 @@ _CodexModelDto _$CodexModelDtoFromJson(Map json) => _CodexModelDto(
   id: json['id'] as String?,
   displayName: json['displayName'] as String?,
   hidden: json['hidden'] as bool?,
-  supportedReasoningEfforts:
-      (json['supportedReasoningEfforts'] as List<dynamic>?)
-          ?.map(
-            (e) => CodexReasoningEffortOptionDto.fromJson(
-              Map<String, dynamic>.from(e as Map),
-            ),
-          )
-          .toList(),
+  supportedReasoningEfforts: const CodexReasoningEffortListConverter().fromJson(
+    json['supportedReasoningEfforts'],
+  ),
   defaultReasoningEffort: json['defaultReasoningEffort'] as String?,
   isDefault: json['isDefault'] as bool?,
 );

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -15,6 +15,7 @@ import "codex_metadata_repository.dart";
 import "models/codex_collaboration_mode.dart";
 import "repositories/codex_catalog_repository.dart";
 import "repositories/codex_message_repository.dart";
+import "repositories/codex_model_repository.dart";
 import "repositories/codex_skill_repository.dart";
 import "repositories/codex_thread_repository.dart";
 import "repositories/models/codex_thread_record.dart";
@@ -239,6 +240,7 @@ class CodexPlugin implements CodexManagedApi {
         final appServerApi = CodexAppServerApi(client: client);
         _sessionService.attachAppServerRepositories(
           threadRepository: CodexThreadRepository(appServerApi: appServerApi),
+          modelRepository: CodexModelRepository(appServerApi: appServerApi),
           skillRepository: CodexSkillRepository(appServerApi: appServerApi),
         );
         _subscribeToNotifications(client);
@@ -1009,57 +1011,7 @@ class CodexPlugin implements CodexManagedApi {
   ) => _sessionService.getSessionMessages(sessionId: sessionId);
 
   @override
-  Future<List<PluginAgent>> getAgents({required String projectId}) async {
-    final (:modelID, :providerID) = _sessionService.resolveModelDefaults(projectId: projectId);
-    var resolvedModelID = modelID;
-    if (resolvedModelID == null) {
-      String? firstVisibleModelID;
-      for (final model in await _listModels()) {
-        if (model["hidden"] == true) continue;
-        final id = model["id"] as String?;
-        if (id == null || id.isEmpty) continue;
-        firstVisibleModelID ??= id;
-        if (model["isDefault"] == true) {
-          resolvedModelID = id;
-          break;
-        }
-      }
-      resolvedModelID ??= firstVisibleModelID;
-    }
-    final agentModel = resolvedModelID == null
-        ? null
-        : PluginAgentModel(
-            modelID: resolvedModelID,
-            providerID: providerID,
-            variant: null,
-          );
-    return [
-      for (final collaborationMode in CodexCollaborationMode.values)
-        if (agentModel != null || collaborationMode == CodexCollaborationMode.defaultMode)
-          PluginAgent(
-            name: collaborationMode.agentName,
-            description: collaborationMode.description,
-            model: agentModel,
-            mode: PluginAgentMode.primary,
-            hidden: false,
-          ),
-    ];
-  }
-
-  static String _providerDisplayName(String providerId) {
-    return switch (providerId.toLowerCase()) {
-      "openai" => "OpenAI",
-      "anthropic" => "Anthropic",
-      "google" => "Google",
-      "mistral" => "Mistral",
-      "groq" => "Groq",
-      "xai" => "xAI",
-      "deepseek" => "DeepSeek",
-      "azure" => "Azure OpenAI",
-      "amazon-bedrock" || "bedrock" => "Amazon Bedrock",
-      _ => providerId,
-    };
-  }
+  Future<List<PluginAgent>> getAgents({required String projectId}) => _sessionService.getAgents(projectId: projectId);
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({
@@ -1117,141 +1069,8 @@ class CodexPlugin implements CodexManagedApi {
   }
 
   @override
-  Future<PluginProvidersResult> getProviders({required String projectId}) async {
-    final (:modelID, :providerID) = _sessionService.resolveModelDefaults(projectId: projectId);
-
-    // Prefer codex's live catalog (`model/list`) so the mobile picker shows
-    // every model the user can switch to, not just the configured default.
-    final models = await _listModels();
-    if (models.isNotEmpty) {
-      String? defaultId;
-      final pluginModels = <PluginModel>[];
-      for (final model in models) {
-        if (model["hidden"] == true) continue;
-        final id = model["id"] as String?;
-        if (id == null || id.isEmpty) continue;
-        if (model["isDefault"] == true) defaultId = id;
-        final displayName = model["displayName"] as String?;
-        pluginModels.add(
-          PluginModel(
-            id: id,
-            name: displayName == null || displayName.isEmpty ? id : displayName,
-            variants: _reasoningEffortVariants(model),
-            family: null,
-            isAvailable: true,
-            releaseDate: null,
-          ),
-        );
-      }
-      if (pluginModels.isNotEmpty) {
-        final defaultModelID = _sessionService.selectCatalogDefaultModel(
-          scopedModelID: modelID,
-          catalogModelIds: [for (final model in pluginModels) model.id],
-          catalogDefaultId: defaultId,
-        );
-        return PluginProvidersResult(
-          providers: [
-            PluginProvider.custom(
-              id: providerID,
-              name: _providerDisplayName(providerID),
-              authType: PluginProviderAuthType.unknown,
-              models: pluginModels,
-              // Non-null: the catalog is non-empty here, so the repository
-              // always resolves at least the first catalog model.
-              defaultModelID: defaultModelID ?? pluginModels.first.id,
-            ),
-          ],
-        );
-      }
-    }
-
-    // Offline / `model/list` unavailable — fall back to the single configured
-    // model so the picker still shows something usable.
-    if (modelID == null) {
-      return const PluginProvidersResult(providers: []);
-    }
-    return PluginProvidersResult(
-      providers: [
-        PluginProvider.custom(
-          id: providerID,
-          name: _providerDisplayName(providerID),
-          authType: PluginProviderAuthType.unknown,
-          models: [
-            PluginModel(
-              id: modelID,
-              name: modelID,
-              variants: const [],
-              family: null,
-              isAvailable: true,
-              releaseDate: null,
-            ),
-          ],
-          defaultModelID: modelID,
-        ),
-      ],
-    );
-  }
-
-  /// Extracts a codex model's reasoning-effort tokens (the mobile "variants")
-  /// from its `model/list` entry, ordered the way the variant picker should
-  /// present them.
-  ///
-  /// codex reports `supportedReasoningEfforts` as `{reasoningEffort, description}`
-  /// options (e.g. low/medium/high/xhigh) plus a `defaultReasoningEffort`. The
-  /// effort tokens are codex's `ReasoningEffort` enum values, which pass straight
-  /// through as the `turn/start` `effort` override — no mapping table needed.
-  ///
-  /// `defaultReasoningEffort` is surfaced FIRST: the mobile picker auto-selects
-  /// the first variant when a user switches model (with no prior pick), so
-  /// leading with codex's own default keeps a model switch at the model's
-  /// intended effort instead of silently dropping to the lowest one. The picker
-  /// also offers a synthetic "default" (null) row, and codex applies
-  /// `defaultReasoningEffort` whenever no `effort` is sent, so the null
-  /// selection and the leading token resolve to the same effort.
-  List<String> _reasoningEffortVariants(Map<String, dynamic> model) {
-    final supported = model["supportedReasoningEfforts"];
-    if (supported is! List) return const [];
-    final efforts = <String>[];
-    for (final option in supported) {
-      String? token;
-      if (option is String) {
-        token = option;
-      } else if (option is Map) {
-        final value = option["reasoningEffort"];
-        if (value is String) token = value;
-      }
-      if (token != null && token.isNotEmpty && !efforts.contains(token)) {
-        efforts.add(token);
-      }
-    }
-    final defaultEffort = model["defaultReasoningEffort"];
-    if (defaultEffort is String && efforts.remove(defaultEffort)) {
-      efforts.insert(0, defaultEffort);
-    }
-    return efforts;
-  }
-
-  /// Fetches codex's model catalog via the `model/list` RPC. Returns an empty
-  /// list when the transport isn't connected or the call fails, so callers can
-  /// fall back to the locally-derived default.
-  Future<List<Map<String, dynamic>>> _listModels() async {
-    final client = _client;
-    if (client == null) return const [];
-    try {
-      final result = await client.request(
-        method: "model/list",
-        params: const <String, dynamic>{},
-      );
-      final data = (result as Map?)?["data"];
-      if (data is! List) return const [];
-      return [
-        for (final entry in data)
-          if (entry is Map) entry.cast<String, dynamic>(),
-      ];
-    } on Object {
-      return const [];
-    }
-  }
+  Future<PluginProvidersResult> getProviders({required String projectId}) =>
+      _sessionService.getProviders(projectId: projectId);
 
   @override
   List<PluginProjectActivitySummary> getActiveSessionsSummary() {

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_model_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_model_repository.dart
@@ -20,14 +20,14 @@ class CodexModelRepository {
     final models = <PluginModel>[];
     for (final model in response.data) {
       if (model.hidden == true) continue;
-      final id = _usefulText(model.id);
+      final id = _usefulText(value: model.id);
       if (id == null) continue;
       if (model.isDefault == true) defaultModelID = id;
       models.add(
         PluginModel(
           id: id,
-          name: _usefulText(model.displayName) ?? id,
-          variants: _reasoningEffortVariants(model),
+          name: _usefulText(value: model.displayName) ?? id,
+          variants: _reasoningEffortVariants(model: model),
           family: null,
           isAvailable: true,
           releaseDate: null,
@@ -37,20 +37,20 @@ class CodexModelRepository {
     return (defaultModelID: defaultModelID, models: models);
   }
 
-  List<String> _reasoningEffortVariants(CodexModelDto model) {
+  List<String> _reasoningEffortVariants({required CodexModelDto model}) {
     final efforts = <String>[];
     for (final option in model.supportedReasoningEfforts ?? const <CodexReasoningEffortOptionDto>[]) {
-      final effort = _usefulText(option.reasoningEffort);
+      final effort = _usefulText(value: option.reasoningEffort);
       if (effort != null && !efforts.contains(effort)) efforts.add(effort);
     }
-    final defaultEffort = _usefulText(model.defaultReasoningEffort);
+    final defaultEffort = _usefulText(value: model.defaultReasoningEffort);
     if (defaultEffort != null && efforts.remove(defaultEffort)) {
       efforts.insert(0, defaultEffort);
     }
     return efforts;
   }
 
-  String? _usefulText(String? value) {
+  String? _usefulText({required String? value}) {
     final trimmed = value?.trim();
     return trimmed == null || trimmed.isEmpty ? null : trimmed;
   }

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_model_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_model_repository.dart
@@ -1,0 +1,57 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../api/codex_app_server_api.dart";
+import "../api/models/codex_model_dto.dart";
+
+typedef CodexModelCatalog = ({
+  String? defaultModelID,
+  List<PluginModel> models,
+});
+
+/// Maps Codex's app-server model catalog into selectable plugin models.
+class CodexModelRepository {
+  CodexModelRepository({required CodexAppServerApi appServerApi}) : _appServerApi = appServerApi;
+
+  final CodexAppServerApi _appServerApi;
+
+  Future<CodexModelCatalog> listModels() async {
+    final response = await _appServerApi.listModels();
+    String? defaultModelID;
+    final models = <PluginModel>[];
+    for (final model in response.data) {
+      if (model.hidden == true) continue;
+      final id = _usefulText(model.id);
+      if (id == null) continue;
+      if (model.isDefault == true) defaultModelID = id;
+      models.add(
+        PluginModel(
+          id: id,
+          name: _usefulText(model.displayName) ?? id,
+          variants: _reasoningEffortVariants(model),
+          family: null,
+          isAvailable: true,
+          releaseDate: null,
+        ),
+      );
+    }
+    return (defaultModelID: defaultModelID, models: models);
+  }
+
+  List<String> _reasoningEffortVariants(CodexModelDto model) {
+    final efforts = <String>[];
+    for (final option in model.supportedReasoningEfforts ?? const <CodexReasoningEffortOptionDto>[]) {
+      final effort = _usefulText(option.reasoningEffort);
+      if (effort != null && !efforts.contains(effort)) efforts.add(effort);
+    }
+    final defaultEffort = _usefulText(model.defaultReasoningEffort);
+    if (defaultEffort != null && efforts.remove(defaultEffort)) {
+      efforts.insert(0, defaultEffort);
+    }
+    return efforts;
+  }
+
+  String? _usefulText(String? value) {
+    final trimmed = value?.trim();
+    return trimmed == null || trimmed.isEmpty ? null : trimmed;
+  }
+}

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
@@ -6,6 +6,7 @@ import "../codex_metadata_repository.dart";
 import "../models/codex_collaboration_mode.dart";
 import "../repositories/codex_catalog_repository.dart";
 import "../repositories/codex_message_repository.dart";
+import "../repositories/codex_model_repository.dart";
 import "../repositories/codex_skill_repository.dart";
 import "../repositories/codex_thread_repository.dart";
 import "../repositories/models/codex_thread_record.dart";
@@ -37,20 +38,24 @@ class CodexSessionService {
   final String _launchDirectory;
 
   CodexThreadRepository? _threadRepository;
+  CodexModelRepository? _modelRepository;
   CodexSkillRepository? _skillRepository;
   final Set<String> _loadedThreads = {};
   final Map<String, String> _threadModels = {};
 
   void attachAppServerRepositories({
     required CodexThreadRepository threadRepository,
+    required CodexModelRepository modelRepository,
     required CodexSkillRepository skillRepository,
   }) {
     _threadRepository = threadRepository;
+    _modelRepository = modelRepository;
     _skillRepository = skillRepository;
   }
 
   void detachAppServerRepositories() {
     _threadRepository = null;
+    _modelRepository = null;
     _skillRepository = null;
     _loadedThreads.clear();
     _threadModels.clear();
@@ -85,6 +90,36 @@ class CodexSessionService {
       return commands;
     }
     return [...commands, _compactionCommand];
+  }
+
+  Future<List<PluginAgent>> getAgents({required String projectId}) async {
+    final options = await _resolveModelOptions(projectId: projectId);
+    return options.agents;
+  }
+
+  Future<PluginProvidersResult> getProviders({
+    required String projectId,
+  }) async {
+    final options = await _resolveModelOptions(projectId: projectId);
+    return options.providers;
+  }
+
+  Future<
+    ({
+      List<PluginAgent> agents,
+      List<PluginCommand> commands,
+      PluginProvidersResult providers,
+    })
+  >
+  getSessionOptions({required String projectId}) async {
+    final modelOptionsFuture = _resolveModelOptions(projectId: projectId);
+    final commandsFuture = getCommands(projectId: projectId);
+    final modelOptions = await modelOptionsFuture;
+    return (
+      agents: modelOptions.agents,
+      commands: await commandsFuture,
+      providers: modelOptions.providers,
+    );
   }
 
   Future<CodexThreadRecord> startThread({
@@ -372,6 +407,102 @@ class CodexSessionService {
     }
     if (catalogDefaultId != null) return catalogDefaultId;
     return catalogModelIds.isEmpty ? null : catalogModelIds.first;
+  }
+
+  Future<
+    ({
+      List<PluginAgent> agents,
+      PluginProvidersResult providers,
+    })
+  >
+  _resolveModelOptions({required String projectId}) async {
+    final (:modelID, :providerID) = resolveModelDefaults(
+      projectId: projectId,
+    );
+    final catalog = await _listModels();
+    final models = catalog.models.isEmpty
+        ? [
+            if (modelID != null)
+              PluginModel(
+                id: modelID,
+                name: modelID,
+                variants: const [],
+                family: null,
+                isAvailable: true,
+                releaseDate: null,
+              ),
+          ]
+        : catalog.models;
+    final selectedModelID = selectCatalogDefaultModel(
+      scopedModelID: modelID,
+      catalogModelIds: [for (final model in models) model.id],
+      catalogDefaultId: catalog.defaultModelID,
+    );
+    final agentModel = selectedModelID == null
+        ? null
+        : PluginAgentModel(
+            modelID: selectedModelID,
+            providerID: providerID,
+            variant: null,
+          );
+    return (
+      agents: [
+        for (final collaborationMode in CodexCollaborationMode.values)
+          if (agentModel != null || collaborationMode == CodexCollaborationMode.defaultMode)
+            PluginAgent(
+              name: collaborationMode.agentName,
+              description: collaborationMode.description,
+              model: agentModel,
+              mode: PluginAgentMode.primary,
+              hidden: false,
+            ),
+      ],
+      providers: PluginProvidersResult(
+        providers: selectedModelID == null
+            ? const []
+            : [
+                PluginProvider.custom(
+                  id: providerID,
+                  name: _providerDisplayName(providerID),
+                  authType: PluginProviderAuthType.unknown,
+                  models: models,
+                  defaultModelID: selectedModelID,
+                ),
+              ],
+      ),
+    );
+  }
+
+  Future<CodexModelCatalog> _listModels() async {
+    final repository = _modelRepository;
+    if (repository == null) {
+      return (defaultModelID: null, models: const <PluginModel>[]);
+    }
+    try {
+      return await repository.listModels();
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        "[codex] model discovery failed; using configured fallback",
+        error,
+        stackTrace,
+      );
+      return (defaultModelID: null, models: const <PluginModel>[]);
+    }
+  }
+
+  String _providerDisplayName(String providerID) {
+    return switch (providerID.toLowerCase()) {
+      "openai" => "OpenAI",
+      "anthropic" => "Anthropic",
+      "google" => "Google",
+      "mistral" => "Mistral",
+      "groq" => "Groq",
+      "xai" => "xAI",
+      "deepseek" => "DeepSeek",
+      "azure" => "Azure OpenAI",
+      "amazon-bedrock" || "bedrock" => "Amazon Bedrock",
+      _ => providerID,
+    };
   }
 
   CodexThreadRepository get _connectedThreadRepository {

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
@@ -463,7 +463,7 @@ class CodexSessionService {
             : [
                 PluginProvider.custom(
                   id: providerID,
-                  name: _providerDisplayName(providerID),
+                  name: _providerDisplayName(providerID: providerID),
                   authType: PluginProviderAuthType.unknown,
                   models: models,
                   defaultModelID: selectedModelID,
@@ -490,7 +490,7 @@ class CodexSessionService {
     }
   }
 
-  String _providerDisplayName(String providerID) {
+  String _providerDisplayName({required String providerID}) {
     return switch (providerID.toLowerCase()) {
       "openai" => "OpenAI",
       "anthropic" => "Anthropic",

--- a/bridge/sesori_plugin_codex/test/codex_model_repository_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_model_repository_test.dart
@@ -45,6 +45,44 @@ void main() {
 
       await expectLater(api.listModels(), throwsStateError);
     });
+
+    test("preserves supported effort shapes while skipping unknown list entries", () async {
+      final api = CodexAppServerApi(
+        client: _StubClient(
+          response: const {
+            "data": [
+              false,
+              {
+                "id": "gpt-5.5",
+                "supportedReasoningEfforts": [
+                  "low",
+                  {"reasoningEffort": "high", "description": "Deep"},
+                  7,
+                ],
+              },
+            ],
+          },
+        ),
+      );
+
+      final response = await api.listModels();
+
+      expect(response.data, hasLength(1));
+      expect(
+        response.data.single.supportedReasoningEfforts?.map(
+          (option) => option.reasoningEffort,
+        ),
+        ["low", "high"],
+      );
+    });
+
+    test("rejects a model/list response whose data field is not a list", () async {
+      final api = CodexAppServerApi(
+        client: _StubClient(response: const {"data": "invalid"}),
+      );
+
+      await expectLater(api.listModels(), throwsFormatException);
+    });
   });
 
   group("CodexModelRepository", () {

--- a/bridge/sesori_plugin_codex/test/codex_model_repository_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_model_repository_test.dart
@@ -83,6 +83,23 @@ void main() {
 
       await expectLater(api.listModels(), throwsFormatException);
     });
+
+    test("rejects a non-list supported reasoning-effort field", () async {
+      final api = CodexAppServerApi(
+        client: _StubClient(
+          response: const {
+            "data": [
+              {
+                "id": "gpt-5.5",
+                "supportedReasoningEfforts": "invalid",
+              },
+            ],
+          },
+        ),
+      );
+
+      await expectLater(api.listModels(), throwsFormatException);
+    });
   });
 
   group("CodexModelRepository", () {

--- a/bridge/sesori_plugin_codex/test/codex_model_repository_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_model_repository_test.dart
@@ -1,0 +1,166 @@
+import "package:codex_plugin/src/api/codex_app_server_api.dart";
+import "package:codex_plugin/src/api/models/codex_model_dto.dart";
+import "package:codex_plugin/src/codex_app_server_client.dart";
+import "package:codex_plugin/src/repositories/codex_model_repository.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("CodexAppServerApi", () {
+    test("decodes the typed model/list response", () async {
+      final client = _StubClient(
+        response: const {
+          "data": [
+            {
+              "id": "gpt-5.5",
+              "displayName": "GPT-5.5",
+              "hidden": false,
+              "supportedReasoningEfforts": [
+                {
+                  "reasoningEffort": "high",
+                  "description": "Deep reasoning",
+                },
+              ],
+              "defaultReasoningEffort": "high",
+              "isDefault": true,
+            },
+          ],
+          "nextCursor": "next-page",
+        },
+      );
+
+      final response = await CodexAppServerApi(client: client).listModels();
+
+      expect(client.method, "model/list");
+      expect(client.params, isEmpty);
+      expect(response.nextCursor, "next-page");
+      expect(response.data.single.id, "gpt-5.5");
+      expect(
+        response.data.single.supportedReasoningEfforts?.single.reasoningEffort,
+        "high",
+      );
+    });
+
+    test("rejects a non-object model/list response", () async {
+      final api = CodexAppServerApi(client: _StubClient(response: const []));
+
+      await expectLater(api.listModels(), throwsStateError);
+    });
+  });
+
+  group("CodexModelRepository", () {
+    test("filters hidden models and falls back to the id for a blank display name", () async {
+      final repository = CodexModelRepository(
+        appServerApi: _StubAppServerApi(
+          response: const CodexModelListResponseDto(
+            data: [
+              CodexModelDto(
+                id: "gpt-visible",
+                displayName: "  ",
+                hidden: false,
+                supportedReasoningEfforts: [],
+                defaultReasoningEffort: null,
+                isDefault: true,
+              ),
+              CodexModelDto(
+                id: "gpt-hidden",
+                displayName: "Hidden",
+                hidden: true,
+                supportedReasoningEfforts: [],
+                defaultReasoningEffort: null,
+                isDefault: false,
+              ),
+              CodexModelDto(
+                id: "  ",
+                displayName: "Missing identity",
+                hidden: false,
+                supportedReasoningEfforts: [],
+                defaultReasoningEffort: null,
+                isDefault: false,
+              ),
+            ],
+            nextCursor: null,
+          ),
+        ),
+      );
+
+      final catalog = await repository.listModels();
+
+      expect(catalog.models, hasLength(1));
+      expect(catalog.models.single.id, "gpt-visible");
+      expect(catalog.models.single.name, "gpt-visible");
+      expect(catalog.defaultModelID, "gpt-visible");
+    });
+
+    test("orders the default reasoning effort first and removes duplicates", () async {
+      final repository = CodexModelRepository(
+        appServerApi: _StubAppServerApi(
+          response: const CodexModelListResponseDto(
+            data: [
+              CodexModelDto(
+                id: "gpt-5.5",
+                displayName: "GPT-5.5",
+                hidden: false,
+                supportedReasoningEfforts: [
+                  CodexReasoningEffortOptionDto(
+                    reasoningEffort: "low",
+                    description: "Fast",
+                  ),
+                  CodexReasoningEffortOptionDto(
+                    reasoningEffort: "medium",
+                    description: "Balanced",
+                  ),
+                  CodexReasoningEffortOptionDto(
+                    reasoningEffort: "high",
+                    description: "Deep",
+                  ),
+                  CodexReasoningEffortOptionDto(
+                    reasoningEffort: "medium",
+                    description: "Duplicate",
+                  ),
+                ],
+                defaultReasoningEffort: "medium",
+                isDefault: false,
+              ),
+            ],
+            nextCursor: null,
+          ),
+        ),
+      );
+
+      final catalog = await repository.listModels();
+
+      expect(catalog.models.single.variants, ["medium", "low", "high"]);
+    });
+  });
+}
+
+class _StubClient extends CodexAppServerClient {
+  _StubClient({required this.response}) : super(serverUrl: "ws://127.0.0.1:0");
+
+  final Object? response;
+  String? method;
+  Object? params;
+
+  @override
+  Future<dynamic> request({
+    required String method,
+    Object? params,
+    Duration timeout = const Duration(seconds: 30),
+  }) async {
+    this.method = method;
+    this.params = params;
+    return response;
+  }
+}
+
+class _StubAppServerApi extends CodexAppServerApi {
+  _StubAppServerApi({required this.response})
+    : super(
+        client: CodexAppServerClient(serverUrl: "ws://127.0.0.1:0"),
+      );
+
+  final CodexModelListResponseDto response;
+
+  @override
+  Future<CodexModelListResponseDto> listModels() async => response;
+}

--- a/bridge/sesori_plugin_codex/test/codex_session_service_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_session_service_test.dart
@@ -6,6 +6,7 @@ import "package:codex_plugin/src/codex_metadata_repository.dart";
 import "package:codex_plugin/src/models/codex_collaboration_mode.dart";
 import "package:codex_plugin/src/repositories/codex_catalog_repository.dart";
 import "package:codex_plugin/src/repositories/codex_message_repository.dart";
+import "package:codex_plugin/src/repositories/codex_model_repository.dart";
 import "package:codex_plugin/src/repositories/codex_skill_repository.dart";
 import "package:codex_plugin/src/repositories/codex_thread_repository.dart";
 import "package:codex_plugin/src/repositories/models/codex_thread_record.dart";
@@ -19,6 +20,7 @@ void main() {
     final firstRepository = _StubThreadRepository();
     service.attachAppServerRepositories(
       threadRepository: firstRepository,
+      modelRepository: _StubModelRepository(),
       skillRepository: _StubSkillRepository(),
     );
     await service.resumeThreadIfNeeded(threadId: "thread-id", force: false);
@@ -27,6 +29,7 @@ void main() {
     final secondRepository = _StubThreadRepository();
     service.attachAppServerRepositories(
       threadRepository: secondRepository,
+      modelRepository: _StubModelRepository(),
       skillRepository: _StubSkillRepository(),
     );
     await service.resumeThreadIfNeeded(threadId: "thread-id", force: false);
@@ -49,6 +52,7 @@ void main() {
     );
     service.attachAppServerRepositories(
       threadRepository: threadRepository,
+      modelRepository: _StubModelRepository(),
       skillRepository: skillRepository,
     );
 
@@ -70,6 +74,7 @@ void main() {
     final service = _newService();
     service.attachAppServerRepositories(
       threadRepository: _StubThreadRepository(),
+      modelRepository: _StubModelRepository(),
       skillRepository: _StubSkillRepository(error: StateError("skills unavailable")),
     );
 
@@ -83,6 +88,7 @@ void main() {
     final threadRepository = _StubThreadRepository();
     service.attachAppServerRepositories(
       threadRepository: threadRepository,
+      modelRepository: _StubModelRepository(),
       skillRepository: _StubSkillRepository(),
     );
 
@@ -112,18 +118,150 @@ void main() {
     expect(threadRepository.compactCount, 1);
     expect(compacted.turnId, isNull);
   });
+
+  test("getSessionOptions uses one model catalog read for coherent agents and providers", () async {
+    final service = _newService(
+      metadataRepository: _StubMetadataRepository(
+        defaults: const CodexConfigDefaults(
+          model: "gpt-project",
+          modelProvider: "azure",
+        ),
+      ),
+    );
+    final modelRepository = _StubModelRepository(
+      catalog: (
+        defaultModelID: "gpt-default",
+        models: const [
+          PluginModel(
+            id: "gpt-default",
+            name: "Default model",
+            variants: [],
+            family: null,
+            isAvailable: true,
+            releaseDate: null,
+          ),
+          PluginModel(
+            id: "gpt-project",
+            name: "Project model",
+            variants: ["medium", "high"],
+            family: null,
+            isAvailable: true,
+            releaseDate: null,
+          ),
+        ],
+      ),
+    );
+    service.attachAppServerRepositories(
+      threadRepository: _StubThreadRepository(),
+      modelRepository: modelRepository,
+      skillRepository: _StubSkillRepository(
+        commands: const [
+          PluginCommand(
+            name: "review",
+            provider: null,
+            source: PluginCommandSource.skill,
+          ),
+        ],
+      ),
+    );
+
+    final options = await service.getSessionOptions(projectId: "/repo");
+
+    expect(modelRepository.listCount, 1);
+    expect(options.agents.map((agent) => agent.name), ["Default", "Plan"]);
+    expect(
+      options.agents.map((agent) => agent.model?.modelID),
+      everyElement("gpt-project"),
+    );
+    final provider = options.providers.providers.single;
+    expect(provider.id, "azure");
+    expect(provider.name, "Azure OpenAI");
+    expect(provider.defaultModelID, "gpt-project");
+    expect(provider.models.map((model) => model.id), [
+      "gpt-default",
+      "gpt-project",
+    ]);
+    expect(options.commands.map((command) => command.name), [
+      "review",
+      "compact",
+    ]);
+  });
+
+  test("model discovery failure retains the configured model fallback", () async {
+    final service = _newService(
+      metadataRepository: _StubMetadataRepository(
+        defaults: const CodexConfigDefaults(
+          model: "configured-model",
+          modelProvider: "openai",
+        ),
+      ),
+    );
+    service.attachAppServerRepositories(
+      threadRepository: _StubThreadRepository(),
+      modelRepository: _StubModelRepository(
+        error: StateError("models unavailable"),
+      ),
+      skillRepository: _StubSkillRepository(),
+    );
+
+    final providers = await service.getProviders(projectId: "/repo");
+
+    final provider = providers.providers.single;
+    expect(provider.defaultModelID, "configured-model");
+    expect(provider.models.single.id, "configured-model");
+    expect(provider.models.single.name, "configured-model");
+  });
 }
 
-CodexSessionService _newService() {
+CodexSessionService _newService({
+  CodexMetadataRepository? metadataRepository,
+}) {
   final rolloutApi = CodexRolloutApi(environment: const {});
   return CodexSessionService(
     catalogRepository: CodexCatalogRepository(rolloutApi: rolloutApi),
     messageRepository: CodexMessageRepository(rolloutApi: rolloutApi),
-    metadataRepository: CodexMetadataRepository(
-      configReader: CodexConfigReader(environment: const {}),
-    ),
+    metadataRepository:
+        metadataRepository ??
+        CodexMetadataRepository(
+          configReader: CodexConfigReader(environment: const {}),
+        ),
     launchDirectory: "/repo",
   );
+}
+
+class _StubMetadataRepository extends CodexMetadataRepository {
+  _StubMetadataRepository({required this.defaults}) : super(configReader: CodexConfigReader(environment: const {}));
+
+  final CodexConfigDefaults defaults;
+
+  @override
+  CodexConfigDefaults readConfigDefaults() => defaults;
+}
+
+class _StubModelRepository extends CodexModelRepository {
+  _StubModelRepository({
+    this.catalog = const (
+      defaultModelID: null,
+      models: <PluginModel>[],
+    ),
+    this.error,
+  }) : super(
+         appServerApi: CodexAppServerApi(
+           client: CodexAppServerClient(serverUrl: "ws://127.0.0.1:0"),
+         ),
+       );
+
+  final CodexModelCatalog catalog;
+  final Object? error;
+  int listCount = 0;
+
+  @override
+  Future<CodexModelCatalog> listModels() async {
+    listCount += 1;
+    final failure = error;
+    if (failure != null) throw failure;
+    return catalog;
+  }
 }
 
 class _StubSkillRepository extends CodexSkillRepository {


### PR DESCRIPTION
## Summary

- add Freezed/JSON DTOs plus typed API and repository ownership for Codex `model/list`
- centralize Codex agent, provider, model-default, reasoning-variant, and fallback decisions in `CodexSessionService`
- add a preparatory service aggregate that resolves agents, providers, and commands with one model-catalog request
- reduce the Codex plugin facade to existing route delegation without changing released wire contracts

## Behavior preserved and clarified

- hidden and invalid models remain excluded; blank display names fall back to model IDs
- project rollout/config defaults win when selectable, followed by the live catalog default and then its first visible model
- model-discovery failure remains observable and falls back to the configured model
- Default remains available without a model, while Plan requires a resolved model
- reasoning efforts preserve backend order, deduplicate tokens, and place the backend default first
- compact remains available when skill discovery fails and is not duplicated when advertised

## Verification

- `dart run build_runner build --delete-conflicting-outputs`
- `dart test test/codex_model_repository_test.dart test/codex_session_service_test.dart test/codex_metadata_repository_test.dart`
- `dart test` — all 201 tests passed
- `dart analyze --fatal-infos`
- targeted `dart format --output=none --set-exit-if-changed ...`
- `git diff --check`
- Aristotle implementation review: approved with no findings

## Series

Step 2/6 of `multi-plugin-release-prep`. Step 1 merged in #605. The next step adds the backend-neutral aggregate and scoped plugin contract across all plugin implementations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed Codex model catalog and centralized session-option discovery to make agents/providers consistent and simpler. Preserves catalog variants and default/fallback logic without changing public contracts.

- **New Features**
  - Added Freezed/JSON DTOs for the model catalog and a typed `listModels` method in `CodexAppServerApi`.
  - Introduced `CodexModelRepository` to map the catalog to `PluginModel`s and order/deduplicate reasoning variants with the backend default first.
  - Added `getSessionOptions` in `CodexSessionService` to resolve agents, providers, and commands with one catalog read.

- **Bug Fixes**
  - Providers now preserve the catalog’s variants for each model (no recomputation), keeping backend order with the default first.
  - Strictly validate `model/list` responses and reasoning options; reject non-object responses and non-list `supportedReasoningEfforts` to prevent bad data from propagating.

<sup>Written for commit 50f2ad540a8a2bd9f4941a421a91ac509f48fdeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

