### PR TITLE
[multi-plugin-release-prep] feat(bridge): expose cached session options [step 4.F/6]

### DIFF
--- a/.plan/active/multi-plugin-release-prep/TRACKER.md
+++ b/.plan/active/multi-plugin-release-prep/TRACKER.md
@@ -185,4 +185,8 @@
   Orchestrator composition and teardown. All 153 focused
   handler/listener/repository/Orchestrator tests and all 2,253 bridge-app tests
   passed, as did bridge-app fatal analysis and `git diff --check`. Aristotle
-  approved the implementation architecture without findings.
+  approved the implementation architecture without findings. Review follow-up
+  rejects non-canonical or unknown plugin IDs at the route boundary, uses named
+  DAO/private parameters, and synchronously starts local refresh listeners before
+  debug mutation routes can become reachable. All 65 focused follow-up tests and
+  bridge-app fatal analysis passed.

--- a/.plan/active/multi-plugin-release-prep/TRACKER.md
+++ b/.plan/active/multi-plugin-release-prep/TRACKER.md
@@ -2,11 +2,11 @@
 
 ## Current State
 
-- **Implementation base:** `origin/main` at `37da883a`
-- **Series state:** Steps 1/6 through 4.D/6 are merged; oversized PR #620 is
-  frozen as a draft and replaced by the Step 4.E/6 through 4.F/6 sequence
-- **Current step:** Step 4.E/6 — cache policy and intent-aware coalescing
-- **Next action:** monitor and merge PR #627
+- **Implementation base:** `origin/main` at `e25be863`
+- **Series state:** Steps 1/6 through 4.E/6 are merged; oversized PR #620 is
+  closed, with its frozen branch retained only as the split implementation source
+- **Current step:** Step 4.F/6 — route, listeners, and lifecycle wiring
+- **Next action:** commit, push, and open the verified Step 4.F/6 implementation
 
 ## Delivery
 
@@ -19,9 +19,9 @@
 | [x] | Step 4.B/6 — scoped cache schema/runtime database | `multi-plugin-release-prep-cache-schema` | PR #624 merged |
 | [x] | Step 4.C/6 — migration and DAO verification | `multi-plugin-release-prep-cache-verification` | PR #625 merged |
 | [x] | Step 4.D/6 — capture/persistence repository | `multi-plugin-release-prep-cache-repository` | PR #626 merged |
-| [ ] | Step 4.E/6 — cache policy/coalescing service | `multi-plugin-release-prep-cache-service` | PR #627 ready |
-| [ ] | Step 4.F/6 — route, listeners, and lifecycle wiring | `multi-plugin-release-prep-cache-route` | Blocked on 4.E |
-| [ ] | Step 5/6 — cached New Session client flow | `multi-plugin-release-prep-client-options` | Blocked on Step 4 merge |
+| [x] | Step 4.E/6 — cache policy/coalescing service | `multi-plugin-release-prep-cache-service` | PR #627 merged |
+| [ ] | Step 4.F/6 — route, listeners, and lifecycle wiring | `multi-plugin-release-prep-cache-route` | Verified; ready to open |
+| [ ] | Step 5/6 — cached New Session client flow | `multi-plugin-release-prep-client-options` | Blocked on Step 4.F merge |
 | [ ] | Step 6/6 — consolidated Harnesses settings | `multi-plugin-release-prep-harness-settings` | Blocked on Step 5 merge |
 
 ## Locked Decisions
@@ -177,4 +177,12 @@
   persistence/repository/service tests and bridge-app fatal analysis passed with
   `git diff --check`. Aristotle's second/final review approved the preceding
   revised architecture without findings; the later feedback fixes were not
-  re-reviewed because implementation review is capped at two passes.
+  re-reviewed because implementation review is capped at two passes. PR #627
+  merged to `main` as `e25be863`.
+- Step 4.F/6 preparation (2026-07-30): added the typed aggregate route and
+  discovery capability, stable project attribution on binding commits,
+  independent creation/options-change refresh listeners, and shared relay/debug
+  Orchestrator composition and teardown. All 153 focused
+  handler/listener/repository/Orchestrator tests and all 2,253 bridge-app tests
+  passed, as did bridge-app fatal analysis and `git diff --check`. Aristotle
+  approved the implementation architecture without findings.

--- a/bridge/app/lib/src/api/database/daos/session_options_cache_dao.dart
+++ b/bridge/app/lib/src/api/database/daos/session_options_cache_dao.dart
@@ -8,7 +8,7 @@ part "session_options_cache_dao.g.dart";
 
 @DriftAccessor(tables: [SessionOptionsCacheTable])
 class SessionOptionsCacheDao extends DatabaseAccessor<AppDatabase> with _$SessionOptionsCacheDaoMixin {
-  SessionOptionsCacheDao(super.attachedDatabase);
+  SessionOptionsCacheDao({required AppDatabase database}) : super(database);
 
   Future<SessionOptionsCacheTableData?> getRow({
     required String pluginId,

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -221,7 +221,7 @@ class Orchestrator {
       runtime: _pluginRuntime,
       projectsDao: _database.projectsDao,
       sessionDao: _database.sessionDao,
-      cacheDao: SessionOptionsCacheDao(_database),
+      cacheDao: SessionOptionsCacheDao(database: _database),
     );
     final sessionOptionsService = SessionOptionsService(
       repository: sessionOptionsRepository,
@@ -446,8 +446,6 @@ class Orchestrator {
       }
       sessionBindingCommitListener.start();
       sessionDeletionListener.start();
-      sessionOptionsCreationRefreshListener.start();
-      sessionOptionsChangedRefreshListener.start();
     });
     final router = RequestRouter(
       handlers: [
@@ -457,7 +455,10 @@ class Orchestrator {
         PostPluginLifecycleCommandHandler(lifecycleService: _pluginLifecycleService),
         GetPluginSetupHandler(lifecycleService: _pluginLifecycleService),
         GetPluginsHandler(lifecycleService: _pluginLifecycleService, bridgeIdProvider: _bridgeRegistrationService),
-        PostSessionOptionsHandler(service: sessionOptionsService),
+        PostSessionOptionsHandler(
+          service: sessionOptionsService,
+          pluginIds: pluginComposition.sessionOptionsScopeById.keys.toSet(),
+        ),
         RestartBridgeHandler(restartService: _restartService),
         GetCurrentProjectHandler(projectRepository: projectRepository),
         GetProjectsHandler(projectActivityService: projectActivityService),
@@ -762,6 +763,8 @@ class OrchestratorSession {
       return Future.error(StateError("OrchestratorSession has already started"), StackTrace.current);
     }
 
+    _sessionOptionsCreationRefreshListener.start();
+    _sessionOptionsChangedRefreshListener.start();
     final readiness = Completer<OrchestratorSessionStartResult>();
     final lifecycleFuture = Future<void>.microtask(
       () => _runLifecycle(readiness: readiness),

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -11,6 +11,7 @@ import "package:rxdart/rxdart.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../api/database/daos/session_options_cache_dao.dart";
 import "../api/database/database.dart";
 import "../auth/access_token_provider.dart";
 import "../auth/bridge_registration_service.dart";
@@ -20,6 +21,8 @@ import "../listeners/plugin_catalog_hydration_listener.dart";
 import "../listeners/plugin_event_listener.dart";
 import "../listeners/session_binding_commit_listener.dart";
 import "../listeners/session_deletion_listener.dart";
+import "../listeners/session_options_changed_refresh_listener.dart";
+import "../listeners/session_options_creation_refresh_listener.dart";
 import "../push/completion_notifier.dart";
 import "../push/completion_push_listener.dart";
 import "../push/maintenance_push_listener.dart";
@@ -65,6 +68,7 @@ import "repositories/provider_repository.dart";
 import "repositories/pull_request_repository.dart";
 import "repositories/question_repository.dart";
 import "repositories/session_diff_repository.dart";
+import "repositories/session_options_repository.dart";
 import "repositories/session_repository.dart";
 import "repositories/session_unseen_calculator.dart";
 import "repositories/session_unseen_repository.dart";
@@ -96,6 +100,7 @@ import "routing/health_check_handler.dart";
 import "routing/hide_project_handler.dart";
 import "routing/open_project_handler.dart";
 import "routing/post_agents_handler.dart";
+import "routing/post_session_options_handler.dart";
 import "routing/reject_question_handler.dart";
 import "routing/rename_project_handler.dart";
 import "routing/rename_session_handler.dart";
@@ -119,6 +124,7 @@ import "services/session_event_dispatcher.dart";
 import "services/session_event_service.dart";
 import "services/session_lifecycle_service.dart";
 import "services/session_mutation_dispatcher.dart";
+import "services/session_options_service.dart";
 import "services/session_prompt_service.dart";
 import "services/session_unseen_service.dart";
 import "services/session_view_tracker.dart";
@@ -144,6 +150,7 @@ class Orchestrator {
   final String _legacyMissingPluginId;
   final PluginLifecycleService _pluginLifecycleService;
   final PluginRuntime _pluginRuntime;
+  final ServerClock _clock;
   final AppDatabase _database;
   final http.Client _httpClient;
   final ProcessRunner _processRunner;
@@ -161,6 +168,7 @@ class Orchestrator {
     required String legacyMissingPluginId,
     required PluginLifecycleService pluginLifecycleService,
     required PluginRuntime pluginRuntime,
+    required ServerClock clock,
     required AppDatabase database,
     required http.Client httpClient,
     required ProcessRunner processRunner,
@@ -177,6 +185,7 @@ class Orchestrator {
        _legacyMissingPluginId = legacyMissingPluginId,
        _pluginLifecycleService = pluginLifecycleService,
        _pluginRuntime = pluginRuntime,
+       _clock = clock,
        _database = database,
        _httpClient = httpClient,
        _processRunner = processRunner,
@@ -207,6 +216,18 @@ class Orchestrator {
       unseenCalculator: unseenCalculator,
       projectCatalogIdentityCalculator: projectCatalogIdentityCalculator,
       aggregateSourceDeadline: aggregateSourceDeadline,
+    );
+    final sessionOptionsRepository = SessionOptionsRepository(
+      runtime: _pluginRuntime,
+      projectsDao: _database.projectsDao,
+      sessionDao: _database.sessionDao,
+      cacheDao: SessionOptionsCacheDao(_database),
+    );
+    final sessionOptionsService = SessionOptionsService(
+      repository: sessionOptionsRepository,
+      pluginScopes: pluginComposition.sessionOptionsScopeById,
+      clock: _clock,
+      retention: const Duration(days: 30),
     );
     final deletedSessionStorageCleanupService = DeletedSessionStorageCleanupService(
       sessionRepository: sessionRepository,
@@ -411,12 +432,22 @@ class Orchestrator {
       source: sessionMutationDispatcher.deletedSessions,
       dispatcher: sessionEventDispatcher,
     );
+    final sessionOptionsCreationRefreshListener = SessionOptionsCreationRefreshListener(
+      source: sessionRepository.bindingCommits,
+      service: sessionOptionsService,
+    );
+    final sessionOptionsChangedRefreshListener = SessionOptionsChangedRefreshListener(
+      runtime: _pluginRuntime,
+      service: sessionOptionsService,
+    );
     final normalizedPluginEvents = sessionEventDispatcher.events.doOnListen(() {
       for (final listener in pluginEventListeners) {
         listener.start();
       }
       sessionBindingCommitListener.start();
       sessionDeletionListener.start();
+      sessionOptionsCreationRefreshListener.start();
+      sessionOptionsChangedRefreshListener.start();
     });
     final router = RequestRouter(
       handlers: [
@@ -426,6 +457,7 @@ class Orchestrator {
         PostPluginLifecycleCommandHandler(lifecycleService: _pluginLifecycleService),
         GetPluginSetupHandler(lifecycleService: _pluginLifecycleService),
         GetPluginsHandler(lifecycleService: _pluginLifecycleService, bridgeIdProvider: _bridgeRegistrationService),
+        PostSessionOptionsHandler(service: sessionOptionsService),
         RestartBridgeHandler(restartService: _restartService),
         GetCurrentProjectHandler(projectRepository: projectRepository),
         GetProjectsHandler(projectActivityService: projectActivityService),
@@ -491,6 +523,8 @@ class Orchestrator {
       pluginEventListeners: pluginEventListeners,
       sessionBindingCommitListener: sessionBindingCommitListener,
       sessionDeletionListener: sessionDeletionListener,
+      sessionOptionsCreationRefreshListener: sessionOptionsCreationRefreshListener,
+      sessionOptionsChangedRefreshListener: sessionOptionsChangedRefreshListener,
       sessionEventDispatcher: sessionEventDispatcher,
       pluginRuntime: _pluginRuntime,
       pushDispatcher: pushDispatcher,
@@ -556,6 +590,8 @@ class OrchestratorSession {
   final List<PluginEventListener> _pluginEventListeners;
   final SessionBindingCommitListener _sessionBindingCommitListener;
   final SessionDeletionListener _sessionDeletionListener;
+  final SessionOptionsCreationRefreshListener _sessionOptionsCreationRefreshListener;
+  final SessionOptionsChangedRefreshListener _sessionOptionsChangedRefreshListener;
   final SessionEventDispatcher _sessionEventDispatcher;
   final PluginRuntime _pluginRuntime;
   final List<int> _roomKey;
@@ -623,6 +659,8 @@ class OrchestratorSession {
     required List<PluginEventListener> pluginEventListeners,
     required SessionBindingCommitListener sessionBindingCommitListener,
     required SessionDeletionListener sessionDeletionListener,
+    required SessionOptionsCreationRefreshListener sessionOptionsCreationRefreshListener,
+    required SessionOptionsChangedRefreshListener sessionOptionsChangedRefreshListener,
     required SessionEventDispatcher sessionEventDispatcher,
     required PluginRuntime pluginRuntime,
     required PushDispatcher pushDispatcher,
@@ -656,6 +694,8 @@ class OrchestratorSession {
        _pluginEventListeners = pluginEventListeners,
        _sessionBindingCommitListener = sessionBindingCommitListener,
        _sessionDeletionListener = sessionDeletionListener,
+       _sessionOptionsCreationRefreshListener = sessionOptionsCreationRefreshListener,
+       _sessionOptionsChangedRefreshListener = sessionOptionsChangedRefreshListener,
        _sessionEventDispatcher = sessionEventDispatcher,
        _pluginRuntime = pluginRuntime,
        _pushDispatcher = pushDispatcher,
@@ -933,6 +973,8 @@ class OrchestratorSession {
       for (final listener in _pluginEventListeners) attempt(listener.dispose),
       attempt(_sessionBindingCommitListener.dispose),
       attempt(_sessionDeletionListener.dispose),
+      attempt(_sessionOptionsCreationRefreshListener.dispose),
+      attempt(_sessionOptionsChangedRefreshListener.dispose),
     ]);
     await attempt(_sessionEventDispatcher.dispose);
     await attempt(_permissionAutoApprovalService.dispose);

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -54,6 +54,7 @@ enum SessionBindingCommitKind { sessionCreation, catalogSync }
 
 typedef SessionBindingsCommitted = ({
   String pluginId,
+  String projectId,
   int generation,
   SessionBindingCommitKind kind,
   List<String> backendSessionIds,
@@ -207,6 +208,7 @@ class SessionRepository {
     );
     _publishBindingsCommitted(
       pluginId: pluginId,
+      projectId: projectId,
       generation: result.generation,
       kind: SessionBindingCommitKind.sessionCreation,
       backendSessionIds: [result.created.id],
@@ -798,6 +800,7 @@ class SessionRepository {
     });
     _publishBindingsCommitted(
       pluginId: pluginId,
+      projectId: result.project.projectId,
       generation: generation,
       kind: SessionBindingCommitKind.catalogSync,
       backendSessionIds: result.committedByBackendId.keys.toList(growable: false),
@@ -1333,6 +1336,7 @@ class SessionRepository {
 
   void _publishBindingsCommitted({
     required String pluginId,
+    required String projectId,
     required int generation,
     required SessionBindingCommitKind kind,
     required List<String> backendSessionIds,
@@ -1340,6 +1344,7 @@ class SessionRepository {
     if (backendSessionIds.isEmpty || _bindingCommitsController.isClosed) return;
     _bindingCommitsController.add((
       pluginId: pluginId,
+      projectId: projectId,
       generation: generation,
       kind: kind,
       backendSessionIds: List<String>.unmodifiable(backendSessionIds),

--- a/bridge/app/lib/src/bridge/routing/post_session_options_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/post_session_options_handler.dart
@@ -7,11 +7,15 @@ import "../services/session_options_service.dart";
 import "request_handler.dart";
 
 class PostSessionOptionsHandler extends RequestHandlerBase {
-  PostSessionOptionsHandler({required SessionOptionsService service})
-    : _service = service,
-      super(HttpMethod.post, "/session/options");
+  PostSessionOptionsHandler({
+    required SessionOptionsService service,
+    required Set<String> pluginIds,
+  }) : _service = service,
+       _pluginIds = Set.unmodifiable(pluginIds),
+       super(HttpMethod.post, "/session/options");
 
   final SessionOptionsService _service;
+  final Set<String> _pluginIds;
 
   @override
   Future<RelayResponse> handleInternal(
@@ -29,7 +33,13 @@ class PostSessionOptionsHandler extends RequestHandlerBase {
     } on Object {
       return _error(request: request, status: 400, code: SessionOptionsErrorCode.unknown);
     }
-    if (body.projectId.trim().isEmpty || body.pluginId.trim().isEmpty) {
+    final projectId = body.projectId.trim();
+    final pluginId = body.pluginId.trim();
+    if (projectId.isEmpty ||
+        pluginId.isEmpty ||
+        projectId != body.projectId ||
+        pluginId != body.pluginId ||
+        !_pluginIds.contains(pluginId)) {
       return _error(request: request, status: 400, code: SessionOptionsErrorCode.unknown);
     }
 
@@ -41,8 +51,8 @@ class PostSessionOptionsHandler extends RequestHandlerBase {
     final SessionOptionsOutcome outcome;
     try {
       outcome = refresh == "true"
-          ? await _service.refreshExplicit(pluginId: body.pluginId, projectId: body.projectId)
-          : await _service.loadCacheOnly(pluginId: body.pluginId, projectId: body.projectId);
+          ? await _service.refreshExplicit(pluginId: pluginId, projectId: projectId)
+          : await _service.loadCacheOnly(pluginId: pluginId, projectId: projectId);
     } on Object catch (error, stackTrace) {
       Log.w("Session options request failed", error, stackTrace);
       return _error(request: request, status: 500, code: SessionOptionsErrorCode.unknown);
@@ -74,11 +84,11 @@ class PostSessionOptionsHandler extends RequestHandlerBase {
         status: 502,
         code: SessionOptionsErrorCode.refreshFailedUnavailable,
       ),
-      SessionOptionsAutomaticNoOp() => _unexpectedAutomaticNoOp(request),
+      SessionOptionsAutomaticNoOp() => _unexpectedAutomaticNoOp(request: request),
     };
   }
 
-  RelayResponse _unexpectedAutomaticNoOp(RelayRequest request) {
+  RelayResponse _unexpectedAutomaticNoOp({required RelayRequest request}) {
     Log.w("Explicit session options request produced an automatic no-op outcome");
     return _error(request: request, status: 500, code: SessionOptionsErrorCode.unknown);
   }

--- a/bridge/app/lib/src/bridge/routing/post_session_options_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/post_session_options_handler.dart
@@ -1,0 +1,110 @@
+import "dart:convert";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../services/session_options_service.dart";
+import "request_handler.dart";
+
+class PostSessionOptionsHandler extends RequestHandlerBase {
+  PostSessionOptionsHandler({required SessionOptionsService service})
+    : _service = service,
+      super(HttpMethod.post, "/session/options");
+
+  final SessionOptionsService _service;
+
+  @override
+  Future<RelayResponse> handleInternal(
+    RelayRequest request, {
+    required Map<String, String> pathParams,
+    required Map<String, String> queryParams,
+    required String? fragment,
+  }) async {
+    final rawBody = request.body;
+    if (rawBody == null) return _error(request: request, status: 400, code: SessionOptionsErrorCode.unknown);
+
+    final PluginProjectIdRequest body;
+    try {
+      body = PluginProjectIdRequest.fromJson(jsonDecodeMap(rawBody));
+    } on Object {
+      return _error(request: request, status: 400, code: SessionOptionsErrorCode.unknown);
+    }
+    if (body.projectId.trim().isEmpty || body.pluginId.trim().isEmpty) {
+      return _error(request: request, status: 400, code: SessionOptionsErrorCode.unknown);
+    }
+
+    final refresh = queryParams["refresh"];
+    if (refresh != null && refresh != "false" && refresh != "true") {
+      return _error(request: request, status: 400, code: SessionOptionsErrorCode.unknown);
+    }
+
+    final SessionOptionsOutcome outcome;
+    try {
+      outcome = refresh == "true"
+          ? await _service.refreshExplicit(pluginId: body.pluginId, projectId: body.projectId)
+          : await _service.loadCacheOnly(pluginId: body.pluginId, projectId: body.projectId);
+    } on Object catch (error, stackTrace) {
+      Log.w("Session options request failed", error, stackTrace);
+      return _error(request: request, status: 500, code: SessionOptionsErrorCode.unknown);
+    }
+
+    return switch (outcome) {
+      SessionOptionsAvailable(:final response) => _jsonResponse(
+        request: request,
+        status: 200,
+        body: response.toJson(),
+      ),
+      SessionOptionsCacheUnavailable() => _error(
+        request: request,
+        status: 503,
+        code: SessionOptionsErrorCode.cacheUnavailable,
+      ),
+      SessionOptionsProjectNotFound() => _error(
+        request: request,
+        status: 404,
+        code: SessionOptionsErrorCode.projectNotFound,
+      ),
+      SessionOptionsRefreshFailedRetained() => _error(
+        request: request,
+        status: 502,
+        code: SessionOptionsErrorCode.refreshFailedRetained,
+      ),
+      SessionOptionsRefreshFailedUnavailable() => _error(
+        request: request,
+        status: 502,
+        code: SessionOptionsErrorCode.refreshFailedUnavailable,
+      ),
+      SessionOptionsAutomaticNoOp() => _unexpectedAutomaticNoOp(request),
+    };
+  }
+
+  RelayResponse _unexpectedAutomaticNoOp(RelayRequest request) {
+    Log.w("Explicit session options request produced an automatic no-op outcome");
+    return _error(request: request, status: 500, code: SessionOptionsErrorCode.unknown);
+  }
+
+  RelayResponse _error({
+    required RelayRequest request,
+    required int status,
+    required SessionOptionsErrorCode code,
+  }) {
+    return _jsonResponse(
+      request: request,
+      status: status,
+      body: SessionOptionsErrorResponse(code: code).toJson(),
+    );
+  }
+
+  RelayResponse _jsonResponse({
+    required RelayRequest request,
+    required int status,
+    required Map<String, dynamic> body,
+  }) {
+    return RelayResponse(
+      id: request.id,
+      status: status,
+      headers: const {"content-type": "application/json"},
+      body: jsonEncode(body),
+    );
+  }
+}

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -801,6 +801,7 @@ class BridgeRuntimeRunner {
         legacyMissingPluginId: legacyMissingPluginId,
         pluginLifecycleService: activePluginLifecycleService,
         pluginRuntime: activePluginRuntime,
+        clock: serverClock,
         database: database,
         httpClient: httpClient,
         processRunner: processRunner,

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -840,12 +840,17 @@ class BridgeRuntimeRunner {
         );
       }
 
+      registerSignalHandlers(session: activeRuntime.session, subscriptions: subscriptions);
+      // start() synchronously subscribes local route-trigger listeners before
+      // the debug server can expose mutation routes.
+      final sessionStart = activeRuntime.session.start();
+      sessionStart.ignore();
+      sessionRun = activeRuntime.session.waitUntilStopped();
       debugServer = await startDebugServerIfRequested(
         debugPort: options.debugPort,
         runtime: activeRuntime,
         shutdownCoordinator: shutdownCoordinator,
       );
-      registerSignalHandlers(session: activeRuntime.session, subscriptions: subscriptions);
       // Background: check + download + stage + apply-in-place on a 4h cadence.
       // The swap takes effect on the next launch (or a phone-triggered restart).
       shutdownCoordinator.add(disposable: updateLifecycle.dispose);
@@ -877,8 +882,6 @@ class BridgeRuntimeRunner {
       }
 
       try {
-        final sessionStart = activeRuntime.session.start();
-        sessionRun = activeRuntime.session.waitUntilStopped();
         final startResult = await sessionStart;
         if (startResult == OrchestratorSessionStartResult.ready) {
           if (onboardingPreparation case final preparation?) {

--- a/bridge/app/lib/src/listeners/session_options_changed_refresh_listener.dart
+++ b/bridge/app/lib/src/listeners/session_options_changed_refresh_listener.dart
@@ -1,0 +1,88 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../bridge/runtime/plugin_runtime.dart";
+import "../bridge/services/session_options_service.dart";
+
+class SessionOptionsChangedRefreshListener {
+  SessionOptionsChangedRefreshListener({
+    required PluginRuntime runtime,
+    required SessionOptionsService service,
+  }) : _runtime = runtime,
+       _service = service;
+
+  final PluginRuntime _runtime;
+  final SessionOptionsService _service;
+  final Set<Future<void>> _pending = {};
+  StreamSubscription<SourcedPluginRuntimeEvent>? _subscription;
+  Future<void>? _disposeFuture;
+  bool _disposed = false;
+
+  void start() {
+    if (_subscription != null || _disposed) return;
+    _subscription = _runtime.backendEvents.listen(
+      (source) {
+        final event = source.event;
+        if (event is! BridgeSseSessionOptionsChanged ||
+            !_runtime.isCurrentGeneration(pluginId: source.pluginId, generation: source.generation)) {
+          return;
+        }
+        _track(
+          _refresh(
+            pluginId: source.pluginId,
+            backendSessionId: event.sessionID,
+            generation: source.generation,
+          ),
+        );
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        Log.w("Session options change trigger stream failed", error, stackTrace);
+      },
+    );
+  }
+
+  Future<void> dispose() => _disposeFuture ??= _dispose();
+
+  Future<void> _dispose() async {
+    _disposed = true;
+    await _subscription?.cancel();
+    await Future.wait(_pending.toList(growable: false));
+  }
+
+  void _track(Future<void> operation) {
+    _pending.add(operation);
+    unawaited(operation.whenComplete(() => _pending.remove(operation)));
+  }
+
+  Future<void> _refresh({
+    required String pluginId,
+    required String backendSessionId,
+    required int generation,
+  }) async {
+    try {
+      final outcome = await _service.refreshActiveOnlyForBackendSession(
+        pluginId: pluginId,
+        backendSessionId: backendSessionId,
+        generation: generation,
+      );
+      switch (outcome) {
+        case SessionOptionsAvailable() ||
+            SessionOptionsAutomaticNoOp() ||
+            SessionOptionsRefreshFailedRetained() ||
+            SessionOptionsRefreshFailedUnavailable():
+          return;
+        case SessionOptionsProjectNotFound():
+          Log.w('Automatic session options refresh found no bound project for plugin "$pluginId"');
+        case SessionOptionsCacheUnavailable():
+          Log.w('Automatic session options refresh returned an unexpected cache miss for plugin "$pluginId"');
+      }
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        'Automatic session options refresh failed after an options-change event for plugin "$pluginId"',
+        error,
+        stackTrace,
+      );
+    }
+  }
+}

--- a/bridge/app/lib/src/listeners/session_options_creation_refresh_listener.dart
+++ b/bridge/app/lib/src/listeners/session_options_creation_refresh_listener.dart
@@ -1,0 +1,74 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../bridge/repositories/session_repository.dart";
+import "../bridge/services/session_options_service.dart";
+
+class SessionOptionsCreationRefreshListener {
+  SessionOptionsCreationRefreshListener({
+    required Stream<SessionBindingsCommitted> source,
+    required SessionOptionsService service,
+  }) : _source = source,
+       _service = service;
+
+  final Stream<SessionBindingsCommitted> _source;
+  final SessionOptionsService _service;
+  final Set<Future<void>> _pending = {};
+  StreamSubscription<SessionBindingsCommitted>? _subscription;
+  Future<void>? _disposeFuture;
+  bool _disposed = false;
+
+  void start() {
+    if (_subscription != null || _disposed) return;
+    _subscription = _source.listen(
+      (commit) {
+        if (commit.kind != SessionBindingCommitKind.sessionCreation) return;
+        _track(_refresh(commit));
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        Log.w("Session options creation trigger stream failed", error, stackTrace);
+      },
+    );
+  }
+
+  Future<void> dispose() => _disposeFuture ??= _dispose();
+
+  Future<void> _dispose() async {
+    _disposed = true;
+    await _subscription?.cancel();
+    await Future.wait(_pending.toList(growable: false));
+  }
+
+  void _track(Future<void> operation) {
+    _pending.add(operation);
+    unawaited(operation.whenComplete(() => _pending.remove(operation)));
+  }
+
+  Future<void> _refresh(SessionBindingsCommitted commit) async {
+    try {
+      final outcome = await _service.refreshActiveOnly(
+        pluginId: commit.pluginId,
+        projectId: commit.projectId,
+        generation: commit.generation,
+      );
+      switch (outcome) {
+        case SessionOptionsAvailable() ||
+            SessionOptionsAutomaticNoOp() ||
+            SessionOptionsRefreshFailedRetained() ||
+            SessionOptionsRefreshFailedUnavailable():
+          return;
+        case SessionOptionsProjectNotFound():
+          Log.w('Automatic session options refresh found no committed project for plugin "${commit.pluginId}"');
+        case SessionOptionsCacheUnavailable():
+          Log.w('Automatic session options refresh returned an unexpected cache miss for plugin "${commit.pluginId}"');
+      }
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        'Automatic session options refresh failed after session creation for plugin "${commit.pluginId}"',
+        error,
+        stackTrace,
+      );
+    }
+  }
+}

--- a/bridge/app/lib/src/listeners/session_options_creation_refresh_listener.dart
+++ b/bridge/app/lib/src/listeners/session_options_creation_refresh_listener.dart
@@ -24,7 +24,7 @@ class SessionOptionsCreationRefreshListener {
     _subscription = _source.listen(
       (commit) {
         if (commit.kind != SessionBindingCommitKind.sessionCreation) return;
-        _track(_refresh(commit));
+        _track(_refresh(commit: commit));
       },
       onError: (Object error, StackTrace stackTrace) {
         Log.w("Session options creation trigger stream failed", error, stackTrace);
@@ -45,7 +45,7 @@ class SessionOptionsCreationRefreshListener {
     unawaited(operation.whenComplete(() => _pending.remove(operation)));
   }
 
-  Future<void> _refresh(SessionBindingsCommitted commit) async {
+  Future<void> _refresh({required SessionBindingsCommitted commit}) async {
     try {
       final outcome = await _service.refreshActiveOnly(
         pluginId: commit.pluginId,

--- a/bridge/app/lib/src/routing/get_plugins_handler.dart
+++ b/bridge/app/lib/src/routing/get_plugins_handler.dart
@@ -23,6 +23,7 @@ class GetPluginsHandler extends GetRequestHandler<PluginListResponse> {
     return PluginListResponse(
       bridgeId: _bridgeIdProvider.bridgeId,
       plugins: _lifecycleService.selectableMetadataSnapshot,
+      supportsSessionOptions: true,
     );
   }
 }

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -57,6 +57,7 @@ Future<_DebugServerHarness> _createDebugServerHarness({
     legacyMissingPluginId: plugin.id,
     pluginLifecycleService: lifecycleService,
     pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
+    clock: const ServerClock(),
     database: db,
     httpClient: httpClient,
     processRunner: ProcessRunner(),
@@ -218,7 +219,7 @@ void main() {
       );
     });
 
-    test("debug client disconnect does not tear down the shared plugin listener", () async {
+    test("debug client disconnect does not tear down the orchestrator plugin listeners", () async {
       final trackingPlugin = _TrackingBridgePlugin();
       final trackingDb = createTestDatabase();
       final trackingHarness = await _createDebugServerHarness(
@@ -236,7 +237,7 @@ void main() {
       final second = await _SseTestClient.connect(trackingServer.boundPort!);
 
       await Future<void>.delayed(const Duration(milliseconds: 50));
-      expect(trackingPlugin.subscribeCount, equals(1));
+      expect(trackingPlugin.subscribeCount, equals(2));
 
       await second.close();
       await Future<void>.delayed(const Duration(milliseconds: 100));

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -438,6 +438,7 @@ class _OrchestratorHarness {
       legacyMissingPluginId: "opencode",
       pluginLifecycleService: lifecycleService,
       pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
+      clock: const ServerClock(),
       database: database,
       httpClient: httpClient,
       processRunner: ProcessRunner(),

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -68,6 +68,7 @@ void main() {
       legacyMissingPluginId: "opencode",
       pluginLifecycleService: lifecycleService,
       pluginRuntime: pluginRuntime,
+      clock: const ServerClock(),
       database: database,
       httpClient: httpClient,
       processRunner: ProcessRunner(),
@@ -140,6 +141,7 @@ void main() {
       legacyMissingPluginId: plugin.id,
       pluginLifecycleService: lifecycleService,
       pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
+      clock: const ServerClock(),
       database: database,
       httpClient: httpClient,
       processRunner: ProcessRunner(),
@@ -190,6 +192,7 @@ void main() {
         legacyMissingPluginId: plugin.id,
         pluginLifecycleService: lifecycleService,
         pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
+        clock: const ServerClock(),
         database: database,
         httpClient: httpClient,
         processRunner: ProcessRunner(),
@@ -255,7 +258,7 @@ void main() {
       harness.plugin.add(const BridgeSseVcsBranchUpdated());
 
       expect(await laterEvent.timeout(const Duration(seconds: 2)), isA<SesoriVcsBranchUpdated>());
-      expect(harness.plugin.subscribeCount, 1);
+      expect(harness.plugin.subscribeCount, 2);
     });
   });
 }
@@ -305,6 +308,7 @@ class _TestHarness {
       legacyMissingPluginId: plugin.id,
       pluginLifecycleService: lifecycleService,
       pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
+      clock: const ServerClock(),
       database: database,
       httpClient: httpClient,
       processRunner: ProcessRunner(),

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -176,7 +176,7 @@ void main() {
   });
 
   group("OrchestratorSession SSE error recovery", () {
-    test("initial relay connect failure does not leave push listeners running", () async {
+    test("local options listener starts before an initial relay connect failure", () async {
       final plugin = _ThrowingSummaryPlugin();
       final database = createTestDatabase();
       final lifecycleService = await createSinglePluginLifecycleService(plugin: plugin);
@@ -219,7 +219,7 @@ void main() {
       await expectLater(localWireEventsDone, completes);
       await expectLater(session.start(), throwsA(isA<StateError>()));
 
-      expect(plugin.subscribeCount, equals(0));
+      expect(plugin.subscribeCount, equals(1));
 
       await lifecycleService.dispose();
       httpClient.close();

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -11,6 +11,7 @@ import "package:sesori_bridge/src/bridge/models/bridge_config.dart";
 import "package:sesori_bridge/src/bridge/orchestrator.dart";
 import "package:sesori_bridge/src/bridge/relay_client.dart";
 import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show ServerClock;
 import "package:sesori_shared/sesori_shared.dart" hide PermissionReply;
 import "package:test/test.dart";
 
@@ -303,6 +304,7 @@ class _RegistrationHarness {
       legacyMissingPluginId: plugin.id,
       pluginLifecycleService: lifecycleService,
       pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
+      clock: const ServerClock(),
       database: database,
       httpClient: httpClient,
       processRunner: ProcessRunner(),

--- a/bridge/app/test/bridge/orchestrator_token_reauth_test.dart
+++ b/bridge/app/test/bridge/orchestrator_token_reauth_test.dart
@@ -12,6 +12,7 @@ import "package:sesori_bridge/src/bridge/models/bridge_config.dart";
 import "package:sesori_bridge/src/bridge/orchestrator.dart";
 import "package:sesori_bridge/src/bridge/relay_client.dart";
 import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show ServerClock;
 import "package:sesori_shared/sesori_shared.dart" hide PermissionReply;
 import "package:test/test.dart";
 
@@ -330,6 +331,7 @@ class _ReauthHarness {
       legacyMissingPluginId: plugin.id,
       pluginLifecycleService: lifecycleService,
       pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
+      clock: const ServerClock(),
       database: database,
       httpClient: httpClient,
       processRunner: ProcessRunner(),

--- a/bridge/app/test/bridge/persistence/database_test.dart
+++ b/bridge/app/test/bridge/persistence/database_test.dart
@@ -35,7 +35,7 @@ void main() {
   test("session options CAS requires the exact next revision", () async {
     final database = createTestDatabase();
     addTearDown(database.close);
-    final dao = SessionOptionsCacheDao(database);
+    final dao = SessionOptionsCacheDao(database: database);
     const row = SessionOptionsCacheTableData(
       pluginId: "plugin",
       scope: PluginSessionOptionsScope.plugin,

--- a/bridge/app/test/bridge/persistence/session_options_cache_dao_test.dart
+++ b/bridge/app/test/bridge/persistence/session_options_cache_dao_test.dart
@@ -12,7 +12,7 @@ void main() {
 
     setUp(() {
       db = createTestDatabase();
-      dao = SessionOptionsCacheDao(db);
+      dao = SessionOptionsCacheDao(database: db);
     });
 
     tearDown(() async {

--- a/bridge/app/test/bridge/repositories/session_options_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_options_repository_test.dart
@@ -21,7 +21,7 @@ void main() {
 
     setUp(() {
       database = createTestDatabase();
-      cacheDao = SessionOptionsCacheDao(database);
+      cacheDao = SessionOptionsCacheDao(database: database);
       plugin = _FakePlugin();
       runtime = _RecordingPluginRuntime(plugin: plugin);
       repository = SessionOptionsRepository(

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -936,6 +936,7 @@ void main() {
       }
       final commits = await commitsFuture;
       expect(commits.map((commit) => commit.kind), everyElement(SessionBindingCommitKind.sessionCreation));
+      expect(commits.map((commit) => commit.projectId), everyElement("/repo"));
       expect(commits.map((commit) => commit.generation), everyElement(1));
     });
 
@@ -1352,6 +1353,7 @@ void main() {
       expect(plugin.lastGetProjectDirectory, directory);
       expect(plugin.lastGetSessionsWorktree, directory);
       expect(commit.pluginId, plugin.id);
+      expect(commit.projectId, directory);
       expect(commit.backendSessionIds, ["backend-root"]);
       expect(commit.kind, SessionBindingCommitKind.catalogSync);
       expect(commit.generation, 1);

--- a/bridge/app/test/bridge/routing/get_plugin_setup_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_plugin_setup_handler_test.dart
@@ -102,6 +102,7 @@ void main() {
       expect(response.plugins.map((plugin) => plugin.id), ["ready"]);
       expect(response.plugins.single.isDefault, isTrue);
       expect(response.bridgeId, "br_test1234");
+      expect(response.supportsSessionOptions, isTrue);
     });
   });
 }

--- a/bridge/app/test/bridge/routing/post_session_options_handler_test.dart
+++ b/bridge/app/test/bridge/routing/post_session_options_handler_test.dart
@@ -1,0 +1,248 @@
+import "dart:convert";
+
+import "package:sesori_bridge/src/bridge/routing/post_session_options_handler.dart";
+import "package:sesori_bridge/src/bridge/services/session_options_service.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "routing_test_helpers.dart";
+
+void main() {
+  group("PostSessionOptionsHandler", () {
+    late _FakeSessionOptionsService service;
+    late PostSessionOptionsHandler handler;
+
+    setUp(() {
+      service = _FakeSessionOptionsService();
+      handler = PostSessionOptionsHandler(service: service);
+    });
+
+    test("handles only POST /session/options", () {
+      expect(handler.canHandle(makeRequest("POST", "/session/options")), isTrue);
+      expect(handler.canHandle(makeRequest("GET", "/session/options")), isFalse);
+      expect(handler.canHandle(makeRequest("POST", "/session/options/extra")), isFalse);
+    });
+
+    for (final (description, body) in <(String, String?)>[
+      ("missing", null),
+      ("malformed", "{"),
+      ("invalid", jsonEncode({"projectId": 1, "pluginId": "plugin"})),
+      ("empty", jsonEncode({"projectId": " ", "pluginId": "plugin"})),
+    ]) {
+      test("returns typed 400 for $description body", () async {
+        final response = await _send(handler: handler, body: body);
+
+        _expectError(response, status: 400, code: SessionOptionsErrorCode.unknown);
+        expect(service.calls, isEmpty);
+      });
+    }
+
+    test("missing and exact false refresh load cache only", () async {
+      for (final path in ["/session/options", "/session/options?refresh=false"]) {
+        service.calls.clear();
+
+        final response = await _send(handler: handler, path: path, body: _requestBody);
+
+        expect(response.status, 200);
+        expect(service.calls, [
+          const (
+            operation: _SessionOptionsOperation.loadCacheOnly,
+            pluginId: "plugin",
+            projectId: "project",
+          ),
+        ]);
+      }
+    });
+
+    test("exact true refreshes explicitly", () async {
+      final response = await _send(
+        handler: handler,
+        path: "/session/options?refresh=true",
+        body: _requestBody,
+      );
+
+      expect(response.status, 200);
+      expect(service.calls, [
+        const (
+          operation: _SessionOptionsOperation.refreshExplicit,
+          pluginId: "plugin",
+          projectId: "project",
+        ),
+      ]);
+    });
+
+    for (final refresh in ["", "TRUE", "False", "1"]) {
+      test("rejects refresh=$refresh", () async {
+        final response = await _send(
+          handler: handler,
+          path: "/session/options?refresh=${Uri.encodeQueryComponent(refresh)}",
+          body: _requestBody,
+        );
+
+        _expectError(response, status: 400, code: SessionOptionsErrorCode.unknown);
+        expect(service.calls, isEmpty);
+      });
+    }
+
+    test("maps available options to typed 200 JSON", () async {
+      service.outcome = const SessionOptionsAvailable(response: _optionsResponse);
+
+      final response = await _send(handler: handler, body: _requestBody);
+
+      expect(response.status, 200);
+      expect(response.headers, containsPair("content-type", "application/json"));
+      expect(SessionOptionsResponse.fromJson(jsonDecodeMap(response.body!)), _optionsResponse);
+    });
+
+    for (final mapping in <({SessionOptionsOutcome outcome, int status, SessionOptionsErrorCode code})>[
+      (
+        outcome: const SessionOptionsCacheUnavailable(),
+        status: 503,
+        code: SessionOptionsErrorCode.cacheUnavailable,
+      ),
+      (
+        outcome: const SessionOptionsProjectNotFound(),
+        status: 404,
+        code: SessionOptionsErrorCode.projectNotFound,
+      ),
+      (
+        outcome: const SessionOptionsRefreshFailedRetained(
+          failure: SessionOptionsKnownRefreshFailure(),
+        ),
+        status: 502,
+        code: SessionOptionsErrorCode.refreshFailedRetained,
+      ),
+      (
+        outcome: const SessionOptionsRefreshFailedUnavailable(
+          failure: SessionOptionsKnownRefreshFailure(),
+        ),
+        status: 502,
+        code: SessionOptionsErrorCode.refreshFailedUnavailable,
+      ),
+    ]) {
+      test("maps ${mapping.code.name} to ${mapping.status}", () async {
+        service.outcome = mapping.outcome;
+
+        final response = await _send(handler: handler, body: _requestBody);
+
+        _expectError(response, status: mapping.status, code: mapping.code);
+      });
+    }
+
+    test("maps automatic no-op to safe typed 500", () async {
+      service.outcome = const SessionOptionsAutomaticNoOp();
+
+      final response = await _send(handler: handler, body: _requestBody);
+
+      _expectError(response, status: 500, code: SessionOptionsErrorCode.unknown);
+    });
+
+    test("does not forward plugin status codes or error text", () async {
+      service.error = const PluginOperationException("capture", statusCode: 418, message: "sensitive upstream text");
+
+      final response = await _send(
+        handler: handler,
+        path: "/session/options?refresh=true",
+        body: _requestBody,
+      );
+
+      _expectError(response, status: 500, code: SessionOptionsErrorCode.unknown);
+      expect(response.body, isNot(contains("sensitive")));
+    });
+  });
+}
+
+const _optionsResponse = SessionOptionsResponse(
+  agents: Agents(agents: []),
+  providers: ProviderListResponse(items: [], connectedOnly: true),
+  commands: CommandListResponse(items: []),
+);
+
+final _requestBody = jsonEncode(const PluginProjectIdRequest(projectId: "project", pluginId: "plugin").toJson());
+
+Future<RelayResponse> _send({
+  required PostSessionOptionsHandler handler,
+  String path = "/session/options",
+  required String? body,
+}) {
+  final request = makeRequest("POST", path, body: body);
+  final params = handler.extractParams(request);
+  return handler.handleInternal(
+    request,
+    pathParams: params.pathParams,
+    queryParams: params.queryParams,
+    fragment: params.fragment,
+  );
+}
+
+void _expectError(
+  RelayResponse response, {
+  required int status,
+  required SessionOptionsErrorCode code,
+}) {
+  expect(response.status, status);
+  expect(response.headers, containsPair("content-type", "application/json"));
+  expect(
+    SessionOptionsErrorResponse.fromJson(jsonDecodeMap(response.body!)),
+    SessionOptionsErrorResponse(code: code),
+  );
+}
+
+enum _SessionOptionsOperation { loadCacheOnly, refreshExplicit }
+
+typedef _SessionOptionsCall = ({
+  _SessionOptionsOperation operation,
+  String pluginId,
+  String projectId,
+});
+
+class _FakeSessionOptionsService implements SessionOptionsService {
+  SessionOptionsOutcome outcome = const SessionOptionsAvailable(response: _optionsResponse);
+  Object? error;
+  final List<_SessionOptionsCall> calls = [];
+
+  @override
+  Future<SessionOptionsOutcome> loadCacheOnly({required String pluginId, required String projectId}) {
+    calls.add(
+      (
+        operation: _SessionOptionsOperation.loadCacheOnly,
+        pluginId: pluginId,
+        projectId: projectId,
+      ),
+    );
+    return _complete();
+  }
+
+  @override
+  Future<SessionOptionsOutcome> refreshExplicit({required String pluginId, required String projectId}) {
+    calls.add(
+      (
+        operation: _SessionOptionsOperation.refreshExplicit,
+        pluginId: pluginId,
+        projectId: projectId,
+      ),
+    );
+    return _complete();
+  }
+
+  Future<SessionOptionsOutcome> _complete() async {
+    final failure = error;
+    if (failure != null) throw failure;
+    return outcome;
+  }
+
+  @override
+  Future<SessionOptionsOutcome> refreshActiveOnly({
+    required String pluginId,
+    required String projectId,
+    required int generation,
+  }) async => const SessionOptionsAutomaticNoOp();
+
+  @override
+  Future<SessionOptionsOutcome> refreshActiveOnlyForBackendSession({
+    required String pluginId,
+    required String backendSessionId,
+    required int generation,
+  }) async => const SessionOptionsAutomaticNoOp();
+}

--- a/bridge/app/test/bridge/routing/post_session_options_handler_test.dart
+++ b/bridge/app/test/bridge/routing/post_session_options_handler_test.dart
@@ -15,7 +15,10 @@ void main() {
 
     setUp(() {
       service = _FakeSessionOptionsService();
-      handler = PostSessionOptionsHandler(service: service);
+      handler = PostSessionOptionsHandler(
+        service: service,
+        pluginIds: const {"plugin"},
+      );
     });
 
     test("handles only POST /session/options", () {
@@ -29,6 +32,8 @@ void main() {
       ("malformed", "{"),
       ("invalid", jsonEncode({"projectId": 1, "pluginId": "plugin"})),
       ("empty", jsonEncode({"projectId": " ", "pluginId": "plugin"})),
+      ("non-canonical", jsonEncode({"projectId": " project", "pluginId": "plugin"})),
+      ("unknown plugin", jsonEncode({"projectId": "project", "pluginId": "unknown"})),
     ]) {
       test("returns typed 400 for $description body", () async {
         final response = await _send(handler: handler, body: body);

--- a/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
@@ -1,3 +1,5 @@
+import "dart:convert";
+
 import "package:fake_async/fake_async.dart";
 import "package:http/http.dart" as http;
 import "package:sesori_bridge/src/auth/token_refresher.dart";
@@ -15,13 +17,15 @@ import "package:sesori_bridge/src/push/push_notification_client.dart";
 import "package:sesori_bridge/src/push/push_notification_content_builder.dart";
 import "package:sesori_bridge/src/push/push_rate_limiter.dart";
 import "package:sesori_bridge/src/push/push_session_state_tracker.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show ServerClock;
+import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
 import "../../helpers/plugin_lifecycle_test_support.dart";
 import "../../helpers/restart_test_support.dart";
 import "../../helpers/test_database.dart";
 import "../../helpers/test_helpers.dart";
-import "../routing/routing_test_helpers.dart" show FakeBridgePlugin;
+import "../routing/routing_test_helpers.dart" show FakeBridgePlugin, makeRequest;
 
 void main() {
   test("push subsystem listeners stay passive during runtime composition", () {
@@ -62,6 +66,7 @@ void main() {
       legacyMissingPluginId: plugin.id,
       pluginLifecycleService: lifecycleService,
       pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
+      clock: const ServerClock(),
       database: database,
       httpClient: httpClient,
       processRunner: ProcessRunner(),
@@ -82,6 +87,19 @@ void main() {
     final debugServer = runtime.createDebugServer(port: 0);
 
     expect(identical(debugServer.router, runtime.session.router), isTrue);
+    final routed = await debugServer.router.route(
+      makeRequest(
+        "POST",
+        "/session/options",
+        body: jsonEncode(PluginProjectIdRequest(projectId: "missing", pluginId: plugin.id).toJson()),
+      ),
+    );
+    expect(routed.status, 404);
+    expect(routed.headers, containsPair("content-type", "application/json"));
+    expect(
+      SessionOptionsErrorResponse.fromJson(jsonDecodeMap(routed.body!)).code,
+      SessionOptionsErrorCode.projectNotFound,
+    );
 
     await debugServer.stop();
     await runtime.close();

--- a/bridge/app/test/bridge/services/session_event_dispatcher_test.dart
+++ b/bridge/app/test/bridge/services/session_event_dispatcher_test.dart
@@ -148,6 +148,7 @@ void main() {
     await dispatcher.dispatchBindingsCommitted(
       commit: (
         pluginId: "plugin",
+        projectId: "project",
         generation: 2,
         kind: SessionBindingCommitKind.catalogSync,
         backendSessionIds: const ["session"],

--- a/bridge/app/test/bridge/services/session_event_service_test.dart
+++ b/bridge/app/test/bridge/services/session_event_service_test.dart
@@ -562,6 +562,7 @@ void main() {
       final output = await service.handleBindingsCommitted(
         commit: (
           pluginId: plugin.id,
+          projectId: "project",
           generation: 1,
           kind: SessionBindingCommitKind.catalogSync,
           backendSessionIds: const ["backend-root"],
@@ -642,6 +643,7 @@ void main() {
       final output = await service.handleBindingsCommitted(
         commit: (
           pluginId: plugin.id,
+          projectId: "project",
           generation: 1,
           kind: SessionBindingCommitKind.sessionCreation,
           backendSessionIds: const ["backend-root"],
@@ -664,6 +666,7 @@ void main() {
       final output = await service.handleBindingsCommitted(
         commit: (
           pluginId: plugin.id,
+          projectId: "project",
           generation: 1,
           kind: SessionBindingCommitKind.sessionCreation,
           backendSessionIds: const ["backend-root"],
@@ -718,6 +721,7 @@ void main() {
       final output = await service.handleBindingsCommitted(
         commit: (
           pluginId: plugin.id,
+          projectId: "project",
           generation: 1,
           kind: SessionBindingCommitKind.catalogSync,
           backendSessionIds: const ["backend-root"],
@@ -773,6 +777,7 @@ void main() {
       final output = await service.handleBindingsCommitted(
         commit: (
           pluginId: plugin.id,
+          projectId: "project",
           generation: 2,
           kind: SessionBindingCommitKind.catalogSync,
           backendSessionIds: const ["backend-root"],
@@ -858,6 +863,7 @@ void main() {
       final output = await service.handleBindingsCommitted(
         commit: (
           pluginId: plugin.id,
+          projectId: "project",
           generation: 1,
           kind: SessionBindingCommitKind.catalogSync,
           backendSessionIds: const ["backend-root"],
@@ -931,6 +937,7 @@ void main() {
       final output = await service.handleBindingsCommitted(
         commit: (
           pluginId: plugin.id,
+          projectId: "project",
           generation: 1,
           kind: SessionBindingCommitKind.catalogSync,
           backendSessionIds: const ["backend-root"],

--- a/bridge/app/test/listeners/session_event_trigger_listeners_test.dart
+++ b/bridge/app/test/listeners/session_event_trigger_listeners_test.dart
@@ -19,12 +19,14 @@ void main() {
 
     source.add((
       pluginId: "other",
+      projectId: "other-project",
       generation: 1,
       kind: SessionBindingCommitKind.catalogSync,
       backendSessionIds: const ["ignored"],
     ));
     source.add((
       pluginId: "selected",
+      projectId: "selected-project",
       generation: 2,
       kind: SessionBindingCommitKind.sessionCreation,
       backendSessionIds: const ["root"],
@@ -34,12 +36,14 @@ void main() {
     expect(dispatcher.commits, [
       (
         pluginId: "other",
+        projectId: "other-project",
         generation: 1,
         kind: SessionBindingCommitKind.catalogSync,
         backendSessionIds: const ["ignored"],
       ),
       (
         pluginId: "selected",
+        projectId: "selected-project",
         generation: 2,
         kind: SessionBindingCommitKind.sessionCreation,
         backendSessionIds: const ["root"],

--- a/bridge/app/test/listeners/session_options_refresh_listeners_test.dart
+++ b/bridge/app/test/listeners/session_options_refresh_listeners_test.dart
@@ -1,0 +1,240 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
+import "package:sesori_bridge/src/bridge/runtime/plugin_runtime.dart";
+import "package:sesori_bridge/src/bridge/services/session_options_service.dart";
+import "package:sesori_bridge/src/listeners/session_options_changed_refresh_listener.dart";
+import "package:sesori_bridge/src/listeners/session_options_creation_refresh_listener.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("SessionOptionsCreationRefreshListener", () {
+    late StreamController<SessionBindingsCommitted> source;
+    late _FakeSessionOptionsService service;
+    late SessionOptionsCreationRefreshListener listener;
+
+    setUp(() {
+      source = StreamController<SessionBindingsCommitted>.broadcast(sync: true);
+      service = _FakeSessionOptionsService();
+      listener = SessionOptionsCreationRefreshListener(source: source.stream, service: service)..start();
+    });
+
+    tearDown(() async {
+      await listener.dispose();
+      await source.close();
+    });
+
+    test("refreshes only session-creation commits with stable project attribution", () async {
+      source.add(_commit(kind: SessionBindingCommitKind.catalogSync, projectId: "catalog-project"));
+      source.add(_commit(kind: SessionBindingCommitKind.sessionCreation, projectId: "stable-project"));
+      await _flushEvents();
+
+      expect(service.creationCalls, [
+        (pluginId: "plugin", projectId: "stable-project", generation: 7),
+      ]);
+      expect(service.successfulCreationProjects, ["stable-project"]);
+    });
+
+    test("passes stale generations to the service fence without refreshing", () async {
+      service.currentGeneration = 8;
+
+      source.add(_commit(kind: SessionBindingCommitKind.sessionCreation, projectId: "stale-project"));
+      await _flushEvents();
+
+      expect(service.creationCalls.single.generation, 7);
+      expect(service.successfulCreationProjects, isEmpty);
+    });
+
+    test("contains an async refresh error and continues listening", () async {
+      service.failingCreationProjects.add("fails");
+
+      source.add(_commit(kind: SessionBindingCommitKind.sessionCreation, projectId: "fails"));
+      source.add(_commit(kind: SessionBindingCommitKind.sessionCreation, projectId: "continues"));
+      await _flushEvents();
+
+      expect(service.creationCalls.map((call) => call.projectId), ["fails", "continues"]);
+      expect(service.successfulCreationProjects, ["continues"]);
+    });
+  });
+
+  group("SessionOptionsChangedRefreshListener", () {
+    late _FakePluginRuntime runtime;
+    late _FakeSessionOptionsService service;
+    late SessionOptionsChangedRefreshListener listener;
+
+    setUp(() {
+      runtime = _FakePluginRuntime();
+      service = _FakeSessionOptionsService();
+      listener = SessionOptionsChangedRefreshListener(runtime: runtime, service: service)..start();
+    });
+
+    tearDown(() async {
+      await listener.dispose();
+      await runtime.closeEvents();
+    });
+
+    test("ignores generic and stale events and refreshes a current options change", () async {
+      service.boundBackendSessionIds.add("current-session");
+
+      runtime.emit(event: const BridgeSseVcsBranchUpdated(), generation: 7);
+      runtime.emit(event: const BridgeSseSessionOptionsChanged(sessionID: "stale-session"), generation: 6);
+      runtime.emit(event: const BridgeSseSessionOptionsChanged(sessionID: "current-session"), generation: 7);
+      await _flushEvents();
+
+      expect(runtime.generationChecks, [
+        (pluginId: "plugin", generation: 6),
+        (pluginId: "plugin", generation: 7),
+      ]);
+      expect(service.backendCalls, [
+        (pluginId: "plugin", backendSessionId: "current-session", generation: 7),
+      ]);
+      expect(service.successfulBackendSessions, ["current-session"]);
+    });
+
+    test("pre-binding options changes no-op without preventing a later refresh", () async {
+      runtime.emit(event: const BridgeSseSessionOptionsChanged(sessionID: "new-session"), generation: 7);
+      await _flushEvents();
+
+      expect(service.backendCalls, hasLength(1));
+      expect(service.successfulBackendSessions, isEmpty);
+
+      service.boundBackendSessionIds.add("new-session");
+      runtime.emit(event: const BridgeSseSessionOptionsChanged(sessionID: "new-session"), generation: 7);
+      await _flushEvents();
+
+      expect(service.backendCalls, hasLength(2));
+      expect(service.successfulBackendSessions, ["new-session"]);
+    });
+
+    test("contains source and async refresh errors and continues listening", () async {
+      service
+        ..boundBackendSessionIds.addAll(["fails", "continues"])
+        ..failingBackendSessionIds.add("fails");
+
+      runtime.addError(StateError("source failed"));
+      runtime.emit(event: const BridgeSseSessionOptionsChanged(sessionID: "fails"), generation: 7);
+      runtime.emit(event: const BridgeSseSessionOptionsChanged(sessionID: "continues"), generation: 7);
+      await _flushEvents();
+
+      expect(service.backendCalls.map((call) => call.backendSessionId), ["fails", "continues"]);
+      expect(service.successfulBackendSessions, ["continues"]);
+    });
+
+    test("dispose cancels its runtime subscription", () async {
+      await listener.dispose();
+
+      runtime.emit(event: const BridgeSseSessionOptionsChanged(sessionID: "after-dispose"), generation: 7);
+      await _flushEvents();
+
+      expect(service.backendCalls, isEmpty);
+    });
+  });
+}
+
+SessionBindingsCommitted _commit({
+  required SessionBindingCommitKind kind,
+  required String projectId,
+}) {
+  return (
+    pluginId: "plugin",
+    projectId: projectId,
+    generation: 7,
+    kind: kind,
+    backendSessionIds: const ["backend-session"],
+  );
+}
+
+Future<void> _flushEvents() async {
+  await Future<void>.delayed(Duration.zero);
+  await Future<void>.delayed(Duration.zero);
+}
+
+const _optionsResponse = SessionOptionsResponse(
+  agents: Agents(agents: []),
+  providers: ProviderListResponse(items: [], connectedOnly: true),
+  commands: CommandListResponse(items: []),
+);
+
+class _FakeSessionOptionsService implements SessionOptionsService {
+  int currentGeneration = 7;
+  final Set<String> boundBackendSessionIds = {};
+  final Set<String> failingCreationProjects = {};
+  final Set<String> failingBackendSessionIds = {};
+  final List<({String pluginId, String projectId, int generation})> creationCalls = [];
+  final List<({String pluginId, String backendSessionId, int generation})> backendCalls = [];
+  final List<String> successfulCreationProjects = [];
+  final List<String> successfulBackendSessions = [];
+
+  @override
+  Future<SessionOptionsOutcome> refreshActiveOnly({
+    required String pluginId,
+    required String projectId,
+    required int generation,
+  }) async {
+    creationCalls.add((pluginId: pluginId, projectId: projectId, generation: generation));
+    if (failingCreationProjects.contains(projectId)) throw StateError("creation refresh failed");
+    if (generation != currentGeneration) return const SessionOptionsAutomaticNoOp();
+    successfulCreationProjects.add(projectId);
+    return const SessionOptionsAvailable(response: _optionsResponse);
+  }
+
+  @override
+  Future<SessionOptionsOutcome> refreshActiveOnlyForBackendSession({
+    required String pluginId,
+    required String backendSessionId,
+    required int generation,
+  }) async {
+    backendCalls.add((pluginId: pluginId, backendSessionId: backendSessionId, generation: generation));
+    if (failingBackendSessionIds.contains(backendSessionId)) throw StateError("event refresh failed");
+    if (generation != currentGeneration || !boundBackendSessionIds.contains(backendSessionId)) {
+      return const SessionOptionsAutomaticNoOp();
+    }
+    successfulBackendSessions.add(backendSessionId);
+    return const SessionOptionsAvailable(response: _optionsResponse);
+  }
+
+  @override
+  Future<SessionOptionsOutcome> loadCacheOnly({required String pluginId, required String projectId}) async {
+    return const SessionOptionsCacheUnavailable();
+  }
+
+  @override
+  Future<SessionOptionsOutcome> refreshExplicit({required String pluginId, required String projectId}) async {
+    return const SessionOptionsRefreshFailedUnavailable(
+      failure: SessionOptionsKnownRefreshFailure(),
+    );
+  }
+}
+
+class _FakePluginRuntime implements PluginRuntime {
+  final StreamController<SourcedPluginRuntimeEvent> _events = StreamController.broadcast(sync: true);
+  final List<({String pluginId, int generation})> generationChecks = [];
+
+  @override
+  Stream<SourcedPluginRuntimeEvent> get backendEvents => _events.stream;
+
+  @override
+  bool isCurrentGeneration({required String pluginId, required int generation}) {
+    generationChecks.add((pluginId: pluginId, generation: generation));
+    return pluginId == "plugin" && generation == 7;
+  }
+
+  void emit({required BridgeSseEvent event, required int generation}) {
+    _events.add((
+      pluginId: "plugin",
+      generation: generation,
+      event: event,
+      allowDuringStop: false,
+      terminalHandoffConsumed: null,
+    ));
+  }
+
+  void addError(Object error) => _events.addError(error, StackTrace.current);
+
+  Future<void> closeEvents() => _events.close();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}


### PR DESCRIPTION
## Summary

- expose `POST /session/options` with cache-only default reads, explicit `refresh=true`, and typed success/error responses
- publish the session-options discovery capability and carry stable project attribution on binding commits
- add independent creation and backend options-change refresh listeners with generation fencing and lifecycle-safe disposal
- compose the 30-day cache service once in `Orchestrator` and share the route through relay and debug flows

## Verification

- 153 focused handler, listener, repository, and Orchestrator tests
- full bridge-app suite: 2,253 tests
- `dart analyze --fatal-infos`
- `git diff --check`
- Aristotle architecture review: approved with no findings

## Series

Step 4.F/6, following #627. Step 5 remains blocked until this bridge cache route and refresh lifecycle merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cached session options flow with `POST /session/options` (cache-first with `refresh=true` to refetch), wired into the Orchestrator with a 30‑day retention and automatic refreshes. Startup is hardened so refresh listeners are subscribed before any debug routes are reachable.

- **New Features**
  - `POST /session/options`:
    - Reads from cache by default; pass `refresh=true` to refetch.
    - Typed JSON for success and errors; upstream status/text not surfaced.
    - Rejects non-canonical or unknown `pluginId`.
  - Discovery: `GET /plugins` now includes `supportsSessionOptions: true`.
  - Orchestrator:
    - Composes a single `SessionOptionsService` (30‑day retention via `ServerClock`) and shares the route in relay and debug servers.
    - Adds generation-fenced, lifecycle-safe refresh listeners for session creation and `SessionOptionsChanged` events.
  - Session binding commits now carry `projectId` to enable stable attribution on refresh.

- **Bug Fixes**
  - Start local session‑options refresh listeners synchronously before the debug server exposes mutation routes, ensuring safe handling during startup.

<sup>Written for commit ad6276931b5db621416237f5fcf71355cd022392. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

