### PR TITLE
[user-analytics] Add bounded outcome analytics contracts [step 4.A/5]

### DIFF
--- a/.plan/active/user-analytics/PLAN.md
+++ b/.plan/active/user-analytics/PLAN.md
@@ -417,13 +417,17 @@ mixed `src/analytics/` bucket. The concrete dependency direction is:
 | `ProductAnalyticsPreferenceApi` in `module_core/lib/src/api/product_analytics_preference_api.dart` | Layer 1; constructor requires `AuthenticatedHttpApiClient` | Calls authenticated GET/PUT `/product-analytics/preference` under a fixed 10-second operation deadline. GET parses `{preference, revision, userKey}`; PUT requires `{preference, expectedRevision, operationId}` and parses the same key on success/conflict. It validates the key as 64-character lowercase hex, serializes closed values, parses external strings at the boundary, and returns explicit success/conflict/timeout/failure. A timed-out transport may finish, but server compare-and-set prevents it from overwriting a newer committed revision. |
 | `ProductAnalyticsPreferenceStorage` in `module_core/lib/src/api/storage/` | Layer 1 data source; constructor requires `SecureStorage` | Reads/writes/deletes only closed preference synchronization records. It does not reconcile accounts, call APIs, hash IDs, or emit analytics. |
 | `AnalyticsDeliveryResult`, `ProductAnalyticsPreference`, versioned synchronized/pending preference records, and explicit repository results under `module_core/lib/src/repositories/models/` | Layer-2 contracts | Delivery is `acceptedBySdk`, `deferredUntilPreference`, or `failed`, never an untruthful “reported” boolean. Preference records carry the last server revision and validated server-derived `userKey` required for ordered compare-and-set updates and event delivery. |
-| `AnalyticsRepository` in `module_core/lib/src/repositories/analytics_repository.dart` | Layer 2; constructor requires `AnalyticsApi` | Exposes distinct typed product and installation delivery methods and maps API exceptions to explicit `AnalyticsDeliveryResult` without redundant logging. Product delivery accepts only the already-validated server-derived pseudonymous key, never a raw account ID, while installation delivery accepts only `InstallationAnalyticsEvent` and cannot receive a `user_key`. Each event contract adds its pinned schema version during typed serialization. |
+| `AnalyticsRepository` in `module_core/lib/src/repositories/analytics_repository.dart` | Layer 2; constructor requires `AnalyticsApi` | Exposes distinct typed product and installation delivery methods, applies the shared bounded SDK deadline, and maps API exceptions/timeouts to explicit `AnalyticsDeliveryResult` without redundant logging. Product delivery accepts only the already-validated server-derived pseudonymous key, never a raw account ID, while installation delivery accepts only `InstallationAnalyticsEvent` and cannot receive a `user_key`. Each event contract adds its pinned schema version during typed serialization. |
 | `ProductAnalyticsPreferenceRepository` in `module_core/lib/src/repositories/product_analytics_preference_repository.dart` | Layer 2; requires `ProductAnalyticsPreferenceApi` and `ProductAnalyticsPreferenceStorage` | Fetch/update server preference, scope local records to one account, and persist only versioned `synced`, `pendingDisable`, or `pendingEnable` records. Every PUT uses the last observed revision plus stable operation ID. Conflict on disable triggers one bounded GET/retry against the new revision; conflict on enable remains inactive and returns explicit refresh-required state so an older enable cannot automatically override a newer disable. `pendingEnable` is never permission to emit. |
 | `ProductAnalyticsState`, independent preference/synchronization variants, and closed fixed-capacity `DeferredProductAnalyticsCandidates` under `module_core/lib/src/services/models/` | Layer-3 service state | Represents active/inactive/pending/failure truth plus only activation/project-available/diff-adoption/current-date-session-activity deferred slots without nullable coordination fields or a generic queue; it is not part of the Foundation sink contract. |
-| `ProductAnalyticsService` in `module_core/lib/src/services/product_analytics_service.dart` | Layer 3, `@lazySingleton`; requires immutable `AnalyticsRuntimeCapability`, read-only `AuthSession`, `AnalyticsRepository`, and `ProductAnalyticsPreferenceRepository` | Sole owner of preference/custom-event lifecycle and Consumer `logEvent`. Exposes a replaying state stream plus `start`, `markPostSplashReady`, explicit `refreshPreference`, `setPreference`, `retryPendingDisable`, bounded `prepareForLogout`, and `dispose`. It performs one server read per post-readiness auth generation plus explicit Settings refresh/actions—no lifecycle timer/polling—and sends no product event unless active. While same-generation preference is unknown, a closed fixed-capacity deferred model may retain one activation candidate, first non-empty project availability, first non-empty diff adoption, and one authoritative session-activity occurrence; there is no generic event queue. |
+| `ProductAnalyticsPreferenceService` in `module_core/lib/src/services/product_analytics_preference_service.dart` | Layer 3, injected collaborator; requires immutable `AnalyticsRuntimeCapability`, read-only `AuthSession`, and `ProductAnalyticsPreferenceRepository` | Sole owner of authenticated generation, preference reconciliation, local/runtime snapshots, logout preparation, and the replaying `ProductAnalyticsState`. `ProductAnalyticsService` is its single disposal owner. It exposes only validated current/deferrable delivery-generation context to the facade. |
+| `ProductAnalyticsService` in `module_core/lib/src/services/product_analytics_service.dart` | Layer 3 delivery facade, `@lazySingleton`; requires `AnalyticsRepository` and `ProductAnalyticsPreferenceService` | Owns Consumer `logEvent`, generation readiness dispatchers, the fixed same-generation deferred candidate slots, ordered one-shot draining, delivery observability, and facade disposal. Preference/account lifecycle stays in its injected collaborator. It delegates preference commands/state, never polls, never owns raw auth state, and sends no product event without a validated active delivery context. |
 | `InstallationAnalyticsService` in `module_core/lib/src/services/installation_analytics_service.dart` | Layer 3, `@lazySingleton`; requires immutable `AnalyticsRuntimeCapability` and `AnalyticsRepository` | Accepts only typed login-attempt lifecycle methods, maps the sealed auth provider exhaustively to `AnalyticsLoginProvider`, classifies timeout versus bounded authentication/launch failure, and reports best-effort. It has no account/preference state, buffers nothing, and remains inactive in debug/profile/unsupported builds or when legacy-ID cleanup failed. |
 | `AnalyticsRouteListener` in `module_core/lib/src/routing/analytics_route_listener.dart` | Layer-4 routing listener, `@lazySingleton`; requires `RouteSource` and `ProductAnalyticsService` | Owns route subscription, maps `AppRouteDef` exhaustively to `AnalyticsScreen`, signals readiness on the first non-splash route, and reports stable screens only while active. It never passes a route model/path to Foundation. |
-| `SessionActivityAnalyticsConsumer` in `module_core/lib/src/consumers/analytics/session_activity_analytics_consumer.dart` | Explicit Consumer layer above Layer-4 state; constructed/owned by `SessionDetailScreen`, requires its `SessionDetailCubit`, `RouteSource`, `LifecycleSource`, and `ProductAnalyticsService` | Combines bounded loaded-state classification with actual `sessionDetail` route visibility and resumed lifecycle. It emits first empty once and non-empty at most once per UTC date only while the detail route is topmost; nested diffs/background SSE cannot create false monitoring activity. The service, not this consumer, owns any deferred envelope after `deferredUntilPreference`. |
+| `SessionActivityAnalyticsListener` in `module_core/lib/src/consumers/analytics/session_activity_analytics_listener.dart` | Explicit stream listener above Layer-4 state; constructed/owned by one `SessionDetailScreen`, requires its `SessionDetailCubit`, `LifecycleSource`, `ProductAnalyticsService`, and an initial per-instance visibility value | Combines bounded loaded-state classification with resumed lifecycle and a typed `setRouteVisible` intent supplied by the owning Flutter route instance. It never infers visibility from global `AppRouteDef`. It emits first empty once and non-empty at most once per UTC date only while that exact detail page is current; covered parents, nested diffs, and background SSE cannot create false monitoring activity. The service owns any envelope after `deferredUntilPreference`. |
+| `ComposerDraftStorage` in `module_core/lib/src/api/storage/composer_draft_storage.dart` | Layer 1 in-memory data source | Stores only immutable `ComposerDraft` values by existing/session-new-session key for the current process. Whitespace clear removes the row; it owns no edit or analytics decisions. |
+| `ComposerDraftRepository` in `module_core/lib/src/repositories/composer_draft_repository.dart` | Layer 2; requires `ComposerDraftStorage` | Provides typed read/write/clear operations to existing- and new-session Cubits. Product shells and widgets never resolve storage directly. |
+| `ComposerDraft`, half-open `VoiceOriginSpan(start, end)`, and `ComposerDraftCalculator` under `module_core/lib/src/services/models/` and `services/` | Layer-3 immutable state plus pure shared business transformation | Draft state contains text plus normalized, ordered, non-overlapping voice-origin spans. The calculator applies explicit typed replacement and voice insertion transforms; the model validates data but owns no edit policy. `inputMode` is derived from whether any voice span survives. |
 | `ProductAnalyticsPreferenceCubit` in `module_core/lib/src/cubits/product_analytics_preference/` | Consumer; constructor requires `ProductAnalyticsService` | Subscribes to service state and exposes toggle/retry intents. Mobile Settings constructs it; it is not in DI. |
 | `FirebaseAnalyticsClient` in `app/lib/core/platform/firebase_analytics_client.dart` | Thin mobile Foundation adapter, `@LazySingleton(as: AnalyticsClient)`; requires `FirebaseAnalytics` and immutable `AnalyticsRuntimeCapability` | Rejects all operations unless capability is enabled, serializes only typed product/installation events plus their permitted shared fields, and throws canonical-event failures upward. For `product_screen_viewed`, after the canonical custom event is accepted it also best-effort calls `FirebaseAnalytics.logScreenView` with the same pinned screen name and stable `GoRouter` screen class; mirror failure is logged but does not rewrite canonical delivery. It never applies global identity/collection overrides and contains no route/preference/hash business logic. Firebase-disabled environments use the no-op client plus disabled capability. |
 | `FirebaseAnalyticsIdentityMigration` in `app/lib/core/platform/firebase_analytics_identity_migration.dart` | Mobile-only reusable pre-DI helper; constructed directly with `FirebaseAnalytics.instance` after Firebase initialization in foreground `main` and the FCM background entry point | Awaits `setUserId(id: null)`. Foreground maps concrete Firebase cleanup failure to the surface-neutral `AnalyticsRuntimeCapability.disabled(identitySafetyPreconditionFailed)` for phase-1 DI; Firebase-specific cause and logging stay in the shell. The background handler runs the same idempotent clear immediately after its independent `Firebase.initializeApp` and before handler work; failure logs and ends/classifies that whole background execution as potentially legacy-keyed. Automatic initialization can still precede either clear, so recurring legacy deletion covers that unavoidable window. Keep both calls through minimum-supported-version adoption plus the 90-day raw window, then remove explicitly. |
@@ -639,19 +643,23 @@ for the eventual completion/failure and then clears it. Logout/cubit close or a
 new validated attempt clears/replaces it without emitting a fabricated terminal
 event. The context is never persisted or sent as an identifier.
 
-**Voice flow:** A successful non-empty transcription sets the composer input
-classification to `voice_assisted`; the widget dispatches a typed completion to
-its owning Cubit, which emits one content-free
-`voice_transcription_completed` through `ProductAnalyticsService`. The flag
-remains voice-assisted through subsequent manual edits, resets when the composer
-is cleared/reset, and is captured with the submission. Existing-session queued
-items retain only the enum alongside their existing content/command; successful
-send is reported later with that enum. New-session creation threads the same
-enum into its successful outcome. Change in-memory `DraftStore` from raw string
-values to typed `ComposerDraft(text, inputMode)` for both session and
-`new-session:<projectId>` keys, so navigation/disposal/restoration preserves
-voice contribution. Whitespace clear removes the whole draft/origin. No
-transcript, duration, audio metadata, or text length is emitted or persisted.
+**Voice flow:** A successful non-empty transcription adds one half-open
+voice-origin span for the inserted transcript and dispatches a typed completion
+to the owning Cubit, which emits one content-free
+`voice_transcription_completed` through `ProductAnalyticsService`. A pure
+`ComposerDraftCalculator` transforms normalized spans for typed insertion,
+deletion, partial/full replacement, and identical selected-text replacement.
+Untouched voice fragments preserve contribution; replaced/deleted fragments do
+not. `inputMode` is derived as `voice_assisted` only while at least one voice
+span survives and resets to typed when none remains or the composer clears.
+Existing-session queued items retain only that derived enum alongside their
+existing content/command; successful send is reported later with the enum.
+New-session creation threads the same enum into its successful outcome.
+`ComposerDraftRepository` stores immutable `ComposerDraft(text, voiceSpans)` for
+both session and `new-session:<projectId>` keys through `ComposerDraftStorage`,
+so disposal/restoration preserves exact mixed attribution. Whitespace clear
+removes the whole draft/origin. No transcript, duration, audio metadata, or text
+length is emitted or durably persisted.
 
 ### Outcome event catalog
 
@@ -709,9 +717,10 @@ used as account creation or activation evidence.
   OAuth timeout terminal state, through `InstallationAnalyticsService`.
 - `ProjectListCubit`: first successful empty and first successful non-empty
   inventory states.
-- `SessionActivityAnalyticsConsumer` combining `SessionDetailCubit` state,
-  `RouteSource`, and `LifecycleSource`: first empty diagnostic and one actually
-  visible/foreground non-empty activity per UTC date.
+- `SessionActivityAnalyticsListener` combining `SessionDetailCubit` state,
+  `LifecycleSource`, and the owning Flutter route instance's typed visibility
+  intent: first empty diagnostic and one actually visible/foreground non-empty
+  activity per UTC date.
 - `SessionDetailCubit.sendMessage` and `_drainQueuedMessages`: accepted
   existing-session messages with the captured input-mode enum.
 - `NewSessionCubit.createSession`: accepted created session/message and bounded
@@ -739,15 +748,15 @@ merely to avoid updating tests.
 | Owner change | Exact flow and deduplication |
 | --- | --- |
 | `ProjectListCubit` | Add required `ProductAnalyticsService`. Empty diagnostic advances only after SDK acceptance and is not buffered. First non-empty is submitted to the service's fixed project-available slot while preference is unknown; the cubit consumes its lifetime guard only after `acceptedBySdk` or `deferredUntilPreference`, because the service owns that deferred semantic. Refreshes never repeat an accepted/deferred classification. The warehouse milestone uses only earliest non-empty. |
-| `SessionActivityAnalyticsConsumer` | `SessionDetailScreen` constructs this explicit higher-layer consumer with the screen-owned cubit plus `RouteSource`, `LifecycleSource`, and product analytics service. It retains only accepted/deferred visibility/date guards. The service exclusively retains a deferred envelope across route/date changes for the same generation; the consumer never stores a second candidate. Background/nested-diffs SSE never creates a candidate; disable/auth change drops service-held state. |
+| `SessionActivityAnalyticsListener` | Each `SessionDetailScreen` constructs this explicit higher-layer listener with the screen-owned cubit, `LifecycleSource`, product analytics service, and `ModalRoute.of(context)?.isCurrent` as initial visibility. `didChangeDependencies` sends later visibility edges through `setRouteVisible`; core never imports Flutter or infers instance visibility from global route type. The listener retains only accepted/deferred visibility/date guards. The service exclusively retains a deferred envelope across route/date changes for the same generation. Background/covered-parent SSE never creates a candidate; disable/auth change drops service-held state. |
 | `LoginCubit` / Apple mobile call site | Add required `InstallationAnalyticsService` and one closed `ActiveLoginAnalyticsAttempt`. Cubit intents pass the sealed `AuthProvider` and typed terminal cause; `InstallationAnalyticsService` solely owns exhaustive provider/failure mapping to analytics enums. Report one start after input validation and exactly one terminal completion/failure; interrupted OAuth polling retains provider through `_onAppResumed`, and timeout is failed. For Apple, the UI invokes the Cubit begin intent before the native sheet, then exactly one credential continuation or cancelled/failure terminal intent. Desktop resolves shared methods through its no-op client. |
 | `SessionDetailCubit` send paths | Direct `sendMessage` and `_drainQueuedMessages` call one private `_reportAcceptedSubmission` only on `SuccessResponse`. The queued item retains its existing text/command plus the closed input-mode enum; analytics derives text/command classification without reading content. Error/requeue emits nothing, and each dequeued successful item reports once. |
 | `NewSessionCubit` | Add required product analytics service and required input-mode argument on creation. Capture workspace/submission/input classifications before awaiting. `SuccessResponse` makes one `session_created_with_message` call; `ErrorResponse` emits only bounded `session_creation_failed`. It never also emits the existing-session event. |
-| Mobile composer call sites / owning Cubits / `DraftStore` | After `stopAndTranscribe()` returns a non-empty transcript, the widget dispatches a typed transcription-completed intent to its owning Cubit; that Cubit reports `voice_transcription_completed` through the service and carries `voice_assisted` into existing/new-session submit methods. Replace draft strings with typed `ComposerDraft` so dispose/restore for either key preserves the enum. Manual edits do not erase contribution; clearing/resetting the composer removes text+origin. Product behavior does not await analytics delivery. |
+| Mobile composer call sites / owning Cubits / draft layers | `PromptInput` sends typed edit, voice insertion, save, restore, and clear intents through its owning Cubit; it does not resolve storage. Existing- and new-session Cubits require `ComposerDraftRepository` and share `ComposerDraftCalculator`. The calculator updates half-open spans for insertion, deletion, partial/full replacement, and identical selected replacement; restoration uses the exact saved spans. After `stopAndTranscribe()` returns non-empty, the owning Cubit reports completion and returns the transformed draft. Product behavior does not await analytics delivery. |
 | `SessionDetailCubit` question/permission/abort | Report after each verified success branch. Question answers/rejections carry no answer data. Change `replyToPermission` to pattern-match `SuccessResponse`/`ErrorResponse` instead of treating every non-throwing response as true; only success maps the existing `PermissionReply` enum and reports. Abort reports only after every root/active-child response succeeds. |
 | `DiffCubit` | Add required product analytics service. Empty diagnostic advances only after SDK acceptance and is not buffered. First non-empty may occupy the service's fixed diff-adoption slot while preference is unknown; consume its guard only after accepted/deferred result. Only non-empty defines adoption, and SSE refreshes do not repeat accepted/deferred state. |
 | `AnalyticsRouteListener` / `FirebaseAnalyticsClient` | Listener maps every `AppRouteDef` to pinned `AnalyticsScreen`, deduplicates unchanged routes, and reports only after product analytics activates. The adapter logs canonical `product_screen_viewed`, then best-effort calls `logScreenView` with the same name. Native automatic screen reporting is disabled and standard rows are excluded from account-level models. |
-| Screen constructors/tests | `ProjectListScreen`, `NewSessionScreen`, `SessionDetailScreen`, and `SessionDiffsScreen` pass the phase-3 product analytics service from GetIt into required cubit constructors. `SessionDetailScreen` also owns/disposes `SessionActivityAnalyticsConsumer`. Core tests inject recording services/routes/lifecycle and assert event count/shape. |
+| Screen constructors/tests | `ProjectListScreen`, `NewSessionScreen`, `SessionDetailScreen`, and `SessionDiffsScreen` pass phase-3 services/repositories from GetIt into required cubit constructors. `SessionDetailScreen` also owns/disposes its per-route `SessionActivityAnalyticsListener` and supplies visibility edges. Core tests inject recording services/lifecycle and assert event count/shape. |
 
 ## Deferred Extensions
 
@@ -1435,56 +1444,72 @@ directory name.
   subsequent client fixes must preserve it or suppress all account-linked
   Sesori product events.
 
-### PR 4/5 — Outcome, voice, and login instrumentation
+### PR 4.A/5 — Bounded outcome contracts and delivery
 
-**Title:** `[user-analytics] Instrument activation and engagement outcomes [step 4/5]`
+**Title:** `[user-analytics] Add bounded outcome analytics contracts [step 4.A/5]`
 
 **Repository:** apps monorepo
 
-- Add the event catalog variants and bounded enum serialization.
-- Add `analytics_activation_ready(activation_schema_version=1)` to this outcome
-  release and emit it on first active transition. PR-3.D
-  `analytics_schema_ready` remains foundation diagnostics only; set
-  `behavioral_schema_v1_start_at` and admit activation cohorts only after this
-  PR-4 capability appears in production export.
+- Add the closed outcome event catalog, bounded enum serialization, and privacy
+  contract tests without wiring product consumers yet.
+- Put one bounded SDK deadline at the analytics repository boundary and keep
+  explicit accepted/deferred/failed delivery results.
+- Add generation-scoped fixed candidate slots for activation, project
+  availability, diff adoption, and visible session activity while preference is
+  genuinely unresolved. This is not a generic queue: schema-readiness failure
+  retains the bounded slots for a later explicit preference-state trigger;
+  accepted readiness drains each retained outcome once, and an SDK rejection is
+  observable but does not create hidden retry or duplicate-delivery semantics.
+- Keep `analytics_schema_ready` as the existing foundation diagnostic. Define
+  but do not emit `analytics_activation_ready` in this substep.
+
+### PR 4.B/5 — Account-less login outcomes
+
+**Title:** `[user-analytics] Instrument account-less login outcomes [step 4.B/5]`
+
+**Repository:** apps monorepo
+
 - Instrument `LoginCubit` through `InstallationAnalyticsService` with one start
-  and one terminal completion/failure (including timeout) per valid attempt;
-  the Cubit passes sealed auth providers/typed causes and the service owns their
-  exhaustive analytics-enum mapping. Events remain account-less and carry only
-  pinned provider/failure enums. Add
-  the mobile Apple begin/failure intents before/after the native authorization
-  sheet so cancellation/launch failures share the same honest denominator.
-- Instrument the authoritative core/app seams listed above, including both
-  direct and queued message success, while keeping analytics best-effort and
-  non-blocking.
+  and one terminal completion/failure (including timeout) per valid attempt.
+- Keep provider and failure mapping exhaustive and account-less. Starting Apple
+  sign-in is an explicit new login intent that leaves resumable OAuth before the
+  native sheet; cancellation/launch/authentication outcomes terminate only that
+  Apple attempt.
+- Wire mobile Apple and desktop no-op consumers and add focused lifecycle tests.
+
+### PR 4.C/5 — Activation and voice outcomes
+
+**Title:** `[user-analytics] Instrument activation and voice outcomes [step 4.C/5]`
+
+**Repository:** apps monorepo
+
+- Instrument authoritative direct/queued message and session-creation outcomes,
+  plus successful content-free voice transcription completion.
 - Thread `input_mode=typed/voice_assisted` through existing/new-session sends and
-  queued submissions; store typed text+input mode in `DraftStore` across composer
-  disposal/restoration; after successful Flutter transcription, dispatch a typed
-  outcome to the owning Cubit, which reports the content-free event through the
-  service.
-- Retain only the fixed activation/project-available/diff-adoption candidates
-  while same-generation preference is unknown, preserving their occurrence
-  times. The route-visible activity consumer submits one current-date candidate,
-  but `ProductAnalyticsService` solely owns it after `deferredUntilPreference`,
-  then emits on active or drops it under the declared disabled/auth rules.
-- Regenerate only source-generated outputs.
-- Add focused tests that failures/taps/queued-only operations do not activate,
-  each successful message path makes one service call, new-session success is not
-  double counted, a non-throwing permission `ErrorResponse` returns failure and
-  emits no success, sensitive inputs cannot enter parameter maps, bounded
-  milestone candidates survive preference-unknown without consuming guards,
-  deferred envelopes preserve authoritative occurrence time and invalid clock
-  values are excluded from time-bound warehouse metrics,
-  activation-ready exposure excludes foundation-only binaries, first-message
-  deferral survives preference resolution,
-  empty-to-non-empty transitions report once, resumed/later-date monitoring can
-  report again without SSE inflation, voice-assisted origin survives queueing
-  and both existing/new-session draft restoration without transcript data,
-  interrupted/resumed OAuth retains its provider, and login timeout/failure
-  makes one bounded terminal installation event without an account key. Widget
-  tests verify Apple start is
-  emitted before opening the native sheet and cancellation/failure terminates
-  that attempt without calling the Cubit start twice.
+  queues. Immutable `ComposerDraft` contains validated compact half-open spans;
+  `ComposerDraftCalculator` owns pure edit transformations, and owning Cubits
+  persist through `ComposerDraftRepository`. Widgets do not resolve storage,
+  maintain a per-code-unit bitmap, or infer restored mixed attribution from one
+  aggregate flag.
+- Verify full/partial/identical replacement, mixed-draft restoration, queueing,
+  creation deduplication, and content-free parameters.
+
+### PR 4.D/5 — Visible engagement outcomes and capability marker
+
+**Title:** `[user-analytics] Instrument visible engagement outcomes [step 4.D/5]`
+
+**Repository:** apps monorepo
+
+- Instrument project inventory, questions, permissions, abort, diffs, and the
+  route-instance-visible foreground `SessionActivityAnalyticsListener`.
+- Emit `analytics_activation_ready(activation_schema_version=1)` only here, once
+  the complete behavioral schema and authoritative consumers exist. Gate bounded
+  candidate draining behind accepted schema and activation readiness.
+- Verify empty/non-empty lifetime guards, resumed/later-UTC-date activity,
+  hidden parent routes, non-throwing permission failures, bounded deferral, and
+  sensitive-input exclusion.
+- Do not release the partial 4.A-4.C state. Set `behavioral_schema_v1_start_at`
+  and admit activation cohorts only after 4.D appears in production export.
 
 ### PR 5/5 — Warehouse models and dashboards
 

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -125,9 +125,12 @@
 ## Implementation Series
 
 The total remains fixed at five rollout steps. Titles retain this slug and step
-count across both repositories; Step 3 is delivered as stacked PR substeps
-3.A-3.D. The former combined apps PR #610 was frozen and closed as superseded by
-PRs #611-#614 so each review stays near 1,500 added lines.
+count across both repositories; Steps 3 and 4 are delivered as stacked PR
+substeps. The former combined apps PR #610 was frozen and closed as superseded by
+PRs #611-#614. Oversized outcome PR #629 was likewise closed and preserved as a
+reference before rebuilding Step 4 as 4.A-4.D. Each replacement targets a
+coherent review below roughly 1,200 added lines rather than accumulating review
+patches in one umbrella diff.
 
 | Step | Repository | Required title | Status | Depends on |
 | --- | --- | --- | --- | --- |
@@ -136,9 +139,12 @@ PRs #611-#614 so each review stays near 1,500 added lines.
 | 3.A/5 | apps monorepo | `[user-analytics] Add client analytics contracts and delivery [step 3.A/5]` | PR #611 merged as `3a181ee3` on 2026-07-30; frozen PR #610 remains superseded | Step 2 deployed |
 | 3.B/5 | apps monorepo | `[user-analytics] Add durable analytics preference sync [step 3.B/5]` | PR #612 merged as `a792481b` on 2026-07-30 | Step 3.A |
 | 3.C/5 | apps monorepo | `[user-analytics] Add account-linked analytics lifecycle [step 3.C/5]` | PR #613 merged as `53e9453f` on 2026-07-30, including supplemental lifecycle decomposition PR #619 | Step 3.B |
-| 3.D/5 | apps monorepo | `[user-analytics] Integrate analytics settings and routing [step 3.D/5]` | PR #614 merged as `fb8cd0e8` on 2026-07-30; focused account-page UX follow-up PR #628 is open | Step 3.C |
-| 4/5 | apps monorepo | `[user-analytics] Instrument activation and engagement outcomes [step 4/5]` | Not started | Step 3.D released |
-| 5/5 | apps monorepo + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | Not started | Steps 2 and 4, controlled Firebase export, split auth-private/privacy-private/control IAM |
+| 3.D/5 | apps monorepo | `[user-analytics] Integrate analytics settings and routing [step 3.D/5]` | PR #614 merged as `fb8cd0e8`; focused account-page UX follow-up PR #628 merged as `5e42bedc` on 2026-07-30 | Step 3.C |
+| 4.A/5 | apps monorepo | `[user-analytics] Add bounded outcome analytics contracts [step 4.A/5]` | In progress on `user-analytics-outcome-contracts`; oversized PR #629 is closed as superseded | Step 3.D released |
+| 4.B/5 | apps monorepo | `[user-analytics] Instrument account-less login outcomes [step 4.B/5]` | Not started | Step 4.A |
+| 4.C/5 | apps monorepo | `[user-analytics] Instrument activation and voice outcomes [step 4.C/5]` | Not started | Step 4.B |
+| 4.D/5 | apps monorepo | `[user-analytics] Instrument visible engagement outcomes [step 4.D/5]` | Not started | Step 4.C |
+| 5/5 | apps monorepo + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | Not started | Steps 2 and 4.D, controlled Firebase export, split auth-private/privacy-private/control IAM |
 
 ## Release Evidence
 

--- a/client/module_core/lib/src/foundation/models/product_analytics/product_analytics_event.dart
+++ b/client/module_core/lib/src/foundation/models/product_analytics/product_analytics_event.dart
@@ -59,11 +59,130 @@ enum AnalyticsInputMode {
   const AnalyticsInputMode({required this.wireValue});
 }
 
+enum AnalyticsInventoryState {
+  empty(wireValue: "empty"),
+  nonEmpty(wireValue: "non_empty");
+
+  final String wireValue;
+  const AnalyticsInventoryState({required this.wireValue});
+}
+
+enum AnalyticsActivityState {
+  empty(wireValue: "empty"),
+  nonEmpty(wireValue: "non_empty");
+
+  final String wireValue;
+  const AnalyticsActivityState({required this.wireValue});
+}
+
+enum AnalyticsSubmissionKind {
+  text(wireValue: "text"),
+  command(wireValue: "command");
+
+  final String wireValue;
+  const AnalyticsSubmissionKind({required this.wireValue});
+}
+
+@immutable
+sealed class AnalyticsSubmission {
+  const AnalyticsSubmission();
+
+  const factory AnalyticsSubmission.text({required AnalyticsInputMode inputMode}) = AnalyticsTextSubmission;
+  const factory AnalyticsSubmission.command() = AnalyticsCommandSubmission;
+
+  AnalyticsSubmissionKind get kind;
+  AnalyticsInputMode get inputMode;
+}
+
+final class AnalyticsTextSubmission extends AnalyticsSubmission {
+  @override
+  final AnalyticsInputMode inputMode;
+
+  const AnalyticsTextSubmission({required this.inputMode});
+
+  @override
+  AnalyticsSubmissionKind get kind => AnalyticsSubmissionKind.text;
+}
+
+final class AnalyticsCommandSubmission extends AnalyticsSubmission {
+  const AnalyticsCommandSubmission();
+
+  @override
+  AnalyticsSubmissionKind get kind => AnalyticsSubmissionKind.command;
+
+  @override
+  AnalyticsInputMode get inputMode => AnalyticsInputMode.typed;
+}
+
+enum AnalyticsWorkspaceKind {
+  project(wireValue: "project"),
+  dedicatedWorktree(wireValue: "dedicated_worktree");
+
+  final String wireValue;
+  const AnalyticsWorkspaceKind({required this.wireValue});
+}
+
+enum AnalyticsSessionCreationFailureReason {
+  notAuthenticated(wireValue: "not_authenticated"),
+  serverRejected(wireValue: "server_rejected"),
+  networkDown(wireValue: "network_down"),
+  badResponse(wireValue: "bad_response"),
+  unknown(wireValue: "unknown");
+
+  final String wireValue;
+  const AnalyticsSessionCreationFailureReason({required this.wireValue});
+}
+
+enum AnalyticsPermissionDecision {
+  once(wireValue: "once"),
+  always(wireValue: "always"),
+  reject(wireValue: "reject");
+
+  final String wireValue;
+  const AnalyticsPermissionDecision({required this.wireValue});
+}
+
+enum AnalyticsChangeState {
+  empty(wireValue: "empty"),
+  nonEmpty(wireValue: "non_empty");
+
+  final String wireValue;
+  const AnalyticsChangeState({required this.wireValue});
+}
+
 @immutable
 sealed class ProductAnalyticsEvent {
   const ProductAnalyticsEvent();
 
   const factory ProductAnalyticsEvent.analyticsSchemaReady() = AnalyticsSchemaReadyEvent;
+  const factory ProductAnalyticsEvent.analyticsActivationReady() = AnalyticsActivationReadyEvent;
+  const factory ProductAnalyticsEvent.projectInventoryLoaded({
+    required AnalyticsInventoryState inventoryState,
+  }) = ProjectInventoryLoadedEvent;
+  const factory ProductAnalyticsEvent.sessionActivityViewed({
+    required AnalyticsActivityState activityState,
+  }) = SessionActivityViewedEvent;
+  const factory ProductAnalyticsEvent.sessionMessageSent({
+    required AnalyticsSubmission submission,
+  }) = SessionMessageSentEvent;
+  const factory ProductAnalyticsEvent.sessionCreatedWithMessage({
+    required AnalyticsSubmission submission,
+    required AnalyticsWorkspaceKind workspaceKind,
+  }) = SessionCreatedWithMessageEvent;
+  const factory ProductAnalyticsEvent.sessionCreationFailed({
+    required AnalyticsSessionCreationFailureReason failureReason,
+    required AnalyticsWorkspaceKind workspaceKind,
+  }) = SessionCreationFailedEvent;
+  const factory ProductAnalyticsEvent.voiceTranscriptionCompleted() = VoiceTranscriptionCompletedEvent;
+  const factory ProductAnalyticsEvent.sessionQuestionAnswered() = SessionQuestionAnsweredEvent;
+  const factory ProductAnalyticsEvent.sessionQuestionRejected() = SessionQuestionRejectedEvent;
+  const factory ProductAnalyticsEvent.sessionPermissionAnswered({
+    required AnalyticsPermissionDecision decision,
+  }) = SessionPermissionAnsweredEvent;
+  const factory ProductAnalyticsEvent.sessionAbortSucceeded() = SessionAbortSucceededEvent;
+  const factory ProductAnalyticsEvent.sessionDiffViewed({
+    required AnalyticsChangeState changeState,
+  }) = SessionDiffViewedEvent;
   const factory ProductAnalyticsEvent.needHelpMenuOpened({required OnboardingSurface surface}) =
       NeedHelpMenuOpenedEvent;
   const factory ProductAnalyticsEvent.supportLinkOpened({
@@ -111,6 +230,154 @@ final class AnalyticsSchemaReadyEvent extends ProductAnalyticsEvent {
 
   @override
   Map<String, String> get parameters => const {};
+}
+
+final class AnalyticsActivationReadyEvent extends ProductAnalyticsEvent {
+  const AnalyticsActivationReadyEvent();
+
+  @override
+  String get wireName => "analytics_activation_ready";
+
+  @override
+  Map<String, String> get parameters => const {"activation_schema_version": "1"};
+}
+
+final class ProjectInventoryLoadedEvent extends ProductAnalyticsEvent {
+  final AnalyticsInventoryState inventoryState;
+  const ProjectInventoryLoadedEvent({required this.inventoryState});
+
+  @override
+  String get wireName => "project_inventory_loaded";
+
+  @override
+  Map<String, String> get parameters => {"inventory_state": inventoryState.wireValue};
+}
+
+final class SessionActivityViewedEvent extends ProductAnalyticsEvent {
+  final AnalyticsActivityState activityState;
+  const SessionActivityViewedEvent({required this.activityState});
+
+  @override
+  String get wireName => "session_activity_viewed";
+
+  @override
+  Map<String, String> get parameters => {"activity_state": activityState.wireValue};
+}
+
+final class SessionMessageSentEvent extends ProductAnalyticsEvent {
+  final AnalyticsSubmission submission;
+  const SessionMessageSentEvent({required this.submission});
+
+  AnalyticsSubmissionKind get submissionKind => submission.kind;
+  AnalyticsInputMode get inputMode => submission.inputMode;
+
+  @override
+  String get wireName => "session_message_sent";
+
+  @override
+  Map<String, String> get parameters => {
+    "submission_kind": submissionKind.wireValue,
+    "input_mode": inputMode.wireValue,
+  };
+}
+
+final class SessionCreatedWithMessageEvent extends ProductAnalyticsEvent {
+  final AnalyticsSubmission submission;
+  final AnalyticsWorkspaceKind workspaceKind;
+  const SessionCreatedWithMessageEvent({
+    required this.submission,
+    required this.workspaceKind,
+  });
+
+  AnalyticsSubmissionKind get submissionKind => submission.kind;
+  AnalyticsInputMode get inputMode => submission.inputMode;
+
+  @override
+  String get wireName => "session_created_with_message";
+
+  @override
+  Map<String, String> get parameters => {
+    "submission_kind": submissionKind.wireValue,
+    "input_mode": inputMode.wireValue,
+    "workspace_kind": workspaceKind.wireValue,
+  };
+}
+
+final class SessionCreationFailedEvent extends ProductAnalyticsEvent {
+  final AnalyticsSessionCreationFailureReason failureReason;
+  final AnalyticsWorkspaceKind workspaceKind;
+  const SessionCreationFailedEvent({required this.failureReason, required this.workspaceKind});
+
+  @override
+  String get wireName => "session_creation_failed";
+
+  @override
+  Map<String, String> get parameters => {
+    "failure_reason": failureReason.wireValue,
+    "workspace_kind": workspaceKind.wireValue,
+  };
+}
+
+final class VoiceTranscriptionCompletedEvent extends ProductAnalyticsEvent {
+  const VoiceTranscriptionCompletedEvent();
+
+  @override
+  String get wireName => "voice_transcription_completed";
+
+  @override
+  Map<String, String> get parameters => const {};
+}
+
+final class SessionQuestionAnsweredEvent extends ProductAnalyticsEvent {
+  const SessionQuestionAnsweredEvent();
+
+  @override
+  String get wireName => "session_question_answered";
+
+  @override
+  Map<String, String> get parameters => const {};
+}
+
+final class SessionQuestionRejectedEvent extends ProductAnalyticsEvent {
+  const SessionQuestionRejectedEvent();
+
+  @override
+  String get wireName => "session_question_rejected";
+
+  @override
+  Map<String, String> get parameters => const {};
+}
+
+final class SessionPermissionAnsweredEvent extends ProductAnalyticsEvent {
+  final AnalyticsPermissionDecision decision;
+  const SessionPermissionAnsweredEvent({required this.decision});
+
+  @override
+  String get wireName => "session_permission_answered";
+
+  @override
+  Map<String, String> get parameters => {"decision": decision.wireValue};
+}
+
+final class SessionAbortSucceededEvent extends ProductAnalyticsEvent {
+  const SessionAbortSucceededEvent();
+
+  @override
+  String get wireName => "session_abort_succeeded";
+
+  @override
+  Map<String, String> get parameters => const {};
+}
+
+final class SessionDiffViewedEvent extends ProductAnalyticsEvent {
+  final AnalyticsChangeState changeState;
+  const SessionDiffViewedEvent({required this.changeState});
+
+  @override
+  String get wireName => "session_diff_viewed";
+
+  @override
+  Map<String, String> get parameters => {"change_state": changeState.wireValue};
 }
 
 final class NeedHelpMenuOpenedEvent extends ProductAnalyticsEvent {

--- a/client/module_core/lib/src/repositories/analytics_repository.dart
+++ b/client/module_core/lib/src/repositories/analytics_repository.dart
@@ -1,31 +1,40 @@
 import "package:injectable/injectable.dart";
+import "package:meta/meta.dart";
 
 import "../api/analytics_api.dart";
 import "../foundation/models/product_analytics/installation_analytics_event.dart";
 import "../foundation/models/product_analytics/product_analytics_event.dart";
 import "models/analytics_delivery_result.dart";
 
+const _analyticsDeliveryDeadline = Duration(seconds: 10);
+
 @lazySingleton
 class AnalyticsRepository {
   final AnalyticsApi _api;
+  final Duration _deliveryDeadline;
 
-  AnalyticsRepository({required AnalyticsApi api}) : _api = api;
+  AnalyticsRepository({required AnalyticsApi api}) : _api = api, _deliveryDeadline = _analyticsDeliveryDeadline;
+
+  @visibleForTesting
+  AnalyticsRepository.withDeliveryDeadline({
+    required AnalyticsApi api,
+    required Duration deliveryDeadline,
+  }) : _api = api,
+       _deliveryDeadline = deliveryDeadline;
 
   Future<AnalyticsDeliveryResult> logProductEvent({
     required ProductAnalyticsEnvelope envelope,
     required String userKey,
-  }) async {
-    try {
-      await _api.logProductEvent(envelope: envelope, userKey: userKey);
-      return AnalyticsDeliveryResult.acceptedBySdk;
-    } on Object {
-      return AnalyticsDeliveryResult.failed;
-    }
-  }
+  }) => _deliver(
+    operation: () => _api.logProductEvent(envelope: envelope, userKey: userKey),
+  );
 
-  Future<AnalyticsDeliveryResult> logInstallationEvent({required InstallationAnalyticsEvent event}) async {
+  Future<AnalyticsDeliveryResult> logInstallationEvent({required InstallationAnalyticsEvent event}) =>
+      _deliver(operation: () => _api.logInstallationEvent(event: event));
+
+  Future<AnalyticsDeliveryResult> _deliver({required Future<void> Function() operation}) async {
     try {
-      await _api.logInstallationEvent(event: event);
+      await operation().timeout(_deliveryDeadline);
       return AnalyticsDeliveryResult.acceptedBySdk;
     } on Object {
       return AnalyticsDeliveryResult.failed;

--- a/client/module_core/lib/src/services/models/deferred_product_analytics_candidates.dart
+++ b/client/module_core/lib/src/services/models/deferred_product_analytics_candidates.dart
@@ -1,0 +1,219 @@
+import "../../foundation/models/product_analytics/product_analytics_event.dart";
+
+final class DeferredProductAnalyticsRetention {
+  final DeferredProductAnalyticsCandidates candidates;
+  final bool retained;
+
+  const DeferredProductAnalyticsRetention({required this.candidates, required this.retained});
+}
+
+sealed class DeferredProductAnalyticsDrain {
+  const DeferredProductAnalyticsDrain();
+}
+
+final class DeferredProductAnalyticsDrainComplete extends DeferredProductAnalyticsDrain {
+  const DeferredProductAnalyticsDrainComplete();
+}
+
+final class DeferredProductAnalyticsDrainNext extends DeferredProductAnalyticsDrain {
+  final ProductAnalyticsEnvelope envelope;
+  final DeferredProductAnalyticsCandidates remainingCandidates;
+
+  const DeferredProductAnalyticsDrainNext({
+    required this.envelope,
+    required this.remainingCandidates,
+  });
+}
+
+final class DeferredProductAnalyticsCandidates {
+  final int generation;
+  final _DeferredProductAnalyticsCandidate _activation;
+  final _DeferredProductAnalyticsCandidate _projectAvailable;
+  final _DeferredProductAnalyticsCandidate _diffAdoption;
+  final _DeferredProductAnalyticsCandidate _sessionActivity;
+
+  const DeferredProductAnalyticsCandidates._({
+    required this.generation,
+    required _DeferredProductAnalyticsCandidate activation,
+    required _DeferredProductAnalyticsCandidate projectAvailable,
+    required _DeferredProductAnalyticsCandidate diffAdoption,
+    required _DeferredProductAnalyticsCandidate sessionActivity,
+  }) : _activation = activation,
+       _projectAvailable = projectAvailable,
+       _diffAdoption = diffAdoption,
+       _sessionActivity = sessionActivity;
+
+  const DeferredProductAnalyticsCandidates.empty({required this.generation})
+    : _activation = const _DeferredProductAnalyticsCandidateEmpty(),
+      _projectAvailable = const _DeferredProductAnalyticsCandidateEmpty(),
+      _diffAdoption = const _DeferredProductAnalyticsCandidateEmpty(),
+      _sessionActivity = const _DeferredProductAnalyticsCandidateEmpty();
+
+  DeferredProductAnalyticsRetention retain({required ProductAnalyticsEnvelope envelope}) => switch (envelope.event) {
+    SessionMessageSentEvent() || SessionCreatedWithMessageEvent() => _retainActivation(envelope: envelope),
+    ProjectInventoryLoadedEvent(inventoryState: AnalyticsInventoryState.nonEmpty) => _retainProject(
+      envelope: envelope,
+    ),
+    SessionDiffViewedEvent(changeState: AnalyticsChangeState.nonEmpty) => _retainDiff(envelope: envelope),
+    SessionActivityViewedEvent(activityState: AnalyticsActivityState.nonEmpty) => _retainActivity(
+      envelope: envelope,
+    ),
+    AnalyticsSchemaReadyEvent() ||
+    AnalyticsActivationReadyEvent() ||
+    ProjectInventoryLoadedEvent(inventoryState: AnalyticsInventoryState.empty) ||
+    SessionActivityViewedEvent(activityState: AnalyticsActivityState.empty) ||
+    SessionCreationFailedEvent() ||
+    VoiceTranscriptionCompletedEvent() ||
+    SessionQuestionAnsweredEvent() ||
+    SessionQuestionRejectedEvent() ||
+    SessionPermissionAnsweredEvent() ||
+    SessionAbortSucceededEvent() ||
+    SessionDiffViewedEvent(changeState: AnalyticsChangeState.empty) ||
+    NeedHelpMenuOpenedEvent() ||
+    SupportLinkOpenedEvent() ||
+    WhyBridgeOpenedEvent() ||
+    InstallCommandCopiedEvent() ||
+    InstallCommandSharedEvent() ||
+    RunCommandCopiedEvent() ||
+    RunCommandSharedEvent() ||
+    ProductScreenViewedEvent() => DeferredProductAnalyticsRetention(candidates: this, retained: false),
+  };
+
+  DeferredProductAnalyticsDrain drainNext() {
+    if (_activation case _DeferredProductAnalyticsCandidateRetained(:final envelope)) {
+      return DeferredProductAnalyticsDrainNext(
+        envelope: envelope,
+        remainingCandidates: DeferredProductAnalyticsCandidates._(
+          generation: generation,
+          activation: const _DeferredProductAnalyticsCandidateEmpty(),
+          projectAvailable: _projectAvailable,
+          diffAdoption: _diffAdoption,
+          sessionActivity: _sessionActivity,
+        ),
+      );
+    }
+    if (_projectAvailable case _DeferredProductAnalyticsCandidateRetained(:final envelope)) {
+      return DeferredProductAnalyticsDrainNext(
+        envelope: envelope,
+        remainingCandidates: DeferredProductAnalyticsCandidates._(
+          generation: generation,
+          activation: _activation,
+          projectAvailable: const _DeferredProductAnalyticsCandidateEmpty(),
+          diffAdoption: _diffAdoption,
+          sessionActivity: _sessionActivity,
+        ),
+      );
+    }
+    if (_diffAdoption case _DeferredProductAnalyticsCandidateRetained(:final envelope)) {
+      return DeferredProductAnalyticsDrainNext(
+        envelope: envelope,
+        remainingCandidates: DeferredProductAnalyticsCandidates._(
+          generation: generation,
+          activation: _activation,
+          projectAvailable: _projectAvailable,
+          diffAdoption: const _DeferredProductAnalyticsCandidateEmpty(),
+          sessionActivity: _sessionActivity,
+        ),
+      );
+    }
+    if (_sessionActivity case _DeferredProductAnalyticsCandidateRetained(:final envelope)) {
+      return DeferredProductAnalyticsDrainNext(
+        envelope: envelope,
+        remainingCandidates: DeferredProductAnalyticsCandidates._(
+          generation: generation,
+          activation: _activation,
+          projectAvailable: _projectAvailable,
+          diffAdoption: _diffAdoption,
+          sessionActivity: const _DeferredProductAnalyticsCandidateEmpty(),
+        ),
+      );
+    }
+    return const DeferredProductAnalyticsDrainComplete();
+  }
+
+  DeferredProductAnalyticsRetention _retainActivation({required ProductAnalyticsEnvelope envelope}) {
+    final retention = _activation.retain(envelope: envelope);
+    return DeferredProductAnalyticsRetention(
+      candidates: DeferredProductAnalyticsCandidates._(
+        generation: generation,
+        activation: retention.candidate,
+        projectAvailable: _projectAvailable,
+        diffAdoption: _diffAdoption,
+        sessionActivity: _sessionActivity,
+      ),
+      retained: retention.retained,
+    );
+  }
+
+  DeferredProductAnalyticsRetention _retainProject({required ProductAnalyticsEnvelope envelope}) {
+    final retention = _projectAvailable.retain(envelope: envelope);
+    return DeferredProductAnalyticsRetention(
+      candidates: DeferredProductAnalyticsCandidates._(
+        generation: generation,
+        activation: _activation,
+        projectAvailable: retention.candidate,
+        diffAdoption: _diffAdoption,
+        sessionActivity: _sessionActivity,
+      ),
+      retained: retention.retained,
+    );
+  }
+
+  DeferredProductAnalyticsRetention _retainDiff({required ProductAnalyticsEnvelope envelope}) {
+    final retention = _diffAdoption.retain(envelope: envelope);
+    return DeferredProductAnalyticsRetention(
+      candidates: DeferredProductAnalyticsCandidates._(
+        generation: generation,
+        activation: _activation,
+        projectAvailable: _projectAvailable,
+        diffAdoption: retention.candidate,
+        sessionActivity: _sessionActivity,
+      ),
+      retained: retention.retained,
+    );
+  }
+
+  DeferredProductAnalyticsRetention _retainActivity({required ProductAnalyticsEnvelope envelope}) {
+    final retention = _sessionActivity.retain(envelope: envelope);
+    return DeferredProductAnalyticsRetention(
+      candidates: DeferredProductAnalyticsCandidates._(
+        generation: generation,
+        activation: _activation,
+        projectAvailable: _projectAvailable,
+        diffAdoption: _diffAdoption,
+        sessionActivity: retention.candidate,
+      ),
+      retained: retention.retained,
+    );
+  }
+}
+
+sealed class _DeferredProductAnalyticsCandidate {
+  const _DeferredProductAnalyticsCandidate();
+
+  ({_DeferredProductAnalyticsCandidate candidate, bool retained}) retain({
+    required ProductAnalyticsEnvelope envelope,
+  });
+}
+
+final class _DeferredProductAnalyticsCandidateEmpty extends _DeferredProductAnalyticsCandidate {
+  const _DeferredProductAnalyticsCandidateEmpty();
+
+  @override
+  ({_DeferredProductAnalyticsCandidate candidate, bool retained}) retain({
+    required ProductAnalyticsEnvelope envelope,
+  }) => (
+    candidate: _DeferredProductAnalyticsCandidateRetained(envelope: envelope),
+    retained: true,
+  );
+}
+
+final class _DeferredProductAnalyticsCandidateRetained extends _DeferredProductAnalyticsCandidate {
+  final ProductAnalyticsEnvelope envelope;
+  const _DeferredProductAnalyticsCandidateRetained({required this.envelope});
+
+  @override
+  ({_DeferredProductAnalyticsCandidate candidate, bool retained}) retain({
+    required ProductAnalyticsEnvelope envelope,
+  }) => (candidate: this, retained: false);
+}

--- a/client/module_core/lib/src/services/product_analytics_generation_event_dispatcher.dart
+++ b/client/module_core/lib/src/services/product_analytics_generation_event_dispatcher.dart
@@ -2,35 +2,35 @@ import "dart:async";
 
 import "../repositories/models/analytics_delivery_result.dart";
 
-final class ProductAnalyticsSchemaReadinessDispatcher {
+final class ProductAnalyticsGenerationEventDispatcher {
   int? _readyGeneration;
-  ({int generation, Future<void> future})? _activeDelivery;
+  ({int generation, Future<AnalyticsDeliveryResult> future})? _activeDelivery;
 
-  Future<void> dispatch({
+  Future<AnalyticsDeliveryResult> dispatch({
     required int generation,
     required Future<AnalyticsDeliveryResult> Function() deliver,
   }) async {
-    if (_readyGeneration == generation) return;
+    if (_readyGeneration == generation) return AnalyticsDeliveryResult.acceptedBySdk;
     final active = _activeDelivery;
     if (active != null && active.generation == generation) {
-      await active.future;
-      return;
+      return active.future;
     }
 
     final future = _deliver(generation: generation, deliver: deliver);
     _activeDelivery = (generation: generation, future: future);
     try {
-      await future;
+      return await future;
     } finally {
       if (identical(_activeDelivery?.future, future)) _activeDelivery = null;
     }
   }
 
-  Future<void> _deliver({
+  Future<AnalyticsDeliveryResult> _deliver({
     required int generation,
     required Future<AnalyticsDeliveryResult> Function() deliver,
   }) async {
     final result = await deliver();
     if (result == AnalyticsDeliveryResult.acceptedBySdk) _readyGeneration = generation;
+    return result;
   }
 }

--- a/client/module_core/lib/src/services/product_analytics_preference_service.dart
+++ b/client/module_core/lib/src/services/product_analytics_preference_service.dart
@@ -31,6 +31,7 @@ final class ProductAnalyticsDeliveryContext {
 
 @lazySingleton
 class ProductAnalyticsPreferenceService {
+  final AnalyticsRuntimeCapability _capability;
   final AuthSession _authSession;
   final ProductAnalyticsPreferenceRepository _preferenceRepository;
   final ProductAnalyticsPreferenceStateMapper _stateMapper;
@@ -52,7 +53,8 @@ class ProductAnalyticsPreferenceService {
     required AnalyticsRuntimeCapability capability,
     required AuthSession authSession,
     required ProductAnalyticsPreferenceRepository preferenceRepository,
-  }) : _authSession = authSession,
+  }) : _capability = capability,
+       _authSession = authSession,
        _preferenceRepository = preferenceRepository,
        _stateMapper = ProductAnalyticsPreferenceStateMapper(capability: capability);
 
@@ -83,6 +85,22 @@ class ProductAnalyticsPreferenceService {
 
   bool isCurrentDeliveryContext({required ProductAnalyticsDeliveryContext context}) =>
       !_disposed && _matches(generation: context.generation, userId: context.userId);
+
+  int? get authenticatedGeneration {
+    if (_disposed) return null;
+    final userId = _userId;
+    return userId != null && _authSessionMatches(userId: userId) ? _generation : null;
+  }
+
+  int? get deferrableGeneration {
+    if (!_capability.isEnabled ||
+        _isPreparingLogout ||
+        state.preference is! ProductAnalyticsPreferenceUnknown ||
+        state.synchronization is ProductAnalyticsSynchronizationFailed) {
+      return null;
+    }
+    return authenticatedGeneration;
+  }
 
   Future<void> start() {
     if (_disposed) return Future<void>.value();

--- a/client/module_core/lib/src/services/product_analytics_service.dart
+++ b/client/module_core/lib/src/services/product_analytics_service.dart
@@ -8,17 +8,20 @@ import "../foundation/models/product_analytics/product_analytics_preference.dart
 import "../logging/logging.dart";
 import "../repositories/analytics_repository.dart";
 import "../repositories/models/analytics_delivery_result.dart";
+import "models/deferred_product_analytics_candidates.dart";
 import "models/product_analytics_state.dart";
+import "product_analytics_generation_event_dispatcher.dart";
 import "product_analytics_preference_service.dart";
-import "product_analytics_schema_readiness_dispatcher.dart";
 
 @lazySingleton
 class ProductAnalyticsService {
   final AnalyticsRepository _analyticsRepository;
   final ProductAnalyticsPreferenceService _preferenceService;
-  final ProductAnalyticsSchemaReadinessDispatcher _schemaReadiness = ProductAnalyticsSchemaReadinessDispatcher();
+  final ProductAnalyticsGenerationEventDispatcher _schemaReadiness = ProductAnalyticsGenerationEventDispatcher();
 
   StreamSubscription<ProductAnalyticsState>? _stateSubscription;
+  DeferredProductAnalyticsCandidates? _deferredCandidates;
+  ({int generation, Future<void> future})? _activeGenerationDispatch;
   Future<void>? _startFuture;
   Future<void>? _disposeFuture;
   bool _disposed = false;
@@ -60,10 +63,30 @@ class ProductAnalyticsService {
     required DateTime occurredAtUtc,
   }) async {
     if (_disposed) return AnalyticsDeliveryResult.failed;
+    final envelope = ProductAnalyticsEnvelope(event: event, occurredAtUtc: occurredAtUtc);
     final context = _preferenceService.deliveryContext;
-    if (context == null) return AnalyticsDeliveryResult.failed;
+    if (context != null) return _deliver(envelope: envelope, context: context);
+
+    final generation = _preferenceService.deferrableGeneration;
+    if (generation == null) return AnalyticsDeliveryResult.failed;
+    var candidates = _deferredCandidates;
+    if (candidates == null || candidates.generation != generation) {
+      candidates = DeferredProductAnalyticsCandidates.empty(generation: generation);
+    }
+    final retention = candidates.retain(envelope: envelope);
+    _deferredCandidates = retention.candidates;
+    return retention.retained ? AnalyticsDeliveryResult.deferredUntilPreference : AnalyticsDeliveryResult.failed;
+  }
+
+  Future<AnalyticsDeliveryResult> _deliver({
+    required ProductAnalyticsEnvelope envelope,
+    required ProductAnalyticsDeliveryContext context,
+  }) async {
+    if (_disposed || !_preferenceService.isCurrentDeliveryContext(context: context)) {
+      return AnalyticsDeliveryResult.failed;
+    }
     final result = await _analyticsRepository.logProductEvent(
-      envelope: ProductAnalyticsEnvelope(event: event, occurredAtUtc: occurredAtUtc),
+      envelope: envelope,
       userKey: context.userKey,
     );
     return !_disposed && _preferenceService.isCurrentDeliveryContext(context: context)
@@ -72,29 +95,98 @@ class ProductAnalyticsService {
   }
 
   void _onPreferenceState({required ProductAnalyticsState state}) {
-    if (_disposed || !state.isActive) return;
+    if (_disposed) return;
+    _synchronizeDeferredCandidates(state: state);
+    if (!state.isActive) return;
     final context = _preferenceService.deliveryContext;
     if (context == null) return;
     unawaited(
-      _schemaReadiness
-          .dispatch(
-            generation: context.generation,
-            deliver: () => logEvent(
-              event: const ProductAnalyticsEvent.analyticsSchemaReady(),
-              occurredAtUtc: DateTime.now().toUtc(),
-            ),
-          )
-          .catchError((Object error, StackTrace stackTrace) {
-            logw("Failed to report analytics schema readiness", error, stackTrace);
-          }),
+      _coalesceActiveGenerationDispatch(context: context).catchError((Object error, StackTrace stackTrace) {
+        logw("Failed to dispatch active product analytics generation", error, stackTrace);
+      }),
     );
   }
+
+  Future<void> _coalesceActiveGenerationDispatch({required ProductAnalyticsDeliveryContext context}) {
+    final active = _activeGenerationDispatch;
+    if (active != null && active.generation == context.generation) return active.future;
+
+    late final Future<void> future;
+    future = _dispatchActiveGeneration(context: context).whenComplete(() {
+      if (identical(_activeGenerationDispatch?.future, future)) {
+        _activeGenerationDispatch = null;
+      }
+    });
+    _activeGenerationDispatch = (generation: context.generation, future: future);
+    return future;
+  }
+
+  void _synchronizeDeferredCandidates({required ProductAnalyticsState state}) {
+    final generation = _preferenceService.authenticatedGeneration;
+    final candidates = _deferredCandidates;
+    if (generation == null || (candidates != null && candidates.generation != generation)) {
+      _deferredCandidates = null;
+      return;
+    }
+    final shouldDrop = switch (state.preference) {
+      ProductAnalyticsPreferenceKnown(preference: ProductAnalyticsPreference.disabled) => true,
+      ProductAnalyticsPreferenceUnknown() =>
+        state.synchronization is ProductAnalyticsSynchronizationFailed &&
+            _preferenceService.deferrableGeneration == null,
+      ProductAnalyticsPreferenceKnown(preference: ProductAnalyticsPreference.enabled) => false,
+    };
+    if (!state.isActive && shouldDrop) {
+      _deferredCandidates = null;
+    }
+  }
+
+  Future<void> _dispatchActiveGeneration({required ProductAnalyticsDeliveryContext context}) async {
+    final schemaResult = await _schemaReadiness.dispatch(
+      generation: context.generation,
+      deliver: () => _deliver(
+        envelope: ProductAnalyticsEnvelope(
+          event: const ProductAnalyticsEvent.analyticsSchemaReady(),
+          occurredAtUtc: DateTime.now().toUtc(),
+        ),
+        context: context,
+      ),
+    );
+    if (schemaResult != AnalyticsDeliveryResult.acceptedBySdk) {
+      if (_isCurrentActiveContext(context: context)) logw("Failed to deliver analytics schema readiness");
+      return;
+    }
+    if (!_isCurrentActiveContext(context: context)) return;
+
+    while (_isCurrentActiveContext(context: context)) {
+      final candidates = _deferredCandidates;
+      if (candidates == null || candidates.generation != context.generation) return;
+      switch (candidates.drainNext()) {
+        case DeferredProductAnalyticsDrainComplete():
+          _deferredCandidates = null;
+          return;
+        case DeferredProductAnalyticsDrainNext(:final envelope, :final remainingCandidates):
+          // Transfer ownership of only this candidate to the in-flight SDK
+          // attempt. Remaining fixed slots stay service-owned if activity is
+          // suppressed before the next iteration.
+          _deferredCandidates = remainingCandidates;
+          final result = await _deliver(envelope: envelope, context: context);
+          if (result == AnalyticsDeliveryResult.failed && _isCurrentActiveContext(context: context)) {
+            logw("Failed to deliver deferred product analytics event");
+          }
+      }
+    }
+  }
+
+  bool _isCurrentActiveContext({required ProductAnalyticsDeliveryContext context}) =>
+      !_disposed && state.isActive && _preferenceService.isCurrentDeliveryContext(context: context);
 
   @disposeMethod
   Future<void> dispose() => _disposeFuture ??= _dispose();
 
   Future<void> _dispose() async {
     _disposed = true;
+    _deferredCandidates = null;
+    _activeGenerationDispatch = null;
     await _stateSubscription?.cancel();
     _stateSubscription = null;
     await _preferenceService.dispose();

--- a/client/module_core/test/foundation/product_analytics_event_test.dart
+++ b/client/module_core/test/foundation/product_analytics_event_test.dart
@@ -10,6 +10,86 @@ void main() {
         const {},
       ),
       (
+        const ProductAnalyticsEvent.analyticsActivationReady(),
+        "analytics_activation_ready",
+        const {"activation_schema_version": "1"},
+      ),
+      (
+        const ProductAnalyticsEvent.projectInventoryLoaded(
+          inventoryState: AnalyticsInventoryState.nonEmpty,
+        ),
+        "project_inventory_loaded",
+        const {"inventory_state": "non_empty"},
+      ),
+      (
+        const ProductAnalyticsEvent.sessionActivityViewed(
+          activityState: AnalyticsActivityState.empty,
+        ),
+        "session_activity_viewed",
+        const {"activity_state": "empty"},
+      ),
+      (
+        const ProductAnalyticsEvent.sessionMessageSent(
+          submission: AnalyticsSubmission.command(),
+        ),
+        "session_message_sent",
+        const {"submission_kind": "command", "input_mode": "typed"},
+      ),
+      (
+        const ProductAnalyticsEvent.sessionCreatedWithMessage(
+          submission: AnalyticsSubmission.text(inputMode: AnalyticsInputMode.voiceAssisted),
+          workspaceKind: AnalyticsWorkspaceKind.dedicatedWorktree,
+        ),
+        "session_created_with_message",
+        const {
+          "submission_kind": "text",
+          "input_mode": "voice_assisted",
+          "workspace_kind": "dedicated_worktree",
+        },
+      ),
+      (
+        const ProductAnalyticsEvent.sessionCreationFailed(
+          failureReason: AnalyticsSessionCreationFailureReason.networkDown,
+          workspaceKind: AnalyticsWorkspaceKind.project,
+        ),
+        "session_creation_failed",
+        const {"failure_reason": "network_down", "workspace_kind": "project"},
+      ),
+      (
+        const ProductAnalyticsEvent.voiceTranscriptionCompleted(),
+        "voice_transcription_completed",
+        const {},
+      ),
+      (
+        const ProductAnalyticsEvent.sessionQuestionAnswered(),
+        "session_question_answered",
+        const {},
+      ),
+      (
+        const ProductAnalyticsEvent.sessionQuestionRejected(),
+        "session_question_rejected",
+        const {},
+      ),
+      (
+        const ProductAnalyticsEvent.sessionPermissionAnswered(
+          decision: AnalyticsPermissionDecision.always,
+        ),
+        "session_permission_answered",
+        const {"decision": "always"},
+      ),
+      (
+        const ProductAnalyticsEvent.sessionAbortSucceeded(),
+        "session_abort_succeeded",
+        const {},
+      ),
+      (
+        const ProductAnalyticsEvent.sessionDiffViewed(
+          changeState: AnalyticsChangeState.nonEmpty,
+        ),
+        "session_diff_viewed",
+        const {"change_state": "non_empty"},
+      ),
+      (
         const ProductAnalyticsEvent.needHelpMenuOpened(surface: OnboardingSurface.connectSetup),
         "onboarding_need_help_opened",
         const {"surface": "connect_setup"},

--- a/client/module_core/test/helpers/test_helpers.dart
+++ b/client/module_core/test/helpers/test_helpers.dart
@@ -9,16 +9,20 @@ import "package:sesori_dart_core/src/api/session_api.dart";
 import "package:sesori_dart_core/src/capabilities/server_connection/connection_service.dart";
 import "package:sesori_dart_core/src/capabilities/server_connection/server_connection_config.dart";
 import "package:sesori_dart_core/src/capabilities/session/session_service.dart";
+import "package:sesori_dart_core/src/foundation/models/product_analytics/product_analytics_event.dart";
 import "package:sesori_dart_core/src/platform/lifecycle_source.dart";
 import "package:sesori_dart_core/src/platform/route_source.dart";
 import "package:sesori_dart_core/src/repositories/bridge_repository.dart";
+import "package:sesori_dart_core/src/repositories/models/analytics_delivery_result.dart";
 import "package:sesori_dart_core/src/repositories/plugin_preference_repository.dart";
 import "package:sesori_dart_core/src/repositories/plugin_repository.dart";
 import "package:sesori_dart_core/src/repositories/project_repository.dart";
 import "package:sesori_dart_core/src/repositories/registered_bridges_store.dart";
 import "package:sesori_dart_core/src/repositories/session_repository.dart";
 import "package:sesori_dart_core/src/routing/app_routes.dart";
+import "package:sesori_dart_core/src/services/models/product_analytics_state.dart";
 import "package:sesori_dart_core/src/services/models/session_activity_info.dart";
+import "package:sesori_dart_core/src/services/product_analytics_service.dart";
 import "package:sesori_dart_core/src/services/registered_bridges_service.dart";
 import "package:sesori_dart_core/src/services/session_unseen_tracker.dart";
 import "package:sesori_dart_core/src/services/session_viewing_service.dart";
@@ -119,6 +123,20 @@ class MockSessionApi extends Mock implements SessionApi {}
 class MockSessionService extends Mock implements SessionService {}
 
 class MockSessionRepository extends Mock implements SessionRepository {}
+
+class MockProductAnalyticsService extends Mock implements ProductAnalyticsService {}
+
+MockProductAnalyticsService stubbedProductAnalyticsService() {
+  final mock = MockProductAnalyticsService();
+  when(
+    () => mock.logEvent(
+      event: any(named: "event"),
+      occurredAtUtc: any(named: "occurredAtUtc"),
+    ),
+  ).thenAnswer((_) async => AnalyticsDeliveryResult.acceptedBySdk);
+  when(() => mock.state).thenReturn(ProductAnalyticsState.initial);
+  return mock;
+}
 
 class MockBridgeRepository extends Mock implements BridgeRepository {}
 
@@ -309,6 +327,8 @@ void registerAllFallbackValues() {
   registerFallbackValue(const ServerConnectionConfig(relayHost: "fake.example.com"));
   registerFallbackValue(FakeUri());
   registerFallbackValue(StackTrace.empty);
+  registerFallbackValue(const ProductAnalyticsEvent.analyticsSchemaReady());
+  registerFallbackValue(DateTime.utc(2026));
 }
 
 Project testProject({String? id, String? path, String? name}) {

--- a/client/module_core/test/repositories/analytics_repository_test.dart
+++ b/client/module_core/test/repositories/analytics_repository_test.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:mocktail/mocktail.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:test/test.dart";
@@ -72,6 +74,28 @@ void main() {
     ).thenThrow(StateError("sdk unavailable"));
     expect(
       await repository.logInstallationEvent(event: event),
+      AnalyticsDeliveryResult.failed,
+    );
+  });
+
+  test("a stalled SDK operation fails after the bounded delivery deadline", () async {
+    final repository = AnalyticsRepository.withDeliveryDeadline(
+      api: api,
+      deliveryDeadline: Duration.zero,
+    );
+    final envelope = ProductAnalyticsEnvelope(
+      event: const ProductAnalyticsEvent.analyticsSchemaReady(),
+      occurredAtUtc: DateTime.utc(2026),
+    );
+    when(
+      () => api.logProductEvent(
+        envelope: any(named: "envelope"),
+        userKey: _userKey,
+      ),
+    ).thenAnswer((_) => Completer<void>().future);
+
+    expect(
+      await repository.logProductEvent(envelope: envelope, userKey: _userKey),
       AnalyticsDeliveryResult.failed,
     );
   });

--- a/client/module_core/test/services/product_analytics_service_test.dart
+++ b/client/module_core/test/services/product_analytics_service_test.dart
@@ -121,6 +121,8 @@ class _FakePreferenceRepository extends Mock implements ProductAnalyticsPreferen
 class _RecordingAnalyticsRepository extends Mock implements AnalyticsRepository {
   final calls = <({ProductAnalyticsEnvelope envelope, String userKey})>[];
   AnalyticsDeliveryResult result = AnalyticsDeliveryResult.acceptedBySdk;
+  Queue<AnalyticsDeliveryResult>? results;
+  final deliveryFutures = Queue<Future<AnalyticsDeliveryResult>>();
   Completer<AnalyticsDeliveryResult>? deliveryCompleter;
 
   @override
@@ -129,9 +131,11 @@ class _RecordingAnalyticsRepository extends Mock implements AnalyticsRepository 
     required String userKey,
   }) async {
     calls.add((envelope: envelope, userKey: userKey));
+    if (deliveryFutures.isNotEmpty) return deliveryFutures.removeFirst();
     final completer = deliveryCompleter;
     if (completer != null) return completer.future;
-    return result;
+    final queuedResults = results;
+    return queuedResults == null || queuedResults.isEmpty ? result : queuedResults.removeFirst();
   }
 }
 
@@ -170,6 +174,13 @@ void main() {
       analyticsRepository: analyticsRepository,
       preferenceService: preferenceService,
     );
+  }
+
+  Future<void> waitForAnalyticsCalls({required int count}) async {
+    for (var i = 0; i < 20 && analyticsRepository.calls.length < count; i++) {
+      await Future<void>.delayed(Duration.zero);
+    }
+    expect(analyticsRepository.calls.length, greaterThanOrEqualTo(count));
   }
 
   tearDown(() async {
@@ -301,15 +312,199 @@ void main() {
 
     reconciliation.complete(ProductAnalyticsPreferenceSynchronized(record: record));
     await readinessFuture;
+    await waitForAnalyticsCalls(count: 1);
 
     expect(preferenceRepository.reconcileCalls, hasLength(1));
     expect(service.state.isActive, isTrue);
-    expect(analyticsRepository.calls, hasLength(1));
-    expect(analyticsRepository.calls.single.envelope.event, isA<AnalyticsSchemaReadyEvent>());
-    expect(analyticsRepository.calls.single.userKey, _userKeyA);
+    expect(
+      analyticsRepository.calls.map((call) => call.envelope.event),
+      [const ProductAnalyticsEvent.analyticsSchemaReady()],
+    );
+    expect(analyticsRepository.calls.map((call) => call.userKey), everyElement(_userKeyA));
 
     await service.markPostSplashReady();
     expect(preferenceRepository.reconcileCalls, hasLength(1));
+  });
+
+  test("schema readiness precedes a deferred first-message outcome and preserves occurrence time", () async {
+    createService();
+    final occurredAt = DateTime.utc(2026, 7, 30, 10, 15);
+    final enabled = _record(
+      userId: _userA.id,
+      userKey: _userKeyA,
+      preference: ProductAnalyticsPreference.enabled,
+    );
+    preferenceRepository.reconcileHandlers.add(
+      (_, _) async => ProductAnalyticsPreferenceSynchronized(record: enabled),
+    );
+    await service.start();
+
+    expect(
+      await service.logEvent(
+        event: const ProductAnalyticsEvent.sessionMessageSent(
+          submission: AnalyticsSubmission.text(inputMode: AnalyticsInputMode.typed),
+        ),
+        occurredAtUtc: occurredAt,
+      ),
+      AnalyticsDeliveryResult.deferredUntilPreference,
+    );
+    expect(analyticsRepository.calls, isEmpty);
+
+    await service.markPostSplashReady();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(
+      analyticsRepository.calls.map((call) => call.envelope.event),
+      [
+        const ProductAnalyticsEvent.analyticsSchemaReady(),
+        const ProductAnalyticsEvent.sessionMessageSent(
+          submission: AnalyticsSubmission.text(inputMode: AnalyticsInputMode.typed),
+        ),
+      ],
+    );
+    expect(analyticsRepository.calls.last.envelope.occurredAtUtc, occurredAt);
+  });
+
+  test("retains deferred outcomes until schema readiness is accepted", () async {
+    createService();
+    final enabled = _record(
+      userId: _userA.id,
+      userKey: _userKeyA,
+      preference: ProductAnalyticsPreference.enabled,
+    );
+    preferenceRepository.reconcileHandlers
+      ..add((_, _) async => ProductAnalyticsPreferenceSynchronized(record: enabled))
+      ..add((_, _) async => ProductAnalyticsPreferenceSynchronized(record: enabled));
+    analyticsRepository.results = Queue.of([AnalyticsDeliveryResult.failed]);
+    await service.start();
+    expect(
+      await service.logEvent(
+        event: const ProductAnalyticsEvent.sessionMessageSent(
+          submission: AnalyticsSubmission.text(inputMode: AnalyticsInputMode.typed),
+        ),
+        occurredAtUtc: DateTime.utc(2026, 7, 30),
+      ),
+      AnalyticsDeliveryResult.deferredUntilPreference,
+    );
+
+    await service.markPostSplashReady();
+    await waitForAnalyticsCalls(count: 1);
+    expect(analyticsRepository.calls, hasLength(1));
+
+    analyticsRepository.result = AnalyticsDeliveryResult.acceptedBySdk;
+    await service.refreshPreference();
+    await waitForAnalyticsCalls(count: 3);
+
+    expect(
+      analyticsRepository.calls.map((call) => call.envelope.event),
+      [
+        const ProductAnalyticsEvent.analyticsSchemaReady(),
+        const ProductAnalyticsEvent.analyticsSchemaReady(),
+        const ProductAnalyticsEvent.sessionMessageSent(
+          submission: AnalyticsSubmission.text(inputMode: AnalyticsInputMode.typed),
+        ),
+      ],
+    );
+  });
+
+  test("failed deferred outcome delivery remains operationally observable", () async {
+    createService();
+    final enabled = _record(
+      userId: _userA.id,
+      userKey: _userKeyA,
+      preference: ProductAnalyticsPreference.enabled,
+    );
+    preferenceRepository.reconcileHandlers.add(
+      (_, _) async => ProductAnalyticsPreferenceSynchronized(record: enabled),
+    );
+    analyticsRepository.results = Queue.of([
+      AnalyticsDeliveryResult.acceptedBySdk,
+      AnalyticsDeliveryResult.failed,
+    ]);
+    final logLines = <String>[];
+
+    await runZoned(
+      () async {
+        await service.start();
+        await service.logEvent(
+          event: const ProductAnalyticsEvent.sessionMessageSent(
+            submission: AnalyticsSubmission.text(inputMode: AnalyticsInputMode.typed),
+          ),
+          occurredAtUtc: DateTime.utc(2026, 7, 30),
+        );
+        await service.markPostSplashReady();
+        await waitForAnalyticsCalls(count: 2);
+      },
+      zoneSpecification: ZoneSpecification(print: (_, _, _, line) => logLines.add(line)),
+    );
+
+    expect(logLines, contains("Failed to deliver deferred product analytics event"));
+  });
+
+  test("retains unattempted fixed slots across a same-generation inactive refresh", () async {
+    createService();
+    final enabled = _record(
+      userId: _userA.id,
+      userKey: _userKeyA,
+      preference: ProductAnalyticsPreference.enabled,
+    );
+    final refreshResult = Completer<ProductAnalyticsPreferenceRepositoryResult>();
+    preferenceRepository.reconcileHandlers
+      ..add((_, _) async => ProductAnalyticsPreferenceSynchronized(record: enabled))
+      ..add((_, _) => refreshResult.future);
+    final firstCandidateResult = Completer<AnalyticsDeliveryResult>();
+    analyticsRepository.deliveryFutures
+      ..add(Future.value(AnalyticsDeliveryResult.acceptedBySdk))
+      ..add(firstCandidateResult.future);
+
+    await service.start();
+    expect(
+      await service.logEvent(
+        event: const ProductAnalyticsEvent.sessionMessageSent(
+          submission: AnalyticsSubmission.text(inputMode: AnalyticsInputMode.typed),
+        ),
+        occurredAtUtc: DateTime.utc(2026, 7, 30, 10),
+      ),
+      AnalyticsDeliveryResult.deferredUntilPreference,
+    );
+    expect(
+      await service.logEvent(
+        event: const ProductAnalyticsEvent.projectInventoryLoaded(
+          inventoryState: AnalyticsInventoryState.nonEmpty,
+        ),
+        occurredAtUtc: DateTime.utc(2026, 7, 30, 11),
+      ),
+      AnalyticsDeliveryResult.deferredUntilPreference,
+    );
+
+    await service.markPostSplashReady();
+    await waitForAnalyticsCalls(count: 2);
+    final refreshFuture = service.refreshPreference();
+    while (preferenceRepository.reconcileCalls.length < 2) {
+      await Future<void>.delayed(Duration.zero);
+    }
+    expect(service.state.isActive, isFalse);
+
+    firstCandidateResult.complete(AnalyticsDeliveryResult.acceptedBySdk);
+    await Future<void>.delayed(Duration.zero);
+    expect(analyticsRepository.calls, hasLength(2));
+
+    refreshResult.complete(ProductAnalyticsPreferenceSynchronized(record: enabled));
+    await refreshFuture;
+    await waitForAnalyticsCalls(count: 3);
+
+    expect(
+      analyticsRepository.calls.map((call) => call.envelope.event),
+      [
+        const ProductAnalyticsEvent.analyticsSchemaReady(),
+        const ProductAnalyticsEvent.sessionMessageSent(
+          submission: AnalyticsSubmission.text(inputMode: AnalyticsInputMode.typed),
+        ),
+        const ProductAnalyticsEvent.projectInventoryLoaded(
+          inventoryState: AnalyticsInventoryState.nonEmpty,
+        ),
+      ],
+    );
   });
 
   test("disabled runtime retains preference truth but never emits custom events", () async {
@@ -335,7 +530,7 @@ void main() {
     expect(analyticsRepository.calls, isEmpty);
   });
 
-  test("schema readiness retries after SDK rejection in the same auth generation", () async {
+  test("readiness events retry after SDK rejection in the same auth generation", () async {
     createService();
     final record = _record(
       userId: _userA.id,
@@ -349,15 +544,18 @@ void main() {
 
     await service.start();
     await service.markPostSplashReady();
-    expect(analyticsRepository.calls, hasLength(1));
+    await waitForAnalyticsCalls(count: 1);
 
     analyticsRepository.result = AnalyticsDeliveryResult.acceptedBySdk;
     await service.refreshPreference();
+    await waitForAnalyticsCalls(count: 2);
 
-    expect(analyticsRepository.calls, hasLength(2));
     expect(
       analyticsRepository.calls.map((call) => call.envelope.event),
-      everyElement(isA<AnalyticsSchemaReadyEvent>()),
+      [
+        const ProductAnalyticsEvent.analyticsSchemaReady(),
+        const ProductAnalyticsEvent.analyticsSchemaReady(),
+      ],
     );
   });
 
@@ -379,13 +577,26 @@ void main() {
     expect(preferenceRepository.reconcileCalls, isEmpty);
     expect(service.state.availability, isA<ProductAnalyticsInactive>());
     expect(analyticsRepository.calls, isEmpty);
+    expect(
+      await service.logEvent(
+        event: const ProductAnalyticsEvent.sessionMessageSent(
+          submission: AnalyticsSubmission.text(inputMode: AnalyticsInputMode.typed),
+        ),
+        occurredAtUtc: DateTime.utc(2026, 7, 30),
+      ),
+      AnalyticsDeliveryResult.failed,
+    );
 
     preferenceRepository.throwOnLoad = false;
     await service.refreshPreference();
+    await waitForAnalyticsCalls(count: 1);
 
     expect(preferenceRepository.reconcileCalls, hasLength(1));
     expect(service.state.isActive, isTrue);
-    expect(analyticsRepository.calls.single.envelope.event, isA<AnalyticsSchemaReadyEvent>());
+    expect(
+      analyticsRepository.calls.map((call) => call.envelope.event),
+      [const ProductAnalyticsEvent.analyticsSchemaReady()],
+    );
   });
 
   test("a retried local read cannot overwrite a newer preference request", () async {
@@ -446,6 +657,7 @@ void main() {
     );
     await service.start();
     await service.markPostSplashReady();
+    await waitForAnalyticsCalls(count: 1);
     analyticsRepository.calls.clear();
 
     final pendingCompleter = Completer<ProductAnalyticsPreferenceRepositoryResult>();
@@ -1409,6 +1621,7 @@ void main() {
     );
     await service.start();
     await service.markPostSplashReady();
+    await waitForAnalyticsCalls(count: 1);
     analyticsRepository.calls.clear();
 
     final refreshResult = Completer<ProductAnalyticsPreferenceRepositoryResult>();
@@ -1668,6 +1881,7 @@ void main() {
     );
     await service.start();
     await service.markPostSplashReady();
+    await waitForAnalyticsCalls(count: 1);
     analyticsRepository.calls.clear();
 
     authSession.emit(state: const AuthState.authenticated(user: _userB));
@@ -1692,6 +1906,7 @@ void main() {
     );
     await service.start();
     await service.markPostSplashReady();
+    await waitForAnalyticsCalls(count: 1);
     analyticsRepository.calls.clear();
 
     final loadB = Completer<LocalProductAnalyticsPreference?>();


### PR DESCRIPTION
## Summary
- add the closed, bounded product-outcome event catalog and delivery results
- retain only fixed generation-scoped activation, project, diff, and session-activity candidates while preference is unknown
- preserve authoritative occurrence timestamps and drain retained candidates in typed order after schema readiness

## Stack
1. **#632 — bounded outcome contracts (this PR)**
2. #634 — account-less login outcomes
3. #633 — activation and voice outcomes
4. #631 — visible engagement outcomes and capability marker

This stack supersedes closed reference PR #629.

## Verification
- focused `module_core` analytics tests
- `dart analyze` in `client/module_core`, `client/app`, and `client/desktop`
- architecture implementation review approved
