### PR TITLE
Fix image attachment filenames and iOS Photos metadata

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/message_part_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/message_part_mapper.dart
@@ -33,12 +33,12 @@ class MessagePartMapper {
   static const int _maxRemoteUrlCharacters = 4096;
   static const int _maxMimeCharacters = 255;
   static const int _maxToolAttachmentCount = 4;
-  static const Set<String> _supportedInlineRasterMimes = {
-    "image/bmp",
-    "image/gif",
-    "image/jpeg",
-    "image/png",
-    "image/webp",
+  static const Map<String, Set<String>> _supportedInlineRasterExtensions = {
+    "image/bmp": {"bmp"},
+    "image/gif": {"gif"},
+    "image/jpeg": {"jpg", "jpeg"},
+    "image/png": {"png"},
+    "image/webp": {"webp"},
   };
 
   /// Maps a generated [Part] union to the plugin-facing [PluginMessagePart].
@@ -271,7 +271,7 @@ class MessagePartMapper {
         ? null
         : _normalizedValue(value: headerParts.first, maxCharacters: _maxMimeCharacters);
     final mime = _normalizedMime(mime: raw.mime, fallback: headerMime);
-    if (!_supportedInlineRasterMimes.contains(mime.split(";").first.trim())) {
+    if (!_supportedInlineRasterExtensions.containsKey(mime.split(";").first.trim())) {
       return PluginMessageAttachment.metadata(mime: mime, filename: filename);
     }
 
@@ -406,14 +406,7 @@ class MessagePartMapper {
     final extensionStart = filename.lastIndexOf(".");
     if (extensionStart <= 0 || extensionStart == filename.length - 1) return null;
     final extension = filename.substring(extensionStart + 1).toLowerCase();
-    final allowedExtensions = switch (_normalizedMime(mime: mime, fallback: null).split(";").first.trim()) {
-      "image/bmp" => const {"bmp"},
-      "image/gif" => const {"gif"},
-      "image/jpeg" => const {"jpg", "jpeg"},
-      "image/png" => const {"png"},
-      "image/webp" => const {"webp"},
-      _ => const <String>{},
-    };
-    return allowedExtensions.contains(extension) ? filename : null;
+    final normalizedMime = _normalizedMime(mime: mime, fallback: null).split(";").first.trim();
+    return (_supportedInlineRasterExtensions[normalizedMime]?.contains(extension) ?? false) ? filename : null;
   }
 }

--- a/bridge/sesori_plugin_opencode/lib/src/message_part_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/message_part_mapper.dart
@@ -227,17 +227,20 @@ class MessagePartMapper {
     sessionID: raw.sessionID,
     messageID: raw.messageID,
     type: PluginMessagePartType.file,
-    attachment: _mapAttachment(raw: raw),
+    attachment: _mapAttachment(raw: raw, fallbackFilename: null),
   );
 
-  PluginMessageAttachment _mapAttachment({required FilePart raw}) {
+  PluginMessageAttachment _mapAttachment({required FilePart raw, required String? fallbackFilename}) {
     final isDataUrl = _isDataUrl(url: raw.url);
     final canParseUri = !isDataUrl && raw.url.length <= _maxRemoteUrlCharacters;
     if (!isDataUrl && !canParseUri) {
       Log.w("OpenCode attachment URL exceeds the transport limit; forwarding metadata only");
     }
     final uri = canParseUri ? Uri.tryParse(raw.url) : null;
-    final filename = normalizePluginMessageAttachmentFilename(filename: raw.filename) ?? _filenameFromUri(uri: uri);
+    final filename =
+        normalizePluginMessageAttachmentFilename(filename: raw.filename) ??
+        _filenameFromUri(uri: uri) ??
+        fallbackFilename;
     if (isDataUrl) {
       return _mapDataAttachment(raw: raw, filename: filename);
     }
@@ -363,7 +366,10 @@ class MessagePartMapper {
       _ => null,
     };
     final attachments = switch (state) {
-      ToolStateCompleted(:final attachments) => _mapToolAttachments(attachments: attachments),
+      ToolStateCompleted(:final attachments, :final title) => _mapToolAttachments(
+        attachments: attachments,
+        title: title,
+      ),
       _ => const <PluginMessageAttachment>[],
     };
     return PluginToolState(
@@ -377,14 +383,37 @@ class MessagePartMapper {
     );
   }
 
-  List<PluginMessageAttachment> _mapToolAttachments({required List<FilePart>? attachments}) {
+  List<PluginMessageAttachment> _mapToolAttachments({
+    required List<FilePart>? attachments,
+    required String? title,
+  }) {
     final rawAttachments = attachments ?? const <FilePart>[];
     if (rawAttachments.length > _maxToolAttachmentCount) {
       Log.w("OpenCode tool returned too many attachments; forwarding only the bounded prefix");
     }
+    final titleFilename = rawAttachments.length == 1
+        ? _filenameFromToolTitle(title: title, mime: rawAttachments.single.mime)
+        : null;
     return rawAttachments
         .take(_maxToolAttachmentCount)
-        .map((attachment) => _mapAttachment(raw: attachment))
+        .map((attachment) => _mapAttachment(raw: attachment, fallbackFilename: titleFilename))
         .toList(growable: false);
+  }
+
+  String? _filenameFromToolTitle({required String? title, required String mime}) {
+    final filename = normalizePluginMessageAttachmentFilename(filename: title);
+    if (filename == null) return null;
+    final extensionStart = filename.lastIndexOf(".");
+    if (extensionStart <= 0 || extensionStart == filename.length - 1) return null;
+    final extension = filename.substring(extensionStart + 1).toLowerCase();
+    final allowedExtensions = switch (_normalizedMime(mime: mime, fallback: null).split(";").first.trim()) {
+      "image/bmp" => const {"bmp"},
+      "image/gif" => const {"gif"},
+      "image/jpeg" => const {"jpg", "jpeg"},
+      "image/png" => const {"png"},
+      "image/webp" => const {"webp"},
+      _ => const <String>{},
+    };
+    return allowedExtensions.contains(extension) ? filename : null;
   }
 }

--- a/bridge/sesori_plugin_opencode/test/message_part_mapper_test.dart
+++ b/bridge/sesori_plugin_opencode/test/message_part_mapper_test.dart
@@ -192,6 +192,84 @@ void main() {
     );
   });
 
+  test("derives a single image tool attachment filename from its path title", () {
+    final part = mapper.mapPart(
+      ToolPart(
+        id: "part-tool",
+        sessionID: "session-1",
+        messageID: "message-1",
+        callID: "call-1",
+        tool: "read",
+        state: ToolStateCompleted(
+          input: const {},
+          output: "Image read successfully",
+          title: r"client\assets\images\why-needed.png",
+          metadata: const {},
+          time: const ToolStateCompletedTime(start: 0, end: 1, compacted: null),
+          attachments: [
+            _filePart(
+              url: "data:image/png;base64,aGVsbG8=",
+              mime: "image/png",
+              filename: null,
+              source: null,
+            ),
+          ],
+        ),
+        metadata: null,
+      ),
+    );
+
+    expect(
+      part.state?.attachments.single,
+      equals(
+        const PluginMessageAttachment.inlineImage(
+          mime: "image/png",
+          base64: "aGVsbG8=",
+          filename: "why-needed.png",
+        ),
+      ),
+    );
+  });
+
+  test("does not treat a non-filename tool title as attachment metadata", () {
+    final part = mapper.mapPart(
+      ToolPart(
+        id: "part-tool",
+        sessionID: "session-1",
+        messageID: "message-1",
+        callID: "call-1",
+        tool: "webfetch",
+        state: ToolStateCompleted(
+          input: const {},
+          output: "Image fetched successfully",
+          title: "https://files.example.com/image.png (image/png)",
+          metadata: const {},
+          time: const ToolStateCompletedTime(start: 0, end: 1, compacted: null),
+          attachments: [
+            _filePart(
+              url: "data:image/png;base64,aGVsbG8=",
+              mime: "image/png",
+              filename: null,
+              source: null,
+            ),
+          ],
+        ),
+        metadata: null,
+      ),
+    );
+
+    expect(
+      part.state?.attachments.single,
+      equals(
+        const PluginMessageAttachment.inlineImage(
+          mime: "image/png",
+          base64: "aGVsbG8=",
+          filename: null,
+        ),
+      ),
+    );
+  });
+
   test("bounds total inline bytes in completed tool attachments", () {
     final threeMegabyteImage = base64Encode(Uint8List(3 * 1024 * 1024));
     final part = mapper.mapPart(

--- a/client/app/ios/Runner/Info.plist
+++ b/client/app/ios/Runner/Info.plist
@@ -90,6 +90,8 @@
 		<string>Microphone access is needed for voice-to-text transcription</string>
 		<key>NSPhotoLibraryAddUsageDescription</key>
 		<string>Photos access is needed to save images from coding sessions</string>
+		<key>NSPhotoLibraryUsageDescription</key>
+		<string>Sesori uses photo library access only to save images from coding sessions when you choose Save</string>
 		<key>CFBundleURLTypes</key>
 		<array>
 			<dict>

--- a/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
+++ b/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
@@ -121,7 +121,7 @@ void main() {
     const attachment = MessageAttachment.inlineImage(
       mime: "image/png",
       base64: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==",
-      filename: "image.png",
+      filename: "why-needed.png",
     );
 
     await tester.pumpWidget(_app(child: const FilePartWidget(attachment: attachment)));
@@ -148,6 +148,7 @@ void main() {
     expect(find.byIcon(Icons.content_copy), findsOneWidget);
     expect(find.byIcon(Icons.share_outlined), findsOneWidget);
     expect(find.byIcon(Icons.download_outlined), findsOneWidget);
+    expect(find.text("why-needed.png"), findsOneWidget);
     final fullscreen = tester.widget<Image>(find.byKey(ImageAttachmentViewer.imageKey));
     expect(identical(fullscreen.image, preview.image), isTrue);
     final memoryImage = (preview.image as ResizeImage).imageProvider as MemoryImage;
@@ -181,6 +182,10 @@ void main() {
 
     expect(find.text("image.png"), findsNothing);
     expect(find.text("Unknown file"), findsNothing);
+    await tester.tap(find.byIcon(Icons.download_outlined));
+    await tester.pump();
+
+    expect(imageSaver.savedFilename, "image.png");
   });
 
   testWidgets("keeps display and action filenames separate when saving", (tester) async {

--- a/client/module_core/test/repositories/message_image_repository_test.dart
+++ b/client/module_core/test/repositories/message_image_repository_test.dart
@@ -137,6 +137,43 @@ void main() {
     expect(result, isA<MessageImageLoadRejected>());
   });
 
+  test("uses the declared image MIME extension when the filename is absent", () async {
+    final repository = MessageImageRepository(
+      api: MessageImageApi(client: MockClient((_) async => http.Response("unexpected", 500))),
+    );
+    final cases = <({String mime, List<int> bytes, String expectedFilename})>[
+      (mime: "image/bmp", bytes: const [0x42, 0x4D], expectedFilename: "image.bmp"),
+      (mime: "image/gif", bytes: const [0x47, 0x49, 0x46, 0x38, 0x39, 0x61], expectedFilename: "image.gif"),
+      (mime: "image/jpeg", bytes: const [0xFF, 0xD8, 0xFF], expectedFilename: "image.jpg"),
+      (
+        mime: "image/png",
+        bytes: const [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A],
+        expectedFilename: "image.png",
+      ),
+      (
+        mime: "image/webp",
+        bytes: const [0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50],
+        expectedFilename: "image.webp",
+      ),
+    ];
+
+    for (final imageCase in cases) {
+      final result = await repository.load(
+        attachment: MessageAttachment.inlineImage(
+          mime: imageCase.mime,
+          base64: base64Encode(imageCase.bytes),
+          filename: null,
+        ),
+      );
+
+      expect(
+        (result as MessageImageLoadSuccess).actionFilename,
+        imageCase.expectedFilename,
+        reason: imageCase.mime,
+      );
+    }
+  });
+
   test("bounds action filenames by UTF-8 byte length", () async {
     final repository = MessageImageRepository(
       api: MessageImageApi(client: MockClient((_) async => http.Response("unexpected", 500))),


### PR DESCRIPTION
## Summary

- derive the basename for a single OpenCode image tool attachment from its path-bearing title when the extension matches the declared MIME
- preserve the original filename in the image viewer and Save action while retaining MIME-derived `image.<extension>` fallbacks when metadata has no name
- add the iOS `NSPhotoLibraryUsageDescription` required by App Store validation for the linked Photos plugin

## Context

OpenCode's `read` tool emits image bytes as a data URL without a `filename`, while the completed tool title retains the source path. The bridge now forwards only the safe basename and rejects title shapes that do not look like a matching image filename.

App Store Connect rejected build 381 with `ITMS-90683` because only `NSPhotoLibraryAddUsageDescription` was present. The release iOS bundle now contains both required Photos purpose strings.

## Verification

- `dart analyze --fatal-infos` in `bridge/sesori_plugin_opencode`
- `dart test test/message_part_mapper_test.dart` (9 passed)
- `dart analyze` in `client/module_core`
- `dart test test/repositories/message_image_repository_test.dart` (9 passed)
- `dart analyze` in `client/app`
- `flutter test test/features/session_detail/widgets/file_part_widget_test.dart` (12 passed)
- `flutter build macos --debug`
- `flutter build ios --release --no-codesign`
- `plutil -lint` and key extraction against both the source and packaged iOS `Info.plist`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes image attachment filenames and adds the missing iOS photo library permission to pass App Store review. Also centralizes MIME-to-extension logic for consistency across title parsing and fallbacks.

- **Bug Fixes**
  - Derive a safe basename from the tool title for single image attachments when the extension matches the declared MIME; ignore titles that aren’t valid filenames.
  - Show the original filename in the viewer; use a MIME-based fallback `image.<ext>` for the Save action when the filename is absent.
  - Apply MIME-derived fallbacks for inline images with no name (`image.bmp`, `image.gif`, `image.jpg`, `image.png`, `image.webp`).
  - Add NSPhotoLibraryUsageDescription to iOS Info.plist to satisfy App Store validation (ITMS-90683).

- **Refactors**
  - Centralize image MIME-to-extension mapping to validate title-derived filenames and inline support (e.g., `jpg`/`jpeg`).

<sup>Written for commit e8ad814110cc449cf0911fb90143a58182dde3e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

