### PR TITLE
docs(plan): archive completed plugin plans

### DIFF
--- a/.plan/completed/multi-plugin-release-prep/PLAN.md
+++ b/.plan/completed/multi-plugin-release-prep/PLAN.md
@@ -3,9 +3,9 @@
 ## Status
 
 - **Plan slug:** `multi-plugin-release-prep`
-- **Status:** Steps 1/6 through 5.C/6 merged; Step 6/6 is in progress
+- **Status:** complete; Steps 1/6 through 6/6 merged
 - **Plan delivery:** this document and its tracker are Step 1/6
-- **Implementation base:** `origin/main` at `4be1e7bb`
+- **Completion base:** `origin/main` at final Step 6 merge `0da8ec7c`
 - **Approved product direction:** Codex remains project-aware; Cursor and the
   ACP-backed option state use plugin-scoped caching; OpenCode remains
   project-scoped
@@ -737,7 +737,7 @@ refresh-outcome reporting after the active user-analytics foundation lands.
 
 ## Completion
 
-The plan completes after all six PRs merge, New Session switching reads durable
+The plan completed after all six steps merged, New Session switching reads durable
 scope-correct options and dynamically starts only the selected harness on cache
 miss, explicit cache-only and forced-refresh semantics plus old-bridge
 degradation are verified, both cache scopes survive restart, and the single

--- a/.plan/completed/multi-plugin-release-prep/TRACKER.md
+++ b/.plan/completed/multi-plugin-release-prep/TRACKER.md
@@ -2,11 +2,11 @@
 
 ## Current State
 
-- **Implementation base:** `origin/main` at `4be1e7bb`
-- **Series state:** Steps 1/6 through 5.C/6 are merged; oversized PR #620 is
+- **Completion base:** `origin/main` at final Step 6 merge `0da8ec7c`
+- **Series state:** complete; Steps 1/6 through 6/6 merged; oversized PR #620 is
   closed, with its frozen branch retained only as the split implementation source
-- **Current step:** Step 6/6 — consolidated Harnesses settings
-- **Next action:** monitor final Step 6 PR #647 through review and CI
+- **Current step:** complete
+- **Next action:** none; plan archived after the final implementation merge
 
 ## Delivery
 
@@ -24,7 +24,7 @@
 | [x] | Step 5.A/6 — cached session-option client layers | `multi-plugin-release-prep-client-options` | PR #635 merged |
 | [x] | Step 5.B/6 — cached New Session composer | `multi-plugin-release-prep-client-options-ui` | PR #636 merged |
 | [x] | Step 5.C/6 — dynamic session-option cache misses | `multi-plugin-release-prep-dynamic-options` | PR #642 merged |
-| [ ] | Step 6/6 — consolidated Harnesses settings | `multi-plugin-release-prep-harness-settings` | [PR #647](https://github.com/sesori-ai/sesori_apps_monorepo/pull/647) open against `main` |
+| [x] | Step 6/6 — consolidated Harnesses settings | `multi-plugin-release-prep-harness-settings` | [PR #647](https://github.com/sesori-ai/sesori_apps_monorepo/pull/647) merged as `0da8ec7c` |
 
 ## Locked Decisions
 
@@ -311,3 +311,6 @@
   than transitional stacked delivery.
 - Step 6/6 delivery (2026-07-31): committed as `f300d958`, pushed, and opened as
   PR #647 against `main`.
+- Step 6/6 merge (2026-07-31): PR #647 merged to `main` as `0da8ec7c`. All
+  planned release-preparation steps are complete, and the plan moved to the
+  completed archive.

--- a/.plan/completed/plugin-lifecycle-migration/PLAN.html
+++ b/.plan/completed/plugin-lifecycle-migration/PLAN.html
@@ -87,7 +87,7 @@
   <h1>Plugin Lifecycle Migration Plan</h1>
   <div class="sub">Move all OpenCode runtime ownership (spawn, ports, health, ownership records, DB maintenance) out of <code>bridge/app</code> and into the OpenCode plugin, behind a plugin interface that supports managed-runtime, direct-CLI, and remote-server plugins — with per-plugin enable/start/stop. Delivered as a ladder of small, always-green PRs.</div>
   <div class="meta">
-    <span><b>Status:</b> in progress (rev 7 — PRs 1–11 merged, PR 12 shipped #249, PR 13 shipped #251; PR 14 had no remaining deletions and was folded into PR 15 docs sweep; codegen / line-budget rule revised per maintainer review; shipped cards carry delta callouts binding on later PRs)</span>
+    <span><b>Status:</b> complete (PRs 1–13 merged; empty PR 14 folded into the final PR 15 docs sweep, shipped as #252)</span>
     <span><b>Date:</b> 2026-06-10 (rev 3: 2026-06-11; rev 4–6: 2026-06-12)</span>
     <span><b>PRs:</b> 15, strictly sequential</span>
     <span><b>Max PR size:</b> ~2,000 hand-written changed lines (soft target; generated code excluded)</span>
@@ -392,6 +392,7 @@
   </li>
 </ul>
 <div class="safe"><b>Why always-green:</b> docs only; no production code changes.</div>
+<div class="callout green"><b>Shipped as #252 (2026-06-13).</b> The final docs sweep closed the plugin-lifecycle migration ladder.</div>
 </div>
 
 <h2><span class="num">4</span>Risk register → where each is retired</h2>

--- a/.plan/completed/setup-aware-harness-settings/E2E.md
+++ b/.plan/completed/setup-aware-harness-settings/E2E.md
@@ -1,0 +1,112 @@
+# Setup-Aware Harness Settings: Simulator E2E
+
+## Status
+
+- **Date:** 2026-07-31
+- **Result:** passed on the final current-main single-screen Harnesses design
+- **Product baseline:** PR #595 merged the original Step 8/8 controls as
+  `a30b671b`; PR #647 later consolidated the overview and controls into one
+  screen and merged to `main` as `0da8ec7c`
+- **Scope:** close the remaining real-simulator gate for
+  `setup-aware-harness-settings` and its parent lifecycle plan
+
+This record tests the current product destination. The original Stage 13 plan
+described an overview plus a nested management page, but PR #647 intentionally
+removed that nested route and folded its controls into the surviving Harnesses
+screen. The checks below therefore apply the original lifecycle, timeout,
+capability, persistence, and cleanup requirements to that final single screen.
+
+## Environment
+
+- iPhone 17 simulator running iOS 26.5.
+- Installed Sesori app (`com.sesori.app`), already signed into the same account
+  as the bridge.
+- Source bridge and app behavior from the PR #647/current-main code.
+- Bridge debug server on `127.0.0.1:9977`.
+- Durable bridge data at `~/.local/share/sesori-dev`.
+- Existing `random stuff` project used for session behavior.
+- The first startup had imported existing project/session catalog data, but the
+  bridge database had no test mutations from this E2E run.
+- A pre-existing externally managed OpenCode server was already listening on
+  `127.0.0.1:4096`. It was treated as unrelated user state and was not stopped
+  or replaced.
+
+## Initial Snapshot
+
+`GET /plugin/management` showed:
+
+- Codex, Cursor, and OpenCode setup `ready`;
+- all three eligible and enabled;
+- default idle timeout `10` minutes;
+- no per-harness timeout overrides; and
+- normal managed-mode capabilities `lifecycle`, `setupRefresh`, and
+  `idleTimeout` for all three harnesses.
+
+The initially connected app had activated the three harnesses while loading
+catalog data. Later clean bridge starts correctly returned them to `dormant`
+until demand.
+
+## Test Record
+
+| ID | Check | Exact action | Observed result |
+|---|---|---|---|
+| E2E-01 | Settings navigation | Opened Settings from Projects. | Harnesses was immediately below Notifications in the same grouped settings card. |
+| E2E-02 | Final single-screen presentation | Opened Harnesses. | One screen showed the bridge default and all registered harnesses. Codex, Cursor, and OpenCode rendered distinct bundled logos; OpenCode carried the Default badge. Setup/runtime/work facts matched the live management snapshot. |
+| E2E-03 | Setup refresh | Tapped **Refresh setup** for Codex. | Codex remained setup `ready`, active, and idle with no action or refresh error. |
+| E2E-04 | Safe restart | Tapped **Restart** for idle Codex. | The command completed and Codex returned active/idle without an error. |
+| E2E-05 | Per-harness no-timeout override | Opened Codex **Idle timeout**, selected **No timeout**, and saved. | The Prego sheet closed, the card showed “This harness stays running / No timeout,” and the bridge reported `idleTimeoutMins: 0` with `hasIdleTimeoutOverride: true`. |
+| E2E-06 | Clear timeout override | Tapped **Use bridge default** for Codex. | The override cleared, the card returned to 10 minutes, and the bridge reported `hasIdleTimeoutOverride: false`. |
+| E2E-07 | Apply one timeout to all | Opened **Default idle timeout**, selected Custom, entered `12`, and saved. | The bridge default and every capable harness changed to 12 minutes; all per-harness override flags remained false. |
+| E2E-08 | Persistence across bridge process restart | Sent `POST /global/restart`, observed the app enter **Loading harnesses**, then relaunched the source bridge against the same absolute data directory when the detached source handoff did not return. | After reconnect, the app and bridge still showed the 12-minute default for all three harnesses with no overrides. This verifies durable settings persistence across shutdown/start and client reconnection. See the source-handoff follow-up below. |
+| E2E-09 | Restore timeout baseline | Set the global custom timeout back to `10`. | Default and effective timeouts returned to 10 minutes with no overrides. |
+| E2E-10 | Safe disable and enable | Disabled dormant Codex, inspected the card, then enabled it again. | Disable produced runtime `disabled`; the card kept setup context and the enable/setup actions while hiding runtime/work/restart/timeout facts. Enable re-inspected setup and returned Codex active/idle. |
+| E2E-11 | Create from resulting harness state | Opened `random stuff`, created a Codex session with Dedicated worktree off, and submitted: ``E2E lifecycle test: run `sleep 90`, then reply exactly E2E COMPLETE. Do not modify any files.`` | The session was created successfully, appeared as Running, and Codex management work state became `busy`. No worktree or file change was created. |
+| E2E-12 | Busy safe-conflict copy | While the session was busy, toggled Codex off. | Safe disable produced a non-dismissible Prego confirmation sheet titled **Force disable harness?** with the warning that active work may be interrupted and the action is sent once. |
+| E2E-13 | Force cancellation | Tapped **Cancel** on the first confirmation. | No force mutation was sent; Codex remained active/busy and the session remained Running. |
+| E2E-14 | Explicit one-shot force | Repeated safe disable and tapped **Force action** once. | Codex became disabled with unknown work state. The test session stopped showing Running but remained visible in the session list. |
+| E2E-15 | Forced-disable session reconciliation | Re-enabled Codex and reopened the test session. | Messages loaded again and retained the interrupted turn, including aborted sleep-tool output. The session was not lost or left falsely running. |
+| E2E-16 | Attach-only capability declaration | Stopped only the E2E bridge and started it with `--opencode-no-auto-start --opencode-port=4096`, attaching to the pre-existing server. | The bridge published only `setupRefresh` for OpenCode, effective timeout `0`, setup `ready`, and runtime `dormant`. The unrelated OpenCode process remained running. |
+| E2E-17 | Attach-only UI enforcement | Inspected the OpenCode card and tapped its remaining setup refresh action. | The card showed **Managed outside Sesori** and explained that Sesori would not start, stop, restart, or suspend it. Enable/disable, restart, and timeout controls were absent; **Refresh setup** remained and completed with setup still ready. |
+| E2E-18 | Return to managed mode | Stopped only the attach-mode bridge and restarted the ordinary source bridge without attach flags. | The app reconnected and OpenCode again exposed normal lifecycle/setup/timeout controls. The pre-existing server on port 4096 remained untouched. |
+
+## Cleanup And Restored State
+
+- Deleted the E2E Codex session from `random stuff`; a final `/sessions` query
+  found no session titled `E2E lifecycle test`.
+- Dedicated worktree was disabled for the test session, and the turn performed
+  only sleep commands; no project file changes were produced.
+- Restored the bridge default timeout to 10 minutes.
+- Confirmed Codex, Cursor, and OpenCode are setup-ready, enabled, and have no
+  per-harness timeout overrides.
+- Confirmed ordinary managed-mode capabilities are restored for all three.
+- Left the source bridge running normally on debug port 9977 against the same
+  durable data directory.
+- Left the simulator on the Projects surface.
+- Did not stop, replace, or reconfigure the pre-existing OpenCode server on
+  port 4096.
+
+## Follow-Up Candidates
+
+These are explicit follow-up options, not blockers for the Stage 13 lifecycle
+and persistence gate completed above:
+
+1. **Restart handoff on the post-test tilde fix:** the debug restart request
+   acknowledged and shut down the source `dart run` process, but its detached
+   successor did not return on port 9977. Manual source relaunch against the same
+   absolute data directory proved persistence and reconnection. PR #651
+   (`7ad9ceed`) subsequently fixed `~` expansion for `--data-dir`; repeat the
+   source or installed-binary handoff on #651 or later if restart handoff itself
+   needs release evidence.
+2. **Busy force-restart variant:** this run exercised safe conflict, cancel, and
+   one-shot force through disable. Widget and service suites cover restart; a
+   later manual pass can repeat the busy flow with Restart if desired.
+3. **Real older bridge unsupported state:** no older bridge fixture was
+   available. Unsupported and failed-refresh presentation remain covered by
+   focused contract/widget tests.
+4. **Unknown harness/generic logo:** the normal bundled bridge advertises only
+   the three known harnesses, so the forward-compatible generic card remains a
+   widget/contract test case.
+5. **Invalid custom timeout:** this pass verified no-timeout `0`, positive custom
+   apply-all, override, and clear. Invalid/non-positive custom input remains
+   covered by focused widget/service tests and can be repeated manually if a
+   UI-validation-specific follow-up is requested.

--- a/.plan/completed/setup-aware-harness-settings/PLAN.md
+++ b/.plan/completed/setup-aware-harness-settings/PLAN.md
@@ -3,12 +3,11 @@
 ## Status
 
 - **Plan slug:** `setup-aware-harness-settings`
-- **Parent plan:** `.plan/active/setup-aware-plugin-lifecycle`
-- **Status:** ready for implementation; no Stage 13 implementation branch has
-  started
-- **Implementation base:** current `origin/main` after Stage 12 merge
-  `6cedf5bd`, force-disable reconciliation `877f0b58`, and Cursor recency
-  `ae060c5f`
+- **Parent plan:** `.plan/completed/setup-aware-plugin-lifecycle`
+- **Status:** complete; all eight replacement PRs merged and final simulator E2E
+  passed on the current single-screen Harnesses destination
+- **Completion base:** `origin/main` at current-main Harnesses consolidation
+  `0da8ec7c`; final Stage 13 implementation merged as `a30b671b`
 - **Reference only:** frozen PR #511, substantive implementation commit
   `167a3ee7`, action-preservation follow-up `bc3918cb`, head `4f07172f`
 
@@ -1110,6 +1109,11 @@ Production files:
 
 ## Real Simulator E2E
 
+The completed current-main execution record is in `E2E.md`. PR #647 replaced
+the original two-page presentation below with one consolidated Harnesses screen;
+the final run applied the same lifecycle, timeout, capability, persistence, and
+cleanup gates to that current product destination.
+
 Use the available iOS simulator with the PR build and the source bridge from
 this repository. Launch the bridge with
 `--data-dir ~/.local/share/sesori-dev` so it reuses the existing login and
@@ -1138,7 +1142,8 @@ and handle every bridge process before startup, not only after testing.
 
 ## Completion
 
-Stage 13 completes after all seven PRs merge, the Harnesses entry and two
-pages are verified against a real bridge and simulator in `random stuff`,
-frozen PR #511 is closed as superseded, and the parent tracker records merge
-commits and verification.
+Stage 13 completed after all eight replacement PRs merged, frozen PR #511 closed
+as superseded, and the final lifecycle controls were verified against a real
+bridge and simulator in `random stuff`. PR #647 subsequently consolidated the
+two original pages into the current single Harnesses screen; `E2E.md` records
+the final current-main verification, cleanup, and optional follow-ups.

--- a/.plan/completed/setup-aware-harness-settings/TRACKER.md
+++ b/.plan/completed/setup-aware-harness-settings/TRACKER.md
@@ -2,9 +2,11 @@
 
 ## Current State
 
-- **Implementation base:** `origin/main` at `3adaf4e4` after Step 7/8 merged
-- **Series state:** Step 8/8 PR #595 open; management controls implemented and verified
-- **Next action:** monitor and settle PR #595
+- **Completion base:** `origin/main` at current-main Harnesses consolidation
+  `0da8ec7c`; final Stage 13 implementation merged as `a30b671b`
+- **Series state:** complete; all eight replacement PRs merged and final
+  current-main simulator E2E passed
+- **Next action:** none; child plan archived with its parent
 
 ## Delivery
 
@@ -17,7 +19,7 @@
 | [x] | Step 5/7 — Harnesses overview and state contract | `setup-aware-harness-settings-overview` | PR #592 merged as `1b0f9874`; combined simulator E2E passed |
 | [x] | Step 6/8 — management actions | `setup-aware-harness-settings-state` | PR #593 merged as `075951cb`; estimate 650-800 changed lines |
 | [x] | Step 7/8 — management capabilities | `setup-aware-harness-settings-capabilities` | PR #594 merged as `3adaf4e4` |
-| [ ] | Step 8/8 — management controls | `setup-aware-harness-settings-controls` | PR #595 open; 1,416 changed lines (generated localization and test-matrix overage) |
+| [x] | Step 8/8 — management controls | `setup-aware-harness-settings-controls` | PR #595 merged as `a30b671b`; 1,416 changed lines (generated localization and test-matrix overage) |
 
 ## Source Material
 
@@ -189,3 +191,19 @@
   module_core, desktop, and module_desktop_core. Architecture review's sole
   finding was applied by using the shared fail-closed `PluginRuntimeState.isEnabled`
   semantic rather than classifying lifecycle state in the Flutter shell.
+- Step 8/8 delivery (2026-07-28): PR #595 merged to `main` as `a30b671b` and
+  frozen PR #511 closed as superseded. PR #647 later folded the overview and
+  management controls into one current-main Harnesses screen as `0da8ec7c`.
+- Final simulator E2E (2026-07-31): the iPhone 17 simulator and source bridge
+  verified current-main navigation, bundled logos and live facts, setup refresh,
+  safe restart, safe disable/enable, no-timeout override and clear, apply-all
+  timeout persistence across bridge process restart, busy conflict copy,
+  cancellation with no force mutation, one-shot force disable, retained session
+  reconciliation after re-enable, and successful session creation in
+  `random stuff`. A pre-existing OpenCode server on port 4096 was used for
+  no-auto-start attach mode; the UI exposed only setup refresh and explained
+  that lifecycle/timeout ownership was external. The 10-minute/no-override/all-
+  enabled baseline was restored, the E2E session was deleted, the unrelated
+  OpenCode process was left untouched, and the ordinary source bridge was left
+  running. Exact actions, observations, cleanup, and optional follow-ups are in
+  `E2E.md`.

--- a/.plan/completed/setup-aware-plugin-lifecycle/PLAN.md
+++ b/.plan/completed/setup-aware-plugin-lifecycle/PLAN.md
@@ -3,12 +3,13 @@
 ## Status
 
 - **Plan slug:** `setup-aware-plugin-lifecycle`
-- **Status:** Stages 10-12 are merged; Stage 13 remains
-- **Implementation base:** `origin/main` at Stage 12 merge `6cedf5bd`
+- **Status:** complete; Stages 10-13 merged and final Stage 13 simulator E2E passed
+- **Completion base:** `origin/main` at current-main Harnesses consolidation
+  `0da8ec7c`; final Stage 13 implementation merged as `a30b671b`
 - **Predecessor:** parallel-plugin Stages 0-9 and bridge-app-onboarding W02 are merged
 - **Delivery:** Completed Stage 12 is recorded in
-  `.plan/completed/setup-aware-plugin-management`; Stage 13 is the remaining
-  client-settings stage
+  `.plan/completed/setup-aware-plugin-management`; completed Stage 13 is
+  recorded in `.plan/completed/setup-aware-harness-settings`
 
 This plan replaces the first unmerged implementation. Nothing introduced only
 by that implementation needs compatibility handling. Released contracts still
@@ -679,8 +680,8 @@ the listed source files and committed with their stage.
 ### Stage 13 / former PR #511 files
 
 The concrete Stage 13 replacement delivery is owned by
-`.plan/active/setup-aware-harness-settings`. That child plan contains the
-current seven-PR sequence, exact branches/titles, file boundaries, size
+`.plan/completed/setup-aware-harness-settings`. That child plan contains the
+completed eight-PR sequence, exact branches/titles, file boundaries, size
 estimates, compatibility handling, and verification gates. The original frozen
 PR #511 inventory remains source material only; reconstruct behavior against
 current main rather than porting its generated output, unordered revision
@@ -749,8 +750,8 @@ closed as superseded and remains source material only.
 
 ### Stage 13 / former PR #511 — redesigned mobile Harnesses settings
 
-The concrete replacement is the seven-PR child series in
-`.plan/active/setup-aware-harness-settings`:
+The concrete replacement is the eight-PR child series in
+`.plan/completed/setup-aware-harness-settings`:
 
 1. per-bridge last-submitted harness preference;
 2. management transport and typed repository results;
@@ -760,7 +761,9 @@ The concrete replacement is the seven-PR child series in
 5. Notifications-consistent read-only Harnesses page directly below the
    Notifications settings entry;
 6. mutation cubit actions over service-owned safe/force policy;
-7. dedicated Harness management controls page.
+7. backend-neutral management capability declaration and bridge enforcement;
+8. capability-gated Harness management controls, later folded into the current
+   single-screen destination by PR #647.
 
 The child plan records exact branches, PR titles, production files, estimates,
 wire compatibility, race handling, focused tests, and real-simulator E2E using
@@ -780,6 +783,13 @@ remain reference material and are not rewritten.
 - Client stage runs focused module-core and Flutter settings/new-session tests,
   then mobile and desktop fatal analysis.
 - Do not rerun unchanged passing commands. CI supplies the full repository matrix.
+
+## Completion
+
+Stages 10-13 are complete. The Stage 13 child merged all eight replacement PRs,
+frozen PR #511 closed as superseded, and final current-main simulator E2E passed
+on 2026-07-31. The durable action-by-action record and cleanup state are in
+`.plan/completed/setup-aware-harness-settings/E2E.md`.
 
 ## Deferred Installation
 

--- a/.plan/completed/setup-aware-plugin-lifecycle/TRACKER.md
+++ b/.plan/completed/setup-aware-plugin-lifecycle/TRACKER.md
@@ -2,12 +2,11 @@
 
 ## Plan State
 
-- **Status:** Stages 10-12 are merged; Stage 13 remains
-- **Base:** `origin/main` at Stage 12 merge `6cedf5bd`
-- **Current branch:** `plan/stage-13-pr-sizing` plan update
-- **Current stage:** Stage 13 — redesigned mobile Harnesses settings
-- **Next action:** implement Step 1/7 from
-  `.plan/active/setup-aware-harness-settings` after this plan PR merges
+- **Status:** complete; Stages 10-13 merged and final Stage 13 simulator E2E passed
+- **Completion base:** `origin/main` at current-main Harnesses consolidation
+  `0da8ec7c`; final Stage 13 implementation merged as `a30b671b`
+- **Current stage:** complete
+- **Next action:** none; parent and completed child archived
 
 ## Frozen Oversized Stack
 
@@ -19,10 +18,10 @@ complete.
 | Old PR | State | Replacement |
 |---|---|---|
 | #507 | Merged | Redesigned Stage 10, merged as `4ef55675` |
-| #508 | Open, frozen | Oversized Stage 11-P01 reference at `f6cd675d`; replaced by P01A-P01D |
-| #509 | Open, frozen | Dormancy descendant; rebuild/retarget after P01D |
+| #508 | Closed, superseded | Oversized Stage 11-P01 reference at `f6cd675d`; replaced by P01A-P01D |
+| #509 | Closed, superseded | Replaced by the merged Stage 11-P02 dormant-runtime rebuild |
 | #510 | Closed, superseded | Replaced by the six-PR Stage 12 child series |
-| #511 | Open, frozen | Client descendant; rebuild/retarget after rebuilt management stage |
+| #511 | Closed, superseded | Replaced by the eight-PR Stage 13 child series |
 
 Old verification results are historical evidence only; replacement stages must
 run their focused verification again.
@@ -38,7 +37,7 @@ run their focused verification again.
 | [x] | Stage 11-P01D — bridge-owned projects and defaults | `setup-aware-plugin-lifecycle-project-ownership` | #550 merged as `5020c003` |
 | [x] | Stage 11-P02 — dormancy and numeric idle timeout | `setup-aware-plugin-lifecycle-dormant-runtime` | #556 merged as `41e03f12` |
 | [x] | Stage 12 — headless management | six-PR child series | #563, #567-#570, and #572 merged; recorded in `.plan/completed/setup-aware-plugin-management` |
-| [ ] | Stage 13 — redesigned mobile Harnesses settings | seven-PR `setup-aware-harness-settings` child series | child plan defines exact branches/titles, file boundaries, estimates, and E2E gates |
+| [x] | Stage 13 — redesigned mobile Harnesses settings | eight-PR `setup-aware-harness-settings` child series | #579, #583, #589, #590, #592-#595 merged; current-main E2E passed and is recorded in `.plan/completed/setup-aware-harness-settings/E2E.md` |
 
 ## Locked Redesign Deltas
 
@@ -342,3 +341,18 @@ run their focused verification again.
 - Required real simulator E2E with the source bridge running
   `--data-dir ~/.local/share/sesori-dev`, the existing login, and the
   `random stuff` project; the temporary E2E bridge must be stopped afterward.
+
+### 2026-07-31 — Stage 13 complete
+
+- The eight replacement PRs merged as #579, #583, #589, #590, and #592-#595;
+  final Step 8 merged as `a30b671b`. Frozen PR #511 closed as superseded.
+- PR #647 later consolidated the overview and management pages into the final
+  single Harnesses screen and merged as `0da8ec7c`.
+- Current-main simulator E2E verified navigation, live status and logos, setup
+  refresh, safe restart, safe disable/enable, timeout override/clear/apply-all
+  and persistence, busy safe-conflict/cancel/one-shot force behavior, retained
+  forced-disable session reconciliation, session creation and cleanup, and
+  OpenCode no-auto-start capability gating against a pre-existing server.
+- Restored the 10-minute/no-override/all-enabled baseline, deleted the test
+  session, left unrelated processes untouched, and left the ordinary source
+  bridge running. The full record is in the completed child plan's `E2E.md`.

--- a/.plan/completed/setup-aware-plugin-management/PLAN.md
+++ b/.plan/completed/setup-aware-plugin-management/PLAN.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **Plan slug:** `setup-aware-plugin-management`
-- **Parent plan:** `.plan/active/setup-aware-plugin-lifecycle`
+- **Parent plan:** `.plan/completed/setup-aware-plugin-lifecycle`
 - **Status:** complete; P01-P06 merged and frozen PR #510 closed as superseded
 - **Completion base:** `origin/main` at final Stage 12 merge `6cedf5bd`
 - **Reference only:** PR #510, substantive commit `c4104e73`, fixture follow-up


### PR DESCRIPTION
## Summary

- archive the completed multi-plugin release-preparation plan after PR #647 merged
- archive the completed setup-aware Harnesses child and plugin-lifecycle parent plans
- archive the legacy plugin-lifecycle migration from `docs/plans` after its final PR #252 docs sweep
- add a durable action-by-action simulator E2E record with cleanup state and optional follow-ups
- update completed child/parent references and leave only genuinely ongoing plans under `.plan/active`

## Simulator E2E

- verified the final single-screen Harnesses destination on an iPhone 17 simulator against the source bridge
- covered setup refresh, safe restart, safe disable/enable, timeout override/clear/apply-all, and persistence across bridge process restart
- created a busy Codex session in `random stuff`, verified safe-conflict copy, cancel-without-force, one-shot force disable, and retained session reconciliation after re-enable
- verified OpenCode no-auto-start attach mode exposes setup refresh while hiding lifecycle and timeout controls
- restored the 10-minute/no-override/all-enabled baseline, deleted the test session, and left unrelated processes untouched
- recorded the source restart-handoff observation and the subsequent `--data-dir` tilde fix from PR #651 as an explicit optional follow-up

## Verification

- `git diff --cached --check`
- archived-path and stale-active-reference checks
- confirmed `.plan/active` now contains only `output-image-support`, `session-pull-request-monitoring`, and `user-analytics`
- audited `docs/plans`; `auth-reconnect-ux-plan.md` remains there because PRs 4-7 and a deferred recovery step are not complete
- no Dart or Flutter suites run for this documentation-only PR
