### PR TITLE
[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]

### DIFF
--- a/.plan/active/user-analytics/PLAN.md
+++ b/.plan/active/user-analytics/PLAN.md
@@ -378,7 +378,9 @@ pseudonymous personal data. Documentation and access controls must call it that.
   seam and used only as validated warehouse time—not registered as a GA custom
   dimension.
 - Stable screen enum.
-- Platform and app version/build supplied by Firebase.
+- Platform and app version supplied by Firebase. Build number is not emitted by
+  the typed clients or exposed by the GA4 raw app-info record, so it is not a
+  warehouse/reporting dimension.
 - Bounded onboarding, interaction, voice-input, login-provider, login-failure,
   and product-failure enums.
 
@@ -973,14 +975,15 @@ only raw-ID-to-`user_key` handoff, and raw account ID never crosses it.
 | Class/file | Layer/dependencies | Responsibility |
 | --- | --- | --- |
 | `google_api_foundation.dart`, `bigquery_privacy_deletion_client.dart`, and `ga_user_deletion_client.dart` | Neutral Google credential/transport foundation plus peer Foundation clients | Shared metadata-first credential acquisition and bounded Google API failures live in the neutral file. The peer clients own typed BigQuery operations within allowlisted datasets and typed GA User Deletion API submission; neither client depends on the other, orchestrates deletion, or receives a raw account ID. |
-| `privacy_deletion_api.dart` | Layer 1; requires both clients | Loads pending privacy-private targets for request processing; upserts/reads the permanent deletion-exclusion control; range-joins the overlapping raw window against **all** permanent tombstones for sweeps; discovers currently linkable installation IDs, deletes matching warehouse rows, submits app-instance/legacy-user deletion, rebuilds aggregates, and updates target status through typed operations. |
-| `privacy_deletion_repository.dart` | Layer 2; requires API | Owns idempotent request status, target validation, run checkpoints, one-shot tombstone-aware auth-export cutoff reads, and explicit operation/result mapping. It never orchestrates cross-system cleanup or persists discovered installation IDs. |
-| `privacy_deletion_service.dart` | Layer 3; requires repository | Orchestrates exclusion-before-delete, one readiness check, upstream/raw/keyed deletion, fixed rebuild, verification, and completion. When no successful auth export has `runCutoff >= suppressedAt`, it returns retryable and relies on the external job/operator to invoke the idempotent command again rather than polling in-process. |
+| `privacy_deletion_api.dart` | Layer 1; requires both clients | Loads pending privacy-private targets for request processing; transactionally advances the keyed-publication epoch while upserting/reading the permanent deletion-exclusion control; range-joins the overlapping raw window against **all** permanent tombstones for sweeps; discovers currently linkable installation IDs, deletes matching warehouse rows, submits app-instance/legacy-user deletion, rebuilds aggregates, and updates target status through typed operations. |
+| `privacy_deletion_repository.dart` | Layer 2; requires API | Owns idempotent request status, target validation, run checkpoints, typed latest-auth-snapshot retrieval, and explicit operation/result mapping. It never decides lifecycle readiness, orchestrates cross-system cleanup, or persists discovered installation IDs. |
+| `privacy_deletion_service.dart` | Layer 3; requires repository and clock | Orchestrates exclusion-before-delete, evaluates one-shot tombstone-aware auth readiness using the configured publication-age/clock policy plus cutoff, then owns upstream/raw/keyed deletion, fixed rebuild, verification, and completion. When no fresh successful auth export has `runCutoff >= suppressedAt`, it returns retryable and relies on the external job/operator to invoke the idempotent command again rather than polling in-process. A sweep applies that gate to the newest permanent tombstone before auth-private cleanup or checkpoint advancement. |
 | `run_privacy_deletion.dart` / `sweep_privacy_deletions.dart` | Manual and scheduled composition roots | Construct with the attached metadata-server identity by default (with explicit local ADC fallback only for approved operator runs), process one request or a checkpointed raw-partition range, return only aggregate status, and close clients. Each daily sweep starts from the earlier of the last-success watermark continuation and the latest three UTC event dates, matching GA4 late-arrival recomputation; it joins every scanned version against all permanent deletion tombstones regardless of target completion/age. Submission/deletion is idempotent and acts only on future **keyed** uploads. |
 
 Use a dedicated deletion service account with BigQuery Job User, read of the
 restricted privacy-target/raw datasets, write only to the deletion-exclusion
-control, sweep checkpoint, and privacy-target status, delete/rebuild permission
+control, keyed-publication guard, sweep checkpoint, and privacy-target status,
+delete/rebuild permission
 on auth-private/curated (and matching retained raw rows), metadata-only reporting
 inventory access, plus the minimum GA deletion API role. It has no Mongo access,
 reporting mutation, or general controls/deployment role. The attached identity
@@ -1117,7 +1120,7 @@ not weaken the written privacy boundary to fit an unchecked property.
    `emitted_at` via `TIMESTAMP_MICROS(event_timestamp)`, parse required integer
    `occurred_at_micros` the same way as `occurred_at`,
    require schema version and non-null custom `user_key`, and retain Firebase
-   platform/app version/build. Reject occurrence later than emitted time beyond
+   platform/app version. Reject occurrence later than emitted time beyond
    the documented clock-skew allowance. User-milestone/cohort joins additionally
    require occurrence no earlier than account creation beyond that allowance;
    invalid timing remains a data-quality count and is excluded from time-bound
@@ -1139,7 +1142,7 @@ not weaken the written privacy boundary to fit an unchecked property.
 3. **`user_activity_daily`**: one row per user/date with monitor, control,
    message, voice-assisted, transcription, diff, screen, and feature
    flags/counts.
-4. **`user_milestones`**: auth timestamps plus earliest foundation and
+4. **`user_milestones`**: auth timestamps plus earliest schema-ready foundation and
    activation-capable exposure,
    project availability, full activation, monitor activity, and feature
    milestones. Full activation is the minimum of the two successful message
@@ -1147,8 +1150,9 @@ not weaken the written privacy boundary to fit an unchecked property.
    `activation_capable_at` is the earliest activation-ready event or activation
    outcome.
 5. **`activation_cohorts`**: account-cohort denominators only when activation-
-   capable schema-v1 exposure occurs within 24 hours of account creation, plus
-   1/7/30-day milestone flags, times to milestone, cohort maturity, and separate
+   capable schema-v1 exposure occurs within 24 hours of account creation, with
+   ordered account -> bridge -> project -> message progression, 1/7/30-day
+   milestone flags, times to milestone, cohort maturity, and separate
    preference/foundation/activation-capability coverage.
 6. **`retention_cohorts`**: activation-anchored W1/W4 eligibility and activity.
 
@@ -1162,6 +1166,10 @@ snapshot and anti-joins the permanent internal exclusion table. Therefore a
 disable or newly added internal exclusion takes effect after the next auth
 export/report refresh even when an older curated partition exists; those gates
 are not applied only at the historical partition's original build time.
+Keyed transforms capture a shared publication epoch before staging and advance
+it inside their publication transaction. Permanent tombstone insertion advances
+the same singleton transactionally. An epoch mismatch or overlapping write
+aborts rather than republishing a concurrently deleted user.
 
 The auth export atomically publishes snapshot metadata (`run_id`, immutable
 source cutoff, completion time, eligible/source counts) with its tables. Before
@@ -1522,6 +1530,9 @@ directory name.
 
 - Add `tool/product_analytics/` data contract, parameterized deployment tool,
   DDL, transforms, fixture assertions, scheduled-query definitions, and runbook.
+- Bootstrap datasets/reference tables first, publish and validate the initial
+  auth snapshot, then apply auth-dependent transforms; full apply fails closed
+  when no initial auth snapshot exists.
 - Create auth-private/privacy-private/controls/curated/reporting datasets in the raw GA4
   location; keep export-job write access confined to auth-private and grant only
   authorized-view reads for internal exclusion; configure IAM, expiration,

--- a/.plan/active/user-analytics/PLAN.md
+++ b/.plan/active/user-analytics/PLAN.md
@@ -1544,6 +1544,19 @@ directory name.
 - Record dashboard owner, refresh schedule, metric definitions, and rollback/
   incident steps in the runbook.
 
+**Step 5 completion includes the cloud setup above.** Merging the repository PR
+delivers the reviewed automation and contracts, but does not complete Step 5 by
+itself. After the required security/privacy decisions are approved, the same
+Step 5 work must use the checked-in runbook and tools to create the service
+identities and dataset ACLs, authorize views, apply warehouse schemas, provision
+auth export and privacy jobs, apply transform/deletion schedules, run deployed
+assertions and deletion drills, build/restrict Looker, and record go-live
+evidence. These are tracked delivery tasks, not an out-of-band setup handed to
+the user. The user supplies approvals, restricted values, and any admin-only
+authorization that cannot be delegated; the implementing operator performs and
+verifies the setup. Keep Step 5 open until every applicable cloud and dashboard
+acceptance item passes.
+
 ### Deployability, compatibility, and rollback by step
 
 | State | Independently usable behavior | Deployment prerequisites/order | Rollback boundary |
@@ -1744,3 +1757,13 @@ The work is complete when:
 - The executive page can truthfully report new accounts, setup, full
   activation, WAU/growth, W1/W4 retention when mature, activity depth, and the
   selected feature-adoption metrics without manual spreadsheet logic.
+
+## Final Step — Archive The Completed Plan
+
+After every completion criterion above and every in-scope tracker item is done,
+record the final PR, cloud setup, access, deletion-drill, dashboard, and release
+evidence in `TRACKER.md`. Then, as the last action of this plan, move the entire
+plan directory (including its tracker and supporting files) from
+`.plan/active/user-analytics/` to `.plan/completed/user-analytics/` and commit
+that move. Do not copy it, leave an active duplicate, or archive it while any
+required Step 5 setup or acceptance work remains.

--- a/.plan/active/user-analytics/PLAN.md
+++ b/.plan/active/user-analytics/PLAN.md
@@ -972,18 +972,19 @@ only raw-ID-to-`user_key` handoff, and raw account ID never crosses it.
 
 | Class/file | Layer/dependencies | Responsibility |
 | --- | --- | --- |
-| `bigquery_privacy_deletion_client.dart` and `ga_user_deletion_client.dart` | Foundation clients | Typed BigQuery operations within allowlisted datasets and typed GA User Deletion API submission; no orchestration or raw account ID. |
+| `google_api_foundation.dart`, `bigquery_privacy_deletion_client.dart`, and `ga_user_deletion_client.dart` | Neutral Google credential/transport foundation plus peer Foundation clients | Shared metadata-first credential acquisition and bounded Google API failures live in the neutral file. The peer clients own typed BigQuery operations within allowlisted datasets and typed GA User Deletion API submission; neither client depends on the other, orchestrates deletion, or receives a raw account ID. |
 | `privacy_deletion_api.dart` | Layer 1; requires both clients | Loads pending privacy-private targets for request processing; upserts/reads the permanent deletion-exclusion control; range-joins the overlapping raw window against **all** permanent tombstones for sweeps; discovers currently linkable installation IDs, deletes matching warehouse rows, submits app-instance/legacy-user deletion, rebuilds aggregates, and updates target status through typed operations. |
-| `privacy_deletion_repository.dart` | Layer 2; requires API | Owns idempotent request status, target validation, run checkpoints, tombstone-aware auth-export cutoff checks, and explicit result mapping. It never persists discovered installation IDs. |
-| `privacy_deletion_service.dart` | Layer 3; requires repository | Orchestrates exclusion-before-delete, waits for a successful auth export with `runCutoff >= suppressedAt`, performs final delete/rebuild/verification, and marks the request complete or retryable. |
-| `run_privacy_deletion.dart` / `sweep_privacy_deletions.dart` | Manual and scheduled composition roots | Construct with ADC/config, process one request or a checkpointed raw-partition range, return only aggregate status, and close clients. Each daily sweep starts from the earlier of the last-success watermark continuation and the latest three UTC event dates, matching GA4 late-arrival recomputation; it joins every scanned version against all permanent deletion tombstones regardless of target completion/age. Submission/deletion is idempotent and acts only on future **keyed** uploads. |
+| `privacy_deletion_repository.dart` | Layer 2; requires API | Owns idempotent request status, target validation, run checkpoints, one-shot tombstone-aware auth-export cutoff reads, and explicit operation/result mapping. It never orchestrates cross-system cleanup or persists discovered installation IDs. |
+| `privacy_deletion_service.dart` | Layer 3; requires repository | Orchestrates exclusion-before-delete, one readiness check, upstream/raw/keyed deletion, fixed rebuild, verification, and completion. When no successful auth export has `runCutoff >= suppressedAt`, it returns retryable and relies on the external job/operator to invoke the idempotent command again rather than polling in-process. |
+| `run_privacy_deletion.dart` / `sweep_privacy_deletions.dart` | Manual and scheduled composition roots | Construct with the attached metadata-server identity by default (with explicit local ADC fallback only for approved operator runs), process one request or a checkpointed raw-partition range, return only aggregate status, and close clients. Each daily sweep starts from the earlier of the last-success watermark continuation and the latest three UTC event dates, matching GA4 late-arrival recomputation; it joins every scanned version against all permanent deletion tombstones regardless of target completion/age. Submission/deletion is idempotent and acts only on future **keyed** uploads. |
 
 Use a dedicated deletion service account with BigQuery Job User, read of the
 restricted privacy-target/raw datasets, write only to the deletion-exclusion
-control and privacy-target status, delete/rebuild permission on auth-private/curated/
-reporting (and matching retained raw rows), plus the minimum GA deletion API
-role. It has no Mongo access and no general controls/deployment role. Secret
-Manager/ADC supply credentials; no service-account key enters Git.
+control, sweep checkpoint, and privacy-target status, delete/rebuild permission
+on auth-private/curated (and matching retained raw rows), metadata-only reporting
+inventory access, plus the minimum GA deletion API role. It has no Mongo access,
+reporting mutation, or general controls/deployment role. The attached identity
+supplies production credentials; no service-account key enters Git.
 
 No persistent account-to-installation map is created. Once currently linkable
 app-instance IDs are submitted and raw keyed rows are deleted/expired, later

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -105,6 +105,25 @@
 - [ ] Confirm cloud preflight facts: Firebase/GA4 BigQuery link, property ID,
   billing, dataset location, existing raw tables/IAM/expiration, GA4 retention/
   deletion configuration, scheduler connectivity, and dashboard access group.
+  Partial preflight on 2026-07-31 found Firebase project `sesori-ai`, GA4
+  property `529377727`, and daily raw dataset `analytics_529377727` in
+  `europe-west3`, with tables beginning at `events_20260725`. Billing account
+  `Sesori Billing` is active and linked. A project-scoped USD 10 monthly alert
+  budget now covers all services at 50/80/100 percent actual and 100 percent
+  forecasted spend. The raw dataset defaults and all six existing daily tables
+  now expire after 90 days instead of 60. BigQuery on-demand query overrides are
+  10 GiB per project/day and 2 GiB per principal/day. Restricted IAM, GA4 privacy
+  settings, scheduler identities, exact start-time recording, and Looker
+  ownership remain blocked or unverified; do not enable additional export modes
+  or deploy transforms yet.
+- [x] Implement the local Step 5 warehouse, reporting, deployment, and privacy-
+  deletion assets. The final architecture pass approved neutral Google
+  credential ownership, Service-owned deletion sequencing, one-shot auth
+  readiness with external retry, and the layered API/Repository boundaries.
+  Focused Dart formatting/analyze/privacy tests, render-only validation of seven
+  SQL assets and five schedules, and `git diff --check` pass. BigQuery fixture
+  execution remains blocked by the current query-byte quota; no repository SQL,
+  schedules, IAM, or dashboards have been applied to cloud resources.
 
 ## Immediate Operational Action
 
@@ -143,8 +162,8 @@ patches in one umbrella diff.
 | 4.A/5 | apps monorepo | `[user-analytics] Add bounded outcome analytics contracts [step 4.A/5]` | PR #632 merged as `e3e6b6e7` on 2026-07-31; oversized PR #629 remains closed as superseded | Step 3.D released |
 | 4.B/5 | apps monorepo | `[user-analytics] Instrument account-less login outcomes [step 4.B/5]` | PR #634 merged as `5223c27d` on 2026-07-31 | Step 4.A |
 | 4.C/5 | apps monorepo | `[user-analytics] Instrument activation and voice outcomes [step 4.C/5]` | PR #633 merged as `c662a639` on 2026-07-31 | Step 4.B |
-| 4.D/5 | apps monorepo | `[user-analytics] Instrument visible engagement outcomes [step 4.D/5]` | PR #631 open on `user-analytics-visible-engagement-outcomes`; verified and approved | Step 4.C |
-| 5/5 | apps monorepo + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | Not started | Steps 2 and 4.D, controlled Firebase export, split auth-private/privacy-private/control IAM |
+| 4.D/5 | apps monorepo | `[user-analytics] Instrument visible engagement outcomes [step 4.D/5]` | PR #631 merged as `671c67ed` on 2026-07-31 | Step 4.C |
+| 5/5 | apps monorepo + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | Local repository assets implemented and architecture-approved; cloud application remains blocked. Billing/budget and 90-day raw expiration are configured, while restricted IAM, GA4 privacy settings, identities, exact timestamps, fixture execution, and dashboard ownership remain unresolved | Steps 2 and 4.D, controlled Firebase export, split auth-private/privacy-private/control IAM |
 
 ## Release Evidence
 

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -125,6 +125,16 @@
   BigQuery metric fixture passed in `europe-west3` on 2026-07-31. Deployed-schema
   assertions remain deferred until an approved warehouse exists; no repository
   SQL, schedules, IAM, or dashboards have been applied to cloud resources.
+- [x] Apply valid PR #641 review findings locally: split first-run bootstrap from
+  auth-dependent apply; make DDL dry-run limits explicit; bound schedule
+  inventory and move schedule SQL out of argv; harden metadata/API timeouts and
+  SQL boundaries; require fresh tombstone-aware request/sweep cleanup; serialize
+  tombstones with keyed publication; guard transform watermarks; enforce ordered
+  activation progression and schema-ready foundation; remove unsupported build
+  dimensions; and extend focused Dart/BigQuery fixtures. A two-pass architecture
+  review moved deployment policy to orchestration and freshness policy to the
+  deletion Service, then approved the revised boundaries. Review replies, push,
+  and renewed PR checks remain pending.
 
 ## Immediate Operational Action
 
@@ -194,7 +204,7 @@ patches in one umbrella diff.
 | 4.B/5 | apps monorepo | `[user-analytics] Instrument account-less login outcomes [step 4.B/5]` | PR #634 merged as `5223c27d` on 2026-07-31 | Step 4.A |
 | 4.C/5 | apps monorepo | `[user-analytics] Instrument activation and voice outcomes [step 4.C/5]` | PR #633 merged as `c662a639` on 2026-07-31 | Step 4.B |
 | 4.D/5 | apps monorepo | `[user-analytics] Instrument visible engagement outcomes [step 4.D/5]` | PR #631 merged as `671c67ed` on 2026-07-31 | Step 4.C |
-| 5/5 | apps monorepo + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | PR #641 open; local repository assets implemented, metric fixtures passed, and architecture approved. Required Step 5 cloud setup remains tracked above and blocked pending approved restricted values. Billing/budget and 90-day raw expiration are configured, while restricted IAM, GA4 privacy settings, identities, exact timestamps, deployed-schema assertions, jobs/schedules, deletion drill, and dashboard setup remain unresolved | Steps 2 and 4.D, controlled Firebase export, split auth-private/privacy-private/control IAM |
+| 5/5 | apps monorepo + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | PR #641 open; local repository assets and review fixes are implemented, focused Dart checks and updated metric fixtures pass, and the review-fix architecture is approved. Review replies/push and renewed PR checks remain pending. Required Step 5 cloud setup remains tracked above and blocked pending approved restricted values. Billing/budget and 90-day raw expiration are configured, while restricted IAM, GA4 privacy settings, identities, exact timestamps, deployed-schema assertions, jobs/schedules, deletion drill, and dashboard setup remain unresolved | Steps 2 and 4.D, controlled Firebase export, split auth-private/privacy-private/control IAM |
 
 ## Release Evidence
 

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -133,8 +133,10 @@
   activation progression and schema-ready foundation; remove unsupported build
   dimensions; and extend focused Dart/BigQuery fixtures. A two-pass architecture
   review moved deployment policy to orchestration and freshness policy to the
-  deletion Service, then approved the revised boundaries. Review replies, push,
-  and renewed PR checks remain pending.
+  deletion Service, then approved the revised boundaries. Commit `94e969c1` is
+  pushed; all 34 bot review threads received `[Sesori reply]` assessments.
+  Addressed threads were resolved or auto-resolved, while four discussion
+  threads remain open by policy. Renewed PR checks are in progress.
 
 ## Immediate Operational Action
 
@@ -204,7 +206,7 @@ patches in one umbrella diff.
 | 4.B/5 | apps monorepo | `[user-analytics] Instrument account-less login outcomes [step 4.B/5]` | PR #634 merged as `5223c27d` on 2026-07-31 | Step 4.A |
 | 4.C/5 | apps monorepo | `[user-analytics] Instrument activation and voice outcomes [step 4.C/5]` | PR #633 merged as `c662a639` on 2026-07-31 | Step 4.B |
 | 4.D/5 | apps monorepo | `[user-analytics] Instrument visible engagement outcomes [step 4.D/5]` | PR #631 merged as `671c67ed` on 2026-07-31 | Step 4.C |
-| 5/5 | apps monorepo + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | PR #641 open; local repository assets and review fixes are implemented, focused Dart checks and updated metric fixtures pass, and the review-fix architecture is approved. Review replies/push and renewed PR checks remain pending. Required Step 5 cloud setup remains tracked above and blocked pending approved restricted values. Billing/budget and 90-day raw expiration are configured, while restricted IAM, GA4 privacy settings, identities, exact timestamps, deployed-schema assertions, jobs/schedules, deletion drill, and dashboard setup remain unresolved | Steps 2 and 4.D, controlled Firebase export, split auth-private/privacy-private/control IAM |
+| 5/5 | apps monorepo + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | PR #641 open; local repository assets and review fixes are implemented and pushed, focused Dart checks and updated metric fixtures pass, the review-fix architecture is approved, and all 34 review threads received assessments. Four non-addressed/partial discussion threads remain open and renewed PR checks are in progress. Required Step 5 cloud setup remains tracked above and blocked pending approved restricted values. Billing/budget and 90-day raw expiration are configured, while restricted IAM, GA4 privacy settings, identities, exact timestamps, deployed-schema assertions, jobs/schedules, deletion drill, and dashboard setup remain unresolved | Steps 2 and 4.D, controlled Firebase export, split auth-private/privacy-private/control IAM |
 
 ## Release Evidence
 

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -121,9 +121,10 @@
   credential ownership, Service-owned deletion sequencing, one-shot auth
   readiness with external retry, and the layered API/Repository boundaries.
   Focused Dart formatting/analyze/privacy tests, render-only validation of seven
-  SQL assets and five schedules, and `git diff --check` pass. BigQuery fixture
-  execution remains blocked by the current query-byte quota; no repository SQL,
-  schedules, IAM, or dashboards have been applied to cloud resources.
+  SQL assets and five schedules, and `git diff --check` pass. The self-contained
+  BigQuery metric fixture passed in `europe-west3` on 2026-07-31. Deployed-schema
+  assertions remain deferred until an approved warehouse exists; no repository
+  SQL, schedules, IAM, or dashboards have been applied to cloud resources.
 
 ## Immediate Operational Action
 
@@ -163,7 +164,7 @@ patches in one umbrella diff.
 | 4.B/5 | apps monorepo | `[user-analytics] Instrument account-less login outcomes [step 4.B/5]` | PR #634 merged as `5223c27d` on 2026-07-31 | Step 4.A |
 | 4.C/5 | apps monorepo | `[user-analytics] Instrument activation and voice outcomes [step 4.C/5]` | PR #633 merged as `c662a639` on 2026-07-31 | Step 4.B |
 | 4.D/5 | apps monorepo | `[user-analytics] Instrument visible engagement outcomes [step 4.D/5]` | PR #631 merged as `671c67ed` on 2026-07-31 | Step 4.C |
-| 5/5 | apps monorepo + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | Local repository assets implemented and architecture-approved; cloud application remains blocked. Billing/budget and 90-day raw expiration are configured, while restricted IAM, GA4 privacy settings, identities, exact timestamps, fixture execution, and dashboard ownership remain unresolved | Steps 2 and 4.D, controlled Firebase export, split auth-private/privacy-private/control IAM |
+| 5/5 | apps monorepo + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | Local repository assets implemented, metric fixtures passed, and architecture approved; cloud application remains blocked. Billing/budget and 90-day raw expiration are configured, while restricted IAM, GA4 privacy settings, identities, exact timestamps, deployed-schema assertions, and dashboard ownership remain unresolved | Steps 2 and 4.D, controlled Firebase export, split auth-private/privacy-private/control IAM |
 
 ## Release Evidence
 

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -142,6 +142,36 @@
   only after production `analytics_activation_ready` appears; foundation-only
   and account-less login events do not qualify.
 
+## Step 5 Cloud Setup And Go-Live
+
+This setup is required Step 5 delivery work, not a prerequisite delegated to the
+user and not a separate future project. PR #641 supplies the reviewed automation
+and runbook. After the user approves the restricted values and security/privacy
+decisions, the implementing operator must execute and verify all unchecked work:
+
+- [ ] Record the approved GA4 privacy posture, exact raw/behavioral UTC start
+  timestamps, service identities, schedule owners, dashboard owner/viewer group,
+  and refresh policy in the restricted deployment record.
+- [ ] Create the separate deployment, auth-export, auth-suppression, transform,
+  privacy-deletion, and Looker identities; remove broad inherited data access;
+  apply the dataset/table IAM matrix and exact authorized-view ACLs; pass every
+  positive and expected-deny access probe.
+- [ ] Apply the same-location warehouse schemas and views with the checked-in
+  deployment tool, run the deployed-schema assertions, and reconcile the first
+  complete raw/auth/curated/reporting data.
+- [ ] Provision and smoke-test the isolated auth export and suppression jobs,
+  transform schedules, request deletion command, and recurring privacy sweep;
+  complete the non-production in-flight export and delayed-upload deletion drill.
+- [ ] Build the restricted three-page Looker report, verify its data sources,
+  maturity/coverage/freshness labels and sharing controls, then record asset IDs
+  and go-live evidence.
+- [ ] Keep Step 5 open until all setup, verification, deletion, access, and
+  dashboard acceptance items pass; merging PR #641 alone does not complete it.
+- [ ] **Final plan action:** after every completion criterion and tracker item is
+  complete, record final evidence and move the entire
+  `.plan/active/user-analytics/` directory to
+  `.plan/completed/user-analytics/`; commit the move and leave no active copy.
+
 ## Implementation Series
 
 The total remains fixed at five rollout steps. Titles retain this slug and step
@@ -164,7 +194,7 @@ patches in one umbrella diff.
 | 4.B/5 | apps monorepo | `[user-analytics] Instrument account-less login outcomes [step 4.B/5]` | PR #634 merged as `5223c27d` on 2026-07-31 | Step 4.A |
 | 4.C/5 | apps monorepo | `[user-analytics] Instrument activation and voice outcomes [step 4.C/5]` | PR #633 merged as `c662a639` on 2026-07-31 | Step 4.B |
 | 4.D/5 | apps monorepo | `[user-analytics] Instrument visible engagement outcomes [step 4.D/5]` | PR #631 merged as `671c67ed` on 2026-07-31 | Step 4.C |
-| 5/5 | apps monorepo + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | Local repository assets implemented, metric fixtures passed, and architecture approved; cloud application remains blocked. Billing/budget and 90-day raw expiration are configured, while restricted IAM, GA4 privacy settings, identities, exact timestamps, deployed-schema assertions, and dashboard ownership remain unresolved | Steps 2 and 4.D, controlled Firebase export, split auth-private/privacy-private/control IAM |
+| 5/5 | apps monorepo + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | PR #641 open; local repository assets implemented, metric fixtures passed, and architecture approved. Required Step 5 cloud setup remains tracked above and blocked pending approved restricted values. Billing/budget and 90-day raw expiration are configured, while restricted IAM, GA4 privacy settings, identities, exact timestamps, deployed-schema assertions, jobs/schedules, deletion drill, and dashboard setup remain unresolved | Steps 2 and 4.D, controlled Firebase export, split auth-private/privacy-private/control IAM |
 
 ## Release Evidence
 

--- a/tool/product_analytics/LOOKER_STUDIO.md
+++ b/tool/product_analytics/LOOKER_STUDIO.md
@@ -1,0 +1,453 @@
+# Looker Studio reporting contract
+
+This document pins the manually built, restricted Looker Studio report for
+Step 5. The report is not a safely deployable repository artifact. Operators
+must build it from this contract, record the asset in the restricted deployment
+record, and repeat the verification checklist after every report or data-source
+change.
+
+The warehouse remains authoritative. Looker formats and filters aggregate
+reporting fields; it does not reconstruct user-level metrics, blend raw sources,
+or invent alternate denominators.
+
+## Required restricted fields
+
+These values must remain placeholders in this repository. Fill them in the
+restricted deployment record before any report is shared.
+
+| Field | Required value |
+| --- | --- |
+| Report owner | **REQUIRED TO FILL:** `<DASHBOARD_OWNER>` |
+| Authorized viewer group | **REQUIRED TO FILL:** `<DASHBOARD_VIEWER_GROUP>` |
+| Looker data-source identity | **REQUIRED TO FILL:** `<LOOKER_SERVICE_ACCOUNT>` |
+| Access-review owner | **REQUIRED TO FILL:** `<DASHBOARD_ACCESS_REVIEW_OWNER>` |
+| Report URL/asset ID | **REQUIRED TO FILL in restricted record:** `<DASHBOARD_ASSET>` |
+| Data-source asset IDs | **REQUIRED TO FILL in restricted record:** `<LOOKER_DATA_SOURCE_ASSETS>` |
+| Refresh/cache policy | **REQUIRED TO FILL in restricted record:** `<DASHBOARD_REFRESH_POLICY>` |
+
+**Dashboard sharing is blocked until the report owner and viewer group are
+approved.** Never replace these placeholders in Git with personal email
+addresses, internal group names, service-account addresses, or asset URLs.
+
+## Report boundary
+
+Create exactly one initial report with exactly these three pages, in this order:
+
+1. **Executive snapshot**
+2. **Activation**
+3. **Retention and engagement**
+
+Additional feature, acquisition, product-quality, or data-quality pages are
+deferred. Do not silently add them to the initial investor report.
+
+All data sources must be reusable BigQuery data sources backed only by
+identifier-free objects in
+`sesori-ai.sesori_analytics_reporting`. Do not connect Looker to
+`analytics_529377727`, auth-private, privacy-private, controls, curated tables,
+custom SQL over those datasets, or an extract containing `user_key`.
+
+Use `<LOOKER_SERVICE_ACCOUNT>` or another explicitly approved owner-credential
+configuration that has BigQuery Job User plus Data Viewer on
+`sesori_analytics_reporting` only. Report viewers must not receive direct
+BigQuery access through report membership.
+
+Record `<DASHBOARD_REFRESH_POLICY>` for every reusable data source. Use live
+reporting views rather than extracts; cache refresh must follow the completed
+warehouse schedules and may never make the displayed freshness label newer than
+the source `data_quality` timestamps.
+
+## Reporting-only data sources
+
+Create one reusable source per reporting view. Preserve these source names so
+chart audits are unambiguous.
+
+| Looker source name | BigQuery object | Permitted use |
+| --- | --- | --- |
+| `PA - Investor Snapshot` | `sesori-ai.sesori_analytics_reporting.investor_snapshot` | Independently labeled latest complete account and engagement periods plus latest mature seven-day activation cohort |
+| `PA - Weekly KPIs` | `sesori-ai.sesori_analytics_reporting.weekly_kpis` | Complete-week trends and engagement depth |
+| `PA - Activation Funnel` | `sesori-ai.sesori_analytics_reporting.activation_funnel` | Mature setup/activation cohorts and timing |
+| `PA - Retention` | `sesori-ai.sesori_analytics_reporting.retention` | Mature W1/W4 cohorts |
+| `PA - Feature Adoption` | `sesori-ai.sesori_analytics_reporting.feature_adoption` | Bounded feature/voice/control aggregates |
+| `PA - Installation Login` | `sesori-ai.sesori_analytics_reporting.installation_login_funnel` | Account-less login attempt diagnostics only |
+| `PA - Screen Usage` | `sesori-ai.sesori_analytics_reporting.screen_usage` | Canonical custom screen aggregates |
+| `PA - Onboarding Friction` | `sesori-ai.sesori_analytics_reporting.onboarding_friction` | Empty/failure/support/install diagnostics |
+| `PA - Data Quality` | `sesori-ai.sesori_analytics_reporting.data_quality` | Freshness, coverage, maturity, and pipeline state |
+
+If a required chart field is absent from the reporting view, change the
+versioned warehouse model and assertions. Do not work around it by connecting a
+private source, adding a per-user extract, or blending sources in Looker.
+
+## Global semantic contract
+
+### Time and complete periods
+
+- Set report timezone to UTC.
+- Weeks begin Monday and end Sunday.
+- Default weekly controls to the latest 12 complete Monday-Sunday weeks.
+- Default cohort charts to mature cohorts only.
+- Default daily diagnostics to dates whose warehouse completion flag is true.
+- Never include the current partial week in scorecards, comparisons, exported
+  PDFs, or investor screenshots.
+- An operator-only `Period mode` control may expose `Complete periods` and
+  `Live partial period`; default it to `Complete periods` on every page.
+- When live mode is selected, display a persistent "LIVE PARTIAL PERIOD - NOT
+  FOR INVESTOR EXPORT" banner and suppress prior-period percentage claims that
+  are not like-for-like.
+
+Use source completion/maturity fields. Do not derive completeness from the
+viewer browser clock or GA property timezone.
+
+### Rates and formulas
+
+Warehouse-provided metric values are authoritative for latest-row scorecards,
+four-week growth, percentiles, and cohort retention. Do not average percentages
+or recompute distinct users in Looker.
+
+Where a chart groups reporting rows and therefore must calculate a displayed
+rate, the only allowed formula is a ratio of summed source components:
+
+```text
+CASE
+  WHEN SUM(denominator) = 0 THEN NULL
+  ELSE SUM(numerator) / SUM(denominator)
+END
+```
+
+Give each chart-specific numerator and denominator explicit aliases before
+using this formula. Never use `AVG(rate)`, `COUNT_DISTINCT(user_key)`, a blended
+denominator, or zero for an absent/immature denominator.
+
+Pin these definitions:
+
+| Metric | Numerator | Denominator/formula |
+| --- | --- | --- |
+| Weekly new accounts | External, non-deletion-suppressed accounts created in the complete week | Count; ordinary product-analytics opt-out does not reduce this aggregate auth metric |
+| 7-day bridge setup conversion | Accounts with first bridge registration within 7 x 24 hours of creation | External accounts in the cohort whose full seven-day window elapsed |
+| 7-day full activation conversion | Analytics-eligible accounts with first successful message outcome within 7 x 24 hours of account creation | Accounts at least seven days old, created on/after the behavioral start, and activation-capable within 24 hours; untimely/legacy accounts are unmeasurable, not failures |
+| Meaningful WAU | Distinct eligible users with non-empty visible session activity or a confirmed control outcome in the complete week | Count; screens/app opens/empty/failure/queued-only rows do not qualify |
+| Controller WAU | Distinct eligible users with a successful message, question/permission action, abort, or session creation with message | Count |
+| W1 retention | Activated eligible users with meaningful activity on days 7-13 after activation | Activated users whose complete W1 window elapsed |
+| W4 retention | Activated eligible users with meaningful activity on days 28-34 after activation | Activated users whose complete W4 window elapsed |
+| Active days per WAU | Source-provided P50/P75 of distinct UTC meaningful-activity dates | Meaningful users in that complete week; do not aggregate percentiles in Looker |
+| Remote interventions per controller | Successful control outcomes | Controller WAU |
+| Voice-assisted message share | Successful messages with `input_mode=voice_assisted` | All successful messages in the same complete/filter scope |
+| Four-week WAU growth | Source-provided latest complete-week meaningful WAU divided by meaningful WAU four complete weeks earlier, minus one | Null when either sample is absent |
+| Login attempt completion | Account-less completed attempts | Account-less started attempts under the same provider/app-version/date filters |
+
+Full activation is the earliest successful `session_message_sent` or
+`session_created_with_message`. A tap, queue insertion, failed creation, empty
+session, permission/question answer, or legacy metadata request is not full
+activation.
+
+### Required labels
+
+Every rate chart and scorecard must expose all of these adjacent to the value,
+either as visible subtitle fields or companion scorecards:
+
+- `Numerator: <count>`;
+- `Denominator: <count and population>`;
+- `Coverage: <preference, foundation, and activation-capability numerator / denominator as applicable>`;
+- `Maturity: <window and latest mature cohort/date>`; and
+- `Freshness: raw <as-of>, auth <as-of>, reporting <as-of/status>`.
+
+The compact freshness/coverage/maturity strip from `PA - Data Quality` appears
+at the top of every page and is never hidden by business filters. Use explicit
+status text in addition to color so stale and inaccessible states remain
+understandable in screenshots and to color-impaired viewers.
+
+Allowed freshness labels are:
+
+| Label | Meaning |
+| --- | --- |
+| `Fresh` | Raw, auth, and reporting layers satisfy their declared freshness policy |
+| `Stale - last good data shown` | A layer is late/failed and reporting intentionally retains prior publication |
+| `Blocked - auth snapshot invalid` | User-level publication aborted because the snapshot was stale, partial, or unreconciled |
+| `No mature cohort` | The full metric window has not elapsed; value must be null, not zero |
+| `Live partial period` | Operator selected an incomplete period; never investor-exportable |
+
+### Coverage labels
+
+Do not combine these into one vague "analytics coverage" percentage:
+
+| Coverage | Required interpretation |
+| --- | --- |
+| Preference coverage | External accounts represented by current enabled reporting preference versus all eligible external accounts in scope |
+| Foundation coverage | Accounts with timely `analytics_schema_ready` foundation exposure; diagnostic only |
+| Activation-capability coverage | Accounts with `analytics_activation_ready` schema v1 or a qualifying activation outcome within 24 hours of creation |
+| Measurable activation population | Mature accounts satisfying behavioral start, current eligibility, and timely activation-capability rules |
+
+Opted-out and unsupported/legacy accounts are not silently counted as
+non-activations. Display both coverage counts and percentages wherever an
+account behavior rate is shown.
+
+### Maturity labels
+
+Pin the visible maturity text to the metric window:
+
+| Metric | Mature when |
+| --- | --- |
+| 7-day setup/activation | Seven full 24-hour days have elapsed after account creation |
+| W1 retention | Day 13 after activation has fully elapsed for every activated user in the displayed activation week |
+| W4 retention | Day 34 after activation has fully elapsed for every activated user in the displayed activation week; operationally available after 35 days |
+| Complete week | The UTC Monday-Sunday week ended before the current week |
+
+Never let a dashboard date control override maturity filtering without also
+switching to the clearly marked live/operator mode.
+
+## Filter contract
+
+Filters must preserve numerator/denominator populations. A filter may appear
+only when the reporting view supplies both components under that dimension.
+
+| Filter | Pages | Default | Rules |
+| --- | --- | --- | --- |
+| `Period mode` | All | `Complete periods` | Live mode adds warning banner and cannot be saved as default |
+| Complete week range | Executive; Retention and engagement | Latest 12 complete weeks | UTC Monday-Sunday only |
+| Account cohort week | Activation | Latest mature cohorts available | Applies only to cohort-compatible activation/setup charts |
+| Platform | Activation diagnostics; Retention and engagement feature/screen panels | All | Do not apply to auth-only new-account totals unless source supplies matched denominator |
+| App version | Login/onboarding/screen diagnostics only | All | Never use to redefine account activation/retention denominator |
+| Login provider | Separated login diagnostic panel only | All | Closed values `github`, `google`, `apple`, `email` |
+| Input mode/workspace kind/feature | Relevant adoption charts only | All | Do not cross-filter headline scorecards |
+| Screen | Screen usage chart only | All | Pinned canonical custom screen names only |
+
+Do not expose free-text filters, `user_key`, event-level drill-through, raw app
+instance/session identifiers, report URL parameters carrying dimensions, or a
+cross-page filter that changes only a numerator.
+
+## Page 1: Executive snapshot
+
+Purpose: investor/product-leadership readout of complete-period growth,
+activation, retention, and data trust.
+
+`PA - Investor Snapshot` intentionally selects three applicable periods
+independently. Account cards use `account_week_start/end`, engagement cards use
+`engagement_week_start/end`, and setup/activation cards use
+`activation_cohort_week/end`. Show the applicable period beside every card;
+never imply these dates are one shared week. Before a seven-day activation
+cohort matures, keep activation values null and show `No mature cohort` while
+the account and engagement cards continue to render.
+
+### Pinned charts
+
+| Chart | Source | Contract and filters |
+| --- | --- | --- |
+| `E0 - Data trust strip` | `PA - Data Quality` | Raw/auth/reporting as-of, pipeline status, preference/foundation/activation-capability coverage, latest mature W1/W4 cohorts; unaffected by business filters |
+| `E1 - Weekly new accounts` | `PA - Investor Snapshot` | Latest complete week count, prior complete-week value and delta; label external account population |
+| `E2 - 7-day bridge setup` | `PA - Investor Snapshot` | Rate plus visible numerator/eligible mature denominator; latest complete eligible cohort |
+| `E3 - 7-day full activation` | `PA - Investor Snapshot` | Rate plus numerator, mature measurable denominator, and all three coverage labels |
+| `E4 - Meaningful WAU` | `PA - Investor Snapshot` | Latest complete week count and prior comparison |
+| `E5 - Controller WAU` | `PA - Investor Snapshot` | Latest complete week count and prior comparison |
+| `E6 - W1 retention` | `PA - Retention` | Latest mature cohort rate, numerator/denominator, maturity; null when no mature cohort |
+| `E7 - W4 retention` | `PA - Retention` | Latest mature cohort rate, numerator/denominator, maturity; directional label when sample is small; null when unavailable |
+| `E8 - Four-week WAU growth` | `PA - Investor Snapshot` | Source-provided value only; null if current or four-weeks-prior sample is unavailable |
+| `E9 - KPI trends` | `PA - Weekly KPIs` | Complete-week series for new accounts, meaningful WAU, controller WAU; latest 12 complete weeks |
+| `E10 - Activation funnel` | `PA - Activation Funnel` | Account -> bridge -> project -> successful message; mature counts/rates; notification registration shown beside, not as a required step |
+
+Do not place login conversion on this page. Do not show a headline metric without
+its sample size and trust strip in the same screenshot/export viewport.
+
+## Page 2: Activation
+
+Purpose: explain setup-to-value conversion, time to activation, and bounded
+onboarding/login friction without redefining the headline population.
+
+### Pinned charts
+
+| Chart | Source | Contract and filters |
+| --- | --- | --- |
+| `A0 - Data trust strip` | `PA - Data Quality` | Same fixed strip as Page 1 |
+| `A1 - Mature cohort funnel` | `PA - Activation Funnel` | Account -> bridge -> project -> message by account cohort; show step numerator, original cohort denominator, conversion, maturity, and coverage |
+| `A2 - 1/7/30-day setup table` | `PA - Activation Funnel` | Bridge/project/message windows only where each cohort is mature for that window; null for immature cells |
+| `A3 - Time-to-step distribution` | `PA - Activation Funnel` | Aggregate pre-bucketed account counts for bridge, project, and full-activation elapsed time plus source-provided full-activation P50/P75; no per-user rows or Looker percentile calculation |
+| `A4 - Activation path split` | `PA - Activation Funnel` | Existing-session message versus remotely created session with message; mutually exclusive first-activation counts |
+| `A5 - Notification registration` | `PA - Activation Funnel` | Side-adoption panel visually separated from required funnel; label it notification registration, never "mobile setup" |
+| `A6 - Onboarding friction` | `PA - Onboarding Friction` | Empty inventory/activity/diff, bounded session-creation failures, and confirmed support/install outcomes; complete dates only |
+| `A7 - Login attempt completion` | `PA - Installation Login` | Separate diagnostic panel with started/completed/failed counts and summed-ratio completion by provider; include mandatory limitation label below |
+| `A8 - Login failure mix` | `PA - Installation Login` | Fixed bounded authentication/launch/cancelled/timeout/unknown failure series by provider/app version/date; counts of attempts, never unique people |
+
+### Mandatory login limitation
+
+Display this text verbatim beside every login chart and in exports that contain
+one:
+
+> Installation-level sign-in attempt diagnostics. They contain no account key
+> or attempt identifier, may include internal/test release traffic, and cannot
+> be interpreted as unique people, account creation, or account activation.
+
+The login source must have `includes_internal_test_traffic=true`. Treat a false
+or missing value as a data-quality failure and hide the panel until corrected.
+Never blend login attempts with auth account cohorts.
+
+## Page 3: Retention and engagement
+
+Purpose: show mature return behavior and adoption of remote-control and
+differentiating features.
+
+### Pinned charts
+
+| Chart | Source | Contract and filters |
+| --- | --- | --- |
+| `R0 - Data trust strip` | `PA - Data Quality` | Same fixed strip as Pages 1-2 |
+| `R1 - W1/W4 cohort heatmap` | `PA - Retention` | Activation cohort week, W1/W4 numerator, eligible denominator, rate, and maturity; immature cells are null/hatched, not zero |
+| `R2 - Meaningful and controller WAU` | `PA - Weekly KPIs` | Complete-week two-series trend; source definitions only |
+| `R3 - Active days per WAU` | `PA - Weekly KPIs` | Source-provided P50/P75 for complete weeks; no percentile reaggregation |
+| `R4 - Remote interventions per controller` | `PA - Weekly KPIs` | Successful intervention numerator divided by Controller WAU; show successful messages separately from other controls |
+| `R5 - Message depth` | `PA - Weekly KPIs` | Successful accepted messages per meaningful/controller user as explicitly supplied; no queued/failed events |
+| `R6 - Voice adoption` | `PA - Feature Adoption` | Weekly transcription users and voice-assisted successful-message users/share; visible numerator and message/user denominator |
+| `R7 - Session creation/worktree adoption` | `PA - Feature Adoption` | Successful remote-created sessions and dedicated-worktree share; failures shown separately, never in success numerator |
+| `R8 - Remote feature adoption` | `PA - Feature Adoption` | Diff users, question answers/rejections, permission answers, and aborts; confirmed outcomes only |
+| `R9 - Screen usage` | `PA - Screen Usage` | Canonical `product_screen_viewed` users/views by pinned screen; standard Firebase `screen_view` excluded; never classify as activity |
+
+The W1/W4 heatmap must show activated-cohort size even when the retained numerator
+is zero. When no cohort is mature, show "No mature cohort" and null rather than
+a fabricated 0%.
+
+## Field and style contract
+
+Use human-readable labels only as presentation aliases. Preserve source field
+types and aggregation:
+
+| Field class | Looker aggregation/display |
+| --- | --- |
+| Counts/numerators/denominators | `SUM` only at the view's declared compatible grain; whole numbers |
+| Distinct-user metrics already aggregated by SQL | Use source value; never `COUNT_DISTINCT` in Looker |
+| Rates | Percent with one decimal; ratio-of-sums only when grouping compatible rows |
+| Four-week growth | Source value; signed percent with one decimal; null remains blank/not available |
+| P50/P75 | Source value; duration unit labeled; never averaged or recalculated |
+| UTC date/week/cohort | ISO date; week label includes Monday start date |
+| Freshness timestamps | UTC date/time with `UTC` in label |
+| Booleans/status | Human-readable bounded label; no silent filter of failures |
+
+Do not use chart sampling, approximate Looker calculations, auto date ranges,
+cross-source blends, community visualizations that copy data, or report-level
+extracts. Disable viewer data-source reuse and report copying. Restrict download,
+print, and copy features to the explicitly approved policy; investor screenshots
+must retain trust/maturity labels.
+
+## Manual build sequence
+
+1. Clear the cloud deployment block in the runbook.
+2. Verify all reporting views and schema assertions in BigQuery, then confirm
+   each view is authorized on only the exact auth/controls/curated source
+   datasets it reads as listed in the warehouse runbook.
+3. Create reusable data sources under `<DASHBOARD_OWNER>` using
+   `<LOOKER_SERVICE_ACCOUNT>` credentials and reporting-only access.
+4. Confirm each data source exposes no `user_key`, raw identifier, free-text
+   event parameter, or private dataset field.
+5. Build exactly the three pages and chart IDs above.
+6. Apply the complete-period, numerator/denominator, coverage, maturity, and
+   freshness contracts.
+7. Reconcile every chart against a direct query of its reporting view for the
+   same filters.
+8. Share only with `<DASHBOARD_VIEWER_GROUP>` after all access tests pass.
+9. Record report/data-source asset IDs and verification timestamp in the
+   restricted deployment record.
+
+## Manual access verification
+
+Repeat this checklist before first sharing, after any IAM/credential/share
+change, and at least quarterly. Record pass/fail evidence without identities or
+asset URLs in this repository.
+
+### BigQuery identity tests
+
+Using approved service-account impersonation, verify the Looker identity can
+query one reporting view. `bq` uses the active Cloud SDK credential and honors
+`CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT`; it does not accept a bq
+`--impersonate_service_account` flag. The human verifier needs a narrowly
+approved, resource-scoped Service Account Token Creator grant (or an equivalent
+custom impersonation role containing only the required token-minting
+`iam.serviceAccounts.getAccessToken` permission) on
+`<LOOKER_SERVICE_ACCOUNT>`. Do not grant Token Creator at project scope, and
+remove a temporary verifier grant after recording the result:
+
+```bash
+CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT="<LOOKER_SERVICE_ACCOUNT>" \
+  bq query \
+    --project_id=sesori-ai \
+    --location=europe-west3 \
+    --use_legacy_sql=false \
+    'SELECT * FROM `sesori-ai.sesori_analytics_reporting.investor_snapshot` LIMIT 1'
+```
+
+Then verify each of these expected-deny probes fails with `Access Denied`:
+
+```bash
+CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT="<LOOKER_SERVICE_ACCOUNT>" \
+  bq query \
+    --project_id=sesori-ai \
+    --location=europe-west3 \
+    --use_legacy_sql=false \
+    'SELECT 1 FROM `sesori-ai.analytics_529377727.events_20260725` LIMIT 0'
+
+CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT="<LOOKER_SERVICE_ACCOUNT>" \
+  bq query \
+    --project_id=sesori-ai \
+    --location=europe-west3 \
+    --use_legacy_sql=false \
+    'SELECT 1 FROM `sesori-ai.sesori_analytics_auth_private.auth_user_milestones` LIMIT 0'
+
+CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT="<LOOKER_SERVICE_ACCOUNT>" \
+  bq query \
+    --project_id=sesori-ai \
+    --location=europe-west3 \
+    --use_legacy_sql=false \
+    'SELECT 1 FROM `sesori-ai.sesori_analytics_privacy_private.product_analytics_deletion_targets` LIMIT 0'
+
+CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT="<LOOKER_SERVICE_ACCOUNT>" \
+  bq query \
+    --project_id=sesori-ai \
+    --location=europe-west3 \
+    --use_legacy_sql=false \
+    'SELECT 1 FROM `sesori-ai.sesori_analytics_curated.events_flattened` LIMIT 0'
+```
+
+Also verify the reporting schema contains no `user_key`. Do not grant access to
+make a deny probe pass; a successful deny probe blocks sharing and requires IAM
+remediation.
+
+### Report sharing tests
+
+- Sign in as `<DASHBOARD_OWNER>` and verify edit access plus all data-source
+  credentials/owners are the approved restricted values.
+- Sign in as one ordinary member of `<DASHBOARD_VIEWER_GROUP>` and verify view
+  access, all charts, labels, and filters work without direct BigQuery roles.
+- Sign in as an authenticated account outside the group and verify access is
+  denied even with the report URL.
+- Open the URL in a private/anonymous browser and verify access is denied.
+- Verify link sharing, public embedding, organization-wide sharing, report copy,
+  and data-source reuse are disabled.
+- Verify a viewer cannot edit credentials, inspect SQL, add a private data
+  source, or navigate to a BigQuery object.
+- Verify permitted download/print output retains complete-period, sample-size,
+  coverage, maturity, freshness, and login limitation labels.
+- Search report fields, calculated fields, filters, chart drill-downs, URL
+  parameters, and permitted exports for `user_key` and prohibited identifiers;
+  require zero findings.
+
+### Value reconciliation
+
+For at least three complete UTC event dates and the latest complete week,
+compare every scorecard/chart with its reporting-view row under identical
+filters. Rates must equal summed numerator divided by summed denominator;
+percentiles and four-week growth must equal source-provided values. Record
+aggregate values, query job IDs, source/reporting as-of timestamps, and outcome
+only. Never record user keys or raw rows.
+
+## Change and incident handling
+
+Treat any of these as a report incident: a missing trust strip, partial period
+shown as complete, zero replacing null maturity, hidden denominator, mismatched
+coverage, stale data without a stale label, login diagnostics represented as
+people/accounts, a private data source, unexpected sharing, or a chart that does
+not reconcile.
+
+Immediately hide or pause the affected chart/report, revoke unintended sharing,
+and preserve privacy/deletion operations. Restore the last known-good reporting
+source/report version or fix the warehouse contract, then repeat schema, value,
+and access verification. Do not repair a report incident by broadening IAM,
+connecting raw data, adding an unreviewed blend, or removing labels.
+
+Record the report version/change date, owner, affected chart IDs, complete
+periods, last good warehouse/report freshness, access impact, correction, and
+verification result in the restricted operations record.

--- a/tool/product_analytics/README.md
+++ b/tool/product_analytics/README.md
@@ -257,7 +257,7 @@ a Looker-side alias.
 | `analytics_529377727` | Raw restricted | Firebase-managed `events_YYYYMMDD`; 90-day default and current-table expiration | Analytics/security admins and transform/deletion identities only |
 | `sesori_analytics_auth_private` | Pseudonymous private | Current eligible auth snapshot, aggregate setup cohorts, run metadata/state, and expiring staging tables | Auth export writes; transform reads; deletion repairs; admins oversee |
 | `sesori_analytics_privacy_private` | Privacy restricted | Deletion targets and status only | Suppression handoff and deletion identity; security/privacy admins |
-| `sesori_analytics_controls` | Restricted controls | Permanent internal and deletion exclusions, measurement starts, freshness policy, and authorized exclusion view | Deployment identity writes; transform reads; auth export sees one authorized view only |
+| `sesori_analytics_controls` | Restricted controls | Permanent internal and deletion exclusions, measurement starts, freshness policy, keyed-publication guard, and authorized exclusion view | Deployment identity writes; transform reads plus table-scoped guard update; auth export sees one authorized view only |
 | `sesori_analytics_curated` | Minimized pseudonymous | Allowlisted event facts, daily user activity, milestones, cohorts, and scheduled intermediates | Transform identity writes; analytics engineers read; deletion repairs |
 | `sesori_analytics_reporting` | Identifier-free reporting | Aggregate authorized reporting views | Deployment creates views; Looker and approved product leadership read; deletion receives metadata-only inventory access |
 
@@ -301,6 +301,7 @@ not a successful session creation or full activation.
 | `internal_exclusion_control_state` | Singleton common `control_updated_at`; advance only when the permanent exclusion set is reviewed |
 | `auth_permanent_internal_exclusions` | Read-only projection for auth export with `user_key`, `is_active`, and common `control_updated_at`, including a null-key freshness sentinel |
 | `permanent_deletion_exclusions` | Permanent HMAC `user_key` tombstones used by every flattened/reported rebuild and recurring sweep |
+| `keyed_publication_guard` | Singleton epoch advanced transactionally by tombstone insertion and keyed publication to prevent concurrent repopulation |
 | `analytics_measurement_config` | Exactly one approved `raw_export_start_at`, one independently approved `behavioral_schema_v1_start_at`, clock-skew/freshness policy, and update audit metadata |
 | `product_analytics_privacy_sweep_state` | Last successful raw-partition watermark and run status; no discovered installation identifier is persisted |
 
@@ -309,14 +310,14 @@ not a successful session creation or full activation.
 | Object | Grain and contract |
 | --- | --- |
 | `transform_state` | One last-success watermark/quality row per transform with source range, completion/auth freshness, bounded rejection counts, and latest event times; no identifiers |
-| `events_flattened` | One deduplicated, allowlisted account-linked custom event; keeps `user_key`, event name, schema, validated occurrence/emission UTC timestamps, platform/app version/build, and bounded event parameters only |
+| `events_flattened` | One deduplicated, allowlisted account-linked custom event; keeps `user_key`, event name, schema, validated occurrence/emission UTC timestamps, platform/app version, and bounded event parameters only |
 | `installation_login_daily` | UTC date/platform/app version/provider/failure-kind aggregate counts; never contains `user_pseudo_id` or `user_key`; always flags `includes_internal_test_traffic=true` |
 | `user_activity_daily` | One eligible user/UTC date with bounded monitoring, control, message, voice, diff, screen, and feature flags/counts |
 | `user_milestones` | One eligible user with auth milestones and earliest foundation, activation-capable, project, activation, monitoring, and feature milestones |
 | `activation_cohorts` | Account creation cohort with 1/7/30-day setup/activation flags, latency, maturity, and separate preference/foundation/activation-capability coverage |
 | `retention_cohorts` | Activation-week cohort with W1 (days 7-13) and W4 (days 28-34) eligible denominators, meaningful-activity numerators, and separate flags that become mature only after every activated user in that week has completed the window |
 | `weekly_engagement` | One complete UTC Monday-Sunday week with meaningful/controller WAU, activity-depth percentiles, intervention/message/voice/feature totals, and refresh time |
-| `screen_usage_weekly` | Complete week/platform/app version/build/pinned screen with identifier-free unique-user and view counts |
+| `screen_usage_weekly` | Complete week/platform/app version/pinned screen with identifier-free unique-user and view counts |
 | `onboarding_friction_weekly` | Complete week and bounded diagnostic dimensions with identifier-free user/event counts |
 
 `events_flattened` is recoverable only while the relevant raw partitions remain
@@ -396,9 +397,9 @@ access. No runtime receives a downloadable service-account key.
 | `<ANALYTICS_SECURITY_ADMIN_GROUP>` | Administer approved analytics datasets, IAM reviews, raw/privacy incident access | Routine dashboard use as a reason for raw access |
 | `<DEPLOYMENT_SERVICE_ACCOUNT>` | BigQuery Job User; create/update derived schemas, approved controls, authorized views, IAM, and transfer configs; act-as only approved schedule identities | Runtime Mongo secret; GA event identifiers; routine dashboard credentials |
 | `<AUTH_EXPORT_SERVICE_ACCOUNT>` | BigQuery Job User; Data Editor on `sesori_analytics_auth_private`; table-level read of the authorized internal-exclusion view; managed Mongo/HMAC secrets | Controls write/DDL; privacy-private, raw, curated, or reporting access; project-wide data roles |
-| `<TRANSFORM_SERVICE_ACCOUNT>` | BigQuery Job User; Data Viewer on raw, auth-private, and controls; Data Editor on curated only; run only declared schedules | Privacy-private; reporting writes; Mongo; GA Admin mutation; IAM or control-table mutation |
+| `<TRANSFORM_SERVICE_ACCOUNT>` | BigQuery Job User; Data Viewer on raw, auth-private, and controls; Data Editor on curated; table-scoped Data Editor on `keyed_publication_guard`; run only declared schedules | Privacy-private; reporting writes; Mongo; GA Admin mutation; IAM or any other control-table mutation |
 | `<AUTH_SUPPRESSION_SERVICE_ACCOUNT>` | BigQuery Job User; Mongo suppression operation; table-scoped query/MERGE and status read on `product_analytics_deletion_targets` only; managed HMAC/Mongo secrets | Dataset-wide privacy access; auth export tables, controls, raw, curated, reporting, and GA Admin API |
-| `<PRIVACY_DELETION_SERVICE_ACCOUNT>` | BigQuery Job User; read privacy targets/raw; write deletion exclusions/status and the sweep checkpoint; delete affected raw/auth-private/curated keyed rows; rebuild the fixed curated aggregate chain; metadata-only inventory access on reporting; Analytics Admin `analytics.edit` only for deletion submission | Reporting data mutation; Mongo; deployment/IAM administration; unrelated control mutation; Looker ownership; general GA property administration |
+| `<PRIVACY_DELETION_SERVICE_ACCOUNT>` | BigQuery Job User; read privacy targets/raw; write deletion exclusions/status, the sweep checkpoint, and `keyed_publication_guard`; delete affected raw/auth-private/curated keyed rows; rebuild the fixed curated aggregate chain; metadata-only inventory access on reporting; Analytics Admin `analytics.edit` only for deletion submission | Reporting data mutation; Mongo; deployment/IAM administration; any other control mutation; Looker ownership; general GA property administration |
 | `<LOOKER_SERVICE_ACCOUNT>` | BigQuery Job User and Data Viewer on `sesori_analytics_reporting` only | Raw, auth-private, privacy-private, controls, curated, `user_key`, and write access |
 | `<DASHBOARD_VIEWER_GROUP>` | View the restricted Looker report through approved data-source credentials | Direct BigQuery access, data-source editing/reuse, public/link sharing |
 | Auth web runtime | Existing web preference service and managed HMAC secret | Every BigQuery role and every warehouse/deletion class |
@@ -521,9 +522,11 @@ source-dataset access. Any later reporting view that reads a private source
 requires a reviewed ACL update; reporting-dataset membership is never a blanket
 authorization for future views.
 
-Then grant the auth-export identity table-level read on only that view, and
-grant the deployment identity service-account act-as on only the approved
-transform identity. `roles/iam.serviceAccountUser` supplies
+Then grant the auth-export identity table-level read on only that view. Grant
+the transform and privacy-deletion identities table-scoped Data Editor on only
+the shared publication guard; dataset-wide controls write remains forbidden.
+Finally, grant the deployment identity service-account act-as on only the
+approved transform identity. `roles/iam.serviceAccountUser` supplies
 `iam.serviceAccounts.actAs`; do not replace it with project-wide Service Account
 User or Token Creator:
 
@@ -532,6 +535,16 @@ bq --project_id=sesori-ai add-iam-policy-binding \
   --member="serviceAccount:<AUTH_EXPORT_SERVICE_ACCOUNT>" \
   --role="roles/bigquery.dataViewer" \
   "sesori-ai:sesori_analytics_controls.auth_permanent_internal_exclusions"
+
+bq --project_id=sesori-ai add-iam-policy-binding \
+  --member="serviceAccount:<TRANSFORM_SERVICE_ACCOUNT>" \
+  --role="roles/bigquery.dataEditor" \
+  "sesori-ai:sesori_analytics_controls.keyed_publication_guard"
+
+bq --project_id=sesori-ai add-iam-policy-binding \
+  --member="serviceAccount:<PRIVACY_DELETION_SERVICE_ACCOUNT>" \
+  --role="roles/bigquery.dataEditor" \
+  "sesori-ai:sesori_analytics_controls.keyed_publication_guard"
 
 gcloud iam service-accounts add-iam-policy-binding \
   "<TRANSFORM_SERVICE_ACCOUNT>" \
@@ -591,7 +604,8 @@ Confirm the transform service-account policy contains exactly the approved
 deployment principal under `roles/iam.serviceAccountUser` and no unintended
 Token Creator grant. After schedule application, confirm each transfer config
 runs as `<TRANSFORM_SERVICE_ACCOUNT>`, then require expected-deny probes against
-privacy-private data and IAM mutation to fail under that identity. Any
+privacy-private data, every other controls mutation, and IAM mutation to fail
+under that identity. Any
 unexpected success blocks rollout; remove the excess grant rather than
 broadening the matrix.
 
@@ -730,6 +744,10 @@ BigQuery SCRIPT estimates are best-effort. Accuracy can be `PRECISE`,
 below actual billed bytes and is not evidence that a query fits its allocation.
 If BigQuery omits the estimate, the tool prints `totalBytesProcessed=unavailable`
 and `accuracy=UNKNOWN` rather than inferring precision.
+For a multi-statement DDL asset, BigQuery dry-run validation stops after the
+first DDL statement. The CLI reports this limitation explicitly; dry-run is not
+proof that every schema object is valid. The deployed-schema assertions below
+remain mandatory after apply.
 Review the estimate and accuracy against both the manifest allocation and the 2
 GiB principal/10 GiB project daily quotas, then verify actual production job
 bytes before enabling schedules. Dry-run success does not prove a cost ceiling,
@@ -737,10 +755,33 @@ IAM deny boundaries, source freshness, or metric correctness. If `bq` fails or
 returns malformed output, the tool reports only a bounded operation error and
 suppresses backend details.
 
+### Bootstrap schemas, then publish auth
+
+On a new warehouse, create only the datasets and reference schemas first:
+
+```bash
+dart tool/product_analytics/deploy.dart \
+  --project=sesori-ai \
+  --location=europe-west3 \
+  --raw-dataset-id=analytics_529377727 \
+  --auth-dataset-id=sesori_analytics_auth_private \
+  --privacy-dataset-id=sesori_analytics_privacy_private \
+  --controls-dataset-id=sesori_analytics_controls \
+  --curated-dataset-id=sesori_analytics_curated \
+  --reporting-dataset-id=sesori_analytics_reporting \
+  --raw-export-start-at="<RAW_EXPORT_START_AT_UTC>" \
+  --behavioral-schema-v1-start-at="<BEHAVIORAL_SCHEMA_V1_START_AT_UTC>" \
+  --bootstrap
+```
+
+Next run and validate the initial auth export described below. Do not run
+auth-dependent transforms before that snapshot exists.
+
 ### Apply schemas and transforms without schedules
 
 Only after the deployment block is cleared, pass the explicit mutating
-`--apply` mode without `--apply-schedules`:
+`--apply` mode without `--apply-schedules`. The command fails before applying
+any asset when `product_analytics_export_runs` has no initial snapshot:
 
 ```bash
 dart tool/product_analytics/deploy.dart \
@@ -794,10 +835,12 @@ perl -pe '
 
 Require both `metric_contract_assertions.sql` and
 `schema_allowlist_assertions.sql` to pass. Assertions cover activation success
-versus queued/failed attempts, timely activation capability, cohort maturity,
-W1/W4 boundaries, occurrence time, internal/disabled/deleted exclusion,
-monitoring deduplication, voice classification, account-less login isolation,
-custom-screen-only reporting, stale auth snapshots, and late-event replacement.
+versus queued/failed attempts, ordered account-to-bridge-to-project-to-message
+progression, timely activation capability, cohort maturity, W1/W4 boundaries,
+occurrence time, internal/disabled/deleted exclusion, the keyed publication
+guard, monitoring deduplication, voice classification, account-less login
+isolation, custom-screen-only reporting, stale auth snapshots, and late-event
+replacement.
 
 ### Apply schedules
 
@@ -850,6 +893,12 @@ started runs can overlap. The SQL scripts therefore enforce same-run auth and
 upstream watermark guards before publication, and each write is transactional
 or idempotent. Do not weaken those guards or assume schedule timing provides
 mutual exclusion.
+
+Keyed transforms and permanent deletion tombstones also advance the shared
+`keyed_publication_guard` singleton inside their transactions. Every transform
+captures the epoch before staging and fails if it changes, while an overlapping
+tombstone/publication causes a transaction conflict. This prevents a staged
+aggregate from republishing a user whose tombstone arrived concurrently.
 
 Before creating or updating any transfer config, `--apply-schedules` lists
 scheduled-query configs in the location. If any display name beginning with
@@ -1013,6 +1062,12 @@ approved change in the restricted operations record.
 Privacy deletion is an isolated, idempotent source-to-warehouse flow. It is not
 an ad hoc console query and not a public route.
 
+The required repository preflight for any privacy-job change is:
+
+```bash
+dart tool/product_analytics/privacy_deletion/privacy_deletion_test.dart
+```
+
 ### 1. Source suppression and handoff
 
 After independently verifying the requester and external request ID, run the
@@ -1085,12 +1140,14 @@ checked-in `20_user_activity_daily.sql` -> `30_user_milestones.sql` ->
 The command adds and verifies the permanent deletion exclusion first, then
 performs one immediate privacy-preserving raw/curated cleanup and rebuild. It
 reads auth-export readiness exactly once; it never polls or sleeps inside the
-process. If no successful export has `run_cutoff >= suppressed_at`, the command
-records a bounded retryable outcome and exits. The approved external job or
-operator must run the auth export and invoke the same idempotent deletion
-command again. The preliminary pass deliberately does not mutate auth-private
-publication while an older export may still own that snapshot. Once a later
-invocation observes the qualifying export, the final pass deletes the key from
+process. If no successful export has `run_cutoff >= suppressed_at`, or its
+source cutoff/publication is stale or future-dated under the warehouse
+freshness policy, the command records a bounded retryable outcome and exits. The
+approved external job or operator must run the auth export and invoke the same
+idempotent deletion command again. The preliminary pass deliberately does not
+mutate auth-private publication while an older export may still own that
+snapshot. Once a later invocation observes the qualifying export, the final
+pass deletes the key from
 auth-private and curated keyed tables, repeats the fixed rebuild, verifies
 keyed/raw absence and post-request transform state, and only then marks the
 request complete. Do not declare warehouse completion before both the
@@ -1168,6 +1225,10 @@ age/status, deletes newly landed keyed rows, and resubmits newly discovered app
 instances through `submitUserDeletion`. It persists no account-install mapping
 and automatically uses the same fixed checked-in 20 -> 30 -> 40 rebuild chain;
 there is no operator-supplied rebuild path or command.
+Before any auth-private cleanup or checkpoint advancement, the sweep requires a
+fresh successful auth export whose cutoff covers the newest tombstone. A stale
+or pre-tombstone export produces a bounded retryable result without cleanup or
+checkpoint advancement.
 
 The enforceable promise is source/warehouse suppression plus recurring removal
 of future **keyed uploads**. An automatic-only installation that never emitted a

--- a/tool/product_analytics/README.md
+++ b/tool/product_analytics/README.md
@@ -1,0 +1,1284 @@
+# Product analytics warehouse runbook
+
+This directory owns the Step 5 operator contract for the Sesori product
+analytics warehouse. It covers controlled deployment, the warehouse data
+dictionary, daily operation, privacy deletion, recovery, and release
+reconciliation. Dashboard construction is pinned separately in
+[`LOOKER_STUDIO.md`](LOOKER_STUDIO.md).
+
+All reporting time is UTC. Complete weeks are Monday through Sunday. Never put
+credentials, pseudonymization secrets, raw account identifiers, installation
+identifiers, or live internal-user keys in this repository, command arguments,
+logs, tickets, or dashboard URLs.
+
+## Deployment block
+
+**Cloud deployment is blocked.** Do not apply datasets, transforms, transfer
+configurations, auth-export scheduling, privacy-deletion scheduling, or Looker
+data sources until all of the following are approved and recorded in the
+restricted deployment record:
+
+- GA4 two-month retention, Google Signals, and advertising/privacy settings;
+- restricted project and dataset IAM with broad inherited data access removed;
+- separate deployment, auth-export, transform, deletion, and Looker service
+  identities;
+- the exact UTC `raw_export_start_at`, which cannot be inferred from a daily
+  table suffix;
+- the restricted Looker report owner; and
+- the restricted Looker viewer group.
+
+As of 2026-07-31, those approvals are unverified. All mutating commands remain
+blocked even though the raw export, retention expiration, billing, budget, and
+query-quota facts below have been observed.
+
+The unresolved values below are intentional placeholders. Preserve them in
+source control and fill the corresponding values only in the restricted
+deployment record or managed runtime configuration.
+
+| Required approval | Restricted value |
+| --- | --- |
+| Analytics/security administrator group | `<ANALYTICS_SECURITY_ADMIN_GROUP>` |
+| Deployment identity | `<DEPLOYMENT_SERVICE_ACCOUNT>` |
+| Auth-export identity | `<AUTH_EXPORT_SERVICE_ACCOUNT>` |
+| Auth suppression identity | `<AUTH_SUPPRESSION_SERVICE_ACCOUNT>` |
+| Scheduled-transform identity | `<TRANSFORM_SERVICE_ACCOUNT>` |
+| Privacy-deletion identity | `<PRIVACY_DELETION_SERVICE_ACCOUNT>` |
+| Looker data-source identity | `<LOOKER_SERVICE_ACCOUNT>` |
+| Exact controlled raw start | `<RAW_EXPORT_START_AT_UTC>` |
+| Behavioral schema-v1 start | `<BEHAVIORAL_SCHEMA_V1_START_AT_UTC>` |
+| Auth-export schedule | `<AUTH_EXPORT_SCHEDULE_UTC>` |
+| Transform schedule owner | `<TRANSFORM_SCHEDULE_OWNER>` |
+| Privacy sweep schedule | `<PRIVACY_SWEEP_SCHEDULE_UTC>` |
+| Dashboard owner | `<DASHBOARD_OWNER>` |
+| Dashboard viewer group | `<DASHBOARD_VIEWER_GROUP>` |
+| Dashboard refresh/cache policy | `<DASHBOARD_REFRESH_POLICY>` |
+
+## Verified cloud facts
+
+These facts were observed during the 2026-07-31 controlled preflight. They do
+not clear the deployment block above.
+
+| Fact | Verified value |
+| --- | --- |
+| GCP/Firebase project | `sesori-ai` |
+| GA4 property | `529377727` |
+| Raw GA4 dataset | `analytics_529377727` |
+| BigQuery location | `europe-west3` |
+| Export mode | Daily tables; do not enable streaming/intraday export |
+| Earliest daily table | `events_20260725`, representing 2026-07-25 |
+| Raw default table expiration | 90 days |
+| Existing raw daily-table expiration | 90 days |
+| Billing | Active and linked |
+| Alert budget | USD 10 per month, project scoped, all services |
+| Actual-spend alert thresholds | 50%, 80%, and 100% |
+| Forecast-spend alert threshold | 100% |
+| BigQuery on-demand project query quota | 10 GiB per day |
+| BigQuery on-demand principal query quota | 2 GiB per day |
+
+The earliest table date is evidence that export data exists. It is not an exact
+`raw_export_start_at`, does not prove the first table was controlled before it
+landed, and does not prove GA4 privacy settings or IAM were correct at that
+time.
+
+## Controlled preflight
+
+Use a named operator account with read-only project, billing, IAM, BigQuery,
+Firebase, and GA4 access for preflight. Record command output in the restricted
+change record. Do not use a deployment service account for discovery and do not
+grant roles merely to make a check pass.
+
+### 1. Establish the operator context
+
+Run from the apps-monorepo root:
+
+```bash
+gcloud config get-value project
+gcloud auth list --filter=status:ACTIVE
+bq version
+dart --version
+```
+
+The selected project must be `sesori-ai`. `bq`, including calls made by
+`deploy.dart`, uses the active Cloud SDK credential shown by `gcloud auth list`;
+it does not use Application Default Credentials (ADC). The auth export uses ADC;
+privacy-deletion jobs use their attached metadata-server identity by default.
+They never perform login or read a downloaded service-account key file. Check
+local ADC separately only for explicit operator API checks or an approved manual
+privacy run that opts into fallback:
+
+```bash
+gcloud auth application-default print-access-token >/dev/null
+```
+
+Stop if either credential source is ambiguous, a JSON key is being used, or the
+operator cannot distinguish read-only preflight from a mutating deployment.
+
+### 2. Verify GA4 privacy settings
+
+GA4 property `529377727` must use two-month event/user-data retention, with the
+reset-on-new-activity behavior disabled so activity cannot extend the intended
+two-month user-data window. Google Signals must be disabled.
+
+Read the current Admin API values with an operator credential that has only the
+required Analytics read scope. Put the bearer header in a mode-600 curl config;
+never place an access token in curl's command arguments or shell history:
+
+```bash
+umask 077
+ANALYTICS_TOKEN_FILE="$(mktemp)"
+ANALYTICS_CURL_CONFIG="$(mktemp)"
+gcloud auth application-default print-access-token \
+  --scopes=https://www.googleapis.com/auth/analytics.readonly \
+  >"${ANALYTICS_TOKEN_FILE}"
+{
+  printf '%s\n' 'fail' 'silent' 'show-error'
+  printf 'header = "Authorization: Bearer '
+  tr -d '\r\n' <"${ANALYTICS_TOKEN_FILE}"
+  printf '"\n'
+} >"${ANALYTICS_CURL_CONFIG}"
+rm -f "${ANALYTICS_TOKEN_FILE}"
+
+curl --config "${ANALYTICS_CURL_CONFIG}" \
+  "https://analyticsadmin.googleapis.com/v1alpha/properties/529377727/dataRetentionSettings"
+
+curl --config "${ANALYTICS_CURL_CONFIG}" \
+  "https://analyticsadmin.googleapis.com/v1alpha/properties/529377727/googleSignalsSettings"
+
+rm -f "${ANALYTICS_CURL_CONFIG}"
+unset ANALYTICS_TOKEN_FILE ANALYTICS_CURL_CONFIG
+```
+
+Require and record all of this evidence:
+
+- `eventDataRetention` is `TWO_MONTHS`;
+- `resetUserDataOnNewActivity` is `false`;
+- Google Signals `state` is `GOOGLE_SIGNALS_DISABLED`, not unspecified or
+  merely pending a change;
+- ads personalization is disabled for the property and every applicable data
+  stream;
+- ad storage and ad user-data features are disabled;
+- no Google Ads or ad-network audience activation broadens the approved use;
+- Android `AD_ID`, Apple IDFV collection, and automatic ad-network registration
+  remain disabled in the released Firebase configuration; and
+- the property timezone is recorded, while this warehouse still reports in UTC.
+
+Retention and Google Signals have Admin API read methods. The remaining ads and
+stream settings must also be inspected in GA4/Firebase Admin because no single
+API response proves the complete posture. Capture screenshots or exported
+configuration in the restricted approval record, not in this repository.
+
+If any setting is unverified or cannot be applied, stop. Do not alter the
+privacy boundary in this runbook to match a looser property.
+
+### 3. Verify the raw export
+
+Use explicit project and location on every BigQuery operation:
+
+```bash
+bq show --project_id=sesori-ai --format=prettyjson \
+  sesori-ai:analytics_529377727
+
+bq ls --project_id=sesori-ai --format=prettyjson --max_results=1000 \
+  sesori-ai:analytics_529377727
+
+bq show --project_id=sesori-ai --format=prettyjson \
+  sesori-ai:analytics_529377727.events_20260725
+```
+
+Verify that the dataset location is `europe-west3`, the default expiration is
+90 days, every current `events_YYYYMMDD` table expires 90 days after creation,
+and no `events_intraday_*` table exists. Recheck all tables rather than assuming
+the default repaired tables created before the default changed.
+
+The GA4 link must remain daily-only. Do not unlink it as a rollback mechanism;
+export is not retroactive and unlinking creates an unrecoverable gap.
+
+### 4. Verify billing controls and quotas
+
+Confirm the active billing link, the project-scoped all-services USD 10 monthly
+alert budget, its notification channels, and these thresholds:
+
+| Threshold type | Threshold | Nominal monthly spend |
+| --- | --- | --- |
+| Actual | 50% | USD 5 |
+| Actual | 80% | USD 8 |
+| Actual | 100% | USD 10 |
+| Forecast | 100% | USD 10 forecast |
+
+Confirm BigQuery on-demand query quota overrides are 10 GiB per project per day
+and 2 GiB per principal per day. Record quota names and effective values from
+the Cloud console/API in the restricted deployment record.
+
+Budgets are **alerts only**. They do not cap spend, reject queries, disable
+services, or guarantee timely delivery. Query quotas can reject warehouse or
+dashboard queries, but they do not cap non-query service costs and are not a
+replacement for the budget. A failed scheduled query caused by quota exhaustion
+is a freshness incident, not a zero-usage day.
+
+### 5. Verify restricted IAM
+
+Export the project IAM policy for restricted review and inspect dataset/table
+access separately:
+
+```bash
+gcloud projects get-iam-policy sesori-ai --format=json
+
+bq show --project_id=sesori-ai --format=prettyjson \
+  sesori-ai:analytics_529377727
+```
+
+Reject broad primitive roles and project-wide BigQuery data-viewer/editor roles
+that make raw or private datasets visible to ordinary project members. Confirm
+that each service identity in the identity matrix below exists, is owned by the
+approved team, uses keyless workload identity/ADC, and has no unexplained role.
+
+### 6. Go/no-go record
+
+Preflight passes only when every approval placeholder has a value in the
+restricted record, every expected deny test succeeds, the exact raw start is
+approved, and the dashboard owner/group are approved. A partially complete
+check is a no-go. Dry-running repository SQL is permitted before approval;
+mutating cloud state is not.
+
+## Data architecture
+
+All derived datasets must be created in `europe-west3`. Dataset names are fixed
+defaults for this deployment; changing one requires an explicit migration, not
+a Looker-side alias.
+
+### Dataset dictionary
+
+| Dataset | Classification | Retention and contents | Allowed readers/writers |
+| --- | --- | --- | --- |
+| `analytics_529377727` | Raw restricted | Firebase-managed `events_YYYYMMDD`; 90-day default and current-table expiration | Analytics/security admins and transform/deletion identities only |
+| `sesori_analytics_auth_private` | Pseudonymous private | Current eligible auth snapshot, aggregate setup cohorts, run metadata/state, and expiring staging tables | Auth export writes; transform reads; deletion repairs; admins oversee |
+| `sesori_analytics_privacy_private` | Privacy restricted | Deletion targets and status only | Suppression handoff and deletion identity; security/privacy admins |
+| `sesori_analytics_controls` | Restricted controls | Permanent internal and deletion exclusions, measurement starts, freshness policy, and authorized exclusion view | Deployment identity writes; transform reads; auth export sees one authorized view only |
+| `sesori_analytics_curated` | Minimized pseudonymous | Allowlisted event facts, daily user activity, milestones, cohorts, and scheduled intermediates | Transform identity writes; analytics engineers read; deletion repairs |
+| `sesori_analytics_reporting` | Identifier-free reporting | Aggregate authorized reporting views | Deployment creates views; Looker and approved product leadership read; deletion receives metadata-only inventory access |
+
+Looker Studio and routine viewers may access only
+`sesori_analytics_reporting`. They must not receive access to raw, auth-private,
+privacy-private, controls, curated user-level tables, or `user_key`.
+
+### Raw boundary
+
+The vendor-managed raw GA4 schema can contain `user_pseudo_id`, GA session
+identifiers, device and app metadata, derived geography, stream/bundle metadata,
+traffic-source strings, Firebase automatic events, and native `screen_view`
+rows. Source IP is not an exported column, but Google may derive geography
+before export.
+
+The curated pipeline must never select installation IDs, session IDs, device
+brand/model, geography, user properties, advertising/vendor identifiers,
+bundle sequence, stream ID, or arbitrary traffic-source values. Firebase
+automatic events and native `screen_view` do not define product activity.
+
+### Auth-private objects
+
+| Object | Grain and contract |
+| --- | --- |
+| `auth_user_milestones` | One currently eligible, non-internal, non-suppressed account per `user_key`; account creation, notification registration, bridge registration, legacy metadata-request milestone, and export time |
+| `auth_weekly_setup_cohorts` | One external-account creation week; identifier-free account totals, preference coverage, and 1/7/30-day setup counts after internal/source suppression |
+| `product_analytics_export_runs` | One successful export publication; aggregate source/exclusion/reconciliation counts, immutable cutoff, completion, and freshness metadata only |
+| `product_analytics_export_state` | Singleton distributed lease and last successfully published cutoff; an equal/older or overlapping run cannot replace newer state |
+| Run staging tables | One export run; only pseudonymous or aggregate rows, hidden from reporting and expiring within 24 hours |
+
+`notification_registered_at` proves notification registration, not complete
+mobile setup. `legacy_first_metadata_request_at` is a historical setup signal,
+not a successful session creation or full activation.
+
+### Privacy-private and control objects
+
+| Object | Contract |
+| --- | --- |
+| `product_analytics_deletion_targets` | External privacy request ID, HMAC `user_key`, deletion-only legacy Firebase user ID, source tombstone time, status, and non-identifying operation metadata; no raw account ID |
+| `permanent_internal_user_exclusions` | Permanent HMAC `user_key`, owner, reason, and creation time; never committed to Git and never expired to reintroduce history |
+| `internal_exclusion_control_state` | Singleton common `control_updated_at`; advance only when the permanent exclusion set is reviewed |
+| `auth_permanent_internal_exclusions` | Read-only projection for auth export with `user_key`, `is_active`, and common `control_updated_at`, including a null-key freshness sentinel |
+| `permanent_deletion_exclusions` | Permanent HMAC `user_key` tombstones used by every flattened/reported rebuild and recurring sweep |
+| `analytics_measurement_config` | Exactly one approved `raw_export_start_at`, one independently approved `behavioral_schema_v1_start_at`, clock-skew/freshness policy, and update audit metadata |
+| `product_analytics_privacy_sweep_state` | Last successful raw-partition watermark and run status; no discovered installation identifier is persisted |
+
+### Curated objects
+
+| Object | Grain and contract |
+| --- | --- |
+| `transform_state` | One last-success watermark/quality row per transform with source range, completion/auth freshness, bounded rejection counts, and latest event times; no identifiers |
+| `events_flattened` | One deduplicated, allowlisted account-linked custom event; keeps `user_key`, event name, schema, validated occurrence/emission UTC timestamps, platform/app version/build, and bounded event parameters only |
+| `installation_login_daily` | UTC date/platform/app version/provider/failure-kind aggregate counts; never contains `user_pseudo_id` or `user_key`; always flags `includes_internal_test_traffic=true` |
+| `user_activity_daily` | One eligible user/UTC date with bounded monitoring, control, message, voice, diff, screen, and feature flags/counts |
+| `user_milestones` | One eligible user with auth milestones and earliest foundation, activation-capable, project, activation, monitoring, and feature milestones |
+| `activation_cohorts` | Account creation cohort with 1/7/30-day setup/activation flags, latency, maturity, and separate preference/foundation/activation-capability coverage |
+| `retention_cohorts` | Activation-week cohort with W1 (days 7-13) and W4 (days 28-34) eligible denominators, meaningful-activity numerators, and separate flags that become mature only after every activated user in that week has completed the window |
+| `weekly_engagement` | One complete UTC Monday-Sunday week with meaningful/controller WAU, activity-depth percentiles, intervention/message/voice/feature totals, and refresh time |
+| `screen_usage_weekly` | Complete week/platform/app version/build/pinned screen with identifier-free unique-user and view counts |
+| `onboarding_friction_weekly` | Complete week and bounded diagnostic dimensions with identifier-free user/event counts |
+
+`events_flattened` is recoverable only while the relevant raw partitions remain
+inside the 90-day window. Minimized pseudonymous curated facts are retained for
+426 days (approximately 14 months) initially. Identifier-free aggregate history may be retained longer
+only after privacy approval.
+
+### Reporting views
+
+| View | Contract |
+| --- | --- |
+| `investor_snapshot` | One null-capable headline row with independently labeled latest complete account week, engagement week, and mature seven-day activation cohort, plus comparisons, coverage, and as-of timestamps |
+| `weekly_kpis` | Complete-week new accounts, meaningful/controller WAU, growth, activity depth, and setup/activation conversion |
+| `activation_funnel` | Account-to-bridge-to-project-to-message cohorts with mature 1/7/30-day windows, aggregate time-to-step buckets/percentiles, and notification registration kept separate |
+| `retention` | Activation-anchored W1/W4 cohort-maturity flags; numerators, eligible denominators, and rates remain null until every activated user in the week completes that window |
+| `feature_adoption` | Worktree, diff, question/permission, abort, remote-created-session, voice, and related bounded adoption aggregates |
+| `installation_login_funnel` | Account-less attempt started/completed/failed aggregates and provider rates; diagnostic only and potentially includes internal/test release traffic |
+| `screen_usage` | Account-level users/views for pinned screens from `product_screen_viewed` only |
+| `onboarding_friction` | Empty states, bounded creation failures, and confirmed support/install outcomes |
+| `data_quality` | Raw/auth/reporting freshness, schema/app versions, invalid timing/identity/enums, exclusion counts, coverage, maturity, and pipeline status |
+
+The exact Looker chart, field, filter, formula, and labeling contract is in
+[`LOOKER_STUDIO.md`](LOOKER_STUDIO.md). Do not reproduce warehouse metric logic
+with ad hoc Looker blends or formulas.
+
+### Event allowlist
+
+Every account-linked event also has schema version, a validated 64-character
+lowercase HMAC `user_key`, and `occurred_at_micros`. The warehouse converts raw
+GA microseconds with `TIMESTAMP_MICROS`; it does not substitute SDK emission time
+when occurrence time is invalid.
+
+| Event | Allowed event-specific parameters | Reporting meaning |
+| --- | --- | --- |
+| `analytics_schema_ready` | None | Foundation/preference coverage only |
+| `analytics_activation_ready` | `activation_schema_version=1` | Activation-capable exposure, never activity |
+| `project_inventory_loaded` | `inventory_state=empty\|non_empty` | Project availability or onboarding friction |
+| `session_activity_viewed` | `activity_state=empty\|non_empty` | Visible meaningful monitoring; non-empty only qualifies as activity |
+| `session_message_sent` | `submission_kind=text\|command`, `input_mode=typed\|voice_assisted` | Existing-session full activation/control activity |
+| `session_created_with_message` | `submission_kind`, `input_mode`, `workspace_kind=project\|dedicated_worktree` | Remote-created-session full activation |
+| `session_creation_failed` | `failure_reason=not_authenticated\|server_rejected\|network_down\|bad_response\|unknown`, `workspace_kind` | Bounded creation friction only |
+| `voice_transcription_completed` | None | Content-free voice adoption |
+| `session_question_answered` | None | Successful intervention |
+| `session_question_rejected` | None | Successful intervention |
+| `session_permission_answered` | `decision=once\|always\|reject` | Successful intervention |
+| `session_abort_succeeded` | None | Successful intervention |
+| `session_diff_viewed` | `change_state=empty\|non_empty` | Non-empty diff adoption; empty is diagnostic |
+| `onboarding_need_help_opened` | `surface=connect_setup\|connected_empty\|bridge_offline` | Confirmed onboarding interaction |
+| `onboarding_support_link_opened` | `channel=email\|discord\|x`, `surface` | Confirmed external-link handoff |
+| `onboarding_why_bridge_opened` | `surface` | Onboarding information use |
+| `bridge_install_command_copied` | `method=curl\|powershell\|npm\|bun`, `os=unix\|windows`, `surface` | Confirmed copy outcome |
+| `bridge_install_command_shared` | `method`, `os`, `surface` | Confirmed share outcome |
+| `bridge_run_command_copied` | `surface` | Confirmed copy outcome |
+| `bridge_run_command_shared` | `surface` | Confirmed share outcome |
+| `product_screen_viewed` | `screen=login\|projects\|settings\|settings_notifications\|settings_profile\|sessions\|new_session\|session_detail\|session_diffs` | Canonical account-linked screen reporting; never meaningful activity |
+
+The account-less allowlist is separate:
+
+| Event | Allowed parameters | Limitation |
+| --- | --- | --- |
+| `login_attempt_started` | `provider=github\|google\|apple\|email` | Attempt denominator, not a person/account count |
+| `login_attempt_completed` | `provider` | Attempt completion, not account creation |
+| `login_attempt_failed` | `provider`, `failure_kind=authentication\|launch\|cancelled\|timeout\|unknown` | Bounded failure diagnostic |
+
+These login rows have no `user_key` or attempt ID. They cannot be reliably
+internal-filtered without creating the forbidden account-installation mapping,
+so they stay out of account funnels, retention, and investor headlines.
+
+## Least-privilege identity matrix
+
+Use separate identities even if one person administers several roles. Project
+roles grant job execution only where needed; dataset/table ACLs grant data
+access. No runtime receives a downloadable service-account key.
+
+| Identity | Minimum permitted access | Explicitly denied |
+| --- | --- | --- |
+| `<ANALYTICS_SECURITY_ADMIN_GROUP>` | Administer approved analytics datasets, IAM reviews, raw/privacy incident access | Routine dashboard use as a reason for raw access |
+| `<DEPLOYMENT_SERVICE_ACCOUNT>` | BigQuery Job User; create/update derived schemas, approved controls, authorized views, IAM, and transfer configs; act-as only approved schedule identities | Runtime Mongo secret; GA event identifiers; routine dashboard credentials |
+| `<AUTH_EXPORT_SERVICE_ACCOUNT>` | BigQuery Job User; Data Editor on `sesori_analytics_auth_private`; table-level read of the authorized internal-exclusion view; managed Mongo/HMAC secrets | Controls write/DDL; privacy-private, raw, curated, or reporting access; project-wide data roles |
+| `<TRANSFORM_SERVICE_ACCOUNT>` | BigQuery Job User; Data Viewer on raw, auth-private, and controls; Data Editor on curated only; run only declared schedules | Privacy-private; reporting writes; Mongo; GA Admin mutation; IAM or control-table mutation |
+| `<AUTH_SUPPRESSION_SERVICE_ACCOUNT>` | BigQuery Job User; Mongo suppression operation; table-scoped query/MERGE and status read on `product_analytics_deletion_targets` only; managed HMAC/Mongo secrets | Dataset-wide privacy access; auth export tables, controls, raw, curated, reporting, and GA Admin API |
+| `<PRIVACY_DELETION_SERVICE_ACCOUNT>` | BigQuery Job User; read privacy targets/raw; write deletion exclusions/status and the sweep checkpoint; delete affected raw/auth-private/curated keyed rows; rebuild the fixed curated aggregate chain; metadata-only inventory access on reporting; Analytics Admin `analytics.edit` only for deletion submission | Reporting data mutation; Mongo; deployment/IAM administration; unrelated control mutation; Looker ownership; general GA property administration |
+| `<LOOKER_SERVICE_ACCOUNT>` | BigQuery Job User and Data Viewer on `sesori_analytics_reporting` only | Raw, auth-private, privacy-private, controls, curated, `user_key`, and write access |
+| `<DASHBOARD_VIEWER_GROUP>` | View the restricted Looker report through approved data-source credentials | Direct BigQuery access, data-source editing/reuse, public/link sharing |
+| Auth web runtime | Existing web preference service and managed HMAC secret | Every BigQuery role and every warehouse/deletion class |
+
+Before rollout, test both positive and negative access paths. A successful
+expected-deny query is a release blocker.
+
+## Blocked IAM and API application procedure
+
+**This entire procedure remains blocked. Do not run any command in this section
+until every identity placeholder and the deployment change are approved.** The
+commands are retained as an exact keyless application procedure; they are not
+evidence that any grant or API is currently present.
+
+After approval, run as the named deployment operator, confirm the active Cloud
+SDK identity and project again, and enable only the required APIs if an approved
+preflight proves one is disabled:
+
+```bash
+gcloud services enable \
+  bigquery.googleapis.com \
+  bigquerydatatransfer.googleapis.com \
+  iam.googleapis.com \
+  iamcredentials.googleapis.com \
+  --project=sesori-ai
+```
+
+Apply the dataset/table roles from the least-privilege matrix individually; do
+not substitute project-wide BigQuery data roles. After `00_datasets.sql` and
+`50_reporting_views.sql` have created the views, add each view to every source
+dataset it reads. Merely granting Looker access to the reporting dataset is not
+enough: without these authorized-view ACL entries, a reporting-only identity
+cannot query the views, while granting it the source datasets would break the
+privacy boundary.
+
+Use the etag-protected REST procedure below. It preserves every existing ACL
+entry and keeps the bearer token in a mode-600 curl config rather than a command
+argument. The controls self-authorization is for the auth-export exclusion
+view; the remaining entries authorize the identifier-free reporting views over
+their exact auth, controls, and curated sources:
+
+```bash
+umask 077
+BQ_TOKEN_FILE="$(mktemp)"
+BQ_CURL_CONFIG="$(mktemp)"
+ACL_FILE="$(mktemp)"
+PATCH_FILE="$(mktemp)"
+gcloud auth print-access-token >"${BQ_TOKEN_FILE}"
+{
+  printf '%s\n' 'fail' 'silent' 'show-error'
+  printf 'header = "Authorization: Bearer '
+  tr -d '\r\n' <"${BQ_TOKEN_FILE}"
+  printf '"\n'
+} >"${BQ_CURL_CONFIG}"
+rm -f "${BQ_TOKEN_FILE}"
+
+authorize_views() {
+  SOURCE_DATASET="$1"
+  VIEW_DATASET="$2"
+  VIEW_NAMES_JSON="$3"
+
+  curl --config "${BQ_CURL_CONFIG}" \
+    "https://bigquery.googleapis.com/bigquery/v2/projects/sesori-ai/datasets/${SOURCE_DATASET}?datasetView=ACL" \
+    >"${ACL_FILE}"
+
+  jq --arg project "sesori-ai" \
+    --arg view_dataset "${VIEW_DATASET}" \
+    --argjson views "${VIEW_NAMES_JSON}" '
+      (.access // []) as $access
+      | {access: reduce $views[] as $view ($access;
+          if any(.[]?;
+            .view.projectId == $project
+            and .view.datasetId == $view_dataset
+            and .view.tableId == $view)
+          then .
+          else . + [{view: {
+            projectId: $project,
+            datasetId: $view_dataset,
+            tableId: $view
+          }}]
+          end
+        )}
+    ' "${ACL_FILE}" >"${PATCH_FILE}"
+
+  ETAG="$(jq -r '.etag // empty' "${ACL_FILE}")"
+  test -n "${ETAG}"
+  curl --config "${BQ_CURL_CONFIG}" --request PATCH \
+    --header "Content-Type: application/json" \
+    --header "If-Match: ${ETAG}" \
+    --data-binary "@${PATCH_FILE}" \
+    "https://bigquery.googleapis.com/bigquery/v2/projects/sesori-ai/datasets/${SOURCE_DATASET}?updateMode=UPDATE_ACL"
+}
+
+authorize_views \
+  sesori_analytics_controls \
+  sesori_analytics_controls \
+  '["auth_permanent_internal_exclusions"]'
+authorize_views \
+  sesori_analytics_auth_private \
+  sesori_analytics_reporting \
+  '["data_quality"]'
+authorize_views \
+  sesori_analytics_controls \
+  sesori_analytics_reporting \
+  '["data_quality"]'
+authorize_views \
+  sesori_analytics_curated \
+  sesori_analytics_reporting \
+  '["weekly_kpis","investor_snapshot","activation_funnel","retention","feature_adoption","installation_login_funnel","screen_usage","onboarding_friction","data_quality"]'
+
+rm -f "${BQ_CURL_CONFIG}" "${ACL_FILE}" "${PATCH_FILE}"
+unset BQ_TOKEN_FILE BQ_CURL_CONFIG ACL_FILE PATCH_FILE ETAG
+unset SOURCE_DATASET VIEW_DATASET VIEW_NAMES_JSON
+unset -f authorize_views
+```
+
+Fetch every source dataset ACL again and verify those exact view entries exist,
+no other reporting view was authorized, and no Looker principal gained direct
+source-dataset access. Any later reporting view that reads a private source
+requires a reviewed ACL update; reporting-dataset membership is never a blanket
+authorization for future views.
+
+Then grant the auth-export identity table-level read on only that view, and
+grant the deployment identity service-account act-as on only the approved
+transform identity. `roles/iam.serviceAccountUser` supplies
+`iam.serviceAccounts.actAs`; do not replace it with project-wide Service Account
+User or Token Creator:
+
+```bash
+bq --project_id=sesori-ai add-iam-policy-binding \
+  --member="serviceAccount:<AUTH_EXPORT_SERVICE_ACCOUNT>" \
+  --role="roles/bigquery.dataViewer" \
+  "sesori-ai:sesori_analytics_controls.auth_permanent_internal_exclusions"
+
+gcloud iam service-accounts add-iam-policy-binding \
+  "<TRANSFORM_SERVICE_ACCOUNT>" \
+  --project=sesori-ai \
+  --member="serviceAccount:<DEPLOYMENT_SERVICE_ACCOUNT>" \
+  --role="roles/iam.serviceAccountUser"
+```
+
+Verify effective act-as without creating a transfer config. Before the binding,
+the response `permissions` array must be empty; after the binding, it must
+contain exactly `iam.serviceAccounts.actAs`. The verifier needs separately
+approved, resource-scoped impersonation permission on the deployment identity
+for this check:
+
+```bash
+umask 077
+DEPLOYMENT_TOKEN_FILE="$(mktemp)"
+DEPLOYMENT_CURL_CONFIG="$(mktemp)"
+gcloud auth print-access-token \
+  --impersonate-service-account="<DEPLOYMENT_SERVICE_ACCOUNT>" \
+  >"${DEPLOYMENT_TOKEN_FILE}"
+{
+  printf '%s\n' 'fail' 'silent' 'show-error'
+  printf 'header = "Authorization: Bearer '
+  tr -d '\r\n' <"${DEPLOYMENT_TOKEN_FILE}"
+  printf '"\n'
+} >"${DEPLOYMENT_CURL_CONFIG}"
+rm -f "${DEPLOYMENT_TOKEN_FILE}"
+
+curl --config "${DEPLOYMENT_CURL_CONFIG}" --request POST \
+  --header "Content-Type: application/json" \
+  --data '{"permissions":["iam.serviceAccounts.actAs"]}' \
+  "https://iam.googleapis.com/v1/projects/-/serviceAccounts/<TRANSFORM_SERVICE_ACCOUNT>:testIamPermissions"
+
+rm -f "${DEPLOYMENT_CURL_CONFIG}"
+unset DEPLOYMENT_TOKEN_FILE DEPLOYMENT_CURL_CONFIG
+```
+
+Before the grants, both auth-export probes below must be denied. After the
+grants, only the view query may succeed; the underlying-table query must still
+return `Access Denied`. Run these as the approved verifier with narrowly scoped,
+time-bounded impersonation permission on the identity under test:
+
+```bash
+CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT="<AUTH_EXPORT_SERVICE_ACCOUNT>" \
+  bq query --project_id=sesori-ai --location=europe-west3 \
+    --use_legacy_sql=false \
+    'SELECT user_key, is_active, control_updated_at FROM `sesori-ai.sesori_analytics_controls.auth_permanent_internal_exclusions` LIMIT 0'
+
+CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT="<AUTH_EXPORT_SERVICE_ACCOUNT>" \
+  bq query --project_id=sesori-ai --location=europe-west3 \
+    --use_legacy_sql=false \
+    'SELECT 1 FROM `sesori-ai.sesori_analytics_controls.permanent_internal_user_exclusions` LIMIT 0'
+```
+
+Confirm the transform service-account policy contains exactly the approved
+deployment principal under `roles/iam.serviceAccountUser` and no unintended
+Token Creator grant. After schedule application, confirm each transfer config
+runs as `<TRANSFORM_SERVICE_ACCOUNT>`, then require expected-deny probes against
+privacy-private data and IAM mutation to fail under that identity. Any
+unexpected success blocks rollout; remove the excess grant rather than
+broadening the matrix.
+
+## Authorized internal-exclusion view
+
+The auth export must receive exactly one fully qualified view:
+`sesori-ai.sesori_analytics_controls.auth_permanent_internal_exclusions`.
+Grant access to the view, not the controls dataset or underlying table.
+
+The view contract is exactly:
+
+| Column | Type | Rule |
+| --- | --- | --- |
+| `user_key` | nullable `STRING` | Active rows are unique lowercase 64-character HMAC hex values; the null row is the freshness sentinel |
+| `is_active` | non-null `BOOL` | `true` for active permanent exclusions; `false` for the null-key sentinel |
+| `control_updated_at` | non-null `TIMESTAMP` | One common control version/update time across every returned row |
+
+The view must return one null-`user_key` sentinel even when no internal account
+is listed. Missing, stale, malformed, duplicate, mixed-version, or oversized
+output aborts auth publication; the export must never fall back to an empty set.
+The default maximum age is 48 hours, the default maximum active set is 10,000,
+and the runtime hard maximums remain 30 days and 100,000 respectively.
+
+The control owner must review the permanent set and advance the common
+`control_updated_at` through the protected control procedure at least once
+inside every 48-hour window, including when the set is unchanged. Do not update
+the timestamp automatically without an actual review; a stale sentinel is
+supposed to stop auth publication.
+
+Internal/test exclusions are permanent. Add only a server-derived HMAC
+`user_key` through a protected operator flow with an owner and reason. Never
+derive the key in SQL, put the raw account ID or key in a ticket, or delete an
+exclusion to make historical metrics rise. Every curated rebuild and every
+current eligible-user reporting join must continue to exclude it.
+
+## Measurement controls
+
+Store controls in `sesori_analytics_controls` through the deployment identity.
+They are immutable measurement boundaries, not dashboard parameters.
+
+### `raw_export_start_at`
+
+Set `<RAW_EXPORT_START_AT_UTC>` only after an operator verifies the first daily
+table under the approved raw ACL, 90-day expiration, daily-only link, and GA4
+privacy settings. Use the exact recorded UTC verification timestamp. Do not use
+`2026-07-25T00:00:00Z`, the `events_20260725` suffix, table creation time, or
+the beginning of an app release as a substitute.
+
+### `behavioral_schema_v1_start_at`
+
+Set `<BEHAVIORAL_SCHEMA_V1_START_AT_UTC>` only after the production outcome
+release produces `analytics_activation_ready` with
+`activation_schema_version=1` in controlled raw export. Foundation-only
+`analytics_schema_ready` and account-less login events do not qualify.
+
+Activation/retention eligibility also requires each account to have
+activation-capable exposure no later than 24 hours after account creation. The
+global timestamp alone never makes a legacy client measurable.
+
+If either timestamp is disputed, stop publication. Do not silently rewrite it;
+open an incident, preserve the prior control version/evidence, approve a
+correction, rebuild affected outputs, and annotate the reporting interval.
+
+## Deployment CLI
+
+The deploy command renders checked-in identifier placeholders and invokes `bq`
+non-interactively with explicit project/location. It does not log in, read key
+files, create secrets, insert internal keys, or discover approval values.
+
+Run all commands from the apps-monorepo root. The exact common arguments are:
+
+```text
+--project=sesori-ai
+--location=europe-west3
+--raw-dataset-id=analytics_529377727
+--auth-dataset-id=sesori_analytics_auth_private
+--privacy-dataset-id=sesori_analytics_privacy_private
+--controls-dataset-id=sesori_analytics_controls
+--curated-dataset-id=sesori_analytics_curated
+--reporting-dataset-id=sesori_analytics_reporting
+--raw-export-start-at=<RAW_EXPORT_START_AT_UTC>
+--behavioral-schema-v1-start-at=<BEHAVIORAL_SCHEMA_V1_START_AT_UTC>
+```
+
+Placeholders are shown literally and are not executable values. Obtain approved
+timestamps from the restricted record without committing them if policy keeps
+those values private.
+
+### Render and validate only
+
+With no mode flag, the command validates the manifest and renders every numeric
+SQL template in memory. It does not invoke `bq` or mutate anything:
+
+The timestamps below are deliberately synthetic and safe only because this is
+render-only mode. Never reuse them with `--dry-run` or `--apply`.
+
+```bash
+dart tool/product_analytics/deploy.dart \
+  --project=sesori-ai \
+  --location=europe-west3 \
+  --raw-dataset-id=analytics_529377727 \
+  --auth-dataset-id=sesori_analytics_auth_private \
+  --privacy-dataset-id=sesori_analytics_privacy_private \
+  --controls-dataset-id=sesori_analytics_controls \
+  --curated-dataset-id=sesori_analytics_curated \
+  --reporting-dataset-id=sesori_analytics_reporting \
+  --raw-export-start-at="2000-01-01T00:00:00Z" \
+  --behavioral-schema-v1-start-at="2000-01-02T00:00:00Z"
+```
+
+### BigQuery dry-run
+
+This command validates arguments, renders every SQL asset, and submits BigQuery
+whole-script dry runs. The tool requests JSON from `bq`, parses it, and prints
+only `totalBytesProcessed` plus `totalBytesProcessedAccuracy` from that backend
+response for each asset. It must not mutate datasets, tables, views, or
+schedules:
+
+```bash
+dart tool/product_analytics/deploy.dart \
+  --project=sesori-ai \
+  --location=europe-west3 \
+  --raw-dataset-id=analytics_529377727 \
+  --auth-dataset-id=sesori_analytics_auth_private \
+  --privacy-dataset-id=sesori_analytics_privacy_private \
+  --controls-dataset-id=sesori_analytics_controls \
+  --curated-dataset-id=sesori_analytics_curated \
+  --reporting-dataset-id=sesori_analytics_reporting \
+  --raw-export-start-at="<RAW_EXPORT_START_AT_UTC>" \
+  --behavioral-schema-v1-start-at="<BEHAVIORAL_SCHEMA_V1_START_AT_UTC>" \
+  --dry-run
+```
+
+BigQuery SCRIPT estimates are best-effort. Accuracy can be `PRECISE`,
+`LOWER_BOUND`, `UPPER_BOUND`, or `UNKNOWN`; a `LOWER_BOUND` can be materially
+below actual billed bytes and is not evidence that a query fits its allocation.
+If BigQuery omits the estimate, the tool prints `totalBytesProcessed=unavailable`
+and `accuracy=UNKNOWN` rather than inferring precision.
+Review the estimate and accuracy against both the manifest allocation and the 2
+GiB principal/10 GiB project daily quotas, then verify actual production job
+bytes before enabling schedules. Dry-run success does not prove a cost ceiling,
+IAM deny boundaries, source freshness, or metric correctness. If `bq` fails or
+returns malformed output, the tool reports only a bounded operation error and
+suppresses backend details.
+
+### Apply schemas and transforms without schedules
+
+Only after the deployment block is cleared, pass the explicit mutating
+`--apply` mode without `--apply-schedules`:
+
+```bash
+dart tool/product_analytics/deploy.dart \
+  --project=sesori-ai \
+  --location=europe-west3 \
+  --raw-dataset-id=analytics_529377727 \
+  --auth-dataset-id=sesori_analytics_auth_private \
+  --privacy-dataset-id=sesori_analytics_privacy_private \
+  --controls-dataset-id=sesori_analytics_controls \
+  --curated-dataset-id=sesori_analytics_curated \
+  --reporting-dataset-id=sesori_analytics_reporting \
+  --raw-export-start-at="<RAW_EXPORT_START_AT_UTC>" \
+  --behavioral-schema-v1-start-at="<BEHAVIORAL_SCHEMA_V1_START_AT_UTC>" \
+  --apply
+```
+
+Apply order is fixed: datasets/reference schemas, flattened events, account-less
+login aggregates, daily activity, milestones/cohorts, then reporting views. A
+failure stops the run; do not skip ahead or point Looker at partial objects.
+Every direct apply job uses that asset's manifest/deployment
+`maximum_bytes_billed`; scheduled-query runs cannot use this job setting.
+
+### Run fixture and schema assertions
+
+The deployment CLI intentionally operates only on numeric assets under `sql/`;
+it has no assertion mode. Run the self-contained metric fixture directly. The
+schema assertion intentionally contains dataset placeholders, so render only
+the six allowlisted identifiers into the `bq` stdin stream; do not create an
+operator-edited SQL copy:
+
+```bash
+bq --headless=true --quiet=true \
+  --project_id=sesori-ai \
+  --location=europe-west3 \
+  query --use_legacy_sql=false --maximum_bytes_billed=1073741824 \
+  < tool/product_analytics/tests/metric_contract_assertions.sql
+
+perl -pe '
+  s/\{\{PROJECT_ID\}\}/sesori-ai/g;
+  s/\{\{AUTH_DATASET_ID\}\}/sesori_analytics_auth_private/g;
+  s/\{\{PRIVACY_DATASET_ID\}\}/sesori_analytics_privacy_private/g;
+  s/\{\{CONTROLS_DATASET_ID\}\}/sesori_analytics_controls/g;
+  s/\{\{CURATED_DATASET_ID\}\}/sesori_analytics_curated/g;
+  s/\{\{REPORTING_DATASET_ID\}\}/sesori_analytics_reporting/g;
+' tool/product_analytics/tests/schema_allowlist_assertions.sql \
+  | bq --headless=true --quiet=true \
+      --project_id=sesori-ai \
+      --location=europe-west3 \
+      query --use_legacy_sql=false --maximum_bytes_billed=1073741824
+```
+
+Require both `metric_contract_assertions.sql` and
+`schema_allowlist_assertions.sql` to pass. Assertions cover activation success
+versus queued/failed attempts, timely activation capability, cohort maturity,
+W1/W4 boundaries, occurrence time, internal/disabled/deleted exclusion,
+monitoring deduplication, voice classification, account-less login isolation,
+custom-screen-only reporting, stale auth snapshots, and late-event replacement.
+
+### Apply schedules
+
+Schedules are a separate deliberate phase. First complete one manual auth
+export and one manual transform chain. Then create/update only the transfer
+configs declared in `sql/schedules.json`:
+
+```bash
+dart tool/product_analytics/deploy.dart \
+  --project=sesori-ai \
+  --location=europe-west3 \
+  --raw-dataset-id=analytics_529377727 \
+  --auth-dataset-id=sesori_analytics_auth_private \
+  --privacy-dataset-id=sesori_analytics_privacy_private \
+  --controls-dataset-id=sesori_analytics_controls \
+  --curated-dataset-id=sesori_analytics_curated \
+  --reporting-dataset-id=sesori_analytics_reporting \
+  --raw-export-start-at="<RAW_EXPORT_START_AT_UTC>" \
+  --behavioral-schema-v1-start-at="<BEHAVIORAL_SCHEMA_V1_START_AT_UTC>" \
+  --transform-service-account="<TRANSFORM_SERVICE_ACCOUNT>" \
+  --apply \
+  --apply-schedules
+```
+
+`--apply-schedules` is invalid unless both `--apply` and
+`--transform-service-account` are supplied. The current manifest is:
+
+| Display name | UTC cadence | Query | Recent dates | Daily allocation/direct-apply maximum |
+| --- | --- | --- | --- | --- |
+| `Sesori Product Analytics - 10 Events Flattened` | Daily 04:00 | `10_events_flattened.sql` | 3 | 512 MiB |
+| `Sesori Product Analytics - 15 Installation Login Daily` | Daily 04:15 | `15_installation_login_daily.sql` | 3 | 256 MiB |
+| `Sesori Product Analytics - 20 User Activity Daily` | Daily 04:30 | `20_user_activity_daily.sql` | 3 | 256 MiB |
+| `Sesori Product Analytics - 30 User Milestones` | Daily 04:45 | `30_user_milestones.sql` | 3 | 256 MiB |
+| `Sesori Product Analytics - 40 Activation Retention` | Daily 05:00 | `40_activation_retention.sql` | 3 | 512 MiB |
+
+The manifest is the source of truth for query file, cadence, recent-date
+recomputation, display name, and byte allocation. Validation rejects any one
+schedule above 512 MiB or a cumulative allocation above 1.75 GiB
+(1,879,048,192 bytes). The listed allocations total exactly 1.75 GiB, leaving
+256 MiB of headroom below the transform principal's 2 GiB daily quota.
+Scheduled-query transfer configs do not support a runtime
+`maximum_bytes_billed`; project/principal query quotas remain the runtime
+enforcement. Do not apply schedules unless measured production bytes fit both
+quotas. Do not create console-only schedules or use a human owner. Record
+transfer-config IDs in the restricted deployment record.
+
+Transfer configs are independent schedules, not one orchestrated chain. The
+15-minute spacing is normal sequencing only; delayed, retried, or manually
+started runs can overlap. The SQL scripts therefore enforce same-run auth and
+upstream watermark guards before publication, and each write is transactional
+or idempotent. Do not weaken those guards or assume schedule timing provides
+mutual exclusion.
+
+Before creating or updating any transfer config, `--apply-schedules` lists
+scheduled-query configs in the location. If any display name beginning with
+`Sesori Product Analytics - ` is absent from `sql/schedules.json`, the tool
+fails before the first schedule write. It never auto-deletes an obsolete
+config; review, disable, and remove it only through a separately approved
+operation, then rerun deployment.
+
+## Auth export
+
+The auth export is a one-shot command in `sesori_auth_server`; it is not an HTTP
+handler and the auth web process must never construct BigQuery clients.
+Run source-tree commands in the `sesori_auth_server` repository root, not the
+apps-monorepo root.
+
+### Runtime environment
+
+Configure these non-secret values on the isolated job:
+
+```text
+PRODUCT_ANALYTICS_GCP_PROJECT_ID=sesori-ai
+PRODUCT_ANALYTICS_AUTH_DATASET_ID=sesori_analytics_auth_private
+PRODUCT_ANALYTICS_INTERNAL_EXCLUSION_VIEW=sesori-ai.sesori_analytics_controls.auth_permanent_internal_exclusions
+PRODUCT_ANALYTICS_BIGQUERY_LOCATION=europe-west3
+PRODUCT_ANALYTICS_EXPORT_BATCH_LIMIT=500
+PRODUCT_ANALYTICS_INTERNAL_EXCLUSION_MAX_KEYS=10000
+PRODUCT_ANALYTICS_INTERNAL_EXCLUSION_MAX_AGE_MS=172800000
+```
+
+Inject `MONGODB_URI` and `PRODUCT_ANALYTICS_PSEUDONYMIZATION_KEY` from managed
+secrets. Never print, export into a checked-in env file, or manually retype the
+key. The web, export, and suppression runtimes use the same long-lived canonical
+base64 HMAC key. Rotation requires a coordinated re-key migration and is not an
+incident-response shortcut.
+
+The exact production image command is:
+
+```bash
+node dist/scripts/export-product-analytics.js
+```
+
+The source-tree equivalent for an approved non-production/manual run is:
+
+```bash
+npm run export-product-analytics
+```
+
+Both use ADC. Do not set `GOOGLE_APPLICATION_CREDENTIALS` to a downloaded key.
+
+### Scheduling
+
+Create a daily Cloud Run Job or equivalently isolated scheduler at
+`<AUTH_EXPORT_SCHEDULE_UTC>`. It must securely reach MongoDB, run as
+`<AUTH_EXPORT_SERVICE_ACCOUNT>`, use the same built image with the command
+override above, disallow overlapping executions, and remain independent of auth
+HTTP availability. If GCP cannot securely reach MongoDB, use an isolated job on
+the existing host rather than adding export work to the web process.
+
+Choose `<AUTH_EXPORT_SCHEDULE_UTC>` so a healthy export completes before the
+04:30 UTC user-level transform. The raw-only 04:00/04:15 transforms may run
+independently, but user-level publication must still assert a reconciled auth
+snapshot no older than 36 hours.
+
+Before enabling the schedule:
+
+- provision permanent auth-private schemas with the deployment identity;
+- grant only the IAM in the matrix;
+- authorize only the internal-exclusion view;
+- run one manual export with a fixed cutoff;
+- verify source, exclusion, enabled, staging, and published counts reconcile;
+- verify an equal/older or overlapping cutoff cannot publish; and
+- verify a failed run leaves the prior snapshot and cohorts intact.
+
+The run stages pseudonymous/aggregate rows, reloads the internal controls before
+promotion, reconciles current preference changes, and atomically publishes both
+auth products plus metadata. It never exports OAuth/provider identity, email,
+username, raw account ID, bridge/device identifiers, or reminder timestamps.
+
+## Freshness and recovery
+
+### Expected freshness
+
+| Layer | Healthy condition |
+| --- | --- |
+| Raw GA4 | A daily table arrives; latest three UTC event dates remain mutable for late events |
+| Auth export | Latest successful reconciled snapshot completed no more than 36 hours ago |
+| Flattened/login | Latest three UTC event dates recomputed successfully within the declared schedule |
+| User-level models | Built only from a fresh reconciled auth snapshot and current exclusions |
+| Reporting | Watermark reaches the last complete eligible period and `data_quality` reports fresh |
+| Looker | Every page displays raw/auth/reporting as-of values and stale state explicitly |
+
+An absent event can mean zero usage, delayed GA export, stale auth, failed
+transform, exclusion, unsupported client coverage, or an immature cohort. Never
+interpret it as product decline until `data_quality` distinguishes those cases.
+
+### Stale auth snapshot
+
+If the latest auth snapshot is missing, partial, unreconciled, or older than 36
+hours, user-level transforms must fail before mutation. Keep the last known-good
+reporting tables visible with stale status. `events_flattened` and
+`installation_login_daily` may continue ingesting recoverable raw facts; do not
+publish an empty user day.
+
+Recover in this order:
+
+1. Pause dependent user-level schedules, not privacy sweeps.
+2. Correct Mongo connectivity, authorized-view freshness, IAM, quota, or job
+   failure without broadening access.
+3. Run the auth export and require a newer reconciled `run_cutoff`.
+4. Recompute user-level data from the first UTC date after the last successfully
+   published reporting watermark through the latest three mutable event dates.
+5. Keep the range within the 90-day raw recovery window and dry-run byte cost.
+6. Run assertions and three-day reconciliation before advancing freshness.
+7. Resume schedules and annotate the incident interval.
+
+If the missing range has expired from raw storage, do not fabricate or copy
+forward behavioral facts. Publish an explicit measurement gap.
+
+### Late arrivals
+
+Every daily event transform recomputes at least the latest three UTC event dates
+and replaces idempotently. Recovery additionally covers any watermark gap. A
+late keyed event for a permanently deleted account is anti-joined on rebuild and
+is also covered by the overlapping privacy sweep.
+
+## Cost controls
+
+Every scheduled query declares a conservative byte allocation in
+`sql/schedules.json`: no query may exceed 512 MiB and the daily sum may not
+exceed 1.75 GiB. Direct apply uses each value as `maximum_bytes_billed`.
+Scheduled runs have no per-job maximum setting, so the 2 GiB transform-principal
+quota is the runtime backstop. Review dry-run estimate values and accuracy
+before apply and actual job bytes after material changes. A SCRIPT
+`LOWER_BOUND` estimate is not a ceiling. Partition filters must be mandatory;
+materialize repeated daily/intermediate work instead of letting Looker scan raw
+events.
+
+Operational limits are:
+
+- 10 GiB of on-demand query bytes per project per day;
+- 2 GiB of on-demand query bytes per principal per day;
+- USD 10 monthly all-services project alert budget;
+- actual-spend alerts at 50%, 80%, and 100%; and
+- forecast-spend alert at 100%.
+
+The budget is not an enforcement cap. Alert delivery can lag, all GCP services
+contribute to it, and BigQuery storage/streaming/non-query costs are not stopped
+by query quotas. Conversely, a quota failure can make reports stale before the
+budget alerts. At 50%, inspect billing by service/SKU and query job bytes. At
+80%, pause nonessential ad hoc/dashboard refreshes and investigate. At 100% or
+forecast 100%, pause non-privacy schedules if needed; never pause source
+suppression, deletion exclusion, or required deletion sweeps merely to save
+cost. Raising budget/quota values requires explicit approval.
+
+Perform a monthly cost review even when no alert fires. Record actual spend,
+forecast, bytes by scheduled identity, Looker bytes, failed quota jobs, and any
+approved change in the restricted operations record.
+
+## Privacy deletion
+
+Privacy deletion is an isolated, idempotent source-to-warehouse flow. It is not
+an ad hoc console query and not a public route.
+
+### 1. Source suppression and handoff
+
+After independently verifying the requester and external request ID, run the
+auth-server suppression command under its dedicated identity. Start the command
+without putting request content in argv or shell history, then provide the
+bounded JSON through protected stdin. Run the source command from the
+`sesori_auth_server` repository root:
+
+```bash
+npm run suppress-product-analytics-export
+```
+
+The production image command is:
+
+```bash
+node dist/scripts/suppress-product-analytics-export.js
+```
+
+Protected stdin has this shape; values shown are placeholders and must not be
+copied into this repository:
+
+```json
+{"userId":"<VERIFIED_MONGO_ACCOUNT_ID>","requestId":"<EXTERNAL_PRIVACY_REQUEST_ID>"}
+```
+
+The command atomically disables analytics and writes the permanent source
+tombstone before handing only the HMAC key, deletion-only legacy Firebase user
+ID, tombstone time, external request ID, and status to privacy-private. Output
+contains request ID/status only. A handoff failure leaves source suppression in
+place and is safely retryable.
+
+### 2. Warehouse deletion
+
+Run the layered warehouse command by external request ID under
+`<PRIVACY_DELETION_SERVICE_ACCOUNT>`:
+
+These Dart privacy jobs call the BigQuery and Analytics Admin REST APIs with
+the attached runtime identity from the GCP metadata server. They do not use the
+active Cloud SDK credential that `bq` uses. Production and scheduled jobs are
+metadata-only and fail if that identity is unavailable. An approved local
+operator run may explicitly add `--allow-gcloud-adc-fallback` to use
+`gcloud auth application-default`; fallback is disabled by default and the
+aggregate result reports when it was used. Never put that flag on a production
+or scheduled job. Leave `GOOGLE_APPLICATION_CREDENTIALS` unset because
+downloaded key files and arbitrary credential files are intentionally rejected.
+
+```bash
+dart tool/product_analytics/privacy_deletion/run_privacy_deletion.dart \
+  --project=sesori-ai \
+  --location=europe-west3 \
+  --analytics-property-id=529377727 \
+  --raw-dataset=analytics_529377727 \
+  --auth-dataset=sesori_analytics_auth_private \
+  --privacy-dataset=sesori_analytics_privacy_private \
+  --controls-dataset=sesori_analytics_controls \
+  --curated-dataset=sesori_analytics_curated \
+  --reporting-dataset=sesori_analytics_reporting \
+  --exclusions-table=permanent_deletion_exclusions \
+  --sweep-state-table=product_analytics_privacy_sweep_state \
+  --request-id="<EXTERNAL_PRIVACY_REQUEST_ID>"
+```
+
+Run the same command with `--dry-run` first. Dry-run performs reads and BigQuery
+planning but no mutation, status change, aggregate rebuild execution, or upstream
+Analytics Admin API call. The command accepts no operator-selected aggregate
+query or executable. For a mutating run it automatically rebuilds the fixed,
+checked-in `20_user_activity_daily.sql` -> `30_user_milestones.sql` ->
+`40_activation_retention.sql` transform chain in that order.
+
+The command adds and verifies the permanent deletion exclusion first, then
+performs one immediate privacy-preserving raw/curated cleanup and rebuild. It
+reads auth-export readiness exactly once; it never polls or sleeps inside the
+process. If no successful export has `run_cutoff >= suppressed_at`, the command
+records a bounded retryable outcome and exits. The approved external job or
+operator must run the auth export and invoke the same idempotent deletion
+command again. The preliminary pass deliberately does not mutate auth-private
+publication while an older export may still own that snapshot. Once a later
+invocation observes the qualifying export, the final pass deletes the key from
+auth-private and curated keyed tables, repeats the fixed rebuild, verifies
+keyed/raw absence and post-request transform state, and only then marks the
+request complete. Do not declare warehouse completion before both the
+tombstone-aware export and final cleanup succeed.
+
+Before either request cleanup or a recurring sweep, the job compares the
+deployed auth/curated/reporting `user_key` column inventory with its checked-in
+closed table inventory. It also rejects intraday raw export, unsupported
+`events_*` names, or a gap in the controlled retained daily-table sequence.
+Those checks are fail-closed: update the reviewed code and IAM contract when the
+warehouse schema intentionally changes; never bypass coverage with command-line
+table lists or a shorter retention window. Preliminary cleanup may observe an
+active, validated auth milestone staging table, but final cleanup, completion,
+and recurring sweep checkpoints fail closed until every such staging table has
+expired or the owning export has removed it; no auth-private keyed staging row
+is silently left outside deletion verification.
+
+### 3. Current GA deletion submission
+
+Use the current Google Analytics Admin API v1alpha
+`properties.submitUserDeletion` method. The legacy Google Analytics User
+Deletion API v3 `userDeletionRequests:upsert` endpoint is sunset and must not be
+called.
+
+The current endpoint is:
+
+```text
+POST https://analyticsadmin.googleapis.com/v1alpha/properties/529377727:submitUserDeletion
+```
+
+The deletion identity requires the narrow
+`https://www.googleapis.com/auth/analytics.edit` OAuth scope. For each currently
+linkable installation discovered inside the restricted 90-day raw window, send
+exactly one union field:
+
+```json
+{"appInstanceId":"<DISCOVERED_APP_INSTANCE_ID>"}
+```
+
+For data created by legacy releases that set Firebase global `user_id`, submit
+the deletion-only prior SHA-256 value as:
+
+```json
+{"userId":"<DELETION_ONLY_LEGACY_FIREBASE_USER_ID>"}
+```
+
+Never submit the new HMAC `user_key` as `userId`; it was not the historical GA
+global user ID. Never send both union fields in one request. Do not persist or
+log discovered app-instance IDs. Record only the external privacy request ID,
+aggregate submission status, and returned `deletionRequestTime` in restricted
+status.
+
+### 4. Recurring keyed-upload sweep
+
+Run the checkpointed command daily at `<PRIVACY_SWEEP_SCHEDULE_UTC>`:
+
+```bash
+dart tool/product_analytics/privacy_deletion/sweep_privacy_deletions.dart \
+  --project=sesori-ai \
+  --location=europe-west3 \
+  --analytics-property-id=529377727 \
+  --raw-dataset=analytics_529377727 \
+  --auth-dataset=sesori_analytics_auth_private \
+  --privacy-dataset=sesori_analytics_privacy_private \
+  --controls-dataset=sesori_analytics_controls \
+  --curated-dataset=sesori_analytics_curated \
+  --reporting-dataset=sesori_analytics_reporting \
+  --exclusions-table=permanent_deletion_exclusions \
+  --sweep-state-table=product_analytics_privacy_sweep_state
+```
+
+Each sweep starts from the earlier of the watermark continuation and the latest
+three UTC event dates, scans every permanent tombstone regardless of request
+age/status, deletes newly landed keyed rows, and resubmits newly discovered app
+instances through `submitUserDeletion`. It persists no account-install mapping
+and automatically uses the same fixed checked-in 20 -> 30 -> 40 rebuild chain;
+there is no operator-supplied rebuild path or command.
+
+The enforceable promise is source/warehouse suppression plus recurring removal
+of future **keyed uploads**. An automatic-only installation that never emitted a
+keyed event cannot be linked to an account by design. Its upstream data follows
+the verified two-month GA retention, while an already-exported restricted raw
+row may remain until the separate 90-day expiration. State both limits in the
+request response; never promise indefinite automatic-event deletion.
+
+Before production rollout, complete a non-production drill covering an
+in-flight pre-tombstone auth export, final tombstone-aware export, flattened
+non-repopulation, aggregate rebuild, a delayed keyed upload into a previously
+swept mutable partition, watermark-gap recovery, current Admin API submission,
+and expected IAM denials.
+
+## Incidents and rollback
+
+Privacy controls have a forward-fix floor. Permanent internal/deletion
+exclusions, source tombstones, and recurring deletion sweeps continue during a
+reporting rollback.
+
+| Incident | Immediate response | Recovery/rollback boundary |
+| --- | --- | --- |
+| Broad raw/private access | Revoke unintended access, pause Looker and non-privacy transforms, preserve evidence | Reapply reviewed ACLs and deny tests before resuming; do not copy data elsewhere |
+| Missing raw expiration or intraday table | Stop rollout, restrict access, apply 90-day expiration to every affected table, disable streaming/intraday | Verify all current/default expirations; do not unlink daily export |
+| GA privacy setting drift | Stop dashboard/data acceptance and non-privacy schedules | Restore approved settings, record affected interval, assess deletion/disclosure impact |
+| Sensitive/unallowlisted field | Pause affected transform/report source, restrict output, open privacy incident | Forward-fix allowlist and delete/rebuild affected outputs; never expose the field for debugging |
+| Stale/failed auth export | Keep last-good reports visibly stale; pause dependent user-level transforms | Publish a newer reconciled snapshot and backfill watermark gap within 90 days |
+| Incorrect metric/SQL | Pause affected schedules and dashboard charts | Redeploy last known-good SQL/views or corrected version, rebuild, rerun assertions/reconciliation |
+| Query quota exhaustion | Pause nonessential/ad hoc work and dashboard refreshes; keep stale label | Resume after quota window/reduced bytes; quota increase requires approval |
+| Budget alert | Inspect all-service billing and query jobs; at high severity pause non-privacy schedules | Resume after cause/cost approval; budget itself never shut off spend |
+| Deletion failure | Keep source tombstone/exclusion active and mark request retryable | Retry idempotently; never roll back suppression to make export succeed |
+| Dashboard oversharing | Revoke report/data-source sharing immediately and audit access | Restore only approved owner/group and repeat manual access tests |
+| Wrong measurement timestamp | Stop affected publication and preserve old control/evidence | Approve a versioned correction, rebuild affected range, and annotate the gap/change |
+
+A Step 5 reporting rollback may pause or restore auth export, transforms,
+reporting views, and Looker sources to the last known-good version. Raw daily
+export and prior good auth tables remain; app behavior is unaffected. Never use
+rollback to re-enable a deleted account, remove a permanent exclusion, broaden
+IAM, or revert the client privacy gate.
+
+Record incident start/end UTC, affected layers/periods, last good commit and
+watermarks, privacy assessment, actions, owner, and reconciliation evidence.
+Do not include event payloads, keys, identifiers, paths, or raw error text.
+
+## Release smoke and reconciliation
+
+Use a release build and synthetic content. Do not enable debug-build custom
+event sharing for convenience and do not inspect prompts, messages,
+transcripts, paths, names, or raw payload text.
+
+### End-to-end smoke
+
+1. Use an approved synthetic smoke account and record its restricted HMAC key
+   outside Git/logs.
+2. Complete account creation, notification registration if applicable, bridge
+   registration, a successful non-empty project inventory, and one successfully
+   accepted user-authored message.
+3. Confirm `analytics_activation_ready` schema v1, the expected project event,
+   and exactly one of `session_message_sent` or
+   `session_created_with_message`; queued/failed attempts must not activate.
+4. Navigate a pinned route and verify one canonical `product_screen_viewed` plus
+   one matching native `screen_view`, with no automatic duplicate. Curated
+   account reporting uses only the canonical event.
+5. If testing voice, verify only `input_mode=voice_assisted` and the content-free
+   transcription completion appear, with no transcript/audio-derived value.
+6. Wait for the complete daily raw table; verify allowed names/types/parameters
+   and the absence of prohibited fields without viewing content values.
+7. Run auth export, transform chain, and reporting views. Verify the account
+   joins, full activation uses occurrence time, and the complete-day aggregate
+   advances.
+8. Add the smoke account to the permanent internal exclusion through the
+   protected control flow, rerun auth export/rebuild, and verify it disappears
+   from historical/future account reporting. Never remove that exclusion.
+
+The account-less login smoke must separately prove only provider/failure enums,
+no `user_key` or attempt ID, and the diagnostic
+`includes_internal_test_traffic=true` label. Do not join it to the smoke account.
+
+### Three-complete-day reconciliation
+
+Before sharing Looker, reconcile at least three complete UTC event dates through
+this chain:
+
+```text
+GA4 allowlisted custom-event aggregate
+-> events_flattened / installation_login_daily
+-> user_activity_daily and user_milestones
+-> cohort/reporting views
+-> Looker chart values
+```
+
+For each date record aggregate counts only. Require:
+
+- raw-to-flattened differences are explained by duplicate, schema, timing,
+  internal, deletion, or allowlist data-quality counts;
+- flattened-to-daily event contributions reconcile by bounded event class;
+- auth eligible counts reconcile to source totals after internal/suppressed and
+  preference filtering;
+- full activation is only the earliest successful accepted message outcome;
+- meaningful/controller WAU excludes opens, screens, empty states, failures,
+  and queued-only actions;
+- activation and retention denominators include only mature, timely
+  activation-capable cohorts;
+- W1 is days 7-13 and W4 is days 28-34 after activation;
+- login counts remain installation-attempt diagnostics and out of headlines;
+- every page shows numerator, denominator, coverage, maturity, and raw/auth/
+  reporting freshness; and
+- the Looker values equal reporting-view values under the same complete-period
+  filters.
+
+Finally test IAM manually: auth export cannot write controls/curated/reporting;
+transforms cannot read privacy-private; Looker cannot query raw/private/curated
+or expose `user_key`; ordinary viewers cannot bypass report sharing. Complete
+the access checklist in [`LOOKER_STUDIO.md`](LOOKER_STUDIO.md).
+
+Do not claim release completion until the first W1 cohort is mature and
+reviewed. W4 requires 35 days after activation; show null and "no mature cohort"
+rather than zero when none has completed the full window.

--- a/tool/product_analytics/README.md
+++ b/tool/product_analytics/README.md
@@ -27,6 +27,10 @@ restricted deployment record:
 - the restricted Looker report owner; and
 - the restricted Looker viewer group.
 
+This block is a safety gate, not a scope boundary. Creating and verifying these
+cloud resources is required Step 5 delivery work after approval; merging the
+repository PR alone does not complete the analytics rollout.
+
 As of 2026-07-31, those approvals are unverified. All mutating commands remain
 blocked even though the raw export, retention expiration, billing, budget, and
 query-quota facts below have been observed.

--- a/tool/product_analytics/deploy.dart
+++ b/tool/product_analytics/deploy.dart
@@ -1,0 +1,1154 @@
+import 'dart:convert';
+import 'dart:io';
+
+const String _help = '''
+Deploy Sesori product analytics BigQuery SQL.
+
+Usage:
+  dart tool/product_analytics/deploy.dart [mode] \\
+    --project <project-id> \\
+    --location <bigquery-location> \\
+    --raw-dataset-id <dataset-id> \\
+    --auth-dataset-id <dataset-id> \\
+    --privacy-dataset-id <dataset-id> \\
+    --controls-dataset-id <dataset-id> \\
+    --curated-dataset-id <dataset-id> \\
+    --reporting-dataset-id <dataset-id> \\
+    --raw-export-start-at <UTC-RFC3339> \\
+    --behavioral-schema-v1-start-at <UTC-RFC3339> \\
+    [--transform-service-account <service-account-email>] \\
+    [--apply-schedules]
+
+Modes:
+  (none)       Validate the manifest and render every SQL template in memory.
+               No BigQuery command is run and no resource is changed.
+  --dry-run    Run a best-effort whole-script BigQuery dry run for each numeric
+               SQL asset and print its byte estimate and estimate accuracy.
+  --apply      Dry-run and then execute each numeric SQL asset in dependency
+               order. This is the only mode that mutates BigQuery resources.
+
+Schedule deployment:
+  Scheduled-query transfer configs are created or updated only when --apply,
+  --apply-schedules, and --transform-service-account are all supplied. Existing
+  configs are matched by exact display name. Scheduled DML/DDL scripts own their
+  writes, so transfer configs have no destination table setting. The operation
+  fails before schedule writes if a prefixed Sesori config is not in the
+  manifest; obsolete configs are never auto-deleted.
+
+Cost guardrail:
+  BigQuery's scheduled_query data source does not expose a runtime
+  maximum_bytes_billed parameter. schedules.json maxBytesBilled values allocate
+  at most 1.75 GiB/day to the transform principal and bound direct apply jobs.
+  Configure project/principal query quotas to guard scheduled runs at runtime.
+  BigQuery SCRIPT dry-run estimates can be LOWER_BOUND and are best-effort
+  validation.
+
+Other:
+  --help, -h   Show this help.
+''';
+
+const Set<String> _requiredValueFlags = <String>{
+  '--project',
+  '--location',
+  '--raw-dataset-id',
+  '--auth-dataset-id',
+  '--privacy-dataset-id',
+  '--controls-dataset-id',
+  '--curated-dataset-id',
+  '--reporting-dataset-id',
+  '--raw-export-start-at',
+  '--behavioral-schema-v1-start-at',
+};
+
+const Set<String> _optionalValueFlags = <String>{'--transform-service-account'};
+
+const Set<String> _booleanFlags = <String>{
+  '--dry-run',
+  '--apply',
+  '--apply-schedules',
+};
+
+const Set<String> _scheduleManifestFields = <String>{
+  'queryFile',
+  'displayName',
+  'cadence',
+  'recentDateRecomputationWindow',
+  'maxBytesBilled',
+};
+
+const String _scheduleDisplayNamePrefix = 'Sesori Product Analytics - ';
+const int _maxScheduledQueryBytes = 536870912;
+const int _maxScheduledQueryDailyBytes = 1879048192;
+
+const Map<String, int> _deploymentOnlyMaxBytesBilled = <String, int>{
+  '00_datasets.sql': 1073741824,
+  '50_reporting_views.sql': 1073741824,
+};
+
+const String _runtimeCostNotice =
+    'Cost guardrail: scheduled_query has no runtime maximum_bytes_billed '
+    'parameter. Manifest allocations total at most 1.75 GiB/day and direct '
+    'apply jobs use maximum_bytes_billed; project/principal query quotas must '
+    'guard scheduled runs. Whole-script dry-run estimates are best-effort and '
+    'may have LOWER_BOUND accuracy.';
+
+final RegExp _projectIdPattern = RegExp(r'^[a-z][a-z0-9-]{4,28}[a-z0-9]$');
+final RegExp _locationPattern = RegExp(r'^[A-Za-z0-9-]+$');
+final RegExp _datasetIdPattern = RegExp(r'^[A-Za-z0-9_]{1,1024}$');
+final RegExp _serviceAccountPattern = RegExp(
+  r'^[a-z0-9][a-z0-9-]{4,28}[a-z0-9]@'
+  r'[a-z][a-z0-9-]{4,28}[a-z0-9]\.iam\.gserviceaccount\.com$',
+);
+final RegExp _utcTimestampPattern = RegExp(
+  r'^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})'
+  r'(?:\.\d{1,6})?Z$',
+);
+final RegExp _numericSqlFilePattern = RegExp(r'^([0-9]+)_[a-z0-9_]+\.sql$');
+final RegExp _placeholderPattern = RegExp(r'\{\{[^{}]+\}\}');
+final RegExp _printableAsciiPattern = RegExp(r'^[\x20-\x7E]+$');
+final RegExp _dailyCadencePattern = RegExp(
+  r'^every day (?:[01][0-9]|2[0-3]):[0-5][0-9]$',
+);
+
+enum _Mode { renderOnly, dryRun, apply }
+
+enum _DryRunAccuracy {
+  unknown(wireValue: 'UNKNOWN'),
+  precise(wireValue: 'PRECISE'),
+  lowerBound(wireValue: 'LOWER_BOUND'),
+  upperBound(wireValue: 'UPPER_BOUND');
+
+  const _DryRunAccuracy({required this.wireValue});
+
+  final String wireValue;
+
+  static _DryRunAccuracy? tryParse({required Object? value}) {
+    for (final accuracy in values) {
+      if (accuracy.wireValue == value) {
+        return accuracy;
+      }
+    }
+    return null;
+  }
+}
+
+class _CliError implements Exception {
+  const _CliError({required this.message}) : cause = null;
+
+  const _CliError.withCause({required this.message, required Object cause})
+    : cause = cause;
+
+  final String message;
+  final Object? cause;
+}
+
+class _Options {
+  const _Options({
+    required this.mode,
+    required this.applySchedules,
+    required this.projectId,
+    required this.location,
+    required this.rawDatasetId,
+    required this.authDatasetId,
+    required this.privacyDatasetId,
+    required this.controlsDatasetId,
+    required this.curatedDatasetId,
+    required this.reportingDatasetId,
+    required this.rawExportStartAt,
+    required this.behavioralSchemaV1StartAt,
+    required this.transformServiceAccount,
+  });
+
+  final _Mode mode;
+  final bool applySchedules;
+  final String projectId;
+  final String location;
+  final String rawDatasetId;
+  final String authDatasetId;
+  final String privacyDatasetId;
+  final String controlsDatasetId;
+  final String curatedDatasetId;
+  final String reportingDatasetId;
+  final String rawExportStartAt;
+  final String behavioralSchemaV1StartAt;
+  final String? transformServiceAccount;
+}
+
+class _ScheduleDefinition {
+  const _ScheduleDefinition({
+    required this.queryFile,
+    required this.displayName,
+    required this.cadence,
+    required this.recentDateRecomputationWindow,
+    required this.maxBytesBilled,
+    required this.dependencyOrder,
+  });
+
+  final String queryFile;
+  final String displayName;
+  final String cadence;
+  final int recentDateRecomputationWindow;
+  final int maxBytesBilled;
+  final int dependencyOrder;
+}
+
+class _SqlAsset {
+  const _SqlAsset({
+    required this.fileName,
+    required this.dependencyOrder,
+    required this.renderedSql,
+    required this.maxBytesBilled,
+    required this.schedule,
+  });
+
+  final String fileName;
+  final int dependencyOrder;
+  final String renderedSql;
+  final int maxBytesBilled;
+  final _ScheduleDefinition? schedule;
+}
+
+class _CommandResult {
+  const _CommandResult({required this.standardOutput});
+
+  final String standardOutput;
+}
+
+class _DryRunEstimate {
+  const _DryRunEstimate({
+    required this.totalBytesProcessed,
+    required this.accuracy,
+  });
+
+  final String? totalBytesProcessed;
+  final _DryRunAccuracy accuracy;
+}
+
+Future<void> main(final List<String> args) async {
+  if (args.contains('--help') || args.contains('-h')) {
+    stdout.write(_help);
+    return;
+  }
+
+  try {
+    final options = _parseOptions(args: args);
+    final productAnalyticsDirectory = File.fromUri(Platform.script).parent;
+    final sqlDirectory = Directory(
+      _joinPath(parent: productAnalyticsDirectory.path, child: 'sql'),
+    );
+    final schedules = await _loadSchedules(
+      path: _joinPath(parent: sqlDirectory.path, child: 'schedules.json'),
+    );
+    final assets = await _loadSqlAssets(
+      directory: sqlDirectory,
+      schedules: schedules,
+      replacements: _placeholderReplacements(options: options),
+    );
+
+    _printValidatedPlan(assets: assets, schedules: schedules);
+    stdout.writeln(_runtimeCostNotice);
+
+    if (options.mode == _Mode.renderOnly) {
+      stdout.writeln(
+        'Validation complete. No BigQuery commands were run and no resources '
+        'were changed.',
+      );
+      return;
+    }
+
+    final bq = _BqRunner(
+      projectId: options.projectId,
+      location: options.location,
+    );
+    for (final asset in assets) {
+      stdout.writeln(
+        'Dry-running ${asset.fileName} with allocatedBytes='
+        '${asset.maxBytesBilled}.',
+      );
+      await bq.runQuery(asset: asset, dryRun: true);
+
+      if (options.mode == _Mode.apply) {
+        stdout.writeln('Applying ${asset.fileName}.');
+        await bq.runQuery(asset: asset, dryRun: false);
+      }
+    }
+
+    if (options.mode == _Mode.dryRun) {
+      stdout.writeln(
+        'Best-effort whole-script dry run complete. No resources were changed '
+        'by this tool.',
+      );
+      return;
+    }
+
+    if (options.applySchedules) {
+      await _applySchedules(
+        bq: bq,
+        schedules: schedules,
+        assets: assets,
+        serviceAccount: options.transformServiceAccount!,
+      );
+    } else {
+      stdout.writeln(
+        'SQL apply complete. Scheduled-query configs were not changed; '
+        '--apply-schedules was not supplied.',
+      );
+    }
+  } on _CliError catch (error) {
+    stderr.writeln(error.message);
+    exitCode = 1;
+  } on Object {
+    stderr.writeln(
+      'Error: Product analytics deployment failed unexpectedly. No backend '
+      'error details were printed.',
+    );
+    exitCode = 1;
+  }
+}
+
+_Options _parseOptions({required List<String> args}) {
+  final values = <String, String>{};
+  final enabledFlags = <String>{};
+  final valueFlags = <String>{..._requiredValueFlags, ..._optionalValueFlags};
+
+  for (var index = 0; index < args.length; index++) {
+    final argument = args[index];
+
+    if (_booleanFlags.contains(argument)) {
+      if (!enabledFlags.add(argument)) {
+        throw _CliError(
+          message: 'Error: $argument was supplied more than once.',
+        );
+      }
+      continue;
+    }
+
+    final equalsIndex = argument.indexOf('=');
+    final flag = equalsIndex == -1
+        ? argument
+        : argument.substring(0, equalsIndex);
+    if (!valueFlags.contains(flag)) {
+      throw const _CliError(
+        message:
+            'Error: Unknown argument. Use --help to see supported options.',
+      );
+    }
+    if (values.containsKey(flag)) {
+      throw _CliError(message: 'Error: $flag was supplied more than once.');
+    }
+
+    late final String value;
+    if (equalsIndex != -1) {
+      value = argument.substring(equalsIndex + 1);
+    } else {
+      final valueIndex = index + 1;
+      if (valueIndex >= args.length || args[valueIndex].startsWith('--')) {
+        throw _CliError(message: 'Error: Missing value for $flag.');
+      }
+      value = args[valueIndex];
+      index = valueIndex;
+    }
+
+    if (value.isEmpty || value != value.trim()) {
+      throw _CliError(message: 'Error: Invalid value for $flag.');
+    }
+    values[flag] = value;
+  }
+
+  for (final flag in _requiredValueFlags) {
+    if (!values.containsKey(flag)) {
+      throw _CliError(message: 'Error: Missing required argument $flag.');
+    }
+  }
+
+  final dryRun = enabledFlags.contains('--dry-run');
+  final apply = enabledFlags.contains('--apply');
+  if (dryRun && apply) {
+    throw const _CliError(
+      message: 'Error: --dry-run and --apply are mutually exclusive.',
+    );
+  }
+
+  final mode = dryRun
+      ? _Mode.dryRun
+      : apply
+      ? _Mode.apply
+      : _Mode.renderOnly;
+  final applySchedules = enabledFlags.contains('--apply-schedules');
+  if (applySchedules && mode != _Mode.apply) {
+    throw const _CliError(
+      message: 'Error: --apply-schedules requires --apply.',
+    );
+  }
+  if (applySchedules && values['--transform-service-account'] == null) {
+    throw const _CliError(
+      message: 'Error: --apply-schedules requires --transform-service-account.',
+    );
+  }
+
+  final projectId = values['--project']!;
+  final location = values['--location']!;
+  if (!_projectIdPattern.hasMatch(projectId)) {
+    throw const _CliError(message: 'Error: Invalid value for --project.');
+  }
+  if (!_locationPattern.hasMatch(location)) {
+    throw const _CliError(message: 'Error: Invalid value for --location.');
+  }
+
+  final datasetValues = <String, String>{
+    '--raw-dataset-id': values['--raw-dataset-id']!,
+    '--auth-dataset-id': values['--auth-dataset-id']!,
+    '--privacy-dataset-id': values['--privacy-dataset-id']!,
+    '--controls-dataset-id': values['--controls-dataset-id']!,
+    '--curated-dataset-id': values['--curated-dataset-id']!,
+    '--reporting-dataset-id': values['--reporting-dataset-id']!,
+  };
+  for (final entry in datasetValues.entries) {
+    if (!_datasetIdPattern.hasMatch(entry.value)) {
+      throw _CliError(message: 'Error: Invalid value for ${entry.key}.');
+    }
+  }
+  final distinctDatasetIds = datasetValues.values.toSet();
+  if (distinctDatasetIds.length != datasetValues.length) {
+    throw const _CliError(message: 'Error: All dataset IDs must be distinct.');
+  }
+
+  final rawExportStartAt = values['--raw-export-start-at']!;
+  final behavioralSchemaV1StartAt = values['--behavioral-schema-v1-start-at']!;
+  final rawExportStart = _parseUtcTimestamp(
+    value: rawExportStartAt,
+    flag: '--raw-export-start-at',
+  );
+  final behavioralSchemaV1Start = _parseUtcTimestamp(
+    value: behavioralSchemaV1StartAt,
+    flag: '--behavioral-schema-v1-start-at',
+  );
+  if (behavioralSchemaV1Start.isBefore(rawExportStart)) {
+    throw const _CliError(
+      message:
+          'Error: --behavioral-schema-v1-start-at must not be earlier than '
+          '--raw-export-start-at.',
+    );
+  }
+
+  final transformServiceAccount = values['--transform-service-account'];
+  if (transformServiceAccount != null &&
+      !_serviceAccountPattern.hasMatch(transformServiceAccount)) {
+    throw const _CliError(
+      message: 'Error: Invalid value for --transform-service-account.',
+    );
+  }
+
+  return _Options(
+    mode: mode,
+    applySchedules: applySchedules,
+    projectId: projectId,
+    location: location,
+    rawDatasetId: datasetValues['--raw-dataset-id']!,
+    authDatasetId: datasetValues['--auth-dataset-id']!,
+    privacyDatasetId: datasetValues['--privacy-dataset-id']!,
+    controlsDatasetId: datasetValues['--controls-dataset-id']!,
+    curatedDatasetId: datasetValues['--curated-dataset-id']!,
+    reportingDatasetId: datasetValues['--reporting-dataset-id']!,
+    rawExportStartAt: rawExportStartAt,
+    behavioralSchemaV1StartAt: behavioralSchemaV1StartAt,
+    transformServiceAccount: transformServiceAccount,
+  );
+}
+
+DateTime _parseUtcTimestamp({required String value, required String flag}) {
+  final match = _utcTimestampPattern.firstMatch(value);
+  final parsed = DateTime.tryParse(value);
+  if (match == null || parsed == null || !parsed.isUtc) {
+    throw _CliError(
+      message:
+          'Error: $flag must be a valid UTC RFC3339 timestamp ending in Z.',
+    );
+  }
+
+  final expectedParts = <int>[
+    int.parse(match.group(1)!),
+    int.parse(match.group(2)!),
+    int.parse(match.group(3)!),
+    int.parse(match.group(4)!),
+    int.parse(match.group(5)!),
+    int.parse(match.group(6)!),
+  ];
+  final parsedParts = <int>[
+    parsed.year,
+    parsed.month,
+    parsed.day,
+    parsed.hour,
+    parsed.minute,
+    parsed.second,
+  ];
+  if (expectedParts[0] == 0 ||
+      !_sameIntegers(left: expectedParts, right: parsedParts)) {
+    throw _CliError(
+      message:
+          'Error: $flag must be a valid UTC RFC3339 timestamp ending in Z.',
+    );
+  }
+  return parsed;
+}
+
+bool _sameIntegers({required List<int> left, required List<int> right}) {
+  if (left.length != right.length) {
+    return false;
+  }
+  for (var index = 0; index < left.length; index++) {
+    if (left[index] != right[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+Map<String, String> _placeholderReplacements({required _Options options}) =>
+    <String, String>{
+      '{{PROJECT_ID}}': options.projectId,
+      '{{RAW_DATASET_ID}}': options.rawDatasetId,
+      '{{AUTH_DATASET_ID}}': options.authDatasetId,
+      '{{PRIVACY_DATASET_ID}}': options.privacyDatasetId,
+      '{{CONTROLS_DATASET_ID}}': options.controlsDatasetId,
+      '{{CURATED_DATASET_ID}}': options.curatedDatasetId,
+      '{{REPORTING_DATASET_ID}}': options.reportingDatasetId,
+      '{{RAW_EXPORT_START_AT}}': options.rawExportStartAt,
+      '{{BEHAVIORAL_SCHEMA_V1_START_AT}}': options.behavioralSchemaV1StartAt,
+    };
+
+Future<List<_ScheduleDefinition>> _loadSchedules({required String path}) async {
+  late final String content;
+  try {
+    content = await File(path).readAsString();
+  } on FileSystemException catch (error) {
+    throw _CliError.withCause(
+      message: 'Error: Could not read sql/schedules.json.',
+      cause: error,
+    );
+  }
+
+  late final Object? decoded;
+  try {
+    decoded = jsonDecode(content);
+  } on FormatException catch (error) {
+    throw _CliError.withCause(
+      message: 'Error: sql/schedules.json is not valid JSON.',
+      cause: error,
+    );
+  }
+  if (decoded is! List<Object?> || decoded.isEmpty) {
+    throw const _CliError(
+      message: 'Error: sql/schedules.json must be a non-empty JSON array.',
+    );
+  }
+
+  final schedules = <_ScheduleDefinition>[];
+  final queryFiles = <String>{};
+  final displayNames = <String>{};
+  for (var index = 0; index < decoded.length; index++) {
+    final rawEntry = decoded[index];
+    if (rawEntry is! Map<String, Object?> ||
+        rawEntry.length != _scheduleManifestFields.length ||
+        !_scheduleManifestFields.every(rawEntry.containsKey)) {
+      throw _CliError(
+        message:
+            'Error: Schedule entry ${index + 1} must contain exactly the '
+            'documented fields.',
+      );
+    }
+
+    final queryFile = rawEntry['queryFile'];
+    final displayName = rawEntry['displayName'];
+    final cadence = rawEntry['cadence'];
+    final recentDateRecomputationWindow =
+        rawEntry['recentDateRecomputationWindow'];
+    final maxBytesBilled = rawEntry['maxBytesBilled'];
+    if (queryFile is! String) {
+      throw _CliError(
+        message: 'Error: Schedule entry ${index + 1} has an invalid queryFile.',
+      );
+    }
+    final fileMatch = _numericSqlFilePattern.firstMatch(queryFile);
+    if (fileMatch == null) {
+      throw _CliError(
+        message: 'Error: Schedule entry ${index + 1} has an invalid queryFile.',
+      );
+    }
+    if (displayName is! String ||
+        displayName.isEmpty ||
+        displayName != displayName.trim() ||
+        displayName.length > 256 ||
+        !_printableAsciiPattern.hasMatch(displayName)) {
+      throw _CliError(
+        message:
+            'Error: Schedule entry ${index + 1} has an invalid displayName.',
+      );
+    }
+    if (cadence is! String || !_dailyCadencePattern.hasMatch(cadence)) {
+      throw _CliError(
+        message: 'Error: Schedule entry ${index + 1} has an invalid cadence.',
+      );
+    }
+    if (recentDateRecomputationWindow is! int ||
+        recentDateRecomputationWindow != 3) {
+      throw _CliError(
+        message:
+            'Error: Schedule entry ${index + 1} must declare the SQL-owned '
+            'three-date recomputation window.',
+      );
+    }
+    if (maxBytesBilled is! int ||
+        maxBytesBilled <= 0 ||
+        maxBytesBilled > _maxScheduledQueryBytes) {
+      throw _CliError(
+        message:
+            'Error: Schedule entry ${index + 1} maxBytesBilled must be between '
+            '1 and $_maxScheduledQueryBytes.',
+      );
+    }
+    if (!queryFiles.add(queryFile)) {
+      throw const _CliError(
+        message: 'Error: Schedule queryFile values must be unique.',
+      );
+    }
+    if (!displayNames.add(displayName)) {
+      throw const _CliError(
+        message: 'Error: Schedule displayName values must be unique.',
+      );
+    }
+
+    schedules.add(
+      _ScheduleDefinition(
+        queryFile: queryFile,
+        displayName: displayName,
+        cadence: cadence,
+        recentDateRecomputationWindow: recentDateRecomputationWindow,
+        maxBytesBilled: maxBytesBilled,
+        dependencyOrder: int.parse(fileMatch.group(1)!),
+      ),
+    );
+  }
+
+  final dailyScheduledBytes = schedules.fold<int>(
+    0,
+    (total, schedule) => total + schedule.maxBytesBilled,
+  );
+  if (dailyScheduledBytes > _maxScheduledQueryDailyBytes) {
+    throw const _CliError(
+      message:
+          'Error: Scheduled maxBytesBilled values exceed the 1.75 GiB daily '
+          'transform-principal allocation.',
+    );
+  }
+
+  schedules.sort(_compareSchedules);
+  return schedules;
+}
+
+int _compareSchedules(
+  final _ScheduleDefinition left,
+  final _ScheduleDefinition right,
+) {
+  final order = left.dependencyOrder.compareTo(right.dependencyOrder);
+  return order != 0 ? order : left.queryFile.compareTo(right.queryFile);
+}
+
+Future<List<_SqlAsset>> _loadSqlAssets({
+  required Directory directory,
+  required List<_ScheduleDefinition> schedules,
+  required Map<String, String> replacements,
+}) async {
+  late final List<FileSystemEntity> entries;
+  try {
+    entries = await directory.list(followLinks: false).toList();
+  } on FileSystemException catch (error) {
+    throw _CliError.withCause(
+      message: 'Error: Could not list product analytics SQL.',
+      cause: error,
+    );
+  }
+
+  final scheduleByFile = <String, _ScheduleDefinition>{
+    for (final schedule in schedules) schedule.queryFile: schedule,
+  };
+  final assets = <_SqlAsset>[];
+  final foundFiles = <String>{};
+  for (final entry in entries) {
+    if (entry is! File) {
+      continue;
+    }
+    final fileName = _baseName(path: entry.path);
+    final fileMatch = _numericSqlFilePattern.firstMatch(fileName);
+    if (fileMatch == null) {
+      continue;
+    }
+    foundFiles.add(fileName);
+
+    final schedule = scheduleByFile[fileName];
+    final deploymentOnlyCeiling = _deploymentOnlyMaxBytesBilled[fileName];
+    if (schedule != null && deploymentOnlyCeiling != null) {
+      throw _CliError(
+        message:
+            'Error: $fileName cannot be both scheduled and deployment-only.',
+      );
+    }
+    final maxBytesBilled = schedule?.maxBytesBilled ?? deploymentOnlyCeiling;
+    if (maxBytesBilled == null) {
+      throw _CliError(
+        message: 'Error: $fileName has no explicit maxBytesBilled ceiling.',
+      );
+    }
+
+    late final String template;
+    try {
+      template = await entry.readAsString();
+    } on FileSystemException catch (error) {
+      throw _CliError.withCause(
+        message: 'Error: Could not read $fileName.',
+        cause: error,
+      );
+    }
+    final renderedSql = _renderSql(
+      fileName: fileName,
+      template: template,
+      replacements: replacements,
+    );
+    assets.add(
+      _SqlAsset(
+        fileName: fileName,
+        dependencyOrder: int.parse(fileMatch.group(1)!),
+        renderedSql: renderedSql,
+        maxBytesBilled: maxBytesBilled,
+        schedule: schedule,
+      ),
+    );
+  }
+
+  if (assets.isEmpty) {
+    throw const _CliError(
+      message: 'Error: No numeric product analytics SQL files were found.',
+    );
+  }
+  for (final schedule in schedules) {
+    if (!foundFiles.contains(schedule.queryFile)) {
+      throw _CliError(
+        message:
+            'Error: Schedule query file ${schedule.queryFile} was not found.',
+      );
+    }
+  }
+
+  assets.sort(_compareSqlAssets);
+  return assets;
+}
+
+int _compareSqlAssets(final _SqlAsset left, final _SqlAsset right) {
+  final order = left.dependencyOrder.compareTo(right.dependencyOrder);
+  return order != 0 ? order : left.fileName.compareTo(right.fileName);
+}
+
+String _renderSql({
+  required String fileName,
+  required String template,
+  required Map<String, String> replacements,
+}) {
+  if (template.trim().isEmpty) {
+    throw _CliError(message: 'Error: $fileName is empty.');
+  }
+
+  for (final match in _placeholderPattern.allMatches(template)) {
+    final placeholder = match.group(0)!;
+    if (!replacements.containsKey(placeholder)) {
+      throw _CliError(
+        message:
+            'Error: $fileName contains an unsupported template placeholder.',
+      );
+    }
+  }
+
+  var rendered = template;
+  for (final replacement in replacements.entries) {
+    rendered = rendered.replaceAll(replacement.key, replacement.value);
+  }
+  if (_placeholderPattern.hasMatch(rendered) ||
+      rendered.contains('{{') ||
+      rendered.contains('}}')) {
+    throw _CliError(
+      message: 'Error: $fileName contains an unresolved template placeholder.',
+    );
+  }
+  return rendered;
+}
+
+void _printValidatedPlan({
+  required List<_SqlAsset> assets,
+  required List<_ScheduleDefinition> schedules,
+}) {
+  stdout.writeln(
+    'Validated and rendered ${assets.length} SQL assets in numeric dependency '
+    'order:',
+  );
+  for (final asset in assets) {
+    final kind = asset.schedule == null ? 'deployment-only' : 'scheduled';
+    stdout.writeln(
+      '  ${asset.fileName}: $kind, maxBytesBilled=${asset.maxBytesBilled}',
+    );
+  }
+  stdout.writeln('Loaded ${schedules.length} scheduled-query definitions:');
+  for (final schedule in schedules) {
+    stdout.writeln(
+      '  ${schedule.queryFile}: ${schedule.cadence}, recompute '
+      '${schedule.recentDateRecomputationWindow} recent UTC dates',
+    );
+  }
+  final dailyScheduledBytes = schedules.fold<int>(
+    0,
+    (total, schedule) => total + schedule.maxBytesBilled,
+  );
+  stdout.writeln(
+    'Scheduled daily allocation: $dailyScheduledBytes bytes '
+    '(limit $_maxScheduledQueryDailyBytes).',
+  );
+}
+
+Future<void> _applySchedules({
+  required _BqRunner bq,
+  required List<_ScheduleDefinition> schedules,
+  required List<_SqlAsset> assets,
+  required String serviceAccount,
+}) async {
+  final assetsByFile = <String, _SqlAsset>{
+    for (final asset in assets) asset.fileName: asset,
+  };
+  final existingConfigs = await bq.listScheduledQueryConfigs();
+  final manifestDisplayNames = schedules
+      .map((schedule) => schedule.displayName)
+      .toSet();
+  final obsoleteConfigCount = existingConfigs.entries
+      .where(
+        (entry) =>
+            entry.key.startsWith(_scheduleDisplayNamePrefix) &&
+            !manifestDisplayNames.contains(entry.key),
+      )
+      .fold<int>(0, (count, entry) => count + entry.value.length);
+  if (obsoleteConfigCount > 0) {
+    throw _CliError(
+      message:
+          'Error: Found $obsoleteConfigCount Sesori Product Analytics '
+          'scheduled-query config(s) not declared in sql/schedules.json. No '
+          'schedules were created or updated; review obsolete configs '
+          'manually.',
+    );
+  }
+
+  for (final schedule in schedules) {
+    final matchingConfigs =
+        existingConfigs[schedule.displayName] ?? const <String>[];
+    if (matchingConfigs.length > 1) {
+      throw _CliError(
+        message:
+            'Error: More than one scheduled-query config has the exact '
+            'display name for ${schedule.queryFile}. No schedules were '
+            'created or updated.',
+      );
+    }
+  }
+
+  for (final schedule in schedules) {
+    final matchingConfigs =
+        existingConfigs[schedule.displayName] ?? const <String>[];
+    final asset = assetsByFile[schedule.queryFile]!;
+    if (matchingConfigs.isEmpty) {
+      stdout.writeln('Creating schedule for ${schedule.queryFile}.');
+      await bq.createScheduledQuery(
+        schedule: schedule,
+        renderedSql: asset.renderedSql,
+        serviceAccount: serviceAccount,
+      );
+    } else {
+      stdout.writeln('Updating schedule for ${schedule.queryFile}.');
+      await bq.updateScheduledQuery(
+        resourceName: matchingConfigs.single,
+        schedule: schedule,
+        renderedSql: asset.renderedSql,
+        serviceAccount: serviceAccount,
+      );
+    }
+  }
+
+  stdout.writeln(
+    'SQL and scheduled-query apply complete. Runtime byte guardrails remain '
+    'the responsibility of project/principal query quotas.',
+  );
+}
+
+class _BqRunner {
+  const _BqRunner({required this.projectId, required this.location});
+
+  final String projectId;
+  final String location;
+
+  Future<void> runQuery({
+    required _SqlAsset asset,
+    required bool dryRun,
+  }) async {
+    final result = await _run(
+      arguments: <String>[
+        ..._globalArguments(format: dryRun ? 'json' : 'none'),
+        'query',
+        '--use_legacy_sql=false',
+        if (!dryRun) '--maximum_bytes_billed=${asset.maxBytesBilled}',
+        '--dry_run=$dryRun',
+      ],
+      standardInput: asset.renderedSql,
+      operation: dryRun
+          ? 'dry-run ${asset.fileName}'
+          : 'apply ${asset.fileName}',
+    );
+    if (dryRun) {
+      final estimate = _parseDryRunEstimate(
+        standardOutput: result.standardOutput,
+        fileName: asset.fileName,
+      );
+      stdout.writeln(
+        'Dry-run estimate for ${asset.fileName}: totalBytesProcessed='
+        '${estimate.totalBytesProcessed ?? 'unavailable'}, accuracy='
+        '${estimate.accuracy.wireValue}.',
+      );
+    }
+  }
+
+  Future<Map<String, List<String>>> listScheduledQueryConfigs() async {
+    final result = await _run(
+      arguments: <String>[
+        ..._globalArguments(format: 'json'),
+        'ls',
+        '--transfer_config=true',
+        '--transfer_location=$location',
+        '--filter=dataSourceIds:scheduled_query',
+        '--max_results=1000',
+      ],
+      standardInput: null,
+      operation: 'list scheduled-query configs',
+    );
+
+    late final Object? decoded;
+    try {
+      decoded = jsonDecode(result.standardOutput);
+    } on FormatException catch (error) {
+      throw _CliError.withCause(
+        message: 'Error: bq returned an invalid scheduled-query config list.',
+        cause: error,
+      );
+    }
+    if (decoded is! List<Object?>) {
+      throw const _CliError(
+        message: 'Error: bq returned an invalid scheduled-query config list.',
+      );
+    }
+
+    final configsByDisplayName = <String, List<String>>{};
+    for (final rawConfig in decoded) {
+      if (rawConfig is! Map<String, Object?>) {
+        throw const _CliError(
+          message: 'Error: bq returned an invalid scheduled-query config.',
+        );
+      }
+      final dataSourceId =
+          rawConfig['dataSourceId'] ?? rawConfig['data_source_id'];
+      if (dataSourceId != null && dataSourceId != 'scheduled_query') {
+        continue;
+      }
+      final displayName = rawConfig['displayName'] ?? rawConfig['display_name'];
+      final resourceName = rawConfig['name'];
+      if (displayName is! String || resourceName is! String) {
+        throw const _CliError(
+          message: 'Error: bq returned an incomplete scheduled-query config.',
+        );
+      }
+      if (!_validTransferConfigName(
+        resourceName: resourceName,
+        expectedLocation: location,
+      )) {
+        throw const _CliError(
+          message:
+              'Error: bq returned an invalid scheduled-query resource name.',
+        );
+      }
+      configsByDisplayName
+          .putIfAbsent(displayName, () => <String>[])
+          .add(resourceName);
+    }
+    return configsByDisplayName;
+  }
+
+  Future<void> createScheduledQuery({
+    required _ScheduleDefinition schedule,
+    required String renderedSql,
+    required String serviceAccount,
+  }) async {
+    await _run(
+      arguments: <String>[
+        ..._globalArguments(format: 'none'),
+        'mk',
+        '--transfer_config=true',
+        '--data_source=scheduled_query',
+        '--display_name=${schedule.displayName}',
+        '--schedule=${schedule.cadence}',
+        '--params=${jsonEncode(<String, String>{'query': renderedSql})}',
+        '--service_account_name=$serviceAccount',
+      ],
+      standardInput: null,
+      operation: 'create schedule for ${schedule.queryFile}',
+    );
+  }
+
+  Future<void> updateScheduledQuery({
+    required String resourceName,
+    required _ScheduleDefinition schedule,
+    required String renderedSql,
+    required String serviceAccount,
+  }) async {
+    await _run(
+      arguments: <String>[
+        ..._globalArguments(format: 'none'),
+        'update',
+        '--transfer_config=true',
+        '--display_name=${schedule.displayName}',
+        '--schedule=${schedule.cadence}',
+        '--params=${jsonEncode(<String, String>{'query': renderedSql})}',
+        '--service_account_name=$serviceAccount',
+        '--update_credentials=true',
+        resourceName,
+      ],
+      standardInput: null,
+      operation: 'update schedule for ${schedule.queryFile}',
+    );
+  }
+
+  List<String> _globalArguments({required String format}) => <String>[
+    '--headless=true',
+    '--quiet=true',
+    '--synchronous_mode=true',
+    '--project_id=$projectId',
+    '--location=$location',
+    '--format=$format',
+  ];
+
+  Future<_CommandResult> _run({
+    required List<String> arguments,
+    required String? standardInput,
+    required String operation,
+  }) async {
+    late final Process process;
+    try {
+      process = await Process.start('bq', arguments, runInShell: false);
+    } on ProcessException catch (error) {
+      throw _CliError.withCause(
+        message:
+            'Error: Could not start bq. Install the Google Cloud CLI and make '
+            'bq available on PATH.',
+        cause: error,
+      );
+    }
+
+    final standardOutputFuture = process.stdout.transform(utf8.decoder).join();
+    final standardErrorFuture = process.stderr.transform(utf8.decoder).join();
+    try {
+      if (standardInput != null) {
+        process.stdin.write(standardInput);
+      }
+      await process.stdin.close();
+    } on Object catch (error) {
+      process.kill();
+      await standardOutputFuture;
+      await standardErrorFuture;
+      throw _CliError.withCause(
+        message:
+            'Error: Could not send input to bq while attempting to $operation.',
+        cause: error,
+      );
+    }
+
+    final commandExitCode = await process.exitCode;
+    final standardOutput = await standardOutputFuture;
+    await standardErrorFuture;
+    if (commandExitCode != 0) {
+      throw _CliError(
+        message:
+            'Error: bq failed while attempting to $operation '
+            '(exit code $commandExitCode). Backend error details were '
+            'suppressed.',
+      );
+    }
+    return _CommandResult(standardOutput: standardOutput);
+  }
+}
+
+_DryRunEstimate _parseDryRunEstimate({
+  required String standardOutput,
+  required String fileName,
+}) {
+  late final Object? decoded;
+  try {
+    decoded = jsonDecode(standardOutput);
+  } on FormatException catch (error) {
+    throw _CliError.withCause(
+      message: 'Error: bq returned invalid dry-run JSON for $fileName.',
+      cause: error,
+    );
+  }
+
+  final statistics = decoded is Map<String, Object?>
+      ? decoded['statistics']
+      : null;
+  final queryStatistics = statistics is Map<String, Object?>
+      ? statistics['query']
+      : null;
+  if (queryStatistics is! Map<String, Object?>) {
+    throw _CliError(
+      message: 'Error: bq returned invalid dry-run statistics for $fileName.',
+    );
+  }
+
+  final totalBytesProcessed = queryStatistics['totalBytesProcessed'];
+  if (totalBytesProcessed != null &&
+      (totalBytesProcessed is! String ||
+          !RegExp(r'^\d+$').hasMatch(totalBytesProcessed))) {
+    throw _CliError(
+      message: 'Error: bq returned invalid dry-run statistics for $fileName.',
+    );
+  }
+  final accuracy = totalBytesProcessed == null
+      ? _DryRunAccuracy.unknown
+      : _DryRunAccuracy.tryParse(
+              value: queryStatistics['totalBytesProcessedAccuracy'],
+            ) ??
+            _DryRunAccuracy.unknown;
+  return _DryRunEstimate(
+    totalBytesProcessed: totalBytesProcessed as String?,
+    accuracy: accuracy,
+  );
+}
+
+bool _validTransferConfigName({
+  required String resourceName,
+  required String expectedLocation,
+}) {
+  final parts = resourceName.split('/');
+  return parts.length == 6 &&
+      parts[0] == 'projects' &&
+      parts[1].isNotEmpty &&
+      parts[2] == 'locations' &&
+      parts[3].toLowerCase() == expectedLocation.toLowerCase() &&
+      parts[4] == 'transferConfigs' &&
+      parts[5].isNotEmpty &&
+      parts.every(_printableAsciiPattern.hasMatch);
+}
+
+String _joinPath({required String parent, required String child}) =>
+    '$parent${Platform.pathSeparator}$child';
+
+String _baseName({required String path}) =>
+    path.split(Platform.pathSeparator).last;

--- a/tool/product_analytics/deploy.dart
+++ b/tool/product_analytics/deploy.dart
@@ -24,8 +24,10 @@ Modes:
                No BigQuery command is run and no resource is changed.
   --dry-run    Run a best-effort whole-script BigQuery dry run for each numeric
                SQL asset and print its byte estimate and estimate accuracy.
+  --bootstrap  Dry-run and apply only 00_datasets.sql. Use this once before the
+               initial auth export on a new warehouse.
   --apply      Dry-run and then execute each numeric SQL asset in dependency
-               order. This is the only mode that mutates BigQuery resources.
+               order after verifying that an auth snapshot already exists.
 
 Schedule deployment:
   Scheduled-query transfer configs are created or updated only when --apply,
@@ -64,6 +66,7 @@ const Set<String> _optionalValueFlags = <String>{'--transform-service-account'};
 
 const Set<String> _booleanFlags = <String>{
   '--dry-run',
+  '--bootstrap',
   '--apply',
   '--apply-schedules',
 };
@@ -110,7 +113,7 @@ final RegExp _dailyCadencePattern = RegExp(
   r'^every day (?:[01][0-9]|2[0-3]):[0-5][0-9]$',
 );
 
-enum _Mode { renderOnly, dryRun, apply }
+enum _Mode { renderOnly, dryRun, bootstrap, apply }
 
 enum _DryRunAccuracy {
   unknown(wireValue: 'UNKNOWN'),
@@ -260,17 +263,47 @@ Future<void> main(final List<String> args) async {
       projectId: options.projectId,
       location: options.location,
     );
-    for (final asset in assets) {
+    if (options.mode == _Mode.apply) {
+      final authSnapshotCount = await bq.loadInitialAuthSnapshotCount(
+        authDatasetId: options.authDatasetId,
+      );
+      if (authSnapshotCount < 1) {
+        throw const _CliError(
+          message:
+              'Error: No initial auth snapshot exists. Run --bootstrap, publish '
+              'and validate the initial auth export, then run --apply.',
+        );
+      }
+    }
+    final selectedAssets = options.mode == _Mode.bootstrap
+        ? assets.where((asset) => asset.fileName == '00_datasets.sql').toList()
+        : assets;
+    for (final asset in selectedAssets) {
       stdout.writeln(
         'Dry-running ${asset.fileName} with allocatedBytes='
         '${asset.maxBytesBilled}.',
       );
+      if (asset.schedule == null) {
+        stdout.writeln(
+          'DDL dry-run limitation for ${asset.fileName}: BigQuery validates '
+          'only through the first DDL statement; deployed-schema assertions '
+          'remain required.',
+        );
+      }
       await bq.runQuery(asset: asset, dryRun: true);
 
-      if (options.mode == _Mode.apply) {
+      if (options.mode == _Mode.bootstrap || options.mode == _Mode.apply) {
         stdout.writeln('Applying ${asset.fileName}.');
         await bq.runQuery(asset: asset, dryRun: false);
       }
+    }
+
+    if (options.mode == _Mode.bootstrap) {
+      stdout.writeln(
+        'Bootstrap apply complete. Publish and validate the initial auth '
+        'snapshot before running --apply.',
+      );
+      return;
     }
 
     if (options.mode == _Mode.dryRun) {
@@ -362,15 +395,19 @@ _Options _parseOptions({required List<String> args}) {
   }
 
   final dryRun = enabledFlags.contains('--dry-run');
+  final bootstrap = enabledFlags.contains('--bootstrap');
   final apply = enabledFlags.contains('--apply');
-  if (dryRun && apply) {
+  if (<bool>[dryRun, bootstrap, apply].where((value) => value).length > 1) {
     throw const _CliError(
-      message: 'Error: --dry-run and --apply are mutually exclusive.',
+      message:
+          'Error: --dry-run, --bootstrap, and --apply are mutually exclusive.',
     );
   }
 
   final mode = dryRun
       ? _Mode.dryRun
+      : bootstrap
+      ? _Mode.bootstrap
       : apply
       ? _Mode.apply
       : _Mode.renderOnly;
@@ -579,6 +616,7 @@ Future<List<_ScheduleDefinition>> _loadSchedules({required String path}) async {
         displayName.isEmpty ||
         displayName != displayName.trim() ||
         displayName.length > 256 ||
+        !displayName.startsWith(_scheduleDisplayNamePrefix) ||
         !_printableAsciiPattern.hasMatch(displayName)) {
       throw _CliError(
         message:
@@ -889,6 +927,43 @@ class _BqRunner {
   final String projectId;
   final String location;
 
+  Future<int> loadInitialAuthSnapshotCount({
+    required String authDatasetId,
+  }) async {
+    final result = await _run(
+      arguments: <String>[
+        ..._globalArguments(format: 'json'),
+        'query',
+        '--use_legacy_sql=false',
+      ],
+      standardInput:
+          'SELECT COUNT(*) AS snapshot_count FROM '
+          '`$projectId.$authDatasetId.product_analytics_export_runs`',
+      operation: 'read the initial auth snapshot count',
+    );
+    late final Object? decoded;
+    try {
+      decoded = jsonDecode(result.standardOutput);
+    } on FormatException catch (error) {
+      throw _CliError.withCause(
+        message: 'Error: bq returned an invalid auth snapshot count.',
+        cause: error,
+      );
+    }
+    final snapshotRow = decoded is List<Object?> && decoded.length == 1
+        ? decoded.single
+        : null;
+    final snapshotCount = snapshotRow is Map<String, Object?>
+        ? snapshotRow['snapshot_count']
+        : null;
+    if (snapshotCount is! String || int.tryParse(snapshotCount) == null) {
+      throw const _CliError(
+        message: 'Error: bq returned an invalid auth snapshot count.',
+      );
+    }
+    return int.parse(snapshotCount);
+  }
+
   Future<void> runQuery({
     required _SqlAsset asset,
     required bool dryRun,
@@ -947,6 +1022,13 @@ class _BqRunner {
         message: 'Error: bq returned an invalid scheduled-query config list.',
       );
     }
+    if (decoded.length >= 1000) {
+      throw const _CliError(
+        message:
+            'Error: Scheduled-query config listing reached the 1000-result '
+            'safety limit and may be truncated. No schedules were changed.',
+      );
+    }
 
     final configsByDisplayName = <String, List<String>>{};
     for (final rawConfig in decoded) {
@@ -988,7 +1070,7 @@ class _BqRunner {
     required String renderedSql,
     required String serviceAccount,
   }) async {
-    await _run(
+    await _runScheduleCommand(
       arguments: <String>[
         ..._globalArguments(format: 'none'),
         'mk',
@@ -996,10 +1078,9 @@ class _BqRunner {
         '--data_source=scheduled_query',
         '--display_name=${schedule.displayName}',
         '--schedule=${schedule.cadence}',
-        '--params=${jsonEncode(<String, String>{'query': renderedSql})}',
         '--service_account_name=$serviceAccount',
       ],
-      standardInput: null,
+      renderedSql: renderedSql,
       operation: 'create schedule for ${schedule.queryFile}',
     );
   }
@@ -1010,21 +1091,66 @@ class _BqRunner {
     required String renderedSql,
     required String serviceAccount,
   }) async {
-    await _run(
+    await _runScheduleCommand(
       arguments: <String>[
         ..._globalArguments(format: 'none'),
         'update',
         '--transfer_config=true',
         '--display_name=${schedule.displayName}',
         '--schedule=${schedule.cadence}',
-        '--params=${jsonEncode(<String, String>{'query': renderedSql})}',
         '--service_account_name=$serviceAccount',
         '--update_credentials=true',
         resourceName,
       ],
-      standardInput: null,
+      renderedSql: renderedSql,
       operation: 'update schedule for ${schedule.queryFile}',
     );
+  }
+
+  Future<void> _runScheduleCommand({
+    required List<String> arguments,
+    required String renderedSql,
+    required String operation,
+  }) async {
+    Directory? temporaryDirectory;
+    try {
+      temporaryDirectory = await Directory.systemTemp.createTemp(
+        'sesori-product-analytics-',
+      );
+      final paramsFile = File(
+        _joinPath(parent: temporaryDirectory.path, child: 'bq-flags.txt'),
+      );
+      await paramsFile.writeAsString(
+        '--params=${jsonEncode(<String, String>{'query': renderedSql})}\n',
+        flush: true,
+      );
+      final commandIndex = arguments.indexWhere(
+        (argument) => argument == 'mk' || argument == 'update',
+      );
+      if (commandIndex < 0) {
+        throw const _CliError(
+          message: 'Error: Invalid bq schedule command configuration.',
+        );
+      }
+      await _run(
+        arguments: <String>[
+          ...arguments.take(commandIndex + 1),
+          '--flagfile=${paramsFile.path}',
+          ...arguments.skip(commandIndex + 1),
+        ],
+        standardInput: null,
+        operation: operation,
+      );
+    } on FileSystemException catch (error) {
+      throw _CliError.withCause(
+        message: 'Error: Could not prepare bq schedule parameters.',
+        cause: error,
+      );
+    } finally {
+      if (temporaryDirectory != null && temporaryDirectory.existsSync()) {
+        await temporaryDirectory.delete(recursive: true);
+      }
+    }
   }
 
   List<String> _globalArguments({required String format}) => <String>[

--- a/tool/product_analytics/privacy_deletion/bigquery_privacy_deletion_client.dart
+++ b/tool/product_analytics/privacy_deletion/bigquery_privacy_deletion_client.dart
@@ -1,0 +1,528 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'google_api_foundation.dart';
+import 'privacy_deletion_models.dart';
+
+sealed class BigQueryParameter {
+  const BigQueryParameter({required this.name});
+
+  final String name;
+
+  Map<String, Object?> toJson();
+}
+
+final class BigQueryStringParameter extends BigQueryParameter {
+  const BigQueryStringParameter({required super.name, required this.value});
+
+  final String? value;
+
+  @override
+  Map<String, Object?> toJson() => <String, Object?>{
+    'name': name,
+    'parameterType': <String, Object?>{'type': 'STRING'},
+    'parameterValue': <String, Object?>{'value': value},
+  };
+}
+
+final class BigQueryTimestampParameter extends BigQueryParameter {
+  const BigQueryTimestampParameter({required super.name, required this.value});
+
+  final DateTime value;
+
+  @override
+  Map<String, Object?> toJson() => <String, Object?>{
+    'name': name,
+    'parameterType': <String, Object?>{'type': 'TIMESTAMP'},
+    'parameterValue': <String, Object?>{
+      'value': value.toUtc().toIso8601String(),
+    },
+  };
+}
+
+final class BigQueryDateParameter extends BigQueryParameter {
+  const BigQueryDateParameter({required super.name, required this.value});
+
+  final DateTime value;
+
+  @override
+  Map<String, Object?> toJson() => <String, Object?>{
+    'name': name,
+    'parameterType': <String, Object?>{'type': 'DATE'},
+    'parameterValue': <String, Object?>{'value': formatUtcDate(date: value)},
+  };
+}
+
+final class BigQueryBoolParameter extends BigQueryParameter {
+  const BigQueryBoolParameter({required super.name, required this.value});
+
+  final bool value;
+
+  @override
+  Map<String, Object?> toJson() => <String, Object?>{
+    'name': name,
+    'parameterType': <String, Object?>{'type': 'BOOL'},
+    'parameterValue': <String, Object?>{'value': value.toString()},
+  };
+}
+
+final class BigQueryStringArrayParameter extends BigQueryParameter {
+  BigQueryStringArrayParameter({
+    required super.name,
+    required List<String> values,
+  }) : values = List<String>.unmodifiable(values);
+
+  final List<String> values;
+
+  @override
+  Map<String, Object?> toJson() => <String, Object?>{
+    'name': name,
+    'parameterType': <String, Object?>{
+      'type': 'ARRAY',
+      'arrayType': <String, Object?>{'type': 'STRING'},
+    },
+    'parameterValue': <String, Object?>{
+      'arrayValues': values
+          .map((final value) => <String, Object?>{'value': value})
+          .toList(),
+    },
+  };
+}
+
+final class BigQueryStatement {
+  BigQueryStatement({
+    required this.sql,
+    required List<BigQueryParameter> parameters,
+    required List<BigQueryDatasetReference> referencedDatasets,
+    required this.isMutation,
+    required this.dryRun,
+  }) : parameters = List<BigQueryParameter>.unmodifiable(parameters),
+       referencedDatasets = List<BigQueryDatasetReference>.unmodifiable(
+         referencedDatasets,
+       );
+
+  final String sql;
+  final List<BigQueryParameter> parameters;
+  final List<BigQueryDatasetReference> referencedDatasets;
+  final bool isMutation;
+  final bool dryRun;
+}
+
+final class BigQueryStatementResult {
+  const BigQueryStatementResult({
+    required this.rows,
+    required this.affectedRows,
+    required this.dryRun,
+  });
+
+  final List<Map<String, Object?>> rows;
+  final int affectedRows;
+  final bool dryRun;
+}
+
+abstract interface class BigQueryPrivacyDeletionClient {
+  Future<BigQueryStatementResult> execute({
+    required BigQueryStatement statement,
+  });
+
+  void close();
+}
+
+final class RestBigQueryPrivacyDeletionClient
+    implements BigQueryPrivacyDeletionClient {
+  RestBigQueryPrivacyDeletionClient({
+    required this.projectId,
+    required this.location,
+    required List<BigQueryDatasetReference> allowedDatasets,
+    required GoogleAccessTokenProvider accessTokenProvider,
+    required Duration queryTimeout,
+  }) : _allowedDatasetKeys = Set<String>.unmodifiable(
+         allowedDatasets.map((final value) => value.allowlistKey),
+       ),
+       _accessTokenProvider = accessTokenProvider,
+       _queryTimeout = queryTimeout,
+       _httpClient = HttpClient() {
+    if (_allowedDatasetKeys.isEmpty) {
+      throw const PrivacyDeletionValidationException(
+        field: 'allowed_datasets',
+        requirement: 'at least one dataset',
+      );
+    }
+    for (final dataset in allowedDatasets) {
+      if (dataset.projectId.value != projectId.value) {
+        throw const PrivacyDeletionValidationException(
+          field: 'allowed_datasets',
+          requirement: 'all datasets in the configured project',
+        );
+      }
+    }
+    _httpClient.connectionTimeout = const Duration(seconds: 15);
+  }
+
+  final GcpProjectId projectId;
+  final BigQueryLocation location;
+  final Set<String> _allowedDatasetKeys;
+  final GoogleAccessTokenProvider _accessTokenProvider;
+  final Duration _queryTimeout;
+  final HttpClient _httpClient;
+
+  @override
+  Future<BigQueryStatementResult> execute({
+    required BigQueryStatement statement,
+  }) async {
+    _validateStatement(statement: statement);
+    try {
+      if (statement.dryRun) {
+        final dryRunResponse = await _postJson(
+          uri: Uri.https(
+            'bigquery.googleapis.com',
+            '/bigquery/v2/projects/${projectId.value}/jobs',
+          ),
+          body: <String, Object?>{
+            'jobReference': <String, Object?>{
+              'projectId': projectId.value,
+              'location': location.value,
+              'jobId':
+                  'privacy_deletion_dry_run_${pid}_'
+                  '${DateTime.now().microsecondsSinceEpoch}',
+            },
+            'configuration': <String, Object?>{
+              'dryRun': true,
+              'query': <String, Object?>{
+                'query': statement.sql,
+                'useLegacySql': false,
+                'parameterMode': 'NAMED',
+                'queryParameters': statement.parameters
+                    .map((final parameter) => parameter.toJson())
+                    .toList(),
+              },
+            },
+          },
+        );
+        _throwForJobStatusErrors(response: dryRunResponse);
+        return const BigQueryStatementResult(
+          rows: <Map<String, Object?>>[],
+          affectedRows: 0,
+          dryRun: true,
+        );
+      }
+      final initial = await _postJson(
+        uri: Uri.https(
+          'bigquery.googleapis.com',
+          '/bigquery/v2/projects/${projectId.value}/queries',
+        ),
+        body: <String, Object?>{
+          'query': statement.sql,
+          'useLegacySql': false,
+          'parameterMode': 'NAMED',
+          'queryParameters': statement.parameters
+              .map((final parameter) => parameter.toJson())
+              .toList(),
+          'location': location.value,
+          'timeoutMs': 10000,
+        },
+      );
+      _throwForQueryErrors(response: initial);
+
+      final pages = <Map<String, dynamic>>[];
+      var current = initial;
+      final deadline = DateTime.now().add(_queryTimeout);
+      while (current['jobComplete'] != true) {
+        if (DateTime.now().isAfter(deadline)) {
+          throw const BigQueryQueryTimeoutException();
+        }
+        final jobReference = current['jobReference'];
+        if (jobReference is! Map<String, dynamic> ||
+            jobReference['jobId'] is! String) {
+          throw const BigQueryResponseShapeException();
+        }
+        await Future<void>.delayed(const Duration(seconds: 1));
+        current = await _getQueryResults(
+          jobId: jobReference['jobId'] as String,
+          pageToken: null,
+        );
+        _throwForQueryErrors(response: current);
+      }
+      pages.add(current);
+
+      var pageToken = current['pageToken'];
+      final jobReference = current['jobReference'] ?? initial['jobReference'];
+      while (pageToken is String && pageToken.isNotEmpty) {
+        if (jobReference is! Map<String, dynamic> ||
+            jobReference['jobId'] is! String) {
+          throw const BigQueryResponseShapeException();
+        }
+        current = await _getQueryResults(
+          jobId: jobReference['jobId'] as String,
+          pageToken: pageToken,
+        );
+        _throwForQueryErrors(response: current);
+        pages.add(current);
+        pageToken = current['pageToken'];
+      }
+
+      final rows = <Map<String, Object?>>[];
+      for (final page in pages) {
+        rows.addAll(_decodeRows(response: page));
+      }
+      String? affectedRowsRaw;
+      for (final page in pages) {
+        final value = page['numDmlAffectedRows'];
+        if (value is String) {
+          affectedRowsRaw = value;
+        }
+      }
+      return BigQueryStatementResult(
+        rows: List<Map<String, Object?>>.unmodifiable(rows),
+        affectedRows: affectedRowsRaw == null
+            ? 0
+            : int.tryParse(affectedRowsRaw) ?? 0,
+        dryRun: false,
+      );
+    } catch (error, stackTrace) {
+      if (error is BigQueryPrivacyDeletionClientException) {
+        rethrow;
+      }
+      throw BigQueryPrivacyDeletionClientException(
+        mutation: statement.isMutation,
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+    }
+  }
+
+  void _validateStatement({required BigQueryStatement statement}) {
+    if (statement.sql.trim().isEmpty) {
+      throw const PrivacyDeletionValidationException(
+        field: 'query',
+        requirement: 'non-empty GoogleSQL',
+      );
+    }
+    final declaredKeys = statement.referencedDatasets
+        .map((final value) => value.allowlistKey)
+        .toSet();
+    if (declaredKeys.any((final key) => !_allowedDatasetKeys.contains(key))) {
+      throw const PrivacyDeletionValidationException(
+        field: 'query_datasets',
+        requirement: 'only configured allowlisted datasets',
+      );
+    }
+    final forbidden = RegExp(
+      r'\b(EXECUTE\s+IMMEDIATE|EXTERNAL_QUERY|EXPORT\s+DATA|LOAD\s+DATA|CREATE\s+CONNECTION)\b',
+      caseSensitive: false,
+    );
+    if (forbidden.hasMatch(statement.sql)) {
+      throw const PrivacyDeletionValidationException(
+        field: 'query',
+        requirement: 'no dynamic, external, export, load, or connection SQL',
+      );
+    }
+    for (final match in RegExp(r'`([^`]+)`').allMatches(statement.sql)) {
+      final identifier = match.group(1)!;
+      final parts = identifier.split('.');
+      if (parts.length < 3) {
+        continue;
+      }
+      final key = '${parts[0]}.${parts[1]}';
+      if (!_allowedDatasetKeys.contains(key) || !declaredKeys.contains(key)) {
+        throw const PrivacyDeletionValidationException(
+          field: 'query_identifiers',
+          requirement:
+              'fully qualified references in declared allowlisted datasets',
+        );
+      }
+    }
+    final unquotedReferencePattern = RegExp(
+      r'\b(?:FROM|JOIN|UPDATE|INTO|CALL|TABLE)\s+'
+      r'([A-Za-z_][A-Za-z0-9_-]*\.[A-Za-z_][A-Za-z0-9_]*\.'
+      r'[A-Za-z_][A-Za-z0-9_*]*)',
+      caseSensitive: false,
+    );
+    for (final match in unquotedReferencePattern.allMatches(statement.sql)) {
+      final parts = match.group(1)!.split('.');
+      final key = '${parts[0]}.${parts[1]}';
+      if (!_allowedDatasetKeys.contains(key) || !declaredKeys.contains(key)) {
+        throw const PrivacyDeletionValidationException(
+          field: 'query_identifiers',
+          requirement:
+              'unquoted references in declared allowlisted datasets only',
+        );
+      }
+    }
+    final parameterNames = <String>{};
+    for (final parameter in statement.parameters) {
+      if (!RegExp(r'^[A-Za-z_][A-Za-z0-9_]{0,127}$').hasMatch(parameter.name) ||
+          !parameterNames.add(parameter.name)) {
+        throw const PrivacyDeletionValidationException(
+          field: 'query_parameters',
+          requirement: 'unique valid named parameters',
+        );
+      }
+    }
+  }
+
+  Future<Map<String, dynamic>> _getQueryResults({
+    required String jobId,
+    required String? pageToken,
+  }) {
+    return _getJson(
+      uri: Uri.https(
+        'bigquery.googleapis.com',
+        '/bigquery/v2/projects/${projectId.value}/queries/$jobId',
+        <String, String>{
+          'location': location.value,
+          'timeoutMs': '10000',
+          if (pageToken != null) 'pageToken': pageToken,
+        },
+      ),
+    );
+  }
+
+  Future<Map<String, dynamic>> _postJson({
+    required Uri uri,
+    required Map<String, Object?> body,
+  }) async {
+    final token = await _accessTokenProvider.accessToken();
+    final request = await _httpClient.postUrl(uri);
+    request.headers.set(
+      HttpHeaders.authorizationHeader,
+      'Bearer ${token.value}',
+    );
+    request.headers.contentType = ContentType.json;
+    request.write(jsonEncode(body));
+    return _readResponse(request: request);
+  }
+
+  Future<Map<String, dynamic>> _getJson({required Uri uri}) async {
+    final token = await _accessTokenProvider.accessToken();
+    final request = await _httpClient.getUrl(uri);
+    request.headers.set(
+      HttpHeaders.authorizationHeader,
+      'Bearer ${token.value}',
+    );
+    return _readResponse(request: request);
+  }
+
+  Future<Map<String, dynamic>> _readResponse({
+    required HttpClientRequest request,
+  }) async {
+    final response = await request.close().timeout(_queryTimeout);
+    final body = await response.transform(utf8.decoder).join();
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw GoogleApiHttpException(statusCode: response.statusCode);
+    }
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(body);
+    } catch (error, stackTrace) {
+      throw GoogleApiPayloadException(
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+    }
+    if (decoded is! Map<String, dynamic>) {
+      throw const BigQueryResponseShapeException();
+    }
+    return decoded;
+  }
+
+  void _throwForQueryErrors({required Map<String, dynamic> response}) {
+    final errors = response['errors'];
+    if (errors is List && errors.isNotEmpty) {
+      throw BigQueryJobException(errorCount: errors.length);
+    }
+  }
+
+  void _throwForJobStatusErrors({required Map<String, dynamic> response}) {
+    final status = response['status'];
+    if (status is! Map<String, dynamic>) {
+      throw const BigQueryResponseShapeException();
+    }
+    final errors = status['errors'];
+    if (status['errorResult'] != null ||
+        (errors is List && errors.isNotEmpty)) {
+      throw BigQueryJobException(
+        errorCount: errors is List && errors.isNotEmpty ? errors.length : 1,
+      );
+    }
+  }
+
+  List<Map<String, Object?>> _decodeRows({
+    required Map<String, dynamic> response,
+  }) {
+    final rawRows = response['rows'];
+    if (rawRows == null) {
+      return const <Map<String, Object?>>[];
+    }
+    final schema = response['schema'];
+    if (rawRows is! List || schema is! Map<String, dynamic>) {
+      throw const BigQueryResponseShapeException();
+    }
+    final rawFields = schema['fields'];
+    if (rawFields is! List) {
+      throw const BigQueryResponseShapeException();
+    }
+    final fieldNames = rawFields.map((final rawField) {
+      if (rawField is! Map<String, dynamic> || rawField['name'] is! String) {
+        throw const BigQueryResponseShapeException();
+      }
+      return rawField['name'] as String;
+    }).toList();
+
+    return rawRows.map((final rawRow) {
+      if (rawRow is! Map<String, dynamic> || rawRow['f'] is! List) {
+        throw const BigQueryResponseShapeException();
+      }
+      final cells = rawRow['f'] as List;
+      if (cells.length != fieldNames.length) {
+        throw const BigQueryResponseShapeException();
+      }
+      final row = <String, Object?>{};
+      for (var index = 0; index < fieldNames.length; index++) {
+        final cell = cells[index];
+        if (cell is! Map<String, dynamic>) {
+          throw const BigQueryResponseShapeException();
+        }
+        row[fieldNames[index]] = cell['v'];
+      }
+      return row;
+    }).toList();
+  }
+
+  @override
+  void close() {
+    _httpClient.close(force: true);
+  }
+}
+
+final class BigQueryPrivacyDeletionClientException implements Exception {
+  const BigQueryPrivacyDeletionClientException({
+    required this.mutation,
+    required this.innerError,
+    required this.innerStackTrace,
+  });
+
+  final bool mutation;
+  final Object innerError;
+  final StackTrace innerStackTrace;
+
+  @override
+  String toString() => mutation
+      ? 'A BigQuery privacy-deletion mutation failed.'
+      : 'A BigQuery privacy-deletion read failed.';
+}
+
+final class BigQueryQueryTimeoutException implements Exception {
+  const BigQueryQueryTimeoutException();
+}
+
+final class BigQueryResponseShapeException implements Exception {
+  const BigQueryResponseShapeException();
+}
+
+final class BigQueryJobException implements Exception {
+  const BigQueryJobException({required this.errorCount});
+
+  final int errorCount;
+}

--- a/tool/product_analytics/privacy_deletion/bigquery_privacy_deletion_client.dart
+++ b/tool/product_analytics/privacy_deletion/bigquery_privacy_deletion_client.dart
@@ -308,14 +308,23 @@ final class RestBigQueryPrivacyDeletionClient
         requirement: 'only configured allowlisted datasets',
       );
     }
+    final sqlWithoutTemporaryTableCreates = statement.sql.replaceAll(
+      RegExp(
+        r'\bCREATE\s+(?:OR\s+REPLACE\s+)?TEMP(?:ORARY)?\s+TABLE\b',
+        caseSensitive: false,
+      ),
+      '',
+    );
     final forbidden = RegExp(
-      r'\b(EXECUTE\s+IMMEDIATE|EXTERNAL_QUERY|EXPORT\s+DATA|LOAD\s+DATA|CREATE\s+CONNECTION)\b',
+      r'\b(EXECUTE\s+IMMEDIATE|EXTERNAL_QUERY|EXPORT\s+DATA|LOAD\s+DATA|'
+      r'CREATE|ALTER|DROP|TRUNCATE|GRANT|REVOKE)\b',
       caseSensitive: false,
     );
-    if (forbidden.hasMatch(statement.sql)) {
+    if (forbidden.hasMatch(sqlWithoutTemporaryTableCreates)) {
       throw const PrivacyDeletionValidationException(
         field: 'query',
-        requirement: 'no dynamic, external, export, load, or connection SQL',
+        requirement:
+            'no dynamic, external, export, load, connection, or persistent DDL SQL',
       );
     }
     for (final match in RegExp(r'`([^`]+)`').allMatches(statement.sql)) {
@@ -408,7 +417,10 @@ final class RestBigQueryPrivacyDeletionClient
     required HttpClientRequest request,
   }) async {
     final response = await request.close().timeout(_queryTimeout);
-    final body = await response.transform(utf8.decoder).join();
+    final body = await response
+        .transform(utf8.decoder)
+        .join()
+        .timeout(_queryTimeout);
     if (response.statusCode < 200 || response.statusCode >= 300) {
       throw GoogleApiHttpException(statusCode: response.statusCode);
     }

--- a/tool/product_analytics/privacy_deletion/ga_user_deletion_client.dart
+++ b/tool/product_analytics/privacy_deletion/ga_user_deletion_client.dart
@@ -1,0 +1,146 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'google_api_foundation.dart';
+import 'privacy_deletion_models.dart';
+
+sealed class GaUserDeletionIdentifier {
+  const GaUserDeletionIdentifier();
+
+  Map<String, String> toRequestBody();
+}
+
+final class GaAppInstanceDeletionIdentifier extends GaUserDeletionIdentifier {
+  const GaAppInstanceDeletionIdentifier({required this.appInstanceId});
+
+  final AppInstanceId appInstanceId;
+
+  @override
+  Map<String, String> toRequestBody() => <String, String>{
+    'appInstanceId': appInstanceId.value,
+  };
+}
+
+final class GaLegacyUserDeletionIdentifier extends GaUserDeletionIdentifier {
+  const GaLegacyUserDeletionIdentifier({required this.legacyUserId});
+
+  final LegacyFirebaseUserId legacyUserId;
+
+  @override
+  Map<String, String> toRequestBody() => <String, String>{
+    'userId': legacyUserId.value,
+  };
+}
+
+final class GaUserDeletionSubmission {
+  const GaUserDeletionSubmission({required this.deletionRequestTime});
+
+  final DateTime? deletionRequestTime;
+}
+
+abstract interface class GaUserDeletionClient {
+  Future<GaUserDeletionSubmission> submit({
+    required GaUserDeletionIdentifier identifier,
+  });
+
+  void close();
+}
+
+final class GoogleAnalyticsAdminUserDeletionClient
+    implements GaUserDeletionClient {
+  GoogleAnalyticsAdminUserDeletionClient({
+    required this.propertyId,
+    required GoogleAccessTokenProvider accessTokenProvider,
+    required Duration requestTimeout,
+  }) : _accessTokenProvider = accessTokenProvider,
+       _requestTimeout = requestTimeout,
+       _httpClient = HttpClient() {
+    _httpClient.connectionTimeout = const Duration(seconds: 15);
+  }
+
+  final AnalyticsPropertyId propertyId;
+  final GoogleAccessTokenProvider _accessTokenProvider;
+  final Duration _requestTimeout;
+  final HttpClient _httpClient;
+
+  @override
+  Future<GaUserDeletionSubmission> submit({
+    required GaUserDeletionIdentifier identifier,
+  }) async {
+    try {
+      final token = await _accessTokenProvider.accessToken();
+      final uri = Uri.https(
+        'analyticsadmin.googleapis.com',
+        '/v1alpha/properties/${propertyId.value}:submitUserDeletion',
+      );
+      final request = await _httpClient.postUrl(uri);
+      request.headers.set(
+        HttpHeaders.authorizationHeader,
+        'Bearer ${token.value}',
+      );
+      request.headers.contentType = ContentType.json;
+      request.write(jsonEncode(identifier.toRequestBody()));
+      final response = await request.close().timeout(_requestTimeout);
+      final body = await response
+          .transform(utf8.decoder)
+          .join()
+          .timeout(_requestTimeout);
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw GoogleApiHttpException(statusCode: response.statusCode);
+      }
+      final Object? decoded;
+      try {
+        decoded = jsonDecode(body);
+      } catch (error, stackTrace) {
+        throw GoogleApiPayloadException(
+          innerError: error,
+          innerStackTrace: stackTrace,
+        );
+      }
+      if (decoded is! Map<String, dynamic>) {
+        throw const GaUserDeletionResponseShapeException();
+      }
+      final rawTime = decoded['deletionRequestTime'];
+      final deletionRequestTime = rawTime == null
+          ? null
+          : rawTime is String
+          ? DateTime.tryParse(rawTime)?.toUtc()
+          : null;
+      if (rawTime != null && deletionRequestTime == null) {
+        throw const GaUserDeletionResponseShapeException();
+      }
+      return GaUserDeletionSubmission(deletionRequestTime: deletionRequestTime);
+    } catch (error, stackTrace) {
+      if (error is GaUserDeletionClientException) {
+        rethrow;
+      }
+      throw GaUserDeletionClientException(
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+    }
+  }
+
+  @override
+  void close() {
+    _httpClient.close(force: true);
+  }
+}
+
+final class GaUserDeletionClientException implements Exception {
+  const GaUserDeletionClientException({
+    required this.innerError,
+    required this.innerStackTrace,
+  });
+
+  final Object innerError;
+  final StackTrace innerStackTrace;
+
+  @override
+  String toString() =>
+      'Google Analytics Admin API user-deletion submission failed.';
+}
+
+final class GaUserDeletionResponseShapeException implements Exception {
+  const GaUserDeletionResponseShapeException();
+}

--- a/tool/product_analytics/privacy_deletion/google_api_foundation.dart
+++ b/tool/product_analytics/privacy_deletion/google_api_foundation.dart
@@ -1,0 +1,284 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'privacy_deletion_models.dart';
+
+const String bigQueryOAuthScope = 'https://www.googleapis.com/auth/bigquery';
+const String analyticsEditOAuthScope =
+    'https://www.googleapis.com/auth/analytics.edit';
+
+enum AdcCredentialSource {
+  notUsed,
+  metadataServer,
+  gcloudApplicationDefault;
+
+  String get wireValue => switch (this) {
+    notUsed => 'not_used',
+    metadataServer => 'metadata_server',
+    gcloudApplicationDefault => 'gcloud_application_default',
+  };
+}
+
+final class GoogleAccessToken {
+  const GoogleAccessToken({
+    required this.value,
+    required this.expiresAt,
+    required this.source,
+    required this.recoveredMetadataFailure,
+  });
+
+  final String value;
+  final DateTime expiresAt;
+  final AdcCredentialSource source;
+  final AccessTokenAcquisitionException? recoveredMetadataFailure;
+}
+
+abstract interface class GoogleAccessTokenProvider {
+  AdcCredentialSource get lastSource;
+  bool get usedFallback;
+
+  Future<GoogleAccessToken> accessToken();
+
+  void close();
+}
+
+final class ApplicationDefaultAccessTokenProvider
+    implements GoogleAccessTokenProvider {
+  ApplicationDefaultAccessTokenProvider({
+    required Set<String> scopes,
+    required Duration metadataTimeout,
+    required bool allowGcloudApplicationDefaultFallback,
+    required DateTime Function() now,
+  }) : _scopes = List<String>.unmodifiable(scopes.toList()..sort()),
+       _metadataTimeout = metadataTimeout,
+       _allowGcloudApplicationDefaultFallback =
+           allowGcloudApplicationDefaultFallback,
+       _now = now,
+       _metadataClient = HttpClient() {
+    if (_scopes.isEmpty) {
+      throw const PrivacyDeletionValidationException(
+        field: 'oauth_scopes',
+        requirement: 'at least one OAuth scope',
+      );
+    }
+    _metadataClient.connectionTimeout = metadataTimeout;
+  }
+
+  final List<String> _scopes;
+  final Duration _metadataTimeout;
+  final bool _allowGcloudApplicationDefaultFallback;
+  final DateTime Function() _now;
+  final HttpClient _metadataClient;
+  GoogleAccessToken? _cachedToken;
+  AdcCredentialSource _lastSource = AdcCredentialSource.notUsed;
+  bool _usedFallback = false;
+
+  @override
+  AdcCredentialSource get lastSource => _lastSource;
+
+  @override
+  bool get usedFallback => _usedFallback;
+
+  @override
+  Future<GoogleAccessToken> accessToken() async {
+    final cached = _cachedToken;
+    if (cached != null &&
+        cached.expiresAt.isAfter(_now().add(const Duration(minutes: 2)))) {
+      return cached;
+    }
+
+    AccessTokenAcquisitionException? metadataFailure;
+    try {
+      final token = await _metadataAccessToken();
+      _cachedToken = token;
+      _lastSource = token.source;
+      return token;
+    } catch (error, stackTrace) {
+      metadataFailure = AccessTokenAcquisitionException(
+        source: AdcCredentialSource.metadataServer,
+        innerError: error,
+        innerStackTrace: stackTrace,
+        priorFailure: null,
+      );
+    }
+
+    if (!_allowGcloudApplicationDefaultFallback) {
+      throw metadataFailure;
+    }
+
+    try {
+      final token = await _gcloudApplicationDefaultAccessToken(
+        metadataFailure: metadataFailure,
+      );
+      _cachedToken = token;
+      _lastSource = token.source;
+      _usedFallback = true;
+      return token;
+    } catch (error, stackTrace) {
+      throw AccessTokenAcquisitionException(
+        source: AdcCredentialSource.gcloudApplicationDefault,
+        innerError: error,
+        innerStackTrace: stackTrace,
+        priorFailure: metadataFailure,
+      );
+    }
+  }
+
+  Future<GoogleAccessToken> _metadataAccessToken() async {
+    final scopes = Uri.encodeQueryComponent(_scopes.join(','));
+    final uri = Uri.parse(
+      'http://metadata.google.internal/computeMetadata/v1/instance/'
+      'service-accounts/default/token?scopes=$scopes',
+    );
+    final request = await _metadataClient.getUrl(uri).timeout(_metadataTimeout);
+    request.headers.set('Metadata-Flavor', 'Google');
+    final response = await request.close().timeout(_metadataTimeout);
+    if (response.statusCode != HttpStatus.ok) {
+      await response.drain<void>().timeout(_metadataTimeout);
+      throw MetadataServerResponseException(statusCode: response.statusCode);
+    }
+    final body = await response
+        .transform(utf8.decoder)
+        .join()
+        .timeout(_metadataTimeout);
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(body);
+    } catch (error, stackTrace) {
+      throw CredentialPayloadException(
+        source: AdcCredentialSource.metadataServer,
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+    }
+    if (decoded is! Map<String, dynamic>) {
+      throw const CredentialPayloadShapeException(
+        source: AdcCredentialSource.metadataServer,
+      );
+    }
+    final token = decoded['access_token'];
+    final expiresIn = decoded['expires_in'];
+    if (token is! String || token.isEmpty || expiresIn is! num) {
+      throw const CredentialPayloadShapeException(
+        source: AdcCredentialSource.metadataServer,
+      );
+    }
+    return GoogleAccessToken(
+      value: token,
+      expiresAt: _now().add(Duration(seconds: expiresIn.toInt())),
+      source: AdcCredentialSource.metadataServer,
+      recoveredMetadataFailure: null,
+    );
+  }
+
+  Future<GoogleAccessToken> _gcloudApplicationDefaultAccessToken({
+    required AccessTokenAcquisitionException metadataFailure,
+  }) async {
+    final result = await Process.run(
+      'gcloud',
+      <String>[
+        'auth',
+        'application-default',
+        'print-access-token',
+        '--scopes=${_scopes.join(',')}',
+      ],
+      environment: applicationDefaultProcessEnvironment(
+        parentEnvironment: Platform.environment,
+      ),
+      includeParentEnvironment: false,
+      runInShell: false,
+    );
+    if (result.exitCode != 0) {
+      throw GcloudApplicationDefaultException(exitCode: result.exitCode);
+    }
+    final token = (result.stdout as String).trim();
+    if (token.isEmpty || token.contains(RegExp(r'\s'))) {
+      throw const CredentialPayloadShapeException(
+        source: AdcCredentialSource.gcloudApplicationDefault,
+      );
+    }
+    return GoogleAccessToken(
+      value: token,
+      expiresAt: _now().add(const Duration(minutes: 45)),
+      source: AdcCredentialSource.gcloudApplicationDefault,
+      recoveredMetadataFailure: metadataFailure,
+    );
+  }
+
+  @override
+  void close() {
+    _metadataClient.close(force: true);
+  }
+}
+
+Map<String, String> applicationDefaultProcessEnvironment({
+  required Map<String, String> parentEnvironment,
+}) {
+  return Map<String, String>.from(parentEnvironment)
+    ..remove('GOOGLE_APPLICATION_CREDENTIALS');
+}
+
+final class AccessTokenAcquisitionException implements Exception {
+  const AccessTokenAcquisitionException({
+    required this.source,
+    required this.innerError,
+    required this.innerStackTrace,
+    required this.priorFailure,
+  });
+
+  final AdcCredentialSource source;
+  final Object innerError;
+  final StackTrace innerStackTrace;
+  final AccessTokenAcquisitionException? priorFailure;
+
+  @override
+  String toString() =>
+      'Could not acquire Application Default Credentials from '
+      '${source.wireValue}.';
+}
+
+final class MetadataServerResponseException implements Exception {
+  const MetadataServerResponseException({required this.statusCode});
+
+  final int statusCode;
+}
+
+final class GcloudApplicationDefaultException implements Exception {
+  const GcloudApplicationDefaultException({required this.exitCode});
+
+  final int exitCode;
+}
+
+final class CredentialPayloadShapeException implements Exception {
+  const CredentialPayloadShapeException({required this.source});
+
+  final AdcCredentialSource source;
+}
+
+final class CredentialPayloadException implements Exception {
+  const CredentialPayloadException({
+    required this.source,
+    required this.innerError,
+    required this.innerStackTrace,
+  });
+
+  final AdcCredentialSource source;
+  final Object innerError;
+  final StackTrace innerStackTrace;
+}
+
+final class GoogleApiHttpException implements Exception {
+  const GoogleApiHttpException({required this.statusCode});
+
+  final int statusCode;
+}
+
+final class GoogleApiPayloadException implements Exception {
+  const GoogleApiPayloadException({
+    required this.innerError,
+    required this.innerStackTrace,
+  });
+
+  final Object innerError;
+  final StackTrace innerStackTrace;
+}

--- a/tool/product_analytics/privacy_deletion/google_api_foundation.dart
+++ b/tool/product_analytics/privacy_deletion/google_api_foundation.dart
@@ -62,6 +62,7 @@ final class ApplicationDefaultAccessTokenProvider
       );
     }
     _metadataClient.connectionTimeout = metadataTimeout;
+    _metadataClient.findProxy = (uri) => 'DIRECT';
   }
 
   final List<String> _scopes;

--- a/tool/product_analytics/privacy_deletion/privacy_deletion_api.dart
+++ b/tool/product_analytics/privacy_deletion/privacy_deletion_api.dart
@@ -1,0 +1,1621 @@
+import 'dart:io';
+
+import 'bigquery_privacy_deletion_client.dart';
+import 'ga_user_deletion_client.dart';
+import 'google_api_foundation.dart';
+import 'privacy_deletion_models.dart';
+
+final class PrivacyDeletionWarehouseSchema {
+  PrivacyDeletionWarehouseSchema({
+    required this.rawDataset,
+    required this.authDataset,
+    required this.privacyDataset,
+    required this.controlsDataset,
+    required this.curatedDataset,
+    required this.reportingDataset,
+    required this.targetsTable,
+    required this.exclusionsTable,
+    required this.authExportRunsTable,
+    required this.sweepStateTable,
+    required List<BigQueryTableReference> authKeyedTables,
+    required List<BigQueryTableReference> curatedKeyedTables,
+    required List<BigQueryTableReference> reportingKeyedTables,
+  }) : authKeyedTables = List<BigQueryTableReference>.unmodifiable(
+         authKeyedTables,
+       ),
+       curatedKeyedTables = List<BigQueryTableReference>.unmodifiable(
+         curatedKeyedTables,
+       ),
+       reportingKeyedTables = List<BigQueryTableReference>.unmodifiable(
+         reportingKeyedTables,
+       ) {
+    _validateTableDataset(table: targetsTable, dataset: privacyDataset);
+    _validateTableDataset(table: exclusionsTable, dataset: controlsDataset);
+    _validateTableDataset(table: authExportRunsTable, dataset: authDataset);
+    _validateTableDataset(table: sweepStateTable, dataset: controlsDataset);
+    for (final table in this.authKeyedTables) {
+      _validateTableDataset(table: table, dataset: authDataset);
+    }
+    for (final table in this.curatedKeyedTables) {
+      _validateTableDataset(table: table, dataset: curatedDataset);
+    }
+    for (final table in this.reportingKeyedTables) {
+      _validateTableDataset(table: table, dataset: reportingDataset);
+    }
+  }
+
+  final BigQueryDatasetReference rawDataset;
+  final BigQueryDatasetReference authDataset;
+  final BigQueryDatasetReference privacyDataset;
+  final BigQueryDatasetReference controlsDataset;
+  final BigQueryDatasetReference curatedDataset;
+  final BigQueryDatasetReference reportingDataset;
+  final BigQueryTableReference targetsTable;
+  final BigQueryTableReference exclusionsTable;
+  final BigQueryTableReference authExportRunsTable;
+  final BigQueryTableReference sweepStateTable;
+  final List<BigQueryTableReference> authKeyedTables;
+  final List<BigQueryTableReference> curatedKeyedTables;
+  final List<BigQueryTableReference> reportingKeyedTables;
+
+  List<BigQueryTableReference> get allKeyedTables =>
+      List<BigQueryTableReference>.unmodifiable(<BigQueryTableReference>[
+        ...authKeyedTables,
+        ...curatedKeyedTables,
+        ...reportingKeyedTables,
+      ]);
+
+  static void _validateTableDataset({
+    required BigQueryTableReference table,
+    required BigQueryDatasetReference dataset,
+  }) {
+    if (table.dataset.allowlistKey != dataset.allowlistKey) {
+      throw const PrivacyDeletionValidationException(
+        field: 'warehouse_schema',
+        requirement: 'every table in its declared allowlisted dataset',
+      );
+    }
+  }
+}
+
+abstract interface class AggregateRebuilder {
+  Future<AggregateRebuildResult> rebuild({required bool dryRun});
+}
+
+enum AggregateTransform {
+  userActivityDaily(
+    fileName: '20_user_activity_daily.sql',
+    modelName: 'user_activity_daily',
+  ),
+  userMilestones(
+    fileName: '30_user_milestones.sql',
+    modelName: 'user_milestones',
+  ),
+  activationRetention(
+    fileName: '40_activation_retention.sql',
+    modelName: 'activation_retention',
+  );
+
+  const AggregateTransform({required this.fileName, required this.modelName});
+
+  final String fileName;
+  final String modelName;
+}
+
+abstract interface class AggregateTransformLoader {
+  Future<String> load({required AggregateTransform transform});
+}
+
+final class RepositoryAggregateTransformLoader
+    implements AggregateTransformLoader {
+  const RepositoryAggregateTransformLoader();
+
+  @override
+  Future<String> load({required AggregateTransform transform}) {
+    final asset = Platform.script.resolve('../sql/${transform.fileName}');
+    return File.fromUri(asset).readAsString();
+  }
+}
+
+final class FixedAggregateRebuilder implements AggregateRebuilder {
+  FixedAggregateRebuilder({
+    required BigQueryPrivacyDeletionClient client,
+    required PrivacyDeletionWarehouseSchema schema,
+    required AggregateTransformLoader loader,
+  }) : _client = client,
+       _schema = schema,
+       _loader = loader;
+
+  final BigQueryPrivacyDeletionClient _client;
+  final PrivacyDeletionWarehouseSchema _schema;
+  final AggregateTransformLoader _loader;
+
+  @override
+  Future<AggregateRebuildResult> rebuild({required bool dryRun}) async {
+    try {
+      final scripts = <String>[];
+      for (final transform in AggregateTransform.values) {
+        scripts.add(
+          renderAggregateTransform(
+            template: await _loader.load(transform: transform),
+            schema: _schema,
+          ),
+        );
+      }
+
+      final rebuildStartedAt = dryRun ? null : await _serverTimestamp();
+      for (final script in scripts) {
+        await _client.execute(
+          statement: BigQueryStatement(
+            sql: script,
+            parameters: const <BigQueryParameter>[],
+            referencedDatasets: <BigQueryDatasetReference>[
+              _schema.authDataset,
+              _schema.controlsDataset,
+              _schema.curatedDataset,
+            ],
+            isMutation: true,
+            dryRun: dryRun,
+          ),
+        );
+      }
+      if (rebuildStartedAt != null) {
+        await _verifyCompletedTransforms(rebuildStartedAt: rebuildStartedAt);
+      }
+      return AggregateRebuildResult(
+        plannedOperations: AggregateTransform.values.length,
+        executedOperations: dryRun ? 0 : AggregateTransform.values.length,
+      );
+    } catch (error, stackTrace) {
+      throw AggregateRebuildException(
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<DateTime> _serverTimestamp() async {
+    final result = await _client.execute(
+      statement: BigQueryStatement(
+        sql: 'SELECT CURRENT_TIMESTAMP() AS rebuild_started_at',
+        parameters: const <BigQueryParameter>[],
+        referencedDatasets: const <BigQueryDatasetReference>[],
+        isMutation: false,
+        dryRun: false,
+      ),
+    );
+    if (result.rows.length != 1) {
+      throw const BigQueryResponseShapeException();
+    }
+    return _requiredTimestamp(
+      row: result.rows.single,
+      field: 'rebuild_started_at',
+    );
+  }
+
+  Future<void> _verifyCompletedTransforms({
+    required DateTime rebuildStartedAt,
+  }) async {
+    final result = await _client.execute(
+      statement: BigQueryStatement(
+        sql:
+            '''
+WITH latest_auth_snapshot AS (
+  SELECT published_at
+  FROM ${_schema.authExportRunsTable.sqlIdentifier}
+  ORDER BY published_at DESC, run_cutoff DESC
+  LIMIT 1
+),
+required_models AS (
+  SELECT model_name
+  FROM UNNEST([
+    'user_activity_daily',
+    'user_milestones',
+    'activation_retention'
+  ]) AS model_name
+)
+SELECT COUNT(*) AS matching_count
+FROM required_models
+WHERE EXISTS (
+  SELECT 1
+  FROM `${_schema.curatedDataset.projectId.value}.${_schema.curatedDataset.datasetId.value}.transform_state` AS state
+  CROSS JOIN latest_auth_snapshot AS auth
+  WHERE state.model_name = required_models.model_name
+    AND state.completed_at >= @rebuild_started_at
+    AND state.auth_snapshot_published_at = auth.published_at
+)
+''',
+        parameters: <BigQueryParameter>[
+          BigQueryTimestampParameter(
+            name: 'rebuild_started_at',
+            value: rebuildStartedAt,
+          ),
+        ],
+        referencedDatasets: <BigQueryDatasetReference>[
+          _schema.authDataset,
+          _schema.curatedDataset,
+        ],
+        isMutation: false,
+        dryRun: false,
+      ),
+    );
+    final matchingModels = _singleResultCount(result: result);
+    if (matchingModels != AggregateTransform.values.length) {
+      throw AggregateTransformVerificationException(
+        expectedModels: AggregateTransform.values.length,
+        matchingModels: matchingModels,
+      );
+    }
+  }
+}
+
+final class AggregateRebuildException implements Exception {
+  const AggregateRebuildException({
+    required this.innerError,
+    required this.innerStackTrace,
+  });
+
+  final Object innerError;
+  final StackTrace innerStackTrace;
+}
+
+final class AggregateTransformVerificationException implements Exception {
+  const AggregateTransformVerificationException({
+    required this.expectedModels,
+    required this.matchingModels,
+  });
+
+  final int expectedModels;
+  final int matchingModels;
+}
+
+String renderAggregateTransform({
+  required String template,
+  required PrivacyDeletionWarehouseSchema schema,
+}) {
+  final replacements = <String, String>{
+    '{{PROJECT_ID}}': schema.rawDataset.projectId.value,
+    '{{RAW_DATASET_ID}}': schema.rawDataset.datasetId.value,
+    '{{AUTH_DATASET_ID}}': schema.authDataset.datasetId.value,
+    '{{PRIVACY_DATASET_ID}}': schema.privacyDataset.datasetId.value,
+    '{{CONTROLS_DATASET_ID}}': schema.controlsDataset.datasetId.value,
+    '{{CURATED_DATASET_ID}}': schema.curatedDataset.datasetId.value,
+    '{{REPORTING_DATASET_ID}}': schema.reportingDataset.datasetId.value,
+  };
+  var rendered = template;
+  for (final entry in replacements.entries) {
+    rendered = rendered.replaceAll(entry.key, entry.value);
+  }
+  if (RegExp(r'\{\{[^}]+\}\}').hasMatch(rendered)) {
+    throw const PrivacyDeletionValidationException(
+      field: 'aggregate_transform',
+      requirement: 'only supported uppercase project and dataset placeholders',
+    );
+  }
+  return rendered;
+}
+
+final class UpstreamDeletionResult {
+  const UpstreamDeletionResult({
+    required this.plannedSubmissions,
+    required this.executedSubmissions,
+  });
+
+  final int plannedSubmissions;
+  final int executedSubmissions;
+}
+
+final class PrivacyDeletionApi {
+  PrivacyDeletionApi({
+    required BigQueryPrivacyDeletionClient bigQueryClient,
+    required GaUserDeletionClient gaUserDeletionClient,
+    required PrivacyDeletionWarehouseSchema schema,
+    required AggregateRebuilder aggregateRebuilder,
+    required int parameterBatchSize,
+  }) : _bigQueryClient = bigQueryClient,
+       _gaUserDeletionClient = gaUserDeletionClient,
+       _schema = schema,
+       _aggregateRebuilder = aggregateRebuilder,
+       _parameterBatchSize = parameterBatchSize {
+    if (parameterBatchSize < 1) {
+      throw const PrivacyDeletionValidationException(
+        field: 'parameter_batch_size',
+        requirement: 'a positive integer',
+      );
+    }
+  }
+
+  static const String _sweepName = 'product_analytics_privacy_deletion';
+
+  final BigQueryPrivacyDeletionClient _bigQueryClient;
+  final GaUserDeletionClient _gaUserDeletionClient;
+  final PrivacyDeletionWarehouseSchema _schema;
+  final AggregateRebuilder _aggregateRebuilder;
+  final int _parameterBatchSize;
+
+  Future<PrivacyDeletionTarget?> loadTarget({
+    required PrivacyRequestId requestId,
+  }) async {
+    final result = await _executeBigQuery(
+      operation: PrivacyDeletionOperation.loadTarget,
+      statement: BigQueryStatement(
+        sql:
+            '''
+SELECT request_id, user_key, legacy_firebase_user_id, suppressed_at, status
+FROM ${_schema.targetsTable.sqlIdentifier}
+WHERE request_id = @request_id
+LIMIT 2
+''',
+        parameters: <BigQueryParameter>[
+          BigQueryStringParameter(name: 'request_id', value: requestId.value),
+        ],
+        referencedDatasets: <BigQueryDatasetReference>[_schema.privacyDataset],
+        isMutation: false,
+        dryRun: false,
+      ),
+    );
+    if (result.rows.isEmpty) {
+      return null;
+    }
+    if (result.rows.length != 1) {
+      throw _malformedTarget(
+        innerError: const TargetCardinalityException(),
+        innerStackTrace: StackTrace.current,
+      );
+    }
+    try {
+      final row = result.rows.single;
+      final loadedRequestId = PrivacyRequestId.parse(
+        value: _requiredString(row: row, field: 'request_id'),
+      );
+      if (loadedRequestId.value != requestId.value) {
+        throw const TargetRequestMismatchException();
+      }
+      return PrivacyDeletionTarget(
+        requestId: loadedRequestId,
+        userKey: PseudonymousUserKey.parse(
+          value: _requiredString(row: row, field: 'user_key'),
+        ),
+        legacyFirebaseUserId: LegacyFirebaseUserId.parse(
+          value: _requiredString(row: row, field: 'legacy_firebase_user_id'),
+        ),
+        suppressedAt: _requiredTimestamp(row: row, field: 'suppressed_at'),
+        status: PrivacyDeletionTargetStatus.parse(
+          value: _requiredString(row: row, field: 'status'),
+        ),
+      );
+    } catch (error, stackTrace) {
+      throw _malformedTarget(innerError: error, innerStackTrace: stackTrace);
+    }
+  }
+
+  Future<void> upsertPermanentExclusion({
+    required PrivacyDeletionTarget target,
+    required bool dryRun,
+  }) async {
+    await _executeBigQuery(
+      operation: PrivacyDeletionOperation.upsertExclusion,
+      statement: BigQueryStatement(
+        sql:
+            '''
+MERGE ${_schema.exclusionsTable.sqlIdentifier} AS destination
+USING (
+  SELECT @user_key AS user_key, @suppressed_at AS suppressed_at
+) AS source
+ON destination.user_key = source.user_key
+WHEN MATCHED AND source.suppressed_at < destination.suppressed_at THEN
+  UPDATE SET
+    suppressed_at = source.suppressed_at,
+    updated_at = CURRENT_TIMESTAMP()
+WHEN NOT MATCHED THEN
+  INSERT (user_key, suppressed_at, created_at, updated_at)
+  VALUES (source.user_key, source.suppressed_at, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP())
+''',
+        parameters: <BigQueryParameter>[
+          BigQueryStringParameter(
+            name: 'user_key',
+            value: target.userKey.value,
+          ),
+          BigQueryTimestampParameter(
+            name: 'suppressed_at',
+            value: target.suppressedAt,
+          ),
+        ],
+        referencedDatasets: <BigQueryDatasetReference>[_schema.controlsDataset],
+        isMutation: true,
+        dryRun: dryRun,
+      ),
+    );
+  }
+
+  Future<bool> permanentExclusionExists({
+    required PseudonymousUserKey userKey,
+  }) async {
+    final result = await _executeBigQuery(
+      operation: PrivacyDeletionOperation.readExclusion,
+      statement: BigQueryStatement(
+        sql:
+            '''
+SELECT COUNT(*) AS matching_count
+FROM ${_schema.exclusionsTable.sqlIdentifier}
+WHERE user_key = @user_key
+''',
+        parameters: <BigQueryParameter>[
+          BigQueryStringParameter(name: 'user_key', value: userKey.value),
+        ],
+        referencedDatasets: <BigQueryDatasetReference>[_schema.controlsDataset],
+        isMutation: false,
+        dryRun: false,
+      ),
+    );
+    return _singleCount(result: result) == 1;
+  }
+
+  Future<AuthExportSnapshot?> latestSuccessfulAuthExport() async {
+    final result = await _executeBigQuery(
+      operation: PrivacyDeletionOperation.readAuthExport,
+      statement: BigQueryStatement(
+        sql:
+            '''
+SELECT run_cutoff, published_at
+FROM ${_schema.authExportRunsTable.sqlIdentifier}
+ORDER BY published_at DESC, run_cutoff DESC
+LIMIT 1
+''',
+        parameters: const <BigQueryParameter>[],
+        referencedDatasets: <BigQueryDatasetReference>[_schema.authDataset],
+        isMutation: false,
+        dryRun: false,
+      ),
+    );
+    if (result.rows.isEmpty) {
+      return null;
+    }
+    try {
+      return AuthExportSnapshot(
+        runCutoff: _requiredTimestamp(
+          row: result.rows.single,
+          field: 'run_cutoff',
+        ),
+        publishedAt: _requiredTimestamp(
+          row: result.rows.single,
+          field: 'published_at',
+        ),
+      );
+    } catch (error, stackTrace) {
+      throw PrivacyDeletionOperationException(
+        failureKind: PrivacyDeletionFailureKind.warehouseRead,
+        operation: PrivacyDeletionOperation.readAuthExport,
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<void> validateKeyedTableInventory({
+    required bool allowAuthStagingTables,
+  }) async {
+    final result = await _executeBigQuery(
+      operation: PrivacyDeletionOperation.validateWarehouseSchema,
+      statement: BigQueryStatement(
+        sql:
+            '''
+SELECT 'auth' AS dataset_scope, table_name
+FROM `${_schema.authDataset.projectId.value}.${_schema.authDataset.datasetId.value}.INFORMATION_SCHEMA.COLUMNS`
+WHERE column_name = 'user_key'
+UNION ALL
+SELECT 'curated' AS dataset_scope, table_name
+FROM `${_schema.curatedDataset.projectId.value}.${_schema.curatedDataset.datasetId.value}.INFORMATION_SCHEMA.COLUMNS`
+WHERE column_name = 'user_key'
+UNION ALL
+SELECT 'reporting' AS dataset_scope, table_name
+FROM `${_schema.reportingDataset.projectId.value}.${_schema.reportingDataset.datasetId.value}.INFORMATION_SCHEMA.COLUMNS`
+WHERE column_name = 'user_key'
+ORDER BY dataset_scope, table_name
+''',
+        parameters: const <BigQueryParameter>[],
+        referencedDatasets: <BigQueryDatasetReference>[
+          _schema.authDataset,
+          _schema.curatedDataset,
+          _schema.reportingDataset,
+        ],
+        isMutation: false,
+        dryRun: false,
+      ),
+    );
+
+    final expectedAuthTables = _schema.authKeyedTables
+        .map((final table) => table.tableId.value)
+        .toSet();
+    final expectedCuratedTables = _schema.curatedKeyedTables
+        .map((final table) => table.tableId.value)
+        .toSet();
+    final expectedReportingTables = _schema.reportingKeyedTables
+        .map((final table) => table.tableId.value)
+        .toSet();
+    final foundExpectedAuthTables = <String>{};
+    final foundCuratedTables = <String>{};
+    final foundReportingTables = <String>{};
+    final unexpectedTables = <String>[];
+    var authStagingTableCount = 0;
+
+    try {
+      for (final row in result.rows) {
+        final datasetScope = _requiredString(row: row, field: 'dataset_scope');
+        final tableName = _requiredString(row: row, field: 'table_name');
+        switch (datasetScope) {
+          case 'auth':
+            if (expectedAuthTables.contains(tableName)) {
+              foundExpectedAuthTables.add(tableName);
+            } else if (RegExp(
+              r'^auth_user_milestones_staging_[a-z0-9_]{8,80}$',
+            ).hasMatch(tableName)) {
+              authStagingTableCount += 1;
+            } else {
+              unexpectedTables.add('$datasetScope.$tableName');
+            }
+          case 'curated':
+            foundCuratedTables.add(tableName);
+            if (!expectedCuratedTables.contains(tableName)) {
+              unexpectedTables.add('$datasetScope.$tableName');
+            }
+          case 'reporting':
+            foundReportingTables.add(tableName);
+            if (!expectedReportingTables.contains(tableName)) {
+              unexpectedTables.add('$datasetScope.$tableName');
+            }
+          default:
+            throw const BigQueryRowShapeException(field: 'dataset_scope');
+        }
+      }
+    } catch (error, stackTrace) {
+      throw PrivacyDeletionOperationException(
+        failureKind: PrivacyDeletionFailureKind.verification,
+        operation: PrivacyDeletionOperation.validateWarehouseSchema,
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+    }
+
+    final expectedTablesMissing =
+        !foundExpectedAuthTables.containsAll(expectedAuthTables) ||
+        !foundCuratedTables.containsAll(expectedCuratedTables) ||
+        !foundReportingTables.containsAll(expectedReportingTables);
+    if (unexpectedTables.isNotEmpty ||
+        expectedTablesMissing ||
+        (!allowAuthStagingTables && authStagingTableCount != 0)) {
+      throw PrivacyDeletionOperationException(
+        failureKind: PrivacyDeletionFailureKind.verification,
+        operation: PrivacyDeletionOperation.validateWarehouseSchema,
+        innerError: KeyedTableInventoryException(
+          unexpectedTableCount: unexpectedTables.length,
+          expectedTablesMissing: expectedTablesMissing,
+          authStagingTableCount: authStagingTableCount,
+        ),
+        innerStackTrace: StackTrace.current,
+      );
+    }
+  }
+
+  Future<List<PermanentDeletionTombstone>> loadAllPermanentTombstones() async {
+    final result = await _executeBigQuery(
+      operation: PrivacyDeletionOperation.readTombstones,
+      statement: BigQueryStatement(
+        sql:
+            '''
+SELECT exclusion.user_key, exclusion.suppressed_at, target.legacy_firebase_user_id
+FROM ${_schema.exclusionsTable.sqlIdentifier} AS exclusion
+LEFT JOIN ${_schema.targetsTable.sqlIdentifier} AS target
+  ON target.user_key = exclusion.user_key
+QUALIFY ROW_NUMBER() OVER (
+  PARTITION BY exclusion.user_key
+  ORDER BY target.suppressed_at ASC, target.request_id ASC
+) = 1
+''',
+        parameters: const <BigQueryParameter>[],
+        referencedDatasets: <BigQueryDatasetReference>[
+          _schema.controlsDataset,
+          _schema.privacyDataset,
+        ],
+        isMutation: false,
+        dryRun: false,
+      ),
+    );
+    try {
+      return List<PermanentDeletionTombstone>.unmodifiable(
+        result.rows.map(
+          (final row) => PermanentDeletionTombstone(
+            userKey: PseudonymousUserKey.parse(
+              value: _requiredString(row: row, field: 'user_key'),
+            ),
+            legacyFirebaseUserId: LegacyFirebaseUserId.parse(
+              value: _requiredString(
+                row: row,
+                field: 'legacy_firebase_user_id',
+              ),
+            ),
+            suppressedAt: _requiredTimestamp(row: row, field: 'suppressed_at'),
+          ),
+        ),
+      );
+    } catch (error, stackTrace) {
+      throw PrivacyDeletionOperationException(
+        failureKind: PrivacyDeletionFailureKind.malformedTarget,
+        operation: PrivacyDeletionOperation.readTombstones,
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<List<AppInstanceId>> discoverInstallationsForTarget({
+    required PseudonymousUserKey userKey,
+    required UtcDateRange range,
+  }) {
+    return _discoverInstallations(range: range, onlyUserKey: userKey);
+  }
+
+  Future<List<AppInstanceId>> discoverInstallationsForAllTombstones({
+    required UtcDateRange range,
+  }) {
+    return _discoverInstallations(range: range, onlyUserKey: null);
+  }
+
+  Future<List<AppInstanceId>> _discoverInstallations({
+    required UtcDateRange range,
+    required PseudonymousUserKey? onlyUserKey,
+  }) async {
+    final rawTables = await _rawTables(range: range);
+    if (rawTables.isEmpty) {
+      return const <AppInstanceId>[];
+    }
+    final matchingRows = onlyUserKey == null
+        ? '''
+SELECT DISTINCT raw.user_pseudo_id
+FROM raw_keyed_events AS raw
+JOIN ${_schema.exclusionsTable.sqlIdentifier} AS exclusion
+  ON exclusion.user_key = raw.user_key
+'''
+        : '''
+SELECT DISTINCT raw.user_pseudo_id
+FROM raw_keyed_events AS raw
+WHERE raw.user_key = @only_user_key
+''';
+    final result = await _executeBigQuery(
+      operation: PrivacyDeletionOperation.discoverInstallations,
+      statement: BigQueryStatement(
+        sql:
+            '''
+WITH raw_keyed_events AS (
+${_rawKeyedEventsUnion(tables: rawTables)}
+)
+$matchingRows
+''',
+        parameters: <BigQueryParameter>[
+          if (onlyUserKey != null)
+            BigQueryStringParameter(
+              name: 'only_user_key',
+              value: onlyUserKey.value,
+            ),
+        ],
+        referencedDatasets: <BigQueryDatasetReference>[
+          _schema.rawDataset,
+          if (onlyUserKey == null) _schema.controlsDataset,
+        ],
+        isMutation: false,
+        dryRun: false,
+      ),
+    );
+    try {
+      return List<AppInstanceId>.unmodifiable(
+        result.rows.map(
+          (final row) => AppInstanceId.parse(
+            value: _requiredString(row: row, field: 'user_pseudo_id'),
+          ),
+        ),
+      );
+    } catch (error, stackTrace) {
+      throw PrivacyDeletionOperationException(
+        failureKind: PrivacyDeletionFailureKind.malformedTarget,
+        operation: PrivacyDeletionOperation.discoverInstallations,
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<UpstreamDeletionResult> submitUpstreamDeletions({
+    required List<AppInstanceId> appInstanceIds,
+    required List<LegacyFirebaseUserId> legacyUserIds,
+    required bool dryRun,
+  }) async {
+    final uniqueAppIds = <String, AppInstanceId>{
+      for (final value in appInstanceIds) value.value: value,
+    }.values.toList();
+    final uniqueLegacyIds = <String, LegacyFirebaseUserId>{
+      for (final value in legacyUserIds) value.value: value,
+    }.values.toList();
+    final planned = uniqueAppIds.length + uniqueLegacyIds.length;
+    if (dryRun) {
+      return UpstreamDeletionResult(
+        plannedSubmissions: planned,
+        executedSubmissions: 0,
+      );
+    }
+    var executed = 0;
+    try {
+      for (final appInstanceId in uniqueAppIds) {
+        await _gaUserDeletionClient.submit(
+          identifier: GaAppInstanceDeletionIdentifier(
+            appInstanceId: appInstanceId,
+          ),
+        );
+        executed += 1;
+      }
+      for (final legacyUserId in uniqueLegacyIds) {
+        await _gaUserDeletionClient.submit(
+          identifier: GaLegacyUserDeletionIdentifier(
+            legacyUserId: legacyUserId,
+          ),
+        );
+        executed += 1;
+      }
+      return UpstreamDeletionResult(
+        plannedSubmissions: planned,
+        executedSubmissions: executed,
+      );
+    } catch (error, stackTrace) {
+      throw PrivacyDeletionOperationException(
+        failureKind: _isCredentialFailure(error: error)
+            ? PrivacyDeletionFailureKind.credentials
+            : PrivacyDeletionFailureKind.upstreamSubmission,
+        operation: PrivacyDeletionOperation.submitUpstream,
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<WarehouseMutationResult> deleteRawContributions({
+    required UtcDateRange range,
+    required List<PseudonymousUserKey> userKeys,
+    required List<LegacyFirebaseUserId> legacyUserIds,
+    required List<AppInstanceId> appInstanceIds,
+    required bool dryRun,
+  }) async {
+    final tables = await _rawTables(range: range);
+    var total = const WarehouseMutationResult.none();
+    total = total.add(
+      other: await _deleteRawDimension(
+        tables: tables,
+        kind: _RawIdentifierKind.userKey,
+        values: _uniqueStrings(
+          values: userKeys.map((final value) => value.value).toList(),
+        ),
+        dryRun: dryRun,
+      ),
+    );
+    total = total.add(
+      other: await _deleteRawDimension(
+        tables: tables,
+        kind: _RawIdentifierKind.legacyUserId,
+        values: _uniqueStrings(
+          values: legacyUserIds.map((final value) => value.value).toList(),
+        ),
+        dryRun: dryRun,
+      ),
+    );
+    total = total.add(
+      other: await _deleteRawDimension(
+        tables: tables,
+        kind: _RawIdentifierKind.appInstanceId,
+        values: _uniqueStrings(
+          values: appInstanceIds.map((final value) => value.value).toList(),
+        ),
+        dryRun: dryRun,
+      ),
+    );
+    return total;
+  }
+
+  Future<WarehouseMutationResult> _deleteRawDimension({
+    required List<BigQueryTableReference> tables,
+    required _RawIdentifierKind kind,
+    required List<String> values,
+    required bool dryRun,
+  }) async {
+    if (values.isEmpty || tables.isEmpty) {
+      return const WarehouseMutationResult.none();
+    }
+    var planned = 0;
+    var executed = 0;
+    var affected = 0;
+    for (final batch in _chunks(values: values, size: _parameterBatchSize)) {
+      for (final table in tables) {
+        planned += 1;
+        final result = await _executeBigQuery(
+          operation: PrivacyDeletionOperation.deleteRaw,
+          statement: BigQueryStatement(
+            sql:
+                '''
+DELETE FROM ${table.sqlIdentifier}
+WHERE ${kind.predicate}
+''',
+            parameters: <BigQueryParameter>[
+              BigQueryStringArrayParameter(
+                name: 'identifier_values',
+                values: batch,
+              ),
+            ],
+            referencedDatasets: <BigQueryDatasetReference>[_schema.rawDataset],
+            isMutation: true,
+            dryRun: dryRun,
+          ),
+        );
+        if (!dryRun) {
+          executed += 1;
+          affected += result.affectedRows;
+        }
+      }
+    }
+    return WarehouseMutationResult(
+      plannedJobs: planned,
+      executedJobs: executed,
+      affectedRows: affected,
+    );
+  }
+
+  Future<WarehouseMutationResult> deleteKeyedContributions({
+    required List<PseudonymousUserKey> userKeys,
+    required bool includeAuthTables,
+    required bool dryRun,
+  }) async {
+    final values = _uniqueStrings(
+      values: userKeys.map((final value) => value.value).toList(),
+    );
+    if (values.isEmpty) {
+      return const WarehouseMutationResult.none();
+    }
+    var planned = 0;
+    var executed = 0;
+    var affected = 0;
+    final tables = <BigQueryTableReference>[
+      if (includeAuthTables) ..._schema.authKeyedTables,
+      ..._schema.curatedKeyedTables,
+      ..._schema.reportingKeyedTables,
+    ];
+    for (final batch in _chunks(values: values, size: _parameterBatchSize)) {
+      for (final table in tables) {
+        planned += 1;
+        final result = await _executeBigQuery(
+          operation: PrivacyDeletionOperation.deleteKeyed,
+          statement: BigQueryStatement(
+            sql:
+                '''
+DELETE FROM ${table.sqlIdentifier}
+WHERE user_key IN UNNEST(@user_keys)
+''',
+            parameters: <BigQueryParameter>[
+              BigQueryStringArrayParameter(name: 'user_keys', values: batch),
+            ],
+            referencedDatasets: <BigQueryDatasetReference>[table.dataset],
+            isMutation: true,
+            dryRun: dryRun,
+          ),
+        );
+        if (!dryRun) {
+          executed += 1;
+          affected += result.affectedRows;
+        }
+      }
+    }
+    return WarehouseMutationResult(
+      plannedJobs: planned,
+      executedJobs: executed,
+      affectedRows: affected,
+    );
+  }
+
+  Future<AggregateRebuildResult> rebuildAggregates({
+    required bool dryRun,
+  }) async {
+    try {
+      return await _aggregateRebuilder.rebuild(dryRun: dryRun);
+    } catch (error, stackTrace) {
+      throw PrivacyDeletionOperationException(
+        failureKind: PrivacyDeletionFailureKind.aggregateRebuild,
+        operation: PrivacyDeletionOperation.rebuildAggregates,
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<WarehouseVerificationResult> verifyNoRepopulation({
+    required UtcDateRange rawRange,
+    required List<PseudonymousUserKey> userKeys,
+    required List<LegacyFirebaseUserId> legacyUserIds,
+    required List<AppInstanceId> appInstanceIds,
+    required bool includeAuthTables,
+  }) async {
+    var checks = 0;
+    var violations = 0;
+    final userKeyValues = _uniqueStrings(
+      values: userKeys.map((final value) => value.value).toList(),
+    );
+    if (userKeyValues.isNotEmpty) {
+      for (final batch in _chunks(
+        values: userKeyValues,
+        size: _parameterBatchSize,
+      )) {
+        checks += 1;
+        final exclusionCount = await _count(
+          operation: PrivacyDeletionOperation.verifyDeletion,
+          sql:
+              '''
+SELECT COUNT(DISTINCT user_key) AS matching_count
+FROM ${_schema.exclusionsTable.sqlIdentifier}
+WHERE user_key IN UNNEST(@identifier_values)
+''',
+          values: batch,
+          datasets: <BigQueryDatasetReference>[_schema.controlsDataset],
+        );
+        if (exclusionCount != batch.length) {
+          violations += 1;
+        }
+        final keyedTables = <BigQueryTableReference>[
+          if (includeAuthTables) ..._schema.authKeyedTables,
+          ..._schema.curatedKeyedTables,
+          ..._schema.reportingKeyedTables,
+        ];
+        for (final table in keyedTables) {
+          checks += 1;
+          final count = await _count(
+            operation: PrivacyDeletionOperation.verifyDeletion,
+            sql:
+                '''
+SELECT COUNT(*) AS matching_count
+FROM ${table.sqlIdentifier}
+WHERE user_key IN UNNEST(@identifier_values)
+''',
+            values: batch,
+            datasets: <BigQueryDatasetReference>[table.dataset],
+          );
+          if (count != 0) {
+            violations += 1;
+          }
+        }
+      }
+    }
+
+    final rawTables = await _rawTables(range: rawRange);
+    final dimensions = <(_RawIdentifierKind, List<String>)>[
+      (_RawIdentifierKind.userKey, userKeyValues),
+      (
+        _RawIdentifierKind.legacyUserId,
+        _uniqueStrings(
+          values: legacyUserIds.map((final value) => value.value).toList(),
+        ),
+      ),
+      (
+        _RawIdentifierKind.appInstanceId,
+        _uniqueStrings(
+          values: appInstanceIds.map((final value) => value.value).toList(),
+        ),
+      ),
+    ];
+    for (final dimension in dimensions) {
+      for (final batch in _chunks(
+        values: dimension.$2,
+        size: _parameterBatchSize,
+      )) {
+        for (final table in rawTables) {
+          checks += 1;
+          final count = await _count(
+            operation: PrivacyDeletionOperation.verifyDeletion,
+            sql:
+                '''
+SELECT COUNT(*) AS matching_count
+FROM ${table.sqlIdentifier}
+WHERE ${dimension.$1.predicate}
+''',
+            values: batch,
+            datasets: <BigQueryDatasetReference>[_schema.rawDataset],
+          );
+          if (count != 0) {
+            violations += 1;
+          }
+        }
+      }
+    }
+    return WarehouseVerificationResult(
+      checksRun: checks,
+      violationChecks: violations,
+    );
+  }
+
+  Future<void> updateTargetStatus({
+    required PrivacyRequestId requestId,
+    required PrivacyDeletionTargetStatus status,
+    required PrivacyDeletionFailureKind? failureKind,
+  }) async {
+    try {
+      await _bigQueryClient.execute(
+        statement: BigQueryStatement(
+          sql:
+              '''
+UPDATE ${_schema.targetsTable.sqlIdentifier}
+SET
+  status = @status,
+  last_error_code = @last_error_code,
+  completed_at = IF(
+    @status = @completed_status,
+    COALESCE(completed_at, CURRENT_TIMESTAMP()),
+    completed_at
+  ),
+  updated_at = CURRENT_TIMESTAMP()
+WHERE request_id = @request_id
+  AND status != @completed_status
+''',
+          parameters: <BigQueryParameter>[
+            BigQueryStringParameter(name: 'status', value: status.wireValue),
+            BigQueryStringParameter(
+              name: 'last_error_code',
+              value: failureKind?.wireValue,
+            ),
+            BigQueryStringParameter(
+              name: 'completed_status',
+              value: PrivacyDeletionTargetStatus.completed.wireValue,
+            ),
+            BigQueryStringParameter(name: 'request_id', value: requestId.value),
+          ],
+          referencedDatasets: <BigQueryDatasetReference>[
+            _schema.privacyDataset,
+          ],
+          isMutation: true,
+          dryRun: false,
+        ),
+      );
+      final verification = await _bigQueryClient.execute(
+        statement: BigQueryStatement(
+          sql:
+              '''
+SELECT status
+FROM ${_schema.targetsTable.sqlIdentifier}
+WHERE request_id = @request_id
+LIMIT 2
+''',
+          parameters: <BigQueryParameter>[
+            BigQueryStringParameter(name: 'request_id', value: requestId.value),
+          ],
+          referencedDatasets: <BigQueryDatasetReference>[
+            _schema.privacyDataset,
+          ],
+          isMutation: false,
+          dryRun: false,
+        ),
+      );
+      if (verification.rows.length != 1) {
+        throw TargetStatusCardinalityException(
+          matchingTargets: verification.rows.length,
+        );
+      }
+      final actualStatus = PrivacyDeletionTargetStatus.parse(
+        value: _requiredString(row: verification.rows.single, field: 'status'),
+      );
+      if (actualStatus != status) {
+        throw TargetStatusMismatchException(
+          requestedStatus: status,
+          actualStatus: actualStatus,
+        );
+      }
+    } catch (error, stackTrace) {
+      throw PrivacyDeletionOperationException(
+        failureKind: _isCredentialFailure(error: error)
+            ? PrivacyDeletionFailureKind.credentials
+            : PrivacyDeletionFailureKind.statusUpdate,
+        operation: PrivacyDeletionOperation.updateTargetStatus,
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<DateTime?> latestRawEventTableDate() async {
+    final informationSchema =
+        '`${_schema.rawDataset.projectId.value}.'
+        '${_schema.rawDataset.datasetId.value}.INFORMATION_SCHEMA.TABLES`';
+    final result = await _executeBigQuery(
+      operation: PrivacyDeletionOperation.readRawTables,
+      statement: BigQueryStatement(
+        sql:
+            '''
+WITH measurement AS (
+  SELECT DATE_SUB(DATE(raw_export_start_at), INTERVAL 1 DAY) AS controlled_start_date
+  FROM `${_schema.controlsDataset.projectId.value}.${_schema.controlsDataset.datasetId.value}.analytics_measurement_config`
+  WHERE config_key = 'singleton'
+),
+raw_tables AS (
+  SELECT table_name
+  FROM $informationSchema
+  WHERE table_type = @table_type
+    AND STARTS_WITH(table_name, 'events_')
+),
+summary AS (
+  SELECT
+    measurement.controlled_start_date,
+    MAX(IF(
+      REGEXP_CONTAINS(table_name, r'^events_[0-9]{8}\$'),
+      SAFE.PARSE_DATE('%Y%m%d', SUBSTR(table_name, 8)),
+      NULL
+    )) AS latest_raw_date,
+    COUNTIF(REGEXP_CONTAINS(table_name, r'^events_intraday_[0-9]{8}\$')) AS intraday_table_count,
+    COUNTIF(NOT REGEXP_CONTAINS(table_name, r'^events_[0-9]{8}\$')) AS unsupported_export_table_count,
+    COALESCE(
+      ARRAY_AGG(
+        IF(
+          REGEXP_CONTAINS(table_name, r'^events_[0-9]{8}\$'),
+          SAFE.PARSE_DATE('%Y%m%d', SUBSTR(table_name, 8)),
+          NULL
+        ) IGNORE NULLS
+      ),
+      ARRAY<DATE>[]
+    ) AS daily_dates
+  FROM measurement
+  LEFT JOIN raw_tables ON TRUE
+  GROUP BY measurement.controlled_start_date
+),
+bounded AS (
+  SELECT
+    *,
+    GREATEST(
+      controlled_start_date,
+      DATE_SUB(latest_raw_date, INTERVAL 89 DAY)
+    ) AS expected_start_date
+  FROM summary
+)
+SELECT
+  latest_raw_date,
+  intraday_table_count,
+  unsupported_export_table_count,
+  CASE
+    WHEN latest_raw_date IS NULL OR latest_raw_date < controlled_start_date THEN 1
+    ELSE DATE_DIFF(latest_raw_date, expected_start_date, DAY) + 1 - (
+      SELECT COUNT(DISTINCT event_date)
+      FROM UNNEST(daily_dates) AS event_date
+      WHERE event_date BETWEEN expected_start_date AND latest_raw_date
+    )
+  END AS missing_daily_table_count
+FROM bounded
+''',
+        parameters: const <BigQueryParameter>[
+          BigQueryStringParameter(name: 'table_type', value: 'BASE TABLE'),
+        ],
+        referencedDatasets: <BigQueryDatasetReference>[
+          _schema.rawDataset,
+          _schema.controlsDataset,
+        ],
+        isMutation: false,
+        dryRun: false,
+      ),
+    );
+    try {
+      if (result.rows.length != 1) {
+        throw const BigQueryResponseShapeException();
+      }
+      final row = result.rows.single;
+      final intradayTableCount = _requiredNonnegativeInteger(
+        row: row,
+        field: 'intraday_table_count',
+      );
+      final unsupportedExportTableCount = _requiredNonnegativeInteger(
+        row: row,
+        field: 'unsupported_export_table_count',
+      );
+      final missingDailyTableCount = _requiredNonnegativeInteger(
+        row: row,
+        field: 'missing_daily_table_count',
+      );
+      if (intradayTableCount != 0 ||
+          unsupportedExportTableCount != 0 ||
+          missingDailyTableCount != 0) {
+        throw RawTableInventoryException(
+          intradayTableCount: intradayTableCount,
+          unsupportedExportTableCount: unsupportedExportTableCount,
+          missingDailyTableCount: missingDailyTableCount,
+        );
+      }
+      final value = row['latest_raw_date'];
+      if (value == null) {
+        return null;
+      }
+      if (value is! String) {
+        throw const BigQueryRowShapeException(field: 'latest_raw_date');
+      }
+      final parsed = DateTime.tryParse('${value}T00:00:00Z');
+      if (parsed == null) {
+        throw const BigQueryRowShapeException(field: 'latest_raw_date');
+      }
+      return parsed;
+    } catch (error, stackTrace) {
+      throw PrivacyDeletionOperationException(
+        failureKind: PrivacyDeletionFailureKind.warehouseRead,
+        operation: PrivacyDeletionOperation.readRawTables,
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<DateTime?> readLastSweepSuccessDate() async {
+    final result = await _executeBigQuery(
+      operation: PrivacyDeletionOperation.readSweepCheckpoint,
+      statement: BigQueryStatement(
+        sql:
+            '''
+SELECT last_success_through_date
+FROM ${_schema.sweepStateTable.sqlIdentifier}
+WHERE sweep_name = @sweep_name
+LIMIT 1
+''',
+        parameters: const <BigQueryParameter>[
+          BigQueryStringParameter(name: 'sweep_name', value: _sweepName),
+        ],
+        referencedDatasets: <BigQueryDatasetReference>[_schema.controlsDataset],
+        isMutation: false,
+        dryRun: false,
+      ),
+    );
+    if (result.rows.isEmpty) {
+      return null;
+    }
+    final raw = _requiredString(
+      row: result.rows.single,
+      field: 'last_success_through_date',
+    );
+    final parsed = DateTime.tryParse('${raw}T00:00:00Z');
+    if (parsed == null) {
+      throw PrivacyDeletionOperationException(
+        failureKind: PrivacyDeletionFailureKind.warehouseRead,
+        operation: PrivacyDeletionOperation.readSweepCheckpoint,
+        innerError: const BigQueryRowShapeException(
+          field: 'last_success_through_date',
+        ),
+        innerStackTrace: StackTrace.current,
+      );
+    }
+    return UtcDateRange.utcDate(dateTime: parsed);
+  }
+
+  Future<void> updateSweepSuccessDate({required DateTime throughDate}) async {
+    await _executeBigQuery(
+      operation: PrivacyDeletionOperation.updateSweepCheckpoint,
+      statement: BigQueryStatement(
+        sql:
+            '''
+MERGE ${_schema.sweepStateTable.sqlIdentifier} AS destination
+USING (
+  SELECT @sweep_name AS sweep_name, @through_date AS through_date
+) AS source
+ON destination.sweep_name = source.sweep_name
+WHEN MATCHED AND destination.last_success_through_date < source.through_date THEN
+  UPDATE SET
+    last_success_through_date = source.through_date,
+    updated_at = CURRENT_TIMESTAMP()
+WHEN NOT MATCHED THEN
+  INSERT (sweep_name, last_success_through_date, updated_at)
+  VALUES (source.sweep_name, source.through_date, CURRENT_TIMESTAMP())
+''',
+        parameters: <BigQueryParameter>[
+          const BigQueryStringParameter(name: 'sweep_name', value: _sweepName),
+          BigQueryDateParameter(name: 'through_date', value: throughDate),
+        ],
+        referencedDatasets: <BigQueryDatasetReference>[_schema.controlsDataset],
+        isMutation: true,
+        dryRun: false,
+      ),
+    );
+  }
+
+  Future<List<BigQueryTableReference>> _rawTables({
+    required UtcDateRange range,
+  }) async {
+    final informationSchema =
+        '`${_schema.rawDataset.projectId.value}.'
+        '${_schema.rawDataset.datasetId.value}.INFORMATION_SCHEMA.TABLES`';
+    final dailyTablePattern = r"r'^events_[0-9]{8}$'";
+    final bufferedStart = range.start.subtract(const Duration(days: 1));
+    final bufferedEnd = range.end.add(const Duration(days: 1));
+    final result = await _executeBigQuery(
+      operation: PrivacyDeletionOperation.readRawTables,
+      statement: BigQueryStatement(
+        sql:
+            '''
+SELECT table_name
+FROM $informationSchema
+WHERE table_type = @table_type
+  AND REGEXP_CONTAINS(table_name, $dailyTablePattern)
+  AND SAFE.PARSE_DATE('%Y%m%d', SUBSTR(table_name, 8)) BETWEEN @from_date AND @through_date
+ORDER BY table_name
+''',
+        parameters: <BigQueryParameter>[
+          const BigQueryStringParameter(
+            name: 'table_type',
+            value: 'BASE TABLE',
+          ),
+          BigQueryDateParameter(name: 'from_date', value: bufferedStart),
+          BigQueryDateParameter(name: 'through_date', value: bufferedEnd),
+        ],
+        referencedDatasets: <BigQueryDatasetReference>[_schema.rawDataset],
+        isMutation: false,
+        dryRun: false,
+      ),
+    );
+    try {
+      return List<BigQueryTableReference>.unmodifiable(
+        result.rows.map((final row) {
+          final name = _requiredString(row: row, field: 'table_name');
+          if (!RegExp(r'^events_[0-9]{8}$').hasMatch(name)) {
+            throw const BigQueryRowShapeException(field: 'table_name');
+          }
+          return BigQueryTableReference(
+            dataset: _schema.rawDataset,
+            tableId: BigQueryTableId.parse(field: 'raw_table', value: name),
+          );
+        }),
+      );
+    } catch (error, stackTrace) {
+      throw PrivacyDeletionOperationException(
+        failureKind: PrivacyDeletionFailureKind.warehouseRead,
+        operation: PrivacyDeletionOperation.readRawTables,
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+    }
+  }
+
+  String _rawKeyedEventsUnion({required List<BigQueryTableReference> tables}) {
+    return tables
+        .map(
+          (final table) =>
+              '''
+  SELECT
+    user_pseudo_id,
+    ARRAY(
+      SELECT parameter.value.string_value
+      FROM UNNEST(event_params) AS parameter
+      WHERE parameter.key = 'user_key'
+      LIMIT 1
+    )[SAFE_OFFSET(0)] AS user_key
+  FROM ${table.sqlIdentifier}
+  WHERE user_pseudo_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM UNNEST(event_params) AS parameter
+      WHERE parameter.key = 'user_key'
+        AND parameter.value.string_value IS NOT NULL
+    )
+''',
+        )
+        .join('\nUNION ALL\n');
+  }
+
+  Future<int> _count({
+    required PrivacyDeletionOperation operation,
+    required String sql,
+    required List<String> values,
+    required List<BigQueryDatasetReference> datasets,
+  }) async {
+    final result = await _executeBigQuery(
+      operation: operation,
+      statement: BigQueryStatement(
+        sql: sql,
+        parameters: <BigQueryParameter>[
+          BigQueryStringArrayParameter(
+            name: 'identifier_values',
+            values: values,
+          ),
+        ],
+        referencedDatasets: datasets,
+        isMutation: false,
+        dryRun: false,
+      ),
+    );
+    return _singleCount(result: result);
+  }
+
+  int _singleCount({required BigQueryStatementResult result}) {
+    return _singleResultCount(result: result);
+  }
+
+  Future<BigQueryStatementResult> _executeBigQuery({
+    required PrivacyDeletionOperation operation,
+    required BigQueryStatement statement,
+  }) async {
+    try {
+      return await _bigQueryClient.execute(statement: statement);
+    } catch (error, stackTrace) {
+      if (error is PrivacyDeletionOperationException) {
+        rethrow;
+      }
+      throw PrivacyDeletionOperationException(
+        failureKind: _isCredentialFailure(error: error)
+            ? PrivacyDeletionFailureKind.credentials
+            : statement.isMutation
+            ? PrivacyDeletionFailureKind.warehouseWrite
+            : PrivacyDeletionFailureKind.warehouseRead,
+        operation: operation,
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+    }
+  }
+
+  PrivacyDeletionOperationException _malformedTarget({
+    required Object innerError,
+    required StackTrace innerStackTrace,
+  }) {
+    return PrivacyDeletionOperationException(
+      failureKind: PrivacyDeletionFailureKind.malformedTarget,
+      operation: PrivacyDeletionOperation.loadTarget,
+      innerError: innerError,
+      innerStackTrace: innerStackTrace,
+    );
+  }
+}
+
+int _singleResultCount({required BigQueryStatementResult result}) {
+  if (result.rows.length != 1) {
+    throw const BigQueryResponseShapeException();
+  }
+  final raw = result.rows.single['matching_count'];
+  if (raw is! String || int.tryParse(raw) == null) {
+    throw const BigQueryResponseShapeException();
+  }
+  return int.parse(raw);
+}
+
+int _requiredNonnegativeInteger({
+  required Map<String, Object?> row,
+  required String field,
+}) {
+  final value = row[field];
+  final parsed = value is String ? int.tryParse(value) : null;
+  if (parsed == null || parsed < 0) {
+    throw BigQueryRowShapeException(field: field);
+  }
+  return parsed;
+}
+
+enum _RawIdentifierKind {
+  userKey,
+  legacyUserId,
+  appInstanceId;
+
+  String get predicate => switch (this) {
+    userKey =>
+      '''EXISTS (
+  SELECT 1
+  FROM UNNEST(event_params) AS parameter
+  WHERE parameter.key = 'user_key'
+    AND parameter.value.string_value IN UNNEST(@identifier_values)
+)''',
+    legacyUserId => 'user_id IN UNNEST(@identifier_values)',
+    appInstanceId => 'user_pseudo_id IN UNNEST(@identifier_values)',
+  };
+}
+
+List<String> _uniqueStrings({required List<String> values}) {
+  return List<String>.unmodifiable(values.toSet());
+}
+
+List<List<T>> _chunks<T>({required List<T> values, required int size}) {
+  final chunks = <List<T>>[];
+  for (var offset = 0; offset < values.length; offset += size) {
+    final end = offset + size > values.length ? values.length : offset + size;
+    chunks.add(List<T>.unmodifiable(values.sublist(offset, end)));
+  }
+  return chunks;
+}
+
+String _requiredString({
+  required Map<String, Object?> row,
+  required String field,
+}) {
+  final value = row[field];
+  if (value is! String || value.isEmpty) {
+    throw BigQueryRowShapeException(field: field);
+  }
+  return value;
+}
+
+DateTime _requiredTimestamp({
+  required Map<String, Object?> row,
+  required String field,
+}) {
+  final raw = _requiredString(row: row, field: field);
+  var parsed = DateTime.tryParse(raw);
+  if (parsed == null && raw.endsWith(' UTC')) {
+    parsed = DateTime.tryParse('${raw.substring(0, raw.length - 4)}Z');
+  }
+  if (parsed == null) {
+    final secondsSinceEpoch = double.tryParse(raw);
+    if (secondsSinceEpoch != null) {
+      parsed = DateTime.fromMicrosecondsSinceEpoch(
+        (secondsSinceEpoch * Duration.microsecondsPerSecond).round(),
+        isUtc: true,
+      );
+    }
+  }
+  if (parsed == null) {
+    throw BigQueryRowShapeException(field: field);
+  }
+  return parsed.toUtc();
+}
+
+bool _isCredentialFailure({required Object error}) {
+  if (error is AccessTokenAcquisitionException) {
+    return true;
+  }
+  if (error is BigQueryPrivacyDeletionClientException) {
+    return _isCredentialFailure(error: error.innerError);
+  }
+  if (error is GaUserDeletionClientException) {
+    return _isCredentialFailure(error: error.innerError);
+  }
+  return false;
+}
+
+final class BigQueryRowShapeException implements Exception {
+  const BigQueryRowShapeException({required this.field});
+
+  final String field;
+}
+
+final class TargetCardinalityException implements Exception {
+  const TargetCardinalityException();
+}
+
+final class TargetRequestMismatchException implements Exception {
+  const TargetRequestMismatchException();
+}
+
+final class TargetStatusCardinalityException implements Exception {
+  const TargetStatusCardinalityException({required this.matchingTargets});
+
+  final int matchingTargets;
+}
+
+final class TargetStatusMismatchException implements Exception {
+  const TargetStatusMismatchException({
+    required this.requestedStatus,
+    required this.actualStatus,
+  });
+
+  final PrivacyDeletionTargetStatus requestedStatus;
+  final PrivacyDeletionTargetStatus actualStatus;
+}
+
+final class KeyedTableInventoryException implements Exception {
+  const KeyedTableInventoryException({
+    required this.unexpectedTableCount,
+    required this.expectedTablesMissing,
+    required this.authStagingTableCount,
+  });
+
+  final int unexpectedTableCount;
+  final bool expectedTablesMissing;
+  final int authStagingTableCount;
+}
+
+final class RawTableInventoryException implements Exception {
+  const RawTableInventoryException({
+    required this.intradayTableCount,
+    required this.unsupportedExportTableCount,
+    required this.missingDailyTableCount,
+  });
+
+  final int intradayTableCount;
+  final int unsupportedExportTableCount;
+  final int missingDailyTableCount;
+}

--- a/tool/product_analytics/privacy_deletion/privacy_deletion_api.dart
+++ b/tool/product_analytics/privacy_deletion/privacy_deletion_api.dart
@@ -15,6 +15,7 @@ final class PrivacyDeletionWarehouseSchema {
     required this.reportingDataset,
     required this.targetsTable,
     required this.exclusionsTable,
+    required this.publicationGuardTable,
     required this.authExportRunsTable,
     required this.sweepStateTable,
     required List<BigQueryTableReference> authKeyedTables,
@@ -31,6 +32,10 @@ final class PrivacyDeletionWarehouseSchema {
        ) {
     _validateTableDataset(table: targetsTable, dataset: privacyDataset);
     _validateTableDataset(table: exclusionsTable, dataset: controlsDataset);
+    _validateTableDataset(
+      table: publicationGuardTable,
+      dataset: controlsDataset,
+    );
     _validateTableDataset(table: authExportRunsTable, dataset: authDataset);
     _validateTableDataset(table: sweepStateTable, dataset: controlsDataset);
     for (final table in this.authKeyedTables) {
@@ -52,6 +57,7 @@ final class PrivacyDeletionWarehouseSchema {
   final BigQueryDatasetReference reportingDataset;
   final BigQueryTableReference targetsTable;
   final BigQueryTableReference exclusionsTable;
+  final BigQueryTableReference publicationGuardTable;
   final BigQueryTableReference authExportRunsTable;
   final BigQueryTableReference sweepStateTable;
   final List<BigQueryTableReference> authKeyedTables;
@@ -196,6 +202,9 @@ final class FixedAggregateRebuilder implements AggregateRebuilder {
   Future<void> _verifyCompletedTransforms({
     required DateTime rebuildStartedAt,
   }) async {
+    final requiredModelNames = AggregateTransform.values
+        .map((transform) => "    '${transform.modelName}'")
+        .join(',\n');
     final result = await _client.execute(
       statement: BigQueryStatement(
         sql:
@@ -209,9 +218,7 @@ WITH latest_auth_snapshot AS (
 required_models AS (
   SELECT model_name
   FROM UNNEST([
-    'user_activity_daily',
-    'user_milestones',
-    'activation_retention'
+$requiredModelNames
   ]) AS model_name
 )
 SELECT COUNT(*) AS matching_count
@@ -398,6 +405,15 @@ LIMIT 2
       statement: BigQueryStatement(
         sql:
             '''
+BEGIN TRANSACTION;
+
+UPDATE ${_schema.publicationGuardTable.sqlIdentifier}
+SET publication_epoch = publication_epoch + 1,
+    updated_at = CURRENT_TIMESTAMP()
+WHERE guard_key = 'singleton';
+
+ASSERT @@row_count = 1 AS 'The keyed publication guard singleton is required';
+
 MERGE ${_schema.exclusionsTable.sqlIdentifier} AS destination
 USING (
   SELECT @user_key AS user_key, @suppressed_at AS suppressed_at
@@ -409,7 +425,9 @@ WHEN MATCHED AND source.suppressed_at < destination.suppressed_at THEN
     updated_at = CURRENT_TIMESTAMP()
 WHEN NOT MATCHED THEN
   INSERT (user_key, suppressed_at, created_at, updated_at)
-  VALUES (source.user_key, source.suppressed_at, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP())
+  VALUES (source.user_key, source.suppressed_at, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP());
+
+COMMIT TRANSACTION;
 ''',
         parameters: <BigQueryParameter>[
           BigQueryStringParameter(
@@ -457,13 +475,22 @@ WHERE user_key = @user_key
       statement: BigQueryStatement(
         sql:
             '''
-SELECT run_cutoff, published_at
-FROM ${_schema.authExportRunsTable.sqlIdentifier}
-ORDER BY published_at DESC, run_cutoff DESC
+SELECT
+  export.run_cutoff,
+  export.published_at,
+  config.auth_snapshot_max_age_hours,
+  config.clock_skew_allowance_seconds
+FROM ${_schema.authExportRunsTable.sqlIdentifier} AS export
+CROSS JOIN `${_schema.controlsDataset.projectId.value}.${_schema.controlsDataset.datasetId.value}.analytics_measurement_config` AS config
+WHERE config.config_key = 'singleton'
+ORDER BY export.published_at DESC, export.run_cutoff DESC
 LIMIT 1
 ''',
         parameters: const <BigQueryParameter>[],
-        referencedDatasets: <BigQueryDatasetReference>[_schema.authDataset],
+        referencedDatasets: <BigQueryDatasetReference>[
+          _schema.authDataset,
+          _schema.controlsDataset,
+        ],
         isMutation: false,
         dryRun: false,
       ),
@@ -480,6 +507,18 @@ LIMIT 1
         publishedAt: _requiredTimestamp(
           row: result.rows.single,
           field: 'published_at',
+        ),
+        maxAge: Duration(
+          hours: _requiredPositiveInt(
+            row: result.rows.single,
+            field: 'auth_snapshot_max_age_hours',
+          ),
+        ),
+        futureClockAllowance: Duration(
+          seconds: _requiredPositiveInt(
+            row: result.rows.single,
+            field: 'clock_skew_allowance_seconds',
+          ),
         ),
       );
     } catch (error, stackTrace) {
@@ -1385,6 +1424,7 @@ ORDER BY table_name
       SELECT parameter.value.string_value
       FROM UNNEST(event_params) AS parameter
       WHERE parameter.key = 'user_key'
+        AND parameter.value.string_value IS NOT NULL
       LIMIT 1
     )[SAFE_OFFSET(0)] AS user_key
   FROM ${table.sqlIdentifier}
@@ -1551,6 +1591,22 @@ DateTime _requiredTimestamp({
     throw BigQueryRowShapeException(field: field);
   }
   return parsed.toUtc();
+}
+
+int _requiredPositiveInt({
+  required Map<String, Object?> row,
+  required String field,
+}) {
+  final raw = row[field];
+  final value = switch (raw) {
+    int value => value,
+    String value => int.tryParse(value),
+    _ => null,
+  };
+  if (value == null || value < 1) {
+    throw BigQueryRowShapeException(field: field);
+  }
+  return value;
 }
 
 bool _isCredentialFailure({required Object error}) {

--- a/tool/product_analytics/privacy_deletion/privacy_deletion_config.dart
+++ b/tool/product_analytics/privacy_deletion/privacy_deletion_config.dart
@@ -1,0 +1,446 @@
+import 'privacy_deletion_models.dart';
+
+final class PrivacyDeletionConfig {
+  const PrivacyDeletionConfig({
+    required this.projectId,
+    required this.location,
+    required this.analyticsPropertyId,
+    required this.rawDataset,
+    required this.authDataset,
+    required this.privacyDataset,
+    required this.controlsDataset,
+    required this.curatedDataset,
+    required this.reportingDataset,
+    required this.targetsTable,
+    required this.exclusionsTable,
+    required this.authExportRunsTable,
+    required this.sweepStateTable,
+    required this.authKeyedTables,
+    required this.curatedKeyedTables,
+    required this.reportingKeyedTables,
+    required this.rawRetentionDays,
+    required this.queryTimeout,
+    required this.parameterBatchSize,
+    required this.allowGcloudAdcFallback,
+  });
+
+  final GcpProjectId projectId;
+  final BigQueryLocation location;
+  final AnalyticsPropertyId analyticsPropertyId;
+  final BigQueryDatasetReference rawDataset;
+  final BigQueryDatasetReference authDataset;
+  final BigQueryDatasetReference privacyDataset;
+  final BigQueryDatasetReference controlsDataset;
+  final BigQueryDatasetReference curatedDataset;
+  final BigQueryDatasetReference reportingDataset;
+  final BigQueryTableReference targetsTable;
+  final BigQueryTableReference exclusionsTable;
+  final BigQueryTableReference authExportRunsTable;
+  final BigQueryTableReference sweepStateTable;
+  final List<BigQueryTableReference> authKeyedTables;
+  final List<BigQueryTableReference> curatedKeyedTables;
+  final List<BigQueryTableReference> reportingKeyedTables;
+  final int rawRetentionDays;
+  final Duration queryTimeout;
+  final int parameterBatchSize;
+  final bool allowGcloudAdcFallback;
+
+  List<BigQueryDatasetReference> get allowedDatasets =>
+      <BigQueryDatasetReference>[
+        rawDataset,
+        authDataset,
+        privacyDataset,
+        controlsDataset,
+        curatedDataset,
+        reportingDataset,
+      ];
+}
+
+final class PrivacyDeletionCommandConfig {
+  const PrivacyDeletionCommandConfig({
+    required this.config,
+    required this.requestId,
+    required this.dryRun,
+  });
+
+  factory PrivacyDeletionCommandConfig.parse({
+    required List<String> arguments,
+    required Map<String, String> environment,
+    required bool requestIdRequired,
+  }) {
+    final parsed = _ParsedArguments.parse(arguments: arguments);
+    final projectId = GcpProjectId.parse(
+      value: parsed.requiredValue(
+        name: 'project',
+        environmentName: 'SESORI_ANALYTICS_PROJECT',
+        environment: environment,
+      ),
+    );
+    final rawDataset = _dataset(
+      projectId: projectId,
+      field: 'raw_dataset',
+      value: parsed.requiredValue(
+        name: 'raw-dataset',
+        environmentName: 'SESORI_ANALYTICS_RAW_DATASET',
+        environment: environment,
+      ),
+    );
+    final authDataset = _dataset(
+      projectId: projectId,
+      field: 'auth_dataset',
+      value: parsed.requiredValue(
+        name: 'auth-dataset',
+        environmentName: 'SESORI_ANALYTICS_AUTH_DATASET',
+        environment: environment,
+      ),
+    );
+    final privacyDataset = _dataset(
+      projectId: projectId,
+      field: 'privacy_dataset',
+      value: parsed.requiredValue(
+        name: 'privacy-dataset',
+        environmentName: 'SESORI_ANALYTICS_PRIVACY_DATASET',
+        environment: environment,
+      ),
+    );
+    final controlsDataset = _dataset(
+      projectId: projectId,
+      field: 'controls_dataset',
+      value: parsed.requiredValue(
+        name: 'controls-dataset',
+        environmentName: 'SESORI_ANALYTICS_CONTROLS_DATASET',
+        environment: environment,
+      ),
+    );
+    final curatedDataset = _dataset(
+      projectId: projectId,
+      field: 'curated_dataset',
+      value: parsed.requiredValue(
+        name: 'curated-dataset',
+        environmentName: 'SESORI_ANALYTICS_CURATED_DATASET',
+        environment: environment,
+      ),
+    );
+    final reportingDataset = _dataset(
+      projectId: projectId,
+      field: 'reporting_dataset',
+      value: parsed.requiredValue(
+        name: 'reporting-dataset',
+        environmentName: 'SESORI_ANALYTICS_REPORTING_DATASET',
+        environment: environment,
+      ),
+    );
+
+    final datasets = <BigQueryDatasetReference>[
+      rawDataset,
+      authDataset,
+      privacyDataset,
+      controlsDataset,
+      curatedDataset,
+      reportingDataset,
+    ];
+    final datasetKeys = datasets
+        .map((final value) => value.allowlistKey)
+        .toSet();
+    if (datasetKeys.length != datasets.length) {
+      throw const PrivacyDeletionValidationException(
+        field: 'datasets',
+        requirement:
+            'six distinct raw/auth/privacy/controls/curated/reporting datasets',
+      );
+    }
+
+    final requestIdValue = parsed.optionalValue(
+      name: 'request-id',
+      environmentName: 'SESORI_PRIVACY_REQUEST_ID',
+      environment: environment,
+    );
+    if (requestIdRequired && requestIdValue == null) {
+      throw const PrivacyDeletionValidationException(
+        field: 'request_id',
+        requirement: '--request-id for a manual deletion run',
+      );
+    }
+    if (!requestIdRequired && requestIdValue != null) {
+      throw const PrivacyDeletionValidationException(
+        field: 'request_id',
+        requirement: 'no request ID for a sweep',
+      );
+    }
+
+    final config = PrivacyDeletionConfig(
+      projectId: projectId,
+      location: BigQueryLocation.parse(
+        value: parsed.requiredValue(
+          name: 'location',
+          environmentName: 'SESORI_ANALYTICS_LOCATION',
+          environment: environment,
+        ),
+      ),
+      analyticsPropertyId: AnalyticsPropertyId.parse(
+        value: parsed.requiredValue(
+          name: 'analytics-property-id',
+          environmentName: 'SESORI_ANALYTICS_PROPERTY_ID',
+          environment: environment,
+        ),
+      ),
+      rawDataset: rawDataset,
+      authDataset: authDataset,
+      privacyDataset: privacyDataset,
+      controlsDataset: controlsDataset,
+      curatedDataset: curatedDataset,
+      reportingDataset: reportingDataset,
+      targetsTable: _table(
+        dataset: privacyDataset,
+        field: 'targets_table',
+        value: parsed.valueOrDefault(
+          name: 'targets-table',
+          defaultValue: 'product_analytics_deletion_targets',
+        ),
+      ),
+      exclusionsTable: _table(
+        dataset: controlsDataset,
+        field: 'exclusions_table',
+        value: parsed.valueOrDefault(
+          name: 'exclusions-table',
+          defaultValue: 'permanent_deletion_exclusions',
+        ),
+      ),
+      authExportRunsTable: _table(
+        dataset: authDataset,
+        field: 'auth_export_runs_table',
+        value: parsed.valueOrDefault(
+          name: 'auth-export-runs-table',
+          defaultValue: 'product_analytics_export_runs',
+        ),
+      ),
+      sweepStateTable: _table(
+        dataset: controlsDataset,
+        field: 'sweep_state_table',
+        value: parsed.valueOrDefault(
+          name: 'sweep-state-table',
+          defaultValue: 'product_analytics_privacy_sweep_state',
+        ),
+      ),
+      authKeyedTables: <BigQueryTableReference>[
+        _table(
+          dataset: authDataset,
+          field: 'auth_keyed_tables',
+          value: 'auth_user_milestones',
+        ),
+      ],
+      curatedKeyedTables: <BigQueryTableReference>[
+        for (final tableName in const <String>[
+          'events_flattened',
+          'user_activity_daily',
+          'user_milestones',
+        ])
+          _table(
+            dataset: curatedDataset,
+            field: 'curated_keyed_tables',
+            value: tableName,
+          ),
+      ],
+      reportingKeyedTables: const <BigQueryTableReference>[],
+      rawRetentionDays: 90,
+      queryTimeout: Duration(
+        minutes: parsed.boundedInt(
+          name: 'query-timeout-minutes',
+          defaultValue: 30,
+          minimum: 1,
+          maximum: 120,
+        ),
+      ),
+      parameterBatchSize: parsed.boundedInt(
+        name: 'parameter-batch-size',
+        defaultValue: 500,
+        minimum: 1,
+        maximum: 5000,
+      ),
+      allowGcloudAdcFallback: parsed.hasFlag(name: 'allow-gcloud-adc-fallback'),
+    );
+
+    return PrivacyDeletionCommandConfig(
+      config: config,
+      requestId: requestIdValue == null
+          ? null
+          : PrivacyRequestId.parse(value: requestIdValue),
+      dryRun: parsed.hasFlag(name: 'dry-run'),
+    );
+  }
+
+  final PrivacyDeletionConfig config;
+  final PrivacyRequestId? requestId;
+  final bool dryRun;
+}
+
+BigQueryDatasetReference _dataset({
+  required GcpProjectId projectId,
+  required String field,
+  required String value,
+}) {
+  return BigQueryDatasetReference(
+    projectId: projectId,
+    datasetId: BigQueryDatasetId.parse(field: field, value: value),
+  );
+}
+
+BigQueryTableReference _table({
+  required BigQueryDatasetReference dataset,
+  required String field,
+  required String value,
+}) {
+  return BigQueryTableReference(
+    dataset: dataset,
+    tableId: BigQueryTableId.parse(field: field, value: value),
+  );
+}
+
+final class _ParsedArguments {
+  const _ParsedArguments({required this.values});
+
+  factory _ParsedArguments.parse({required List<String> arguments}) {
+    const booleanFlags = <String>{'dry-run', 'allow-gcloud-adc-fallback'};
+    const valueFlags = <String>{
+      'project',
+      'location',
+      'analytics-property-id',
+      'raw-dataset',
+      'auth-dataset',
+      'privacy-dataset',
+      'controls-dataset',
+      'curated-dataset',
+      'reporting-dataset',
+      'targets-table',
+      'exclusions-table',
+      'auth-export-runs-table',
+      'sweep-state-table',
+      'query-timeout-minutes',
+      'parameter-batch-size',
+      'request-id',
+    };
+    final values = <String, String>{};
+
+    for (var index = 0; index < arguments.length; index++) {
+      final raw = arguments[index];
+      if (!raw.startsWith('--')) {
+        throw const PrivacyDeletionValidationException(
+          field: 'arguments',
+          requirement: 'named --flag value arguments only',
+        );
+      }
+      final equalsIndex = raw.indexOf('=');
+      final name = raw.substring(2, equalsIndex < 0 ? null : equalsIndex);
+      if (booleanFlags.contains(name)) {
+        if (equalsIndex >= 0 || values.containsKey(name)) {
+          throw PrivacyDeletionValidationException(
+            field: name,
+            requirement: 'a single value-less flag',
+          );
+        }
+        values[name] = 'true';
+        continue;
+      }
+      if (!valueFlags.contains(name)) {
+        throw PrivacyDeletionValidationException(
+          field: 'arguments',
+          requirement: 'a supported option; unknown --$name',
+        );
+      }
+      final String value;
+      if (equalsIndex >= 0) {
+        value = raw.substring(equalsIndex + 1);
+      } else {
+        if (index + 1 >= arguments.length ||
+            arguments[index + 1].startsWith('--')) {
+          throw PrivacyDeletionValidationException(
+            field: name,
+            requirement: 'a non-empty value',
+          );
+        }
+        index += 1;
+        value = arguments[index];
+      }
+      if (value.isEmpty) {
+        throw PrivacyDeletionValidationException(
+          field: name,
+          requirement: 'a non-empty value',
+        );
+      }
+      if (values.containsKey(name)) {
+        throw PrivacyDeletionValidationException(
+          field: name,
+          requirement: 'a single value',
+        );
+      } else {
+        values[name] = value;
+      }
+    }
+    return _ParsedArguments(values: values);
+  }
+
+  final Map<String, String> values;
+
+  bool hasFlag({required String name}) => values[name] == 'true';
+
+  String requiredValue({
+    required String name,
+    required String environmentName,
+    required Map<String, String> environment,
+  }) {
+    final value = optionalValue(
+      name: name,
+      environmentName: environmentName,
+      environment: environment,
+    );
+    if (value == null) {
+      throw PrivacyDeletionValidationException(
+        field: name,
+        requirement: '--$name or $environmentName',
+      );
+    }
+    return value;
+  }
+
+  String? optionalValue({
+    required String name,
+    required String environmentName,
+    required Map<String, String> environment,
+  }) {
+    final value = values[name] ?? environment[environmentName];
+    return value == null || value.isEmpty ? null : value;
+  }
+
+  String valueOrDefault({required String name, required String defaultValue}) {
+    return values[name] ?? defaultValue;
+  }
+
+  int boundedInt({
+    required String name,
+    required int defaultValue,
+    required int minimum,
+    required int maximum,
+  }) {
+    final raw = values[name];
+    final parsed = raw == null ? defaultValue : int.tryParse(raw);
+    if (parsed == null || parsed < minimum || parsed > maximum) {
+      throw PrivacyDeletionValidationException(
+        field: name,
+        requirement: 'an integer from $minimum through $maximum',
+      );
+    }
+    return parsed;
+  }
+}
+
+const String privacyDeletionUsage = '''
+Required configuration (flag or SESORI_ANALYTICS_* environment variable):
+  --project --location --analytics-property-id
+  --raw-dataset --auth-dataset --privacy-dataset --controls-dataset
+  --curated-dataset --reporting-dataset
+
+Manual run also requires --request-id. Add --dry-run to execute reads and
+BigQuery plans without mutations, status changes, or upstream calls.
+Production jobs use the attached metadata-server identity only. An approved
+operator may add --allow-gcloud-adc-fallback for an explicit local ADC run.
+''';

--- a/tool/product_analytics/privacy_deletion/privacy_deletion_config.dart
+++ b/tool/product_analytics/privacy_deletion/privacy_deletion_config.dart
@@ -13,6 +13,7 @@ final class PrivacyDeletionConfig {
     required this.reportingDataset,
     required this.targetsTable,
     required this.exclusionsTable,
+    required this.publicationGuardTable,
     required this.authExportRunsTable,
     required this.sweepStateTable,
     required this.authKeyedTables,
@@ -35,6 +36,7 @@ final class PrivacyDeletionConfig {
   final BigQueryDatasetReference reportingDataset;
   final BigQueryTableReference targetsTable;
   final BigQueryTableReference exclusionsTable;
+  final BigQueryTableReference publicationGuardTable;
   final BigQueryTableReference authExportRunsTable;
   final BigQueryTableReference sweepStateTable;
   final List<BigQueryTableReference> authKeyedTables;
@@ -205,6 +207,11 @@ final class PrivacyDeletionCommandConfig {
           name: 'exclusions-table',
           defaultValue: 'permanent_deletion_exclusions',
         ),
+      ),
+      publicationGuardTable: _table(
+        dataset: controlsDataset,
+        field: 'publication_guard_table',
+        value: 'keyed_publication_guard',
       ),
       authExportRunsTable: _table(
         dataset: authDataset,

--- a/tool/product_analytics/privacy_deletion/privacy_deletion_models.dart
+++ b/tool/product_analytics/privacy_deletion/privacy_deletion_models.dart
@@ -1,0 +1,611 @@
+final RegExp _lowercaseSha256Pattern = RegExp(r'^[0-9a-f]{64}$');
+final RegExp _requestIdPattern = RegExp(r'^[A-Za-z0-9_-]{8,128}$');
+final RegExp _projectIdPattern = RegExp(r'^[a-z][a-z0-9-]{4,28}[a-z0-9]$');
+final RegExp _bigQueryIdentifierPattern = RegExp(
+  r'^[A-Za-z_][A-Za-z0-9_]{0,1023}$',
+);
+final RegExp _locationPattern = RegExp(r'^[A-Za-z][A-Za-z0-9-]{1,31}$');
+final RegExp _analyticsPropertyIdPattern = RegExp(r'^[0-9]{1,32}$');
+
+final class GcpProjectId {
+  GcpProjectId._({required this.value});
+
+  factory GcpProjectId.parse({required String value}) {
+    if (!_projectIdPattern.hasMatch(value)) {
+      throw PrivacyDeletionValidationException(
+        field: 'project',
+        requirement: 'a valid lowercase Google Cloud project ID',
+      );
+    }
+    return GcpProjectId._(value: value);
+  }
+
+  final String value;
+}
+
+final class BigQueryDatasetId {
+  BigQueryDatasetId._({required this.value});
+
+  factory BigQueryDatasetId.parse({
+    required String field,
+    required String value,
+  }) {
+    if (!_bigQueryIdentifierPattern.hasMatch(value)) {
+      throw PrivacyDeletionValidationException(
+        field: field,
+        requirement: 'a valid BigQuery dataset identifier',
+      );
+    }
+    return BigQueryDatasetId._(value: value);
+  }
+
+  final String value;
+}
+
+final class BigQueryTableId {
+  BigQueryTableId._({required this.value});
+
+  factory BigQueryTableId.parse({
+    required String field,
+    required String value,
+  }) {
+    if (!_bigQueryIdentifierPattern.hasMatch(value)) {
+      throw PrivacyDeletionValidationException(
+        field: field,
+        requirement: 'a valid BigQuery table identifier',
+      );
+    }
+    return BigQueryTableId._(value: value);
+  }
+
+  final String value;
+}
+
+final class BigQueryLocation {
+  BigQueryLocation._({required this.value});
+
+  factory BigQueryLocation.parse({required String value}) {
+    if (!_locationPattern.hasMatch(value)) {
+      throw PrivacyDeletionValidationException(
+        field: 'location',
+        requirement: 'a valid BigQuery location',
+      );
+    }
+    return BigQueryLocation._(value: value);
+  }
+
+  final String value;
+}
+
+final class AnalyticsPropertyId {
+  AnalyticsPropertyId._({required this.value});
+
+  factory AnalyticsPropertyId.parse({required String value}) {
+    if (!_analyticsPropertyIdPattern.hasMatch(value)) {
+      throw PrivacyDeletionValidationException(
+        field: 'analytics_property_id',
+        requirement: 'a numeric Google Analytics property ID',
+      );
+    }
+    return AnalyticsPropertyId._(value: value);
+  }
+
+  final String value;
+}
+
+final class BigQueryDatasetReference {
+  const BigQueryDatasetReference({
+    required this.projectId,
+    required this.datasetId,
+  });
+
+  final GcpProjectId projectId;
+  final BigQueryDatasetId datasetId;
+
+  String get allowlistKey => '${projectId.value}.${datasetId.value}';
+  String get sqlIdentifier => '`${projectId.value}.${datasetId.value}`';
+}
+
+final class BigQueryTableReference {
+  const BigQueryTableReference({required this.dataset, required this.tableId});
+
+  final BigQueryDatasetReference dataset;
+  final BigQueryTableId tableId;
+
+  String get sqlIdentifier =>
+      '`${dataset.projectId.value}.${dataset.datasetId.value}.${tableId.value}`';
+}
+
+final class PrivacyRequestId {
+  PrivacyRequestId._({required this.value});
+
+  factory PrivacyRequestId.parse({required String value}) {
+    if (!_requestIdPattern.hasMatch(value)) {
+      throw PrivacyDeletionValidationException(
+        field: 'request_id',
+        requirement: '8-128 ASCII letters, digits, underscores, or hyphens',
+      );
+    }
+    return PrivacyRequestId._(value: value);
+  }
+
+  final String value;
+}
+
+final class PseudonymousUserKey {
+  PseudonymousUserKey._({required this.value});
+
+  factory PseudonymousUserKey.parse({required String value}) {
+    if (!_lowercaseSha256Pattern.hasMatch(value)) {
+      throw PrivacyDeletionValidationException(
+        field: 'user_key',
+        requirement: 'exactly 64 lowercase hexadecimal characters',
+      );
+    }
+    return PseudonymousUserKey._(value: value);
+  }
+
+  final String value;
+}
+
+final class LegacyFirebaseUserId {
+  LegacyFirebaseUserId._({required this.value});
+
+  factory LegacyFirebaseUserId.parse({required String value}) {
+    if (!_lowercaseSha256Pattern.hasMatch(value)) {
+      throw PrivacyDeletionValidationException(
+        field: 'legacy_firebase_user_id',
+        requirement: 'exactly 64 lowercase hexadecimal characters',
+      );
+    }
+    return LegacyFirebaseUserId._(value: value);
+  }
+
+  final String value;
+}
+
+final class AppInstanceId {
+  AppInstanceId._({required this.value});
+
+  factory AppInstanceId.parse({required String value}) {
+    final hasControlCharacter = value.codeUnits.any(
+      (final codeUnit) => codeUnit < 0x20 || codeUnit == 0x7f,
+    );
+    if (value.isEmpty || value.length > 256 || hasControlCharacter) {
+      throw PrivacyDeletionValidationException(
+        field: 'app_instance_id',
+        requirement: '1-256 characters without control characters',
+      );
+    }
+    return AppInstanceId._(value: value);
+  }
+
+  final String value;
+}
+
+enum PrivacyDeletionTargetStatus {
+  pending,
+  processing,
+  retryable,
+  completed;
+
+  static PrivacyDeletionTargetStatus parse({required String value}) {
+    return switch (value) {
+      'pending' => pending,
+      'processing' => processing,
+      'retryable' => retryable,
+      'completed' => completed,
+      _ => throw PrivacyDeletionValidationException(
+        field: 'target_status',
+        requirement: 'pending, processing, retryable, or completed',
+      ),
+    };
+  }
+
+  String get wireValue => switch (this) {
+    pending => 'pending',
+    processing => 'processing',
+    retryable => 'retryable',
+    completed => 'completed',
+  };
+}
+
+final class PrivacyDeletionTarget {
+  const PrivacyDeletionTarget({
+    required this.requestId,
+    required this.userKey,
+    required this.legacyFirebaseUserId,
+    required this.suppressedAt,
+    required this.status,
+  });
+
+  final PrivacyRequestId requestId;
+  final PseudonymousUserKey userKey;
+  final LegacyFirebaseUserId legacyFirebaseUserId;
+  final DateTime suppressedAt;
+  final PrivacyDeletionTargetStatus status;
+}
+
+final class PermanentDeletionTombstone {
+  const PermanentDeletionTombstone({
+    required this.userKey,
+    required this.legacyFirebaseUserId,
+    required this.suppressedAt,
+  });
+
+  final PseudonymousUserKey userKey;
+  final LegacyFirebaseUserId legacyFirebaseUserId;
+  final DateTime suppressedAt;
+}
+
+final class UtcDateRange {
+  UtcDateRange._({required this.start, required this.end});
+
+  factory UtcDateRange.fromDates({
+    required DateTime start,
+    required DateTime end,
+  }) {
+    final normalizedStart = utcDate(dateTime: start);
+    final normalizedEnd = utcDate(dateTime: end);
+    if (normalizedStart.isAfter(normalizedEnd)) {
+      throw PrivacyDeletionValidationException(
+        field: 'date_range',
+        requirement: 'start date must not be after end date',
+      );
+    }
+    return UtcDateRange._(start: normalizedStart, end: normalizedEnd);
+  }
+
+  static DateTime utcDate({required DateTime dateTime}) {
+    final utc = dateTime.toUtc();
+    return DateTime.utc(utc.year, utc.month, utc.day);
+  }
+
+  final DateTime start;
+  final DateTime end;
+
+  String get startSuffix => formatCompactUtcDate(date: start);
+  String get endSuffix => formatCompactUtcDate(date: end);
+}
+
+String formatUtcDate({required DateTime date}) {
+  final utc = date.toUtc();
+  return '${utc.year.toString().padLeft(4, '0')}-'
+      '${utc.month.toString().padLeft(2, '0')}-'
+      '${utc.day.toString().padLeft(2, '0')}';
+}
+
+String formatCompactUtcDate({required DateTime date}) {
+  final utc = date.toUtc();
+  return '${utc.year.toString().padLeft(4, '0')}'
+      '${utc.month.toString().padLeft(2, '0')}'
+      '${utc.day.toString().padLeft(2, '0')}';
+}
+
+final class AuthExportSnapshot {
+  const AuthExportSnapshot({
+    required this.runCutoff,
+    required this.publishedAt,
+  });
+
+  final DateTime runCutoff;
+  final DateTime publishedAt;
+}
+
+enum AuthExportReadiness {
+  ready,
+  notReady;
+
+  String get wireValue => switch (this) {
+    ready => 'ready',
+    notReady => 'not_ready',
+  };
+}
+
+enum PrivacyDeletionCleanupPhase {
+  preliminary(includeAuthTables: false),
+  finalPass(includeAuthTables: true);
+
+  const PrivacyDeletionCleanupPhase({required this.includeAuthTables});
+
+  final bool includeAuthTables;
+}
+
+final class AggregateRebuildResult {
+  const AggregateRebuildResult({
+    required this.plannedOperations,
+    required this.executedOperations,
+  });
+
+  final int plannedOperations;
+  final int executedOperations;
+}
+
+final class WarehouseMutationResult {
+  const WarehouseMutationResult({
+    required this.plannedJobs,
+    required this.executedJobs,
+    required this.affectedRows,
+  });
+
+  const WarehouseMutationResult.none()
+    : plannedJobs = 0,
+      executedJobs = 0,
+      affectedRows = 0;
+
+  final int plannedJobs;
+  final int executedJobs;
+  final int affectedRows;
+
+  WarehouseMutationResult add({required WarehouseMutationResult other}) {
+    return WarehouseMutationResult(
+      plannedJobs: plannedJobs + other.plannedJobs,
+      executedJobs: executedJobs + other.executedJobs,
+      affectedRows: affectedRows + other.affectedRows,
+    );
+  }
+}
+
+final class WarehouseVerificationResult {
+  const WarehouseVerificationResult({
+    required this.checksRun,
+    required this.violationChecks,
+  });
+
+  final int checksRun;
+  final int violationChecks;
+}
+
+final class CleanupResult {
+  const CleanupResult({
+    required this.installationsDiscovered,
+    required this.upstreamSubmissionsPlanned,
+    required this.upstreamSubmissionsExecuted,
+    required this.rawMutations,
+    required this.keyedMutations,
+    required this.aggregateRebuild,
+    required this.verification,
+  });
+
+  const CleanupResult.none()
+    : installationsDiscovered = 0,
+      upstreamSubmissionsPlanned = 0,
+      upstreamSubmissionsExecuted = 0,
+      rawMutations = const WarehouseMutationResult.none(),
+      keyedMutations = const WarehouseMutationResult.none(),
+      aggregateRebuild = const AggregateRebuildResult(
+        plannedOperations: 0,
+        executedOperations: 0,
+      ),
+      verification = const WarehouseVerificationResult(
+        checksRun: 0,
+        violationChecks: 0,
+      );
+
+  final int installationsDiscovered;
+  final int upstreamSubmissionsPlanned;
+  final int upstreamSubmissionsExecuted;
+  final WarehouseMutationResult rawMutations;
+  final WarehouseMutationResult keyedMutations;
+  final AggregateRebuildResult aggregateRebuild;
+  final WarehouseVerificationResult verification;
+
+  CleanupResult add({required CleanupResult other}) {
+    return CleanupResult(
+      installationsDiscovered:
+          installationsDiscovered + other.installationsDiscovered,
+      upstreamSubmissionsPlanned:
+          upstreamSubmissionsPlanned + other.upstreamSubmissionsPlanned,
+      upstreamSubmissionsExecuted:
+          upstreamSubmissionsExecuted + other.upstreamSubmissionsExecuted,
+      rawMutations: rawMutations.add(other: other.rawMutations),
+      keyedMutations: keyedMutations.add(other: other.keyedMutations),
+      aggregateRebuild: AggregateRebuildResult(
+        plannedOperations:
+            aggregateRebuild.plannedOperations +
+            other.aggregateRebuild.plannedOperations,
+        executedOperations:
+            aggregateRebuild.executedOperations +
+            other.aggregateRebuild.executedOperations,
+      ),
+      verification: WarehouseVerificationResult(
+        checksRun: verification.checksRun + other.verification.checksRun,
+        violationChecks:
+            verification.violationChecks + other.verification.violationChecks,
+      ),
+    );
+  }
+}
+
+enum PrivacyDeletionOperationKind {
+  request,
+  sweep;
+
+  String get wireValue => switch (this) {
+    request => 'privacy_deletion_request',
+    sweep => 'privacy_deletion_sweep',
+  };
+}
+
+enum PrivacyDeletionOutcome {
+  planned,
+  completed,
+  alreadyCompleted,
+  retryable;
+
+  String get wireValue => switch (this) {
+    planned => 'planned',
+    completed => 'completed',
+    alreadyCompleted => 'already_completed',
+    retryable => 'retryable',
+  };
+}
+
+enum PrivacyDeletionFailureKind {
+  invalidInput,
+  targetNotFound,
+  malformedTarget,
+  credentials,
+  warehouseRead,
+  warehouseWrite,
+  upstreamSubmission,
+  aggregateRebuild,
+  authExportNotReady,
+  verification,
+  statusUpdate,
+  unexpected;
+
+  String get wireValue => switch (this) {
+    invalidInput => 'invalid_input',
+    targetNotFound => 'target_not_found',
+    malformedTarget => 'malformed_target',
+    credentials => 'credentials',
+    warehouseRead => 'warehouse_read',
+    warehouseWrite => 'warehouse_write',
+    upstreamSubmission => 'upstream_submission',
+    aggregateRebuild => 'aggregate_rebuild',
+    authExportNotReady => 'auth_export_not_ready',
+    verification => 'verification',
+    statusUpdate => 'status_update',
+    unexpected => 'unexpected',
+  };
+}
+
+enum PrivacyDeletionOperation {
+  loadTarget,
+  upsertExclusion,
+  readExclusion,
+  readAuthExport,
+  readTombstones,
+  discoverInstallations,
+  submitUpstream,
+  deleteRaw,
+  deleteKeyed,
+  rebuildAggregates,
+  verifyDeletion,
+  updateTargetStatus,
+  validateWarehouseSchema,
+  readSweepCheckpoint,
+  updateSweepCheckpoint,
+  readRawTables;
+
+  String get wireValue => switch (this) {
+    loadTarget => 'load_target',
+    upsertExclusion => 'upsert_exclusion',
+    readExclusion => 'read_exclusion',
+    readAuthExport => 'read_auth_export',
+    readTombstones => 'read_tombstones',
+    discoverInstallations => 'discover_installations',
+    submitUpstream => 'submit_upstream',
+    deleteRaw => 'delete_raw',
+    deleteKeyed => 'delete_keyed',
+    rebuildAggregates => 'rebuild_aggregates',
+    verifyDeletion => 'verify_deletion',
+    updateTargetStatus => 'update_target_status',
+    validateWarehouseSchema => 'validate_warehouse_schema',
+    readSweepCheckpoint => 'read_sweep_checkpoint',
+    updateSweepCheckpoint => 'update_sweep_checkpoint',
+    readRawTables => 'read_raw_tables',
+  };
+}
+
+final class PrivacyDeletionSummary {
+  const PrivacyDeletionSummary({
+    required this.operation,
+    required this.outcome,
+    required this.dryRun,
+    required this.targetsConsidered,
+    required this.authExportReadiness,
+    required this.cleanup,
+    required this.failureKind,
+  });
+
+  final PrivacyDeletionOperationKind operation;
+  final PrivacyDeletionOutcome outcome;
+  final bool dryRun;
+  final int targetsConsidered;
+  final AuthExportReadiness? authExportReadiness;
+  final CleanupResult cleanup;
+  final PrivacyDeletionFailureKind? failureKind;
+
+  bool get succeeded =>
+      outcome == PrivacyDeletionOutcome.completed ||
+      outcome == PrivacyDeletionOutcome.alreadyCompleted ||
+      outcome == PrivacyDeletionOutcome.planned;
+
+  Map<String, Object?> toAggregateJson({
+    required String credentialSource,
+    required bool credentialFallback,
+  }) {
+    return <String, Object?>{
+      'operation': operation.wireValue,
+      'mode': dryRun ? 'dry_run' : 'apply',
+      'outcome': outcome.wireValue,
+      'targets_considered': targetsConsidered,
+      'auth_export': authExportReadiness?.wireValue,
+      'installation_discoveries': cleanup.installationsDiscovered,
+      'upstream_submissions_planned': cleanup.upstreamSubmissionsPlanned,
+      'upstream_submissions_executed': cleanup.upstreamSubmissionsExecuted,
+      'raw_mutation_jobs_planned': cleanup.rawMutations.plannedJobs,
+      'raw_mutation_jobs_executed': cleanup.rawMutations.executedJobs,
+      'keyed_mutation_jobs_planned': cleanup.keyedMutations.plannedJobs,
+      'keyed_mutation_jobs_executed': cleanup.keyedMutations.executedJobs,
+      'aggregate_rebuilds_planned': cleanup.aggregateRebuild.plannedOperations,
+      'aggregate_rebuilds_executed':
+          cleanup.aggregateRebuild.executedOperations,
+      'verification_checks': cleanup.verification.checksRun,
+      'current_violation_checks': cleanup.verification.violationChecks,
+      'failure_kind': failureKind?.wireValue,
+      'credential_source': credentialSource,
+      'credential_fallback': credentialFallback,
+    };
+  }
+}
+
+final class PrivacyDeletionValidationException implements Exception {
+  const PrivacyDeletionValidationException({
+    required this.field,
+    required this.requirement,
+  });
+
+  final String field;
+  final String requirement;
+
+  @override
+  String toString() => 'Invalid $field: expected $requirement.';
+}
+
+final class PrivacyDeletionOperationException implements Exception {
+  const PrivacyDeletionOperationException({
+    required this.failureKind,
+    required this.operation,
+    required this.innerError,
+    required this.innerStackTrace,
+  });
+
+  final PrivacyDeletionFailureKind failureKind;
+  final PrivacyDeletionOperation operation;
+  final Object innerError;
+  final StackTrace innerStackTrace;
+
+  @override
+  String toString() =>
+      'Privacy deletion operation failed: ${operation.wireValue} '
+      '(${failureKind.wireValue}).';
+}
+
+final class PrivacyDeletionRecoveryException implements Exception {
+  const PrivacyDeletionRecoveryException({
+    required this.primaryError,
+    required this.innerError,
+    required this.innerStackTrace,
+  });
+
+  final PrivacyDeletionOperationException primaryError;
+  final Object innerError;
+  final StackTrace innerStackTrace;
+
+  @override
+  String toString() =>
+      'Privacy deletion failed and retryable status could not be recorded.';
+}

--- a/tool/product_analytics/privacy_deletion/privacy_deletion_models.dart
+++ b/tool/product_analytics/privacy_deletion/privacy_deletion_models.dart
@@ -286,10 +286,14 @@ final class AuthExportSnapshot {
   const AuthExportSnapshot({
     required this.runCutoff,
     required this.publishedAt,
+    required this.maxAge,
+    required this.futureClockAllowance,
   });
 
   final DateTime runCutoff;
   final DateTime publishedAt;
+  final Duration maxAge;
+  final Duration futureClockAllowance;
 }
 
 enum AuthExportReadiness {

--- a/tool/product_analytics/privacy_deletion/privacy_deletion_repository.dart
+++ b/tool/product_analytics/privacy_deletion/privacy_deletion_repository.dart
@@ -63,13 +63,8 @@ final class PrivacyDeletionRepository {
     );
   }
 
-  Future<AuthExportReadiness> checkTombstoneAwareAuthExport({
-    required DateTime suppressedAt,
-  }) async {
-    final snapshot = await _api.latestSuccessfulAuthExport();
-    return snapshot != null && !snapshot.runCutoff.isBefore(suppressedAt)
-        ? AuthExportReadiness.ready
-        : AuthExportReadiness.notReady;
+  Future<AuthExportSnapshot?> loadLatestSuccessfulAuthExport() {
+    return _api.latestSuccessfulAuthExport();
   }
 
   Future<List<AppInstanceId>> discoverTargetInstallations({

--- a/tool/product_analytics/privacy_deletion/privacy_deletion_repository.dart
+++ b/tool/product_analytics/privacy_deletion/privacy_deletion_repository.dart
@@ -1,0 +1,296 @@
+import 'privacy_deletion_api.dart';
+import 'privacy_deletion_models.dart';
+
+final class PrivacyDeletionRepository {
+  PrivacyDeletionRepository({
+    required PrivacyDeletionApi api,
+    required int rawRetentionDays,
+    required DateTime Function() now,
+  }) : _api = api,
+       _rawRetentionDays = rawRetentionDays,
+       _now = now {
+    if (rawRetentionDays < 1 || rawRetentionDays > 90) {
+      throw const PrivacyDeletionValidationException(
+        field: 'raw_retention_days',
+        requirement: '1 through 90',
+      );
+    }
+  }
+
+  final PrivacyDeletionApi _api;
+  final int _rawRetentionDays;
+  final DateTime Function() _now;
+
+  Future<PrivacyDeletionTarget> loadTarget({
+    required PrivacyRequestId requestId,
+  }) async {
+    final target = await _api.loadTarget(requestId: requestId);
+    if (target == null) {
+      throw PrivacyDeletionOperationException(
+        failureKind: PrivacyDeletionFailureKind.targetNotFound,
+        operation: PrivacyDeletionOperation.loadTarget,
+        innerError: const PrivacyDeletionTargetNotFoundException(),
+        innerStackTrace: StackTrace.current,
+      );
+    }
+    return target;
+  }
+
+  Future<void> prepareTarget({
+    required PrivacyDeletionTarget target,
+    required bool dryRun,
+  }) async {
+    await _api.upsertPermanentExclusion(target: target, dryRun: dryRun);
+    await validateWarehouseInventory(allowAuthStagingTables: true);
+    if (dryRun) {
+      return;
+    }
+    final exclusionExists = await _api.permanentExclusionExists(
+      userKey: target.userKey,
+    );
+    if (!exclusionExists) {
+      throw PrivacyDeletionOperationException(
+        failureKind: PrivacyDeletionFailureKind.verification,
+        operation: PrivacyDeletionOperation.readExclusion,
+        innerError: const PermanentExclusionMissingException(),
+        innerStackTrace: StackTrace.current,
+      );
+    }
+    await _api.updateTargetStatus(
+      requestId: target.requestId,
+      status: PrivacyDeletionTargetStatus.processing,
+      failureKind: null,
+    );
+  }
+
+  Future<AuthExportReadiness> checkTombstoneAwareAuthExport({
+    required DateTime suppressedAt,
+  }) async {
+    final snapshot = await _api.latestSuccessfulAuthExport();
+    return snapshot != null && !snapshot.runCutoff.isBefore(suppressedAt)
+        ? AuthExportReadiness.ready
+        : AuthExportReadiness.notReady;
+  }
+
+  Future<List<AppInstanceId>> discoverTargetInstallations({
+    required PseudonymousUserKey userKey,
+    required UtcDateRange range,
+  }) {
+    return _api.discoverInstallationsForTarget(userKey: userKey, range: range);
+  }
+
+  Future<List<AppInstanceId>> discoverSweepInstallations({
+    required UtcDateRange range,
+  }) {
+    return _api.discoverInstallationsForAllTombstones(range: range);
+  }
+
+  Future<UpstreamDeletionResult> submitUpstreamDeletions({
+    required List<AppInstanceId> appInstanceIds,
+    required List<LegacyFirebaseUserId> legacyUserIds,
+    required bool dryRun,
+  }) {
+    return _api.submitUpstreamDeletions(
+      appInstanceIds: appInstanceIds,
+      legacyUserIds: legacyUserIds,
+      dryRun: dryRun,
+    );
+  }
+
+  Future<WarehouseMutationResult> deleteRawContributions({
+    required UtcDateRange range,
+    required List<PseudonymousUserKey> userKeys,
+    required List<LegacyFirebaseUserId> legacyUserIds,
+    required List<AppInstanceId> appInstanceIds,
+    required bool dryRun,
+  }) {
+    return _api.deleteRawContributions(
+      range: range,
+      userKeys: userKeys,
+      legacyUserIds: legacyUserIds,
+      appInstanceIds: appInstanceIds,
+      dryRun: dryRun,
+    );
+  }
+
+  Future<WarehouseMutationResult> deleteKeyedContributions({
+    required List<PseudonymousUserKey> userKeys,
+    required bool includeAuthTables,
+    required bool dryRun,
+  }) {
+    return _api.deleteKeyedContributions(
+      userKeys: userKeys,
+      includeAuthTables: includeAuthTables,
+      dryRun: dryRun,
+    );
+  }
+
+  Future<AggregateRebuildResult> rebuildAggregates({required bool dryRun}) {
+    return _api.rebuildAggregates(dryRun: dryRun);
+  }
+
+  Future<WarehouseVerificationResult> verifyNoRepopulation({
+    required UtcDateRange rawRange,
+    required List<PseudonymousUserKey> userKeys,
+    required List<LegacyFirebaseUserId> legacyUserIds,
+    required List<AppInstanceId> appInstanceIds,
+    required bool includeAuthTables,
+    required bool dryRun,
+  }) async {
+    final verification = await _api.verifyNoRepopulation(
+      rawRange: rawRange,
+      userKeys: userKeys,
+      legacyUserIds: legacyUserIds,
+      appInstanceIds: appInstanceIds,
+      includeAuthTables: includeAuthTables,
+    );
+    if (!dryRun && verification.violationChecks != 0) {
+      throw PrivacyDeletionOperationException(
+        failureKind: PrivacyDeletionFailureKind.verification,
+        operation: PrivacyDeletionOperation.verifyDeletion,
+        innerError: DeletionVerificationException(
+          violationChecks: verification.violationChecks,
+        ),
+        innerStackTrace: StackTrace.current,
+      );
+    }
+    return verification;
+  }
+
+  Future<void> markCompleted({required PrivacyRequestId requestId}) {
+    return _api.updateTargetStatus(
+      requestId: requestId,
+      status: PrivacyDeletionTargetStatus.completed,
+      failureKind: null,
+    );
+  }
+
+  Future<void> markRetryable({
+    required PrivacyRequestId requestId,
+    required PrivacyDeletionFailureKind failureKind,
+  }) {
+    return _api.updateTargetStatus(
+      requestId: requestId,
+      status: PrivacyDeletionTargetStatus.retryable,
+      failureKind: failureKind,
+    );
+  }
+
+  Future<List<PermanentDeletionTombstone>> loadAllPermanentTombstones() {
+    return _api.loadAllPermanentTombstones();
+  }
+
+  Future<void> validateWarehouseInventory({
+    required bool allowAuthStagingTables,
+  }) async {
+    await _api.validateKeyedTableInventory(
+      allowAuthStagingTables: allowAuthStagingTables,
+    );
+    await _api.latestRawEventTableDate();
+  }
+
+  Future<UtcDateRange> nextSweepRange() async {
+    final lastSuccessDate = await _api.readLastSweepSuccessDate();
+    final latestRawTableDate = await _api.latestRawEventTableDate();
+    if (latestRawTableDate == null) {
+      throw PrivacyDeletionOperationException(
+        failureKind: PrivacyDeletionFailureKind.warehouseRead,
+        operation: PrivacyDeletionOperation.readRawTables,
+        innerError: const RawEventTableNotFoundException(),
+        innerStackTrace: StackTrace.current,
+      );
+    }
+    final latestCompleteRawDate = calculateLatestCompleteRawDate(
+      now: _now(),
+      latestRawTableDate: latestRawTableDate,
+    );
+    return calculateSweepRange(
+      latestCompleteRawDate: latestCompleteRawDate,
+      lastSuccessDate: lastSuccessDate,
+      rawRetentionDays: _rawRetentionDays,
+    );
+  }
+
+  Future<void> markSweepCompleted({required DateTime throughDate}) {
+    return _api.updateSweepSuccessDate(throughDate: throughDate);
+  }
+
+  UtcDateRange retainedRawRange() {
+    final today = UtcDateRange.utcDate(dateTime: _now());
+    return UtcDateRange.fromDates(
+      start: today.subtract(Duration(days: _rawRetentionDays - 1)),
+      end: today,
+    );
+  }
+
+  static UtcDateRange calculateSweepRange({
+    required DateTime latestCompleteRawDate,
+    required DateTime? lastSuccessDate,
+    required int rawRetentionDays,
+  }) {
+    if (rawRetentionDays < 1 || rawRetentionDays > 90) {
+      throw const PrivacyDeletionValidationException(
+        field: 'raw_retention_days',
+        requirement: '1 through 90',
+      );
+    }
+    final throughDate = UtcDateRange.utcDate(dateTime: latestCompleteRawDate);
+    final oldestRetained = throughDate.subtract(
+      Duration(days: rawRetentionDays - 1),
+    );
+    final latestThreeStart = throughDate.subtract(const Duration(days: 2));
+    final normalizedLastSuccess = lastSuccessDate == null
+        ? null
+        : UtcDateRange.utcDate(dateTime: lastSuccessDate);
+    if (normalizedLastSuccess != null &&
+        normalizedLastSuccess.isAfter(throughDate)) {
+      throw const PrivacyDeletionValidationException(
+        field: 'sweep_checkpoint',
+        requirement: 'a UTC date no later than the latest complete raw date',
+      );
+    }
+    final continuation = normalizedLastSuccess == null
+        ? oldestRetained
+        : normalizedLastSuccess.add(const Duration(days: 1));
+    var start = continuation.isBefore(latestThreeStart)
+        ? continuation
+        : latestThreeStart;
+    if (start.isBefore(oldestRetained)) {
+      start = oldestRetained;
+    }
+    return UtcDateRange.fromDates(start: start, end: throughDate);
+  }
+
+  static DateTime calculateLatestCompleteRawDate({
+    required DateTime now,
+    required DateTime latestRawTableDate,
+  }) {
+    final yesterday = UtcDateRange.utcDate(
+      dateTime: now,
+    ).subtract(const Duration(days: 1));
+    final latestCompleteFromTables = UtcDateRange.utcDate(
+      dateTime: latestRawTableDate,
+    ).subtract(const Duration(days: 1));
+    return latestCompleteFromTables.isBefore(yesterday)
+        ? latestCompleteFromTables
+        : yesterday;
+  }
+}
+
+final class PrivacyDeletionTargetNotFoundException implements Exception {
+  const PrivacyDeletionTargetNotFoundException();
+}
+
+final class PermanentExclusionMissingException implements Exception {
+  const PermanentExclusionMissingException();
+}
+
+final class DeletionVerificationException implements Exception {
+  const DeletionVerificationException({required this.violationChecks});
+
+  final int violationChecks;
+}
+
+final class RawEventTableNotFoundException implements Exception {
+  const RawEventTableNotFoundException();
+}

--- a/tool/product_analytics/privacy_deletion/privacy_deletion_service.dart
+++ b/tool/product_analytics/privacy_deletion/privacy_deletion_service.dart
@@ -1,0 +1,336 @@
+import 'privacy_deletion_models.dart';
+import 'privacy_deletion_repository.dart';
+
+final class PrivacyDeletionService {
+  const PrivacyDeletionService({required PrivacyDeletionRepository repository})
+    : _repository = repository;
+
+  final PrivacyDeletionRepository _repository;
+
+  Future<PrivacyDeletionSummary> runRequest({
+    required PrivacyRequestId requestId,
+    required bool dryRun,
+  }) async {
+    PrivacyDeletionTarget? target;
+    var cleanup = const CleanupResult.none();
+    AuthExportReadiness? readiness;
+    try {
+      target = await _repository.loadTarget(requestId: requestId);
+      if (target.status == PrivacyDeletionTargetStatus.completed) {
+        return PrivacyDeletionSummary(
+          operation: PrivacyDeletionOperationKind.request,
+          outcome: PrivacyDeletionOutcome.alreadyCompleted,
+          dryRun: dryRun,
+          targetsConsidered: 1,
+          authExportReadiness: AuthExportReadiness.ready,
+          cleanup: cleanup,
+          failureKind: null,
+        );
+      }
+
+      await _repository.prepareTarget(target: target, dryRun: dryRun);
+      cleanup = cleanup.add(
+        other: await _cleanupTarget(
+          target: target,
+          phase: PrivacyDeletionCleanupPhase.preliminary,
+          dryRun: dryRun,
+        ),
+      );
+      readiness = await _repository.checkTombstoneAwareAuthExport(
+        suppressedAt: target.suppressedAt,
+      );
+
+      if (dryRun) {
+        if (readiness == AuthExportReadiness.ready) {
+          await _repository.validateWarehouseInventory(
+            allowAuthStagingTables: false,
+          );
+          cleanup = cleanup.add(
+            other: await _cleanupTarget(
+              target: target,
+              phase: PrivacyDeletionCleanupPhase.finalPass,
+              dryRun: true,
+            ),
+          );
+          await _repository.validateWarehouseInventory(
+            allowAuthStagingTables: false,
+          );
+        }
+        return PrivacyDeletionSummary(
+          operation: PrivacyDeletionOperationKind.request,
+          outcome: PrivacyDeletionOutcome.planned,
+          dryRun: true,
+          targetsConsidered: 1,
+          authExportReadiness: readiness,
+          cleanup: cleanup,
+          failureKind: null,
+        );
+      }
+
+      if (readiness == AuthExportReadiness.notReady) {
+        final failure = PrivacyDeletionOperationException(
+          failureKind: PrivacyDeletionFailureKind.authExportNotReady,
+          operation: PrivacyDeletionOperation.readAuthExport,
+          innerError: const AuthExportCutoffNotReadyException(),
+          innerStackTrace: StackTrace.current,
+        );
+        return _recoverRequestFailure(
+          target: target,
+          failure: failure,
+          cleanup: cleanup,
+          readiness: readiness,
+        );
+      }
+
+      await _repository.validateWarehouseInventory(
+        allowAuthStagingTables: false,
+      );
+      cleanup = cleanup.add(
+        other: await _cleanupTarget(
+          target: target,
+          phase: PrivacyDeletionCleanupPhase.finalPass,
+          dryRun: false,
+        ),
+      );
+      await _repository.validateWarehouseInventory(
+        allowAuthStagingTables: false,
+      );
+      await _repository.markCompleted(requestId: target.requestId);
+      return PrivacyDeletionSummary(
+        operation: PrivacyDeletionOperationKind.request,
+        outcome: PrivacyDeletionOutcome.completed,
+        dryRun: false,
+        targetsConsidered: 1,
+        authExportReadiness: readiness,
+        cleanup: cleanup,
+        failureKind: null,
+      );
+    } on PrivacyDeletionOperationException catch (error) {
+      if (target == null || dryRun) {
+        return PrivacyDeletionSummary(
+          operation: PrivacyDeletionOperationKind.request,
+          outcome: PrivacyDeletionOutcome.retryable,
+          dryRun: dryRun,
+          targetsConsidered: target == null ? 0 : 1,
+          authExportReadiness: readiness,
+          cleanup: cleanup,
+          failureKind: error.failureKind,
+        );
+      }
+      return _recoverRequestFailure(
+        target: target,
+        failure: error,
+        cleanup: cleanup,
+        readiness: readiness,
+      );
+    } catch (error, stackTrace) {
+      final failure = PrivacyDeletionOperationException(
+        failureKind: PrivacyDeletionFailureKind.unexpected,
+        operation: PrivacyDeletionOperation.verifyDeletion,
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+      if (target == null || dryRun) {
+        return PrivacyDeletionSummary(
+          operation: PrivacyDeletionOperationKind.request,
+          outcome: PrivacyDeletionOutcome.retryable,
+          dryRun: dryRun,
+          targetsConsidered: target == null ? 0 : 1,
+          authExportReadiness: readiness,
+          cleanup: cleanup,
+          failureKind: failure.failureKind,
+        );
+      }
+      return _recoverRequestFailure(
+        target: target,
+        failure: failure,
+        cleanup: cleanup,
+        readiness: readiness,
+      );
+    }
+  }
+
+  Future<CleanupResult> _cleanupTarget({
+    required PrivacyDeletionTarget target,
+    required PrivacyDeletionCleanupPhase phase,
+    required bool dryRun,
+  }) async {
+    final rawRange = _repository.retainedRawRange();
+    final installations = await _repository.discoverTargetInstallations(
+      userKey: target.userKey,
+      range: rawRange,
+    );
+    return _cleanup(
+      userKeys: <PseudonymousUserKey>[target.userKey],
+      legacyUserIds: <LegacyFirebaseUserId>[target.legacyFirebaseUserId],
+      appInstanceIds: installations,
+      rawRange: rawRange,
+      includeAuthTables: phase.includeAuthTables,
+      dryRun: dryRun,
+    );
+  }
+
+  Future<CleanupResult> _cleanupSweep({
+    required List<PermanentDeletionTombstone> tombstones,
+    required UtcDateRange discoveryRange,
+    required bool dryRun,
+  }) async {
+    if (tombstones.isEmpty) {
+      return const CleanupResult.none();
+    }
+    final installations = await _repository.discoverSweepInstallations(
+      range: discoveryRange,
+    );
+    return _cleanup(
+      userKeys: tombstones.map((final value) => value.userKey).toList(),
+      legacyUserIds: tombstones
+          .map((final value) => value.legacyFirebaseUserId)
+          .toList(),
+      appInstanceIds: installations,
+      rawRange: _repository.retainedRawRange(),
+      includeAuthTables: true,
+      dryRun: dryRun,
+    );
+  }
+
+  Future<CleanupResult> _cleanup({
+    required List<PseudonymousUserKey> userKeys,
+    required List<LegacyFirebaseUserId> legacyUserIds,
+    required List<AppInstanceId> appInstanceIds,
+    required UtcDateRange rawRange,
+    required bool includeAuthTables,
+    required bool dryRun,
+  }) async {
+    final upstream = await _repository.submitUpstreamDeletions(
+      appInstanceIds: appInstanceIds,
+      legacyUserIds: legacyUserIds,
+      dryRun: dryRun,
+    );
+    final rawMutations = await _repository.deleteRawContributions(
+      range: rawRange,
+      userKeys: userKeys,
+      legacyUserIds: legacyUserIds,
+      appInstanceIds: appInstanceIds,
+      dryRun: dryRun,
+    );
+    final keyedMutations = await _repository.deleteKeyedContributions(
+      userKeys: userKeys,
+      includeAuthTables: includeAuthTables,
+      dryRun: dryRun,
+    );
+    final aggregateRebuild = await _repository.rebuildAggregates(
+      dryRun: dryRun,
+    );
+    final verification = await _repository.verifyNoRepopulation(
+      rawRange: rawRange,
+      userKeys: userKeys,
+      legacyUserIds: legacyUserIds,
+      appInstanceIds: appInstanceIds,
+      includeAuthTables: includeAuthTables,
+      dryRun: dryRun,
+    );
+    return CleanupResult(
+      installationsDiscovered: appInstanceIds.length,
+      upstreamSubmissionsPlanned: upstream.plannedSubmissions,
+      upstreamSubmissionsExecuted: upstream.executedSubmissions,
+      rawMutations: rawMutations,
+      keyedMutations: keyedMutations,
+      aggregateRebuild: aggregateRebuild,
+      verification: verification,
+    );
+  }
+
+  Future<PrivacyDeletionSummary> _recoverRequestFailure({
+    required PrivacyDeletionTarget target,
+    required PrivacyDeletionOperationException failure,
+    required CleanupResult cleanup,
+    required AuthExportReadiness? readiness,
+  }) async {
+    try {
+      await _repository.markRetryable(
+        requestId: target.requestId,
+        failureKind: failure.failureKind,
+      );
+    } catch (error, stackTrace) {
+      throw PrivacyDeletionRecoveryException(
+        primaryError: failure,
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+    }
+    return PrivacyDeletionSummary(
+      operation: PrivacyDeletionOperationKind.request,
+      outcome: PrivacyDeletionOutcome.retryable,
+      dryRun: false,
+      targetsConsidered: 1,
+      authExportReadiness: readiness,
+      cleanup: cleanup,
+      failureKind: failure.failureKind,
+    );
+  }
+
+  Future<PrivacyDeletionSummary> runSweep({required bool dryRun}) async {
+    var cleanup = const CleanupResult.none();
+    var targetCount = 0;
+    try {
+      await _repository.validateWarehouseInventory(
+        allowAuthStagingTables: false,
+      );
+      final range = await _repository.nextSweepRange();
+      final tombstones = await _repository.loadAllPermanentTombstones();
+      targetCount = tombstones.length;
+      cleanup = await _cleanupSweep(
+        tombstones: tombstones,
+        discoveryRange: range,
+        dryRun: dryRun,
+      );
+      if (!dryRun) {
+        await _repository.validateWarehouseInventory(
+          allowAuthStagingTables: false,
+        );
+        await _repository.markSweepCompleted(throughDate: range.end);
+      }
+      return PrivacyDeletionSummary(
+        operation: PrivacyDeletionOperationKind.sweep,
+        outcome: dryRun
+            ? PrivacyDeletionOutcome.planned
+            : PrivacyDeletionOutcome.completed,
+        dryRun: dryRun,
+        targetsConsidered: targetCount,
+        authExportReadiness: null,
+        cleanup: cleanup,
+        failureKind: null,
+      );
+    } on PrivacyDeletionOperationException catch (error) {
+      return PrivacyDeletionSummary(
+        operation: PrivacyDeletionOperationKind.sweep,
+        outcome: PrivacyDeletionOutcome.retryable,
+        dryRun: dryRun,
+        targetsConsidered: targetCount,
+        authExportReadiness: null,
+        cleanup: cleanup,
+        failureKind: error.failureKind,
+      );
+    } catch (error, stackTrace) {
+      final failure = PrivacyDeletionOperationException(
+        failureKind: PrivacyDeletionFailureKind.unexpected,
+        operation: PrivacyDeletionOperation.readTombstones,
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+      return PrivacyDeletionSummary(
+        operation: PrivacyDeletionOperationKind.sweep,
+        outcome: PrivacyDeletionOutcome.retryable,
+        dryRun: dryRun,
+        targetsConsidered: targetCount,
+        authExportReadiness: null,
+        cleanup: cleanup,
+        failureKind: failure.failureKind,
+      );
+    }
+  }
+}
+
+final class AuthExportCutoffNotReadyException implements Exception {
+  const AuthExportCutoffNotReadyException();
+}

--- a/tool/product_analytics/privacy_deletion/privacy_deletion_service.dart
+++ b/tool/product_analytics/privacy_deletion/privacy_deletion_service.dart
@@ -2,10 +2,14 @@ import 'privacy_deletion_models.dart';
 import 'privacy_deletion_repository.dart';
 
 final class PrivacyDeletionService {
-  const PrivacyDeletionService({required PrivacyDeletionRepository repository})
-    : _repository = repository;
+  const PrivacyDeletionService({
+    required PrivacyDeletionRepository repository,
+    required DateTime Function() now,
+  }) : _repository = repository,
+       _now = now;
 
   final PrivacyDeletionRepository _repository;
+  final DateTime Function() _now;
 
   Future<PrivacyDeletionSummary> runRequest({
     required PrivacyRequestId requestId,
@@ -36,7 +40,7 @@ final class PrivacyDeletionService {
           dryRun: dryRun,
         ),
       );
-      readiness = await _repository.checkTombstoneAwareAuthExport(
+      readiness = await _checkTombstoneAwareAuthExport(
         suppressedAt: target.suppressedAt,
       );
 
@@ -170,6 +174,35 @@ final class PrivacyDeletionService {
     );
   }
 
+  Future<AuthExportReadiness> _checkTombstoneAwareAuthExport({
+    required DateTime suppressedAt,
+  }) async {
+    return evaluateAuthExportReadiness(
+      snapshot: await _repository.loadLatestSuccessfulAuthExport(),
+      suppressedAt: suppressedAt,
+      now: _now(),
+    );
+  }
+
+  static AuthExportReadiness evaluateAuthExportReadiness({
+    required AuthExportSnapshot? snapshot,
+    required DateTime suppressedAt,
+    required DateTime now,
+  }) {
+    final current = now.toUtc();
+    if (snapshot == null ||
+        snapshot.runCutoff.isBefore(suppressedAt.toUtc()) ||
+        snapshot.runCutoff.isBefore(current.subtract(snapshot.maxAge)) ||
+        snapshot.runCutoff.isAfter(snapshot.publishedAt) ||
+        snapshot.publishedAt.isBefore(current.subtract(snapshot.maxAge)) ||
+        snapshot.publishedAt.isAfter(
+          current.add(snapshot.futureClockAllowance),
+        )) {
+      return AuthExportReadiness.notReady;
+    }
+    return AuthExportReadiness.ready;
+  }
+
   Future<CleanupResult> _cleanupSweep({
     required List<PermanentDeletionTombstone> tombstones,
     required UtcDateRange discoveryRange,
@@ -272,6 +305,7 @@ final class PrivacyDeletionService {
   Future<PrivacyDeletionSummary> runSweep({required bool dryRun}) async {
     var cleanup = const CleanupResult.none();
     var targetCount = 0;
+    AuthExportReadiness? readiness;
     try {
       await _repository.validateWarehouseInventory(
         allowAuthStagingTables: false,
@@ -279,6 +313,25 @@ final class PrivacyDeletionService {
       final range = await _repository.nextSweepRange();
       final tombstones = await _repository.loadAllPermanentTombstones();
       targetCount = tombstones.length;
+      if (tombstones.isNotEmpty) {
+        final latestSuppressedAt = tombstones
+            .map((tombstone) => tombstone.suppressedAt)
+            .reduce((left, right) => left.isAfter(right) ? left : right);
+        readiness = await _checkTombstoneAwareAuthExport(
+          suppressedAt: latestSuppressedAt,
+        );
+        if (readiness == AuthExportReadiness.notReady) {
+          return PrivacyDeletionSummary(
+            operation: PrivacyDeletionOperationKind.sweep,
+            outcome: PrivacyDeletionOutcome.retryable,
+            dryRun: dryRun,
+            targetsConsidered: targetCount,
+            authExportReadiness: readiness,
+            cleanup: cleanup,
+            failureKind: PrivacyDeletionFailureKind.authExportNotReady,
+          );
+        }
+      }
       cleanup = await _cleanupSweep(
         tombstones: tombstones,
         discoveryRange: range,
@@ -297,7 +350,7 @@ final class PrivacyDeletionService {
             : PrivacyDeletionOutcome.completed,
         dryRun: dryRun,
         targetsConsidered: targetCount,
-        authExportReadiness: null,
+        authExportReadiness: readiness,
         cleanup: cleanup,
         failureKind: null,
       );
@@ -307,7 +360,7 @@ final class PrivacyDeletionService {
         outcome: PrivacyDeletionOutcome.retryable,
         dryRun: dryRun,
         targetsConsidered: targetCount,
-        authExportReadiness: null,
+        authExportReadiness: readiness,
         cleanup: cleanup,
         failureKind: error.failureKind,
       );
@@ -323,7 +376,7 @@ final class PrivacyDeletionService {
         outcome: PrivacyDeletionOutcome.retryable,
         dryRun: dryRun,
         targetsConsidered: targetCount,
-        authExportReadiness: null,
+        authExportReadiness: readiness,
         cleanup: cleanup,
         failureKind: failure.failureKind,
       );

--- a/tool/product_analytics/privacy_deletion/privacy_deletion_test.dart
+++ b/tool/product_analytics/privacy_deletion/privacy_deletion_test.dart
@@ -1,0 +1,1027 @@
+import 'dart:convert';
+
+import 'bigquery_privacy_deletion_client.dart';
+import 'ga_user_deletion_client.dart';
+import 'google_api_foundation.dart';
+import 'privacy_deletion_api.dart';
+import 'privacy_deletion_config.dart';
+import 'privacy_deletion_models.dart';
+import 'privacy_deletion_repository.dart';
+
+Future<void> main() async {
+  _testIdentifiers();
+  _testConfigurationAllowlistAndDefaults();
+  _testSweepRanges();
+  _testCleanupPhases();
+  _testAnalyticsAdminRequestShapes();
+  await _testLatestSuccessfulAuthExportSql();
+  await _testKeyedTableInventory();
+  await _testRawDateAndInstallationDiscovery();
+  await _testFixedAggregateChain();
+  await _testStatusVerification();
+  _testAggregateOnlyOutput();
+}
+
+void _testIdentifiers() {
+  for (final value in <String>['A_1-b2C3', '${'A' * 126}_-', 'request_123']) {
+    _expect(
+      condition: PrivacyRequestId.parse(value: value).value == value,
+      message: 'valid request ID was not retained',
+    );
+  }
+  for (final value in <String>[
+    'A' * 7,
+    'A' * 129,
+    'abc.defgh',
+    'abc:defgh',
+    'abcdefg/',
+    'abcdé123',
+  ]) {
+    _expectThrows<PrivacyDeletionValidationException>(
+      body: () => PrivacyRequestId.parse(value: value),
+      message: 'request ID outside ^[A-Za-z0-9_-]{8,128}\$ was accepted',
+    );
+  }
+
+  final lowercaseKey = 'a' * 64;
+  _expect(
+    condition:
+        PseudonymousUserKey.parse(value: lowercaseKey).value == lowercaseKey,
+    message: 'valid lowercase key was not retained',
+  );
+  _expectThrows<PrivacyDeletionValidationException>(
+    body: () => PseudonymousUserKey.parse(value: lowercaseKey.toUpperCase()),
+    message: 'uppercase key was accepted',
+  );
+  _expectThrows<PrivacyDeletionValidationException>(
+    body: () => LegacyFirebaseUserId.parse(value: 'a' * 63),
+    message: 'short legacy ID was accepted',
+  );
+}
+
+void _testConfigurationAllowlistAndDefaults() {
+  final command = PrivacyDeletionCommandConfig.parse(
+    arguments: <String>[..._baseArguments(includeRequestId: true), '--dry-run'],
+    environment: const <String, String>{},
+    requestIdRequired: true,
+  );
+  _expect(
+    condition: command.config.allowedDatasets.length == 6,
+    message: 'the six datasets were not allowlisted',
+  );
+  _expect(
+    condition:
+        command.config.exclusionsTable.tableId.value ==
+        'permanent_deletion_exclusions',
+    message: 'the permanent deletion exclusions default is incorrect',
+  );
+  _expect(
+    condition:
+        command.config.rawRetentionDays == 90 &&
+        command.config.authKeyedTables
+                .map((final table) => table.tableId.value)
+                .join(',') ==
+            'auth_user_milestones' &&
+        command.config.curatedKeyedTables
+                .map((final table) => table.tableId.value)
+                .join(',') ==
+            'events_flattened,user_activity_daily,user_milestones' &&
+        command.config.reportingKeyedTables.isEmpty,
+    message:
+        'privacy coverage inventory is not pinned to the warehouse contract',
+  );
+  _expect(condition: command.dryRun, message: 'dry-run flag was not parsed');
+  _expect(
+    condition: !command.config.allowGcloudAdcFallback,
+    message: 'gcloud ADC fallback must be disabled by default',
+  );
+  final localOperatorCommand = PrivacyDeletionCommandConfig.parse(
+    arguments: <String>[
+      ..._baseArguments(includeRequestId: false),
+      '--allow-gcloud-adc-fallback',
+    ],
+    environment: const <String, String>{},
+    requestIdRequired: false,
+  );
+  _expect(
+    condition: localOperatorCommand.config.allowGcloudAdcFallback,
+    message: 'explicit local gcloud ADC fallback was not parsed',
+  );
+  final fallbackEnvironment = applicationDefaultProcessEnvironment(
+    parentEnvironment: const <String, String>{
+      'PATH': '/approved/bin',
+      'GOOGLE_APPLICATION_CREDENTIALS': '/forbidden/key.json',
+    },
+  );
+  _expect(
+    condition:
+        fallbackEnvironment['PATH'] == '/approved/bin' &&
+        !fallbackEnvironment.containsKey('GOOGLE_APPLICATION_CREDENTIALS'),
+    message: 'gcloud fallback environment retained an arbitrary key path',
+  );
+
+  _expectThrows<PrivacyDeletionValidationException>(
+    body: () => PrivacyDeletionCommandConfig.parse(
+      arguments: <String>[
+        ..._baseArguments(includeRequestId: false),
+        '--aggregate-rebuild-command',
+        '/tmp/rebuild',
+      ],
+      environment: const <String, String>{},
+      requestIdRequired: false,
+    ),
+    message: 'arbitrary aggregate command configuration was accepted',
+  );
+  for (final option in const <String>[
+    '--auth-keyed-tables',
+    '--curated-keyed-tables',
+    '--reporting-keyed-tables',
+    '--raw-retention-days',
+    '--auth-wait-minutes',
+    '--auth-poll-seconds',
+  ]) {
+    _expectThrows<PrivacyDeletionValidationException>(
+      body: () => PrivacyDeletionCommandConfig.parse(
+        arguments: <String>[
+          ..._baseArguments(includeRequestId: false),
+          option,
+          'unsafe_override',
+        ],
+        environment: const <String, String>{},
+        requestIdRequired: false,
+      ),
+      message: 'unsupported privacy lifecycle option $option was accepted',
+    );
+  }
+
+  final duplicateDatasets = _baseArguments(includeRequestId: false);
+  duplicateDatasets[duplicateDatasets.indexOf('--auth-dataset') + 1] =
+      'analytics_123456789';
+  _expectThrows<PrivacyDeletionValidationException>(
+    body: () => PrivacyDeletionCommandConfig.parse(
+      arguments: duplicateDatasets,
+      environment: const <String, String>{},
+      requestIdRequired: false,
+    ),
+    message: 'duplicate datasets were accepted',
+  );
+}
+
+void _testCleanupPhases() {
+  _expect(
+    condition:
+        !PrivacyDeletionCleanupPhase.preliminary.includeAuthTables &&
+        PrivacyDeletionCleanupPhase.finalPass.includeAuthTables,
+    message:
+        'preliminary cleanup must preserve auth publication until the final pass',
+  );
+}
+
+void _testSweepRanges() {
+  final now = DateTime.utc(2026, 7, 31, 15);
+  final latestComplete =
+      PrivacyDeletionRepository.calculateLatestCompleteRawDate(
+        now: now,
+        latestRawTableDate: DateTime.utc(2026, 7, 31),
+      );
+  _expect(
+    condition: formatUtcDate(date: latestComplete) == '2026-07-30',
+    message: 'latest raw table suffix was not reduced by one day',
+  );
+  final capped = PrivacyDeletionRepository.calculateLatestCompleteRawDate(
+    now: now,
+    latestRawTableDate: DateTime.utc(2026, 8, 3),
+  );
+  _expect(
+    condition: formatUtcDate(date: capped) == '2026-07-30',
+    message: 'latest complete raw date was not capped at yesterday UTC',
+  );
+  final delayed = PrivacyDeletionRepository.calculateLatestCompleteRawDate(
+    now: now,
+    latestRawTableDate: DateTime.utc(2026, 7, 29),
+  );
+  _expect(
+    condition: formatUtcDate(date: delayed) == '2026-07-28',
+    message: 'delayed raw exports did not conservatively move the sweep anchor',
+  );
+
+  final gapRange = PrivacyDeletionRepository.calculateSweepRange(
+    latestCompleteRawDate: latestComplete,
+    lastSuccessDate: DateTime.utc(2026, 7, 20),
+    rawRetentionDays: 90,
+  );
+  _expect(
+    condition: formatUtcDate(date: gapRange.start) == '2026-07-21',
+    message: 'watermark gap did not start at continuation',
+  );
+  _expect(
+    condition: formatUtcDate(date: gapRange.end) == '2026-07-30',
+    message: 'sweep did not end at the latest complete raw date',
+  );
+  final overlapRange = PrivacyDeletionRepository.calculateSweepRange(
+    latestCompleteRawDate: latestComplete,
+    lastSuccessDate: DateTime.utc(2026, 7, 29),
+    rawRetentionDays: 90,
+  );
+  _expect(
+    condition: formatUtcDate(date: overlapRange.start) == '2026-07-28',
+    message: 'latest three complete UTC dates were not rescanned',
+  );
+  _expectThrows<PrivacyDeletionValidationException>(
+    body: () => PrivacyDeletionRepository.calculateSweepRange(
+      latestCompleteRawDate: latestComplete,
+      lastSuccessDate: DateTime.utc(2026, 7, 31),
+      rawRetentionDays: 90,
+    ),
+    message: 'checkpoint after the latest complete raw date was accepted',
+  );
+}
+
+void _testAnalyticsAdminRequestShapes() {
+  final appIdentifier = GaAppInstanceDeletionIdentifier(
+    appInstanceId: AppInstanceId.parse(value: 'app-instance'),
+  );
+  _expect(
+    condition:
+        jsonEncode(appIdentifier.toRequestBody()) ==
+        '{"appInstanceId":"app-instance"}',
+    message: 'app-instance request does not use Admin API appInstanceId',
+  );
+  final legacyId = 'b' * 64;
+  final legacyIdentifier = GaLegacyUserDeletionIdentifier(
+    legacyUserId: LegacyFirebaseUserId.parse(value: legacyId),
+  );
+  _expect(
+    condition: legacyIdentifier.toRequestBody().keys.single == 'userId',
+    message: 'legacy Firebase request does not use Admin API userId',
+  );
+
+  final parameter = BigQueryStringArrayParameter(
+    name: 'user_keys',
+    values: <String>[legacyId],
+  ).toJson();
+  _expect(
+    condition: parameter['name'] == 'user_keys',
+    message: 'BigQuery value was not represented as a named parameter',
+  );
+}
+
+Future<void> _testLatestSuccessfulAuthExportSql() async {
+  final client = _FakeBigQueryClient(
+    handler: ({required statement, required index}) {
+      return const BigQueryStatementResult(
+        rows: <Map<String, Object?>>[
+          <String, Object?>{
+            'run_cutoff': '2026-07-30T10:00:00Z',
+            'published_at': '2026-07-30T10:05:00Z',
+          },
+        ],
+        affectedRows: 0,
+        dryRun: false,
+      );
+    },
+  );
+  final snapshot = await _api(client: client).latestSuccessfulAuthExport();
+  _expect(condition: snapshot != null, message: 'auth snapshot was not loaded');
+  _expect(
+    condition:
+        snapshot!.runCutoff == DateTime.utc(2026, 7, 30, 10) &&
+        snapshot.publishedAt == DateTime.utc(2026, 7, 30, 10, 5),
+    message: 'auth snapshot timestamps were parsed incorrectly',
+  );
+  final statement = client.statements.single;
+  _expect(
+    condition: statement.sql.contains(
+      'ORDER BY published_at DESC, run_cutoff DESC',
+    ),
+    message: 'latest auth snapshot ordering is incorrect',
+  );
+  _expect(
+    condition:
+        !statement.sql.contains('status') &&
+        !statement.sql.contains('reconciliation_passed') &&
+        statement.parameters.isEmpty,
+    message: 'latest auth query references columns absent from successful runs',
+  );
+}
+
+Future<void> _testKeyedTableInventory() async {
+  final validRows = <Map<String, Object?>>[
+    <String, Object?>{
+      'dataset_scope': 'auth',
+      'table_name': 'auth_user_milestones',
+    },
+    <String, Object?>{
+      'dataset_scope': 'auth',
+      'table_name': 'auth_user_milestones_staging_run_12345',
+    },
+    for (final tableName in const <String>[
+      'events_flattened',
+      'user_activity_daily',
+      'user_milestones',
+    ])
+      <String, Object?>{'dataset_scope': 'curated', 'table_name': tableName},
+  ];
+  final validClient = _FakeBigQueryClient(
+    handler: ({required statement, required index}) => BigQueryStatementResult(
+      rows: validRows,
+      affectedRows: 0,
+      dryRun: false,
+    ),
+  );
+  await _api(
+    client: validClient,
+  ).validateKeyedTableInventory(allowAuthStagingTables: true);
+  _expect(
+    condition:
+        validClient.statements.single.sql.contains(
+          'INFORMATION_SCHEMA.COLUMNS',
+        ) &&
+        validClient.statements.single.sql.contains("column_name = 'user_key'"),
+    message: 'keyed-table inventory does not inspect deployed user_key columns',
+  );
+
+  final stagingClient = _FakeBigQueryClient(
+    handler: ({required statement, required index}) => BigQueryStatementResult(
+      rows: validRows,
+      affectedRows: 0,
+      dryRun: false,
+    ),
+  );
+  final stagingFailure =
+      await _expectThrowsAsync<PrivacyDeletionOperationException>(
+        body: () => _api(
+          client: stagingClient,
+        ).validateKeyedTableInventory(allowAuthStagingTables: false),
+        message: 'auth staging table was accepted during final cleanup',
+      );
+  _expect(
+    condition:
+        stagingFailure.innerError is KeyedTableInventoryException &&
+        (stagingFailure.innerError as KeyedTableInventoryException)
+                .authStagingTableCount ==
+            1,
+    message: 'active auth staging inventory was not classified safely',
+  );
+
+  final invalidClient = _FakeBigQueryClient(
+    handler: ({required statement, required index}) => BigQueryStatementResult(
+      rows: <Map<String, Object?>>[
+        ...validRows,
+        <String, Object?>{
+          'dataset_scope': 'curated',
+          'table_name': 'untracked_user_export',
+        },
+      ],
+      affectedRows: 0,
+      dryRun: false,
+    ),
+  );
+  final failure = await _expectThrowsAsync<PrivacyDeletionOperationException>(
+    body: () => _api(
+      client: invalidClient,
+    ).validateKeyedTableInventory(allowAuthStagingTables: true),
+    message: 'an untracked keyed table was accepted',
+  );
+  _expect(
+    condition:
+        failure.operation == PrivacyDeletionOperation.validateWarehouseSchema &&
+        failure.innerError is KeyedTableInventoryException,
+    message: 'untracked keyed table failure was not classified as verification',
+  );
+}
+
+Future<void> _testRawDateAndInstallationDiscovery() async {
+  final client = _FakeBigQueryClient(
+    handler: ({required statement, required index}) {
+      return switch (index) {
+        0 => const BigQueryStatementResult(
+          rows: <Map<String, Object?>>[
+            <String, Object?>{
+              'latest_raw_date': '2026-07-31',
+              'intraday_table_count': '0',
+              'unsupported_export_table_count': '0',
+              'missing_daily_table_count': '0',
+            },
+          ],
+          affectedRows: 0,
+          dryRun: false,
+        ),
+        1 || 3 => const BigQueryStatementResult(
+          rows: <Map<String, Object?>>[
+            <String, Object?>{'table_name': 'events_20260710'},
+            <String, Object?>{'table_name': 'events_20260713'},
+          ],
+          affectedRows: 0,
+          dryRun: false,
+        ),
+        2 => const BigQueryStatementResult(
+          rows: <Map<String, Object?>>[
+            <String, Object?>{'user_pseudo_id': 'target-installation'},
+          ],
+          affectedRows: 0,
+          dryRun: false,
+        ),
+        4 => const BigQueryStatementResult(
+          rows: <Map<String, Object?>>[
+            <String, Object?>{'user_pseudo_id': 'tombstone-installation'},
+          ],
+          affectedRows: 0,
+          dryRun: false,
+        ),
+        _ => throw StateError('unexpected BigQuery statement'),
+      };
+    },
+  );
+  final api = _api(client: client);
+  final latestRawDate = await api.latestRawEventTableDate();
+  _expect(
+    condition: latestRawDate == DateTime.utc(2026, 7, 31),
+    message: 'latest raw table date was not discovered',
+  );
+  _expect(
+    condition:
+        client.statements.first.sql.contains('SAFE.PARSE_DATE') &&
+        client.statements.first.sql.contains("r'^events_[0-9]{8}\$'") &&
+        client.statements.first.sql.contains('intraday_table_count') &&
+        client.statements.first.sql.contains('missing_daily_table_count'),
+    message: 'raw inventory query does not fail closed on export drift or gaps',
+  );
+
+  final driftedClient = _FakeBigQueryClient(
+    handler: ({required statement, required index}) =>
+        const BigQueryStatementResult(
+          rows: <Map<String, Object?>>[
+            <String, Object?>{
+              'latest_raw_date': '2026-07-31',
+              'intraday_table_count': '1',
+              'unsupported_export_table_count': '1',
+              'missing_daily_table_count': '0',
+            },
+          ],
+          affectedRows: 0,
+          dryRun: false,
+        ),
+  );
+  final driftFailure =
+      await _expectThrowsAsync<PrivacyDeletionOperationException>(
+        body: () => _api(client: driftedClient).latestRawEventTableDate(),
+        message: 'intraday export drift was accepted by deletion',
+      );
+  _expect(
+    condition:
+        driftFailure.operation == PrivacyDeletionOperation.readRawTables &&
+        driftFailure.innerError is RawTableInventoryException,
+    message: 'raw export drift was not surfaced as an inventory failure',
+  );
+
+  final range = UtcDateRange.fromDates(
+    start: DateTime.utc(2026, 7, 10),
+    end: DateTime.utc(2026, 7, 12),
+  );
+  final targetInstallations = await api.discoverInstallationsForTarget(
+    userKey: PseudonymousUserKey.parse(value: 'c' * 64),
+    range: range,
+  );
+  _expect(
+    condition: targetInstallations.single.value == 'target-installation',
+    message: 'target installation was not decoded',
+  );
+  final targetTableScan = client.statements[1];
+  final bufferedStart = _parameter<BigQueryDateParameter>(
+    statement: targetTableScan,
+    name: 'from_date',
+  );
+  final bufferedEnd = _parameter<BigQueryDateParameter>(
+    statement: targetTableScan,
+    name: 'through_date',
+  );
+  _expect(
+    condition:
+        formatUtcDate(date: bufferedStart.value) == '2026-07-09' &&
+        formatUtcDate(date: bufferedEnd.value) == '2026-07-13',
+    message: 'raw table discovery did not include a one-day date buffer',
+  );
+  final targetDiscovery = client.statements[2];
+  _expect(
+    condition:
+        targetDiscovery.sql.contains('WHERE raw.user_key = @only_user_key') &&
+        !targetDiscovery.sql.contains('permanent_deletion_exclusions') &&
+        targetDiscovery.referencedDatasets.length == 1,
+    message: 'target discovery still depends on a persisted exclusion row',
+  );
+
+  final tombstoneInstallations = await api
+      .discoverInstallationsForAllTombstones(range: range);
+  _expect(
+    condition: tombstoneInstallations.single.value == 'tombstone-installation',
+    message: 'tombstone installation was not decoded',
+  );
+  final tombstoneDiscovery = client.statements[4];
+  _expect(
+    condition:
+        tombstoneDiscovery.sql.contains('permanent_deletion_exclusions') &&
+        tombstoneDiscovery.sql.contains('JOIN') &&
+        tombstoneDiscovery.parameters.isEmpty &&
+        tombstoneDiscovery.referencedDatasets.length == 2,
+    message: 'all-tombstone discovery no longer joins permanent exclusions',
+  );
+}
+
+Future<void> _testFixedAggregateChain() async {
+  final schema = _schema();
+  _expect(
+    condition:
+        AggregateTransform.values
+            .map((final transform) => transform.fileName)
+            .join(',') ==
+        '20_user_activity_daily.sql,30_user_milestones.sql,'
+            '40_activation_retention.sql',
+    message: 'fixed aggregate transform assets or order changed',
+  );
+  const repositoryLoader = RepositoryAggregateTransformLoader();
+  for (final transform in AggregateTransform.values) {
+    final checkedInTemplate = await repositoryLoader.load(transform: transform);
+    _expect(
+      condition:
+          checkedInTemplate.isNotEmpty &&
+          checkedInTemplate.contains('{{PROJECT_ID}}'),
+      message: 'checked-in aggregate transform could not be loaded',
+    );
+  }
+  final templates = <AggregateTransform, String>{
+    for (final transform in AggregateTransform.values)
+      transform:
+          '-- ${transform.fileName}\n'
+          'SELECT * FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.source`;\n'
+          'DELETE FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.'
+          '${transform.modelName}` WHERE TRUE;',
+  };
+  final dryRunLoader = _FakeAggregateTransformLoader(templates: templates);
+  final dryRunClient = _FakeBigQueryClient(
+    handler: ({required statement, required index}) => BigQueryStatementResult(
+      rows: const <Map<String, Object?>>[],
+      affectedRows: 0,
+      dryRun: statement.dryRun,
+    ),
+  );
+  final dryRunResult = await FixedAggregateRebuilder(
+    client: dryRunClient,
+    schema: schema,
+    loader: dryRunLoader,
+  ).rebuild(dryRun: true);
+  _expect(
+    condition:
+        dryRunResult.plannedOperations == 3 &&
+        dryRunResult.executedOperations == 0 &&
+        dryRunClient.statements.length == 3,
+    message: 'dry-run did not plan exactly the fixed three-script chain',
+  );
+  _expect(
+    condition:
+        dryRunLoader.loaded.join(',') == AggregateTransform.values.join(','),
+    message: 'aggregate scripts were not loaded sequentially',
+  );
+  for (var index = 0; index < dryRunClient.statements.length; index++) {
+    final statement = dryRunClient.statements[index];
+    _expect(
+      condition:
+          statement.dryRun &&
+          statement.isMutation &&
+          statement.parameters.isEmpty &&
+          statement.sql.contains(AggregateTransform.values[index].fileName) &&
+          !statement.sql.contains('{{'),
+      message: 'aggregate dry-run script was not safely rendered and planned',
+    );
+  }
+  _expectThrows<PrivacyDeletionValidationException>(
+    body: () => renderAggregateTransform(
+      template: "SELECT TIMESTAMP('{{RAW_EXPORT_START_AT}}')",
+      schema: schema,
+    ),
+    message: 'timestamp placeholder was accepted by aggregate rendering',
+  );
+  _expectThrows<PrivacyDeletionValidationException>(
+    body: () => renderAggregateTransform(
+      template: 'SELECT * FROM `{{project}}.dataset.table`',
+      schema: schema,
+    ),
+    message: 'lowercase arbitrary placeholder was accepted',
+  );
+
+  final applyClient = _FakeBigQueryClient(
+    handler: ({required statement, required index}) {
+      return switch (index) {
+        0 => const BigQueryStatementResult(
+          rows: <Map<String, Object?>>[
+            <String, Object?>{'rebuild_started_at': '2026-07-31T12:00:00Z'},
+          ],
+          affectedRows: 0,
+          dryRun: false,
+        ),
+        4 => const BigQueryStatementResult(
+          rows: <Map<String, Object?>>[
+            <String, Object?>{'matching_count': '3'},
+          ],
+          affectedRows: 0,
+          dryRun: false,
+        ),
+        _ => const BigQueryStatementResult(
+          rows: <Map<String, Object?>>[],
+          affectedRows: 0,
+          dryRun: false,
+        ),
+      };
+    },
+  );
+  final applyResult = await FixedAggregateRebuilder(
+    client: applyClient,
+    schema: schema,
+    loader: _FakeAggregateTransformLoader(templates: templates),
+  ).rebuild(dryRun: false);
+  _expect(
+    condition:
+        applyResult.executedOperations == 3 &&
+        applyClient.statements.length == 5 &&
+        applyClient.statements.first.sql.contains('CURRENT_TIMESTAMP()'),
+    message: 'apply did not timestamp and execute the fixed chain',
+  );
+  final verification = applyClient.statements.last;
+  _expect(
+    condition:
+        verification.sql.contains('user_activity_daily') &&
+        verification.sql.contains('user_milestones') &&
+        verification.sql.contains('activation_retention') &&
+        verification.sql.contains('completed_at >= @rebuild_started_at') &&
+        verification.sql.contains(
+          'ORDER BY published_at DESC, run_cutoff DESC',
+        ) &&
+        verification.sql.contains('auth_snapshot_published_at'),
+    message: 'aggregate completion verification is incomplete',
+  );
+
+  final failedClient = _FakeBigQueryClient(
+    handler: ({required statement, required index}) {
+      return switch (index) {
+        0 => const BigQueryStatementResult(
+          rows: <Map<String, Object?>>[
+            <String, Object?>{'rebuild_started_at': '2026-07-31T12:00:00Z'},
+          ],
+          affectedRows: 0,
+          dryRun: false,
+        ),
+        4 => const BigQueryStatementResult(
+          rows: <Map<String, Object?>>[
+            <String, Object?>{'matching_count': '2'},
+          ],
+          affectedRows: 0,
+          dryRun: false,
+        ),
+        _ => const BigQueryStatementResult(
+          rows: <Map<String, Object?>>[],
+          affectedRows: 0,
+          dryRun: false,
+        ),
+      };
+    },
+  );
+  final failure = await _expectThrowsAsync<AggregateRebuildException>(
+    body: () => FixedAggregateRebuilder(
+      client: failedClient,
+      schema: schema,
+      loader: _FakeAggregateTransformLoader(templates: templates),
+    ).rebuild(dryRun: false),
+    message: 'incomplete aggregate transform state was accepted',
+  );
+  _expect(
+    condition: failure.innerError is AggregateTransformVerificationException,
+    message: 'aggregate verification failure lost its typed inner error',
+  );
+}
+
+Future<void> _testStatusVerification() async {
+  final completedClient = _FakeBigQueryClient(
+    handler: ({required statement, required index}) {
+      return index == 0
+          ? const BigQueryStatementResult(
+              rows: <Map<String, Object?>>[],
+              affectedRows: 0,
+              dryRun: false,
+            )
+          : const BigQueryStatementResult(
+              rows: <Map<String, Object?>>[
+                <String, Object?>{'status': 'completed'},
+              ],
+              affectedRows: 0,
+              dryRun: false,
+            );
+    },
+  );
+  await _api(client: completedClient).updateTargetStatus(
+    requestId: PrivacyRequestId.parse(value: 'request_123'),
+    status: PrivacyDeletionTargetStatus.completed,
+    failureKind: null,
+  );
+  _expect(
+    condition:
+        completedClient.statements.length == 2 &&
+        completedClient.statements.first.sql.contains(
+          'status != @completed_status',
+        ) &&
+        completedClient.statements.last.sql.contains('SELECT status'),
+    message: 'completed status is not terminal and read-back verified',
+  );
+
+  final mismatchClient = _FakeBigQueryClient(
+    handler: ({required statement, required index}) {
+      return index == 0
+          ? const BigQueryStatementResult(
+              rows: <Map<String, Object?>>[],
+              affectedRows: 0,
+              dryRun: false,
+            )
+          : const BigQueryStatementResult(
+              rows: <Map<String, Object?>>[
+                <String, Object?>{'status': 'processing'},
+              ],
+              affectedRows: 0,
+              dryRun: false,
+            );
+    },
+  );
+  final failure = await _expectThrowsAsync<PrivacyDeletionOperationException>(
+    body: () => _api(client: mismatchClient).updateTargetStatus(
+      requestId: PrivacyRequestId.parse(value: 'request_123'),
+      status: PrivacyDeletionTargetStatus.completed,
+      failureKind: null,
+    ),
+    message: 'status update succeeded without reaching requested state',
+  );
+  _expect(
+    condition:
+        failure.failureKind == PrivacyDeletionFailureKind.statusUpdate &&
+        failure.innerError is TargetStatusMismatchException,
+    message: 'status read-back failure lost its typed cause',
+  );
+
+  final missingClient = _FakeBigQueryClient(
+    handler: ({required statement, required index}) =>
+        const BigQueryStatementResult(
+          rows: <Map<String, Object?>>[],
+          affectedRows: 0,
+          dryRun: false,
+        ),
+  );
+  final missingFailure =
+      await _expectThrowsAsync<PrivacyDeletionOperationException>(
+        body: () => _api(client: missingClient).updateTargetStatus(
+          requestId: PrivacyRequestId.parse(value: 'request_123'),
+          status: PrivacyDeletionTargetStatus.retryable,
+          failureKind: PrivacyDeletionFailureKind.warehouseRead,
+        ),
+        message: 'status update succeeded for a missing target',
+      );
+  _expect(
+    condition:
+        missingFailure.failureKind == PrivacyDeletionFailureKind.statusUpdate &&
+        missingFailure.innerError is TargetStatusCardinalityException,
+    message: 'missing target status failure lost its typed cause',
+  );
+}
+
+void _testAggregateOnlyOutput() {
+  final summary = PrivacyDeletionSummary(
+    operation: PrivacyDeletionOperationKind.request,
+    outcome: PrivacyDeletionOutcome.planned,
+    dryRun: true,
+    targetsConsidered: 1,
+    authExportReadiness: AuthExportReadiness.notReady,
+    cleanup: const CleanupResult.none(),
+    failureKind: null,
+  );
+  final output = jsonEncode(
+    summary.toAggregateJson(
+      credentialSource: AdcCredentialSource.notUsed.wireValue,
+      credentialFallback: false,
+    ),
+  );
+  for (final forbidden in const <String>[
+    'request_id',
+    'user_key',
+    'user_pseudo_id',
+    'app_instance_id',
+  ]) {
+    _expect(
+      condition: !output.contains(forbidden),
+      message: 'aggregate output exposed $forbidden',
+    );
+  }
+}
+
+List<String> _baseArguments({required bool includeRequestId}) {
+  return <String>[
+    '--project',
+    'sesori-ai',
+    '--location',
+    'EU',
+    '--analytics-property-id',
+    '123456789',
+    '--raw-dataset',
+    'analytics_123456789',
+    '--auth-dataset',
+    'sesori_analytics_auth_private',
+    '--privacy-dataset',
+    'sesori_analytics_privacy_private',
+    '--controls-dataset',
+    'sesori_analytics_controls',
+    '--curated-dataset',
+    'sesori_analytics_curated',
+    '--reporting-dataset',
+    'sesori_analytics_reporting',
+    if (includeRequestId) ...<String>['--request-id', 'request_123'],
+  ];
+}
+
+PrivacyDeletionApi _api({required BigQueryPrivacyDeletionClient client}) {
+  return PrivacyDeletionApi(
+    bigQueryClient: client,
+    gaUserDeletionClient: const _FakeGaUserDeletionClient(),
+    schema: _schema(),
+    aggregateRebuilder: const _FakeAggregateRebuilder(),
+    parameterBatchSize: 10,
+  );
+}
+
+PrivacyDeletionWarehouseSchema _schema() {
+  final projectId = GcpProjectId.parse(value: 'sesori-ai');
+  final raw = _dataset(projectId: projectId, datasetId: 'analytics_123456789');
+  final auth = _dataset(projectId: projectId, datasetId: 'auth_private');
+  final privacy = _dataset(projectId: projectId, datasetId: 'privacy_private');
+  final controls = _dataset(projectId: projectId, datasetId: 'controls');
+  final curated = _dataset(projectId: projectId, datasetId: 'curated');
+  final reporting = _dataset(projectId: projectId, datasetId: 'reporting');
+  return PrivacyDeletionWarehouseSchema(
+    rawDataset: raw,
+    authDataset: auth,
+    privacyDataset: privacy,
+    controlsDataset: controls,
+    curatedDataset: curated,
+    reportingDataset: reporting,
+    targetsTable: _table(
+      dataset: privacy,
+      tableId: 'product_analytics_deletion_targets',
+    ),
+    exclusionsTable: _table(
+      dataset: controls,
+      tableId: 'permanent_deletion_exclusions',
+    ),
+    authExportRunsTable: _table(
+      dataset: auth,
+      tableId: 'product_analytics_export_runs',
+    ),
+    sweepStateTable: _table(
+      dataset: controls,
+      tableId: 'product_analytics_privacy_sweep_state',
+    ),
+    authKeyedTables: <BigQueryTableReference>[
+      _table(dataset: auth, tableId: 'auth_user_milestones'),
+    ],
+    curatedKeyedTables: <BigQueryTableReference>[
+      _table(dataset: curated, tableId: 'events_flattened'),
+      _table(dataset: curated, tableId: 'user_activity_daily'),
+      _table(dataset: curated, tableId: 'user_milestones'),
+    ],
+    reportingKeyedTables: const <BigQueryTableReference>[],
+  );
+}
+
+BigQueryDatasetReference _dataset({
+  required GcpProjectId projectId,
+  required String datasetId,
+}) {
+  return BigQueryDatasetReference(
+    projectId: projectId,
+    datasetId: BigQueryDatasetId.parse(field: 'test_dataset', value: datasetId),
+  );
+}
+
+BigQueryTableReference _table({
+  required BigQueryDatasetReference dataset,
+  required String tableId,
+}) {
+  return BigQueryTableReference(
+    dataset: dataset,
+    tableId: BigQueryTableId.parse(field: 'test_table', value: tableId),
+  );
+}
+
+T _parameter<T extends BigQueryParameter>({
+  required BigQueryStatement statement,
+  required String name,
+}) {
+  return statement.parameters.whereType<T>().singleWhere(
+    (final parameter) => parameter.name == name,
+  );
+}
+
+void _expect({required bool condition, required String message}) {
+  if (!condition) {
+    throw StateError(message);
+  }
+}
+
+T _expectThrows<T extends Object>({
+  required void Function() body,
+  required String message,
+}) {
+  try {
+    body();
+  } catch (error) {
+    if (error is T) {
+      return error;
+    }
+    throw StateError('$message; received ${error.runtimeType}');
+  }
+  throw StateError(message);
+}
+
+Future<T> _expectThrowsAsync<T extends Object>({
+  required Future<void> Function() body,
+  required String message,
+}) async {
+  try {
+    await body();
+  } catch (error) {
+    if (error is T) {
+      return error;
+    }
+    throw StateError('$message; received ${error.runtimeType}');
+  }
+  throw StateError(message);
+}
+
+typedef _BigQueryHandler =
+    BigQueryStatementResult Function({
+      required BigQueryStatement statement,
+      required int index,
+    });
+
+final class _FakeBigQueryClient implements BigQueryPrivacyDeletionClient {
+  _FakeBigQueryClient({required _BigQueryHandler handler}) : _handler = handler;
+
+  final _BigQueryHandler _handler;
+  final List<BigQueryStatement> statements = <BigQueryStatement>[];
+
+  @override
+  Future<BigQueryStatementResult> execute({
+    required BigQueryStatement statement,
+  }) async {
+    final index = statements.length;
+    statements.add(statement);
+    return _handler(statement: statement, index: index);
+  }
+
+  @override
+  void close() {}
+}
+
+final class _FakeAggregateTransformLoader implements AggregateTransformLoader {
+  _FakeAggregateTransformLoader({
+    required Map<AggregateTransform, String> templates,
+  }) : _templates = Map<AggregateTransform, String>.unmodifiable(templates);
+
+  final Map<AggregateTransform, String> _templates;
+  final List<AggregateTransform> loaded = <AggregateTransform>[];
+
+  @override
+  Future<String> load({required AggregateTransform transform}) async {
+    loaded.add(transform);
+    return _templates[transform]!;
+  }
+}
+
+final class _FakeAggregateRebuilder implements AggregateRebuilder {
+  const _FakeAggregateRebuilder();
+
+  @override
+  Future<AggregateRebuildResult> rebuild({required bool dryRun}) async {
+    return AggregateRebuildResult(
+      plannedOperations: 3,
+      executedOperations: dryRun ? 0 : 3,
+    );
+  }
+}
+
+final class _FakeGaUserDeletionClient implements GaUserDeletionClient {
+  const _FakeGaUserDeletionClient();
+
+  @override
+  Future<GaUserDeletionSubmission> submit({
+    required GaUserDeletionIdentifier identifier,
+  }) async {
+    return const GaUserDeletionSubmission(deletionRequestTime: null);
+  }
+
+  @override
+  void close() {}
+}

--- a/tool/product_analytics/privacy_deletion/privacy_deletion_test.dart
+++ b/tool/product_analytics/privacy_deletion/privacy_deletion_test.dart
@@ -7,13 +7,17 @@ import 'privacy_deletion_api.dart';
 import 'privacy_deletion_config.dart';
 import 'privacy_deletion_models.dart';
 import 'privacy_deletion_repository.dart';
+import 'privacy_deletion_service.dart';
 
 Future<void> main() async {
   _testIdentifiers();
   _testConfigurationAllowlistAndDefaults();
   _testSweepRanges();
   _testCleanupPhases();
+  _testAuthExportReadiness();
   _testAnalyticsAdminRequestShapes();
+  await _testPermanentExclusionPublicationGuard();
+  await _testPersistentDdlRejected();
   await _testLatestSuccessfulAuthExportSql();
   await _testKeyedTableInventory();
   await _testRawDateAndInstallationDiscovery();
@@ -74,6 +78,12 @@ void _testConfigurationAllowlistAndDefaults() {
         command.config.exclusionsTable.tableId.value ==
         'permanent_deletion_exclusions',
     message: 'the permanent deletion exclusions default is incorrect',
+  );
+  _expect(
+    condition:
+        command.config.publicationGuardTable.tableId.value ==
+        'keyed_publication_guard',
+    message: 'the keyed publication guard default is incorrect',
   );
   _expect(
     condition:
@@ -167,6 +177,67 @@ void _testConfigurationAllowlistAndDefaults() {
   );
 }
 
+Future<void> _testPermanentExclusionPublicationGuard() async {
+  final client = _FakeBigQueryClient(
+    handler: ({required statement, required index}) =>
+        const BigQueryStatementResult(
+          rows: <Map<String, Object?>>[],
+          affectedRows: 1,
+          dryRun: false,
+        ),
+  );
+  await _api(client: client).upsertPermanentExclusion(
+    target: PrivacyDeletionTarget(
+      requestId: PrivacyRequestId.parse(value: 'request_123'),
+      userKey: PseudonymousUserKey.parse(value: 'a' * 64),
+      legacyFirebaseUserId: LegacyFirebaseUserId.parse(value: 'b' * 64),
+      suppressedAt: DateTime.utc(2026, 7, 31, 10),
+      status: PrivacyDeletionTargetStatus.pending,
+    ),
+    dryRun: false,
+  );
+  final statement = client.statements.single;
+  _expect(
+    condition:
+        statement.sql.contains('BEGIN TRANSACTION') &&
+        statement.sql.contains('keyed_publication_guard') &&
+        statement.sql.contains('publication_epoch = publication_epoch + 1') &&
+        statement.sql.contains('permanent_deletion_exclusions') &&
+        statement.sql.contains('COMMIT TRANSACTION') &&
+        statement.referencedDatasets.length == 1,
+    message:
+        'permanent exclusion insertion is not serialized with keyed publication',
+  );
+}
+
+Future<void> _testPersistentDdlRejected() async {
+  final projectId = GcpProjectId.parse(value: 'sesori-ai');
+  final dataset = _dataset(projectId: projectId, datasetId: 'curated');
+  final client = RestBigQueryPrivacyDeletionClient(
+    projectId: projectId,
+    location: BigQueryLocation.parse(value: 'europe-west3'),
+    allowedDatasets: <BigQueryDatasetReference>[dataset],
+    accessTokenProvider: const _FakeAccessTokenProvider(),
+    queryTimeout: const Duration(seconds: 1),
+  );
+  try {
+    await _expectThrowsAsync<PrivacyDeletionValidationException>(
+      body: () => client.execute(
+        statement: BigQueryStatement(
+          sql: 'CREATE TABLE `sesori-ai.curated.unreviewed` (value STRING)',
+          parameters: const <BigQueryParameter>[],
+          referencedDatasets: <BigQueryDatasetReference>[dataset],
+          isMutation: true,
+          dryRun: false,
+        ),
+      ),
+      message: 'persistent DDL was accepted by the privacy BigQuery client',
+    );
+  } finally {
+    client.close();
+  }
+}
+
 void _testCleanupPhases() {
   _expect(
     condition:
@@ -252,7 +323,9 @@ void _testAnalyticsAdminRequestShapes() {
     legacyUserId: LegacyFirebaseUserId.parse(value: legacyId),
   );
   _expect(
-    condition: legacyIdentifier.toRequestBody().keys.single == 'userId',
+    condition:
+        legacyIdentifier.toRequestBody().keys.single == 'userId' &&
+        legacyIdentifier.toRequestBody()['userId'] == legacyId,
     message: 'legacy Firebase request does not use Admin API userId',
   );
 
@@ -261,8 +334,100 @@ void _testAnalyticsAdminRequestShapes() {
     values: <String>[legacyId],
   ).toJson();
   _expect(
-    condition: parameter['name'] == 'user_keys',
+    condition:
+        jsonEncode(parameter) ==
+        jsonEncode(<String, Object?>{
+          'name': 'user_keys',
+          'parameterType': <String, Object?>{
+            'type': 'ARRAY',
+            'arrayType': <String, Object?>{'type': 'STRING'},
+          },
+          'parameterValue': <String, Object?>{
+            'arrayValues': <Map<String, Object?>>[
+              <String, Object?>{'value': legacyId},
+            ],
+          },
+        }),
     message: 'BigQuery value was not represented as a named parameter',
+  );
+}
+
+void _testAuthExportReadiness() {
+  final now = DateTime.utc(2026, 7, 31, 12);
+  AuthExportSnapshot snapshot({
+    required DateTime runCutoff,
+    required DateTime publishedAt,
+  }) => AuthExportSnapshot(
+    runCutoff: runCutoff,
+    publishedAt: publishedAt,
+    maxAge: const Duration(hours: 36),
+    futureClockAllowance: const Duration(minutes: 5),
+  );
+
+  _expect(
+    condition:
+        PrivacyDeletionService.evaluateAuthExportReadiness(
+          snapshot: snapshot(
+            runCutoff: DateTime.utc(2026, 7, 31, 10),
+            publishedAt: DateTime.utc(2026, 7, 31, 10, 5),
+          ),
+          suppressedAt: DateTime.utc(2026, 7, 31, 9),
+          now: now,
+        ) ==
+        AuthExportReadiness.ready,
+    message: 'a fresh tombstone-aware auth export was rejected',
+  );
+  for (final staleSnapshot in <AuthExportSnapshot?>[
+    null,
+    snapshot(
+      runCutoff: DateTime.utc(2026, 7, 31, 8),
+      publishedAt: DateTime.utc(2026, 7, 31, 10),
+    ),
+    snapshot(
+      runCutoff: DateTime.utc(2026, 7, 29, 23, 59),
+      publishedAt: DateTime.utc(2026, 7, 30),
+    ),
+    snapshot(
+      runCutoff: DateTime.utc(2026, 7, 31, 12, 6),
+      publishedAt: DateTime.utc(2026, 7, 31, 12, 6),
+    ),
+  ]) {
+    _expect(
+      condition:
+          PrivacyDeletionService.evaluateAuthExportReadiness(
+            snapshot: staleSnapshot,
+            suppressedAt: DateTime.utc(2026, 7, 31, 9),
+            now: now,
+          ) ==
+          AuthExportReadiness.notReady,
+      message: 'an unsafe auth export was accepted for final cleanup',
+    );
+  }
+  _expect(
+    condition:
+        PrivacyDeletionService.evaluateAuthExportReadiness(
+          snapshot: snapshot(
+            runCutoff: DateTime.utc(2026, 7, 29, 23, 59),
+            publishedAt: DateTime.utc(2026, 7, 29, 23, 59),
+          ),
+          suppressedAt: DateTime.utc(2026, 7, 29, 20),
+          now: now,
+        ) ==
+        AuthExportReadiness.notReady,
+    message: 'a tombstone-aware but stale auth export was accepted',
+  );
+  _expect(
+    condition:
+        PrivacyDeletionService.evaluateAuthExportReadiness(
+          snapshot: snapshot(
+            runCutoff: DateTime.utc(2026, 7, 29, 23, 59),
+            publishedAt: DateTime.utc(2026, 7, 31, 11),
+          ),
+          suppressedAt: DateTime.utc(2026, 7, 29, 20),
+          now: now,
+        ) ==
+        AuthExportReadiness.notReady,
+    message: 'a freshly published snapshot with a stale cutoff was accepted',
   );
 }
 
@@ -274,6 +439,8 @@ Future<void> _testLatestSuccessfulAuthExportSql() async {
           <String, Object?>{
             'run_cutoff': '2026-07-30T10:00:00Z',
             'published_at': '2026-07-30T10:05:00Z',
+            'auth_snapshot_max_age_hours': '36',
+            'clock_skew_allowance_seconds': '300',
           },
         ],
         affectedRows: 0,
@@ -286,13 +453,15 @@ Future<void> _testLatestSuccessfulAuthExportSql() async {
   _expect(
     condition:
         snapshot!.runCutoff == DateTime.utc(2026, 7, 30, 10) &&
-        snapshot.publishedAt == DateTime.utc(2026, 7, 30, 10, 5),
+        snapshot.publishedAt == DateTime.utc(2026, 7, 30, 10, 5) &&
+        snapshot.maxAge == const Duration(hours: 36) &&
+        snapshot.futureClockAllowance == const Duration(minutes: 5),
     message: 'auth snapshot timestamps were parsed incorrectly',
   );
   final statement = client.statements.single;
   _expect(
     condition: statement.sql.contains(
-      'ORDER BY published_at DESC, run_cutoff DESC',
+      'ORDER BY export.published_at DESC, export.run_cutoff DESC',
     ),
     message: 'latest auth snapshot ordering is incorrect',
   );
@@ -875,6 +1044,10 @@ PrivacyDeletionWarehouseSchema _schema() {
       dataset: controls,
       tableId: 'permanent_deletion_exclusions',
     ),
+    publicationGuardTable: _table(
+      dataset: controls,
+      tableId: 'keyed_publication_guard',
+    ),
     authExportRunsTable: _table(
       dataset: auth,
       tableId: 'product_analytics_export_runs',
@@ -1010,6 +1183,24 @@ final class _FakeAggregateRebuilder implements AggregateRebuilder {
       executedOperations: dryRun ? 0 : 3,
     );
   }
+}
+
+final class _FakeAccessTokenProvider implements GoogleAccessTokenProvider {
+  const _FakeAccessTokenProvider();
+
+  @override
+  AdcCredentialSource get lastSource => AdcCredentialSource.notUsed;
+
+  @override
+  bool get usedFallback => false;
+
+  @override
+  Future<GoogleAccessToken> accessToken() {
+    throw StateError('accessToken must not be called during local validation');
+  }
+
+  @override
+  void close() {}
 }
 
 final class _FakeGaUserDeletionClient implements GaUserDeletionClient {

--- a/tool/product_analytics/privacy_deletion/run_privacy_deletion.dart
+++ b/tool/product_analytics/privacy_deletion/run_privacy_deletion.dart
@@ -26,6 +26,13 @@ Future<void> main(final List<String> arguments) async {
       requestIdRequired: true,
     );
     final config = command.config;
+    final requestId = command.requestId;
+    if (requestId == null) {
+      throw const PrivacyDeletionValidationException(
+        field: 'request_id',
+        requirement: 'required for request processing',
+      );
+    }
     tokenProvider = ApplicationDefaultAccessTokenProvider(
       scopes: const <String>{bigQueryOAuthScope, analyticsEditOAuthScope},
       metadataTimeout: const Duration(seconds: 1),
@@ -61,9 +68,12 @@ Future<void> main(final List<String> arguments) async {
       rawRetentionDays: config.rawRetentionDays,
       now: DateTime.now,
     );
-    final service = PrivacyDeletionService(repository: repository);
+    final service = PrivacyDeletionService(
+      repository: repository,
+      now: DateTime.now,
+    );
     final summary = await service.runRequest(
-      requestId: command.requestId!,
+      requestId: requestId,
       dryRun: command.dryRun,
     );
     _writeSummary(summary: summary, tokenProvider: tokenProvider);
@@ -113,6 +123,7 @@ PrivacyDeletionWarehouseSchema _warehouseSchema({
     reportingDataset: config.reportingDataset,
     targetsTable: config.targetsTable,
     exclusionsTable: config.exclusionsTable,
+    publicationGuardTable: config.publicationGuardTable,
     authExportRunsTable: config.authExportRunsTable,
     sweepStateTable: config.sweepStateTable,
     authKeyedTables: config.authKeyedTables,

--- a/tool/product_analytics/privacy_deletion/run_privacy_deletion.dart
+++ b/tool/product_analytics/privacy_deletion/run_privacy_deletion.dart
@@ -1,0 +1,163 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'bigquery_privacy_deletion_client.dart';
+import 'ga_user_deletion_client.dart';
+import 'google_api_foundation.dart';
+import 'privacy_deletion_api.dart';
+import 'privacy_deletion_config.dart';
+import 'privacy_deletion_models.dart';
+import 'privacy_deletion_repository.dart';
+import 'privacy_deletion_service.dart';
+
+Future<void> main(final List<String> arguments) async {
+  if (arguments.contains('--help')) {
+    stdout.write(privacyDeletionUsage);
+    return;
+  }
+
+  ApplicationDefaultAccessTokenProvider? tokenProvider;
+  BigQueryPrivacyDeletionClient? bigQueryClient;
+  GaUserDeletionClient? gaClient;
+  try {
+    final command = PrivacyDeletionCommandConfig.parse(
+      arguments: arguments,
+      environment: Platform.environment,
+      requestIdRequired: true,
+    );
+    final config = command.config;
+    tokenProvider = ApplicationDefaultAccessTokenProvider(
+      scopes: const <String>{bigQueryOAuthScope, analyticsEditOAuthScope},
+      metadataTimeout: const Duration(seconds: 1),
+      allowGcloudApplicationDefaultFallback: config.allowGcloudAdcFallback,
+      now: DateTime.now,
+    );
+    bigQueryClient = RestBigQueryPrivacyDeletionClient(
+      projectId: config.projectId,
+      location: config.location,
+      allowedDatasets: config.allowedDatasets,
+      accessTokenProvider: tokenProvider,
+      queryTimeout: config.queryTimeout,
+    );
+    gaClient = GoogleAnalyticsAdminUserDeletionClient(
+      propertyId: config.analyticsPropertyId,
+      accessTokenProvider: tokenProvider,
+      requestTimeout: config.queryTimeout,
+    );
+    final schema = _warehouseSchema(config: config);
+    final api = PrivacyDeletionApi(
+      bigQueryClient: bigQueryClient,
+      gaUserDeletionClient: gaClient,
+      schema: schema,
+      aggregateRebuilder: FixedAggregateRebuilder(
+        client: bigQueryClient,
+        schema: schema,
+        loader: const RepositoryAggregateTransformLoader(),
+      ),
+      parameterBatchSize: config.parameterBatchSize,
+    );
+    final repository = PrivacyDeletionRepository(
+      api: api,
+      rawRetentionDays: config.rawRetentionDays,
+      now: DateTime.now,
+    );
+    final service = PrivacyDeletionService(repository: repository);
+    final summary = await service.runRequest(
+      requestId: command.requestId!,
+      dryRun: command.dryRun,
+    );
+    _writeSummary(summary: summary, tokenProvider: tokenProvider);
+    if (!summary.succeeded) {
+      exitCode = 2;
+    }
+  } on PrivacyDeletionValidationException {
+    _writeFailure(
+      operation: PrivacyDeletionOperationKind.request,
+      failureKind: PrivacyDeletionFailureKind.invalidInput,
+      dryRun: arguments.contains('--dry-run'),
+      tokenProvider: tokenProvider,
+    );
+    exitCode = 64;
+  } on PrivacyDeletionRecoveryException {
+    _writeFailure(
+      operation: PrivacyDeletionOperationKind.request,
+      failureKind: PrivacyDeletionFailureKind.statusUpdate,
+      dryRun: arguments.contains('--dry-run'),
+      tokenProvider: tokenProvider,
+    );
+    exitCode = 2;
+  } catch (_) {
+    _writeFailure(
+      operation: PrivacyDeletionOperationKind.request,
+      failureKind: PrivacyDeletionFailureKind.unexpected,
+      dryRun: arguments.contains('--dry-run'),
+      tokenProvider: tokenProvider,
+    );
+    exitCode = 2;
+  } finally {
+    gaClient?.close();
+    bigQueryClient?.close();
+    tokenProvider?.close();
+  }
+}
+
+PrivacyDeletionWarehouseSchema _warehouseSchema({
+  required PrivacyDeletionConfig config,
+}) {
+  return PrivacyDeletionWarehouseSchema(
+    rawDataset: config.rawDataset,
+    authDataset: config.authDataset,
+    privacyDataset: config.privacyDataset,
+    controlsDataset: config.controlsDataset,
+    curatedDataset: config.curatedDataset,
+    reportingDataset: config.reportingDataset,
+    targetsTable: config.targetsTable,
+    exclusionsTable: config.exclusionsTable,
+    authExportRunsTable: config.authExportRunsTable,
+    sweepStateTable: config.sweepStateTable,
+    authKeyedTables: config.authKeyedTables,
+    curatedKeyedTables: config.curatedKeyedTables,
+    reportingKeyedTables: config.reportingKeyedTables,
+  );
+}
+
+void _writeSummary({
+  required PrivacyDeletionSummary summary,
+  required ApplicationDefaultAccessTokenProvider tokenProvider,
+}) {
+  stdout.writeln(
+    jsonEncode(
+      summary.toAggregateJson(
+        credentialSource: tokenProvider.lastSource.wireValue,
+        credentialFallback: tokenProvider.usedFallback,
+      ),
+    ),
+  );
+}
+
+void _writeFailure({
+  required PrivacyDeletionOperationKind operation,
+  required PrivacyDeletionFailureKind failureKind,
+  required bool dryRun,
+  required ApplicationDefaultAccessTokenProvider? tokenProvider,
+}) {
+  final summary = PrivacyDeletionSummary(
+    operation: operation,
+    outcome: PrivacyDeletionOutcome.retryable,
+    dryRun: dryRun,
+    targetsConsidered: 0,
+    authExportReadiness: null,
+    cleanup: const CleanupResult.none(),
+    failureKind: failureKind,
+  );
+  stdout.writeln(
+    jsonEncode(
+      summary.toAggregateJson(
+        credentialSource:
+            tokenProvider?.lastSource.wireValue ??
+            AdcCredentialSource.notUsed.wireValue,
+        credentialFallback: tokenProvider?.usedFallback ?? false,
+      ),
+    ),
+  );
+}

--- a/tool/product_analytics/privacy_deletion/sweep_privacy_deletions.dart
+++ b/tool/product_analytics/privacy_deletion/sweep_privacy_deletions.dart
@@ -61,7 +61,10 @@ Future<void> main(final List<String> arguments) async {
       rawRetentionDays: config.rawRetentionDays,
       now: DateTime.now,
     );
-    final service = PrivacyDeletionService(repository: repository);
+    final service = PrivacyDeletionService(
+      repository: repository,
+      now: DateTime.now,
+    );
     final summary = await service.runSweep(dryRun: command.dryRun);
     _writeSummary(summary: summary, tokenProvider: tokenProvider);
     if (!summary.succeeded) {
@@ -100,6 +103,7 @@ PrivacyDeletionWarehouseSchema _warehouseSchema({
     reportingDataset: config.reportingDataset,
     targetsTable: config.targetsTable,
     exclusionsTable: config.exclusionsTable,
+    publicationGuardTable: config.publicationGuardTable,
     authExportRunsTable: config.authExportRunsTable,
     sweepStateTable: config.sweepStateTable,
     authKeyedTables: config.authKeyedTables,

--- a/tool/product_analytics/privacy_deletion/sweep_privacy_deletions.dart
+++ b/tool/product_analytics/privacy_deletion/sweep_privacy_deletions.dart
@@ -1,0 +1,149 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'bigquery_privacy_deletion_client.dart';
+import 'ga_user_deletion_client.dart';
+import 'google_api_foundation.dart';
+import 'privacy_deletion_api.dart';
+import 'privacy_deletion_config.dart';
+import 'privacy_deletion_models.dart';
+import 'privacy_deletion_repository.dart';
+import 'privacy_deletion_service.dart';
+
+Future<void> main(final List<String> arguments) async {
+  if (arguments.contains('--help')) {
+    stdout.write(privacyDeletionUsage);
+    return;
+  }
+
+  ApplicationDefaultAccessTokenProvider? tokenProvider;
+  BigQueryPrivacyDeletionClient? bigQueryClient;
+  GaUserDeletionClient? gaClient;
+  try {
+    final command = PrivacyDeletionCommandConfig.parse(
+      arguments: arguments,
+      environment: Platform.environment,
+      requestIdRequired: false,
+    );
+    final config = command.config;
+    tokenProvider = ApplicationDefaultAccessTokenProvider(
+      scopes: const <String>{bigQueryOAuthScope, analyticsEditOAuthScope},
+      metadataTimeout: const Duration(seconds: 1),
+      allowGcloudApplicationDefaultFallback: config.allowGcloudAdcFallback,
+      now: DateTime.now,
+    );
+    bigQueryClient = RestBigQueryPrivacyDeletionClient(
+      projectId: config.projectId,
+      location: config.location,
+      allowedDatasets: config.allowedDatasets,
+      accessTokenProvider: tokenProvider,
+      queryTimeout: config.queryTimeout,
+    );
+    gaClient = GoogleAnalyticsAdminUserDeletionClient(
+      propertyId: config.analyticsPropertyId,
+      accessTokenProvider: tokenProvider,
+      requestTimeout: config.queryTimeout,
+    );
+    final schema = _warehouseSchema(config: config);
+    final api = PrivacyDeletionApi(
+      bigQueryClient: bigQueryClient,
+      gaUserDeletionClient: gaClient,
+      schema: schema,
+      aggregateRebuilder: FixedAggregateRebuilder(
+        client: bigQueryClient,
+        schema: schema,
+        loader: const RepositoryAggregateTransformLoader(),
+      ),
+      parameterBatchSize: config.parameterBatchSize,
+    );
+    final repository = PrivacyDeletionRepository(
+      api: api,
+      rawRetentionDays: config.rawRetentionDays,
+      now: DateTime.now,
+    );
+    final service = PrivacyDeletionService(repository: repository);
+    final summary = await service.runSweep(dryRun: command.dryRun);
+    _writeSummary(summary: summary, tokenProvider: tokenProvider);
+    if (!summary.succeeded) {
+      exitCode = 2;
+    }
+  } on PrivacyDeletionValidationException {
+    _writeFailure(
+      failureKind: PrivacyDeletionFailureKind.invalidInput,
+      dryRun: arguments.contains('--dry-run'),
+      tokenProvider: tokenProvider,
+    );
+    exitCode = 64;
+  } catch (_) {
+    _writeFailure(
+      failureKind: PrivacyDeletionFailureKind.unexpected,
+      dryRun: arguments.contains('--dry-run'),
+      tokenProvider: tokenProvider,
+    );
+    exitCode = 2;
+  } finally {
+    gaClient?.close();
+    bigQueryClient?.close();
+    tokenProvider?.close();
+  }
+}
+
+PrivacyDeletionWarehouseSchema _warehouseSchema({
+  required PrivacyDeletionConfig config,
+}) {
+  return PrivacyDeletionWarehouseSchema(
+    rawDataset: config.rawDataset,
+    authDataset: config.authDataset,
+    privacyDataset: config.privacyDataset,
+    controlsDataset: config.controlsDataset,
+    curatedDataset: config.curatedDataset,
+    reportingDataset: config.reportingDataset,
+    targetsTable: config.targetsTable,
+    exclusionsTable: config.exclusionsTable,
+    authExportRunsTable: config.authExportRunsTable,
+    sweepStateTable: config.sweepStateTable,
+    authKeyedTables: config.authKeyedTables,
+    curatedKeyedTables: config.curatedKeyedTables,
+    reportingKeyedTables: config.reportingKeyedTables,
+  );
+}
+
+void _writeSummary({
+  required PrivacyDeletionSummary summary,
+  required ApplicationDefaultAccessTokenProvider tokenProvider,
+}) {
+  stdout.writeln(
+    jsonEncode(
+      summary.toAggregateJson(
+        credentialSource: tokenProvider.lastSource.wireValue,
+        credentialFallback: tokenProvider.usedFallback,
+      ),
+    ),
+  );
+}
+
+void _writeFailure({
+  required PrivacyDeletionFailureKind failureKind,
+  required bool dryRun,
+  required ApplicationDefaultAccessTokenProvider? tokenProvider,
+}) {
+  final summary = PrivacyDeletionSummary(
+    operation: PrivacyDeletionOperationKind.sweep,
+    outcome: PrivacyDeletionOutcome.retryable,
+    dryRun: dryRun,
+    targetsConsidered: 0,
+    authExportReadiness: null,
+    cleanup: const CleanupResult.none(),
+    failureKind: failureKind,
+  );
+  stdout.writeln(
+    jsonEncode(
+      summary.toAggregateJson(
+        credentialSource:
+            tokenProvider?.lastSource.wireValue ??
+            AdcCredentialSource.notUsed.wireValue,
+        credentialFallback: tokenProvider?.usedFallback ?? false,
+      ),
+    ),
+  );
+}

--- a/tool/product_analytics/sql/00_datasets.sql
+++ b/tool/product_analytics/sql/00_datasets.sql
@@ -216,6 +216,20 @@ CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_del
 CLUSTER BY user_key
 OPTIONS (description = 'Permanent deletion tombstones applied to every keyed warehouse recomputation');
 
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.keyed_publication_guard` (
+  guard_key STRING NOT NULL,
+  publication_epoch INT64 NOT NULL,
+  updated_at TIMESTAMP NOT NULL
+)
+OPTIONS (description = 'Singleton transaction-conflict guard serializing tombstones and keyed publication');
+
+MERGE `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.keyed_publication_guard` AS target
+USING (SELECT 'singleton' AS guard_key) AS source
+ON target.guard_key = source.guard_key
+WHEN NOT MATCHED THEN
+  INSERT (guard_key, publication_epoch, updated_at)
+  VALUES ('singleton', 0, CURRENT_TIMESTAMP());
+
 CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.product_analytics_privacy_sweep_state` (
   sweep_name STRING NOT NULL,
   last_success_through_date DATE NOT NULL,
@@ -259,7 +273,6 @@ CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flatten
   user_key STRING NOT NULL,
   platform STRING,
   app_version STRING,
-  app_build STRING,
   activation_schema_version INT64,
   inventory_state STRING,
   activity_state STRING,
@@ -289,7 +302,6 @@ CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.installation_l
   schema_version INT64 NOT NULL,
   platform STRING,
   app_version STRING,
-  app_build STRING,
   provider STRING NOT NULL,
   failure_kind STRING,
   event_count INT64 NOT NULL,
@@ -464,7 +476,6 @@ CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.screen_usage_w
   week_end DATE NOT NULL,
   platform STRING,
   app_version STRING,
-  app_build STRING,
   screen STRING NOT NULL,
   unique_users INT64 NOT NULL,
   view_count INT64 NOT NULL,
@@ -480,7 +491,6 @@ CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.onboarding_fri
   metric_name STRING NOT NULL,
   platform STRING,
   app_version STRING,
-  app_build STRING,
   surface STRING,
   channel STRING,
   install_method STRING,

--- a/tool/product_analytics/sql/00_datasets.sql
+++ b/tool/product_analytics/sql/00_datasets.sql
@@ -278,7 +278,7 @@ CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flatten
 PARTITION BY source_export_date
 CLUSTER BY event_name, user_key
 OPTIONS (
-  description = 'Allowlisted account-linked product events; no installation, user_id, content, arbitrary parameter, geo, or device fields',
+  description = 'Allowlisted account-linked product events partitioned by UTC emission date; no installation, user_id, content, arbitrary parameter, geo, or device fields',
   partition_expiration_days = 426
 );
 
@@ -299,7 +299,7 @@ CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.installation_l
 PARTITION BY source_export_date
 CLUSTER BY event_name, provider
 OPTIONS (
-  description = 'Identifier-free direct event counts for the account-less login funnel',
+  description = 'Identifier-free direct account-less login event counts partitioned by UTC emission date',
   partition_expiration_days = 426
 );
 
@@ -417,9 +417,11 @@ CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.retention_coho
   activation_week_end DATE NOT NULL,
   data_as_of_at TIMESTAMP NOT NULL,
   activated_users INT64 NOT NULL,
+  w1_cohort_mature BOOL NOT NULL,
   w1_eligible_users INT64 NOT NULL,
   w1_retained_users INT64 NOT NULL,
   w1_retention_rate FLOAT64,
+  w4_cohort_mature BOOL NOT NULL,
   w4_eligible_users INT64 NOT NULL,
   w4_retained_users INT64 NOT NULL,
   w4_retention_rate FLOAT64,

--- a/tool/product_analytics/sql/00_datasets.sql
+++ b/tool/product_analytics/sql/00_datasets.sql
@@ -1,0 +1,494 @@
+-- BigQuery Standard SQL. The query job location must match the Firebase export.
+ASSERT TIMESTAMP('{{RAW_EXPORT_START_AT}}') <= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+  AS 'behavioral_schema_v1_start_at must not precede raw_export_start_at';
+ASSERT TIMESTAMP('{{RAW_EXPORT_START_AT}}') <= CURRENT_TIMESTAMP()
+  AS 'raw_export_start_at must not be in the future';
+ASSERT TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}') <= CURRENT_TIMESTAMP()
+  AS 'behavioral_schema_v1_start_at must not be in the future';
+
+CREATE SCHEMA IF NOT EXISTS `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}`;
+CREATE SCHEMA IF NOT EXISTS `{{PROJECT_ID}}.{{PRIVACY_DATASET_ID}}`;
+CREATE SCHEMA IF NOT EXISTS `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}`;
+CREATE SCHEMA IF NOT EXISTS `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}`;
+CREATE SCHEMA IF NOT EXISTS `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}`;
+
+ALTER SCHEMA `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}`
+SET OPTIONS (description = 'Restricted current auth eligibility and identifier-free setup cohorts');
+ALTER SCHEMA `{{PROJECT_ID}}.{{PRIVACY_DATASET_ID}}`
+SET OPTIONS (description = 'Restricted product analytics privacy-deletion handoff');
+ALTER SCHEMA `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}`
+SET OPTIONS (description = 'Restricted permanent exclusions and analytics measurement controls');
+ALTER SCHEMA `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}`
+SET OPTIONS (description = 'Minimized pseudonymous product analytics facts and aggregates');
+ALTER SCHEMA `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}`
+SET OPTIONS (description = 'Identifier-free authorized product analytics views');
+
+-- These four schemas intentionally match the auth export repository exactly.
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_user_milestones` (
+  user_key STRING NOT NULL,
+  account_created_at TIMESTAMP NOT NULL,
+  notification_registered_at TIMESTAMP,
+  bridge_registered_at TIMESTAMP,
+  legacy_first_metadata_request_at TIMESTAMP,
+  exported_at TIMESTAMP NOT NULL
+)
+CLUSTER BY user_key
+OPTIONS (description = 'Current analytics-eligible auth snapshot; replaced atomically by the auth export');
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_weekly_setup_cohorts` (
+  cohort_week DATE NOT NULL,
+  total_accounts INT64 NOT NULL,
+  enabled_accounts INT64 NOT NULL,
+  notification_registered_within_1_day INT64 NOT NULL,
+  notification_registered_within_7_days INT64 NOT NULL,
+  notification_registered_within_30_days INT64 NOT NULL,
+  bridge_registered_within_1_day INT64 NOT NULL,
+  bridge_registered_within_7_days INT64 NOT NULL,
+  bridge_registered_within_30_days INT64 NOT NULL,
+  legacy_first_metadata_request_within_1_day INT64 NOT NULL,
+  legacy_first_metadata_request_within_7_days INT64 NOT NULL,
+  legacy_first_metadata_request_within_30_days INT64 NOT NULL,
+  exported_at TIMESTAMP NOT NULL
+)
+OPTIONS (description = 'Identifier-free external-account setup cohorts from the auth export');
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.product_analytics_export_runs` (
+  run_id STRING NOT NULL,
+  run_cutoff TIMESTAMP NOT NULL,
+  preference_scan_cutoff TIMESTAMP NOT NULL,
+  control_updated_at TIMESTAMP NOT NULL,
+  users_scanned INT64 NOT NULL,
+  source_suppressed_users INT64 NOT NULL,
+  internal_users INT64 NOT NULL,
+  external_accounts INT64 NOT NULL,
+  enabled_accounts INT64 NOT NULL,
+  opted_out_accounts INT64 NOT NULL,
+  preference_after_cutoff_accounts INT64 NOT NULL,
+  late_preference_rows_removed INT64 NOT NULL,
+  milestone_rows_published INT64 NOT NULL,
+  cohort_rows_published INT64 NOT NULL,
+  published_at TIMESTAMP NOT NULL
+)
+PARTITION BY DATE(published_at)
+OPTIONS (description = 'Successful auth export metadata without source account identifiers');
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.product_analytics_export_state` (
+  state_key STRING NOT NULL,
+  active_run_id STRING,
+  lease_expires_at TIMESTAMP,
+  last_published_run_id STRING,
+  last_published_cutoff TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL
+)
+OPTIONS (description = 'Singleton lease and monotonic auth export publication state');
+
+MERGE `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.product_analytics_export_state` AS target
+USING (SELECT 'singleton' AS state_key) AS source
+ON target.state_key = source.state_key
+WHEN NOT MATCHED THEN
+  INSERT (state_key, active_run_id, lease_expires_at, last_published_run_id, last_published_cutoff, updated_at)
+  VALUES ('singleton', NULL, NULL, NULL, NULL, CURRENT_TIMESTAMP());
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{PRIVACY_DATASET_ID}}.product_analytics_deletion_targets` (
+  request_id STRING NOT NULL,
+  user_key STRING NOT NULL,
+  legacy_firebase_user_id STRING NOT NULL,
+  suppressed_at TIMESTAMP NOT NULL,
+  status STRING NOT NULL,
+  last_error_code STRING,
+  completed_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL
+)
+CLUSTER BY request_id
+OPTIONS (description = 'Restricted auth-to-deletion-job handoff; never exposed to reporting');
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.analytics_measurement_config` (
+  config_key STRING NOT NULL,
+  raw_export_start_at TIMESTAMP NOT NULL,
+  behavioral_schema_v1_start_at TIMESTAMP NOT NULL,
+  clock_skew_allowance_seconds INT64 NOT NULL,
+  auth_snapshot_max_age_hours INT64 NOT NULL,
+  raw_late_arrival_days INT64 NOT NULL,
+  updated_at TIMESTAMP NOT NULL
+)
+OPTIONS (description = 'Singleton pinned analytics measurement boundaries and freshness policy');
+
+ASSERT (
+  SELECT COUNT(*) = 0 OR (COUNT(*) = 1 AND COUNTIF(config_key = 'singleton') = 1)
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.analytics_measurement_config`
+) AS 'analytics measurement config must contain only the singleton row';
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.analytics_measurement_config`
+  WHERE config_key = 'singleton'
+    AND (
+      raw_export_start_at != TIMESTAMP('{{RAW_EXPORT_START_AT}}')
+      OR behavioral_schema_v1_start_at != TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+      OR clock_skew_allowance_seconds != 300
+      OR auth_snapshot_max_age_hours != 36
+      OR raw_late_arrival_days != 3
+    )
+) AS 'analytics measurement boundaries and policies are immutable after first deployment';
+
+MERGE `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.analytics_measurement_config` AS target
+USING (
+  SELECT
+    'singleton' AS config_key,
+    TIMESTAMP('{{RAW_EXPORT_START_AT}}') AS raw_export_start_at,
+    TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}') AS behavioral_schema_v1_start_at,
+    300 AS clock_skew_allowance_seconds,
+    36 AS auth_snapshot_max_age_hours,
+    3 AS raw_late_arrival_days
+) AS source
+ON target.config_key = source.config_key
+WHEN MATCHED THEN UPDATE SET
+  raw_export_start_at = source.raw_export_start_at,
+  behavioral_schema_v1_start_at = source.behavioral_schema_v1_start_at,
+  clock_skew_allowance_seconds = source.clock_skew_allowance_seconds,
+  auth_snapshot_max_age_hours = source.auth_snapshot_max_age_hours,
+  raw_late_arrival_days = source.raw_late_arrival_days,
+  updated_at = CURRENT_TIMESTAMP()
+WHEN NOT MATCHED THEN
+  INSERT (
+    config_key,
+    raw_export_start_at,
+    behavioral_schema_v1_start_at,
+    clock_skew_allowance_seconds,
+    auth_snapshot_max_age_hours,
+    raw_late_arrival_days,
+    updated_at
+  )
+  VALUES (
+    source.config_key,
+    source.raw_export_start_at,
+    source.behavioral_schema_v1_start_at,
+    source.clock_skew_allowance_seconds,
+    source.auth_snapshot_max_age_hours,
+    source.raw_late_arrival_days,
+    CURRENT_TIMESTAMP()
+  );
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_internal_user_exclusions` (
+  user_key STRING NOT NULL,
+  owner STRING NOT NULL,
+  reason STRING NOT NULL,
+  created_at TIMESTAMP NOT NULL
+)
+CLUSTER BY user_key
+OPTIONS (description = 'Permanent internal/test account exclusions; entries must never be deactivated or expired');
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.internal_exclusion_control_state` (
+  state_key STRING NOT NULL,
+  control_updated_at TIMESTAMP NOT NULL
+)
+OPTIONS (description = 'Explicit freshness sentinel advanced whenever the permanent exclusion set is reviewed');
+
+MERGE `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.internal_exclusion_control_state` AS target
+USING (SELECT 'singleton' AS state_key) AS source
+ON target.state_key = source.state_key
+WHEN NOT MATCHED THEN
+  INSERT (state_key, control_updated_at) VALUES ('singleton', CURRENT_TIMESTAMP());
+
+CREATE OR REPLACE VIEW `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.auth_permanent_internal_exclusions`
+OPTIONS (description = 'Authorized auth-export view with one null-key freshness sentinel') AS
+SELECT
+  exclusion.user_key,
+  TRUE AS is_active,
+  state.control_updated_at
+FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_internal_user_exclusions` AS exclusion
+CROSS JOIN `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.internal_exclusion_control_state` AS state
+WHERE state.state_key = 'singleton'
+UNION ALL
+SELECT
+  CAST(NULL AS STRING) AS user_key,
+  FALSE AS is_active,
+  state.control_updated_at
+FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.internal_exclusion_control_state` AS state
+WHERE state.state_key = 'singleton';
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions` (
+  user_key STRING NOT NULL,
+  suppressed_at TIMESTAMP NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL
+)
+CLUSTER BY user_key
+OPTIONS (description = 'Permanent deletion tombstones applied to every keyed warehouse recomputation');
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.product_analytics_privacy_sweep_state` (
+  sweep_name STRING NOT NULL,
+  last_success_through_date DATE NOT NULL,
+  updated_at TIMESTAMP NOT NULL
+)
+OPTIONS (description = 'Identifier-free monotonic checkpoint for overlapping keyed-upload deletion sweeps');
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state` (
+  model_name STRING NOT NULL,
+  source_start_date DATE NOT NULL,
+  source_end_date DATE NOT NULL,
+  completed_at TIMESTAMP NOT NULL,
+  auth_snapshot_published_at TIMESTAMP,
+  source_rows INT64 NOT NULL,
+  deduplicated_rows INT64 NOT NULL,
+  published_rows INT64 NOT NULL,
+  missing_identity_rows INT64 NOT NULL,
+  malformed_identity_rows INT64 NOT NULL,
+  missing_schema_rows INT64 NOT NULL,
+  unsupported_schema_rows INT64 NOT NULL,
+  missing_occurrence_rows INT64 NOT NULL,
+  future_occurrence_rows INT64 NOT NULL,
+  before_account_rows INT64 NOT NULL,
+  invalid_parameter_rows INT64 NOT NULL,
+  unknown_enum_rows INT64 NOT NULL,
+  internal_excluded_rows INT64 NOT NULL,
+  deletion_excluded_rows INT64 NOT NULL,
+  ineligible_user_rows INT64 NOT NULL,
+  latest_emitted_at TIMESTAMP,
+  latest_occurred_at TIMESTAMP
+)
+OPTIONS (description = 'Identifier-free last-success watermark, freshness, and bounded quality counters per transform');
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flattened` (
+  event_name STRING NOT NULL,
+  source_export_date DATE NOT NULL,
+  emitted_at TIMESTAMP NOT NULL,
+  occurred_at_micros INT64 NOT NULL,
+  occurred_at TIMESTAMP NOT NULL,
+  schema_version INT64 NOT NULL,
+  user_key STRING NOT NULL,
+  platform STRING,
+  app_version STRING,
+  app_build STRING,
+  activation_schema_version INT64,
+  inventory_state STRING,
+  activity_state STRING,
+  submission_kind STRING,
+  input_mode STRING,
+  workspace_kind STRING,
+  failure_reason STRING,
+  decision STRING,
+  change_state STRING,
+  surface STRING,
+  channel STRING,
+  method STRING,
+  os STRING,
+  screen STRING
+)
+PARTITION BY source_export_date
+CLUSTER BY event_name, user_key
+OPTIONS (
+  description = 'Allowlisted account-linked product events; no installation, user_id, content, arbitrary parameter, geo, or device fields',
+  partition_expiration_days = 426
+);
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.installation_login_daily` (
+  source_export_date DATE NOT NULL,
+  event_date DATE NOT NULL,
+  event_name STRING NOT NULL,
+  schema_version INT64 NOT NULL,
+  platform STRING,
+  app_version STRING,
+  app_build STRING,
+  provider STRING NOT NULL,
+  failure_kind STRING,
+  event_count INT64 NOT NULL,
+  includes_internal_test_traffic BOOL NOT NULL,
+  refreshed_at TIMESTAMP NOT NULL
+)
+PARTITION BY source_export_date
+CLUSTER BY event_name, provider
+OPTIONS (
+  description = 'Identifier-free direct event counts for the account-less login funnel',
+  partition_expiration_days = 426
+);
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.user_activity_daily` (
+  activity_date DATE NOT NULL,
+  user_key STRING NOT NULL,
+  meaningful_activity BOOL NOT NULL,
+  controller_activity BOOL NOT NULL,
+  monitor_event_count INT64 NOT NULL,
+  control_event_count INT64 NOT NULL,
+  message_event_count INT64 NOT NULL,
+  voice_assisted_message_count INT64 NOT NULL,
+  voice_transcription_count INT64 NOT NULL,
+  project_available_count INT64 NOT NULL,
+  remote_created_session_count INT64 NOT NULL,
+  dedicated_worktree_creation_count INT64 NOT NULL,
+  session_creation_failure_count INT64 NOT NULL,
+  question_answer_count INT64 NOT NULL,
+  question_rejection_count INT64 NOT NULL,
+  permission_answer_count INT64 NOT NULL,
+  abort_count INT64 NOT NULL,
+  non_empty_diff_view_count INT64 NOT NULL,
+  screen_view_count INT64 NOT NULL,
+  onboarding_interaction_count INT64 NOT NULL,
+  first_meaningful_at TIMESTAMP,
+  last_meaningful_at TIMESTAMP,
+  refreshed_at TIMESTAMP NOT NULL
+)
+PARTITION BY activity_date
+CLUSTER BY user_key
+OPTIONS (
+  description = 'One current-eligible user/date row with bounded product activity flags and counts',
+  partition_expiration_days = 426
+);
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.user_milestones` (
+  user_key STRING NOT NULL,
+  account_created_at TIMESTAMP NOT NULL,
+  notification_registered_at TIMESTAMP,
+  bridge_registered_at TIMESTAMP,
+  legacy_first_metadata_request_at TIMESTAMP,
+  foundation_exposed_at TIMESTAMP,
+  analytics_schema_ready_at TIMESTAMP,
+  activation_capable_at TIMESTAMP,
+  project_available_at TIMESTAMP,
+  full_activation_at TIMESTAMP,
+  full_activation_source STRING,
+  full_activation_input_mode STRING,
+  monitor_activity_at TIMESTAMP,
+  voice_transcription_at TIMESTAMP,
+  voice_assisted_message_at TIMESTAMP,
+  remote_created_session_at TIMESTAMP,
+  dedicated_worktree_at TIMESTAMP,
+  diff_viewed_at TIMESTAMP,
+  question_intervention_at TIMESTAMP,
+  permission_intervention_at TIMESTAMP,
+  abort_at TIMESTAMP,
+  first_screen_view_at TIMESTAMP,
+  onboarding_interaction_at TIMESTAMP,
+  refreshed_at TIMESTAMP NOT NULL
+)
+PARTITION BY DATE(account_created_at)
+CLUSTER BY user_key
+OPTIONS (
+  description = 'Current-eligible auth and product milestones anchored to validated occurrence time',
+  partition_expiration_days = 426
+);
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.activation_cohorts` (
+  cohort_week DATE NOT NULL,
+  cohort_week_end DATE NOT NULL,
+  data_as_of_at TIMESTAMP NOT NULL,
+  total_accounts INT64 NOT NULL,
+  enabled_accounts INT64 NOT NULL,
+  preference_coverage FLOAT64,
+  foundation_exposed_accounts INT64 NOT NULL,
+  foundation_coverage FLOAT64,
+  behavioral_window_mature_accounts INT64 NOT NULL,
+  activation_capable_accounts INT64 NOT NULL,
+  activation_capability_coverage FLOAT64,
+  project_available_within_1_day INT64 NOT NULL,
+  project_available_within_7_days INT64 NOT NULL,
+  project_available_within_30_days INT64 NOT NULL,
+  activation_eligible_1_day_accounts INT64 NOT NULL,
+  activated_within_1_day INT64 NOT NULL,
+  activation_eligible_7_day_accounts INT64 NOT NULL,
+  activated_within_7_days INT64 NOT NULL,
+  activation_eligible_30_day_accounts INT64 NOT NULL,
+  activated_within_30_days INT64 NOT NULL,
+  existing_session_activations INT64 NOT NULL,
+  remote_created_session_activations INT64 NOT NULL,
+  time_to_project_p50_seconds INT64,
+  time_to_project_p75_seconds INT64,
+  time_to_activation_p50_seconds INT64,
+  time_to_activation_p75_seconds INT64,
+  notification_registered_within_1_day INT64 NOT NULL,
+  notification_registered_within_7_days INT64 NOT NULL,
+  notification_registered_within_30_days INT64 NOT NULL,
+  bridge_registered_within_1_day INT64 NOT NULL,
+  bridge_registered_within_7_days INT64 NOT NULL,
+  bridge_registered_within_30_days INT64 NOT NULL,
+  legacy_metadata_request_within_1_day INT64 NOT NULL,
+  legacy_metadata_request_within_7_days INT64 NOT NULL,
+  legacy_metadata_request_within_30_days INT64 NOT NULL,
+  setup_1_day_mature BOOL NOT NULL,
+  setup_7_day_mature BOOL NOT NULL,
+  setup_30_day_mature BOOL NOT NULL,
+  refreshed_at TIMESTAMP NOT NULL
+)
+PARTITION BY cohort_week
+OPTIONS (description = 'Identifier-free weekly setup, coverage, maturity, and activation cohorts', partition_expiration_days = 426);
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.retention_cohorts` (
+  activation_week DATE NOT NULL,
+  activation_week_end DATE NOT NULL,
+  data_as_of_at TIMESTAMP NOT NULL,
+  activated_users INT64 NOT NULL,
+  w1_eligible_users INT64 NOT NULL,
+  w1_retained_users INT64 NOT NULL,
+  w1_retention_rate FLOAT64,
+  w4_eligible_users INT64 NOT NULL,
+  w4_retained_users INT64 NOT NULL,
+  w4_retention_rate FLOAT64,
+  refreshed_at TIMESTAMP NOT NULL
+)
+PARTITION BY activation_week
+OPTIONS (description = 'Identifier-free activation-anchored half-open W1 and W4 retention cohorts', partition_expiration_days = 426);
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.weekly_engagement` (
+  week_start DATE NOT NULL,
+  week_end DATE NOT NULL,
+  data_as_of_at TIMESTAMP NOT NULL,
+  meaningful_wau INT64 NOT NULL,
+  controller_wau INT64 NOT NULL,
+  active_days_p50 INT64,
+  active_days_p75 INT64,
+  remote_interventions INT64 NOT NULL,
+  remote_interventions_per_controller FLOAT64,
+  successful_messages INT64 NOT NULL,
+  voice_assisted_messages INT64 NOT NULL,
+  voice_assisted_message_users INT64 NOT NULL,
+  voice_transcription_users INT64 NOT NULL,
+  remote_created_session_users INT64 NOT NULL,
+  remote_created_sessions INT64 NOT NULL,
+  dedicated_worktree_users INT64 NOT NULL,
+  dedicated_worktree_sessions INT64 NOT NULL,
+  diff_users INT64 NOT NULL,
+  question_users INT64 NOT NULL,
+  permission_users INT64 NOT NULL,
+  abort_users INT64 NOT NULL,
+  screen_users INT64 NOT NULL,
+  project_available_users INT64 NOT NULL,
+  refreshed_at TIMESTAMP NOT NULL
+)
+PARTITION BY week_start
+OPTIONS (description = 'Identifier-free complete Monday-Sunday engagement and feature aggregates', partition_expiration_days = 426);
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.screen_usage_weekly` (
+  week_start DATE NOT NULL,
+  week_end DATE NOT NULL,
+  platform STRING,
+  app_version STRING,
+  app_build STRING,
+  screen STRING NOT NULL,
+  unique_users INT64 NOT NULL,
+  view_count INT64 NOT NULL,
+  refreshed_at TIMESTAMP NOT NULL
+)
+PARTITION BY week_start
+CLUSTER BY screen
+OPTIONS (description = 'Identifier-free complete-week canonical product screen usage', partition_expiration_days = 426);
+
+CREATE TABLE IF NOT EXISTS `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.onboarding_friction_weekly` (
+  week_start DATE NOT NULL,
+  week_end DATE NOT NULL,
+  metric_name STRING NOT NULL,
+  platform STRING,
+  app_version STRING,
+  app_build STRING,
+  surface STRING,
+  channel STRING,
+  install_method STRING,
+  install_os STRING,
+  failure_reason STRING,
+  workspace_kind STRING,
+  unique_users INT64 NOT NULL,
+  event_count INT64 NOT NULL,
+  refreshed_at TIMESTAMP NOT NULL
+)
+PARTITION BY week_start
+CLUSTER BY metric_name
+OPTIONS (description = 'Identifier-free complete-week bounded onboarding and creation-friction aggregates', partition_expiration_days = 426);

--- a/tool/product_analytics/sql/10_events_flattened.sql
+++ b/tool/product_analytics/sql/10_events_flattened.sql
@@ -16,8 +16,19 @@ DECLARE previous_source_end_date DATE DEFAULT (
   WHERE model_name = 'events_flattened'
   LIMIT 1
 );
+DECLARE previous_completed_at TIMESTAMP DEFAULT (
+  SELECT completed_at
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
+  WHERE model_name = 'events_flattened'
+  LIMIT 1
+);
 DECLARE scan_start_date DATE;
 DECLARE rows_inserted INT64 DEFAULT 0;
+DECLARE keyed_publication_epoch INT64 DEFAULT (
+  SELECT publication_epoch
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.keyed_publication_guard`
+  WHERE guard_key = 'singleton'
+);
 
 SET scan_start_date = GREATEST(
   raw_start_date,
@@ -37,6 +48,8 @@ ASSERT previous_source_end_date IS NULL OR scan_end_date >= previous_source_end_
   AS 'The latest available GA4 daily export regressed behind the published watermark';
 ASSERT scan_start_date >= DATE_SUB(scan_end_date, INTERVAL 89 DAY)
   AS 'The flattened-event watermark gap exceeds the recoverable 90-day raw window';
+ASSERT keyed_publication_epoch IS NOT NULL
+  AS 'The keyed publication guard singleton is required';
 
 -- Property-local suffixes can straddle UTC dates. Scan one suffix day around
 -- the UTC range, then retain and partition only by the UTC emission date.
@@ -111,7 +124,6 @@ parameterized AS (
     raw.* EXCEPT (event_params),
     (
       SELECT AS STRUCT
-        MAX(IF(parameter.key = 'app_build', COALESCE(parameter.value.string_value, CAST(parameter.value.int_value AS STRING)), NULL)) AS app_build,
         MAX(IF(parameter.key = 'user_key', parameter.value.string_value, NULL)) AS user_key,
         MAX(IF(parameter.key = 'schema_version', parameter.value.int_value, NULL)) AS schema_version,
         MAX(IF(parameter.key = 'occurred_at_micros', parameter.value.int_value, NULL)) AS occurred_at_micros,
@@ -259,7 +271,6 @@ deduplicated AS (
         occurred_at_micros,
         platform,
         app_version,
-        app_build,
         activation_schema_version_raw,
         inventory_state,
         activity_state,
@@ -308,7 +319,6 @@ SELECT
   user_key,
   platform,
   app_version,
-  app_build,
   IF(
     event_name = 'analytics_activation_ready',
     SAFE_CAST(activation_schema_version_raw AS INT64),
@@ -381,7 +391,27 @@ SELECT
   MAX(IF(occurred_at <= TIMESTAMP_ADD(emitted_at, INTERVAL 300 SECOND), occurred_at, NULL)) AS latest_occurred_at
 FROM candidate_stage;
 
+ASSERT previous_source_end_date IS NOT DISTINCT FROM (
+  SELECT source_end_date
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
+  WHERE model_name = 'events_flattened'
+  LIMIT 1
+) AND previous_completed_at IS NOT DISTINCT FROM (
+  SELECT completed_at
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
+  WHERE model_name = 'events_flattened'
+  LIMIT 1
+) AS 'events_flattened state changed while the transform was staged';
+
 BEGIN TRANSACTION;
+
+UPDATE `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.keyed_publication_guard`
+SET publication_epoch = publication_epoch + 1,
+    updated_at = CURRENT_TIMESTAMP()
+WHERE guard_key = 'singleton'
+  AND publication_epoch = keyed_publication_epoch;
+ASSERT @@row_count = 1
+  AS 'A tombstone or keyed publication changed while events were staged';
 
 -- The broad partition predicate lets a newly added permanent tombstone remove
 -- every retained keyed fact, not just the three mutable source dates.
@@ -407,7 +437,6 @@ INSERT INTO `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flattened` (
   user_key,
   platform,
   app_version,
-  app_build,
   activation_schema_version,
   inventory_state,
   activity_state,
@@ -445,7 +474,10 @@ USING (
   FROM quality_stage AS quality
 ) AS source
 ON target.model_name = source.model_name
-WHEN MATCHED THEN UPDATE SET
+WHEN MATCHED
+  AND target.source_end_date IS NOT DISTINCT FROM previous_source_end_date
+  AND target.completed_at IS NOT DISTINCT FROM previous_completed_at
+THEN UPDATE SET
   source_start_date = scan_start_date,
   source_end_date = scan_end_date,
   completed_at = CURRENT_TIMESTAMP(),
@@ -514,5 +546,7 @@ WHEN NOT MATCHED THEN INSERT (
   source.latest_emitted_at,
   source.latest_occurred_at
 );
+ASSERT @@row_count = 1
+  AS 'events_flattened state changed before watermark publication';
 
 COMMIT TRANSACTION;

--- a/tool/product_analytics/sql/10_events_flattened.sql
+++ b/tool/product_analytics/sql/10_events_flattened.sql
@@ -1,6 +1,6 @@
--- BigQuery Standard SQL. Rebuild mutable GA4 daily exports plus any watermark gap.
+-- BigQuery Standard SQL. Rebuild mutable UTC emission dates plus any watermark gap.
 DECLARE raw_start_date DATE DEFAULT DATE(TIMESTAMP('{{RAW_EXPORT_START_AT}}'));
-DECLARE latest_available_source_date DATE DEFAULT (
+DECLARE latest_available_suffix_date DATE DEFAULT (
   SELECT MAX(PARSE_DATE('%Y%m%d', SUBSTR(table_name, 8)))
   FROM `{{PROJECT_ID}}.{{RAW_DATASET_ID}}.INFORMATION_SCHEMA.TABLES`
   WHERE table_type = 'BASE TABLE'
@@ -8,7 +8,7 @@ DECLARE latest_available_source_date DATE DEFAULT (
 );
 DECLARE scan_end_date DATE DEFAULT LEAST(
   DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 1 DAY),
-  latest_available_source_date
+  DATE_SUB(latest_available_suffix_date, INTERVAL 1 DAY)
 );
 DECLARE previous_source_end_date DATE DEFAULT (
   SELECT source_end_date
@@ -38,40 +38,50 @@ ASSERT previous_source_end_date IS NULL OR scan_end_date >= previous_source_end_
 ASSERT scan_start_date >= DATE_SUB(scan_end_date, INTERVAL 89 DAY)
   AS 'The flattened-event watermark gap exceeds the recoverable 90-day raw window';
 
--- Only approved scalar metadata is materialized. Bundle fields are transiently
--- used for duplicate removal and never enter a curated table.
+-- Property-local suffixes can straddle UTC dates. Scan one suffix day around
+-- the UTC range, then retain and partition only by the UTC emission date.
+-- Raw identity fields are transiently used for duplicate removal and never
+-- enter a curated table.
 CREATE TEMP TABLE candidate_stage AS
-WITH extracted AS (
+WITH raw_events AS (
   SELECT
     event_name,
-    PARSE_DATE('%Y%m%d', _TABLE_SUFFIX) AS source_export_date,
+    DATE(TIMESTAMP_MICROS(event_timestamp)) AS source_export_date,
     event_timestamp,
+    user_pseudo_id,
     event_bundle_sequence_id,
     batch_event_index,
     platform,
     app_info.version AS app_version,
-    (SELECT ANY_VALUE(COALESCE(value.string_value, CAST(value.int_value AS STRING))) FROM UNNEST(event_params) WHERE key = 'app_build') AS app_build,
-    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'user_key') AS user_key,
-    (SELECT ANY_VALUE(COALESCE(value.int_value, SAFE_CAST(value.string_value AS INT64))) FROM UNNEST(event_params) WHERE key = 'schema_version') AS schema_version,
-    (SELECT ANY_VALUE(COALESCE(value.int_value, SAFE_CAST(value.string_value AS INT64))) FROM UNNEST(event_params) WHERE key = 'occurred_at_micros') AS occurred_at_micros,
-    (SELECT ANY_VALUE(COALESCE(value.int_value, SAFE_CAST(value.string_value AS INT64))) FROM UNNEST(event_params) WHERE key = 'activation_schema_version') AS activation_schema_version,
-    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'inventory_state') AS inventory_state,
-    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'activity_state') AS activity_state,
-    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'submission_kind') AS submission_kind,
-    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'input_mode') AS input_mode,
-    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'workspace_kind') AS workspace_kind,
-    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'failure_reason') AS failure_reason,
-    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'decision') AS decision,
-    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'change_state') AS change_state,
-    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'surface') AS surface,
-    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'channel') AS channel,
-    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'method') AS method,
-    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'os') AS os,
-    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'screen') AS screen
+    event_params,
+    ARRAY_CONCAT(
+      ['user_key', 'schema_version', 'occurred_at_micros'],
+      CASE event_name
+        WHEN 'analytics_activation_ready' THEN ['activation_schema_version']
+        WHEN 'project_inventory_loaded' THEN ['inventory_state']
+        WHEN 'session_activity_viewed' THEN ['activity_state']
+        WHEN 'session_message_sent' THEN ['submission_kind', 'input_mode']
+        WHEN 'session_created_with_message' THEN ['submission_kind', 'input_mode', 'workspace_kind']
+        WHEN 'session_creation_failed' THEN ['failure_reason', 'workspace_kind']
+        WHEN 'session_permission_answered' THEN ['decision']
+        WHEN 'session_diff_viewed' THEN ['change_state']
+        WHEN 'onboarding_need_help_opened' THEN ['surface']
+        WHEN 'onboarding_support_link_opened' THEN ['surface', 'channel']
+        WHEN 'onboarding_why_bridge_opened' THEN ['surface']
+        WHEN 'bridge_install_command_copied' THEN ['surface', 'method', 'os']
+        WHEN 'bridge_install_command_shared' THEN ['surface', 'method', 'os']
+        WHEN 'bridge_run_command_copied' THEN ['surface']
+        WHEN 'bridge_run_command_shared' THEN ['surface']
+        WHEN 'product_screen_viewed' THEN ['screen']
+        ELSE ARRAY<STRING>[]
+      END
+    ) AS required_parameter_names
   FROM `{{PROJECT_ID}}.{{RAW_DATASET_ID}}.events_*`
-  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d', scan_start_date) AND FORMAT_DATE('%Y%m%d', scan_end_date)
+  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d', DATE_SUB(scan_start_date, INTERVAL 1 DAY))
+    AND FORMAT_DATE('%Y%m%d', DATE_ADD(scan_end_date, INTERVAL 1 DAY))
     AND REGEXP_CONTAINS(_TABLE_SUFFIX, r'^\d{8}$')
     AND event_timestamp >= UNIX_MICROS(TIMESTAMP('{{RAW_EXPORT_START_AT}}'))
+    AND DATE(TIMESTAMP_MICROS(event_timestamp)) BETWEEN scan_start_date AND scan_end_date
     AND event_name IN (
       'analytics_schema_ready',
       'analytics_activation_ready',
@@ -96,6 +106,64 @@ WITH extracted AS (
       'product_screen_viewed'
     )
 ),
+parameterized AS (
+  SELECT
+    raw.* EXCEPT (event_params),
+    (
+      SELECT AS STRUCT
+        MAX(IF(parameter.key = 'app_build', COALESCE(parameter.value.string_value, CAST(parameter.value.int_value AS STRING)), NULL)) AS app_build,
+        MAX(IF(parameter.key = 'user_key', parameter.value.string_value, NULL)) AS user_key,
+        MAX(IF(parameter.key = 'schema_version', parameter.value.int_value, NULL)) AS schema_version,
+        MAX(IF(parameter.key = 'occurred_at_micros', parameter.value.int_value, NULL)) AS occurred_at_micros,
+        MAX(IF(parameter.key = 'activation_schema_version', parameter.value.string_value, NULL)) AS activation_schema_version_raw,
+        MAX(IF(parameter.key = 'inventory_state', parameter.value.string_value, NULL)) AS inventory_state,
+        MAX(IF(parameter.key = 'activity_state', parameter.value.string_value, NULL)) AS activity_state,
+        MAX(IF(parameter.key = 'submission_kind', parameter.value.string_value, NULL)) AS submission_kind,
+        MAX(IF(parameter.key = 'input_mode', parameter.value.string_value, NULL)) AS input_mode,
+        MAX(IF(parameter.key = 'workspace_kind', parameter.value.string_value, NULL)) AS workspace_kind,
+        MAX(IF(parameter.key = 'failure_reason', parameter.value.string_value, NULL)) AS failure_reason,
+        MAX(IF(parameter.key = 'decision', parameter.value.string_value, NULL)) AS decision,
+        MAX(IF(parameter.key = 'change_state', parameter.value.string_value, NULL)) AS change_state,
+        MAX(IF(parameter.key = 'surface', parameter.value.string_value, NULL)) AS surface,
+        MAX(IF(parameter.key = 'channel', parameter.value.string_value, NULL)) AS channel,
+        MAX(IF(parameter.key = 'method', parameter.value.string_value, NULL)) AS method,
+        MAX(IF(parameter.key = 'os', parameter.value.string_value, NULL)) AS os,
+        MAX(IF(parameter.key = 'screen', parameter.value.string_value, NULL)) AS screen,
+        COUNTIF(parameter.key IN UNNEST(raw.required_parameter_names)) AS required_parameter_count,
+        COUNT(DISTINCT IF(parameter.key IN UNNEST(raw.required_parameter_names), parameter.key, NULL)) AS distinct_required_parameter_count,
+        COUNTIF(
+          parameter.key IN UNNEST(raw.required_parameter_names)
+          AND (
+            (
+              parameter.key IN ('schema_version', 'occurred_at_micros')
+              AND parameter.value.int_value IS NOT NULL
+              AND parameter.value.string_value IS NULL
+              AND parameter.value.float_value IS NULL
+              AND parameter.value.double_value IS NULL
+            )
+            OR (
+              parameter.key NOT IN ('schema_version', 'occurred_at_micros')
+              AND parameter.value.string_value IS NOT NULL
+              AND parameter.value.int_value IS NULL
+              AND parameter.value.float_value IS NULL
+              AND parameter.value.double_value IS NULL
+            )
+          )
+        ) AS correctly_typed_required_parameter_count
+      FROM UNNEST(raw.event_params) AS parameter
+    ) AS parameters
+  FROM raw_events AS raw
+),
+extracted AS (
+  SELECT
+    parameterized.* EXCEPT (parameters),
+    parameters.*,
+    parameters.required_parameter_count = ARRAY_LENGTH(required_parameter_names)
+      AND parameters.distinct_required_parameter_count = ARRAY_LENGTH(required_parameter_names)
+      AND parameters.correctly_typed_required_parameter_count = ARRAY_LENGTH(required_parameter_names)
+      AS parameter_shape_valid
+  FROM parameterized
+),
 timestamped AS (
   SELECT
     *,
@@ -108,22 +176,20 @@ timestamped AS (
     END AS occurred_at
   FROM extracted
 ),
-contract_checked AS (
+value_checked AS (
   SELECT
     *,
     CASE event_name
       WHEN 'analytics_schema_ready' THEN TRUE
-      WHEN 'analytics_activation_ready' THEN activation_schema_version = 1
+      WHEN 'analytics_activation_ready' THEN TRUE
       WHEN 'project_inventory_loaded' THEN inventory_state IN ('empty', 'non_empty')
       WHEN 'session_activity_viewed' THEN activity_state IN ('empty', 'non_empty')
       WHEN 'session_message_sent' THEN
         submission_kind IN ('text', 'command')
         AND input_mode IN ('typed', 'voice_assisted')
-        AND (submission_kind != 'command' OR input_mode = 'typed')
       WHEN 'session_created_with_message' THEN
         submission_kind IN ('text', 'command')
         AND input_mode IN ('typed', 'voice_assisted')
-        AND (submission_kind != 'command' OR input_mode = 'typed')
         AND workspace_kind IN ('project', 'dedicated_worktree')
       WHEN 'session_creation_failed' THEN
         failure_reason IN ('not_authenticated', 'server_rejected', 'network_down', 'bad_response', 'unknown')
@@ -161,16 +227,30 @@ contract_checked AS (
         'session_diffs'
       )
       ELSE FALSE
-    END AS contract_valid
+    END AS bounded_enum_valid,
+    CASE
+      WHEN event_name = 'analytics_activation_ready' THEN activation_schema_version_raw = '1'
+      WHEN event_name IN ('session_message_sent', 'session_created_with_message') THEN
+        submission_kind != 'command' OR input_mode = 'typed'
+      ELSE TRUE
+    END AS parameter_semantics_valid
   FROM timestamped
+),
+contract_checked AS (
+  SELECT
+    *,
+    parameter_shape_valid
+      AND bounded_enum_valid
+      AND parameter_semantics_valid AS contract_valid
+  FROM value_checked
 ),
 deduplicated AS (
   SELECT
     *,
     ROW_NUMBER() OVER (
       PARTITION BY
+        user_pseudo_id,
         event_name,
-        source_export_date,
         event_timestamp,
         event_bundle_sequence_id,
         batch_event_index,
@@ -180,7 +260,7 @@ deduplicated AS (
         platform,
         app_version,
         app_build,
-        activation_schema_version,
+        activation_schema_version_raw,
         inventory_state,
         activity_state,
         submission_kind,
@@ -193,7 +273,10 @@ deduplicated AS (
         channel,
         method,
         os,
-        screen
+        screen,
+        parameter_shape_valid,
+        bounded_enum_valid,
+        parameter_semantics_valid
       ORDER BY event_timestamp
     ) AS duplicate_rank
   FROM contract_checked
@@ -226,7 +309,11 @@ SELECT
   platform,
   app_version,
   app_build,
-  IF(event_name = 'analytics_activation_ready', activation_schema_version, NULL) AS activation_schema_version,
+  IF(
+    event_name = 'analytics_activation_ready',
+    SAFE_CAST(activation_schema_version_raw AS INT64),
+    NULL
+  ) AS activation_schema_version,
   IF(event_name = 'project_inventory_loaded', inventory_state, NULL) AS inventory_state,
   IF(event_name = 'session_activity_viewed', activity_state, NULL) AS activity_state,
   IF(event_name IN ('session_message_sent', 'session_created_with_message'), submission_kind, NULL) AS submission_kind,
@@ -277,19 +364,16 @@ SELECT
   COUNTIF(duplicate_rank = 1 AND occurred_at > TIMESTAMP_ADD(emitted_at, INTERVAL 300 SECOND)) AS future_occurrence_rows,
   COUNTIF(
     duplicate_rank = 1
-    AND schema_version = 1
-    AND REGEXP_CONTAINS(user_key, r'^[a-f0-9]{64}$')
-    AND occurred_at IS NOT NULL
-    AND occurred_at <= TIMESTAMP_ADD(emitted_at, INTERVAL 300 SECOND)
-    AND contract_valid IS NOT TRUE
+    AND (
+      parameter_shape_valid IS NOT TRUE
+      OR parameter_semantics_valid IS NOT TRUE
+    )
   ) AS invalid_parameter_rows,
   COUNTIF(
     duplicate_rank = 1
-    AND schema_version = 1
-    AND REGEXP_CONTAINS(user_key, r'^[a-f0-9]{64}$')
-    AND occurred_at IS NOT NULL
-    AND occurred_at <= TIMESTAMP_ADD(emitted_at, INTERVAL 300 SECOND)
-    AND contract_valid IS NOT TRUE
+    AND parameter_shape_valid
+    AND parameter_semantics_valid
+    AND bounded_enum_valid IS NOT TRUE
   ) AS unknown_enum_rows,
   COUNTIF(duplicate_rank = 1 AND is_internal_excluded) AS internal_excluded_rows,
   COUNTIF(duplicate_rank = 1 AND is_deletion_excluded) AS deletion_excluded_rows,

--- a/tool/product_analytics/sql/10_events_flattened.sql
+++ b/tool/product_analytics/sql/10_events_flattened.sql
@@ -1,0 +1,434 @@
+-- BigQuery Standard SQL. Rebuild mutable GA4 daily exports plus any watermark gap.
+DECLARE raw_start_date DATE DEFAULT DATE(TIMESTAMP('{{RAW_EXPORT_START_AT}}'));
+DECLARE latest_available_source_date DATE DEFAULT (
+  SELECT MAX(PARSE_DATE('%Y%m%d', SUBSTR(table_name, 8)))
+  FROM `{{PROJECT_ID}}.{{RAW_DATASET_ID}}.INFORMATION_SCHEMA.TABLES`
+  WHERE table_type = 'BASE TABLE'
+    AND REGEXP_CONTAINS(table_name, r'^events_\d{8}$')
+);
+DECLARE scan_end_date DATE DEFAULT LEAST(
+  DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 1 DAY),
+  latest_available_source_date
+);
+DECLARE previous_source_end_date DATE DEFAULT (
+  SELECT source_end_date
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
+  WHERE model_name = 'events_flattened'
+  LIMIT 1
+);
+DECLARE scan_start_date DATE;
+DECLARE rows_inserted INT64 DEFAULT 0;
+
+SET scan_start_date = GREATEST(
+  raw_start_date,
+  IF(
+    previous_source_end_date IS NULL,
+    raw_start_date,
+    LEAST(
+      DATE_ADD(previous_source_end_date, INTERVAL 1 DAY),
+      DATE_SUB(scan_end_date, INTERVAL 2 DAY)
+    )
+  )
+);
+
+ASSERT scan_start_date <= scan_end_date
+  AS 'No complete GA4 daily export is available at or after raw_export_start_at';
+ASSERT previous_source_end_date IS NULL OR scan_end_date >= previous_source_end_date
+  AS 'The latest available GA4 daily export regressed behind the published watermark';
+ASSERT scan_start_date >= DATE_SUB(scan_end_date, INTERVAL 89 DAY)
+  AS 'The flattened-event watermark gap exceeds the recoverable 90-day raw window';
+
+-- Only approved scalar metadata is materialized. Bundle fields are transiently
+-- used for duplicate removal and never enter a curated table.
+CREATE TEMP TABLE candidate_stage AS
+WITH extracted AS (
+  SELECT
+    event_name,
+    PARSE_DATE('%Y%m%d', _TABLE_SUFFIX) AS source_export_date,
+    event_timestamp,
+    event_bundle_sequence_id,
+    batch_event_index,
+    platform,
+    app_info.version AS app_version,
+    (SELECT ANY_VALUE(COALESCE(value.string_value, CAST(value.int_value AS STRING))) FROM UNNEST(event_params) WHERE key = 'app_build') AS app_build,
+    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'user_key') AS user_key,
+    (SELECT ANY_VALUE(COALESCE(value.int_value, SAFE_CAST(value.string_value AS INT64))) FROM UNNEST(event_params) WHERE key = 'schema_version') AS schema_version,
+    (SELECT ANY_VALUE(COALESCE(value.int_value, SAFE_CAST(value.string_value AS INT64))) FROM UNNEST(event_params) WHERE key = 'occurred_at_micros') AS occurred_at_micros,
+    (SELECT ANY_VALUE(COALESCE(value.int_value, SAFE_CAST(value.string_value AS INT64))) FROM UNNEST(event_params) WHERE key = 'activation_schema_version') AS activation_schema_version,
+    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'inventory_state') AS inventory_state,
+    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'activity_state') AS activity_state,
+    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'submission_kind') AS submission_kind,
+    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'input_mode') AS input_mode,
+    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'workspace_kind') AS workspace_kind,
+    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'failure_reason') AS failure_reason,
+    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'decision') AS decision,
+    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'change_state') AS change_state,
+    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'surface') AS surface,
+    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'channel') AS channel,
+    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'method') AS method,
+    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'os') AS os,
+    (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'screen') AS screen
+  FROM `{{PROJECT_ID}}.{{RAW_DATASET_ID}}.events_*`
+  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d', scan_start_date) AND FORMAT_DATE('%Y%m%d', scan_end_date)
+    AND REGEXP_CONTAINS(_TABLE_SUFFIX, r'^\d{8}$')
+    AND event_timestamp >= UNIX_MICROS(TIMESTAMP('{{RAW_EXPORT_START_AT}}'))
+    AND event_name IN (
+      'analytics_schema_ready',
+      'analytics_activation_ready',
+      'project_inventory_loaded',
+      'session_activity_viewed',
+      'session_message_sent',
+      'session_created_with_message',
+      'session_creation_failed',
+      'voice_transcription_completed',
+      'session_question_answered',
+      'session_question_rejected',
+      'session_permission_answered',
+      'session_abort_succeeded',
+      'session_diff_viewed',
+      'onboarding_need_help_opened',
+      'onboarding_support_link_opened',
+      'onboarding_why_bridge_opened',
+      'bridge_install_command_copied',
+      'bridge_install_command_shared',
+      'bridge_run_command_copied',
+      'bridge_run_command_shared',
+      'product_screen_viewed'
+    )
+),
+timestamped AS (
+  SELECT
+    *,
+    TIMESTAMP_MICROS(event_timestamp) AS emitted_at,
+    CASE
+      WHEN occurred_at_micros BETWEEN
+        UNIX_MICROS(TIMESTAMP '0001-01-01 00:00:00+00') AND
+        UNIX_MICROS(TIMESTAMP '9999-12-31 23:59:59.999999+00')
+      THEN TIMESTAMP_MICROS(occurred_at_micros)
+    END AS occurred_at
+  FROM extracted
+),
+contract_checked AS (
+  SELECT
+    *,
+    CASE event_name
+      WHEN 'analytics_schema_ready' THEN TRUE
+      WHEN 'analytics_activation_ready' THEN activation_schema_version = 1
+      WHEN 'project_inventory_loaded' THEN inventory_state IN ('empty', 'non_empty')
+      WHEN 'session_activity_viewed' THEN activity_state IN ('empty', 'non_empty')
+      WHEN 'session_message_sent' THEN
+        submission_kind IN ('text', 'command')
+        AND input_mode IN ('typed', 'voice_assisted')
+        AND (submission_kind != 'command' OR input_mode = 'typed')
+      WHEN 'session_created_with_message' THEN
+        submission_kind IN ('text', 'command')
+        AND input_mode IN ('typed', 'voice_assisted')
+        AND (submission_kind != 'command' OR input_mode = 'typed')
+        AND workspace_kind IN ('project', 'dedicated_worktree')
+      WHEN 'session_creation_failed' THEN
+        failure_reason IN ('not_authenticated', 'server_rejected', 'network_down', 'bad_response', 'unknown')
+        AND workspace_kind IN ('project', 'dedicated_worktree')
+      WHEN 'voice_transcription_completed' THEN TRUE
+      WHEN 'session_question_answered' THEN TRUE
+      WHEN 'session_question_rejected' THEN TRUE
+      WHEN 'session_permission_answered' THEN decision IN ('once', 'always', 'reject')
+      WHEN 'session_abort_succeeded' THEN TRUE
+      WHEN 'session_diff_viewed' THEN change_state IN ('empty', 'non_empty')
+      WHEN 'onboarding_need_help_opened' THEN surface IN ('connect_setup', 'connected_empty', 'bridge_offline')
+      WHEN 'onboarding_support_link_opened' THEN
+        surface IN ('connect_setup', 'connected_empty', 'bridge_offline')
+        AND channel IN ('email', 'discord', 'x')
+      WHEN 'onboarding_why_bridge_opened' THEN surface IN ('connect_setup', 'connected_empty', 'bridge_offline')
+      WHEN 'bridge_install_command_copied' THEN
+        surface IN ('connect_setup', 'connected_empty', 'bridge_offline')
+        AND method IN ('curl', 'powershell', 'npm', 'bun')
+        AND os IN ('unix', 'windows')
+      WHEN 'bridge_install_command_shared' THEN
+        surface IN ('connect_setup', 'connected_empty', 'bridge_offline')
+        AND method IN ('curl', 'powershell', 'npm', 'bun')
+        AND os IN ('unix', 'windows')
+      WHEN 'bridge_run_command_copied' THEN surface IN ('connect_setup', 'connected_empty', 'bridge_offline')
+      WHEN 'bridge_run_command_shared' THEN surface IN ('connect_setup', 'connected_empty', 'bridge_offline')
+      WHEN 'product_screen_viewed' THEN screen IN (
+        'login',
+        'projects',
+        'settings',
+        'settings_notifications',
+        'settings_profile',
+        'sessions',
+        'new_session',
+        'session_detail',
+        'session_diffs'
+      )
+      ELSE FALSE
+    END AS contract_valid
+  FROM timestamped
+),
+deduplicated AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (
+      PARTITION BY
+        event_name,
+        source_export_date,
+        event_timestamp,
+        event_bundle_sequence_id,
+        batch_event_index,
+        user_key,
+        schema_version,
+        occurred_at_micros,
+        platform,
+        app_version,
+        app_build,
+        activation_schema_version,
+        inventory_state,
+        activity_state,
+        submission_kind,
+        input_mode,
+        workspace_kind,
+        failure_reason,
+        decision,
+        change_state,
+        surface,
+        channel,
+        method,
+        os,
+        screen
+      ORDER BY event_timestamp
+    ) AS duplicate_rank
+  FROM contract_checked
+),
+internal_keys AS (
+  SELECT DISTINCT user_key
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_internal_user_exclusions`
+),
+deleted_keys AS (
+  SELECT DISTINCT user_key
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions`
+)
+SELECT
+  source.*,
+  internal_keys.user_key IS NOT NULL AS is_internal_excluded,
+  deleted_keys.user_key IS NOT NULL AS is_deletion_excluded
+FROM deduplicated AS source
+LEFT JOIN internal_keys USING (user_key)
+LEFT JOIN deleted_keys USING (user_key);
+
+CREATE TEMP TABLE flattened_stage AS
+SELECT
+  event_name,
+  source_export_date,
+  emitted_at,
+  occurred_at_micros,
+  occurred_at,
+  schema_version,
+  user_key,
+  platform,
+  app_version,
+  app_build,
+  IF(event_name = 'analytics_activation_ready', activation_schema_version, NULL) AS activation_schema_version,
+  IF(event_name = 'project_inventory_loaded', inventory_state, NULL) AS inventory_state,
+  IF(event_name = 'session_activity_viewed', activity_state, NULL) AS activity_state,
+  IF(event_name IN ('session_message_sent', 'session_created_with_message'), submission_kind, NULL) AS submission_kind,
+  IF(event_name IN ('session_message_sent', 'session_created_with_message'), input_mode, NULL) AS input_mode,
+  IF(event_name IN ('session_created_with_message', 'session_creation_failed'), workspace_kind, NULL) AS workspace_kind,
+  IF(event_name = 'session_creation_failed', failure_reason, NULL) AS failure_reason,
+  IF(event_name = 'session_permission_answered', decision, NULL) AS decision,
+  IF(event_name = 'session_diff_viewed', change_state, NULL) AS change_state,
+  IF(
+    event_name IN (
+      'onboarding_need_help_opened',
+      'onboarding_support_link_opened',
+      'onboarding_why_bridge_opened',
+      'bridge_install_command_copied',
+      'bridge_install_command_shared',
+      'bridge_run_command_copied',
+      'bridge_run_command_shared'
+    ),
+    surface,
+    NULL
+  ) AS surface,
+  IF(event_name = 'onboarding_support_link_opened', channel, NULL) AS channel,
+  IF(event_name IN ('bridge_install_command_copied', 'bridge_install_command_shared'), method, NULL) AS method,
+  IF(event_name IN ('bridge_install_command_copied', 'bridge_install_command_shared'), os, NULL) AS os,
+  IF(event_name = 'product_screen_viewed', screen, NULL) AS screen
+FROM candidate_stage
+WHERE duplicate_rank = 1
+  AND schema_version = 1
+  AND REGEXP_CONTAINS(user_key, r'^[a-f0-9]{64}$')
+  AND occurred_at IS NOT NULL
+  -- Five minutes is the pinned client-clock allowance. Later occurrence is
+  -- rejected rather than silently replaced with Firebase emission time.
+  AND occurred_at <= TIMESTAMP_ADD(emitted_at, INTERVAL 300 SECOND)
+  AND contract_valid
+  AND NOT is_internal_excluded
+  AND NOT is_deletion_excluded;
+
+CREATE TEMP TABLE quality_stage AS
+SELECT
+  COUNT(*) AS source_rows,
+  COUNTIF(duplicate_rank = 1) AS deduplicated_rows,
+  (SELECT COUNT(*) FROM flattened_stage) AS published_rows,
+  COUNTIF(duplicate_rank = 1 AND user_key IS NULL) AS missing_identity_rows,
+  COUNTIF(duplicate_rank = 1 AND user_key IS NOT NULL AND NOT REGEXP_CONTAINS(user_key, r'^[a-f0-9]{64}$')) AS malformed_identity_rows,
+  COUNTIF(duplicate_rank = 1 AND schema_version IS NULL) AS missing_schema_rows,
+  COUNTIF(duplicate_rank = 1 AND schema_version IS NOT NULL AND schema_version != 1) AS unsupported_schema_rows,
+  COUNTIF(duplicate_rank = 1 AND occurred_at IS NULL) AS missing_occurrence_rows,
+  COUNTIF(duplicate_rank = 1 AND occurred_at > TIMESTAMP_ADD(emitted_at, INTERVAL 300 SECOND)) AS future_occurrence_rows,
+  COUNTIF(
+    duplicate_rank = 1
+    AND schema_version = 1
+    AND REGEXP_CONTAINS(user_key, r'^[a-f0-9]{64}$')
+    AND occurred_at IS NOT NULL
+    AND occurred_at <= TIMESTAMP_ADD(emitted_at, INTERVAL 300 SECOND)
+    AND contract_valid IS NOT TRUE
+  ) AS invalid_parameter_rows,
+  COUNTIF(
+    duplicate_rank = 1
+    AND schema_version = 1
+    AND REGEXP_CONTAINS(user_key, r'^[a-f0-9]{64}$')
+    AND occurred_at IS NOT NULL
+    AND occurred_at <= TIMESTAMP_ADD(emitted_at, INTERVAL 300 SECOND)
+    AND contract_valid IS NOT TRUE
+  ) AS unknown_enum_rows,
+  COUNTIF(duplicate_rank = 1 AND is_internal_excluded) AS internal_excluded_rows,
+  COUNTIF(duplicate_rank = 1 AND is_deletion_excluded) AS deletion_excluded_rows,
+  MAX(emitted_at) AS latest_emitted_at,
+  MAX(IF(occurred_at <= TIMESTAMP_ADD(emitted_at, INTERVAL 300 SECOND), occurred_at, NULL)) AS latest_occurred_at
+FROM candidate_stage;
+
+BEGIN TRANSACTION;
+
+-- The broad partition predicate lets a newly added permanent tombstone remove
+-- every retained keyed fact, not just the three mutable source dates.
+DELETE FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flattened`
+WHERE source_export_date >= raw_start_date
+  AND (
+    source_export_date BETWEEN scan_start_date AND scan_end_date
+    OR user_key IN (
+      SELECT user_key FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_internal_user_exclusions`
+    )
+    OR user_key IN (
+      SELECT user_key FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions`
+    )
+  );
+
+INSERT INTO `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flattened` (
+  event_name,
+  source_export_date,
+  emitted_at,
+  occurred_at_micros,
+  occurred_at,
+  schema_version,
+  user_key,
+  platform,
+  app_version,
+  app_build,
+  activation_schema_version,
+  inventory_state,
+  activity_state,
+  submission_kind,
+  input_mode,
+  workspace_kind,
+  failure_reason,
+  decision,
+  change_state,
+  surface,
+  channel,
+  method,
+  os,
+  screen
+)
+SELECT stage.*
+FROM flattened_stage AS stage
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_internal_user_exclusions` AS internal
+  WHERE internal.user_key = stage.user_key
+)
+AND NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions` AS deleted
+  WHERE deleted.user_key = stage.user_key
+);
+SET rows_inserted = @@row_count;
+
+MERGE `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state` AS target
+USING (
+  SELECT
+    'events_flattened' AS model_name,
+    quality.*
+  FROM quality_stage AS quality
+) AS source
+ON target.model_name = source.model_name
+WHEN MATCHED THEN UPDATE SET
+  source_start_date = scan_start_date,
+  source_end_date = scan_end_date,
+  completed_at = CURRENT_TIMESTAMP(),
+  auth_snapshot_published_at = NULL,
+  source_rows = source.source_rows,
+  deduplicated_rows = source.deduplicated_rows,
+  published_rows = rows_inserted,
+  missing_identity_rows = source.missing_identity_rows,
+  malformed_identity_rows = source.malformed_identity_rows,
+  missing_schema_rows = source.missing_schema_rows,
+  unsupported_schema_rows = source.unsupported_schema_rows,
+  missing_occurrence_rows = source.missing_occurrence_rows,
+  future_occurrence_rows = source.future_occurrence_rows,
+  before_account_rows = 0,
+  invalid_parameter_rows = source.invalid_parameter_rows,
+  unknown_enum_rows = source.unknown_enum_rows,
+  internal_excluded_rows = source.internal_excluded_rows,
+  deletion_excluded_rows = source.deletion_excluded_rows,
+  ineligible_user_rows = 0,
+  latest_emitted_at = source.latest_emitted_at,
+  latest_occurred_at = source.latest_occurred_at
+WHEN NOT MATCHED THEN INSERT (
+  model_name,
+  source_start_date,
+  source_end_date,
+  completed_at,
+  auth_snapshot_published_at,
+  source_rows,
+  deduplicated_rows,
+  published_rows,
+  missing_identity_rows,
+  malformed_identity_rows,
+  missing_schema_rows,
+  unsupported_schema_rows,
+  missing_occurrence_rows,
+  future_occurrence_rows,
+  before_account_rows,
+  invalid_parameter_rows,
+  unknown_enum_rows,
+  internal_excluded_rows,
+  deletion_excluded_rows,
+  ineligible_user_rows,
+  latest_emitted_at,
+  latest_occurred_at
+) VALUES (
+  source.model_name,
+  scan_start_date,
+  scan_end_date,
+  CURRENT_TIMESTAMP(),
+  NULL,
+  source.source_rows,
+  source.deduplicated_rows,
+  rows_inserted,
+  source.missing_identity_rows,
+  source.malformed_identity_rows,
+  source.missing_schema_rows,
+  source.unsupported_schema_rows,
+  source.missing_occurrence_rows,
+  source.future_occurrence_rows,
+  0,
+  source.invalid_parameter_rows,
+  source.unknown_enum_rows,
+  source.internal_excluded_rows,
+  source.deletion_excluded_rows,
+  0,
+  source.latest_emitted_at,
+  source.latest_occurred_at
+);
+
+COMMIT TRANSACTION;

--- a/tool/product_analytics/sql/15_installation_login_daily.sql
+++ b/tool/product_analytics/sql/15_installation_login_daily.sql
@@ -1,0 +1,198 @@
+-- BigQuery Standard SQL. This transform intentionally never reads or carries an
+-- installation identifier; its unit is an account-less login event count.
+DECLARE raw_start_date DATE DEFAULT DATE(TIMESTAMP('{{RAW_EXPORT_START_AT}}'));
+DECLARE latest_available_source_date DATE DEFAULT (
+  SELECT MAX(PARSE_DATE('%Y%m%d', SUBSTR(table_name, 8)))
+  FROM `{{PROJECT_ID}}.{{RAW_DATASET_ID}}.INFORMATION_SCHEMA.TABLES`
+  WHERE table_type = 'BASE TABLE'
+    AND REGEXP_CONTAINS(table_name, r'^events_\d{8}$')
+);
+DECLARE scan_end_date DATE DEFAULT LEAST(
+  DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 1 DAY),
+  latest_available_source_date
+);
+DECLARE previous_source_end_date DATE DEFAULT (
+  SELECT source_end_date
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
+  WHERE model_name = 'installation_login_daily'
+  LIMIT 1
+);
+DECLARE scan_start_date DATE;
+
+SET scan_start_date = GREATEST(
+  raw_start_date,
+  IF(
+    previous_source_end_date IS NULL,
+    raw_start_date,
+    LEAST(
+      DATE_ADD(previous_source_end_date, INTERVAL 1 DAY),
+      DATE_SUB(scan_end_date, INTERVAL 2 DAY)
+    )
+  )
+);
+
+ASSERT scan_start_date <= scan_end_date
+  AS 'No complete GA4 daily export is available at or after raw_export_start_at';
+ASSERT previous_source_end_date IS NULL OR scan_end_date >= previous_source_end_date
+  AS 'The latest available GA4 daily export regressed behind the published watermark';
+ASSERT scan_start_date >= DATE_SUB(scan_end_date, INTERVAL 89 DAY)
+  AS 'The login watermark gap exceeds the recoverable 90-day raw window';
+
+CREATE TEMP TABLE login_candidate_stage AS
+SELECT
+  PARSE_DATE('%Y%m%d', _TABLE_SUFFIX) AS source_export_date,
+  DATE(TIMESTAMP_MICROS(event_timestamp)) AS event_date,
+  TIMESTAMP_MICROS(event_timestamp) AS emitted_at,
+  event_name,
+  platform,
+  app_info.version AS app_version,
+  (SELECT ANY_VALUE(COALESCE(value.string_value, CAST(value.int_value AS STRING))) FROM UNNEST(event_params) WHERE key = 'app_build') AS app_build,
+  (SELECT ANY_VALUE(COALESCE(value.int_value, SAFE_CAST(value.string_value AS INT64))) FROM UNNEST(event_params) WHERE key = 'schema_version') AS schema_version,
+  (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'provider') AS provider,
+  (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'failure_kind') AS failure_kind
+FROM `{{PROJECT_ID}}.{{RAW_DATASET_ID}}.events_*`
+WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d', scan_start_date) AND FORMAT_DATE('%Y%m%d', scan_end_date)
+  AND REGEXP_CONTAINS(_TABLE_SUFFIX, r'^\d{8}$')
+  AND event_timestamp >= UNIX_MICROS(TIMESTAMP('{{RAW_EXPORT_START_AT}}'))
+  AND event_name IN ('login_attempt_started', 'login_attempt_completed', 'login_attempt_failed');
+
+CREATE TEMP TABLE login_stage AS
+SELECT
+  source_export_date,
+  event_date,
+  event_name,
+  schema_version,
+  platform,
+  app_version,
+  app_build,
+  provider,
+  IF(event_name = 'login_attempt_failed', failure_kind, NULL) AS failure_kind,
+  COUNT(*) AS event_count,
+  TRUE AS includes_internal_test_traffic,
+  CURRENT_TIMESTAMP() AS refreshed_at
+FROM login_candidate_stage
+WHERE schema_version = 1
+  AND provider IN ('github', 'google', 'apple', 'email')
+  AND (
+    (event_name IN ('login_attempt_started', 'login_attempt_completed') AND failure_kind IS NULL)
+    OR (event_name = 'login_attempt_failed' AND failure_kind IN ('authentication', 'launch', 'cancelled', 'timeout', 'unknown'))
+  )
+GROUP BY source_export_date, event_date, event_name, schema_version, platform, app_version, app_build, provider, failure_kind;
+
+CREATE TEMP TABLE quality_stage AS
+SELECT
+  COUNT(*) AS source_rows,
+  COALESCE((SELECT SUM(event_count) FROM login_stage), 0) AS published_rows,
+  COUNTIF(schema_version IS NULL) AS missing_schema_rows,
+  COUNTIF(schema_version IS NOT NULL AND schema_version != 1) AS unsupported_schema_rows,
+  COUNTIF(
+    schema_version = 1
+    AND COALESCE((
+      provider IN ('github', 'google', 'apple', 'email')
+      AND (
+        (event_name IN ('login_attempt_started', 'login_attempt_completed') AND failure_kind IS NULL)
+        OR (event_name = 'login_attempt_failed' AND failure_kind IN ('authentication', 'launch', 'cancelled', 'timeout', 'unknown'))
+      )
+    ), FALSE) = FALSE
+  ) AS invalid_parameter_rows,
+  MAX(emitted_at) AS latest_emitted_at
+FROM login_candidate_stage;
+
+BEGIN TRANSACTION;
+
+DELETE FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.installation_login_daily`
+WHERE source_export_date BETWEEN scan_start_date AND scan_end_date;
+
+INSERT INTO `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.installation_login_daily` (
+  source_export_date,
+  event_date,
+  event_name,
+  schema_version,
+  platform,
+  app_version,
+  app_build,
+  provider,
+  failure_kind,
+  event_count,
+  includes_internal_test_traffic,
+  refreshed_at
+)
+SELECT * FROM login_stage;
+
+MERGE `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state` AS target
+USING (
+  SELECT 'installation_login_daily' AS model_name, quality.*
+  FROM quality_stage AS quality
+) AS source
+ON target.model_name = source.model_name
+WHEN MATCHED THEN UPDATE SET
+  source_start_date = scan_start_date,
+  source_end_date = scan_end_date,
+  completed_at = CURRENT_TIMESTAMP(),
+  auth_snapshot_published_at = NULL,
+  source_rows = source.source_rows,
+  deduplicated_rows = source.source_rows,
+  published_rows = source.published_rows,
+  missing_identity_rows = 0,
+  malformed_identity_rows = 0,
+  missing_schema_rows = source.missing_schema_rows,
+  unsupported_schema_rows = source.unsupported_schema_rows,
+  missing_occurrence_rows = 0,
+  future_occurrence_rows = 0,
+  before_account_rows = 0,
+  invalid_parameter_rows = source.invalid_parameter_rows,
+  unknown_enum_rows = source.invalid_parameter_rows,
+  internal_excluded_rows = 0,
+  deletion_excluded_rows = 0,
+  ineligible_user_rows = 0,
+  latest_emitted_at = source.latest_emitted_at,
+  latest_occurred_at = NULL
+WHEN NOT MATCHED THEN INSERT (
+  model_name,
+  source_start_date,
+  source_end_date,
+  completed_at,
+  auth_snapshot_published_at,
+  source_rows,
+  deduplicated_rows,
+  published_rows,
+  missing_identity_rows,
+  malformed_identity_rows,
+  missing_schema_rows,
+  unsupported_schema_rows,
+  missing_occurrence_rows,
+  future_occurrence_rows,
+  before_account_rows,
+  invalid_parameter_rows,
+  unknown_enum_rows,
+  internal_excluded_rows,
+  deletion_excluded_rows,
+  ineligible_user_rows,
+  latest_emitted_at,
+  latest_occurred_at
+) VALUES (
+  source.model_name,
+  scan_start_date,
+  scan_end_date,
+  CURRENT_TIMESTAMP(),
+  NULL,
+  source.source_rows,
+  source.source_rows,
+  source.published_rows,
+  0,
+  0,
+  source.missing_schema_rows,
+  source.unsupported_schema_rows,
+  0,
+  0,
+  0,
+  source.invalid_parameter_rows,
+  source.invalid_parameter_rows,
+  0,
+  0,
+  0,
+  source.latest_emitted_at,
+  NULL
+);
+
+COMMIT TRANSACTION;

--- a/tool/product_analytics/sql/15_installation_login_daily.sql
+++ b/tool/product_analytics/sql/15_installation_login_daily.sql
@@ -17,6 +17,12 @@ DECLARE previous_source_end_date DATE DEFAULT (
   WHERE model_name = 'installation_login_daily'
   LIMIT 1
 );
+DECLARE previous_completed_at TIMESTAMP DEFAULT (
+  SELECT completed_at
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
+  WHERE model_name = 'installation_login_daily'
+  LIMIT 1
+);
 DECLARE scan_start_date DATE;
 
 SET scan_start_date = GREATEST(
@@ -69,7 +75,6 @@ parameterized AS (
     raw.* EXCEPT (event_params),
     (
       SELECT AS STRUCT
-        MAX(IF(parameter.key = 'app_build', COALESCE(parameter.value.string_value, CAST(parameter.value.int_value AS STRING)), NULL)) AS app_build,
         MAX(IF(parameter.key = 'schema_version', parameter.value.int_value, NULL)) AS schema_version,
         MAX(IF(parameter.key = 'provider', parameter.value.string_value, NULL)) AS provider,
         MAX(IF(parameter.key = 'failure_kind', parameter.value.string_value, NULL)) AS failure_kind,
@@ -129,7 +134,6 @@ deduplicated AS (
         schema_version,
         platform,
         app_version,
-        app_build,
         provider,
         failure_kind,
         parameter_shape_valid,
@@ -149,7 +153,6 @@ SELECT
   schema_version,
   platform,
   app_version,
-  app_build,
   provider,
   IF(event_name = 'login_attempt_failed', failure_kind, NULL) AS failure_kind,
   COUNT(*) AS event_count,
@@ -161,7 +164,7 @@ WHERE duplicate_rank = 1
   AND parameter_shape_valid
   AND parameter_semantics_valid
   AND bounded_enum_valid
-GROUP BY source_export_date, event_date, event_name, schema_version, platform, app_version, app_build, provider, failure_kind;
+GROUP BY source_export_date, event_date, event_name, schema_version, platform, app_version, provider, failure_kind;
 
 CREATE TEMP TABLE quality_stage AS
 SELECT
@@ -186,6 +189,18 @@ SELECT
   MAX(emitted_at) AS latest_emitted_at
 FROM login_candidate_stage;
 
+ASSERT previous_source_end_date IS NOT DISTINCT FROM (
+  SELECT source_end_date
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
+  WHERE model_name = 'installation_login_daily'
+  LIMIT 1
+) AND previous_completed_at IS NOT DISTINCT FROM (
+  SELECT completed_at
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
+  WHERE model_name = 'installation_login_daily'
+  LIMIT 1
+) AS 'installation_login_daily state changed while the transform was staged';
+
 BEGIN TRANSACTION;
 
 DELETE FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.installation_login_daily`
@@ -198,7 +213,6 @@ INSERT INTO `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.installation_login_daily` (
   schema_version,
   platform,
   app_version,
-  app_build,
   provider,
   failure_kind,
   event_count,
@@ -213,7 +227,10 @@ USING (
   FROM quality_stage AS quality
 ) AS source
 ON target.model_name = source.model_name
-WHEN MATCHED THEN UPDATE SET
+WHEN MATCHED
+  AND target.source_end_date IS NOT DISTINCT FROM previous_source_end_date
+  AND target.completed_at IS NOT DISTINCT FROM previous_completed_at
+THEN UPDATE SET
   source_start_date = scan_start_date,
   source_end_date = scan_end_date,
   completed_at = CURRENT_TIMESTAMP(),
@@ -282,5 +299,7 @@ WHEN NOT MATCHED THEN INSERT (
   source.latest_emitted_at,
   NULL
 );
+ASSERT @@row_count = 1
+  AS 'installation_login_daily state changed before watermark publication';
 
 COMMIT TRANSACTION;

--- a/tool/product_analytics/sql/15_installation_login_daily.sql
+++ b/tool/product_analytics/sql/15_installation_login_daily.sql
@@ -1,7 +1,7 @@
--- BigQuery Standard SQL. This transform intentionally never reads or carries an
--- installation identifier; its unit is an account-less login event count.
+-- BigQuery Standard SQL. user_pseudo_id is used only as transient duplicate
+-- identity; no installation identifier is persisted or grouped.
 DECLARE raw_start_date DATE DEFAULT DATE(TIMESTAMP('{{RAW_EXPORT_START_AT}}'));
-DECLARE latest_available_source_date DATE DEFAULT (
+DECLARE latest_available_suffix_date DATE DEFAULT (
   SELECT MAX(PARSE_DATE('%Y%m%d', SUBSTR(table_name, 8)))
   FROM `{{PROJECT_ID}}.{{RAW_DATASET_ID}}.INFORMATION_SCHEMA.TABLES`
   WHERE table_type = 'BASE TABLE'
@@ -9,7 +9,7 @@ DECLARE latest_available_source_date DATE DEFAULT (
 );
 DECLARE scan_end_date DATE DEFAULT LEAST(
   DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 1 DAY),
-  latest_available_source_date
+  DATE_SUB(latest_available_suffix_date, INTERVAL 1 DAY)
 );
 DECLARE previous_source_end_date DATE DEFAULT (
   SELECT source_end_date
@@ -39,22 +39,107 @@ ASSERT scan_start_date >= DATE_SUB(scan_end_date, INTERVAL 89 DAY)
   AS 'The login watermark gap exceeds the recoverable 90-day raw window';
 
 CREATE TEMP TABLE login_candidate_stage AS
-SELECT
-  PARSE_DATE('%Y%m%d', _TABLE_SUFFIX) AS source_export_date,
-  DATE(TIMESTAMP_MICROS(event_timestamp)) AS event_date,
-  TIMESTAMP_MICROS(event_timestamp) AS emitted_at,
-  event_name,
-  platform,
-  app_info.version AS app_version,
-  (SELECT ANY_VALUE(COALESCE(value.string_value, CAST(value.int_value AS STRING))) FROM UNNEST(event_params) WHERE key = 'app_build') AS app_build,
-  (SELECT ANY_VALUE(COALESCE(value.int_value, SAFE_CAST(value.string_value AS INT64))) FROM UNNEST(event_params) WHERE key = 'schema_version') AS schema_version,
-  (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'provider') AS provider,
-  (SELECT ANY_VALUE(value.string_value) FROM UNNEST(event_params) WHERE key = 'failure_kind') AS failure_kind
-FROM `{{PROJECT_ID}}.{{RAW_DATASET_ID}}.events_*`
-WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d', scan_start_date) AND FORMAT_DATE('%Y%m%d', scan_end_date)
-  AND REGEXP_CONTAINS(_TABLE_SUFFIX, r'^\d{8}$')
-  AND event_timestamp >= UNIX_MICROS(TIMESTAMP('{{RAW_EXPORT_START_AT}}'))
-  AND event_name IN ('login_attempt_started', 'login_attempt_completed', 'login_attempt_failed');
+WITH raw_events AS (
+  SELECT
+    DATE(TIMESTAMP_MICROS(event_timestamp)) AS source_export_date,
+    DATE(TIMESTAMP_MICROS(event_timestamp)) AS event_date,
+    TIMESTAMP_MICROS(event_timestamp) AS emitted_at,
+    event_timestamp,
+    user_pseudo_id,
+    event_bundle_sequence_id,
+    batch_event_index,
+    event_name,
+    platform,
+    app_info.version AS app_version,
+    event_params,
+    CASE
+      WHEN event_name = 'login_attempt_failed' THEN ['schema_version', 'provider', 'failure_kind']
+      ELSE ['schema_version', 'provider']
+    END AS required_parameter_names
+  FROM `{{PROJECT_ID}}.{{RAW_DATASET_ID}}.events_*`
+  WHERE _TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d', DATE_SUB(scan_start_date, INTERVAL 1 DAY))
+    AND FORMAT_DATE('%Y%m%d', DATE_ADD(scan_end_date, INTERVAL 1 DAY))
+    AND REGEXP_CONTAINS(_TABLE_SUFFIX, r'^\d{8}$')
+    AND event_timestamp >= UNIX_MICROS(TIMESTAMP('{{RAW_EXPORT_START_AT}}'))
+    AND DATE(TIMESTAMP_MICROS(event_timestamp)) BETWEEN scan_start_date AND scan_end_date
+    AND event_name IN ('login_attempt_started', 'login_attempt_completed', 'login_attempt_failed')
+),
+parameterized AS (
+  SELECT
+    raw.* EXCEPT (event_params),
+    (
+      SELECT AS STRUCT
+        MAX(IF(parameter.key = 'app_build', COALESCE(parameter.value.string_value, CAST(parameter.value.int_value AS STRING)), NULL)) AS app_build,
+        MAX(IF(parameter.key = 'schema_version', parameter.value.int_value, NULL)) AS schema_version,
+        MAX(IF(parameter.key = 'provider', parameter.value.string_value, NULL)) AS provider,
+        MAX(IF(parameter.key = 'failure_kind', parameter.value.string_value, NULL)) AS failure_kind,
+        COUNTIF(parameter.key = 'failure_kind') AS failure_kind_parameter_count,
+        COUNTIF(parameter.key IN UNNEST(raw.required_parameter_names)) AS required_parameter_count,
+        COUNT(DISTINCT IF(parameter.key IN UNNEST(raw.required_parameter_names), parameter.key, NULL)) AS distinct_required_parameter_count,
+        COUNTIF(
+          parameter.key IN UNNEST(raw.required_parameter_names)
+          AND (
+            (
+              parameter.key = 'schema_version'
+              AND parameter.value.int_value IS NOT NULL
+              AND parameter.value.string_value IS NULL
+              AND parameter.value.float_value IS NULL
+              AND parameter.value.double_value IS NULL
+            )
+            OR (
+              parameter.key != 'schema_version'
+              AND parameter.value.string_value IS NOT NULL
+              AND parameter.value.int_value IS NULL
+              AND parameter.value.float_value IS NULL
+              AND parameter.value.double_value IS NULL
+            )
+          )
+        ) AS correctly_typed_required_parameter_count
+      FROM UNNEST(raw.event_params) AS parameter
+    ) AS parameters
+  FROM raw_events AS raw
+),
+contract_checked AS (
+  SELECT
+    parameterized.* EXCEPT (parameters),
+    parameters.*,
+    parameters.required_parameter_count = ARRAY_LENGTH(required_parameter_names)
+      AND parameters.distinct_required_parameter_count = ARRAY_LENGTH(required_parameter_names)
+      AND parameters.correctly_typed_required_parameter_count = ARRAY_LENGTH(required_parameter_names)
+      AS parameter_shape_valid,
+    event_name = 'login_attempt_failed' OR parameters.failure_kind_parameter_count = 0
+      AS parameter_semantics_valid,
+    parameters.provider IN ('github', 'google', 'apple', 'email')
+      AND (
+        event_name != 'login_attempt_failed'
+        OR parameters.failure_kind IN ('authentication', 'launch', 'cancelled', 'timeout', 'unknown')
+      ) AS bounded_enum_valid
+  FROM parameterized
+),
+deduplicated AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (
+      PARTITION BY
+        user_pseudo_id,
+        event_name,
+        event_timestamp,
+        event_bundle_sequence_id,
+        batch_event_index,
+        schema_version,
+        platform,
+        app_version,
+        app_build,
+        provider,
+        failure_kind,
+        parameter_shape_valid,
+        parameter_semantics_valid,
+        bounded_enum_valid
+      ORDER BY event_timestamp
+    ) AS duplicate_rank
+  FROM contract_checked
+)
+SELECT * FROM deduplicated;
 
 CREATE TEMP TABLE login_stage AS
 SELECT
@@ -71,30 +156,33 @@ SELECT
   TRUE AS includes_internal_test_traffic,
   CURRENT_TIMESTAMP() AS refreshed_at
 FROM login_candidate_stage
-WHERE schema_version = 1
-  AND provider IN ('github', 'google', 'apple', 'email')
-  AND (
-    (event_name IN ('login_attempt_started', 'login_attempt_completed') AND failure_kind IS NULL)
-    OR (event_name = 'login_attempt_failed' AND failure_kind IN ('authentication', 'launch', 'cancelled', 'timeout', 'unknown'))
-  )
+WHERE duplicate_rank = 1
+  AND schema_version = 1
+  AND parameter_shape_valid
+  AND parameter_semantics_valid
+  AND bounded_enum_valid
 GROUP BY source_export_date, event_date, event_name, schema_version, platform, app_version, app_build, provider, failure_kind;
 
 CREATE TEMP TABLE quality_stage AS
 SELECT
   COUNT(*) AS source_rows,
+  COUNTIF(duplicate_rank = 1) AS deduplicated_rows,
   COALESCE((SELECT SUM(event_count) FROM login_stage), 0) AS published_rows,
-  COUNTIF(schema_version IS NULL) AS missing_schema_rows,
-  COUNTIF(schema_version IS NOT NULL AND schema_version != 1) AS unsupported_schema_rows,
+  COUNTIF(duplicate_rank = 1 AND schema_version IS NULL) AS missing_schema_rows,
+  COUNTIF(duplicate_rank = 1 AND schema_version IS NOT NULL AND schema_version != 1) AS unsupported_schema_rows,
   COUNTIF(
-    schema_version = 1
-    AND COALESCE((
-      provider IN ('github', 'google', 'apple', 'email')
-      AND (
-        (event_name IN ('login_attempt_started', 'login_attempt_completed') AND failure_kind IS NULL)
-        OR (event_name = 'login_attempt_failed' AND failure_kind IN ('authentication', 'launch', 'cancelled', 'timeout', 'unknown'))
-      )
-    ), FALSE) = FALSE
+    duplicate_rank = 1
+    AND (
+      parameter_shape_valid IS NOT TRUE
+      OR parameter_semantics_valid IS NOT TRUE
+    )
   ) AS invalid_parameter_rows,
+  COUNTIF(
+    duplicate_rank = 1
+    AND parameter_shape_valid
+    AND parameter_semantics_valid
+    AND bounded_enum_valid IS NOT TRUE
+  ) AS unknown_enum_rows,
   MAX(emitted_at) AS latest_emitted_at
 FROM login_candidate_stage;
 
@@ -131,7 +219,7 @@ WHEN MATCHED THEN UPDATE SET
   completed_at = CURRENT_TIMESTAMP(),
   auth_snapshot_published_at = NULL,
   source_rows = source.source_rows,
-  deduplicated_rows = source.source_rows,
+  deduplicated_rows = source.deduplicated_rows,
   published_rows = source.published_rows,
   missing_identity_rows = 0,
   malformed_identity_rows = 0,
@@ -141,7 +229,7 @@ WHEN MATCHED THEN UPDATE SET
   future_occurrence_rows = 0,
   before_account_rows = 0,
   invalid_parameter_rows = source.invalid_parameter_rows,
-  unknown_enum_rows = source.invalid_parameter_rows,
+  unknown_enum_rows = source.unknown_enum_rows,
   internal_excluded_rows = 0,
   deletion_excluded_rows = 0,
   ineligible_user_rows = 0,
@@ -177,7 +265,7 @@ WHEN NOT MATCHED THEN INSERT (
   CURRENT_TIMESTAMP(),
   NULL,
   source.source_rows,
-  source.source_rows,
+  source.deduplicated_rows,
   source.published_rows,
   0,
   0,
@@ -187,7 +275,7 @@ WHEN NOT MATCHED THEN INSERT (
   0,
   0,
   source.invalid_parameter_rows,
-  source.invalid_parameter_rows,
+  source.unknown_enum_rows,
   0,
   0,
   0,

--- a/tool/product_analytics/sql/20_user_activity_daily.sql
+++ b/tool/product_analytics/sql/20_user_activity_daily.sql
@@ -24,6 +24,7 @@ DECLARE events_completed_at TIMESTAMP;
 DECLARE retained_start_date DATE;
 DECLARE deletion_exclusion_count INT64;
 DECLARE deletion_exclusion_max_updated_at TIMESTAMP;
+DECLARE keyed_publication_epoch INT64;
 DECLARE rows_inserted INT64 DEFAULT 0;
 
 SET measurement_config = (
@@ -112,6 +113,13 @@ SET (deletion_exclusion_count, deletion_exclusion_max_updated_at) = (
   SELECT AS STRUCT COUNT(*), MAX(updated_at)
   FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions`
 );
+SET keyed_publication_epoch = (
+  SELECT publication_epoch
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.keyed_publication_guard`
+  WHERE guard_key = 'singleton'
+);
+ASSERT keyed_publication_epoch IS NOT NULL
+  AS 'The keyed publication guard singleton is required';
 
 CREATE TEMP TABLE gated_event_stage AS
 WITH internal_keys AS (
@@ -279,6 +287,14 @@ ASSERT deletion_exclusion_count = (
 ) AS 'Permanent deletion exclusions changed while user activity was staged';
 
 BEGIN TRANSACTION;
+
+UPDATE `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.keyed_publication_guard`
+SET publication_epoch = publication_epoch + 1,
+    updated_at = CURRENT_TIMESTAMP()
+WHERE guard_key = 'singleton'
+  AND publication_epoch = keyed_publication_epoch;
+ASSERT @@row_count = 1
+  AS 'A tombstone or keyed publication changed while user activity was staged';
 
 DELETE FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.user_activity_daily`
 WHERE activity_date >= DATE '0001-01-01';

--- a/tool/product_analytics/sql/20_user_activity_daily.sql
+++ b/tool/product_analytics/sql/20_user_activity_daily.sql
@@ -1,0 +1,369 @@
+-- BigQuery Standard SQL. A stale or unreconciled auth snapshot aborts before
+-- any mutation, leaving the previous published activity table intact.
+DECLARE latest_auth_run STRUCT<
+  published_at TIMESTAMP,
+  run_cutoff TIMESTAMP,
+  control_updated_at TIMESTAMP,
+  users_scanned INT64,
+  source_suppressed_users INT64,
+  internal_users INT64,
+  external_accounts INT64,
+  enabled_accounts INT64,
+  opted_out_accounts INT64,
+  preference_after_cutoff_accounts INT64,
+  late_preference_rows_removed INT64,
+  milestone_rows_published INT64,
+  cohort_rows_published INT64
+>;
+DECLARE events_source_end_date DATE;
+DECLARE retained_start_date DATE;
+DECLARE rows_inserted INT64 DEFAULT 0;
+
+SET latest_auth_run = (
+  SELECT AS STRUCT
+    published_at,
+    run_cutoff,
+    control_updated_at,
+    users_scanned,
+    source_suppressed_users,
+    internal_users,
+    external_accounts,
+    enabled_accounts,
+    opted_out_accounts,
+    preference_after_cutoff_accounts,
+    late_preference_rows_removed,
+    milestone_rows_published,
+    cohort_rows_published
+  FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.product_analytics_export_runs`
+  ORDER BY published_at DESC, run_cutoff DESC
+  LIMIT 1
+);
+
+ASSERT latest_auth_run IS NOT NULL AS 'A successful auth snapshot is required';
+ASSERT latest_auth_run.published_at BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 36 HOUR)
+  AND TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 300 SECOND)
+  AS 'The latest auth snapshot is stale or future-dated';
+ASSERT latest_auth_run.run_cutoff BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 36 HOUR)
+  AND latest_auth_run.published_at
+  AS 'The latest auth snapshot source cutoff is stale or later than publication';
+ASSERT latest_auth_run.users_scanned =
+  latest_auth_run.source_suppressed_users + latest_auth_run.internal_users + latest_auth_run.external_accounts
+  AS 'Auth source/exclusion reconciliation failed';
+ASSERT latest_auth_run.external_accounts =
+  latest_auth_run.enabled_accounts
+  + latest_auth_run.opted_out_accounts
+  + latest_auth_run.preference_after_cutoff_accounts
+  + latest_auth_run.late_preference_rows_removed
+  AS 'Auth preference reconciliation failed';
+ASSERT latest_auth_run.milestone_rows_published = latest_auth_run.enabled_accounts
+  AS 'Auth milestone metadata reconciliation failed';
+ASSERT (
+  SELECT COUNT(*) FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_user_milestones`
+) = latest_auth_run.enabled_accounts
+  AS 'Current auth milestone snapshot does not match successful-run metadata';
+ASSERT (
+  SELECT COALESCE(SUM(total_accounts), 0)
+  FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_weekly_setup_cohorts`
+) = latest_auth_run.external_accounts
+  AS 'Auth setup cohort total does not reconcile';
+ASSERT (
+  SELECT COALESCE(SUM(enabled_accounts), 0)
+  FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_weekly_setup_cohorts`
+) = latest_auth_run.enabled_accounts
+  AS 'Auth setup cohort preference coverage does not reconcile';
+ASSERT (
+  SELECT COUNT(*) FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_weekly_setup_cohorts`
+) = latest_auth_run.cohort_rows_published
+  AS 'Auth setup cohort row count does not reconcile';
+ASSERT latest_auth_run.control_updated_at = (
+  SELECT control_updated_at
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.internal_exclusion_control_state`
+  WHERE state_key = 'singleton'
+)
+  AS 'Auth snapshot predates the current permanent internal exclusion control';
+
+SET events_source_end_date = (
+  SELECT source_end_date
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
+  WHERE model_name = 'events_flattened'
+  LIMIT 1
+);
+ASSERT events_source_end_date IS NOT NULL AS 'events_flattened has no successful watermark';
+SET retained_start_date = GREATEST(
+  DATE(TIMESTAMP('{{RAW_EXPORT_START_AT}}')),
+  DATE_SUB(events_source_end_date, INTERVAL 425 DAY)
+);
+
+CREATE TEMP TABLE gated_event_stage AS
+WITH internal_keys AS (
+  SELECT DISTINCT user_key
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_internal_user_exclusions`
+),
+deleted_keys AS (
+  SELECT DISTINCT user_key
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions`
+)
+SELECT
+  event.*,
+  auth.account_created_at,
+  auth.user_key IS NOT NULL AS is_currently_eligible,
+  internal_keys.user_key IS NOT NULL AS is_internal_excluded,
+  deleted_keys.user_key IS NOT NULL AS is_deletion_excluded
+FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flattened` AS event
+LEFT JOIN `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_user_milestones` AS auth USING (user_key)
+LEFT JOIN internal_keys USING (user_key)
+LEFT JOIN deleted_keys USING (user_key)
+WHERE event.source_export_date BETWEEN retained_start_date AND events_source_end_date;
+
+CREATE TEMP TABLE eligible_event_stage AS
+SELECT *
+FROM gated_event_stage
+WHERE is_currently_eligible
+  AND NOT is_internal_excluded
+  AND NOT is_deletion_excluded
+  AND schema_version = 1
+  AND occurred_at >= TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
+  AND occurred_at <= TIMESTAMP_ADD(emitted_at, INTERVAL 300 SECOND)
+  AND DATE(occurred_at) <= events_source_end_date;
+
+CREATE TEMP TABLE activity_stage AS
+WITH counts AS (
+  SELECT
+    DATE(occurred_at) AS activity_date,
+    user_key,
+    COUNTIF(event_name = 'session_activity_viewed' AND activity_state = 'non_empty') AS monitor_event_count,
+    COUNTIF(event_name IN (
+      'session_message_sent',
+      'session_created_with_message',
+      'session_question_answered',
+      'session_question_rejected',
+      'session_permission_answered',
+      'session_abort_succeeded'
+    )) AS control_event_count,
+    COUNTIF(event_name IN ('session_message_sent', 'session_created_with_message')) AS message_event_count,
+    COUNTIF(
+      event_name IN ('session_message_sent', 'session_created_with_message')
+      AND input_mode = 'voice_assisted'
+    ) AS voice_assisted_message_count,
+    COUNTIF(event_name = 'voice_transcription_completed') AS voice_transcription_count,
+    COUNTIF(event_name = 'project_inventory_loaded' AND inventory_state = 'non_empty') AS project_available_count,
+    COUNTIF(event_name = 'session_created_with_message') AS remote_created_session_count,
+    COUNTIF(
+      event_name = 'session_created_with_message' AND workspace_kind = 'dedicated_worktree'
+    ) AS dedicated_worktree_creation_count,
+    COUNTIF(event_name = 'session_creation_failed') AS session_creation_failure_count,
+    COUNTIF(event_name = 'session_question_answered') AS question_answer_count,
+    COUNTIF(event_name = 'session_question_rejected') AS question_rejection_count,
+    COUNTIF(event_name = 'session_permission_answered') AS permission_answer_count,
+    COUNTIF(event_name = 'session_abort_succeeded') AS abort_count,
+    COUNTIF(event_name = 'session_diff_viewed' AND change_state = 'non_empty') AS non_empty_diff_view_count,
+    COUNTIF(event_name = 'product_screen_viewed') AS screen_view_count,
+    COUNTIF(event_name IN (
+      'onboarding_need_help_opened',
+      'onboarding_support_link_opened',
+      'onboarding_why_bridge_opened',
+      'bridge_install_command_copied',
+      'bridge_install_command_shared',
+      'bridge_run_command_copied',
+      'bridge_run_command_shared'
+    )) AS onboarding_interaction_count,
+    MIN(IF(
+      (event_name = 'session_activity_viewed' AND activity_state = 'non_empty')
+      OR event_name IN (
+        'session_message_sent',
+        'session_created_with_message',
+        'session_question_answered',
+        'session_question_rejected',
+        'session_permission_answered',
+        'session_abort_succeeded'
+      ),
+      occurred_at,
+      NULL
+    )) AS first_meaningful_at,
+    MAX(IF(
+      (event_name = 'session_activity_viewed' AND activity_state = 'non_empty')
+      OR event_name IN (
+        'session_message_sent',
+        'session_created_with_message',
+        'session_question_answered',
+        'session_question_rejected',
+        'session_permission_answered',
+        'session_abort_succeeded'
+      ),
+      occurred_at,
+      NULL
+    )) AS last_meaningful_at
+  FROM eligible_event_stage
+  GROUP BY activity_date, user_key
+)
+SELECT
+  activity_date,
+  user_key,
+  monitor_event_count + control_event_count > 0 AS meaningful_activity,
+  control_event_count > 0 AS controller_activity,
+  monitor_event_count,
+  control_event_count,
+  message_event_count,
+  voice_assisted_message_count,
+  voice_transcription_count,
+  project_available_count,
+  remote_created_session_count,
+  dedicated_worktree_creation_count,
+  session_creation_failure_count,
+  question_answer_count,
+  question_rejection_count,
+  permission_answer_count,
+  abort_count,
+  non_empty_diff_view_count,
+  screen_view_count,
+  onboarding_interaction_count,
+  first_meaningful_at,
+  last_meaningful_at,
+  CURRENT_TIMESTAMP() AS refreshed_at
+FROM counts;
+
+CREATE TEMP TABLE quality_stage AS
+SELECT
+  (SELECT COUNT(*) FROM gated_event_stage) AS source_rows,
+  (SELECT COUNT(*) FROM activity_stage) AS published_rows,
+  (SELECT COUNTIF(occurred_at < TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND))
+   FROM gated_event_stage WHERE is_currently_eligible) AS before_account_rows,
+  (SELECT COUNTIF(NOT is_currently_eligible) FROM gated_event_stage) AS ineligible_user_rows,
+  (SELECT COUNTIF(is_internal_excluded) FROM gated_event_stage) AS internal_excluded_rows,
+  (SELECT COUNTIF(is_deletion_excluded) FROM gated_event_stage) AS deletion_excluded_rows,
+  (SELECT MAX(emitted_at) FROM eligible_event_stage) AS latest_emitted_at,
+  (SELECT MAX(occurred_at) FROM eligible_event_stage) AS latest_occurred_at;
+
+ASSERT latest_auth_run.published_at = (
+  SELECT MAX(published_at)
+  FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.product_analytics_export_runs`
+) AS 'Auth snapshot changed while user activity was staged';
+ASSERT latest_auth_run.control_updated_at = (
+  SELECT control_updated_at
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.internal_exclusion_control_state`
+  WHERE state_key = 'singleton'
+) AS 'Internal exclusion control changed while user activity was staged';
+
+BEGIN TRANSACTION;
+
+DELETE FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.user_activity_daily`
+WHERE activity_date >= DATE '0001-01-01';
+
+INSERT INTO `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.user_activity_daily` (
+  activity_date,
+  user_key,
+  meaningful_activity,
+  controller_activity,
+  monitor_event_count,
+  control_event_count,
+  message_event_count,
+  voice_assisted_message_count,
+  voice_transcription_count,
+  project_available_count,
+  remote_created_session_count,
+  dedicated_worktree_creation_count,
+  session_creation_failure_count,
+  question_answer_count,
+  question_rejection_count,
+  permission_answer_count,
+  abort_count,
+  non_empty_diff_view_count,
+  screen_view_count,
+  onboarding_interaction_count,
+  first_meaningful_at,
+  last_meaningful_at,
+  refreshed_at
+)
+SELECT stage.*
+FROM activity_stage AS stage
+WHERE EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_user_milestones` AS auth
+  WHERE auth.user_key = stage.user_key
+)
+AND NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_internal_user_exclusions` AS internal
+  WHERE internal.user_key = stage.user_key
+)
+AND NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions` AS deleted
+  WHERE deleted.user_key = stage.user_key
+);
+SET rows_inserted = @@row_count;
+
+MERGE `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state` AS target
+USING (SELECT 'user_activity_daily' AS model_name, quality.* FROM quality_stage AS quality) AS source
+ON target.model_name = source.model_name
+WHEN MATCHED THEN UPDATE SET
+  source_start_date = retained_start_date,
+  source_end_date = events_source_end_date,
+  completed_at = CURRENT_TIMESTAMP(),
+  auth_snapshot_published_at = latest_auth_run.published_at,
+  source_rows = source.source_rows,
+  deduplicated_rows = source.source_rows,
+  published_rows = rows_inserted,
+  missing_identity_rows = 0,
+  malformed_identity_rows = 0,
+  missing_schema_rows = 0,
+  unsupported_schema_rows = 0,
+  missing_occurrence_rows = 0,
+  future_occurrence_rows = 0,
+  before_account_rows = source.before_account_rows,
+  invalid_parameter_rows = 0,
+  unknown_enum_rows = 0,
+  internal_excluded_rows = source.internal_excluded_rows,
+  deletion_excluded_rows = source.deletion_excluded_rows,
+  ineligible_user_rows = source.ineligible_user_rows,
+  latest_emitted_at = source.latest_emitted_at,
+  latest_occurred_at = source.latest_occurred_at
+WHEN NOT MATCHED THEN INSERT (
+  model_name,
+  source_start_date,
+  source_end_date,
+  completed_at,
+  auth_snapshot_published_at,
+  source_rows,
+  deduplicated_rows,
+  published_rows,
+  missing_identity_rows,
+  malformed_identity_rows,
+  missing_schema_rows,
+  unsupported_schema_rows,
+  missing_occurrence_rows,
+  future_occurrence_rows,
+  before_account_rows,
+  invalid_parameter_rows,
+  unknown_enum_rows,
+  internal_excluded_rows,
+  deletion_excluded_rows,
+  ineligible_user_rows,
+  latest_emitted_at,
+  latest_occurred_at
+) VALUES (
+  source.model_name,
+  retained_start_date,
+  events_source_end_date,
+  CURRENT_TIMESTAMP(),
+  latest_auth_run.published_at,
+  source.source_rows,
+  source.source_rows,
+  rows_inserted,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  source.before_account_rows,
+  0,
+  0,
+  source.internal_excluded_rows,
+  source.deletion_excluded_rows,
+  source.ineligible_user_rows,
+  source.latest_emitted_at,
+  source.latest_occurred_at
+);
+
+COMMIT TRANSACTION;

--- a/tool/product_analytics/sql/20_user_activity_daily.sql
+++ b/tool/product_analytics/sql/20_user_activity_daily.sql
@@ -15,9 +15,23 @@ DECLARE latest_auth_run STRUCT<
   milestone_rows_published INT64,
   cohort_rows_published INT64
 >;
+DECLARE measurement_config STRUCT<
+  raw_export_start_at TIMESTAMP,
+  behavioral_schema_v1_start_at TIMESTAMP
+>;
 DECLARE events_source_end_date DATE;
+DECLARE events_completed_at TIMESTAMP;
 DECLARE retained_start_date DATE;
+DECLARE deletion_exclusion_count INT64;
+DECLARE deletion_exclusion_max_updated_at TIMESTAMP;
 DECLARE rows_inserted INT64 DEFAULT 0;
+
+SET measurement_config = (
+  SELECT AS STRUCT raw_export_start_at, behavioral_schema_v1_start_at
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.analytics_measurement_config`
+  WHERE config_key = 'singleton'
+);
+ASSERT measurement_config IS NOT NULL AS 'The singleton analytics measurement config is required';
 
 SET latest_auth_run = (
   SELECT AS STRUCT
@@ -82,16 +96,21 @@ ASSERT latest_auth_run.control_updated_at = (
 )
   AS 'Auth snapshot predates the current permanent internal exclusion control';
 
-SET events_source_end_date = (
-  SELECT source_end_date
+SET (events_source_end_date, events_completed_at) = (
+  SELECT AS STRUCT source_end_date, completed_at
   FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
   WHERE model_name = 'events_flattened'
   LIMIT 1
 );
-ASSERT events_source_end_date IS NOT NULL AS 'events_flattened has no successful watermark';
+ASSERT events_source_end_date IS NOT NULL AND events_completed_at IS NOT NULL
+  AS 'events_flattened has no successful watermark';
 SET retained_start_date = GREATEST(
-  DATE(TIMESTAMP('{{RAW_EXPORT_START_AT}}')),
+  DATE(measurement_config.raw_export_start_at),
   DATE_SUB(events_source_end_date, INTERVAL 425 DAY)
+);
+SET (deletion_exclusion_count, deletion_exclusion_max_updated_at) = (
+  SELECT AS STRUCT COUNT(*), MAX(updated_at)
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions`
 );
 
 CREATE TEMP TABLE gated_event_stage AS
@@ -243,6 +262,21 @@ ASSERT latest_auth_run.control_updated_at = (
   FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.internal_exclusion_control_state`
   WHERE state_key = 'singleton'
 ) AS 'Internal exclusion control changed while user activity was staged';
+ASSERT (
+  SELECT COUNTIF(
+    source_end_date = events_source_end_date
+    AND completed_at = events_completed_at
+  )
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
+  WHERE model_name = 'events_flattened'
+) = 1 AS 'events_flattened changed while user activity was staged';
+ASSERT deletion_exclusion_count = (
+  SELECT COUNT(*)
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions`
+) AND deletion_exclusion_max_updated_at IS NOT DISTINCT FROM (
+  SELECT MAX(updated_at)
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions`
+) AS 'Permanent deletion exclusions changed while user activity was staged';
 
 BEGIN TRANSACTION;
 

--- a/tool/product_analytics/sql/30_user_milestones.sql
+++ b/tool/product_analytics/sql/30_user_milestones.sql
@@ -15,9 +15,23 @@ DECLARE latest_auth_run STRUCT<
   milestone_rows_published INT64,
   cohort_rows_published INT64
 >;
+DECLARE measurement_config STRUCT<
+  raw_export_start_at TIMESTAMP,
+  behavioral_schema_v1_start_at TIMESTAMP
+>;
 DECLARE events_source_end_date DATE;
+DECLARE events_completed_at TIMESTAMP;
 DECLARE retained_start_date DATE;
+DECLARE deletion_exclusion_count INT64;
+DECLARE deletion_exclusion_max_updated_at TIMESTAMP;
 DECLARE rows_inserted INT64 DEFAULT 0;
+
+SET measurement_config = (
+  SELECT AS STRUCT raw_export_start_at, behavioral_schema_v1_start_at
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.analytics_measurement_config`
+  WHERE config_key = 'singleton'
+);
+ASSERT measurement_config IS NOT NULL AS 'The singleton analytics measurement config is required';
 
 SET latest_auth_run = (
   SELECT AS STRUCT
@@ -82,16 +96,21 @@ ASSERT latest_auth_run.control_updated_at = (
 )
   AS 'Auth snapshot predates the current permanent internal exclusion control';
 
-SET events_source_end_date = (
-  SELECT source_end_date
+SET (events_source_end_date, events_completed_at) = (
+  SELECT AS STRUCT source_end_date, completed_at
   FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
   WHERE model_name = 'events_flattened'
   LIMIT 1
 );
-ASSERT events_source_end_date IS NOT NULL AS 'events_flattened has no successful watermark';
+ASSERT events_source_end_date IS NOT NULL AND events_completed_at IS NOT NULL
+  AS 'events_flattened has no successful watermark';
 SET retained_start_date = GREATEST(
-  DATE(TIMESTAMP('{{RAW_EXPORT_START_AT}}')),
+  DATE(measurement_config.raw_export_start_at),
   DATE_SUB(events_source_end_date, INTERVAL 425 DAY)
+);
+SET (deletion_exclusion_count, deletion_exclusion_max_updated_at) = (
+  SELECT AS STRUCT COUNT(*), MAX(updated_at)
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions`
 );
 
 CREATE TEMP TABLE gated_event_stage AS
@@ -245,6 +264,21 @@ ASSERT latest_auth_run.control_updated_at = (
   FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.internal_exclusion_control_state`
   WHERE state_key = 'singleton'
 ) AS 'Internal exclusion control changed while user milestones were staged';
+ASSERT (
+  SELECT COUNTIF(
+    source_end_date = events_source_end_date
+    AND completed_at = events_completed_at
+  )
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
+  WHERE model_name = 'events_flattened'
+) = 1 AS 'events_flattened changed while user milestones were staged';
+ASSERT deletion_exclusion_count = (
+  SELECT COUNT(*)
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions`
+) AND deletion_exclusion_max_updated_at IS NOT DISTINCT FROM (
+  SELECT MAX(updated_at)
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions`
+) AS 'Permanent deletion exclusions changed while user milestones were staged';
 
 BEGIN TRANSACTION;
 

--- a/tool/product_analytics/sql/30_user_milestones.sql
+++ b/tool/product_analytics/sql/30_user_milestones.sql
@@ -1,0 +1,372 @@
+-- BigQuery Standard SQL. Rebuild the current eligible milestone snapshot only
+-- after the auth export's 36-hour freshness and reconciliation contract passes.
+DECLARE latest_auth_run STRUCT<
+  published_at TIMESTAMP,
+  run_cutoff TIMESTAMP,
+  control_updated_at TIMESTAMP,
+  users_scanned INT64,
+  source_suppressed_users INT64,
+  internal_users INT64,
+  external_accounts INT64,
+  enabled_accounts INT64,
+  opted_out_accounts INT64,
+  preference_after_cutoff_accounts INT64,
+  late_preference_rows_removed INT64,
+  milestone_rows_published INT64,
+  cohort_rows_published INT64
+>;
+DECLARE events_source_end_date DATE;
+DECLARE retained_start_date DATE;
+DECLARE rows_inserted INT64 DEFAULT 0;
+
+SET latest_auth_run = (
+  SELECT AS STRUCT
+    published_at,
+    run_cutoff,
+    control_updated_at,
+    users_scanned,
+    source_suppressed_users,
+    internal_users,
+    external_accounts,
+    enabled_accounts,
+    opted_out_accounts,
+    preference_after_cutoff_accounts,
+    late_preference_rows_removed,
+    milestone_rows_published,
+    cohort_rows_published
+  FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.product_analytics_export_runs`
+  ORDER BY published_at DESC, run_cutoff DESC
+  LIMIT 1
+);
+
+ASSERT latest_auth_run IS NOT NULL AS 'A successful auth snapshot is required';
+ASSERT latest_auth_run.published_at BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 36 HOUR)
+  AND TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 300 SECOND)
+  AS 'The latest auth snapshot is stale or future-dated';
+ASSERT latest_auth_run.run_cutoff BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 36 HOUR)
+  AND latest_auth_run.published_at
+  AS 'The latest auth snapshot source cutoff is stale or later than publication';
+ASSERT latest_auth_run.users_scanned =
+  latest_auth_run.source_suppressed_users + latest_auth_run.internal_users + latest_auth_run.external_accounts
+  AS 'Auth source/exclusion reconciliation failed';
+ASSERT latest_auth_run.external_accounts =
+  latest_auth_run.enabled_accounts
+  + latest_auth_run.opted_out_accounts
+  + latest_auth_run.preference_after_cutoff_accounts
+  + latest_auth_run.late_preference_rows_removed
+  AS 'Auth preference reconciliation failed';
+ASSERT latest_auth_run.milestone_rows_published = latest_auth_run.enabled_accounts
+  AS 'Auth milestone metadata reconciliation failed';
+ASSERT (
+  SELECT COUNT(*) FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_user_milestones`
+) = latest_auth_run.enabled_accounts
+  AS 'Current auth milestone snapshot does not match successful-run metadata';
+ASSERT (
+  SELECT COALESCE(SUM(total_accounts), 0)
+  FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_weekly_setup_cohorts`
+) = latest_auth_run.external_accounts
+  AS 'Auth setup cohort total does not reconcile';
+ASSERT (
+  SELECT COALESCE(SUM(enabled_accounts), 0)
+  FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_weekly_setup_cohorts`
+) = latest_auth_run.enabled_accounts
+  AS 'Auth setup cohort preference coverage does not reconcile';
+ASSERT (
+  SELECT COUNT(*) FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_weekly_setup_cohorts`
+) = latest_auth_run.cohort_rows_published
+  AS 'Auth setup cohort row count does not reconcile';
+ASSERT latest_auth_run.control_updated_at = (
+  SELECT control_updated_at
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.internal_exclusion_control_state`
+  WHERE state_key = 'singleton'
+)
+  AS 'Auth snapshot predates the current permanent internal exclusion control';
+
+SET events_source_end_date = (
+  SELECT source_end_date
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
+  WHERE model_name = 'events_flattened'
+  LIMIT 1
+);
+ASSERT events_source_end_date IS NOT NULL AS 'events_flattened has no successful watermark';
+SET retained_start_date = GREATEST(
+  DATE(TIMESTAMP('{{RAW_EXPORT_START_AT}}')),
+  DATE_SUB(events_source_end_date, INTERVAL 425 DAY)
+);
+
+CREATE TEMP TABLE gated_event_stage AS
+WITH internal_keys AS (
+  SELECT DISTINCT user_key
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_internal_user_exclusions`
+),
+deleted_keys AS (
+  SELECT DISTINCT user_key
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions`
+)
+SELECT
+  event.*,
+  auth.account_created_at,
+  auth.user_key IS NOT NULL AS is_currently_eligible,
+  internal_keys.user_key IS NOT NULL AS is_internal_excluded,
+  deleted_keys.user_key IS NOT NULL AS is_deletion_excluded
+FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flattened` AS event
+LEFT JOIN `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_user_milestones` AS auth USING (user_key)
+LEFT JOIN internal_keys USING (user_key)
+LEFT JOIN deleted_keys USING (user_key)
+WHERE event.source_export_date BETWEEN retained_start_date AND events_source_end_date;
+
+CREATE TEMP TABLE eligible_event_stage AS
+SELECT *
+FROM gated_event_stage
+WHERE is_currently_eligible
+  AND NOT is_internal_excluded
+  AND NOT is_deletion_excluded
+  AND schema_version = 1
+  AND occurred_at >= TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
+  AND occurred_at <= TIMESTAMP_ADD(emitted_at, INTERVAL 300 SECOND)
+  AND DATE(occurred_at) <= events_source_end_date;
+
+CREATE TEMP TABLE event_milestone_stage AS
+SELECT
+  user_key,
+  MIN(occurred_at) AS foundation_exposed_at,
+  MIN(IF(event_name = 'analytics_schema_ready', occurred_at, NULL)) AS analytics_schema_ready_at,
+  MIN(IF(
+    (event_name = 'analytics_activation_ready' AND activation_schema_version = 1)
+    OR event_name IN ('session_message_sent', 'session_created_with_message'),
+    occurred_at,
+    NULL
+  )) AS activation_capable_at,
+  MIN(IF(event_name = 'project_inventory_loaded' AND inventory_state = 'non_empty', occurred_at, NULL)) AS project_available_at,
+  MIN(IF(event_name = 'session_activity_viewed' AND activity_state = 'non_empty', occurred_at, NULL)) AS monitor_activity_at,
+  MIN(IF(event_name = 'voice_transcription_completed', occurred_at, NULL)) AS voice_transcription_at,
+  MIN(IF(
+    event_name IN ('session_message_sent', 'session_created_with_message') AND input_mode = 'voice_assisted',
+    occurred_at,
+    NULL
+  )) AS voice_assisted_message_at,
+  MIN(IF(event_name = 'session_created_with_message', occurred_at, NULL)) AS remote_created_session_at,
+  MIN(IF(
+    event_name = 'session_created_with_message' AND workspace_kind = 'dedicated_worktree',
+    occurred_at,
+    NULL
+  )) AS dedicated_worktree_at,
+  MIN(IF(event_name = 'session_diff_viewed' AND change_state = 'non_empty', occurred_at, NULL)) AS diff_viewed_at,
+  MIN(IF(event_name IN ('session_question_answered', 'session_question_rejected'), occurred_at, NULL)) AS question_intervention_at,
+  MIN(IF(event_name = 'session_permission_answered', occurred_at, NULL)) AS permission_intervention_at,
+  MIN(IF(event_name = 'session_abort_succeeded', occurred_at, NULL)) AS abort_at,
+  MIN(IF(event_name = 'product_screen_viewed', occurred_at, NULL)) AS first_screen_view_at,
+  MIN(IF(event_name IN (
+    'onboarding_need_help_opened',
+    'onboarding_support_link_opened',
+    'onboarding_why_bridge_opened',
+    'bridge_install_command_copied',
+    'bridge_install_command_shared',
+    'bridge_run_command_copied',
+    'bridge_run_command_shared'
+  ), occurred_at, NULL)) AS onboarding_interaction_at
+FROM eligible_event_stage
+GROUP BY user_key;
+
+CREATE TEMP TABLE first_activation_stage AS
+SELECT
+  user_key,
+  ARRAY_AGG(
+    STRUCT(occurred_at, emitted_at, event_name, input_mode)
+    ORDER BY occurred_at, emitted_at, event_name
+    LIMIT 1
+  )[OFFSET(0)] AS activation
+FROM eligible_event_stage
+WHERE event_name IN ('session_message_sent', 'session_created_with_message')
+GROUP BY user_key;
+
+CREATE TEMP TABLE milestone_stage AS
+SELECT
+  auth.user_key,
+  auth.account_created_at,
+  auth.notification_registered_at,
+  auth.bridge_registered_at,
+  auth.legacy_first_metadata_request_at,
+  event.foundation_exposed_at,
+  event.analytics_schema_ready_at,
+  event.activation_capable_at,
+  event.project_available_at,
+  first_activation.activation.occurred_at AS full_activation_at,
+  CASE first_activation.activation.event_name
+    WHEN 'session_message_sent' THEN 'existing_session'
+    WHEN 'session_created_with_message' THEN 'remote_created_session'
+  END AS full_activation_source,
+  first_activation.activation.input_mode AS full_activation_input_mode,
+  event.monitor_activity_at,
+  event.voice_transcription_at,
+  event.voice_assisted_message_at,
+  event.remote_created_session_at,
+  event.dedicated_worktree_at,
+  event.diff_viewed_at,
+  event.question_intervention_at,
+  event.permission_intervention_at,
+  event.abort_at,
+  event.first_screen_view_at,
+  event.onboarding_interaction_at,
+  CURRENT_TIMESTAMP() AS refreshed_at
+FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_user_milestones` AS auth
+LEFT JOIN event_milestone_stage AS event USING (user_key)
+LEFT JOIN first_activation_stage AS first_activation USING (user_key)
+WHERE DATE(auth.account_created_at) >= DATE_SUB(events_source_end_date, INTERVAL 425 DAY)
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_internal_user_exclusions` AS internal
+    WHERE internal.user_key = auth.user_key
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions` AS deleted
+    WHERE deleted.user_key = auth.user_key
+  );
+
+CREATE TEMP TABLE quality_stage AS
+SELECT
+  (SELECT COUNT(*) FROM gated_event_stage) AS source_rows,
+  (SELECT COUNT(*) FROM milestone_stage) AS published_rows,
+  (SELECT COUNTIF(occurred_at < TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND))
+   FROM gated_event_stage WHERE is_currently_eligible) AS before_account_rows,
+  (SELECT COUNTIF(NOT is_currently_eligible) FROM gated_event_stage) AS ineligible_user_rows,
+  (SELECT COUNTIF(is_internal_excluded) FROM gated_event_stage) AS internal_excluded_rows,
+  (SELECT COUNTIF(is_deletion_excluded) FROM gated_event_stage) AS deletion_excluded_rows,
+  (SELECT MAX(emitted_at) FROM eligible_event_stage) AS latest_emitted_at,
+  (SELECT MAX(occurred_at) FROM eligible_event_stage) AS latest_occurred_at;
+
+ASSERT latest_auth_run.published_at = (
+  SELECT MAX(published_at)
+  FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.product_analytics_export_runs`
+) AS 'Auth snapshot changed while user milestones were staged';
+ASSERT latest_auth_run.control_updated_at = (
+  SELECT control_updated_at
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.internal_exclusion_control_state`
+  WHERE state_key = 'singleton'
+) AS 'Internal exclusion control changed while user milestones were staged';
+
+BEGIN TRANSACTION;
+
+DELETE FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.user_milestones`
+WHERE DATE(account_created_at) >= DATE '0001-01-01';
+
+INSERT INTO `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.user_milestones` (
+  user_key,
+  account_created_at,
+  notification_registered_at,
+  bridge_registered_at,
+  legacy_first_metadata_request_at,
+  foundation_exposed_at,
+  analytics_schema_ready_at,
+  activation_capable_at,
+  project_available_at,
+  full_activation_at,
+  full_activation_source,
+  full_activation_input_mode,
+  monitor_activity_at,
+  voice_transcription_at,
+  voice_assisted_message_at,
+  remote_created_session_at,
+  dedicated_worktree_at,
+  diff_viewed_at,
+  question_intervention_at,
+  permission_intervention_at,
+  abort_at,
+  first_screen_view_at,
+  onboarding_interaction_at,
+  refreshed_at
+)
+SELECT stage.*
+FROM milestone_stage AS stage
+WHERE EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_user_milestones` AS auth
+  WHERE auth.user_key = stage.user_key
+)
+AND NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_internal_user_exclusions` AS internal
+  WHERE internal.user_key = stage.user_key
+)
+AND NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions` AS deleted
+  WHERE deleted.user_key = stage.user_key
+);
+SET rows_inserted = @@row_count;
+
+MERGE `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state` AS target
+USING (SELECT 'user_milestones' AS model_name, quality.* FROM quality_stage AS quality) AS source
+ON target.model_name = source.model_name
+WHEN MATCHED THEN UPDATE SET
+  source_start_date = retained_start_date,
+  source_end_date = events_source_end_date,
+  completed_at = CURRENT_TIMESTAMP(),
+  auth_snapshot_published_at = latest_auth_run.published_at,
+  source_rows = source.source_rows,
+  deduplicated_rows = source.source_rows,
+  published_rows = rows_inserted,
+  missing_identity_rows = 0,
+  malformed_identity_rows = 0,
+  missing_schema_rows = 0,
+  unsupported_schema_rows = 0,
+  missing_occurrence_rows = 0,
+  future_occurrence_rows = 0,
+  before_account_rows = source.before_account_rows,
+  invalid_parameter_rows = 0,
+  unknown_enum_rows = 0,
+  internal_excluded_rows = source.internal_excluded_rows,
+  deletion_excluded_rows = source.deletion_excluded_rows,
+  ineligible_user_rows = source.ineligible_user_rows,
+  latest_emitted_at = source.latest_emitted_at,
+  latest_occurred_at = source.latest_occurred_at
+WHEN NOT MATCHED THEN INSERT (
+  model_name,
+  source_start_date,
+  source_end_date,
+  completed_at,
+  auth_snapshot_published_at,
+  source_rows,
+  deduplicated_rows,
+  published_rows,
+  missing_identity_rows,
+  malformed_identity_rows,
+  missing_schema_rows,
+  unsupported_schema_rows,
+  missing_occurrence_rows,
+  future_occurrence_rows,
+  before_account_rows,
+  invalid_parameter_rows,
+  unknown_enum_rows,
+  internal_excluded_rows,
+  deletion_excluded_rows,
+  ineligible_user_rows,
+  latest_emitted_at,
+  latest_occurred_at
+) VALUES (
+  source.model_name,
+  retained_start_date,
+  events_source_end_date,
+  CURRENT_TIMESTAMP(),
+  latest_auth_run.published_at,
+  source.source_rows,
+  source.source_rows,
+  rows_inserted,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  source.before_account_rows,
+  0,
+  0,
+  source.internal_excluded_rows,
+  source.deletion_excluded_rows,
+  source.ineligible_user_rows,
+  source.latest_emitted_at,
+  source.latest_occurred_at
+);
+
+COMMIT TRANSACTION;

--- a/tool/product_analytics/sql/30_user_milestones.sql
+++ b/tool/product_analytics/sql/30_user_milestones.sql
@@ -24,6 +24,7 @@ DECLARE events_completed_at TIMESTAMP;
 DECLARE retained_start_date DATE;
 DECLARE deletion_exclusion_count INT64;
 DECLARE deletion_exclusion_max_updated_at TIMESTAMP;
+DECLARE keyed_publication_epoch INT64;
 DECLARE rows_inserted INT64 DEFAULT 0;
 
 SET measurement_config = (
@@ -112,6 +113,13 @@ SET (deletion_exclusion_count, deletion_exclusion_max_updated_at) = (
   SELECT AS STRUCT COUNT(*), MAX(updated_at)
   FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions`
 );
+SET keyed_publication_epoch = (
+  SELECT publication_epoch
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.keyed_publication_guard`
+  WHERE guard_key = 'singleton'
+);
+ASSERT keyed_publication_epoch IS NOT NULL
+  AS 'The keyed publication guard singleton is required';
 
 CREATE TEMP TABLE gated_event_stage AS
 WITH internal_keys AS (
@@ -148,7 +156,7 @@ WHERE is_currently_eligible
 CREATE TEMP TABLE event_milestone_stage AS
 SELECT
   user_key,
-  MIN(occurred_at) AS foundation_exposed_at,
+  MIN(IF(event_name = 'analytics_schema_ready', occurred_at, NULL)) AS foundation_exposed_at,
   MIN(IF(event_name = 'analytics_schema_ready', occurred_at, NULL)) AS analytics_schema_ready_at,
   MIN(IF(
     (event_name = 'analytics_activation_ready' AND activation_schema_version = 1)
@@ -281,6 +289,14 @@ ASSERT deletion_exclusion_count = (
 ) AS 'Permanent deletion exclusions changed while user milestones were staged';
 
 BEGIN TRANSACTION;
+
+UPDATE `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.keyed_publication_guard`
+SET publication_epoch = publication_epoch + 1,
+    updated_at = CURRENT_TIMESTAMP()
+WHERE guard_key = 'singleton'
+  AND publication_epoch = keyed_publication_epoch;
+ASSERT @@row_count = 1
+  AS 'A tombstone or keyed publication changed while user milestones were staged';
 
 DELETE FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.user_milestones`
 WHERE DATE(account_created_at) >= DATE '0001-01-01';

--- a/tool/product_analytics/sql/40_activation_retention.sql
+++ b/tool/product_analytics/sql/40_activation_retention.sql
@@ -15,12 +15,29 @@ DECLARE latest_auth_run STRUCT<
   milestone_rows_published INT64,
   cohort_rows_published INT64
 >;
+DECLARE measurement_config STRUCT<
+  raw_export_start_at TIMESTAMP,
+  behavioral_schema_v1_start_at TIMESTAMP
+>;
 DECLARE events_source_end_date DATE;
+DECLARE events_completed_at TIMESTAMP;
 DECLARE activity_source_end_date DATE;
+DECLARE activity_completed_at TIMESTAMP;
 DECLARE milestone_source_end_date DATE;
+DECLARE milestone_completed_at TIMESTAMP;
 DECLARE data_as_of_date DATE;
 DECLARE data_as_of_at TIMESTAMP;
 DECLARE retained_start_date DATE;
+DECLARE first_complete_behavioral_week DATE;
+DECLARE deletion_exclusion_count INT64;
+DECLARE deletion_exclusion_max_updated_at TIMESTAMP;
+
+SET measurement_config = (
+  SELECT AS STRUCT raw_export_start_at, behavioral_schema_v1_start_at
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.analytics_measurement_config`
+  WHERE config_key = 'singleton'
+);
+ASSERT measurement_config IS NOT NULL AS 'The singleton analytics measurement config is required';
 
 SET latest_auth_run = (
   SELECT AS STRUCT
@@ -85,11 +102,21 @@ ASSERT latest_auth_run.control_updated_at = (
 )
   AS 'Auth snapshot predates the current permanent internal exclusion control';
 
-SET (events_source_end_date, activity_source_end_date, milestone_source_end_date) = (
+SET (
+  events_source_end_date,
+  events_completed_at,
+  activity_source_end_date,
+  activity_completed_at,
+  milestone_source_end_date,
+  milestone_completed_at
+) = (
   SELECT AS STRUCT
     MAX(IF(model_name = 'events_flattened', source_end_date, NULL)),
+    MAX(IF(model_name = 'events_flattened', completed_at, NULL)),
     MAX(IF(model_name = 'user_activity_daily', source_end_date, NULL)),
-    MAX(IF(model_name = 'user_milestones', source_end_date, NULL))
+    MAX(IF(model_name = 'user_activity_daily', completed_at, NULL)),
+    MAX(IF(model_name = 'user_milestones', source_end_date, NULL)),
+    MAX(IF(model_name = 'user_milestones', completed_at, NULL))
   FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
   WHERE model_name IN ('events_flattened', 'user_activity_daily', 'user_milestones')
 );
@@ -97,6 +124,11 @@ ASSERT events_source_end_date IS NOT NULL
   AND activity_source_end_date IS NOT NULL
   AND milestone_source_end_date IS NOT NULL
   AS 'Required upstream transforms have no successful watermark';
+ASSERT activity_source_end_date = events_source_end_date
+  AND milestone_source_end_date = events_source_end_date
+  AND activity_completed_at >= events_completed_at
+  AND milestone_completed_at >= events_completed_at
+  AS 'User-level upstream transforms are stale relative to events_flattened';
 ASSERT (
   SELECT COUNTIF(
     model_name IN ('user_activity_daily', 'user_milestones')
@@ -105,11 +137,24 @@ ASSERT (
   FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
 ) = 2 AS 'User-level upstream transforms were not built from the current auth snapshot';
 
-SET data_as_of_date = LEAST(events_source_end_date, activity_source_end_date, milestone_source_end_date);
+SET data_as_of_date = events_source_end_date;
 SET data_as_of_at = TIMESTAMP(DATE_ADD(data_as_of_date, INTERVAL 1 DAY));
 SET retained_start_date = GREATEST(
-  DATE(TIMESTAMP('{{RAW_EXPORT_START_AT}}')),
+  DATE(measurement_config.raw_export_start_at),
   DATE_SUB(data_as_of_date, INTERVAL 425 DAY)
+);
+SET first_complete_behavioral_week = CASE
+  WHEN measurement_config.behavioral_schema_v1_start_at = TIMESTAMP(
+    DATE_TRUNC(DATE(measurement_config.behavioral_schema_v1_start_at), WEEK(MONDAY))
+  ) THEN DATE(measurement_config.behavioral_schema_v1_start_at)
+  ELSE DATE_ADD(
+    DATE_TRUNC(DATE(measurement_config.behavioral_schema_v1_start_at), WEEK(MONDAY)),
+    INTERVAL 7 DAY
+  )
+END;
+SET (deletion_exclusion_count, deletion_exclusion_max_updated_at) = (
+  SELECT AS STRUCT COUNT(*), MAX(updated_at)
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions`
 );
 
 CREATE TEMP TABLE current_user_stage AS
@@ -166,84 +211,84 @@ SELECT
   COUNT(*) AS enabled_current_accounts,
   COUNTIF(foundation_exposed_at IS NOT NULL) AS foundation_exposed_accounts,
   COUNTIF(
-    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 1 DAY)
   ) AS behavioral_window_mature_accounts,
   COUNTIF(
-    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 1 DAY)
   ) AS activation_capable_accounts,
   COUNTIF(
-    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 1 DAY)
     AND project_available_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 1 DAY)
   ) AS project_available_within_1_day,
   COUNTIF(
-    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 7 DAY)
     AND project_available_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 7 DAY)
   ) AS project_available_within_7_days,
   COUNTIF(
-    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 30 DAY)
     AND project_available_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 30 DAY)
   ) AS project_available_within_30_days,
   COUNTIF(
-    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 1 DAY)
   ) AS activation_eligible_1_day_accounts,
   COUNTIF(
-    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 1 DAY)
     AND full_activation_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 1 DAY)
   ) AS activated_within_1_day,
   COUNTIF(
-    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 7 DAY)
   ) AS activation_eligible_7_day_accounts,
   COUNTIF(
-    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 7 DAY)
     AND full_activation_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 7 DAY)
   ) AS activated_within_7_days,
   COUNTIF(
-    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 30 DAY)
   ) AS activation_eligible_30_day_accounts,
   COUNTIF(
-    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 30 DAY)
     AND full_activation_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 30 DAY)
   ) AS activated_within_30_days,
   COUNTIF(
-    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND full_activation_at IS NOT NULL
     AND full_activation_source = 'existing_session'
   ) AS existing_session_activations,
   COUNTIF(
-    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND full_activation_at IS NOT NULL
@@ -264,7 +309,7 @@ SELECT
     100
   )[OFFSET(75)] AS time_to_activation_p75_seconds
 FROM current_user_stage
-WHERE account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+WHERE account_created_at >= measurement_config.behavioral_schema_v1_start_at
   AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
     AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
   AND full_activation_at IS NOT NULL
@@ -282,7 +327,7 @@ SELECT
     100
   )[OFFSET(75)] AS time_to_project_p75_seconds
 FROM current_user_stage
-WHERE account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+WHERE account_created_at >= measurement_config.behavioral_schema_v1_start_at
   AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
     AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
   AND project_available_at IS NOT NULL
@@ -369,7 +414,7 @@ SELECT
 FROM current_user_stage AS user
 LEFT JOIN meaningful_event_stage AS event USING (user_key)
 WHERE user.full_activation_at IS NOT NULL
-  AND user.account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+  AND user.account_created_at >= measurement_config.behavioral_schema_v1_start_at
   AND user.activation_capable_at BETWEEN TIMESTAMP_SUB(user.account_created_at, INTERVAL 300 SECOND)
     AND TIMESTAMP_ADD(user.account_created_at, INTERVAL 24 HOUR)
 GROUP BY user.user_key, user.full_activation_at, activation_week, w1_eligible, w4_eligible;
@@ -380,9 +425,11 @@ SELECT
   DATE_ADD(activation_week, INTERVAL 6 DAY) AS activation_week_end,
   data_as_of_at AS data_as_of_at,
   COUNT(*) AS activated_users,
+  COUNTIF(w1_eligible) = COUNT(*) AS w1_cohort_mature,
   COUNTIF(w1_eligible) AS w1_eligible_users,
   COUNTIF(w1_eligible AND w1_retained) AS w1_retained_users,
   SAFE_DIVIDE(COUNTIF(w1_eligible AND w1_retained), COUNTIF(w1_eligible)) AS w1_retention_rate,
+  COUNTIF(w4_eligible) = COUNT(*) AS w4_cohort_mature,
   COUNTIF(w4_eligible) AS w4_eligible_users,
   COUNTIF(w4_eligible AND w4_retained) AS w4_retained_users,
   SAFE_DIVIDE(COUNTIF(w4_eligible AND w4_retained), COUNTIF(w4_eligible)) AS w4_retention_rate,
@@ -414,7 +461,7 @@ SELECT
   SUM(activity.project_available_count) > 0 AS had_project_available
 FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.user_activity_daily` AS activity
 INNER JOIN `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_user_milestones` AS auth USING (user_key)
-WHERE activity.activity_date BETWEEN retained_start_date AND data_as_of_date
+WHERE activity.activity_date BETWEEN first_complete_behavioral_week AND data_as_of_date
   AND DATE_ADD(DATE_TRUNC(activity.activity_date, WEEK(MONDAY)), INTERVAL 6 DAY) <= data_as_of_date
   AND NOT EXISTS (
     SELECT 1 FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_internal_user_exclusions` AS internal
@@ -466,13 +513,19 @@ LEFT JOIN active_day_quantile_stage AS quantiles USING (week_start)
 GROUP BY weekly.week_start, quantiles.active_days_p50, quantiles.active_days_p75;
 
 CREATE TEMP TABLE weekly_engagement_stage AS
-WITH boundaries AS (
+WITH first_week_candidates AS (
   SELECT
     CASE
       WHEN retained_start_date = DATE_TRUNC(retained_start_date, WEEK(MONDAY)) THEN retained_start_date
       ELSE DATE_ADD(DATE_TRUNC(retained_start_date, WEEK(MONDAY)), INTERVAL 7 DAY)
-    END AS first_complete_week,
+    END AS first_retained_complete_week,
+    first_complete_behavioral_week AS first_behavioral_complete_week
+),
+boundaries AS (
+  SELECT
+    GREATEST(first_retained_complete_week, first_behavioral_complete_week) AS first_complete_week,
     DATE_TRUNC(DATE_SUB(data_as_of_date, INTERVAL 6 DAY), WEEK(MONDAY)) AS last_complete_week
+  FROM first_week_candidates
 ),
 week_spine AS (
   SELECT week_start
@@ -520,6 +573,7 @@ SELECT
   CURRENT_TIMESTAMP() AS refreshed_at
 FROM eligible_event_stage
 WHERE event_name = 'product_screen_viewed'
+  AND occurred_at >= TIMESTAMP(first_complete_behavioral_week)
   AND DATE_ADD(DATE_TRUNC(DATE(occurred_at), WEEK(MONDAY)), INTERVAL 6 DAY) <= data_as_of_date
 GROUP BY week_start, week_end, platform, app_version, app_build, screen;
 
@@ -572,6 +626,7 @@ SELECT
   CURRENT_TIMESTAMP() AS refreshed_at
 FROM classified
 WHERE metric_name IS NOT NULL
+  AND week_start >= first_complete_behavioral_week
   AND DATE_ADD(week_start, INTERVAL 6 DAY) <= data_as_of_date
 GROUP BY
   week_start,
@@ -614,6 +669,33 @@ ASSERT latest_auth_run.control_updated_at = (
   FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.internal_exclusion_control_state`
   WHERE state_key = 'singleton'
 ) AS 'Internal exclusion control changed while activation and retention aggregates were staged';
+ASSERT (
+  SELECT
+    COUNTIF(
+      model_name = 'events_flattened'
+      AND source_end_date = events_source_end_date
+      AND completed_at = events_completed_at
+    ) = 1
+    AND COUNTIF(
+      model_name = 'user_activity_daily'
+      AND source_end_date = events_source_end_date
+      AND completed_at = activity_completed_at
+    ) = 1
+    AND COUNTIF(
+      model_name = 'user_milestones'
+      AND source_end_date = events_source_end_date
+      AND completed_at = milestone_completed_at
+    ) = 1
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
+  WHERE model_name IN ('events_flattened', 'user_activity_daily', 'user_milestones')
+) AS 'Upstream transform state changed while activation and retention aggregates were staged';
+ASSERT deletion_exclusion_count = (
+  SELECT COUNT(*)
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions`
+) AND deletion_exclusion_max_updated_at IS NOT DISTINCT FROM (
+  SELECT MAX(updated_at)
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions`
+) AS 'Permanent deletion exclusions changed while activation and retention aggregates were staged';
 
 BEGIN TRANSACTION;
 

--- a/tool/product_analytics/sql/40_activation_retention.sql
+++ b/tool/product_analytics/sql/40_activation_retention.sql
@@ -31,6 +31,7 @@ DECLARE retained_start_date DATE;
 DECLARE first_complete_behavioral_week DATE;
 DECLARE deletion_exclusion_count INT64;
 DECLARE deletion_exclusion_max_updated_at TIMESTAMP;
+DECLARE keyed_publication_epoch INT64;
 
 SET measurement_config = (
   SELECT AS STRUCT raw_export_start_at, behavioral_schema_v1_start_at
@@ -156,9 +157,32 @@ SET (deletion_exclusion_count, deletion_exclusion_max_updated_at) = (
   SELECT AS STRUCT COUNT(*), MAX(updated_at)
   FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions`
 );
+SET keyed_publication_epoch = (
+  SELECT publication_epoch
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.keyed_publication_guard`
+  WHERE guard_key = 'singleton'
+);
+ASSERT keyed_publication_epoch IS NOT NULL
+  AS 'The keyed publication guard singleton is required';
 
 CREATE TEMP TABLE current_user_stage AS
-SELECT milestone.*
+SELECT
+  milestone.*,
+  CASE
+    WHEN milestone.bridge_registered_at >= TIMESTAMP_SUB(milestone.account_created_at, INTERVAL 300 SECOND)
+    THEN milestone.bridge_registered_at
+  END AS ordered_bridge_registered_at,
+  CASE
+    WHEN milestone.bridge_registered_at >= TIMESTAMP_SUB(milestone.account_created_at, INTERVAL 300 SECOND)
+      AND milestone.project_available_at >= TIMESTAMP_SUB(milestone.bridge_registered_at, INTERVAL 300 SECOND)
+    THEN milestone.project_available_at
+  END AS ordered_project_available_at,
+  CASE
+    WHEN milestone.bridge_registered_at >= TIMESTAMP_SUB(milestone.account_created_at, INTERVAL 300 SECOND)
+      AND milestone.project_available_at >= TIMESTAMP_SUB(milestone.bridge_registered_at, INTERVAL 300 SECOND)
+      AND milestone.full_activation_at >= TIMESTAMP_SUB(milestone.project_available_at, INTERVAL 300 SECOND)
+    THEN milestone.full_activation_at
+  END AS ordered_full_activation_at
 FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.user_milestones` AS milestone
 INNER JOIN `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_user_milestones` AS auth USING (user_key)
 WHERE DATE(milestone.account_created_at) BETWEEN retained_start_date AND data_as_of_date
@@ -218,6 +242,7 @@ SELECT
     account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
+    AND ordered_bridge_registered_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 1 DAY)
   ) AS activation_capable_accounts,
   COUNTIF(
@@ -225,73 +250,79 @@ SELECT
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 1 DAY)
-    AND project_available_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 1 DAY)
+    AND ordered_project_available_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 1 DAY)
   ) AS project_available_within_1_day,
   COUNTIF(
     account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 7 DAY)
-    AND project_available_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 7 DAY)
+    AND ordered_project_available_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 7 DAY)
   ) AS project_available_within_7_days,
   COUNTIF(
     account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 30 DAY)
-    AND project_available_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 30 DAY)
+    AND ordered_project_available_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 30 DAY)
   ) AS project_available_within_30_days,
   COUNTIF(
     account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 1 DAY)
+    AND ordered_project_available_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 1 DAY)
   ) AS activation_eligible_1_day_accounts,
   COUNTIF(
     account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 1 DAY)
-    AND full_activation_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 1 DAY)
+    AND ordered_project_available_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 1 DAY)
+    AND ordered_full_activation_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 1 DAY)
   ) AS activated_within_1_day,
   COUNTIF(
     account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 7 DAY)
+    AND ordered_project_available_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 7 DAY)
   ) AS activation_eligible_7_day_accounts,
   COUNTIF(
     account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 7 DAY)
-    AND full_activation_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 7 DAY)
+    AND ordered_project_available_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 7 DAY)
+    AND ordered_full_activation_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 7 DAY)
   ) AS activated_within_7_days,
   COUNTIF(
     account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 30 DAY)
+    AND ordered_project_available_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 30 DAY)
   ) AS activation_eligible_30_day_accounts,
   COUNTIF(
     account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
     AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 30 DAY)
-    AND full_activation_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 30 DAY)
+    AND ordered_project_available_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 30 DAY)
+    AND ordered_full_activation_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 30 DAY)
   ) AS activated_within_30_days,
   COUNTIF(
     account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
-    AND full_activation_at IS NOT NULL
+    AND ordered_full_activation_at IS NOT NULL
     AND full_activation_source = 'existing_session'
   ) AS existing_session_activations,
   COUNTIF(
     account_created_at >= measurement_config.behavioral_schema_v1_start_at
     AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
       AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
-    AND full_activation_at IS NOT NULL
+    AND ordered_full_activation_at IS NOT NULL
     AND full_activation_source = 'remote_created_session'
   ) AS remote_created_session_activations
 FROM current_user_stage
@@ -301,36 +332,36 @@ CREATE TEMP TABLE activation_time_stage AS
 SELECT
   DATE_TRUNC(DATE(account_created_at), WEEK(MONDAY)) AS cohort_week,
   APPROX_QUANTILES(
-    GREATEST(TIMESTAMP_DIFF(full_activation_at, account_created_at, SECOND), 0),
+    GREATEST(TIMESTAMP_DIFF(ordered_full_activation_at, account_created_at, SECOND), 0),
     100
   )[OFFSET(50)] AS time_to_activation_p50_seconds,
   APPROX_QUANTILES(
-    GREATEST(TIMESTAMP_DIFF(full_activation_at, account_created_at, SECOND), 0),
+    GREATEST(TIMESTAMP_DIFF(ordered_full_activation_at, account_created_at, SECOND), 0),
     100
   )[OFFSET(75)] AS time_to_activation_p75_seconds
 FROM current_user_stage
 WHERE account_created_at >= measurement_config.behavioral_schema_v1_start_at
   AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
     AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
-  AND full_activation_at IS NOT NULL
+  AND ordered_full_activation_at IS NOT NULL
 GROUP BY cohort_week;
 
 CREATE TEMP TABLE project_time_stage AS
 SELECT
   DATE_TRUNC(DATE(account_created_at), WEEK(MONDAY)) AS cohort_week,
   APPROX_QUANTILES(
-    GREATEST(TIMESTAMP_DIFF(project_available_at, account_created_at, SECOND), 0),
+    GREATEST(TIMESTAMP_DIFF(ordered_project_available_at, account_created_at, SECOND), 0),
     100
   )[OFFSET(50)] AS time_to_project_p50_seconds,
   APPROX_QUANTILES(
-    GREATEST(TIMESTAMP_DIFF(project_available_at, account_created_at, SECOND), 0),
+    GREATEST(TIMESTAMP_DIFF(ordered_project_available_at, account_created_at, SECOND), 0),
     100
   )[OFFSET(75)] AS time_to_project_p75_seconds
 FROM current_user_stage
 WHERE account_created_at >= measurement_config.behavioral_schema_v1_start_at
   AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
     AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
-  AND project_available_at IS NOT NULL
+  AND ordered_project_available_at IS NOT NULL
 GROUP BY cohort_week;
 
 CREATE TEMP TABLE activation_cohort_stage AS
@@ -399,25 +430,25 @@ WHERE (event_name = 'session_activity_viewed' AND activity_state = 'non_empty')
 CREATE TEMP TABLE retention_user_stage AS
 SELECT
   user.user_key,
-  user.full_activation_at,
-  DATE_TRUNC(DATE(user.full_activation_at), WEEK(MONDAY)) AS activation_week,
-  user.full_activation_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 14 DAY) AS w1_eligible,
+  user.ordered_full_activation_at AS full_activation_at,
+  DATE_TRUNC(DATE(user.ordered_full_activation_at), WEEK(MONDAY)) AS activation_week,
+  user.ordered_full_activation_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 14 DAY) AS w1_eligible,
   COALESCE(LOGICAL_OR(
-    event.occurred_at >= TIMESTAMP_ADD(user.full_activation_at, INTERVAL 7 DAY)
-    AND event.occurred_at < TIMESTAMP_ADD(user.full_activation_at, INTERVAL 14 DAY)
+    event.occurred_at >= TIMESTAMP_ADD(user.ordered_full_activation_at, INTERVAL 7 DAY)
+    AND event.occurred_at < TIMESTAMP_ADD(user.ordered_full_activation_at, INTERVAL 14 DAY)
   ), FALSE) AS w1_retained,
-  user.full_activation_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 35 DAY) AS w4_eligible,
+  user.ordered_full_activation_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 35 DAY) AS w4_eligible,
   COALESCE(LOGICAL_OR(
-    event.occurred_at >= TIMESTAMP_ADD(user.full_activation_at, INTERVAL 28 DAY)
-    AND event.occurred_at < TIMESTAMP_ADD(user.full_activation_at, INTERVAL 35 DAY)
+    event.occurred_at >= TIMESTAMP_ADD(user.ordered_full_activation_at, INTERVAL 28 DAY)
+    AND event.occurred_at < TIMESTAMP_ADD(user.ordered_full_activation_at, INTERVAL 35 DAY)
   ), FALSE) AS w4_retained
 FROM current_user_stage AS user
 LEFT JOIN meaningful_event_stage AS event USING (user_key)
-WHERE user.full_activation_at IS NOT NULL
+WHERE user.ordered_full_activation_at IS NOT NULL
   AND user.account_created_at >= measurement_config.behavioral_schema_v1_start_at
   AND user.activation_capable_at BETWEEN TIMESTAMP_SUB(user.account_created_at, INTERVAL 300 SECOND)
     AND TIMESTAMP_ADD(user.account_created_at, INTERVAL 24 HOUR)
-GROUP BY user.user_key, user.full_activation_at, activation_week, w1_eligible, w4_eligible;
+GROUP BY user.user_key, user.ordered_full_activation_at, activation_week, w1_eligible, w4_eligible;
 
 CREATE TEMP TABLE retention_cohort_stage AS
 SELECT
@@ -566,7 +597,6 @@ SELECT
   DATE_ADD(DATE_TRUNC(DATE(occurred_at), WEEK(MONDAY)), INTERVAL 6 DAY) AS week_end,
   platform,
   app_version,
-  app_build,
   screen,
   COUNT(DISTINCT user_key) AS unique_users,
   COUNT(*) AS view_count,
@@ -575,7 +605,7 @@ FROM eligible_event_stage
 WHERE event_name = 'product_screen_viewed'
   AND occurred_at >= TIMESTAMP(first_complete_behavioral_week)
   AND DATE_ADD(DATE_TRUNC(DATE(occurred_at), WEEK(MONDAY)), INTERVAL 6 DAY) <= data_as_of_date
-GROUP BY week_start, week_end, platform, app_version, app_build, screen;
+GROUP BY week_start, week_end, platform, app_version, screen;
 
 CREATE TEMP TABLE onboarding_friction_stage AS
 WITH classified AS (
@@ -598,7 +628,6 @@ WITH classified AS (
     END AS metric_name,
     platform,
     app_version,
-    app_build,
     surface,
     channel,
     method AS install_method,
@@ -614,7 +643,6 @@ SELECT
   metric_name,
   platform,
   app_version,
-  app_build,
   surface,
   channel,
   install_method,
@@ -634,7 +662,6 @@ GROUP BY
   metric_name,
   platform,
   app_version,
-  app_build,
   surface,
   channel,
   install_method,
@@ -698,6 +725,14 @@ ASSERT deletion_exclusion_count = (
 ) AS 'Permanent deletion exclusions changed while activation and retention aggregates were staged';
 
 BEGIN TRANSACTION;
+
+UPDATE `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.keyed_publication_guard`
+SET publication_epoch = publication_epoch + 1,
+    updated_at = CURRENT_TIMESTAMP()
+WHERE guard_key = 'singleton'
+  AND publication_epoch = keyed_publication_epoch;
+ASSERT @@row_count = 1
+  AS 'A tombstone or keyed publication changed while aggregates were staged';
 
 DELETE FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.activation_cohorts` WHERE cohort_week >= DATE '0001-01-01';
 INSERT INTO `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.activation_cohorts` SELECT * FROM activation_cohort_stage;

--- a/tool/product_analytics/sql/40_activation_retention.sql
+++ b/tool/product_analytics/sql/40_activation_retention.sql
@@ -1,0 +1,708 @@
+-- BigQuery Standard SQL. All outputs are identifier-free and are replaced in a
+-- single transaction only after current auth and upstream transform validation.
+DECLARE latest_auth_run STRUCT<
+  published_at TIMESTAMP,
+  run_cutoff TIMESTAMP,
+  control_updated_at TIMESTAMP,
+  users_scanned INT64,
+  source_suppressed_users INT64,
+  internal_users INT64,
+  external_accounts INT64,
+  enabled_accounts INT64,
+  opted_out_accounts INT64,
+  preference_after_cutoff_accounts INT64,
+  late_preference_rows_removed INT64,
+  milestone_rows_published INT64,
+  cohort_rows_published INT64
+>;
+DECLARE events_source_end_date DATE;
+DECLARE activity_source_end_date DATE;
+DECLARE milestone_source_end_date DATE;
+DECLARE data_as_of_date DATE;
+DECLARE data_as_of_at TIMESTAMP;
+DECLARE retained_start_date DATE;
+
+SET latest_auth_run = (
+  SELECT AS STRUCT
+    published_at,
+    run_cutoff,
+    control_updated_at,
+    users_scanned,
+    source_suppressed_users,
+    internal_users,
+    external_accounts,
+    enabled_accounts,
+    opted_out_accounts,
+    preference_after_cutoff_accounts,
+    late_preference_rows_removed,
+    milestone_rows_published,
+    cohort_rows_published
+  FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.product_analytics_export_runs`
+  ORDER BY published_at DESC, run_cutoff DESC
+  LIMIT 1
+);
+
+ASSERT latest_auth_run IS NOT NULL AS 'A successful auth snapshot is required';
+ASSERT latest_auth_run.published_at BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 36 HOUR)
+  AND TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 300 SECOND)
+  AS 'The latest auth snapshot is stale or future-dated';
+ASSERT latest_auth_run.run_cutoff BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 36 HOUR)
+  AND latest_auth_run.published_at
+  AS 'The latest auth snapshot source cutoff is stale or later than publication';
+ASSERT latest_auth_run.users_scanned =
+  latest_auth_run.source_suppressed_users + latest_auth_run.internal_users + latest_auth_run.external_accounts
+  AS 'Auth source/exclusion reconciliation failed';
+ASSERT latest_auth_run.external_accounts =
+  latest_auth_run.enabled_accounts
+  + latest_auth_run.opted_out_accounts
+  + latest_auth_run.preference_after_cutoff_accounts
+  + latest_auth_run.late_preference_rows_removed
+  AS 'Auth preference reconciliation failed';
+ASSERT latest_auth_run.milestone_rows_published = latest_auth_run.enabled_accounts
+  AS 'Auth milestone metadata reconciliation failed';
+ASSERT (
+  SELECT COUNT(*) FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_user_milestones`
+) = latest_auth_run.enabled_accounts
+  AS 'Current auth milestone snapshot does not match successful-run metadata';
+ASSERT (
+  SELECT COALESCE(SUM(total_accounts), 0)
+  FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_weekly_setup_cohorts`
+) = latest_auth_run.external_accounts
+  AS 'Auth setup cohort total does not reconcile';
+ASSERT (
+  SELECT COALESCE(SUM(enabled_accounts), 0)
+  FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_weekly_setup_cohorts`
+) = latest_auth_run.enabled_accounts
+  AS 'Auth setup cohort preference coverage does not reconcile';
+ASSERT (
+  SELECT COUNT(*) FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_weekly_setup_cohorts`
+) = latest_auth_run.cohort_rows_published
+  AS 'Auth setup cohort row count does not reconcile';
+ASSERT latest_auth_run.control_updated_at = (
+  SELECT control_updated_at
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.internal_exclusion_control_state`
+  WHERE state_key = 'singleton'
+)
+  AS 'Auth snapshot predates the current permanent internal exclusion control';
+
+SET (events_source_end_date, activity_source_end_date, milestone_source_end_date) = (
+  SELECT AS STRUCT
+    MAX(IF(model_name = 'events_flattened', source_end_date, NULL)),
+    MAX(IF(model_name = 'user_activity_daily', source_end_date, NULL)),
+    MAX(IF(model_name = 'user_milestones', source_end_date, NULL))
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
+  WHERE model_name IN ('events_flattened', 'user_activity_daily', 'user_milestones')
+);
+ASSERT events_source_end_date IS NOT NULL
+  AND activity_source_end_date IS NOT NULL
+  AND milestone_source_end_date IS NOT NULL
+  AS 'Required upstream transforms have no successful watermark';
+ASSERT (
+  SELECT COUNTIF(
+    model_name IN ('user_activity_daily', 'user_milestones')
+    AND auth_snapshot_published_at = latest_auth_run.published_at
+  )
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
+) = 2 AS 'User-level upstream transforms were not built from the current auth snapshot';
+
+SET data_as_of_date = LEAST(events_source_end_date, activity_source_end_date, milestone_source_end_date);
+SET data_as_of_at = TIMESTAMP(DATE_ADD(data_as_of_date, INTERVAL 1 DAY));
+SET retained_start_date = GREATEST(
+  DATE(TIMESTAMP('{{RAW_EXPORT_START_AT}}')),
+  DATE_SUB(data_as_of_date, INTERVAL 425 DAY)
+);
+
+CREATE TEMP TABLE current_user_stage AS
+SELECT milestone.*
+FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.user_milestones` AS milestone
+INNER JOIN `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_user_milestones` AS auth USING (user_key)
+WHERE DATE(milestone.account_created_at) BETWEEN retained_start_date AND data_as_of_date
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_internal_user_exclusions` AS internal
+    WHERE internal.user_key = milestone.user_key
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions` AS deleted
+    WHERE deleted.user_key = milestone.user_key
+  );
+
+CREATE TEMP TABLE gated_event_stage AS
+WITH internal_keys AS (
+  SELECT DISTINCT user_key
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_internal_user_exclusions`
+),
+deleted_keys AS (
+  SELECT DISTINCT user_key
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions`
+)
+SELECT
+  event.*,
+  auth.account_created_at,
+  auth.user_key IS NOT NULL AS is_currently_eligible,
+  internal_keys.user_key IS NOT NULL AS is_internal_excluded,
+  deleted_keys.user_key IS NOT NULL AS is_deletion_excluded
+FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flattened` AS event
+LEFT JOIN `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_user_milestones` AS auth USING (user_key)
+LEFT JOIN internal_keys USING (user_key)
+LEFT JOIN deleted_keys USING (user_key)
+WHERE event.source_export_date BETWEEN retained_start_date AND data_as_of_date;
+
+CREATE TEMP TABLE eligible_event_stage AS
+SELECT *
+FROM gated_event_stage
+WHERE is_currently_eligible
+  AND NOT is_internal_excluded
+  AND NOT is_deletion_excluded
+  AND schema_version = 1
+  AND occurred_at >= TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
+  AND occurred_at <= TIMESTAMP_ADD(emitted_at, INTERVAL 300 SECOND)
+  AND occurred_at < data_as_of_at;
+
+CREATE TEMP TABLE behavioral_cohort_stage AS
+SELECT
+  DATE_TRUNC(DATE(account_created_at), WEEK(MONDAY)) AS cohort_week,
+  COUNT(*) AS enabled_current_accounts,
+  COUNTIF(foundation_exposed_at IS NOT NULL) AS foundation_exposed_accounts,
+  COUNTIF(
+    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 1 DAY)
+  ) AS behavioral_window_mature_accounts,
+  COUNTIF(
+    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
+      AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
+    AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 1 DAY)
+  ) AS activation_capable_accounts,
+  COUNTIF(
+    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
+      AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
+    AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 1 DAY)
+    AND project_available_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 1 DAY)
+  ) AS project_available_within_1_day,
+  COUNTIF(
+    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
+      AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
+    AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 7 DAY)
+    AND project_available_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 7 DAY)
+  ) AS project_available_within_7_days,
+  COUNTIF(
+    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
+      AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
+    AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 30 DAY)
+    AND project_available_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 30 DAY)
+  ) AS project_available_within_30_days,
+  COUNTIF(
+    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
+      AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
+    AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 1 DAY)
+  ) AS activation_eligible_1_day_accounts,
+  COUNTIF(
+    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
+      AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
+    AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 1 DAY)
+    AND full_activation_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 1 DAY)
+  ) AS activated_within_1_day,
+  COUNTIF(
+    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
+      AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
+    AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 7 DAY)
+  ) AS activation_eligible_7_day_accounts,
+  COUNTIF(
+    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
+      AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
+    AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 7 DAY)
+    AND full_activation_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 7 DAY)
+  ) AS activated_within_7_days,
+  COUNTIF(
+    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
+      AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
+    AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 30 DAY)
+  ) AS activation_eligible_30_day_accounts,
+  COUNTIF(
+    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
+      AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
+    AND account_created_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 30 DAY)
+    AND full_activation_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 30 DAY)
+  ) AS activated_within_30_days,
+  COUNTIF(
+    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
+      AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
+    AND full_activation_at IS NOT NULL
+    AND full_activation_source = 'existing_session'
+  ) AS existing_session_activations,
+  COUNTIF(
+    account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+    AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
+      AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
+    AND full_activation_at IS NOT NULL
+    AND full_activation_source = 'remote_created_session'
+  ) AS remote_created_session_activations
+FROM current_user_stage
+GROUP BY cohort_week;
+
+CREATE TEMP TABLE activation_time_stage AS
+SELECT
+  DATE_TRUNC(DATE(account_created_at), WEEK(MONDAY)) AS cohort_week,
+  APPROX_QUANTILES(
+    GREATEST(TIMESTAMP_DIFF(full_activation_at, account_created_at, SECOND), 0),
+    100
+  )[OFFSET(50)] AS time_to_activation_p50_seconds,
+  APPROX_QUANTILES(
+    GREATEST(TIMESTAMP_DIFF(full_activation_at, account_created_at, SECOND), 0),
+    100
+  )[OFFSET(75)] AS time_to_activation_p75_seconds
+FROM current_user_stage
+WHERE account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+  AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
+    AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
+  AND full_activation_at IS NOT NULL
+GROUP BY cohort_week;
+
+CREATE TEMP TABLE project_time_stage AS
+SELECT
+  DATE_TRUNC(DATE(account_created_at), WEEK(MONDAY)) AS cohort_week,
+  APPROX_QUANTILES(
+    GREATEST(TIMESTAMP_DIFF(project_available_at, account_created_at, SECOND), 0),
+    100
+  )[OFFSET(50)] AS time_to_project_p50_seconds,
+  APPROX_QUANTILES(
+    GREATEST(TIMESTAMP_DIFF(project_available_at, account_created_at, SECOND), 0),
+    100
+  )[OFFSET(75)] AS time_to_project_p75_seconds
+FROM current_user_stage
+WHERE account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+  AND activation_capable_at BETWEEN TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND)
+    AND TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
+  AND project_available_at IS NOT NULL
+GROUP BY cohort_week;
+
+CREATE TEMP TABLE activation_cohort_stage AS
+SELECT
+  setup.cohort_week,
+  DATE_ADD(setup.cohort_week, INTERVAL 6 DAY) AS cohort_week_end,
+  data_as_of_at AS data_as_of_at,
+  setup.total_accounts,
+  setup.enabled_accounts,
+  SAFE_DIVIDE(setup.enabled_accounts, setup.total_accounts) AS preference_coverage,
+  COALESCE(behavior.foundation_exposed_accounts, 0) AS foundation_exposed_accounts,
+  SAFE_DIVIDE(COALESCE(behavior.foundation_exposed_accounts, 0), setup.enabled_accounts) AS foundation_coverage,
+  COALESCE(behavior.behavioral_window_mature_accounts, 0) AS behavioral_window_mature_accounts,
+  COALESCE(behavior.activation_capable_accounts, 0) AS activation_capable_accounts,
+  SAFE_DIVIDE(
+    COALESCE(behavior.activation_capable_accounts, 0),
+    behavior.behavioral_window_mature_accounts
+  ) AS activation_capability_coverage,
+  COALESCE(behavior.project_available_within_1_day, 0) AS project_available_within_1_day,
+  COALESCE(behavior.project_available_within_7_days, 0) AS project_available_within_7_days,
+  COALESCE(behavior.project_available_within_30_days, 0) AS project_available_within_30_days,
+  COALESCE(behavior.activation_eligible_1_day_accounts, 0) AS activation_eligible_1_day_accounts,
+  COALESCE(behavior.activated_within_1_day, 0) AS activated_within_1_day,
+  COALESCE(behavior.activation_eligible_7_day_accounts, 0) AS activation_eligible_7_day_accounts,
+  COALESCE(behavior.activated_within_7_days, 0) AS activated_within_7_days,
+  COALESCE(behavior.activation_eligible_30_day_accounts, 0) AS activation_eligible_30_day_accounts,
+  COALESCE(behavior.activated_within_30_days, 0) AS activated_within_30_days,
+  COALESCE(behavior.existing_session_activations, 0) AS existing_session_activations,
+  COALESCE(behavior.remote_created_session_activations, 0) AS remote_created_session_activations,
+  project_times.time_to_project_p50_seconds,
+  project_times.time_to_project_p75_seconds,
+  times.time_to_activation_p50_seconds,
+  times.time_to_activation_p75_seconds,
+  setup.notification_registered_within_1_day,
+  setup.notification_registered_within_7_days,
+  setup.notification_registered_within_30_days,
+  setup.bridge_registered_within_1_day,
+  setup.bridge_registered_within_7_days,
+  setup.bridge_registered_within_30_days,
+  setup.legacy_first_metadata_request_within_1_day AS legacy_metadata_request_within_1_day,
+  setup.legacy_first_metadata_request_within_7_days AS legacy_metadata_request_within_7_days,
+  setup.legacy_first_metadata_request_within_30_days AS legacy_metadata_request_within_30_days,
+  data_as_of_at >= TIMESTAMP(DATE_ADD(setup.cohort_week, INTERVAL 8 DAY)) AS setup_1_day_mature,
+  data_as_of_at >= TIMESTAMP(DATE_ADD(setup.cohort_week, INTERVAL 14 DAY)) AS setup_7_day_mature,
+  data_as_of_at >= TIMESTAMP(DATE_ADD(setup.cohort_week, INTERVAL 37 DAY)) AS setup_30_day_mature,
+  CURRENT_TIMESTAMP() AS refreshed_at
+FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_weekly_setup_cohorts` AS setup
+LEFT JOIN behavioral_cohort_stage AS behavior USING (cohort_week)
+LEFT JOIN activation_time_stage AS times USING (cohort_week)
+LEFT JOIN project_time_stage AS project_times USING (cohort_week)
+WHERE setup.cohort_week BETWEEN DATE_SUB(data_as_of_date, INTERVAL 425 DAY) AND data_as_of_date;
+
+CREATE TEMP TABLE meaningful_event_stage AS
+SELECT user_key, occurred_at
+FROM eligible_event_stage
+WHERE (event_name = 'session_activity_viewed' AND activity_state = 'non_empty')
+  OR event_name IN (
+    'session_message_sent',
+    'session_created_with_message',
+    'session_question_answered',
+    'session_question_rejected',
+    'session_permission_answered',
+    'session_abort_succeeded'
+  );
+
+CREATE TEMP TABLE retention_user_stage AS
+SELECT
+  user.user_key,
+  user.full_activation_at,
+  DATE_TRUNC(DATE(user.full_activation_at), WEEK(MONDAY)) AS activation_week,
+  user.full_activation_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 14 DAY) AS w1_eligible,
+  COALESCE(LOGICAL_OR(
+    event.occurred_at >= TIMESTAMP_ADD(user.full_activation_at, INTERVAL 7 DAY)
+    AND event.occurred_at < TIMESTAMP_ADD(user.full_activation_at, INTERVAL 14 DAY)
+  ), FALSE) AS w1_retained,
+  user.full_activation_at <= TIMESTAMP_SUB(data_as_of_at, INTERVAL 35 DAY) AS w4_eligible,
+  COALESCE(LOGICAL_OR(
+    event.occurred_at >= TIMESTAMP_ADD(user.full_activation_at, INTERVAL 28 DAY)
+    AND event.occurred_at < TIMESTAMP_ADD(user.full_activation_at, INTERVAL 35 DAY)
+  ), FALSE) AS w4_retained
+FROM current_user_stage AS user
+LEFT JOIN meaningful_event_stage AS event USING (user_key)
+WHERE user.full_activation_at IS NOT NULL
+  AND user.account_created_at >= TIMESTAMP('{{BEHAVIORAL_SCHEMA_V1_START_AT}}')
+  AND user.activation_capable_at BETWEEN TIMESTAMP_SUB(user.account_created_at, INTERVAL 300 SECOND)
+    AND TIMESTAMP_ADD(user.account_created_at, INTERVAL 24 HOUR)
+GROUP BY user.user_key, user.full_activation_at, activation_week, w1_eligible, w4_eligible;
+
+CREATE TEMP TABLE retention_cohort_stage AS
+SELECT
+  activation_week,
+  DATE_ADD(activation_week, INTERVAL 6 DAY) AS activation_week_end,
+  data_as_of_at AS data_as_of_at,
+  COUNT(*) AS activated_users,
+  COUNTIF(w1_eligible) AS w1_eligible_users,
+  COUNTIF(w1_eligible AND w1_retained) AS w1_retained_users,
+  SAFE_DIVIDE(COUNTIF(w1_eligible AND w1_retained), COUNTIF(w1_eligible)) AS w1_retention_rate,
+  COUNTIF(w4_eligible) AS w4_eligible_users,
+  COUNTIF(w4_eligible AND w4_retained) AS w4_retained_users,
+  SAFE_DIVIDE(COUNTIF(w4_eligible AND w4_retained), COUNTIF(w4_eligible)) AS w4_retention_rate,
+  CURRENT_TIMESTAMP() AS refreshed_at
+FROM retention_user_stage
+GROUP BY activation_week;
+
+CREATE TEMP TABLE user_week_stage AS
+SELECT
+  DATE_TRUNC(activity.activity_date, WEEK(MONDAY)) AS week_start,
+  activity.user_key,
+  COUNTIF(activity.meaningful_activity) > 0 AS meaningful_user,
+  COUNTIF(activity.controller_activity) > 0 AS controller_user,
+  COUNTIF(activity.meaningful_activity) AS active_days,
+  SUM(activity.control_event_count) AS remote_interventions,
+  SUM(activity.message_event_count) AS successful_messages,
+  SUM(activity.voice_assisted_message_count) AS voice_assisted_messages,
+  SUM(activity.voice_assisted_message_count) > 0 AS used_voice_assisted_message,
+  SUM(activity.voice_transcription_count) > 0 AS used_voice_transcription,
+  SUM(activity.remote_created_session_count) > 0 AS used_remote_created_session,
+  SUM(activity.remote_created_session_count) AS remote_created_sessions,
+  SUM(activity.dedicated_worktree_creation_count) > 0 AS used_dedicated_worktree,
+  SUM(activity.dedicated_worktree_creation_count) AS dedicated_worktree_sessions,
+  SUM(activity.non_empty_diff_view_count) > 0 AS used_diff,
+  SUM(activity.question_answer_count + activity.question_rejection_count) > 0 AS used_question,
+  SUM(activity.permission_answer_count) > 0 AS used_permission,
+  SUM(activity.abort_count) > 0 AS used_abort,
+  SUM(activity.screen_view_count) > 0 AS used_screen,
+  SUM(activity.project_available_count) > 0 AS had_project_available
+FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.user_activity_daily` AS activity
+INNER JOIN `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.auth_user_milestones` AS auth USING (user_key)
+WHERE activity.activity_date BETWEEN retained_start_date AND data_as_of_date
+  AND DATE_ADD(DATE_TRUNC(activity.activity_date, WEEK(MONDAY)), INTERVAL 6 DAY) <= data_as_of_date
+  AND NOT EXISTS (
+    SELECT 1 FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_internal_user_exclusions` AS internal
+    WHERE internal.user_key = activity.user_key
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions` AS deleted
+    WHERE deleted.user_key = activity.user_key
+  )
+GROUP BY week_start, activity.user_key;
+
+CREATE TEMP TABLE active_day_quantile_stage AS
+SELECT
+  week_start,
+  APPROX_QUANTILES(active_days, 100)[OFFSET(50)] AS active_days_p50,
+  APPROX_QUANTILES(active_days, 100)[OFFSET(75)] AS active_days_p75
+FROM user_week_stage
+WHERE meaningful_user
+GROUP BY week_start;
+
+CREATE TEMP TABLE weekly_aggregate_stage AS
+SELECT
+  weekly.week_start,
+  DATE_ADD(weekly.week_start, INTERVAL 6 DAY) AS week_end,
+  data_as_of_at AS data_as_of_at,
+  COUNTIF(weekly.meaningful_user) AS meaningful_wau,
+  COUNTIF(weekly.controller_user) AS controller_wau,
+  quantiles.active_days_p50,
+  quantiles.active_days_p75,
+  SUM(weekly.remote_interventions) AS remote_interventions,
+  SAFE_DIVIDE(SUM(weekly.remote_interventions), COUNTIF(weekly.controller_user)) AS remote_interventions_per_controller,
+  SUM(weekly.successful_messages) AS successful_messages,
+  SUM(weekly.voice_assisted_messages) AS voice_assisted_messages,
+  COUNTIF(weekly.used_voice_assisted_message) AS voice_assisted_message_users,
+  COUNTIF(weekly.used_voice_transcription) AS voice_transcription_users,
+  COUNTIF(weekly.used_remote_created_session) AS remote_created_session_users,
+  SUM(weekly.remote_created_sessions) AS remote_created_sessions,
+  COUNTIF(weekly.used_dedicated_worktree) AS dedicated_worktree_users,
+  SUM(weekly.dedicated_worktree_sessions) AS dedicated_worktree_sessions,
+  COUNTIF(weekly.used_diff) AS diff_users,
+  COUNTIF(weekly.used_question) AS question_users,
+  COUNTIF(weekly.used_permission) AS permission_users,
+  COUNTIF(weekly.used_abort) AS abort_users,
+  COUNTIF(weekly.used_screen) AS screen_users,
+  COUNTIF(weekly.had_project_available) AS project_available_users,
+  CURRENT_TIMESTAMP() AS refreshed_at
+FROM user_week_stage AS weekly
+LEFT JOIN active_day_quantile_stage AS quantiles USING (week_start)
+GROUP BY weekly.week_start, quantiles.active_days_p50, quantiles.active_days_p75;
+
+CREATE TEMP TABLE weekly_engagement_stage AS
+WITH boundaries AS (
+  SELECT
+    CASE
+      WHEN retained_start_date = DATE_TRUNC(retained_start_date, WEEK(MONDAY)) THEN retained_start_date
+      ELSE DATE_ADD(DATE_TRUNC(retained_start_date, WEEK(MONDAY)), INTERVAL 7 DAY)
+    END AS first_complete_week,
+    DATE_TRUNC(DATE_SUB(data_as_of_date, INTERVAL 6 DAY), WEEK(MONDAY)) AS last_complete_week
+),
+week_spine AS (
+  SELECT week_start
+  FROM boundaries,
+  UNNEST(GENERATE_DATE_ARRAY(first_complete_week, last_complete_week, INTERVAL 7 DAY)) AS week_start
+)
+SELECT
+  spine.week_start,
+  DATE_ADD(spine.week_start, INTERVAL 6 DAY) AS week_end,
+  data_as_of_at AS data_as_of_at,
+  COALESCE(aggregate.meaningful_wau, 0) AS meaningful_wau,
+  COALESCE(aggregate.controller_wau, 0) AS controller_wau,
+  aggregate.active_days_p50,
+  aggregate.active_days_p75,
+  COALESCE(aggregate.remote_interventions, 0) AS remote_interventions,
+  aggregate.remote_interventions_per_controller,
+  COALESCE(aggregate.successful_messages, 0) AS successful_messages,
+  COALESCE(aggregate.voice_assisted_messages, 0) AS voice_assisted_messages,
+  COALESCE(aggregate.voice_assisted_message_users, 0) AS voice_assisted_message_users,
+  COALESCE(aggregate.voice_transcription_users, 0) AS voice_transcription_users,
+  COALESCE(aggregate.remote_created_session_users, 0) AS remote_created_session_users,
+  COALESCE(aggregate.remote_created_sessions, 0) AS remote_created_sessions,
+  COALESCE(aggregate.dedicated_worktree_users, 0) AS dedicated_worktree_users,
+  COALESCE(aggregate.dedicated_worktree_sessions, 0) AS dedicated_worktree_sessions,
+  COALESCE(aggregate.diff_users, 0) AS diff_users,
+  COALESCE(aggregate.question_users, 0) AS question_users,
+  COALESCE(aggregate.permission_users, 0) AS permission_users,
+  COALESCE(aggregate.abort_users, 0) AS abort_users,
+  COALESCE(aggregate.screen_users, 0) AS screen_users,
+  COALESCE(aggregate.project_available_users, 0) AS project_available_users,
+  CURRENT_TIMESTAMP() AS refreshed_at
+FROM week_spine AS spine
+LEFT JOIN weekly_aggregate_stage AS aggregate USING (week_start);
+
+CREATE TEMP TABLE screen_usage_stage AS
+SELECT
+  DATE_TRUNC(DATE(occurred_at), WEEK(MONDAY)) AS week_start,
+  DATE_ADD(DATE_TRUNC(DATE(occurred_at), WEEK(MONDAY)), INTERVAL 6 DAY) AS week_end,
+  platform,
+  app_version,
+  app_build,
+  screen,
+  COUNT(DISTINCT user_key) AS unique_users,
+  COUNT(*) AS view_count,
+  CURRENT_TIMESTAMP() AS refreshed_at
+FROM eligible_event_stage
+WHERE event_name = 'product_screen_viewed'
+  AND DATE_ADD(DATE_TRUNC(DATE(occurred_at), WEEK(MONDAY)), INTERVAL 6 DAY) <= data_as_of_date
+GROUP BY week_start, week_end, platform, app_version, app_build, screen;
+
+CREATE TEMP TABLE onboarding_friction_stage AS
+WITH classified AS (
+  SELECT
+    DATE_TRUNC(DATE(occurred_at), WEEK(MONDAY)) AS week_start,
+    CASE
+      WHEN event_name = 'project_inventory_loaded' AND inventory_state = 'empty' THEN 'empty_project_inventory'
+      WHEN event_name = 'session_activity_viewed' AND activity_state = 'empty' THEN 'empty_session_activity'
+      WHEN event_name = 'session_diff_viewed' AND change_state = 'empty' THEN 'empty_session_diff'
+      WHEN event_name = 'session_creation_failed' THEN 'session_creation_failed'
+      WHEN event_name IN (
+        'onboarding_need_help_opened',
+        'onboarding_support_link_opened',
+        'onboarding_why_bridge_opened',
+        'bridge_install_command_copied',
+        'bridge_install_command_shared',
+        'bridge_run_command_copied',
+        'bridge_run_command_shared'
+      ) THEN event_name
+    END AS metric_name,
+    platform,
+    app_version,
+    app_build,
+    surface,
+    channel,
+    method AS install_method,
+    os AS install_os,
+    failure_reason,
+    workspace_kind,
+    user_key
+  FROM eligible_event_stage
+)
+SELECT
+  week_start,
+  DATE_ADD(week_start, INTERVAL 6 DAY) AS week_end,
+  metric_name,
+  platform,
+  app_version,
+  app_build,
+  surface,
+  channel,
+  install_method,
+  install_os,
+  failure_reason,
+  workspace_kind,
+  COUNT(DISTINCT user_key) AS unique_users,
+  COUNT(*) AS event_count,
+  CURRENT_TIMESTAMP() AS refreshed_at
+FROM classified
+WHERE metric_name IS NOT NULL
+  AND DATE_ADD(week_start, INTERVAL 6 DAY) <= data_as_of_date
+GROUP BY
+  week_start,
+  week_end,
+  metric_name,
+  platform,
+  app_version,
+  app_build,
+  surface,
+  channel,
+  install_method,
+  install_os,
+  failure_reason,
+  workspace_kind;
+
+CREATE TEMP TABLE quality_stage AS
+SELECT
+  (SELECT COUNT(*) FROM gated_event_stage) AS source_rows,
+  (
+    (SELECT COUNT(*) FROM activation_cohort_stage)
+    + (SELECT COUNT(*) FROM retention_cohort_stage)
+    + (SELECT COUNT(*) FROM weekly_engagement_stage)
+    + (SELECT COUNT(*) FROM screen_usage_stage)
+    + (SELECT COUNT(*) FROM onboarding_friction_stage)
+  ) AS published_rows,
+  (SELECT COUNTIF(occurred_at < TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND))
+   FROM gated_event_stage WHERE is_currently_eligible) AS before_account_rows,
+  (SELECT COUNTIF(NOT is_currently_eligible) FROM gated_event_stage) AS ineligible_user_rows,
+  (SELECT COUNTIF(is_internal_excluded) FROM gated_event_stage) AS internal_excluded_rows,
+  (SELECT COUNTIF(is_deletion_excluded) FROM gated_event_stage) AS deletion_excluded_rows,
+  (SELECT MAX(emitted_at) FROM eligible_event_stage) AS latest_emitted_at,
+  (SELECT MAX(occurred_at) FROM eligible_event_stage) AS latest_occurred_at;
+
+ASSERT latest_auth_run.published_at = (
+  SELECT MAX(published_at)
+  FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.product_analytics_export_runs`
+) AS 'Auth snapshot changed while activation and retention aggregates were staged';
+ASSERT latest_auth_run.control_updated_at = (
+  SELECT control_updated_at
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.internal_exclusion_control_state`
+  WHERE state_key = 'singleton'
+) AS 'Internal exclusion control changed while activation and retention aggregates were staged';
+
+BEGIN TRANSACTION;
+
+DELETE FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.activation_cohorts` WHERE cohort_week >= DATE '0001-01-01';
+INSERT INTO `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.activation_cohorts` SELECT * FROM activation_cohort_stage;
+
+DELETE FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.retention_cohorts` WHERE activation_week >= DATE '0001-01-01';
+INSERT INTO `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.retention_cohorts` SELECT * FROM retention_cohort_stage;
+
+DELETE FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.weekly_engagement` WHERE week_start >= DATE '0001-01-01';
+INSERT INTO `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.weekly_engagement` SELECT * FROM weekly_engagement_stage;
+
+DELETE FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.screen_usage_weekly` WHERE week_start >= DATE '0001-01-01';
+INSERT INTO `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.screen_usage_weekly` SELECT * FROM screen_usage_stage;
+
+DELETE FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.onboarding_friction_weekly` WHERE week_start >= DATE '0001-01-01';
+INSERT INTO `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.onboarding_friction_weekly` SELECT * FROM onboarding_friction_stage;
+
+MERGE `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state` AS target
+USING (SELECT 'activation_retention' AS model_name, quality.* FROM quality_stage AS quality) AS source
+ON target.model_name = source.model_name
+WHEN MATCHED THEN UPDATE SET
+  source_start_date = retained_start_date,
+  source_end_date = data_as_of_date,
+  completed_at = CURRENT_TIMESTAMP(),
+  auth_snapshot_published_at = latest_auth_run.published_at,
+  source_rows = source.source_rows,
+  deduplicated_rows = source.source_rows,
+  published_rows = source.published_rows,
+  missing_identity_rows = 0,
+  malformed_identity_rows = 0,
+  missing_schema_rows = 0,
+  unsupported_schema_rows = 0,
+  missing_occurrence_rows = 0,
+  future_occurrence_rows = 0,
+  before_account_rows = source.before_account_rows,
+  invalid_parameter_rows = 0,
+  unknown_enum_rows = 0,
+  internal_excluded_rows = source.internal_excluded_rows,
+  deletion_excluded_rows = source.deletion_excluded_rows,
+  ineligible_user_rows = source.ineligible_user_rows,
+  latest_emitted_at = source.latest_emitted_at,
+  latest_occurred_at = source.latest_occurred_at
+WHEN NOT MATCHED THEN INSERT (
+  model_name,
+  source_start_date,
+  source_end_date,
+  completed_at,
+  auth_snapshot_published_at,
+  source_rows,
+  deduplicated_rows,
+  published_rows,
+  missing_identity_rows,
+  malformed_identity_rows,
+  missing_schema_rows,
+  unsupported_schema_rows,
+  missing_occurrence_rows,
+  future_occurrence_rows,
+  before_account_rows,
+  invalid_parameter_rows,
+  unknown_enum_rows,
+  internal_excluded_rows,
+  deletion_excluded_rows,
+  ineligible_user_rows,
+  latest_emitted_at,
+  latest_occurred_at
+) VALUES (
+  source.model_name,
+  retained_start_date,
+  data_as_of_date,
+  CURRENT_TIMESTAMP(),
+  latest_auth_run.published_at,
+  source.source_rows,
+  source.source_rows,
+  source.published_rows,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  source.before_account_rows,
+  0,
+  0,
+  source.internal_excluded_rows,
+  source.deletion_excluded_rows,
+  source.ineligible_user_rows,
+  source.latest_emitted_at,
+  source.latest_occurred_at
+);
+
+COMMIT TRANSACTION;

--- a/tool/product_analytics/sql/50_reporting_views.sql
+++ b/tool/product_analytics/sql/50_reporting_views.sql
@@ -5,8 +5,8 @@ CREATE OR REPLACE VIEW `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.weekly_kpis`
 OPTIONS (description = 'Complete Monday-Sunday account, activation, engagement, and growth KPIs') AS
 WITH joined AS (
   SELECT
-    engagement.week_start,
-    engagement.week_end,
+    COALESCE(engagement.week_start, activation.cohort_week) AS week_start,
+    COALESCE(engagement.week_end, activation.cohort_week_end) AS week_end,
     COALESCE(activation.total_accounts, 0) AS new_accounts,
     COALESCE(activation.enabled_accounts, 0) AS analytics_enabled_accounts,
     activation.preference_coverage,
@@ -54,12 +54,18 @@ WITH joined AS (
     engagement.remote_interventions_per_controller,
     engagement.successful_messages,
     engagement.voice_assisted_messages,
-    engagement.data_as_of_at,
-    GREATEST(engagement.refreshed_at, COALESCE(activation.refreshed_at, engagement.refreshed_at)) AS refreshed_at
+    COALESCE(engagement.data_as_of_at, activation.data_as_of_at) AS data_as_of_at,
+    GREATEST(
+      COALESCE(engagement.refreshed_at, activation.refreshed_at),
+      COALESCE(activation.refreshed_at, engagement.refreshed_at)
+    ) AS refreshed_at
   FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.weekly_engagement` AS engagement
-  LEFT JOIN `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.activation_cohorts` AS activation
+  FULL OUTER JOIN `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.activation_cohorts` AS activation
     ON activation.cohort_week = engagement.week_start
-  WHERE engagement.week_end < CURRENT_DATE('UTC')
+  WHERE COALESCE(engagement.week_end, activation.cohort_week_end) < CURRENT_DATE('UTC')
+    AND COALESCE(engagement.week_end, activation.cohort_week_end) < DATE(
+      COALESCE(engagement.data_as_of_at, activation.data_as_of_at)
+    )
 ),
 compared AS (
   SELECT
@@ -77,51 +83,118 @@ SELECT
 FROM compared;
 
 CREATE OR REPLACE VIEW `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.investor_snapshot`
-OPTIONS (description = 'Latest complete-week headline metrics with comparisons, samples, coverage, and freshness') AS
-WITH ordered AS (
+OPTIONS (description = 'Latest applicable account, complete engagement, and mature activation headline periods') AS
+WITH account_periods AS (
   SELECT
-    weekly.*,
+    week_start,
+    week_end,
+    new_accounts,
+    data_as_of_at,
+    refreshed_at,
+    LAG(week_start) OVER (ORDER BY week_start) AS prior_account_week_start,
+    LAG(week_end) OVER (ORDER BY week_start) AS prior_account_week_end,
     LAG(new_accounts) OVER (ORDER BY week_start) AS prior_week_new_accounts,
+    ROW_NUMBER() OVER (ORDER BY week_start DESC) AS recency_rank
+  FROM `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.weekly_kpis`
+  WHERE week_end < DATE(data_as_of_at)
+    AND week_end < CURRENT_DATE('UTC')
+),
+engagement_compared AS (
+  SELECT
+    engagement.*,
+    LAG(week_start) OVER (ORDER BY week_start) AS prior_engagement_week_start,
+    LAG(week_end) OVER (ORDER BY week_start) AS prior_engagement_week_end,
     LAG(meaningful_wau) OVER (ORDER BY week_start) AS prior_week_meaningful_wau,
     LAG(controller_wau) OVER (ORDER BY week_start) AS prior_week_controller_wau,
+    LAG(week_start, 4) OVER (ORDER BY week_start) AS four_week_comparison_week_start,
+    LAG(week_end, 4) OVER (ORDER BY week_start) AS four_week_comparison_week_end,
+    LAG(meaningful_wau, 4) OVER (ORDER BY week_start) AS meaningful_wau_four_weeks_prior
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.weekly_engagement` AS engagement
+  WHERE week_end < DATE(data_as_of_at)
+    AND week_end < CURRENT_DATE('UTC')
+),
+engagement_periods AS (
+  SELECT
+    *,
     ROW_NUMBER() OVER (ORDER BY week_start DESC) AS recency_rank
-  FROM `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.weekly_kpis` AS weekly
+  FROM engagement_compared
+),
+activation_periods AS (
+  SELECT
+    cohort.*,
+    ROW_NUMBER() OVER (ORDER BY cohort_week DESC) AS recency_rank
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.activation_cohorts` AS cohort
+  WHERE setup_7_day_mature
+    AND cohort_week_end < DATE(data_as_of_at)
+    AND cohort_week_end < CURRENT_DATE('UTC')
 )
 SELECT
-  week_start,
-  week_end,
-  new_accounts,
-  prior_week_new_accounts,
-  meaningful_wau,
-  prior_week_meaningful_wau,
-  controller_wau,
-  prior_week_controller_wau,
-  four_week_wau_growth,
-  bridge_setup_within_7_days,
-  bridge_setup_7_day_denominator,
-  bridge_setup_7_day_rate,
-  activated_within_7_days,
-  activation_7_day_denominator,
-  activation_7_day_rate,
-  project_available_within_7_days,
-  project_available_7_day_rate,
-  time_to_project_p50_seconds,
-  time_to_project_p75_seconds,
-  time_to_activation_p50_seconds,
-  time_to_activation_p75_seconds,
-  active_days_p50,
-  active_days_p75,
-  remote_interventions,
-  remote_interventions_per_controller,
-  preference_coverage,
-  foundation_coverage,
-  activation_capability_coverage,
-  one_day_cohort_mature,
-  seven_day_cohort_mature,
-  data_as_of_at,
-  refreshed_at
-FROM ordered
-WHERE recency_rank = 1;
+  account.week_start AS account_week_start,
+  account.week_end AS account_week_end,
+  account.prior_account_week_start,
+  account.prior_account_week_end,
+  account.new_accounts,
+  account.prior_week_new_accounts,
+  engagement.week_start AS engagement_week_start,
+  engagement.week_end AS engagement_week_end,
+  engagement.prior_engagement_week_start,
+  engagement.prior_engagement_week_end,
+  engagement.four_week_comparison_week_start,
+  engagement.four_week_comparison_week_end,
+  engagement.meaningful_wau,
+  engagement.prior_week_meaningful_wau,
+  engagement.controller_wau,
+  engagement.prior_week_controller_wau,
+  IF(
+    engagement.meaningful_wau_four_weeks_prior IS NULL
+      OR engagement.meaningful_wau_four_weeks_prior = 0,
+    NULL,
+    SAFE_DIVIDE(engagement.meaningful_wau, engagement.meaningful_wau_four_weeks_prior) - 1
+  ) AS four_week_wau_growth,
+  activation.cohort_week AS activation_cohort_week,
+  activation.cohort_week_end AS activation_cohort_week_end,
+  activation.bridge_registered_within_7_days AS bridge_setup_within_7_days,
+  activation.total_accounts AS bridge_setup_7_day_denominator,
+  SAFE_DIVIDE(activation.bridge_registered_within_7_days, activation.total_accounts) AS bridge_setup_7_day_rate,
+  activation.activated_within_7_days,
+  activation.activation_eligible_7_day_accounts AS activation_7_day_denominator,
+  SAFE_DIVIDE(
+    activation.activated_within_7_days,
+    activation.activation_eligible_7_day_accounts
+  ) AS activation_7_day_rate,
+  activation.project_available_within_7_days,
+  SAFE_DIVIDE(
+    activation.project_available_within_7_days,
+    activation.activation_eligible_7_day_accounts
+  ) AS project_available_7_day_rate,
+  activation.time_to_project_p50_seconds,
+  activation.time_to_project_p75_seconds,
+  activation.time_to_activation_p50_seconds,
+  activation.time_to_activation_p75_seconds,
+  engagement.active_days_p50,
+  engagement.active_days_p75,
+  engagement.remote_interventions,
+  engagement.remote_interventions_per_controller,
+  activation.preference_coverage,
+  activation.foundation_coverage,
+  activation.activation_capability_coverage,
+  activation.setup_1_day_mature AS one_day_cohort_mature,
+  activation.setup_7_day_mature AS seven_day_cohort_mature,
+  account.data_as_of_at AS account_data_as_of_at,
+  engagement.data_as_of_at AS engagement_data_as_of_at,
+  activation.data_as_of_at AS activation_data_as_of_at,
+  (
+    SELECT MAX(timestamp_value)
+    FROM UNNEST([
+      account.refreshed_at,
+      engagement.refreshed_at,
+      activation.refreshed_at
+    ]) AS timestamp_value
+  ) AS refreshed_at
+FROM (SELECT 1 AS singleton) AS base
+LEFT JOIN account_periods AS account ON account.recency_rank = base.singleton
+LEFT JOIN engagement_periods AS engagement ON engagement.recency_rank = base.singleton
+LEFT JOIN activation_periods AS activation ON activation.recency_rank = base.singleton;
 
 CREATE OR REPLACE VIEW `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.activation_funnel`
 OPTIONS (description = 'Weekly account-to-bridge-to-project-to-message funnel with explicit maturity and coverage') AS
@@ -136,20 +209,20 @@ SELECT
   behavioral_window_mature_accounts,
   activation_capable_accounts,
   IF(setup_1_day_mature, activation_capability_coverage, NULL) AS activation_capability_coverage,
-  project_available_within_1_day,
-  project_available_within_7_days,
-  project_available_within_30_days,
+  IF(setup_1_day_mature, project_available_within_1_day, NULL) AS project_available_within_1_day,
+  IF(setup_7_day_mature, project_available_within_7_days, NULL) AS project_available_within_7_days,
+  IF(setup_30_day_mature, project_available_within_30_days, NULL) AS project_available_within_30_days,
   IF(setup_1_day_mature, SAFE_DIVIDE(project_available_within_1_day, activation_eligible_1_day_accounts), NULL) AS project_available_1_day_rate,
   IF(setup_7_day_mature, SAFE_DIVIDE(project_available_within_7_days, activation_eligible_7_day_accounts), NULL) AS project_available_7_day_rate,
   IF(setup_30_day_mature, SAFE_DIVIDE(project_available_within_30_days, activation_eligible_30_day_accounts), NULL) AS project_available_30_day_rate,
-  activation_eligible_1_day_accounts,
-  activated_within_1_day,
+  IF(setup_1_day_mature, activation_eligible_1_day_accounts, NULL) AS activation_eligible_1_day_accounts,
+  IF(setup_1_day_mature, activated_within_1_day, NULL) AS activated_within_1_day,
   IF(setup_1_day_mature, SAFE_DIVIDE(activated_within_1_day, activation_eligible_1_day_accounts), NULL) AS activation_1_day_rate,
-  activation_eligible_7_day_accounts,
-  activated_within_7_days,
+  IF(setup_7_day_mature, activation_eligible_7_day_accounts, NULL) AS activation_eligible_7_day_accounts,
+  IF(setup_7_day_mature, activated_within_7_days, NULL) AS activated_within_7_days,
   IF(setup_7_day_mature, SAFE_DIVIDE(activated_within_7_days, activation_eligible_7_day_accounts), NULL) AS activation_7_day_rate,
-  activation_eligible_30_day_accounts,
-  activated_within_30_days,
+  IF(setup_30_day_mature, activation_eligible_30_day_accounts, NULL) AS activation_eligible_30_day_accounts,
+  IF(setup_30_day_mature, activated_within_30_days, NULL) AS activated_within_30_days,
   IF(setup_30_day_mature, SAFE_DIVIDE(activated_within_30_days, activation_eligible_30_day_accounts), NULL) AS activation_30_day_rate,
   existing_session_activations,
   remote_created_session_activations,
@@ -175,7 +248,8 @@ SELECT
   data_as_of_at,
   refreshed_at
 FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.activation_cohorts`
-WHERE cohort_week_end < CURRENT_DATE('UTC');
+WHERE cohort_week_end < CURRENT_DATE('UTC')
+  AND cohort_week_end < DATE(data_as_of_at);
 
 CREATE OR REPLACE VIEW `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.retention`
 OPTIONS (description = 'Activation-anchored W1 [7d,14d) and W4 [28d,35d) retention with eligible denominators') AS
@@ -183,12 +257,14 @@ SELECT
   activation_week,
   activation_week_end,
   activated_users,
-  w1_eligible_users,
-  w1_retained_users,
-  w1_retention_rate,
-  w4_eligible_users,
-  w4_retained_users,
-  w4_retention_rate,
+  w1_cohort_mature,
+  IF(w1_cohort_mature, w1_eligible_users, NULL) AS w1_eligible_users,
+  IF(w1_cohort_mature, w1_retained_users, NULL) AS w1_retained_users,
+  IF(w1_cohort_mature, w1_retention_rate, NULL) AS w1_retention_rate,
+  w4_cohort_mature,
+  IF(w4_cohort_mature, w4_eligible_users, NULL) AS w4_eligible_users,
+  IF(w4_cohort_mature, w4_retained_users, NULL) AS w4_retained_users,
+  IF(w4_cohort_mature, w4_retention_rate, NULL) AS w4_retention_rate,
   data_as_of_at,
   refreshed_at
 FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.retention_cohorts`;
@@ -288,6 +364,7 @@ WITH ranked_auth AS (
   SELECT
     published_at,
     run_cutoff,
+    control_updated_at,
     external_accounts,
     enabled_accounts,
     users_scanned,
@@ -304,6 +381,7 @@ latest_auth_values AS (
   SELECT
     MAX(IF(recency_rank = 1, published_at, NULL)) AS published_at,
     MAX(IF(recency_rank = 1, run_cutoff, NULL)) AS run_cutoff,
+    MAX(IF(recency_rank = 1, control_updated_at, NULL)) AS control_updated_at,
     MAX(IF(recency_rank = 1, external_accounts, NULL)) AS external_accounts,
     MAX(IF(recency_rank = 1, enabled_accounts, NULL)) AS enabled_accounts,
     MAX(IF(recency_rank = 1, users_scanned, NULL)) AS users_scanned,
@@ -324,6 +402,10 @@ latest_auth AS (
       AND milestone_rows_published = enabled_accounts AS reconciled
   FROM latest_auth_values
 ),
+current_internal_control AS (
+  SELECT MAX(IF(state_key = 'singleton', control_updated_at, NULL)) AS control_updated_at
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.internal_exclusion_control_state`
+),
 latest_complete_activation AS (
   SELECT *
   FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.activation_cohorts`
@@ -331,9 +413,23 @@ latest_complete_activation AS (
   ORDER BY cohort_week DESC
   LIMIT 1
 ),
-latest_retention AS (
+latest_retention_status AS (
+  SELECT
+    MAX(data_as_of_at) AS data_as_of_at,
+    MAX(refreshed_at) AS refreshed_at
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.retention_cohorts`
+),
+latest_w1_retention AS (
   SELECT *
   FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.retention_cohorts`
+  WHERE w1_cohort_mature
+  ORDER BY activation_week DESC
+  LIMIT 1
+),
+latest_w4_retention AS (
+  SELECT *
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.retention_cohorts`
+  WHERE w4_cohort_mature
   ORDER BY activation_week DESC
   LIMIT 1
 ),
@@ -406,6 +502,8 @@ auth_freshness AS (
     CASE
       WHEN published_at IS NULL THEN 'missing'
       WHEN NOT reconciled THEN 'reconciliation_failed'
+      WHEN latest_auth.control_updated_at IS DISTINCT FROM current_control.control_updated_at
+        THEN 'internal_control_mismatch'
       WHEN published_at > TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 300 SECOND)
         OR run_cutoff > published_at THEN 'future_dated'
       WHEN published_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 36 HOUR)
@@ -416,6 +514,7 @@ auth_freshness AS (
     CAST(NULL AS TIMESTAMP) AS latest_event_at,
     published_at AS latest_transform_at
   FROM latest_auth
+  CROSS JOIN current_internal_control AS current_control
 ),
 coverage AS (
   SELECT
@@ -434,26 +533,37 @@ coverage AS (
     STRUCT('preference' AS metric_name, cohort.enabled_accounts AS metric_count, cohort.preference_coverage AS metric_rate),
     STRUCT('foundation' AS metric_name, cohort.foundation_exposed_accounts AS metric_count, cohort.foundation_coverage AS metric_rate),
     STRUCT('activation_capability' AS metric_name, cohort.activation_capable_accounts AS metric_count, IF(cohort.setup_1_day_mature, cohort.activation_capability_coverage, NULL) AS metric_rate),
-    STRUCT('activation_7_day_maturity' AS metric_name, cohort.activation_eligible_7_day_accounts AS metric_count, IF(cohort.setup_7_day_mature, SAFE_DIVIDE(cohort.activated_within_7_days, cohort.activation_eligible_7_day_accounts), NULL) AS metric_rate)
+    STRUCT('activation_7_day_maturity' AS metric_name, IF(cohort.setup_7_day_mature, cohort.activation_eligible_7_day_accounts, NULL) AS metric_count, IF(cohort.setup_7_day_mature, SAFE_DIVIDE(cohort.activated_within_7_days, cohort.activation_eligible_7_day_accounts), NULL) AS metric_rate)
   ]) AS metric
 ),
 maturity AS (
   SELECT
     CURRENT_TIMESTAMP() AS observed_at,
     'cohort_maturity' AS category,
-    metric.metric_name,
+    'w1_eligible_users' AS metric_name,
     CAST(cohort.activation_week AS STRING) AS dimension_value,
-    metric.metric_count,
-    metric.metric_rate,
-    IF(metric.metric_count = 0, 'not_mature', 'measured') AS status,
-    DATE(cohort.data_as_of_at) AS data_as_of_date,
+    cohort.w1_eligible_users AS metric_count,
+    SAFE_DIVIDE(cohort.w1_eligible_users, cohort.activated_users) AS metric_rate,
+    IF(cohort.activation_week IS NULL, 'not_mature', 'measured') AS status,
+    DATE(COALESCE(cohort.data_as_of_at, latest.data_as_of_at)) AS data_as_of_date,
     CAST(NULL AS TIMESTAMP) AS latest_event_at,
-    cohort.refreshed_at AS latest_transform_at
-  FROM latest_retention AS cohort
-  CROSS JOIN UNNEST([
-    STRUCT('w1_eligible_users' AS metric_name, cohort.w1_eligible_users AS metric_count, SAFE_DIVIDE(cohort.w1_eligible_users, cohort.activated_users) AS metric_rate),
-    STRUCT('w4_eligible_users' AS metric_name, cohort.w4_eligible_users AS metric_count, SAFE_DIVIDE(cohort.w4_eligible_users, cohort.activated_users) AS metric_rate)
-  ]) AS metric
+    COALESCE(cohort.refreshed_at, latest.refreshed_at) AS latest_transform_at
+  FROM latest_retention_status AS latest
+  LEFT JOIN latest_w1_retention AS cohort ON TRUE
+  UNION ALL
+  SELECT
+    CURRENT_TIMESTAMP() AS observed_at,
+    'cohort_maturity' AS category,
+    'w4_eligible_users' AS metric_name,
+    CAST(cohort.activation_week AS STRING) AS dimension_value,
+    cohort.w4_eligible_users AS metric_count,
+    SAFE_DIVIDE(cohort.w4_eligible_users, cohort.activated_users) AS metric_rate,
+    IF(cohort.activation_week IS NULL, 'not_mature', 'measured') AS status,
+    DATE(COALESCE(cohort.data_as_of_at, latest.data_as_of_at)) AS data_as_of_date,
+    CAST(NULL AS TIMESTAMP) AS latest_event_at,
+    COALESCE(cohort.refreshed_at, latest.refreshed_at) AS latest_transform_at
+  FROM latest_retention_status AS latest
+  LEFT JOIN latest_w4_retention AS cohort ON TRUE
 ),
 schema_distribution AS (
   SELECT

--- a/tool/product_analytics/sql/50_reporting_views.sql
+++ b/tool/product_analytics/sql/50_reporting_views.sql
@@ -1,0 +1,502 @@
+-- BigQuery Standard SQL. Every view exposes aggregate, identifier-free fields
+-- only; no reporting schema contains user_key or an installation identifier.
+
+CREATE OR REPLACE VIEW `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.weekly_kpis`
+OPTIONS (description = 'Complete Monday-Sunday account, activation, engagement, and growth KPIs') AS
+WITH joined AS (
+  SELECT
+    engagement.week_start,
+    engagement.week_end,
+    COALESCE(activation.total_accounts, 0) AS new_accounts,
+    COALESCE(activation.enabled_accounts, 0) AS analytics_enabled_accounts,
+    activation.preference_coverage,
+    activation.foundation_coverage,
+    IF(activation.setup_1_day_mature, activation.activation_capability_coverage, NULL) AS activation_capability_coverage,
+    IF(activation.setup_7_day_mature, activation.bridge_registered_within_7_days, NULL) AS bridge_setup_within_7_days,
+    IF(activation.setup_7_day_mature, activation.total_accounts, NULL) AS bridge_setup_7_day_denominator,
+    IF(
+      activation.setup_7_day_mature,
+      SAFE_DIVIDE(activation.bridge_registered_within_7_days, activation.total_accounts),
+      NULL
+    ) AS bridge_setup_7_day_rate,
+    IF(activation.setup_7_day_mature, activation.activated_within_7_days, NULL) AS activated_within_7_days,
+    IF(
+      activation.setup_7_day_mature,
+      activation.activation_eligible_7_day_accounts,
+      NULL
+    ) AS activation_7_day_denominator,
+    IF(
+      activation.setup_7_day_mature,
+      SAFE_DIVIDE(activation.activated_within_7_days, activation.activation_eligible_7_day_accounts),
+      NULL
+    ) AS activation_7_day_rate,
+    IF(
+      activation.setup_7_day_mature,
+      activation.project_available_within_7_days,
+      NULL
+    ) AS project_available_within_7_days,
+    IF(
+      activation.setup_7_day_mature,
+      SAFE_DIVIDE(activation.project_available_within_7_days, activation.activation_eligible_7_day_accounts),
+      NULL
+    ) AS project_available_7_day_rate,
+    IF(activation.setup_7_day_mature, activation.time_to_project_p50_seconds, NULL) AS time_to_project_p50_seconds,
+    IF(activation.setup_7_day_mature, activation.time_to_project_p75_seconds, NULL) AS time_to_project_p75_seconds,
+    IF(activation.setup_7_day_mature, activation.time_to_activation_p50_seconds, NULL) AS time_to_activation_p50_seconds,
+    IF(activation.setup_7_day_mature, activation.time_to_activation_p75_seconds, NULL) AS time_to_activation_p75_seconds,
+    COALESCE(activation.setup_1_day_mature, FALSE) AS one_day_cohort_mature,
+    COALESCE(activation.setup_7_day_mature, FALSE) AS seven_day_cohort_mature,
+    engagement.meaningful_wau,
+    engagement.controller_wau,
+    engagement.active_days_p50,
+    engagement.active_days_p75,
+    engagement.remote_interventions,
+    engagement.remote_interventions_per_controller,
+    engagement.successful_messages,
+    engagement.voice_assisted_messages,
+    engagement.data_as_of_at,
+    GREATEST(engagement.refreshed_at, COALESCE(activation.refreshed_at, engagement.refreshed_at)) AS refreshed_at
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.weekly_engagement` AS engagement
+  LEFT JOIN `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.activation_cohorts` AS activation
+    ON activation.cohort_week = engagement.week_start
+  WHERE engagement.week_end < CURRENT_DATE('UTC')
+),
+compared AS (
+  SELECT
+    joined.*,
+    LAG(meaningful_wau, 4) OVER (ORDER BY week_start) AS meaningful_wau_four_weeks_prior
+  FROM joined
+)
+SELECT
+  *,
+  IF(
+    meaningful_wau_four_weeks_prior IS NULL OR meaningful_wau_four_weeks_prior = 0,
+    NULL,
+    SAFE_DIVIDE(meaningful_wau, meaningful_wau_four_weeks_prior) - 1
+  ) AS four_week_wau_growth
+FROM compared;
+
+CREATE OR REPLACE VIEW `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.investor_snapshot`
+OPTIONS (description = 'Latest complete-week headline metrics with comparisons, samples, coverage, and freshness') AS
+WITH ordered AS (
+  SELECT
+    weekly.*,
+    LAG(new_accounts) OVER (ORDER BY week_start) AS prior_week_new_accounts,
+    LAG(meaningful_wau) OVER (ORDER BY week_start) AS prior_week_meaningful_wau,
+    LAG(controller_wau) OVER (ORDER BY week_start) AS prior_week_controller_wau,
+    ROW_NUMBER() OVER (ORDER BY week_start DESC) AS recency_rank
+  FROM `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.weekly_kpis` AS weekly
+)
+SELECT
+  week_start,
+  week_end,
+  new_accounts,
+  prior_week_new_accounts,
+  meaningful_wau,
+  prior_week_meaningful_wau,
+  controller_wau,
+  prior_week_controller_wau,
+  four_week_wau_growth,
+  bridge_setup_within_7_days,
+  bridge_setup_7_day_denominator,
+  bridge_setup_7_day_rate,
+  activated_within_7_days,
+  activation_7_day_denominator,
+  activation_7_day_rate,
+  project_available_within_7_days,
+  project_available_7_day_rate,
+  time_to_project_p50_seconds,
+  time_to_project_p75_seconds,
+  time_to_activation_p50_seconds,
+  time_to_activation_p75_seconds,
+  active_days_p50,
+  active_days_p75,
+  remote_interventions,
+  remote_interventions_per_controller,
+  preference_coverage,
+  foundation_coverage,
+  activation_capability_coverage,
+  one_day_cohort_mature,
+  seven_day_cohort_mature,
+  data_as_of_at,
+  refreshed_at
+FROM ordered
+WHERE recency_rank = 1;
+
+CREATE OR REPLACE VIEW `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.activation_funnel`
+OPTIONS (description = 'Weekly account-to-bridge-to-project-to-message funnel with explicit maturity and coverage') AS
+SELECT
+  cohort_week,
+  cohort_week_end,
+  total_accounts,
+  enabled_accounts,
+  preference_coverage,
+  foundation_exposed_accounts,
+  foundation_coverage,
+  behavioral_window_mature_accounts,
+  activation_capable_accounts,
+  IF(setup_1_day_mature, activation_capability_coverage, NULL) AS activation_capability_coverage,
+  project_available_within_1_day,
+  project_available_within_7_days,
+  project_available_within_30_days,
+  IF(setup_1_day_mature, SAFE_DIVIDE(project_available_within_1_day, activation_eligible_1_day_accounts), NULL) AS project_available_1_day_rate,
+  IF(setup_7_day_mature, SAFE_DIVIDE(project_available_within_7_days, activation_eligible_7_day_accounts), NULL) AS project_available_7_day_rate,
+  IF(setup_30_day_mature, SAFE_DIVIDE(project_available_within_30_days, activation_eligible_30_day_accounts), NULL) AS project_available_30_day_rate,
+  activation_eligible_1_day_accounts,
+  activated_within_1_day,
+  IF(setup_1_day_mature, SAFE_DIVIDE(activated_within_1_day, activation_eligible_1_day_accounts), NULL) AS activation_1_day_rate,
+  activation_eligible_7_day_accounts,
+  activated_within_7_days,
+  IF(setup_7_day_mature, SAFE_DIVIDE(activated_within_7_days, activation_eligible_7_day_accounts), NULL) AS activation_7_day_rate,
+  activation_eligible_30_day_accounts,
+  activated_within_30_days,
+  IF(setup_30_day_mature, SAFE_DIVIDE(activated_within_30_days, activation_eligible_30_day_accounts), NULL) AS activation_30_day_rate,
+  existing_session_activations,
+  remote_created_session_activations,
+  time_to_project_p50_seconds,
+  time_to_project_p75_seconds,
+  time_to_activation_p50_seconds,
+  time_to_activation_p75_seconds,
+  IF(setup_1_day_mature, notification_registered_within_1_day, NULL) AS notification_registered_within_1_day,
+  IF(setup_7_day_mature, notification_registered_within_7_days, NULL) AS notification_registered_within_7_days,
+  IF(setup_30_day_mature, notification_registered_within_30_days, NULL) AS notification_registered_within_30_days,
+  IF(setup_1_day_mature, bridge_registered_within_1_day, NULL) AS bridge_registered_within_1_day,
+  IF(setup_7_day_mature, bridge_registered_within_7_days, NULL) AS bridge_registered_within_7_days,
+  IF(setup_30_day_mature, bridge_registered_within_30_days, NULL) AS bridge_registered_within_30_days,
+  IF(setup_1_day_mature, legacy_metadata_request_within_1_day, NULL) AS legacy_metadata_request_within_1_day,
+  IF(setup_7_day_mature, legacy_metadata_request_within_7_days, NULL) AS legacy_metadata_request_within_7_days,
+  IF(setup_30_day_mature, legacy_metadata_request_within_30_days, NULL) AS legacy_metadata_request_within_30_days,
+  IF(setup_1_day_mature, SAFE_DIVIDE(bridge_registered_within_1_day, total_accounts), NULL) AS bridge_1_day_rate,
+  IF(setup_7_day_mature, SAFE_DIVIDE(bridge_registered_within_7_days, total_accounts), NULL) AS bridge_7_day_rate,
+  IF(setup_30_day_mature, SAFE_DIVIDE(bridge_registered_within_30_days, total_accounts), NULL) AS bridge_30_day_rate,
+  setup_1_day_mature,
+  setup_7_day_mature,
+  setup_30_day_mature,
+  data_as_of_at,
+  refreshed_at
+FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.activation_cohorts`
+WHERE cohort_week_end < CURRENT_DATE('UTC');
+
+CREATE OR REPLACE VIEW `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.retention`
+OPTIONS (description = 'Activation-anchored W1 [7d,14d) and W4 [28d,35d) retention with eligible denominators') AS
+SELECT
+  activation_week,
+  activation_week_end,
+  activated_users,
+  w1_eligible_users,
+  w1_retained_users,
+  w1_retention_rate,
+  w4_eligible_users,
+  w4_retained_users,
+  w4_retention_rate,
+  data_as_of_at,
+  refreshed_at
+FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.retention_cohorts`;
+
+CREATE OR REPLACE VIEW `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.feature_adoption`
+OPTIONS (description = 'Complete-week bounded feature and voice adoption among current eligible accounts') AS
+SELECT
+  week_start,
+  week_end,
+  meaningful_wau,
+  controller_wau,
+  successful_messages,
+  voice_assisted_messages,
+  voice_assisted_message_users,
+  SAFE_DIVIDE(voice_assisted_message_users, meaningful_wau) AS voice_assisted_user_share,
+  SAFE_DIVIDE(voice_assisted_messages, successful_messages) AS voice_assisted_message_share,
+  voice_transcription_users,
+  remote_created_session_users,
+  remote_created_sessions,
+  dedicated_worktree_users,
+  dedicated_worktree_sessions,
+  SAFE_DIVIDE(dedicated_worktree_sessions, remote_created_sessions) AS dedicated_worktree_session_share,
+  diff_users,
+  question_users,
+  permission_users,
+  abort_users,
+  screen_users,
+  project_available_users,
+  data_as_of_at,
+  refreshed_at
+FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.weekly_engagement`;
+
+CREATE OR REPLACE VIEW `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.installation_login_funnel`
+OPTIONS (description = 'Account-less login event counts; diagnostic only and may include internal/test traffic') AS
+SELECT
+  event_date,
+  schema_version,
+  platform,
+  app_version,
+  app_build,
+  provider,
+  SUM(IF(event_name = 'login_attempt_started', event_count, 0)) AS started_events,
+  SUM(IF(event_name = 'login_attempt_completed', event_count, 0)) AS completed_events,
+  SUM(IF(event_name = 'login_attempt_failed', event_count, 0)) AS failed_events,
+  SUM(IF(event_name = 'login_attempt_failed' AND failure_kind = 'authentication', event_count, 0)) AS authentication_failures,
+  SUM(IF(event_name = 'login_attempt_failed' AND failure_kind = 'launch', event_count, 0)) AS launch_failures,
+  SUM(IF(event_name = 'login_attempt_failed' AND failure_kind = 'cancelled', event_count, 0)) AS cancelled_failures,
+  SUM(IF(event_name = 'login_attempt_failed' AND failure_kind = 'timeout', event_count, 0)) AS timeout_failures,
+  SUM(IF(event_name = 'login_attempt_failed' AND failure_kind = 'unknown', event_count, 0)) AS unknown_failures,
+  SAFE_DIVIDE(
+    SUM(IF(event_name = 'login_attempt_completed', event_count, 0)),
+    SUM(IF(event_name = 'login_attempt_started', event_count, 0))
+  ) AS event_completion_rate,
+  'account_less_login_events' AS measurement_unit,
+  LOGICAL_OR(includes_internal_test_traffic) AS includes_internal_test_traffic,
+  MAX(refreshed_at) AS refreshed_at
+FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.installation_login_daily`
+GROUP BY event_date, schema_version, platform, app_version, app_build, provider;
+
+CREATE OR REPLACE VIEW `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.screen_usage`
+OPTIONS (description = 'Canonical custom product_screen_viewed usage; Firebase-native screen_view is excluded') AS
+SELECT
+  week_start,
+  week_end,
+  platform,
+  app_version,
+  app_build,
+  screen,
+  unique_users,
+  view_count,
+  refreshed_at
+FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.screen_usage_weekly`;
+
+CREATE OR REPLACE VIEW `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.onboarding_friction`
+OPTIONS (description = 'Complete-week empty states, bounded creation failures, and onboarding support/install outcomes') AS
+SELECT
+  week_start,
+  week_end,
+  metric_name,
+  platform,
+  app_version,
+  app_build,
+  surface,
+  channel,
+  install_method,
+  install_os,
+  failure_reason,
+  workspace_kind,
+  unique_users,
+  event_count,
+  refreshed_at
+FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.onboarding_friction_weekly`;
+
+CREATE OR REPLACE VIEW `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.data_quality`
+OPTIONS (description = 'Identifier-free pipeline freshness, bounded schema/app distribution, exclusions, coverage, and maturity') AS
+WITH ranked_auth AS (
+  SELECT
+    published_at,
+    run_cutoff,
+    external_accounts,
+    enabled_accounts,
+    users_scanned,
+    source_suppressed_users,
+    internal_users,
+    opted_out_accounts,
+    preference_after_cutoff_accounts,
+    late_preference_rows_removed,
+    milestone_rows_published,
+    ROW_NUMBER() OVER (ORDER BY published_at DESC, run_cutoff DESC) AS recency_rank
+  FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.product_analytics_export_runs`
+),
+latest_auth_values AS (
+  SELECT
+    MAX(IF(recency_rank = 1, published_at, NULL)) AS published_at,
+    MAX(IF(recency_rank = 1, run_cutoff, NULL)) AS run_cutoff,
+    MAX(IF(recency_rank = 1, external_accounts, NULL)) AS external_accounts,
+    MAX(IF(recency_rank = 1, enabled_accounts, NULL)) AS enabled_accounts,
+    MAX(IF(recency_rank = 1, users_scanned, NULL)) AS users_scanned,
+    MAX(IF(recency_rank = 1, source_suppressed_users, NULL)) AS source_suppressed_users,
+    MAX(IF(recency_rank = 1, internal_users, NULL)) AS internal_users,
+    MAX(IF(recency_rank = 1, opted_out_accounts, NULL)) AS opted_out_accounts,
+    MAX(IF(recency_rank = 1, preference_after_cutoff_accounts, NULL)) AS preference_after_cutoff_accounts,
+    MAX(IF(recency_rank = 1, late_preference_rows_removed, NULL)) AS late_preference_rows_removed,
+    MAX(IF(recency_rank = 1, milestone_rows_published, NULL)) AS milestone_rows_published
+  FROM ranked_auth
+),
+latest_auth AS (
+  SELECT
+    *,
+    users_scanned = source_suppressed_users + internal_users + external_accounts
+      AND external_accounts = enabled_accounts + opted_out_accounts
+        + preference_after_cutoff_accounts + late_preference_rows_removed
+      AND milestone_rows_published = enabled_accounts AS reconciled
+  FROM latest_auth_values
+),
+latest_complete_activation AS (
+  SELECT *
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.activation_cohorts`
+  WHERE cohort_week_end < CURRENT_DATE('UTC')
+  ORDER BY cohort_week DESC
+  LIMIT 1
+),
+latest_retention AS (
+  SELECT *
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.retention_cohorts`
+  ORDER BY activation_week DESC
+  LIMIT 1
+),
+expected_models AS (
+  SELECT model_name
+  FROM UNNEST([
+    'events_flattened',
+    'installation_login_daily',
+    'user_activity_daily',
+    'user_milestones',
+    'activation_retention'
+  ]) AS model_name
+),
+pipeline AS (
+  SELECT
+    CURRENT_TIMESTAMP() AS observed_at,
+    'pipeline' AS category,
+    expected.model_name AS metric_name,
+    CONCAT(CAST(source_start_date AS STRING), '..', CAST(source_end_date AS STRING)) AS dimension_value,
+    published_rows AS metric_count,
+    CAST(NULL AS FLOAT64) AS metric_rate,
+    CASE
+      WHEN state.model_name IS NULL THEN 'missing'
+      WHEN completed_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 36 HOUR) THEN 'stale'
+      WHEN source_end_date < DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 2 DAY) THEN 'source_lagging'
+      ELSE 'ok'
+    END AS status,
+    source_end_date AS data_as_of_date,
+    latest_emitted_at AS latest_event_at,
+    completed_at AS latest_transform_at
+  FROM expected_models AS expected
+  LEFT JOIN `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state` AS state USING (model_name)
+),
+quality_counters AS (
+  SELECT
+    CURRENT_TIMESTAMP() AS observed_at,
+    'quality_counter' AS category,
+    CONCAT(state.model_name, '.', counter.metric_name) AS metric_name,
+    CAST(NULL AS STRING) AS dimension_value,
+    counter.metric_count,
+    CAST(NULL AS FLOAT64) AS metric_rate,
+    IF(counter.metric_count = 0, 'ok', 'review') AS status,
+    state.source_end_date AS data_as_of_date,
+    state.latest_emitted_at AS latest_event_at,
+    state.completed_at AS latest_transform_at
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state` AS state
+  CROSS JOIN UNNEST([
+    STRUCT('missing_identity_rows' AS metric_name, state.missing_identity_rows AS metric_count),
+    STRUCT('malformed_identity_rows' AS metric_name, state.malformed_identity_rows AS metric_count),
+    STRUCT('missing_schema_rows' AS metric_name, state.missing_schema_rows AS metric_count),
+    STRUCT('unsupported_schema_rows' AS metric_name, state.unsupported_schema_rows AS metric_count),
+    STRUCT('missing_occurrence_rows' AS metric_name, state.missing_occurrence_rows AS metric_count),
+    STRUCT('future_occurrence_rows' AS metric_name, state.future_occurrence_rows AS metric_count),
+    STRUCT('before_account_rows' AS metric_name, state.before_account_rows AS metric_count),
+    STRUCT('invalid_parameter_rows' AS metric_name, state.invalid_parameter_rows AS metric_count),
+    STRUCT('unknown_enum_rows' AS metric_name, state.unknown_enum_rows AS metric_count),
+    STRUCT('internal_excluded_rows' AS metric_name, state.internal_excluded_rows AS metric_count),
+    STRUCT('deletion_excluded_rows' AS metric_name, state.deletion_excluded_rows AS metric_count),
+    STRUCT('ineligible_user_rows' AS metric_name, state.ineligible_user_rows AS metric_count)
+  ]) AS counter
+),
+auth_freshness AS (
+  SELECT
+    CURRENT_TIMESTAMP() AS observed_at,
+    'auth_snapshot' AS category,
+    'current_eligible_accounts' AS metric_name,
+    CAST(NULL AS STRING) AS dimension_value,
+    COALESCE(enabled_accounts, 0) AS metric_count,
+    SAFE_DIVIDE(enabled_accounts, external_accounts) AS metric_rate,
+    CASE
+      WHEN published_at IS NULL THEN 'missing'
+      WHEN NOT reconciled THEN 'reconciliation_failed'
+      WHEN published_at > TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 300 SECOND)
+        OR run_cutoff > published_at THEN 'future_dated'
+      WHEN published_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 36 HOUR)
+        OR run_cutoff < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 36 HOUR) THEN 'stale'
+      ELSE 'ok'
+    END AS status,
+    DATE(run_cutoff) AS data_as_of_date,
+    CAST(NULL AS TIMESTAMP) AS latest_event_at,
+    published_at AS latest_transform_at
+  FROM latest_auth
+),
+coverage AS (
+  SELECT
+    CURRENT_TIMESTAMP() AS observed_at,
+    'coverage' AS category,
+    metric.metric_name,
+    CAST(cohort.cohort_week AS STRING) AS dimension_value,
+    metric.metric_count,
+    metric.metric_rate,
+    IF(metric.metric_rate IS NULL, 'not_mature', 'measured') AS status,
+    DATE(cohort.data_as_of_at) AS data_as_of_date,
+    CAST(NULL AS TIMESTAMP) AS latest_event_at,
+    cohort.refreshed_at AS latest_transform_at
+  FROM latest_complete_activation AS cohort
+  CROSS JOIN UNNEST([
+    STRUCT('preference' AS metric_name, cohort.enabled_accounts AS metric_count, cohort.preference_coverage AS metric_rate),
+    STRUCT('foundation' AS metric_name, cohort.foundation_exposed_accounts AS metric_count, cohort.foundation_coverage AS metric_rate),
+    STRUCT('activation_capability' AS metric_name, cohort.activation_capable_accounts AS metric_count, IF(cohort.setup_1_day_mature, cohort.activation_capability_coverage, NULL) AS metric_rate),
+    STRUCT('activation_7_day_maturity' AS metric_name, cohort.activation_eligible_7_day_accounts AS metric_count, IF(cohort.setup_7_day_mature, SAFE_DIVIDE(cohort.activated_within_7_days, cohort.activation_eligible_7_day_accounts), NULL) AS metric_rate)
+  ]) AS metric
+),
+maturity AS (
+  SELECT
+    CURRENT_TIMESTAMP() AS observed_at,
+    'cohort_maturity' AS category,
+    metric.metric_name,
+    CAST(cohort.activation_week AS STRING) AS dimension_value,
+    metric.metric_count,
+    metric.metric_rate,
+    IF(metric.metric_count = 0, 'not_mature', 'measured') AS status,
+    DATE(cohort.data_as_of_at) AS data_as_of_date,
+    CAST(NULL AS TIMESTAMP) AS latest_event_at,
+    cohort.refreshed_at AS latest_transform_at
+  FROM latest_retention AS cohort
+  CROSS JOIN UNNEST([
+    STRUCT('w1_eligible_users' AS metric_name, cohort.w1_eligible_users AS metric_count, SAFE_DIVIDE(cohort.w1_eligible_users, cohort.activated_users) AS metric_rate),
+    STRUCT('w4_eligible_users' AS metric_name, cohort.w4_eligible_users AS metric_count, SAFE_DIVIDE(cohort.w4_eligible_users, cohort.activated_users) AS metric_rate)
+  ]) AS metric
+),
+schema_distribution AS (
+  SELECT
+    CURRENT_TIMESTAMP() AS observed_at,
+    'schema' AS category,
+    'account_event_schema_version' AS metric_name,
+    CAST(schema_version AS STRING) AS dimension_value,
+    COUNT(*) AS metric_count,
+    CAST(NULL AS FLOAT64) AS metric_rate,
+    IF(schema_version = 1, 'supported', 'unsupported') AS status,
+    MAX(DATE(occurred_at)) AS data_as_of_date,
+    MAX(emitted_at) AS latest_event_at,
+    CAST(NULL AS TIMESTAMP) AS latest_transform_at
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flattened`
+  WHERE source_export_date BETWEEN DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 425 DAY)
+    AND DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 1 DAY)
+  GROUP BY schema_version
+),
+app_distribution AS (
+  SELECT
+    CURRENT_TIMESTAMP() AS observed_at,
+    'app_release' AS category,
+    'account_event_rows' AS metric_name,
+    CONCAT(
+      COALESCE(platform, 'unknown'), '/',
+      COALESCE(app_version, 'unknown'), '/',
+      COALESCE(app_build, 'unknown')
+    ) AS dimension_value,
+    COUNT(*) AS metric_count,
+    CAST(NULL AS FLOAT64) AS metric_rate,
+    IF(app_version IS NULL, 'missing_version', 'observed') AS status,
+    MAX(DATE(occurred_at)) AS data_as_of_date,
+    MAX(emitted_at) AS latest_event_at,
+    CAST(NULL AS TIMESTAMP) AS latest_transform_at
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flattened`
+  WHERE source_export_date BETWEEN DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 425 DAY)
+    AND DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 1 DAY)
+  GROUP BY platform, app_version, app_build
+)
+SELECT * FROM pipeline
+UNION ALL SELECT * FROM quality_counters
+UNION ALL SELECT * FROM auth_freshness
+UNION ALL SELECT * FROM coverage
+UNION ALL SELECT * FROM maturity
+UNION ALL SELECT * FROM schema_distribution
+UNION ALL SELECT * FROM app_distribution;

--- a/tool/product_analytics/sql/50_reporting_views.sql
+++ b/tool/product_analytics/sql/50_reporting_views.sql
@@ -304,7 +304,6 @@ SELECT
   schema_version,
   platform,
   app_version,
-  app_build,
   provider,
   SUM(IF(event_name = 'login_attempt_started', event_count, 0)) AS started_events,
   SUM(IF(event_name = 'login_attempt_completed', event_count, 0)) AS completed_events,
@@ -322,7 +321,7 @@ SELECT
   LOGICAL_OR(includes_internal_test_traffic) AS includes_internal_test_traffic,
   MAX(refreshed_at) AS refreshed_at
 FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.installation_login_daily`
-GROUP BY event_date, schema_version, platform, app_version, app_build, provider;
+GROUP BY event_date, schema_version, platform, app_version, provider;
 
 CREATE OR REPLACE VIEW `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.screen_usage`
 OPTIONS (description = 'Canonical custom product_screen_viewed usage; Firebase-native screen_view is excluded') AS
@@ -331,7 +330,6 @@ SELECT
   week_end,
   platform,
   app_version,
-  app_build,
   screen,
   unique_users,
   view_count,
@@ -346,7 +344,6 @@ SELECT
   metric_name,
   platform,
   app_version,
-  app_build,
   surface,
   channel,
   install_method,
@@ -410,6 +407,7 @@ latest_complete_activation AS (
   SELECT *
   FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.activation_cohorts`
   WHERE cohort_week_end < CURRENT_DATE('UTC')
+    AND cohort_week_end < DATE(data_as_of_at)
   ORDER BY cohort_week DESC
   LIMIT 1
 ),
@@ -589,8 +587,7 @@ app_distribution AS (
     'account_event_rows' AS metric_name,
     CONCAT(
       COALESCE(platform, 'unknown'), '/',
-      COALESCE(app_version, 'unknown'), '/',
-      COALESCE(app_build, 'unknown')
+      COALESCE(app_version, 'unknown')
     ) AS dimension_value,
     COUNT(*) AS metric_count,
     CAST(NULL AS FLOAT64) AS metric_rate,
@@ -601,7 +598,7 @@ app_distribution AS (
   FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flattened`
   WHERE source_export_date BETWEEN DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 425 DAY)
     AND DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 1 DAY)
-  GROUP BY platform, app_version, app_build
+  GROUP BY platform, app_version
 )
 SELECT * FROM pipeline
 UNION ALL SELECT * FROM quality_counters

--- a/tool/product_analytics/sql/schedules.json
+++ b/tool/product_analytics/sql/schedules.json
@@ -1,0 +1,37 @@
+[
+  {
+    "queryFile": "10_events_flattened.sql",
+    "displayName": "Sesori Product Analytics - 10 Events Flattened",
+    "cadence": "every day 04:00",
+    "recentDateRecomputationWindow": 3,
+    "maxBytesBilled": 536870912
+  },
+  {
+    "queryFile": "15_installation_login_daily.sql",
+    "displayName": "Sesori Product Analytics - 15 Installation Login Daily",
+    "cadence": "every day 04:15",
+    "recentDateRecomputationWindow": 3,
+    "maxBytesBilled": 268435456
+  },
+  {
+    "queryFile": "20_user_activity_daily.sql",
+    "displayName": "Sesori Product Analytics - 20 User Activity Daily",
+    "cadence": "every day 04:30",
+    "recentDateRecomputationWindow": 3,
+    "maxBytesBilled": 268435456
+  },
+  {
+    "queryFile": "30_user_milestones.sql",
+    "displayName": "Sesori Product Analytics - 30 User Milestones",
+    "cadence": "every day 04:45",
+    "recentDateRecomputationWindow": 3,
+    "maxBytesBilled": 268435456
+  },
+  {
+    "queryFile": "40_activation_retention.sql",
+    "displayName": "Sesori Product Analytics - 40 Activation Retention",
+    "cadence": "every day 05:00",
+    "recentDateRecomputationWindow": 3,
+    "maxBytesBilled": 536870912
+  }
+]

--- a/tool/product_analytics/tests/metric_contract_assertions.sql
+++ b/tool/product_analytics/tests/metric_contract_assertions.sql
@@ -1,0 +1,287 @@
+-- BigQuery Standard SQL. Self-contained fixture assertions; no production data
+-- is read or mutated.
+DECLARE fixture_now TIMESTAMP DEFAULT TIMESTAMP '2026-07-27 00:00:00+00';
+DECLARE account_created_at TIMESTAMP DEFAULT TIMESTAMP '2026-06-01 10:00:00+00';
+DECLARE activation_at TIMESTAMP DEFAULT TIMESTAMP '2026-06-01 11:00:00+00';
+
+CREATE TEMP TABLE expected_account_events (event_name STRING, parameter_names ARRAY<STRING>);
+INSERT INTO expected_account_events VALUES
+  ('analytics_schema_ready', []),
+  ('analytics_activation_ready', ['activation_schema_version']),
+  ('project_inventory_loaded', ['inventory_state']),
+  ('session_activity_viewed', ['activity_state']),
+  ('session_message_sent', ['input_mode', 'submission_kind']),
+  ('session_created_with_message', ['input_mode', 'submission_kind', 'workspace_kind']),
+  ('session_creation_failed', ['failure_reason', 'workspace_kind']),
+  ('voice_transcription_completed', []),
+  ('session_question_answered', []),
+  ('session_question_rejected', []),
+  ('session_permission_answered', ['decision']),
+  ('session_abort_succeeded', []),
+  ('session_diff_viewed', ['change_state']),
+  ('onboarding_need_help_opened', ['surface']),
+  ('onboarding_support_link_opened', ['channel', 'surface']),
+  ('onboarding_why_bridge_opened', ['surface']),
+  ('bridge_install_command_copied', ['method', 'os', 'surface']),
+  ('bridge_install_command_shared', ['method', 'os', 'surface']),
+  ('bridge_run_command_copied', ['surface']),
+  ('bridge_run_command_shared', ['surface']),
+  ('product_screen_viewed', ['screen']);
+
+ASSERT (SELECT COUNT(*) FROM expected_account_events) = 21
+  AS 'The current closed ProductAnalyticsEvent catalog must contain 21 wire events';
+ASSERT (
+  SELECT COUNT(*) = COUNT(DISTINCT event_name)
+  FROM expected_account_events
+) AS 'Account event wire names must be unique';
+ASSERT (
+  SELECT TO_JSON_STRING(parameter_names) = TO_JSON_STRING(['input_mode', 'submission_kind', 'workspace_kind'])
+  FROM expected_account_events
+  WHERE event_name = 'session_created_with_message'
+) AS 'Remote session creation has an exact three-parameter contract';
+ASSERT (
+  SELECT TO_JSON_STRING(parameter_names) = TO_JSON_STRING(['screen'])
+  FROM expected_account_events
+  WHERE event_name = 'product_screen_viewed'
+) AS 'Canonical screen reporting may carry only the pinned screen enum';
+
+CREATE TEMP TABLE expected_installation_events (event_name STRING, parameter_names ARRAY<STRING>);
+INSERT INTO expected_installation_events VALUES
+  ('login_attempt_started', ['provider']),
+  ('login_attempt_completed', ['provider']),
+  ('login_attempt_failed', ['failure_kind', 'provider']);
+
+ASSERT (SELECT COUNT(*) FROM expected_installation_events) = 3
+  AS 'The account-less login catalog must remain exactly three events';
+
+CREATE TEMP TABLE event_fixture (
+  user_key STRING,
+  event_name STRING,
+  occurred_at TIMESTAMP,
+  emitted_at TIMESTAMP,
+  activation_schema_version INT64,
+  activity_state STRING,
+  input_mode STRING,
+  screen STRING
+);
+
+INSERT INTO event_fixture VALUES
+  (REPEAT('a', 64), 'analytics_schema_ready', TIMESTAMP_ADD(account_created_at, INTERVAL 1 MINUTE), TIMESTAMP_ADD(account_created_at, INTERVAL 1 MINUTE), NULL, NULL, NULL, NULL),
+  (REPEAT('a', 64), 'analytics_activation_ready', TIMESTAMP_ADD(account_created_at, INTERVAL 2 MINUTE), TIMESTAMP_ADD(account_created_at, INTERVAL 2 MINUTE), 1, NULL, NULL, NULL),
+  (REPEAT('a', 64), 'session_creation_failed', TIMESTAMP_ADD(account_created_at, INTERVAL 30 MINUTE), TIMESTAMP_ADD(account_created_at, INTERVAL 30 MINUTE), NULL, NULL, NULL, NULL),
+  -- Occurrence is intentionally deferred: emission must not move activation.
+  (REPEAT('a', 64), 'session_message_sent', activation_at, TIMESTAMP_ADD(activation_at, INTERVAL 8 HOUR), NULL, NULL, 'typed', NULL),
+  (REPEAT('a', 64), 'session_activity_viewed', TIMESTAMP_ADD(activation_at, INTERVAL 7 DAY), TIMESTAMP_ADD(activation_at, INTERVAL 7 DAY), NULL, 'non_empty', NULL, NULL),
+  (REPEAT('a', 64), 'session_activity_viewed', TIMESTAMP_ADD(activation_at, INTERVAL 14 DAY), TIMESTAMP_ADD(activation_at, INTERVAL 14 DAY), NULL, 'non_empty', NULL, NULL),
+  (REPEAT('a', 64), 'session_activity_viewed', TIMESTAMP_ADD(activation_at, INTERVAL 28 DAY), TIMESTAMP_ADD(activation_at, INTERVAL 28 DAY), NULL, 'non_empty', NULL, NULL),
+  (REPEAT('a', 64), 'session_activity_viewed', TIMESTAMP_ADD(activation_at, INTERVAL 35 DAY), TIMESTAMP_ADD(activation_at, INTERVAL 35 DAY), NULL, 'non_empty', NULL, NULL),
+  (REPEAT('b', 64), 'analytics_schema_ready', TIMESTAMP_ADD(account_created_at, INTERVAL 1 MINUTE), TIMESTAMP_ADD(account_created_at, INTERVAL 1 MINUTE), NULL, NULL, NULL, NULL),
+  (REPEAT('c', 64), 'analytics_activation_ready', TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR), TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR), 1, NULL, NULL, NULL),
+  (REPEAT('d', 64), 'analytics_activation_ready', TIMESTAMP_ADD(TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR), INTERVAL 1 MICROSECOND), TIMESTAMP_ADD(TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR), INTERVAL 1 MICROSECOND), 1, NULL, NULL, NULL),
+  (REPEAT('e', 64), 'product_screen_viewed', TIMESTAMP_ADD(account_created_at, INTERVAL 5 MINUTE), TIMESTAMP_ADD(account_created_at, INTERVAL 5 MINUTE), NULL, NULL, NULL, 'projects'),
+  (REPEAT('e', 64), 'screen_view', TIMESTAMP_ADD(account_created_at, INTERVAL 6 MINUTE), TIMESTAMP_ADD(account_created_at, INTERVAL 6 MINUTE), NULL, NULL, NULL, 'projects');
+
+ASSERT (
+  SELECT MIN(IF(event_name IN ('session_message_sent', 'session_created_with_message'), occurred_at, NULL))
+  FROM event_fixture
+  WHERE user_key = REPEAT('a', 64)
+) = activation_at AS 'Full activation must use the first successful message occurrence';
+
+ASSERT (
+  SELECT MIN(IF(event_name IN ('session_message_sent', 'session_created_with_message'), emitted_at, NULL))
+  FROM event_fixture
+  WHERE user_key = REPEAT('a', 64)
+) != activation_at AS 'Deferred emission time must remain distinct from occurrence time';
+
+ASSERT (
+  SELECT COUNTIF(event_name = 'session_creation_failed')
+  FROM event_fixture
+  WHERE user_key = REPEAT('a', 64)
+) = 1 AND (
+  SELECT COUNTIF(event_name IN ('session_message_sent', 'session_created_with_message'))
+  FROM event_fixture
+  WHERE user_key = REPEAT('a', 64)
+) = 1 AS 'Failed creation is friction, never activation';
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM event_fixture
+  WHERE user_key = REPEAT('b', 64)
+    AND (
+      (event_name = 'analytics_activation_ready' AND activation_schema_version = 1)
+      OR event_name IN ('session_message_sent', 'session_created_with_message')
+    )
+) AS 'Foundation-only exposure must not create activation eligibility';
+
+ASSERT (
+  SELECT COUNTIF(
+    event_name = 'analytics_activation_ready'
+    AND activation_schema_version = 1
+    AND occurred_at <= TIMESTAMP_ADD(account_created_at, INTERVAL 24 HOUR)
+  )
+  FROM event_fixture
+  WHERE user_key IN (REPEAT('c', 64), REPEAT('d', 64))
+) = 1 AS 'Activation-capable exposure includes 24h exactly and excludes 24h plus one microsecond';
+
+CREATE TEMP TABLE timing_fixture (
+  case_name STRING,
+  account_created_at TIMESTAMP,
+  occurred_at TIMESTAMP,
+  emitted_at TIMESTAMP
+);
+INSERT INTO timing_fixture VALUES
+  ('future_at_allowance', account_created_at, TIMESTAMP_ADD(account_created_at, INTERVAL 300 SECOND), account_created_at),
+  ('future_over_allowance', account_created_at, TIMESTAMP_ADD(TIMESTAMP_ADD(account_created_at, INTERVAL 300 SECOND), INTERVAL 1 MICROSECOND), account_created_at),
+  ('account_at_allowance', account_created_at, TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND), account_created_at),
+  ('account_over_allowance', account_created_at, TIMESTAMP_SUB(TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND), INTERVAL 1 MICROSECOND), account_created_at);
+
+ASSERT (
+  SELECT COUNTIF(occurred_at <= TIMESTAMP_ADD(emitted_at, INTERVAL 300 SECOND))
+  FROM timing_fixture
+  WHERE STARTS_WITH(case_name, 'future_')
+) = 1 AS 'Future occurrence accepts exactly five minutes and rejects one microsecond more';
+ASSERT (
+  SELECT COUNTIF(occurred_at >= TIMESTAMP_SUB(account_created_at, INTERVAL 300 SECOND))
+  FROM timing_fixture
+  WHERE STARTS_WITH(case_name, 'account_')
+) = 1 AS 'Pre-account occurrence accepts exactly five minutes and rejects one microsecond more';
+
+ASSERT account_created_at <= TIMESTAMP_SUB(TIMESTAMP_ADD(account_created_at, INTERVAL 7 DAY), INTERVAL 7 DAY)
+  AS 'A seven-day activation cohort matures at exactly 7x24 hours';
+ASSERT NOT (account_created_at <= TIMESTAMP_SUB(
+  TIMESTAMP_SUB(TIMESTAMP_ADD(account_created_at, INTERVAL 7 DAY), INTERVAL 1 MICROSECOND),
+  INTERVAL 7 DAY
+)) AS 'A seven-day activation cohort is immature one microsecond before its boundary';
+
+ASSERT (
+  SELECT COUNTIF(
+    event_name = 'session_activity_viewed'
+    AND activity_state = 'non_empty'
+    AND occurred_at >= TIMESTAMP_ADD(activation_at, INTERVAL 7 DAY)
+    AND occurred_at < TIMESTAMP_ADD(activation_at, INTERVAL 14 DAY)
+  )
+  FROM event_fixture
+  WHERE user_key = REPEAT('a', 64)
+) = 1 AS 'W1 is the half-open [7d,14d) activation window';
+
+ASSERT (
+  SELECT COUNTIF(
+    event_name = 'session_activity_viewed'
+    AND activity_state = 'non_empty'
+    AND occurred_at >= TIMESTAMP_ADD(activation_at, INTERVAL 28 DAY)
+    AND occurred_at < TIMESTAMP_ADD(activation_at, INTERVAL 35 DAY)
+  )
+  FROM event_fixture
+  WHERE user_key = REPEAT('a', 64)
+) = 1 AS 'W4 is the half-open [28d,35d) activation window';
+
+CREATE TEMP TABLE activity_classification_fixture (event_name STRING, state STRING, meaningful BOOL, controller BOOL);
+INSERT INTO activity_classification_fixture VALUES
+  ('session_activity_viewed', 'empty', FALSE, FALSE),
+  ('session_activity_viewed', 'non_empty', TRUE, FALSE),
+  ('session_message_sent', NULL, TRUE, TRUE),
+  ('session_created_with_message', NULL, TRUE, TRUE),
+  ('session_question_answered', NULL, TRUE, TRUE),
+  ('session_question_rejected', NULL, TRUE, TRUE),
+  ('session_permission_answered', NULL, TRUE, TRUE),
+  ('session_abort_succeeded', NULL, TRUE, TRUE),
+  ('voice_transcription_completed', NULL, FALSE, FALSE),
+  ('session_diff_viewed', 'non_empty', FALSE, FALSE),
+  ('product_screen_viewed', NULL, FALSE, FALSE);
+
+ASSERT (
+  SELECT COUNTIF(meaningful) FROM activity_classification_fixture
+) = 7 AS 'Meaningful activity is non-empty monitoring or a confirmed control outcome';
+ASSERT (
+  SELECT COUNTIF(controller) FROM activity_classification_fixture
+) = 6 AS 'Controller activity is exactly the six successful control event names';
+ASSERT NOT EXISTS (
+  SELECT 1 FROM activity_classification_fixture
+  WHERE event_name IN ('product_screen_viewed', 'voice_transcription_completed', 'session_diff_viewed')
+    AND meaningful
+) AS 'Screens, transcription, and diffs never inflate meaningful WAU';
+
+CREATE TEMP TABLE voice_fixture (submission_kind STRING, input_mode STRING, accepted BOOL);
+INSERT INTO voice_fixture VALUES
+  ('text', 'typed', TRUE),
+  ('text', 'voice_assisted', TRUE),
+  ('command', 'typed', TRUE),
+  ('command', 'voice_assisted', FALSE);
+ASSERT (SELECT COUNTIF(accepted AND input_mode = 'voice_assisted') FROM voice_fixture) = 1
+  AS 'Only accepted text submissions can be voice-assisted';
+
+CREATE TEMP TABLE privacy_gate_fixture (
+  user_key STRING,
+  current_auth_eligible BOOL,
+  internal_excluded BOOL,
+  deletion_excluded BOOL,
+  event_count INT64
+);
+INSERT INTO privacy_gate_fixture VALUES
+  (REPEAT('1', 64), TRUE, FALSE, FALSE, 2),
+  (REPEAT('2', 64), FALSE, FALSE, FALSE, 3),
+  (REPEAT('3', 64), TRUE, TRUE, FALSE, 5),
+  (REPEAT('4', 64), TRUE, FALSE, TRUE, 7);
+
+ASSERT (
+  SELECT SUM(event_count)
+  FROM privacy_gate_fixture
+  WHERE current_auth_eligible AND NOT internal_excluded AND NOT deletion_excluded
+) = 2 AS 'Current eligibility and both permanent exclusions apply before aggregation';
+
+CREATE TEMP TABLE login_fixture (
+  event_date DATE,
+  platform STRING,
+  app_version STRING,
+  provider STRING,
+  failure_kind STRING,
+  event_name STRING
+);
+INSERT INTO login_fixture VALUES
+  (DATE '2026-07-20', 'IOS', '1.0.0', 'github', NULL, 'login_attempt_started'),
+  (DATE '2026-07-20', 'IOS', '1.0.0', 'github', NULL, 'login_attempt_completed'),
+  (DATE '2026-07-20', 'IOS', '1.0.0', 'github', 'timeout', 'login_attempt_failed');
+ASSERT (
+  SELECT SAFE_DIVIDE(COUNTIF(event_name = 'login_attempt_completed'), COUNTIF(event_name = 'login_attempt_started'))
+  FROM login_fixture
+) = 1 AS 'Account-less login completion is a direct event-count rate';
+ASSERT NOT REGEXP_CONTAINS(TO_JSON_STRING(ARRAY(SELECT AS STRUCT * FROM login_fixture)), r'(?i)user_pseudo|user_key|user_id|installation')
+  AS 'Login aggregation fixtures contain no account or installation identifier';
+
+ASSERT (
+  SELECT COUNTIF(event_name = 'product_screen_viewed')
+  FROM event_fixture
+  WHERE user_key = REPEAT('e', 64)
+) = 1 AND (
+  SELECT COUNTIF(event_name = 'screen_view')
+  FROM event_fixture
+  WHERE user_key = REPEAT('e', 64)
+) = 1 AS 'Canonical custom screens remain distinct from the native screen_view mirror';
+
+ASSERT TIMESTAMP_SUB(fixture_now, INTERVAL 36 HOUR) >= TIMESTAMP_SUB(fixture_now, INTERVAL 36 HOUR)
+  AS 'An auth snapshot exactly 36 hours old is fresh';
+ASSERT NOT (
+  TIMESTAMP_SUB(TIMESTAMP_SUB(fixture_now, INTERVAL 36 HOUR), INTERVAL 1 MICROSECOND)
+    >= TIMESTAMP_SUB(fixture_now, INTERVAL 36 HOUR)
+) AS 'An auth snapshot older than 36 hours by one microsecond is stale';
+
+CREATE TEMP TABLE week_fixture (activity_date DATE);
+INSERT INTO week_fixture VALUES
+  (DATE '2026-07-20'),
+  (DATE '2026-07-26'),
+  (DATE '2026-07-27');
+ASSERT (
+  SELECT COUNTIF(
+    DATE_TRUNC(activity_date, WEEK(MONDAY)) = DATE '2026-07-20'
+    AND DATE_ADD(DATE_TRUNC(activity_date, WEEK(MONDAY)), INTERVAL 6 DAY) = DATE '2026-07-26'
+  )
+  FROM week_fixture
+) = 2 AS 'Weeks are complete Monday-Sunday UTC periods';
+
+CREATE TEMP TABLE replacement_fixture (source_date DATE, event_name STRING, event_count INT64);
+INSERT INTO replacement_fixture VALUES (DATE '2026-07-24', 'session_message_sent', 1);
+DELETE FROM replacement_fixture WHERE source_date BETWEEN DATE '2026-07-22' AND DATE '2026-07-24';
+INSERT INTO replacement_fixture VALUES (DATE '2026-07-24', 'session_message_sent', 2);
+ASSERT (
+  SELECT COUNT(*) = 1 AND SUM(event_count) = 2 FROM replacement_fixture
+) AS 'Late-arrival recomputation replaces rather than appends mutable source dates';

--- a/tool/product_analytics/tests/metric_contract_assertions.sql
+++ b/tool/product_analytics/tests/metric_contract_assertions.sql
@@ -153,6 +153,48 @@ ASSERT NOT (account_created_at <= TIMESTAMP_SUB(
   INTERVAL 7 DAY
 )) AS 'A seven-day activation cohort is immature one microsecond before its boundary';
 
+CREATE TEMP TABLE retention_maturity_fixture (
+  activation_week DATE,
+  w1_eligible BOOL,
+  w1_retained BOOL,
+  w4_eligible BOOL,
+  w4_retained BOOL
+);
+INSERT INTO retention_maturity_fixture VALUES
+  (DATE '2026-07-06', TRUE, TRUE, TRUE, FALSE),
+  (DATE '2026-07-06', TRUE, FALSE, TRUE, TRUE),
+  (DATE '2026-07-13', TRUE, TRUE, FALSE, FALSE),
+  (DATE '2026-07-13', FALSE, FALSE, FALSE, FALSE);
+
+CREATE TEMP TABLE retention_maturity_result AS
+SELECT
+  activation_week,
+  COUNTIF(w1_eligible) = COUNT(*) AS w1_cohort_mature,
+  COUNTIF(w1_eligible) AS w1_eligible_users,
+  COUNTIF(w1_eligible AND w1_retained) AS w1_retained_users,
+  COUNTIF(w4_eligible) = COUNT(*) AS w4_cohort_mature,
+  COUNTIF(w4_eligible) AS w4_eligible_users,
+  COUNTIF(w4_eligible AND w4_retained) AS w4_retained_users
+FROM retention_maturity_fixture
+GROUP BY activation_week;
+
+ASSERT (
+  SELECT w1_cohort_mature AND w4_cohort_mature
+  FROM retention_maturity_result
+  WHERE activation_week = DATE '2026-07-06'
+) AS 'Retention cohort maturity requires every activated user window to elapse';
+ASSERT (
+  SELECT
+    NOT w1_cohort_mature
+    AND NOT w4_cohort_mature
+    AND IF(w1_cohort_mature, w1_eligible_users, NULL) IS NULL
+    AND IF(w1_cohort_mature, w1_retained_users, NULL) IS NULL
+    AND IF(w4_cohort_mature, w4_eligible_users, NULL) IS NULL
+    AND IF(w4_cohort_mature, w4_retained_users, NULL) IS NULL
+  FROM retention_maturity_result
+  WHERE activation_week = DATE '2026-07-13'
+) AS 'A partially mature activation week exposes null retention counts';
+
 ASSERT (
   SELECT COUNTIF(
     event_name = 'session_activity_viewed'
@@ -285,3 +327,297 @@ INSERT INTO replacement_fixture VALUES (DATE '2026-07-24', 'session_message_sent
 ASSERT (
   SELECT COUNT(*) = 1 AND SUM(event_count) = 2 FROM replacement_fixture
 ) AS 'Late-arrival recomputation replaces rather than appends mutable source dates';
+
+ASSERT LEAST(
+  DATE_SUB(DATE(fixture_now), INTERVAL 1 DAY),
+  DATE_SUB(DATE '2026-07-26', INTERVAL 1 DAY)
+) = DATE '2026-07-25'
+  AS 'Complete UTC coverage ends no later than one day before the latest property-local suffix';
+
+CREATE TEMP TABLE timezone_scan_fixture (
+  case_name STRING,
+  suffix_date DATE,
+  emitted_at TIMESTAMP
+);
+INSERT INTO timezone_scan_fixture VALUES
+  ('previous_suffix', DATE '2026-07-19', TIMESTAMP '2026-07-20 00:15:00+00'),
+  ('matching_suffix', DATE '2026-07-20', TIMESTAMP '2026-07-20 12:00:00+00'),
+  ('next_suffix', DATE '2026-07-21', TIMESTAMP '2026-07-20 23:45:00+00'),
+  ('suffix_too_early', DATE '2026-07-18', TIMESTAMP '2026-07-20 00:30:00+00'),
+  ('utc_date_outside_range', DATE '2026-07-20', TIMESTAMP '2026-07-19 23:45:00+00');
+
+CREATE TEMP TABLE timezone_scan_result AS
+SELECT
+  case_name,
+  DATE(emitted_at) AS source_export_date
+FROM timezone_scan_fixture
+WHERE suffix_date BETWEEN DATE_SUB(DATE '2026-07-20', INTERVAL 1 DAY)
+    AND DATE_ADD(DATE '2026-07-20', INTERVAL 1 DAY)
+  AND DATE(emitted_at) BETWEEN DATE '2026-07-20' AND DATE '2026-07-20';
+
+ASSERT TO_JSON_STRING(ARRAY(
+  SELECT case_name FROM timezone_scan_result ORDER BY case_name
+)) = TO_JSON_STRING(['matching_suffix', 'next_suffix', 'previous_suffix'])
+  AS 'One-day suffix bounds retain both timezone edges and the UTC date filter removes adjacent UTC dates';
+ASSERT NOT EXISTS (
+  SELECT 1 FROM timezone_scan_result WHERE source_export_date != DATE '2026-07-20'
+) AS 'source_export_date is always derived from the UTC emission timestamp';
+
+CREATE TEMP TABLE raw_duplicate_fixture (
+  event_scope STRING,
+  user_pseudo_id STRING,
+  user_key STRING,
+  event_name STRING,
+  event_timestamp INT64,
+  event_bundle_sequence_id INT64,
+  batch_event_index INT64,
+  bounded_payload STRING
+);
+INSERT INTO raw_duplicate_fixture VALUES
+  ('account', 'account-installation-a', REPEAT('a', 64), 'session_message_sent', 100, 7, 0, 'typed'),
+  ('account', 'account-installation-a', REPEAT('a', 64), 'session_message_sent', 100, 7, 0, 'typed'),
+  ('account', 'account-installation-a', REPEAT('b', 64), 'session_message_sent', 100, 7, 0, 'typed'),
+  ('account', 'account-installation-b', REPEAT('a', 64), 'session_message_sent', 100, 7, 0, 'typed'),
+  ('login', 'login-installation-a', NULL, 'login_attempt_started', 200, 8, 0, 'github'),
+  ('login', 'login-installation-a', NULL, 'login_attempt_started', 200, 8, 0, 'github');
+
+CREATE TEMP TABLE deduplicated_fixture AS
+SELECT * EXCEPT (user_pseudo_id, user_key, duplicate_rank)
+FROM (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (
+      PARTITION BY
+        user_pseudo_id,
+        user_key,
+        event_name,
+        event_timestamp,
+        event_bundle_sequence_id,
+        batch_event_index,
+        bounded_payload
+      ORDER BY event_timestamp
+    ) AS duplicate_rank
+  FROM raw_duplicate_fixture
+)
+WHERE duplicate_rank = 1;
+
+ASSERT (SELECT COUNT(*) FROM raw_duplicate_fixture WHERE event_scope = 'account') = 4
+  AND (SELECT COUNT(*) FROM deduplicated_fixture WHERE event_scope = 'account') = 3
+  AS 'Account duplicate identity includes transient installation identity, user key, bounded payload, bundle, batch, and timestamp';
+ASSERT (SELECT COUNT(*) FROM raw_duplicate_fixture WHERE event_scope = 'login') = 2
+  AND (SELECT COUNT(*) FROM deduplicated_fixture WHERE event_scope = 'login') = 1
+  AS 'Login counts remove equivalent transient Firebase export duplicates';
+ASSERT NOT REGEXP_CONTAINS(
+  TO_JSON_STRING(ARRAY(SELECT AS STRUCT * FROM deduplicated_fixture)),
+  r'(?i)user_pseudo_id|installation-a|installation-b'
+) AS 'Transient duplicate identity never survives into deduplicated output';
+
+CREATE TEMP TABLE parameter_contract_fixture (
+  case_name STRING,
+  required_parameter_names ARRAY<STRING>
+);
+INSERT INTO parameter_contract_fixture VALUES
+  ('valid', ['user_key', 'schema_version', 'occurred_at_micros', 'submission_kind', 'input_mode']),
+  ('duplicate_required', ['user_key', 'schema_version', 'occurred_at_micros', 'submission_kind', 'input_mode']),
+  ('wrong_typed_slot', ['user_key', 'schema_version', 'occurred_at_micros', 'submission_kind', 'input_mode']),
+  ('unknown_enum', ['user_key', 'schema_version', 'occurred_at_micros', 'submission_kind', 'input_mode']);
+
+CREATE TEMP TABLE parameter_value_fixture (
+  case_name STRING,
+  parameter_name STRING,
+  string_value STRING,
+  int_value INT64,
+  float_value FLOAT64,
+  double_value FLOAT64
+);
+INSERT INTO parameter_value_fixture VALUES
+  ('valid', 'user_key', REPEAT('a', 64), NULL, NULL, NULL),
+  ('valid', 'schema_version', NULL, 1, NULL, NULL),
+  ('valid', 'occurred_at_micros', NULL, 100, NULL, NULL),
+  ('valid', 'submission_kind', 'text', NULL, NULL, NULL),
+  ('valid', 'input_mode', 'typed', NULL, NULL, NULL),
+  ('duplicate_required', 'user_key', REPEAT('a', 64), NULL, NULL, NULL),
+  ('duplicate_required', 'schema_version', NULL, 1, NULL, NULL),
+  ('duplicate_required', 'occurred_at_micros', NULL, 100, NULL, NULL),
+  ('duplicate_required', 'submission_kind', 'text', NULL, NULL, NULL),
+  ('duplicate_required', 'input_mode', 'typed', NULL, NULL, NULL),
+  ('duplicate_required', 'input_mode', 'typed', NULL, NULL, NULL),
+  ('wrong_typed_slot', 'user_key', REPEAT('a', 64), NULL, NULL, NULL),
+  ('wrong_typed_slot', 'schema_version', '1', NULL, NULL, NULL),
+  ('wrong_typed_slot', 'occurred_at_micros', NULL, 100, NULL, NULL),
+  ('wrong_typed_slot', 'submission_kind', 'text', NULL, NULL, NULL),
+  ('wrong_typed_slot', 'input_mode', 'typed', NULL, NULL, NULL),
+  ('unknown_enum', 'user_key', REPEAT('a', 64), NULL, NULL, NULL),
+  ('unknown_enum', 'schema_version', NULL, 1, NULL, NULL),
+  ('unknown_enum', 'occurred_at_micros', NULL, 100, NULL, NULL),
+  ('unknown_enum', 'submission_kind', 'text', NULL, NULL, NULL),
+  ('unknown_enum', 'input_mode', 'unbounded', NULL, NULL, NULL);
+
+CREATE TEMP TABLE parameter_validation_fixture AS
+SELECT
+  contract.case_name,
+  (
+    SELECT
+      COUNT(*) = ARRAY_LENGTH(contract.required_parameter_names)
+      AND COUNT(DISTINCT parameter.parameter_name) = ARRAY_LENGTH(contract.required_parameter_names)
+      AND COUNTIF(
+        (
+          parameter.parameter_name IN ('schema_version', 'occurred_at_micros')
+          AND parameter.int_value IS NOT NULL
+          AND parameter.string_value IS NULL
+          AND parameter.float_value IS NULL
+          AND parameter.double_value IS NULL
+        )
+        OR (
+          parameter.parameter_name NOT IN ('schema_version', 'occurred_at_micros')
+          AND parameter.string_value IS NOT NULL
+          AND parameter.int_value IS NULL
+          AND parameter.float_value IS NULL
+          AND parameter.double_value IS NULL
+        )
+      ) = ARRAY_LENGTH(contract.required_parameter_names)
+    FROM parameter_value_fixture AS parameter
+    WHERE parameter.case_name = contract.case_name
+      AND parameter.parameter_name IN UNNEST(contract.required_parameter_names)
+  ) AS parameter_shape_valid,
+  (
+    SELECT MAX(IF(parameter_name = 'input_mode', string_value, NULL)) IN ('typed', 'voice_assisted')
+    FROM parameter_value_fixture AS parameter
+    WHERE parameter.case_name = contract.case_name
+  ) AS bounded_enum_valid
+FROM parameter_contract_fixture AS contract;
+
+ASSERT (SELECT parameter_shape_valid FROM parameter_validation_fixture WHERE case_name = 'valid')
+  AS 'Exactly one correctly typed value for every required parameter is accepted';
+ASSERT NOT (SELECT parameter_shape_valid FROM parameter_validation_fixture WHERE case_name = 'duplicate_required')
+  AS 'A duplicate required parameter is rejected even when both values agree';
+ASSERT NOT (SELECT parameter_shape_valid FROM parameter_validation_fixture WHERE case_name = 'wrong_typed_slot')
+  AS 'Integer shared parameters are rejected when supplied through a string slot';
+ASSERT (
+  SELECT parameter_shape_valid AND NOT bounded_enum_valid
+  FROM parameter_validation_fixture
+  WHERE case_name = 'unknown_enum'
+) AS 'Unknown bounded values remain distinct from invalid parameter shape rows';
+
+CREATE TEMP TABLE login_nullability_fixture (
+  case_name STRING,
+  event_name STRING,
+  failure_kind STRING,
+  expected_valid BOOL
+);
+INSERT INTO login_nullability_fixture VALUES
+  ('failed_with_kind', 'login_attempt_failed', 'timeout', TRUE),
+  ('failed_without_kind', 'login_attempt_failed', NULL, FALSE),
+  ('started_without_kind', 'login_attempt_started', NULL, TRUE),
+  ('started_with_kind', 'login_attempt_started', 'timeout', FALSE);
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM login_nullability_fixture
+  WHERE expected_valid != COALESCE(
+    (event_name = 'login_attempt_failed' AND failure_kind IN ('authentication', 'launch', 'cancelled', 'timeout', 'unknown'))
+      OR (event_name IN ('login_attempt_started', 'login_attempt_completed') AND failure_kind IS NULL),
+    FALSE
+  )
+) AS 'Login failures require one bounded failure kind and non-failures require none';
+
+CREATE TEMP TABLE snapshot_period_fixture (
+  week_start DATE,
+  account_period_available BOOL,
+  complete_engagement_available BOOL,
+  mature_7_day_activation_available BOOL
+);
+INSERT INTO snapshot_period_fixture VALUES
+  (DATE '2026-07-06', TRUE, TRUE, TRUE),
+  (DATE '2026-07-13', TRUE, TRUE, FALSE),
+  (DATE '2026-07-20', TRUE, FALSE, FALSE);
+
+ASSERT (SELECT MAX(IF(account_period_available, week_start, NULL)) FROM snapshot_period_fixture) = DATE '2026-07-20'
+  AND (SELECT MAX(IF(complete_engagement_available, week_start, NULL)) FROM snapshot_period_fixture) = DATE '2026-07-13'
+  AND (SELECT MAX(IF(mature_7_day_activation_available, week_start, NULL)) FROM snapshot_period_fixture) = DATE '2026-07-06'
+  AS 'Investor snapshot periods are selected independently by account, engagement, and 7-day maturity';
+
+ASSERT (
+  SELECT COUNT(*)
+  FROM (SELECT 1 AS singleton) AS base
+  LEFT JOIN (
+    SELECT 1 AS recency_rank
+    FROM snapshot_period_fixture
+    WHERE mature_7_day_activation_available AND FALSE
+  ) AS no_mature_activation
+    ON no_mature_activation.recency_rank = base.singleton
+) = 1 AS 'Investor snapshot keeps one null-capable row before any activation cohort matures';
+
+CREATE TEMP TABLE zero_account_week_fixture (
+  week_start DATE,
+  week_end DATE,
+  new_accounts INT64
+);
+INSERT INTO zero_account_week_fixture VALUES
+  (DATE '2026-07-06', DATE '2026-07-12', 4),
+  (DATE '2026-07-13', DATE '2026-07-19', 0);
+
+CREATE TEMP TABLE zero_account_week_compared AS
+SELECT
+  *,
+  LAG(new_accounts) OVER (ORDER BY week_start) AS prior_week_new_accounts,
+  ROW_NUMBER() OVER (ORDER BY week_start DESC) AS recency_rank
+FROM zero_account_week_fixture;
+
+ASSERT (
+  SELECT
+    week_start = DATE '2026-07-13'
+    AND new_accounts = 0
+    AND prior_week_new_accounts = 4
+  FROM zero_account_week_compared
+  WHERE recency_rank = 1
+) AS 'Investor account periods retain and compare a complete zero-signup week';
+
+CREATE TEMP TABLE publication_gate_fixture (
+  case_name STRING,
+  auth_published_at TIMESTAMP,
+  staged_control_updated_at TIMESTAMP,
+  current_control_updated_at TIMESTAMP,
+  staged_value INT64
+);
+INSERT INTO publication_gate_fixture VALUES
+  (
+    'stale_auth',
+    TIMESTAMP_SUB(TIMESTAMP_SUB(fixture_now, INTERVAL 36 HOUR), INTERVAL 1 MICROSECOND),
+    TIMESTAMP '2026-07-26 00:00:00+00',
+    TIMESTAMP '2026-07-26 00:00:00+00',
+    9
+  ),
+  (
+    'control_mismatch',
+    fixture_now,
+    TIMESTAMP '2026-07-25 00:00:00+00',
+    TIMESTAMP '2026-07-26 00:00:00+00',
+    9
+  ),
+  (
+    'current',
+    fixture_now,
+    TIMESTAMP '2026-07-26 00:00:00+00',
+    TIMESTAMP '2026-07-26 00:00:00+00',
+    9
+  );
+
+CREATE TEMP TABLE publication_target_fixture (case_name STRING, published_value INT64);
+INSERT INTO publication_target_fixture VALUES
+  ('stale_auth', 7),
+  ('control_mismatch', 7),
+  ('current', 7);
+
+UPDATE publication_target_fixture AS target
+SET published_value = gate.staged_value
+FROM publication_gate_fixture AS gate
+WHERE target.case_name = gate.case_name
+  AND gate.auth_published_at BETWEEN TIMESTAMP_SUB(fixture_now, INTERVAL 36 HOUR)
+    AND TIMESTAMP_ADD(fixture_now, INTERVAL 300 SECOND)
+  AND gate.staged_control_updated_at = gate.current_control_updated_at;
+
+ASSERT (
+  SELECT COUNTIF(published_value = 7) = 2 AND COUNTIF(case_name = 'current' AND published_value = 9) = 1
+  FROM publication_target_fixture
+) AS 'Stale auth or a changed control sentinel leaves the previously published target unmodified';

--- a/tool/product_analytics/tests/metric_contract_assertions.sql
+++ b/tool/product_analytics/tests/metric_contract_assertions.sql
@@ -153,6 +153,27 @@ ASSERT NOT (account_created_at <= TIMESTAMP_SUB(
   INTERVAL 7 DAY
 )) AS 'A seven-day activation cohort is immature one microsecond before its boundary';
 
+CREATE TEMP TABLE ordered_funnel_fixture (
+  case_name STRING,
+  account_at TIMESTAMP,
+  bridge_at TIMESTAMP,
+  project_at TIMESTAMP,
+  message_at TIMESTAMP
+);
+INSERT INTO ordered_funnel_fixture VALUES
+  ('ordered', account_created_at, TIMESTAMP_ADD(account_created_at, INTERVAL 1 HOUR), TIMESTAMP_ADD(account_created_at, INTERVAL 2 HOUR), TIMESTAMP_ADD(account_created_at, INTERVAL 3 HOUR)),
+  ('project_before_bridge', account_created_at, TIMESTAMP_ADD(account_created_at, INTERVAL 2 HOUR), TIMESTAMP_ADD(account_created_at, INTERVAL 1 HOUR), TIMESTAMP_ADD(account_created_at, INTERVAL 3 HOUR)),
+  ('message_before_project', account_created_at, TIMESTAMP_ADD(account_created_at, INTERVAL 1 HOUR), TIMESTAMP_ADD(account_created_at, INTERVAL 3 HOUR), TIMESTAMP_ADD(account_created_at, INTERVAL 2 HOUR));
+
+ASSERT (
+  SELECT COUNTIF(
+    bridge_at >= TIMESTAMP_SUB(account_at, INTERVAL 300 SECOND)
+    AND project_at >= TIMESTAMP_SUB(bridge_at, INTERVAL 300 SECOND)
+    AND message_at >= TIMESTAMP_SUB(project_at, INTERVAL 300 SECOND)
+  )
+  FROM ordered_funnel_fixture
+) = 1 AS 'Activation progression must remain account to bridge to project to message';
+
 CREATE TEMP TABLE retention_maturity_fixture (
   activation_week DATE,
   w1_eligible BOOL,

--- a/tool/product_analytics/tests/schema_allowlist_assertions.sql
+++ b/tool/product_analytics/tests/schema_allowlist_assertions.sql
@@ -1,0 +1,432 @@
+-- BigQuery Standard SQL. Run after DDL/transforms against a non-production or
+-- production deployment; assertions inspect schemas and bounded curated values.
+
+CREATE TEMP TABLE expected_flattened_columns AS
+SELECT column_name
+FROM UNNEST([
+  'event_name',
+  'source_export_date',
+  'emitted_at',
+  'occurred_at_micros',
+  'occurred_at',
+  'schema_version',
+  'user_key',
+  'platform',
+  'app_version',
+  'app_build',
+  'activation_schema_version',
+  'inventory_state',
+  'activity_state',
+  'submission_kind',
+  'input_mode',
+  'workspace_kind',
+  'failure_reason',
+  'decision',
+  'change_state',
+  'surface',
+  'channel',
+  'method',
+  'os',
+  'screen'
+]) AS column_name;
+
+ASSERT NOT EXISTS (
+  SELECT column_name FROM expected_flattened_columns
+  EXCEPT DISTINCT
+  SELECT column_name
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.INFORMATION_SCHEMA.COLUMNS`
+  WHERE table_name = 'events_flattened'
+) AND NOT EXISTS (
+  SELECT column_name
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.INFORMATION_SCHEMA.COLUMNS`
+  WHERE table_name = 'events_flattened'
+  EXCEPT DISTINCT
+  SELECT column_name FROM expected_flattened_columns
+) AS 'events_flattened columns must exactly match the approved scalar allowlist';
+
+CREATE TEMP TABLE expected_login_columns AS
+SELECT column_name
+FROM UNNEST([
+  'source_export_date',
+  'event_date',
+  'event_name',
+  'schema_version',
+  'platform',
+  'app_version',
+  'app_build',
+  'provider',
+  'failure_kind',
+  'event_count',
+  'includes_internal_test_traffic',
+  'refreshed_at'
+]) AS column_name;
+
+ASSERT NOT EXISTS (
+  SELECT column_name FROM expected_login_columns
+  EXCEPT DISTINCT
+  SELECT column_name
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.INFORMATION_SCHEMA.COLUMNS`
+  WHERE table_name = 'installation_login_daily'
+) AND NOT EXISTS (
+  SELECT column_name
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.INFORMATION_SCHEMA.COLUMNS`
+  WHERE table_name = 'installation_login_daily'
+  EXCEPT DISTINCT
+  SELECT column_name FROM expected_login_columns
+) AS 'installation_login_daily must remain an identifier-free exact schema';
+
+CREATE TEMP TABLE expected_auth_schemas (
+  table_name STRING,
+  ordered_columns ARRAY<STRING>,
+  required_columns ARRAY<STRING>
+);
+INSERT INTO expected_auth_schemas VALUES
+  (
+    'auth_user_milestones',
+    ['user_key', 'account_created_at', 'notification_registered_at', 'bridge_registered_at', 'legacy_first_metadata_request_at', 'exported_at'],
+    ['user_key', 'account_created_at', 'exported_at']
+  ),
+  (
+    'auth_weekly_setup_cohorts',
+    [
+      'cohort_week',
+      'total_accounts',
+      'enabled_accounts',
+      'notification_registered_within_1_day',
+      'notification_registered_within_7_days',
+      'notification_registered_within_30_days',
+      'bridge_registered_within_1_day',
+      'bridge_registered_within_7_days',
+      'bridge_registered_within_30_days',
+      'legacy_first_metadata_request_within_1_day',
+      'legacy_first_metadata_request_within_7_days',
+      'legacy_first_metadata_request_within_30_days',
+      'exported_at'
+    ],
+    [
+      'cohort_week',
+      'total_accounts',
+      'enabled_accounts',
+      'notification_registered_within_1_day',
+      'notification_registered_within_7_days',
+      'notification_registered_within_30_days',
+      'bridge_registered_within_1_day',
+      'bridge_registered_within_7_days',
+      'bridge_registered_within_30_days',
+      'legacy_first_metadata_request_within_1_day',
+      'legacy_first_metadata_request_within_7_days',
+      'legacy_first_metadata_request_within_30_days',
+      'exported_at'
+    ]
+  ),
+  (
+    'product_analytics_export_runs',
+    [
+      'run_id',
+      'run_cutoff',
+      'preference_scan_cutoff',
+      'control_updated_at',
+      'users_scanned',
+      'source_suppressed_users',
+      'internal_users',
+      'external_accounts',
+      'enabled_accounts',
+      'opted_out_accounts',
+      'preference_after_cutoff_accounts',
+      'late_preference_rows_removed',
+      'milestone_rows_published',
+      'cohort_rows_published',
+      'published_at'
+    ],
+    [
+      'run_id',
+      'run_cutoff',
+      'preference_scan_cutoff',
+      'control_updated_at',
+      'users_scanned',
+      'source_suppressed_users',
+      'internal_users',
+      'external_accounts',
+      'enabled_accounts',
+      'opted_out_accounts',
+      'preference_after_cutoff_accounts',
+      'late_preference_rows_removed',
+      'milestone_rows_published',
+      'cohort_rows_published',
+      'published_at'
+    ]
+  ),
+  (
+    'product_analytics_export_state',
+    ['state_key', 'active_run_id', 'lease_expires_at', 'last_published_run_id', 'last_published_cutoff', 'updated_at'],
+    ['state_key', 'updated_at']
+  );
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM expected_auth_schemas AS expected
+  WHERE TO_JSON_STRING(expected.ordered_columns) != TO_JSON_STRING((
+    SELECT ARRAY_AGG(column_name ORDER BY ordinal_position)
+    FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.INFORMATION_SCHEMA.COLUMNS`
+    WHERE table_name = expected.table_name
+  ))
+) AS 'Permanent auth export columns must exactly match the auth repository contract';
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM expected_auth_schemas AS expected
+  WHERE EXISTS (
+    SELECT required_column FROM UNNEST(expected.required_columns) AS required_column
+    EXCEPT DISTINCT
+    SELECT column_name
+    FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.INFORMATION_SCHEMA.COLUMNS`
+    WHERE table_name = expected.table_name AND is_nullable = 'NO'
+  ) OR EXISTS (
+    SELECT column_name
+    FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.INFORMATION_SCHEMA.COLUMNS`
+    WHERE table_name = expected.table_name AND is_nullable = 'NO'
+    EXCEPT DISTINCT
+    SELECT required_column FROM UNNEST(expected.required_columns) AS required_column
+  )
+) AS 'Permanent auth export required/nullability modes must exactly match the auth repository contract';
+
+ASSERT TO_JSON_STRING((
+  SELECT ARRAY_AGG(column_name ORDER BY ordinal_position)
+  FROM `{{PROJECT_ID}}.{{PRIVACY_DATASET_ID}}.INFORMATION_SCHEMA.COLUMNS`
+  WHERE table_name = 'product_analytics_deletion_targets'
+)) = TO_JSON_STRING(['request_id', 'user_key', 'legacy_firebase_user_id', 'suppressed_at', 'status', 'last_error_code', 'completed_at', 'created_at', 'updated_at'])
+  AS 'Privacy deletion target schema must match the isolated auth handoff';
+
+ASSERT TO_JSON_STRING((
+  SELECT ARRAY_AGG(column_name ORDER BY ordinal_position)
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.INFORMATION_SCHEMA.COLUMNS`
+  WHERE table_name = 'permanent_deletion_exclusions'
+)) = TO_JSON_STRING(['user_key', 'suppressed_at', 'created_at', 'updated_at'])
+  AS 'Permanent deletion exclusion schema must match the privacy processor contract';
+
+ASSERT TO_JSON_STRING((
+  SELECT ARRAY_AGG(column_name ORDER BY ordinal_position)
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.INFORMATION_SCHEMA.COLUMNS`
+  WHERE table_name = 'product_analytics_privacy_sweep_state'
+)) = TO_JSON_STRING(['sweep_name', 'last_success_through_date', 'updated_at'])
+  AS 'Privacy sweep checkpoint must remain identifier-free and monotonic';
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.INFORMATION_SCHEMA.COLUMNS`
+  WHERE LOWER(column_name) IN (
+    'user_pseudo_id',
+    'user_id',
+    'event_params',
+    'user_properties',
+    'geo',
+    'device',
+    'device_model',
+    'device_brand',
+    'advertising_id',
+    'vendor_id',
+    'stream_id',
+    'traffic_source',
+    'prompt',
+    'response',
+    'transcript_text',
+    'code',
+    'path',
+    'project_id',
+    'session_id',
+    'bridge_id',
+    'notification_id',
+    'raw_error'
+  )
+) AS 'Curated schemas must not persist raw identifiers, arbitrary records, device/geo data, or sensitive content';
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.INFORMATION_SCHEMA.COLUMNS`
+  WHERE LOWER(column_name) IN (
+    'user_key',
+    'user_pseudo_id',
+    'user_id',
+    'request_id',
+    'privacy_request_id',
+    'legacy_firebase_user_id',
+    'project_id',
+    'session_id',
+    'bridge_id',
+    'device_id',
+    'notification_id'
+  )
+) AS 'Reporting views must expose no account, installation, entity, or deletion-request identifier';
+
+CREATE TEMP TABLE expected_reporting_views AS
+SELECT table_name
+FROM UNNEST([
+  'investor_snapshot',
+  'weekly_kpis',
+  'activation_funnel',
+  'retention',
+  'feature_adoption',
+  'installation_login_funnel',
+  'screen_usage',
+  'onboarding_friction',
+  'data_quality'
+]) AS table_name;
+
+ASSERT NOT EXISTS (
+  SELECT table_name FROM expected_reporting_views
+  EXCEPT DISTINCT
+  SELECT table_name
+  FROM `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.INFORMATION_SCHEMA.TABLES`
+  WHERE table_type = 'VIEW'
+) AS 'Every required identifier-free reporting view must exist';
+
+ASSERT (
+  SELECT COUNTIF(is_partitioning_column = 'YES')
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.INFORMATION_SCHEMA.COLUMNS`
+  WHERE table_name = 'events_flattened' AND column_name = 'source_export_date'
+) = 1 AS 'events_flattened must remain partitioned by its bounded GA4 source suffix date';
+
+ASSERT (
+  SELECT COUNTIF(clustering_ordinal_position IS NOT NULL)
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.INFORMATION_SCHEMA.COLUMNS`
+  WHERE table_name = 'events_flattened' AND column_name IN ('event_name', 'user_key')
+) = 2 AS 'events_flattened must remain clustered by event_name and user_key';
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flattened`
+  WHERE source_export_date BETWEEN DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 425 DAY)
+    AND DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 1 DAY)
+    AND event_name NOT IN (
+      'analytics_schema_ready',
+      'analytics_activation_ready',
+      'project_inventory_loaded',
+      'session_activity_viewed',
+      'session_message_sent',
+      'session_created_with_message',
+      'session_creation_failed',
+      'voice_transcription_completed',
+      'session_question_answered',
+      'session_question_rejected',
+      'session_permission_answered',
+      'session_abort_succeeded',
+      'session_diff_viewed',
+      'onboarding_need_help_opened',
+      'onboarding_support_link_opened',
+      'onboarding_why_bridge_opened',
+      'bridge_install_command_copied',
+      'bridge_install_command_shared',
+      'bridge_run_command_copied',
+      'bridge_run_command_shared',
+      'product_screen_viewed'
+    )
+) AS 'events_flattened may contain only the current closed ProductAnalyticsEvent catalog';
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flattened`
+  WHERE source_export_date BETWEEN DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 425 DAY)
+    AND DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 1 DAY)
+    AND (
+      schema_version != 1
+      OR NOT REGEXP_CONTAINS(user_key, r'^[a-f0-9]{64}$')
+      OR occurred_at_micros != UNIX_MICROS(occurred_at)
+      OR occurred_at > TIMESTAMP_ADD(emitted_at, INTERVAL 300 SECOND)
+    )
+) AS 'Flattened shared schema, key, occurrence, and clock-skew contracts must hold';
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flattened` AS event
+  WHERE event.source_export_date BETWEEN DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 425 DAY)
+    AND DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 1 DAY)
+    AND (
+      EXISTS (
+        SELECT 1 FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_internal_user_exclusions` AS internal
+        WHERE internal.user_key = event.user_key
+      )
+      OR EXISTS (
+        SELECT 1 FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.permanent_deletion_exclusions` AS deleted
+        WHERE deleted.user_key = event.user_key
+      )
+    )
+) AS 'Permanent internal and deletion exclusions must never survive flattened recomputation';
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flattened`
+  WHERE source_export_date BETWEEN DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 425 DAY)
+    AND DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 1 DAY)
+    AND (
+      (activation_schema_version IS NOT NULL AND event_name != 'analytics_activation_ready')
+      OR (inventory_state IS NOT NULL AND event_name != 'project_inventory_loaded')
+      OR (activity_state IS NOT NULL AND event_name != 'session_activity_viewed')
+      OR (submission_kind IS NOT NULL AND event_name NOT IN ('session_message_sent', 'session_created_with_message'))
+      OR (input_mode IS NOT NULL AND event_name NOT IN ('session_message_sent', 'session_created_with_message'))
+      OR (workspace_kind IS NOT NULL AND event_name NOT IN ('session_created_with_message', 'session_creation_failed'))
+      OR (failure_reason IS NOT NULL AND event_name != 'session_creation_failed')
+      OR (decision IS NOT NULL AND event_name != 'session_permission_answered')
+      OR (change_state IS NOT NULL AND event_name != 'session_diff_viewed')
+      OR (channel IS NOT NULL AND event_name != 'onboarding_support_link_opened')
+      OR (method IS NOT NULL AND event_name NOT IN ('bridge_install_command_copied', 'bridge_install_command_shared'))
+      OR (os IS NOT NULL AND event_name NOT IN ('bridge_install_command_copied', 'bridge_install_command_shared'))
+      OR (screen IS NOT NULL AND event_name != 'product_screen_viewed')
+    )
+) AS 'Event-specific flattened parameter columns must be null outside their exact wire events';
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flattened`
+  WHERE source_export_date BETWEEN DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 425 DAY)
+    AND DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 1 DAY)
+    AND (
+      (activation_schema_version IS NOT NULL AND activation_schema_version != 1)
+      OR (inventory_state IS NOT NULL AND inventory_state NOT IN ('empty', 'non_empty'))
+      OR (activity_state IS NOT NULL AND activity_state NOT IN ('empty', 'non_empty'))
+      OR (submission_kind IS NOT NULL AND submission_kind NOT IN ('text', 'command'))
+      OR (input_mode IS NOT NULL AND input_mode NOT IN ('typed', 'voice_assisted'))
+      OR (submission_kind = 'command' AND input_mode != 'typed')
+      OR (workspace_kind IS NOT NULL AND workspace_kind NOT IN ('project', 'dedicated_worktree'))
+      OR (failure_reason IS NOT NULL AND failure_reason NOT IN ('not_authenticated', 'server_rejected', 'network_down', 'bad_response', 'unknown'))
+      OR (decision IS NOT NULL AND decision NOT IN ('once', 'always', 'reject'))
+      OR (change_state IS NOT NULL AND change_state NOT IN ('empty', 'non_empty'))
+      OR (surface IS NOT NULL AND surface NOT IN ('connect_setup', 'connected_empty', 'bridge_offline'))
+      OR (channel IS NOT NULL AND channel NOT IN ('email', 'discord', 'x'))
+      OR (method IS NOT NULL AND method NOT IN ('curl', 'powershell', 'npm', 'bun'))
+      OR (os IS NOT NULL AND os NOT IN ('unix', 'windows'))
+      OR (screen IS NOT NULL AND screen NOT IN (
+        'login',
+        'projects',
+        'settings',
+        'settings_notifications',
+        'settings_profile',
+        'sessions',
+        'new_session',
+        'session_detail',
+        'session_diffs'
+      ))
+    )
+) AS 'Flattened event parameters must remain inside the closed bounded value allowlists';
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.installation_login_daily`
+  WHERE event_name NOT IN ('login_attempt_started', 'login_attempt_completed', 'login_attempt_failed')
+    OR schema_version != 1
+    OR provider NOT IN ('github', 'google', 'apple', 'email')
+    OR (event_name = 'login_attempt_failed' AND failure_kind NOT IN ('authentication', 'launch', 'cancelled', 'timeout', 'unknown'))
+    OR (event_name != 'login_attempt_failed' AND failure_kind IS NOT NULL)
+    OR NOT includes_internal_test_traffic
+) AS 'Installation login aggregates must retain only the exact bounded diagnostic contract';
+
+ASSERT NOT EXISTS (
+  SELECT model_name
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.transform_state`
+  WHERE model_name NOT IN (
+    'events_flattened',
+    'installation_login_daily',
+    'user_activity_daily',
+    'user_milestones',
+    'activation_retention'
+  )
+) AS 'Transform freshness state must remain a closed model set';

--- a/tool/product_analytics/tests/schema_allowlist_assertions.sql
+++ b/tool/product_analytics/tests/schema_allowlist_assertions.sql
@@ -280,11 +280,155 @@ ASSERT NOT EXISTS (
   WHERE table_type = 'VIEW'
 ) AS 'Every required identifier-free reporting view must exist';
 
+ASSERT NOT EXISTS (
+  SELECT required_column
+  FROM UNNEST([
+    'account_week_start',
+    'account_week_end',
+    'engagement_week_start',
+    'engagement_week_end',
+    'activation_cohort_week',
+    'activation_cohort_week_end',
+    'account_data_as_of_at',
+    'engagement_data_as_of_at',
+    'activation_data_as_of_at'
+  ]) AS required_column
+  EXCEPT DISTINCT
+  SELECT column_name
+  FROM `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.INFORMATION_SCHEMA.COLUMNS`
+  WHERE table_name = 'investor_snapshot'
+) AND NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.INFORMATION_SCHEMA.COLUMNS`
+  WHERE table_name = 'investor_snapshot'
+    AND column_name IN ('week_start', 'week_end', 'data_as_of_at')
+) AS 'Investor snapshot must expose explicit account, engagement, and mature activation periods';
+
+ASSERT NOT EXISTS (
+  SELECT cohort_week
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.activation_cohorts`
+  WHERE cohort_week_end < CURRENT_DATE('UTC')
+    AND cohort_week_end < DATE(data_as_of_at)
+  EXCEPT DISTINCT
+  SELECT week_start
+  FROM `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.weekly_kpis`
+) AS 'weekly_kpis must preserve complete account weeks even without engagement rows';
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.activation_funnel`
+  WHERE (
+      NOT setup_1_day_mature
+      AND COALESCE(
+        project_available_within_1_day,
+        activation_eligible_1_day_accounts,
+        activated_within_1_day,
+        notification_registered_within_1_day,
+        bridge_registered_within_1_day,
+        legacy_metadata_request_within_1_day
+      ) IS NOT NULL
+    ) OR (
+      NOT setup_7_day_mature
+      AND COALESCE(
+        project_available_within_7_days,
+        activation_eligible_7_day_accounts,
+        activated_within_7_days,
+        notification_registered_within_7_days,
+        bridge_registered_within_7_days,
+        legacy_metadata_request_within_7_days
+      ) IS NOT NULL
+    ) OR (
+      NOT setup_30_day_mature
+      AND COALESCE(
+        project_available_within_30_days,
+        activation_eligible_30_day_accounts,
+        activated_within_30_days,
+        notification_registered_within_30_days,
+        bridge_registered_within_30_days,
+        legacy_metadata_request_within_30_days
+      ) IS NOT NULL
+    )
+) AS 'Immature activation-funnel windows must expose null counts rather than partial values';
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.activation_funnel`
+  WHERE cohort_week_end >= DATE(data_as_of_at)
+) AS 'Activation funnel must not expose a week incomplete at its published data watermark';
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.retention`
+  WHERE (
+      NOT w1_cohort_mature
+      AND COALESCE(w1_eligible_users, w1_retained_users) IS NOT NULL
+    ) OR (
+      NOT w4_cohort_mature
+      AND COALESCE(w4_eligible_users, w4_retained_users) IS NOT NULL
+    ) OR (NOT w1_cohort_mature AND w1_retention_rate IS NOT NULL)
+      OR (NOT w4_cohort_mature AND w4_retention_rate IS NOT NULL)
+) AS 'Partially mature activation weeks must not expose W1 or W4 retention results';
+
+ASSERT NOT EXISTS (
+  WITH expected AS (
+    SELECT week_start, week_end, new_accounts
+    FROM `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.weekly_kpis`
+    WHERE week_end < DATE(data_as_of_at)
+      AND week_end < CURRENT_DATE('UTC')
+    ORDER BY week_start DESC
+    LIMIT 1
+  ),
+  actual AS (
+    SELECT account_week_start, account_week_end, new_accounts
+    FROM `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.investor_snapshot`
+  )
+  SELECT 1
+  FROM expected
+  FULL OUTER JOIN actual ON TRUE
+  WHERE expected.week_start IS DISTINCT FROM actual.account_week_start
+    OR expected.week_end IS DISTINCT FROM actual.account_week_end
+    OR expected.new_accounts IS DISTINCT FROM actual.new_accounts
+) AS 'Investor account headline must use the latest complete weekly spine even when signups are zero';
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.weekly_kpis` AS weekly
+  CROSS JOIN `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.analytics_measurement_config` AS config
+  WHERE config.config_key = 'singleton'
+    AND TIMESTAMP(weekly.week_start) < config.behavioral_schema_v1_start_at
+    AND weekly.meaningful_wau IS NOT NULL
+) AS 'Pre-behavior account weeks must retain null engagement rather than a synthetic zero';
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{REPORTING_DATASET_ID}}.data_quality`
+  WHERE category = 'auth_snapshot'
+    AND status = 'ok'
+    AND (
+      SELECT control_updated_at
+      FROM `{{PROJECT_ID}}.{{AUTH_DATASET_ID}}.product_analytics_export_runs`
+      ORDER BY published_at DESC, run_cutoff DESC
+      LIMIT 1
+    ) IS DISTINCT FROM (
+      SELECT control_updated_at
+      FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.internal_exclusion_control_state`
+      WHERE state_key = 'singleton'
+    )
+) AS 'An internal exclusion control mismatch must never be reported as healthy';
+
 ASSERT (
   SELECT COUNTIF(is_partitioning_column = 'YES')
   FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.INFORMATION_SCHEMA.COLUMNS`
   WHERE table_name = 'events_flattened' AND column_name = 'source_export_date'
-) = 1 AS 'events_flattened must remain partitioned by its bounded GA4 source suffix date';
+) = 1 AS 'events_flattened must remain partitioned by its UTC emission date';
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flattened`
+  WHERE source_export_date BETWEEN DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 425 DAY)
+    AND DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 1 DAY)
+    AND source_export_date != DATE(emitted_at)
+) AS 'events_flattened source_export_date must be the UTC emission date';
 
 ASSERT (
   SELECT COUNTIF(clustering_ordinal_position IS NOT NULL)
@@ -367,12 +511,54 @@ ASSERT NOT EXISTS (
       OR (failure_reason IS NOT NULL AND event_name != 'session_creation_failed')
       OR (decision IS NOT NULL AND event_name != 'session_permission_answered')
       OR (change_state IS NOT NULL AND event_name != 'session_diff_viewed')
+      OR (surface IS NOT NULL AND event_name NOT IN (
+        'onboarding_need_help_opened',
+        'onboarding_support_link_opened',
+        'onboarding_why_bridge_opened',
+        'bridge_install_command_copied',
+        'bridge_install_command_shared',
+        'bridge_run_command_copied',
+        'bridge_run_command_shared'
+      ))
       OR (channel IS NOT NULL AND event_name != 'onboarding_support_link_opened')
       OR (method IS NOT NULL AND event_name NOT IN ('bridge_install_command_copied', 'bridge_install_command_shared'))
       OR (os IS NOT NULL AND event_name NOT IN ('bridge_install_command_copied', 'bridge_install_command_shared'))
       OR (screen IS NOT NULL AND event_name != 'product_screen_viewed')
     )
 ) AS 'Event-specific flattened parameter columns must be null outside their exact wire events';
+
+ASSERT NOT EXISTS (
+  SELECT 1
+  FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.events_flattened`
+  WHERE source_export_date BETWEEN DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 425 DAY)
+    AND DATE_SUB(CURRENT_DATE('UTC'), INTERVAL 1 DAY)
+    AND (
+      (event_name = 'analytics_activation_ready' AND activation_schema_version IS NULL)
+      OR (event_name = 'project_inventory_loaded' AND inventory_state IS NULL)
+      OR (event_name = 'session_activity_viewed' AND activity_state IS NULL)
+      OR (event_name = 'session_message_sent' AND (submission_kind IS NULL OR input_mode IS NULL))
+      OR (event_name = 'session_created_with_message' AND (
+        submission_kind IS NULL OR input_mode IS NULL OR workspace_kind IS NULL
+      ))
+      OR (event_name = 'session_creation_failed' AND (failure_reason IS NULL OR workspace_kind IS NULL))
+      OR (event_name = 'session_permission_answered' AND decision IS NULL)
+      OR (event_name = 'session_diff_viewed' AND change_state IS NULL)
+      OR (event_name IN (
+        'onboarding_need_help_opened',
+        'onboarding_support_link_opened',
+        'onboarding_why_bridge_opened',
+        'bridge_install_command_copied',
+        'bridge_install_command_shared',
+        'bridge_run_command_copied',
+        'bridge_run_command_shared'
+      ) AND surface IS NULL)
+      OR (event_name = 'onboarding_support_link_opened' AND channel IS NULL)
+      OR (event_name IN ('bridge_install_command_copied', 'bridge_install_command_shared') AND (
+        method IS NULL OR os IS NULL
+      ))
+      OR (event_name = 'product_screen_viewed' AND screen IS NULL)
+    )
+) AS 'Every event-specific parameter required by the wire event must be present';
 
 ASSERT NOT EXISTS (
   SELECT 1
@@ -411,11 +597,16 @@ ASSERT NOT EXISTS (
 ASSERT NOT EXISTS (
   SELECT 1
   FROM `{{PROJECT_ID}}.{{CURATED_DATASET_ID}}.installation_login_daily`
-  WHERE event_name NOT IN ('login_attempt_started', 'login_attempt_completed', 'login_attempt_failed')
+  WHERE source_export_date != event_date
+    OR event_name NOT IN ('login_attempt_started', 'login_attempt_completed', 'login_attempt_failed')
     OR schema_version != 1
     OR provider NOT IN ('github', 'google', 'apple', 'email')
-    OR (event_name = 'login_attempt_failed' AND failure_kind NOT IN ('authentication', 'launch', 'cancelled', 'timeout', 'unknown'))
+    OR (event_name = 'login_attempt_failed' AND (
+      failure_kind IS NULL
+      OR failure_kind NOT IN ('authentication', 'launch', 'cancelled', 'timeout', 'unknown')
+    ))
     OR (event_name != 'login_attempt_failed' AND failure_kind IS NOT NULL)
+    OR event_count <= 0
     OR NOT includes_internal_test_traffic
 ) AS 'Installation login aggregates must retain only the exact bounded diagnostic contract';
 

--- a/tool/product_analytics/tests/schema_allowlist_assertions.sql
+++ b/tool/product_analytics/tests/schema_allowlist_assertions.sql
@@ -13,7 +13,6 @@ FROM UNNEST([
   'user_key',
   'platform',
   'app_version',
-  'app_build',
   'activation_schema_version',
   'inventory_state',
   'activity_state',
@@ -53,7 +52,6 @@ FROM UNNEST([
   'schema_version',
   'platform',
   'app_version',
-  'app_build',
   'provider',
   'failure_kind',
   'event_count',
@@ -210,6 +208,18 @@ ASSERT TO_JSON_STRING((
   WHERE table_name = 'product_analytics_privacy_sweep_state'
 )) = TO_JSON_STRING(['sweep_name', 'last_success_through_date', 'updated_at'])
   AS 'Privacy sweep checkpoint must remain identifier-free and monotonic';
+
+ASSERT TO_JSON_STRING((
+  SELECT ARRAY_AGG(column_name ORDER BY ordinal_position)
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.INFORMATION_SCHEMA.COLUMNS`
+  WHERE table_name = 'keyed_publication_guard'
+)) = TO_JSON_STRING(['guard_key', 'publication_epoch', 'updated_at'])
+  AS 'Keyed publication guard schema must remain a singleton epoch';
+ASSERT (
+  SELECT COUNT(*) = 1
+    AND COUNTIF(guard_key = 'singleton' AND publication_epoch >= 0) = 1
+  FROM `{{PROJECT_ID}}.{{CONTROLS_DATASET_ID}}.keyed_publication_guard`
+) AS 'Keyed publication guard must contain one valid singleton';
 
 ASSERT NOT EXISTS (
   SELECT 1
@@ -607,7 +617,7 @@ ASSERT NOT EXISTS (
     ))
     OR (event_name != 'login_attempt_failed' AND failure_kind IS NOT NULL)
     OR event_count <= 0
-    OR NOT includes_internal_test_traffic
+    OR includes_internal_test_traffic IS NOT TRUE
 ) AS 'Installation login aggregates must retain only the exact bounded diagnostic contract';
 
 ASSERT NOT EXISTS (


### PR DESCRIPTION
## Summary

- add the Step 5 BigQuery datasets, bounded transforms, reporting views, schedule manifest, fixture assertions, and schema/privacy allowlist assertions
- add the render/dry-run/apply deployment command, restricted Looker Studio contract, and complete operator/IAM/cost runbook
- add a layered, headless privacy-deletion command and recurring keyed-upload sweep using metadata-first credentials, closed warehouse inventory, fixed aggregate rebuilds, and Analytics Admin user deletion
- enforce complete-period and cohort-maturity reporting, zero-account weekly continuity, auth/control freshness, late-arrival recovery, and permanent internal/deletion exclusions

## Privacy and access boundaries

- raw GA4 remains restricted and expires after 90 days
- curated schemas contain only allowlisted pseudonymous fields; reporting views are identifier-free
- reporting access uses exact authorized-view ACLs rather than source-dataset grants
- privacy deletion fails closed on unexpected keyed tables, auth staging, intraday export, raw table gaps, stale auth publication, or verification failures
- production deletion credentials are metadata-server only; local gcloud ADC fallback requires an explicit operator flag

## Verification

- `dart format tool/product_analytics/deploy.dart tool/product_analytics/privacy_deletion`
- `dart analyze tool/product_analytics/deploy.dart tool/product_analytics/privacy_deletion`
- `dart tool/product_analytics/privacy_deletion/privacy_deletion_test.dart`
- self-contained `metric_contract_assertions.sql` executed successfully in BigQuery `europe-west3`
- render-only deployment validated 7 SQL assets and 5 schedules with a total 1.75 GiB/day allocation
- `git diff --check`
- final architecture review approved

## Deployment status

No repository SQL, schedules, IAM, privacy jobs, or dashboards were applied by this PR. Cloud rollout remains safety-blocked pending the recorded GA4 privacy settings, restricted IAM and service identities, exact raw/behavioral timestamps, scheduler ownership, and dashboard owner/viewer group.

The cloud rollout is required Step 5 delivery work, not an out-of-scope prerequisite: after approval, the plan requires applying and verifying identities/ACLs, warehouse schemas, authorized views, jobs and schedules, deletion drills, deployed-schema assertions, and the restricted Looker report. Merging this PR alone does not complete Step 5. The final plan action, after all acceptance items pass, is to move `.plan/active/user-analytics/` to `.plan/completed/user-analytics/`.
