### PR TITLE
[output-image-support] refactor(codex): type image-bearing events [step 5/13]

### DIFF
--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -5,10 +5,10 @@
 - **Plan slug:** `output-image-support`
 - **Implementation base:** `origin/main` at
   `9d2c1e9e79ab80fa8824b9d803a74798eb71140d`
-- **Series state:** Step 4/13 PR open
-- **Current step:** Step 4/13 — seal Codex response items
+- **Series state:** Step 5/13 ready for PR
+- **Current step:** Step 5/13 — type Codex image-bearing events
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** monitor Step 4/13 CI and review
+- **Next action:** open and monitor the Step 5/13 PR
 
 ## Plan Review
 
@@ -29,8 +29,8 @@
 | [x] | 1/13 | `investigate-opencode-image-support` | `[output-image-support] docs: plan output image support [step 1/13]` | 450-700 | [PR #638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638) merged as `bfadd097` |
 | [x] | 2/13 | `output-image-support-codex-rollout-content` | `[output-image-support] refactor(codex): seal rollout content [step 2/13]` | 1,200-1,500 | [PR #639](https://github.com/sesori-ai/sesori_apps_monorepo/pull/639) merged as `17e0ecf1`; 680 changed lines |
 | [x] | 3/13 | `output-image-support-codex-rollout-envelopes` | `[output-image-support] refactor(codex): seal rollout envelopes [step 3/13]` | 900-1,350 | [PR #644](https://github.com/sesori-ai/sesori_apps_monorepo/pull/644) merged as `f78e1f69`; 1,075 changed lines |
-| [ ] | 4/13 | `output-image-support-codex-response-items` | `[output-image-support] refactor(codex): seal response items [step 4/13]` | 1,100-1,500 | [PR #646](https://github.com/sesori-ai/sesori_apps_monorepo/pull/646) open; 1,416 changed lines |
-| [ ] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | Blocked on Step 4 merge |
+| [x] | 4/13 | `output-image-support-codex-response-items` | `[output-image-support] refactor(codex): seal response items [step 4/13]` | 1,100-1,500 | [PR #646](https://github.com/sesori-ai/sesori_apps_monorepo/pull/646) merged as `4be1e7bb`; 1,416 changed lines |
+| [ ] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | Ready for PR; 1,470 changed lines |
 | [ ] | 6/13 | `output-image-support-codex-live-images` | `[output-image-support] feat(codex): surface live output images [step 6/13]` | 900-1,400 | Blocked on Step 5 merge |
 | [ ] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | Blocked on Step 6 merge |
 | [ ] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | Blocked on Step 7 merge |
@@ -115,8 +115,18 @@
   unknown until Step 7. Codex codegen, focused DTO/mapper/history/tailer tests,
   all 213 package tests, `dart pub get`, `dart analyze --fatal-infos`, and
   `git diff --cached --check` pass. `aristotle-impl-review` approved the staged
-  architecture with no findings. The 1,416-line diff is within the 1,100-1,500 target and
-  below the 1,500-line soft cap; no neighboring scope was combined.
+  architecture with no findings. The 1,416-line diff is within the 1,100-1,500
+  target and below the 1,500-line soft cap; no neighboring scope was combined.
+  PR #646 merged as `4be1e7bb` on 2026-07-31.
+- Step 5/13 (2026-07-31): added generated app-server variants and a
+  zero-collaborator parser for image generation plus MCP/dynamic text, image,
+  and audio content; migrated existing MCP/dynamic text/status/error mapping;
+  and kept all image behavior unrendered for Step 6. Codex codegen, focused
+  parser/event tests, all 218 package tests, `dart pub get`,
+  `dart analyze --fatal-infos`, and `git diff --cached --check` pass. The first
+  architecture review moved output projection back to the event mapper; the
+  second `aristotle-impl-review` pass approved with no findings. The 1,470-line
+  diff is below the 1,500-line soft cap; no neighboring scope was combined.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -5,10 +5,10 @@
 - **Plan slug:** `output-image-support`
 - **Implementation base:** `origin/main` at
   `9d2c1e9e79ab80fa8824b9d803a74798eb71140d`
-- **Series state:** Step 5/13 ready for PR
+- **Series state:** Step 5/13 PR open
 - **Current step:** Step 5/13 — type Codex image-bearing events
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** open and monitor the Step 5/13 PR
+- **Next action:** monitor Step 5/13 CI and review
 
 ## Plan Review
 
@@ -30,7 +30,7 @@
 | [x] | 2/13 | `output-image-support-codex-rollout-content` | `[output-image-support] refactor(codex): seal rollout content [step 2/13]` | 1,200-1,500 | [PR #639](https://github.com/sesori-ai/sesori_apps_monorepo/pull/639) merged as `17e0ecf1`; 680 changed lines |
 | [x] | 3/13 | `output-image-support-codex-rollout-envelopes` | `[output-image-support] refactor(codex): seal rollout envelopes [step 3/13]` | 900-1,350 | [PR #644](https://github.com/sesori-ai/sesori_apps_monorepo/pull/644) merged as `f78e1f69`; 1,075 changed lines |
 | [x] | 4/13 | `output-image-support-codex-response-items` | `[output-image-support] refactor(codex): seal response items [step 4/13]` | 1,100-1,500 | [PR #646](https://github.com/sesori-ai/sesori_apps_monorepo/pull/646) merged as `4be1e7bb`; 1,416 changed lines |
-| [ ] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | Ready for PR; 1,470 changed lines |
+| [ ] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | [PR #648](https://github.com/sesori-ai/sesori_apps_monorepo/pull/648) open; 1,470 changed lines |
 | [ ] | 6/13 | `output-image-support-codex-live-images` | `[output-image-support] feat(codex): surface live output images [step 6/13]` | 900-1,400 | Blocked on Step 5 merge |
 | [ ] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | Blocked on Step 6 merge |
 | [ ] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | Blocked on Step 7 merge |

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -30,7 +30,7 @@
 | [x] | 2/13 | `output-image-support-codex-rollout-content` | `[output-image-support] refactor(codex): seal rollout content [step 2/13]` | 1,200-1,500 | [PR #639](https://github.com/sesori-ai/sesori_apps_monorepo/pull/639) merged as `17e0ecf1`; 680 changed lines |
 | [x] | 3/13 | `output-image-support-codex-rollout-envelopes` | `[output-image-support] refactor(codex): seal rollout envelopes [step 3/13]` | 900-1,350 | [PR #644](https://github.com/sesori-ai/sesori_apps_monorepo/pull/644) merged as `f78e1f69`; 1,075 changed lines |
 | [x] | 4/13 | `output-image-support-codex-response-items` | `[output-image-support] refactor(codex): seal response items [step 4/13]` | 1,100-1,500 | [PR #646](https://github.com/sesori-ai/sesori_apps_monorepo/pull/646) merged as `4be1e7bb`; 1,416 changed lines |
-| [ ] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | [PR #648](https://github.com/sesori-ai/sesori_apps_monorepo/pull/648) open; 1,470 changed lines |
+| [ ] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | [PR #648](https://github.com/sesori-ai/sesori_apps_monorepo/pull/648) open; 1,472 changed lines |
 | [ ] | 6/13 | `output-image-support-codex-live-images` | `[output-image-support] feat(codex): surface live output images [step 6/13]` | 900-1,400 | Blocked on Step 5 merge |
 | [ ] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | Blocked on Step 6 merge |
 | [ ] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | Blocked on Step 7 merge |
@@ -125,7 +125,7 @@
   parser/event tests, all 218 package tests, `dart pub get`,
   `dart analyze --fatal-infos`, and `git diff --cached --check` pass. The first
   architecture review moved output projection back to the event mapper; the
-  second `aristotle-impl-review` pass approved with no findings. The 1,470-line
+  second `aristotle-impl-review` pass approved with no findings. The 1,472-line
   diff is below the 1,500-line soft cap; no neighboring scope was combined.
 
 ## Findings And Plan Deltas

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_image_bearing_item_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_image_bearing_item_dto.dart
@@ -1,0 +1,188 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
+part "codex_image_bearing_item_dto.freezed.dart";
+part "codex_image_bearing_item_dto.g.dart";
+
+enum CodexImageGenerationStatus {
+  @JsonValue("in_progress")
+  inProgress,
+  completed,
+  failed,
+  unknown,
+}
+
+enum CodexToolCallStatus {
+  inProgress,
+  completed,
+  failed,
+  declined,
+  unknown,
+}
+
+@Freezed(
+  unionKey: "type",
+  fallbackUnion: "unknown",
+  fromJson: true,
+  toJson: false,
+)
+sealed class CodexImageBearingItemDto with _$CodexImageBearingItemDto {
+  @FreezedUnionValue("imageGeneration")
+  const factory CodexImageBearingItemDto.imageGeneration({
+    required String id,
+    @JsonKey(
+      unknownEnumValue: CodexImageGenerationStatus.unknown,
+      defaultValue: CodexImageGenerationStatus.unknown,
+    )
+    required CodexImageGenerationStatus status,
+    required String? revisedPrompt,
+    required String result,
+    required String? savedPath,
+  }) = CodexImageGenerationItemDto;
+
+  @FreezedUnionValue("mcpToolCall")
+  const factory CodexImageBearingItemDto.mcpToolCall({
+    required String id,
+    required String? server,
+    required String? tool,
+    @JsonKey(
+      unknownEnumValue: CodexToolCallStatus.unknown,
+      defaultValue: CodexToolCallStatus.unknown,
+    )
+    required CodexToolCallStatus status,
+    @JsonKey(name: "result") @CodexMcpResultContentConverter() required List<CodexImageBearingContentDto> content,
+    @CodexToolErrorConverter() required String? error,
+  }) = CodexMcpToolCallItemDto;
+
+  @FreezedUnionValue("dynamicToolCall")
+  const factory CodexImageBearingItemDto.dynamicToolCall({
+    required String id,
+    @CodexToolNameConverter() required String tool,
+    required Object? arguments,
+    @JsonKey(
+      unknownEnumValue: CodexToolCallStatus.unknown,
+      defaultValue: CodexToolCallStatus.unknown,
+    )
+    required CodexToolCallStatus status,
+    @JsonKey(name: "contentItems")
+    @CodexImageBearingContentListConverter()
+    required List<CodexImageBearingContentDto> content,
+  }) = CodexDynamicToolCallItemDto;
+
+  const factory CodexImageBearingItemDto.unknown() = CodexUnknownImageBearingItemDto;
+
+  factory CodexImageBearingItemDto.fromJson(Map<String, dynamic> json) => _$CodexImageBearingItemDtoFromJson(json);
+}
+
+@Freezed(
+  unionKey: "type",
+  fallbackUnion: "unknown",
+  fromJson: true,
+  toJson: false,
+)
+sealed class CodexImageBearingContentDto with _$CodexImageBearingContentDto {
+  @FreezedUnionValue("text")
+  const factory CodexImageBearingContentDto.mcpText({
+    required String text,
+  }) = CodexMcpTextContentDto;
+
+  @FreezedUnionValue("image")
+  const factory CodexImageBearingContentDto.mcpImage({
+    required String data,
+    required String mimeType,
+  }) = CodexMcpImageContentDto;
+
+  @FreezedUnionValue("inputText")
+  const factory CodexImageBearingContentDto.dynamicText({
+    required String text,
+  }) = CodexDynamicTextContentDto;
+
+  @FreezedUnionValue("inputImage")
+  const factory CodexImageBearingContentDto.dynamicImage({
+    required String imageUrl,
+  }) = CodexDynamicImageContentDto;
+
+  @FreezedUnionValue("inputAudio")
+  const factory CodexImageBearingContentDto.dynamicAudio({
+    required String audioUrl,
+  }) = CodexDynamicAudioContentDto;
+
+  const factory CodexImageBearingContentDto.unknown() = CodexUnknownImageBearingContentDto;
+
+  factory CodexImageBearingContentDto.fromJson(Map<String, dynamic> json) =>
+      _$CodexImageBearingContentDtoFromJson(json);
+}
+
+class CodexImageBearingContentListConverter implements JsonConverter<List<CodexImageBearingContentDto>, Object?> {
+  const CodexImageBearingContentListConverter();
+
+  @override
+  List<CodexImageBearingContentDto> fromJson(Object? json) {
+    if (json == null) return const [];
+    if (json is! List) {
+      Log.w("[codex] skipping malformed image-bearing tool content list");
+      return const [];
+    }
+    final content = <CodexImageBearingContentDto>[];
+    for (final item in json) {
+      try {
+        content.add(
+          CodexImageBearingContentDto.fromJson(
+            (item as Map).cast<String, dynamic>(),
+          ),
+        );
+      } on Object {
+        Log.w("[codex] skipping malformed image-bearing tool content item");
+      }
+    }
+    return content;
+  }
+
+  @override
+  Object toJson(List<CodexImageBearingContentDto> object) => throw UnsupportedError("decode only");
+}
+
+class CodexMcpResultContentConverter extends CodexImageBearingContentListConverter {
+  const CodexMcpResultContentConverter();
+
+  @override
+  List<CodexImageBearingContentDto> fromJson(Object? json) {
+    if (json == null) return const [];
+    if (json is! Map) {
+      Log.w("[codex] skipping malformed MCP tool result");
+      return const [];
+    }
+    return super.fromJson(json["content"]);
+  }
+}
+
+class CodexToolErrorConverter implements JsonConverter<String?, Object?> {
+  const CodexToolErrorConverter();
+
+  @override
+  String? fromJson(Object? json) {
+    if (json == null) return null;
+    if (json is Map && json["message"] is String) {
+      return json["message"] as String;
+    }
+    Log.w("[codex] skipping malformed image-bearing tool error");
+    return null;
+  }
+
+  @override
+  Object? toJson(String? object) => throw UnsupportedError("decode only");
+}
+
+class CodexToolNameConverter implements JsonConverter<String, Object?> {
+  const CodexToolNameConverter();
+
+  @override
+  String fromJson(Object? json) {
+    if (json is String && json.isNotEmpty) return json;
+    Log.w("[codex] using fallback for malformed dynamic tool name");
+    return "tool";
+  }
+
+  @override
+  Object toJson(String object) => throw UnsupportedError("decode only");
+}

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_image_bearing_item_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_image_bearing_item_dto.freezed.dart
@@ -1,0 +1,805 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'codex_image_bearing_item_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+CodexImageBearingItemDto _$CodexImageBearingItemDtoFromJson(
+  Map<String, dynamic> json
+) {
+        switch (json['type']) {
+                  case 'imageGeneration':
+          return CodexImageGenerationItemDto.fromJson(
+            json
+          );
+                case 'mcpToolCall':
+          return CodexMcpToolCallItemDto.fromJson(
+            json
+          );
+                case 'dynamicToolCall':
+          return CodexDynamicToolCallItemDto.fromJson(
+            json
+          );
+        
+          default:
+            return CodexUnknownImageBearingItemDto.fromJson(
+  json
+);
+        }
+      
+}
+
+/// @nodoc
+mixin _$CodexImageBearingItemDto {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexImageBearingItemDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CodexImageBearingItemDto()';
+}
+
+
+}
+
+/// @nodoc
+class $CodexImageBearingItemDtoCopyWith<$Res>  {
+$CodexImageBearingItemDtoCopyWith(CodexImageBearingItemDto _, $Res Function(CodexImageBearingItemDto) __);
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexImageGenerationItemDto implements CodexImageBearingItemDto {
+  const CodexImageGenerationItemDto({required this.id, @JsonKey(unknownEnumValue: CodexImageGenerationStatus.unknown, defaultValue: CodexImageGenerationStatus.unknown) required this.status, required this.revisedPrompt, required this.result, required this.savedPath, final  String? $type}): $type = $type ?? 'imageGeneration';
+  factory CodexImageGenerationItemDto.fromJson(Map<String, dynamic> json) => _$CodexImageGenerationItemDtoFromJson(json);
+
+ final  String id;
+@JsonKey(unknownEnumValue: CodexImageGenerationStatus.unknown, defaultValue: CodexImageGenerationStatus.unknown) final  CodexImageGenerationStatus status;
+ final  String? revisedPrompt;
+ final  String result;
+ final  String? savedPath;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexImageBearingItemDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexImageGenerationItemDtoCopyWith<CodexImageGenerationItemDto> get copyWith => _$CodexImageGenerationItemDtoCopyWithImpl<CodexImageGenerationItemDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexImageGenerationItemDto&&(identical(other.id, id) || other.id == id)&&(identical(other.status, status) || other.status == status)&&(identical(other.revisedPrompt, revisedPrompt) || other.revisedPrompt == revisedPrompt)&&(identical(other.result, result) || other.result == result)&&(identical(other.savedPath, savedPath) || other.savedPath == savedPath));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,status,revisedPrompt,result,savedPath);
+
+@override
+String toString() {
+  return 'CodexImageBearingItemDto.imageGeneration(id: $id, status: $status, revisedPrompt: $revisedPrompt, result: $result, savedPath: $savedPath)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexImageGenerationItemDtoCopyWith<$Res> implements $CodexImageBearingItemDtoCopyWith<$Res> {
+  factory $CodexImageGenerationItemDtoCopyWith(CodexImageGenerationItemDto value, $Res Function(CodexImageGenerationItemDto) _then) = _$CodexImageGenerationItemDtoCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(unknownEnumValue: CodexImageGenerationStatus.unknown, defaultValue: CodexImageGenerationStatus.unknown) CodexImageGenerationStatus status, String? revisedPrompt, String result, String? savedPath
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexImageGenerationItemDtoCopyWithImpl<$Res>
+    implements $CodexImageGenerationItemDtoCopyWith<$Res> {
+  _$CodexImageGenerationItemDtoCopyWithImpl(this._self, this._then);
+
+  final CodexImageGenerationItemDto _self;
+  final $Res Function(CodexImageGenerationItemDto) _then;
+
+/// Create a copy of CodexImageBearingItemDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? id = null,Object? status = null,Object? revisedPrompt = freezed,Object? result = null,Object? savedPath = freezed,}) {
+  return _then(CodexImageGenerationItemDto(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as CodexImageGenerationStatus,revisedPrompt: freezed == revisedPrompt ? _self.revisedPrompt : revisedPrompt // ignore: cast_nullable_to_non_nullable
+as String?,result: null == result ? _self.result : result // ignore: cast_nullable_to_non_nullable
+as String,savedPath: freezed == savedPath ? _self.savedPath : savedPath // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexMcpToolCallItemDto implements CodexImageBearingItemDto {
+  const CodexMcpToolCallItemDto({required this.id, required this.server, required this.tool, @JsonKey(unknownEnumValue: CodexToolCallStatus.unknown, defaultValue: CodexToolCallStatus.unknown) required this.status, @JsonKey(name: "result")@CodexMcpResultContentConverter() required final  List<CodexImageBearingContentDto> content, @CodexToolErrorConverter() required this.error, final  String? $type}): _content = content,$type = $type ?? 'mcpToolCall';
+  factory CodexMcpToolCallItemDto.fromJson(Map<String, dynamic> json) => _$CodexMcpToolCallItemDtoFromJson(json);
+
+ final  String id;
+ final  String? server;
+ final  String? tool;
+@JsonKey(unknownEnumValue: CodexToolCallStatus.unknown, defaultValue: CodexToolCallStatus.unknown) final  CodexToolCallStatus status;
+ final  List<CodexImageBearingContentDto> _content;
+@JsonKey(name: "result")@CodexMcpResultContentConverter() List<CodexImageBearingContentDto> get content {
+  if (_content is EqualUnmodifiableListView) return _content;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_content);
+}
+
+@CodexToolErrorConverter() final  String? error;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexImageBearingItemDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexMcpToolCallItemDtoCopyWith<CodexMcpToolCallItemDto> get copyWith => _$CodexMcpToolCallItemDtoCopyWithImpl<CodexMcpToolCallItemDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexMcpToolCallItemDto&&(identical(other.id, id) || other.id == id)&&(identical(other.server, server) || other.server == server)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.status, status) || other.status == status)&&const DeepCollectionEquality().equals(other._content, _content)&&(identical(other.error, error) || other.error == error));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,server,tool,status,const DeepCollectionEquality().hash(_content),error);
+
+@override
+String toString() {
+  return 'CodexImageBearingItemDto.mcpToolCall(id: $id, server: $server, tool: $tool, status: $status, content: $content, error: $error)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexMcpToolCallItemDtoCopyWith<$Res> implements $CodexImageBearingItemDtoCopyWith<$Res> {
+  factory $CodexMcpToolCallItemDtoCopyWith(CodexMcpToolCallItemDto value, $Res Function(CodexMcpToolCallItemDto) _then) = _$CodexMcpToolCallItemDtoCopyWithImpl;
+@useResult
+$Res call({
+ String id, String? server, String? tool,@JsonKey(unknownEnumValue: CodexToolCallStatus.unknown, defaultValue: CodexToolCallStatus.unknown) CodexToolCallStatus status,@JsonKey(name: "result")@CodexMcpResultContentConverter() List<CodexImageBearingContentDto> content,@CodexToolErrorConverter() String? error
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexMcpToolCallItemDtoCopyWithImpl<$Res>
+    implements $CodexMcpToolCallItemDtoCopyWith<$Res> {
+  _$CodexMcpToolCallItemDtoCopyWithImpl(this._self, this._then);
+
+  final CodexMcpToolCallItemDto _self;
+  final $Res Function(CodexMcpToolCallItemDto) _then;
+
+/// Create a copy of CodexImageBearingItemDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? id = null,Object? server = freezed,Object? tool = freezed,Object? status = null,Object? content = null,Object? error = freezed,}) {
+  return _then(CodexMcpToolCallItemDto(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,server: freezed == server ? _self.server : server // ignore: cast_nullable_to_non_nullable
+as String?,tool: freezed == tool ? _self.tool : tool // ignore: cast_nullable_to_non_nullable
+as String?,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as CodexToolCallStatus,content: null == content ? _self._content : content // ignore: cast_nullable_to_non_nullable
+as List<CodexImageBearingContentDto>,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexDynamicToolCallItemDto implements CodexImageBearingItemDto {
+  const CodexDynamicToolCallItemDto({required this.id, @CodexToolNameConverter() required this.tool, required this.arguments, @JsonKey(unknownEnumValue: CodexToolCallStatus.unknown, defaultValue: CodexToolCallStatus.unknown) required this.status, @JsonKey(name: "contentItems")@CodexImageBearingContentListConverter() required final  List<CodexImageBearingContentDto> content, final  String? $type}): _content = content,$type = $type ?? 'dynamicToolCall';
+  factory CodexDynamicToolCallItemDto.fromJson(Map<String, dynamic> json) => _$CodexDynamicToolCallItemDtoFromJson(json);
+
+ final  String id;
+@CodexToolNameConverter() final  String tool;
+ final  Object? arguments;
+@JsonKey(unknownEnumValue: CodexToolCallStatus.unknown, defaultValue: CodexToolCallStatus.unknown) final  CodexToolCallStatus status;
+ final  List<CodexImageBearingContentDto> _content;
+@JsonKey(name: "contentItems")@CodexImageBearingContentListConverter() List<CodexImageBearingContentDto> get content {
+  if (_content is EqualUnmodifiableListView) return _content;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_content);
+}
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexImageBearingItemDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexDynamicToolCallItemDtoCopyWith<CodexDynamicToolCallItemDto> get copyWith => _$CodexDynamicToolCallItemDtoCopyWithImpl<CodexDynamicToolCallItemDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexDynamicToolCallItemDto&&(identical(other.id, id) || other.id == id)&&(identical(other.tool, tool) || other.tool == tool)&&const DeepCollectionEquality().equals(other.arguments, arguments)&&(identical(other.status, status) || other.status == status)&&const DeepCollectionEquality().equals(other._content, _content));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,tool,const DeepCollectionEquality().hash(arguments),status,const DeepCollectionEquality().hash(_content));
+
+@override
+String toString() {
+  return 'CodexImageBearingItemDto.dynamicToolCall(id: $id, tool: $tool, arguments: $arguments, status: $status, content: $content)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexDynamicToolCallItemDtoCopyWith<$Res> implements $CodexImageBearingItemDtoCopyWith<$Res> {
+  factory $CodexDynamicToolCallItemDtoCopyWith(CodexDynamicToolCallItemDto value, $Res Function(CodexDynamicToolCallItemDto) _then) = _$CodexDynamicToolCallItemDtoCopyWithImpl;
+@useResult
+$Res call({
+ String id,@CodexToolNameConverter() String tool, Object? arguments,@JsonKey(unknownEnumValue: CodexToolCallStatus.unknown, defaultValue: CodexToolCallStatus.unknown) CodexToolCallStatus status,@JsonKey(name: "contentItems")@CodexImageBearingContentListConverter() List<CodexImageBearingContentDto> content
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexDynamicToolCallItemDtoCopyWithImpl<$Res>
+    implements $CodexDynamicToolCallItemDtoCopyWith<$Res> {
+  _$CodexDynamicToolCallItemDtoCopyWithImpl(this._self, this._then);
+
+  final CodexDynamicToolCallItemDto _self;
+  final $Res Function(CodexDynamicToolCallItemDto) _then;
+
+/// Create a copy of CodexImageBearingItemDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? id = null,Object? tool = null,Object? arguments = freezed,Object? status = null,Object? content = null,}) {
+  return _then(CodexDynamicToolCallItemDto(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,tool: null == tool ? _self.tool : tool // ignore: cast_nullable_to_non_nullable
+as String,arguments: freezed == arguments ? _self.arguments : arguments ,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as CodexToolCallStatus,content: null == content ? _self._content : content // ignore: cast_nullable_to_non_nullable
+as List<CodexImageBearingContentDto>,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexUnknownImageBearingItemDto implements CodexImageBearingItemDto {
+  const CodexUnknownImageBearingItemDto({final  String? $type}): $type = $type ?? 'unknown';
+  factory CodexUnknownImageBearingItemDto.fromJson(Map<String, dynamic> json) => _$CodexUnknownImageBearingItemDtoFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexUnknownImageBearingItemDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CodexImageBearingItemDto.unknown()';
+}
+
+
+}
+
+
+
+
+CodexImageBearingContentDto _$CodexImageBearingContentDtoFromJson(
+  Map<String, dynamic> json
+) {
+        switch (json['type']) {
+                  case 'text':
+          return CodexMcpTextContentDto.fromJson(
+            json
+          );
+                case 'image':
+          return CodexMcpImageContentDto.fromJson(
+            json
+          );
+                case 'inputText':
+          return CodexDynamicTextContentDto.fromJson(
+            json
+          );
+                case 'inputImage':
+          return CodexDynamicImageContentDto.fromJson(
+            json
+          );
+                case 'inputAudio':
+          return CodexDynamicAudioContentDto.fromJson(
+            json
+          );
+        
+          default:
+            return CodexUnknownImageBearingContentDto.fromJson(
+  json
+);
+        }
+      
+}
+
+/// @nodoc
+mixin _$CodexImageBearingContentDto {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexImageBearingContentDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CodexImageBearingContentDto()';
+}
+
+
+}
+
+/// @nodoc
+class $CodexImageBearingContentDtoCopyWith<$Res>  {
+$CodexImageBearingContentDtoCopyWith(CodexImageBearingContentDto _, $Res Function(CodexImageBearingContentDto) __);
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexMcpTextContentDto implements CodexImageBearingContentDto {
+  const CodexMcpTextContentDto({required this.text, final  String? $type}): $type = $type ?? 'text';
+  factory CodexMcpTextContentDto.fromJson(Map<String, dynamic> json) => _$CodexMcpTextContentDtoFromJson(json);
+
+ final  String text;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexImageBearingContentDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexMcpTextContentDtoCopyWith<CodexMcpTextContentDto> get copyWith => _$CodexMcpTextContentDtoCopyWithImpl<CodexMcpTextContentDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexMcpTextContentDto&&(identical(other.text, text) || other.text == text));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,text);
+
+@override
+String toString() {
+  return 'CodexImageBearingContentDto.mcpText(text: $text)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexMcpTextContentDtoCopyWith<$Res> implements $CodexImageBearingContentDtoCopyWith<$Res> {
+  factory $CodexMcpTextContentDtoCopyWith(CodexMcpTextContentDto value, $Res Function(CodexMcpTextContentDto) _then) = _$CodexMcpTextContentDtoCopyWithImpl;
+@useResult
+$Res call({
+ String text
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexMcpTextContentDtoCopyWithImpl<$Res>
+    implements $CodexMcpTextContentDtoCopyWith<$Res> {
+  _$CodexMcpTextContentDtoCopyWithImpl(this._self, this._then);
+
+  final CodexMcpTextContentDto _self;
+  final $Res Function(CodexMcpTextContentDto) _then;
+
+/// Create a copy of CodexImageBearingContentDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? text = null,}) {
+  return _then(CodexMcpTextContentDto(
+text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexMcpImageContentDto implements CodexImageBearingContentDto {
+  const CodexMcpImageContentDto({required this.data, required this.mimeType, final  String? $type}): $type = $type ?? 'image';
+  factory CodexMcpImageContentDto.fromJson(Map<String, dynamic> json) => _$CodexMcpImageContentDtoFromJson(json);
+
+ final  String data;
+ final  String mimeType;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexImageBearingContentDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexMcpImageContentDtoCopyWith<CodexMcpImageContentDto> get copyWith => _$CodexMcpImageContentDtoCopyWithImpl<CodexMcpImageContentDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexMcpImageContentDto&&(identical(other.data, data) || other.data == data)&&(identical(other.mimeType, mimeType) || other.mimeType == mimeType));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,data,mimeType);
+
+@override
+String toString() {
+  return 'CodexImageBearingContentDto.mcpImage(data: $data, mimeType: $mimeType)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexMcpImageContentDtoCopyWith<$Res> implements $CodexImageBearingContentDtoCopyWith<$Res> {
+  factory $CodexMcpImageContentDtoCopyWith(CodexMcpImageContentDto value, $Res Function(CodexMcpImageContentDto) _then) = _$CodexMcpImageContentDtoCopyWithImpl;
+@useResult
+$Res call({
+ String data, String mimeType
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexMcpImageContentDtoCopyWithImpl<$Res>
+    implements $CodexMcpImageContentDtoCopyWith<$Res> {
+  _$CodexMcpImageContentDtoCopyWithImpl(this._self, this._then);
+
+  final CodexMcpImageContentDto _self;
+  final $Res Function(CodexMcpImageContentDto) _then;
+
+/// Create a copy of CodexImageBearingContentDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? data = null,Object? mimeType = null,}) {
+  return _then(CodexMcpImageContentDto(
+data: null == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as String,mimeType: null == mimeType ? _self.mimeType : mimeType // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexDynamicTextContentDto implements CodexImageBearingContentDto {
+  const CodexDynamicTextContentDto({required this.text, final  String? $type}): $type = $type ?? 'inputText';
+  factory CodexDynamicTextContentDto.fromJson(Map<String, dynamic> json) => _$CodexDynamicTextContentDtoFromJson(json);
+
+ final  String text;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexImageBearingContentDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexDynamicTextContentDtoCopyWith<CodexDynamicTextContentDto> get copyWith => _$CodexDynamicTextContentDtoCopyWithImpl<CodexDynamicTextContentDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexDynamicTextContentDto&&(identical(other.text, text) || other.text == text));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,text);
+
+@override
+String toString() {
+  return 'CodexImageBearingContentDto.dynamicText(text: $text)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexDynamicTextContentDtoCopyWith<$Res> implements $CodexImageBearingContentDtoCopyWith<$Res> {
+  factory $CodexDynamicTextContentDtoCopyWith(CodexDynamicTextContentDto value, $Res Function(CodexDynamicTextContentDto) _then) = _$CodexDynamicTextContentDtoCopyWithImpl;
+@useResult
+$Res call({
+ String text
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexDynamicTextContentDtoCopyWithImpl<$Res>
+    implements $CodexDynamicTextContentDtoCopyWith<$Res> {
+  _$CodexDynamicTextContentDtoCopyWithImpl(this._self, this._then);
+
+  final CodexDynamicTextContentDto _self;
+  final $Res Function(CodexDynamicTextContentDto) _then;
+
+/// Create a copy of CodexImageBearingContentDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? text = null,}) {
+  return _then(CodexDynamicTextContentDto(
+text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexDynamicImageContentDto implements CodexImageBearingContentDto {
+  const CodexDynamicImageContentDto({required this.imageUrl, final  String? $type}): $type = $type ?? 'inputImage';
+  factory CodexDynamicImageContentDto.fromJson(Map<String, dynamic> json) => _$CodexDynamicImageContentDtoFromJson(json);
+
+ final  String imageUrl;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexImageBearingContentDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexDynamicImageContentDtoCopyWith<CodexDynamicImageContentDto> get copyWith => _$CodexDynamicImageContentDtoCopyWithImpl<CodexDynamicImageContentDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexDynamicImageContentDto&&(identical(other.imageUrl, imageUrl) || other.imageUrl == imageUrl));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,imageUrl);
+
+@override
+String toString() {
+  return 'CodexImageBearingContentDto.dynamicImage(imageUrl: $imageUrl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexDynamicImageContentDtoCopyWith<$Res> implements $CodexImageBearingContentDtoCopyWith<$Res> {
+  factory $CodexDynamicImageContentDtoCopyWith(CodexDynamicImageContentDto value, $Res Function(CodexDynamicImageContentDto) _then) = _$CodexDynamicImageContentDtoCopyWithImpl;
+@useResult
+$Res call({
+ String imageUrl
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexDynamicImageContentDtoCopyWithImpl<$Res>
+    implements $CodexDynamicImageContentDtoCopyWith<$Res> {
+  _$CodexDynamicImageContentDtoCopyWithImpl(this._self, this._then);
+
+  final CodexDynamicImageContentDto _self;
+  final $Res Function(CodexDynamicImageContentDto) _then;
+
+/// Create a copy of CodexImageBearingContentDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? imageUrl = null,}) {
+  return _then(CodexDynamicImageContentDto(
+imageUrl: null == imageUrl ? _self.imageUrl : imageUrl // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexDynamicAudioContentDto implements CodexImageBearingContentDto {
+  const CodexDynamicAudioContentDto({required this.audioUrl, final  String? $type}): $type = $type ?? 'inputAudio';
+  factory CodexDynamicAudioContentDto.fromJson(Map<String, dynamic> json) => _$CodexDynamicAudioContentDtoFromJson(json);
+
+ final  String audioUrl;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexImageBearingContentDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexDynamicAudioContentDtoCopyWith<CodexDynamicAudioContentDto> get copyWith => _$CodexDynamicAudioContentDtoCopyWithImpl<CodexDynamicAudioContentDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexDynamicAudioContentDto&&(identical(other.audioUrl, audioUrl) || other.audioUrl == audioUrl));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,audioUrl);
+
+@override
+String toString() {
+  return 'CodexImageBearingContentDto.dynamicAudio(audioUrl: $audioUrl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexDynamicAudioContentDtoCopyWith<$Res> implements $CodexImageBearingContentDtoCopyWith<$Res> {
+  factory $CodexDynamicAudioContentDtoCopyWith(CodexDynamicAudioContentDto value, $Res Function(CodexDynamicAudioContentDto) _then) = _$CodexDynamicAudioContentDtoCopyWithImpl;
+@useResult
+$Res call({
+ String audioUrl
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexDynamicAudioContentDtoCopyWithImpl<$Res>
+    implements $CodexDynamicAudioContentDtoCopyWith<$Res> {
+  _$CodexDynamicAudioContentDtoCopyWithImpl(this._self, this._then);
+
+  final CodexDynamicAudioContentDto _self;
+  final $Res Function(CodexDynamicAudioContentDto) _then;
+
+/// Create a copy of CodexImageBearingContentDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? audioUrl = null,}) {
+  return _then(CodexDynamicAudioContentDto(
+audioUrl: null == audioUrl ? _self.audioUrl : audioUrl // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexUnknownImageBearingContentDto implements CodexImageBearingContentDto {
+  const CodexUnknownImageBearingContentDto({final  String? $type}): $type = $type ?? 'unknown';
+  factory CodexUnknownImageBearingContentDto.fromJson(Map<String, dynamic> json) => _$CodexUnknownImageBearingContentDtoFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexUnknownImageBearingContentDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CodexImageBearingContentDto.unknown()';
+}
+
+
+}
+
+
+
+
+// dart format on

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_image_bearing_item_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_image_bearing_item_dto.g.dart
@@ -1,0 +1,112 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'codex_image_bearing_item_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CodexImageGenerationItemDto _$CodexImageGenerationItemDtoFromJson(Map json) =>
+    CodexImageGenerationItemDto(
+      id: json['id'] as String,
+      status:
+          $enumDecodeNullable(
+            _$CodexImageGenerationStatusEnumMap,
+            json['status'],
+            unknownValue: CodexImageGenerationStatus.unknown,
+          ) ??
+          CodexImageGenerationStatus.unknown,
+      revisedPrompt: json['revisedPrompt'] as String?,
+      result: json['result'] as String,
+      savedPath: json['savedPath'] as String?,
+      $type: json['type'] as String?,
+    );
+
+const _$CodexImageGenerationStatusEnumMap = {
+  CodexImageGenerationStatus.inProgress: 'in_progress',
+  CodexImageGenerationStatus.completed: 'completed',
+  CodexImageGenerationStatus.failed: 'failed',
+  CodexImageGenerationStatus.unknown: 'unknown',
+};
+
+CodexMcpToolCallItemDto _$CodexMcpToolCallItemDtoFromJson(Map json) =>
+    CodexMcpToolCallItemDto(
+      id: json['id'] as String,
+      server: json['server'] as String?,
+      tool: json['tool'] as String?,
+      status:
+          $enumDecodeNullable(
+            _$CodexToolCallStatusEnumMap,
+            json['status'],
+            unknownValue: CodexToolCallStatus.unknown,
+          ) ??
+          CodexToolCallStatus.unknown,
+      content: const CodexMcpResultContentConverter().fromJson(json['result']),
+      error: const CodexToolErrorConverter().fromJson(json['error']),
+      $type: json['type'] as String?,
+    );
+
+const _$CodexToolCallStatusEnumMap = {
+  CodexToolCallStatus.inProgress: 'inProgress',
+  CodexToolCallStatus.completed: 'completed',
+  CodexToolCallStatus.failed: 'failed',
+  CodexToolCallStatus.declined: 'declined',
+  CodexToolCallStatus.unknown: 'unknown',
+};
+
+CodexDynamicToolCallItemDto _$CodexDynamicToolCallItemDtoFromJson(Map json) =>
+    CodexDynamicToolCallItemDto(
+      id: json['id'] as String,
+      tool: const CodexToolNameConverter().fromJson(json['tool']),
+      arguments: json['arguments'],
+      status:
+          $enumDecodeNullable(
+            _$CodexToolCallStatusEnumMap,
+            json['status'],
+            unknownValue: CodexToolCallStatus.unknown,
+          ) ??
+          CodexToolCallStatus.unknown,
+      content: const CodexImageBearingContentListConverter().fromJson(
+        json['contentItems'],
+      ),
+      $type: json['type'] as String?,
+    );
+
+CodexUnknownImageBearingItemDto _$CodexUnknownImageBearingItemDtoFromJson(
+  Map json,
+) => CodexUnknownImageBearingItemDto($type: json['type'] as String?);
+
+CodexMcpTextContentDto _$CodexMcpTextContentDtoFromJson(Map json) =>
+    CodexMcpTextContentDto(
+      text: json['text'] as String,
+      $type: json['type'] as String?,
+    );
+
+CodexMcpImageContentDto _$CodexMcpImageContentDtoFromJson(Map json) =>
+    CodexMcpImageContentDto(
+      data: json['data'] as String,
+      mimeType: json['mimeType'] as String,
+      $type: json['type'] as String?,
+    );
+
+CodexDynamicTextContentDto _$CodexDynamicTextContentDtoFromJson(Map json) =>
+    CodexDynamicTextContentDto(
+      text: json['text'] as String,
+      $type: json['type'] as String?,
+    );
+
+CodexDynamicImageContentDto _$CodexDynamicImageContentDtoFromJson(Map json) =>
+    CodexDynamicImageContentDto(
+      imageUrl: json['imageUrl'] as String,
+      $type: json['type'] as String?,
+    );
+
+CodexDynamicAudioContentDto _$CodexDynamicAudioContentDtoFromJson(Map json) =>
+    CodexDynamicAudioContentDto(
+      audioUrl: json['audioUrl'] as String,
+      $type: json['type'] as String?,
+    );
+
+CodexUnknownImageBearingContentDto _$CodexUnknownImageBearingContentDtoFromJson(
+  Map json,
+) => CodexUnknownImageBearingContentDto($type: json['type'] as String?);

--- a/bridge/sesori_plugin_codex/lib/src/api/parsers/codex_image_bearing_item_parser.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/parsers/codex_image_bearing_item_parser.dart
@@ -1,0 +1,20 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
+import "../models/codex_image_bearing_item_dto.dart";
+
+/// Parses app-server items that can carry generated image content.
+///
+/// This boundary retains typed image/audio fields for later mapping while
+/// exposing only existing text behavior to consumers in this step.
+class CodexImageBearingItemParser {
+  const CodexImageBearingItemParser();
+
+  CodexImageBearingItemDto? parse({required Map<String, dynamic> item}) {
+    try {
+      return CodexImageBearingItemDto.fromJson(item);
+    } on Object {
+      Log.w("[codex] skipping malformed image-bearing app-server item");
+      return null;
+    }
+  }
+}

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -358,7 +358,7 @@ class CodexEventMapper {
           tool: tool ?? "mcp",
           title: _mcpToolTitle(server: server, tool: tool),
           status: _parsedToolStatus(status: status, completed: completed),
-          output: _imageBearingToolOutput(content),
+          output: _imageBearingToolOutput(content: content),
           error: error,
         );
       case CodexDynamicToolCallItemDto(
@@ -385,7 +385,7 @@ class CodexEventMapper {
           output:
               canonical?.result.output ??
               _rolloutToolMapper.clipOutput(
-                _imageBearingToolOutput(content),
+                _imageBearingToolOutput(content: content),
               ),
         );
       case CodexUnknownImageBearingItemDto() || null:
@@ -621,7 +621,9 @@ class CodexEventMapper {
     return rendered.length > 120 ? rendered.substring(0, 120) : rendered;
   }
 
-  String? _imageBearingToolOutput(List<CodexImageBearingContentDto> content) {
+  String? _imageBearingToolOutput({
+    required List<CodexImageBearingContentDto> content,
+  }) {
     final texts = [
       for (final item in content)
         if (item case CodexMcpTextContentDto(:final text) || CodexDynamicTextContentDto(:final text)

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -2,7 +2,9 @@ import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show nor
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" as shared;
 
+import "api/models/codex_image_bearing_item_dto.dart";
 import "api/models/codex_rollout_dto.dart";
+import "api/parsers/codex_image_bearing_item_parser.dart";
 import "codex_app_server_client.dart";
 import "codex_config_reader.dart";
 import "repositories/mappers/codex_rollout_tool_mapper.dart";
@@ -28,9 +30,11 @@ class CodexEventMapper {
   CodexEventMapper({
     required this.pluginId,
     required this.projectCwd,
+    required CodexImageBearingItemParser imageBearingItemParser,
     required CodexRolloutToolMapper rolloutToolMapper,
     this.config = const CodexConfigDefaults.empty(),
-  }) : _rolloutToolMapper = rolloutToolMapper;
+  }) : _imageBearingItemParser = imageBearingItemParser,
+       _rolloutToolMapper = rolloutToolMapper;
 
   final String pluginId;
 
@@ -56,6 +60,7 @@ class CodexEventMapper {
   /// global [config] default — making a model switch look like it never took
   /// effect even though codex honoured it. Falls back to [config] when unknown.
   final Map<String, String> _threadModel = {};
+  final CodexImageBearingItemParser _imageBearingItemParser;
   final CodexRolloutToolMapper _rolloutToolMapper;
 
   /// Raw rollout state keyed by the same `call_id` app-server uses as a
@@ -336,6 +341,57 @@ class CodexEventMapper {
     final itemId = item["id"] as String?;
     if (itemId == null || itemId.isEmpty) return const [];
 
+    final imageBearingItem = _imageBearingItemParser.parse(item: item);
+    switch (imageBearingItem) {
+      case CodexImageGenerationItemDto():
+        return const [];
+      case CodexMcpToolCallItemDto(
+        :final server,
+        :final tool,
+        :final status,
+        :final content,
+        :final error,
+      ):
+        return _toolItemEvents(
+          threadId: threadId,
+          itemId: itemId,
+          tool: tool ?? "mcp",
+          title: _mcpToolTitle(server: server, tool: tool),
+          status: _parsedToolStatus(status: status, completed: completed),
+          output: _imageBearingToolOutput(content),
+          error: error,
+        );
+      case CodexDynamicToolCallItemDto(
+        :final tool,
+        :final arguments,
+        :final status,
+        :final content,
+      ):
+        final canonical = _canonicalRolloutTool(
+          threadId: threadId,
+          itemId: itemId,
+        );
+        return _toolItemEvents(
+          threadId: threadId,
+          itemId: itemId,
+          tool: canonical?.call.tool ?? tool,
+          title: canonical?.call.title ?? _dynamicToolTitle(arguments),
+          status:
+              canonical?.result.status ??
+              _parsedToolStatus(
+                status: status,
+                completed: completed,
+              ),
+          output:
+              canonical?.result.output ??
+              _rolloutToolMapper.clipOutput(
+                _imageBearingToolOutput(content),
+              ),
+        );
+      case CodexUnknownImageBearingItemDto() || null:
+        break;
+    }
+
     switch (item["type"] as String?) {
       case "userMessage":
         return _messageEvents(
@@ -406,38 +462,6 @@ class CodexEventMapper {
           title: _fileChangeTitle(item["changes"]),
           status: _toolStatus(item["status"], completed: completed),
           output: _fileChangeOutput(item["changes"]),
-        );
-      case "mcpToolCall":
-        return _toolItemEvents(
-          threadId: threadId,
-          itemId: itemId,
-          tool: item["tool"] as String? ?? "mcp",
-          title: _mcpToolTitle(item),
-          status: _toolStatus(item["status"], completed: completed),
-          output: _mcpResultText(item["result"]),
-          error: _asMap(item["error"])?["message"] as String?,
-        );
-      case "dynamicToolCall":
-        final canonical = _canonicalRolloutTool(
-          threadId: threadId,
-          itemId: itemId,
-        );
-        return _toolItemEvents(
-          threadId: threadId,
-          itemId: itemId,
-          tool:
-              canonical?.call.tool ??
-              switch (item["tool"]) {
-                final String tool when tool.isNotEmpty => tool,
-                _ => "tool",
-              },
-          title: canonical?.call.title ?? _dynamicToolTitle(item["arguments"]),
-          status: canonical?.result.status ?? _toolStatus(item["status"], completed: completed),
-          output:
-              canonical?.result.output ??
-              _rolloutToolMapper.clipOutput(
-                _dynamicToolOutput(item["contentItems"]),
-              ),
         );
       case "webSearch":
         return _toolItemEvents(
@@ -529,6 +553,18 @@ class CodexEventMapper {
     return completed ? PluginToolStatus.completed : PluginToolStatus.running;
   }
 
+  PluginToolStatus _parsedToolStatus({
+    required CodexToolCallStatus status,
+    required bool completed,
+  }) {
+    return switch (status) {
+      CodexToolCallStatus.inProgress => PluginToolStatus.running,
+      CodexToolCallStatus.completed => PluginToolStatus.completed,
+      CodexToolCallStatus.failed || CodexToolCallStatus.declined => PluginToolStatus.error,
+      CodexToolCallStatus.unknown => completed ? PluginToolStatus.completed : PluginToolStatus.running,
+    };
+  }
+
   ({CodexRolloutToolCall call, CodexRolloutToolResult result})? _canonicalRolloutTool({
     required String threadId,
     required String itemId,
@@ -567,25 +603,12 @@ class CodexEventMapper {
   }
 
   /// A short title for an `mcpToolCall` item (`server/tool`).
-  String? _mcpToolTitle(Map<String, dynamic> item) {
-    final server = item["server"] as String?;
-    final tool = item["tool"] as String?;
+  String? _mcpToolTitle({
+    required String? server,
+    required String? tool,
+  }) {
     if (server != null && tool != null) return "$server/$tool";
     return tool ?? server;
-  }
-
-  /// Best-effort text rendering of an `mcpToolCall` result
-  /// (`{content: [{type:text, text}, …]}`).
-  String? _mcpResultText(Object? result) {
-    final content = _asMap(result)?["content"];
-    if (content is! List) return null;
-    final buffer = StringBuffer();
-    for (final entry in content) {
-      final text = _asMap(entry)?["text"];
-      if (text is String) buffer.write(text);
-    }
-    final out = buffer.toString();
-    return out.isEmpty ? null : out;
   }
 
   /// A concise rendering of the JSON-compatible arguments attached to a
@@ -598,17 +621,14 @@ class CodexEventMapper {
     return rendered.length > 120 ? rendered.substring(0, 120) : rendered;
   }
 
-  /// Concatenates text outputs from a completed `dynamicToolCall`. Image
-  /// outputs have no bridge tool-state representation and are ignored.
-  String? _dynamicToolOutput(Object? contentItems) {
-    if (contentItems is! List) return null;
-    final buffer = StringBuffer();
-    for (final entry in contentItems) {
-      final text = _asMap(entry)?["text"];
-      if (text is String) buffer.write(text);
-    }
-    final output = buffer.toString();
-    return output.isEmpty ? null : output;
+  String? _imageBearingToolOutput(List<CodexImageBearingContentDto> content) {
+    final texts = [
+      for (final item in content)
+        if (item case CodexMcpTextContentDto(:final text) || CodexDynamicTextContentDto(:final text)
+            when text.isNotEmpty)
+          text,
+    ];
+    return texts.isEmpty ? null : texts.join();
   }
 
   /// Builds an assistant message stamped with codex's agent/model/provider.

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -7,6 +7,7 @@ import "package:sesori_shared/sesori_shared.dart" show Harness;
 
 import "api/codex_app_server_api.dart";
 import "api/codex_rollout_api.dart";
+import "api/parsers/codex_image_bearing_item_parser.dart";
 import "approval_registry.dart";
 import "codex_app_server_client.dart";
 import "codex_config_reader.dart";
@@ -126,6 +127,7 @@ class CodexPlugin implements CodexManagedApi {
     final resolvedProjectCwd = projectCwd ?? Directory.current.path;
     final configReader = CodexConfigReader();
     final rolloutApi = CodexRolloutApi();
+    const imageBearingItemParser = CodexImageBearingItemParser();
     const rolloutToolMapper = CodexRolloutToolMapper();
     final catalogRepository = CodexCatalogRepository(rolloutApi: rolloutApi);
     final rolloutTailer = CodexRolloutTailer(
@@ -154,6 +156,7 @@ class CodexPlugin implements CodexManagedApi {
       eventMapper: CodexEventMapper(
         pluginId: pluginId,
         projectCwd: resolvedProjectCwd,
+        imageBearingItemParser: imageBearingItemParser,
         rolloutToolMapper: rolloutToolMapper,
         config: configReader.readDefaults(),
       ),

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -3,6 +3,7 @@ import "dart:io";
 import "package:codex_plugin/codex_plugin.dart";
 import "package:codex_plugin/src/api/codex_app_server_api.dart";
 import "package:codex_plugin/src/api/models/codex_rollout_dto.dart";
+import "package:codex_plugin/src/api/parsers/codex_image_bearing_item_parser.dart";
 import "package:codex_plugin/src/repositories/codex_thread_repository.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" as shared;
@@ -16,10 +17,12 @@ import "package:test/test.dart";
 void main() {
   group("CodexEventMapper", () {
     const projectCwd = "/repo/app";
+    const imageBearingItemParser = CodexImageBearingItemParser();
     const rolloutToolMapper = CodexRolloutToolMapper();
     final mapper = CodexEventMapper(
       pluginId: CodexPlugin.pluginId,
       projectCwd: projectCwd,
+      imageBearingItemParser: imageBearingItemParser,
       rolloutToolMapper: rolloutToolMapper,
     );
     final appServerApi = CodexAppServerApi(
@@ -168,6 +171,7 @@ void main() {
       final scopedMapper = CodexEventMapper(
         pluginId: CodexPlugin.pluginId,
         projectCwd: projectCwd,
+        imageBearingItemParser: imageBearingItemParser,
         rolloutToolMapper: rolloutToolMapper,
       )..setThreadDirectory("t-9", "/repo/app/packages/ui");
 
@@ -186,6 +190,7 @@ void main() {
       final activityMapper = CodexEventMapper(
         pluginId: CodexPlugin.pluginId,
         projectCwd: projectCwd,
+        imageBearingItemParser: imageBearingItemParser,
         rolloutToolMapper: rolloutToolMapper,
       );
       mapThreadStarted(
@@ -231,6 +236,7 @@ void main() {
       final activityMapper = CodexEventMapper(
         pluginId: CodexPlugin.pluginId,
         projectCwd: projectCwd,
+        imageBearingItemParser: imageBearingItemParser,
         rolloutToolMapper: rolloutToolMapper,
       );
       mapThreadStarted(
@@ -401,6 +407,7 @@ void main() {
       final richMapper = CodexEventMapper(
         pluginId: CodexPlugin.pluginId,
         projectCwd: projectCwd,
+        imageBearingItemParser: imageBearingItemParser,
         rolloutToolMapper: rolloutToolMapper,
         config: const CodexConfigDefaults(model: "gpt-5.5", modelProvider: "openai"),
       );
@@ -439,6 +446,7 @@ void main() {
       final richMapper = CodexEventMapper(
         pluginId: CodexPlugin.pluginId,
         projectCwd: projectCwd,
+        imageBearingItemParser: imageBearingItemParser,
         rolloutToolMapper: rolloutToolMapper,
         config: const CodexConfigDefaults(model: "gpt-5.5", modelProvider: "openai"),
       );
@@ -775,6 +783,33 @@ void main() {
       expect(part.state?.output, contains("+b"));
     });
 
+    test("imageGeneration items remain deliberately unrendered", () {
+      for (final (method, status) in [
+        ("item/started", "in_progress"),
+        ("item/completed", "completed"),
+        ("item/completed", "failed"),
+      ]) {
+        final events = mapper.map(
+          CodexServerNotification(
+            method: method,
+            params: {
+              "threadId": "t-1",
+              "item": {
+                "type": "imageGeneration",
+                "id": "i-image",
+                "status": status,
+                "revisedPrompt": "private prompt",
+                "result": "private image payload",
+                "savedPath": "/private/output.png",
+              },
+            },
+          ),
+        );
+
+        expect(events, isEmpty);
+      }
+    });
+
     test("mcpToolCall (failed) → error tool part", () {
       final events = mapper.map(
         const CodexServerNotification(
@@ -787,6 +822,13 @@ void main() {
               "server": "playwright",
               "tool": "click",
               "status": "failed",
+              "result": {
+                "content": [
+                  {"type": "text", "text": "before "},
+                  {"type": "image", "data": "encoded-image", "mimeType": "image/png"},
+                  {"type": "text", "text": "after"},
+                ],
+              },
               "error": {"message": "element not found"},
             },
           },
@@ -797,7 +839,9 @@ void main() {
       expect(part.tool, "click");
       expect(part.state?.status, PluginToolStatus.error);
       expect(part.state?.title, "playwright/click");
+      expect(part.state?.output, "before after");
       expect(part.state?.error, "element not found");
+      expect(part.state?.attachments, isEmpty);
     });
 
     test("dynamicToolCall streams a running tool and its completed output", () {
@@ -853,6 +897,8 @@ void main() {
               "status": "completed",
               "contentItems": [
                 {"type": "inputText", "text": "wait completed"},
+                {"type": "inputImage", "imageUrl": "data:image/png;base64,AA=="},
+                {"type": "inputAudio", "audioUrl": "data:audio/wav;base64,AA=="},
               ],
               "durationMs": 2000,
               "success": true,
@@ -866,13 +912,17 @@ void main() {
       expect(completedPart.id, runningPart.id);
       expect(completedPart.state?.status, PluginToolStatus.completed);
       expect(completedPart.state?.output, "wait completed");
+      expect(completedPart.state?.attachments, isEmpty);
     });
 
     test("dynamicToolCall falls back for malformed or empty tool names", () {
-      for (final rawTool in <Object?>[42, ""]) {
+      for (final (rawTool, method, status, expectedStatus) in <(Object?, String, Object?, PluginToolStatus)>[
+        (42, "item/started", "future_status", PluginToolStatus.running),
+        ("", "item/completed", null, PluginToolStatus.completed),
+      ]) {
         final events = mapper.map(
           CodexServerNotification(
-            method: "item/started",
+            method: method,
             params: {
               "threadId": "t-1",
               "item": {
@@ -880,7 +930,7 @@ void main() {
                 "id": "i-fallback",
                 "tool": rawTool,
                 "arguments": const <String, Object?>{},
-                "status": "inProgress",
+                "status": status,
               },
             },
           ),
@@ -888,7 +938,7 @@ void main() {
 
         final part = (events[1] as BridgeSseMessagePartUpdated).part;
         expect(part.tool, "tool");
-        expect(part.state?.status, PluginToolStatus.running);
+        expect(part.state?.status, expectedStatus);
       }
     });
 

--- a/bridge/sesori_plugin_codex/test/codex_image_bearing_item_parser_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_image_bearing_item_parser_test.dart
@@ -1,0 +1,116 @@
+import "package:codex_plugin/src/api/models/codex_image_bearing_item_dto.dart";
+import "package:codex_plugin/src/api/parsers/codex_image_bearing_item_parser.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("CodexImageBearingItemParser", () {
+    const parser = CodexImageBearingItemParser();
+
+    test("decodes image generation statuses and fields", () {
+      final completed = parser.parse(
+        item: {
+          "type": "imageGeneration",
+          "id": "image-1",
+          "status": "completed",
+          "revisedPrompt": "draw a landscape",
+          "result": "encoded-image",
+          "savedPath": "/private/output.png",
+        },
+      );
+      final unknown = parser.parse(
+        item: {
+          "type": "imageGeneration",
+          "id": "image-2",
+          "status": "future_status",
+          "revisedPrompt": null,
+          "result": "",
+        },
+      );
+
+      expect(completed, isA<CodexImageGenerationItemDto>());
+      final image = completed! as CodexImageGenerationItemDto;
+      expect(image.status, CodexImageGenerationStatus.completed);
+      expect(image.revisedPrompt, "draw a landscape");
+      expect(image.result, "encoded-image");
+      expect(image.savedPath, "/private/output.png");
+      expect((unknown! as CodexImageGenerationItemDto).status, CodexImageGenerationStatus.unknown);
+    });
+
+    test("decodes MCP text and image content without retaining unknown payloads", () {
+      final item = parser.parse(
+        item: {
+          "type": "mcpToolCall",
+          "id": "mcp-1",
+          "server": "playwright",
+          "tool": "screenshot",
+          "status": "failed",
+          "result": {
+            "content": [
+              {"type": "text", "text": "before"},
+              {"type": "image", "data": "encoded-image", "mimeType": "image/png"},
+              {"type": "future_content", "secret": "ignored"},
+              {"type": "text", "text": "after"},
+            ],
+          },
+          "error": {"message": "tool failed"},
+        },
+      );
+
+      final mcp = item! as CodexMcpToolCallItemDto;
+      expect(mcp.status, CodexToolCallStatus.failed);
+      expect(mcp.content, hasLength(4));
+      expect(mcp.content[1], isA<CodexMcpImageContentDto>());
+      final image = mcp.content[1] as CodexMcpImageContentDto;
+      expect(image.data, "encoded-image");
+      expect(image.mimeType, "image/png");
+      expect(mcp.content[2], isA<CodexUnknownImageBearingContentDto>());
+      expect((mcp.content.first as CodexMcpTextContentDto).text, "before");
+      expect((mcp.content.last as CodexMcpTextContentDto).text, "after");
+      expect(mcp.error, "tool failed");
+    });
+
+    test("decodes dynamic text, image, and audio with tolerant tool status", () {
+      final item = parser.parse(
+        item: {
+          "type": "dynamicToolCall",
+          "id": "dynamic-1",
+          "tool": 42,
+          "arguments": {"query": "status"},
+          "status": "future_status",
+          "contentItems": [
+            {"type": "inputText", "text": "first"},
+            {"type": "inputImage", "imageUrl": "data:image/png;base64,AA=="},
+            {"type": "inputAudio", "audioUrl": "data:audio/wav;base64,AA=="},
+            {"type": "inputText", "text": "second"},
+          ],
+        },
+      );
+
+      final dynamic = item! as CodexDynamicToolCallItemDto;
+      expect(dynamic.tool, "tool");
+      expect(dynamic.status, CodexToolCallStatus.unknown);
+      expect(dynamic.content[1], isA<CodexDynamicImageContentDto>());
+      expect(dynamic.content[2], isA<CodexDynamicAudioContentDto>());
+      expect((dynamic.content.first as CodexDynamicTextContentDto).text, "first");
+      expect((dynamic.content.last as CodexDynamicTextContentDto).text, "second");
+    });
+
+    test("keeps unknown items closed and drops malformed known items", () {
+      expect(
+        parser.parse(item: {"type": "future_item", "secret": "ignored"}),
+        isA<CodexUnknownImageBearingItemDto>(),
+      );
+      expect(
+        parser.parse(
+          item: {
+            "type": "imageGeneration",
+            "id": "image-1",
+            "status": "completed",
+            "revisedPrompt": null,
+          },
+        ),
+        isNull,
+      );
+    });
+  });
+}

--- a/bridge/sesori_plugin_codex/test/support/codex_plugin_test_factory.dart
+++ b/bridge/sesori_plugin_codex/test/support/codex_plugin_test_factory.dart
@@ -1,4 +1,5 @@
 import "package:codex_plugin/codex_plugin.dart";
+import "package:codex_plugin/src/api/parsers/codex_image_bearing_item_parser.dart";
 import "package:codex_plugin/src/repositories/codex_catalog_repository.dart";
 import "package:codex_plugin/src/repositories/codex_message_repository.dart";
 import "package:codex_plugin/src/services/codex_session_service.dart";
@@ -34,6 +35,7 @@ CodexPlugin createInjectedCodexPlugin({
     eventMapper: CodexEventMapper(
       pluginId: CodexPlugin.pluginId,
       projectCwd: projectCwd,
+      imageBearingItemParser: const CodexImageBearingItemParser(),
       rolloutToolMapper: rolloutToolMapper,
       config: configReader.readDefaults(),
     ),


### PR DESCRIPTION
## Summary

- add generated app-server DTOs and a zero-collaborator parser for first-class image generation plus MCP/dynamic text, image, and audio content
- migrate existing MCP and dynamic tool text, status, and error mapping to exhaustive typed variants
- retain image-bearing fields only at the backend boundary and deliberately emit no image attachments or generation events until Step 6

## Verification

- `dart pub get`
- focused image-bearing parser and Codex event-mapper tests
- `dart test` (218 tests)
- `dart analyze --fatal-infos`
- `git diff --cached --check`
- `aristotle-impl-review` — approved after moving output projection from the parser to the event mapper

## Plan

Step 5/13 of `.plan/active/output-image-support/PLAN.md`. The 1,470-line diff is within the planned 1,200-1,500 target and below the 1,500-line soft cap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Types and parses image‑bearing Codex events to prepare for output image support. Adds DTOs and a parser, updates the event mapper to use typed MCP/dynamic content and statuses; image attachments are not emitted yet (Step 5/13).

- **Refactors**
  - Added generated app‑server DTOs for image generation plus MCP/dynamic text, image, and audio content.
  - Introduced CodexImageBearingItemParser; updated CodexEventMapper to consume typed items, map tool status/error via enums with fallbacks, and extract only text output; named the image‑output helper parameter; wired into CodexPlugin.
  - Retains image/audio payloads at the backend boundary and ignores them for now (attachments land in Step 6).
  - Added focused parser and mapper tests; suite passes and analysis is clean.

<sup>Written for commit 115376eaf83a702a838c13a360f5e0ff41c88916. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

