### PR TITLE
Fix hold-to-talk recording latency

### DIFF
--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:flutter/gestures.dart" show kPrimaryButton;
 import "package:flutter/material.dart";
 import "package:flutter/services.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
@@ -345,7 +346,7 @@ class _PromptInputState extends State<PromptInput> {
   }
 
   void _handleRecordPointerDown(PointerDownEvent event) {
-    if (_recordingPointer != null) return;
+    if (_recordingPointer != null || (event.buttons & kPrimaryButton) == 0) return;
     _recordingPointer = event.pointer;
     _recordingPointerPosition = event.position;
     unawaited(_handleRecordStart());

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -98,6 +98,7 @@ class _PromptInputState extends State<PromptInput> {
   /// The pointer that owns the current hold. Raw pointer events start the
   /// recorder on touch-down without Flutter's long-press recognition delay.
   int? _recordingPointer;
+  Offset? _recordingPointerPosition;
 
   /// Keeps the typing layout mounted after the keyboard affordance was tapped
   /// while the field wasn't in the tree yet (hold-to-talk / compact layouts),
@@ -346,17 +347,21 @@ class _PromptInputState extends State<PromptInput> {
   void _handleRecordPointerDown(PointerDownEvent event) {
     if (_recordingPointer != null) return;
     _recordingPointer = event.pointer;
+    _recordingPointerPosition = event.position;
     unawaited(_handleRecordStart());
   }
 
   void _handleRecordPointerMove(PointerMoveEvent event) {
     if (event.pointer != _recordingPointer) return;
+    _recordingPointerPosition = event.position;
     _handleRecordDragUpdate(globalPosition: event.position);
   }
 
   void _handleRecordPointerEnd(PointerEvent event) {
     if (event.pointer != _recordingPointer) return;
+    _handleRecordDragUpdate(globalPosition: event.position);
     _recordingPointer = null;
+    _recordingPointerPosition = null;
     unawaited(_handleRecordEnd());
   }
 
@@ -417,8 +422,21 @@ class _PromptInputState extends State<PromptInput> {
     try {
       await _voiceService.startRecording();
       if (!mounted) return;
-      setState(() => _voiceState = _VoiceState.recording);
       final interactionId = _voiceInteractionId;
+      setState(() => _voiceState = _VoiceState.recording);
+      // Startup can finish after the user has already dragged toward cancel.
+      // Reapply the latest position once the newly mounted target has layout.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        final position = _recordingPointerPosition;
+        if (!mounted ||
+            _voiceState != _VoiceState.recording ||
+            interactionId != _voiceInteractionId ||
+            _recordingPointer == null ||
+            position == null) {
+          return;
+        }
+        _handleRecordDragUpdate(globalPosition: position);
+      });
       _minimumRecordingDurationTimer = Timer(_minimumRecordingDuration, () {
         if (_voiceState == _VoiceState.recording && interactionId == _voiceInteractionId) {
           _minimumRecordingDurationReached = true;

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -84,6 +84,7 @@ class PromptInput extends StatefulWidget {
 
 class _PromptInputState extends State<PromptInput> {
   static const _draftCalculator = ComposerDraftCalculator();
+  static const _minimumRecordingDuration = Duration(milliseconds: 200);
   final _controller = TextEditingController();
   final _focusNode = FocusNode();
   late ComposerDraft _draft;
@@ -91,6 +92,12 @@ class _PromptInputState extends State<PromptInput> {
   bool _isApplyingDraft = false;
   _VoiceState _voiceState = _VoiceState.idle;
   StreamSubscription<void>? _maxDurationSub;
+  Timer? _minimumRecordingDurationTimer;
+  bool _minimumRecordingDurationReached = false;
+
+  /// The pointer that owns the current hold. Raw pointer events start the
+  /// recorder on touch-down without Flutter's long-press recognition delay.
+  int? _recordingPointer;
 
   /// Keeps the typing layout mounted after the keyboard affordance was tapped
   /// while the field wasn't in the tree yet (hold-to-talk / compact layouts),
@@ -109,8 +116,8 @@ class _PromptInputState extends State<PromptInput> {
   _ComposerLayout? _pinnedVoiceLayout;
 
   /// Set when the hold is released while [_startRecording] is still awaiting
-  /// the recorder, so the start path stops immediately once recording begins
-  /// instead of letting it outlive the gesture.
+  /// the recorder, so the start path discards the incomplete recording once
+  /// startup settles instead of letting it outlive the gesture.
   bool _releaseRequestedDuringStart = false;
 
   /// True while [_startRecording] is awaiting the recorder ([_voiceState] is
@@ -161,6 +168,7 @@ class _PromptInputState extends State<PromptInput> {
   @override
   void dispose() {
     _maxDurationSub?.cancel();
+    _minimumRecordingDurationTimer?.cancel();
     // Fire-and-forget cancel if the widget is disposed mid-recording or mid-transcription.
     if (_voiceState != _VoiceState.idle) {
       _voiceService.cancelRecording();
@@ -311,6 +319,9 @@ class _PromptInputState extends State<PromptInput> {
     _voiceInteractionId++;
     _isRecordStartInFlight = true;
     _releaseRequestedDuringStart = false;
+    _minimumRecordingDurationTimer?.cancel();
+    _minimumRecordingDurationTimer = null;
+    _minimumRecordingDurationReached = false;
     _cancelDragProgress.value = 0;
     _pinnedVoiceLayout = _restingLayout;
     await _startRecording();
@@ -326,10 +337,27 @@ class _PromptInputState extends State<PromptInput> {
       // later transition will release the pin.
       setState(() => _pinnedVoiceLayout = null);
     } else if (_releaseRequestedDuringStart) {
-      // The hold ended while the recorder was still starting up — stop right
-      // away so recording never outlives the gesture.
-      await _stopAndTranscribe();
+      // The hold ended while the recorder was still starting up, leaving no
+      // meaningful captured duration to transcribe.
+      await _cancelVoiceInteraction();
     }
+  }
+
+  void _handleRecordPointerDown(PointerDownEvent event) {
+    if (_recordingPointer != null) return;
+    _recordingPointer = event.pointer;
+    unawaited(_handleRecordStart());
+  }
+
+  void _handleRecordPointerMove(PointerMoveEvent event) {
+    if (event.pointer != _recordingPointer) return;
+    _handleRecordDragUpdate(globalPosition: event.position);
+  }
+
+  void _handleRecordPointerEnd(PointerEvent event) {
+    if (event.pointer != _recordingPointer) return;
+    _recordingPointer = null;
+    unawaited(_handleRecordEnd());
   }
 
   /// Tracks the hold as it moves, scrubbing the drag-to-cancel presentation
@@ -356,15 +384,17 @@ class _PromptInputState extends State<PromptInput> {
 
   Future<void> _handleRecordEnd() async {
     if (_voiceState == _VoiceState.idle) {
-      // The release raced a recorder that is still starting up (or was a
-      // stray pointer event); [_handleRecordStart] consumes this after the
-      // start completes.
-      _releaseRequestedDuringStart = true;
+      // A release can race a recorder that is still starting up.
+      if (_isRecordStartInFlight) _releaseRequestedDuringStart = true;
       return;
     }
     if (_voiceState != _VoiceState.recording) return;
     if (_cancelDragProgress.value >= 1) {
       // Released on the cancel target — discard instead of transcribing.
+      await _cancelVoiceInteraction();
+      return;
+    }
+    if (!_minimumRecordingDurationReached) {
       await _cancelVoiceInteraction();
       return;
     }
@@ -388,6 +418,12 @@ class _PromptInputState extends State<PromptInput> {
       await _voiceService.startRecording();
       if (!mounted) return;
       setState(() => _voiceState = _VoiceState.recording);
+      final interactionId = _voiceInteractionId;
+      _minimumRecordingDurationTimer = Timer(_minimumRecordingDuration, () {
+        if (_voiceState == _VoiceState.recording && interactionId == _voiceInteractionId) {
+          _minimumRecordingDurationReached = true;
+        }
+      });
     } on MicrophonePermissionDeniedError {
       if (!mounted) return;
       _showVoiceError(context.loc.voiceErrorPermission);
@@ -407,6 +443,8 @@ class _PromptInputState extends State<PromptInput> {
     // long before a slow upload errors out); every continuation below is a
     // no-op once a newer interaction owns the composer.
     final interactionId = _voiceInteractionId;
+    _minimumRecordingDurationTimer?.cancel();
+    _minimumRecordingDurationTimer = null;
     setState(() {
       _voiceState = _VoiceState.transcribing;
       _cancelDragProgress.value = 0;
@@ -478,6 +516,9 @@ class _PromptInputState extends State<PromptInput> {
     // transcribe the recording being discarded. The id bump orphans any
     // still-pending transcription continuation of this interaction.
     _voiceInteractionId++;
+    _minimumRecordingDurationTimer?.cancel();
+    _minimumRecordingDurationTimer = null;
+    _minimumRecordingDurationReached = false;
     setState(() {
       _voiceState = _VoiceState.idle;
       _pinnedVoiceLayout = null;
@@ -1102,7 +1143,7 @@ class _PromptInputState extends State<PromptInput> {
 
   /// Wraps a resting pill's centre in the press-and-hold recording gesture.
   ///
-  /// The detector wraps the voice-aware slot (not the other way around) so it
+  /// The listener wraps the voice-aware slot (not the other way around) so it
   /// stays mounted when the waveform swaps in and still receives the release
   /// that ends the hold. Semantic taps toggle recording — assistive
   /// technologies cannot express the press-and-hold gesture.
@@ -1115,18 +1156,12 @@ class _PromptInputState extends State<PromptInput> {
       excludeSemantics: true,
       onTap: _handleSemanticRecordToggle,
       child: Listener(
-        // A pointer cancel mid-hold (incoming call, system gesture) resets
-        // the accepted long-press silently — no onLongPressEnd — so the raw
-        // pointer stream is the only place to keep the recording bounded by
-        // the gesture.
-        onPointerCancel: (_) => _handleRecordEnd(),
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onLongPressStart: (_) => _handleRecordStart(),
-          onLongPressMoveUpdate: (details) => _handleRecordDragUpdate(globalPosition: details.globalPosition),
-          onLongPressEnd: (_) => _handleRecordEnd(),
-          child: child,
-        ),
+        behavior: HitTestBehavior.opaque,
+        onPointerDown: _handleRecordPointerDown,
+        onPointerMove: _handleRecordPointerMove,
+        onPointerUp: _handleRecordPointerEnd,
+        onPointerCancel: _handleRecordPointerEnd,
+        child: child,
       ),
     );
   }
@@ -1207,29 +1242,24 @@ class _PromptInputState extends State<PromptInput> {
 
     // No Tooltip here: its long-press trigger would race the recording hold.
     // The button keeps its enabled look and swallows plain taps via
-    // [_ignoreTap]; holds outlast the tap recognizer, so the surrounding
-    // detector wins the arena and drives the recording. Semantic taps toggle
-    // recording — assistive technologies cannot express the hold.
+    // [_ignoreTap]; the surrounding raw pointer listener drives recording.
+    // Semantic taps toggle recording because assistive technologies cannot
+    // express the hold.
     return Semantics(
       button: true,
       label: loc.voiceRecord,
       excludeSemantics: true,
       onTap: _handleSemanticRecordToggle,
       child: Listener(
-        // A pointer cancel mid-hold resets the accepted long-press silently —
-        // no onLongPressEnd — so the raw pointer stream is the only place to
-        // keep the recording bounded by the gesture.
-        onPointerCancel: (_) => _handleRecordEnd(),
-        child: GestureDetector(
-          onLongPressStart: (_) => _handleRecordStart(),
-          onLongPressMoveUpdate: (details) => _handleRecordDragUpdate(globalPosition: details.globalPosition),
-          onLongPressEnd: (_) => _handleRecordEnd(),
-          child: const PregoButtonsSolid.iconOnly(
-            leadingIcon: TablerRegular.microphone,
-            hierarchy: PregoButtonsSolidHierarchy.secondary,
-            size: PregoButtonsSolidSize.lg,
-            onPressed: _ignoreTap,
-          ),
+        onPointerDown: _handleRecordPointerDown,
+        onPointerMove: _handleRecordPointerMove,
+        onPointerUp: _handleRecordPointerEnd,
+        onPointerCancel: _handleRecordPointerEnd,
+        child: const PregoButtonsSolid.iconOnly(
+          leadingIcon: TablerRegular.microphone,
+          hierarchy: PregoButtonsSolidHierarchy.secondary,
+          size: PregoButtonsSolidSize.lg,
+          onPressed: _ignoreTap,
         ),
       ),
     );

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -933,6 +933,36 @@ void main() {
     expect(find.byType(EditableText), findsNothing);
   });
 
+  testWidgets("dragging toward cancel during recorder startup is preserved", (tester) async {
+    final startCompleter = Completer<void>();
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) => startCompleter.future);
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) async => "");
+    when(() => voiceTranscriptionService.cancelRecording()).thenAnswer((_) async {});
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    final cancelPosition = tester.getCenter(find.byIcon(TablerRegular.chevron_right));
+    final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
+    await gesture.moveTo(cancelPosition);
+    await tester.pump();
+
+    // The recorder starts after the finger has already reached the future
+    // cancel target. No further movement should be needed to preserve that
+    // intent or update the drag feedback.
+    startCompleter.complete();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pump();
+    expect(find.text("Release to cancel"), findsOneWidget);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+    verify(() => voiceTranscriptionService.cancelRecording()).called(1);
+    verifyNever(() => voiceTranscriptionService.stopAndTranscribe());
+  });
+
   testWidgets("a hold during an in-flight cancel does not present a phantom recording", (tester) async {
     final cancelCompleter = Completer<void>();
     when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -1,7 +1,9 @@
 import "dart:async";
+import "dart:ui" show PointerDeviceKind;
 
 import "package:bloc_test/bloc_test.dart";
 import "package:flutter/foundation.dart";
+import "package:flutter/gestures.dart" show kSecondaryButton;
 import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_test/flutter_test.dart";
@@ -621,6 +623,28 @@ void main() {
     await tester.pumpAndSettle();
 
     verify(() => voiceTranscriptionService.cancelRecording()).called(1);
+    verifyNever(() => voiceTranscriptionService.stopAndTranscribe());
+  });
+
+  testWidgets("a secondary pointer button does not start recording", (tester) async {
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.cancelRecording()).thenAnswer((_) async {});
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.text("Hold to talk")),
+      kind: PointerDeviceKind.mouse,
+      buttons: kSecondaryButton,
+    );
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    verifyNever(() => voiceTranscriptionService.startRecording());
+    verifyNever(() => voiceTranscriptionService.cancelRecording());
     verifyNever(() => voiceTranscriptionService.stopAndTranscribe());
   });
 

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -605,40 +605,69 @@ void main() {
     expect(find.byIcon(TablerSolid.player_stop), findsNothing);
   });
 
-  testWidgets("release during recorder startup still stops the recording", (tester) async {
-    final startCompleter = Completer<void>();
-    final stopCompleter = Completer<String>();
-    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) => startCompleter.future);
+  testWidgets("a very short tap starts recording immediately but never transcribes", (tester) async {
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
     when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
-    when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) => stopCompleter.future);
+    when(() => voiceTranscriptionService.cancelRecording()).thenAnswer((_) async {});
 
     await tester.pumpWidget(_buildApp(cubit: cubit));
     await tester.pumpAndSettle();
 
-    // Hold the hold-to-talk pill long enough for the long-press to fire (the
-    // recording start is now awaiting the recorder), then release before the
+    final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
+    verify(() => voiceTranscriptionService.startRecording()).called(1);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    verify(() => voiceTranscriptionService.cancelRecording()).called(1);
+    verifyNever(() => voiceTranscriptionService.stopAndTranscribe());
+  });
+
+  testWidgets("a short one-word recording still transcribes", (tester) async {
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) async => "yes");
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    verify(() => voiceTranscriptionService.stopAndTranscribe()).called(1);
+    verifyNever(() => voiceTranscriptionService.cancelRecording());
+    expect(find.text("yes"), findsOneWidget);
+  });
+
+  testWidgets("release during recorder startup discards the incomplete recording", (tester) async {
+    final startCompleter = Completer<void>();
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) => startCompleter.future);
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.cancelRecording()).thenAnswer((_) async {});
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    // Recording is requested on touch-down, then the finger lifts before the
     // recorder finishes starting up.
     final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
-    await tester.pump(const Duration(milliseconds: 600));
+    verify(() => voiceTranscriptionService.startRecording()).called(1);
+    await tester.pump(const Duration(milliseconds: 100));
     await gesture.up();
     await tester.pump();
     verifyNever(() => voiceTranscriptionService.stopAndTranscribe());
 
-    // The recorder finishes starting after the finger already lifted — the
-    // composer must stop immediately instead of recording open-endedly.
+    // The recorder finishes starting after the finger already lifted, so the
+    // incomplete local recording is discarded instead of uploaded.
     startCompleter.complete();
     await tester.pump();
-    verify(() => voiceTranscriptionService.stopAndTranscribe()).called(1);
-
-    stopCompleter.complete("transcript");
     await tester.pumpAndSettle();
-    expect(find.text("transcript"), findsOneWidget);
-    verify(cubit.reportVoiceTranscriptionCompleted).called(1);
-    final savedDrafts = verify(
-      () => cubit.saveComposerDraft(draft: captureAny(named: "draft")),
-    ).captured.cast<ComposerDraft>();
-    expect(savedDrafts.last.text, "transcript");
-    expect(savedDrafts.last.voiceSpans, [VoiceOriginSpan(start: 0, end: 10)]);
+    verify(() => voiceTranscriptionService.cancelRecording()).called(1);
+    verifyNever(() => voiceTranscriptionService.stopAndTranscribe());
   });
 
   testWidgets("restored mixed draft keeps voice-assisted input mode when sent", (tester) async {
@@ -739,10 +768,9 @@ void main() {
 
   testWidgets("a second hold during recorder startup does not start a second recording", (tester) async {
     final startCompleter = Completer<void>();
-    final stopCompleter = Completer<String>();
     when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) => startCompleter.future);
     when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
-    when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) => stopCompleter.future);
+    when(() => voiceTranscriptionService.cancelRecording()).thenAnswer((_) async {});
 
     final state = _loadedState(
       pendingQuestions: const [],
@@ -756,26 +784,24 @@ void main() {
     await tester.pumpWidget(_buildApp(cubit: cubit, chatInputMode: ChatInputMode.textFirst));
     await tester.pumpAndSettle();
 
-    // First hold on the mic reaches the recorder; a second long-press (e.g. a
+    // First hold on the mic reaches the recorder; a second press (e.g. a
     // second finger on the same surface after a stray release) while the
     // recorder is still starting must not start again.
     final first = await tester.startGesture(tester.getCenter(find.byIcon(TablerRegular.microphone)));
-    await tester.pump(const Duration(milliseconds: 600));
+    await tester.pump(const Duration(milliseconds: 100));
     await first.up();
     await tester.pump();
     final second = await tester.startGesture(tester.getCenter(find.byIcon(TablerRegular.microphone)));
-    await tester.pump(const Duration(milliseconds: 600));
+    await tester.pump(const Duration(milliseconds: 100));
     await second.up();
     await tester.pump();
     verify(() => voiceTranscriptionService.startRecording()).called(1);
 
-    // Both holds released before startup finished — the pending release stops
-    // the recording as soon as it begins.
+    // Both holds released before startup finished, so the incomplete
+    // recording is discarded as soon as startup settles.
     startCompleter.complete();
     await tester.pump();
-    verify(() => voiceTranscriptionService.stopAndTranscribe()).called(1);
-
-    stopCompleter.complete("transcript");
+    verify(() => voiceTranscriptionService.cancelRecording()).called(1);
     await tester.pumpAndSettle();
   });
 


### PR DESCRIPTION
## Summary
- start hold-to-talk recording on pointer down instead of waiting for Flutter's long-press timeout
- discard recordings shorter than 200 ms so accidental taps never reach transcription
- preserve very short intentional messages and discard releases that race recorder startup

## Testing
- `flutter test test/features/session_detail/widgets/session_detail_body_test.dart`
- `dart analyze` (from `client/app`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hold-to-talk latency by starting recording on pointer down and ignoring non‑primary presses to avoid accidental recordings. Preserves drag-to-cancel during startup; short intentional messages are kept, accidental taps are discarded.

- **Bug Fixes**
  - Start recording on primary-button pointer down with a raw pointer listener; track owning pointer and position for consistent up/move/cancel.
  - Preserve drag-to-cancel that begins during startup by reapplying the last pointer position after mount.
  - Enforce a 200 ms minimum; cancel recordings below the threshold.
  - If the hold ends while startup is in flight, discard the incomplete recording.
  - Update tests for non-primary presses, very short taps, brief valid messages, startup race, double-press, and startup drag-to-cancel.

<sup>Written for commit c2bcce2cb198b441babf78280d2c3faa9bda8bbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

