### PR TITLE
[output-image-support] refactor(codex): seal response items [step 4/13]

### DIFF
--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -5,10 +5,10 @@
 - **Plan slug:** `output-image-support`
 - **Implementation base:** `origin/main` at
   `9d2c1e9e79ab80fa8824b9d803a74798eb71140d`
-- **Series state:** Step 4/13 ready for PR
+- **Series state:** Step 4/13 PR open
 - **Current step:** Step 4/13 — seal Codex response items
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** open and monitor the Step 4/13 PR
+- **Next action:** monitor Step 4/13 CI and review
 
 ## Plan Review
 
@@ -29,7 +29,7 @@
 | [x] | 1/13 | `investigate-opencode-image-support` | `[output-image-support] docs: plan output image support [step 1/13]` | 450-700 | [PR #638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638) merged as `bfadd097` |
 | [x] | 2/13 | `output-image-support-codex-rollout-content` | `[output-image-support] refactor(codex): seal rollout content [step 2/13]` | 1,200-1,500 | [PR #639](https://github.com/sesori-ai/sesori_apps_monorepo/pull/639) merged as `17e0ecf1`; 680 changed lines |
 | [x] | 3/13 | `output-image-support-codex-rollout-envelopes` | `[output-image-support] refactor(codex): seal rollout envelopes [step 3/13]` | 900-1,350 | [PR #644](https://github.com/sesori-ai/sesori_apps_monorepo/pull/644) merged as `f78e1f69`; 1,075 changed lines |
-| [ ] | 4/13 | `output-image-support-codex-response-items` | `[output-image-support] refactor(codex): seal response items [step 4/13]` | 1,100-1,500 | Ready for PR; 1,416 changed lines |
+| [ ] | 4/13 | `output-image-support-codex-response-items` | `[output-image-support] refactor(codex): seal response items [step 4/13]` | 1,100-1,500 | [PR #646](https://github.com/sesori-ai/sesori_apps_monorepo/pull/646) open; 1,416 changed lines |
 | [ ] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | Blocked on Step 4 merge |
 | [ ] | 6/13 | `output-image-support-codex-live-images` | `[output-image-support] feat(codex): surface live output images [step 6/13]` | 900-1,400 | Blocked on Step 5 merge |
 | [ ] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | Blocked on Step 6 merge |

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -5,10 +5,10 @@
 - **Plan slug:** `output-image-support`
 - **Implementation base:** `origin/main` at
   `9d2c1e9e79ab80fa8824b9d803a74798eb71140d`
-- **Series state:** Step 3/13 PR open
-- **Current step:** Step 3/13 — seal Codex rollout envelopes
+- **Series state:** Step 4/13 ready for PR
+- **Current step:** Step 4/13 — seal Codex response items
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** monitor Step 3/13 CI and review
+- **Next action:** open and monitor the Step 4/13 PR
 
 ## Plan Review
 
@@ -28,8 +28,8 @@
 |---|---|---|---|---:|---|
 | [x] | 1/13 | `investigate-opencode-image-support` | `[output-image-support] docs: plan output image support [step 1/13]` | 450-700 | [PR #638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638) merged as `bfadd097` |
 | [x] | 2/13 | `output-image-support-codex-rollout-content` | `[output-image-support] refactor(codex): seal rollout content [step 2/13]` | 1,200-1,500 | [PR #639](https://github.com/sesori-ai/sesori_apps_monorepo/pull/639) merged as `17e0ecf1`; 680 changed lines |
-| [ ] | 3/13 | `output-image-support-codex-rollout-envelopes` | `[output-image-support] refactor(codex): seal rollout envelopes [step 3/13]` | 900-1,350 | [PR #644](https://github.com/sesori-ai/sesori_apps_monorepo/pull/644) open; 1,075 changed lines |
-| [ ] | 4/13 | `output-image-support-codex-response-items` | `[output-image-support] refactor(codex): seal response items [step 4/13]` | 1,100-1,500 | Blocked on Step 3 merge |
+| [x] | 3/13 | `output-image-support-codex-rollout-envelopes` | `[output-image-support] refactor(codex): seal rollout envelopes [step 3/13]` | 900-1,350 | [PR #644](https://github.com/sesori-ai/sesori_apps_monorepo/pull/644) merged as `f78e1f69`; 1,075 changed lines |
+| [ ] | 4/13 | `output-image-support-codex-response-items` | `[output-image-support] refactor(codex): seal response items [step 4/13]` | 1,100-1,500 | Ready for PR; 1,416 changed lines |
 | [ ] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | Blocked on Step 4 merge |
 | [ ] | 6/13 | `output-image-support-codex-live-images` | `[output-image-support] feat(codex): surface live output images [step 6/13]` | 900-1,400 | Blocked on Step 5 merge |
 | [ ] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | Blocked on Step 6 merge |
@@ -108,6 +108,15 @@
   `git diff --cached --check` pass. `aristotle-impl-review` approved the staged
   architecture with no findings. The 1,075-line diff is within the 900-1,350
   target and below the 1,500-line soft cap; no neighboring scope was combined.
+  PR #644 merged as `f78e1f69` on 2026-07-31.
+- Step 4/13 (2026-07-31): sealed response items into message, reasoning,
+  function/custom call and output, web-search, and unknown variants; migrated
+  tool and history consumers to exhaustive patterns; and kept image generation
+  unknown until Step 7. Codex codegen, focused DTO/mapper/history/tailer tests,
+  all 213 package tests, `dart pub get`, `dart analyze --fatal-infos`, and
+  `git diff --cached --check` pass. `aristotle-impl-review` approved the staged
+  architecture with no findings. The 1,416-line diff is within the 1,100-1,500 target and
+  below the 1,500-line soft cap; no neighboring scope was combined.
 
 ## Findings And Plan Deltas
 

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
@@ -1,28 +1,8 @@
-import "dart:convert";
-
 import "package:freezed_annotation/freezed_annotation.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
 part "codex_rollout_dto.freezed.dart";
 part "codex_rollout_dto.g.dart";
-
-enum CodexRolloutPayloadType {
-  @JsonValue("message")
-  message,
-  @JsonValue("reasoning")
-  reasoning,
-  @JsonValue("function_call")
-  functionCall,
-  @JsonValue("function_call_output")
-  functionCallOutput,
-  @JsonValue("custom_tool_call")
-  customToolCall,
-  @JsonValue("custom_tool_call_output")
-  customToolCallOutput,
-  @JsonValue("web_search_call")
-  webSearchCall,
-  unknown,
-}
 
 enum CodexRolloutRole {
   user,
@@ -63,7 +43,7 @@ sealed class CodexRolloutLineDto with _$CodexRolloutLineDto {
   @FreezedUnionValue("response_item")
   const factory CodexRolloutLineDto.responseItem({
     required String? timestamp,
-    required CodexRolloutPayloadDto payload,
+    required CodexRolloutResponseItemDto payload,
   }) = CodexRolloutResponseItemLineDto;
 
   @FreezedUnionValue("compacted")
@@ -75,9 +55,7 @@ sealed class CodexRolloutLineDto with _$CodexRolloutLineDto {
     required String? timestamp,
   }) = CodexRolloutUnknownLineDto;
 
-  factory CodexRolloutLineDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutLineDtoFromJson(
-    _normalizeRolloutLineJson(json: json),
-  );
+  factory CodexRolloutLineDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutLineDtoFromJson(json);
 }
 
 @Freezed(fromJson: true, toJson: false)
@@ -104,28 +82,62 @@ sealed class CodexRolloutTurnContextPayloadDto with _$CodexRolloutTurnContextPay
       _$CodexRolloutTurnContextPayloadDtoFromJson(json);
 }
 
-@Freezed(fromJson: true, toJson: false)
-sealed class CodexRolloutPayloadDto with _$CodexRolloutPayloadDto {
-  const factory CodexRolloutPayloadDto({
+@Freezed(
+  unionKey: "type",
+  fallbackUnion: "unknown",
+  fromJson: true,
+  toJson: false,
+)
+sealed class CodexRolloutResponseItemDto with _$CodexRolloutResponseItemDto {
+  const factory CodexRolloutResponseItemDto.message({
     required String? id,
-    required String? cwd,
-    required String? timestamp,
-    @JsonKey(name: "model_provider") required String? modelProvider,
-    @JsonKey(name: "cli_version") required String? cliVersion,
-    required String? model,
-    @JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) required CodexRolloutPayloadType? type,
-    @JsonKey(unknownEnumValue: CodexRolloutRole.unknown) required CodexRolloutRole? role,
-    @CodexRolloutContentListConverter() required List<CodexRolloutContentDto>? content,
-    @CodexRolloutContentListConverter() required List<CodexRolloutContentDto>? summary,
-    @JsonKey(name: "call_id") required String? callId,
-    required String? name,
-    required String? arguments,
-    required String? input,
-    @CodexRolloutOutputConverter() required List<CodexRolloutContentDto>? output,
-    required CodexRolloutActionDto? action,
-  }) = _CodexRolloutPayloadDto;
+    @JsonKey(unknownEnumValue: CodexRolloutRole.unknown) required CodexRolloutRole role,
+    @CodexRolloutContentListConverter() required List<CodexRolloutContentDto> content,
+  }) = CodexRolloutMessageDto;
 
-  factory CodexRolloutPayloadDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutPayloadDtoFromJson(json);
+  const factory CodexRolloutResponseItemDto.reasoning({
+    required String? id,
+    @CodexRolloutContentListConverter() required List<CodexRolloutContentDto> summary,
+  }) = CodexRolloutReasoningDto;
+
+  @FreezedUnionValue("function_call")
+  const factory CodexRolloutResponseItemDto.functionCall({
+    required String? id,
+    @JsonKey(name: "call_id") required String callId,
+    required String name,
+    required String arguments,
+  }) = CodexRolloutFunctionCallDto;
+
+  @FreezedUnionValue("function_call_output")
+  const factory CodexRolloutResponseItemDto.functionCallOutput({
+    @JsonKey(name: "call_id") required String callId,
+    @CodexRolloutOutputConverter() required List<CodexRolloutContentDto> output,
+  }) = CodexRolloutFunctionCallOutputDto;
+
+  @FreezedUnionValue("custom_tool_call")
+  const factory CodexRolloutResponseItemDto.customToolCall({
+    required String? id,
+    @JsonKey(name: "call_id") required String callId,
+    required String name,
+    required String input,
+  }) = CodexRolloutCustomToolCallDto;
+
+  @FreezedUnionValue("custom_tool_call_output")
+  const factory CodexRolloutResponseItemDto.customToolCallOutput({
+    @JsonKey(name: "call_id") required String callId,
+    @CodexRolloutOutputConverter() required List<CodexRolloutContentDto> output,
+  }) = CodexRolloutCustomToolCallOutputDto;
+
+  @FreezedUnionValue("web_search_call")
+  const factory CodexRolloutResponseItemDto.webSearchCall({
+    required String? id,
+    required CodexRolloutActionDto? action,
+  }) = CodexRolloutWebSearchCallDto;
+
+  const factory CodexRolloutResponseItemDto.unknown() = CodexRolloutUnknownResponseItemDto;
+
+  factory CodexRolloutResponseItemDto.fromJson(Map<String, dynamic> json) =>
+      _$CodexRolloutResponseItemDtoFromJson(json);
 }
 
 @Freezed(
@@ -162,12 +174,12 @@ sealed class CodexRolloutContentDto with _$CodexRolloutContentDto {
 
 /// Decodes typed rollout content without dropping an otherwise valid record
 /// when one nested item has drifted.
-class CodexRolloutContentListConverter implements JsonConverter<List<CodexRolloutContentDto>?, Object?> {
+class CodexRolloutContentListConverter implements JsonConverter<List<CodexRolloutContentDto>, Object?> {
   const CodexRolloutContentListConverter();
 
   @override
-  List<CodexRolloutContentDto>? fromJson(Object? json) {
-    if (json == null) return null;
+  List<CodexRolloutContentDto> fromJson(Object? json) {
+    if (json == null) return const [];
     if (json is! List) {
       Log.w("[codex] skipping malformed rollout content list");
       return const [];
@@ -188,8 +200,7 @@ class CodexRolloutContentListConverter implements JsonConverter<List<CodexRollou
   }
 
   @override
-  Object? toJson(List<CodexRolloutContentDto>? object) {
-    if (object == null) return null;
+  Object toJson(List<CodexRolloutContentDto> object) {
     return [
       for (final content in object) content.toJson(),
     ];
@@ -205,7 +216,7 @@ class CodexRolloutOutputConverter extends CodexRolloutContentListConverter {
   const CodexRolloutOutputConverter();
 
   @override
-  List<CodexRolloutContentDto>? fromJson(Object? json) {
+  List<CodexRolloutContentDto> fromJson(Object? json) {
     if (json is String) {
       return [
         CodexRolloutContentDto.outputText(
@@ -215,27 +226,6 @@ class CodexRolloutOutputConverter extends CodexRolloutContentListConverter {
     }
     return super.fromJson(json);
   }
-}
-
-/// COMPATIBILITY 2026-07-23 (Codex 0.145.x): function calls persist arguments
-/// as JSON-encoded strings, while `tool_search_call` persists the decoded JSON
-/// value directly. Keep both forms until Codex converges the rollout schema or
-/// this DTO models each response-item variant separately.
-Map<String, dynamic> _normalizeRolloutLineJson({
-  required Map<String, dynamic> json,
-}) {
-  final payload = json["payload"];
-  if (json["type"] != "response_item" || payload is! Map) return json;
-  final arguments = payload["arguments"];
-  final normalizeArguments = arguments != null && arguments is! String;
-  if (!normalizeArguments) return json;
-  return {
-    ...json,
-    "payload": {
-      ...payload,
-      "arguments": jsonEncode(arguments),
-    },
-  };
 }
 
 @Freezed(fromJson: true, toJson: false)

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
@@ -407,7 +407,7 @@ class CodexRolloutResponseItemLineDto implements CodexRolloutLineDto {
   factory CodexRolloutResponseItemLineDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutResponseItemLineDtoFromJson(json);
 
 @override final  String? timestamp;
- final  CodexRolloutPayloadDto payload;
+ final  CodexRolloutResponseItemDto payload;
 
 @JsonKey(name: 'type')
 final String $type;
@@ -443,11 +443,11 @@ abstract mixin class $CodexRolloutResponseItemLineDtoCopyWith<$Res> implements $
   factory $CodexRolloutResponseItemLineDtoCopyWith(CodexRolloutResponseItemLineDto value, $Res Function(CodexRolloutResponseItemLineDto) _then) = _$CodexRolloutResponseItemLineDtoCopyWithImpl;
 @override @useResult
 $Res call({
- String? timestamp, CodexRolloutPayloadDto payload
+ String? timestamp, CodexRolloutResponseItemDto payload
 });
 
 
-$CodexRolloutPayloadDtoCopyWith<$Res> get payload;
+$CodexRolloutResponseItemDtoCopyWith<$Res> get payload;
 
 }
 /// @nodoc
@@ -464,7 +464,7 @@ class _$CodexRolloutResponseItemLineDtoCopyWithImpl<$Res>
   return _then(CodexRolloutResponseItemLineDto(
 timestamp: freezed == timestamp ? _self.timestamp : timestamp // ignore: cast_nullable_to_non_nullable
 as String?,payload: null == payload ? _self.payload : payload // ignore: cast_nullable_to_non_nullable
-as CodexRolloutPayloadDto,
+as CodexRolloutResponseItemDto,
   ));
 }
 
@@ -472,9 +472,9 @@ as CodexRolloutPayloadDto,
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
-$CodexRolloutPayloadDtoCopyWith<$Res> get payload {
+$CodexRolloutResponseItemDtoCopyWith<$Res> get payload {
   
-  return $CodexRolloutPayloadDtoCopyWith<$Res>(_self.payload, (value) {
+  return $CodexRolloutResponseItemDtoCopyWith<$Res>(_self.payload, (value) {
     return _then(_self.copyWith(payload: value));
   });
 }
@@ -890,92 +890,74 @@ as String?,
 
 }
 
+CodexRolloutResponseItemDto _$CodexRolloutResponseItemDtoFromJson(
+  Map<String, dynamic> json
+) {
+        switch (json['type']) {
+                  case 'message':
+          return CodexRolloutMessageDto.fromJson(
+            json
+          );
+                case 'reasoning':
+          return CodexRolloutReasoningDto.fromJson(
+            json
+          );
+                case 'function_call':
+          return CodexRolloutFunctionCallDto.fromJson(
+            json
+          );
+                case 'function_call_output':
+          return CodexRolloutFunctionCallOutputDto.fromJson(
+            json
+          );
+                case 'custom_tool_call':
+          return CodexRolloutCustomToolCallDto.fromJson(
+            json
+          );
+                case 'custom_tool_call_output':
+          return CodexRolloutCustomToolCallOutputDto.fromJson(
+            json
+          );
+                case 'web_search_call':
+          return CodexRolloutWebSearchCallDto.fromJson(
+            json
+          );
+        
+          default:
+            return CodexRolloutUnknownResponseItemDto.fromJson(
+  json
+);
+        }
+      
+}
 
 /// @nodoc
-mixin _$CodexRolloutPayloadDto {
+mixin _$CodexRolloutResponseItemDto {
 
- String? get id; String? get cwd; String? get timestamp;@JsonKey(name: "model_provider") String? get modelProvider;@JsonKey(name: "cli_version") String? get cliVersion; String? get model;@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? get type;@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? get role;@CodexRolloutContentListConverter() List<CodexRolloutContentDto>? get content;@CodexRolloutContentListConverter() List<CodexRolloutContentDto>? get summary;@JsonKey(name: "call_id") String? get callId; String? get name; String? get arguments; String? get input;@CodexRolloutOutputConverter() List<CodexRolloutContentDto>? get output; CodexRolloutActionDto? get action;
-/// Create a copy of CodexRolloutPayloadDto
-/// with the given fields replaced by the non-null parameter values.
-@JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-$CodexRolloutPayloadDtoCopyWith<CodexRolloutPayloadDto> get copyWith => _$CodexRolloutPayloadDtoCopyWithImpl<CodexRolloutPayloadDto>(this as CodexRolloutPayloadDto, _$identity);
+
 
 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutPayloadDto&&(identical(other.id, id) || other.id == id)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.cliVersion, cliVersion) || other.cliVersion == cliVersion)&&(identical(other.model, model) || other.model == model)&&(identical(other.type, type) || other.type == type)&&(identical(other.role, role) || other.role == role)&&const DeepCollectionEquality().equals(other.content, content)&&const DeepCollectionEquality().equals(other.summary, summary)&&(identical(other.callId, callId) || other.callId == callId)&&(identical(other.name, name) || other.name == name)&&(identical(other.arguments, arguments) || other.arguments == arguments)&&(identical(other.input, input) || other.input == input)&&const DeepCollectionEquality().equals(other.output, output)&&(identical(other.action, action) || other.action == action));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutResponseItemDto);
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,cwd,timestamp,modelProvider,cliVersion,model,type,role,const DeepCollectionEquality().hash(content),const DeepCollectionEquality().hash(summary),callId,name,arguments,input,const DeepCollectionEquality().hash(output),action);
+int get hashCode => runtimeType.hashCode;
 
 @override
 String toString() {
-  return 'CodexRolloutPayloadDto(id: $id, cwd: $cwd, timestamp: $timestamp, modelProvider: $modelProvider, cliVersion: $cliVersion, model: $model, type: $type, role: $role, content: $content, summary: $summary, callId: $callId, name: $name, arguments: $arguments, input: $input, output: $output, action: $action)';
+  return 'CodexRolloutResponseItemDto()';
 }
 
 
 }
 
 /// @nodoc
-abstract mixin class $CodexRolloutPayloadDtoCopyWith<$Res>  {
-  factory $CodexRolloutPayloadDtoCopyWith(CodexRolloutPayloadDto value, $Res Function(CodexRolloutPayloadDto) _then) = _$CodexRolloutPayloadDtoCopyWithImpl;
-@useResult
-$Res call({
- String? id, String? cwd, String? timestamp,@JsonKey(name: "model_provider") String? modelProvider,@JsonKey(name: "cli_version") String? cliVersion, String? model,@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? type,@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? role,@CodexRolloutContentListConverter() List<CodexRolloutContentDto>? content,@CodexRolloutContentListConverter() List<CodexRolloutContentDto>? summary,@JsonKey(name: "call_id") String? callId, String? name, String? arguments, String? input,@CodexRolloutOutputConverter() List<CodexRolloutContentDto>? output, CodexRolloutActionDto? action
-});
-
-
-$CodexRolloutActionDtoCopyWith<$Res>? get action;
-
-}
-/// @nodoc
-class _$CodexRolloutPayloadDtoCopyWithImpl<$Res>
-    implements $CodexRolloutPayloadDtoCopyWith<$Res> {
-  _$CodexRolloutPayloadDtoCopyWithImpl(this._self, this._then);
-
-  final CodexRolloutPayloadDto _self;
-  final $Res Function(CodexRolloutPayloadDto) _then;
-
-/// Create a copy of CodexRolloutPayloadDto
-/// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? cwd = freezed,Object? timestamp = freezed,Object? modelProvider = freezed,Object? cliVersion = freezed,Object? model = freezed,Object? type = freezed,Object? role = freezed,Object? content = freezed,Object? summary = freezed,Object? callId = freezed,Object? name = freezed,Object? arguments = freezed,Object? input = freezed,Object? output = freezed,Object? action = freezed,}) {
-  return _then(_self.copyWith(
-id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
-as String?,cwd: freezed == cwd ? _self.cwd : cwd // ignore: cast_nullable_to_non_nullable
-as String?,timestamp: freezed == timestamp ? _self.timestamp : timestamp // ignore: cast_nullable_to_non_nullable
-as String?,modelProvider: freezed == modelProvider ? _self.modelProvider : modelProvider // ignore: cast_nullable_to_non_nullable
-as String?,cliVersion: freezed == cliVersion ? _self.cliVersion : cliVersion // ignore: cast_nullable_to_non_nullable
-as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
-as String?,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
-as CodexRolloutPayloadType?,role: freezed == role ? _self.role : role // ignore: cast_nullable_to_non_nullable
-as CodexRolloutRole?,content: freezed == content ? _self.content : content // ignore: cast_nullable_to_non_nullable
-as List<CodexRolloutContentDto>?,summary: freezed == summary ? _self.summary : summary // ignore: cast_nullable_to_non_nullable
-as List<CodexRolloutContentDto>?,callId: freezed == callId ? _self.callId : callId // ignore: cast_nullable_to_non_nullable
-as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
-as String?,arguments: freezed == arguments ? _self.arguments : arguments // ignore: cast_nullable_to_non_nullable
-as String?,input: freezed == input ? _self.input : input // ignore: cast_nullable_to_non_nullable
-as String?,output: freezed == output ? _self.output : output // ignore: cast_nullable_to_non_nullable
-as List<CodexRolloutContentDto>?,action: freezed == action ? _self.action : action // ignore: cast_nullable_to_non_nullable
-as CodexRolloutActionDto?,
-  ));
-}
-/// Create a copy of CodexRolloutPayloadDto
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$CodexRolloutActionDtoCopyWith<$Res>? get action {
-    if (_self.action == null) {
-    return null;
-  }
-
-  return $CodexRolloutActionDtoCopyWith<$Res>(_self.action!, (value) {
-    return _then(_self.copyWith(action: value));
-  });
-}
+class $CodexRolloutResponseItemDtoCopyWith<$Res>  {
+$CodexRolloutResponseItemDtoCopyWith(CodexRolloutResponseItemDto _, $Res Function(CodexRolloutResponseItemDto) __);
 }
 
 
@@ -983,121 +965,539 @@ $CodexRolloutActionDtoCopyWith<$Res>? get action {
 /// @nodoc
 @JsonSerializable(createToJson: false)
 
-class _CodexRolloutPayloadDto implements CodexRolloutPayloadDto {
-  const _CodexRolloutPayloadDto({required this.id, required this.cwd, required this.timestamp, @JsonKey(name: "model_provider") required this.modelProvider, @JsonKey(name: "cli_version") required this.cliVersion, required this.model, @JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) required this.type, @JsonKey(unknownEnumValue: CodexRolloutRole.unknown) required this.role, @CodexRolloutContentListConverter() required final  List<CodexRolloutContentDto>? content, @CodexRolloutContentListConverter() required final  List<CodexRolloutContentDto>? summary, @JsonKey(name: "call_id") required this.callId, required this.name, required this.arguments, required this.input, @CodexRolloutOutputConverter() required final  List<CodexRolloutContentDto>? output, required this.action}): _content = content,_summary = summary,_output = output;
-  factory _CodexRolloutPayloadDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutPayloadDtoFromJson(json);
+class CodexRolloutMessageDto implements CodexRolloutResponseItemDto {
+  const CodexRolloutMessageDto({required this.id, @JsonKey(unknownEnumValue: CodexRolloutRole.unknown) required this.role, @CodexRolloutContentListConverter() required final  List<CodexRolloutContentDto> content, final  String? $type}): _content = content,$type = $type ?? 'message';
+  factory CodexRolloutMessageDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutMessageDtoFromJson(json);
 
-@override final  String? id;
-@override final  String? cwd;
-@override final  String? timestamp;
-@override@JsonKey(name: "model_provider") final  String? modelProvider;
-@override@JsonKey(name: "cli_version") final  String? cliVersion;
-@override final  String? model;
-@override@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) final  CodexRolloutPayloadType? type;
-@override@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) final  CodexRolloutRole? role;
- final  List<CodexRolloutContentDto>? _content;
-@override@CodexRolloutContentListConverter() List<CodexRolloutContentDto>? get content {
-  final value = _content;
-  if (value == null) return null;
+ final  String? id;
+@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) final  CodexRolloutRole role;
+ final  List<CodexRolloutContentDto> _content;
+@CodexRolloutContentListConverter() List<CodexRolloutContentDto> get content {
   if (_content is EqualUnmodifiableListView) return _content;
   // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(value);
+  return EqualUnmodifiableListView(_content);
 }
 
- final  List<CodexRolloutContentDto>? _summary;
-@override@CodexRolloutContentListConverter() List<CodexRolloutContentDto>? get summary {
-  final value = _summary;
-  if (value == null) return null;
-  if (_summary is EqualUnmodifiableListView) return _summary;
-  // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(value);
-}
 
-@override@JsonKey(name: "call_id") final  String? callId;
-@override final  String? name;
-@override final  String? arguments;
-@override final  String? input;
- final  List<CodexRolloutContentDto>? _output;
-@override@CodexRolloutOutputConverter() List<CodexRolloutContentDto>? get output {
-  final value = _output;
-  if (value == null) return null;
-  if (_output is EqualUnmodifiableListView) return _output;
-  // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(value);
-}
+@JsonKey(name: 'type')
+final String $type;
 
-@override final  CodexRolloutActionDto? action;
 
-/// Create a copy of CodexRolloutPayloadDto
+/// Create a copy of CodexRolloutResponseItemDto
 /// with the given fields replaced by the non-null parameter values.
-@override @JsonKey(includeFromJson: false, includeToJson: false)
+@JsonKey(includeFromJson: false, includeToJson: false)
 @pragma('vm:prefer-inline')
-_$CodexRolloutPayloadDtoCopyWith<_CodexRolloutPayloadDto> get copyWith => __$CodexRolloutPayloadDtoCopyWithImpl<_CodexRolloutPayloadDto>(this, _$identity);
+$CodexRolloutMessageDtoCopyWith<CodexRolloutMessageDto> get copyWith => _$CodexRolloutMessageDtoCopyWithImpl<CodexRolloutMessageDto>(this, _$identity);
 
 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexRolloutPayloadDto&&(identical(other.id, id) || other.id == id)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.cliVersion, cliVersion) || other.cliVersion == cliVersion)&&(identical(other.model, model) || other.model == model)&&(identical(other.type, type) || other.type == type)&&(identical(other.role, role) || other.role == role)&&const DeepCollectionEquality().equals(other._content, _content)&&const DeepCollectionEquality().equals(other._summary, _summary)&&(identical(other.callId, callId) || other.callId == callId)&&(identical(other.name, name) || other.name == name)&&(identical(other.arguments, arguments) || other.arguments == arguments)&&(identical(other.input, input) || other.input == input)&&const DeepCollectionEquality().equals(other._output, _output)&&(identical(other.action, action) || other.action == action));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutMessageDto&&(identical(other.id, id) || other.id == id)&&(identical(other.role, role) || other.role == role)&&const DeepCollectionEquality().equals(other._content, _content));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,cwd,timestamp,modelProvider,cliVersion,model,type,role,const DeepCollectionEquality().hash(_content),const DeepCollectionEquality().hash(_summary),callId,name,arguments,input,const DeepCollectionEquality().hash(_output),action);
+int get hashCode => Object.hash(runtimeType,id,role,const DeepCollectionEquality().hash(_content));
 
 @override
 String toString() {
-  return 'CodexRolloutPayloadDto(id: $id, cwd: $cwd, timestamp: $timestamp, modelProvider: $modelProvider, cliVersion: $cliVersion, model: $model, type: $type, role: $role, content: $content, summary: $summary, callId: $callId, name: $name, arguments: $arguments, input: $input, output: $output, action: $action)';
+  return 'CodexRolloutResponseItemDto.message(id: $id, role: $role, content: $content)';
 }
 
 
 }
 
 /// @nodoc
-abstract mixin class _$CodexRolloutPayloadDtoCopyWith<$Res> implements $CodexRolloutPayloadDtoCopyWith<$Res> {
-  factory _$CodexRolloutPayloadDtoCopyWith(_CodexRolloutPayloadDto value, $Res Function(_CodexRolloutPayloadDto) _then) = __$CodexRolloutPayloadDtoCopyWithImpl;
-@override @useResult
+abstract mixin class $CodexRolloutMessageDtoCopyWith<$Res> implements $CodexRolloutResponseItemDtoCopyWith<$Res> {
+  factory $CodexRolloutMessageDtoCopyWith(CodexRolloutMessageDto value, $Res Function(CodexRolloutMessageDto) _then) = _$CodexRolloutMessageDtoCopyWithImpl;
+@useResult
 $Res call({
- String? id, String? cwd, String? timestamp,@JsonKey(name: "model_provider") String? modelProvider,@JsonKey(name: "cli_version") String? cliVersion, String? model,@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? type,@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? role,@CodexRolloutContentListConverter() List<CodexRolloutContentDto>? content,@CodexRolloutContentListConverter() List<CodexRolloutContentDto>? summary,@JsonKey(name: "call_id") String? callId, String? name, String? arguments, String? input,@CodexRolloutOutputConverter() List<CodexRolloutContentDto>? output, CodexRolloutActionDto? action
+ String? id,@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole role,@CodexRolloutContentListConverter() List<CodexRolloutContentDto> content
 });
 
 
-@override $CodexRolloutActionDtoCopyWith<$Res>? get action;
+
 
 }
 /// @nodoc
-class __$CodexRolloutPayloadDtoCopyWithImpl<$Res>
-    implements _$CodexRolloutPayloadDtoCopyWith<$Res> {
-  __$CodexRolloutPayloadDtoCopyWithImpl(this._self, this._then);
+class _$CodexRolloutMessageDtoCopyWithImpl<$Res>
+    implements $CodexRolloutMessageDtoCopyWith<$Res> {
+  _$CodexRolloutMessageDtoCopyWithImpl(this._self, this._then);
 
-  final _CodexRolloutPayloadDto _self;
-  final $Res Function(_CodexRolloutPayloadDto) _then;
+  final CodexRolloutMessageDto _self;
+  final $Res Function(CodexRolloutMessageDto) _then;
 
-/// Create a copy of CodexRolloutPayloadDto
+/// Create a copy of CodexRolloutResponseItemDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? cwd = freezed,Object? timestamp = freezed,Object? modelProvider = freezed,Object? cliVersion = freezed,Object? model = freezed,Object? type = freezed,Object? role = freezed,Object? content = freezed,Object? summary = freezed,Object? callId = freezed,Object? name = freezed,Object? arguments = freezed,Object? input = freezed,Object? output = freezed,Object? action = freezed,}) {
-  return _then(_CodexRolloutPayloadDto(
+@pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? role = null,Object? content = null,}) {
+  return _then(CodexRolloutMessageDto(
 id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
-as String?,cwd: freezed == cwd ? _self.cwd : cwd // ignore: cast_nullable_to_non_nullable
-as String?,timestamp: freezed == timestamp ? _self.timestamp : timestamp // ignore: cast_nullable_to_non_nullable
-as String?,modelProvider: freezed == modelProvider ? _self.modelProvider : modelProvider // ignore: cast_nullable_to_non_nullable
-as String?,cliVersion: freezed == cliVersion ? _self.cliVersion : cliVersion // ignore: cast_nullable_to_non_nullable
-as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
-as String?,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
-as CodexRolloutPayloadType?,role: freezed == role ? _self.role : role // ignore: cast_nullable_to_non_nullable
-as CodexRolloutRole?,content: freezed == content ? _self._content : content // ignore: cast_nullable_to_non_nullable
-as List<CodexRolloutContentDto>?,summary: freezed == summary ? _self._summary : summary // ignore: cast_nullable_to_non_nullable
-as List<CodexRolloutContentDto>?,callId: freezed == callId ? _self.callId : callId // ignore: cast_nullable_to_non_nullable
-as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
-as String?,arguments: freezed == arguments ? _self.arguments : arguments // ignore: cast_nullable_to_non_nullable
-as String?,input: freezed == input ? _self.input : input // ignore: cast_nullable_to_non_nullable
-as String?,output: freezed == output ? _self._output : output // ignore: cast_nullable_to_non_nullable
-as List<CodexRolloutContentDto>?,action: freezed == action ? _self.action : action // ignore: cast_nullable_to_non_nullable
+as String?,role: null == role ? _self.role : role // ignore: cast_nullable_to_non_nullable
+as CodexRolloutRole,content: null == content ? _self._content : content // ignore: cast_nullable_to_non_nullable
+as List<CodexRolloutContentDto>,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutReasoningDto implements CodexRolloutResponseItemDto {
+  const CodexRolloutReasoningDto({required this.id, @CodexRolloutContentListConverter() required final  List<CodexRolloutContentDto> summary, final  String? $type}): _summary = summary,$type = $type ?? 'reasoning';
+  factory CodexRolloutReasoningDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutReasoningDtoFromJson(json);
+
+ final  String? id;
+ final  List<CodexRolloutContentDto> _summary;
+@CodexRolloutContentListConverter() List<CodexRolloutContentDto> get summary {
+  if (_summary is EqualUnmodifiableListView) return _summary;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_summary);
+}
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutResponseItemDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutReasoningDtoCopyWith<CodexRolloutReasoningDto> get copyWith => _$CodexRolloutReasoningDtoCopyWithImpl<CodexRolloutReasoningDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutReasoningDto&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other._summary, _summary));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(_summary));
+
+@override
+String toString() {
+  return 'CodexRolloutResponseItemDto.reasoning(id: $id, summary: $summary)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutReasoningDtoCopyWith<$Res> implements $CodexRolloutResponseItemDtoCopyWith<$Res> {
+  factory $CodexRolloutReasoningDtoCopyWith(CodexRolloutReasoningDto value, $Res Function(CodexRolloutReasoningDto) _then) = _$CodexRolloutReasoningDtoCopyWithImpl;
+@useResult
+$Res call({
+ String? id,@CodexRolloutContentListConverter() List<CodexRolloutContentDto> summary
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexRolloutReasoningDtoCopyWithImpl<$Res>
+    implements $CodexRolloutReasoningDtoCopyWith<$Res> {
+  _$CodexRolloutReasoningDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutReasoningDto _self;
+  final $Res Function(CodexRolloutReasoningDto) _then;
+
+/// Create a copy of CodexRolloutResponseItemDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? summary = null,}) {
+  return _then(CodexRolloutReasoningDto(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,summary: null == summary ? _self._summary : summary // ignore: cast_nullable_to_non_nullable
+as List<CodexRolloutContentDto>,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutFunctionCallDto implements CodexRolloutResponseItemDto {
+  const CodexRolloutFunctionCallDto({required this.id, @JsonKey(name: "call_id") required this.callId, required this.name, required this.arguments, final  String? $type}): $type = $type ?? 'function_call';
+  factory CodexRolloutFunctionCallDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutFunctionCallDtoFromJson(json);
+
+ final  String? id;
+@JsonKey(name: "call_id") final  String callId;
+ final  String name;
+ final  String arguments;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutResponseItemDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutFunctionCallDtoCopyWith<CodexRolloutFunctionCallDto> get copyWith => _$CodexRolloutFunctionCallDtoCopyWithImpl<CodexRolloutFunctionCallDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutFunctionCallDto&&(identical(other.id, id) || other.id == id)&&(identical(other.callId, callId) || other.callId == callId)&&(identical(other.name, name) || other.name == name)&&(identical(other.arguments, arguments) || other.arguments == arguments));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,callId,name,arguments);
+
+@override
+String toString() {
+  return 'CodexRolloutResponseItemDto.functionCall(id: $id, callId: $callId, name: $name, arguments: $arguments)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutFunctionCallDtoCopyWith<$Res> implements $CodexRolloutResponseItemDtoCopyWith<$Res> {
+  factory $CodexRolloutFunctionCallDtoCopyWith(CodexRolloutFunctionCallDto value, $Res Function(CodexRolloutFunctionCallDto) _then) = _$CodexRolloutFunctionCallDtoCopyWithImpl;
+@useResult
+$Res call({
+ String? id,@JsonKey(name: "call_id") String callId, String name, String arguments
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexRolloutFunctionCallDtoCopyWithImpl<$Res>
+    implements $CodexRolloutFunctionCallDtoCopyWith<$Res> {
+  _$CodexRolloutFunctionCallDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutFunctionCallDto _self;
+  final $Res Function(CodexRolloutFunctionCallDto) _then;
+
+/// Create a copy of CodexRolloutResponseItemDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? callId = null,Object? name = null,Object? arguments = null,}) {
+  return _then(CodexRolloutFunctionCallDto(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,callId: null == callId ? _self.callId : callId // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,arguments: null == arguments ? _self.arguments : arguments // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutFunctionCallOutputDto implements CodexRolloutResponseItemDto {
+  const CodexRolloutFunctionCallOutputDto({@JsonKey(name: "call_id") required this.callId, @CodexRolloutOutputConverter() required final  List<CodexRolloutContentDto> output, final  String? $type}): _output = output,$type = $type ?? 'function_call_output';
+  factory CodexRolloutFunctionCallOutputDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutFunctionCallOutputDtoFromJson(json);
+
+@JsonKey(name: "call_id") final  String callId;
+ final  List<CodexRolloutContentDto> _output;
+@CodexRolloutOutputConverter() List<CodexRolloutContentDto> get output {
+  if (_output is EqualUnmodifiableListView) return _output;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_output);
+}
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutResponseItemDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutFunctionCallOutputDtoCopyWith<CodexRolloutFunctionCallOutputDto> get copyWith => _$CodexRolloutFunctionCallOutputDtoCopyWithImpl<CodexRolloutFunctionCallOutputDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutFunctionCallOutputDto&&(identical(other.callId, callId) || other.callId == callId)&&const DeepCollectionEquality().equals(other._output, _output));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,callId,const DeepCollectionEquality().hash(_output));
+
+@override
+String toString() {
+  return 'CodexRolloutResponseItemDto.functionCallOutput(callId: $callId, output: $output)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutFunctionCallOutputDtoCopyWith<$Res> implements $CodexRolloutResponseItemDtoCopyWith<$Res> {
+  factory $CodexRolloutFunctionCallOutputDtoCopyWith(CodexRolloutFunctionCallOutputDto value, $Res Function(CodexRolloutFunctionCallOutputDto) _then) = _$CodexRolloutFunctionCallOutputDtoCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: "call_id") String callId,@CodexRolloutOutputConverter() List<CodexRolloutContentDto> output
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexRolloutFunctionCallOutputDtoCopyWithImpl<$Res>
+    implements $CodexRolloutFunctionCallOutputDtoCopyWith<$Res> {
+  _$CodexRolloutFunctionCallOutputDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutFunctionCallOutputDto _self;
+  final $Res Function(CodexRolloutFunctionCallOutputDto) _then;
+
+/// Create a copy of CodexRolloutResponseItemDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? callId = null,Object? output = null,}) {
+  return _then(CodexRolloutFunctionCallOutputDto(
+callId: null == callId ? _self.callId : callId // ignore: cast_nullable_to_non_nullable
+as String,output: null == output ? _self._output : output // ignore: cast_nullable_to_non_nullable
+as List<CodexRolloutContentDto>,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutCustomToolCallDto implements CodexRolloutResponseItemDto {
+  const CodexRolloutCustomToolCallDto({required this.id, @JsonKey(name: "call_id") required this.callId, required this.name, required this.input, final  String? $type}): $type = $type ?? 'custom_tool_call';
+  factory CodexRolloutCustomToolCallDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutCustomToolCallDtoFromJson(json);
+
+ final  String? id;
+@JsonKey(name: "call_id") final  String callId;
+ final  String name;
+ final  String input;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutResponseItemDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutCustomToolCallDtoCopyWith<CodexRolloutCustomToolCallDto> get copyWith => _$CodexRolloutCustomToolCallDtoCopyWithImpl<CodexRolloutCustomToolCallDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutCustomToolCallDto&&(identical(other.id, id) || other.id == id)&&(identical(other.callId, callId) || other.callId == callId)&&(identical(other.name, name) || other.name == name)&&(identical(other.input, input) || other.input == input));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,callId,name,input);
+
+@override
+String toString() {
+  return 'CodexRolloutResponseItemDto.customToolCall(id: $id, callId: $callId, name: $name, input: $input)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutCustomToolCallDtoCopyWith<$Res> implements $CodexRolloutResponseItemDtoCopyWith<$Res> {
+  factory $CodexRolloutCustomToolCallDtoCopyWith(CodexRolloutCustomToolCallDto value, $Res Function(CodexRolloutCustomToolCallDto) _then) = _$CodexRolloutCustomToolCallDtoCopyWithImpl;
+@useResult
+$Res call({
+ String? id,@JsonKey(name: "call_id") String callId, String name, String input
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexRolloutCustomToolCallDtoCopyWithImpl<$Res>
+    implements $CodexRolloutCustomToolCallDtoCopyWith<$Res> {
+  _$CodexRolloutCustomToolCallDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutCustomToolCallDto _self;
+  final $Res Function(CodexRolloutCustomToolCallDto) _then;
+
+/// Create a copy of CodexRolloutResponseItemDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? callId = null,Object? name = null,Object? input = null,}) {
+  return _then(CodexRolloutCustomToolCallDto(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,callId: null == callId ? _self.callId : callId // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,input: null == input ? _self.input : input // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutCustomToolCallOutputDto implements CodexRolloutResponseItemDto {
+  const CodexRolloutCustomToolCallOutputDto({@JsonKey(name: "call_id") required this.callId, @CodexRolloutOutputConverter() required final  List<CodexRolloutContentDto> output, final  String? $type}): _output = output,$type = $type ?? 'custom_tool_call_output';
+  factory CodexRolloutCustomToolCallOutputDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutCustomToolCallOutputDtoFromJson(json);
+
+@JsonKey(name: "call_id") final  String callId;
+ final  List<CodexRolloutContentDto> _output;
+@CodexRolloutOutputConverter() List<CodexRolloutContentDto> get output {
+  if (_output is EqualUnmodifiableListView) return _output;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_output);
+}
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutResponseItemDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutCustomToolCallOutputDtoCopyWith<CodexRolloutCustomToolCallOutputDto> get copyWith => _$CodexRolloutCustomToolCallOutputDtoCopyWithImpl<CodexRolloutCustomToolCallOutputDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutCustomToolCallOutputDto&&(identical(other.callId, callId) || other.callId == callId)&&const DeepCollectionEquality().equals(other._output, _output));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,callId,const DeepCollectionEquality().hash(_output));
+
+@override
+String toString() {
+  return 'CodexRolloutResponseItemDto.customToolCallOutput(callId: $callId, output: $output)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutCustomToolCallOutputDtoCopyWith<$Res> implements $CodexRolloutResponseItemDtoCopyWith<$Res> {
+  factory $CodexRolloutCustomToolCallOutputDtoCopyWith(CodexRolloutCustomToolCallOutputDto value, $Res Function(CodexRolloutCustomToolCallOutputDto) _then) = _$CodexRolloutCustomToolCallOutputDtoCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: "call_id") String callId,@CodexRolloutOutputConverter() List<CodexRolloutContentDto> output
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexRolloutCustomToolCallOutputDtoCopyWithImpl<$Res>
+    implements $CodexRolloutCustomToolCallOutputDtoCopyWith<$Res> {
+  _$CodexRolloutCustomToolCallOutputDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutCustomToolCallOutputDto _self;
+  final $Res Function(CodexRolloutCustomToolCallOutputDto) _then;
+
+/// Create a copy of CodexRolloutResponseItemDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? callId = null,Object? output = null,}) {
+  return _then(CodexRolloutCustomToolCallOutputDto(
+callId: null == callId ? _self.callId : callId // ignore: cast_nullable_to_non_nullable
+as String,output: null == output ? _self._output : output // ignore: cast_nullable_to_non_nullable
+as List<CodexRolloutContentDto>,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutWebSearchCallDto implements CodexRolloutResponseItemDto {
+  const CodexRolloutWebSearchCallDto({required this.id, required this.action, final  String? $type}): $type = $type ?? 'web_search_call';
+  factory CodexRolloutWebSearchCallDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutWebSearchCallDtoFromJson(json);
+
+ final  String? id;
+ final  CodexRolloutActionDto? action;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutResponseItemDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutWebSearchCallDtoCopyWith<CodexRolloutWebSearchCallDto> get copyWith => _$CodexRolloutWebSearchCallDtoCopyWithImpl<CodexRolloutWebSearchCallDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutWebSearchCallDto&&(identical(other.id, id) || other.id == id)&&(identical(other.action, action) || other.action == action));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,action);
+
+@override
+String toString() {
+  return 'CodexRolloutResponseItemDto.webSearchCall(id: $id, action: $action)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutWebSearchCallDtoCopyWith<$Res> implements $CodexRolloutResponseItemDtoCopyWith<$Res> {
+  factory $CodexRolloutWebSearchCallDtoCopyWith(CodexRolloutWebSearchCallDto value, $Res Function(CodexRolloutWebSearchCallDto) _then) = _$CodexRolloutWebSearchCallDtoCopyWithImpl;
+@useResult
+$Res call({
+ String? id, CodexRolloutActionDto? action
+});
+
+
+$CodexRolloutActionDtoCopyWith<$Res>? get action;
+
+}
+/// @nodoc
+class _$CodexRolloutWebSearchCallDtoCopyWithImpl<$Res>
+    implements $CodexRolloutWebSearchCallDtoCopyWith<$Res> {
+  _$CodexRolloutWebSearchCallDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutWebSearchCallDto _self;
+  final $Res Function(CodexRolloutWebSearchCallDto) _then;
+
+/// Create a copy of CodexRolloutResponseItemDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? action = freezed,}) {
+  return _then(CodexRolloutWebSearchCallDto(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,action: freezed == action ? _self.action : action // ignore: cast_nullable_to_non_nullable
 as CodexRolloutActionDto?,
   ));
 }
 
-/// Create a copy of CodexRolloutPayloadDto
+/// Create a copy of CodexRolloutResponseItemDto
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
@@ -1111,6 +1511,42 @@ $CodexRolloutActionDtoCopyWith<$Res>? get action {
   });
 }
 }
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutUnknownResponseItemDto implements CodexRolloutResponseItemDto {
+  const CodexRolloutUnknownResponseItemDto({final  String? $type}): $type = $type ?? 'unknown';
+  factory CodexRolloutUnknownResponseItemDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutUnknownResponseItemDtoFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutUnknownResponseItemDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CodexRolloutResponseItemDto.unknown()';
+}
+
+
+}
+
+
+
 
 CodexRolloutContentDto _$CodexRolloutContentDtoFromJson(
   Map<String, dynamic> json

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
@@ -37,7 +37,7 @@ CodexRolloutResponseItemLineDto _$CodexRolloutResponseItemLineDtoFromJson(
   Map json,
 ) => CodexRolloutResponseItemLineDto(
   timestamp: json['timestamp'] as String?,
-  payload: CodexRolloutPayloadDto.fromJson(
+  payload: CodexRolloutResponseItemDto.fromJson(
     Map<String, dynamic>.from(json['payload'] as Map),
   ),
   $type: json['type'] as String?,
@@ -69,55 +69,84 @@ _CodexRolloutTurnContextPayloadDto _$CodexRolloutTurnContextPayloadDtoFromJson(
   Map json,
 ) => _CodexRolloutTurnContextPayloadDto(model: json['model'] as String?);
 
-_CodexRolloutPayloadDto _$CodexRolloutPayloadDtoFromJson(
-  Map json,
-) => _CodexRolloutPayloadDto(
-  id: json['id'] as String?,
-  cwd: json['cwd'] as String?,
-  timestamp: json['timestamp'] as String?,
-  modelProvider: json['model_provider'] as String?,
-  cliVersion: json['cli_version'] as String?,
-  model: json['model'] as String?,
-  type: $enumDecodeNullable(
-    _$CodexRolloutPayloadTypeEnumMap,
-    json['type'],
-    unknownValue: CodexRolloutPayloadType.unknown,
-  ),
-  role: $enumDecodeNullable(
-    _$CodexRolloutRoleEnumMap,
-    json['role'],
-    unknownValue: CodexRolloutRole.unknown,
-  ),
-  content: const CodexRolloutContentListConverter().fromJson(json['content']),
-  summary: const CodexRolloutContentListConverter().fromJson(json['summary']),
-  callId: json['call_id'] as String?,
-  name: json['name'] as String?,
-  arguments: json['arguments'] as String?,
-  input: json['input'] as String?,
-  output: const CodexRolloutOutputConverter().fromJson(json['output']),
-  action: json['action'] == null
-      ? null
-      : CodexRolloutActionDto.fromJson(
-          Map<String, dynamic>.from(json['action'] as Map),
-        ),
-);
-
-const _$CodexRolloutPayloadTypeEnumMap = {
-  CodexRolloutPayloadType.message: 'message',
-  CodexRolloutPayloadType.reasoning: 'reasoning',
-  CodexRolloutPayloadType.functionCall: 'function_call',
-  CodexRolloutPayloadType.functionCallOutput: 'function_call_output',
-  CodexRolloutPayloadType.customToolCall: 'custom_tool_call',
-  CodexRolloutPayloadType.customToolCallOutput: 'custom_tool_call_output',
-  CodexRolloutPayloadType.webSearchCall: 'web_search_call',
-  CodexRolloutPayloadType.unknown: 'unknown',
-};
+CodexRolloutMessageDto _$CodexRolloutMessageDtoFromJson(Map json) =>
+    CodexRolloutMessageDto(
+      id: json['id'] as String?,
+      role: $enumDecode(
+        _$CodexRolloutRoleEnumMap,
+        json['role'],
+        unknownValue: CodexRolloutRole.unknown,
+      ),
+      content: const CodexRolloutContentListConverter().fromJson(
+        json['content'],
+      ),
+      $type: json['type'] as String?,
+    );
 
 const _$CodexRolloutRoleEnumMap = {
   CodexRolloutRole.user: 'user',
   CodexRolloutRole.assistant: 'assistant',
   CodexRolloutRole.unknown: 'unknown',
 };
+
+CodexRolloutReasoningDto _$CodexRolloutReasoningDtoFromJson(Map json) =>
+    CodexRolloutReasoningDto(
+      id: json['id'] as String?,
+      summary: const CodexRolloutContentListConverter().fromJson(
+        json['summary'],
+      ),
+      $type: json['type'] as String?,
+    );
+
+CodexRolloutFunctionCallDto _$CodexRolloutFunctionCallDtoFromJson(Map json) =>
+    CodexRolloutFunctionCallDto(
+      id: json['id'] as String?,
+      callId: json['call_id'] as String,
+      name: json['name'] as String,
+      arguments: json['arguments'] as String,
+      $type: json['type'] as String?,
+    );
+
+CodexRolloutFunctionCallOutputDto _$CodexRolloutFunctionCallOutputDtoFromJson(
+  Map json,
+) => CodexRolloutFunctionCallOutputDto(
+  callId: json['call_id'] as String,
+  output: const CodexRolloutOutputConverter().fromJson(json['output']),
+  $type: json['type'] as String?,
+);
+
+CodexRolloutCustomToolCallDto _$CodexRolloutCustomToolCallDtoFromJson(
+  Map json,
+) => CodexRolloutCustomToolCallDto(
+  id: json['id'] as String?,
+  callId: json['call_id'] as String,
+  name: json['name'] as String,
+  input: json['input'] as String,
+  $type: json['type'] as String?,
+);
+
+CodexRolloutCustomToolCallOutputDto
+_$CodexRolloutCustomToolCallOutputDtoFromJson(Map json) =>
+    CodexRolloutCustomToolCallOutputDto(
+      callId: json['call_id'] as String,
+      output: const CodexRolloutOutputConverter().fromJson(json['output']),
+      $type: json['type'] as String?,
+    );
+
+CodexRolloutWebSearchCallDto _$CodexRolloutWebSearchCallDtoFromJson(Map json) =>
+    CodexRolloutWebSearchCallDto(
+      id: json['id'] as String?,
+      action: json['action'] == null
+          ? null
+          : CodexRolloutActionDto.fromJson(
+              Map<String, dynamic>.from(json['action'] as Map),
+            ),
+      $type: json['type'] as String?,
+    );
+
+CodexRolloutUnknownResponseItemDto _$CodexRolloutUnknownResponseItemDtoFromJson(
+  Map json,
+) => CodexRolloutUnknownResponseItemDto($type: json['type'] as String?);
 
 CodexRolloutInputTextDto _$CodexRolloutInputTextDtoFromJson(Map json) =>
     CodexRolloutInputTextDto(

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
@@ -58,7 +58,7 @@ class CodexMessageRepository {
     );
 
     for (final line in lines) {
-      final CodexRolloutPayloadDto payload;
+      final CodexRolloutResponseItemDto payload;
       final String? lineTimestamp;
       switch (line) {
         case CodexRolloutSessionMetadataLineDto(payload: final metadata):
@@ -97,133 +97,127 @@ class CodexMessageRepository {
       }
       final messageTime = _messageTimeFrom(lineTimestamp);
 
-      if (payload.type == CodexRolloutPayloadType.functionCall ||
-          payload.type == CodexRolloutPayloadType.customToolCall) {
-        final call = _rolloutToolMapper.mapCall(payload);
-        if (call == null) continue;
-        final result = toolOutputs[call.id];
-        messages.add(
-          _toolMessage(
-            messageId: call.id,
-            sessionId: sessionId,
-            info: assistantInfo(call.id, messageTime),
-            tool: call.tool,
-            title: call.title,
-            status: result?.status ?? PluginToolStatus.running,
-            output: result?.output,
-          ),
-        );
-        continue;
-      }
-      if (payload.type == CodexRolloutPayloadType.functionCallOutput ||
-          payload.type == CodexRolloutPayloadType.customToolCallOutput) {
-        continue;
-      }
-      if (payload.type == CodexRolloutPayloadType.webSearchCall) {
-        messageCounter += 1;
-        final messageId = _persistedOrLegacyMessageId(
-          payload: payload,
-          legacyCounter: messageCounter,
-        );
-        messages.add(
-          _toolMessage(
-            messageId: messageId,
-            sessionId: sessionId,
-            info: assistantInfo(messageId, messageTime),
-            tool: "web_search",
-            title: payload.action?.query,
-            status: PluginToolStatus.completed,
-            output: null,
-          ),
-        );
-        continue;
-      }
-
-      if (payload.type == CodexRolloutPayloadType.reasoning) {
-        final reasoning = [
-          for (final item in payload.summary ?? const <CodexRolloutContentDto>[])
-            if (item case CodexRolloutSummaryTextDto(:final text) when text.isNotEmpty) text,
-        ].join();
-        if (reasoning.isEmpty) continue;
-
-        messageCounter += 1;
-        final messageId = _persistedOrLegacyMessageId(
-          payload: payload,
-          legacyCounter: messageCounter,
-        );
-        messages.add(
-          PluginMessageWithParts(
-            info: assistantInfo(messageId, messageTime),
-            parts: [
-              PluginMessagePart(
-                id: "$messageId-reasoning",
-                sessionID: sessionId,
-                messageID: messageId,
-                type: PluginMessagePartType.reasoning,
-                text: reasoning,
-                tool: null,
-                state: null,
-                prompt: null,
-                description: null,
-                agent: null,
-                agentName: null,
-                attempt: null,
-                retryError: null,
-                attachment: null,
-              ),
-            ],
-          ),
-        );
-        continue;
-      }
-
-      if (payload.role != CodexRolloutRole.user && payload.role != CodexRolloutRole.assistant) {
-        continue;
-      }
-      final texts = [
-        for (final item in payload.content ?? const <CodexRolloutContentDto>[])
-          if (item case CodexRolloutInputTextDto(:final text) || CodexRolloutOutputTextDto(:final text)
-              when text.isNotEmpty)
-            text,
-      ];
-      if (texts.isEmpty) continue;
-
-      messageCounter += 1;
-      final messageId = _persistedOrLegacyMessageId(
-        payload: payload,
-        legacyCounter: messageCounter,
-      );
-      final info = payload.role == CodexRolloutRole.user
-          ? PluginMessage.user(
-              id: messageId,
-              sessionID: sessionId,
-              agent: null,
-              time: messageTime,
-            )
-          : assistantInfo(messageId, messageTime);
-      messages.add(
-        PluginMessageWithParts(
-          info: info,
-          parts: [
-            PluginMessagePart(
-              id: "$messageId-text",
-              sessionID: sessionId,
-              messageID: messageId,
-              type: PluginMessagePartType.text,
-              text: texts.join(),
-              tool: null,
-              state: null,
-              prompt: null,
-              description: null,
-              agent: null,
-              agentName: null,
-              attempt: null,
-              retryError: null,
-              attachment: null,
+      switch (payload) {
+        case CodexRolloutFunctionCallDto() || CodexRolloutCustomToolCallDto():
+          final call = _rolloutToolMapper.mapCall(payload);
+          if (call == null) continue;
+          final result = toolOutputs[call.id];
+          messages.add(
+            _toolMessage(
+              messageId: call.id,
+              sessionId: sessionId,
+              info: assistantInfo(call.id, messageTime),
+              tool: call.tool,
+              title: call.title,
+              status: result?.status ?? PluginToolStatus.running,
+              output: result?.output,
             ),
-          ],
-        ),
-      );
+          );
+        case CodexRolloutFunctionCallOutputDto() || CodexRolloutCustomToolCallOutputDto():
+          continue;
+        case CodexRolloutWebSearchCallDto(:final id, :final action):
+          messageCounter += 1;
+          final messageId = _persistedOrLegacyMessageId(
+            persistedId: id,
+            legacyCounter: messageCounter,
+          );
+          messages.add(
+            _toolMessage(
+              messageId: messageId,
+              sessionId: sessionId,
+              info: assistantInfo(messageId, messageTime),
+              tool: "web_search",
+              title: action?.query,
+              status: PluginToolStatus.completed,
+              output: null,
+            ),
+          );
+        case CodexRolloutReasoningDto(:final id, :final summary):
+          final reasoning = [
+            for (final item in summary)
+              if (item case CodexRolloutSummaryTextDto(:final text) when text.isNotEmpty) text,
+          ].join();
+          if (reasoning.isEmpty) continue;
+
+          messageCounter += 1;
+          final messageId = _persistedOrLegacyMessageId(
+            persistedId: id,
+            legacyCounter: messageCounter,
+          );
+          messages.add(
+            PluginMessageWithParts(
+              info: assistantInfo(messageId, messageTime),
+              parts: [
+                PluginMessagePart(
+                  id: "$messageId-reasoning",
+                  sessionID: sessionId,
+                  messageID: messageId,
+                  type: PluginMessagePartType.reasoning,
+                  text: reasoning,
+                  tool: null,
+                  state: null,
+                  prompt: null,
+                  description: null,
+                  agent: null,
+                  agentName: null,
+                  attempt: null,
+                  retryError: null,
+                  attachment: null,
+                ),
+              ],
+            ),
+          );
+        case CodexRolloutMessageDto(:final id, :final role, :final content):
+          if (role != CodexRolloutRole.user && role != CodexRolloutRole.assistant) {
+            continue;
+          }
+          final texts = [
+            for (final item in content)
+              if (item case CodexRolloutInputTextDto(:final text) || CodexRolloutOutputTextDto(:final text)
+                  when text.isNotEmpty)
+                text,
+          ];
+          if (texts.isEmpty) continue;
+
+          messageCounter += 1;
+          final messageId = _persistedOrLegacyMessageId(
+            persistedId: id,
+            legacyCounter: messageCounter,
+          );
+          final info = role == CodexRolloutRole.user
+              ? PluginMessage.user(
+                  id: messageId,
+                  sessionID: sessionId,
+                  agent: null,
+                  time: messageTime,
+                )
+              : assistantInfo(messageId, messageTime);
+          messages.add(
+            PluginMessageWithParts(
+              info: info,
+              parts: [
+                PluginMessagePart(
+                  id: "$messageId-text",
+                  sessionID: sessionId,
+                  messageID: messageId,
+                  type: PluginMessagePartType.text,
+                  text: texts.join(),
+                  tool: null,
+                  state: null,
+                  prompt: null,
+                  description: null,
+                  agent: null,
+                  agentName: null,
+                  attempt: null,
+                  retryError: null,
+                  attachment: null,
+                ),
+              ],
+            ),
+          );
+        case CodexRolloutUnknownResponseItemDto():
+          continue;
+      }
     }
     return messages;
   }
@@ -267,10 +261,10 @@ class CodexMessageRepository {
   }
 
   String _persistedOrLegacyMessageId({
-    required CodexRolloutPayloadDto payload,
+    required String? persistedId,
     required int legacyCounter,
   }) {
-    final persisted = payload.id?.trim();
+    final persisted = persistedId?.trim();
     if (persisted != null && persisted.isNotEmpty) return persisted;
     // COMPATIBILITY 2026-07-23 (legacy Codex rollouts): older response-item
     // messages can omit `payload.id`. Keep a deterministic replay-local id so

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
@@ -38,29 +38,72 @@ class CodexRolloutToolResult {
 class CodexRolloutToolMapper {
   const CodexRolloutToolMapper();
 
-  CodexRolloutToolCall? mapCall(CodexRolloutPayloadDto payload) {
-    if (payload.type != CodexRolloutPayloadType.functionCall &&
-        payload.type != CodexRolloutPayloadType.customToolCall) {
-      return null;
-    }
-    final id = _usefulText(payload.callId) ?? _usefulText(payload.id);
-    if (id == null) return null;
-    final name = _usefulText(payload.name) ?? "tool";
+  CodexRolloutToolCall? mapCall(CodexRolloutResponseItemDto payload) {
+    return switch (payload) {
+      CodexRolloutFunctionCallDto(
+        :final id,
+        :final callId,
+        :final name,
+        :final arguments,
+      ) =>
+        _mapCall(
+          id: id,
+          callId: callId,
+          name: name,
+          input: arguments,
+        ),
+      CodexRolloutCustomToolCallDto(
+        :final id,
+        :final callId,
+        :final name,
+        :final input,
+      ) =>
+        _mapCall(
+          id: id,
+          callId: callId,
+          name: name,
+          input: input,
+        ),
+      CodexRolloutMessageDto() ||
+      CodexRolloutReasoningDto() ||
+      CodexRolloutFunctionCallOutputDto() ||
+      CodexRolloutCustomToolCallOutputDto() ||
+      CodexRolloutWebSearchCallDto() ||
+      CodexRolloutUnknownResponseItemDto() => null,
+    };
+  }
+
+  CodexRolloutToolCall? _mapCall({
+    required String? id,
+    required String callId,
+    required String name,
+    required String input,
+  }) {
+    final usefulId = _usefulText(callId) ?? _usefulText(id);
+    if (usefulId == null) return null;
+    final usefulName = _usefulText(name) ?? "tool";
     return CodexRolloutToolCall(
-      id: id,
-      tool: normalizeToolName(name),
-      title: toolCallTitle(payload.arguments ?? payload.input),
+      id: usefulId,
+      tool: normalizeToolName(usefulName),
+      title: toolCallTitle(input),
     );
   }
 
-  CodexRolloutToolResult? mapResult(CodexRolloutPayloadDto payload) {
-    if (payload.type != CodexRolloutPayloadType.functionCallOutput &&
-        payload.type != CodexRolloutPayloadType.customToolCallOutput) {
-      return null;
-    }
-    final callId = _usefulText(payload.callId);
+  CodexRolloutToolResult? mapResult(CodexRolloutResponseItemDto payload) {
+    final output = switch (payload) {
+      CodexRolloutFunctionCallOutputDto(:final callId, :final output) ||
+      CodexRolloutCustomToolCallOutputDto(:final callId, :final output) => (callId, output),
+      CodexRolloutMessageDto() ||
+      CodexRolloutReasoningDto() ||
+      CodexRolloutFunctionCallDto() ||
+      CodexRolloutCustomToolCallDto() ||
+      CodexRolloutWebSearchCallDto() ||
+      CodexRolloutUnknownResponseItemDto() => null,
+    };
+    if (output == null) return null;
+    final callId = _usefulText(output.$1);
     if (callId == null) return null;
-    final rawOutput = toolOutputText(payload.output);
+    final rawOutput = toolOutputText(output.$2);
     return CodexRolloutToolResult(
       callId: callId,
       status: toolOutputStatus(rawOutput),

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -704,6 +704,28 @@ void main() {
       mapper.clearRolloutTurn(threadId: "t-unicode");
     });
 
+    test("image-generation rollout items remain unknown and emit no events", () {
+      final line = CodexRolloutLineDto.fromJson({
+        "type": "response_item",
+        "payload": {
+          "type": "image_generation_call",
+          "id": "image-1",
+          "status": "completed",
+          "result": "not-retained-in-step-4",
+        },
+      });
+
+      expect(
+        line,
+        isA<CodexRolloutResponseItemLineDto>().having(
+          (line) => line.payload,
+          "payload",
+          isA<CodexRolloutUnknownResponseItemDto>(),
+        ),
+      );
+      expect(mapper.mapRolloutLine(threadId: "t-image", line: line), isEmpty);
+    });
+
     test("commandExecution (started/inProgress) → running tool part", () {
       final events = mapper.map(
         const CodexServerNotification(

--- a/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
@@ -141,7 +141,11 @@ void main() {
         }),
         CodexRolloutLineDto.fromJson({
           "type": "response_item",
-          "payload": {"type": "message", "role": "assistant"},
+          "payload": {
+            "type": "message",
+            "role": "assistant",
+            "content": <Object?>[],
+          },
         }),
         CodexRolloutLineDto.fromJson({
           "type": "compacted",
@@ -160,10 +164,40 @@ void main() {
       expect(lines[4], isA<CodexRolloutUnknownLineDto>());
       expect(_sessionMetadataPayload(line: lines[0]).id, "session-id");
       expect(_turnContextPayload(line: lines[1]).model, "gpt-5.4");
-      expect(
-        _responseItemPayload(line: lines[2]).type,
-        CodexRolloutPayloadType.message,
-      );
+      expect(_responseItemPayload(line: lines[2]), isA<CodexRolloutMessageDto>());
+    });
+
+    test("response items decode to closed inner variants", () {
+      CodexRolloutResponseItemDto decode(Map<String, Object?> payload) {
+        return _responseItemPayload(
+          line: CodexRolloutLineDto.fromJson({
+            "type": "response_item",
+            "payload": payload,
+          }),
+        );
+      }
+
+      final items = [
+        decode({"type": "message", "role": "assistant", "content": <Object?>[]}),
+        decode({"type": "reasoning", "summary": <Object?>[]}),
+        decode({"type": "function_call", "call_id": "c1", "name": "exec", "arguments": "{}"}),
+        decode({"type": "function_call_output", "call_id": "c1", "output": "done"}),
+        decode({"type": "custom_tool_call", "call_id": "c2", "name": "exec", "input": "code"}),
+        decode({"type": "custom_tool_call_output", "call_id": "c2", "output": <Object?>[]}),
+        decode({"type": "web_search_call", "action": null}),
+        decode({"type": "future_item", "secret": "ignored"}),
+        decode({"type": "image_generation_call", "result": "ignored"}),
+      ];
+
+      expect(items[0], isA<CodexRolloutMessageDto>());
+      expect(items[1], isA<CodexRolloutReasoningDto>());
+      expect(items[2], isA<CodexRolloutFunctionCallDto>());
+      expect(items[3], isA<CodexRolloutFunctionCallOutputDto>());
+      expect(items[4], isA<CodexRolloutCustomToolCallDto>());
+      expect(items[5], isA<CodexRolloutCustomToolCallOutputDto>());
+      expect(items[6], isA<CodexRolloutWebSearchCallDto>());
+      expect(items[7], isA<CodexRolloutUnknownResponseItemDto>());
+      expect(items[8], isA<CodexRolloutUnknownResponseItemDto>());
     });
 
     test("readHeader does not read beyond its bounded scan window", () {
@@ -209,6 +243,7 @@ void main() {
         "payload": {
           "type": "function_call",
           "name": "secret-tool-name",
+          "call_id": 42,
           "arguments": {
             "type": "secret-token",
             "ghp_secretCredential": "secret-credential",
@@ -229,12 +264,12 @@ void main() {
         output,
         contains(
           'schema={type:enum("response_item"),payload:{'
-          'type:enum("function_call"),name:String,arguments:{type:String,'
+          'type:enum("function_call"),name:String,call_id:int,arguments:{type:String,'
           '<redacted-key>:String,query:String},'
           "action:String}}",
         ),
       );
-      expect(output, contains("error=type 'String'"));
+      expect(output, contains("error=type 'int'"));
       expect(output, isNot(contains("secret-tool-name")));
       expect(output, isNot(contains("secret-token")));
       expect(output, isNot(contains("secret-credential")));
@@ -299,7 +334,7 @@ void main() {
 
       expect(initial.lines, hasLength(1));
       expect(
-        _responseItemPayload(line: initial.lines.single).callId,
+        _responseItemCallId(line: initial.lines.single),
         "call-1",
       );
       expect(initial.trailingBytes, isNotEmpty);
@@ -315,10 +350,7 @@ void main() {
       );
 
       expect(completed.lines, hasLength(1));
-      expect(
-        _responseItemPayload(line: completed.lines.single).type,
-        CodexRolloutPayloadType.functionCallOutput,
-      );
+      expect(_responseItemPayload(line: completed.lines.single), isA<CodexRolloutFunctionCallOutputDto>());
       expect(completed.trailingBytes, isEmpty);
     });
 
@@ -368,7 +400,7 @@ void main() {
 
       expect(completed.lines, hasLength(1));
       expect(
-        _responseItemPayload(line: completed.lines.single).callId,
+        _responseItemCallId(line: completed.lines.single),
         "current-call",
       );
       expect(completed.trailingBytes, isEmpty);
@@ -416,15 +448,9 @@ void main() {
       expect(header, hasLength(3));
       expect(transcript, hasLength(3));
       expect(transcript[1], isA<CodexRolloutResponseItemLineDto>());
-      expect(
-        _responseItemPayload(line: transcript[1]).type,
-        CodexRolloutPayloadType.customToolCallOutput,
-      );
+      expect(_responseItemPayload(line: transcript[1]), isA<CodexRolloutCustomToolCallOutputDto>());
       expect(transcript[2], isA<CodexRolloutResponseItemLineDto>());
-      expect(
-        _responseItemPayload(line: transcript[2]).type,
-        CodexRolloutPayloadType.reasoning,
-      );
+      expect(_responseItemPayload(line: transcript[2]), isA<CodexRolloutReasoningDto>());
     });
 
     test("rollout content decodes closed text, image, and unknown variants", () {
@@ -438,7 +464,7 @@ void main() {
           "detail": "high",
         },
         {"type": "future_content", "payload": "not-rendered"},
-      ])!;
+      ]);
 
       expect(content, hasLength(5));
       expect(content[0], isA<CodexRolloutInputTextDto>());
@@ -466,7 +492,7 @@ void main() {
     });
 
     test("rollout content skips malformed known variants without exposing values", () {
-      late List<CodexRolloutContentDto>? content;
+      late List<CodexRolloutContentDto> content;
       final output = _captureWarnings(() {
         content = const CodexRolloutContentListConverter().fromJson([
           {"type": "output_text", "text": "kept"},
@@ -476,8 +502,8 @@ void main() {
       }, level: LogLevel.verbose);
 
       expect(content, hasLength(2));
-      expect(content?.first, isA<CodexRolloutOutputTextDto>());
-      expect(content?.last, isA<CodexRolloutUnknownContentDto>());
+      expect(content.first, isA<CodexRolloutOutputTextDto>());
+      expect(content.last, isA<CodexRolloutUnknownContentDto>());
       expect(output, contains("skipping malformed rollout content item"));
       expect(output, isNot(contains("not-logged")));
     });
@@ -542,7 +568,7 @@ void main() {
       );
       expect(transcript.last, isA<CodexRolloutResponseItemLineDto>());
       expect(
-        _responseItemPayload(line: transcript.last).summary,
+        _reasoningSummary(line: transcript.last),
         isEmpty,
       );
     });
@@ -574,14 +600,7 @@ void main() {
 
       expect(output, isNot(contains("malformed rollout transcript record")));
       expect(transcript.last, isA<CodexRolloutResponseItemLineDto>());
-      expect(
-        _responseItemPayload(line: transcript.last).type,
-        CodexRolloutPayloadType.unknown,
-      );
-      expect(
-        _responseItemPayload(line: transcript.last).arguments,
-        jsonEncode({"query": "available tools"}),
-      );
+      expect(_responseItemPayload(line: transcript.last), isA<CodexRolloutUnknownResponseItemDto>());
     });
 
     test("listSessions joins index + rollout header and sorts by updatedAt", () {
@@ -722,6 +741,7 @@ void main() {
           jsonEncode({
             "type": "response_item",
             "payload": {
+              "type": "message",
               "id": "user-1",
               "role": "user",
               "content": [
@@ -736,6 +756,7 @@ void main() {
           jsonEncode({
             "type": "response_item",
             "payload": {
+              "type": "message",
               "id": "assistant-1",
               "role": "assistant",
               "content": [
@@ -1021,6 +1042,7 @@ void main() {
               "type": "function_call",
               "name": "exec_command",
               "call_id": "c1",
+              "arguments": "{}",
             },
           }),
           jsonEncode({
@@ -1147,6 +1169,7 @@ void main() {
           jsonEncode({
             "type": "response_item",
             "payload": {
+              "type": "message",
               "role": "user",
               "content": [
                 {"type": "input_text", "text": "ping"},
@@ -1156,6 +1179,7 @@ void main() {
           jsonEncode({
             "type": "response_item",
             "payload": {
+              "type": "message",
               "role": "assistant",
               "content": [
                 {"type": "output_text", "text": "pong"},
@@ -1228,6 +1252,7 @@ void main() {
           jsonEncode({
             "type": "response_item",
             "payload": {
+              "type": "message",
               "role": "assistant",
               "content": [
                 {"type": "output_text", "text": "first"},
@@ -1242,6 +1267,7 @@ void main() {
           jsonEncode({
             "type": "response_item",
             "payload": {
+              "type": "message",
               "role": "assistant",
               "content": [
                 {"type": "output_text", "text": "second"},
@@ -1280,6 +1306,7 @@ void main() {
           jsonEncode({
             "type": "response_item",
             "payload": {
+              "type": "message",
               "role": "assistant",
               "content": [
                 {"type": "output_text", "text": "hi"},
@@ -1322,12 +1349,29 @@ CodexRolloutTurnContextPayloadDto _turnContextPayload({
   };
 }
 
-CodexRolloutPayloadDto _responseItemPayload({
+CodexRolloutResponseItemDto _responseItemPayload({
   required CodexRolloutLineDto line,
 }) {
   return switch (line) {
     CodexRolloutResponseItemLineDto(payload: final payload) => payload,
     _ => throw StateError("Expected response item rollout line"),
+  };
+}
+
+String _responseItemCallId({required CodexRolloutLineDto line}) {
+  return switch (_responseItemPayload(line: line)) {
+    CodexRolloutFunctionCallDto(:final callId) ||
+    CodexRolloutFunctionCallOutputDto(:final callId) ||
+    CodexRolloutCustomToolCallDto(:final callId) ||
+    CodexRolloutCustomToolCallOutputDto(:final callId) => callId,
+    _ => throw StateError("Expected tool response item"),
+  };
+}
+
+List<CodexRolloutContentDto> _reasoningSummary({required CodexRolloutLineDto line}) {
+  return switch (_responseItemPayload(line: line)) {
+    CodexRolloutReasoningDto(:final summary) => summary,
+    _ => throw StateError("Expected reasoning response item"),
   };
 }
 

--- a/bridge/sesori_plugin_codex/test/codex_rollout_tailer_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_tailer_test.dart
@@ -88,7 +88,7 @@ void main() {
       expect(appends, hasLength(1));
       expect(appends.single.sessionId, "session-1");
       expect(
-        _responseItemPayload(line: appends.single.line).callId,
+        _responseItemCallId(line: appends.single.line),
         "current-call",
       );
     });
@@ -136,7 +136,7 @@ void main() {
       expect(appends, hasLength(1));
       expect(appends.single.sessionId, "session-1");
       expect(
-        _responseItemPayload(line: appends.single.line).callId,
+        _responseItemCallId(line: appends.single.line),
         "late-call",
       );
     });
@@ -196,18 +196,19 @@ void main() {
       expect(appends, hasLength(1));
       expect(appends.single.sessionId, "session-1");
       expect(
-        _responseItemPayload(line: appends.single.line).callId,
+        _responseItemCallId(line: appends.single.line),
         "late-existing-call",
       );
     });
   });
 }
 
-CodexRolloutPayloadDto _responseItemPayload({
-  required CodexRolloutLineDto line,
-}) {
+String _responseItemCallId({required CodexRolloutLineDto line}) {
   return switch (line) {
-    CodexRolloutResponseItemLineDto(payload: final payload) => payload,
+    CodexRolloutResponseItemLineDto(
+      payload: CodexRolloutFunctionCallOutputDto(:final callId),
+    ) =>
+      callId,
     _ => throw StateError("Expected response item rollout line"),
   };
 }


### PR DESCRIPTION
## Summary

- replace the flattened Codex rollout response-item payload with sealed message, reasoning, function/custom call and output, web-search, and unknown variants
- migrate tool normalization and history replay to exhaustive variant matching while retaining scalar/structured output compatibility
- keep image-generation and future response items fieldless and unknown until the planned image-history step

## Verification

- `dart pub get`
- focused rollout DTO, mapper, history, tailer, catalog, and metadata tests
- `dart test` (213 tests)
- `dart analyze --fatal-infos`
- `git diff --cached --check`
- `aristotle-impl-review` — approved with no findings

## Plan

Step 4/13 of `.plan/active/output-image-support/PLAN.md`. The 1,416-line diff is within the planned 1,100-1,500 target and below the 1,500-line soft cap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sealed Codex rollout response items into explicit variants and updated parsing/mapping to use exhaustive matching. This simplifies tool handling and prepares safe support for output images; image-generation items remain unknown for now.

- **Refactors**
  - Replaced flattened payload with sealed `CodexRolloutResponseItemDto` variants: message, reasoning, function_call, function_call_output, custom_tool_call, custom_tool_call_output, web_search_call, unknown.
  - Switched `codex_message_repository` to pattern-match variants for messages, reasoning, web search, and tool calls/results; legacy message IDs preserved via persisted-id or deterministic fallback.
  - Updated tool mapper to map calls/results from specific variants; normalization unchanged.
  - Hardened content converters: lists default to [], output accepts strings; removed legacy argument normalization; malformed items are skipped with warnings.
  - Future/image-generation items decode as `unknown` and are ignored until the image-history step; tests updated across tailer, API, and event mapping.

<sup>Written for commit 57e9ad0e02f27b40ee4e40be9a06eeffef584294. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

