### PR TITLE
[multi-plugin-release-prep] feat(bridge): dynamically load missing session options [step 5.C/6]

### DIFF
--- a/.plan/active/multi-plugin-release-prep/PLAN.md
+++ b/.plan/active/multi-plugin-release-prep/PLAN.md
@@ -3,10 +3,9 @@
 ## Status
 
 - **Plan slug:** `multi-plugin-release-prep`
-- **Status:** Steps 1/6 through 3/6 merged; oversized PR #620 is frozen as a
-  draft and replaced by Steps 4.A/6 through 4.F/6
+- **Status:** Steps 1/6 through 5.B/6 merged; Step 5.C/6 is in progress
 - **Plan delivery:** this document and its tracker are Step 1/6
-- **Implementation base:** `origin/main` at `5eabfd0d`
+- **Implementation base:** `origin/main` at `6ffc9f39`
 - **Approved product direction:** Codex remains project-aware; Cursor and the
   ACP-backed option state use plugin-scoped caching; OpenCode remains
   project-scoped
@@ -14,10 +13,9 @@
 ## Goal
 
 Prepare the first multi-plugin release so that opening New Session and switching
-between harnesses does not start dormant backends merely to render agents,
-models, variants, or commands. The bridge owns a durable, scope-aware options
-cache and exposes one aggregate API that starts a harness only after explicit
-user refresh.
+between harnesses serves durable, scope-aware cached options when available. On
+cache miss, the aggregate API may start only the selected harness and populate
+the cache; explicit Refresh still forces fresh backend discovery.
 
 Complete the release preparation by consolidating the two mobile Harnesses
 settings screens into one capability-driven surface with Prego timeout and
@@ -93,12 +91,15 @@ There is one new route:
 
 ```http
 POST /session/options
+POST /session/options?refresh=false
 POST /session/options?refresh=true
 ```
 
 - The body is the existing shared `PluginProjectIdRequest`.
-- Missing `refresh` and exact `refresh=false` are cache-only and must never
-  acquire or start a dormant plugin.
+- Missing `refresh` is dynamic: return a valid cache row immediately, or acquire
+  only the selected plugin on cache miss and populate the cache.
+- Exact `refresh=false` is cache-only and must never acquire or start a dormant
+  plugin.
 - Exact `refresh=true` is an explicit user refresh and may start only the
   requested plugin. It also passes an internal force-discovery mode so a live
   plugin cannot satisfy user refresh from its own stale catalog tracker.
@@ -111,9 +112,10 @@ POST /session/options?refresh=true
   `PluginListResponse`, with the required dated compatibility comment. A new
   bridge publishes `true`; old bridge payloads and the existing discovery-404
   fallback decode `false`.
-- A cache-only miss, expired row, or invalidated project-path row returns HTTP
-  503 with typed `SessionOptionsErrorCode.cacheUnavailable`. It is never encoded
-  as three successful empty lists.
+- An explicit `refresh=false` cache-only miss, expired row, or invalidated
+  project-path row returns HTTP 503 with typed
+  `SessionOptionsErrorCode.cacheUnavailable`. A dynamic miss instead performs
+  one activating fetch and is never encoded as three successful empty lists.
 - Add shared `SessionOptionsErrorResponse` with required forward-safe
   `SessionOptionsErrorCode { cacheUnavailable, projectNotFound,
   refreshFailedRetained, refreshFailedUnavailable, unknown }`. Project absence
@@ -122,18 +124,18 @@ POST /session/options?refresh=true
   is never forwarded because relay HTTP reserves 401 for Sesori authentication
   and rewrites that response before a repository can parse its body. The client
   maps the typed code and never infers domain outcome from status alone.
-- An explicit refresh failure returns `refreshFailedRetained` only while the
-  prior row still passes scope, project-path, and retention validation. The app
-  may preserve that snapshot while reporting failure. A missing, expired, or
-  path-invalidated row is deleted and produces `refreshFailedUnavailable`; the
-  app must clear any previously rendered options before showing unavailable
-  state.
+- An activating fetch failure returns `refreshFailedRetained` only while a row
+  still passes scope, project-path, and retention validation. Dynamic loading
+  returns that concurrently available row as a successful response; explicit
+  refresh may preserve the client snapshot while reporting failure. A missing,
+  expired, or path-invalidated row is deleted and produces
+  `refreshFailedUnavailable`; the app clears any previously rendered options.
 
 ### Compatibility matrix
 
 | Client / bridge | Behavior |
 |---|---|
-| New client / new bridge | Initial load is cache-only. Refresh may start exactly the selected harness. A cache miss leaves session creation available with backend defaults. |
+| New client / new bridge | An omitted `refresh` query is dynamic: serve a valid cache row, or fetch from exactly the selected harness on cache miss. `refresh=false` remains cache-only and `refresh=true` forces discovery. |
 | Old client / new bridge | Existing `/agent`, `/provider`, and `/command` behavior is unchanged and can still start the requested harness. |
 | New client / old bridge | Missing/false discovery capability becomes an explicit unsupported state without calling the aggregate route. Create remains available with null agent/model/variant/command. Explicit Refresh explains that legacy live requests may start the harness, then invokes the existing three routes. |
 
@@ -157,7 +159,7 @@ clients without coupling legacy repositories to the new service.
   deletion.
 - Retention is 30 days, evaluated with injected `ServerClock`. Timestamps are
   never race tokens.
-- Refresh triggers are explicit aggregate refresh, successful session creation
+- Refresh triggers are dynamic aggregate cache miss, explicit aggregate refresh, successful session creation
   while that plugin generation is already active, and a dedicated
   generation-attributed `BridgeSseSessionOptionsChanged` plugin event. There is
   no all-project fanout, polling, or reinterpretation of generic session events.
@@ -175,8 +177,9 @@ clients without coupling legacy repositories to the new service.
   revalidation.
 - `NewSessionCubit` owns connection/plugin/project/user-intent orchestration,
   request-generation fencing, tracker writes, and state emission only.
-- When no cache exists, the UI offers Refresh and keeps Create usable with
-  backend defaults. It does not show an indefinite loading spinner.
+- When no cache exists, the bridge automatically fetches from the selected
+  harness. A failed fetch surfaces an explicit failure and keeps Create usable
+  with backend defaults rather than showing an indefinite loading spinner.
 
 ### Harness settings destination
 
@@ -310,7 +313,7 @@ snapshot. Runtime activation and plugin discovery freshness remain independent
 enums rather than one overloaded boolean.
 
 `SessionOptionsService` requires the repository, immutable descriptor scope map,
-`ServerClock`, and retention duration. It owns key resolution, cache-only read,
+`ServerClock`, and retention duration. It owns key resolution, dynamic/cache-only read,
 path/expiry invalidation, per-key refresh coalescing, capture-mode choice,
 completeness comparison, last-good retention, CAS retry policy, and recovered
 failure observability.
@@ -325,15 +328,27 @@ never resurrected by a failed capture.
 The service permits only these production combinations:
 
 ```text
+dynamic load            -> valid cache, otherwise may activate + PluginSessionOptionsDiscoveryMode.reuse
 explicit refresh        -> may activate + PluginSessionOptionsDiscoveryMode.refresh
 session-created trigger -> active only  + PluginSessionOptionsDiscoveryMode.reuse
 options-changed trigger -> active only  + PluginSessionOptionsDiscoveryMode.reuse
 cache-only read         -> no plugin capture
 ```
 
+`loadDynamic` resolves the cache key/project path once, returns a valid row
+immediately, and otherwise enters the existing per-key coordinator with reuse
+intent, `mayActivate`, `PluginSessionOptionsDiscoveryMode.reuse`, no expected
+generation, and `automatic: false` so HTTP callers receive typed retained or
+unavailable failures rather than trigger-only no-op semantics. Project absence
+returns directly. Expired/path-invalid rows are deleted before capture. If a
+concurrent operation publishes a valid row while the dynamic capture fails,
+`loadDynamic` re-reads and returns that row as `available`; otherwise the
+existing retained/unavailable 502 mapping applies.
+
 Coalescing is intent-aware per cache key:
 
 - reuse joins an in-flight reuse or forced refresh;
+- dynamic cache miss uses reuse intent with non-automatic HTTP failure outcomes;
 - explicit refresh joins an in-flight forced refresh;
 - explicit refresh arriving during reuse queues exactly one forced operation
   after reuse and awaits that forced result; and
@@ -416,7 +431,7 @@ The current codebase maps the Step 4 boundary to these source changes:
   Runtime tests extend the existing `plugin_runtime_test.dart` suite rather than
   creating a second runtime harness.
 - Add `SessionOptionsService` under `bridge/services/`. Its public operations
-  are cache-only load, explicit refresh, active-only refresh for a known
+  are dynamic load, cache-only load, explicit refresh, active-only refresh for a known
   project, and active-only refresh resolved from plugin/backend-session
   identity. Internal sealed outcomes distinguish available, cache unavailable,
   project not found, retained refresh failure, unavailable refresh failure, and
@@ -433,8 +448,10 @@ The current codebase maps the Step 4 boundary to these source changes:
   `RequestHandlerBase`, rather than `BodyRequestHandler`, so expected typed
   failures can return JSON bodies before generic plain-text normalization. It
   reuses `PluginProjectIdRequest.fromJson`, accepts only missing, exact `false`,
-  or exact `true` refresh values from the router's canonical query map, and maps
-  every service outcome to the locked 200/400/404/502/503 contract.
+  or exact `true` refresh values from the router's canonical query map, and
+  dispatches them to dynamic load, cache-only load, and explicit refresh,
+  respectively. It maps every service outcome to the locked
+  200/400/404/502/503 contract.
 - Add `projectId` to `SessionBindingsCommitted`; both current publication sites
   already have the stable value (`createSession`'s requested project and
   `_persistNativeRootSessions`' resolved project). Existing session-event
@@ -464,7 +481,10 @@ verification.
 
 ### Client layers
 
-`SessionApi` adds the aggregate POST and query parameter. `PluginRepository`
+`SessionApi` adds the aggregate POST and names its request intent
+`forceRefresh`: false omits the query for dynamic loading, while true sends
+`refresh=true`. `SessionRepository` and `NewSessionOptionsLoadMode` use the same
+dynamic/forced terminology. `PluginRepository`
 maps the additive `supportsSessionOptions` discovery fact, defaulting false for
 older bridges, and `NewSessionPluginDiscovery` carries that bridge-level fact to
 the composer. `SessionRepository` removes its provider-only cache, maps aggregate
@@ -476,6 +496,14 @@ ordinary failure. It retains the three legacy methods solely for explicit
 old-bridge refresh. `NewSessionOptionsService` receives the discovery capability:
 false returns unsupported without an aggregate call; true permits the aggregate
 call and never converts its typed project failure into legacy fallback.
+
+No aggregate-route 404 triggers legacy fallback. Old bridges are selected by
+the additive discovery capability (including its missing-field default and the
+plugin-discovery 404 compatibility snapshot). Old apps continue using the
+unchanged live POST `/agent`, `/provider`, and `/command` handlers on new
+bridges. Those POST routes are not deprecated because current Session Detail
+still consumes them; only the already-deprecated parameterless GET `/agent`
+route is legacy-only.
 
 `NewSessionOptionsService({required SessionRepository sessionRepository,
 required DefaultModelSelector defaultModelSelector})` owns:
@@ -495,7 +523,7 @@ user selections alone are written to `NewSessionSelectionTracker`; computed
 defaults are not persisted as intent. Existing connection and plugin-switch
 generation fencing remains in the cubit.
 
-The mobile screen renders cached options, cache-unavailable Refresh, old-bridge
+The mobile screen renders dynamically loaded or cached options, old-bridge
 guidance, and retained-data refresh errors. Backend plugin IDs, model names,
 agent names, commands, paths, and project identity never enter analytics or
 backend-neutral UI decisions.
@@ -515,6 +543,7 @@ backend-neutral UI decisions.
 | 4.F/6 | `multi-plugin-release-prep-cache-route` | `[multi-plugin-release-prep] feat(bridge): expose cached session options [step 4.F/6]` | 850-1,150 | Aggregate route/capability, stable binding attribution, automatic refresh listeners, and Orchestrator lifecycle wiring. |
 | 5.A/6 | `multi-plugin-release-prep-client-options` | `[multi-plugin-release-prep] feat(client): add cached session option layers [step 5.A/6]` | 1,350-1,750 | Aggregate API/repository mapping, provider-cache removal, repository-owned catalogs, and service-owned option policy including explicit old-bridge fallback. |
 | 5.B/6 | `multi-plugin-release-prep-client-options-ui` | `[multi-plugin-release-prep] feat(client): use cached session options [step 5.B/6]` | 1,650-2,150 | Repository-mapped plugin source, independent selection intent, composed cubit state, generation fencing, and New Session mobile UI. |
+| 5.C/6 | `multi-plugin-release-prep-dynamic-options` | `[multi-plugin-release-prep] feat(bridge): dynamically load missing session options [step 5.C/6]` | 180-320 | Tri-state aggregate query semantics, dynamic cache-miss fetch, client terminology, and compatibility verification without changing legacy routes. |
 | 6/6 | `multi-plugin-release-prep-harness-settings` | `[multi-plugin-release-prep] refactor(app): consolidate Harness settings [step 6/6]` | 850-1,200 | One Harnesses screen/cubit, capability/setup-aware visibility, route removal, and Prego timeout/force sheets. |
 
 ## Per-Step Verification
@@ -614,6 +643,19 @@ backend-neutral UI decisions.
   clearing after expired/path-invalid cache refresh failure. Run
   module-core/mobile/desktop fatal analysis and Aristotle implementation review.
 
+### Step 5.C/6
+
+- Handler/service tests prove omitted `refresh` serves valid cache data and
+  fetches only on cache miss, `refresh=false` remains cache-only, and
+  `refresh=true` remains forced discovery.
+- Compatibility tests prove new-client/old-bridge capability fallback still
+  uses the legacy routes only after explicit Refresh, while old clients keep
+  using the unchanged live legacy handlers on new bridges.
+- Client API/repository terminology distinguishes dynamic load from forced
+  refresh without adding a transport field or changing old-peer parsing.
+- Run bridge-app and module-core focused tests plus fatal analysis in bridge-app,
+  module-core, mobile, and desktop.
+
 ### Step 6/6
 
 - Route tests prove the management sub-route is removed and Harnesses navigation
@@ -644,7 +686,8 @@ refresh-outcome reporting after the active user-analytics foundation lands.
 
 | Risk | Treatment |
 |---|---|
-| Dormant plugin starts during ordinary rendering | Cache-only route reaches no runtime acquisition. Add an explicit no-start runtime test. |
+| A valid cache unexpectedly starts a dormant plugin | Dynamic load returns a valid row before runtime acquisition; explicit `refresh=false` remains covered by a no-start test. |
+| Concurrent cache fill is hidden behind dynamic fetch failure | Dynamic load re-reads a retained valid row after a failed coalesced capture and returns it as available. |
 | Project options served for a moved directory | Store captured path and invalidate on mismatch. |
 | Refresh failure leaves expired/path-invalid options visible | Validate and delete before capture; unavailable failure clears client options, while retained failure is reserved for a still-valid row. |
 | Old generation overwrites current data | Capture runtime generation and fence every CAS commit with `commitCurrentGeneration`. |
@@ -689,6 +732,7 @@ refresh-outcome reporting after the active user-analytics foundation lands.
 ## Completion
 
 The plan completes after all six PRs merge, New Session switching reads durable
-scope-correct options without starting dormant harnesses, explicit refresh and
-old-bridge degradation are verified, both cache scopes survive restart, and the
-single Harnesses settings page passes capability/setup-aware mobile verification.
+scope-correct options and dynamically starts only the selected harness on cache
+miss, explicit cache-only and forced-refresh semantics plus old-bridge
+degradation are verified, both cache scopes survive restart, and the single
+Harnesses settings page passes capability/setup-aware mobile verification.

--- a/.plan/active/multi-plugin-release-prep/PLAN.md
+++ b/.plan/active/multi-plugin-release-prep/PLAN.md
@@ -323,7 +323,9 @@ row. Only a row that still matches scope/project path and remains inside
 retention is eligible for last-good replay. A repository/plugin `failed` result
 with that valid row becomes refresh-failed-retained; the same failure after
 absence or invalidation becomes refresh-failed-unavailable. Invalid data is
-never resurrected by a failed capture.
+never resurrected by a failed capture. Every project-scoped invalidation
+re-resolves the authoritative path immediately before its revision-fenced delete
+so a stale reader cannot delete a same-revision row published for a moved path.
 
 The service permits only these production combinations:
 

--- a/.plan/active/multi-plugin-release-prep/PLAN.md
+++ b/.plan/active/multi-plugin-release-prep/PLAN.md
@@ -342,10 +342,12 @@ immediately, and otherwise enters the existing per-key coordinator with reuse
 intent, `mayActivate`, `PluginSessionOptionsDiscoveryMode.reuse`, no expected
 generation, and `automatic: false` so HTTP callers receive typed retained or
 unavailable failures rather than trigger-only no-op semantics. Project absence
-returns directly. Expired/path-invalid rows are deleted before capture. If a
+returns directly. Expired/path-invalid rows are deleted before capture, and the
+resolved project path is revalidated immediately before a may-activate capture
+so a moved project cannot start discovery against its stale directory. If a
 concurrent operation publishes a valid row while the dynamic capture fails,
-`loadDynamic` re-reads and returns that row as `available`; otherwise the
-existing retained/unavailable 502 mapping applies.
+`loadDynamic` re-reads and returns that row as `available`; otherwise the existing
+retained/unavailable 502 mapping applies.
 
 Coalescing is intent-aware per cache key:
 

--- a/.plan/active/multi-plugin-release-prep/PLAN.md
+++ b/.plan/active/multi-plugin-release-prep/PLAN.md
@@ -524,9 +524,11 @@ defaults are not persisted as intent. Existing connection and plugin-switch
 generation fencing remains in the cubit.
 
 The mobile screen renders dynamically loaded or cached options, old-bridge
-guidance, and retained-data refresh errors. Backend plugin IDs, model names,
-agent names, commands, paths, and project identity never enter analytics or
-backend-neutral UI decisions.
+guidance, and retained-data refresh errors. An unavailable dynamic load uses
+load-specific state and guidance, while an unavailable forced refresh retains
+explicit Refresh guidance. Backend plugin IDs, model names, agent names,
+commands, paths, and project identity never enter analytics or backend-neutral
+UI decisions.
 
 ## Delivery Sequence
 

--- a/.plan/active/multi-plugin-release-prep/TRACKER.md
+++ b/.plan/active/multi-plugin-release-prep/TRACKER.md
@@ -2,11 +2,11 @@
 
 ## Current State
 
-- **Implementation base:** `origin/main` at `c662a639`
-- **Series state:** Steps 1/6 through 5.A/6 are merged; oversized PR #620 is
+- **Implementation base:** `origin/main` at `bfadd097`
+- **Series state:** Steps 1/6 through 5.B/6 are merged; oversized PR #620 is
   closed, with its frozen branch retained only as the split implementation source
-- **Current step:** Step 5.B/6 — cached New Session composer
-- **Next action:** monitor PR #636 against `main` through review and CI
+- **Current step:** Step 5.C/6 — dynamic session-option cache misses
+- **Next action:** commit and open the verified Step 5.C PR against `main`
 
 ## Delivery
 
@@ -22,14 +22,16 @@
 | [x] | Step 4.E/6 — cache policy/coalescing service | `multi-plugin-release-prep-cache-service` | PR #627 merged |
 | [x] | Step 4.F/6 — route, listeners, and lifecycle wiring | `multi-plugin-release-prep-cache-route` | PR #630 merged |
 | [x] | Step 5.A/6 — cached session-option client layers | `multi-plugin-release-prep-client-options` | PR #635 merged |
-| [ ] | Step 5.B/6 — cached New Session composer | `multi-plugin-release-prep-client-options-ui` | [PR #636](https://github.com/sesori-ai/sesori_apps_monorepo/pull/636) open against `main` |
-| [ ] | Step 6/6 — consolidated Harnesses settings | `multi-plugin-release-prep-harness-settings` | Blocked on Step 5.B merge |
+| [x] | Step 5.B/6 — cached New Session composer | `multi-plugin-release-prep-client-options-ui` | PR #636 merged |
+| [ ] | Step 5.C/6 — dynamic session-option cache misses | `multi-plugin-release-prep-dynamic-options` | Ready for PR |
+| [ ] | Step 6/6 — consolidated Harnesses settings | `multi-plugin-release-prep-harness-settings` | Blocked on Step 5.C merge |
 
 ## Locked Decisions
 
-- One endpoint: `POST /session/options`; `refresh=true` is the only activating
-  aggregate read and also forces backend catalog discovery instead of reusing a
-  plugin's tracker snapshot.
+- One endpoint: `POST /session/options`; omitted `refresh` serves cache when
+  available and activates the selected harness only on cache miss,
+  `refresh=false` is cache-only, and `refresh=true` forces backend catalog
+  discovery instead of reusing a plugin tracker snapshot.
 - OpenCode and Codex cache per project. Cursor caches once per plugin. Codex
   stays project-aware because defaults and skills depend on project context.
 - Cache-only miss is explicit unavailable, not an empty successful catalog.
@@ -79,7 +81,8 @@
 9. `[multi-plugin-release-prep] feat(bridge): expose cached session options [step 4.F/6]`
 10. `[multi-plugin-release-prep] feat(client): add cached session option layers [step 5.A/6]`
 11. `[multi-plugin-release-prep] feat(client): use cached session options [step 5.B/6]`
-12. `[multi-plugin-release-prep] refactor(app): consolidate Harness settings [step 6/6]`
+12. `[multi-plugin-release-prep] feat(bridge): dynamically load missing session options [step 5.C/6]`
+13. `[multi-plugin-release-prep] refactor(app): consolidate Harness settings [step 6/6]`
 
 ## Verification Log
 
@@ -271,3 +274,13 @@
   use mode-neutral “couldn’t update” guidance so automatic cached reload failures
   are not presented as failed user refreshes. The focused widget test, fatal
   mobile analysis, and `git diff --check` passed.
+- Step 5.C/6 preparation (2026-07-31): omitted `refresh` now serves valid cache
+  data or dynamically activates only the selected harness on miss; exact false
+  remains cache-only and exact true remains forced discovery. Client API,
+  repository, service, and cubit terminology now distinguishes dynamic loading
+  from forced refresh while old-bridge capability fallback and all three live
+  legacy POST routes remain unchanged. The 82 focused bridge-app tests, 90
+  module-core tests, 9 shared compatibility tests, and 27 mobile New Session
+  tests passed, as did fatal analysis in bridge-app, module-core, mobile, and
+  desktop plus `git diff --check`. Aristotle approved the implementation
+  architecture without findings.

--- a/.plan/active/multi-plugin-release-prep/TRACKER.md
+++ b/.plan/active/multi-plugin-release-prep/TRACKER.md
@@ -289,6 +289,9 @@
 - Step 5.C/6 review hardening (2026-07-31): dynamic loads queued behind an
   automatic reuse refresh now avoid null-tail coordination and recheck the cache
   before activation, while dynamic-load failures use load-specific client state
-  and copy instead of explicit-Refresh guidance. All 32 service tests, 47 focused
-  module-core tests, and 28 mobile New Session tests passed, as did fatal analysis
-  in bridge-app, module-core, mobile, and desktop plus `git diff --check`.
+  and copy instead of explicit-Refresh guidance. Project-scoped invalidation also
+  re-resolves the authoritative path before deleting expired or undecodable rows,
+  preserving same-revision replacements after a path move. All 34 service tests,
+  47 focused module-core tests, and 28 mobile New Session tests passed, as did
+  fatal analysis in bridge-app, module-core, mobile, and desktop plus
+  `git diff --check`.

--- a/.plan/active/multi-plugin-release-prep/TRACKER.md
+++ b/.plan/active/multi-plugin-release-prep/TRACKER.md
@@ -291,7 +291,7 @@
   before activation, while dynamic-load failures use load-specific client state
   and copy instead of explicit-Refresh guidance. Project-scoped invalidation also
   re-resolves the authoritative path before deleting expired or undecodable rows,
-  preserving same-revision replacements after a path move. All 34 service tests,
-  47 focused module-core tests, and 28 mobile New Session tests passed, as did
-  fatal analysis in bridge-app, module-core, mobile, and desktop plus
-  `git diff --check`.
+  preserving same-revision replacements after a path move; dynamic loading checks
+  that path again immediately before may-activate capture. All 34 service tests,
+  47 focused module-core tests, and 28 mobile New Session tests passed, as did fatal
+  analysis in bridge-app, module-core, mobile, and desktop plus `git diff --check`.

--- a/.plan/active/multi-plugin-release-prep/TRACKER.md
+++ b/.plan/active/multi-plugin-release-prep/TRACKER.md
@@ -286,3 +286,9 @@
   architecture without findings.
 - Step 5.C/6 delivery (2026-07-31): committed as `d0be128e`, pushed, and opened
   as PR #642 against `main`.
+- Step 5.C/6 review hardening (2026-07-31): dynamic loads queued behind an
+  automatic reuse refresh now avoid null-tail coordination and recheck the cache
+  before activation, while dynamic-load failures use load-specific client state
+  and copy instead of explicit-Refresh guidance. All 32 service tests, 47 focused
+  module-core tests, and 28 mobile New Session tests passed, as did fatal analysis
+  in bridge-app, module-core, mobile, and desktop plus `git diff --check`.

--- a/.plan/active/multi-plugin-release-prep/TRACKER.md
+++ b/.plan/active/multi-plugin-release-prep/TRACKER.md
@@ -6,7 +6,7 @@
 - **Series state:** Steps 1/6 through 5.B/6 are merged; oversized PR #620 is
   closed, with its frozen branch retained only as the split implementation source
 - **Current step:** Step 5.C/6 — dynamic session-option cache misses
-- **Next action:** commit and open the verified Step 5.C PR against `main`
+- **Next action:** monitor Step 5.C PR #642 through review and CI
 
 ## Delivery
 
@@ -23,7 +23,7 @@
 | [x] | Step 4.F/6 — route, listeners, and lifecycle wiring | `multi-plugin-release-prep-cache-route` | PR #630 merged |
 | [x] | Step 5.A/6 — cached session-option client layers | `multi-plugin-release-prep-client-options` | PR #635 merged |
 | [x] | Step 5.B/6 — cached New Session composer | `multi-plugin-release-prep-client-options-ui` | PR #636 merged |
-| [ ] | Step 5.C/6 — dynamic session-option cache misses | `multi-plugin-release-prep-dynamic-options` | Ready for PR |
+| [ ] | Step 5.C/6 — dynamic session-option cache misses | `multi-plugin-release-prep-dynamic-options` | [PR #642](https://github.com/sesori-ai/sesori_apps_monorepo/pull/642) open against `main` |
 | [ ] | Step 6/6 — consolidated Harnesses settings | `multi-plugin-release-prep-harness-settings` | Blocked on Step 5.C merge |
 
 ## Locked Decisions
@@ -284,3 +284,5 @@
   tests passed, as did fatal analysis in bridge-app, module-core, mobile, and
   desktop plus `git diff --check`. Aristotle approved the implementation
   architecture without findings.
+- Step 5.C/6 delivery (2026-07-31): committed as `d0be128e`, pushed, and opened
+  as PR #642 against `main`.

--- a/bridge/app/lib/src/bridge/routing/post_session_options_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/post_session_options_handler.dart
@@ -50,9 +50,12 @@ class PostSessionOptionsHandler extends RequestHandlerBase {
 
     final SessionOptionsOutcome outcome;
     try {
-      outcome = refresh == "true"
-          ? await _service.refreshExplicit(pluginId: pluginId, projectId: projectId)
-          : await _service.loadCacheOnly(pluginId: pluginId, projectId: projectId);
+      outcome = switch (refresh) {
+        null => await _service.loadDynamic(pluginId: pluginId, projectId: projectId),
+        "false" => await _service.loadCacheOnly(pluginId: pluginId, projectId: projectId),
+        "true" => await _service.refreshExplicit(pluginId: pluginId, projectId: projectId),
+        _ => throw StateError("validated refresh query has an unsupported value"),
+      };
     } on Object catch (error, stackTrace) {
       Log.w("Session options request failed", error, stackTrace);
       return _error(request: request, status: 500, code: SessionOptionsErrorCode.unknown);

--- a/bridge/app/lib/src/bridge/services/session_options_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_options_service.dart
@@ -99,8 +99,12 @@ class SessionOptionsService {
       generation: null,
       operation: () async {
         final newlyCached = await _readValid(key: resolved.key);
-        if (newlyCached != null && await _isCurrentResolution(resolved: resolved)) {
+        final isCurrentResolution = await _isCurrentResolution(resolved: resolved);
+        if (newlyCached != null && isCurrentResolution) {
           return SessionOptionsAvailable(response: newlyCached.response);
+        }
+        if (!isCurrentResolution) {
+          return _movedProjectOutcome(automatic: false);
         }
         return _refresh(
           resolved: resolved,

--- a/bridge/app/lib/src/bridge/services/session_options_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_options_service.dart
@@ -82,6 +82,47 @@ class SessionOptionsService {
   final Duration _retention;
   final Map<SessionOptionsCacheKey, _RefreshCoordinator> _refreshes = {};
 
+  Future<SessionOptionsOutcome> loadDynamic({
+    required String pluginId,
+    required String projectId,
+  }) async {
+    final resolved = await _resolve(pluginId: pluginId, projectId: projectId);
+    if (resolved == null) return const SessionOptionsProjectNotFound();
+    final cached = await _readValid(key: resolved.key);
+    if (cached != null && await _isCurrentResolution(resolved: resolved)) {
+      return SessionOptionsAvailable(response: cached.response);
+    }
+
+    final outcome = await _coalesce(
+      key: resolved.key,
+      intent: _RefreshIntent.reuse,
+      generation: null,
+      operation: () => _refresh(
+        resolved: resolved,
+        activation: SessionOptionsCaptureActivation.mayActivate,
+        discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+        expectedGeneration: null,
+        automatic: false,
+      ),
+    );
+    if (outcome case SessionOptionsRefreshFailedRetained(:final failure)) {
+      final concurrentlyAvailable = await _readValid(key: resolved.key);
+      if (concurrentlyAvailable != null && await _isCurrentResolution(resolved: resolved)) {
+        final message =
+            "Dynamic session options discovery failed for plugin ${resolved.key.pluginId}; using concurrently published cache";
+        switch (failure) {
+          case SessionOptionsKnownRefreshFailure():
+            Log.w(message);
+          case SessionOptionsCaughtRefreshFailure(:final cause, :final causeStackTrace):
+            Log.w(message, cause, causeStackTrace);
+        }
+        return SessionOptionsAvailable(response: concurrentlyAvailable.response);
+      }
+      return SessionOptionsRefreshFailedUnavailable(failure: failure);
+    }
+    return outcome;
+  }
+
   Future<SessionOptionsOutcome> loadCacheOnly({
     required String pluginId,
     required String projectId,
@@ -505,9 +546,6 @@ class SessionOptionsService {
     required int? generation,
     required Future<SessionOptionsOutcome> Function() operation,
   }) {
-    if (intent == _RefreshIntent.reuse && generation == null) {
-      throw StateError("reuse refresh requires a runtime generation");
-    }
     final existing = _refreshes[key];
     if (existing != null) {
       final forcedTail = existing.forcedTail;

--- a/bridge/app/lib/src/bridge/services/session_options_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_options_service.dart
@@ -491,6 +491,7 @@ class SessionOptionsService {
         return null;
       }
       Log.w("Recovering from undecodable session options cache for plugin ${key.pluginId}");
+      if (!await _isCurrentCacheKey(key: key)) return null;
       final deleted = await _repository.deleteIfRevision(
         key: key,
         expectedRevision: revision,
@@ -505,10 +506,7 @@ class SessionOptionsService {
     final now = _clock.now().toUtc();
     final capturedAt = entry.capturedAt.toUtc();
     if (entry.key != key || capturedAt.isAfter(now) || now.difference(capturedAt) > _retention) {
-      if (entry.key != key && key is ProjectSessionOptionsCacheKey) {
-        final currentPath = await _repository.resolveProjectPath(projectId: key.projectId);
-        if (currentPath != key.projectPath) return null;
-      }
+      if (!await _isCurrentCacheKey(key: key)) return null;
       final deleted = await _repository.deleteIfRevision(
         key: key,
         expectedRevision: entry.revision,
@@ -519,6 +517,14 @@ class SessionOptionsService {
       return null;
     }
     return entry;
+  }
+
+  Future<bool> _isCurrentCacheKey({required SessionOptionsCacheKey key}) async {
+    return switch (key) {
+      PluginSessionOptionsCacheKey() => true,
+      ProjectSessionOptionsCacheKey(:final projectId, :final projectPath) =>
+        await _repository.resolveProjectPath(projectId: projectId) == projectPath,
+    };
   }
 
   Future<_ResolvedSessionOptions?> _resolve({

--- a/bridge/app/lib/src/bridge/services/session_options_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_options_service.dart
@@ -97,13 +97,19 @@ class SessionOptionsService {
       key: resolved.key,
       intent: _RefreshIntent.reuse,
       generation: null,
-      operation: () => _refresh(
-        resolved: resolved,
-        activation: SessionOptionsCaptureActivation.mayActivate,
-        discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
-        expectedGeneration: null,
-        automatic: false,
-      ),
+      operation: () async {
+        final newlyCached = await _readValid(key: resolved.key);
+        if (newlyCached != null && await _isCurrentResolution(resolved: resolved)) {
+          return SessionOptionsAvailable(response: newlyCached.response);
+        }
+        return _refresh(
+          resolved: resolved,
+          activation: SessionOptionsCaptureActivation.mayActivate,
+          discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+          expectedGeneration: null,
+          automatic: false,
+        );
+      },
     );
     if (outcome case SessionOptionsRefreshFailedRetained(:final failure)) {
       final concurrentlyAvailable = await _readValid(key: resolved.key);
@@ -556,7 +562,9 @@ class SessionOptionsService {
 
       if (intent == _RefreshIntent.reuse) {
         if (existing.generation == generation) return existing.running;
-        if (existing.reuseTailGeneration == generation) return existing.reuseTail!;
+        if (existing.reuseTail != null && existing.reuseTailGeneration == generation) {
+          return existing.reuseTail!;
+        }
 
         final predecessor = existing.reuseTail ?? existing.running;
         late final Future<SessionOptionsOutcome> tail;

--- a/bridge/app/test/bridge/routing/post_session_options_handler_test.dart
+++ b/bridge/app/test/bridge/routing/post_session_options_handler_test.dart
@@ -43,21 +43,34 @@ void main() {
       });
     }
 
-    test("missing and exact false refresh load cache only", () async {
-      for (final path in ["/session/options", "/session/options?refresh=false"]) {
-        service.calls.clear();
+    test("missing refresh loads dynamically", () async {
+      final response = await _send(handler: handler, body: _requestBody);
 
-        final response = await _send(handler: handler, path: path, body: _requestBody);
+      expect(response.status, 200);
+      expect(service.calls, [
+        const (
+          operation: _SessionOptionsOperation.loadDynamic,
+          pluginId: "plugin",
+          projectId: "project",
+        ),
+      ]);
+    });
 
-        expect(response.status, 200);
-        expect(service.calls, [
-          const (
-            operation: _SessionOptionsOperation.loadCacheOnly,
-            pluginId: "plugin",
-            projectId: "project",
-          ),
-        ]);
-      }
+    test("exact false refresh loads cache only", () async {
+      final response = await _send(
+        handler: handler,
+        path: "/session/options?refresh=false",
+        body: _requestBody,
+      );
+
+      expect(response.status, 200);
+      expect(service.calls, [
+        const (
+          operation: _SessionOptionsOperation.loadCacheOnly,
+          pluginId: "plugin",
+          projectId: "project",
+        ),
+      ]);
     });
 
     test("exact true refreshes explicitly", () async {
@@ -194,7 +207,7 @@ void _expectError(
   );
 }
 
-enum _SessionOptionsOperation { loadCacheOnly, refreshExplicit }
+enum _SessionOptionsOperation { loadDynamic, loadCacheOnly, refreshExplicit }
 
 typedef _SessionOptionsCall = ({
   _SessionOptionsOperation operation,
@@ -206,6 +219,18 @@ class _FakeSessionOptionsService implements SessionOptionsService {
   SessionOptionsOutcome outcome = const SessionOptionsAvailable(response: _optionsResponse);
   Object? error;
   final List<_SessionOptionsCall> calls = [];
+
+  @override
+  Future<SessionOptionsOutcome> loadDynamic({required String pluginId, required String projectId}) {
+    calls.add(
+      (
+        operation: _SessionOptionsOperation.loadDynamic,
+        pluginId: pluginId,
+        projectId: projectId,
+      ),
+    );
+    return _complete();
+  }
 
   @override
   Future<SessionOptionsOutcome> loadCacheOnly({required String pluginId, required String projectId}) {

--- a/bridge/app/test/bridge/services/session_options_service_test.dart
+++ b/bridge/app/test/bridge/services/session_options_service_test.dart
@@ -182,6 +182,48 @@ void main() {
       expect(repository.stored(key), fresh);
     });
 
+    test("matching-key expiry does not delete a new-path replacement with the same revision", () async {
+      const oldKey = SessionOptionsCacheKey.project(
+        pluginId: "plugin-1",
+        projectId: "project-1",
+        projectPath: "/projects/old",
+      );
+      const newKey = SessionOptionsCacheKey.project(
+        pluginId: "plugin-1",
+        projectId: "project-1",
+        projectPath: "/projects/new",
+      );
+      final expired = _entry(
+        key: oldKey,
+        response: _response(marker: "expired"),
+        capturedAt: now.subtract(const Duration(days: 31)),
+        revision: 1,
+      );
+      final fresh = _entry(
+        key: newKey,
+        response: _response(marker: "fresh"),
+        capturedAt: now,
+        revision: 1,
+      );
+      final repository = _FakeSessionOptionsRepository()
+        ..projectPaths["project-1"] = "/projects/old"
+        ..put(expired);
+      repository.readHandler = (_) async {
+        repository
+          ..projectPaths["project-1"] = "/projects/new"
+          ..put(fresh)
+          ..readHandler = null;
+        return expired;
+      };
+      final service = _service(repository: repository, now: now);
+
+      final outcome = await service.loadDynamic(pluginId: "plugin-1", projectId: "project-1");
+
+      expect(outcome, isA<SessionOptionsRefreshFailedUnavailable>());
+      expect(repository.conditionalDeleteCalls, isEmpty);
+      expect(repository.stored(newKey), fresh);
+    });
+
     test("undecodable cache logging excludes the payload-bearing cause", () async {
       const key = SessionOptionsCacheKey.project(
         pluginId: "plugin-1",
@@ -220,6 +262,39 @@ void main() {
       expect(output, isNot(contains("private-cache-payload")));
       expect(repository.conditionalDeleteCalls.single.expectedRevision, 1);
       expect(repository.stored(key), fresh);
+    });
+
+    test("decode recovery does not delete a new-path replacement with the same revision", () async {
+      const newKey = SessionOptionsCacheKey.project(
+        pluginId: "plugin-1",
+        projectId: "project-1",
+        projectPath: "/projects/new",
+      );
+      final fresh = _entry(
+        key: newKey,
+        response: _response(marker: "fresh"),
+        capturedAt: now,
+        revision: 1,
+      );
+      final repository = _FakeSessionOptionsRepository()..projectPaths["project-1"] = "/projects/old";
+      repository.readHandler = (_) async {
+        repository
+          ..projectPaths["project-1"] = "/projects/new"
+          ..put(fresh)
+          ..readHandler = null;
+        throw SessionOptionsCacheDecodingException(
+          cause: const FormatException("corrupt"),
+          causeStackTrace: StackTrace.current,
+          revision: 1,
+        );
+      };
+      final service = _service(repository: repository, now: now);
+
+      final outcome = await service.loadDynamic(pluginId: "plugin-1", projectId: "project-1");
+
+      expect(outcome, isA<SessionOptionsRefreshFailedUnavailable>());
+      expect(repository.conditionalDeleteCalls, isEmpty);
+      expect(repository.stored(newKey), fresh);
     });
 
     test("decode failure without a revision preserves a concurrently replaced row", () async {

--- a/bridge/app/test/bridge/services/session_options_service_test.dart
+++ b/bridge/app/test/bridge/services/session_options_service_test.dart
@@ -256,6 +256,98 @@ void main() {
     });
   });
 
+  group("SessionOptionsService dynamic loading", () {
+    test("valid cache returns immediately without plugin capture", () async {
+      final repository = _FakeSessionOptionsRepository()
+        ..projectPaths["project-1"] = "/projects/one"
+        ..put(
+          _entry(
+            key: const SessionOptionsCacheKey.plugin(pluginId: "plugin-1"),
+            response: _response(marker: "cached"),
+            capturedAt: now,
+          ),
+        );
+      final service = _service(
+        repository: repository,
+        now: now,
+        scopes: const {"plugin-1": PluginSessionOptionsScope.plugin},
+      );
+
+      final outcome = await service.loadDynamic(pluginId: "plugin-1", projectId: "project-1");
+
+      expect(outcome, isA<SessionOptionsAvailable>());
+      expect((outcome as SessionOptionsAvailable).response, _response(marker: "cached"));
+      expect(repository.captureCalls, isEmpty);
+    });
+
+    test("cache miss activates only the selected plugin with reuse discovery", () async {
+      final repository = _FakeSessionOptionsRepository()
+        ..projectPaths["project-1"] = "/projects/one"
+        ..captureResult = _observed(
+          marker: "dynamic",
+          completeness: PluginSessionOptionsCompleteness.complete,
+          generation: 7,
+        );
+      final service = _service(repository: repository, now: now);
+
+      final outcome = await service.loadDynamic(pluginId: "plugin-1", projectId: "project-1");
+
+      expect(outcome, isA<SessionOptionsAvailable>());
+      expect((outcome as SessionOptionsAvailable).response, _response(marker: "dynamic"));
+      expect(repository.captureCalls, hasLength(1));
+      expect(repository.captureCalls.single.activation, SessionOptionsCaptureActivation.mayActivate);
+      expect(repository.captureCalls.single.discoveryMode, PluginSessionOptionsDiscoveryMode.reuse);
+      expect(repository.captureCalls.single.expectedGeneration, isNull);
+    });
+
+    test("failed dynamic capture returns a concurrently published valid row", () async {
+      const key = SessionOptionsCacheKey.project(
+        pluginId: "plugin-1",
+        projectId: "project-1",
+        projectPath: "/projects/one",
+      );
+      final repository = _FakeSessionOptionsRepository()..projectPaths["project-1"] = "/projects/one";
+      repository.captureHandler = (_) async {
+        repository.put(
+          _entry(
+            key: key,
+            response: _response(marker: "concurrent"),
+            capturedAt: now,
+          ),
+        );
+        return const SessionOptionsCaptureFailed();
+      };
+      final service = _service(repository: repository, now: now);
+
+      final outcome = await service.loadDynamic(pluginId: "plugin-1", projectId: "project-1");
+
+      expect(outcome, isA<SessionOptionsAvailable>());
+      expect((outcome as SessionOptionsAvailable).response, _response(marker: "concurrent"));
+    });
+
+    test("failed dynamic capture without a cache returns unavailable", () async {
+      final repository = _FakeSessionOptionsRepository()
+        ..projectPaths["project-1"] = "/projects/one"
+        ..captureResult = const SessionOptionsCaptureFailed();
+      final service = _service(repository: repository, now: now);
+
+      final outcome = await service.loadDynamic(pluginId: "plugin-1", projectId: "project-1");
+
+      expect(outcome, isA<SessionOptionsRefreshFailedUnavailable>());
+    });
+
+    test("project absence is returned without cache or plugin access", () async {
+      final repository = _FakeSessionOptionsRepository();
+      final service = _service(repository: repository, now: now);
+
+      final outcome = await service.loadDynamic(pluginId: "plugin-1", projectId: "missing");
+
+      expect(outcome, isA<SessionOptionsProjectNotFound>());
+      expect(repository.readCalls, 0);
+      expect(repository.captureCalls, isEmpty);
+    });
+  });
+
   group("SessionOptionsService refresh policy", () {
     test("capture failure retains only a previously valid row", () async {
       final repository = _FakeSessionOptionsRepository()
@@ -777,6 +869,48 @@ void main() {
   });
 
   group("SessionOptionsService coalescing", () {
+    test("dynamic callers coalesce while a forced refresh queues one forced tail", () async {
+      final dynamicGate = Completer<SessionOptionsCaptureResult>();
+      final forcedGate = Completer<SessionOptionsCaptureResult>();
+      final repository = _FakeSessionOptionsRepository()..projectPaths["project-1"] = "/projects/one";
+      repository.captureHandler = (call) {
+        return switch (call.discoveryMode) {
+          PluginSessionOptionsDiscoveryMode.reuse => dynamicGate.future,
+          PluginSessionOptionsDiscoveryMode.refresh => forcedGate.future,
+        };
+      };
+      final service = _service(repository: repository, now: now);
+
+      final dynamic = service.loadDynamic(pluginId: "plugin-1", projectId: "project-1");
+      await _waitFor(condition: () => repository.captureCalls.length == 1);
+      final joinedDynamic = service.loadDynamic(pluginId: "plugin-1", projectId: "project-1");
+      await Future<void>.delayed(Duration.zero);
+      final forced = service.refreshExplicit(pluginId: "plugin-1", projectId: "project-1");
+
+      expect(repository.captureCalls, hasLength(1));
+      dynamicGate.complete(
+        _observed(
+          marker: "dynamic",
+          completeness: PluginSessionOptionsCompleteness.complete,
+          generation: 7,
+        ),
+      );
+      expect((await dynamic as SessionOptionsAvailable).response, _response(marker: "dynamic"));
+      expect((await joinedDynamic as SessionOptionsAvailable).response, _response(marker: "dynamic"));
+
+      await _waitFor(condition: () => repository.captureCalls.length == 2);
+      expect(repository.captureCalls[0].discoveryMode, PluginSessionOptionsDiscoveryMode.reuse);
+      expect(repository.captureCalls[1].discoveryMode, PluginSessionOptionsDiscoveryMode.refresh);
+      forcedGate.complete(
+        _observed(
+          marker: "forced",
+          completeness: PluginSessionOptionsCompleteness.complete,
+          generation: 7,
+        ),
+      );
+      expect((await forced as SessionOptionsAvailable).response, _response(marker: "forced"));
+    });
+
     test("forced callers during reuse share exactly one forced tail and await its result", () async {
       final reuseGate = Completer<SessionOptionsCaptureResult>();
       final forcedGate = Completer<SessionOptionsCaptureResult>();

--- a/bridge/app/test/bridge/services/session_options_service_test.dart
+++ b/bridge/app/test/bridge/services/session_options_service_test.dart
@@ -221,6 +221,7 @@ void main() {
 
       expect(outcome, isA<SessionOptionsRefreshFailedUnavailable>());
       expect(repository.conditionalDeleteCalls, isEmpty);
+      expect(repository.captureCalls, isEmpty);
       expect(repository.stored(newKey), fresh);
     });
 
@@ -294,6 +295,7 @@ void main() {
 
       expect(outcome, isA<SessionOptionsRefreshFailedUnavailable>());
       expect(repository.conditionalDeleteCalls, isEmpty);
+      expect(repository.captureCalls, isEmpty);
       expect(repository.stored(newKey), fresh);
     });
 

--- a/bridge/app/test/bridge/services/session_options_service_test.dart
+++ b/bridge/app/test/bridge/services/session_options_service_test.dart
@@ -869,6 +869,35 @@ void main() {
   });
 
   group("SessionOptionsService coalescing", () {
+    test("dynamic load queued behind automatic reuse returns its newly cached row", () async {
+      final automaticGate = Completer<SessionOptionsCaptureResult>();
+      final repository = _FakeSessionOptionsRepository()
+        ..projectPaths["project-1"] = "/projects/one"
+        ..captureHandler = (_) => automaticGate.future;
+      final service = _service(repository: repository, now: now);
+
+      final automatic = service.refreshActiveOnly(
+        pluginId: "plugin-1",
+        projectId: "project-1",
+        generation: 7,
+      );
+      await _waitFor(condition: () => repository.captureCalls.length == 1);
+      final dynamic = service.loadDynamic(pluginId: "plugin-1", projectId: "project-1");
+      await Future<void>.delayed(Duration.zero);
+
+      automaticGate.complete(
+        _observed(
+          marker: "automatic",
+          completeness: PluginSessionOptionsCompleteness.complete,
+          generation: 7,
+        ),
+      );
+
+      expect((await automatic as SessionOptionsAvailable).response, _response(marker: "automatic"));
+      expect((await dynamic as SessionOptionsAvailable).response, _response(marker: "automatic"));
+      expect(repository.captureCalls, hasLength(1));
+    });
+
     test("dynamic callers coalesce while a forced refresh queues one forced tail", () async {
       final dynamicGate = Completer<SessionOptionsCaptureResult>();
       final forcedGate = Completer<SessionOptionsCaptureResult>();

--- a/bridge/app/test/listeners/session_options_refresh_listeners_test.dart
+++ b/bridge/app/test/listeners/session_options_refresh_listeners_test.dart
@@ -168,6 +168,11 @@ class _FakeSessionOptionsService implements SessionOptionsService {
   final List<String> successfulBackendSessions = [];
 
   @override
+  Future<SessionOptionsOutcome> loadDynamic({required String pluginId, required String projectId}) async {
+    return const SessionOptionsCacheUnavailable();
+  }
+
+  @override
   Future<SessionOptionsOutcome> refreshActiveOnly({
     required String pluginId,
     required String projectId,

--- a/client/app/lib/features/new_session/new_session_screen.dart
+++ b/client/app/lib/features/new_session/new_session_screen.dart
@@ -151,6 +151,9 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
       case NewSessionOptionsRefreshFailureUnavailableState():
         message = loc.newSessionOptionsRefreshFailedUnavailable;
         isFailure = true;
+      case NewSessionOptionsLoadFailureUnavailableState():
+        message = loc.newSessionOptionsLoadFailedUnavailable;
+        isFailure = true;
       case NewSessionOptionsUnavailableState():
         message = loc.newSessionOptionsUnavailable;
         isFailure = false;

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -628,6 +628,7 @@
   "newSessionOptionsRefresh": "Refresh",
   "newSessionOptionsCached": "Using cached coding tool options.",
   "newSessionOptionsUnavailable": "No cached options are available. You can create with defaults or refresh now.",
+  "newSessionOptionsLoadFailedUnavailable": "Couldn’t load options. You can create with defaults or try again.",
   "newSessionOptionsLegacyBridge": "This bridge can load options only by starting the selected coding tool. You can create with defaults or refresh now.",
   "newSessionOptionsUpdateFailedRetained": "Couldn’t update options. Previously cached options are still available.",
   "newSessionOptionsRefreshFailedUnavailable": "Refresh failed and no valid cached options remain. You can create with defaults.",

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -2227,6 +2227,12 @@ abstract class AppLocalizations {
   /// **'No cached options are available. You can create with defaults or refresh now.'**
   String get newSessionOptionsUnavailable;
 
+  /// No description provided for @newSessionOptionsLoadFailedUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn’t load options. You can create with defaults or try again.'**
+  String get newSessionOptionsLoadFailedUnavailable;
+
   /// No description provided for @newSessionOptionsLegacyBridge.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -1144,6 +1144,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'No cached options are available. You can create with defaults or refresh now.';
 
   @override
+  String get newSessionOptionsLoadFailedUnavailable =>
+      'Couldn’t load options. You can create with defaults or try again.';
+
+  @override
   String get newSessionOptionsLegacyBridge =>
       'This bridge can load options only by starting the selected coding tool. You can create with defaults or refresh now.';
 

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -424,6 +424,23 @@ void main() {
     ).called(1);
   });
 
+  testWidgets("failed dynamic load uses load guidance instead of refresh guidance", (tester) async {
+    when(
+      () => sessionRepository.loadSessionOptions(
+        projectId: "project-1",
+        pluginId: "plugin-1",
+        forceRefresh: false,
+      ),
+    ).thenAnswer((_) async => const SessionOptionsRepositoryRefreshFailedUnavailable());
+
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+    final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
+
+    expect(find.text(loc.newSessionOptionsLoadFailedUnavailable), findsOneWidget);
+    expect(find.text(loc.newSessionOptionsRefreshFailedUnavailable), findsNothing);
+  });
+
   testWidgets("retained refresh failure keeps cached options visible", (tester) async {
     when(
       () => sessionRepository.loadSessionOptions(

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -191,7 +191,7 @@ void main() {
       () => sessionRepository.loadSessionOptions(
         projectId: any(named: "projectId"),
         pluginId: any(named: "pluginId"),
-        refresh: any(named: "refresh"),
+        forceRefresh: any(named: "forceRefresh"),
       ),
     ).thenAnswer((invocation) async {
       final projectId = invocation.namedArguments[#projectId]! as String;
@@ -363,7 +363,7 @@ void main() {
       () => sessionRepository.loadSessionOptions(
         projectId: any(named: "projectId"),
         pluginId: any(named: "pluginId"),
-        refresh: any(named: "refresh"),
+        forceRefresh: any(named: "forceRefresh"),
       ),
     );
 
@@ -377,12 +377,12 @@ void main() {
     expect(find.text(loc.newSessionOptionsLegacyBridge), findsOneWidget);
   });
 
-  testWidgets("cache miss keeps creation available with backend defaults", (tester) async {
+  testWidgets("unavailable dynamic load keeps creation available with backend defaults", (tester) async {
     when(
       () => sessionRepository.loadSessionOptions(
         projectId: "project-1",
         pluginId: "plugin-1",
-        refresh: false,
+        forceRefresh: false,
       ),
     ).thenAnswer((_) async => const SessionOptionsRepositoryCacheUnavailable());
     when(
@@ -429,11 +429,11 @@ void main() {
       () => sessionRepository.loadSessionOptions(
         projectId: "project-1",
         pluginId: "plugin-1",
-        refresh: any(named: "refresh"),
+        forceRefresh: any(named: "forceRefresh"),
       ),
     ).thenAnswer((invocation) async {
-      final refresh = invocation.namedArguments[#refresh]! as bool;
-      return refresh
+      final forceRefresh = invocation.namedArguments[#forceRefresh]! as bool;
+      return forceRefresh
           ? const SessionOptionsRepositoryRefreshFailedRetained()
           : SessionOptionsRepositoryAvailable(catalog: _testSessionOptionsCatalog());
     });
@@ -456,11 +456,11 @@ void main() {
       () => sessionRepository.loadSessionOptions(
         projectId: "project-1",
         pluginId: "plugin-1",
-        refresh: any(named: "refresh"),
+        forceRefresh: any(named: "forceRefresh"),
       ),
     ).thenAnswer((invocation) async {
-      final refresh = invocation.namedArguments[#refresh]! as bool;
-      return refresh
+      final forceRefresh = invocation.namedArguments[#forceRefresh]! as bool;
+      return forceRefresh
           ? const SessionOptionsRepositoryRefreshFailedUnavailable()
           : SessionOptionsRepositoryAvailable(catalog: _testSessionOptionsCatalog());
     });

--- a/client/module_core/lib/src/api/session_api.dart
+++ b/client/module_core/lib/src/api/session_api.dart
@@ -44,13 +44,13 @@ class SessionApi {
   Future<ApiResponse<SessionOptionsResponse>> loadSessionOptions({
     required String projectId,
     required String pluginId,
-    required bool refresh,
+    required bool forceRefresh,
   }) {
     return _client.post(
       "/session/options",
       fromJson: SessionOptionsResponse.fromJson,
       body: PluginProjectIdRequest(projectId: projectId, pluginId: pluginId),
-      queryParameters: refresh ? const {"refresh": "true"} : null,
+      queryParameters: forceRefresh ? const {"refresh": "true"} : null,
     );
   }
 

--- a/client/module_core/lib/src/cubits/new_session/new_session_cubit.dart
+++ b/client/module_core/lib/src/cubits/new_session/new_session_cubit.dart
@@ -158,7 +158,7 @@ class NewSessionCubit extends Cubit<NewSessionState> {
             await _loadOptions(
               pluginId: selectedPlugin.id,
               generation: generation,
-              mode: NewSessionOptionsLoadMode.cached,
+              mode: NewSessionOptionsLoadMode.dynamicLoad,
               previousOptions: previousOptions,
               source: source,
             );
@@ -268,7 +268,7 @@ class NewSessionCubit extends Cubit<NewSessionState> {
       _loadOptions(
         pluginId: pluginId,
         generation: generation,
-        mode: NewSessionOptionsLoadMode.cached,
+        mode: NewSessionOptionsLoadMode.dynamicLoad,
         previousOptions: null,
         source: source,
       ),
@@ -302,7 +302,7 @@ class NewSessionCubit extends Cubit<NewSessionState> {
     await _loadOptions(
       pluginId: plugin.id,
       generation: generation,
-      mode: NewSessionOptionsLoadMode.refresh,
+      mode: NewSessionOptionsLoadMode.forcedRefresh,
       previousOptions: previousOptions,
       source: source,
     );

--- a/client/module_core/lib/src/cubits/new_session/new_session_cubit.dart
+++ b/client/module_core/lib/src/cubits/new_session/new_session_cubit.dart
@@ -352,6 +352,7 @@ class NewSessionCubit extends Cubit<NewSessionState> {
       ),
       NewSessionOptionsUnsupported() => const NewSessionOptionsUnsupportedState(),
       NewSessionOptionsUnavailable() => const NewSessionOptionsUnavailableState(),
+      NewSessionOptionsLoadFailureUnavailable() => const NewSessionOptionsLoadFailureUnavailableState(),
       NewSessionOptionsFailureRetained(:final options, :final source) => NewSessionOptionsFailureRetainedState(
         options: options,
         source: source,
@@ -448,6 +449,7 @@ class NewSessionCubit extends Cubit<NewSessionState> {
       NewSessionOptionsAvailableState() ||
       NewSessionOptionsUnsupportedState() ||
       NewSessionOptionsUnavailableState() ||
+      NewSessionOptionsLoadFailureUnavailableState() ||
       NewSessionOptionsFailureState() ||
       NewSessionOptionsRefreshFailureUnavailableState() ||
       null => NewSessionOptionsAvailableState(options: options, source: source),

--- a/client/module_core/lib/src/cubits/new_session/new_session_state.dart
+++ b/client/module_core/lib/src/cubits/new_session/new_session_state.dart
@@ -27,6 +27,8 @@ sealed class NewSessionOptionsLoadState with _$NewSessionOptionsLoadState {
 
   const factory NewSessionOptionsLoadState.unavailable() = NewSessionOptionsUnavailableState;
 
+  const factory NewSessionOptionsLoadState.loadFailureUnavailable() = NewSessionOptionsLoadFailureUnavailableState;
+
   const factory NewSessionOptionsLoadState.failure({
     required RemoteFailureReason reason,
     required NewSessionOptionsSource source,
@@ -49,6 +51,7 @@ extension NewSessionOptionsLoadStateData on NewSessionOptionsLoadState {
     NewSessionOptionsLoadingState() ||
     NewSessionOptionsUnsupportedState() ||
     NewSessionOptionsUnavailableState() ||
+    NewSessionOptionsLoadFailureUnavailableState() ||
     NewSessionOptionsFailureState() ||
     NewSessionOptionsRefreshFailureUnavailableState() => null,
   };
@@ -63,6 +66,7 @@ extension NewSessionOptionsLoadStateData on NewSessionOptionsLoadState {
     NewSessionOptionsFailureRetainedState(:final source) => source,
     NewSessionOptionsUnsupportedState() => NewSessionOptionsSource.legacy,
     NewSessionOptionsUnavailableState() ||
+    NewSessionOptionsLoadFailureUnavailableState() ||
     NewSessionOptionsRefreshFailureUnavailableState() => NewSessionOptionsSource.aggregate,
   };
 }

--- a/client/module_core/lib/src/cubits/new_session/new_session_state.freezed.dart
+++ b/client/module_core/lib/src/cubits/new_session/new_session_state.freezed.dart
@@ -329,6 +329,38 @@ String toString() {
 /// @nodoc
 
 
+class NewSessionOptionsLoadFailureUnavailableState implements NewSessionOptionsLoadState {
+  const NewSessionOptionsLoadFailureUnavailableState();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NewSessionOptionsLoadFailureUnavailableState);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'NewSessionOptionsLoadState.loadFailureUnavailable()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
 class NewSessionOptionsFailureState implements NewSessionOptionsLoadState {
   const NewSessionOptionsFailureState({required this.reason, required this.source});
   

--- a/client/module_core/lib/src/repositories/session_repository.dart
+++ b/client/module_core/lib/src/repositories/session_repository.dart
@@ -143,12 +143,12 @@ class SessionRepository {
   Future<SessionOptionsRepositoryResult> loadSessionOptions({
     required String projectId,
     required String pluginId,
-    required bool refresh,
+    required bool forceRefresh,
   }) async {
     final response = await _api.loadSessionOptions(
       projectId: projectId,
       pluginId: pluginId,
-      refresh: refresh,
+      forceRefresh: forceRefresh,
     );
     return switch (response) {
       SuccessResponse(:final data) => SessionOptionsRepositoryAvailable(

--- a/client/module_core/lib/src/services/new_session_options_service.dart
+++ b/client/module_core/lib/src/services/new_session_options_service.dart
@@ -29,7 +29,7 @@ sealed class NewSessionOptionsLoadResult {
   const NewSessionOptionsLoadResult();
 }
 
-enum NewSessionOptionsLoadMode { cached, refresh }
+enum NewSessionOptionsLoadMode { dynamicLoad, forcedRefresh }
 
 final class NewSessionOptionsLoaded extends NewSessionOptionsLoadResult {
   const NewSessionOptionsLoaded({required this.options, required this.source});
@@ -84,7 +84,7 @@ class NewSessionOptionsService {
     required NewSessionOptionsData? previousOptions,
   }) async {
     if (source == NewSessionOptionsSource.legacy) {
-      if (mode == NewSessionOptionsLoadMode.cached) {
+      if (mode == NewSessionOptionsLoadMode.dynamicLoad) {
         return previousOptions == null
             ? const NewSessionOptionsUnsupported()
             : NewSessionOptionsLoaded(options: previousOptions, source: NewSessionOptionsSource.legacy);
@@ -100,7 +100,7 @@ class NewSessionOptionsService {
     final result = await _sessionRepository.loadSessionOptions(
       projectId: projectId,
       pluginId: pluginId,
-      refresh: mode == NewSessionOptionsLoadMode.refresh,
+      forceRefresh: mode == NewSessionOptionsLoadMode.forcedRefresh,
     );
     return switch (result) {
       SessionOptionsRepositoryAvailable(:final catalog) => NewSessionOptionsLoaded(

--- a/client/module_core/lib/src/services/new_session_options_service.dart
+++ b/client/module_core/lib/src/services/new_session_options_service.dart
@@ -46,6 +46,10 @@ final class NewSessionOptionsUnavailable extends NewSessionOptionsLoadResult {
   const NewSessionOptionsUnavailable();
 }
 
+final class NewSessionOptionsLoadFailureUnavailable extends NewSessionOptionsLoadResult {
+  const NewSessionOptionsLoadFailureUnavailable();
+}
+
 final class NewSessionOptionsFailureRetained extends NewSessionOptionsLoadResult {
   const NewSessionOptionsFailureRetained({required this.options, required this.source});
 
@@ -123,7 +127,10 @@ class NewSessionOptionsService {
                 options: previousOptions,
                 source: NewSessionOptionsSource.aggregate,
               ),
-      SessionOptionsRepositoryRefreshFailedUnavailable() => const NewSessionOptionsRefreshFailureUnavailable(),
+      SessionOptionsRepositoryRefreshFailedUnavailable() => switch (mode) {
+        NewSessionOptionsLoadMode.dynamicLoad => const NewSessionOptionsLoadFailureUnavailable(),
+        NewSessionOptionsLoadMode.forcedRefresh => const NewSessionOptionsRefreshFailureUnavailable(),
+      },
       SessionOptionsRepositoryFailure(:final error) => _transientFailure(
         error: error,
         source: NewSessionOptionsSource.aggregate,

--- a/client/module_core/test/api/session_api_test.dart
+++ b/client/module_core/test/api/session_api_test.dart
@@ -23,7 +23,7 @@ void main() {
       commands: CommandListResponse(items: <CommandInfo>[]),
     );
 
-    test("loadSessionOptions posts the aggregate request without a cache-only query", () async {
+    test("loadSessionOptions omits the query for dynamic loading", () async {
       when(
         () => client.post<SessionOptionsResponse>(
           any(),
@@ -39,7 +39,7 @@ void main() {
       final response = await api.loadSessionOptions(
         projectId: "project-1",
         pluginId: "plugin-1",
-        refresh: false,
+        forceRefresh: false,
       );
 
       expect((response as SuccessResponse<SessionOptionsResponse>).data, options);
@@ -66,7 +66,7 @@ void main() {
       await api.loadSessionOptions(
         projectId: "project-1",
         pluginId: "plugin-1",
-        refresh: true,
+        forceRefresh: true,
       );
 
       verify(

--- a/client/module_core/test/cubits/new_session/new_session_plugin_selection_test.dart
+++ b/client/module_core/test/cubits/new_session/new_session_plugin_selection_test.dart
@@ -498,7 +498,7 @@ void main() {
         () => sessionRepository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "plugin-a",
-          refresh: any(named: "refresh"),
+          forceRefresh: any(named: "forceRefresh"),
         ),
       ).thenAnswer((_) async {
         loadCalls++;
@@ -534,7 +534,7 @@ void main() {
         () => sessionRepository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "plugin-a",
-          refresh: any(named: "refresh"),
+          forceRefresh: any(named: "forceRefresh"),
         ),
       ).thenAnswer((_) async {
         loadCalls++;
@@ -602,7 +602,7 @@ void main() {
         () => sessionRepository.loadSessionOptions(
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
-          refresh: any(named: "refresh"),
+          forceRefresh: any(named: "forceRefresh"),
         ),
       );
     });
@@ -667,7 +667,7 @@ void main() {
         () => sessionRepository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "plugin-a",
-          refresh: any(named: "refresh"),
+          forceRefresh: any(named: "forceRefresh"),
         ),
       ).thenAnswer((_) async {
         loadCalls++;
@@ -805,7 +805,7 @@ void main() {
         () => sessionRepository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "plugin-a",
-          refresh: any(named: "refresh"),
+          forceRefresh: any(named: "forceRefresh"),
         ),
       ).thenAnswer(
         (_) async => SessionOptionsRepositoryAvailable(
@@ -847,7 +847,7 @@ void main() {
         () => sessionRepository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "plugin-a",
-          refresh: any(named: "refresh"),
+          forceRefresh: any(named: "forceRefresh"),
         ),
       ).thenAnswer((_) async {
         loadCalls++;
@@ -883,7 +883,7 @@ void main() {
         () => sessionRepository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "plugin-a",
-          refresh: any(named: "refresh"),
+          forceRefresh: any(named: "forceRefresh"),
         ),
       ).thenAnswer((_) async {
         loadCalls++;
@@ -1605,7 +1605,7 @@ void main() {
         () => sessionRepository.loadSessionOptions(
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
-          refresh: true,
+          forceRefresh: true,
         ),
       );
 

--- a/client/module_core/test/helpers/test_helpers.dart
+++ b/client/module_core/test/helpers/test_helpers.dart
@@ -332,7 +332,7 @@ void delegateSessionOptionsRepositoryToService({
     () => repository.loadSessionOptions(
       projectId: any(named: "projectId"),
       pluginId: any(named: "pluginId"),
-      refresh: any(named: "refresh"),
+      forceRefresh: any(named: "forceRefresh"),
     ),
   ).thenAnswer((invocation) async {
     final projectId = invocation.namedArguments[#projectId]! as String;

--- a/client/module_core/test/repositories/session_repository_test.dart
+++ b/client/module_core/test/repositories/session_repository_test.dart
@@ -239,13 +239,13 @@ void main() {
       commands: CommandListResponse(items: <CommandInfo>[]),
     );
     when(
-      () => api.loadSessionOptions(projectId: "p1", pluginId: "plugin-1", refresh: false),
+      () => api.loadSessionOptions(projectId: "p1", pluginId: "plugin-1", forceRefresh: false),
     ).thenAnswer((_) async => ApiResponse.success(response));
 
     final result = await repository.loadSessionOptions(
       projectId: "p1",
       pluginId: "plugin-1",
-      refresh: false,
+      forceRefresh: false,
     );
 
     expect(
@@ -269,7 +269,7 @@ void main() {
       final api = MockSessionApi();
       final repository = SessionRepository(api: api);
       when(
-        () => api.loadSessionOptions(projectId: "p1", pluginId: "plugin-1", refresh: true),
+        () => api.loadSessionOptions(projectId: "p1", pluginId: "plugin-1", forceRefresh: true),
       ).thenAnswer(
         (_) async => ApiResponse.error(
           ApiError.nonSuccessCode(
@@ -282,7 +282,7 @@ void main() {
       final result = await repository.loadSessionOptions(
         projectId: "p1",
         pluginId: "plugin-1",
-        refresh: true,
+        forceRefresh: true,
       );
 
       expect(result.runtimeType, expectedType, reason: "failed to map $code from HTTP $status");
@@ -294,7 +294,7 @@ void main() {
     final api = MockSessionApi();
     final repository = SessionRepository(api: api);
     when(
-      () => api.loadSessionOptions(projectId: "p1", pluginId: "plugin-1", refresh: true),
+      () => api.loadSessionOptions(projectId: "p1", pluginId: "plugin-1", forceRefresh: true),
     ).thenAnswer(
       (_) async => ApiResponse.error(
         ApiError.nonSuccessCode(
@@ -309,7 +309,7 @@ void main() {
     final result = await repository.loadSessionOptions(
       projectId: "p1",
       pluginId: "plugin-1",
-      refresh: true,
+      forceRefresh: true,
     );
 
     expect(result, isA<SessionOptionsRepositoryRefreshFailedRetained>());
@@ -325,13 +325,13 @@ void main() {
       final repository = SessionRepository(api: api);
       final error = ApiError.nonSuccessCode(errorCode: 599, rawErrorString: body);
       when(
-        () => api.loadSessionOptions(projectId: "p1", pluginId: "plugin-1", refresh: false),
+        () => api.loadSessionOptions(projectId: "p1", pluginId: "plugin-1", forceRefresh: false),
       ).thenAnswer((_) async => ApiResponse.error(error));
 
       final result = await repository.loadSessionOptions(
         projectId: "p1",
         pluginId: "plugin-1",
-        refresh: false,
+        forceRefresh: false,
       );
 
       expect(result, isA<SessionOptionsRepositoryFailure>().having((value) => value.error, "error", error));

--- a/client/module_core/test/services/new_session_options_service_test.dart
+++ b/client/module_core/test/services/new_session_options_service_test.dart
@@ -273,6 +273,23 @@ void main() {
       );
       expect(unavailable, isA<NewSessionOptionsUnavailable>());
 
+      when(
+        () => repository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "plugin-1",
+          forceRefresh: false,
+        ),
+      ).thenAnswer((_) async => const SessionOptionsRepositoryRefreshFailedUnavailable());
+      final dynamicFailure = await service.load(
+        projectId: "project-1",
+        pluginId: "plugin-1",
+        source: NewSessionOptionsSource.aggregate,
+        mode: NewSessionOptionsLoadMode.dynamicLoad,
+        restoredSelection: null,
+        previousOptions: null,
+      );
+      expect(dynamicFailure, isA<NewSessionOptionsLoadFailureUnavailable>());
+
       const previous = NewSessionOptionsData(
         agents: [],
         providers: [],

--- a/client/module_core/test/services/new_session_options_service_test.dart
+++ b/client/module_core/test/services/new_session_options_service_test.dart
@@ -28,7 +28,7 @@ void main() {
         projectId: "project-1",
         pluginId: "plugin-1",
         source: NewSessionOptionsSource.legacy,
-        mode: NewSessionOptionsLoadMode.cached,
+        mode: NewSessionOptionsLoadMode.dynamicLoad,
         restoredSelection: null,
         previousOptions: null,
       );
@@ -38,7 +38,7 @@ void main() {
         () => repository.loadSessionOptions(
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
-          refresh: any(named: "refresh"),
+          forceRefresh: any(named: "forceRefresh"),
         ),
       );
       verifyNever(
@@ -63,7 +63,7 @@ void main() {
         projectId: "project-1",
         pluginId: "plugin-1",
         source: NewSessionOptionsSource.legacy,
-        mode: NewSessionOptionsLoadMode.refresh,
+        mode: NewSessionOptionsLoadMode.forcedRefresh,
         restoredSelection: null,
         previousOptions: null,
       );
@@ -82,7 +82,7 @@ void main() {
         () => repository.loadSessionOptions(
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
-          refresh: any(named: "refresh"),
+          forceRefresh: any(named: "forceRefresh"),
         ),
       );
     });
@@ -97,7 +97,7 @@ void main() {
         projectId: "project-1",
         pluginId: "plugin-1",
         source: NewSessionOptionsSource.legacy,
-        mode: NewSessionOptionsLoadMode.refresh,
+        mode: NewSessionOptionsLoadMode.forcedRefresh,
         restoredSelection: null,
         previousOptions: null,
       );
@@ -112,7 +112,7 @@ void main() {
         () => repository.loadSessionOptions(
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
-          refresh: any(named: "refresh"),
+          forceRefresh: any(named: "forceRefresh"),
         ),
       );
     });
@@ -120,14 +120,14 @@ void main() {
     test("aggregate failure never falls back to the legacy repository", () async {
       final error = ApiError.nonSuccessCode(errorCode: 404, rawErrorString: null);
       when(
-        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", refresh: false),
+        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", forceRefresh: false),
       ).thenAnswer((_) async => SessionOptionsRepositoryProjectNotFound(error: error));
 
       final result = await service.load(
         projectId: "project-1",
         pluginId: "plugin-1",
         source: NewSessionOptionsSource.aggregate,
-        mode: NewSessionOptionsLoadMode.cached,
+        mode: NewSessionOptionsLoadMode.dynamicLoad,
         restoredSelection: null,
         previousOptions: null,
       );
@@ -158,7 +158,7 @@ void main() {
         commands: [_command(name: "review")],
       );
       when(
-        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", refresh: false),
+        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", forceRefresh: false),
       ).thenAnswer((_) async => SessionOptionsRepositoryAvailable(catalog: catalog));
 
       final result =
@@ -166,7 +166,7 @@ void main() {
                 projectId: "project-1",
                 pluginId: "plugin-1",
                 source: NewSessionOptionsSource.aggregate,
-                mode: NewSessionOptionsLoadMode.cached,
+                mode: NewSessionOptionsLoadMode.dynamicLoad,
                 restoredSelection: const NewSessionSelectionIntent(
                   agentName: "review",
                   model: NewSessionModelIntent(providerId: "provider-a", modelId: "model-a"),
@@ -196,7 +196,7 @@ void main() {
         commands: const [],
       );
       when(
-        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", refresh: false),
+        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", forceRefresh: false),
       ).thenAnswer((_) async => SessionOptionsRepositoryAvailable(catalog: catalog));
 
       final result =
@@ -204,7 +204,7 @@ void main() {
                 projectId: "project-1",
                 pluginId: "plugin-1",
                 source: NewSessionOptionsSource.aggregate,
-                mode: NewSessionOptionsLoadMode.cached,
+                mode: NewSessionOptionsLoadMode.dynamicLoad,
                 restoredSelection: const NewSessionSelectionIntent(
                   agentName: "missing",
                   model: NewSessionModelIntent(providerId: "provider-a", modelId: "unavailable"),
@@ -237,7 +237,7 @@ void main() {
         commands: [refreshedCommand],
       );
       when(
-        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", refresh: false),
+        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", forceRefresh: false),
       ).thenAnswer((_) async => SessionOptionsRepositoryAvailable(catalog: catalog));
 
       final result =
@@ -245,7 +245,7 @@ void main() {
                 projectId: "project-1",
                 pluginId: "plugin-1",
                 source: NewSessionOptionsSource.aggregate,
-                mode: NewSessionOptionsLoadMode.cached,
+                mode: NewSessionOptionsLoadMode.dynamicLoad,
                 restoredSelection: const NewSessionSelectionIntent(
                   agentName: "build",
                   model: NewSessionModelIntent(providerId: "provider-a", modelId: "model-a"),
@@ -261,13 +261,13 @@ void main() {
 
     test("maps cache and refresh outcomes without retaining invalid options", () async {
       when(
-        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", refresh: false),
+        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", forceRefresh: false),
       ).thenAnswer((_) async => const SessionOptionsRepositoryCacheUnavailable());
       final unavailable = await service.load(
         projectId: "project-1",
         pluginId: "plugin-1",
         source: NewSessionOptionsSource.aggregate,
-        mode: NewSessionOptionsLoadMode.cached,
+        mode: NewSessionOptionsLoadMode.dynamicLoad,
         restoredSelection: null,
         previousOptions: null,
       );
@@ -283,13 +283,13 @@ void main() {
         availableVariants: [],
       );
       when(
-        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", refresh: true),
+        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", forceRefresh: true),
       ).thenAnswer((_) async => SessionOptionsRepositoryFailure(error: ApiError.generic()));
       final transientFailure = await service.load(
         projectId: "project-1",
         pluginId: "plugin-1",
         source: NewSessionOptionsSource.aggregate,
-        mode: NewSessionOptionsLoadMode.refresh,
+        mode: NewSessionOptionsLoadMode.forcedRefresh,
         restoredSelection: null,
         previousOptions: previous,
       );
@@ -301,13 +301,13 @@ void main() {
       );
 
       when(
-        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", refresh: true),
+        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", forceRefresh: true),
       ).thenAnswer((_) async => const SessionOptionsRepositoryRefreshFailedRetained());
       final retained = await service.load(
         projectId: "project-1",
         pluginId: "plugin-1",
         source: NewSessionOptionsSource.aggregate,
-        mode: NewSessionOptionsLoadMode.refresh,
+        mode: NewSessionOptionsLoadMode.forcedRefresh,
         restoredSelection: null,
         previousOptions: previous,
       );
@@ -321,13 +321,13 @@ void main() {
       );
 
       when(
-        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", refresh: true),
+        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", forceRefresh: true),
       ).thenAnswer((_) async => const SessionOptionsRepositoryRefreshFailedUnavailable());
       final cleared = await service.load(
         projectId: "project-1",
         pluginId: "plugin-1",
         source: NewSessionOptionsSource.aggregate,
-        mode: NewSessionOptionsLoadMode.refresh,
+        mode: NewSessionOptionsLoadMode.forcedRefresh,
         restoredSelection: null,
         previousOptions: previous,
       );


### PR DESCRIPTION
## Summary

- make an omitted `refresh` query dynamically serve valid cached session options or activate only the selected harness on cache miss
- preserve explicit `refresh=false` cache-only reads and `refresh=true` forced backend discovery
- rename client request/load intent to distinguish dynamic loading from forced refresh
- retain capability-based old-bridge fallback and unchanged live legacy option routes

## Compatibility

- New client + old bridge: plugin discovery capability fallback continues to use legacy `/agent`, `/provider`, and `/command` routes only after explicit Refresh.
- Old client + new bridge: the live legacy POST routes remain unchanged.
- New client + new bridge: aggregate requests omit `refresh` for dynamic loading and send `refresh=true` only for explicit forced refresh.

## Verification

- 82 focused bridge-app tests
- 90 focused module-core tests
- 9 shared compatibility tests
- 27 mobile New Session tests
- `dart analyze --fatal-infos` in `bridge/app` and `client/module_core`
- `flutter analyze --fatal-infos` in `client/app` and `client/desktop`
- `git diff --check`
- Aristotle implementation review approved without findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dynamic session option loading on the bridge. Missing `refresh` serves cached data or starts only the selected harness on cache miss, with project-path checks that prevent stale captures and path-fenced invalidation that avoids deleting valid replacements after path moves.

- **New Features**
  - `POST /session/options`: no query uses dynamic load; `refresh=false` is cache-only; `refresh=true` forces discovery.
  - `SessionOptionsService.loadDynamic`: reuse-mode with `mayActivate`; revalidates project path before activating; on failure, returns a concurrently published valid cache row when available, else typed unavailable.
  - Client New Session: adds load-failure state/copy (`newSessionOptionsLoadFailedUnavailable`) for dynamic-load failures.

- **Refactors**
  - Route handler dispatch maps missing/false/true to `loadDynamic`/`loadCacheOnly`/`refreshExplicit`.
  - Coalescing hardening: dynamic loads can queue behind automatic reuse and recheck the cache before activation; reuse-tail null safety; removed the generation requirement for reuse so dynamic callers coalesce correctly.
  - Path-fenced invalidation and decode recovery re-check the current project path before delete; dynamic capture also rejects stale paths before activation.
  - Client API/repository: rename `refresh` to `forceRefresh`; `false` omits the query, `true` sends `refresh=true`. `NewSessionOptionsLoadMode` renamed to `dynamicLoad`/`forcedRefresh`; cubit defaults to dynamic load.

<sup>Written for commit f3271a953c289610837393e978cd449fa861afb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

