### PR TITLE
Document analytics platform repository ownership

### DIFF
--- a/.plan/active/user-analytics/PLAN.md
+++ b/.plan/active/user-analytics/PLAN.md
@@ -1154,9 +1154,12 @@ not weaken the written privacy boundary to fit an unchecked property.
    outcome.
 5. **`activation_cohorts`**: account-cohort denominators only when activation-
    capable schema-v1 exposure occurs within 24 hours of account creation, with
-   ordered account -> bridge -> project -> message progression, 1/7/30-day
-   milestone flags, times to milestone, cohort maturity, and separate
+   order-validated bridge/project setup diagnostics, 1/7/30-day milestone flags,
+   times to milestone, cohort maturity, and separate
    preference/foundation/activation-capability coverage.
+   Headline activation, time-to-activation, and retention always use the
+   authoritative message-based `full_activation_at`; missing, delayed, or
+   out-of-order bridge/project milestones cannot omit or move that timestamp.
 6. **`retention_cohorts`**: activation-anchored W1/W4 eligibility and activity.
 
 Materialize partitioned daily/intermediate tables where repeated Looker scans

--- a/.plan/active/user-analytics/PLAN.md
+++ b/.plan/active/user-analytics/PLAN.md
@@ -983,10 +983,9 @@ only raw-ID-to-`user_key` handoff, and raw account ID never crosses it.
 Use a dedicated deletion service account with BigQuery Job User, read of the
 restricted privacy-target/raw datasets, write only to the deletion-exclusion
 control, keyed-publication guard, sweep checkpoint, and privacy-target status,
-delete/rebuild permission on auth-private/curated (and matching retained raw
-rows), metadata-only reporting
-inventory access, plus the minimum GA deletion API role. It has no Mongo
-access,
+delete/rebuild permission on auth-private/curated and matching retained raw
+rows, metadata-only reporting inventory access, plus the minimum GA deletion
+API role. It has no Mongo access,
 reporting mutation, or general controls/deployment role. The attached identity
 supplies production credentials; no service-account key enters Git.
 
@@ -1561,8 +1560,8 @@ directory name.
 repository implementation delivers the reviewed automation and contracts, but
 does not complete Step 5 by itself. After the required security/privacy
 decisions are approved, the same Step 5 work must use the checked-in runbook and
-tools to create the service
-identities and dataset ACLs, authorize views, apply warehouse schemas, provision
+tools to create service identities and dataset ACLs, authorize views, apply
+warehouse schemas, provision
 auth export and privacy jobs, apply transform/deletion schedules, run deployed
 assertions and deletion drills, build/restrict Looker, and record go-live
 evidence. These are tracked delivery tasks, not an out-of-band setup handed to

--- a/.plan/active/user-analytics/PLAN.md
+++ b/.plan/active/user-analytics/PLAN.md
@@ -235,7 +235,7 @@ honestly labeled setup trends.
 | `client/desktop` | `lib/core/platform/no_op_analytics_client.dart`, DI generated file | Satisfy the shared core platform capability without collecting desktop analytics. | No desktop product events or UI are added. Analyze/test verifies core DI remains resolvable. |
 | `client/module_desktop_core` | No planned production edit; tests/build are downstream validation | Continue unchanged. | Shared core DI/downstream validation only. |
 | `bridge/app` | No planned production or contract edit | Remain outside product analytics. | No additional bridge validation beyond normal CI is caused by this plan. |
-| Apps monorepo tooling | `tool/product_analytics/` (deployment tooling/SQL/runbook plus `privacy_deletion/` layered command flow) | Version BigQuery DDL, transforms, assertions, dashboard contract, deletion exclusion/upstream submission, and recurring keyed-upload sweep. | Cloud deployment supplies property/project/location and ADC identities; no credentials or live identifiers enter Git. |
+| Private analytics platform repository | `sesori-ai/sesori_analytics_platform`: root deployment tooling/SQL plus `privacy_deletion/` layered command flow and gradual-disclosure `docs/` | Version BigQuery DDL, transforms, assertions, dashboard contract, deletion exclusion/upstream submission, and recurring keyed-upload sweep outside the product-app repository. | Cloud deployment supplies property/project/location and ADC identities; no credentials or live identifiers enter Git. |
 
 ## Privacy And Identity Contract
 
@@ -378,7 +378,9 @@ pseudonymous personal data. Documentation and access controls must call it that.
   seam and used only as validated warehouse time—not registered as a GA custom
   dimension.
 - Stable screen enum.
-- Platform and app version/build supplied by Firebase.
+- Platform and app version supplied by Firebase. Build number is not emitted by
+  the typed clients or exposed by the GA4 raw app-info record, so it is not a
+  warehouse/reporting dimension.
 - Bounded onboarding, interaction, voice-input, login-provider, login-failure,
   and product-failure enums.
 
@@ -968,22 +970,24 @@ only on `privacy_private.product_analytics_deletion_targets`; it cannot query GA
 raw data or mutate controls/curated/reporting. The restricted target table is the
 only raw-ID-to-`user_key` handoff, and raw account ID never crosses it.
 
-**Warehouse/upstream deletion (`tool/product_analytics/privacy_deletion/`):**
+**Warehouse/upstream deletion (`sesori_analytics_platform/privacy_deletion/`):**
 
 | Class/file | Layer/dependencies | Responsibility |
 | --- | --- | --- |
-| `bigquery_privacy_deletion_client.dart` and `ga_user_deletion_client.dart` | Foundation clients | Typed BigQuery operations within allowlisted datasets and typed GA User Deletion API submission; no orchestration or raw account ID. |
-| `privacy_deletion_api.dart` | Layer 1; requires both clients | Loads pending privacy-private targets for request processing; upserts/reads the permanent deletion-exclusion control; range-joins the overlapping raw window against **all** permanent tombstones for sweeps; discovers currently linkable installation IDs, deletes matching warehouse rows, submits app-instance/legacy-user deletion, rebuilds aggregates, and updates target status through typed operations. |
-| `privacy_deletion_repository.dart` | Layer 2; requires API | Owns idempotent request status, target validation, run checkpoints, tombstone-aware auth-export cutoff checks, and explicit result mapping. It never persists discovered installation IDs. |
-| `privacy_deletion_service.dart` | Layer 3; requires repository | Orchestrates exclusion-before-delete, waits for a successful auth export with `runCutoff >= suppressedAt`, performs final delete/rebuild/verification, and marks the request complete or retryable. |
-| `run_privacy_deletion.dart` / `sweep_privacy_deletions.dart` | Manual and scheduled composition roots | Construct with ADC/config, process one request or a checkpointed raw-partition range, return only aggregate status, and close clients. Each daily sweep starts from the earlier of the last-success watermark continuation and the latest three UTC event dates, matching GA4 late-arrival recomputation; it joins every scanned version against all permanent deletion tombstones regardless of target completion/age. Submission/deletion is idempotent and acts only on future **keyed** uploads. |
+| `google_api_foundation.dart`, `bigquery_privacy_deletion_client.dart`, and `ga_user_deletion_client.dart` | Neutral Google credential/transport foundation plus peer Foundation clients | Shared metadata-first credential acquisition and bounded Google API failures live in the neutral file. The peer clients own typed BigQuery operations within allowlisted datasets and typed GA User Deletion API submission; neither client depends on the other, orchestrates deletion, or receives a raw account ID. |
+| `privacy_deletion_api.dart` | Layer 1; requires both clients | Loads pending privacy-private targets for request processing; transactionally advances the keyed-publication epoch while upserting/reading the permanent deletion-exclusion control; range-joins the overlapping raw window against **all** permanent tombstones for sweeps; discovers currently linkable installation IDs, deletes matching warehouse rows, submits app-instance/legacy-user deletion, rebuilds aggregates, and updates target status through typed operations. |
+| `privacy_deletion_repository.dart` | Layer 2; requires API | Owns idempotent request status, target validation, run checkpoints, typed latest-auth-snapshot retrieval, and explicit operation/result mapping. It never decides lifecycle readiness, orchestrates cross-system cleanup, or persists discovered installation IDs. |
+| `privacy_deletion_service.dart` | Layer 3; requires repository and clock | Orchestrates exclusion-before-delete, evaluates one-shot tombstone-aware auth readiness using the configured publication-age/clock policy plus cutoff, then owns upstream/raw/keyed deletion, fixed rebuild, verification, and completion. When no fresh successful auth export has `runCutoff >= suppressedAt`, it returns retryable and relies on the external job/operator to invoke the idempotent command again rather than polling in-process. A sweep applies that gate to the newest permanent tombstone before auth-private cleanup or checkpoint advancement. |
+| `run_privacy_deletion.dart` / `sweep_privacy_deletions.dart` | Manual and scheduled composition roots | Construct with the attached metadata-server identity by default (with explicit local ADC fallback only for approved operator runs), process one request or a checkpointed raw-partition range, return only aggregate status, and close clients. Each daily sweep starts from the earlier of the last-success watermark continuation and the latest three UTC event dates, matching GA4 late-arrival recomputation; it joins every scanned version against all permanent deletion tombstones regardless of target completion/age. Submission/deletion is idempotent and acts only on future **keyed** uploads. |
 
 Use a dedicated deletion service account with BigQuery Job User, read of the
 restricted privacy-target/raw datasets, write only to the deletion-exclusion
-control and privacy-target status, delete/rebuild permission on auth-private/curated/
-reporting (and matching retained raw rows), plus the minimum GA deletion API
-role. It has no Mongo access and no general controls/deployment role. Secret
-Manager/ADC supply credentials; no service-account key enters Git.
+control, keyed-publication guard, sweep checkpoint, and privacy-target status,
+delete/rebuild permission on auth-private/curated (and matching retained raw
+rows), metadata-only reporting
+inventory access, plus the minimum GA deletion API role. It has no Mongo access,
+reporting mutation, or general controls/deployment role. The attached identity
+supplies production credentials; no service-account key enters Git.
 
 No persistent account-to-installation map is created. Once currently linkable
 app-instance IDs are submitted and raw keyed rows are deleted/expired, later
@@ -1042,36 +1046,37 @@ property/project IDs:
 | `sesori_analytics_curated` | Analytics engineers | Flattened allowlisted events, daily user activity, user milestones, scheduled intermediate tables |
 | `sesori_analytics_reporting` | Looker service account/product leadership | Identifier-free authorized views and dashboard tables |
 
-Version deployable assets under `tool/product_analytics/`: a data dictionary,
-templated DDL and scheduled-query SQL, a small deployment command accepting
-project/GA4 dataset/location, BigQuery `ASSERT` fixture tests, and an operations
-runbook. Never commit service-account material or live internal user keys.
+Version deployable assets in the private
+`sesori-ai/sesori_analytics_platform` repository: a data dictionary, templated
+DDL and scheduled-query SQL, a small deployment command accepting project/GA4
+dataset/location, BigQuery `ASSERT` fixture tests, and an operations runbook.
+Never commit service-account material or live internal user keys.
 
 The initial file ownership is fixed:
 
-- `tool/product_analytics/deploy.dart` validates named project, location, raw,
+- `deploy.dart` validates named project, location, raw,
   auth-private/privacy-private/controls/curated/reporting datasets, and both
   start timestamps;
   renders identifier placeholders from the checked-in SQL; and invokes `bq`
   non-interactively with the explicit location. It does not perform `gcloud`
   login or read key files.
-- `tool/product_analytics/sql/00_datasets.sql` creates/configures derived
+- `sql/00_datasets.sql` creates/configures derived
    datasets and reference tables; `10_events_flattened.sql`,
    `15_installation_login_daily.sql`, `20_user_activity_daily.sql`,
    `30_user_milestones.sql`,
   `40_activation_retention.sql`, and `50_reporting_views.sql` own the dependency
   order described below.
-- `tool/product_analytics/sql/schedules.json` is a credential-free manifest of
+- `sql/schedules.json` is a credential-free manifest of
   query file, destination, cadence, recent-date recomputation window, and max
   bytes; the deploy command creates/updates those transfer configs only after a
   `--apply-schedules` flag.
-- `tool/product_analytics/tests/metric_contract_assertions.sql` uses temporary
+- `tests/metric_contract_assertions.sql` uses temporary
   fixture tables and BigQuery `ASSERT`; `schema_allowlist_assertions.sql` fails
   when curated columns/event parameters exceed the approved contract.
-- `tool/product_analytics/README.md` is the operator runbook/data dictionary;
-  `LOOKER_STUDIO.md` pins page sources, filters, formulas, access group, and
-  manual dashboard verification because Looker Studio report layout is not a
-  safely deployable repository artifact.
+- Root `README.md` is a short navigation entry point; task guides under `docs/`
+  provide gradual disclosure, `docs/reference/full-runbook.md` is the exhaustive
+  operator/data reference, and `docs/reporting/looker-studio.md` pins page
+  sources, filters, formulas, access, and manual dashboard verification.
 
 ### Vendor-managed raw GA4 boundary
 
@@ -1116,7 +1121,7 @@ not weaken the written privacy boundary to fit an unchecked property.
    `emitted_at` via `TIMESTAMP_MICROS(event_timestamp)`, parse required integer
    `occurred_at_micros` the same way as `occurred_at`,
    require schema version and non-null custom `user_key`, and retain Firebase
-   platform/app version/build. Reject occurrence later than emitted time beyond
+   platform/app version. Reject occurrence later than emitted time beyond
    the documented clock-skew allowance. User-milestone/cohort joins additionally
    require occurrence no earlier than account creation beyond that allowance;
    invalid timing remains a data-quality count and is excluded from time-bound
@@ -1138,7 +1143,7 @@ not weaken the written privacy boundary to fit an unchecked property.
 3. **`user_activity_daily`**: one row per user/date with monitor, control,
    message, voice-assisted, transcription, diff, screen, and feature
    flags/counts.
-4. **`user_milestones`**: auth timestamps plus earliest foundation and
+4. **`user_milestones`**: auth timestamps plus earliest schema-ready foundation and
    activation-capable exposure,
    project availability, full activation, monitor activity, and feature
    milestones. Full activation is the minimum of the two successful message
@@ -1146,8 +1151,9 @@ not weaken the written privacy boundary to fit an unchecked property.
    `activation_capable_at` is the earliest activation-ready event or activation
    outcome.
 5. **`activation_cohorts`**: account-cohort denominators only when activation-
-   capable schema-v1 exposure occurs within 24 hours of account creation, plus
-   1/7/30-day milestone flags, times to milestone, cohort maturity, and separate
+   capable schema-v1 exposure occurs within 24 hours of account creation, with
+   ordered account -> bridge -> project -> message progression, 1/7/30-day
+   milestone flags, times to milestone, cohort maturity, and separate
    preference/foundation/activation-capability coverage.
 6. **`retention_cohorts`**: activation-anchored W1/W4 eligibility and activity.
 
@@ -1161,6 +1167,10 @@ snapshot and anti-joins the permanent internal exclusion table. Therefore a
 disable or newly added internal exclusion takes effect after the next auth
 export/report refresh even when an older curated partition exists; those gates
 are not applied only at the historical partition's original build time.
+Keyed transforms capture a shared publication epoch before staging and advance
+it inside their publication transaction. Permanent tombstone insertion advances
+the same singleton transactionally. An epoch mismatch or overlapping write
+aborts rather than republishing a concurrently deleted user.
 
 The auth export atomically publishes snapshot metadata (`run_id`, immutable
 source cutoff, completion time, eligible/source counts) with its tables. Before
@@ -1517,10 +1527,13 @@ directory name.
 
 **Title:** `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]`
 
-**Repository:** apps monorepo plus cloud deployment
+**Repository:** private `sesori-ai/sesori_analytics_platform` plus cloud deployment
 
-- Add `tool/product_analytics/` data contract, parameterized deployment tool,
+- Add the analytics-platform data contract, parameterized deployment tool,
   DDL, transforms, fixture assertions, scheduled-query definitions, and runbook.
+- Bootstrap datasets/reference tables first, publish and validate the initial
+  auth snapshot, then apply auth-dependent transforms; full apply fails closed
+  when no initial auth snapshot exists.
 - Create auth-private/privacy-private/controls/curated/reporting datasets in the raw GA4
   location; keep export-job write access confined to auth-private and grant only
   authorized-view reads for internal exclusion; configure IAM, expiration,
@@ -1542,6 +1555,20 @@ directory name.
   reporting view without inspecting sensitive payloads.
 - Record dashboard owner, refresh schedule, metric definitions, and rollback/
   incident steps in the runbook.
+
+**Step 5 completion includes the cloud setup above.** Landing the standalone
+repository implementation delivers the reviewed automation and contracts, but
+does not complete Step 5 by itself. After the required security/privacy
+decisions are approved, the same
+Step 5 work must use the checked-in runbook and tools to create the service
+identities and dataset ACLs, authorize views, apply warehouse schemas, provision
+auth export and privacy jobs, apply transform/deletion schedules, run deployed
+assertions and deletion drills, build/restrict Looker, and record go-live
+evidence. These are tracked delivery tasks, not an out-of-band setup handed to
+the user. The user supplies approvals, restricted values, and any admin-only
+authorization that cannot be delegated; the implementing operator performs and
+verifies the setup. Keep Step 5 open until every applicable cloud and dashboard
+acceptance item passes.
 
 ### Deployability, compatibility, and rollback by step
 
@@ -1743,3 +1770,13 @@ The work is complete when:
 - The executive page can truthfully report new accounts, setup, full
   activation, WAU/growth, W1/W4 retention when mature, activity depth, and the
   selected feature-adoption metrics without manual spreadsheet logic.
+
+## Final Step — Archive The Completed Plan
+
+After every completion criterion above and every in-scope tracker item is done,
+record the final PR, cloud setup, access, deletion-drill, dashboard, and release
+evidence in `TRACKER.md`. Then, as the last action of this plan, move the entire
+plan directory (including its tracker and supporting files) from
+`.plan/active/user-analytics/` to `.plan/completed/user-analytics/` and commit
+that move. Do not copy it, leave an active duplicate, or archive it while any
+required Step 5 setup or acceptance work remains.

--- a/.plan/active/user-analytics/PLAN.md
+++ b/.plan/active/user-analytics/PLAN.md
@@ -82,7 +82,7 @@ silently compared with a mature one.
 | Bridge registered | First bridge registration (`ActivationState.bridgeSetupAt`) | Auth server |
 | Project available | First successful project inventory containing at least one project after instrumentation starts | App event |
 | Legacy session signal | First accepted `/sessions/generate-metadata` request (`ActivationState.firstSessionAt`) | Auth server |
-| Foundation analytics exposure | Earliest schema-v1 `analytics_schema_ready` or other accepted account-linked foundation event | App event; diagnostic coverage only |
+| Foundation analytics exposure | Earliest schema-v1 `analytics_schema_ready` | App event; diagnostic schema-readiness coverage only |
 | Activation-capable exposure | Earliest `analytics_activation_ready(activation_schema_version=1)` or accepted full-activation outcome, provided it occurs within 24 hours of account creation | App event from the outcome-instrumentation release |
 | Full activation | Earliest successful `session_message_sent` or `session_created_with_message` | App event |
 
@@ -943,12 +943,14 @@ Job acceptance checks before promotion:
 Use Application Default Credentials, Secret Manager for Mongo access, and an
 export service account limited to BigQuery Job User plus Data Editor on
 `sesori_analytics_auth_private` plus table-level Data Viewer on the one
-authorized permanent-internal-exclusion view. It has no controls dataset write/DDL
-role and no role on privacy-private, raw, curated, or reporting datasets, so it
-cannot mutate deletion targets, exclusions, or config. A separate scheduled-transform identity has read-only access to raw,
-auth-private, and controls plus write access to curated; the deployment identity
-alone owns schemas/IAM/control-table writes. The auth web runtime receives no
-BigQuery role.
+authorized permanent-internal-exclusion view. It has no controls dataset
+write/DDL role and no role on privacy-private, raw, curated, or reporting
+datasets, so it cannot mutate deletion targets, exclusions, or config. A
+separate scheduled-transform identity has read-only access to raw, auth-private,
+and controls, table-scoped update access only to the keyed-publication guard,
+and write access to curated; the deployment identity alone owns schemas, IAM,
+and every other control-table write. The auth web runtime receives no BigQuery
+role.
 
 ### Privacy deletion executable architecture
 
@@ -1042,9 +1044,9 @@ property/project IDs:
 | `analytics_<property_id>` | Raw restricted | Firebase-managed GA4 daily tables |
 | `sesori_analytics_auth_private` | Security/analytics admins, auth export job; transform identity read-only | Auth eligible-user snapshot/staging and aggregate setup cohorts only |
 | `sesori_analytics_privacy_private` | Security/privacy admins, auth suppression command limited writer, deletion job | Product-analytics deletion targets/status only; auth export identity has no access |
-| `sesori_analytics_controls` | Security/analytics admins and deployment identity; transform identity read-only; auth-export identity can read only an authorized permanent-internal-exclusion view | Internal-user and deletion exclusions, dual measurement timestamps, export freshness policy |
+| `sesori_analytics_controls` | Security/analytics admins and deployment identity; transform identity read-only except table-scoped keyed-publication-guard updates; auth-export identity can read only an authorized permanent-internal-exclusion view | Internal-user and deletion exclusions, dual measurement timestamps, export freshness policy, keyed-publication guard |
 | `sesori_analytics_curated` | Analytics engineers | Flattened allowlisted events, daily user activity, user milestones, scheduled intermediate tables |
-| `sesori_analytics_reporting` | Looker service account/product leadership | Identifier-free authorized views and dashboard tables |
+| `sesori_analytics_reporting` | Looker service account/product leadership | Identifier-free authorized reporting views only; no stored keyed or materialized dashboard tables |
 
 Version deployable assets in the private
 `sesori-ai/sesori_analytics_platform` repository: a data dictionary, templated
@@ -1229,8 +1231,9 @@ only three days.
 - Implement a privacy-request runbook/job that first calls the auth-source
   suppression operation, verifies preference disabled plus
   `productAnalyticsExportSuppressedAt`, and only then adds `user_key` to a
-  restricted deletion-exclusion control. It deletes matching auth-private/
-  curated/reporting rows and rebuilds identifier-free setup cohorts. It does not
+  restricted deletion-exclusion control. It deletes matching auth-private and
+  curated keyed rows and rebuilds identifier-free setup cohorts. Reporting is
+  view-only and therefore has no stored contribution to delete. It does not
   declare warehouse completion until an auth export with
   `runCutoff >= productAnalyticsExportSuppressedAt` has published, then performs
   one final delete/rebuild and verifies the key/contribution remains absent.

--- a/.plan/active/user-analytics/PLAN.md
+++ b/.plan/active/user-analytics/PLAN.md
@@ -985,7 +985,8 @@ restricted privacy-target/raw datasets, write only to the deletion-exclusion
 control, keyed-publication guard, sweep checkpoint, and privacy-target status,
 delete/rebuild permission on auth-private/curated (and matching retained raw
 rows), metadata-only reporting
-inventory access, plus the minimum GA deletion API role. It has no Mongo access,
+inventory access, plus the minimum GA deletion API role. It has no Mongo
+access,
 reporting mutation, or general controls/deployment role. The attached identity
 supplies production credentials; no service-account key enters Git.
 
@@ -1559,8 +1560,8 @@ directory name.
 **Step 5 completion includes the cloud setup above.** Landing the standalone
 repository implementation delivers the reviewed automation and contracts, but
 does not complete Step 5 by itself. After the required security/privacy
-decisions are approved, the same
-Step 5 work must use the checked-in runbook and tools to create the service
+decisions are approved, the same Step 5 work must use the checked-in runbook and
+tools to create the service
 identities and dataset ACLs, authorize views, apply warehouse schemas, provision
 auth export and privacy jobs, apply transform/deletion schedules, run deployed
 assertions and deletion drills, build/restrict Looker, and record go-live

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -105,17 +105,14 @@
 - [ ] Confirm cloud preflight facts: Firebase/GA4 BigQuery link, property ID,
   billing, dataset location, existing raw tables/IAM/expiration, GA4 retention/
   deletion configuration, scheduler connectivity, and dashboard access group.
-  Partial preflight on 2026-07-31 found Firebase project `sesori-ai`, GA4
-  property `529377727`, and daily raw dataset `analytics_529377727` in
-  `europe-west3`, with tables beginning at `events_20260725`. Billing account
-  `Sesori Billing` is active and linked. A project-scoped USD 10 monthly alert
-  budget now covers all services at 50/80/100 percent actual and 100 percent
-  forecasted spend. The raw dataset defaults and all six existing daily tables
-  now expire after 90 days instead of 60. BigQuery on-demand query overrides are
-  10 GiB per project/day and 2 GiB per principal/day. Restricted IAM, GA4 privacy
-  settings, scheduler identities, exact start-time recording, and Looker
-  ownership remain blocked or unverified; do not enable additional export modes
-  or deploy transforms yet.
+  Partial preflight on 2026-07-31 verified active billing and an existing daily
+  raw export in the required same region. A project budget alert, 90-day raw
+  default/current-table expiration, and bounded on-demand query overrides are
+  configured. Exact project/property/dataset/location/table, billing, budget,
+  and quota values belong only in the restricted deployment record. Restricted
+  IAM, GA4 privacy settings, scheduler identities, exact start-time recording,
+  and Looker ownership remain blocked or unverified; do not enable additional
+  export modes or deploy transforms yet.
 - [x] Implement the local Step 5 warehouse, reporting, deployment, and privacy-
   deletion assets. The final architecture pass approved neutral Google
   credential ownership, Service-owned deletion sequencing, one-shot auth
@@ -173,16 +170,24 @@ the implementing operator must execute and verify all unchecked work:
 - [ ] Record the approved GA4 privacy posture, exact raw/behavioral UTC start
   timestamps, service identities, schedule owners, dashboard owner/viewer group,
   and refresh policy in the restricted deployment record.
+- [ ] Apply and verify two-month GA4 event/user-data retention, disabled Google
+  Signals, ad personalization, ad storage/user-data features, and disabled
+  Firebase native advertising identifiers; store the evidence in the restricted
+  deployment record.
 - [ ] Create the separate deployment, auth-export, auth-suppression, transform,
   privacy-deletion, and Looker identities; remove broad inherited data access;
   apply the dataset/table IAM matrix and exact authorized-view ACLs; pass every
   positive and expected-deny access probe.
-- [ ] Apply the same-location warehouse schemas and views with the checked-in
-  deployment tool, run the deployed-schema assertions, and reconcile the first
-  complete raw/auth/curated/reporting data.
+- [ ] Run the checked-in bootstrap-only deployment to create the same-location
+  datasets and reference schemas; do not apply auth-dependent transforms yet.
 - [ ] Provision and smoke-test the isolated auth export and suppression jobs,
-  transform schedules, request deletion command, and recurring privacy sweep;
-  complete the non-production in-flight export and delayed-upload deletion drill.
+  publish the initial auth snapshot, and verify its freshness and reconciliation.
+- [ ] Run the auth-dependent warehouse apply only after that snapshot exists;
+  apply schemas/views, run deployed-schema assertions, and reconcile the first
+  complete raw/auth/curated/reporting data.
+- [ ] Provision and smoke-test transform schedules, the request deletion command,
+  and recurring privacy sweep; complete the non-production in-flight export and
+  delayed-upload deletion drill.
 - [ ] Build the restricted three-page Looker report, verify its data sources,
   maturity/coverage/freshness labels and sharing controls, then record asset IDs
   and go-live evidence.

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -130,9 +130,9 @@
   schedule inventory and move schedule SQL out of argv; harden metadata/API
   timeouts and SQL boundaries; require fresh tombstone-aware request/sweep
   cleanup; serialize tombstones with keyed publication; guard transform
-  watermarks; enforce ordered activation progression and schema-ready foundation;
-  remove unsupported build
-  dimensions; and extend focused Dart/BigQuery fixtures. A two-pass architecture
+  watermarks; enforce ordered activation progression and schema-ready
+  foundation; remove unsupported build dimensions; and extend focused
+  Dart/BigQuery fixtures. A two-pass architecture
   review moved deployment policy to orchestration and freshness policy to the
   deletion Service, then approved the revised boundaries. All 34 bot review
   threads received `[Sesori reply]` assessments before the code moved.

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -126,12 +126,12 @@
   assertions remain deferred until an approved warehouse exists; no repository
   SQL, schedules, IAM, or dashboards have been applied to cloud resources.
 - [x] Apply valid PR #641 review findings before migration: split first-run
-  bootstrap from
-  auth-dependent apply; make DDL dry-run limits explicit; bound schedule
-  inventory and move schedule SQL out of argv; harden metadata/API timeouts and
-  SQL boundaries; require fresh tombstone-aware request/sweep cleanup; serialize
-  tombstones with keyed publication; guard transform watermarks; enforce ordered
-  activation progression and schema-ready foundation; remove unsupported build
+  bootstrap from auth-dependent apply; make DDL dry-run limits explicit; bound
+  schedule inventory and move schedule SQL out of argv; harden metadata/API
+  timeouts and SQL boundaries; require fresh tombstone-aware request/sweep
+  cleanup; serialize tombstones with keyed publication; guard transform
+  watermarks; enforce ordered activation progression and schema-ready foundation;
+  remove unsupported build
   dimensions; and extend focused Dart/BigQuery fixtures. A two-pass architecture
   review moved deployment policy to orchestration and freshness policy to the
   deletion Service, then approved the revised boundaries. All 34 bot review
@@ -166,6 +166,7 @@ user and not a separate future project. The private
 `sesori-ai/sesori_analytics_platform` repository supplies the reviewed
 automation and runbook; apps-monorepo PR #641 was closed as superseded by that
 repository.
+
 After the user approves the restricted values and security/privacy decisions,
 the implementing operator must execute and verify all unchecked work:
 

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -132,7 +132,10 @@
   Dart/BigQuery fixtures. A two-pass architecture
   review moved deployment policy to orchestration and freshness policy to the
   deletion Service, then approved the revised boundaries. All 34 bot review
-  threads received `[Sesori reply]` assessments before the code moved.
+  threads received `[Sesori reply]` assessments before the code moved. PR #650
+  follow-up review found that the resulting setup-order gate also reached
+  headline activation/retention; the required standalone correction is tracked
+  below and blocks warehouse apply.
 - [x] Move the complete Step 5 warehouse/reporting/deletion implementation and
   its scoped Git history out of the apps monorepo into private repository
   `sesori-ai/sesori_analytics_platform`. Commit `743e5330` is the current
@@ -149,9 +152,11 @@
 - [ ] Reuse that exact pseudonymization secret when the disabled export and
   suppression runtimes are created. Do not record the value or rotate it without
   a coordinated re-key migration.
-- [ ] Establish restricted project IAM, then enable or verify Firebase **daily-
-  only** BigQuery export; apply/verify raw dataset ACL and 90-day expiration
-  before the first daily table and record exact UTC `raw_export_start_at`.
+- [ ] Complete the existing-link contingency: establish restricted project IAM;
+  verify Firebase export is **daily-only**; audit and remediate ACL/90-day
+  expiration on every landed raw table; record the original preflight miss and
+  remediation evidence; and derive exact UTC `raw_export_start_at` from the first
+  qualified controlled daily table rather than backdating it to link creation.
   Export is not retroactive. Record `behavioral_schema_v1_start_at` separately
   only after production `analytics_activation_ready` appears; foundation-only
   and account-less login events do not qualify.
@@ -178,6 +183,10 @@ the implementing operator must execute and verify all unchecked work:
   privacy-deletion, and Looker identities; remove broad inherited data access;
   apply the dataset/table IAM matrix and exact authorized-view ACLs; pass every
   positive and expected-deny access probe.
+- [ ] Before warehouse apply, correct and verify the standalone activation-
+  cohort SQL/fixtures so headline activation, time-to-activation, and retention
+  use authoritative `full_activation_at` independently of bridge/project order;
+  reserve ordered bridge/project timestamps for setup diagnostics.
 - [ ] Run the checked-in bootstrap-only deployment to create the same-location
   datasets and reference schemas; do not apply auth-dependent transforms yet.
 - [ ] Provision and smoke-test the isolated auth export and suppression jobs,

--- a/.plan/active/user-analytics/TRACKER.md
+++ b/.plan/active/user-analytics/TRACKER.md
@@ -105,6 +105,43 @@
 - [ ] Confirm cloud preflight facts: Firebase/GA4 BigQuery link, property ID,
   billing, dataset location, existing raw tables/IAM/expiration, GA4 retention/
   deletion configuration, scheduler connectivity, and dashboard access group.
+  Partial preflight on 2026-07-31 found Firebase project `sesori-ai`, GA4
+  property `529377727`, and daily raw dataset `analytics_529377727` in
+  `europe-west3`, with tables beginning at `events_20260725`. Billing account
+  `Sesori Billing` is active and linked. A project-scoped USD 10 monthly alert
+  budget now covers all services at 50/80/100 percent actual and 100 percent
+  forecasted spend. The raw dataset defaults and all six existing daily tables
+  now expire after 90 days instead of 60. BigQuery on-demand query overrides are
+  10 GiB per project/day and 2 GiB per principal/day. Restricted IAM, GA4 privacy
+  settings, scheduler identities, exact start-time recording, and Looker
+  ownership remain blocked or unverified; do not enable additional export modes
+  or deploy transforms yet.
+- [x] Implement the local Step 5 warehouse, reporting, deployment, and privacy-
+  deletion assets. The final architecture pass approved neutral Google
+  credential ownership, Service-owned deletion sequencing, one-shot auth
+  readiness with external retry, and the layered API/Repository boundaries.
+  Focused Dart formatting/analyze/privacy tests, render-only validation of seven
+  SQL assets and five schedules, and `git diff --check` pass. The self-contained
+  BigQuery metric fixture passed in `europe-west3` on 2026-07-31. Deployed-schema
+  assertions remain deferred until an approved warehouse exists; no repository
+  SQL, schedules, IAM, or dashboards have been applied to cloud resources.
+- [x] Apply valid PR #641 review findings before migration: split first-run
+  bootstrap from
+  auth-dependent apply; make DDL dry-run limits explicit; bound schedule
+  inventory and move schedule SQL out of argv; harden metadata/API timeouts and
+  SQL boundaries; require fresh tombstone-aware request/sweep cleanup; serialize
+  tombstones with keyed publication; guard transform watermarks; enforce ordered
+  activation progression and schema-ready foundation; remove unsupported build
+  dimensions; and extend focused Dart/BigQuery fixtures. A two-pass architecture
+  review moved deployment policy to orchestration and freshness policy to the
+  deletion Service, then approved the revised boundaries. All 34 bot review
+  threads received `[Sesori reply]` assessments before the code moved.
+- [x] Move the complete Step 5 warehouse/reporting/deletion implementation and
+  its scoped Git history out of the apps monorepo into private repository
+  `sesori-ai/sesori_analytics_platform`. Commit `743e5330` is the current
+  standalone `main`. Root documentation is now a 72-line entry point with task
+  guides and deep references under `docs/`; standalone format, analyze, privacy
+  tests, render validation, and Markdown-link validation pass.
 
 ## Immediate Operational Action
 
@@ -121,6 +158,40 @@
   Export is not retroactive. Record `behavioral_schema_v1_start_at` separately
   only after production `analytics_activation_ready` appears; foundation-only
   and account-less login events do not qualify.
+
+## Step 5 Cloud Setup And Go-Live
+
+This setup is required Step 5 delivery work, not a prerequisite delegated to the
+user and not a separate future project. The private
+`sesori-ai/sesori_analytics_platform` repository supplies the reviewed
+automation and runbook; apps-monorepo PR #641 was closed as superseded by that
+repository.
+After the user approves the restricted values and security/privacy decisions,
+the implementing operator must execute and verify all unchecked work:
+
+- [ ] Record the approved GA4 privacy posture, exact raw/behavioral UTC start
+  timestamps, service identities, schedule owners, dashboard owner/viewer group,
+  and refresh policy in the restricted deployment record.
+- [ ] Create the separate deployment, auth-export, auth-suppression, transform,
+  privacy-deletion, and Looker identities; remove broad inherited data access;
+  apply the dataset/table IAM matrix and exact authorized-view ACLs; pass every
+  positive and expected-deny access probe.
+- [ ] Apply the same-location warehouse schemas and views with the checked-in
+  deployment tool, run the deployed-schema assertions, and reconcile the first
+  complete raw/auth/curated/reporting data.
+- [ ] Provision and smoke-test the isolated auth export and suppression jobs,
+  transform schedules, request deletion command, and recurring privacy sweep;
+  complete the non-production in-flight export and delayed-upload deletion drill.
+- [ ] Build the restricted three-page Looker report, verify its data sources,
+  maturity/coverage/freshness labels and sharing controls, then record asset IDs
+  and go-live evidence.
+- [ ] Keep Step 5 open until all setup, verification, deletion, access, and
+  dashboard acceptance items pass; creating the analytics repository alone does
+  not complete it.
+- [ ] **Final plan action:** after every completion criterion and tracker item is
+  complete, record final evidence and move the entire
+  `.plan/active/user-analytics/` directory to
+  `.plan/completed/user-analytics/`; commit the move and leave no active copy.
 
 ## Implementation Series
 
@@ -143,8 +214,8 @@ patches in one umbrella diff.
 | 4.A/5 | apps monorepo | `[user-analytics] Add bounded outcome analytics contracts [step 4.A/5]` | PR #632 merged as `e3e6b6e7` on 2026-07-31; oversized PR #629 remains closed as superseded | Step 3.D released |
 | 4.B/5 | apps monorepo | `[user-analytics] Instrument account-less login outcomes [step 4.B/5]` | PR #634 merged as `5223c27d` on 2026-07-31 | Step 4.A |
 | 4.C/5 | apps monorepo | `[user-analytics] Instrument activation and voice outcomes [step 4.C/5]` | PR #633 merged as `c662a639` on 2026-07-31 | Step 4.B |
-| 4.D/5 | apps monorepo | `[user-analytics] Instrument visible engagement outcomes [step 4.D/5]` | PR #631 open on `user-analytics-visible-engagement-outcomes`; verified and approved | Step 4.C |
-| 5/5 | apps monorepo + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | Not started | Steps 2 and 4.D, controlled Firebase export, split auth-private/privacy-private/control IAM |
+| 4.D/5 | apps monorepo | `[user-analytics] Instrument visible engagement outcomes [step 4.D/5]` | PR #631 merged as `671c67ed` on 2026-07-31 | Step 4.C |
+| 5/5 | private `sesori_analytics_platform` + cloud | `[user-analytics] Add BigQuery metrics and Looker dashboards [step 5/5]` | Repository implementation and scoped history migrated to private `sesori-ai/sesori_analytics_platform` `main` at `743e5330`; apps-monorepo PR #641 was closed as superseded. Focused standalone checks and metric fixtures pass, and the review-fix architecture is approved. Required Step 5 cloud setup remains tracked above and blocked pending approved restricted values. Billing/budget and 90-day raw expiration are configured, while restricted IAM, GA4 privacy settings, identities, exact timestamps, deployed-schema assertions, jobs/schedules, deletion drill, and dashboard setup remain unresolved | Steps 2 and 4.D, controlled Firebase export, split auth-private/privacy-private/control IAM |
 
 ## Release Evidence
 


### PR DESCRIPTION
## Summary
- record the migration of the Step 5 warehouse, reporting, and privacy-deletion implementation into the private `sesori-ai/sesori_analytics_platform` repository
- keep the active cross-repository plan and cloud rollout checklist in the apps monorepo
- preserve the remaining security, privacy, deployment, verification, and final archival gates rather than treating repository creation as Step 5 completion

## Verification
- `git diff --check origin/main...HEAD`
- Documentation/plan-only change; Dart and Flutter suites were not run per repository guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Step 5 (warehouse, reporting, privacy deletion) into the private `sesori-ai/sesori_analytics_platform` repo and tightens the rollout gates. Clarifies IAM, keyed‑publication/epoch controls, and makes reporting view‑only; Step 5 stays open until cloud setup is deployed and verified.

- **Migration**
  - Point deployment tooling, SQL, tests, and `privacy_deletion` to the private `sesori-ai/sesori_analytics_platform` with the new layout (`deploy.dart`, `sql/`, `tests/`, `docs/`) and a neutral `google_api_foundation.dart`; default to the metadata‑server identity with local ADC fallback; split bootstrap from auth‑dependent apply.
  - Apply review updates and acceptance gates: add a keyed‑publication guard with epoch serialization; tighten IAM (transform identity table‑scoped guard updates, no auth web runtime role); externalize auth‑readiness retry; remove the unsupported build number; enforce ordered activation progression while keeping headline activation/retention anchored to message‑based events; reporting is views‑only.
  - Keep the cross‑repo rollout plan/checklist here; add the Step 5 cloud setup/go‑live checklist with preflight findings and an existing‑link contingency; add the final archive step; note remaining blocked items (restricted IAM, identities, privacy settings, exact timestamps, jobs/schedules, deployed‑schema assertions, deletion drill, Looker).

<sup>Written for commit 6b5cd6f7f3e86b30664ff735f6dcbf487ba35211. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

