### PR TITLE
[output-image-support] feat(codex): surface live output images [step 6/13]

### DIFF
--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -5,10 +5,10 @@
 - **Plan slug:** `output-image-support`
 - **Implementation base:** `origin/main` at
   `9d2c1e9e79ab80fa8824b9d803a74798eb71140d`
-- **Series state:** Step 5/13 PR open
-- **Current step:** Step 5/13 — type Codex image-bearing events
+- **Series state:** Step 6/13 ready for PR
+- **Current step:** Step 6/13 — surface live Codex images
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** monitor Step 5/13 CI and review
+- **Next action:** open and monitor the Step 6/13 PR
 
 ## Plan Review
 
@@ -30,8 +30,8 @@
 | [x] | 2/13 | `output-image-support-codex-rollout-content` | `[output-image-support] refactor(codex): seal rollout content [step 2/13]` | 1,200-1,500 | [PR #639](https://github.com/sesori-ai/sesori_apps_monorepo/pull/639) merged as `17e0ecf1`; 680 changed lines |
 | [x] | 3/13 | `output-image-support-codex-rollout-envelopes` | `[output-image-support] refactor(codex): seal rollout envelopes [step 3/13]` | 900-1,350 | [PR #644](https://github.com/sesori-ai/sesori_apps_monorepo/pull/644) merged as `f78e1f69`; 1,075 changed lines |
 | [x] | 4/13 | `output-image-support-codex-response-items` | `[output-image-support] refactor(codex): seal response items [step 4/13]` | 1,100-1,500 | [PR #646](https://github.com/sesori-ai/sesori_apps_monorepo/pull/646) merged as `4be1e7bb`; 1,416 changed lines |
-| [ ] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | [PR #648](https://github.com/sesori-ai/sesori_apps_monorepo/pull/648) open; 1,472 changed lines |
-| [ ] | 6/13 | `output-image-support-codex-live-images` | `[output-image-support] feat(codex): surface live output images [step 6/13]` | 900-1,400 | Blocked on Step 5 merge |
+| [x] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | [PR #648](https://github.com/sesori-ai/sesori_apps_monorepo/pull/648) merged as `e9a03363`; 1,472 changed lines |
+| [ ] | 6/13 | `output-image-support-codex-live-images` | `[output-image-support] feat(codex): surface live output images [step 6/13]` | 900-1,400 | Ready for PR; 830 changed lines |
 | [ ] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | Blocked on Step 6 merge |
 | [ ] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | Blocked on Step 7 merge |
 | [ ] | 9/13 | `output-image-support-acp-content-mapping` | `[output-image-support] refactor(acp): centralize tool content mapping [step 9/13]` | 1,100-1,500 | Blocked on Step 8 merge |
@@ -126,7 +126,18 @@
   `dart analyze --fatal-infos`, and `git diff --cached --check` pass. The first
   architecture review moved output projection back to the event mapper; the
   second `aristotle-impl-review` pass approved with no findings. The 1,472-line
-  diff is below the 1,500-line soft cap; no neighboring scope was combined.
+  diff is below the 1,500-line soft cap; no neighboring scope was combined. PR
+  #648 merged as `e9a03363` on 2026-07-31.
+- Step 6/13 (2026-07-31): added the bounded Codex image attachment mapper and
+  surfaced stable first-class generation, MCP, and dynamic live image tool
+  attachments while preserving text, errors, statuses, and rollout enrichment.
+  Count, decoded-byte, MIME, base64, metadata fallback, basename, privacy-log,
+  remote/local, audio, and `imageView` policies have focused coverage. All 229
+  package tests, `dart pub get`, `dart analyze --fatal-infos`, and
+  `git diff --cached --check` pass. `aristotle-impl-review` approved the staged
+  architecture and security boundaries with no findings. The 830-line diff is
+  below the 1,500-line soft cap. Analytics remain excluded because this is
+  passive rendering without an authoritative action.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -5,10 +5,10 @@
 - **Plan slug:** `output-image-support`
 - **Implementation base:** `origin/main` at
   `9d2c1e9e79ab80fa8824b9d803a74798eb71140d`
-- **Series state:** Step 6/13 ready for PR
+- **Series state:** Step 6/13 open as [PR #652](https://github.com/sesori-ai/sesori_apps_monorepo/pull/652)
 - **Current step:** Step 6/13 — surface live Codex images
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** open and monitor the Step 6/13 PR
+- **Next action:** monitor PR #652 and address CI or review findings
 
 ## Plan Review
 
@@ -31,7 +31,7 @@
 | [x] | 3/13 | `output-image-support-codex-rollout-envelopes` | `[output-image-support] refactor(codex): seal rollout envelopes [step 3/13]` | 900-1,350 | [PR #644](https://github.com/sesori-ai/sesori_apps_monorepo/pull/644) merged as `f78e1f69`; 1,075 changed lines |
 | [x] | 4/13 | `output-image-support-codex-response-items` | `[output-image-support] refactor(codex): seal response items [step 4/13]` | 1,100-1,500 | [PR #646](https://github.com/sesori-ai/sesori_apps_monorepo/pull/646) merged as `4be1e7bb`; 1,416 changed lines |
 | [x] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | [PR #648](https://github.com/sesori-ai/sesori_apps_monorepo/pull/648) merged as `e9a03363`; 1,472 changed lines |
-| [ ] | 6/13 | `output-image-support-codex-live-images` | `[output-image-support] feat(codex): surface live output images [step 6/13]` | 900-1,400 | Ready for PR; 830 changed lines |
+| [ ] | 6/13 | `output-image-support-codex-live-images` | `[output-image-support] feat(codex): surface live output images [step 6/13]` | 900-1,400 | [PR #652](https://github.com/sesori-ai/sesori_apps_monorepo/pull/652) open; 830 changed lines |
 | [ ] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | Blocked on Step 6 merge |
 | [ ] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | Blocked on Step 7 merge |
 | [ ] | 9/13 | `output-image-support-acp-content-mapping` | `[output-image-support] refactor(acp): centralize tool content mapping [step 9/13]` | 1,100-1,500 | Blocked on Step 8 merge |

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -7,6 +7,7 @@ import "api/models/codex_rollout_dto.dart";
 import "api/parsers/codex_image_bearing_item_parser.dart";
 import "codex_app_server_client.dart";
 import "codex_config_reader.dart";
+import "repositories/mappers/codex_image_attachment_mapper.dart";
 import "repositories/mappers/codex_rollout_tool_mapper.dart";
 import "repositories/models/codex_thread_record.dart";
 
@@ -30,10 +31,12 @@ class CodexEventMapper {
   CodexEventMapper({
     required this.pluginId,
     required this.projectCwd,
+    required CodexImageAttachmentMapper imageAttachmentMapper,
     required CodexImageBearingItemParser imageBearingItemParser,
     required CodexRolloutToolMapper rolloutToolMapper,
     this.config = const CodexConfigDefaults.empty(),
-  }) : _imageBearingItemParser = imageBearingItemParser,
+  }) : _imageAttachmentMapper = imageAttachmentMapper,
+       _imageBearingItemParser = imageBearingItemParser,
        _rolloutToolMapper = rolloutToolMapper;
 
   final String pluginId;
@@ -60,6 +63,7 @@ class CodexEventMapper {
   /// global [config] default — making a model switch look like it never took
   /// effect even though codex honoured it. Falls back to [config] when unknown.
   final Map<String, String> _threadModel = {};
+  final CodexImageAttachmentMapper _imageAttachmentMapper;
   final CodexImageBearingItemParser _imageBearingItemParser;
   final CodexRolloutToolMapper _rolloutToolMapper;
 
@@ -285,6 +289,7 @@ class CodexEventMapper {
         tool: call.tool,
         title: call.title,
         status: PluginToolStatus.running,
+        attachments: const [],
       );
     }
     final result = _rolloutToolMapper.mapResult(payload);
@@ -300,6 +305,7 @@ class CodexEventMapper {
       title: originalCall.title,
       status: result.status,
       output: result.output,
+      attachments: const [],
     );
   }
 
@@ -343,8 +349,32 @@ class CodexEventMapper {
 
     final imageBearingItem = _imageBearingItemParser.parse(item: item);
     switch (imageBearingItem) {
-      case CodexImageGenerationItemDto():
-        return const [];
+      case CodexImageGenerationItemDto(
+        :final status,
+        :final result,
+        :final savedPath,
+      ):
+        final toolStatus = _imageGenerationToolStatus(
+          status: status,
+          completed: completed,
+        );
+        return _toolItemEvents(
+          threadId: threadId,
+          itemId: itemId,
+          tool: "image_generation",
+          status: toolStatus,
+          attachments: toolStatus == PluginToolStatus.completed
+              ? _imageAttachmentMapper.map(
+                  candidates: [
+                    CodexImageAttachmentCandidate.base64(
+                      data: result,
+                      mime: "image/png",
+                      filenameHint: savedPath,
+                    ),
+                  ],
+                )
+              : const [],
+        );
       case CodexMcpToolCallItemDto(
         :final server,
         :final tool,
@@ -360,6 +390,17 @@ class CodexEventMapper {
           status: _parsedToolStatus(status: status, completed: completed),
           output: _imageBearingToolOutput(content: content),
           error: error,
+          attachments: _imageAttachmentMapper.map(
+            candidates: [
+              for (final item in content)
+                if (item case CodexMcpImageContentDto(:final data, :final mimeType))
+                  CodexImageAttachmentCandidate.base64(
+                    data: data,
+                    mime: mimeType,
+                    filenameHint: null,
+                  ),
+            ],
+          ),
         );
       case CodexDynamicToolCallItemDto(
         :final tool,
@@ -387,6 +428,15 @@ class CodexEventMapper {
               _rolloutToolMapper.clipOutput(
                 _imageBearingToolOutput(content: content),
               ),
+          attachments: _imageAttachmentMapper.map(
+            candidates: [
+              for (final item in content)
+                if (item case CodexDynamicImageContentDto(:final imageUrl))
+                  CodexImageAttachmentCandidate.imageUrl(
+                    imageUrl: imageUrl,
+                  ),
+            ],
+          ),
         );
       case CodexUnknownImageBearingItemDto() || null:
         break;
@@ -453,6 +503,7 @@ class CodexEventMapper {
               _rolloutToolMapper.clipOutput(
                 item["aggregatedOutput"] as String?,
               ),
+          attachments: const [],
         );
       case "fileChange":
         return _toolItemEvents(
@@ -462,6 +513,7 @@ class CodexEventMapper {
           title: _fileChangeTitle(item["changes"]),
           status: _toolStatus(item["status"], completed: completed),
           output: _fileChangeOutput(item["changes"]),
+          attachments: const [],
         );
       case "webSearch":
         return _toolItemEvents(
@@ -471,6 +523,7 @@ class CodexEventMapper {
           title: item["query"] as String?,
           // webSearch items carry no status field.
           status: completed ? PluginToolStatus.completed : PluginToolStatus.running,
+          attachments: const [],
         );
       case "contextCompaction":
         return [
@@ -480,6 +533,7 @@ class CodexEventMapper {
             tool: "compact",
             title: completed ? "Context compacted" : "Compacting context",
             status: completed ? PluginToolStatus.completed : PluginToolStatus.running,
+            attachments: const [],
           ),
           if (completed) BridgeSseSessionCompacted(sessionID: threadId),
         ];
@@ -502,6 +556,7 @@ class CodexEventMapper {
     required String itemId,
     required String tool,
     required PluginToolStatus status,
+    required List<PluginMessageAttachment> attachments,
     String? title,
     String? output,
     String? error,
@@ -523,7 +578,7 @@ class CodexEventMapper {
             title: title,
             output: output,
             error: error ?? (status == PluginToolStatus.error ? output : null),
-            attachments: const [],
+            attachments: attachments,
           ),
           prompt: null,
           description: null,
@@ -562,6 +617,18 @@ class CodexEventMapper {
       CodexToolCallStatus.completed => PluginToolStatus.completed,
       CodexToolCallStatus.failed || CodexToolCallStatus.declined => PluginToolStatus.error,
       CodexToolCallStatus.unknown => completed ? PluginToolStatus.completed : PluginToolStatus.running,
+    };
+  }
+
+  PluginToolStatus _imageGenerationToolStatus({
+    required CodexImageGenerationStatus status,
+    required bool completed,
+  }) {
+    return switch (status) {
+      CodexImageGenerationStatus.inProgress => PluginToolStatus.running,
+      CodexImageGenerationStatus.completed => PluginToolStatus.completed,
+      CodexImageGenerationStatus.failed => PluginToolStatus.error,
+      CodexImageGenerationStatus.unknown => completed ? PluginToolStatus.completed : PluginToolStatus.running,
     };
   }
 

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -19,6 +19,7 @@ import "repositories/codex_message_repository.dart";
 import "repositories/codex_model_repository.dart";
 import "repositories/codex_skill_repository.dart";
 import "repositories/codex_thread_repository.dart";
+import "repositories/mappers/codex_image_attachment_mapper.dart";
 import "repositories/mappers/codex_rollout_tool_mapper.dart";
 import "repositories/models/codex_thread_record.dart";
 import "runtime/codex_managed_api.dart";
@@ -127,6 +128,7 @@ class CodexPlugin implements CodexManagedApi {
     final resolvedProjectCwd = projectCwd ?? Directory.current.path;
     final configReader = CodexConfigReader();
     final rolloutApi = CodexRolloutApi();
+    const imageAttachmentMapper = CodexImageAttachmentMapper();
     const imageBearingItemParser = CodexImageBearingItemParser();
     const rolloutToolMapper = CodexRolloutToolMapper();
     final catalogRepository = CodexCatalogRepository(rolloutApi: rolloutApi);
@@ -156,6 +158,7 @@ class CodexPlugin implements CodexManagedApi {
       eventMapper: CodexEventMapper(
         pluginId: pluginId,
         projectCwd: resolvedProjectCwd,
+        imageAttachmentMapper: imageAttachmentMapper,
         imageBearingItemParser: imageBearingItemParser,
         rolloutToolMapper: rolloutToolMapper,
         config: configReader.readDefaults(),

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_image_attachment_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_image_attachment_mapper.dart
@@ -1,0 +1,325 @@
+import "dart:convert";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart"
+    show decodedBase64Length, isInlineMessageAttachmentWithinSizeLimit, maxInlineMessageAttachmentBytes;
+
+sealed class CodexImageAttachmentCandidate {
+  const CodexImageAttachmentCandidate();
+
+  const factory CodexImageAttachmentCandidate.base64({
+    required String data,
+    required String mime,
+    required String? filenameHint,
+  }) = CodexBase64ImageAttachmentCandidate;
+
+  const factory CodexImageAttachmentCandidate.imageUrl({
+    required String imageUrl,
+  }) = CodexImageUrlAttachmentCandidate;
+}
+
+final class CodexBase64ImageAttachmentCandidate extends CodexImageAttachmentCandidate {
+  const CodexBase64ImageAttachmentCandidate({
+    required this.data,
+    required this.mime,
+    required this.filenameHint,
+  });
+
+  final String data;
+  final String mime;
+  final String? filenameHint;
+}
+
+final class CodexImageUrlAttachmentCandidate extends CodexImageAttachmentCandidate {
+  const CodexImageUrlAttachmentCandidate({required this.imageUrl});
+
+  final String imageUrl;
+}
+
+final class CodexImageAttachmentMapper {
+  const CodexImageAttachmentMapper();
+
+  static const int _maxAttachmentCount = 4;
+  static const int _maxDataUrlHeaderCharacters = 256;
+  static const int _maxUrlCharactersForFilename = 4096;
+  static const int _maxMimeCharacters = 255;
+  static const String _fallbackMime = "application/octet-stream";
+  static const Set<String> _supportedRasterMimeEssences = {
+    "image/bmp",
+    "image/gif",
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+  };
+
+  List<PluginMessageAttachment> map({
+    required Iterable<CodexImageAttachmentCandidate> candidates,
+  }) {
+    final attachments = <PluginMessageAttachment>[];
+    final warned = <_ImageDegradationReason>{};
+    var remainingBytes = maxInlineMessageAttachmentBytes;
+    var candidateIndex = 0;
+
+    for (final candidate in candidates) {
+      if (candidateIndex >= _maxAttachmentCount) {
+        _warnOnce(
+          reason: _ImageDegradationReason.countOverflow,
+          warned: warned,
+        );
+        candidateIndex += 1;
+        continue;
+      }
+      candidateIndex += 1;
+
+      final result = _mapCandidate(
+        candidate: candidate,
+        remainingBytes: remainingBytes,
+      );
+      switch (result) {
+        case _InlineImageResult(:final attachment, :final decodedBytes):
+          attachments.add(attachment);
+          remainingBytes -= decodedBytes;
+        case _MetadataImageResult(:final attachment, :final reason):
+          attachments.add(attachment);
+          _warnOnce(reason: reason, warned: warned);
+      }
+    }
+    return attachments.toList(growable: false);
+  }
+
+  _ImageMappingResult _mapCandidate({
+    required CodexImageAttachmentCandidate candidate,
+    required int remainingBytes,
+  }) {
+    return switch (candidate) {
+      CodexBase64ImageAttachmentCandidate(:final data, :final mime, :final filenameHint) => _mapEncoded(
+        encoded: data,
+        mime: mime,
+        filename: normalizePluginMessageAttachmentFilename(filename: filenameHint),
+        remainingBytes: remainingBytes,
+      ),
+      CodexImageUrlAttachmentCandidate(:final imageUrl) => _mapImageUrl(
+        imageUrl: imageUrl,
+        remainingBytes: remainingBytes,
+      ),
+    };
+  }
+
+  _ImageMappingResult _mapImageUrl({
+    required String imageUrl,
+    required int remainingBytes,
+  }) {
+    if (!_isDataUrl(url: imageUrl)) {
+      return _metadata(
+        mime: _fallbackMime,
+        filename: _filenameFromUrl(url: imageUrl),
+        reason: _ImageDegradationReason.unsupported,
+      );
+    }
+
+    final prefixLength = imageUrl.length < 5 + _maxDataUrlHeaderCharacters + 1
+        ? imageUrl.length
+        : 5 + _maxDataUrlHeaderCharacters + 1;
+    final separator = imageUrl.substring(0, prefixLength).indexOf(",", 5);
+    if (separator < 5) {
+      return _metadata(
+        mime: _fallbackMime,
+        filename: null,
+        reason: _ImageDegradationReason.invalid,
+      );
+    }
+
+    final headerParts = imageUrl.substring(5, separator).split(";");
+    final mime = _normalizeMime(raw: headerParts.first);
+    final isBase64 = headerParts.skip(1).any((part) => part.trim().toLowerCase() == "base64");
+    if (!isBase64) {
+      return _metadata(
+        mime: mime,
+        filename: null,
+        reason: _ImageDegradationReason.invalid,
+      );
+    }
+    if (!_supportedRasterMimeEssences.contains(_mimeEssence(mime: mime))) {
+      return _metadata(
+        mime: mime,
+        filename: null,
+        reason: _ImageDegradationReason.unsupported,
+      );
+    }
+    final encodedLength = imageUrl.length - separator - 1;
+    if (encodedLength == 0) {
+      return _metadata(
+        mime: mime,
+        filename: null,
+        reason: _ImageDegradationReason.invalid,
+      );
+    }
+    if (!isInlineMessageAttachmentWithinSizeLimit(base64Length: encodedLength)) {
+      return _metadata(
+        mime: mime,
+        filename: null,
+        reason: _ImageDegradationReason.oversized,
+      );
+    }
+    return _mapEncoded(
+      encoded: imageUrl.substring(separator + 1),
+      mime: mime,
+      filename: null,
+      remainingBytes: remainingBytes,
+    );
+  }
+
+  _ImageMappingResult _mapEncoded({
+    required String encoded,
+    required String mime,
+    required String? filename,
+    required int remainingBytes,
+  }) {
+    final normalizedMime = _normalizeMime(raw: mime);
+    if (!_supportedRasterMimeEssences.contains(_mimeEssence(mime: normalizedMime))) {
+      return _metadata(
+        mime: normalizedMime,
+        filename: filename,
+        reason: _ImageDegradationReason.unsupported,
+      );
+    }
+    if (encoded.isEmpty) {
+      return _metadata(
+        mime: normalizedMime,
+        filename: filename,
+        reason: _ImageDegradationReason.invalid,
+      );
+    }
+    if (!isInlineMessageAttachmentWithinSizeLimit(base64Length: encoded.length)) {
+      return _metadata(
+        mime: normalizedMime,
+        filename: filename,
+        reason: _ImageDegradationReason.oversized,
+      );
+    }
+
+    final normalized = _tryNormalizeBase64(encoded: encoded);
+    if (normalized == null) {
+      return _metadata(
+        mime: normalizedMime,
+        filename: filename,
+        reason: _ImageDegradationReason.invalid,
+      );
+    }
+    if (!isInlineMessageAttachmentWithinSizeLimit(base64Length: normalized.length)) {
+      return _metadata(
+        mime: normalizedMime,
+        filename: filename,
+        reason: _ImageDegradationReason.oversized,
+      );
+    }
+
+    final decodedBytes = decodedBase64Length(base64Data: normalized);
+    if (decodedBytes > remainingBytes) {
+      return _metadata(
+        mime: normalizedMime,
+        filename: filename,
+        reason: _ImageDegradationReason.aggregateOverflow,
+      );
+    }
+    return _InlineImageResult(
+      attachment: PluginMessageAttachment.inlineImage(
+        mime: normalizedMime,
+        base64: normalized,
+        filename: filename,
+      ),
+      decodedBytes: decodedBytes,
+    );
+  }
+
+  _MetadataImageResult _metadata({
+    required String mime,
+    required String? filename,
+    required _ImageDegradationReason reason,
+  }) {
+    return _MetadataImageResult(
+      attachment: PluginMessageAttachment.metadata(
+        mime: _normalizeMime(raw: mime),
+        filename: filename,
+      ),
+      reason: reason,
+    );
+  }
+
+  String? _tryNormalizeBase64({required String encoded}) {
+    try {
+      return base64.normalize(encoded);
+    } on FormatException {
+      return null;
+    }
+  }
+
+  String _normalizeMime({required String? raw}) {
+    final trimmed = raw?.trim();
+    if (trimmed == null || trimmed.isEmpty) return _fallbackMime;
+    return String.fromCharCodes(trimmed.runes.take(_maxMimeCharacters)).toLowerCase();
+  }
+
+  String _mimeEssence({required String mime}) => mime.split(";").first.trim();
+
+  bool _isDataUrl({required String url}) => url.length >= 5 && url.substring(0, 5).toLowerCase() == "data:";
+
+  String? _filenameFromUrl({required String url}) {
+    if (url.length > _maxUrlCharactersForFilename) return null;
+    final uri = Uri.tryParse(url);
+    if (uri == null || uri.pathSegments.isEmpty) return null;
+    final segments = uri.pathSegments.where((segment) => segment.isNotEmpty);
+    return segments.isEmpty ? null : normalizePluginMessageAttachmentFilename(filename: segments.last);
+  }
+
+  void _warnOnce({
+    required _ImageDegradationReason reason,
+    required Set<_ImageDegradationReason> warned,
+  }) {
+    if (!warned.add(reason)) return;
+    Log.w(
+      switch (reason) {
+        _ImageDegradationReason.invalid => "[codex] invalid image attachment; forwarding metadata only",
+        _ImageDegradationReason.unsupported => "[codex] unsupported image attachment; forwarding metadata only",
+        _ImageDegradationReason.oversized =>
+          "[codex] image attachment exceeds the transport limit; forwarding metadata only",
+        _ImageDegradationReason.aggregateOverflow =>
+          "[codex] image attachments exceed the aggregate transport limit; forwarding metadata only",
+        _ImageDegradationReason.countOverflow =>
+          "[codex] image attachment collection exceeds the count limit; dropping excess candidates",
+      },
+    );
+  }
+}
+
+enum _ImageDegradationReason {
+  invalid,
+  unsupported,
+  oversized,
+  aggregateOverflow,
+  countOverflow,
+}
+
+sealed class _ImageMappingResult {
+  const _ImageMappingResult();
+}
+
+final class _InlineImageResult extends _ImageMappingResult {
+  const _InlineImageResult({
+    required this.attachment,
+    required this.decodedBytes,
+  });
+
+  final PluginMessageAttachment attachment;
+  final int decodedBytes;
+}
+
+final class _MetadataImageResult extends _ImageMappingResult {
+  const _MetadataImageResult({
+    required this.attachment,
+    required this.reason,
+  });
+
+  final PluginMessageAttachment attachment;
+  final _ImageDegradationReason reason;
+}

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -5,6 +5,7 @@ import "package:codex_plugin/src/api/codex_app_server_api.dart";
 import "package:codex_plugin/src/api/models/codex_rollout_dto.dart";
 import "package:codex_plugin/src/api/parsers/codex_image_bearing_item_parser.dart";
 import "package:codex_plugin/src/repositories/codex_thread_repository.dart";
+import "package:codex_plugin/src/repositories/mappers/codex_image_attachment_mapper.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" as shared;
 import "package:test/test.dart";
@@ -17,11 +18,13 @@ import "package:test/test.dart";
 void main() {
   group("CodexEventMapper", () {
     const projectCwd = "/repo/app";
+    const imageAttachmentMapper = CodexImageAttachmentMapper();
     const imageBearingItemParser = CodexImageBearingItemParser();
     const rolloutToolMapper = CodexRolloutToolMapper();
     final mapper = CodexEventMapper(
       pluginId: CodexPlugin.pluginId,
       projectCwd: projectCwd,
+      imageAttachmentMapper: imageAttachmentMapper,
       imageBearingItemParser: imageBearingItemParser,
       rolloutToolMapper: rolloutToolMapper,
     );
@@ -171,6 +174,7 @@ void main() {
       final scopedMapper = CodexEventMapper(
         pluginId: CodexPlugin.pluginId,
         projectCwd: projectCwd,
+        imageAttachmentMapper: imageAttachmentMapper,
         imageBearingItemParser: imageBearingItemParser,
         rolloutToolMapper: rolloutToolMapper,
       )..setThreadDirectory("t-9", "/repo/app/packages/ui");
@@ -190,6 +194,7 @@ void main() {
       final activityMapper = CodexEventMapper(
         pluginId: CodexPlugin.pluginId,
         projectCwd: projectCwd,
+        imageAttachmentMapper: imageAttachmentMapper,
         imageBearingItemParser: imageBearingItemParser,
         rolloutToolMapper: rolloutToolMapper,
       );
@@ -236,6 +241,7 @@ void main() {
       final activityMapper = CodexEventMapper(
         pluginId: CodexPlugin.pluginId,
         projectCwd: projectCwd,
+        imageAttachmentMapper: imageAttachmentMapper,
         imageBearingItemParser: imageBearingItemParser,
         rolloutToolMapper: rolloutToolMapper,
       );
@@ -407,6 +413,7 @@ void main() {
       final richMapper = CodexEventMapper(
         pluginId: CodexPlugin.pluginId,
         projectCwd: projectCwd,
+        imageAttachmentMapper: imageAttachmentMapper,
         imageBearingItemParser: imageBearingItemParser,
         rolloutToolMapper: rolloutToolMapper,
         config: const CodexConfigDefaults(model: "gpt-5.5", modelProvider: "openai"),
@@ -446,6 +453,7 @@ void main() {
       final richMapper = CodexEventMapper(
         pluginId: CodexPlugin.pluginId,
         projectCwd: projectCwd,
+        imageAttachmentMapper: imageAttachmentMapper,
         imageBearingItemParser: imageBearingItemParser,
         rolloutToolMapper: rolloutToolMapper,
         config: const CodexConfigDefaults(model: "gpt-5.5", modelProvider: "openai"),
@@ -783,13 +791,13 @@ void main() {
       expect(part.state?.output, contains("+b"));
     });
 
-    test("imageGeneration items remain deliberately unrendered", () {
-      for (final (method, status) in [
-        ("item/started", "in_progress"),
-        ("item/completed", "completed"),
-        ("item/completed", "failed"),
-      ]) {
-        final events = mapper.map(
+    test("imageGeneration upserts one stable tool part across its lifecycle", () {
+      List<BridgeSseEvent> mapImage({
+        required String method,
+        required String status,
+        required String result,
+      }) {
+        return mapper.map(
           CodexServerNotification(
             method: method,
             params: {
@@ -799,15 +807,39 @@ void main() {
                 "id": "i-image",
                 "status": status,
                 "revisedPrompt": "private prompt",
-                "result": "private image payload",
+                "result": result,
                 "savedPath": "/private/output.png",
               },
             },
           ),
         );
-
-        expect(events, isEmpty);
       }
+
+      final started = mapImage(method: "item/started", status: "in_progress", result: "");
+      final completed = mapImage(method: "item/completed", status: "completed", result: "AA==");
+      final failed = mapImage(method: "item/completed", status: "failed", result: "AA==");
+
+      final runningPart = (started[1] as BridgeSseMessagePartUpdated).part;
+      final completedPart = (completed[1] as BridgeSseMessagePartUpdated).part;
+      final failedPart = (failed[1] as BridgeSseMessagePartUpdated).part;
+      expect(started, hasLength(2));
+      expect(runningPart.id, "i-image-tool");
+      expect(runningPart.messageID, "i-image");
+      expect(runningPart.tool, "image_generation");
+      expect(runningPart.state?.status, PluginToolStatus.running);
+      expect(runningPart.state?.title, isNull);
+      expect(runningPart.state?.attachments, isEmpty);
+      expect(completedPart.id, runningPart.id);
+      expect(completedPart.state?.status, PluginToolStatus.completed);
+      final image = completedPart.state!.attachments.single as PluginMessageAttachmentInlineImage;
+      expect(image.mime, "image/png");
+      expect(image.base64, "AA==");
+      expect(image.filename, "output.png");
+      expect(completedPart.toString(), isNot(contains("private prompt")));
+      expect(completedPart.toString(), isNot(contains("/private/")));
+      expect(failedPart.id, runningPart.id);
+      expect(failedPart.state?.status, PluginToolStatus.error);
+      expect(failedPart.state?.attachments, isEmpty);
     });
 
     test("mcpToolCall (failed) → error tool part", () {
@@ -825,7 +857,11 @@ void main() {
               "result": {
                 "content": [
                   {"type": "text", "text": "before "},
-                  {"type": "image", "data": "encoded-image", "mimeType": "image/png"},
+                  {"type": "image", "data": "AA==", "mimeType": "image/png"},
+                  {"type": "image", "data": "AA==", "mimeType": "image/png"},
+                  {"type": "image", "data": "AA==", "mimeType": "image/png"},
+                  {"type": "image", "data": "AA==", "mimeType": "image/png"},
+                  {"type": "image", "data": "AA==", "mimeType": "image/png"},
                   {"type": "text", "text": "after"},
                 ],
               },
@@ -841,7 +877,8 @@ void main() {
       expect(part.state?.title, "playwright/click");
       expect(part.state?.output, "before after");
       expect(part.state?.error, "element not found");
-      expect(part.state?.attachments, isEmpty);
+      expect(part.state?.attachments, hasLength(4));
+      expect(part.state?.attachments, everyElement(isA<PluginMessageAttachmentInlineImage>()));
     });
 
     test("dynamicToolCall streams a running tool and its completed output", () {
@@ -898,6 +935,7 @@ void main() {
               "contentItems": [
                 {"type": "inputText", "text": "wait completed"},
                 {"type": "inputImage", "imageUrl": "data:image/png;base64,AA=="},
+                {"type": "inputImage", "imageUrl": "https://example.com/private/remote.png?token=secret"},
                 {"type": "inputAudio", "audioUrl": "data:audio/wav;base64,AA=="},
               ],
               "durationMs": 2000,
@@ -912,7 +950,29 @@ void main() {
       expect(completedPart.id, runningPart.id);
       expect(completedPart.state?.status, PluginToolStatus.completed);
       expect(completedPart.state?.output, "wait completed");
-      expect(completedPart.state?.attachments, isEmpty);
+      expect(completedPart.state?.attachments, hasLength(2));
+      expect(completedPart.state?.attachments[0], isA<PluginMessageAttachmentInlineImage>());
+      final remote = completedPart.state!.attachments[1] as PluginMessageAttachmentMetadata;
+      expect(remote.mime, "application/octet-stream");
+      expect(remote.filename, "remote.png");
+    });
+
+    test("imageView local paths remain unsupported", () {
+      final events = mapper.map(
+        const CodexServerNotification(
+          method: "item/completed",
+          params: {
+            "threadId": "t-1",
+            "item": {
+              "type": "imageView",
+              "id": "i-view",
+              "path": "/private/output.png",
+            },
+          },
+        ),
+      );
+
+      expect(events, isEmpty);
     });
 
     test("dynamicToolCall falls back for malformed or empty tool names", () {

--- a/bridge/sesori_plugin_codex/test/codex_image_attachment_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_image_attachment_mapper_test.dart
@@ -1,0 +1,316 @@
+import "dart:convert";
+import "dart:io";
+import "dart:typed_data";
+
+import "package:codex_plugin/src/repositories/mappers/codex_image_attachment_mapper.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" show maxInlineMessageAttachmentBytes;
+import "package:test/test.dart";
+
+void main() {
+  group("CodexImageAttachmentMapper", () {
+    const mapper = CodexImageAttachmentMapper();
+
+    test("allows the bounded raster MIME set and normalizes filenames", () {
+      for (final mime in [
+        "image/bmp",
+        "image/gif",
+        "IMAGE/JPEG; charset=binary",
+        "image/png",
+        "image/webp",
+      ]) {
+        final attachment = mapper
+            .map(
+              candidates: [
+                CodexImageAttachmentCandidate.base64(
+                  data: "AA==",
+                  mime: " $mime ",
+                  filenameHint: r" C:\private\render.png ",
+                ),
+              ],
+            )
+            .single;
+
+        expect(attachment, isA<PluginMessageAttachmentInlineImage>());
+        final image = attachment as PluginMessageAttachmentInlineImage;
+        expect(image.mime, mime.trim().toLowerCase());
+        expect(image.filename, "render.png");
+        expect(image.base64, "AA==");
+      }
+    });
+
+    test("normalizes supported base64 and data URL forms", () {
+      final attachments = mapper.map(
+        candidates: const [
+          CodexImageAttachmentCandidate.base64(
+            data: "AA",
+            mime: "image/png",
+            filenameHint: null,
+          ),
+          CodexImageAttachmentCandidate.base64(
+            data: "-_8=",
+            mime: "image/png",
+            filenameHint: null,
+          ),
+          CodexImageAttachmentCandidate.base64(
+            data: "%2BA%3D%3D",
+            mime: "image/png",
+            filenameHint: null,
+          ),
+          CodexImageAttachmentCandidate.imageUrl(
+            imageUrl: "DATA:image/png;BASE64,AA==",
+          ),
+        ],
+      );
+
+      expect(
+        attachments.map((attachment) => (attachment as PluginMessageAttachmentInlineImage).base64),
+        ["AA==", "+/8=", "+A==", "AA=="],
+      );
+    });
+
+    test("rejects malformed base64 and bounded data URL headers", () {
+      final attachments = mapper.map(
+        candidates: [
+          for (final data in ["A", "A===", "AA=A", "AA\n=="])
+            CodexImageAttachmentCandidate.base64(
+              data: data,
+              mime: "image/png",
+              filenameHint: null,
+            ),
+        ],
+      );
+      final oversizedHeader = mapper
+          .map(
+            candidates: [
+              CodexImageAttachmentCandidate.imageUrl(
+                imageUrl: "data:${"a" * 257};base64,AA==",
+              ),
+            ],
+          )
+          .single;
+
+      expect(attachments, everyElement(isA<PluginMessageAttachmentMetadata>()));
+      expect(oversizedHeader, isA<PluginMessageAttachmentMetadata>());
+    });
+
+    test("converts invalid, unsupported, and remote candidates to metadata", () {
+      final attachments = mapper.map(
+        candidates: const [
+          CodexImageAttachmentCandidate.base64(
+            data: "not base64",
+            mime: "image/png",
+            filenameHint: null,
+          ),
+          CodexImageAttachmentCandidate.base64(
+            data: "AA==",
+            mime: "image/svg+xml",
+            filenameHint: null,
+          ),
+          CodexImageAttachmentCandidate.imageUrl(
+            imageUrl: "https://example.com/private/output.png?token=secret",
+          ),
+          CodexImageAttachmentCandidate.imageUrl(
+            imageUrl: "data:image/png,not-base64",
+          ),
+        ],
+      );
+
+      expect(attachments, everyElement(isA<PluginMessageAttachmentMetadata>()));
+      final remote = attachments[2] as PluginMessageAttachmentMetadata;
+      expect(remote.mime, "application/octet-stream");
+      expect(remote.filename, "output.png");
+    });
+
+    test("the bounded prefix consumes invalid slots and drops later images", () {
+      final attachments = mapper.map(
+        candidates: [
+          const CodexImageAttachmentCandidate.base64(
+            data: "invalid payload",
+            mime: "image/png",
+            filenameHint: null,
+          ),
+          for (var index = 0; index < 4; index++)
+            const CodexImageAttachmentCandidate.base64(
+              data: "AA==",
+              mime: "image/png",
+              filenameHint: null,
+            ),
+        ],
+      );
+
+      expect(attachments, hasLength(4));
+      expect(attachments.first, isA<PluginMessageAttachmentMetadata>());
+      expect(attachments.skip(1), everyElement(isA<PluginMessageAttachmentInlineImage>()));
+    });
+
+    test("drops excess candidates before inspecting their payload", () {
+      final output = _captureWarnings(() {
+        mapper.map(
+          candidates: [
+            for (var index = 0; index < 4; index++)
+              const CodexImageAttachmentCandidate.base64(
+                data: "AA==",
+                mime: "image/png",
+                filenameHint: null,
+              ),
+            const CodexImageAttachmentCandidate.base64(
+              data: "private invalid payload",
+              mime: "image/svg+xml",
+              filenameHint: "/private/secret.svg",
+            ),
+          ],
+        );
+      });
+
+      expect(output, contains("count limit"));
+      expect(output, isNot(contains("invalid image attachment")));
+      expect(output, isNot(contains("unsupported image attachment")));
+      expect(output, isNot(contains("private")));
+    });
+
+    test("enforces individual and aggregate decoded byte limits", () {
+      final threeMiB = base64Encode(Uint8List(3 * 1024 * 1024));
+      final tooLarge = base64Encode(Uint8List(maxInlineMessageAttachmentBytes + 1));
+      final attachments = mapper.map(
+        candidates: [
+          CodexImageAttachmentCandidate.base64(
+            data: threeMiB,
+            mime: "image/png",
+            filenameHint: null,
+          ),
+          CodexImageAttachmentCandidate.base64(
+            data: threeMiB,
+            mime: "image/png",
+            filenameHint: null,
+          ),
+          const CodexImageAttachmentCandidate.base64(
+            data: "AA==",
+            mime: "image/png",
+            filenameHint: null,
+          ),
+          CodexImageAttachmentCandidate.base64(
+            data: tooLarge,
+            mime: "image/png",
+            filenameHint: null,
+          ),
+        ],
+      );
+
+      expect(attachments[0], isA<PluginMessageAttachmentInlineImage>());
+      expect(attachments[1], isA<PluginMessageAttachmentMetadata>());
+      expect(attachments[2], isA<PluginMessageAttachmentInlineImage>());
+      expect(attachments[3], isA<PluginMessageAttachmentMetadata>());
+    });
+
+    test("deduplicates privacy-safe warnings per collection and reason", () {
+      late List<PluginMessageAttachment> attachments;
+      final output = _captureWarnings(() {
+        attachments = mapper.map(
+          candidates: const [
+            CodexImageAttachmentCandidate.base64(
+              data: "private invalid payload",
+              mime: "image/png",
+              filenameHint: "/private/secret.png",
+            ),
+            CodexImageAttachmentCandidate.base64(
+              data: "another private invalid payload",
+              mime: "image/png",
+              filenameHint: "secret-2.png",
+            ),
+            CodexImageAttachmentCandidate.imageUrl(
+              imageUrl: "https://secret.example/private.png?token=credential",
+            ),
+            CodexImageAttachmentCandidate.imageUrl(
+              imageUrl: "file:///private/secret.png",
+            ),
+            CodexImageAttachmentCandidate.base64(
+              data: "AA==",
+              mime: "image/png",
+              filenameHint: "dropped-secret.png",
+            ),
+          ],
+        );
+      });
+
+      expect(attachments, hasLength(4));
+      expect("invalid image attachment".allMatches(output), hasLength(1));
+      expect("unsupported image attachment".allMatches(output), hasLength(1));
+      expect("count limit".allMatches(output), hasLength(1));
+      for (final secret in [
+        "private invalid payload",
+        "secret.example",
+        "/private/secret.png",
+        "credential",
+        "FormatException",
+      ]) {
+        expect(output, isNot(contains(secret)));
+      }
+    });
+
+    test("warning deduplication resets for each collection", () {
+      final output = _captureWarnings(() {
+        for (var collection = 0; collection < 2; collection++) {
+          mapper.map(
+            candidates: const [
+              CodexImageAttachmentCandidate.base64(
+                data: "invalid payload",
+                mime: "image/png",
+                filenameHint: null,
+              ),
+            ],
+          );
+        }
+      });
+
+      expect("invalid image attachment".allMatches(output), hasLength(2));
+    });
+
+    test("candidate and attachment strings do not expose encoded data", () {
+      const secret = "private-encoded-payload";
+      const candidate = CodexImageAttachmentCandidate.base64(
+        data: secret,
+        mime: "image/png",
+        filenameHint: null,
+      );
+      final attachment = mapper
+          .map(
+            candidates: const [
+              CodexImageAttachmentCandidate.base64(
+                data: "AA==",
+                mime: "image/png",
+                filenameHint: null,
+              ),
+            ],
+          )
+          .single;
+
+      expect(candidate.toString(), isNot(contains(secret)));
+      expect(attachment.toString(), isNot(contains("AA==")));
+    });
+  });
+}
+
+String _captureWarnings(void Function() action) {
+  final previousLevel = Log.level;
+  final stderr = _BufferingStdout();
+  try {
+    Log.level = LogLevel.warning;
+    IOOverrides.runZoned(action, stderr: () => stderr);
+  } finally {
+    Log.level = previousLevel;
+  }
+  return stderr.text;
+}
+
+class _BufferingStdout implements Stdout {
+  final StringBuffer _buffer = StringBuffer();
+
+  String get text => _buffer.toString();
+
+  @override
+  void writeln([Object? object = ""]) => _buffer.writeln(object);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}

--- a/bridge/sesori_plugin_codex/test/support/codex_plugin_test_factory.dart
+++ b/bridge/sesori_plugin_codex/test/support/codex_plugin_test_factory.dart
@@ -2,6 +2,7 @@ import "package:codex_plugin/codex_plugin.dart";
 import "package:codex_plugin/src/api/parsers/codex_image_bearing_item_parser.dart";
 import "package:codex_plugin/src/repositories/codex_catalog_repository.dart";
 import "package:codex_plugin/src/repositories/codex_message_repository.dart";
+import "package:codex_plugin/src/repositories/mappers/codex_image_attachment_mapper.dart";
 import "package:codex_plugin/src/services/codex_session_service.dart";
 
 CodexPlugin createInjectedCodexPlugin({
@@ -35,6 +36,7 @@ CodexPlugin createInjectedCodexPlugin({
     eventMapper: CodexEventMapper(
       pluginId: CodexPlugin.pluginId,
       projectCwd: projectCwd,
+      imageAttachmentMapper: const CodexImageAttachmentMapper(),
       imageBearingItemParser: const CodexImageBearingItemParser(),
       rolloutToolMapper: rolloutToolMapper,
       config: configReader.readDefaults(),


### PR DESCRIPTION
## Summary

- add a Codex-owned image attachment mapper with raster MIME allowlisting, four-image and 5 MiB aggregate limits, strict base64 handling, metadata degradation, basename-only filenames, and privacy-safe deduplicated warnings
- surface first-class image-generation lifecycle updates through one stable tool part and attach completed PNG output
- attach MCP and dynamic data images without losing existing text, errors, statuses, or rollout enrichment; keep remote/local images metadata-only and continue dropping audio and `imageView`

## Verification

- `dart pub get`
- focused image attachment mapper and event integration tests
- `dart test` (229 tests)
- `dart analyze --fatal-infos`
- `git diff --cached --check`
- `aristotle-impl-review` — approved with no findings

## Plan

Step 6/13 of `.plan/active/output-image-support/PLAN.md`. The complete 830-line diff is below the original estimate and the 1,500-line soft cap; no adjacent scope was combined. Analytics remain excluded because this is passive rendering without an authoritative user action.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds live output images to Codex by emitting image attachments on tool parts via a bounded, privacy-safe mapper. Preserves existing text, errors, and statuses; attaches images when safe.

- New Features
  - Added `CodexImageAttachmentMapper` with raster MIME allowlist (bmp, gif, jpeg, png, webp), max 4 images per message, decoded-byte and aggregate limits, strict base64/data URL parsing, metadata fallback, basename-only filenames, and deduplicated warnings.
  - Image generation: single stable `image_generation` tool part across the lifecycle; attaches PNG output on completion using `savedPath` for the filename.
  - MCP tool calls: preserves text/errors and attaches inline images from base64 content.
  - Dynamic tool calls: inlines data URL images; remote/local image paths become metadata-only; audio and `imageView` remain unsupported.

<sup>Written for commit a57dd231799f86cec715e6d833f107763348652c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

