### PR TITLE
Fix Android back behavior with composer keyboard

### DIFF
--- a/client/app/lib/features/new_session/new_session_screen.dart
+++ b/client/app/lib/features/new_session/new_session_screen.dart
@@ -232,6 +232,9 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
       },
       child: PregoGlassScaffold(
         title: loc.sessionListNewSession,
+        // Toolbar navigation is explicit: unlike Android system back, it must
+        // not be vetoed by the composer's keyboard-dismissal PopScope.
+        onBack: _dismissScreen,
         // The options own their scroll while the composer remains fixed, so
         // use the full viewport behind a fixed title just like session chat.
         titleMode: PregoTopNavigationTitleMode.inline,

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:flutter/gestures.dart" show kPrimaryButton;
 import "package:flutter/material.dart";
 import "package:flutter/services.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
@@ -345,7 +346,7 @@ class _PromptInputState extends State<PromptInput> {
   }
 
   void _handleRecordPointerDown(PointerDownEvent event) {
-    if (_recordingPointer != null) return;
+    if (_recordingPointer != null || (event.buttons & kPrimaryButton) == 0) return;
     _recordingPointer = event.pointer;
     _recordingPointerPosition = event.position;
     unawaited(_handleRecordStart());

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -4,6 +4,7 @@ import "package:flutter/gestures.dart" show kPrimaryButton;
 import "package:flutter/material.dart";
 import "package:flutter/services.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
+import "package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart";
 import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -618,10 +619,6 @@ class _PromptInputState extends State<PromptInput> {
     // The resting layout follows the settings choice live.
     context.watch<ChatInputModeCubit>();
     final prego = context.prego;
-    final shouldDismissKeyboardBeforePop =
-        Theme.of(context).platform == TargetPlatform.android &&
-        _focusNode.hasFocus &&
-        View.of(context).viewInsets.bottom > 0;
 
     return DecoratedBox(
       // Floating composer: no bar surface, no separator line. The scaffold
@@ -648,12 +645,18 @@ class _PromptInputState extends State<PromptInput> {
           ?widget.header,
           // A focused composer consumes the first route pop so Android back
           // dismisses the keyboard before a later back leaves the screen.
-          PopScope(
-            canPop: !shouldDismissKeyboardBeforePop,
-            onPopInvokedWithResult: (didPop, _) {
-              if (!didPop && shouldDismissKeyboardBeforePop) _focusNode.unfocus();
+          KeyboardVisibilityBuilder(
+            builder: (context, isKeyboardVisible) {
+              final shouldDismissKeyboardBeforePop =
+                  Theme.of(context).platform == TargetPlatform.android && _focusNode.hasFocus && isKeyboardVisible;
+              return PopScope(
+                canPop: !shouldDismissKeyboardBeforePop,
+                onPopInvokedWithResult: (didPop, _) {
+                  if (!didPop && shouldDismissKeyboardBeforePop) _focusNode.unfocus();
+                },
+                child: _buildComposerTopSlot(context),
+              );
             },
-            child: _buildComposerTopSlot(context),
           ),
 
           // Group only the input container with the text field via a

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -98,6 +98,7 @@ class _PromptInputState extends State<PromptInput> {
   /// The pointer that owns the current hold. Raw pointer events start the
   /// recorder on touch-down without Flutter's long-press recognition delay.
   int? _recordingPointer;
+  Offset? _recordingPointerPosition;
 
   /// Keeps the typing layout mounted after the keyboard affordance was tapped
   /// while the field wasn't in the tree yet (hold-to-talk / compact layouts),
@@ -346,17 +347,21 @@ class _PromptInputState extends State<PromptInput> {
   void _handleRecordPointerDown(PointerDownEvent event) {
     if (_recordingPointer != null) return;
     _recordingPointer = event.pointer;
+    _recordingPointerPosition = event.position;
     unawaited(_handleRecordStart());
   }
 
   void _handleRecordPointerMove(PointerMoveEvent event) {
     if (event.pointer != _recordingPointer) return;
+    _recordingPointerPosition = event.position;
     _handleRecordDragUpdate(globalPosition: event.position);
   }
 
   void _handleRecordPointerEnd(PointerEvent event) {
     if (event.pointer != _recordingPointer) return;
+    _handleRecordDragUpdate(globalPosition: event.position);
     _recordingPointer = null;
+    _recordingPointerPosition = null;
     unawaited(_handleRecordEnd());
   }
 
@@ -417,8 +422,21 @@ class _PromptInputState extends State<PromptInput> {
     try {
       await _voiceService.startRecording();
       if (!mounted) return;
-      setState(() => _voiceState = _VoiceState.recording);
       final interactionId = _voiceInteractionId;
+      setState(() => _voiceState = _VoiceState.recording);
+      // Startup can finish after the user has already dragged toward cancel.
+      // Reapply the latest position once the newly mounted target has layout.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        final position = _recordingPointerPosition;
+        if (!mounted ||
+            _voiceState != _VoiceState.recording ||
+            interactionId != _voiceInteractionId ||
+            _recordingPointer == null ||
+            position == null) {
+          return;
+        }
+        _handleRecordDragUpdate(globalPosition: position);
+      });
       _minimumRecordingDurationTimer = Timer(_minimumRecordingDuration, () {
         if (_voiceState == _VoiceState.recording && interactionId == _voiceInteractionId) {
           _minimumRecordingDurationReached = true;

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -618,6 +618,10 @@ class _PromptInputState extends State<PromptInput> {
     // The resting layout follows the settings choice live.
     context.watch<ChatInputModeCubit>();
     final prego = context.prego;
+    final shouldDismissKeyboardBeforePop =
+        Theme.of(context).platform == TargetPlatform.android &&
+        _focusNode.hasFocus &&
+        View.of(context).viewInsets.bottom > 0;
 
     return DecoratedBox(
       // Floating composer: no bar surface, no separator line. The scaffold
@@ -645,9 +649,9 @@ class _PromptInputState extends State<PromptInput> {
           // A focused composer consumes the first route pop so Android back
           // dismisses the keyboard before a later back leaves the screen.
           PopScope(
-            canPop: !_focusNode.hasFocus,
+            canPop: !shouldDismissKeyboardBeforePop,
             onPopInvokedWithResult: (didPop, _) {
-              if (!didPop && _focusNode.hasFocus) _focusNode.unfocus();
+              if (!didPop && shouldDismissKeyboardBeforePop) _focusNode.unfocus();
             },
             child: _buildComposerTopSlot(context),
           ),

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -642,7 +642,15 @@ class _PromptInputState extends State<PromptInput> {
         mainAxisSize: .min,
         children: [
           ?widget.header,
-          _buildComposerTopSlot(context),
+          // A focused composer consumes the first route pop so Android back
+          // dismisses the keyboard before a later back leaves the screen.
+          PopScope(
+            canPop: !_focusNode.hasFocus,
+            onPopInvokedWithResult: (didPop, _) {
+              if (!didPop && _focusNode.hasFocus) _focusNode.unfocus();
+            },
+            child: _buildComposerTopSlot(context),
+          ),
 
           // Group only the input container with the text field via a
           // TextFieldTapRegion. The field's default `onTapOutside` unfocuses

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -84,6 +84,7 @@ class PromptInput extends StatefulWidget {
 
 class _PromptInputState extends State<PromptInput> {
   static const _draftCalculator = ComposerDraftCalculator();
+  static const _minimumRecordingDuration = Duration(milliseconds: 200);
   final _controller = TextEditingController();
   final _focusNode = FocusNode();
   late ComposerDraft _draft;
@@ -91,6 +92,12 @@ class _PromptInputState extends State<PromptInput> {
   bool _isApplyingDraft = false;
   _VoiceState _voiceState = _VoiceState.idle;
   StreamSubscription<void>? _maxDurationSub;
+  Timer? _minimumRecordingDurationTimer;
+  bool _minimumRecordingDurationReached = false;
+
+  /// The pointer that owns the current hold. Raw pointer events start the
+  /// recorder on touch-down without Flutter's long-press recognition delay.
+  int? _recordingPointer;
 
   /// Keeps the typing layout mounted after the keyboard affordance was tapped
   /// while the field wasn't in the tree yet (hold-to-talk / compact layouts),
@@ -109,8 +116,8 @@ class _PromptInputState extends State<PromptInput> {
   _ComposerLayout? _pinnedVoiceLayout;
 
   /// Set when the hold is released while [_startRecording] is still awaiting
-  /// the recorder, so the start path stops immediately once recording begins
-  /// instead of letting it outlive the gesture.
+  /// the recorder, so the start path discards the incomplete recording once
+  /// startup settles instead of letting it outlive the gesture.
   bool _releaseRequestedDuringStart = false;
 
   /// True while [_startRecording] is awaiting the recorder ([_voiceState] is
@@ -161,6 +168,7 @@ class _PromptInputState extends State<PromptInput> {
   @override
   void dispose() {
     _maxDurationSub?.cancel();
+    _minimumRecordingDurationTimer?.cancel();
     // Fire-and-forget cancel if the widget is disposed mid-recording or mid-transcription.
     if (_voiceState != _VoiceState.idle) {
       _voiceService.cancelRecording();
@@ -311,6 +319,9 @@ class _PromptInputState extends State<PromptInput> {
     _voiceInteractionId++;
     _isRecordStartInFlight = true;
     _releaseRequestedDuringStart = false;
+    _minimumRecordingDurationTimer?.cancel();
+    _minimumRecordingDurationTimer = null;
+    _minimumRecordingDurationReached = false;
     _cancelDragProgress.value = 0;
     _pinnedVoiceLayout = _restingLayout;
     await _startRecording();
@@ -326,10 +337,27 @@ class _PromptInputState extends State<PromptInput> {
       // later transition will release the pin.
       setState(() => _pinnedVoiceLayout = null);
     } else if (_releaseRequestedDuringStart) {
-      // The hold ended while the recorder was still starting up — stop right
-      // away so recording never outlives the gesture.
-      await _stopAndTranscribe();
+      // The hold ended while the recorder was still starting up, leaving no
+      // meaningful captured duration to transcribe.
+      await _cancelVoiceInteraction();
     }
+  }
+
+  void _handleRecordPointerDown(PointerDownEvent event) {
+    if (_recordingPointer != null) return;
+    _recordingPointer = event.pointer;
+    unawaited(_handleRecordStart());
+  }
+
+  void _handleRecordPointerMove(PointerMoveEvent event) {
+    if (event.pointer != _recordingPointer) return;
+    _handleRecordDragUpdate(globalPosition: event.position);
+  }
+
+  void _handleRecordPointerEnd(PointerEvent event) {
+    if (event.pointer != _recordingPointer) return;
+    _recordingPointer = null;
+    unawaited(_handleRecordEnd());
   }
 
   /// Tracks the hold as it moves, scrubbing the drag-to-cancel presentation
@@ -356,15 +384,17 @@ class _PromptInputState extends State<PromptInput> {
 
   Future<void> _handleRecordEnd() async {
     if (_voiceState == _VoiceState.idle) {
-      // The release raced a recorder that is still starting up (or was a
-      // stray pointer event); [_handleRecordStart] consumes this after the
-      // start completes.
-      _releaseRequestedDuringStart = true;
+      // A release can race a recorder that is still starting up.
+      if (_isRecordStartInFlight) _releaseRequestedDuringStart = true;
       return;
     }
     if (_voiceState != _VoiceState.recording) return;
     if (_cancelDragProgress.value >= 1) {
       // Released on the cancel target — discard instead of transcribing.
+      await _cancelVoiceInteraction();
+      return;
+    }
+    if (!_minimumRecordingDurationReached) {
       await _cancelVoiceInteraction();
       return;
     }
@@ -388,6 +418,12 @@ class _PromptInputState extends State<PromptInput> {
       await _voiceService.startRecording();
       if (!mounted) return;
       setState(() => _voiceState = _VoiceState.recording);
+      final interactionId = _voiceInteractionId;
+      _minimumRecordingDurationTimer = Timer(_minimumRecordingDuration, () {
+        if (_voiceState == _VoiceState.recording && interactionId == _voiceInteractionId) {
+          _minimumRecordingDurationReached = true;
+        }
+      });
     } on MicrophonePermissionDeniedError {
       if (!mounted) return;
       _showVoiceError(context.loc.voiceErrorPermission);
@@ -407,6 +443,8 @@ class _PromptInputState extends State<PromptInput> {
     // long before a slow upload errors out); every continuation below is a
     // no-op once a newer interaction owns the composer.
     final interactionId = _voiceInteractionId;
+    _minimumRecordingDurationTimer?.cancel();
+    _minimumRecordingDurationTimer = null;
     setState(() {
       _voiceState = _VoiceState.transcribing;
       _cancelDragProgress.value = 0;
@@ -478,6 +516,9 @@ class _PromptInputState extends State<PromptInput> {
     // transcribe the recording being discarded. The id bump orphans any
     // still-pending transcription continuation of this interaction.
     _voiceInteractionId++;
+    _minimumRecordingDurationTimer?.cancel();
+    _minimumRecordingDurationTimer = null;
+    _minimumRecordingDurationReached = false;
     setState(() {
       _voiceState = _VoiceState.idle;
       _pinnedVoiceLayout = null;
@@ -1102,7 +1143,7 @@ class _PromptInputState extends State<PromptInput> {
 
   /// Wraps a resting pill's centre in the press-and-hold recording gesture.
   ///
-  /// The detector wraps the voice-aware slot (not the other way around) so it
+  /// The listener wraps the voice-aware slot (not the other way around) so it
   /// stays mounted when the waveform swaps in and still receives the release
   /// that ends the hold. Semantic taps toggle recording — assistive
   /// technologies cannot express the press-and-hold gesture.
@@ -1115,18 +1156,12 @@ class _PromptInputState extends State<PromptInput> {
       excludeSemantics: true,
       onTap: _handleSemanticRecordToggle,
       child: Listener(
-        // A pointer cancel mid-hold (incoming call, system gesture) resets
-        // the accepted long-press silently — no onLongPressEnd — so the raw
-        // pointer stream is the only place to keep the recording bounded by
-        // the gesture.
-        onPointerCancel: (_) => _handleRecordEnd(),
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onLongPressStart: (_) => _handleRecordStart(),
-          onLongPressMoveUpdate: (details) => _handleRecordDragUpdate(globalPosition: details.globalPosition),
-          onLongPressEnd: (_) => _handleRecordEnd(),
-          child: child,
-        ),
+        behavior: HitTestBehavior.opaque,
+        onPointerDown: _handleRecordPointerDown,
+        onPointerMove: _handleRecordPointerMove,
+        onPointerUp: _handleRecordPointerEnd,
+        onPointerCancel: _handleRecordPointerEnd,
+        child: child,
       ),
     );
   }
@@ -1207,29 +1242,24 @@ class _PromptInputState extends State<PromptInput> {
 
     // No Tooltip here: its long-press trigger would race the recording hold.
     // The button keeps its enabled look and swallows plain taps via
-    // [_ignoreTap]; holds outlast the tap recognizer, so the surrounding
-    // detector wins the arena and drives the recording. Semantic taps toggle
-    // recording — assistive technologies cannot express the hold.
+    // [_ignoreTap]; the surrounding raw pointer listener drives recording.
+    // Semantic taps toggle recording because assistive technologies cannot
+    // express the hold.
     return Semantics(
       button: true,
       label: loc.voiceRecord,
       excludeSemantics: true,
       onTap: _handleSemanticRecordToggle,
       child: Listener(
-        // A pointer cancel mid-hold resets the accepted long-press silently —
-        // no onLongPressEnd — so the raw pointer stream is the only place to
-        // keep the recording bounded by the gesture.
-        onPointerCancel: (_) => _handleRecordEnd(),
-        child: GestureDetector(
-          onLongPressStart: (_) => _handleRecordStart(),
-          onLongPressMoveUpdate: (details) => _handleRecordDragUpdate(globalPosition: details.globalPosition),
-          onLongPressEnd: (_) => _handleRecordEnd(),
-          child: const PregoButtonsSolid.iconOnly(
-            leadingIcon: TablerRegular.microphone,
-            hierarchy: PregoButtonsSolidHierarchy.secondary,
-            size: PregoButtonsSolidSize.lg,
-            onPressed: _ignoreTap,
-          ),
+        onPointerDown: _handleRecordPointerDown,
+        onPointerMove: _handleRecordPointerMove,
+        onPointerUp: _handleRecordPointerEnd,
+        onPointerCancel: _handleRecordPointerEnd,
+        child: const PregoButtonsSolid.iconOnly(
+          leadingIcon: TablerRegular.microphone,
+          hierarchy: PregoButtonsSolidHierarchy.secondary,
+          size: PregoButtonsSolidSize.lg,
+          onPressed: _ignoreTap,
         ),
       ),
     );

--- a/client/app/lib/features/session_detail/widgets/session_detail_body.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_body.dart
@@ -2,6 +2,7 @@ import "dart:async";
 
 import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
+import "package:go_router/go_router.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/module_prego.dart";
@@ -134,6 +135,9 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
       // (reversed) scroll, so the outer page must not scroll — otherwise a drag
       // that starts on the pinned composer overscrolls/bounces the whole page.
       scrollable: false,
+      // Toolbar navigation is explicit: unlike Android system back, it must
+      // not be vetoed by the composer's keyboard-dismissal PopScope.
+      onBack: showLeading ? () => context.pop() : null,
       automaticallyImplyLeading: showLeading,
       actions: actions.isEmpty ? null : actions,
       slivers: [

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -87,6 +87,11 @@ dependencies:
   vector_graphics: ^1.2.2
   flutter_chat_ui: ^2.11.1
   flutter_chat_core: ^2.9.0
+  flutter_keyboard_visibility:
+    git:
+      url: https://github.com/vespr-wallet/flutter_keyboard_visibility.git
+      ref: d8d628478d35687e3373735a377c663b19586fa0
+      path: flutter_keyboard_visibility
 
 dev_dependencies:
   flutter_test:

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -2,6 +2,7 @@ import "dart:async";
 
 import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
+import "package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:get_it/get_it.dart";
 import "package:go_router/go_router.dart";
@@ -120,6 +121,7 @@ void main() {
   // renders its flat (cue) menu here — the menu rows are Material InkWells, not
   // GlassMenuItems. Finders below target those InkWells.
   setUp(() async {
+    KeyboardVisibilityTesting.setVisibilityForTesting(false);
     await GetIt.instance.reset();
     sessionService = MockSessionService();
     sessionRepository = MockSessionRepository();
@@ -309,12 +311,12 @@ void main() {
   });
 
   testWidgets("toolbar back pops the route while the Android keyboard is visible", (tester) async {
-    addTearDown(tester.view.resetViewInsets);
-    tester.view.viewInsets = const FakeViewPadding(bottom: 300);
     await tester.pumpWidget(_buildApp());
     await tester.pumpAndSettle();
     await enterTypingMode(tester);
     expect(tester.widget<EditableText>(find.byType(EditableText)).focusNode.hasFocus, isTrue);
+    KeyboardVisibilityTesting.setVisibilityForTesting(true);
+    await tester.pumpAndSettle();
 
     await tester.tap(find.byIcon(TablerRegular.chevron_left));
     await tester.pumpAndSettle();

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -308,6 +308,20 @@ void main() {
     await connectionStatus.close();
   });
 
+  testWidgets("toolbar back pops the route while the Android keyboard is visible", (tester) async {
+    addTearDown(tester.view.resetViewInsets);
+    tester.view.viewInsets = const FakeViewPadding(bottom: 300);
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+    await enterTypingMode(tester);
+    expect(tester.widget<EditableText>(find.byType(EditableText)).focusNode.hasFocus, isTrue);
+
+    await tester.tap(find.byIcon(TablerRegular.chevron_left));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(NewSessionScreen), findsNothing);
+  });
+
   testWidgets("known unsupported project never shows the worktree toggle while composer data loads", (tester) async {
     final projectResponse = Completer<ApiResponse<Project>>();
     when(

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -476,14 +476,20 @@ void main() {
   });
 
   testWidgets("system back dismisses the composer keyboard before popping the route", (tester) async {
+    addTearDown(tester.view.resetViewInsets);
     await tester.pumpWidget(_buildApp(cubit: cubit, startAtPreviousScreen: true));
     await tester.pumpAndSettle();
     await tester.tap(find.text("Open session"));
     await tester.pumpAndSettle();
 
+    tester.view.viewInsets = const FakeViewPadding(bottom: 300);
+    await tester.pump();
     await enterTypingMode(tester);
     final focusNode = composerFocus(tester);
     expect(focusNode.hasFocus, isTrue);
+    final fieldContext = tester.element(find.byType(EditableText));
+    expect(Theme.of(fieldContext).platform, TargetPlatform.android);
+    expect(View.of(fieldContext).viewInsets.bottom, greaterThan(0));
 
     await tester.binding.handlePopRoute();
     await tester.pumpAndSettle();
@@ -497,6 +503,28 @@ void main() {
 
     expect(find.byType(SessionDetailBody), findsNothing);
     expect(find.text("Open session"), findsOneWidget);
+  });
+
+  testWidgets("iOS back navigation stays available while the composer is focused", (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    addTearDown(tester.view.resetViewInsets);
+    tester.view.viewInsets = const FakeViewPadding(bottom: 300);
+    try {
+      await tester.pumpWidget(_buildApp(cubit: cubit, startAtPreviousScreen: true));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text("Open session"));
+      await tester.pumpAndSettle();
+      await enterTypingMode(tester);
+      expect(composerFocus(tester).hasFocus, isTrue);
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SessionDetailBody), findsNothing);
+      expect(find.text("Open session"), findsOneWidget);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
   });
 
   testWidgets("opening a composer menu dismisses the keyboard (glass path)", (tester) async {

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -505,6 +505,25 @@ void main() {
     expect(find.text("Open session"), findsOneWidget);
   });
 
+  testWidgets("toolbar back pops the route while the Android keyboard is visible", (tester) async {
+    addTearDown(tester.view.resetViewInsets);
+    await tester.pumpWidget(_buildApp(cubit: cubit, startAtPreviousScreen: true));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text("Open session"));
+    await tester.pumpAndSettle();
+
+    tester.view.viewInsets = const FakeViewPadding(bottom: 300);
+    await tester.pump();
+    await enterTypingMode(tester);
+    expect(composerFocus(tester).hasFocus, isTrue);
+
+    await tester.tap(find.byIcon(TablerRegular.chevron_left));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SessionDetailBody), findsNothing);
+    expect(find.text("Open session"), findsOneWidget);
+  });
+
   testWidgets("iOS back navigation stays available while the composer is focused", (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
     addTearDown(tester.view.resetViewInsets);

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -933,6 +933,36 @@ void main() {
     expect(find.byType(EditableText), findsNothing);
   });
 
+  testWidgets("dragging toward cancel during recorder startup is preserved", (tester) async {
+    final startCompleter = Completer<void>();
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) => startCompleter.future);
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) async => "");
+    when(() => voiceTranscriptionService.cancelRecording()).thenAnswer((_) async {});
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    final cancelPosition = tester.getCenter(find.byIcon(TablerRegular.chevron_right));
+    final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
+    await gesture.moveTo(cancelPosition);
+    await tester.pump();
+
+    // The recorder starts after the finger has already reached the future
+    // cancel target. No further movement should be needed to preserve that
+    // intent or update the drag feedback.
+    startCompleter.complete();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pump();
+    expect(find.text("Release to cancel"), findsOneWidget);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+    verify(() => voiceTranscriptionService.cancelRecording()).called(1);
+    verifyNever(() => voiceTranscriptionService.stopAndTranscribe());
+  });
+
   testWidgets("a hold during an in-flight cancel does not present a phantom recording", (tester) async {
     final cancelCompleter = Completer<void>();
     when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -6,6 +6,7 @@ import "package:flutter/foundation.dart";
 import "package:flutter/gestures.dart" show kSecondaryButton;
 import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
+import "package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:get_it/get_it.dart";
 import "package:go_router/go_router.dart";
@@ -153,6 +154,7 @@ void main() {
   // renders its flat (cue) menu here — the menu rows are Material InkWells, not
   // GlassMenuItems. Finders below target those InkWells.
   setUp(() async {
+    KeyboardVisibilityTesting.setVisibilityForTesting(false);
     await GetIt.instance.reset();
     cubit = MockSessionDetailCubit();
     voiceTranscriptionService = MockVoiceTranscriptionService();
@@ -476,20 +478,22 @@ void main() {
   });
 
   testWidgets("system back dismisses the composer keyboard before popping the route", (tester) async {
-    addTearDown(tester.view.resetViewInsets);
     await tester.pumpWidget(_buildApp(cubit: cubit, startAtPreviousScreen: true));
     await tester.pumpAndSettle();
     await tester.tap(find.text("Open session"));
     await tester.pumpAndSettle();
 
-    tester.view.viewInsets = const FakeViewPadding(bottom: 300);
-    await tester.pump();
     await enterTypingMode(tester);
     final focusNode = composerFocus(tester);
     expect(focusNode.hasFocus, isTrue);
     final fieldContext = tester.element(find.byType(EditableText));
     expect(Theme.of(fieldContext).platform, TargetPlatform.android);
-    expect(View.of(fieldContext).viewInsets.bottom, greaterThan(0));
+
+    // Focus changes before the platform reports the raised IME. The composer
+    // must subscribe to this later visibility update so its PopScope activates.
+    KeyboardVisibilityTesting.setVisibilityForTesting(true);
+    await tester.pumpAndSettle();
+    expect(focusNode.hasFocus, isTrue);
 
     await tester.binding.handlePopRoute();
     await tester.pumpAndSettle();
@@ -506,16 +510,15 @@ void main() {
   });
 
   testWidgets("toolbar back pops the route while the Android keyboard is visible", (tester) async {
-    addTearDown(tester.view.resetViewInsets);
     await tester.pumpWidget(_buildApp(cubit: cubit, startAtPreviousScreen: true));
     await tester.pumpAndSettle();
     await tester.tap(find.text("Open session"));
     await tester.pumpAndSettle();
 
-    tester.view.viewInsets = const FakeViewPadding(bottom: 300);
-    await tester.pump();
     await enterTypingMode(tester);
     expect(composerFocus(tester).hasFocus, isTrue);
+    KeyboardVisibilityTesting.setVisibilityForTesting(true);
+    await tester.pumpAndSettle();
 
     await tester.tap(find.byIcon(TablerRegular.chevron_left));
     await tester.pumpAndSettle();
@@ -526,8 +529,6 @@ void main() {
 
   testWidgets("iOS back navigation stays available while the composer is focused", (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-    addTearDown(tester.view.resetViewInsets);
-    tester.view.viewInsets = const FakeViewPadding(bottom: 300);
     try {
       await tester.pumpWidget(_buildApp(cubit: cubit, startAtPreviousScreen: true));
       await tester.pumpAndSettle();
@@ -535,6 +536,8 @@ void main() {
       await tester.pumpAndSettle();
       await enterTypingMode(tester);
       expect(composerFocus(tester).hasFocus, isTrue);
+      KeyboardVisibilityTesting.setVisibilityForTesting(true);
+      await tester.pumpAndSettle();
 
       await tester.binding.handlePopRoute();
       await tester.pumpAndSettle();

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -30,9 +30,22 @@ Widget _buildApp({
   required SessionDetailCubit cubit,
   ChatInputMode chatInputMode = ChatInputMode.voiceFirst,
   StubChatInputModeCubit? chatInputModeCubit,
+  bool startAtPreviousScreen = false,
 }) {
   final router = GoRouter(
+    initialLocation: startAtPreviousScreen ? "/previous" : "/",
     routes: [
+      GoRoute(
+        path: "/previous",
+        builder: (context, state) => Scaffold(
+          body: Center(
+            child: TextButton(
+              onPressed: () => context.push("/"),
+              child: const Text("Open session"),
+            ),
+          ),
+        ),
+      ),
       GoRoute(
         path: "/",
         builder: (context, state) => BlocProvider<SessionDetailCubit>.value(
@@ -460,6 +473,30 @@ void main() {
     await tester.tap(find.byIcon(TablerRegular.arrow_up));
     await tester.pump();
     expect(composerFocus(tester).hasFocus, isTrue, reason: "send must not dismiss the keyboard");
+  });
+
+  testWidgets("system back dismisses the composer keyboard before popping the route", (tester) async {
+    await tester.pumpWidget(_buildApp(cubit: cubit, startAtPreviousScreen: true));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text("Open session"));
+    await tester.pumpAndSettle();
+
+    await enterTypingMode(tester);
+    final focusNode = composerFocus(tester);
+    expect(focusNode.hasFocus, isTrue);
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(focusNode.hasFocus, isFalse);
+    expect(find.byType(SessionDetailBody), findsOneWidget);
+    expect(find.text("Open session"), findsNothing);
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SessionDetailBody), findsNothing);
+    expect(find.text("Open session"), findsOneWidget);
   });
 
   testWidgets("opening a composer menu dismisses the keyboard (glass path)", (tester) async {

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -1,7 +1,9 @@
 import "dart:async";
+import "dart:ui" show PointerDeviceKind;
 
 import "package:bloc_test/bloc_test.dart";
 import "package:flutter/foundation.dart";
+import "package:flutter/gestures.dart" show kSecondaryButton;
 import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_test/flutter_test.dart";
@@ -621,6 +623,28 @@ void main() {
     await tester.pumpAndSettle();
 
     verify(() => voiceTranscriptionService.cancelRecording()).called(1);
+    verifyNever(() => voiceTranscriptionService.stopAndTranscribe());
+  });
+
+  testWidgets("a secondary pointer button does not start recording", (tester) async {
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.cancelRecording()).thenAnswer((_) async {});
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.text("Hold to talk")),
+      kind: PointerDeviceKind.mouse,
+      buttons: kSecondaryButton,
+    );
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    verifyNever(() => voiceTranscriptionService.startRecording());
+    verifyNever(() => voiceTranscriptionService.cancelRecording());
     verifyNever(() => voiceTranscriptionService.stopAndTranscribe());
   });
 

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -605,40 +605,69 @@ void main() {
     expect(find.byIcon(TablerSolid.player_stop), findsNothing);
   });
 
-  testWidgets("release during recorder startup still stops the recording", (tester) async {
-    final startCompleter = Completer<void>();
-    final stopCompleter = Completer<String>();
-    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) => startCompleter.future);
+  testWidgets("a very short tap starts recording immediately but never transcribes", (tester) async {
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
     when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
-    when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) => stopCompleter.future);
+    when(() => voiceTranscriptionService.cancelRecording()).thenAnswer((_) async {});
 
     await tester.pumpWidget(_buildApp(cubit: cubit));
     await tester.pumpAndSettle();
 
-    // Hold the hold-to-talk pill long enough for the long-press to fire (the
-    // recording start is now awaiting the recorder), then release before the
+    final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
+    verify(() => voiceTranscriptionService.startRecording()).called(1);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    verify(() => voiceTranscriptionService.cancelRecording()).called(1);
+    verifyNever(() => voiceTranscriptionService.stopAndTranscribe());
+  });
+
+  testWidgets("a short one-word recording still transcribes", (tester) async {
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) async => "yes");
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    verify(() => voiceTranscriptionService.stopAndTranscribe()).called(1);
+    verifyNever(() => voiceTranscriptionService.cancelRecording());
+    expect(find.text("yes"), findsOneWidget);
+  });
+
+  testWidgets("release during recorder startup discards the incomplete recording", (tester) async {
+    final startCompleter = Completer<void>();
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) => startCompleter.future);
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.cancelRecording()).thenAnswer((_) async {});
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    // Recording is requested on touch-down, then the finger lifts before the
     // recorder finishes starting up.
     final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
-    await tester.pump(const Duration(milliseconds: 600));
+    verify(() => voiceTranscriptionService.startRecording()).called(1);
+    await tester.pump(const Duration(milliseconds: 100));
     await gesture.up();
     await tester.pump();
     verifyNever(() => voiceTranscriptionService.stopAndTranscribe());
 
-    // The recorder finishes starting after the finger already lifted — the
-    // composer must stop immediately instead of recording open-endedly.
+    // The recorder finishes starting after the finger already lifted, so the
+    // incomplete local recording is discarded instead of uploaded.
     startCompleter.complete();
     await tester.pump();
-    verify(() => voiceTranscriptionService.stopAndTranscribe()).called(1);
-
-    stopCompleter.complete("transcript");
     await tester.pumpAndSettle();
-    expect(find.text("transcript"), findsOneWidget);
-    verify(cubit.reportVoiceTranscriptionCompleted).called(1);
-    final savedDrafts = verify(
-      () => cubit.saveComposerDraft(draft: captureAny(named: "draft")),
-    ).captured.cast<ComposerDraft>();
-    expect(savedDrafts.last.text, "transcript");
-    expect(savedDrafts.last.voiceSpans, [VoiceOriginSpan(start: 0, end: 10)]);
+    verify(() => voiceTranscriptionService.cancelRecording()).called(1);
+    verifyNever(() => voiceTranscriptionService.stopAndTranscribe());
   });
 
   testWidgets("restored mixed draft keeps voice-assisted input mode when sent", (tester) async {
@@ -739,10 +768,9 @@ void main() {
 
   testWidgets("a second hold during recorder startup does not start a second recording", (tester) async {
     final startCompleter = Completer<void>();
-    final stopCompleter = Completer<String>();
     when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) => startCompleter.future);
     when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
-    when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) => stopCompleter.future);
+    when(() => voiceTranscriptionService.cancelRecording()).thenAnswer((_) async {});
 
     final state = _loadedState(
       pendingQuestions: const [],
@@ -756,26 +784,24 @@ void main() {
     await tester.pumpWidget(_buildApp(cubit: cubit, chatInputMode: ChatInputMode.textFirst));
     await tester.pumpAndSettle();
 
-    // First hold on the mic reaches the recorder; a second long-press (e.g. a
+    // First hold on the mic reaches the recorder; a second press (e.g. a
     // second finger on the same surface after a stray release) while the
     // recorder is still starting must not start again.
     final first = await tester.startGesture(tester.getCenter(find.byIcon(TablerRegular.microphone)));
-    await tester.pump(const Duration(milliseconds: 600));
+    await tester.pump(const Duration(milliseconds: 100));
     await first.up();
     await tester.pump();
     final second = await tester.startGesture(tester.getCenter(find.byIcon(TablerRegular.microphone)));
-    await tester.pump(const Duration(milliseconds: 600));
+    await tester.pump(const Duration(milliseconds: 100));
     await second.up();
     await tester.pump();
     verify(() => voiceTranscriptionService.startRecording()).called(1);
 
-    // Both holds released before startup finished — the pending release stops
-    // the recording as soon as it begins.
+    // Both holds released before startup finished, so the incomplete
+    // recording is discarded as soon as startup settles.
     startCompleter.complete();
     await tester.pump();
-    verify(() => voiceTranscriptionService.stopAndTranscribe()).called(1);
-
-    stopCompleter.complete("transcript");
+    verify(() => voiceTranscriptionService.cancelRecording()).called(1);
     await tester.pumpAndSettle();
   });
 

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -606,6 +606,56 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.1"
+  flutter_keyboard_visibility:
+    dependency: transitive
+    description:
+      path: flutter_keyboard_visibility
+      ref: d8d628478d35687e3373735a377c663b19586fa0
+      resolved-ref: d8d628478d35687e3373735a377c663b19586fa0
+      url: "https://github.com/vespr-wallet/flutter_keyboard_visibility.git"
+    source: git
+    version: "6.0.2"
+  flutter_keyboard_visibility_linux:
+    dependency: transitive
+    description:
+      name: flutter_keyboard_visibility_linux
+      sha256: "6fba7cd9bb033b6ddd8c2beb4c99ad02d728f1e6e6d9b9446667398b2ac39f08"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  flutter_keyboard_visibility_macos:
+    dependency: transitive
+    description:
+      name: flutter_keyboard_visibility_macos
+      sha256: c5c49b16fff453dfdafdc16f26bdd8fb8d55812a1d50b0ce25fc8d9f2e53d086
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  flutter_keyboard_visibility_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_keyboard_visibility_platform_interface
+      sha256: e43a89845873f7be10cb3884345ceb9aebf00a659f479d1c8f4293fcb37022a4
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
+  flutter_keyboard_visibility_web:
+    dependency: transitive
+    description:
+      path: flutter_keyboard_visibility_web
+      ref: "4303f02862cf94bd196f3740cea7671d243b7239"
+      resolved-ref: "4303f02862cf94bd196f3740cea7671d243b7239"
+      url: "https://github.com/vespr-wallet/flutter_keyboard_visibility.git"
+    source: git
+    version: "2.0.1"
+  flutter_keyboard_visibility_windows:
+    dependency: transitive
+    description:
+      name: flutter_keyboard_visibility_windows
+      sha256: fc4b0f0b6be9b93ae527f3d527fb56ee2d918cd88bbca438c478af7bcfd0ef73
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   flutter_lints:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- consume the first route pop while the shared composer field is focused
- dismiss the keyboard without leaving the new-session or session-detail screen
- allow the next back gesture or button press to navigate normally

## Testing
- `flutter test test/features/session_detail/widgets/session_detail_body_test.dart`
- `dart analyze` (from `client/app`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Android back behavior when the composer is focused. System back now dismisses the keyboard first and stays on New Session/Session Detail; toolbar back always pops immediately.

- **Bug Fixes**
  - Wrap the composer top slot in a `PopScope` driven by `flutter_keyboard_visibility` so on Android, only when the field is focused and the keyboard is visible, the first back intercepts and unfocuses to hide the keyboard.
  - Preserve toolbar back by wiring scaffold `onBack` in New Session and Session Detail; add widget tests for the two-step Android back flow, toolbar back with keyboard visible, and iOS back staying available.

- **Dependencies**
  - Add `flutter_keyboard_visibility` (git) for reliable keyboard visibility and testing hooks.

<sup>Written for commit eaeb3e1ee1ad5efe7050197a1a426a7a6cbec479. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

