### PR TITLE
[output-image-support] refactor(codex): seal rollout content [step 2/13]

### DIFF
--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -5,10 +5,10 @@
 - **Plan slug:** `output-image-support`
 - **Implementation base:** `origin/main` at
   `9d2c1e9e79ab80fa8824b9d803a74798eb71140d`
-- **Series state:** Step 2/13 ready for PR delivery
+- **Series state:** Step 2/13 PR open
 - **Current step:** Step 2/13 — seal Codex rollout content
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** commit, push, open, and monitor the Step 2/13 PR
+- **Next action:** monitor Step 2/13 CI and review
 
 ## Plan Review
 
@@ -27,7 +27,7 @@
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
 | [x] | 1/13 | `investigate-opencode-image-support` | `[output-image-support] docs: plan output image support [step 1/13]` | 450-700 | [PR #638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638) merged as `bfadd097` |
-| [ ] | 2/13 | `output-image-support-codex-rollout-content` | `[output-image-support] refactor(codex): seal rollout content [step 2/13]` | 1,200-1,500 | Ready for PR; 642 changed lines |
+| [ ] | 2/13 | `output-image-support-codex-rollout-content` | `[output-image-support] refactor(codex): seal rollout content [step 2/13]` | 1,200-1,500 | [PR #639](https://github.com/sesori-ai/sesori_apps_monorepo/pull/639) open; 642 changed lines |
 | [ ] | 3/13 | `output-image-support-codex-rollout-envelopes` | `[output-image-support] refactor(codex): seal rollout envelopes [step 3/13]` | 900-1,350 | Blocked on Step 2 merge |
 | [ ] | 4/13 | `output-image-support-codex-response-items` | `[output-image-support] refactor(codex): seal response items [step 4/13]` | 1,100-1,500 | Blocked on Step 3 merge |
 | [ ] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | Blocked on Step 4 merge |
@@ -96,8 +96,8 @@
   and history consumers. Codex codegen, focused tests, all 210 package tests,
   `dart pub get`, `dart analyze --fatal-infos`, and `git diff --cached --check`
   pass. `aristotle-impl-review` approved the staged architecture with no
-  findings. The 642-line diff is below the 1,500-line soft cap; no neighboring
-  scope was combined.
+  findings. Commit `3b18da2d` is open as [PR #639](https://github.com/sesori-ai/sesori_apps_monorepo/pull/639).
+  The 642-line diff is below the 1,500-line soft cap; no neighboring scope was combined.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -5,10 +5,10 @@
 - **Plan slug:** `output-image-support`
 - **Implementation base:** `origin/main` at
   `9d2c1e9e79ab80fa8824b9d803a74798eb71140d`
-- **Series state:** Step 1/13 plan PR open
-- **Current step:** Step 1/13 — durable plan, tracker, and Plan Maker rules
+- **Series state:** Step 2/13 ready for PR delivery
+- **Current step:** Step 2/13 — seal Codex rollout content
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** monitor Step 1/13 CI and review
+- **Next action:** commit, push, open, and monitor the Step 2/13 PR
 
 ## Plan Review
 
@@ -26,8 +26,8 @@
 
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
-| [ ] | 1/13 | `investigate-opencode-image-support` | `[output-image-support] docs: plan output image support [step 1/13]` | 450-700 | [PR #638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638) open |
-| [ ] | 2/13 | `output-image-support-codex-rollout-content` | `[output-image-support] refactor(codex): seal rollout content [step 2/13]` | 1,200-1,500 | Blocked on Step 1 merge |
+| [x] | 1/13 | `investigate-opencode-image-support` | `[output-image-support] docs: plan output image support [step 1/13]` | 450-700 | [PR #638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638) merged as `bfadd097` |
+| [ ] | 2/13 | `output-image-support-codex-rollout-content` | `[output-image-support] refactor(codex): seal rollout content [step 2/13]` | 1,200-1,500 | Ready for PR; 642 changed lines |
 | [ ] | 3/13 | `output-image-support-codex-rollout-envelopes` | `[output-image-support] refactor(codex): seal rollout envelopes [step 3/13]` | 900-1,350 | Blocked on Step 2 merge |
 | [ ] | 4/13 | `output-image-support-codex-response-items` | `[output-image-support] refactor(codex): seal response items [step 4/13]` | 1,100-1,500 | Blocked on Step 3 merge |
 | [ ] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | Blocked on Step 4 merge |
@@ -60,6 +60,8 @@
 
 - Merge in numeric order. A successor may target its immediate predecessor while
   both are open, but each step must remain independently buildable and valid.
+- After a PR merges, continue automatically with the next numbered step without
+  waiting for another user prompt. Stop only for a material decision or blocker.
 - Count additions plus deletions, including generated files and tests, against
   each PR base. Target no more than 1,500 changed lines per PR as a soft cap;
   split coherently first or record why an expected overage is unavoidable.
@@ -86,10 +88,21 @@
   [PR #638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638). The PR
   now also codifies the requested Plan Maker lifecycle and 1,500-line soft-cap
   rules; its current diff is 617 changed lines and `git diff --check` passes. No
-  Dart or Flutter suites were run for this documentation-only step.
+  Dart or Flutter suites were run for this documentation-only step. PR #638
+  merged as `bfadd097` on 2026-07-31.
+- Step 2/13 (2026-07-31): sealed rollout content into required text, image, and
+  unknown variants; moved the rollout tool mapper into the repository mapping
+  layer; and wired one instance from the production composition root into live
+  and history consumers. Codex codegen, focused tests, all 210 package tests,
+  `dart pub get`, `dart analyze --fatal-infos`, and `git diff --cached --check`
+  pass. `aristotle-impl-review` approved the staged architecture with no
+  findings. The 642-line diff is below the 1,500-line soft cap; no neighboring
+  scope was combined.
 
 ## Findings And Plan Deltas
 
+- **2026-07-31 — Automatic continuation:** After each merged PR, proceed with
+  the next numbered step without waiting for another explicit user request.
 - **2026-07-31 — Lifecycle and line budget:** Set a 1,500 changed-line soft cap,
   retained plan delivery as Step 1/13, kept the eleven implementation boundaries
   as Steps 2/13 through 12/13, and added plan retirement as Step 13/13.

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -27,7 +27,7 @@
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
 | [x] | 1/13 | `investigate-opencode-image-support` | `[output-image-support] docs: plan output image support [step 1/13]` | 450-700 | [PR #638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638) merged as `bfadd097` |
-| [ ] | 2/13 | `output-image-support-codex-rollout-content` | `[output-image-support] refactor(codex): seal rollout content [step 2/13]` | 1,200-1,500 | [PR #639](https://github.com/sesori-ai/sesori_apps_monorepo/pull/639) open; 642 changed lines |
+| [ ] | 2/13 | `output-image-support-codex-rollout-content` | `[output-image-support] refactor(codex): seal rollout content [step 2/13]` | 1,200-1,500 | [PR #639](https://github.com/sesori-ai/sesori_apps_monorepo/pull/639) open; 680 changed lines |
 | [ ] | 3/13 | `output-image-support-codex-rollout-envelopes` | `[output-image-support] refactor(codex): seal rollout envelopes [step 3/13]` | 900-1,350 | Blocked on Step 2 merge |
 | [ ] | 4/13 | `output-image-support-codex-response-items` | `[output-image-support] refactor(codex): seal response items [step 4/13]` | 1,100-1,500 | Blocked on Step 3 merge |
 | [ ] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | Blocked on Step 4 merge |
@@ -97,7 +97,7 @@
   `dart pub get`, `dart analyze --fatal-infos`, and `git diff --cached --check`
   pass. `aristotle-impl-review` approved the staged architecture with no
   findings. Commit `3b18da2d` is open as [PR #639](https://github.com/sesori-ai/sesori_apps_monorepo/pull/639).
-  The 642-line diff is below the 1,500-line soft cap; no neighboring scope was combined.
+  The 680-line diff is below the 1,500-line soft cap; no neighboring scope was combined.
 
 ## Findings And Plan Deltas
 

--- a/bridge/sesori_plugin_codex/lib/codex_plugin.dart
+++ b/bridge/sesori_plugin_codex/lib/codex_plugin.dart
@@ -11,7 +11,7 @@ export "src/codex_config_reader.dart";
 export "src/codex_event_mapper.dart";
 export "src/codex_metadata_repository.dart";
 export "src/codex_plugin_impl.dart";
-export "src/codex_rollout_tool_mapper.dart";
+export "src/repositories/mappers/codex_rollout_tool_mapper.dart";
 // Runtime lifecycle: the descriptor is the public entry point the bridge
 // registers in bin/bridge.dart.
 export "src/runtime/codex_bridge_plugin.dart";

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
@@ -42,16 +42,6 @@ enum CodexRolloutRole {
   unknown,
 }
 
-enum CodexRolloutContentType {
-  @JsonValue("input_text")
-  inputText,
-  @JsonValue("output_text")
-  outputText,
-  @JsonValue("summary_text")
-  summaryText,
-  unknown,
-}
-
 @Freezed(fromJson: true, toJson: false)
 sealed class CodexSessionIndexEntryDto with _$CodexSessionIndexEntryDto {
   const factory CodexSessionIndexEntryDto({
@@ -100,12 +90,34 @@ sealed class CodexRolloutPayloadDto with _$CodexRolloutPayloadDto {
   factory CodexRolloutPayloadDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutPayloadDtoFromJson(json);
 }
 
-@Freezed(fromJson: true, toJson: false)
+@Freezed(
+  unionKey: "type",
+  fallbackUnion: "unknown",
+  fromJson: true,
+  toJson: false,
+)
 sealed class CodexRolloutContentDto with _$CodexRolloutContentDto {
-  const factory CodexRolloutContentDto({
-    @JsonKey(unknownEnumValue: CodexRolloutContentType.unknown) required CodexRolloutContentType? type,
-    required String? text,
-  }) = _CodexRolloutContentDto;
+  @FreezedUnionValue("input_text")
+  const factory CodexRolloutContentDto.inputText({
+    required String text,
+  }) = CodexRolloutInputTextDto;
+
+  @FreezedUnionValue("output_text")
+  const factory CodexRolloutContentDto.outputText({
+    required String text,
+  }) = CodexRolloutOutputTextDto;
+
+  @FreezedUnionValue("summary_text")
+  const factory CodexRolloutContentDto.summaryText({
+    required String text,
+  }) = CodexRolloutSummaryTextDto;
+
+  @FreezedUnionValue("input_image")
+  const factory CodexRolloutContentDto.inputImage({
+    @JsonKey(name: "image_url") required String imageUrl,
+  }) = CodexRolloutInputImageDto;
+
+  const factory CodexRolloutContentDto.unknown() = CodexRolloutUnknownContentDto;
 
   factory CodexRolloutContentDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutContentDtoFromJson(json);
 }
@@ -142,15 +154,24 @@ class CodexRolloutContentListConverter implements JsonConverter<List<CodexRollou
     if (object == null) return null;
     return [
       for (final content in object)
-        {
-          "type": switch (content.type) {
-            CodexRolloutContentType.inputText => "input_text",
-            CodexRolloutContentType.outputText => "output_text",
-            CodexRolloutContentType.summaryText => "summary_text",
-            CodexRolloutContentType.unknown => "unknown",
-            null => null,
+        switch (content) {
+          CodexRolloutInputTextDto(:final text) => {
+            "type": "input_text",
+            "text": text,
           },
-          "text": content.text,
+          CodexRolloutOutputTextDto(:final text) => {
+            "type": "output_text",
+            "text": text,
+          },
+          CodexRolloutSummaryTextDto(:final text) => {
+            "type": "summary_text",
+            "text": text,
+          },
+          CodexRolloutInputImageDto(:final imageUrl) => {
+            "type": "input_image",
+            "image_url": imageUrl,
+          },
+          CodexRolloutUnknownContentDto() => {"type": "unknown"},
         },
     ];
   }
@@ -168,8 +189,7 @@ class CodexRolloutOutputConverter extends CodexRolloutContentListConverter {
   List<CodexRolloutContentDto>? fromJson(Object? json) {
     if (json is String) {
       return [
-        CodexRolloutContentDto(
-          type: CodexRolloutContentType.outputText,
+        CodexRolloutContentDto.outputText(
           text: json,
         ),
       ];

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
@@ -94,7 +94,7 @@ sealed class CodexRolloutPayloadDto with _$CodexRolloutPayloadDto {
   unionKey: "type",
   fallbackUnion: "unknown",
   fromJson: true,
-  toJson: false,
+  toJson: true,
 )
 sealed class CodexRolloutContentDto with _$CodexRolloutContentDto {
   @FreezedUnionValue("input_text")
@@ -153,26 +153,7 @@ class CodexRolloutContentListConverter implements JsonConverter<List<CodexRollou
   Object? toJson(List<CodexRolloutContentDto>? object) {
     if (object == null) return null;
     return [
-      for (final content in object)
-        switch (content) {
-          CodexRolloutInputTextDto(:final text) => {
-            "type": "input_text",
-            "text": text,
-          },
-          CodexRolloutOutputTextDto(:final text) => {
-            "type": "output_text",
-            "text": text,
-          },
-          CodexRolloutSummaryTextDto(:final text) => {
-            "type": "summary_text",
-            "text": text,
-          },
-          CodexRolloutInputImageDto(:final imageUrl) => {
-            "type": "input_image",
-            "image_url": imageUrl,
-          },
-          CodexRolloutUnknownContentDto() => {"type": "unknown"},
-        },
+      for (final content in object) content.toJson(),
     ];
   }
 }

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
@@ -561,6 +561,8 @@ mixin _$CodexRolloutContentDto {
 
 
 
+  /// Serializes this CodexRolloutContentDto to a JSON map.
+  Map<String, dynamic> toJson();
 
 
 @override
@@ -588,7 +590,7 @@ $CodexRolloutContentDtoCopyWith(CodexRolloutContentDto _, $Res Function(CodexRol
 
 
 /// @nodoc
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 
 class CodexRolloutInputTextDto implements CodexRolloutContentDto {
   const CodexRolloutInputTextDto({required this.text, final  String? $type}): $type = $type ?? 'input_text';
@@ -606,7 +608,10 @@ final String $type;
 @pragma('vm:prefer-inline')
 $CodexRolloutInputTextDtoCopyWith<CodexRolloutInputTextDto> get copyWith => _$CodexRolloutInputTextDtoCopyWithImpl<CodexRolloutInputTextDto>(this, _$identity);
 
-
+@override
+Map<String, dynamic> toJson() {
+  return _$CodexRolloutInputTextDtoToJson(this, );
+}
 
 @override
 bool operator ==(Object other) {
@@ -658,7 +663,7 @@ as String,
 }
 
 /// @nodoc
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 
 class CodexRolloutOutputTextDto implements CodexRolloutContentDto {
   const CodexRolloutOutputTextDto({required this.text, final  String? $type}): $type = $type ?? 'output_text';
@@ -676,7 +681,10 @@ final String $type;
 @pragma('vm:prefer-inline')
 $CodexRolloutOutputTextDtoCopyWith<CodexRolloutOutputTextDto> get copyWith => _$CodexRolloutOutputTextDtoCopyWithImpl<CodexRolloutOutputTextDto>(this, _$identity);
 
-
+@override
+Map<String, dynamic> toJson() {
+  return _$CodexRolloutOutputTextDtoToJson(this, );
+}
 
 @override
 bool operator ==(Object other) {
@@ -728,7 +736,7 @@ as String,
 }
 
 /// @nodoc
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 
 class CodexRolloutSummaryTextDto implements CodexRolloutContentDto {
   const CodexRolloutSummaryTextDto({required this.text, final  String? $type}): $type = $type ?? 'summary_text';
@@ -746,7 +754,10 @@ final String $type;
 @pragma('vm:prefer-inline')
 $CodexRolloutSummaryTextDtoCopyWith<CodexRolloutSummaryTextDto> get copyWith => _$CodexRolloutSummaryTextDtoCopyWithImpl<CodexRolloutSummaryTextDto>(this, _$identity);
 
-
+@override
+Map<String, dynamic> toJson() {
+  return _$CodexRolloutSummaryTextDtoToJson(this, );
+}
 
 @override
 bool operator ==(Object other) {
@@ -798,7 +809,7 @@ as String,
 }
 
 /// @nodoc
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 
 class CodexRolloutInputImageDto implements CodexRolloutContentDto {
   const CodexRolloutInputImageDto({@JsonKey(name: "image_url") required this.imageUrl, final  String? $type}): $type = $type ?? 'input_image';
@@ -816,7 +827,10 @@ final String $type;
 @pragma('vm:prefer-inline')
 $CodexRolloutInputImageDtoCopyWith<CodexRolloutInputImageDto> get copyWith => _$CodexRolloutInputImageDtoCopyWithImpl<CodexRolloutInputImageDto>(this, _$identity);
 
-
+@override
+Map<String, dynamic> toJson() {
+  return _$CodexRolloutInputImageDtoToJson(this, );
+}
 
 @override
 bool operator ==(Object other) {
@@ -868,7 +882,7 @@ as String,
 }
 
 /// @nodoc
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 
 class CodexRolloutUnknownContentDto implements CodexRolloutContentDto {
   const CodexRolloutUnknownContentDto({final  String? $type}): $type = $type ?? 'unknown';
@@ -881,7 +895,10 @@ final String $type;
 
 
 
-
+@override
+Map<String, dynamic> toJson() {
+  return _$CodexRolloutUnknownContentDtoToJson(this, );
+}
 
 @override
 bool operator ==(Object other) {

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
@@ -527,66 +527,62 @@ $CodexRolloutActionDtoCopyWith<$Res>? get action {
 }
 }
 
+CodexRolloutContentDto _$CodexRolloutContentDtoFromJson(
+  Map<String, dynamic> json
+) {
+        switch (json['type']) {
+                  case 'input_text':
+          return CodexRolloutInputTextDto.fromJson(
+            json
+          );
+                case 'output_text':
+          return CodexRolloutOutputTextDto.fromJson(
+            json
+          );
+                case 'summary_text':
+          return CodexRolloutSummaryTextDto.fromJson(
+            json
+          );
+                case 'input_image':
+          return CodexRolloutInputImageDto.fromJson(
+            json
+          );
+        
+          default:
+            return CodexRolloutUnknownContentDto.fromJson(
+  json
+);
+        }
+      
+}
 
 /// @nodoc
 mixin _$CodexRolloutContentDto {
 
-@JsonKey(unknownEnumValue: CodexRolloutContentType.unknown) CodexRolloutContentType? get type; String? get text;
-/// Create a copy of CodexRolloutContentDto
-/// with the given fields replaced by the non-null parameter values.
-@JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-$CodexRolloutContentDtoCopyWith<CodexRolloutContentDto> get copyWith => _$CodexRolloutContentDtoCopyWithImpl<CodexRolloutContentDto>(this as CodexRolloutContentDto, _$identity);
+
 
 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutContentDto&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutContentDto);
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,type,text);
+int get hashCode => runtimeType.hashCode;
 
 @override
 String toString() {
-  return 'CodexRolloutContentDto(type: $type, text: $text)';
+  return 'CodexRolloutContentDto()';
 }
 
 
 }
 
 /// @nodoc
-abstract mixin class $CodexRolloutContentDtoCopyWith<$Res>  {
-  factory $CodexRolloutContentDtoCopyWith(CodexRolloutContentDto value, $Res Function(CodexRolloutContentDto) _then) = _$CodexRolloutContentDtoCopyWithImpl;
-@useResult
-$Res call({
-@JsonKey(unknownEnumValue: CodexRolloutContentType.unknown) CodexRolloutContentType? type, String? text
-});
-
-
-
-
-}
-/// @nodoc
-class _$CodexRolloutContentDtoCopyWithImpl<$Res>
-    implements $CodexRolloutContentDtoCopyWith<$Res> {
-  _$CodexRolloutContentDtoCopyWithImpl(this._self, this._then);
-
-  final CodexRolloutContentDto _self;
-  final $Res Function(CodexRolloutContentDto) _then;
-
-/// Create a copy of CodexRolloutContentDto
-/// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? type = freezed,Object? text = freezed,}) {
-  return _then(_self.copyWith(
-type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
-as CodexRolloutContentType?,text: freezed == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
-as String?,
-  ));
-}
-
+class $CodexRolloutContentDtoCopyWith<$Res>  {
+$CodexRolloutContentDtoCopyWith(CodexRolloutContentDto _, $Res Function(CodexRolloutContentDto) __);
 }
 
 
@@ -594,44 +590,47 @@ as String?,
 /// @nodoc
 @JsonSerializable(createToJson: false)
 
-class _CodexRolloutContentDto implements CodexRolloutContentDto {
-  const _CodexRolloutContentDto({@JsonKey(unknownEnumValue: CodexRolloutContentType.unknown) required this.type, required this.text});
-  factory _CodexRolloutContentDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutContentDtoFromJson(json);
+class CodexRolloutInputTextDto implements CodexRolloutContentDto {
+  const CodexRolloutInputTextDto({required this.text, final  String? $type}): $type = $type ?? 'input_text';
+  factory CodexRolloutInputTextDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutInputTextDtoFromJson(json);
 
-@override@JsonKey(unknownEnumValue: CodexRolloutContentType.unknown) final  CodexRolloutContentType? type;
-@override final  String? text;
+ final  String text;
+
+@JsonKey(name: 'type')
+final String $type;
+
 
 /// Create a copy of CodexRolloutContentDto
 /// with the given fields replaced by the non-null parameter values.
-@override @JsonKey(includeFromJson: false, includeToJson: false)
+@JsonKey(includeFromJson: false, includeToJson: false)
 @pragma('vm:prefer-inline')
-_$CodexRolloutContentDtoCopyWith<_CodexRolloutContentDto> get copyWith => __$CodexRolloutContentDtoCopyWithImpl<_CodexRolloutContentDto>(this, _$identity);
+$CodexRolloutInputTextDtoCopyWith<CodexRolloutInputTextDto> get copyWith => _$CodexRolloutInputTextDtoCopyWithImpl<CodexRolloutInputTextDto>(this, _$identity);
 
 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexRolloutContentDto&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutInputTextDto&&(identical(other.text, text) || other.text == text));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,type,text);
+int get hashCode => Object.hash(runtimeType,text);
 
 @override
 String toString() {
-  return 'CodexRolloutContentDto(type: $type, text: $text)';
+  return 'CodexRolloutContentDto.inputText(text: $text)';
 }
 
 
 }
 
 /// @nodoc
-abstract mixin class _$CodexRolloutContentDtoCopyWith<$Res> implements $CodexRolloutContentDtoCopyWith<$Res> {
-  factory _$CodexRolloutContentDtoCopyWith(_CodexRolloutContentDto value, $Res Function(_CodexRolloutContentDto) _then) = __$CodexRolloutContentDtoCopyWithImpl;
-@override @useResult
+abstract mixin class $CodexRolloutInputTextDtoCopyWith<$Res> implements $CodexRolloutContentDtoCopyWith<$Res> {
+  factory $CodexRolloutInputTextDtoCopyWith(CodexRolloutInputTextDto value, $Res Function(CodexRolloutInputTextDto) _then) = _$CodexRolloutInputTextDtoCopyWithImpl;
+@useResult
 $Res call({
-@JsonKey(unknownEnumValue: CodexRolloutContentType.unknown) CodexRolloutContentType? type, String? text
+ String text
 });
 
 
@@ -639,25 +638,270 @@ $Res call({
 
 }
 /// @nodoc
-class __$CodexRolloutContentDtoCopyWithImpl<$Res>
-    implements _$CodexRolloutContentDtoCopyWith<$Res> {
-  __$CodexRolloutContentDtoCopyWithImpl(this._self, this._then);
+class _$CodexRolloutInputTextDtoCopyWithImpl<$Res>
+    implements $CodexRolloutInputTextDtoCopyWith<$Res> {
+  _$CodexRolloutInputTextDtoCopyWithImpl(this._self, this._then);
 
-  final _CodexRolloutContentDto _self;
-  final $Res Function(_CodexRolloutContentDto) _then;
+  final CodexRolloutInputTextDto _self;
+  final $Res Function(CodexRolloutInputTextDto) _then;
 
 /// Create a copy of CodexRolloutContentDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? type = freezed,Object? text = freezed,}) {
-  return _then(_CodexRolloutContentDto(
-type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
-as CodexRolloutContentType?,text: freezed == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
-as String?,
+@pragma('vm:prefer-inline') $Res call({Object? text = null,}) {
+  return _then(CodexRolloutInputTextDto(
+text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
+as String,
   ));
 }
 
 
 }
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutOutputTextDto implements CodexRolloutContentDto {
+  const CodexRolloutOutputTextDto({required this.text, final  String? $type}): $type = $type ?? 'output_text';
+  factory CodexRolloutOutputTextDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutOutputTextDtoFromJson(json);
+
+ final  String text;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutContentDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutOutputTextDtoCopyWith<CodexRolloutOutputTextDto> get copyWith => _$CodexRolloutOutputTextDtoCopyWithImpl<CodexRolloutOutputTextDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutOutputTextDto&&(identical(other.text, text) || other.text == text));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,text);
+
+@override
+String toString() {
+  return 'CodexRolloutContentDto.outputText(text: $text)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutOutputTextDtoCopyWith<$Res> implements $CodexRolloutContentDtoCopyWith<$Res> {
+  factory $CodexRolloutOutputTextDtoCopyWith(CodexRolloutOutputTextDto value, $Res Function(CodexRolloutOutputTextDto) _then) = _$CodexRolloutOutputTextDtoCopyWithImpl;
+@useResult
+$Res call({
+ String text
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexRolloutOutputTextDtoCopyWithImpl<$Res>
+    implements $CodexRolloutOutputTextDtoCopyWith<$Res> {
+  _$CodexRolloutOutputTextDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutOutputTextDto _self;
+  final $Res Function(CodexRolloutOutputTextDto) _then;
+
+/// Create a copy of CodexRolloutContentDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? text = null,}) {
+  return _then(CodexRolloutOutputTextDto(
+text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutSummaryTextDto implements CodexRolloutContentDto {
+  const CodexRolloutSummaryTextDto({required this.text, final  String? $type}): $type = $type ?? 'summary_text';
+  factory CodexRolloutSummaryTextDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutSummaryTextDtoFromJson(json);
+
+ final  String text;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutContentDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutSummaryTextDtoCopyWith<CodexRolloutSummaryTextDto> get copyWith => _$CodexRolloutSummaryTextDtoCopyWithImpl<CodexRolloutSummaryTextDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutSummaryTextDto&&(identical(other.text, text) || other.text == text));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,text);
+
+@override
+String toString() {
+  return 'CodexRolloutContentDto.summaryText(text: $text)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutSummaryTextDtoCopyWith<$Res> implements $CodexRolloutContentDtoCopyWith<$Res> {
+  factory $CodexRolloutSummaryTextDtoCopyWith(CodexRolloutSummaryTextDto value, $Res Function(CodexRolloutSummaryTextDto) _then) = _$CodexRolloutSummaryTextDtoCopyWithImpl;
+@useResult
+$Res call({
+ String text
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexRolloutSummaryTextDtoCopyWithImpl<$Res>
+    implements $CodexRolloutSummaryTextDtoCopyWith<$Res> {
+  _$CodexRolloutSummaryTextDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutSummaryTextDto _self;
+  final $Res Function(CodexRolloutSummaryTextDto) _then;
+
+/// Create a copy of CodexRolloutContentDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? text = null,}) {
+  return _then(CodexRolloutSummaryTextDto(
+text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutInputImageDto implements CodexRolloutContentDto {
+  const CodexRolloutInputImageDto({@JsonKey(name: "image_url") required this.imageUrl, final  String? $type}): $type = $type ?? 'input_image';
+  factory CodexRolloutInputImageDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutInputImageDtoFromJson(json);
+
+@JsonKey(name: "image_url") final  String imageUrl;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutContentDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutInputImageDtoCopyWith<CodexRolloutInputImageDto> get copyWith => _$CodexRolloutInputImageDtoCopyWithImpl<CodexRolloutInputImageDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutInputImageDto&&(identical(other.imageUrl, imageUrl) || other.imageUrl == imageUrl));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,imageUrl);
+
+@override
+String toString() {
+  return 'CodexRolloutContentDto.inputImage(imageUrl: $imageUrl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutInputImageDtoCopyWith<$Res> implements $CodexRolloutContentDtoCopyWith<$Res> {
+  factory $CodexRolloutInputImageDtoCopyWith(CodexRolloutInputImageDto value, $Res Function(CodexRolloutInputImageDto) _then) = _$CodexRolloutInputImageDtoCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: "image_url") String imageUrl
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexRolloutInputImageDtoCopyWithImpl<$Res>
+    implements $CodexRolloutInputImageDtoCopyWith<$Res> {
+  _$CodexRolloutInputImageDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutInputImageDto _self;
+  final $Res Function(CodexRolloutInputImageDto) _then;
+
+/// Create a copy of CodexRolloutContentDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? imageUrl = null,}) {
+  return _then(CodexRolloutInputImageDto(
+imageUrl: null == imageUrl ? _self.imageUrl : imageUrl // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutUnknownContentDto implements CodexRolloutContentDto {
+  const CodexRolloutUnknownContentDto({final  String? $type}): $type = $type ?? 'unknown';
+  factory CodexRolloutUnknownContentDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutUnknownContentDtoFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutUnknownContentDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CodexRolloutContentDto.unknown()';
+}
+
+
+}
+
+
+
 
 
 /// @nodoc

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
@@ -92,11 +92,19 @@ CodexRolloutInputTextDto _$CodexRolloutInputTextDtoFromJson(Map json) =>
       $type: json['type'] as String?,
     );
 
+Map<String, dynamic> _$CodexRolloutInputTextDtoToJson(
+  CodexRolloutInputTextDto instance,
+) => <String, dynamic>{'text': instance.text, 'type': instance.$type};
+
 CodexRolloutOutputTextDto _$CodexRolloutOutputTextDtoFromJson(Map json) =>
     CodexRolloutOutputTextDto(
       text: json['text'] as String,
       $type: json['type'] as String?,
     );
+
+Map<String, dynamic> _$CodexRolloutOutputTextDtoToJson(
+  CodexRolloutOutputTextDto instance,
+) => <String, dynamic>{'text': instance.text, 'type': instance.$type};
 
 CodexRolloutSummaryTextDto _$CodexRolloutSummaryTextDtoFromJson(Map json) =>
     CodexRolloutSummaryTextDto(
@@ -104,15 +112,27 @@ CodexRolloutSummaryTextDto _$CodexRolloutSummaryTextDtoFromJson(Map json) =>
       $type: json['type'] as String?,
     );
 
+Map<String, dynamic> _$CodexRolloutSummaryTextDtoToJson(
+  CodexRolloutSummaryTextDto instance,
+) => <String, dynamic>{'text': instance.text, 'type': instance.$type};
+
 CodexRolloutInputImageDto _$CodexRolloutInputImageDtoFromJson(Map json) =>
     CodexRolloutInputImageDto(
       imageUrl: json['image_url'] as String,
       $type: json['type'] as String?,
     );
 
+Map<String, dynamic> _$CodexRolloutInputImageDtoToJson(
+  CodexRolloutInputImageDto instance,
+) => <String, dynamic>{'image_url': instance.imageUrl, 'type': instance.$type};
+
 CodexRolloutUnknownContentDto _$CodexRolloutUnknownContentDtoFromJson(
   Map json,
 ) => CodexRolloutUnknownContentDto($type: json['type'] as String?);
+
+Map<String, dynamic> _$CodexRolloutUnknownContentDtoToJson(
+  CodexRolloutUnknownContentDto instance,
+) => <String, dynamic>{'type': instance.$type};
 
 _CodexRolloutActionDto _$CodexRolloutActionDtoFromJson(Map json) =>
     _CodexRolloutActionDto(query: json['query'] as String?);

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
@@ -86,22 +86,33 @@ const _$CodexRolloutRoleEnumMap = {
   CodexRolloutRole.unknown: 'unknown',
 };
 
-_CodexRolloutContentDto _$CodexRolloutContentDtoFromJson(Map json) =>
-    _CodexRolloutContentDto(
-      type: $enumDecodeNullable(
-        _$CodexRolloutContentTypeEnumMap,
-        json['type'],
-        unknownValue: CodexRolloutContentType.unknown,
-      ),
-      text: json['text'] as String?,
+CodexRolloutInputTextDto _$CodexRolloutInputTextDtoFromJson(Map json) =>
+    CodexRolloutInputTextDto(
+      text: json['text'] as String,
+      $type: json['type'] as String?,
     );
 
-const _$CodexRolloutContentTypeEnumMap = {
-  CodexRolloutContentType.inputText: 'input_text',
-  CodexRolloutContentType.outputText: 'output_text',
-  CodexRolloutContentType.summaryText: 'summary_text',
-  CodexRolloutContentType.unknown: 'unknown',
-};
+CodexRolloutOutputTextDto _$CodexRolloutOutputTextDtoFromJson(Map json) =>
+    CodexRolloutOutputTextDto(
+      text: json['text'] as String,
+      $type: json['type'] as String?,
+    );
+
+CodexRolloutSummaryTextDto _$CodexRolloutSummaryTextDtoFromJson(Map json) =>
+    CodexRolloutSummaryTextDto(
+      text: json['text'] as String,
+      $type: json['type'] as String?,
+    );
+
+CodexRolloutInputImageDto _$CodexRolloutInputImageDtoFromJson(Map json) =>
+    CodexRolloutInputImageDto(
+      imageUrl: json['image_url'] as String,
+      $type: json['type'] as String?,
+    );
+
+CodexRolloutUnknownContentDto _$CodexRolloutUnknownContentDtoFromJson(
+  Map json,
+) => CodexRolloutUnknownContentDto($type: json['type'] as String?);
 
 _CodexRolloutActionDto _$CodexRolloutActionDtoFromJson(Map json) =>
     _CodexRolloutActionDto(query: json['query'] as String?);

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -5,7 +5,7 @@ import "package:sesori_shared/sesori_shared.dart" as shared;
 import "api/models/codex_rollout_dto.dart";
 import "codex_app_server_client.dart";
 import "codex_config_reader.dart";
-import "codex_rollout_tool_mapper.dart";
+import "repositories/mappers/codex_rollout_tool_mapper.dart";
 import "repositories/models/codex_thread_record.dart";
 
 /// Translates `codex app-server` `ServerNotification` frames into
@@ -28,8 +28,9 @@ class CodexEventMapper {
   CodexEventMapper({
     required this.pluginId,
     required this.projectCwd,
+    required CodexRolloutToolMapper rolloutToolMapper,
     this.config = const CodexConfigDefaults.empty(),
-  });
+  }) : _rolloutToolMapper = rolloutToolMapper;
 
   final String pluginId;
 
@@ -55,7 +56,7 @@ class CodexEventMapper {
   /// global [config] default — making a model switch look like it never took
   /// effect even though codex honoured it. Falls back to [config] when unknown.
   final Map<String, String> _threadModel = {};
-  static const CodexRolloutToolMapper _rolloutToolMapper = CodexRolloutToolMapper();
+  final CodexRolloutToolMapper _rolloutToolMapper;
 
   /// Raw rollout state keyed by the same `call_id` app-server uses as a
   /// command item id. It lets late normalized item notifications reuse the

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -18,6 +18,7 @@ import "repositories/codex_message_repository.dart";
 import "repositories/codex_model_repository.dart";
 import "repositories/codex_skill_repository.dart";
 import "repositories/codex_thread_repository.dart";
+import "repositories/mappers/codex_rollout_tool_mapper.dart";
 import "repositories/models/codex_thread_record.dart";
 import "runtime/codex_managed_api.dart";
 import "services/codex_rollout_tailer.dart";
@@ -125,6 +126,7 @@ class CodexPlugin implements CodexManagedApi {
     final resolvedProjectCwd = projectCwd ?? Directory.current.path;
     final configReader = CodexConfigReader();
     final rolloutApi = CodexRolloutApi();
+    const rolloutToolMapper = CodexRolloutToolMapper();
     final catalogRepository = CodexCatalogRepository(rolloutApi: rolloutApi);
     final rolloutTailer = CodexRolloutTailer(
       rolloutApi: rolloutApi,
@@ -142,13 +144,17 @@ class CodexPlugin implements CodexManagedApi {
       clientFactory: null,
       sessionService: CodexSessionService(
         catalogRepository: catalogRepository,
-        messageRepository: CodexMessageRepository(rolloutApi: rolloutApi),
+        messageRepository: CodexMessageRepository(
+          rolloutApi: rolloutApi,
+          rolloutToolMapper: rolloutToolMapper,
+        ),
         metadataRepository: metadataRepository,
         launchDirectory: resolvedProjectCwd,
       ),
       eventMapper: CodexEventMapper(
         pluginId: pluginId,
         projectCwd: resolvedProjectCwd,
+        rolloutToolMapper: rolloutToolMapper,
         config: configReader.readDefaults(),
       ),
       rolloutTailer: rolloutTailer,

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
@@ -3,14 +3,18 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "../api/codex_rollout_api.dart";
 import "../api/models/codex_rollout_dto.dart";
 import "../codex_config_reader.dart";
-import "../codex_rollout_tool_mapper.dart";
+import "mappers/codex_rollout_tool_mapper.dart";
 
 /// Layer-2 mapping from typed rollout transcript DTOs to plugin messages.
 class CodexMessageRepository {
-  CodexMessageRepository({required CodexRolloutApi rolloutApi}) : _rolloutApi = rolloutApi;
+  CodexMessageRepository({
+    required CodexRolloutApi rolloutApi,
+    required CodexRolloutToolMapper rolloutToolMapper,
+  }) : _rolloutApi = rolloutApi,
+       _rolloutToolMapper = rolloutToolMapper;
 
   final CodexRolloutApi _rolloutApi;
-  static const CodexRolloutToolMapper _toolMapper = CodexRolloutToolMapper();
+  final CodexRolloutToolMapper _rolloutToolMapper;
 
   List<PluginMessageWithParts> readMessages({
     required String rolloutPath,
@@ -35,7 +39,7 @@ class CodexMessageRepository {
     for (final line in lines) {
       final payload = line.payload;
       if (payload == null) continue;
-      final result = _toolMapper.mapResult(payload);
+      final result = _rolloutToolMapper.mapResult(payload);
       if (result != null) toolOutputs[result.callId] = result;
     }
 
@@ -92,7 +96,7 @@ class CodexMessageRepository {
 
       if (payload.type == CodexRolloutPayloadType.functionCall ||
           payload.type == CodexRolloutPayloadType.customToolCall) {
-        final call = _toolMapper.mapCall(payload);
+        final call = _rolloutToolMapper.mapCall(payload);
         if (call == null) continue;
         final result = toolOutputs[call.id];
         messages.add(
@@ -133,10 +137,10 @@ class CodexMessageRepository {
       }
 
       if (payload.type == CodexRolloutPayloadType.reasoning) {
-        final reasoning = _contentTexts(
-          payload.summary,
-          acceptedTypes: const {CodexRolloutContentType.summaryText},
-        ).join();
+        final reasoning = [
+          for (final item in payload.summary ?? const <CodexRolloutContentDto>[])
+            if (item case CodexRolloutSummaryTextDto(:final text) when text.isNotEmpty) text,
+        ].join();
         if (reasoning.isEmpty) continue;
 
         messageCounter += 1;
@@ -173,13 +177,12 @@ class CodexMessageRepository {
       if (payload.role != CodexRolloutRole.user && payload.role != CodexRolloutRole.assistant) {
         continue;
       }
-      final texts = _contentTexts(
-        payload.content,
-        acceptedTypes: const {
-          CodexRolloutContentType.inputText,
-          CodexRolloutContentType.outputText,
-        },
-      );
+      final texts = [
+        for (final item in payload.content ?? const <CodexRolloutContentDto>[])
+          if (item case CodexRolloutInputTextDto(:final text) || CodexRolloutOutputTextDto(:final text)
+              when text.isNotEmpty)
+            text,
+      ];
       if (texts.isEmpty) continue;
 
       messageCounter += 1;
@@ -220,16 +223,6 @@ class CodexMessageRepository {
       );
     }
     return messages;
-  }
-
-  List<String> _contentTexts(
-    List<CodexRolloutContentDto>? content, {
-    required Set<CodexRolloutContentType> acceptedTypes,
-  }) {
-    return [
-      for (final item in content ?? const <CodexRolloutContentDto>[])
-        if (item.text case final text? when acceptedTypes.contains(item.type) && text.isNotEmpty) text,
-    ];
   }
 
   PluginMessageWithParts _toolMessage({

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
@@ -3,7 +3,7 @@ import "dart:convert";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" show jsonDecodeMap;
 
-import "api/models/codex_rollout_dto.dart";
+import "../../api/models/codex_rollout_dto.dart";
 
 class CodexRolloutToolCall {
   const CodexRolloutToolCall({
@@ -144,13 +144,20 @@ class CodexRolloutToolMapper {
 
   String? toolOutputText(List<CodexRolloutContentDto>? output) {
     final texts = [
-      for (final item in output ?? const <CodexRolloutContentDto>[])
-        if (item.text case final text?
-            when (item.type == CodexRolloutContentType.inputText || item.type == CodexRolloutContentType.outputText) &&
-                text.isNotEmpty)
-          text,
+      for (final item in output ?? const <CodexRolloutContentDto>[]) ?_toolContentText(content: item),
     ];
     return texts.isEmpty ? null : texts.join();
+  }
+
+  String? _toolContentText({required CodexRolloutContentDto content}) {
+    return switch (content) {
+      CodexRolloutInputTextDto(:final text) || CodexRolloutOutputTextDto(:final text) when text.isNotEmpty => text,
+      CodexRolloutInputTextDto() ||
+      CodexRolloutOutputTextDto() ||
+      CodexRolloutSummaryTextDto() ||
+      CodexRolloutInputImageDto() ||
+      CodexRolloutUnknownContentDto() => null,
+    };
   }
 
   /// Derives process failure from the executor envelope retained in rollout

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -16,7 +16,12 @@ import "package:test/test.dart";
 void main() {
   group("CodexEventMapper", () {
     const projectCwd = "/repo/app";
-    final mapper = CodexEventMapper(pluginId: CodexPlugin.pluginId, projectCwd: projectCwd);
+    const rolloutToolMapper = CodexRolloutToolMapper();
+    final mapper = CodexEventMapper(
+      pluginId: CodexPlugin.pluginId,
+      projectCwd: projectCwd,
+      rolloutToolMapper: rolloutToolMapper,
+    );
     final appServerApi = CodexAppServerApi(
       client: CodexAppServerClient(serverUrl: "ws://127.0.0.1:0"),
     );
@@ -160,8 +165,11 @@ void main() {
     test("thread/name/updated uses the plugin-fed directory for its project id", () {
       // A thread/name/updated notification carries no cwd, so the mapper relies
       // on the directory the plugin learned when the thread was started/resumed.
-      final scopedMapper = CodexEventMapper(pluginId: CodexPlugin.pluginId, projectCwd: projectCwd)
-        ..setThreadDirectory("t-9", "/repo/app/packages/ui");
+      final scopedMapper = CodexEventMapper(
+        pluginId: CodexPlugin.pluginId,
+        projectCwd: projectCwd,
+        rolloutToolMapper: rolloutToolMapper,
+      )..setThreadDirectory("t-9", "/repo/app/packages/ui");
 
       final events = scopedMapper.map(
         const CodexServerNotification(
@@ -178,6 +186,7 @@ void main() {
       final activityMapper = CodexEventMapper(
         pluginId: CodexPlugin.pluginId,
         projectCwd: projectCwd,
+        rolloutToolMapper: rolloutToolMapper,
       );
       mapThreadStarted(
         activityMapper,
@@ -222,6 +231,7 @@ void main() {
       final activityMapper = CodexEventMapper(
         pluginId: CodexPlugin.pluginId,
         projectCwd: projectCwd,
+        rolloutToolMapper: rolloutToolMapper,
       );
       mapThreadStarted(
         activityMapper,
@@ -391,6 +401,7 @@ void main() {
       final richMapper = CodexEventMapper(
         pluginId: CodexPlugin.pluginId,
         projectCwd: projectCwd,
+        rolloutToolMapper: rolloutToolMapper,
         config: const CodexConfigDefaults(model: "gpt-5.5", modelProvider: "openai"),
       );
       // thread/started carries the provider; the mapper remembers it per thread.
@@ -428,6 +439,7 @@ void main() {
       final richMapper = CodexEventMapper(
         pluginId: CodexPlugin.pluginId,
         projectCwd: projectCwd,
+        rolloutToolMapper: rolloutToolMapper,
         config: const CodexConfigDefaults(model: "gpt-5.5", modelProvider: "openai"),
       );
       mapThreadStarted(

--- a/bridge/sesori_plugin_codex/test/codex_metadata_repository_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_metadata_repository_test.dart
@@ -42,7 +42,10 @@ void main() {
         metadata: metadata,
         sessions: CodexSessionService(
           catalogRepository: CodexCatalogRepository(rolloutApi: rolloutApi),
-          messageRepository: CodexMessageRepository(rolloutApi: rolloutApi),
+          messageRepository: CodexMessageRepository(
+            rolloutApi: rolloutApi,
+            rolloutToolMapper: const CodexRolloutToolMapper(),
+          ),
           metadataRepository: metadata,
           launchDirectory: launchProject.path,
         ),

--- a/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
@@ -403,6 +403,16 @@ void main() {
         "data:image/png;base64,AA==",
       );
       expect(content[4], isA<CodexRolloutUnknownContentDto>());
+      expect(const CodexRolloutContentListConverter().toJson(content), [
+        {"type": "input_text", "text": "input"},
+        {"type": "output_text", "text": "output"},
+        {"type": "summary_text", "text": "summary"},
+        {
+          "type": "input_image",
+          "image_url": "data:image/png;base64,AA==",
+        },
+        {"type": "future_content"},
+      ]);
     });
 
     test("rollout content skips malformed known variants without exposing values", () {

--- a/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
@@ -26,7 +26,10 @@ void main() {
         environment: {"CODEX_HOME": codexHome.path},
       );
       catalogRepository = CodexCatalogRepository(rolloutApi: rolloutApi);
-      messageRepository = CodexMessageRepository(rolloutApi: rolloutApi);
+      messageRepository = CodexMessageRepository(
+        rolloutApi: rolloutApi,
+        rolloutToolMapper: const CodexRolloutToolMapper(),
+      );
     });
 
     tearDown(() {
@@ -374,6 +377,51 @@ void main() {
       );
     });
 
+    test("rollout content decodes closed text, image, and unknown variants", () {
+      final content = const CodexRolloutContentListConverter().fromJson([
+        {"type": "input_text", "text": "input"},
+        {"type": "output_text", "text": "output"},
+        {"type": "summary_text", "text": "summary"},
+        {
+          "type": "input_image",
+          "image_url": "data:image/png;base64,AA==",
+          "detail": "high",
+        },
+        {"type": "future_content", "payload": "not-rendered"},
+      ])!;
+
+      expect(content, hasLength(5));
+      expect(content[0], isA<CodexRolloutInputTextDto>());
+      expect((content[0] as CodexRolloutInputTextDto).text, "input");
+      expect(content[1], isA<CodexRolloutOutputTextDto>());
+      expect((content[1] as CodexRolloutOutputTextDto).text, "output");
+      expect(content[2], isA<CodexRolloutSummaryTextDto>());
+      expect((content[2] as CodexRolloutSummaryTextDto).text, "summary");
+      expect(content[3], isA<CodexRolloutInputImageDto>());
+      expect(
+        (content[3] as CodexRolloutInputImageDto).imageUrl,
+        "data:image/png;base64,AA==",
+      );
+      expect(content[4], isA<CodexRolloutUnknownContentDto>());
+    });
+
+    test("rollout content skips malformed known variants without exposing values", () {
+      late List<CodexRolloutContentDto>? content;
+      final output = _captureWarnings(() {
+        content = const CodexRolloutContentListConverter().fromJson([
+          {"type": "output_text", "text": "kept"},
+          {"type": "input_image", "image_url": 42},
+          {"type": "future_content", "secret": "not-logged"},
+        ]);
+      }, level: LogLevel.verbose);
+
+      expect(content, hasLength(2));
+      expect(content?.first, isA<CodexRolloutOutputTextDto>());
+      expect(content?.last, isA<CodexRolloutUnknownContentDto>());
+      expect(output, contains("skipping malformed rollout content item"));
+      expect(output, isNot(contains("not-logged")));
+    });
+
     test("turn_context scalar summary is not reported as malformed", () {
       final path = _writeRollout(
         codexHome,
@@ -609,6 +657,10 @@ void main() {
               "role": "user",
               "content": [
                 {"type": "input_text", "text": "hello, codex"},
+                {
+                  "type": "input_image",
+                  "image_url": "data:image/png;base64,AA==",
+                },
               ],
             },
           }),
@@ -637,6 +689,8 @@ void main() {
       expect(messages, hasLength(2));
       expect(messages[0].info, isA<PluginMessageUser>());
       expect(messages[0].parts.first.text, equals("hello, codex"));
+      expect(messages[0].parts, hasLength(1));
+      expect(messages[0].parts.single.attachment, isNull);
       expect(messages[1].info, isA<PluginMessageAssistant>());
       expect(messages[1].parts.first.text, equals("hello back!"));
       expect(messages[0].info.sessionID, equals("019a0000-1111-2222-3333-aaaaaaaaaaaa"));
@@ -830,6 +884,10 @@ void main() {
               "call_id": "call-1",
               "output": [
                 {"type": "input_text", "text": "total 0\n"},
+                {
+                  "type": "input_image",
+                  "image_url": "data:image/png;base64,AA==",
+                },
                 "schema-drifted item",
                 {"type": "input_text", "text": "foo.dart"},
               ],
@@ -873,6 +931,7 @@ void main() {
       expect(tool.state?.status, PluginToolStatus.completed);
       expect(tool.state?.title, "ls -la");
       expect(tool.state?.output, contains("foo.dart"));
+      expect(tool.state?.attachments, isEmpty);
 
       final assistant = messages[2];
       expect(assistant.parts.single.text, "Done");
@@ -1085,6 +1144,7 @@ void main() {
         rolloutApi: CodexRolloutApi(
           environment: {"CODEX_HOME": codexHome.path},
         ),
+        rolloutToolMapper: const CodexRolloutToolMapper(),
       );
       final path = _writeRollout(
         codexHome,
@@ -1140,6 +1200,7 @@ void main() {
         rolloutApi: CodexRolloutApi(
           environment: {"CODEX_HOME": codexHome.path},
         ),
+        rolloutToolMapper: const CodexRolloutToolMapper(),
       );
       final path = _writeRollout(
         codexHome,

--- a/bridge/sesori_plugin_codex/test/codex_session_service_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_session_service_test.dart
@@ -9,6 +9,7 @@ import "package:codex_plugin/src/repositories/codex_message_repository.dart";
 import "package:codex_plugin/src/repositories/codex_model_repository.dart";
 import "package:codex_plugin/src/repositories/codex_skill_repository.dart";
 import "package:codex_plugin/src/repositories/codex_thread_repository.dart";
+import "package:codex_plugin/src/repositories/mappers/codex_rollout_tool_mapper.dart";
 import "package:codex_plugin/src/repositories/models/codex_thread_record.dart";
 import "package:codex_plugin/src/services/codex_session_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
@@ -262,7 +263,10 @@ CodexSessionService _newService({
   final rolloutApi = CodexRolloutApi(environment: const {});
   return CodexSessionService(
     catalogRepository: CodexCatalogRepository(rolloutApi: rolloutApi),
-    messageRepository: CodexMessageRepository(rolloutApi: rolloutApi),
+    messageRepository: CodexMessageRepository(
+      rolloutApi: rolloutApi,
+      rolloutToolMapper: const CodexRolloutToolMapper(),
+    ),
     metadataRepository:
         metadataRepository ??
         CodexMetadataRepository(

--- a/bridge/sesori_plugin_codex/test/support/codex_plugin_test_factory.dart
+++ b/bridge/sesori_plugin_codex/test/support/codex_plugin_test_factory.dart
@@ -12,6 +12,7 @@ CodexPlugin createInjectedCodexPlugin({
   Duration rolloutPollInterval = const Duration(milliseconds: 10),
 }) {
   final rolloutApi = CodexRolloutApi(environment: environment);
+  const rolloutToolMapper = CodexRolloutToolMapper();
   final catalogRepository = CodexCatalogRepository(rolloutApi: rolloutApi);
   final configReader = CodexConfigReader(environment: environment);
   final metadataRepository = CodexMetadataRepository(
@@ -23,13 +24,17 @@ CodexPlugin createInjectedCodexPlugin({
     clientFactory: clientFactory,
     sessionService: CodexSessionService(
       catalogRepository: catalogRepository,
-      messageRepository: CodexMessageRepository(rolloutApi: rolloutApi),
+      messageRepository: CodexMessageRepository(
+        rolloutApi: rolloutApi,
+        rolloutToolMapper: rolloutToolMapper,
+      ),
       metadataRepository: metadataRepository,
       launchDirectory: projectCwd,
     ),
     eventMapper: CodexEventMapper(
       pluginId: CodexPlugin.pluginId,
       projectCwd: projectCwd,
+      rolloutToolMapper: rolloutToolMapper,
       config: configReader.readDefaults(),
     ),
     rolloutTailer: CodexRolloutTailer(


### PR DESCRIPTION
## Summary

- replace the flattened rollout content type plus nullable text field with generated sealed input-text, output-text, summary-text, input-image, and unknown variants
- require each known variant's valid data and retain forward-compatible unknown fallback plus per-item malformed-content recovery
- use generated union serialization in the list converter, including preservation of unknown discriminators
- parse persisted `input_image.image_url` without exposing images before the later bounded image-mapping step
- move `CodexRolloutToolMapper` into the repository mapping layer
- inject one mapper instance from the `CodexPlugin` composition root into both live rollout enrichment and history replay
- preserve existing message, reasoning, tool-output, clipping, status, and malformed-record behavior

## Series

- Step 2/13 of `output-image-support`
- depends on merged plan PR #638
- 680 changed lines including generated output and tests, below the 1,500-line soft cap; no neighboring scope was combined

## Verification

- `dart pub get`
- focused rollout, event-mapper, session-service, and metadata tests
- full `dart test` in `bridge/sesori_plugin_codex` — 210 tests passed
- review follow-up: `dart test test/codex_rollout_api_test.dart` — 33 tests passed
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_codex`
- `git diff --check origin/main...HEAD`
- `aristotle-impl-review` — approved with no findings
