### PR TITLE
Redesign the session chat composer text field

### DIFF
--- a/client/app/lib/features/new_session/new_session_screen.dart
+++ b/client/app/lib/features/new_session/new_session_screen.dart
@@ -244,6 +244,7 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
                             // leaving and returning to the new-session screen before
                             // a session exists; cleared once the session is created.
                             draftKey: "new-session:${widget.projectId}",
+                            hasMessages: false,
                             isBusy: state is NewSessionSending,
                             onSend: (String text, String? command) {
                               context.read<NewSessionCubit>().createSession(

--- a/client/app/lib/features/session_detail/widgets/composer_options_accordion.dart
+++ b/client/app/lib/features/session_detail/widgets/composer_options_accordion.dart
@@ -1,0 +1,118 @@
+import "package:flutter/material.dart";
+import "package:theme_prego/interactions/prego_tappable.dart";
+import "package:theme_prego/module_prego.dart";
+
+import "../../../core/extensions/build_context_x.dart";
+
+/// The composer's advanced-options drawer: a pill that holds a chevron toggle
+/// and expands accordion-style to reveal the actions that don't warrant a
+/// permanent spot in the composer — today just the slash-commands picker,
+/// later things like attaching files or images.
+class ComposerOptionsAccordion extends StatefulWidget {
+  /// Disables the revealed actions (not the toggle) while the composer is
+  /// recording or transcribing, mirroring the old always-visible slash button.
+  final bool actionsEnabled;
+  final VoidCallback onSlashCommandsTap;
+
+  const ComposerOptionsAccordion({
+    super.key,
+    required this.actionsEnabled,
+    required this.onSlashCommandsTap,
+  });
+
+  @override
+  State<ComposerOptionsAccordion> createState() => _ComposerOptionsAccordionState();
+}
+
+class _ComposerOptionsAccordionState extends State<ComposerOptionsAccordion> {
+  bool _isOpen = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    final loc = context.loc;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: prego.colors.bgSurface4,
+        borderRadius: BorderRadius.circular(PregoRadius.full),
+        border: Border.all(color: prego.colors.borderPrimary),
+        boxShadow: [
+          BoxShadow(color: prego.colors.shadowXs, offset: const Offset(0, 1), blurRadius: 2),
+        ],
+      ),
+      child: Padding(
+        // Chevron hugs the trailing edge (Figma: 3/2/6/2) so the pill reads as
+        // opening toward the field; revealed actions slide out on the leading
+        // side.
+        padding: const EdgeInsetsDirectional.fromSTEB(3, 2, 6, 2),
+        child: AnimatedSize(
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOutCubic,
+          alignment: AlignmentDirectional.centerEnd,
+          child: SizedBox(
+            height: 40,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (_isOpen) ...[
+                  _AccordionIconButton(
+                    icon: TablerRegular.slash,
+                    tooltip: loc.sessionDetailCommandPickerTitle,
+                    onTap: widget.actionsEnabled
+                        ? () {
+                            setState(() => _isOpen = false);
+                            widget.onSlashCommandsTap();
+                          }
+                        : null,
+                  ),
+                  const SizedBox(width: 2),
+                ],
+                _AccordionIconButton(
+                  icon: TablerRegular.chevron_right,
+                  tooltip: loc.sessionDetailMoreActions,
+                  rotated: _isOpen,
+                  onTap: () => setState(() => _isOpen = !_isOpen),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A 32pt transparent circular icon button used inside the accordion pill.
+class _AccordionIconButton extends StatelessWidget {
+  final IconData icon;
+  final String tooltip;
+  final bool rotated;
+  final VoidCallback? onTap;
+
+  const _AccordionIconButton({
+    required this.icon,
+    required this.tooltip,
+    required this.onTap,
+    this.rotated = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    return Tooltip(
+      message: tooltip,
+      child: PregoTappable(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(PregoRadius.full),
+        containerBuilder: (Widget child) => SizedBox.square(dimension: 32, child: child),
+        child: AnimatedRotation(
+          turns: rotated ? 0.5 : 0,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOutCubic,
+          child: Icon(icon, size: 18, color: prego.colors.textPrimary),
+        ),
+      ),
+    );
+  }
+}

--- a/client/app/lib/features/session_detail/widgets/composer_options_accordion.dart
+++ b/client/app/lib/features/session_detail/widgets/composer_options_accordion.dart
@@ -70,7 +70,7 @@ class _ComposerOptionsAccordionState extends State<ComposerOptionsAccordion> {
                 ],
                 _AccordionIconButton(
                   icon: TablerRegular.chevron_right,
-                  tooltip: loc.sessionDetailMoreActions,
+                  tooltip: _isOpen ? loc.sessionDetailHideActions : loc.sessionDetailMoreActions,
                   rotated: _isOpen,
                   onTap: () => setState(() => _isOpen = !_isOpen),
                 ),

--- a/client/app/lib/features/session_detail/widgets/composer_options_accordion.dart
+++ b/client/app/lib/features/session_detail/widgets/composer_options_accordion.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
 import "package:theme_prego/interactions/prego_tappable.dart";
 import "package:theme_prego/module_prego.dart";
 
@@ -8,6 +9,10 @@ import "../../../core/extensions/build_context_x.dart";
 /// and expands accordion-style to reveal the actions that don't warrant a
 /// permanent spot in the composer — today just the slash-commands picker,
 /// later things like attaching files or images.
+///
+/// Styled after the Figma `View options actions left` component: closed it
+/// reads as a single round `pregoButtonsSolid` (44pt, skeuomorphic surface);
+/// opened, each option is an icon button sharing that one joined background.
 class ComposerOptionsAccordion extends StatefulWidget {
   /// Disables the revealed actions (not the toggle) while the composer is
   /// recording or transcribing, mirroring the old always-visible slash button.
@@ -41,42 +46,52 @@ class _ComposerOptionsAccordionState extends State<ComposerOptionsAccordion> {
           BoxShadow(color: prego.colors.shadowXs, offset: const Offset(0, 1), blurRadius: 2),
         ],
       ),
-      child: Padding(
-        // Chevron hugs the trailing edge (Figma: 3/2/6/2) so the pill reads as
-        // opening toward the field; revealed actions slide out on the leading
-        // side.
-        padding: const EdgeInsetsDirectional.fromSTEB(3, 2, 6, 2),
-        child: AnimatedSize(
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.easeOutCubic,
-          alignment: AlignmentDirectional.centerEnd,
-          child: SizedBox(
-            height: 40,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                if (_isOpen) ...[
-                  _AccordionIconButton(
-                    icon: TablerRegular.slash,
-                    tooltip: loc.sessionDetailCommandPickerTitle,
-                    onTap: widget.actionsEnabled
-                        ? () {
-                            setState(() => _isOpen = false);
-                            widget.onSlashCommandsTap();
-                          }
-                        : null,
-                  ),
-                  const SizedBox(width: 2),
-                ],
-                _AccordionIconButton(
-                  icon: TablerRegular.chevron_right,
-                  tooltip: _isOpen ? loc.sessionDetailHideActions : loc.sessionDetailMoreActions,
-                  rotated: _isOpen,
-                  onTap: () => setState(() => _isOpen = !_isOpen),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(PregoRadius.full),
+        child: Stack(
+          children: [
+            Padding(
+              // 6pt insets centre the 32pt buttons in a 44pt-tall pill, so the
+              // closed state is exactly the 44pt circle of the solid-button
+              // neighbours. The chevron anchors at the trailing edge; revealed
+              // actions slide out on the leading side, toward the field's
+              // leading edge.
+              padding: const EdgeInsets.all(PregoSpacing.sm),
+              child: AnimatedSize(
+                duration: const Duration(milliseconds: 200),
+                curve: Curves.easeOutCubic,
+                alignment: AlignmentDirectional.centerEnd,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (_isOpen) ...[
+                      _AccordionIconButton(
+                        icon: TablerRegular.slash,
+                        tooltip: loc.sessionDetailCommandPickerTitle,
+                        onTap: widget.actionsEnabled
+                            ? () {
+                                setState(() => _isOpen = false);
+                                widget.onSlashCommandsTap();
+                              }
+                            : null,
+                      ),
+                      const SizedBox(width: PregoSpacing.md),
+                    ],
+                    _AccordionIconButton(
+                      icon: TablerRegular.chevron_right,
+                      tooltip: _isOpen ? loc.sessionDetailHideActions : loc.sessionDetailMoreActions,
+                      rotated: _isOpen,
+                      onTap: () => setState(() => _isOpen = !_isOpen),
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
-          ),
+            PregoSkeuomorphicOverlay(
+              innerBorderColor: prego.colors.skeuomorphicInnerBorder,
+              bottomShadowColor: prego.colors.skeuomorphicShadow,
+            ),
+          ],
         ),
       ),
     );

--- a/client/app/lib/features/session_detail/widgets/prompt_editor_sheet.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_editor_sheet.dart
@@ -1,0 +1,72 @@
+import "dart:math" as math;
+
+import "package:flutter/material.dart";
+import "package:theme_prego/module_prego.dart";
+
+import "../../../core/extensions/build_context_x.dart";
+
+/// Fullscreen editor for the composer text, opened from the composer's
+/// expand button so long prompts can be read and edited comfortably.
+///
+/// Shares the composer's [TextEditingController], so edits flow straight back
+/// into the inline field; dismissing the sheet returns to the composer with
+/// the text (and any in-progress draft persistence) untouched.
+class PromptEditorSheet extends StatelessWidget {
+  final TextEditingController controller;
+  final String placeholder;
+
+  const PromptEditorSheet({
+    super.key,
+    required this.controller,
+    required this.placeholder,
+  });
+
+  static Future<void> show(
+    BuildContext context, {
+    required TextEditingController controller,
+    required String placeholder,
+  }) {
+    // Status-bar inset, captured before presenting: the modal route strips
+    // the top inset from both `padding` and `viewPadding`, so inside the
+    // sheet it reads as 0.
+    final topInset = MediaQuery.paddingOf(context).top;
+    return showPregoBottomSheet<void>(
+      context: context,
+      title: context.loc.sessionDetailEditorTitle,
+      builder: (sheetContext) {
+        // Fill the space between the status bar and the keyboard so the sheet
+        // always rises to full height; the field hosts its own scrolling, so
+        // it needs this bounded height (the sheet re-adds the keyboard inset
+        // below the body).
+        final screenHeight = MediaQuery.heightOf(sheetContext);
+        final keyboard = MediaQuery.viewInsetsOf(sheetContext).bottom;
+        final height = screenHeight - topInset - PregoBottomSheet.contentTopInset - keyboard;
+        return SizedBox(
+          height: math.max(height, screenHeight * 0.3),
+          child: PromptEditorSheet(controller: controller, placeholder: placeholder),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    return TextField(
+      controller: controller,
+      autofocus: true,
+      expands: true,
+      maxLines: null,
+      textAlignVertical: TextAlignVertical.top,
+      keyboardType: TextInputType.multiline,
+      textInputAction: TextInputAction.newline,
+      style: prego.textTheme.textMd.regular.copyWith(color: prego.colors.textPrimary),
+      decoration: InputDecoration(
+        isCollapsed: true,
+        border: InputBorder.none,
+        hintText: placeholder,
+        hintStyle: prego.textTheme.textMd.regular.copyWith(color: prego.colors.textSecondary),
+      ),
+    );
+  }
+}

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -93,6 +93,12 @@ class _PromptInputState extends State<PromptInput> {
   /// instead of letting it outlive the gesture.
   bool _releaseRequestedDuringStart = false;
 
+  /// True while [_startRecording] is awaiting the recorder ([_voiceState] is
+  /// still idle then). Guards against a second start — a concurrent hold on
+  /// the other surface or a repeated assistive-tech activation — and routes
+  /// those to the release path instead.
+  bool _isRecordStartInFlight = false;
+
   VoiceTranscriptionService get _voiceService => getIt<VoiceTranscriptionService>();
 
   @override
@@ -249,10 +255,12 @@ class _PromptInputState extends State<PromptInput> {
   }
 
   Future<void> _handleRecordStart() async {
-    if (_voiceState != _VoiceState.idle) return;
+    if (_voiceState != _VoiceState.idle || _isRecordStartInFlight) return;
+    _isRecordStartInFlight = true;
     _releaseRequestedDuringStart = false;
     _pinnedVoiceLayout = _restingLayout;
     await _startRecording();
+    _isRecordStartInFlight = false;
     if (!mounted) return;
     if (_voiceState == _VoiceState.idle) {
       // Recording never started (permission denied / recorder error), so no
@@ -278,9 +286,11 @@ class _PromptInputState extends State<PromptInput> {
   }
 
   /// Assistive-technology activation: a semantic tap cannot express the
-  /// press-and-hold gesture, so activation toggles recording instead.
+  /// press-and-hold gesture, so activation toggles recording instead. An
+  /// activation while the recorder is still starting up counts as the stop
+  /// half of the toggle, not another start.
   Future<void> _handleSemanticRecordToggle() async {
-    if (_voiceState == _VoiceState.recording) {
+    if (_voiceState == _VoiceState.recording || _isRecordStartInFlight) {
       await _handleRecordEnd();
     } else {
       await _handleRecordStart();

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -88,6 +88,11 @@ class _PromptInputState extends State<PromptInput> {
   /// and never receive the release.
   _ComposerLayout? _pinnedVoiceLayout;
 
+  /// Set when the hold is released while [_startRecording] is still awaiting
+  /// the recorder, so the start path stops immediately once recording begins
+  /// instead of letting it outlive the gesture.
+  bool _releaseRequestedDuringStart = false;
+
   VoiceTranscriptionService get _voiceService => getIt<VoiceTranscriptionService>();
 
   @override
@@ -183,7 +188,11 @@ class _PromptInputState extends State<PromptInput> {
   /// voice interaction.
   _ComposerLayout get _restingLayout {
     if (_showsTypingLayout) return _ComposerLayout.typing;
-    return widget.hasMessages ? _ComposerLayout.compact : _ComposerLayout.holdToTalk;
+    // A busy session is past its fresh state even while the first message
+    // hasn't landed in the list yet (e.g. it was sent from another device) —
+    // resting compact keeps the stop control reachable.
+    if (widget.hasMessages || widget.isBusy) return _ComposerLayout.compact;
+    return _ComposerLayout.holdToTalk;
   }
 
   _ComposerLayout get _layout => _pinnedVoiceLayout ?? _restingLayout;
@@ -241,18 +250,41 @@ class _PromptInputState extends State<PromptInput> {
 
   Future<void> _handleRecordStart() async {
     if (_voiceState != _VoiceState.idle) return;
+    _releaseRequestedDuringStart = false;
     _pinnedVoiceLayout = _restingLayout;
     await _startRecording();
-    if (mounted && _voiceState == _VoiceState.idle) {
+    if (!mounted) return;
+    if (_voiceState == _VoiceState.idle) {
       // Recording never started (permission denied / recorder error), so no
       // later transition will release the pin.
       setState(() => _pinnedVoiceLayout = null);
+    } else if (_releaseRequestedDuringStart) {
+      // The hold ended while the recorder was still starting up — stop right
+      // away so recording never outlives the gesture.
+      await _stopAndTranscribe();
     }
   }
 
   Future<void> _handleRecordEnd() async {
+    if (_voiceState == _VoiceState.idle) {
+      // The release raced a recorder that is still starting up (or was a
+      // stray pointer event); [_handleRecordStart] consumes this after the
+      // start completes.
+      _releaseRequestedDuringStart = true;
+      return;
+    }
     if (_voiceState != _VoiceState.recording) return;
     await _stopAndTranscribe();
+  }
+
+  /// Assistive-technology activation: a semantic tap cannot express the
+  /// press-and-hold gesture, so activation toggles recording instead.
+  Future<void> _handleSemanticRecordToggle() async {
+    if (_voiceState == _VoiceState.recording) {
+      await _handleRecordEnd();
+    } else {
+      await _handleRecordStart();
+    }
   }
 
   Future<void> _startRecording() async {
@@ -487,20 +519,31 @@ class _PromptInputState extends State<PromptInput> {
           Expanded(
             // The detector wraps the voice-aware slot (not the other way
             // around) so it stays mounted when the recording indicator swaps
-            // in and still receives the release that ends the hold.
+            // in and still receives the release that ends the hold. Semantic
+            // taps toggle recording — assistive technologies cannot express
+            // the press-and-hold gesture.
             child: Semantics(
               button: true,
               label: loc.sessionDetailHoldToTalk,
-              child: GestureDetector(
-                behavior: HitTestBehavior.opaque,
-                onLongPressStart: (_) => _handleRecordStart(),
-                onLongPressEnd: (_) => _handleRecordEnd(),
-                child: _buildVoiceAwareSlot(
-                  height: _actionButtonSize,
-                  idle: Center(
-                    child: Text(
-                      loc.sessionDetailHoldToTalk,
-                      style: prego.textTheme.textMd.regular.copyWith(color: prego.colors.textSecondary),
+              excludeSemantics: true,
+              onTap: _handleSemanticRecordToggle,
+              child: Listener(
+                // A pointer cancel mid-hold (incoming call, system gesture)
+                // resets the accepted long-press silently — no onLongPressEnd
+                // — so the raw pointer stream is the only place to keep the
+                // recording bounded by the gesture.
+                onPointerCancel: (_) => _handleRecordEnd(),
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onLongPressStart: (_) => _handleRecordStart(),
+                  onLongPressEnd: (_) => _handleRecordEnd(),
+                  child: _buildVoiceAwareSlot(
+                    height: _actionButtonSize,
+                    idle: Center(
+                      child: Text(
+                        loc.sessionDetailHoldToTalk,
+                        style: prego.textTheme.textMd.regular.copyWith(color: prego.colors.textSecondary),
+                      ),
                     ),
                   ),
                 ),
@@ -708,18 +751,27 @@ class _PromptInputState extends State<PromptInput> {
     // No Tooltip here: its long-press trigger would race the recording hold.
     // The button keeps its enabled look and swallows plain taps via
     // [_ignoreTap]; holds outlast the tap recognizer, so the surrounding
-    // detector wins the arena and drives the recording.
+    // detector wins the arena and drives the recording. Semantic taps toggle
+    // recording — assistive technologies cannot express the hold.
     return Semantics(
       button: true,
       label: loc.voiceRecord,
-      child: GestureDetector(
-        onLongPressStart: (_) => _handleRecordStart(),
-        onLongPressEnd: (_) => _handleRecordEnd(),
-        child: const PregoButtonsSolid.iconOnly(
-          leadingIcon: TablerRegular.microphone,
-          hierarchy: PregoButtonsSolidHierarchy.secondary,
-          size: PregoButtonsSolidSize.lg,
-          onPressed: _ignoreTap,
+      excludeSemantics: true,
+      onTap: _handleSemanticRecordToggle,
+      child: Listener(
+        // A pointer cancel mid-hold resets the accepted long-press silently —
+        // no onLongPressEnd — so the raw pointer stream is the only place to
+        // keep the recording bounded by the gesture.
+        onPointerCancel: (_) => _handleRecordEnd(),
+        child: GestureDetector(
+          onLongPressStart: (_) => _handleRecordStart(),
+          onLongPressEnd: (_) => _handleRecordEnd(),
+          child: const PregoButtonsSolid.iconOnly(
+            leadingIcon: TablerRegular.microphone,
+            hierarchy: PregoButtonsSolidHierarchy.secondary,
+            size: PregoButtonsSolidSize.lg,
+            onPressed: _ignoreTap,
+          ),
         ),
       ),
     );

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -6,6 +6,8 @@ import "package:flutter/services.dart";
 import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
+import "package:theme_prego/interactions/prego_tappable.dart";
 import "package:theme_prego/module_prego.dart";
 
 import "../../../capabilities/voice/voice_transcription_service.dart";
@@ -13,11 +15,22 @@ import "../../../core/constants.dart";
 import "../../../core/di/injection.dart";
 import "../../../core/extensions/build_context_x.dart";
 import "../../../core/widgets/command_picker_sheet.dart";
+import "composer_options_accordion.dart";
+import "prompt_editor_sheet.dart";
 
 enum _VoiceState { idle, recording, transcribing }
 
+/// The composer's three visual states: the fresh-session hold-to-talk pill,
+/// the compact follow-up pill, and the expanded typing container.
+enum _ComposerLayout { holdToTalk, compact, typing }
+
 class PromptInput extends StatefulWidget {
   final bool isBusy;
+
+  /// Whether the session already has (or has queued) messages. A fresh
+  /// session opens with the hold-to-talk pill; once messages exist the
+  /// composer rests as a compact "Follow up" field instead.
+  final bool hasMessages;
   final void Function(String text, String? command) onSend;
   final VoidCallback onAbort;
   final Widget? composerHeader;
@@ -37,6 +50,7 @@ class PromptInput extends StatefulWidget {
   const PromptInput({
     super.key,
     required this.isBusy,
+    required this.hasMessages,
     required this.onSend,
     required this.onAbort,
     required this.composerHeader,
@@ -58,12 +72,31 @@ class _PromptInputState extends State<PromptInput> {
   _VoiceState _voiceState = _VoiceState.idle;
   StreamSubscription<void>? _maxDurationSub;
 
+  /// Keeps the typing layout mounted after the keyboard affordance was tapped
+  /// while the field wasn't in the tree yet (hold-to-talk / compact layouts),
+  /// until the post-frame focus request lands. Cleared when focus leaves.
+  bool _typingRequested = false;
+
+  /// Whether the field holds sendable text. Mirrored into state so the
+  /// composer only rebuilds when emptiness flips (layout + send/stop swap),
+  /// not on every keystroke.
+  bool _hasText = false;
+
+  /// Layout pinned for the duration of a voice interaction. Swapping the
+  /// field slot for the recording/transcribing indicators must not relayout
+  /// the composer mid-hold — the gesture-owning elements would be reparented
+  /// and never receive the release.
+  _ComposerLayout? _pinnedVoiceLayout;
+
   VoiceTranscriptionService get _voiceService => getIt<VoiceTranscriptionService>();
 
   @override
   void initState() {
     super.initState();
     _restoreDraft();
+    _hasText = _controller.text.trim().isNotEmpty;
+    _controller.addListener(_handleTextChanged);
+    _focusNode.addListener(_handleFocusChanged);
     _maxDurationSub = _voiceService.onMaxDurationReached.listen((_) {
       if (_voiceState == _VoiceState.recording && mounted) {
         _showRecordingLimitReached();
@@ -125,6 +158,55 @@ class _PromptInputState extends State<PromptInput> {
     store.clear(key);
   }
 
+  void _handleTextChanged() {
+    final hasText = _controller.text.trim().isNotEmpty;
+    if (hasText != _hasText && mounted) {
+      setState(() => _hasText = hasText);
+    }
+  }
+
+  void _handleFocusChanged() {
+    if (!mounted) return;
+    // Rebuild on both edges: gaining focus keeps the typing layout up via the
+    // focus check; losing it (with nothing to show) collapses back to the
+    // resting pill.
+    setState(() {
+      if (!_focusNode.hasFocus) _typingRequested = false;
+    });
+  }
+
+  /// Whether the expanded typing container is showing (vs. the resting
+  /// hold-to-talk / compact pills).
+  bool get _showsTypingLayout => _typingRequested || _focusNode.hasFocus || _hasText || widget.stagedCommand != null;
+
+  /// The layout the composer would rest in right now, ignoring any pinned
+  /// voice interaction.
+  _ComposerLayout get _restingLayout {
+    if (_showsTypingLayout) return _ComposerLayout.typing;
+    return widget.hasMessages ? _ComposerLayout.compact : _ComposerLayout.holdToTalk;
+  }
+
+  _ComposerLayout get _layout => _pinnedVoiceLayout ?? _restingLayout;
+
+  bool get _hasSendableContent => _hasText || widget.stagedCommand != null;
+
+  /// Switches to the typing layout and raises the keyboard. Focus is
+  /// requested post-frame because the field only mounts with the typing
+  /// layout.
+  void _enterTypingMode() {
+    if (_voiceState != _VoiceState.idle) return;
+    setState(() => _typingRequested = true);
+    _focusComposerField();
+  }
+
+  /// Requests focus after the current frame, so it also works right after a
+  /// rebuild that (re)mounts the typing layout's field.
+  void _focusComposerField() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _focusNode.requestFocus();
+    });
+  }
+
   void _handleSend() {
     final stagedCommand = widget.stagedCommand;
     if (stagedCommand != null) {
@@ -153,19 +235,24 @@ class _PromptInputState extends State<PromptInput> {
       _restoreDraftFor(widget.draftKey);
     }
     if (oldWidget.stagedCommand?.name != widget.stagedCommand?.name && widget.stagedCommand != null) {
-      _focusNode.requestFocus();
+      _focusComposerField();
     }
   }
 
-  Future<void> _handleMicTap() async {
-    switch (_voiceState) {
-      case _VoiceState.idle:
-        await _startRecording();
-      case _VoiceState.recording:
-        await _stopAndTranscribe();
-      case _VoiceState.transcribing:
-        await _cancelTranscription();
+  Future<void> _handleRecordStart() async {
+    if (_voiceState != _VoiceState.idle) return;
+    _pinnedVoiceLayout = _restingLayout;
+    await _startRecording();
+    if (mounted && _voiceState == _VoiceState.idle) {
+      // Recording never started (permission denied / recorder error), so no
+      // later transition will release the pin.
+      setState(() => _pinnedVoiceLayout = null);
     }
+  }
+
+  Future<void> _handleRecordEnd() async {
+    if (_voiceState != _VoiceState.recording) return;
+    await _stopAndTranscribe();
   }
 
   Future<void> _startRecording() async {
@@ -199,7 +286,9 @@ class _PromptInputState extends State<PromptInput> {
       }
       // Move cursor to end.
       _controller.selection = TextSelection.collapsed(offset: _controller.text.length);
-      _focusNode.requestFocus();
+      // The transcript lands in the typing layout, whose field may only mount
+      // with this rebuild — focus once it exists.
+      _focusComposerField();
     } on TranscriptionCancelledError {
       // User cancelled — nothing to do, finally resets state.
     } on NotAuthenticatedVoiceError {
@@ -214,7 +303,10 @@ class _PromptInputState extends State<PromptInput> {
       _showVoiceError(context.loc.voiceErrorTranscription);
     } finally {
       if (mounted) {
-        setState(() => _voiceState = _VoiceState.idle);
+        setState(() {
+          _voiceState = _VoiceState.idle;
+          _pinnedVoiceLayout = null;
+        });
       }
     }
   }
@@ -226,7 +318,10 @@ class _PromptInputState extends State<PromptInput> {
       loge("Failed to cancel transcription", error);
     }
     if (!mounted) return;
-    setState(() => _voiceState = _VoiceState.idle);
+    setState(() {
+      _voiceState = _VoiceState.idle;
+      _pinnedVoiceLayout = null;
+    });
   }
 
   void _showVoiceError(String message) {
@@ -258,23 +353,36 @@ class _PromptInputState extends State<PromptInput> {
     );
     if (!mounted || selected == null) return;
     widget.onCommandSelected(selected);
-    _focusNode.requestFocus();
+    _focusComposerField();
   }
 
-  String _commandHintText(BuildContext context) {
+  Future<void> _openEditorSheet() async {
+    await PromptEditorSheet.show(
+      context,
+      controller: _controller,
+      placeholder: _hintText(context),
+    );
+    if (!mounted) return;
+    // Return the keyboard to the inline field. Via [_enterTypingMode] because
+    // an empty composer collapses to a pill while the sheet holds focus.
+    _enterTypingMode();
+  }
+
+  String _hintText(BuildContext context) {
     final command = widget.stagedCommand;
-    if (command == null) return context.loc.sessionDetailPromptHint;
-    for (final hint in command.hints ?? <String>[]) {
-      final trimmed = hint.trim();
-      if (trimmed.isNotEmpty) return trimmed;
+    if (command != null) {
+      for (final hint in command.hints ?? <String>[]) {
+        final trimmed = hint.trim();
+        if (trimmed.isNotEmpty) return trimmed;
+      }
+      return context.loc.sessionDetailCommandArgumentsHint;
     }
-    return context.loc.sessionDetailCommandArgumentsHint;
+    return widget.hasMessages ? context.loc.sessionDetailFollowUpHint : context.loc.sessionDetailPromptHint;
   }
 
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
-    final loc = context.loc;
 
     return DecoratedBox(
       // Floating composer: no bar surface, no separator line. The scaffold
@@ -282,7 +390,7 @@ class _PromptInputState extends State<PromptInput> {
       // dissolves as it scrolls past — the same scrim the glass top navigation
       // bar uses (PregoGlassScaffold), mirrored to the bottom edge: opaque
       // where the controls sit, transparent where content emerges above. The
-      // controls keep their own glass.
+      // controls keep their own surfaces.
       decoration: BoxDecoration(
         gradient: LinearGradient(
           begin: Alignment.center,
@@ -314,7 +422,7 @@ class _PromptInputState extends State<PromptInput> {
             ),
           },
 
-          // Group only the input row with the text field via a
+          // Group only the input container with the text field via a
           // TextFieldTapRegion. The field's default `onTapOutside` unfocuses
           // (and dismisses the keyboard) on any pointer-down outside this
           // region; keeping the send button inside stops the hide/re-show
@@ -328,121 +436,326 @@ class _PromptInputState extends State<PromptInput> {
                 top: widget.header != null ? 4 : 8,
                 bottom: MediaQuery.paddingOf(context).bottom + 8,
               ),
-              child: Row(
-                spacing: 8,
-                crossAxisAlignment: .end,
-                children: [
-                  PregoButtonsIconGlass(
-                    onPressed: _voiceState == _VoiceState.idle ? _openCommandPicker : null,
-                    icon: TablerRegular.slash,
-                    semanticLabel: loc.sessionDetailCommandPickerTitle,
-                  ),
-                  Expanded(
-                    child: switch (_voiceState) {
-                      _VoiceState.recording => _RecordingIndicator(amplitudeStream: _voiceService.amplitudeStream),
-                      _VoiceState.transcribing => const _TranscribingIndicator(),
-                      _VoiceState.idle => CallbackShortcuts(
-                        // Cmd/Ctrl+Enter sends (handy with a hardware keyboard);
-                        // plain Enter stays a newline via textInputAction below.
-                        bindings: <ShortcutActivator, VoidCallback>{
-                          const SingleActivator(LogicalKeyboardKey.enter, meta: true): _handleSend,
-                          const SingleActivator(LogicalKeyboardKey.enter, control: true): _handleSend,
-                        },
-                        child: GlassTextField(
-                          controller: _controller,
-                          focusNode: _focusNode,
-                          minLines: 1,
-                          maxLines: 5,
-                          textInputAction: TextInputAction.newline,
-                          // Command-aware placeholder: the staged command's hint,
-                          // else the default prompt hint. The glass field supplies
-                          // its own surface/fill/border, so only the hint text
-                          // carries over from the old InputDecoration.
-                          placeholder: _commandHintText(context),
-                        ),
-                      ),
-                    },
-                  ),
-                  _MicButton(
-                    voiceState: _voiceState,
-                    onTap: _handleMicTap,
-                  ),
-                  if (_voiceState == _VoiceState.idle) ...[
-                    // GlassIconButton has no tooltip/semanticLabel, so wrap it in
-                    // a Tooltip to restore the long-press/hover label and the
-                    // screen-reader name the old IconButton carried.
-                    Tooltip(
-                      message: loc.sessionDetailSend,
-                      child: GlassIconButton(
-                        onPressed: _handleSend,
-                        icon: const Icon(Icons.send),
-                        glowColor: prego.colors.bgBrandSolid,
-                      ),
-                    ),
-                    if (widget.isBusy)
-                      Tooltip(
-                        message: loc.sessionDetailAbort,
-                        child: GlassIconButton(
-                          onPressed: widget.onAbort,
-                          icon: const Icon(Icons.stop_circle),
-                          glowColor: prego.colors.fgErrorPrimary,
-                        ),
-                      ),
-                  ],
-                ],
-              ),
+              child: switch (_layout) {
+                _ComposerLayout.typing => _buildTypingComposer(context),
+                _ComposerLayout.compact => _buildCompactComposer(context),
+                _ComposerLayout.holdToTalk => _buildHoldToTalkComposer(context),
+              },
             ),
           ),
         ],
       ),
     );
   }
-}
 
-// -----------------------------------------------------------------------------
-// Mic button
-// -----------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // Composer layouts
+  // ---------------------------------------------------------------------------
 
-class _MicButton extends StatelessWidget {
-  final _VoiceState voiceState;
-  final VoidCallback onTap;
+  BoxDecoration _containerDecoration(
+    PregoDesignSystem prego, {
+    required Color borderColor,
+    required double radius,
+  }) {
+    return BoxDecoration(
+      color: prego.colors.bgSurface2,
+      borderRadius: BorderRadius.circular(radius),
+      border: Border.all(color: borderColor),
+      boxShadow: [
+        BoxShadow(color: prego.colors.shadowXs, offset: const Offset(0, 1), blurRadius: 2),
+      ],
+    );
+  }
 
-  const _MicButton({required this.voiceState, required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
+  /// Fresh-session resting state: one pill whose whole centre is a
+  /// press-and-hold voice target, with a keyboard button to switch to typing.
+  Widget _buildHoldToTalkComposer(BuildContext context) {
     final prego = context.prego;
     final loc = context.loc;
 
-    // GlassIconButton exposes no tooltip/semanticLabel, so wrap each state's
-    // button in a Tooltip to keep the long-press/hover label and screen-reader
-    // name the old IconButton provided.
-    return switch (voiceState) {
-      _VoiceState.idle => Tooltip(
-        message: loc.voiceRecord,
-        child: GlassIconButton(
-          onPressed: onTap,
-          icon: const Icon(Icons.mic_none),
-          glowColor: prego.colors.textSecondary,
-        ),
+    return Container(
+      padding: const EdgeInsets.all(PregoSpacing.sm),
+      decoration: _containerDecoration(
+        prego,
+        borderColor: prego.colors.borderSecondary,
+        radius: PregoRadius.full,
       ),
-      _VoiceState.recording => Tooltip(
-        message: loc.voiceStopRecording,
-        child: GlassIconButton(
-          onPressed: onTap,
-          icon: const Icon(Icons.stop_circle_outlined),
-          glowColor: prego.colors.fgErrorPrimary,
-        ),
+      child: Row(
+        spacing: PregoSpacing.md,
+        children: [
+          _buildOptionsAccordion(),
+          Expanded(
+            // The detector wraps the voice-aware slot (not the other way
+            // around) so it stays mounted when the recording indicator swaps
+            // in and still receives the release that ends the hold.
+            child: Semantics(
+              button: true,
+              label: loc.sessionDetailHoldToTalk,
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onLongPressStart: (_) => _handleRecordStart(),
+                onLongPressEnd: (_) => _handleRecordEnd(),
+                child: _buildVoiceAwareSlot(
+                  height: _actionButtonSize,
+                  idle: Center(
+                    child: Text(
+                      loc.sessionDetailHoldToTalk,
+                      style: prego.textTheme.textMd.regular.copyWith(color: prego.colors.textSecondary),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Tooltip(
+            message: loc.sessionDetailTypeMessage,
+            child: PregoButtonsSolid.iconOnly(
+              leadingIcon: TablerRegular.keyboard,
+              hierarchy: PregoButtonsSolidHierarchy.secondary,
+              size: PregoButtonsSolidSize.lg,
+              onPressed: _enterTypingMode,
+            ),
+          ),
+        ],
       ),
-      _VoiceState.transcribing => Tooltip(
-        message: loc.voiceCancelTranscription,
-        child: GlassIconButton(
-          onPressed: onTap,
-          icon: const Icon(Icons.close),
-          glowColor: prego.colors.fgErrorPrimary,
-        ),
+    );
+  }
+
+  /// Resting state once the session has messages: a compact pill whose field
+  /// area invites a follow-up, with mic and send/stop alongside.
+  Widget _buildCompactComposer(BuildContext context) {
+    final prego = context.prego;
+
+    return Container(
+      padding: const EdgeInsets.all(PregoSpacing.sm),
+      decoration: _containerDecoration(
+        prego,
+        borderColor: prego.colors.borderPrimary,
+        radius: PregoRadius.full,
       ),
+      child: Row(
+        spacing: PregoSpacing.md,
+        children: [
+          _buildOptionsAccordion(),
+          Expanded(
+            child: _buildVoiceAwareSlot(
+              height: _actionButtonSize,
+              idle: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: _enterTypingMode,
+                child: Align(
+                  alignment: AlignmentDirectional.centerStart,
+                  child: Padding(
+                    padding: const EdgeInsetsDirectional.only(start: PregoSpacing.xs),
+                    child: Text(
+                      _hintText(context),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: prego.textTheme.textMd.regular.copyWith(color: prego.colors.textSecondary),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Row(
+            spacing: PregoSpacing.sm,
+            children: [
+              _buildMicButton(context),
+              _buildPrimaryActionButton(context),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// The expanded typing container: multiline field with the fullscreen-editor
+  /// button in its top-right corner, and the action row below.
+  Widget _buildTypingComposer(BuildContext context) {
+    final prego = context.prego;
+    final loc = context.loc;
+
+    return Container(
+      padding: const EdgeInsets.all(PregoSpacing.sm),
+      decoration: _containerDecoration(
+        prego,
+        borderColor: prego.colors.borderPrimary,
+        radius: PregoRadius.x3l,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        spacing: PregoSpacing.md,
+        children: [
+          Stack(
+            children: [
+              Padding(
+                // Clear the expand button on the trailing edge so text never
+                // runs underneath it.
+                padding: const EdgeInsetsDirectional.fromSTEB(PregoSpacing.xs, 0, 36, 0),
+                child: _buildVoiceAwareSlot(
+                  height: null,
+                  idle: CallbackShortcuts(
+                    // Cmd/Ctrl+Enter sends (handy with a hardware keyboard);
+                    // plain Enter stays a newline via textInputAction below.
+                    bindings: <ShortcutActivator, VoidCallback>{
+                      const SingleActivator(LogicalKeyboardKey.enter, meta: true): _handleSend,
+                      const SingleActivator(LogicalKeyboardKey.enter, control: true): _handleSend,
+                    },
+                    child: TextField(
+                      controller: _controller,
+                      focusNode: _focusNode,
+                      minLines: 1,
+                      maxLines: 6,
+                      keyboardType: TextInputType.multiline,
+                      textInputAction: TextInputAction.newline,
+                      // Material's default keeps focus on mobile touch taps;
+                      // this composer wants outside taps (e.g. the picker
+                      // pills above the region) to dismiss the keyboard — the
+                      // behaviour the TextFieldTapRegion grouping was built
+                      // around.
+                      onTapOutside: (_) => _focusNode.unfocus(),
+                      style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textPrimary),
+                      decoration: InputDecoration(
+                        isCollapsed: true,
+                        border: InputBorder.none,
+                        contentPadding: const EdgeInsets.symmetric(vertical: PregoSpacing.md),
+                        // Command-aware placeholder: the staged command's hint,
+                        // else the follow-up/default prompt hint.
+                        hintText: _hintText(context),
+                        hintStyle: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textSecondary),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              PositionedDirectional(
+                top: 0,
+                end: 0,
+                child: Tooltip(
+                  message: loc.sessionDetailExpandEditor,
+                  child: PregoTappable(
+                    onTap: _voiceState == _VoiceState.idle ? _openEditorSheet : null,
+                    borderRadius: BorderRadius.circular(PregoRadius.full),
+                    containerBuilder: (Widget child) => SizedBox.square(dimension: 32, child: child),
+                    child: Icon(TablerRegular.maximize, size: 18, color: prego.colors.textSecondary),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          Row(
+            children: [
+              _buildOptionsAccordion(),
+              const Spacer(),
+              _buildMicButton(context),
+              const SizedBox(width: PregoSpacing.sm),
+              _buildPrimaryActionButton(context),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Shared pieces
+  // ---------------------------------------------------------------------------
+
+  /// The mic / send buttons and the accordion's closed pill are all 44pt.
+  static const double _actionButtonSize = 44;
+
+  Widget _buildOptionsAccordion() {
+    return ComposerOptionsAccordion(
+      actionsEnabled: _voiceState == _VoiceState.idle,
+      onSlashCommandsTap: _openCommandPicker,
+    );
+  }
+
+  /// Shows [idle] normally, or the recording / transcribing feedback in its
+  /// place while a voice interaction is running. [height] constrains the
+  /// indicators inside the 44pt-tall resting pills; the typing layout passes
+  /// null and keeps their intrinsic height.
+  Widget _buildVoiceAwareSlot({required double? height, required Widget idle}) {
+    final indicator = switch (_voiceState) {
+      _VoiceState.recording => _RecordingIndicator(amplitudeStream: _voiceService.amplitudeStream),
+      _VoiceState.transcribing => const _TranscribingIndicator(),
+      _VoiceState.idle => null,
     };
+    if (indicator == null) {
+      return height == null ? idle : SizedBox(height: height, child: idle);
+    }
+    return height == null ? indicator : SizedBox(height: height, child: indicator);
+  }
+
+  /// Hold-to-record microphone. While transcribing it becomes the cancel
+  /// affordance, mirroring the old tap-to-cancel behaviour.
+  Widget _buildMicButton(BuildContext context) {
+    final loc = context.loc;
+
+    if (_voiceState == _VoiceState.transcribing) {
+      return Tooltip(
+        message: loc.voiceCancelTranscription,
+        child: PregoButtonsSolid.iconOnly(
+          leadingIcon: TablerRegular.x,
+          hierarchy: PregoButtonsSolidHierarchy.secondary,
+          size: PregoButtonsSolidSize.lg,
+          onPressed: _cancelTranscription,
+        ),
+      );
+    }
+
+    // No Tooltip here: its long-press trigger would race the recording hold.
+    // The button keeps its enabled look and swallows plain taps via
+    // [_ignoreTap]; holds outlast the tap recognizer, so the surrounding
+    // detector wins the arena and drives the recording.
+    return Semantics(
+      button: true,
+      label: loc.voiceRecord,
+      child: GestureDetector(
+        onLongPressStart: (_) => _handleRecordStart(),
+        onLongPressEnd: (_) => _handleRecordEnd(),
+        child: const PregoButtonsSolid.iconOnly(
+          leadingIcon: TablerRegular.microphone,
+          hierarchy: PregoButtonsSolidHierarchy.secondary,
+          size: PregoButtonsSolidSize.lg,
+          onPressed: _ignoreTap,
+        ),
+      ),
+    );
+  }
+
+  /// Keeps the mic rendering in its enabled look; recording is press-and-hold,
+  /// so a plain tap deliberately does nothing.
+  static void _ignoreTap() {}
+
+  /// The dark action button: sends when there is content to send, otherwise
+  /// stops the agent's in-flight work while it is busy.
+  Widget _buildPrimaryActionButton(BuildContext context) {
+    final loc = context.loc;
+    final showStop = widget.isBusy && !_hasSendableContent;
+
+    if (showStop) {
+      return Tooltip(
+        message: loc.sessionDetailAbort,
+        child: PregoButtonsSolid.iconOnly(
+          leadingIcon: TablerSolid.player_stop,
+          hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
+          size: PregoButtonsSolidSize.lg,
+          onPressed: widget.onAbort,
+        ),
+      );
+    }
+
+    return Tooltip(
+      message: loc.sessionDetailSend,
+      child: PregoButtonsSolid.iconOnly(
+        leadingIcon: TablerRegular.arrow_up,
+        hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
+        size: PregoButtonsSolidSize.lg,
+        onPressed: _handleSend,
+      ),
+    );
   }
 }
 

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -305,7 +305,11 @@ class _PromptInputState extends State<PromptInput> {
     } on MicrophonePermissionDeniedError {
       if (!mounted) return;
       _showVoiceError(context.loc.voiceErrorPermission);
-    } on VoiceTranscriptionError catch (error) {
+    } catch (error) {
+      // Typed voice errors and anything else the recorder throws (platform /
+      // filesystem failures) both land here: an error escaping this method
+      // would leave the in-flight guard and pinned layout stuck, silently
+      // killing voice input for the rest of the session.
       loge("Failed to start recording", error);
       if (!mounted) return;
       _showVoiceError(context.loc.voiceErrorRecording);

--- a/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
@@ -164,6 +164,10 @@ class _SessionDetailLoadedViewState extends State<SessionDetailLoadedView> {
                     padding: const EdgeInsets.symmetric(horizontal: 16),
                     child: PromptInput(
                       draftKey: widget.sessionId,
+                      // Queued messages count: the user has already "sent"
+                      // something, so the composer should rest as a follow-up
+                      // field even before the first message lands in the list.
+                      hasMessages: state.messages.isNotEmpty || state.queuedMessages.isNotEmpty,
                       isBusy: hasActiveWork(
                         sessionStatus: state.sessionStatus,
                         childStatuses: state.childStatuses,

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -321,6 +321,30 @@
   "sessionDetailErrorTitle": "Failed to load messages",
   "sessionDetailRetry": "Retry",
   "sessionDetailPromptHint": "Ask anything...",
+  "sessionDetailHoldToTalk": "Hold to talk",
+  "@sessionDetailHoldToTalk": {
+    "description": "Label centered in the fresh-session composer pill; holding it records a voice message that is transcribed into the field."
+  },
+  "sessionDetailFollowUpHint": "Follow up...",
+  "@sessionDetailFollowUpHint": {
+    "description": "Composer placeholder once the session already has messages."
+  },
+  "sessionDetailTypeMessage": "Type a message",
+  "@sessionDetailTypeMessage": {
+    "description": "Accessibility label of the keyboard button that switches the composer from hold-to-talk to typing."
+  },
+  "sessionDetailMoreActions": "More actions",
+  "@sessionDetailMoreActions": {
+    "description": "Accessibility label of the chevron that expands the composer's advanced-options drawer."
+  },
+  "sessionDetailExpandEditor": "Expand editor",
+  "@sessionDetailExpandEditor": {
+    "description": "Accessibility label of the button that opens the fullscreen message editor."
+  },
+  "sessionDetailEditorTitle": "Message",
+  "@sessionDetailEditorTitle": {
+    "description": "Title of the fullscreen message editor sheet."
+  },
   "sessionDetailCommandArgumentsHint": "Optional arguments",
   "sessionDetailCommandPickerTitle": "Slash commands",
   "sessionDetailCommandSearch": "Search commands...",

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -337,6 +337,10 @@
   "@sessionDetailMoreActions": {
     "description": "Accessibility label of the chevron that expands the composer's advanced-options drawer."
   },
+  "sessionDetailHideActions": "Hide actions",
+  "@sessionDetailHideActions": {
+    "description": "Accessibility label of the chevron while the composer's advanced-options drawer is open and tapping it collapses the drawer."
+  },
   "sessionDetailExpandEditor": "Expand editor",
   "@sessionDetailExpandEditor": {
     "description": "Accessibility label of the button that opens the fullscreen message editor."

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -1069,6 +1069,42 @@ abstract class AppLocalizations {
   /// **'Ask anything...'**
   String get sessionDetailPromptHint;
 
+  /// Label centered in the fresh-session composer pill; holding it records a voice message that is transcribed into the field.
+  ///
+  /// In en, this message translates to:
+  /// **'Hold to talk'**
+  String get sessionDetailHoldToTalk;
+
+  /// Composer placeholder once the session already has messages.
+  ///
+  /// In en, this message translates to:
+  /// **'Follow up...'**
+  String get sessionDetailFollowUpHint;
+
+  /// Accessibility label of the keyboard button that switches the composer from hold-to-talk to typing.
+  ///
+  /// In en, this message translates to:
+  /// **'Type a message'**
+  String get sessionDetailTypeMessage;
+
+  /// Accessibility label of the chevron that expands the composer's advanced-options drawer.
+  ///
+  /// In en, this message translates to:
+  /// **'More actions'**
+  String get sessionDetailMoreActions;
+
+  /// Accessibility label of the button that opens the fullscreen message editor.
+  ///
+  /// In en, this message translates to:
+  /// **'Expand editor'**
+  String get sessionDetailExpandEditor;
+
+  /// Title of the fullscreen message editor sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Message'**
+  String get sessionDetailEditorTitle;
+
   /// No description provided for @sessionDetailCommandArgumentsHint.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -1093,6 +1093,12 @@ abstract class AppLocalizations {
   /// **'More actions'**
   String get sessionDetailMoreActions;
 
+  /// Accessibility label of the chevron while the composer's advanced-options drawer is open and tapping it collapses the drawer.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide actions'**
+  String get sessionDetailHideActions;
+
   /// Accessibility label of the button that opens the fullscreen message editor.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -523,6 +523,24 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionDetailPromptHint => 'Ask anything...';
 
   @override
+  String get sessionDetailHoldToTalk => 'Hold to talk';
+
+  @override
+  String get sessionDetailFollowUpHint => 'Follow up...';
+
+  @override
+  String get sessionDetailTypeMessage => 'Type a message';
+
+  @override
+  String get sessionDetailMoreActions => 'More actions';
+
+  @override
+  String get sessionDetailExpandEditor => 'Expand editor';
+
+  @override
+  String get sessionDetailEditorTitle => 'Message';
+
+  @override
   String get sessionDetailCommandArgumentsHint => 'Optional arguments';
 
   @override

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -535,6 +535,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionDetailMoreActions => 'More actions';
 
   @override
+  String get sessionDetailHideActions => 'Hide actions';
+
+  @override
   String get sessionDetailExpandEditor => 'Expand editor';
 
   @override

--- a/client/app/test/core/widgets/session_split/session_split_shell_test.dart
+++ b/client/app/test/core/widgets/session_split/session_split_shell_test.dart
@@ -201,10 +201,14 @@ void main() {
       expect(find.byType(NewSessionScreen), findsOneWidget);
 
       // Start sending; creation is now in flight. Scope to the composer — the
-      // session-detail route behind the pushed overlay also has a prompt field.
+      // session-detail route behind the pushed overlay also has a prompt
+      // composer. The fresh composer rests in its hold-to-talk pill, so enter
+      // the typing layout via the keyboard button first.
       final newSession = find.byType(NewSessionScreen);
+      await tester.tap(find.descendant(of: newSession, matching: find.byIcon(TablerRegular.keyboard)));
+      await tester.pumpAndSettle();
       await tester.enterText(find.descendant(of: newSession, matching: find.byType(EditableText)), "do the thing");
-      await tester.tap(find.descendant(of: newSession, matching: find.byIcon(Icons.send)), warnIfMissed: false);
+      await tester.tap(find.descendant(of: newSession, matching: find.byIcon(TablerRegular.arrow_up)), warnIfMissed: false);
       await tester.pump();
       expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
 

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -85,6 +85,13 @@ Widget _buildApp({
   );
 }
 
+/// The composer rests in its hold-to-talk pill (no text field) until the
+/// keyboard button switches it to the typing layout and focuses the field.
+Future<void> enterTypingMode(WidgetTester tester) async {
+  await tester.tap(find.byIcon(TablerRegular.keyboard));
+  await tester.pumpAndSettle();
+}
+
 void main() {
   late MockSessionService sessionService;
   late MockPluginRepository pluginRepository;
@@ -425,6 +432,7 @@ void main() {
 
     await tester.pumpWidget(_buildApp());
     await tester.pumpAndSettle();
+    await enterTypingMode(tester);
     await tester.enterText(find.byType(EditableText), "one\ntwo\nthree\nfour\nfive");
     await tester.pumpAndSettle();
 
@@ -689,8 +697,13 @@ void main() {
       findsOneWidget,
     );
 
-    await tester.enterText(find.byType(EditableText), "must not send");
-    await tester.tap(find.byIcon(Icons.send), warnIfMissed: false);
+    // The disabled composer ignores pointers entirely: the keyboard affordance
+    // cannot even enter the typing layout, so no field or send control exists
+    // to submit through.
+    await tester.tap(find.byIcon(TablerRegular.keyboard), warnIfMissed: false);
+    await tester.pumpAndSettle();
+    expect(find.byType(EditableText), findsNothing);
+    expect(find.byIcon(TablerRegular.arrow_up), findsNothing);
     await tester.pump();
     verifyNever(
       () => sessionService.createSessionWithMessage(
@@ -852,8 +865,9 @@ void main() {
 
     final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
 
+    await enterTypingMode(tester);
     await tester.enterText(find.byType(EditableText), "test message");
-    await tester.tap(find.byIcon(Icons.send), warnIfMissed: false);
+    await tester.tap(find.byIcon(TablerRegular.arrow_up), warnIfMissed: false);
     await tester.pump();
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
@@ -881,18 +895,20 @@ void main() {
     await tester.pumpWidget(_buildApp(initialSupportsDedicatedWorktrees: true));
     await tester.pumpAndSettle();
 
+    await enterTypingMode(tester);
     await tester.enterText(find.byType(EditableText), "test message");
-    await tester.tap(find.byIcon(Icons.send), warnIfMissed: false);
+    await tester.tap(find.byIcon(TablerRegular.arrow_up), warnIfMissed: false);
     await tester.pump();
 
     final absorbingFinder = find.byWidgetPredicate(
       (widget) => widget is AbsorbPointer && widget.absorbing,
     );
     expect(absorbingFinder, findsOneWidget);
-    expect(find.byIcon(Icons.stop_circle), findsOneWidget);
-
-    await tester.tap(find.byIcon(Icons.send), warnIfMissed: false);
-    await tester.pump();
+    // With the message sent (field cleared) and creation in flight, the dark
+    // action button turns into the stop control — there is no send affordance
+    // left to double-submit through.
+    expect(find.byIcon(TablerSolid.player_stop), findsOneWidget);
+    expect(find.byIcon(TablerRegular.arrow_up), findsNothing);
 
     verify(
       () => sessionService.createSessionWithMessage(
@@ -930,8 +946,9 @@ void main() {
 
     final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
 
+    await enterTypingMode(tester);
     await tester.enterText(find.byType(EditableText), "test message");
-    await tester.tap(find.byIcon(Icons.send), warnIfMissed: false);
+    await tester.tap(find.byIcon(TablerRegular.arrow_up), warnIfMissed: false);
     await tester.pump();
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
@@ -973,8 +990,9 @@ void main() {
 
     final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
 
+    await enterTypingMode(tester);
     await tester.enterText(find.byType(EditableText), "test message");
-    await tester.tap(find.byIcon(Icons.send), warnIfMissed: false);
+    await tester.tap(find.byIcon(TablerRegular.arrow_up), warnIfMissed: false);
     await tester.pump();
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
@@ -1019,8 +1037,9 @@ void main() {
     await tester.pumpWidget(_buildApp(initialSupportsDedicatedWorktrees: true));
     await tester.pumpAndSettle();
 
+    await enterTypingMode(tester);
     await tester.enterText(find.byType(EditableText), "test message");
-    await tester.tap(find.byIcon(Icons.send));
+    await tester.tap(find.byIcon(TablerRegular.arrow_up));
     await tester.pump();
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
@@ -1058,8 +1077,9 @@ void main() {
 
     final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
 
+    await enterTypingMode(tester);
     await tester.enterText(find.byType(EditableText), "test message");
-    await tester.tap(find.byIcon(Icons.send));
+    await tester.tap(find.byIcon(TablerRegular.arrow_up));
     await tester.pump();
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
@@ -1091,8 +1111,9 @@ void main() {
     await tester.pumpWidget(_buildApp(initialSupportsDedicatedWorktrees: true));
     await tester.pumpAndSettle();
 
+    await enterTypingMode(tester);
     await tester.enterText(find.byType(EditableText), "test message");
-    await tester.tap(find.byIcon(Icons.send));
+    await tester.tap(find.byIcon(TablerRegular.arrow_up));
     await tester.pump();
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
@@ -1103,8 +1124,12 @@ void main() {
     expect(find.byKey(const Key("new_session_loading_overlay")), findsNothing);
     // Error text now comes from the shared, localized ApiError mapping.
     expect(find.text("An unknown error occurred"), findsOneWidget);
+
+    // Sending excluded focus from the composer, so it collapsed back to its
+    // resting pill; it must be usable again for the retry.
+    await enterTypingMode(tester);
     expect(find.byType(EditableText), findsOneWidget);
-    expect(find.byIcon(Icons.send), findsOneWidget);
+    expect(find.byIcon(TablerRegular.arrow_up), findsOneWidget);
 
     await tester.enterText(find.byType(EditableText), "retry message");
     await tester.pump();
@@ -1119,6 +1144,7 @@ void main() {
     await tester.pumpWidget(_buildApp(initialSupportsDedicatedWorktrees: true));
     await tester.pumpAndSettle();
 
+    await enterTypingMode(tester);
     await tester.enterText(find.byType(EditableText), "half-written idea");
     await tester.pump();
 

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -579,6 +579,47 @@ void main() {
     expect(find.text("transcript"), findsOneWidget);
   });
 
+  testWidgets("a second hold during recorder startup does not start a second recording", (tester) async {
+    final startCompleter = Completer<void>();
+    final stopCompleter = Completer<String>();
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) => startCompleter.future);
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) => stopCompleter.future);
+
+    final state = _loadedState(
+      pendingQuestions: const [],
+      pendingPermissions: const [],
+      messages: [testMessageWithParts()],
+    );
+    when(() => cubit.state).thenReturn(state);
+    whenListen(cubit, const Stream<SessionDetailState>.empty(), initialState: state);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    // First hold on the mic reaches the recorder; a second long-press (e.g. a
+    // second finger on the same surface after a stray release) while the
+    // recorder is still starting must not start again.
+    final first = await tester.startGesture(tester.getCenter(find.byIcon(TablerRegular.microphone)));
+    await tester.pump(const Duration(milliseconds: 600));
+    await first.up();
+    await tester.pump();
+    final second = await tester.startGesture(tester.getCenter(find.byIcon(TablerRegular.microphone)));
+    await tester.pump(const Duration(milliseconds: 600));
+    await second.up();
+    await tester.pump();
+    verify(() => voiceTranscriptionService.startRecording()).called(1);
+
+    // Both holds released before startup finished — the pending release stops
+    // the recording as soon as it begins.
+    startCompleter.complete();
+    await tester.pump();
+    verify(() => voiceTranscriptionService.stopAndTranscribe()).called(1);
+
+    stopCompleter.complete("transcript");
+    await tester.pumpAndSettle();
+  });
+
   testWidgets("accordion reveals the slash-commands action and opens the picker", (tester) async {
     await tester.pumpWidget(_buildApp(cubit: cubit));
     await tester.pumpAndSettle();

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -11,6 +11,7 @@ import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:mocktail/mocktail.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/capabilities/voice/voice_transcription_service.dart";
+import "package:sesori_mobile/features/session_detail/widgets/prompt_editor_sheet.dart";
 import "package:sesori_mobile/features/session_detail/widgets/session_detail_body.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -60,12 +61,14 @@ Widget _buildApp({required SessionDetailCubit cubit}) {
 SessionDetailLoaded _loadedState({
   required List<SesoriQuestionAsked> pendingQuestions,
   required List<SesoriPermissionAsked> pendingPermissions,
+  List<MessageWithParts> messages = const [],
+  SessionStatus sessionStatus = const SessionStatus.idle(),
 }) {
   final provider = testProviderListResponse().items.first;
   return SessionDetailLoaded(
-    messages: const [],
+    messages: messages,
     streamingText: const {},
-    sessionStatus: const SessionStatus.idle(),
+    sessionStatus: sessionStatus,
     pendingQuestions: pendingQuestions,
     pendingPermissions: pendingPermissions,
     sessionTitle: "Session",
@@ -405,27 +408,35 @@ void main() {
     expect(find.text("Choose a release channel"), findsOneWidget);
   });
 
-  // Only the input row is grouped with the text field via a TextFieldTapRegion,
-  // so tapping the send button does not fire the field's default `onTapOutside`
-  // (which unfocuses and dismisses the keyboard) — without the region, send
-  // flickered the keyboard (hide then re-show). The agent/model/variant pills
-  // live in the composer header, outside the region, so tapping them is a tap
-  // "outside" the field and dismisses the keyboard by design.
+  // Only the input container is grouped with the text field via a
+  // TextFieldTapRegion, so tapping the send button does not fire the field's
+  // default `onTapOutside` (which unfocuses and dismisses the keyboard) —
+  // without the region, send flickered the keyboard (hide then re-show). The
+  // agent/model/variant pills live in the composer header, outside the region,
+  // so tapping them is a tap "outside" the field and dismisses the keyboard by
+  // design.
   FocusNode composerFocus(WidgetTester tester) => tester.widget<EditableText>(find.byType(EditableText)).focusNode;
+
+  // A fresh session rests in the hold-to-talk pill, which hosts no text field;
+  // the keyboard button switches the composer to its typing layout and focuses
+  // the field (focus lands post-frame).
+  Future<void> enterTypingMode(WidgetTester tester) async {
+    await tester.tap(find.byIcon(TablerRegular.keyboard));
+    await tester.pumpAndSettle();
+  }
 
   testWidgets("pressing send keeps the composer field focused", (tester) async {
     await tester.pumpWidget(_buildApp(cubit: cubit));
     await tester.pumpAndSettle();
 
     // Focus the field — the keyboard would rise.
-    await tester.tap(find.byType(EditableText));
-    await tester.pump();
+    await enterTypingMode(tester);
     expect(composerFocus(tester).hasFocus, isTrue);
 
     // Send with an empty field: `_handleSend` is a no-op that does not
     // re-request focus, so focus retention here proves the tap itself didn't
     // unfocus the field (which is what produced the hide/re-show flicker).
-    await tester.tap(find.byIcon(Icons.send));
+    await tester.tap(find.byIcon(TablerRegular.arrow_up));
     await tester.pump();
     expect(composerFocus(tester).hasFocus, isTrue, reason: "send must not dismiss the keyboard");
   });
@@ -445,18 +456,133 @@ void main() {
       await tester.pumpWidget(_buildApp(cubit: cubit));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(EditableText));
-      await tester.pump();
+      await enterTypingMode(tester);
       expect(composerFocus(tester).hasFocus, isTrue);
 
       // Tapping the variant pill opens its glass popup and, because the pill is
-      // outside the field's tap region, dismisses the keyboard.
+      // outside the field's tap region, dismisses the keyboard. The unfocused,
+      // empty composer then collapses back to its resting pill, unmounting the
+      // field — which is the proof the focus was dropped.
       await tester.tap(find.widgetWithText(GlassButton, "xhigh"));
       await tester.pumpAndSettle();
       expect(find.widgetWithText(GlassMenuItem, "xhigh"), findsOneWidget);
-      expect(composerFocus(tester).hasFocus, isFalse, reason: "opening a composer menu must dismiss the keyboard");
+      expect(
+        find.byType(EditableText),
+        findsNothing,
+        reason: "opening a composer menu must dismiss the keyboard and collapse the composer",
+      );
     } finally {
       debugDefaultTargetPlatformOverride = null;
     }
+  });
+
+  testWidgets("fresh session rests in hold-to-talk and the keyboard button enters typing", (tester) async {
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    // Hold-to-talk pill: no text field, no mic/send circles — the pill itself
+    // records and the keyboard button switches to typing.
+    expect(find.byType(EditableText), findsNothing);
+    expect(find.text("Hold to talk"), findsOneWidget);
+    expect(find.byIcon(TablerRegular.arrow_up), findsNothing);
+
+    await enterTypingMode(tester);
+
+    expect(find.byType(EditableText), findsOneWidget);
+    expect(composerFocus(tester).hasFocus, isTrue);
+    expect(find.byIcon(TablerRegular.arrow_up), findsOneWidget);
+    expect(find.byIcon(TablerRegular.microphone), findsOneWidget);
+  });
+
+  testWidgets("session with messages rests as a follow-up field that expands on tap", (tester) async {
+    final state = _loadedState(
+      pendingQuestions: const [],
+      pendingPermissions: const [],
+      messages: [testMessageWithParts()],
+    );
+    when(() => cubit.state).thenReturn(state);
+    whenListen(cubit, const Stream<SessionDetailState>.empty(), initialState: state);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    expect(find.text("Hold to talk"), findsNothing);
+    expect(find.text("Follow up..."), findsOneWidget);
+
+    await tester.tap(find.text("Follow up..."));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(EditableText), findsOneWidget);
+    expect(composerFocus(tester).hasFocus, isTrue);
+  });
+
+  testWidgets("busy composer shows stop instead of send and forwards abort", (tester) async {
+    final state = _loadedState(
+      pendingQuestions: const [],
+      pendingPermissions: const [],
+      messages: [testMessageWithParts()],
+      sessionStatus: const SessionStatus.busy(),
+    );
+    when(() => cubit.state).thenReturn(state);
+    whenListen(cubit, const Stream<SessionDetailState>.empty(), initialState: state);
+    when(() => cubit.abort()).thenAnswer((_) async {});
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    // Bounded pumps throughout: the busy status keeps an activity indicator
+    // animating in the message area, so pumpAndSettle would never settle.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    // Nothing to send yet, so the dark action button is the stop control.
+    expect(find.byIcon(TablerRegular.arrow_up), findsNothing);
+    await tester.tap(find.byIcon(TablerSolid.player_stop));
+    verify(() => cubit.abort()).called(1);
+
+    // Typed text flips the same button back to send: sending queues while the
+    // agent works, so it must stay reachable.
+    await tester.tap(find.text("Follow up..."));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.enterText(find.byType(EditableText), "follow-up");
+    await tester.pump();
+    expect(find.byIcon(TablerRegular.arrow_up), findsOneWidget);
+    expect(find.byIcon(TablerSolid.player_stop), findsNothing);
+  });
+
+  testWidgets("accordion reveals the slash-commands action and opens the picker", (tester) async {
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(TablerRegular.slash), findsNothing);
+
+    await tester.tap(find.byIcon(TablerRegular.chevron_right));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(TablerRegular.slash), findsOneWidget);
+
+    await tester.tap(find.byIcon(TablerRegular.slash));
+    // Bounded pumps: the picker sheet shows a loading shimmer while its
+    // entries are prepared, which never settles.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(find.text("Slash commands"), findsOneWidget);
+  });
+
+  testWidgets("expand button opens the fullscreen editor sharing the composer text", (tester) async {
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    await enterTypingMode(tester);
+    await tester.enterText(find.byType(EditableText), "long prompt");
+    await tester.pump();
+
+    await tester.tap(find.byIcon(TablerRegular.maximize));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(PromptEditorSheet), findsOneWidget);
+    // The sheet edits the same controller, so it shows the composer's text.
+    expect(
+      find.descendant(of: find.byType(PromptEditorSheet), matching: find.text("long prompt")),
+      findsOneWidget,
+    );
   });
 }

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -549,6 +549,36 @@ void main() {
     expect(find.byIcon(TablerSolid.player_stop), findsNothing);
   });
 
+  testWidgets("release during recorder startup still stops the recording", (tester) async {
+    final startCompleter = Completer<void>();
+    final stopCompleter = Completer<String>();
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) => startCompleter.future);
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) => stopCompleter.future);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    // Hold the hold-to-talk pill long enough for the long-press to fire (the
+    // recording start is now awaiting the recorder), then release before the
+    // recorder finishes starting up.
+    final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
+    await tester.pump(const Duration(milliseconds: 600));
+    await gesture.up();
+    await tester.pump();
+    verifyNever(() => voiceTranscriptionService.stopAndTranscribe());
+
+    // The recorder finishes starting after the finger already lifted — the
+    // composer must stop immediately instead of recording open-endedly.
+    startCompleter.complete();
+    await tester.pump();
+    verify(() => voiceTranscriptionService.stopAndTranscribe()).called(1);
+
+    stopCompleter.complete("transcript");
+    await tester.pumpAndSettle();
+    expect(find.text("transcript"), findsOneWidget);
+  });
+
   testWidgets("accordion reveals the slash-commands action and opens the picker", (tester) async {
     await tester.pumpWidget(_buildApp(cubit: cubit));
     await tester.pumpAndSettle();

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -620,6 +620,40 @@ void main() {
     await tester.pumpAndSettle();
   });
 
+  testWidgets("an unexpected recorder-start failure does not block later recordings", (tester) async {
+    var startCalls = 0;
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {
+      startCalls++;
+      if (startCalls == 1) throw StateError("recorder unavailable");
+    });
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) async => "");
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    // First hold fails with an error outside the typed voice errors — it must
+    // be handled (error snackbar) rather than escaping and leaving the start
+    // guards stuck.
+    final first = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
+    await tester.pump(const Duration(milliseconds: 600));
+    await first.up();
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+
+    // Let the error snackbar time out — it floats over the composer pill and
+    // would swallow the next hold.
+    await tester.pump(const Duration(seconds: 5));
+    await tester.pumpAndSettle();
+
+    // A later hold reaches the recorder again.
+    final second = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
+    await tester.pump(const Duration(milliseconds: 600));
+    expect(startCalls, 2);
+    await second.up();
+    await tester.pumpAndSettle();
+  });
+
   testWidgets("accordion reveals the slash-commands action and opens the picker", (tester) async {
     await tester.pumpWidget(_buildApp(cubit: cubit));
     await tester.pumpAndSettle();

--- a/client/module_prego/lib/components/buttons/prego_buttons_solid.dart
+++ b/client/module_prego/lib/components/buttons/prego_buttons_solid.dart
@@ -275,7 +275,7 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
                 children: [
                   child,
                   if (showSkeuomorphicOverlay)
-                    _SkeuomorphicInnerOverlay(
+                    PregoSkeuomorphicOverlay(
                       innerBorderColor: colors.skeuomorphicInnerBorder,
                       bottomShadowColor: skeuomorphicBottomColor,
                     ),
@@ -788,19 +788,25 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
 }
 
 // ---------------------------------------------------------------------------
-// Private helper widgets
+// Helper widgets
 // ---------------------------------------------------------------------------
 
-/// Paints the skeuomorphic inner border used on Primary and Secondary hierarchy.
+/// Paints the skeuomorphic inner border used on Primary and Secondary hierarchy,
+/// and on solid-button-like surfaces built outside this file (e.g. joined
+/// button groups that share one pill background).
 ///
 /// Uses [CustomPainter] to approximate the two Figma inner shadow layers:
 /// - A 1px inset stroke around the entire pill (inner border highlight).
 /// - A 2px inset stroke along the bottom edge only (depth shadow).
 ///
+/// Positioned to fill, so it must be placed inside a [Stack] that is sized by
+/// the surface it decorates.
+///
 /// In the Secondary focused state, [bottomShadowColor] is set to
-/// [skeuomorphicInnerBorder] so both layers use the same token.
-class _SkeuomorphicInnerOverlay extends StatelessWidget {
-  const _SkeuomorphicInnerOverlay({
+/// `skeuomorphicInnerBorder` so both layers use the same token.
+class PregoSkeuomorphicOverlay extends StatelessWidget {
+  const PregoSkeuomorphicOverlay({
+    super.key,
     required this.innerBorderColor,
     required this.bottomShadowColor,
   });


### PR DESCRIPTION
## Summary

Implements the new Figma design for the session chat composer (nodes 4410-8473, 4410-10713, 4410-9250). The composer now has three states:

| State | When | Contents |
|---|---|---|
| **Hold-to-talk pill** | Fresh session, nothing to show in the field | Advanced-options accordion · centred "Hold to talk" (hold records, release transcribes) · keyboard button that switches to typing |
| **Compact "Follow up..." pill** | Session has (or has queued) messages, field unfocused + empty | Accordion · tappable placeholder (expands to typing) · hold-to-record mic · dark action button |
| **Expanded typing container** | Field focused / holds text / staged command | Multiline field with an expand button (fullscreen editor sheet) · action row with accordion, mic and the dark action button |

The dark action button sends when there is content to send and becomes the **stop** control while the agent is busy with an empty field, so aborting stays one tap away mid-turn (sending still queues while busy).

## Details

- **Advanced-options accordion**: the always-visible slash button moved into an expanding pill on the left (chevron toggles it); future actions like attaching files/images will live there too.
- **Fullscreen editor** (`PromptEditorSheet`): opened from the expand button; shares the composer's `TextEditingController`, so edits flow back live.
- **Voice**: mic switches from tap-toggle to press-and-hold (per design); the recording waveform / transcribing feedback is unchanged and renders in the field slot. The layout is pinned while a voice interaction runs so the gesture-owning elements are never reparented mid-hold.
- **Keyboard behaviour preserved**: the plain `TextField` gets an explicit `onTapOutside` unfocus (GlassTextField used to do this itself), so picker-pill taps still dismiss the keyboard while send/mic/accordion taps inside the `TextFieldTapRegion` keep it up.
- **Buttons** are `PregoButtonsSolid.iconOnly` (`secondary` for mic/keyboard, `primaryAlt` for send/stop) with Tabler icons, so light/dark tokens flip correctly.
- The agent/model/variant picker pills and their menus are untouched in this PR.

## Verification

- `flutter analyze` clean; full `client/app` test suite green (772 tests), including new coverage for the three states, the stop/send swap, the accordion → command picker flow, and the fullscreen editor.
- Verified live on the iPhone 17 Pro Max simulator against a real bridge (Test Folder 2 → OpenCode session): all three states, accordion + slash sheet, fullscreen editor round-trip, hold-to-record waveform, send/stop swap while the agent worked, and light + dark mode.

https://claude.ai/code/session_014C16XK9nrqo8gUmbMhjFR9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the session chat composer with three states (hold‑to‑talk, compact follow‑up, expanded typing) and added an advanced-options accordion plus a fullscreen editor; the primary action swaps between send and stop based on context. The accordion now matches solid-button styling (44pt circle closed, joined pill open) using the shared `PregoSkeuomorphicOverlay`.

- **Bug Fixes**
  - Recording gesture is robust: release or assistive-tech activation during startup stops immediately; pointer-cancel ends recording; a second hold while starting won’t start again.
  - Accessibility: mic and hold-to-talk support a semantic tap that toggles recording; the accordion chevron announces “Hide actions” when open.
  - Busy sessions rest in the compact layout before the first message, keeping Stop reachable.
  - Recorder-start failures are handled: unexpected errors are caught, state is reset, and a recording error is shown.

- **Migration**
  - `PromptInput` now requires `hasMessages`. Pass `false` for new sessions; pass `true` when the session has messages or queued messages.

<sup>Written for commit 221e84c6b1958777fd5cb456468d38949ce9c01f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

