### PR TITLE
[output-image-support] refactor(codex): seal rollout envelopes [step 3/13]

### DIFF
--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -5,10 +5,10 @@
 - **Plan slug:** `output-image-support`
 - **Implementation base:** `origin/main` at
   `9d2c1e9e79ab80fa8824b9d803a74798eb71140d`
-- **Series state:** Step 3/13 ready for PR
+- **Series state:** Step 3/13 PR open
 - **Current step:** Step 3/13 — seal Codex rollout envelopes
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** open and monitor the Step 3/13 PR
+- **Next action:** monitor Step 3/13 CI and review
 
 ## Plan Review
 
@@ -28,7 +28,7 @@
 |---|---|---|---|---:|---|
 | [x] | 1/13 | `investigate-opencode-image-support` | `[output-image-support] docs: plan output image support [step 1/13]` | 450-700 | [PR #638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638) merged as `bfadd097` |
 | [x] | 2/13 | `output-image-support-codex-rollout-content` | `[output-image-support] refactor(codex): seal rollout content [step 2/13]` | 1,200-1,500 | [PR #639](https://github.com/sesori-ai/sesori_apps_monorepo/pull/639) merged as `17e0ecf1`; 680 changed lines |
-| [ ] | 3/13 | `output-image-support-codex-rollout-envelopes` | `[output-image-support] refactor(codex): seal rollout envelopes [step 3/13]` | 900-1,350 | Ready for PR; 1,075 changed lines |
+| [ ] | 3/13 | `output-image-support-codex-rollout-envelopes` | `[output-image-support] refactor(codex): seal rollout envelopes [step 3/13]` | 900-1,350 | [PR #644](https://github.com/sesori-ai/sesori_apps_monorepo/pull/644) open; 1,075 changed lines |
 | [ ] | 4/13 | `output-image-support-codex-response-items` | `[output-image-support] refactor(codex): seal response items [step 4/13]` | 1,100-1,500 | Blocked on Step 3 merge |
 | [ ] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | Blocked on Step 4 merge |
 | [ ] | 6/13 | `output-image-support-codex-live-images` | `[output-image-support] feat(codex): surface live output images [step 6/13]` | 900-1,400 | Blocked on Step 5 merge |

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -5,10 +5,10 @@
 - **Plan slug:** `output-image-support`
 - **Implementation base:** `origin/main` at
   `9d2c1e9e79ab80fa8824b9d803a74798eb71140d`
-- **Series state:** Step 2/13 PR open
-- **Current step:** Step 2/13 — seal Codex rollout content
+- **Series state:** Step 3/13 ready for PR
+- **Current step:** Step 3/13 — seal Codex rollout envelopes
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** monitor Step 2/13 CI and review
+- **Next action:** open and monitor the Step 3/13 PR
 
 ## Plan Review
 
@@ -27,8 +27,8 @@
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
 | [x] | 1/13 | `investigate-opencode-image-support` | `[output-image-support] docs: plan output image support [step 1/13]` | 450-700 | [PR #638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638) merged as `bfadd097` |
-| [ ] | 2/13 | `output-image-support-codex-rollout-content` | `[output-image-support] refactor(codex): seal rollout content [step 2/13]` | 1,200-1,500 | [PR #639](https://github.com/sesori-ai/sesori_apps_monorepo/pull/639) open; 680 changed lines |
-| [ ] | 3/13 | `output-image-support-codex-rollout-envelopes` | `[output-image-support] refactor(codex): seal rollout envelopes [step 3/13]` | 900-1,350 | Blocked on Step 2 merge |
+| [x] | 2/13 | `output-image-support-codex-rollout-content` | `[output-image-support] refactor(codex): seal rollout content [step 2/13]` | 1,200-1,500 | [PR #639](https://github.com/sesori-ai/sesori_apps_monorepo/pull/639) merged as `17e0ecf1`; 680 changed lines |
+| [ ] | 3/13 | `output-image-support-codex-rollout-envelopes` | `[output-image-support] refactor(codex): seal rollout envelopes [step 3/13]` | 900-1,350 | Ready for PR; 1,075 changed lines |
 | [ ] | 4/13 | `output-image-support-codex-response-items` | `[output-image-support] refactor(codex): seal response items [step 4/13]` | 1,100-1,500 | Blocked on Step 3 merge |
 | [ ] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | Blocked on Step 4 merge |
 | [ ] | 6/13 | `output-image-support-codex-live-images` | `[output-image-support] feat(codex): surface live output images [step 6/13]` | 900-1,400 | Blocked on Step 5 merge |
@@ -96,8 +96,18 @@
   and history consumers. Codex codegen, focused tests, all 210 package tests,
   `dart pub get`, `dart analyze --fatal-infos`, and `git diff --cached --check`
   pass. `aristotle-impl-review` approved the staged architecture with no
-  findings. Commit `3b18da2d` is open as [PR #639](https://github.com/sesori-ai/sesori_apps_monorepo/pull/639).
-  The 680-line diff is below the 1,500-line soft cap; no neighboring scope was combined.
+  findings. Commit `3b18da2d` was opened as [PR #639](https://github.com/sesori-ai/sesori_apps_monorepo/pull/639).
+  The 680-line diff is below the 1,500-line soft cap; no neighboring scope was combined. PR #639
+  merged as `17e0ecf1` on 2026-07-31.
+- Step 3/13 (2026-07-31): sealed the outer rollout envelope into session
+  metadata, turn context, response item, compacted, and unknown variants;
+  retained the existing response-item payload representation for Step 4; and
+  migrated catalog, tailer, live-event, and history consumers atomically. Codex
+  codegen, focused structural/catalog/tailer/mapper/repository tests, all 211
+  package tests, `dart pub get`, `dart analyze --fatal-infos`, and
+  `git diff --cached --check` pass. `aristotle-impl-review` approved the staged
+  architecture with no findings. The 1,075-line diff is within the 900-1,350
+  target and below the 1,500-line soft cap; no neighboring scope was combined.
 
 ## Findings And Plan Deltas
 

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
@@ -6,18 +6,6 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 part "codex_rollout_dto.freezed.dart";
 part "codex_rollout_dto.g.dart";
 
-enum CodexRolloutLineType {
-  @JsonValue("session_meta")
-  sessionMeta,
-  @JsonValue("turn_context")
-  turnContext,
-  @JsonValue("response_item")
-  responseItem,
-  @JsonValue("compacted")
-  compacted,
-  unknown,
-}
-
 enum CodexRolloutPayloadType {
   @JsonValue("message")
   message,
@@ -53,17 +41,67 @@ sealed class CodexSessionIndexEntryDto with _$CodexSessionIndexEntryDto {
   factory CodexSessionIndexEntryDto.fromJson(Map<String, dynamic> json) => _$CodexSessionIndexEntryDtoFromJson(json);
 }
 
-@Freezed(fromJson: true, toJson: false)
+@Freezed(
+  unionKey: "type",
+  fallbackUnion: "unknown",
+  fromJson: true,
+  toJson: false,
+)
 sealed class CodexRolloutLineDto with _$CodexRolloutLineDto {
-  const factory CodexRolloutLineDto({
+  @FreezedUnionValue("session_meta")
+  const factory CodexRolloutLineDto.sessionMetadata({
     required String? timestamp,
-    @JsonKey(unknownEnumValue: CodexRolloutLineType.unknown) required CodexRolloutLineType? type,
-    required CodexRolloutPayloadDto? payload,
-  }) = _CodexRolloutLineDto;
+    required CodexRolloutSessionMetadataPayloadDto payload,
+  }) = CodexRolloutSessionMetadataLineDto;
+
+  @FreezedUnionValue("turn_context")
+  const factory CodexRolloutLineDto.turnContext({
+    required String? timestamp,
+    required CodexRolloutTurnContextPayloadDto payload,
+  }) = CodexRolloutTurnContextLineDto;
+
+  @FreezedUnionValue("response_item")
+  const factory CodexRolloutLineDto.responseItem({
+    required String? timestamp,
+    required CodexRolloutPayloadDto payload,
+  }) = CodexRolloutResponseItemLineDto;
+
+  @FreezedUnionValue("compacted")
+  const factory CodexRolloutLineDto.compacted({
+    required String? timestamp,
+  }) = CodexRolloutCompactedLineDto;
+
+  const factory CodexRolloutLineDto.unknown({
+    required String? timestamp,
+  }) = CodexRolloutUnknownLineDto;
 
   factory CodexRolloutLineDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutLineDtoFromJson(
     _normalizeRolloutLineJson(json: json),
   );
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CodexRolloutSessionMetadataPayloadDto with _$CodexRolloutSessionMetadataPayloadDto {
+  const factory CodexRolloutSessionMetadataPayloadDto({
+    required String? id,
+    required String? cwd,
+    required String? timestamp,
+    @JsonKey(name: "model_provider") required String? modelProvider,
+    @JsonKey(name: "cli_version") required String? cliVersion,
+  }) = _CodexRolloutSessionMetadataPayloadDto;
+
+  factory CodexRolloutSessionMetadataPayloadDto.fromJson(Map<String, dynamic> json) =>
+      _$CodexRolloutSessionMetadataPayloadDtoFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CodexRolloutTurnContextPayloadDto with _$CodexRolloutTurnContextPayloadDto {
+  const factory CodexRolloutTurnContextPayloadDto({
+    required String? model,
+  }) = _CodexRolloutTurnContextPayloadDto;
+
+  factory CodexRolloutTurnContextPayloadDto.fromJson(Map<String, dynamic> json) =>
+      _$CodexRolloutTurnContextPayloadDtoFromJson(json);
 }
 
 @Freezed(fromJson: true, toJson: false)
@@ -179,12 +217,6 @@ class CodexRolloutOutputConverter extends CodexRolloutContentListConverter {
   }
 }
 
-/// Normalizes overloaded payload fields before generated DTO decoding.
-///
-/// Reasoning response items use a typed content list, while `turn_context`
-/// records legitimately use a scalar string. The latter is context metadata,
-/// not a renderable reasoning part, so only that line type drops the field.
-///
 /// COMPATIBILITY 2026-07-23 (Codex 0.145.x): function calls persist arguments
 /// as JSON-encoded strings, while `tool_search_call` persists the decoded JSON
 /// value directly. Keep both forms until Codex converges the rollout schema or
@@ -193,17 +225,15 @@ Map<String, dynamic> _normalizeRolloutLineJson({
   required Map<String, dynamic> json,
 }) {
   final payload = json["payload"];
-  if (payload is! Map) return json;
-  final normalizeSummary = json["type"] == "turn_context" && payload["summary"] is String;
+  if (json["type"] != "response_item" || payload is! Map) return json;
   final arguments = payload["arguments"];
   final normalizeArguments = arguments != null && arguments is! String;
-  if (!normalizeSummary && !normalizeArguments) return json;
+  if (!normalizeArguments) return json;
   return {
     ...json,
     "payload": {
       ...payload,
-      if (normalizeSummary) "summary": null,
-      if (normalizeArguments) "arguments": jsonEncode(arguments),
+      "arguments": jsonEncode(arguments),
     },
   };
 }

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
@@ -146,11 +146,39 @@ as String?,
 
 }
 
+CodexRolloutLineDto _$CodexRolloutLineDtoFromJson(
+  Map<String, dynamic> json
+) {
+        switch (json['type']) {
+                  case 'session_meta':
+          return CodexRolloutSessionMetadataLineDto.fromJson(
+            json
+          );
+                case 'turn_context':
+          return CodexRolloutTurnContextLineDto.fromJson(
+            json
+          );
+                case 'response_item':
+          return CodexRolloutResponseItemLineDto.fromJson(
+            json
+          );
+                case 'compacted':
+          return CodexRolloutCompactedLineDto.fromJson(
+            json
+          );
+        
+          default:
+            return CodexRolloutUnknownLineDto.fromJson(
+  json
+);
+        }
+      
+}
 
 /// @nodoc
 mixin _$CodexRolloutLineDto {
 
- String? get timestamp;@JsonKey(unknownEnumValue: CodexRolloutLineType.unknown) CodexRolloutLineType? get type; CodexRolloutPayloadDto? get payload;
+ String? get timestamp;
 /// Create a copy of CodexRolloutLineDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -161,16 +189,16 @@ $CodexRolloutLineDtoCopyWith<CodexRolloutLineDto> get copyWith => _$CodexRollout
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutLineDto&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.type, type) || other.type == type)&&(identical(other.payload, payload) || other.payload == payload));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutLineDto&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,timestamp,type,payload);
+int get hashCode => Object.hash(runtimeType,timestamp);
 
 @override
 String toString() {
-  return 'CodexRolloutLineDto(timestamp: $timestamp, type: $type, payload: $payload)';
+  return 'CodexRolloutLineDto(timestamp: $timestamp)';
 }
 
 
@@ -181,11 +209,11 @@ abstract mixin class $CodexRolloutLineDtoCopyWith<$Res>  {
   factory $CodexRolloutLineDtoCopyWith(CodexRolloutLineDto value, $Res Function(CodexRolloutLineDto) _then) = _$CodexRolloutLineDtoCopyWithImpl;
 @useResult
 $Res call({
- String? timestamp,@JsonKey(unknownEnumValue: CodexRolloutLineType.unknown) CodexRolloutLineType? type, CodexRolloutPayloadDto? payload
+ String? timestamp
 });
 
 
-$CodexRolloutPayloadDtoCopyWith<$Res>? get payload;
+
 
 }
 /// @nodoc
@@ -198,27 +226,13 @@ class _$CodexRolloutLineDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexRolloutLineDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? timestamp = freezed,Object? type = freezed,Object? payload = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? timestamp = freezed,}) {
   return _then(_self.copyWith(
 timestamp: freezed == timestamp ? _self.timestamp : timestamp // ignore: cast_nullable_to_non_nullable
-as String?,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
-as CodexRolloutLineType?,payload: freezed == payload ? _self.payload : payload // ignore: cast_nullable_to_non_nullable
-as CodexRolloutPayloadDto?,
+as String?,
   ));
 }
-/// Create a copy of CodexRolloutLineDto
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$CodexRolloutPayloadDtoCopyWith<$Res>? get payload {
-    if (_self.payload == null) {
-    return null;
-  }
 
-  return $CodexRolloutPayloadDtoCopyWith<$Res>(_self.payload!, (value) {
-    return _then(_self.copyWith(payload: value));
-  });
-}
 }
 
 
@@ -226,67 +240,69 @@ $CodexRolloutPayloadDtoCopyWith<$Res>? get payload {
 /// @nodoc
 @JsonSerializable(createToJson: false)
 
-class _CodexRolloutLineDto implements CodexRolloutLineDto {
-  const _CodexRolloutLineDto({required this.timestamp, @JsonKey(unknownEnumValue: CodexRolloutLineType.unknown) required this.type, required this.payload});
-  factory _CodexRolloutLineDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutLineDtoFromJson(json);
+class CodexRolloutSessionMetadataLineDto implements CodexRolloutLineDto {
+  const CodexRolloutSessionMetadataLineDto({required this.timestamp, required this.payload, final  String? $type}): $type = $type ?? 'session_meta';
+  factory CodexRolloutSessionMetadataLineDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutSessionMetadataLineDtoFromJson(json);
 
 @override final  String? timestamp;
-@override@JsonKey(unknownEnumValue: CodexRolloutLineType.unknown) final  CodexRolloutLineType? type;
-@override final  CodexRolloutPayloadDto? payload;
+ final  CodexRolloutSessionMetadataPayloadDto payload;
+
+@JsonKey(name: 'type')
+final String $type;
+
 
 /// Create a copy of CodexRolloutLineDto
 /// with the given fields replaced by the non-null parameter values.
 @override @JsonKey(includeFromJson: false, includeToJson: false)
 @pragma('vm:prefer-inline')
-_$CodexRolloutLineDtoCopyWith<_CodexRolloutLineDto> get copyWith => __$CodexRolloutLineDtoCopyWithImpl<_CodexRolloutLineDto>(this, _$identity);
+$CodexRolloutSessionMetadataLineDtoCopyWith<CodexRolloutSessionMetadataLineDto> get copyWith => _$CodexRolloutSessionMetadataLineDtoCopyWithImpl<CodexRolloutSessionMetadataLineDto>(this, _$identity);
 
 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexRolloutLineDto&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.type, type) || other.type == type)&&(identical(other.payload, payload) || other.payload == payload));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutSessionMetadataLineDto&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.payload, payload) || other.payload == payload));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,timestamp,type,payload);
+int get hashCode => Object.hash(runtimeType,timestamp,payload);
 
 @override
 String toString() {
-  return 'CodexRolloutLineDto(timestamp: $timestamp, type: $type, payload: $payload)';
+  return 'CodexRolloutLineDto.sessionMetadata(timestamp: $timestamp, payload: $payload)';
 }
 
 
 }
 
 /// @nodoc
-abstract mixin class _$CodexRolloutLineDtoCopyWith<$Res> implements $CodexRolloutLineDtoCopyWith<$Res> {
-  factory _$CodexRolloutLineDtoCopyWith(_CodexRolloutLineDto value, $Res Function(_CodexRolloutLineDto) _then) = __$CodexRolloutLineDtoCopyWithImpl;
+abstract mixin class $CodexRolloutSessionMetadataLineDtoCopyWith<$Res> implements $CodexRolloutLineDtoCopyWith<$Res> {
+  factory $CodexRolloutSessionMetadataLineDtoCopyWith(CodexRolloutSessionMetadataLineDto value, $Res Function(CodexRolloutSessionMetadataLineDto) _then) = _$CodexRolloutSessionMetadataLineDtoCopyWithImpl;
 @override @useResult
 $Res call({
- String? timestamp,@JsonKey(unknownEnumValue: CodexRolloutLineType.unknown) CodexRolloutLineType? type, CodexRolloutPayloadDto? payload
+ String? timestamp, CodexRolloutSessionMetadataPayloadDto payload
 });
 
 
-@override $CodexRolloutPayloadDtoCopyWith<$Res>? get payload;
+$CodexRolloutSessionMetadataPayloadDtoCopyWith<$Res> get payload;
 
 }
 /// @nodoc
-class __$CodexRolloutLineDtoCopyWithImpl<$Res>
-    implements _$CodexRolloutLineDtoCopyWith<$Res> {
-  __$CodexRolloutLineDtoCopyWithImpl(this._self, this._then);
+class _$CodexRolloutSessionMetadataLineDtoCopyWithImpl<$Res>
+    implements $CodexRolloutSessionMetadataLineDtoCopyWith<$Res> {
+  _$CodexRolloutSessionMetadataLineDtoCopyWithImpl(this._self, this._then);
 
-  final _CodexRolloutLineDto _self;
-  final $Res Function(_CodexRolloutLineDto) _then;
+  final CodexRolloutSessionMetadataLineDto _self;
+  final $Res Function(CodexRolloutSessionMetadataLineDto) _then;
 
 /// Create a copy of CodexRolloutLineDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? timestamp = freezed,Object? type = freezed,Object? payload = freezed,}) {
-  return _then(_CodexRolloutLineDto(
+@override @pragma('vm:prefer-inline') $Res call({Object? timestamp = freezed,Object? payload = null,}) {
+  return _then(CodexRolloutSessionMetadataLineDto(
 timestamp: freezed == timestamp ? _self.timestamp : timestamp // ignore: cast_nullable_to_non_nullable
-as String?,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
-as CodexRolloutLineType?,payload: freezed == payload ? _self.payload : payload // ignore: cast_nullable_to_non_nullable
-as CodexRolloutPayloadDto?,
+as String?,payload: null == payload ? _self.payload : payload // ignore: cast_nullable_to_non_nullable
+as CodexRolloutSessionMetadataPayloadDto,
   ));
 }
 
@@ -294,15 +310,584 @@ as CodexRolloutPayloadDto?,
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
-$CodexRolloutPayloadDtoCopyWith<$Res>? get payload {
-    if (_self.payload == null) {
-    return null;
-  }
-
-  return $CodexRolloutPayloadDtoCopyWith<$Res>(_self.payload!, (value) {
+$CodexRolloutSessionMetadataPayloadDtoCopyWith<$Res> get payload {
+  
+  return $CodexRolloutSessionMetadataPayloadDtoCopyWith<$Res>(_self.payload, (value) {
     return _then(_self.copyWith(payload: value));
   });
 }
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutTurnContextLineDto implements CodexRolloutLineDto {
+  const CodexRolloutTurnContextLineDto({required this.timestamp, required this.payload, final  String? $type}): $type = $type ?? 'turn_context';
+  factory CodexRolloutTurnContextLineDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutTurnContextLineDtoFromJson(json);
+
+@override final  String? timestamp;
+ final  CodexRolloutTurnContextPayloadDto payload;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutLineDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutTurnContextLineDtoCopyWith<CodexRolloutTurnContextLineDto> get copyWith => _$CodexRolloutTurnContextLineDtoCopyWithImpl<CodexRolloutTurnContextLineDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutTurnContextLineDto&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.payload, payload) || other.payload == payload));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,timestamp,payload);
+
+@override
+String toString() {
+  return 'CodexRolloutLineDto.turnContext(timestamp: $timestamp, payload: $payload)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutTurnContextLineDtoCopyWith<$Res> implements $CodexRolloutLineDtoCopyWith<$Res> {
+  factory $CodexRolloutTurnContextLineDtoCopyWith(CodexRolloutTurnContextLineDto value, $Res Function(CodexRolloutTurnContextLineDto) _then) = _$CodexRolloutTurnContextLineDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String? timestamp, CodexRolloutTurnContextPayloadDto payload
+});
+
+
+$CodexRolloutTurnContextPayloadDtoCopyWith<$Res> get payload;
+
+}
+/// @nodoc
+class _$CodexRolloutTurnContextLineDtoCopyWithImpl<$Res>
+    implements $CodexRolloutTurnContextLineDtoCopyWith<$Res> {
+  _$CodexRolloutTurnContextLineDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutTurnContextLineDto _self;
+  final $Res Function(CodexRolloutTurnContextLineDto) _then;
+
+/// Create a copy of CodexRolloutLineDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? timestamp = freezed,Object? payload = null,}) {
+  return _then(CodexRolloutTurnContextLineDto(
+timestamp: freezed == timestamp ? _self.timestamp : timestamp // ignore: cast_nullable_to_non_nullable
+as String?,payload: null == payload ? _self.payload : payload // ignore: cast_nullable_to_non_nullable
+as CodexRolloutTurnContextPayloadDto,
+  ));
+}
+
+/// Create a copy of CodexRolloutLineDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CodexRolloutTurnContextPayloadDtoCopyWith<$Res> get payload {
+  
+  return $CodexRolloutTurnContextPayloadDtoCopyWith<$Res>(_self.payload, (value) {
+    return _then(_self.copyWith(payload: value));
+  });
+}
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutResponseItemLineDto implements CodexRolloutLineDto {
+  const CodexRolloutResponseItemLineDto({required this.timestamp, required this.payload, final  String? $type}): $type = $type ?? 'response_item';
+  factory CodexRolloutResponseItemLineDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutResponseItemLineDtoFromJson(json);
+
+@override final  String? timestamp;
+ final  CodexRolloutPayloadDto payload;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutLineDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutResponseItemLineDtoCopyWith<CodexRolloutResponseItemLineDto> get copyWith => _$CodexRolloutResponseItemLineDtoCopyWithImpl<CodexRolloutResponseItemLineDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutResponseItemLineDto&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.payload, payload) || other.payload == payload));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,timestamp,payload);
+
+@override
+String toString() {
+  return 'CodexRolloutLineDto.responseItem(timestamp: $timestamp, payload: $payload)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutResponseItemLineDtoCopyWith<$Res> implements $CodexRolloutLineDtoCopyWith<$Res> {
+  factory $CodexRolloutResponseItemLineDtoCopyWith(CodexRolloutResponseItemLineDto value, $Res Function(CodexRolloutResponseItemLineDto) _then) = _$CodexRolloutResponseItemLineDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String? timestamp, CodexRolloutPayloadDto payload
+});
+
+
+$CodexRolloutPayloadDtoCopyWith<$Res> get payload;
+
+}
+/// @nodoc
+class _$CodexRolloutResponseItemLineDtoCopyWithImpl<$Res>
+    implements $CodexRolloutResponseItemLineDtoCopyWith<$Res> {
+  _$CodexRolloutResponseItemLineDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutResponseItemLineDto _self;
+  final $Res Function(CodexRolloutResponseItemLineDto) _then;
+
+/// Create a copy of CodexRolloutLineDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? timestamp = freezed,Object? payload = null,}) {
+  return _then(CodexRolloutResponseItemLineDto(
+timestamp: freezed == timestamp ? _self.timestamp : timestamp // ignore: cast_nullable_to_non_nullable
+as String?,payload: null == payload ? _self.payload : payload // ignore: cast_nullable_to_non_nullable
+as CodexRolloutPayloadDto,
+  ));
+}
+
+/// Create a copy of CodexRolloutLineDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CodexRolloutPayloadDtoCopyWith<$Res> get payload {
+  
+  return $CodexRolloutPayloadDtoCopyWith<$Res>(_self.payload, (value) {
+    return _then(_self.copyWith(payload: value));
+  });
+}
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutCompactedLineDto implements CodexRolloutLineDto {
+  const CodexRolloutCompactedLineDto({required this.timestamp, final  String? $type}): $type = $type ?? 'compacted';
+  factory CodexRolloutCompactedLineDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutCompactedLineDtoFromJson(json);
+
+@override final  String? timestamp;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutLineDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutCompactedLineDtoCopyWith<CodexRolloutCompactedLineDto> get copyWith => _$CodexRolloutCompactedLineDtoCopyWithImpl<CodexRolloutCompactedLineDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutCompactedLineDto&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,timestamp);
+
+@override
+String toString() {
+  return 'CodexRolloutLineDto.compacted(timestamp: $timestamp)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutCompactedLineDtoCopyWith<$Res> implements $CodexRolloutLineDtoCopyWith<$Res> {
+  factory $CodexRolloutCompactedLineDtoCopyWith(CodexRolloutCompactedLineDto value, $Res Function(CodexRolloutCompactedLineDto) _then) = _$CodexRolloutCompactedLineDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String? timestamp
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexRolloutCompactedLineDtoCopyWithImpl<$Res>
+    implements $CodexRolloutCompactedLineDtoCopyWith<$Res> {
+  _$CodexRolloutCompactedLineDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutCompactedLineDto _self;
+  final $Res Function(CodexRolloutCompactedLineDto) _then;
+
+/// Create a copy of CodexRolloutLineDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? timestamp = freezed,}) {
+  return _then(CodexRolloutCompactedLineDto(
+timestamp: freezed == timestamp ? _self.timestamp : timestamp // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutUnknownLineDto implements CodexRolloutLineDto {
+  const CodexRolloutUnknownLineDto({required this.timestamp, final  String? $type}): $type = $type ?? 'unknown';
+  factory CodexRolloutUnknownLineDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutUnknownLineDtoFromJson(json);
+
+@override final  String? timestamp;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutLineDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutUnknownLineDtoCopyWith<CodexRolloutUnknownLineDto> get copyWith => _$CodexRolloutUnknownLineDtoCopyWithImpl<CodexRolloutUnknownLineDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutUnknownLineDto&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,timestamp);
+
+@override
+String toString() {
+  return 'CodexRolloutLineDto.unknown(timestamp: $timestamp)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutUnknownLineDtoCopyWith<$Res> implements $CodexRolloutLineDtoCopyWith<$Res> {
+  factory $CodexRolloutUnknownLineDtoCopyWith(CodexRolloutUnknownLineDto value, $Res Function(CodexRolloutUnknownLineDto) _then) = _$CodexRolloutUnknownLineDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String? timestamp
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexRolloutUnknownLineDtoCopyWithImpl<$Res>
+    implements $CodexRolloutUnknownLineDtoCopyWith<$Res> {
+  _$CodexRolloutUnknownLineDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutUnknownLineDto _self;
+  final $Res Function(CodexRolloutUnknownLineDto) _then;
+
+/// Create a copy of CodexRolloutLineDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? timestamp = freezed,}) {
+  return _then(CodexRolloutUnknownLineDto(
+timestamp: freezed == timestamp ? _self.timestamp : timestamp // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$CodexRolloutSessionMetadataPayloadDto {
+
+ String? get id; String? get cwd; String? get timestamp;@JsonKey(name: "model_provider") String? get modelProvider;@JsonKey(name: "cli_version") String? get cliVersion;
+/// Create a copy of CodexRolloutSessionMetadataPayloadDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutSessionMetadataPayloadDtoCopyWith<CodexRolloutSessionMetadataPayloadDto> get copyWith => _$CodexRolloutSessionMetadataPayloadDtoCopyWithImpl<CodexRolloutSessionMetadataPayloadDto>(this as CodexRolloutSessionMetadataPayloadDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutSessionMetadataPayloadDto&&(identical(other.id, id) || other.id == id)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.cliVersion, cliVersion) || other.cliVersion == cliVersion));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,cwd,timestamp,modelProvider,cliVersion);
+
+@override
+String toString() {
+  return 'CodexRolloutSessionMetadataPayloadDto(id: $id, cwd: $cwd, timestamp: $timestamp, modelProvider: $modelProvider, cliVersion: $cliVersion)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutSessionMetadataPayloadDtoCopyWith<$Res>  {
+  factory $CodexRolloutSessionMetadataPayloadDtoCopyWith(CodexRolloutSessionMetadataPayloadDto value, $Res Function(CodexRolloutSessionMetadataPayloadDto) _then) = _$CodexRolloutSessionMetadataPayloadDtoCopyWithImpl;
+@useResult
+$Res call({
+ String? id, String? cwd, String? timestamp,@JsonKey(name: "model_provider") String? modelProvider,@JsonKey(name: "cli_version") String? cliVersion
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexRolloutSessionMetadataPayloadDtoCopyWithImpl<$Res>
+    implements $CodexRolloutSessionMetadataPayloadDtoCopyWith<$Res> {
+  _$CodexRolloutSessionMetadataPayloadDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutSessionMetadataPayloadDto _self;
+  final $Res Function(CodexRolloutSessionMetadataPayloadDto) _then;
+
+/// Create a copy of CodexRolloutSessionMetadataPayloadDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? cwd = freezed,Object? timestamp = freezed,Object? modelProvider = freezed,Object? cliVersion = freezed,}) {
+  return _then(_self.copyWith(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,cwd: freezed == cwd ? _self.cwd : cwd // ignore: cast_nullable_to_non_nullable
+as String?,timestamp: freezed == timestamp ? _self.timestamp : timestamp // ignore: cast_nullable_to_non_nullable
+as String?,modelProvider: freezed == modelProvider ? _self.modelProvider : modelProvider // ignore: cast_nullable_to_non_nullable
+as String?,cliVersion: freezed == cliVersion ? _self.cliVersion : cliVersion // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexRolloutSessionMetadataPayloadDto implements CodexRolloutSessionMetadataPayloadDto {
+  const _CodexRolloutSessionMetadataPayloadDto({required this.id, required this.cwd, required this.timestamp, @JsonKey(name: "model_provider") required this.modelProvider, @JsonKey(name: "cli_version") required this.cliVersion});
+  factory _CodexRolloutSessionMetadataPayloadDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutSessionMetadataPayloadDtoFromJson(json);
+
+@override final  String? id;
+@override final  String? cwd;
+@override final  String? timestamp;
+@override@JsonKey(name: "model_provider") final  String? modelProvider;
+@override@JsonKey(name: "cli_version") final  String? cliVersion;
+
+/// Create a copy of CodexRolloutSessionMetadataPayloadDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexRolloutSessionMetadataPayloadDtoCopyWith<_CodexRolloutSessionMetadataPayloadDto> get copyWith => __$CodexRolloutSessionMetadataPayloadDtoCopyWithImpl<_CodexRolloutSessionMetadataPayloadDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexRolloutSessionMetadataPayloadDto&&(identical(other.id, id) || other.id == id)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.cliVersion, cliVersion) || other.cliVersion == cliVersion));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,cwd,timestamp,modelProvider,cliVersion);
+
+@override
+String toString() {
+  return 'CodexRolloutSessionMetadataPayloadDto(id: $id, cwd: $cwd, timestamp: $timestamp, modelProvider: $modelProvider, cliVersion: $cliVersion)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexRolloutSessionMetadataPayloadDtoCopyWith<$Res> implements $CodexRolloutSessionMetadataPayloadDtoCopyWith<$Res> {
+  factory _$CodexRolloutSessionMetadataPayloadDtoCopyWith(_CodexRolloutSessionMetadataPayloadDto value, $Res Function(_CodexRolloutSessionMetadataPayloadDto) _then) = __$CodexRolloutSessionMetadataPayloadDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String? id, String? cwd, String? timestamp,@JsonKey(name: "model_provider") String? modelProvider,@JsonKey(name: "cli_version") String? cliVersion
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexRolloutSessionMetadataPayloadDtoCopyWithImpl<$Res>
+    implements _$CodexRolloutSessionMetadataPayloadDtoCopyWith<$Res> {
+  __$CodexRolloutSessionMetadataPayloadDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexRolloutSessionMetadataPayloadDto _self;
+  final $Res Function(_CodexRolloutSessionMetadataPayloadDto) _then;
+
+/// Create a copy of CodexRolloutSessionMetadataPayloadDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? cwd = freezed,Object? timestamp = freezed,Object? modelProvider = freezed,Object? cliVersion = freezed,}) {
+  return _then(_CodexRolloutSessionMetadataPayloadDto(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,cwd: freezed == cwd ? _self.cwd : cwd // ignore: cast_nullable_to_non_nullable
+as String?,timestamp: freezed == timestamp ? _self.timestamp : timestamp // ignore: cast_nullable_to_non_nullable
+as String?,modelProvider: freezed == modelProvider ? _self.modelProvider : modelProvider // ignore: cast_nullable_to_non_nullable
+as String?,cliVersion: freezed == cliVersion ? _self.cliVersion : cliVersion // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$CodexRolloutTurnContextPayloadDto {
+
+ String? get model;
+/// Create a copy of CodexRolloutTurnContextPayloadDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutTurnContextPayloadDtoCopyWith<CodexRolloutTurnContextPayloadDto> get copyWith => _$CodexRolloutTurnContextPayloadDtoCopyWithImpl<CodexRolloutTurnContextPayloadDto>(this as CodexRolloutTurnContextPayloadDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutTurnContextPayloadDto&&(identical(other.model, model) || other.model == model));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,model);
+
+@override
+String toString() {
+  return 'CodexRolloutTurnContextPayloadDto(model: $model)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutTurnContextPayloadDtoCopyWith<$Res>  {
+  factory $CodexRolloutTurnContextPayloadDtoCopyWith(CodexRolloutTurnContextPayloadDto value, $Res Function(CodexRolloutTurnContextPayloadDto) _then) = _$CodexRolloutTurnContextPayloadDtoCopyWithImpl;
+@useResult
+$Res call({
+ String? model
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexRolloutTurnContextPayloadDtoCopyWithImpl<$Res>
+    implements $CodexRolloutTurnContextPayloadDtoCopyWith<$Res> {
+  _$CodexRolloutTurnContextPayloadDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutTurnContextPayloadDto _self;
+  final $Res Function(CodexRolloutTurnContextPayloadDto) _then;
+
+/// Create a copy of CodexRolloutTurnContextPayloadDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? model = freezed,}) {
+  return _then(_self.copyWith(
+model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexRolloutTurnContextPayloadDto implements CodexRolloutTurnContextPayloadDto {
+  const _CodexRolloutTurnContextPayloadDto({required this.model});
+  factory _CodexRolloutTurnContextPayloadDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutTurnContextPayloadDtoFromJson(json);
+
+@override final  String? model;
+
+/// Create a copy of CodexRolloutTurnContextPayloadDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexRolloutTurnContextPayloadDtoCopyWith<_CodexRolloutTurnContextPayloadDto> get copyWith => __$CodexRolloutTurnContextPayloadDtoCopyWithImpl<_CodexRolloutTurnContextPayloadDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexRolloutTurnContextPayloadDto&&(identical(other.model, model) || other.model == model));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,model);
+
+@override
+String toString() {
+  return 'CodexRolloutTurnContextPayloadDto(model: $model)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexRolloutTurnContextPayloadDtoCopyWith<$Res> implements $CodexRolloutTurnContextPayloadDtoCopyWith<$Res> {
+  factory _$CodexRolloutTurnContextPayloadDtoCopyWith(_CodexRolloutTurnContextPayloadDto value, $Res Function(_CodexRolloutTurnContextPayloadDto) _then) = __$CodexRolloutTurnContextPayloadDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String? model
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexRolloutTurnContextPayloadDtoCopyWithImpl<$Res>
+    implements _$CodexRolloutTurnContextPayloadDtoCopyWith<$Res> {
+  __$CodexRolloutTurnContextPayloadDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexRolloutTurnContextPayloadDto _self;
+  final $Res Function(_CodexRolloutTurnContextPayloadDto) _then;
+
+/// Create a copy of CodexRolloutTurnContextPayloadDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? model = freezed,}) {
+  return _then(_CodexRolloutTurnContextPayloadDto(
+model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
 }
 
 

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
@@ -13,28 +13,61 @@ _CodexSessionIndexEntryDto _$CodexSessionIndexEntryDtoFromJson(Map json) =>
       updatedAt: json['updated_at'] as String?,
     );
 
-_CodexRolloutLineDto _$CodexRolloutLineDtoFromJson(Map json) =>
-    _CodexRolloutLineDto(
+CodexRolloutSessionMetadataLineDto _$CodexRolloutSessionMetadataLineDtoFromJson(
+  Map json,
+) => CodexRolloutSessionMetadataLineDto(
+  timestamp: json['timestamp'] as String?,
+  payload: CodexRolloutSessionMetadataPayloadDto.fromJson(
+    Map<String, dynamic>.from(json['payload'] as Map),
+  ),
+  $type: json['type'] as String?,
+);
+
+CodexRolloutTurnContextLineDto _$CodexRolloutTurnContextLineDtoFromJson(
+  Map json,
+) => CodexRolloutTurnContextLineDto(
+  timestamp: json['timestamp'] as String?,
+  payload: CodexRolloutTurnContextPayloadDto.fromJson(
+    Map<String, dynamic>.from(json['payload'] as Map),
+  ),
+  $type: json['type'] as String?,
+);
+
+CodexRolloutResponseItemLineDto _$CodexRolloutResponseItemLineDtoFromJson(
+  Map json,
+) => CodexRolloutResponseItemLineDto(
+  timestamp: json['timestamp'] as String?,
+  payload: CodexRolloutPayloadDto.fromJson(
+    Map<String, dynamic>.from(json['payload'] as Map),
+  ),
+  $type: json['type'] as String?,
+);
+
+CodexRolloutCompactedLineDto _$CodexRolloutCompactedLineDtoFromJson(Map json) =>
+    CodexRolloutCompactedLineDto(
       timestamp: json['timestamp'] as String?,
-      type: $enumDecodeNullable(
-        _$CodexRolloutLineTypeEnumMap,
-        json['type'],
-        unknownValue: CodexRolloutLineType.unknown,
-      ),
-      payload: json['payload'] == null
-          ? null
-          : CodexRolloutPayloadDto.fromJson(
-              Map<String, dynamic>.from(json['payload'] as Map),
-            ),
+      $type: json['type'] as String?,
     );
 
-const _$CodexRolloutLineTypeEnumMap = {
-  CodexRolloutLineType.sessionMeta: 'session_meta',
-  CodexRolloutLineType.turnContext: 'turn_context',
-  CodexRolloutLineType.responseItem: 'response_item',
-  CodexRolloutLineType.compacted: 'compacted',
-  CodexRolloutLineType.unknown: 'unknown',
-};
+CodexRolloutUnknownLineDto _$CodexRolloutUnknownLineDtoFromJson(Map json) =>
+    CodexRolloutUnknownLineDto(
+      timestamp: json['timestamp'] as String?,
+      $type: json['type'] as String?,
+    );
+
+_CodexRolloutSessionMetadataPayloadDto
+_$CodexRolloutSessionMetadataPayloadDtoFromJson(Map json) =>
+    _CodexRolloutSessionMetadataPayloadDto(
+      id: json['id'] as String?,
+      cwd: json['cwd'] as String?,
+      timestamp: json['timestamp'] as String?,
+      modelProvider: json['model_provider'] as String?,
+      cliVersion: json['cli_version'] as String?,
+    );
+
+_CodexRolloutTurnContextPayloadDto _$CodexRolloutTurnContextPayloadDtoFromJson(
+  Map json,
+) => _CodexRolloutTurnContextPayloadDto(model: json['model'] as String?);
 
 _CodexRolloutPayloadDto _$CodexRolloutPayloadDtoFromJson(
   Map json,

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -263,8 +263,13 @@ class CodexEventMapper {
     required String threadId,
     required CodexRolloutLineDto line,
   }) {
-    if (line.type != CodexRolloutLineType.responseItem) return const [];
-    final payload = line.payload;
+    final payload = switch (line) {
+      CodexRolloutResponseItemLineDto(payload: final payload) => payload,
+      CodexRolloutSessionMetadataLineDto() ||
+      CodexRolloutTurnContextLineDto() ||
+      CodexRolloutCompactedLineDto() ||
+      CodexRolloutUnknownLineDto() => null,
+    };
     if (payload == null) return const [];
     final call = _rolloutToolMapper.mapCall(payload);
     if (call != null) {

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_catalog_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_catalog_repository.dart
@@ -180,27 +180,23 @@ class CodexCatalogRepository {
     String? cliVersion;
     String? model;
     for (final line in lines) {
-      switch (line.type) {
-        case CodexRolloutLineType.sessionMeta:
+      switch (line) {
+        case CodexRolloutSessionMetadataLineDto(:final payload):
           // Forked/subagent rollouts begin with their own metadata and then
           // include the parent's copied session metadata. The leading header
           // remains authoritative for the file.
           if (id != null) continue;
-          final payload = line.payload;
-          final metadataId = payload?.id;
+          final metadataId = payload.id;
           if (metadataId == null || metadataId.isEmpty) continue;
           id = metadataId;
-          cwd = payload?.cwd;
-          timestamp = _tryParseDate(payload?.timestamp);
-          modelProvider = payload?.modelProvider;
-          cliVersion = payload?.cliVersion;
-        case CodexRolloutLineType.turnContext:
-          final candidate = line.payload?.model;
+          cwd = payload.cwd;
+          timestamp = _tryParseDate(payload.timestamp);
+          modelProvider = payload.modelProvider;
+          cliVersion = payload.cliVersion;
+        case CodexRolloutTurnContextLineDto(:final payload):
+          final candidate = payload.model;
           if (candidate != null && candidate.isNotEmpty) model = candidate;
-        case CodexRolloutLineType.responseItem:
-        case CodexRolloutLineType.compacted:
-        case CodexRolloutLineType.unknown:
-        case null:
+        case CodexRolloutResponseItemLineDto() || CodexRolloutCompactedLineDto() || CodexRolloutUnknownLineDto():
           break;
       }
     }

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
@@ -37,10 +37,10 @@ class CodexMessageRepository {
 
     final toolOutputs = <String, CodexRolloutToolResult>{};
     for (final line in lines) {
-      final payload = line.payload;
-      if (payload == null) continue;
-      final result = _rolloutToolMapper.mapResult(payload);
-      if (result != null) toolOutputs[result.callId] = result;
+      if (line case CodexRolloutResponseItemLineDto(payload: final payload)) {
+        final result = _rolloutToolMapper.mapResult(payload);
+        if (result != null) toolOutputs[result.callId] = result;
+      }
     }
 
     final messages = <PluginMessageWithParts>[];
@@ -58,16 +58,17 @@ class CodexMessageRepository {
     );
 
     for (final line in lines) {
-      final payload = line.payload;
-      switch (line.type) {
-        case CodexRolloutLineType.sessionMeta:
-          sessionProvider ??= payload?.modelProvider;
+      final CodexRolloutPayloadDto payload;
+      final String? lineTimestamp;
+      switch (line) {
+        case CodexRolloutSessionMetadataLineDto(payload: final metadata):
+          sessionProvider ??= metadata.modelProvider;
           continue;
-        case CodexRolloutLineType.turnContext:
-          final model = payload?.model;
+        case CodexRolloutTurnContextLineDto(payload: final context):
+          final model = context.model;
           if (model != null && model.isNotEmpty) currentModel = model;
           continue;
-        case CodexRolloutLineType.compacted:
+        case CodexRolloutCompactedLineDto(timestamp: final timestamp):
           messageCounter += 1;
           final messageId = "codex-compaction-$messageCounter";
           messages.add(
@@ -76,7 +77,7 @@ class CodexMessageRepository {
               sessionId: sessionId,
               info: assistantInfo(
                 messageId,
-                _messageTimeFrom(line.timestamp),
+                _messageTimeFrom(timestamp),
               ),
               tool: "compact",
               title: "Context compacted",
@@ -85,14 +86,16 @@ class CodexMessageRepository {
             ),
           );
           continue;
-        case CodexRolloutLineType.responseItem:
-          break;
-        case CodexRolloutLineType.unknown:
-        case null:
+        case CodexRolloutResponseItemLineDto(
+          payload: final responseItem,
+          timestamp: final timestamp,
+        ):
+          payload = responseItem;
+          lineTimestamp = timestamp;
+        case CodexRolloutUnknownLineDto():
           continue;
       }
-      if (payload == null) continue;
-      final messageTime = _messageTimeFrom(line.timestamp);
+      final messageTime = _messageTimeFrom(lineTimestamp);
 
       if (payload.type == CodexRolloutPayloadType.functionCall ||
           payload.type == CodexRolloutPayloadType.customToolCall) {

--- a/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
@@ -120,11 +120,50 @@ void main() {
         timestamp: "2026-04-17T10:00:00Z",
         cliVersion: "0.121.0",
       );
-      final meta = rolloutApi.readHeader(rolloutPath: path).first.payload;
-      expect(meta?.id, equals("019a0000-1111-2222-3333-aaaaaaaaaaaa"));
-      expect(meta?.cwd, equals("/repo/app"));
-      expect(meta?.timestamp, equals("2026-04-17T10:00:00Z"));
-      expect(meta?.cliVersion, equals("0.121.0"));
+      final line = rolloutApi.readHeader(rolloutPath: path).first;
+      expect(line, isA<CodexRolloutSessionMetadataLineDto>());
+      final meta = _sessionMetadataPayload(line: line);
+      expect(meta.id, equals("019a0000-1111-2222-3333-aaaaaaaaaaaa"));
+      expect(meta.cwd, equals("/repo/app"));
+      expect(meta.timestamp, equals("2026-04-17T10:00:00Z"));
+      expect(meta.cliVersion, equals("0.121.0"));
+    });
+
+    test("rollout records decode to closed outer variants", () {
+      final lines = [
+        CodexRolloutLineDto.fromJson({
+          "type": "session_meta",
+          "payload": {"id": "session-id"},
+        }),
+        CodexRolloutLineDto.fromJson({
+          "type": "turn_context",
+          "payload": {"model": "gpt-5.4"},
+        }),
+        CodexRolloutLineDto.fromJson({
+          "type": "response_item",
+          "payload": {"type": "message", "role": "assistant"},
+        }),
+        CodexRolloutLineDto.fromJson({
+          "type": "compacted",
+          "payload": {"replacement_history": <Object?>[]},
+        }),
+        CodexRolloutLineDto.fromJson({
+          "type": "future_line",
+          "payload": "ignored unknown payload",
+        }),
+      ];
+
+      expect(lines[0], isA<CodexRolloutSessionMetadataLineDto>());
+      expect(lines[1], isA<CodexRolloutTurnContextLineDto>());
+      expect(lines[2], isA<CodexRolloutResponseItemLineDto>());
+      expect(lines[3], isA<CodexRolloutCompactedLineDto>());
+      expect(lines[4], isA<CodexRolloutUnknownLineDto>());
+      expect(_sessionMetadataPayload(line: lines[0]).id, "session-id");
+      expect(_turnContextPayload(line: lines[1]).model, "gpt-5.4");
+      expect(
+        _responseItemPayload(line: lines[2]).type,
+        CodexRolloutPayloadType.message,
+      );
     });
 
     test("readHeader does not read beyond its bounded scan window", () {
@@ -140,7 +179,10 @@ void main() {
 
       final lines = rolloutApi.readHeader(rolloutPath: path);
 
-      expect(lines.first.payload?.id, "session-id");
+      expect(
+        _sessionMetadataPayload(line: lines.first).id,
+        "session-id",
+      );
     });
 
     test("readTranscript warns for malformed non-final rows", () {
@@ -256,7 +298,10 @@ void main() {
       );
 
       expect(initial.lines, hasLength(1));
-      expect(initial.lines.single.payload?.callId, "call-1");
+      expect(
+        _responseItemPayload(line: initial.lines.single).callId,
+        "call-1",
+      );
       expect(initial.trailingBytes, isNotEmpty);
 
       File(path).writeAsStringSync(
@@ -271,7 +316,7 @@ void main() {
 
       expect(completed.lines, hasLength(1));
       expect(
-        completed.lines.single.payload?.type,
+        _responseItemPayload(line: completed.lines.single).type,
         CodexRolloutPayloadType.functionCallOutput,
       );
       expect(completed.trailingBytes, isEmpty);
@@ -322,7 +367,10 @@ void main() {
       );
 
       expect(completed.lines, hasLength(1));
-      expect(completed.lines.single.payload?.callId, "current-call");
+      expect(
+        _responseItemPayload(line: completed.lines.single).callId,
+        "current-call",
+      );
       expect(completed.trailingBytes, isEmpty);
     });
 
@@ -367,12 +415,14 @@ void main() {
       expect(output, isNot(contains("malformed rollout")));
       expect(header, hasLength(3));
       expect(transcript, hasLength(3));
+      expect(transcript[1], isA<CodexRolloutResponseItemLineDto>());
       expect(
-        transcript[1].payload?.type,
+        _responseItemPayload(line: transcript[1]).type,
         CodexRolloutPayloadType.customToolCallOutput,
       );
+      expect(transcript[2], isA<CodexRolloutResponseItemLineDto>());
       expect(
-        transcript[2].payload?.type,
+        _responseItemPayload(line: transcript[2]).type,
         CodexRolloutPayloadType.reasoning,
       );
     });
@@ -456,9 +506,11 @@ void main() {
       }, level: LogLevel.verbose);
 
       expect(output, isNot(contains("malformed rollout content list")));
-      expect(transcript.last.type, CodexRolloutLineType.turnContext);
-      expect(transcript.last.payload?.model, "gpt-5.4");
-      expect(transcript.last.payload?.summary, isNull);
+      expect(transcript.last, isA<CodexRolloutTurnContextLineDto>());
+      expect(
+        _turnContextPayload(line: transcript.last).model,
+        "gpt-5.4",
+      );
     });
 
     test("response_item scalar summary remains observable as malformed", () {
@@ -488,8 +540,11 @@ void main() {
         "malformed rollout content list".allMatches(output),
         hasLength(1),
       );
-      expect(transcript.last.type, CodexRolloutLineType.responseItem);
-      expect(transcript.last.payload?.summary, isEmpty);
+      expect(transcript.last, isA<CodexRolloutResponseItemLineDto>());
+      expect(
+        _responseItemPayload(line: transcript.last).summary,
+        isEmpty,
+      );
     });
 
     test("object-form tool search arguments do not invalidate the record", () {
@@ -518,9 +573,13 @@ void main() {
       }, level: LogLevel.verbose);
 
       expect(output, isNot(contains("malformed rollout transcript record")));
-      expect(transcript.last.payload?.type, CodexRolloutPayloadType.unknown);
+      expect(transcript.last, isA<CodexRolloutResponseItemLineDto>());
       expect(
-        transcript.last.payload?.arguments,
+        _responseItemPayload(line: transcript.last).type,
+        CodexRolloutPayloadType.unknown,
+      );
+      expect(
+        _responseItemPayload(line: transcript.last).arguments,
         jsonEncode({"query": "available tools"}),
       );
     });
@@ -1243,6 +1302,33 @@ void main() {
       expect(assistant.providerID, equals("openai"));
     });
   });
+}
+
+CodexRolloutSessionMetadataPayloadDto _sessionMetadataPayload({
+  required CodexRolloutLineDto line,
+}) {
+  return switch (line) {
+    CodexRolloutSessionMetadataLineDto(payload: final payload) => payload,
+    _ => throw StateError("Expected session metadata rollout line"),
+  };
+}
+
+CodexRolloutTurnContextPayloadDto _turnContextPayload({
+  required CodexRolloutLineDto line,
+}) {
+  return switch (line) {
+    CodexRolloutTurnContextLineDto(payload: final payload) => payload,
+    _ => throw StateError("Expected turn context rollout line"),
+  };
+}
+
+CodexRolloutPayloadDto _responseItemPayload({
+  required CodexRolloutLineDto line,
+}) {
+  return switch (line) {
+    CodexRolloutResponseItemLineDto(payload: final payload) => payload,
+    _ => throw StateError("Expected response item rollout line"),
+  };
 }
 
 String _captureWarnings(

--- a/bridge/sesori_plugin_codex/test/codex_rollout_tailer_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_tailer_test.dart
@@ -3,6 +3,7 @@ import "dart:convert";
 import "dart:io";
 
 import "package:codex_plugin/src/api/codex_rollout_api.dart";
+import "package:codex_plugin/src/api/models/codex_rollout_dto.dart";
 import "package:codex_plugin/src/repositories/codex_catalog_repository.dart";
 import "package:codex_plugin/src/services/codex_rollout_tailer.dart";
 import "package:path/path.dart" as p;
@@ -86,7 +87,10 @@ void main() {
 
       expect(appends, hasLength(1));
       expect(appends.single.sessionId, "session-1");
-      expect(appends.single.line.payload?.callId, "current-call");
+      expect(
+        _responseItemPayload(line: appends.single.line).callId,
+        "current-call",
+      );
     });
 
     test("finish waits for a rollout created after completion begins", () async {
@@ -131,7 +135,10 @@ void main() {
 
       expect(appends, hasLength(1));
       expect(appends.single.sessionId, "session-1");
-      expect(appends.single.line.payload?.callId, "late-call");
+      expect(
+        _responseItemPayload(line: appends.single.line).callId,
+        "late-call",
+      );
     });
 
     test("finish waits for a late append to an existing rollout", () async {
@@ -188,9 +195,21 @@ void main() {
 
       expect(appends, hasLength(1));
       expect(appends.single.sessionId, "session-1");
-      expect(appends.single.line.payload?.callId, "late-existing-call");
+      expect(
+        _responseItemPayload(line: appends.single.line).callId,
+        "late-existing-call",
+      );
     });
   });
+}
+
+CodexRolloutPayloadDto _responseItemPayload({
+  required CodexRolloutLineDto line,
+}) {
+  return switch (line) {
+    CodexRolloutResponseItemLineDto(payload: final payload) => payload,
+    _ => throw StateError("Expected response item rollout line"),
+  };
 }
 
 class _ThrowingPositionApi extends CodexRolloutApi {


### PR DESCRIPTION
## Summary

- replace the flattened Codex rollout outer discriminator with sealed session metadata, turn context, response item, compacted, and unknown envelope variants
- give metadata and turn-context records dedicated payload DTOs while retaining the existing response-item payload representation for Step 4
- migrate catalog, tailer, live-event, and history consumers atomically and add structural decoding coverage

## Verification

- `dart pub get`
- focused rollout API, tailer, event mapper, catalog, metadata, and message repository tests
- `dart test` (211 tests)
- `dart analyze --fatal-infos`
- `git diff --cached --check`
- `aristotle-impl-review` — approved with no findings

## Plan

Step 3/13 of `.plan/active/output-image-support/PLAN.md`. The 1,075-line diff is within the planned 900-1,350 target and below the 1,500-line soft cap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sealed the Codex rollout outer envelope into `freezed` union variants and updated consumers to switch on variants instead of a flat `type` enum. This clarifies decoding, removes ambiguous fields, and sets up output image support next.

- **Refactors**
  - Replaced flat `CodexRolloutLineDto` with union variants: `session_meta`, `turn_context`, `response_item`, `compacted`, `unknown` (fallback).
  - Added `CodexRolloutSessionMetadataPayloadDto` and `CodexRolloutTurnContextPayloadDto`; kept `CodexRolloutPayloadDto` for response items (for Step 4).
  - Updated `codex_plugin` consumers (catalog, messages, event mapper, tailer/history) to pattern-match variants.
  - Normalize tool-call `arguments` only for `response_item`; removed summary coercion from `turn_context`.
  - Expanded structural decoding tests (including `unknown` fallback) and tightened catalog/tailer/mapper/repository coverage.

- **Migration**
  - Replace `line.type` checks with matching on `CodexRolloutLineDto` variants.
  - Use `CodexRolloutSessionMetadataPayloadDto` and `CodexRolloutTurnContextPayloadDto` where applicable.
  - Response-item handling stays the same for now.

<sup>Written for commit 940ec30132f05dcd9f3dec9f890e5659bac5beff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

