### PR TITLE
fix(bridge): expand tilde in --data-dir

### DIFF
--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -229,6 +229,7 @@ class LogoutCommand extends cli.Command<void> {
       dataDirectory = BridgeCliOptions.resolveDataDirectory(
         dataDirectoryFlag: dataDirectoryFlag,
         defaultDataDirectory: defaultDataDirectory,
+        environment: Platform.environment,
       );
     } on ArgParserException catch (error) {
       usageException(error.message);

--- a/bridge/app/lib/src/bridge/runtime/bridge_cli_options.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_cli_options.dart
@@ -1,7 +1,8 @@
-import "dart:io" show Directory, FileSystemEntity, FileSystemEntityType;
+import "dart:io" show Directory, FileSystemEntity, FileSystemEntityType, Platform;
 
 import "package:args/args.dart" show ArgParserException, ArgResults;
 import "package:path/path.dart" as path;
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show resolveUserHomeDirectory;
 
 class BridgeCliOptions {
   final List<String> cliArgs;
@@ -78,7 +79,23 @@ class BridgeCliOptions {
     if (dataDirectoryFlag.trim().isEmpty) {
       throw ArgParserException("--data-dir must not be empty.");
     }
-    return path.normalize(path.absolute(dataDirectoryFlag));
+    final expandedDataDirectory = _expandHomeDirectory(dataDirectoryFlag);
+    return path.normalize(path.absolute(expandedDataDirectory));
+  }
+
+  static String _expandHomeDirectory(String dataDirectory) {
+    if (dataDirectory != "~" &&
+        !dataDirectory.startsWith("~/") &&
+        !dataDirectory.startsWith("~${Platform.pathSeparator}")) {
+      return dataDirectory;
+    }
+
+    final homeDirectory = resolveUserHomeDirectory(environment: Platform.environment);
+    if (homeDirectory == null) {
+      throw ArgParserException("Cannot expand --data-dir: home directory is not set.");
+    }
+    if (dataDirectory == "~") return homeDirectory;
+    return path.join(homeDirectory, dataDirectory.substring(2));
   }
 
   static bool isDefaultDataDirectory({

--- a/bridge/app/lib/src/bridge/runtime/bridge_cli_options.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_cli_options.dart
@@ -51,6 +51,7 @@ class BridgeCliOptions {
     final dataDirectory = resolveDataDirectory(
       dataDirectoryFlag: results["data-dir"] as String?,
       defaultDataDirectory: defaultDataDirectory,
+      environment: environment,
     );
 
     // Supervised-only option: trim and treat blank as absent. Do NOT validate
@@ -74,23 +75,30 @@ class BridgeCliOptions {
   static String resolveDataDirectory({
     required String? dataDirectoryFlag,
     required String defaultDataDirectory,
+    required Map<String, String> environment,
   }) {
     if (dataDirectoryFlag == null) return defaultDataDirectory;
     if (dataDirectoryFlag.trim().isEmpty) {
       throw ArgParserException("--data-dir must not be empty.");
     }
-    final expandedDataDirectory = _expandHomeDirectory(dataDirectoryFlag);
+    final expandedDataDirectory = _expandHomeDirectory(
+      dataDirectory: dataDirectoryFlag,
+      environment: environment,
+    );
     return path.normalize(path.absolute(expandedDataDirectory));
   }
 
-  static String _expandHomeDirectory(String dataDirectory) {
+  static String _expandHomeDirectory({
+    required String dataDirectory,
+    required Map<String, String> environment,
+  }) {
     if (dataDirectory != "~" &&
         !dataDirectory.startsWith("~/") &&
         !dataDirectory.startsWith("~${Platform.pathSeparator}")) {
       return dataDirectory;
     }
 
-    final homeDirectory = resolveUserHomeDirectory(environment: Platform.environment);
+    final homeDirectory = resolveUserHomeDirectory(environment: environment);
     if (homeDirectory == null) {
       throw ArgParserException("Cannot expand --data-dir: home directory is not set.");
     }

--- a/bridge/app/test/bridge/runtime/bridge_cli_options_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_cli_options_test.dart
@@ -3,6 +3,7 @@ import "dart:io";
 import "package:args/args.dart";
 import "package:path/path.dart" as path;
 import "package:sesori_bridge/src/bridge/runtime/bridge_cli_options.dart";
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show resolveUserHomeDirectory;
 import "package:test/test.dart";
 
 void main() {
@@ -44,6 +45,22 @@ void main() {
         options.dataDirectory,
         path.normalize(path.absolute("relative-data")),
       );
+    });
+
+    test("expands a leading tilde to the user's home directory", () {
+      final options = _parseOptions(args: const ["--data-dir", "~/sesori-dev"]);
+      final homeDirectory = resolveUserHomeDirectory(environment: Platform.environment);
+
+      expect(homeDirectory, isNotNull);
+      expect(options.dataDirectory, path.normalize(path.absolute(path.join(homeDirectory!, "sesori-dev"))));
+    });
+
+    test("expands a bare tilde to the user's home directory", () {
+      final options = _parseOptions(args: const ["--data-dir", "~"]);
+      final homeDirectory = resolveUserHomeDirectory(environment: Platform.environment);
+
+      expect(homeDirectory, isNotNull);
+      expect(options.dataDirectory, path.normalize(path.absolute(homeDirectory!)));
     });
 
     test("rejects an empty explicit path", () {

--- a/bridge/app/test/bridge/runtime/bridge_cli_options_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_cli_options_test.dart
@@ -3,7 +3,6 @@ import "dart:io";
 import "package:args/args.dart";
 import "package:path/path.dart" as path;
 import "package:sesori_bridge/src/bridge/runtime/bridge_cli_options.dart";
-import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show resolveUserHomeDirectory;
 import "package:test/test.dart";
 
 void main() {
@@ -49,18 +48,14 @@ void main() {
 
     test("expands a leading tilde to the user's home directory", () {
       final options = _parseOptions(args: const ["--data-dir", "~/sesori-dev"]);
-      final homeDirectory = resolveUserHomeDirectory(environment: Platform.environment);
 
-      expect(homeDirectory, isNotNull);
-      expect(options.dataDirectory, path.normalize(path.absolute(path.join(homeDirectory!, "sesori-dev"))));
+      expect(options.dataDirectory, "/test/home/sesori-dev");
     });
 
     test("expands a bare tilde to the user's home directory", () {
       final options = _parseOptions(args: const ["--data-dir", "~"]);
-      final homeDirectory = resolveUserHomeDirectory(environment: Platform.environment);
 
-      expect(homeDirectory, isNotNull);
-      expect(options.dataDirectory, path.normalize(path.absolute(homeDirectory!)));
+      expect(options.dataDirectory, "/test/home");
     });
 
     test("rejects an empty explicit path", () {
@@ -75,8 +70,31 @@ void main() {
         BridgeCliOptions.resolveDataDirectory(
           dataDirectoryFlag: "relative-logout-data",
           defaultDataDirectory: "/default/sesori-data",
+          environment: const {},
         ),
         path.normalize(path.absolute("relative-logout-data")),
+      );
+    });
+
+    test("uses the injected environment when expanding a tilde", () {
+      expect(
+        BridgeCliOptions.resolveDataDirectory(
+          dataDirectoryFlag: "~/logout-data",
+          defaultDataDirectory: "/default/sesori-data",
+          environment: const {"HOME": "/injected/home"},
+        ),
+        "/injected/home/logout-data",
+      );
+    });
+
+    test("rejects a tilde when the home directory is unavailable", () {
+      expect(
+        () => BridgeCliOptions.resolveDataDirectory(
+          dataDirectoryFlag: "~/missing-home",
+          defaultDataDirectory: "/default/sesori-data",
+          environment: const {},
+        ),
+        throwsA(isA<ArgParserException>()),
       );
     });
 
@@ -167,7 +185,7 @@ BridgeCliOptions _parseOptions({required List<String> args}) {
   return BridgeCliOptions.fromArgResults(
     cliArgs: args,
     results: results,
-    environment: const {},
+    environment: const {"HOME": "/test/home"},
     defaultAuthUrl: "https://api.sesori.com",
     defaultDataDirectory: "/default/sesori-data",
   );


### PR DESCRIPTION
## Summary

- Expand `~` and `~/...` in `--data-dir` using the resolved user home directory.
- Add CLI option coverage for a bare tilde and a home-relative path.

## Verification

- `dart test test/bridge/runtime/bridge_cli_options_test.dart`
- `dart analyze --fatal-infos`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands `~` in `--data-dir` to the user's home directory in the Bridge CLI, supporting `~` and `~/...`. Honors the injected environment when resolving HOME and adds tests and a clear error if HOME is missing.

- **Bug Fixes**
  - Expands `~` and `~/...` via `resolveUserHomeDirectory` from `sesori_bridge_foundation`; uses the injected environment (CLI passes `Platform.environment`).
  - Throws an error when the home directory is not set.
  - Adds tests for bare `~`, home-relative paths, and environment override.

<sup>Written for commit fd4a0547c64e03dfbfb1eb056ebd9b54c2a19e38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

