### PR TITLE
[output-image-support] refactor(acp): type content blocks [step 8/13]

### DIFF
--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -33,7 +33,7 @@
 | [x] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | [PR #648](https://github.com/sesori-ai/sesori_apps_monorepo/pull/648) merged as `e9a03363`; 1,472 changed lines |
 | [x] | 6/13 | `output-image-support-codex-live-images` | `[output-image-support] feat(codex): surface live output images [step 6/13]` | 900-1,400 | [PR #652](https://github.com/sesori-ai/sesori_apps_monorepo/pull/652) merged as `737226d8`; 830 changed lines |
 | [x] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | [PR #657](https://github.com/sesori-ai/sesori_apps_monorepo/pull/657) merged as `4ca1cb90`; 589 changed lines |
-| [ ] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | [PR #658](https://github.com/sesori-ai/sesori_apps_monorepo/pull/658) open; 1,034 changed lines |
+| [ ] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | [PR #658](https://github.com/sesori-ai/sesori_apps_monorepo/pull/658) open; 1,088 changed lines |
 | [ ] | 9/13 | `output-image-support-acp-content-mapping` | `[output-image-support] refactor(acp): centralize tool content mapping [step 9/13]` | 1,100-1,500 | Blocked on Step 8 merge |
 | [ ] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | Blocked on Step 9 merge |
 | [ ] | 11/13 | `output-image-support-acp-tool-images` | `[output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | Blocked on Step 10 merge |
@@ -162,8 +162,11 @@
   mapper/live/replay tests, all 165 ACP tests, all 108 Cursor tests,
   `dart pub get`, fatal analysis in both packages, and
   `git diff --cached --check` pass. `aristotle-impl-review` approved with no
-  findings. The 1,034 changed-line diff is below the 1,500-line soft cap; no
-  neighboring scope was combined.
+  findings. The 1,088 changed-line diff is below the 1,500-line soft cap; no
+  neighboring scope was combined. PR review restored the prior fail-soft text
+  fallback for untyped, future, and nested-wrapper maps after known typed
+  variants are considered; all 68 focused ACP tests, 7 Cursor mapper tests, and
+  fatal analysis in both packages pass.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -33,7 +33,7 @@
 | [x] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | [PR #648](https://github.com/sesori-ai/sesori_apps_monorepo/pull/648) merged as `e9a03363`; 1,472 changed lines |
 | [x] | 6/13 | `output-image-support-codex-live-images` | `[output-image-support] feat(codex): surface live output images [step 6/13]` | 900-1,400 | [PR #652](https://github.com/sesori-ai/sesori_apps_monorepo/pull/652) merged as `737226d8`; 830 changed lines |
 | [x] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | [PR #657](https://github.com/sesori-ai/sesori_apps_monorepo/pull/657) merged as `4ca1cb90`; 589 changed lines |
-| [ ] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | [PR #658](https://github.com/sesori-ai/sesori_apps_monorepo/pull/658) open; 1,088 changed lines |
+| [ ] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | [PR #658](https://github.com/sesori-ai/sesori_apps_monorepo/pull/658) open; 1,119 changed lines |
 | [ ] | 9/13 | `output-image-support-acp-content-mapping` | `[output-image-support] refactor(acp): centralize tool content mapping [step 9/13]` | 1,100-1,500 | Blocked on Step 8 merge |
 | [ ] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | Blocked on Step 9 merge |
 | [ ] | 11/13 | `output-image-support-acp-tool-images` | `[output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | Blocked on Step 10 merge |
@@ -162,11 +162,13 @@
   mapper/live/replay tests, all 165 ACP tests, all 108 Cursor tests,
   `dart pub get`, fatal analysis in both packages, and
   `git diff --cached --check` pass. `aristotle-impl-review` approved with no
-  findings. The 1,088 changed-line diff is below the 1,500-line soft cap; no
+  findings. The 1,119 changed-line diff is below the 1,500-line soft cap; no
   neighboring scope was combined. PR review restored the prior fail-soft text
   fallback for untyped, future, and nested-wrapper maps after known typed
-  variants are considered; all 68 focused ACP tests, 7 Cursor mapper tests, and
-  fatal analysis in both packages pass.
+  variants are considered; all 69 focused ACP tests, 7 Cursor mapper tests, and
+  fatal analysis in both packages pass. A second bot review hardened filename
+  derivation to supported hierarchical `file`, `http`, and `https` URIs only;
+  all 7 mapper tests and fatal ACP analysis pass.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -5,10 +5,10 @@
 - **Plan slug:** `output-image-support`
 - **Implementation base:** `origin/main` at
   `9d2c1e9e79ab80fa8824b9d803a74798eb71140d`
-- **Series state:** Step 8/13 ready for PR
+- **Series state:** Step 8/13 open as [PR #658](https://github.com/sesori-ai/sesori_apps_monorepo/pull/658)
 - **Current step:** Step 8/13 — type ACP content blocks
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** open and monitor the Step 8/13 PR
+- **Next action:** monitor PR #658 and address CI or review findings
 
 ## Plan Review
 
@@ -33,7 +33,7 @@
 | [x] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | [PR #648](https://github.com/sesori-ai/sesori_apps_monorepo/pull/648) merged as `e9a03363`; 1,472 changed lines |
 | [x] | 6/13 | `output-image-support-codex-live-images` | `[output-image-support] feat(codex): surface live output images [step 6/13]` | 900-1,400 | [PR #652](https://github.com/sesori-ai/sesori_apps_monorepo/pull/652) merged as `737226d8`; 830 changed lines |
 | [x] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | [PR #657](https://github.com/sesori-ai/sesori_apps_monorepo/pull/657) merged as `4ca1cb90`; 589 changed lines |
-| [ ] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | Ready for PR; 1,034 changed lines |
+| [ ] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | [PR #658](https://github.com/sesori-ai/sesori_apps_monorepo/pull/658) open; 1,034 changed lines |
 | [ ] | 9/13 | `output-image-support-acp-content-mapping` | `[output-image-support] refactor(acp): centralize tool content mapping [step 9/13]` | 1,100-1,500 | Blocked on Step 8 merge |
 | [ ] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | Blocked on Step 9 merge |
 | [ ] | 11/13 | `output-image-support-acp-tool-images` | `[output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | Blocked on Step 10 merge |

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -5,10 +5,10 @@
 - **Plan slug:** `output-image-support`
 - **Implementation base:** `origin/main` at
   `9d2c1e9e79ab80fa8824b9d803a74798eb71140d`
-- **Series state:** Step 7/13 open as [PR #657](https://github.com/sesori-ai/sesori_apps_monorepo/pull/657)
-- **Current step:** Step 7/13 — restore Codex image history
+- **Series state:** Step 8/13 ready for PR
+- **Current step:** Step 8/13 — type ACP content blocks
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** monitor PR #657 and address CI or review findings
+- **Next action:** open and monitor the Step 8/13 PR
 
 ## Plan Review
 
@@ -32,8 +32,8 @@
 | [x] | 4/13 | `output-image-support-codex-response-items` | `[output-image-support] refactor(codex): seal response items [step 4/13]` | 1,100-1,500 | [PR #646](https://github.com/sesori-ai/sesori_apps_monorepo/pull/646) merged as `4be1e7bb`; 1,416 changed lines |
 | [x] | 5/13 | `output-image-support-codex-image-events` | `[output-image-support] refactor(codex): type image-bearing events [step 5/13]` | 1,200-1,500 | [PR #648](https://github.com/sesori-ai/sesori_apps_monorepo/pull/648) merged as `e9a03363`; 1,472 changed lines |
 | [x] | 6/13 | `output-image-support-codex-live-images` | `[output-image-support] feat(codex): surface live output images [step 6/13]` | 900-1,400 | [PR #652](https://github.com/sesori-ai/sesori_apps_monorepo/pull/652) merged as `737226d8`; 830 changed lines |
-| [ ] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | [PR #657](https://github.com/sesori-ai/sesori_apps_monorepo/pull/657) open; 589 changed lines |
-| [ ] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | Blocked on Step 7 merge |
+| [x] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | [PR #657](https://github.com/sesori-ai/sesori_apps_monorepo/pull/657) merged as `4ca1cb90`; 589 changed lines |
+| [ ] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | Ready for PR; 1,034 changed lines |
 | [ ] | 9/13 | `output-image-support-acp-content-mapping` | `[output-image-support] refactor(acp): centralize tool content mapping [step 9/13]` | 1,100-1,500 | Blocked on Step 8 merge |
 | [ ] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | Blocked on Step 9 merge |
 | [ ] | 11/13 | `output-image-support-acp-tool-images` | `[output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | Blocked on Step 10 merge |
@@ -152,6 +152,18 @@
   and exposed only `status`/`result` field names in schema-only malformed-image
   diagnostics; all 37 rollout tests and fatal analysis pass. Missing required
   image fields remain malformed rather than creating an invalid partial item.
+  PR #657 merged as `4ca1cb90` on 2026-07-31.
+- Step 8/13 (2026-07-31): generated typed ACP text, image, known-unsupported,
+  and unknown content blocks; added the stateless ACP content mapper; and wired
+  one explicit policy through live, plugin, replay, and Cursor composition.
+  Live/replay text behavior remains unchanged while individual image MIME,
+  base64, size, and basename-only URI metadata are validated without
+  materializing image parts before the tracker step. ACP codegen, focused
+  mapper/live/replay tests, all 165 ACP tests, all 108 Cursor tests,
+  `dart pub get`, fatal analysis in both packages, and
+  `git diff --cached --check` pass. `aristotle-impl-review` approved with no
+  findings. The 1,034 changed-line diff is below the 1,500-line soft cap; no
+  neighboring scope was combined.
 
 ## Findings And Plan Deltas
 

--- a/bridge/sesori_plugin_acp/lib/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/acp_plugin.dart
@@ -15,6 +15,7 @@ export "src/acp_session_configuration_tracker.dart";
 export "src/acp_session_loader.dart";
 export "src/acp_session_options_service.dart";
 export "src/acp_stdio_client.dart";
+export "src/repositories/mappers/acp_content_mapper.dart";
 // Plugin-lifecycle housing: the BridgePlugin wrapper + the host-backed process
 // factory a descriptor uses to run an ACP agent under the bridge's lifecycle.
 export "src/runtime/acp_bridge_plugin.dart";

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -6,6 +6,7 @@ import "acp_content.dart";
 import "acp_protocol.dart";
 import "acp_session_configuration_tracker.dart";
 import "acp_stdio_client.dart";
+import "repositories/mappers/acp_content_mapper.dart";
 
 /// A backend "halt notice": the agent ended a turn without doing the requested
 /// work and instead streamed a terminal notice telling the user to change
@@ -53,7 +54,9 @@ class AcpEventMapper {
     required this.agentId,
     required this.pluginId,
     required AcpSessionConfigurationTracker configurationTracker,
+    required AcpContentMapper contentMapper,
   }) : _configurationTracker = configurationTracker,
+       _contentMapper = contentMapper,
        launchDirectory = normalizeProjectDirectory(directory: launchDirectory);
 
   /// The bridge launch directory (canonicalized) — the fallback project
@@ -67,6 +70,7 @@ class AcpEventMapper {
   final String pluginId;
 
   final AcpSessionConfigurationTracker _configurationTracker;
+  final AcpContentMapper _contentMapper;
 
   /// The model/provider to stamp on [sessionId]'s assistant messages.
   String? modelForSession({required String sessionId}) =>
@@ -408,7 +412,7 @@ class AcpEventMapper {
     required String partSuffix,
     required PluginMessagePartType partType,
   }) {
-    final text = acpContentText(update["content"]);
+    final text = _contentMapper.text(content: update["content"]);
     if (text == null || text.isEmpty) return const [];
 
     // A backend may end a turn without doing the requested work and instead

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -14,6 +14,7 @@ import "acp_protocol.dart";
 import "acp_session_loader.dart";
 import "acp_session_options_service.dart";
 import "acp_stdio_client.dart";
+import "repositories/mappers/acp_content_mapper.dart";
 
 /// Base [BridgeDerivedProjectsPluginApi] implementation for any ACP (Agent
 /// Client Protocol) agent driven over stdio.
@@ -39,11 +40,13 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     required this.launchSpec,
     required String launchDirectory,
     required this.eventMapper,
+    required AcpContentMapper contentMapper,
     required AcpCommandTracker commandTracker,
     required AcpSessionOptionsService sessionOptionsService,
     AcpProcessFactory? processFactory,
   }) : launchDirectory = normalizeProjectDirectory(directory: launchDirectory),
        _processFactory = processFactory,
+       _contentMapper = contentMapper,
        _commandTracker = commandTracker,
        _sessionOptionsService = sessionOptionsService,
        _eventBuffer = BufferedUntilFirstListener<BridgeSseEvent>();
@@ -66,6 +69,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   final AcpEventMapper eventMapper;
 
   final AcpProcessFactory? _processFactory;
+  final AcpContentMapper _contentMapper;
   final BufferedUntilFirstListener<BridgeSseEvent> _eventBuffer;
 
   /// Snapshot of the agent's advertised slash commands, fed by the
@@ -1300,6 +1304,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       // Reclassify a halt notice (e.g. Cursor's account/plan gate) the same way
       // the live stream does, so reloaded history renders it identically.
       haltClassifier: eventMapper.classifyHaltNotice,
+      contentMapper: _contentMapper,
     );
     StreamSubscription<AcpNotification>? sub;
     AcpCommandListener? commandListener;

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -2,6 +2,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "acp_content.dart";
 import "acp_event_mapper.dart" show AcpHaltNotice;
+import "repositories/mappers/acp_content_mapper.dart";
 
 /// Accumulates the `session/update` notifications replayed by `session/load`
 /// into ordered [PluginMessageWithParts] for `getSessionMessages`.
@@ -17,7 +18,8 @@ class AcpReplayCollector {
     this.providerId,
     required this.initialUserMessageId,
     required this.haltClassifier,
-  });
+    required AcpContentMapper contentMapper,
+  }) : _contentMapper = contentMapper;
 
   final String sessionId;
   final String agentId;
@@ -28,6 +30,7 @@ class AcpReplayCollector {
   /// notice as an error message exactly as it appeared live. Null on backends
   /// with no halt notices.
   final AcpHaltNotice? Function({required String text})? haltClassifier;
+  final AcpContentMapper _contentMapper;
 
   /// Model/provider stamped on replayed assistant messages. Mutable so the
   /// plugin can set the loaded session's real model after `session/load`
@@ -44,13 +47,13 @@ class AcpReplayCollector {
     if (update == null) return;
     switch (update["sessionUpdate"] as String?) {
       case "agent_message_chunk":
-        final t = acpContentText(update["content"]);
+        final t = _contentMapper.text(content: update["content"]);
         if (t != null) _assistant(messageId: _chunkMessageId(update)).text.write(t);
       case "agent_thought_chunk":
-        final t = acpContentText(update["content"]);
+        final t = _contentMapper.text(content: update["content"]);
         if (t != null) _assistant(messageId: _chunkMessageId(update)).reasoning.write(t);
       case "user_message_chunk":
-        final t = acpContentText(update["content"]);
+        final t = _contentMapper.text(content: update["content"]);
         if (t != null) _user(messageId: _chunkMessageId(update)).text.write(t);
       case "tool_call":
         final id = update["toolCallId"] as String?;
@@ -101,10 +104,7 @@ class AcpReplayCollector {
     // lone assistant message) is surfaced as an error message so a reloaded
     // session matches the live rendering. Only a pure-text terminal notice
     // qualifies — no reasoning, no tools — matching the shape the backend emits.
-    if (draft.role == "assistant" &&
-        draft.reasoning.isEmpty &&
-        draft.tools.isEmpty &&
-        draft.text.isNotEmpty) {
+    if (draft.role == "assistant" && draft.reasoning.isEmpty && draft.tools.isEmpty && draft.text.isNotEmpty) {
       final halt = haltClassifier?.call(text: draft.text.toString());
       if (halt != null) {
         return PluginMessageWithParts(
@@ -209,8 +209,7 @@ class AcpReplayCollector {
   _Draft _assistantForTool() {
     if (_drafts.isNotEmpty && _drafts.last.role == "assistant") {
       final last = _drafts.last;
-      if (last.acpMessageId != null ||
-          (last.text.isEmpty && last.reasoning.isEmpty)) {
+      if (last.acpMessageId != null || (last.text.isEmpty && last.reasoning.isEmpty)) {
         return last;
       }
     }
@@ -226,8 +225,7 @@ class AcpReplayCollector {
   _Draft _ensureRole(String role, {String? messageId}) {
     if (_drafts.isNotEmpty && _drafts.last.role == role) {
       final last = _drafts.last;
-      if (last.acpMessageId == messageId &&
-          !(messageId == null && last.tools.isNotEmpty)) {
+      if (last.acpMessageId == messageId && !(messageId == null && last.tools.isNotEmpty)) {
         return last;
       }
     }
@@ -242,9 +240,7 @@ class AcpReplayCollector {
         : "$sessionId-h${_seq++}-$role";
     final draft = _Draft(
       role: role,
-      id: isFirstUser && initialUserMessageId != null
-          ? initialUserMessageId!
-          : defaultId,
+      id: isFirstUser && initialUserMessageId != null ? initialUserMessageId! : defaultId,
       acpMessageId: messageId,
     );
     _drafts.add(draft);

--- a/bridge/sesori_plugin_acp/lib/src/api/models/acp_content_block_dto.dart
+++ b/bridge/sesori_plugin_acp/lib/src/api/models/acp_content_block_dto.dart
@@ -1,0 +1,35 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "acp_content_block_dto.freezed.dart";
+part "acp_content_block_dto.g.dart";
+
+@Freezed(
+  unionKey: "type",
+  fallbackUnion: "unknown",
+  fromJson: true,
+  toJson: false,
+)
+sealed class AcpContentBlockDto with _$AcpContentBlockDto {
+  const factory AcpContentBlockDto.text({
+    required String text,
+  }) = AcpTextContentBlockDto;
+
+  const factory AcpContentBlockDto.image({
+    required String data,
+    required String mimeType,
+    required String? uri,
+  }) = AcpImageContentBlockDto;
+
+  @FreezedUnionValue("audio")
+  const factory AcpContentBlockDto.unsupportedAudio() = AcpUnsupportedAudioContentBlockDto;
+
+  @FreezedUnionValue("resource")
+  const factory AcpContentBlockDto.unsupportedResource() = AcpUnsupportedResourceContentBlockDto;
+
+  @FreezedUnionValue("resource_link")
+  const factory AcpContentBlockDto.unsupportedResourceLink() = AcpUnsupportedResourceLinkContentBlockDto;
+
+  const factory AcpContentBlockDto.unknown() = AcpUnknownContentBlockDto;
+
+  factory AcpContentBlockDto.fromJson(Map<String, dynamic> json) => _$AcpContentBlockDtoFromJson(json);
+}

--- a/bridge/sesori_plugin_acp/lib/src/api/models/acp_content_block_dto.freezed.dart
+++ b/bridge/sesori_plugin_acp/lib/src/api/models/acp_content_block_dto.freezed.dart
@@ -1,0 +1,366 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'acp_content_block_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+AcpContentBlockDto _$AcpContentBlockDtoFromJson(
+  Map<String, dynamic> json
+) {
+        switch (json['type']) {
+                  case 'text':
+          return AcpTextContentBlockDto.fromJson(
+            json
+          );
+                case 'image':
+          return AcpImageContentBlockDto.fromJson(
+            json
+          );
+                case 'audio':
+          return AcpUnsupportedAudioContentBlockDto.fromJson(
+            json
+          );
+                case 'resource':
+          return AcpUnsupportedResourceContentBlockDto.fromJson(
+            json
+          );
+                case 'resource_link':
+          return AcpUnsupportedResourceLinkContentBlockDto.fromJson(
+            json
+          );
+        
+          default:
+            return AcpUnknownContentBlockDto.fromJson(
+  json
+);
+        }
+      
+}
+
+/// @nodoc
+mixin _$AcpContentBlockDto {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AcpContentBlockDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'AcpContentBlockDto()';
+}
+
+
+}
+
+/// @nodoc
+class $AcpContentBlockDtoCopyWith<$Res>  {
+$AcpContentBlockDtoCopyWith(AcpContentBlockDto _, $Res Function(AcpContentBlockDto) __);
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class AcpTextContentBlockDto implements AcpContentBlockDto {
+  const AcpTextContentBlockDto({required this.text, final  String? $type}): $type = $type ?? 'text';
+  factory AcpTextContentBlockDto.fromJson(Map<String, dynamic> json) => _$AcpTextContentBlockDtoFromJson(json);
+
+ final  String text;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of AcpContentBlockDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AcpTextContentBlockDtoCopyWith<AcpTextContentBlockDto> get copyWith => _$AcpTextContentBlockDtoCopyWithImpl<AcpTextContentBlockDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AcpTextContentBlockDto&&(identical(other.text, text) || other.text == text));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,text);
+
+@override
+String toString() {
+  return 'AcpContentBlockDto.text(text: $text)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AcpTextContentBlockDtoCopyWith<$Res> implements $AcpContentBlockDtoCopyWith<$Res> {
+  factory $AcpTextContentBlockDtoCopyWith(AcpTextContentBlockDto value, $Res Function(AcpTextContentBlockDto) _then) = _$AcpTextContentBlockDtoCopyWithImpl;
+@useResult
+$Res call({
+ String text
+});
+
+
+
+
+}
+/// @nodoc
+class _$AcpTextContentBlockDtoCopyWithImpl<$Res>
+    implements $AcpTextContentBlockDtoCopyWith<$Res> {
+  _$AcpTextContentBlockDtoCopyWithImpl(this._self, this._then);
+
+  final AcpTextContentBlockDto _self;
+  final $Res Function(AcpTextContentBlockDto) _then;
+
+/// Create a copy of AcpContentBlockDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? text = null,}) {
+  return _then(AcpTextContentBlockDto(
+text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class AcpImageContentBlockDto implements AcpContentBlockDto {
+  const AcpImageContentBlockDto({required this.data, required this.mimeType, required this.uri, final  String? $type}): $type = $type ?? 'image';
+  factory AcpImageContentBlockDto.fromJson(Map<String, dynamic> json) => _$AcpImageContentBlockDtoFromJson(json);
+
+ final  String data;
+ final  String mimeType;
+ final  String? uri;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of AcpContentBlockDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AcpImageContentBlockDtoCopyWith<AcpImageContentBlockDto> get copyWith => _$AcpImageContentBlockDtoCopyWithImpl<AcpImageContentBlockDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AcpImageContentBlockDto&&(identical(other.data, data) || other.data == data)&&(identical(other.mimeType, mimeType) || other.mimeType == mimeType)&&(identical(other.uri, uri) || other.uri == uri));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,data,mimeType,uri);
+
+@override
+String toString() {
+  return 'AcpContentBlockDto.image(data: $data, mimeType: $mimeType, uri: $uri)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AcpImageContentBlockDtoCopyWith<$Res> implements $AcpContentBlockDtoCopyWith<$Res> {
+  factory $AcpImageContentBlockDtoCopyWith(AcpImageContentBlockDto value, $Res Function(AcpImageContentBlockDto) _then) = _$AcpImageContentBlockDtoCopyWithImpl;
+@useResult
+$Res call({
+ String data, String mimeType, String? uri
+});
+
+
+
+
+}
+/// @nodoc
+class _$AcpImageContentBlockDtoCopyWithImpl<$Res>
+    implements $AcpImageContentBlockDtoCopyWith<$Res> {
+  _$AcpImageContentBlockDtoCopyWithImpl(this._self, this._then);
+
+  final AcpImageContentBlockDto _self;
+  final $Res Function(AcpImageContentBlockDto) _then;
+
+/// Create a copy of AcpContentBlockDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? data = null,Object? mimeType = null,Object? uri = freezed,}) {
+  return _then(AcpImageContentBlockDto(
+data: null == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as String,mimeType: null == mimeType ? _self.mimeType : mimeType // ignore: cast_nullable_to_non_nullable
+as String,uri: freezed == uri ? _self.uri : uri // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class AcpUnsupportedAudioContentBlockDto implements AcpContentBlockDto {
+  const AcpUnsupportedAudioContentBlockDto({final  String? $type}): $type = $type ?? 'audio';
+  factory AcpUnsupportedAudioContentBlockDto.fromJson(Map<String, dynamic> json) => _$AcpUnsupportedAudioContentBlockDtoFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AcpUnsupportedAudioContentBlockDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'AcpContentBlockDto.unsupportedAudio()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class AcpUnsupportedResourceContentBlockDto implements AcpContentBlockDto {
+  const AcpUnsupportedResourceContentBlockDto({final  String? $type}): $type = $type ?? 'resource';
+  factory AcpUnsupportedResourceContentBlockDto.fromJson(Map<String, dynamic> json) => _$AcpUnsupportedResourceContentBlockDtoFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AcpUnsupportedResourceContentBlockDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'AcpContentBlockDto.unsupportedResource()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class AcpUnsupportedResourceLinkContentBlockDto implements AcpContentBlockDto {
+  const AcpUnsupportedResourceLinkContentBlockDto({final  String? $type}): $type = $type ?? 'resource_link';
+  factory AcpUnsupportedResourceLinkContentBlockDto.fromJson(Map<String, dynamic> json) => _$AcpUnsupportedResourceLinkContentBlockDtoFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AcpUnsupportedResourceLinkContentBlockDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'AcpContentBlockDto.unsupportedResourceLink()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class AcpUnknownContentBlockDto implements AcpContentBlockDto {
+  const AcpUnknownContentBlockDto({final  String? $type}): $type = $type ?? 'unknown';
+  factory AcpUnknownContentBlockDto.fromJson(Map<String, dynamic> json) => _$AcpUnknownContentBlockDtoFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AcpUnknownContentBlockDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'AcpContentBlockDto.unknown()';
+}
+
+
+}
+
+
+
+
+// dart format on

--- a/bridge/sesori_plugin_acp/lib/src/api/models/acp_content_block_dto.g.dart
+++ b/bridge/sesori_plugin_acp/lib/src/api/models/acp_content_block_dto.g.dart
@@ -1,0 +1,36 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'acp_content_block_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+AcpTextContentBlockDto _$AcpTextContentBlockDtoFromJson(Map json) =>
+    AcpTextContentBlockDto(
+      text: json['text'] as String,
+      $type: json['type'] as String?,
+    );
+
+AcpImageContentBlockDto _$AcpImageContentBlockDtoFromJson(Map json) =>
+    AcpImageContentBlockDto(
+      data: json['data'] as String,
+      mimeType: json['mimeType'] as String,
+      uri: json['uri'] as String?,
+      $type: json['type'] as String?,
+    );
+
+AcpUnsupportedAudioContentBlockDto _$AcpUnsupportedAudioContentBlockDtoFromJson(
+  Map json,
+) => AcpUnsupportedAudioContentBlockDto($type: json['type'] as String?);
+
+AcpUnsupportedResourceContentBlockDto
+_$AcpUnsupportedResourceContentBlockDtoFromJson(Map json) =>
+    AcpUnsupportedResourceContentBlockDto($type: json['type'] as String?);
+
+AcpUnsupportedResourceLinkContentBlockDto
+_$AcpUnsupportedResourceLinkContentBlockDtoFromJson(Map json) =>
+    AcpUnsupportedResourceLinkContentBlockDto($type: json['type'] as String?);
+
+AcpUnknownContentBlockDto _$AcpUnknownContentBlockDtoFromJson(Map json) =>
+    AcpUnknownContentBlockDto($type: json['type'] as String?);

--- a/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
@@ -116,7 +116,12 @@ final class AcpContentMapper {
       dto = AcpContentBlockDto.fromJson(content.cast<String, dynamic>());
     } on Object {
       _warnOnce(reason: _AcpContentWarning.malformed, warned: warned);
-      yield const AcpMappedUnknownContentBlock();
+      final fallback = _legacyMapContent(content: content, warned: warned);
+      if (fallback.isEmpty) {
+        yield const AcpMappedUnknownContentBlock();
+      } else {
+        yield* fallback;
+      }
       return;
     }
 
@@ -130,8 +135,26 @@ final class AcpContentMapper {
           AcpUnsupportedResourceLinkContentBlockDto():
         yield const AcpMappedUnsupportedContentBlock();
       case AcpUnknownContentBlockDto():
-        yield const AcpMappedUnknownContentBlock();
+        final fallback = _legacyMapContent(content: content, warned: warned);
+        if (fallback.isEmpty) {
+          yield const AcpMappedUnknownContentBlock();
+        } else {
+          yield* fallback;
+        }
     }
+  }
+
+  List<AcpMappedContentBlock> _legacyMapContent({
+    required Map<dynamic, dynamic> content,
+    required Set<_AcpContentWarning> warned,
+  }) {
+    final text = content["text"];
+    if (text is String && text.isNotEmpty) {
+      return [AcpMappedTextContentBlock(text: text)];
+    }
+    final nested = content["content"];
+    if (nested == null) return const [];
+    return _mapValue(content: nested, warned: warned).toList(growable: false);
   }
 
   AcpMappedImageContentBlock _mapImage({

--- a/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
@@ -1,0 +1,255 @@
+import "dart:convert";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart"
+    show decodedBase64Length, isInlineMessageAttachmentWithinSizeLimit, maxInlineMessageAttachmentBytes;
+
+import "../../api/models/acp_content_block_dto.dart";
+
+sealed class AcpMappedContentBlock {
+  const AcpMappedContentBlock();
+}
+
+final class AcpMappedTextContentBlock extends AcpMappedContentBlock {
+  const AcpMappedTextContentBlock({required this.text});
+
+  final String text;
+}
+
+sealed class AcpMappedImageContentBlock extends AcpMappedContentBlock {
+  const AcpMappedImageContentBlock();
+}
+
+final class AcpMappedInlineImageContentBlock extends AcpMappedImageContentBlock {
+  const AcpMappedInlineImageContentBlock({
+    required this.attachment,
+    required this.decodedBytes,
+  });
+
+  final PluginMessageAttachmentInlineImage attachment;
+  final int decodedBytes;
+}
+
+final class AcpMappedMetadataImageContentBlock extends AcpMappedImageContentBlock {
+  const AcpMappedMetadataImageContentBlock({
+    required this.attachment,
+    required this.reason,
+  });
+
+  final PluginMessageAttachmentMetadata attachment;
+  final AcpImageDegradationReason reason;
+}
+
+final class AcpMappedUnsupportedContentBlock extends AcpMappedContentBlock {
+  const AcpMappedUnsupportedContentBlock();
+}
+
+final class AcpMappedUnknownContentBlock extends AcpMappedContentBlock {
+  const AcpMappedUnknownContentBlock();
+}
+
+enum AcpImageDegradationReason {
+  invalid,
+  unsupported,
+  oversized,
+}
+
+/// Maps standard ACP content blocks into backend-neutral, individually
+/// validated content while retaining no URI or source-path data.
+///
+/// Message-level ordering, count, and aggregate-byte state belong to the
+/// per-message tracker introduced with image materialization. This mapper owns
+/// only one candidate's typed decoding and transport-safe normalization.
+final class AcpContentMapper {
+  const AcpContentMapper();
+
+  static const int _maxUriCharactersForFilename = 4096;
+  static const int _maxMimeCharacters = 255;
+  static const String _fallbackMime = "application/octet-stream";
+  static const Set<String> _supportedRasterMimeEssences = {
+    "image/bmp",
+    "image/gif",
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+  };
+
+  List<AcpMappedContentBlock> map({required Object? content}) {
+    final warned = <_AcpContentWarning>{};
+    return _mapValue(content: content, warned: warned).toList(growable: false);
+  }
+
+  String? text({required Object? content}) {
+    final buffer = StringBuffer();
+    for (final block in map(content: content)) {
+      if (block case AcpMappedTextContentBlock(:final text) when text.isNotEmpty) {
+        buffer.write(text);
+      }
+    }
+    final result = buffer.toString();
+    return result.isEmpty ? null : result;
+  }
+
+  Iterable<AcpMappedContentBlock> _mapValue({
+    required Object? content,
+    required Set<_AcpContentWarning> warned,
+  }) sync* {
+    if (content == null) return;
+    if (content is String) {
+      yield AcpMappedTextContentBlock(text: content);
+      return;
+    }
+    if (content is List) {
+      for (final entry in content) {
+        yield* _mapValue(content: entry, warned: warned);
+      }
+      return;
+    }
+    if (content is! Map) {
+      _warnOnce(reason: _AcpContentWarning.malformed, warned: warned);
+      yield const AcpMappedUnknownContentBlock();
+      return;
+    }
+
+    final AcpContentBlockDto dto;
+    try {
+      dto = AcpContentBlockDto.fromJson(content.cast<String, dynamic>());
+    } on Object {
+      _warnOnce(reason: _AcpContentWarning.malformed, warned: warned);
+      yield const AcpMappedUnknownContentBlock();
+      return;
+    }
+
+    switch (dto) {
+      case AcpTextContentBlockDto(:final text):
+        yield AcpMappedTextContentBlock(text: text);
+      case AcpImageContentBlockDto(:final data, :final mimeType, :final uri):
+        yield _mapImage(data: data, mime: mimeType, uri: uri);
+      case AcpUnsupportedAudioContentBlockDto() ||
+          AcpUnsupportedResourceContentBlockDto() ||
+          AcpUnsupportedResourceLinkContentBlockDto():
+        yield const AcpMappedUnsupportedContentBlock();
+      case AcpUnknownContentBlockDto():
+        yield const AcpMappedUnknownContentBlock();
+    }
+  }
+
+  AcpMappedImageContentBlock _mapImage({
+    required String data,
+    required String mime,
+    required String? uri,
+  }) {
+    final normalizedMime = _normalizeMime(raw: mime);
+    final filename = _filenameFromUri(uri: uri);
+    if (!_supportedRasterMimeEssences.contains(_mimeEssence(mime: normalizedMime))) {
+      return _metadata(
+        mime: normalizedMime,
+        filename: filename,
+        reason: AcpImageDegradationReason.unsupported,
+      );
+    }
+    if (data.isEmpty) {
+      return _metadata(
+        mime: normalizedMime,
+        filename: filename,
+        reason: AcpImageDegradationReason.invalid,
+      );
+    }
+    if (!isInlineMessageAttachmentWithinSizeLimit(base64Length: data.length)) {
+      return _metadata(
+        mime: normalizedMime,
+        filename: filename,
+        reason: AcpImageDegradationReason.oversized,
+      );
+    }
+
+    final normalized = _tryNormalizeBase64(encoded: data);
+    if (normalized == null) {
+      return _metadata(
+        mime: normalizedMime,
+        filename: filename,
+        reason: AcpImageDegradationReason.invalid,
+      );
+    }
+    if (!isInlineMessageAttachmentWithinSizeLimit(base64Length: normalized.length)) {
+      return _metadata(
+        mime: normalizedMime,
+        filename: filename,
+        reason: AcpImageDegradationReason.oversized,
+      );
+    }
+
+    final decodedBytes = decodedBase64Length(base64Data: normalized);
+    if (decodedBytes > maxInlineMessageAttachmentBytes) {
+      return _metadata(
+        mime: normalizedMime,
+        filename: filename,
+        reason: AcpImageDegradationReason.oversized,
+      );
+    }
+    return AcpMappedInlineImageContentBlock(
+      attachment:
+          PluginMessageAttachment.inlineImage(
+                mime: normalizedMime,
+                base64: normalized,
+                filename: filename,
+              )
+              as PluginMessageAttachmentInlineImage,
+      decodedBytes: decodedBytes,
+    );
+  }
+
+  AcpMappedMetadataImageContentBlock _metadata({
+    required String mime,
+    required String? filename,
+    required AcpImageDegradationReason reason,
+  }) {
+    return AcpMappedMetadataImageContentBlock(
+      attachment:
+          PluginMessageAttachment.metadata(
+                mime: mime,
+                filename: filename,
+              )
+              as PluginMessageAttachmentMetadata,
+      reason: reason,
+    );
+  }
+
+  String? _tryNormalizeBase64({required String encoded}) {
+    try {
+      return base64.normalize(encoded);
+    } on FormatException {
+      return null;
+    }
+  }
+
+  String _normalizeMime({required String? raw}) {
+    final trimmed = raw?.trim();
+    if (trimmed == null || trimmed.isEmpty) return _fallbackMime;
+    return String.fromCharCodes(trimmed.runes.take(_maxMimeCharacters)).toLowerCase();
+  }
+
+  String _mimeEssence({required String mime}) => mime.split(";").first.trim();
+
+  String? _filenameFromUri({required String? uri}) {
+    if (uri == null || uri.isEmpty || uri.length > _maxUriCharactersForFilename) {
+      return null;
+    }
+    final parsed = Uri.tryParse(uri);
+    if (parsed == null || parsed.pathSegments.isEmpty) return null;
+    final segments = parsed.pathSegments.where((segment) => segment.isNotEmpty);
+    return segments.isEmpty ? null : normalizePluginMessageAttachmentFilename(filename: segments.last);
+  }
+
+  void _warnOnce({
+    required _AcpContentWarning reason,
+    required Set<_AcpContentWarning> warned,
+  }) {
+    if (!warned.add(reason)) return;
+    Log.w("[acp] skipping malformed content block");
+  }
+}
+
+enum _AcpContentWarning {
+  malformed,
+}

--- a/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
@@ -73,6 +73,11 @@ final class AcpContentMapper {
     "image/png",
     "image/webp",
   };
+  static const Set<String> _supportedFilenameUriSchemes = {
+    "file",
+    "http",
+    "https",
+  };
 
   List<AcpMappedContentBlock> map({required Object? content}) {
     final warned = <_AcpContentWarning>{};
@@ -259,7 +264,12 @@ final class AcpContentMapper {
       return null;
     }
     final parsed = Uri.tryParse(uri);
-    if (parsed == null || parsed.pathSegments.isEmpty) return null;
+    if (parsed == null ||
+        !_supportedFilenameUriSchemes.contains(parsed.scheme) ||
+        (!parsed.hasAuthority && !parsed.path.startsWith("/")) ||
+        parsed.pathSegments.isEmpty) {
+      return null;
+    }
     final segments = parsed.pathSegments.where((segment) => segment.isNotEmpty);
     return segments.isEmpty ? null : normalizePluginMessageAttachmentFilename(filename: segments.last);
   }

--- a/bridge/sesori_plugin_acp/test/acp_commands_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_commands_test.dart
@@ -99,11 +99,13 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
+        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
           agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
+          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(
@@ -234,11 +236,13 @@ void main() {
       agentDisplayName: "ACP",
       launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
       launchDirectory: "/repo",
+      contentMapper: const AcpContentMapper(),
       eventMapper: AcpEventMapper(
         launchDirectory: "/repo",
         agentId: "acp",
         pluginId: "acp",
         configurationTracker: configurationTracker,
+        contentMapper: const AcpContentMapper(),
       ),
       commandTracker: commandTracker,
       sessionOptionsService: AcpSessionOptionsService(

--- a/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
@@ -121,6 +121,25 @@ void main() {
       expect(tooLarge.reason, AcpImageDegradationReason.oversized);
     });
 
+    test("does not derive metadata filenames from opaque URIs", () {
+      for (final uri in ["data:text/plain,secret", "mailto:secret@example.com"]) {
+        final mapped =
+            mapper
+                    .map(
+                      content: {
+                        "type": "image",
+                        "data": "not base64",
+                        "mimeType": "image/png",
+                        "uri": uri,
+                      },
+                    )
+                    .single
+                as AcpMappedMetadataImageContentBlock;
+
+        expect(mapped.attachment.filename, isNull);
+      }
+    });
+
     test("separates known unsupported and future content variants", () {
       final mapped = mapper.map(
         content: [

--- a/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
@@ -1,0 +1,162 @@
+import "dart:convert";
+import "dart:io";
+import "dart:typed_data";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" show maxInlineMessageAttachmentBytes;
+import "package:test/test.dart";
+
+void main() {
+  group("AcpContentMapper", () {
+    const mapper = AcpContentMapper();
+
+    test("preserves standard and legacy text while flattening lists", () {
+      expect(
+        mapper.text(
+          content: [
+            {"type": "text", "text": "standard "},
+            "legacy ",
+            [
+              {"type": "text", "text": "nested"},
+            ],
+          ],
+        ),
+        "standard legacy nested",
+      );
+      expect(mapper.text(content: {"type": "text", "text": ""}), isNull);
+    });
+
+    test("allows the bounded raster MIME set and retains only a URI basename", () {
+      for (final mime in [
+        "image/bmp",
+        "image/gif",
+        "IMAGE/JPEG; charset=binary",
+        "image/png",
+        "image/webp",
+      ]) {
+        final mapped =
+            mapper
+                    .map(
+                      content: {
+                        "type": "image",
+                        "data": "AA",
+                        "mimeType": " $mime ",
+                        "uri": "https://secret.example/private/output.png?token=credential",
+                      },
+                    )
+                    .single
+                as AcpMappedInlineImageContentBlock;
+
+        expect(mapped.attachment.mime, mime.trim().toLowerCase());
+        expect(mapped.attachment.base64, "AA==");
+        expect(mapped.attachment.filename, "output.png");
+        expect(mapped.decodedBytes, 1);
+        expect(mapped.toString(), isNot(contains("secret.example")));
+        expect(mapped.toString(), isNot(contains("credential")));
+      }
+    });
+
+    test("degrades invalid, unsupported, and oversized images to metadata", () {
+      final oversized = base64Encode(Uint8List(maxInlineMessageAttachmentBytes + 1));
+      final mapped = mapper.map(
+        content: [
+          {
+            "type": "image",
+            "data": "not base64",
+            "mimeType": "image/png",
+            "uri": "file:///private/invalid.png",
+          },
+          {
+            "type": "image",
+            "data": "AA==",
+            "mimeType": "image/svg+xml",
+            "uri": "file:///private/vector.svg",
+          },
+          {
+            "type": "image",
+            "data": oversized,
+            "mimeType": "image/png",
+            "uri": null,
+          },
+        ],
+      );
+
+      final invalid = mapped[0] as AcpMappedMetadataImageContentBlock;
+      final unsupported = mapped[1] as AcpMappedMetadataImageContentBlock;
+      final tooLarge = mapped[2] as AcpMappedMetadataImageContentBlock;
+      expect(invalid.reason, AcpImageDegradationReason.invalid);
+      expect(invalid.attachment.filename, "invalid.png");
+      expect(unsupported.reason, AcpImageDegradationReason.unsupported);
+      expect(unsupported.attachment.mime, "image/svg+xml");
+      expect(unsupported.attachment.filename, "vector.svg");
+      expect(tooLarge.reason, AcpImageDegradationReason.oversized);
+    });
+
+    test("separates known unsupported and future content variants", () {
+      final mapped = mapper.map(
+        content: [
+          {"type": "audio", "data": "private audio", "mimeType": "audio/wav"},
+          {
+            "type": "resource",
+            "resource": {"uri": "file:///private/source.dart", "text": "private source"},
+          },
+          {"type": "resource_link", "uri": "file:///private/source.dart", "name": "source.dart"},
+          {"type": "future_block", "private": "future payload"},
+        ],
+      );
+
+      expect(mapped.take(3), everyElement(isA<AcpMappedUnsupportedContentBlock>()));
+      expect(mapped.last, isA<AcpMappedUnknownContentBlock>());
+      expect(
+        mapper.text(
+          content: {"type": "audio", "data": "private audio", "mimeType": "audio/wav"},
+        ),
+        isNull,
+      );
+    });
+
+    test("malformed known blocks recover with one privacy-safe warning", () {
+      late List<AcpMappedContentBlock> mapped;
+      final output = _captureWarnings(() {
+        mapped = mapper.map(
+          content: [
+            {"type": "text", "text": 42, "private": "secret text"},
+            {"type": "image", "mimeType": "image/png", "uri": "file:///private/secret.png"},
+          ],
+        );
+      });
+
+      expect(mapped, hasLength(2));
+      expect(mapped, everyElement(isA<AcpMappedUnknownContentBlock>()));
+      expect("malformed content block".allMatches(output), hasLength(1));
+      expect(output, isNot(contains("secret text")));
+      expect(output, isNot(contains("secret.png")));
+      expect(output, isNot(contains("type cast")));
+    });
+  });
+}
+
+String _captureWarnings(void Function() action) {
+  final previousLevel = Log.level;
+  final stderr = _BufferingStdout();
+  try {
+    Log.level = LogLevel.warning;
+    IOOverrides.runZoned(action, stderr: () => stderr);
+  } finally {
+    Log.level = previousLevel;
+  }
+  return stderr.text;
+}
+
+class _BufferingStdout implements Stdout {
+  final StringBuffer _buffer = StringBuffer();
+
+  String get text => _buffer.toString();
+
+  @override
+  void writeln([Object? object = ""]) => _buffer.writeln(object);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}

--- a/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
@@ -27,6 +27,34 @@ void main() {
       expect(mapper.text(content: {"type": "text", "text": ""}), isNull);
     });
 
+    test("preserves untyped, future, and wrapped text after known variant parsing", () {
+      expect(mapper.text(content: {"text": "untyped"}), "untyped");
+      expect(
+        mapper.text(content: {"type": "future_block", "text": "future"}),
+        "future",
+      );
+      expect(
+        mapper.text(
+          content: {
+            "type": "content",
+            "content": {"type": "text", "text": "wrapped"},
+          },
+        ),
+        "wrapped",
+      );
+
+      final knownImage = mapper.map(
+        content: {
+          "type": "image",
+          "data": "AA==",
+          "mimeType": "image/png",
+          "uri": null,
+          "text": "must not bypass image validation",
+        },
+      );
+      expect(knownImage.single, isA<AcpMappedInlineImageContentBlock>());
+    });
+
     test("allows the bounded raster MIME set and retains only a URI basename", () {
       for (final mime in [
         "image/bmp",

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -18,6 +18,7 @@ void main() {
         agentId: "cursor",
         pluginId: "cursor",
         configurationTracker: configurationTracker,
+        contentMapper: const AcpContentMapper(),
       );
     });
 
@@ -57,6 +58,29 @@ void main() {
       }));
       expect(second.whereType<BridgeSseMessageUpdated>(), isEmpty);
       expect(second.whereType<BridgeSseMessagePartDelta>().single.delta, "lo");
+    });
+
+    test("validated image chunks remain unmaterialized until the content tracker lands", () {
+      mapper.beginTurn("s1");
+      final imageEvents = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "mixed",
+        "content": {
+          "type": "image",
+          "data": "AA==",
+          "mimeType": "image/png",
+          "uri": "file:///private/output.png",
+        },
+      }));
+      final textEvents = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "mixed",
+        "content": {"type": "text", "text": "visible"},
+      }));
+
+      expect(imageEvents, isEmpty);
+      expect(textEvents.whereType<BridgeSseMessageUpdated>(), hasLength(1));
+      expect(textEvents.whereType<BridgeSseMessagePartDelta>().single.delta, "visible");
     });
 
     test("agent_thought_chunk maps to a reasoning part", () {
@@ -856,7 +880,12 @@ void main() {
 /// as a halt notice, using the trimmed text as the shown message.
 class _HaltMapper extends AcpEventMapper {
   _HaltMapper({required super.configurationTracker})
-    : super(launchDirectory: "/repo", agentId: "cursor", pluginId: "cursor");
+    : super(
+        launchDirectory: "/repo",
+        agentId: "cursor",
+        pluginId: "cursor",
+        contentMapper: const AcpContentMapper(),
+      );
 
   @override
   AcpHaltNotice? classifyHaltNotice({required String text}) {

--- a/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
@@ -25,11 +25,13 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
+        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
           agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
+          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(
@@ -234,11 +236,13 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
+        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
           agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
+          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(

--- a/bridge/sesori_plugin_acp/test/acp_initialize_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_initialize_test.dart
@@ -22,11 +22,13 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
+        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
           agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
+          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(

--- a/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
@@ -24,11 +24,13 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
+        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
           agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
+          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(

--- a/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
@@ -27,11 +27,13 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
+        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
           agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
+          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(
@@ -738,11 +740,13 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
+        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
           agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
+          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(
@@ -865,6 +869,7 @@ class _RegistryCapturingAcpPlugin extends AcpPlugin {
     required super.launchSpec,
     required super.launchDirectory,
     required super.eventMapper,
+    required super.contentMapper,
     required super.commandTracker,
     required super.sessionOptionsService,
     super.processFactory,

--- a/bridge/sesori_plugin_acp/test/acp_reconnect_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_reconnect_test.dart
@@ -21,11 +21,13 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
+        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
           agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
+          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(

--- a/bridge/sesori_plugin_acp/test/acp_resume_only_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_only_test.dart
@@ -24,11 +24,13 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
+        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
           agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
+          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(

--- a/bridge/sesori_plugin_acp/test/acp_resume_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_test.dart
@@ -23,11 +23,13 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
+        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
           agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
+          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -16,6 +16,7 @@ void main() {
         providerId: null,
         initialUserMessageId: "s1-initial-user",
         haltClassifier: null,
+        contentMapper: const AcpContentMapper(),
       )
         ..consume(upd({
           "sessionUpdate": "user_message_chunk",
@@ -42,6 +43,7 @@ void main() {
         providerId: "cursor",
         initialUserMessageId: null,
         haltClassifier: null,
+        contentMapper: const AcpContentMapper(),
       )
         ..consume(upd({
           "sessionUpdate": "user_message_chunk",
@@ -86,6 +88,7 @@ void main() {
         agentId: "Cursor",
         initialUserMessageId: null,
         haltClassifier: null,
+        contentMapper: const AcpContentMapper(),
       )
         ..consume(upd({
           "sessionUpdate": "agent_message_chunk",
@@ -115,6 +118,7 @@ void main() {
         agentId: "Cursor",
         initialUserMessageId: null,
         haltClassifier: null,
+        contentMapper: const AcpContentMapper(),
       )
         ..consume(upd({
           "sessionUpdate": "tool_call",
@@ -146,6 +150,7 @@ void main() {
         agentId: "Cursor",
         initialUserMessageId: null,
         haltClassifier: null,
+        contentMapper: const AcpContentMapper(),
       )
         ..consume(upd({
           "sessionUpdate": "tool_call",
@@ -172,6 +177,7 @@ void main() {
         agentId: "Cursor",
         initialUserMessageId: null,
         haltClassifier: null,
+        contentMapper: const AcpContentMapper(),
       )
         ..consume(upd({
           "sessionUpdate": "tool_call",
@@ -194,6 +200,7 @@ void main() {
         providerId: "cursor",
         initialUserMessageId: null,
         haltClassifier: null,
+        contentMapper: const AcpContentMapper(),
       )..consume(upd({
           "sessionUpdate": "agent_message_chunk",
           "content": {"type": "text", "text": "hi"},
@@ -211,6 +218,7 @@ void main() {
         agentId: "Cursor",
         initialUserMessageId: null,
         haltClassifier: null,
+        contentMapper: const AcpContentMapper(),
       )
         ..consume(upd({
           "sessionUpdate": "agent_message_chunk",
@@ -241,6 +249,7 @@ void main() {
         agentId: "Cursor",
         initialUserMessageId: null,
         haltClassifier: null,
+        contentMapper: const AcpContentMapper(),
       )
         ..consume(upd({
           "sessionUpdate": "agent_message_chunk",
@@ -253,12 +262,49 @@ void main() {
       expect(collector.build().single.parts.single.text, "one flow");
     });
 
+    test("validated replay images remain unmaterialized without changing text grouping", () {
+      final collector = AcpReplayCollector(
+        sessionId: "s1",
+        agentId: "Cursor",
+        initialUserMessageId: null,
+        haltClassifier: null,
+        contentMapper: const AcpContentMapper(),
+      )
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "mixed",
+          "content": {"type": "text", "text": "before"},
+        }))
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "mixed",
+          "content": {
+            "type": "image",
+            "data": "AA==",
+            "mimeType": "image/png",
+            "uri": "file:///private/output.png",
+          },
+        }))
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "mixed",
+          "content": {"type": "text", "text": "after"},
+        }));
+
+      final message = collector.build().single;
+      expect(message.parts, hasLength(1));
+      expect(message.parts.single.type, PluginMessagePartType.text);
+      expect(message.parts.single.text, "beforeafter");
+      expect(message.parts.single.attachment, isNull);
+    });
+
     test("an explicit messageId after id-less text starts a new message", () {
       final collector = AcpReplayCollector(
         sessionId: "s1",
         agentId: "Cursor",
         initialUserMessageId: null,
         haltClassifier: null,
+        contentMapper: const AcpContentMapper(),
       )
         ..consume(upd({
           "sessionUpdate": "agent_message_chunk",
@@ -282,6 +328,7 @@ void main() {
         agentId: "Cursor",
         initialUserMessageId: null,
         haltClassifier: null,
+        contentMapper: const AcpContentMapper(),
       )
         ..consume(upd({
           "sessionUpdate": "agent_message_chunk",
@@ -305,6 +352,7 @@ void main() {
         agentId: "Cursor",
         initialUserMessageId: null,
         haltClassifier: null,
+        contentMapper: const AcpContentMapper(),
       )
         ..consume(upd({
           "sessionUpdate": "agent_thought_chunk",
@@ -341,6 +389,7 @@ void main() {
         haltClassifier: ({required text}) => text.trim() == "Check your settings to continue"
             ? const AcpHaltNotice(errorName: "cursor_gate", message: "Check your settings to continue")
             : null,
+        contentMapper: const AcpContentMapper(),
       )..consume(upd({
           "sessionUpdate": "agent_message_chunk",
           "content": {"type": "text", "text": "\n\nCheck your settings to continue"},
@@ -358,6 +407,7 @@ void main() {
         agentId: "Cursor",
         initialUserMessageId: null,
         haltClassifier: null,
+        contentMapper: const AcpContentMapper(),
       )
         ..consume(upd({
           "sessionUpdate": "agent_message_chunk",

--- a/bridge/sesori_plugin_acp/test/acp_session_options_service_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_options_service_test.dart
@@ -17,6 +17,7 @@ void main() {
       agentId: "agent",
       pluginId: "plugin",
       configurationTracker: tracker,
+      contentMapper: const AcpContentMapper(),
     );
 
     final defaultEvents = mapper.map(_messageUpdate(sessionId: "other"));

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -14,6 +14,7 @@ class _GatedSelectionPlugin extends AcpPlugin {
     required super.launchSpec,
     required super.launchDirectory,
     required super.eventMapper,
+    required super.contentMapper,
     required super.commandTracker,
     required super.sessionOptionsService,
     required AcpProcessFactory super.processFactory,
@@ -63,11 +64,13 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
+        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
           agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
+          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(
@@ -296,11 +299,13 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
+        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
           agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
+          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(
@@ -425,11 +430,13 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
+        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
           agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
+          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(
@@ -651,11 +658,13 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
+        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
           agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
+          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
@@ -8,6 +8,7 @@ class CursorEventMapper extends AcpEventMapper {
     required super.launchDirectory,
     required super.pluginId,
     required super.configurationTracker,
+    required super.contentMapper,
   }) : super(agentId: pluginId);
 
   @override

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
@@ -48,6 +48,7 @@ class CursorPlugin extends AcpPlugin implements PersistedSessionCleanupApi {
     final commandTracker = AcpCommandTracker();
     final stagedCommandTracker = AcpCommandTracker();
     final configurationTracker = AcpSessionConfigurationTracker();
+    const contentMapper = AcpContentMapper();
     final acpSessionOptionsService = AcpSessionOptionsService(
       configurationTracker: configurationTracker,
       commandTracker: commandTracker,
@@ -79,7 +80,9 @@ class CursorPlugin extends AcpPlugin implements PersistedSessionCleanupApi {
         launchDirectory: cwd,
         pluginId: pluginId,
         configurationTracker: configurationTracker,
+        contentMapper: contentMapper,
       ),
+      contentMapper: contentMapper,
       processFactory: processFactory,
       catalogService: catalogService,
       catalogCommandListener: catalogCommandListener,
@@ -95,6 +98,7 @@ class CursorPlugin extends AcpPlugin implements PersistedSessionCleanupApi {
   CursorPlugin._({
     required super.launchSpec,
     required super.launchDirectory,
+    required super.contentMapper,
     required CursorEventMapper mapper,
     required CursorCatalogService catalogService,
     required AcpCommandListener catalogCommandListener,

--- a/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
@@ -10,6 +10,7 @@ void main() {
       launchDirectory: "/repo",
       pluginId: CursorPlugin.pluginId,
       configurationTracker: AcpSessionConfigurationTracker(),
+      contentMapper: const AcpContentMapper(),
     );
 
     test("cursor/update_todos maps to a todo update", () {


### PR DESCRIPTION
## Complexity

⚙️ Moderate — generated ACP contract variants, explicit cross-package composition, and live/replay consumer migration.

## What

- add generated ACP text, image, known-unsupported, and unknown content-block DTOs
- add a stateless ACP content mapper that preserves text behavior and validates individual raster image MIME, base64, size, and basename-only URI metadata
- inject one explicit mapping policy through ACP live events, plugin-owned replay, and Cursor composition

## Why

Live and replay currently inspect raw ACP content independently. A typed backend-local boundary is required before later steps can add ordered image state without allowing live/history behavior or security policy to drift.

## Risk and test focus

The main risks are text regression, malformed-content failures, leaked image URI/payload data, and accidental early image rendering. Tests cover standard and legacy text, generated variants, raster allowlisting, strict base64 and size handling, metadata degradation, basename-only URI handling, privacy-safe malformed recovery, live/replay text grouping, and Cursor inheritance.

There is no database, shared-wire, relay, client, or analytics impact. There is intentionally no user-visible image behavior in this step; validated images remain unmaterialized until the planned tracker step.

## Expected result

ACP and Cursor continue rendering text exactly as before through one typed mapping seam. Standard image blocks are safely normalized for future tracker consumption, while audio, resources, future variants, and image rendering remain unsupported at this stage.

## Verification

- ACP codegen (`dart run build_runner build --delete-conflicting-outputs`)
- focused ACP mapper/live/replay tests (69 tests)
- focused Cursor event mapping tests (7 tests)
- full ACP suite (165 tests)
- full Cursor suite (108 tests)
- `dart pub get`
- `dart analyze --fatal-infos` in ACP and Cursor
- `git diff --cached --check`
- `aristotle-impl-review` — approved with no findings

## Plan

Step 8/13 of `.plan/active/output-image-support/PLAN.md`. The complete 1,119-line diff is below the original estimate and the 1,500-line soft cap; no adjacent scope was combined.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed ACP content blocks and a stateless content mapper to validate and normalize text and image content across live and replay. Text behavior is unchanged; images are validated but not materialized yet.

- **Refactors**
  - Generated content-block DTOs: text, image, unsupported (audio/resource/resource_link), and unknown.
  - Added `AcpContentMapper` to flatten text and validate images (MIME, base64, size); derives filenames only from hierarchical `file`/`http`/`https` URIs (opaque URIs rejected) and degrades invalid/unsupported/oversized images to metadata.
  - Routed the mapper through `AcpEventMapper`, `AcpReplayCollector`, `AcpPlugin`, and the Cursor plugin to enforce one mapping policy in live and replay; exported `AcpContentMapper`.
  - Preserved legacy fail-soft text fallback for untyped, future, and nested-wrapper maps after typed parsing.

- **Migration**
  - Run codegen: `dart run build_runner build --delete-conflicting-outputs`.
  - No user-visible changes; no DB/relay/client impact.

<sup>Written for commit ceeaf2378284739e10169e4be44a2ae099cd47f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

