### PR TITLE
⚙️ [session-pull-request-monitoring] feat(bridge): scope GitHub PR queries [step 2.a/9]

### DIFF
--- a/.plan/active/session-pull-request-monitoring/PLAN.md
+++ b/.plan/active/session-pull-request-monitoring/PLAN.md
@@ -515,7 +515,7 @@ settings screen analytics continue unchanged.
   overage.
 - Never hand-edit generated files. Internal Dart contracts update every
   in-repository consumer in lockstep.
-- Run `aristotle-impl-review` for Steps 2–8 because they alter production
+- Run `aristotle-impl-review` for Steps 2.a–8 because they alter production
   persistence, APIs, ownership, lifecycle, public/wire contracts, or cross-layer
   flow. Do not run it for documentation-only Steps 1 or 9.
 
@@ -524,7 +524,9 @@ settings screen analytics continue unchanged.
 | Step | Branch | Exact PR title | Complexity rationale | Changed-line target | Outcome |
 |---|---|---|---|---:|---|
 | 1/9 | `plan/session-pull-request-monitoring/replan-current-pr-only` | `🌿 [session-pull-request-monitoring] docs: plan current PR monitoring [step 1/9]` | Documentation/instruction/agent-definition changes only, with no runtime behavior. | 4,000–7,000 | Publish this reviewed plan/tracker and the reusable PR communication/cleanup rules. |
-| 2/9 | `session-pull-request-monitoring-scoped-pr-cache` | `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2/9]` | Drift migration plus fail-closed account identity and cache visibility. | 1,300–2,000 | Migrate current branch/repository/login scope and repository-keyed ephemeral PR cache while preserving request-driven behavior. |
+| 2.a/9 | `session-pull-request-monitoring-scoped-source` | `⚙️ [session-pull-request-monitoring] feat(bridge): scope GitHub PR queries [step 2.a/9]` | Typed identity/repository evidence and deterministic repository-pinned CLI queries. | 500–900 | Make the existing request-driven source verify its active login and canonical repository before querying that repository explicitly. |
+| 2.b/9 | `session-pull-request-monitoring-scoped-pr-persistence` | `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2.b/9]` | Drift migration, generated artifacts, transactional writer ownership, and scoped cache joins. | 4,200–5,200 | Migrate current branch/repository/login scope and the repository-keyed ephemeral PR cache while preserving request-driven behavior. |
+| 2.c/9 | `session-pull-request-monitoring-scoped-pr-reads` | `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]` | Fresh request identity gating, list/detail failure behavior, and privacy-sensitive regressions. | 1,200–1,700 | Require fresh login evidence for every PR-bearing read and fail closed without blocking session/catalog data. |
 | 3/9 | `session-pull-request-monitoring-graphql-selection` | `🚧 [session-pull-request-monitoring] feat(bridge): batch exact PR selection [step 3/9]` | Typed dynamic GraphQL batching/pagination, identity fencing, and deterministic selection. | 1,000–1,500 | Replace repository-wide open-list CLI reads with typed exact-target GraphQL batching and open/terminal selection. |
 | 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | Git/process resolution, persisted scope, cache races, and cross-layer rendering. | 1,100–1,500 | Resolve every root's current branch/repository on each request refresh, scope selected cache, and map the live branch. |
 | 5/9 | `session-pull-request-monitoring-view-scheduler` | `🚧 [session-pull-request-monitoring] feat(bridge): schedule viewed-project PR refresh [step 5/9]` | Multi-device connection lifecycle and serialized add-during-flight scheduling. | 900–1,400 | Route per-connection project presence and run one fixed 30-second aggregate scheduler. |
@@ -541,7 +543,7 @@ Scope:
 
 - Publish the current-branch architecture and tracker as one plan authority.
 - Consolidate execution guidance into the top-level plan files.
-- Record the fixed nine emoji-prefixed titles, line budgets, existing PR #457
+- Record the fixed top-level sequence and emoji-prefixed titles, line budgets, existing PR #457
   contract baseline, current code baseline, open-PR drift, and final retirement
   step.
 - Update root repository guidance, Plan Maker, and Plan Worker with the reusable
@@ -556,7 +558,36 @@ Verification:
 - confirm only this plan directory, root `AGENTS.md`, and the two requested
   agent definitions changed
 
-### Step 2/9 — Scoped PR persistence
+### Step 2.a/9 — Scoped GitHub source queries
+
+Scope:
+
+- Pin current `main` and record drift from the merged plan baseline.
+- Add typed active-login verification and canonical lowercase GitHub
+  `owner/repo` resolution at the API/repository boundary.
+- Require the existing request-driven writer to obtain both pieces of evidence
+  before GitHub work and pass canonical `owner/repo` through every repository
+  layer.
+- Pin repository-wide `gh pr list` and `gh pr view` calls with `--repo` so
+  `GH_REPO` or another CLI default cannot redirect data under the wrong scope.
+- Keep the existing unscoped database shape and read behavior unchanged; Steps
+  2.b and 2.c own persistence and fresh read gating respectively.
+
+Acceptance:
+
+- Identity verification failure skips source refresh without claiming the user
+  is signed out.
+- Non-GitHub, malformed, or unavailable remotes cannot start a PR query.
+- Every PR list/view command targets the canonical repository explicitly.
+- No database, wire, client, timer, or settings behavior changes.
+
+Verification:
+
+- `GhCliApi`, canonical remote, and `PrSyncService` source-scope tests
+- bridge fatal-info analysis and focused/full tests as warranted
+- `git diff --check` and changed-line count
+
+### Step 2.b/9 — Scoped PR persistence
 
 Scope:
 
@@ -566,13 +597,12 @@ Scope:
   repository/login-scoped PR rows/key.
 - Rebuild legacy cache empty because no valid repository/login backfill exists.
 - Keep creation `branch_name` unchanged.
-- Add the minimal active-login and canonical project-remote reads needed for the
-  existing request-driven writer to populate required scoped rows before the
-  GraphQL source lands.
-- Require every PR-bearing session read to receive a freshly verified typed
-  GitHub login from the calling handler/service; explicit absence omits PR data.
-- Adapt existing request-driven writer/read code to the new required cache row
-  shape without activating current-branch semantics yet.
+- Adapt the Step 2.a request-driven writer to populate the required row scope in
+  one repository-owned transaction before the GraphQL source lands.
+- Join cached rows to persisted project login and session repository/branch
+  scope without adding fresh request-time identity gating yet.
+- Preserve established PR scope when catalog publication updates project or
+  session rows.
 - Add schema verifier, old-row, key/FK/cascade, and cache-empty migration tests.
 
 Acceptance:
@@ -580,17 +610,45 @@ Acceptance:
 - Existing project/session/catalog identities and cleanup metadata survive.
 - Old unscoped PR rows cannot become visible after migration.
 - Request-driven refresh can repopulate scoped rows on the next request.
-- Switching or invalidating `gh` identity between two session reads prevents
-  the second response from exposing the first login's cached PR metadata.
 - No project presence, timer, or client behavior ships.
 
 Verification:
 
 - Drift schema/code generation and migration tests
 - focused DAO/repository/session mapping tests
-- list/detail read-gate tests for same/switched/unknown/failed identity
 - bridge analyze/tests for changed modules
 - generated-line count and overage rationale recorded in tracker
+
+### Step 2.c/9 — Fresh scoped PR reads
+
+Scope:
+
+- Map API identity output into repository-owned `VerifiedGithubLogin` evidence
+  and require every PR-bearing `SessionRepository` read to receive it explicitly.
+- Have list/detail handlers verify identity freshly before mapping cached PR
+  metadata; explicit absence returns the session and branch without a PR.
+- Add the read-scoped login to persisted project/row/repository/branch joins.
+- Treat scoped cache selection as authoritative during enrichment, clearing
+  incoming PR/history data before applying a freshly selected row.
+- Propagate refresh failure to waited list handling so timeout/source/query
+  failures return sessions without cached PR metadata.
+
+Acceptance:
+
+- Switching or invalidating `gh` identity between two session reads prevents
+  the second response from exposing the first login's cached PR metadata.
+- Failed or timed-out waited refreshes preserve session/catalog data while
+  stripping PR metadata.
+- Catalog reads remain database-owned; only privacy-sensitive PR enrichment
+  depends on fresh identity evidence.
+- No project presence, timer, settings, client, or wire behavior ships.
+
+Verification:
+
+- session mapping tests for same/switched/unknown/failed identity
+- list/detail read-gate and waited-refresh failure tests
+- bridge fatal-info analysis and focused/full tests as warranted
+- `git diff --check` and changed-line count
 
 ### Step 3/9 — Exact GraphQL selection
 
@@ -816,7 +874,7 @@ Verification:
 
 Scope:
 
-- Confirm Steps 2–8 merged and required verification/findings are recorded.
+- Confirm Steps 2.a–8 merged and required verification/findings are recorded.
 - Mark the tracker complete.
 - Move the entire directory unchanged except final state from
   `.plan/active/session-pull-request-monitoring/` to

--- a/.plan/active/session-pull-request-monitoring/PLAN.md
+++ b/.plan/active/session-pull-request-monitoring/PLAN.md
@@ -3,14 +3,14 @@
 ## Status
 
 - **Plan slug:** `session-pull-request-monitoring`
-- **Status:** Approved — Step 1/9 plan PR [#649](https://github.com/sesori-ai/sesori_apps_monorepo/pull/649) open
-- **Plan revision date:** 2026-07-31
+- **Status:** Approved — Step 1/9 merged; Step 2.a/9 PR [#662](https://github.com/sesori-ai/sesori_apps_monorepo/pull/662) open
+- **Plan revision date:** 2026-08-01
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Implementation base:** `main`
-- **Latest audited tip:** `10c7afb9ff55d7fe91d15a48e1ef8ba08e7a3484`
+- **Latest audited tip:** `edff10828f17a45c40ba5bc02db109977a856411`
 - **Existing contract baseline:** [#457](https://github.com/sesori-ai/sesori_apps_monorepo/pull/457) shipped additive
   `RelayProjectView` and `Session.pullRequestHistory` contracts.
-- **Delivery:** one plan PR, seven sequential implementation PRs, and
+- **Delivery:** one plan PR, nine sequential implementation PRs, and
   one plan-retirement PR.
 
 This document and `TRACKER.md` are the sole current implementation authority.
@@ -623,8 +623,8 @@ Verification:
 
 Scope:
 
-- Map API identity output into repository-owned `VerifiedGithubLogin` evidence
-  and require every PR-bearing `SessionRepository` read to receive it explicitly.
+- Thread the Step 2.a repository-produced `VerifiedGithubLogin` evidence into
+  every PR-bearing `SessionRepository` read explicitly.
 - Have list/detail handlers verify identity freshly before mapping cached PR
   metadata; explicit absence returns the session and branch without a PR.
 - Add the read-scoped login to persisted project/row/repository/branch joins.

--- a/.plan/active/session-pull-request-monitoring/PLAN.md
+++ b/.plan/active/session-pull-request-monitoring/PLAN.md
@@ -486,8 +486,8 @@ settings screen analytics continue unchanged.
 
 ## Delivery Rules
 
-- The series has exactly nine PRs. Every title uses the fixed
-  `<emoji> [session-pull-request-monitoring] ... [step x/9]` form below.
+- The series has nine top-level steps, with Step 2 delivered through ordered
+  2.a–2.c PRs. Every title uses the fixed denominator and substep form below.
 - Step 1 raises this complete plan and updates the repository, Plan Maker, and
   Plan Worker PR communication rules. It changes `.plan/**`, root `AGENTS.md`,
   and the two agent definitions only, so it runs documentation/config validation
@@ -508,11 +508,11 @@ settings screen analytics continue unchanged.
   plan into three top-level documents while deleting several thousand lines of
   redundant stage files in the same atomic change. Splitting those files would
   leave more than one implementation authority during review.
-- Step 2 may modestly exceed 1,500 because one Drift table rekey, generated
-  schema/steps, migration callback, writer adaptation, and migration tests must
-  ship together. Record actual generated size and seek a coherent split before
-  proceeding if production/test logic—not generated migration output—causes the
-  overage.
+- Step 2.b is expected to exceed 1,500 because one Drift table rekey, generated
+  schema/steps, migration callback, transactional writer adaptation, and
+  migration tests must ship together. Its 4,200–5,200 target includes the known
+  generated bundle. Record actual generated size and seek another coherent split
+  if production/test logic—not generated migration output—causes extra overage.
 - Never hand-edit generated files. Internal Dart contracts update every
   in-repository consumer in lockstep.
 - Run `aristotle-impl-review` for Steps 2.a–8 because they alter production
@@ -911,7 +911,7 @@ Verification:
 
 The feature is complete only when:
 
-- all nine titled PRs merge in order;
+- every titled PR in the fixed top-level/substep sequence merges in order;
 - the current session branch and one selected same-repository PR obey the locked
   rules for dedicated/non-dedicated/shared/detached cases;
 - multi-device project presence and one configured bridge timer are proven;

--- a/.plan/active/session-pull-request-monitoring/TRACKER.md
+++ b/.plan/active/session-pull-request-monitoring/TRACKER.md
@@ -9,7 +9,7 @@
 - **Current step:** Step 2.a/9 — scoped GitHub source queries
 - **Plan PR:** [#649](https://github.com/sesori-ai/sesori_apps_monorepo/pull/649) merged
 - **Superseded prototype:** [#659](https://github.com/sesori-ai/sesori_apps_monorepo/pull/659) closed
-- **Next action:** commit and raise Step 2.a/9
+- **Next action:** monitor CI/review and merge Step 2.a/9 [PR #662](https://github.com/sesori-ai/sesori_apps_monorepo/pull/662)
 
 ## Existing Baseline
 
@@ -39,7 +39,7 @@
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
 | [x] | 1/9 | `plan/session-pull-request-monitoring/replan-current-pr-only` | `🌿 [session-pull-request-monitoring] docs: plan current PR monitoring [step 1/9]` | 4,000–7,000 | [PR #649](https://github.com/sesori-ai/sesori_apps_monorepo/pull/649) merged as `f969754b` |
-| [ ] | 2.a/9 | `session-pull-request-monitoring-scoped-source` | `⚙️ [session-pull-request-monitoring] feat(bridge): scope GitHub PR queries [step 2.a/9]` | 500–900 | Implemented, locally verified, and architecture finding addressed on `edff1082` |
+| [ ] | 2.a/9 | `session-pull-request-monitoring-scoped-source` | `⚙️ [session-pull-request-monitoring] feat(bridge): scope GitHub PR queries [step 2.a/9]` | 500–900 | [PR #662](https://github.com/sesori-ai/sesori_apps_monorepo/pull/662) open from the current branch head; locally verified against base `edff1082` |
 | [ ] | 2.b/9 | `session-pull-request-monitoring-scoped-pr-persistence` | `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2.b/9]` | 4,200–5,200 | Blocked on Step 2.a; generated migration overage is unavoidable |
 | [ ] | 2.c/9 | `session-pull-request-monitoring-scoped-pr-reads` | `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]` | 1,200–1,700 | Blocked on Step 2.b |
 | [ ] | 3/9 | `session-pull-request-monitoring-graphql-selection` | `🚧 [session-pull-request-monitoring] feat(bridge): batch exact PR selection [step 3/9]` | 1,000–1,500 | Blocked on Step 2.c merge |
@@ -161,7 +161,7 @@
   non-compiling intermediate state.
 - **Step 2.a/9 local verification:** `dart analyze --fatal-infos` and the focused
   `GhCliApi`, `PrSourceRepository`, and `PrSyncService` suites pass (43 tests).
-  `git diff --check` passes. The 862 changed lines remain inside the 500–900
+  `git diff --check` passes. The 886 changed lines remain inside the 500–900
   target, including plan/tracker drift updates and tests.
 - **Step 2.a/9 architecture review:** Aristotle rejected duplicate identity
   canonicalization in the initial API/repository models. The API model now owns
@@ -171,8 +171,10 @@
 - **PR #662 review follow-up:** Corrected stale delivery/overage wording, generated
   the raw API identity as a Freezed model, made identity failures and timeouts
   user-visible without claiming cached metadata is hidden, and fixed the new test
-  helper signature. The approved `/9` denominator remains because 2.a–2.c are
-  ordered substeps of the fixed nine-step sequence, not new top-level steps.
+  helper signature. Follow-up review preserved nonzero command failures and pinned
+  selectors to `github.com`, while reconciling the plan/tracker state. The approved
+  `/9` denominator remains because 2.a–2.c are ordered substeps of the fixed
+  nine-step sequence, not new top-level steps.
 
 ## Findings and Plan Deltas
 

--- a/.plan/active/session-pull-request-monitoring/TRACKER.md
+++ b/.plan/active/session-pull-request-monitoring/TRACKER.md
@@ -160,14 +160,19 @@
   separating it from its required writer/tests would create an untestable or
   non-compiling intermediate state.
 - **Step 2.a/9 local verification:** `dart analyze --fatal-infos` and the focused
-  `GhCliApi`, `PrSourceRepository`, and `PrSyncService` suites pass (41 tests).
-  `git diff --check` passes. The 640 changed lines remain inside the 500–900
+  `GhCliApi`, `PrSourceRepository`, and `PrSyncService` suites pass (43 tests).
+  `git diff --check` passes. The 862 changed lines remain inside the 500–900
   target, including plan/tracker drift updates and tests.
 - **Step 2.a/9 architecture review:** Aristotle rejected duplicate identity
   canonicalization in the initial API/repository models. The API model now owns
   only raw typed CLI output; `PrSourceRepository` exclusively trims, validates,
   and canonicalizes `VerifiedGithubLogin`. The required finding was addressed;
   repository policy does not re-review direct corrections.
+- **PR #662 review follow-up:** Corrected stale delivery/overage wording, generated
+  the raw API identity as a Freezed model, made identity failures and timeouts
+  user-visible without claiming cached metadata is hidden, and fixed the new test
+  helper signature. The approved `/9` denominator remains because 2.a–2.c are
+  ordered substeps of the fixed nine-step sequence, not new top-level steps.
 
 ## Findings and Plan Deltas
 

--- a/.plan/active/session-pull-request-monitoring/TRACKER.md
+++ b/.plan/active/session-pull-request-monitoring/TRACKER.md
@@ -4,11 +4,12 @@
 
 - **Plan slug:** `session-pull-request-monitoring`
 - **Implementation base:** `main` at
-  `10c7afb9ff55d7fe91d15a48e1ef8ba08e7a3484`
-- **Series state:** Step 1/9 plan PR open; architecture approved
-- **Current step:** Step 1/9 — durable plan and PR guidance
-- **Plan PR:** [#649](https://github.com/sesori-ai/sesori_apps_monorepo/pull/649)
-- **Next action:** monitor CI/review and merge Step 1/9 before starting Step 2/9
+  `edff10828f17a45c40ba5bc02db109977a856411`
+- **Series state:** Step 1/9 merged; Step 2 split into 2.a–2.c
+- **Current step:** Step 2.a/9 — scoped GitHub source queries
+- **Plan PR:** [#649](https://github.com/sesori-ai/sesori_apps_monorepo/pull/649) merged
+- **Superseded prototype:** [#659](https://github.com/sesori-ai/sesori_apps_monorepo/pull/659) closed
+- **Next action:** commit and raise Step 2.a/9
 
 ## Existing Baseline
 
@@ -37,9 +38,11 @@
 
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
-| [ ] | 1/9 | `plan/session-pull-request-monitoring/replan-current-pr-only` | `🌿 [session-pull-request-monitoring] docs: plan current PR monitoring [step 1/9]` | 4,000–7,000 | [PR #649](https://github.com/sesori-ai/sesori_apps_monorepo/pull/649) open; architecture/docs validation passed |
-| [ ] | 2/9 | `session-pull-request-monitoring-scoped-pr-cache` | `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2/9]` | 1,300–2,000 | Blocked on Step 1 merge; generated migration overage may be unavoidable |
-| [ ] | 3/9 | `session-pull-request-monitoring-graphql-selection` | `🚧 [session-pull-request-monitoring] feat(bridge): batch exact PR selection [step 3/9]` | 1,000–1,500 | Blocked on Step 2 merge |
+| [x] | 1/9 | `plan/session-pull-request-monitoring/replan-current-pr-only` | `🌿 [session-pull-request-monitoring] docs: plan current PR monitoring [step 1/9]` | 4,000–7,000 | [PR #649](https://github.com/sesori-ai/sesori_apps_monorepo/pull/649) merged as `f969754b` |
+| [ ] | 2.a/9 | `session-pull-request-monitoring-scoped-source` | `⚙️ [session-pull-request-monitoring] feat(bridge): scope GitHub PR queries [step 2.a/9]` | 500–900 | Implemented, locally verified, and architecture finding addressed on `edff1082` |
+| [ ] | 2.b/9 | `session-pull-request-monitoring-scoped-pr-persistence` | `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2.b/9]` | 4,200–5,200 | Blocked on Step 2.a; generated migration overage is unavoidable |
+| [ ] | 2.c/9 | `session-pull-request-monitoring-scoped-pr-reads` | `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]` | 1,200–1,700 | Blocked on Step 2.b |
+| [ ] | 3/9 | `session-pull-request-monitoring-graphql-selection` | `🚧 [session-pull-request-monitoring] feat(bridge): batch exact PR selection [step 3/9]` | 1,000–1,500 | Blocked on Step 2.c merge |
 | [ ] | 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | 1,100–1,500 | Blocked on Step 3 merge |
 | [ ] | 5/9 | `session-pull-request-monitoring-view-scheduler` | `🚧 [session-pull-request-monitoring] feat(bridge): schedule viewed-project PR refresh [step 5/9]` | 900–1,400 | Blocked on Step 4 merge |
 | [ ] | 6/9 | `session-pull-request-monitoring-bridge-settings` | `⚙️ [session-pull-request-monitoring] feat(bridge): configure PR refresh cadence [step 6/9]` | 1,000–1,500 | Blocked on Step 5 merge |
@@ -50,7 +53,9 @@
 ## Exact PR Titles
 
 1. `🌿 [session-pull-request-monitoring] docs: plan current PR monitoring [step 1/9]`
-2. `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2/9]`
+2.a. `⚙️ [session-pull-request-monitoring] feat(bridge): scope GitHub PR queries [step 2.a/9]`
+2.b. `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2.b/9]`
+2.c. `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]`
 3. `🚧 [session-pull-request-monitoring] feat(bridge): batch exact PR selection [step 3/9]`
 4. `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]`
 5. `🚧 [session-pull-request-monitoring] feat(bridge): schedule viewed-project PR refresh [step 5/9]`
@@ -61,7 +66,7 @@
 
 ## Execution Rules
 
-- Merge in numeric order. Each implementation step starts from current `main`
+- Merge in numeric/substep order. Each implementation step starts from current `main`
   after its predecessor merges and records a drift audit.
 - Step 1 is the plan PR. Step 9 moves the plan from active to completed and has
   no production changes.
@@ -75,7 +80,7 @@
 - Every schema change exports/generates from current `main`; never rewrite a
   merged Drift migration or generated file.
 - Run directly relevant tests/analyzers and architecture implementation review
-  for Steps 2–8. Documentation-only Steps 1/9 and 9/9 use plan/docs validation.
+  for Steps 2.a–8. Documentation-only Steps 1/9 and 9/9 use plan/docs validation.
 - Reassess causal cleanup in every implementation step; remove directly obsolete
   code/data/tests in the coherent owning PR or record why removal is deferred.
 - After each merge, update this tracker in the next step and proceed in order
@@ -83,9 +88,9 @@
 
 ## Current Drift and Open Work
 
-- Latest audited `main`: `10c7afb9ff55d7fe91d15a48e1ef8ba08e7a3484`.
-- Drift schema: v12. Step 2 allocates the next version present on its actual
-  baseline, not a hard-coded v13.
+- Latest audited `main`: `edff10828f17a45c40ba5bc02db109977a856411`.
+- Drift schema: v12. Step 2.b allocates the next version present on its actual
+  baseline; Step 2.a intentionally has no database change.
 - Parallel-plugin plan: complete through Stage 9 / PR #497.
 - PR #647 is merged and consolidates Harness settings into one screen. Its
   numeric-input/mutation pattern is current evidence for Step 8; PR cadence
@@ -147,6 +152,22 @@
   architecture. `git diff --check` passes, exact titles match between
   plan/tracker, and change scope is limited to this plan plus the three
   instruction/agent files.
+- **Step 2 prototype and split:** PR #659 proved the end-to-end implementation
+  and passed bridge tests/review fixes, but its 6,848 changed lines exceeded the
+  1,500-line soft cap. It was closed without force-pushing. Step 2 is now split
+  into source (2.a), persistence/migration (2.b), and fresh reads (2.c). The
+  generated migration bundle still makes 2.b an unavoidable documented overage;
+  separating it from its required writer/tests would create an untestable or
+  non-compiling intermediate state.
+- **Step 2.a/9 local verification:** `dart analyze --fatal-infos` and the focused
+  `GhCliApi`, `PrSourceRepository`, and `PrSyncService` suites pass (41 tests).
+  `git diff --check` passes. The 640 changed lines remain inside the 500–900
+  target, including plan/tracker drift updates and tests.
+- **Step 2.a/9 architecture review:** Aristotle rejected duplicate identity
+  canonicalization in the initial API/repository models. The API model now owns
+  only raw typed CLI output; `PrSourceRepository` exclusively trims, validates,
+  and canonicalizes `VerifiedGithubLogin`. The required finding was addressed;
+  repository policy does not re-review direct corrections.
 
 ## Findings and Plan Deltas
 
@@ -161,8 +182,9 @@
   per-project timers.
 - **2026-07-31 — Settings:** Fixed cadence defaults to 30 seconds per bridge,
   supports live client mutation, and intentionally has no JSON file watcher.
-- **2026-07-31 — Plan lifecycle:** Fixed a nine-PR series with this plan as
-  Step 1/9 and active-to-completed retirement as Step 9/9.
+- **2026-07-31 — Plan lifecycle:** Keep nine top-level steps with this plan as
+  Step 1/9 and active-to-completed retirement as Step 9/9; Step 2 uses ordered
+  2.a–2.c substeps after the reviewed implementation exceeded the line cap.
 - **2026-07-31 — PR #649 review:** Corrected the reviewed baseline SHA; required
   candidate pagination past newer fork heads, read-time GitHub identity gating,
   a coalesced add-during-flight refresh, and independent branch display for

--- a/.plan/active/session-pull-request-monitoring/TRACKER.md
+++ b/.plan/active/session-pull-request-monitoring/TRACKER.md
@@ -161,7 +161,7 @@
   non-compiling intermediate state.
 - **Step 2.a/9 local verification:** `dart analyze --fatal-infos` and the focused
   `GhCliApi`, `PrSourceRepository`, and `PrSyncService` suites pass (43 tests).
-  `git diff --check` passes. The 886 changed lines remain inside the 500–900
+  `git diff --check` passes. The 883 changed lines remain inside the 500–900
   target, including plan/tracker drift updates and tests.
 - **Step 2.a/9 architecture review:** Aristotle rejected duplicate identity
   canonicalization in the initial API/repository models. The API model now owns

--- a/bridge/app/lib/src/bridge/api/gh_authenticated_identity.dart
+++ b/bridge/app/lib/src/bridge/api/gh_authenticated_identity.dart
@@ -1,0 +1,5 @@
+final class GhAuthenticatedIdentity {
+  final String rawLogin;
+
+  const GhAuthenticatedIdentity({required this.rawLogin});
+}

--- a/bridge/app/lib/src/bridge/api/gh_authenticated_identity.dart
+++ b/bridge/app/lib/src/bridge/api/gh_authenticated_identity.dart
@@ -1,5 +1,8 @@
-final class GhAuthenticatedIdentity {
-  final String rawLogin;
+import "package:freezed_annotation/freezed_annotation.dart";
 
-  const GhAuthenticatedIdentity({required this.rawLogin});
+part "gh_authenticated_identity.freezed.dart";
+
+@freezed
+sealed class GhAuthenticatedIdentity with _$GhAuthenticatedIdentity {
+  const factory GhAuthenticatedIdentity({required String rawLogin}) = _GhAuthenticatedIdentity;
 }

--- a/bridge/app/lib/src/bridge/api/gh_authenticated_identity.freezed.dart
+++ b/bridge/app/lib/src/bridge/api/gh_authenticated_identity.freezed.dart
@@ -1,0 +1,142 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'gh_authenticated_identity.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$GhAuthenticatedIdentity {
+
+ String get rawLogin;
+/// Create a copy of GhAuthenticatedIdentity
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GhAuthenticatedIdentityCopyWith<GhAuthenticatedIdentity> get copyWith => _$GhAuthenticatedIdentityCopyWithImpl<GhAuthenticatedIdentity>(this as GhAuthenticatedIdentity, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GhAuthenticatedIdentity&&(identical(other.rawLogin, rawLogin) || other.rawLogin == rawLogin));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,rawLogin);
+
+@override
+String toString() {
+  return 'GhAuthenticatedIdentity(rawLogin: $rawLogin)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GhAuthenticatedIdentityCopyWith<$Res>  {
+  factory $GhAuthenticatedIdentityCopyWith(GhAuthenticatedIdentity value, $Res Function(GhAuthenticatedIdentity) _then) = _$GhAuthenticatedIdentityCopyWithImpl;
+@useResult
+$Res call({
+ String rawLogin
+});
+
+
+
+
+}
+/// @nodoc
+class _$GhAuthenticatedIdentityCopyWithImpl<$Res>
+    implements $GhAuthenticatedIdentityCopyWith<$Res> {
+  _$GhAuthenticatedIdentityCopyWithImpl(this._self, this._then);
+
+  final GhAuthenticatedIdentity _self;
+  final $Res Function(GhAuthenticatedIdentity) _then;
+
+/// Create a copy of GhAuthenticatedIdentity
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? rawLogin = null,}) {
+  return _then(_self.copyWith(
+rawLogin: null == rawLogin ? _self.rawLogin : rawLogin // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+
+
+class _GhAuthenticatedIdentity implements GhAuthenticatedIdentity {
+  const _GhAuthenticatedIdentity({required this.rawLogin});
+  
+
+@override final  String rawLogin;
+
+/// Create a copy of GhAuthenticatedIdentity
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GhAuthenticatedIdentityCopyWith<_GhAuthenticatedIdentity> get copyWith => __$GhAuthenticatedIdentityCopyWithImpl<_GhAuthenticatedIdentity>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GhAuthenticatedIdentity&&(identical(other.rawLogin, rawLogin) || other.rawLogin == rawLogin));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,rawLogin);
+
+@override
+String toString() {
+  return 'GhAuthenticatedIdentity(rawLogin: $rawLogin)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GhAuthenticatedIdentityCopyWith<$Res> implements $GhAuthenticatedIdentityCopyWith<$Res> {
+  factory _$GhAuthenticatedIdentityCopyWith(_GhAuthenticatedIdentity value, $Res Function(_GhAuthenticatedIdentity) _then) = __$GhAuthenticatedIdentityCopyWithImpl;
+@override @useResult
+$Res call({
+ String rawLogin
+});
+
+
+
+
+}
+/// @nodoc
+class __$GhAuthenticatedIdentityCopyWithImpl<$Res>
+    implements _$GhAuthenticatedIdentityCopyWith<$Res> {
+  __$GhAuthenticatedIdentityCopyWithImpl(this._self, this._then);
+
+  final _GhAuthenticatedIdentity _self;
+  final $Res Function(_GhAuthenticatedIdentity) _then;
+
+/// Create a copy of GhAuthenticatedIdentity
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? rawLogin = null,}) {
+  return _then(_GhAuthenticatedIdentity(
+rawLogin: null == rawLogin ? _self.rawLogin : rawLogin // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/bridge/app/lib/src/bridge/api/gh_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/gh_cli_api.dart
@@ -60,12 +60,18 @@ class GhCliApi {
   }
 
   Future<GhAuthenticatedIdentity?> getAuthenticatedIdentity() async {
+    const arguments = ["api", "--hostname", "github.com", "user", "--jq", ".login"];
     final result = await _processRunner.run(
       "gh",
-      const ["api", "--hostname", "github.com", "user", "--jq", ".login"],
+      arguments,
     );
     if (result.exitCode != 0) {
-      return null;
+      throw ProcessException(
+        "gh",
+        arguments,
+        result.stderr.toString(),
+        result.exitCode,
+      );
     }
 
     _authenticationFailureReported = false;
@@ -97,7 +103,7 @@ class GhCliApi {
         "pr",
         "list",
         "--repo",
-        githubRepositoryIdentity,
+        "github.com/$githubRepositoryIdentity",
         "--state",
         "open",
         "--json",
@@ -127,7 +133,7 @@ class GhCliApi {
         "view",
         number.toString(),
         "--repo",
-        githubRepositoryIdentity,
+        "github.com/$githubRepositoryIdentity",
         "--json",
         "number,url,title,state,headRefName,isCrossRepository,mergeable,reviewDecision,statusCheckRollup",
       ],

--- a/bridge/app/lib/src/bridge/api/gh_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/gh_cli_api.dart
@@ -59,7 +59,7 @@ class GhCliApi {
     }
   }
 
-  Future<GhAuthenticatedIdentity?> getAuthenticatedIdentity() async {
+  Future<GhAuthenticatedIdentity> getAuthenticatedIdentity() async {
     const arguments = ["api", "--hostname", "github.com", "user", "--jq", ".login"];
     final result = await _processRunner.run(
       "gh",

--- a/bridge/app/lib/src/bridge/api/gh_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/gh_cli_api.dart
@@ -4,12 +4,14 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Conso
 import "package:sesori_shared/sesori_shared.dart" show jsonDecodeListMap, jsonDecodeMap;
 
 import "../foundation/process_runner.dart";
+import "gh_authenticated_identity.dart";
 import "gh_pull_request.dart";
 
 class GhCliApi {
   final ProcessRunner _processRunner;
   bool _availabilityFailureReported = false;
   bool _authenticationFailureReported = false;
+  bool _identityVerificationFailureReported = false;
 
   GhCliApi({required ProcessRunner processRunner}) : _processRunner = processRunner;
 
@@ -58,6 +60,30 @@ class GhCliApi {
     }
   }
 
+  Future<GhAuthenticatedIdentity?> getAuthenticatedIdentity() async {
+    try {
+      final result = await _processRunner.run(
+        "gh",
+        const ["api", "--hostname", "github.com", "user", "--jq", ".login"],
+      );
+      if (result.exitCode != 0) {
+        _reportIdentityVerificationFailure();
+        return null;
+      }
+
+      _authenticationFailureReported = false;
+      _identityVerificationFailureReported = false;
+      return GhAuthenticatedIdentity(rawLogin: result.stdout.toString());
+    } on ProcessException {
+      _reportAvailabilityFailure(
+        message:
+            "GitHub CLI (gh) is not installed or is unavailable on PATH. "
+            "GitHub pull request and CI status sync is disabled.",
+      );
+      return null;
+    }
+  }
+
   void _reportAvailabilityFailure({required String message}) {
     if (_availabilityFailureReported) return;
     _availabilityFailureReported = true;
@@ -73,12 +99,27 @@ class GhCliApi {
     );
   }
 
-  Future<List<GhPullRequest>> listOpenPrs({required String workingDirectory}) async {
+  void _reportIdentityVerificationFailure() {
+    if (_identityVerificationFailureReported) return;
+    _identityVerificationFailureReported = true;
+    Console.warning(
+      "GitHub CLI (gh) could not verify the active github.com account. "
+      "GitHub pull request and CI status metadata is hidden until verification succeeds. "
+      "Run 'gh auth status --hostname github.com' to check authentication and connectivity.",
+    );
+  }
+
+  Future<List<GhPullRequest>> listOpenPrs({
+    required String workingDirectory,
+    required String githubRepositoryIdentity,
+  }) async {
     final result = await _processRunner.run(
       "gh",
-      const <String>[
+      <String>[
         "pr",
         "list",
+        "--repo",
+        githubRepositoryIdentity,
         "--state",
         "open",
         "--json",
@@ -99,6 +140,7 @@ class GhCliApi {
   Future<GhPullRequest> getPrByNumber({
     required int number,
     required String workingDirectory,
+    required String githubRepositoryIdentity,
   }) async {
     final result = await _processRunner.run(
       "gh",
@@ -106,6 +148,8 @@ class GhCliApi {
         "pr",
         "view",
         number.toString(),
+        "--repo",
+        githubRepositoryIdentity,
         "--json",
         "number,url,title,state,headRefName,isCrossRepository,mergeable,reviewDecision,statusCheckRollup",
       ],

--- a/bridge/app/lib/src/bridge/api/gh_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/gh_cli_api.dart
@@ -11,7 +11,6 @@ class GhCliApi {
   final ProcessRunner _processRunner;
   bool _availabilityFailureReported = false;
   bool _authenticationFailureReported = false;
-  bool _identityVerificationFailureReported = false;
 
   GhCliApi({required ProcessRunner processRunner}) : _processRunner = processRunner;
 
@@ -61,27 +60,16 @@ class GhCliApi {
   }
 
   Future<GhAuthenticatedIdentity?> getAuthenticatedIdentity() async {
-    try {
-      final result = await _processRunner.run(
-        "gh",
-        const ["api", "--hostname", "github.com", "user", "--jq", ".login"],
-      );
-      if (result.exitCode != 0) {
-        _reportIdentityVerificationFailure();
-        return null;
-      }
-
-      _authenticationFailureReported = false;
-      _identityVerificationFailureReported = false;
-      return GhAuthenticatedIdentity(rawLogin: result.stdout.toString());
-    } on ProcessException {
-      _reportAvailabilityFailure(
-        message:
-            "GitHub CLI (gh) is not installed or is unavailable on PATH. "
-            "GitHub pull request and CI status sync is disabled.",
-      );
+    final result = await _processRunner.run(
+      "gh",
+      const ["api", "--hostname", "github.com", "user", "--jq", ".login"],
+    );
+    if (result.exitCode != 0) {
       return null;
     }
+
+    _authenticationFailureReported = false;
+    return GhAuthenticatedIdentity(rawLogin: result.stdout.toString());
   }
 
   void _reportAvailabilityFailure({required String message}) {
@@ -96,16 +84,6 @@ class GhCliApi {
     Console.warning(
       "GitHub CLI (gh) is not authenticated for github.com. Run 'gh auth login' or set GH_TOKEN/GITHUB_TOKEN "
       "to enable GitHub pull request and CI status sync.",
-    );
-  }
-
-  void _reportIdentityVerificationFailure() {
-    if (_identityVerificationFailureReported) return;
-    _identityVerificationFailureReported = true;
-    Console.warning(
-      "GitHub CLI (gh) could not verify the active github.com account. "
-      "GitHub pull request and CI status metadata is hidden until verification succeeds. "
-      "Run 'gh auth status --hostname github.com' to check authentication and connectivity.",
     );
   }
 

--- a/bridge/app/lib/src/bridge/repositories/models/verified_github_login.dart
+++ b/bridge/app/lib/src/bridge/repositories/models/verified_github_login.dart
@@ -1,0 +1,13 @@
+final class VerifiedGithubLogin {
+  final String login;
+
+  const VerifiedGithubLogin._({required this.login});
+
+  static VerifiedGithubLogin? tryParse({required String rawLogin}) {
+    final login = rawLogin.trim().toLowerCase();
+    if (login.isEmpty) {
+      return null;
+    }
+    return VerifiedGithubLogin._(login: login);
+  }
+}

--- a/bridge/app/lib/src/bridge/repositories/pr_source_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/pr_source_repository.dart
@@ -18,9 +18,6 @@ class PrSourceRepository {
 
   Future<VerifiedGithubLogin?> getAuthenticatedIdentity() async {
     final identity = await _ghCli.getAuthenticatedIdentity();
-    if (identity == null) {
-      return null;
-    }
     return VerifiedGithubLogin.tryParse(rawLogin: identity.rawLogin);
   }
 

--- a/bridge/app/lib/src/bridge/repositories/pr_source_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/pr_source_repository.dart
@@ -1,8 +1,12 @@
 import "../api/gh_cli_api.dart";
 import "../api/gh_pull_request.dart";
 import "../api/git_cli_api.dart";
+import "mappers/git_remote_identity_parser.dart";
+import "models/verified_github_login.dart";
 
 class PrSourceRepository {
+  static const GitRemoteIdentityParser _remoteIdentityParser = GitRemoteIdentityParser();
+
   final GhCliApi _ghCli;
   final GitCliApi _gitCli;
 
@@ -12,11 +16,45 @@ class PrSourceRepository {
 
   Future<bool> isGithubCliAuthenticated() => _ghCli.isAuthenticated();
 
-  Future<bool> hasGitHubRemote({required String projectPath}) => _gitCli.hasGitHubRemote(projectPath: projectPath);
+  Future<VerifiedGithubLogin?> getAuthenticatedIdentity() async {
+    final identity = await _ghCli.getAuthenticatedIdentity();
+    if (identity == null) {
+      return null;
+    }
+    return VerifiedGithubLogin.tryParse(rawLogin: identity.rawLogin);
+  }
 
-  Future<List<GhPullRequest>> listOpenPrs({required String workingDirectory}) =>
-      _ghCli.listOpenPrs(workingDirectory: workingDirectory);
+  Future<String?> getGithubRepositoryIdentity({required String projectPath}) async {
+    final remoteUrl = await _gitCli.getRemoteUrl(projectPath: projectPath);
+    if (remoteUrl == null) {
+      return null;
+    }
+    final identity = _remoteIdentityParser.parse(remoteUrl: remoteUrl);
+    if (identity == null || identity.host != "github.com") {
+      return null;
+    }
+    final segments = identity.slug.split("/");
+    if (segments.length != 2 || segments.any((segment) => segment.isEmpty)) {
+      return null;
+    }
+    return identity.slug.toLowerCase();
+  }
 
-  Future<GhPullRequest> getPrByNumber({required int number, required String workingDirectory}) =>
-      _ghCli.getPrByNumber(number: number, workingDirectory: workingDirectory);
+  Future<List<GhPullRequest>> listOpenPrs({
+    required String workingDirectory,
+    required String githubRepositoryIdentity,
+  }) => _ghCli.listOpenPrs(
+    workingDirectory: workingDirectory,
+    githubRepositoryIdentity: githubRepositoryIdentity,
+  );
+
+  Future<GhPullRequest> getPrByNumber({
+    required int number,
+    required String workingDirectory,
+    required String githubRepositoryIdentity,
+  }) => _ghCli.getPrByNumber(
+    number: number,
+    workingDirectory: workingDirectory,
+    githubRepositoryIdentity: githubRepositoryIdentity,
+  );
 }

--- a/bridge/app/lib/src/bridge/services/pr_sync_service.dart
+++ b/bridge/app/lib/src/bridge/services/pr_sync_service.dart
@@ -1,7 +1,7 @@
 import "dart:async";
 
 import "package:clock/clock.dart";
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Console, Log;
 
 import "../repositories/models/stored_session.dart";
 import "../repositories/models/verified_github_login.dart";
@@ -21,6 +21,7 @@ class PrSyncService {
   final Set<String> _activeRefreshes = <String>{};
   ({bool capable, DateTime checkedAt})? _githubCliCapabilityCache;
   Future<bool>? _githubCliCapabilityCheck;
+  bool _identityVerificationFailureReported = false;
 
   static const _githubCliCapabilityCacheTtl = Duration(seconds: 30);
 
@@ -40,8 +41,15 @@ class PrSyncService {
 
   Future<VerifiedGithubLogin?> _verifyGithubIdentity() async {
     try {
-      return await _prSource.getAuthenticatedIdentity();
+      final identity = await _prSource.getAuthenticatedIdentity();
+      if (identity == null) {
+        _reportIdentityVerificationFailure();
+        return null;
+      }
+      _identityVerificationFailureReported = false;
+      return identity;
     } on Object catch (error, stackTrace) {
+      _reportIdentityVerificationFailure();
       Log.w(
         "[PrSyncService] Failed to verify the active GitHub identity; PR refresh is skipped",
         error,
@@ -49,6 +57,16 @@ class PrSyncService {
       );
       return null;
     }
+  }
+
+  void _reportIdentityVerificationFailure() {
+    if (_identityVerificationFailureReported) return;
+    _identityVerificationFailureReported = true;
+    Console.warning(
+      "GitHub CLI (gh) could not verify the active github.com account. "
+      "GitHub pull request and CI status metadata cannot be refreshed until verification succeeds. "
+      "Run 'gh auth status --hostname github.com' to check authentication and connectivity.",
+    );
   }
 
   Future<void> triggerRefresh({required String projectId, required String projectPath}) async {

--- a/bridge/app/lib/src/bridge/services/pr_sync_service.dart
+++ b/bridge/app/lib/src/bridge/services/pr_sync_service.dart
@@ -87,15 +87,15 @@ class PrSyncService {
         return;
       }
 
-      final verifiedGithubLogin = await _verifyGithubIdentity();
-      if (verifiedGithubLogin == null) {
-        return;
-      }
-
       final githubRepositoryIdentity = await _prSource.getGithubRepositoryIdentity(
         projectPath: projectPath,
       );
       if (githubRepositoryIdentity == null) {
+        return;
+      }
+
+      final verifiedGithubLogin = await _verifyGithubIdentity();
+      if (verifiedGithubLogin == null) {
         return;
       }
 

--- a/bridge/app/lib/src/bridge/services/pr_sync_service.dart
+++ b/bridge/app/lib/src/bridge/services/pr_sync_service.dart
@@ -4,6 +4,7 @@ import "package:clock/clock.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
 import "../repositories/models/stored_session.dart";
+import "../repositories/models/verified_github_login.dart";
 import "../repositories/pr_source_repository.dart";
 import "../repositories/pull_request_repository.dart";
 import "../repositories/session_repository.dart";
@@ -16,14 +17,11 @@ class PrSyncService {
   final Duration _debounceWindow;
   final StreamController<String> _prChangesController = StreamController<String>.broadcast();
 
-  final Map<String, ({bool value, DateTime cachedAt})> _hasGitHubRemoteCache =
-      <String, ({bool value, DateTime cachedAt})>{};
   final Map<String, DateTime> _lastRefreshTimes = <String, DateTime>{};
   final Set<String> _activeRefreshes = <String>{};
   ({bool capable, DateTime checkedAt})? _githubCliCapabilityCache;
   Future<bool>? _githubCliCapabilityCheck;
 
-  static const _remoteCacheTtl = Duration(minutes: 10);
   static const _githubCliCapabilityCacheTtl = Duration(seconds: 30);
 
   PrSyncService({
@@ -39,6 +37,19 @@ class PrSyncService {
        _debounceWindow = debounceWindow;
 
   Stream<String> get prChanges => _prChangesController.stream;
+
+  Future<VerifiedGithubLogin?> _verifyGithubIdentity() async {
+    try {
+      return await _prSource.getAuthenticatedIdentity();
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        "[PrSyncService] Failed to verify the active GitHub identity; PR refresh is skipped",
+        error,
+        stackTrace,
+      );
+      return null;
+    }
+  }
 
   Future<void> triggerRefresh({required String projectId, required String projectPath}) async {
     if (_activeRefreshes.contains(projectId)) {
@@ -58,16 +69,23 @@ class PrSyncService {
         return;
       }
 
-      final cached = _hasGitHubRemoteCache[projectPath];
-      if (cached == null || _clock.now().difference(cached.cachedAt) > _remoteCacheTtl) {
-        final hasRemote = await _prSource.hasGitHubRemote(projectPath: projectPath);
-        _hasGitHubRemoteCache[projectPath] = (value: hasRemote, cachedAt: _clock.now());
-      }
-      if (_hasGitHubRemoteCache[projectPath] case final cachedRemote? when !cachedRemote.value) {
+      final verifiedGithubLogin = await _verifyGithubIdentity();
+      if (verifiedGithubLogin == null) {
         return;
       }
 
-      await _refresh(projectId: projectId, projectPath: projectPath);
+      final githubRepositoryIdentity = await _prSource.getGithubRepositoryIdentity(
+        projectPath: projectPath,
+      );
+      if (githubRepositoryIdentity == null) {
+        return;
+      }
+
+      await _refresh(
+        projectId: projectId,
+        projectPath: projectPath,
+        githubRepositoryIdentity: githubRepositoryIdentity,
+      );
     } finally {
       _activeRefreshes.remove(projectId);
     }
@@ -100,10 +118,17 @@ class PrSyncService {
     return capable;
   }
 
-  Future<void> _refresh({required String projectId, required String projectPath}) async {
+  Future<void> _refresh({
+    required String projectId,
+    required String projectPath,
+    required String githubRepositoryIdentity,
+  }) async {
     try {
       final (openPrs, storedSessions, activePrs) = await (
-        _prSource.listOpenPrs(workingDirectory: projectPath),
+        _prSource.listOpenPrs(
+          workingDirectory: projectPath,
+          githubRepositoryIdentity: githubRepositoryIdentity,
+        ),
         _sessionRepository.getStoredSessionsByProjectId(projectId: projectId),
         _pullRequestRepository.getActivePullRequestsByProjectId(projectId: projectId),
       ).wait;
@@ -147,6 +172,7 @@ class PrSyncService {
           final finalPr = await _prSource.getPrByNumber(
             number: disappeared.prNumber,
             workingDirectory: projectPath,
+            githubRepositoryIdentity: githubRepositoryIdentity,
           );
 
           if (_pullRequestRepository.hasChangedFromExisting(existing: disappeared, pr: finalPr)) {

--- a/bridge/app/test/bridge/api/gh_cli_api_test.dart
+++ b/bridge/app/test/bridge/api/gh_cli_api_test.dart
@@ -166,7 +166,7 @@ void main() {
 
       final identity = await service.getAuthenticatedIdentity();
 
-      expect(identity?.rawLogin, "  OctoCat\n");
+      expect(identity.rawLogin, "  OctoCat\n");
       expect(processRunner.invocations, hasLength(1));
       expect(processRunner.invocations.single.command, "gh");
       expect(
@@ -192,7 +192,7 @@ void main() {
     test("preserves an empty login for repository validation", () async {
       processRunner.enqueueResult(result: _ok(stdout: "  \n"));
 
-      expect((await service.getAuthenticatedIdentity())?.rawLogin, "  \n");
+      expect((await service.getAuthenticatedIdentity()).rawLogin, "  \n");
     });
 
     test("propagates a process failure for the caller to handle", () async {

--- a/bridge/app/test/bridge/api/gh_cli_api_test.dart
+++ b/bridge/app/test/bridge/api/gh_cli_api_test.dart
@@ -175,18 +175,10 @@ void main() {
       expect(processRunner.invocations.single.workingDirectory, isNull);
     });
 
-    test("reports an identity verification failure without claiming sign-out", () async {
-      final stderrLines = <String>[];
+    test("returns null when the identity command fails", () async {
       processRunner.enqueueResult(result: _fail(exitCode: 1));
 
-      await IOOverrides.runZoned(
-        () async => expect(await service.getAuthenticatedIdentity(), isNull),
-        stderr: () => _CapturingStdout(stderrLines),
-      );
-
-      expect(stderrLines, hasLength(1));
-      expect(stderrLines.single, contains("could not verify the active github.com account"));
-      expect(stderrLines.single, isNot(contains("is not authenticated")));
+      expect(await service.getAuthenticatedIdentity(), isNull);
     });
 
     test("preserves an empty login for repository validation", () async {
@@ -195,12 +187,15 @@ void main() {
       expect((await service.getAuthenticatedIdentity())?.rawLogin, "  \n");
     });
 
-    test("returns null when gh is unavailable", () async {
+    test("propagates a process failure for the caller to handle", () async {
       processRunner.enqueueError(
         error: const ProcessException("gh", <String>["api"], "boom", 1),
       );
 
-      expect(await service.getAuthenticatedIdentity(), isNull);
+      await expectLater(
+        service.getAuthenticatedIdentity(),
+        throwsA(isA<ProcessException>()),
+      );
     });
 
     test("propagates timeout for the caller to handle", () async {

--- a/bridge/app/test/bridge/api/gh_cli_api_test.dart
+++ b/bridge/app/test/bridge/api/gh_cli_api_test.dart
@@ -8,6 +8,8 @@ import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+const _githubRepositoryIdentity = "sesori-ai/sesori_apps_monorepo";
+
 void main() {
   group("GhCliApi.isAvailable", () {
     late _FakeProcessRunner processRunner;
@@ -149,6 +151,68 @@ void main() {
     });
   });
 
+  group("GhCliApi.getAuthenticatedIdentity", () {
+    late _FakeProcessRunner processRunner;
+    late GhCliApi service;
+
+    setUp(() {
+      processRunner = _FakeProcessRunner();
+      service = GhCliApi(processRunner: processRunner);
+    });
+
+    test("returns the raw login from the github.com user endpoint", () async {
+      processRunner.enqueueResult(result: _ok(stdout: "  OctoCat\n"));
+
+      final identity = await service.getAuthenticatedIdentity();
+
+      expect(identity?.rawLogin, "  OctoCat\n");
+      expect(processRunner.invocations, hasLength(1));
+      expect(processRunner.invocations.single.command, "gh");
+      expect(
+        processRunner.invocations.single.arguments,
+        ["api", "--hostname", "github.com", "user", "--jq", ".login"],
+      );
+      expect(processRunner.invocations.single.workingDirectory, isNull);
+    });
+
+    test("reports an identity verification failure without claiming sign-out", () async {
+      final stderrLines = <String>[];
+      processRunner.enqueueResult(result: _fail(exitCode: 1));
+
+      await IOOverrides.runZoned(
+        () async => expect(await service.getAuthenticatedIdentity(), isNull),
+        stderr: () => _CapturingStdout(stderrLines),
+      );
+
+      expect(stderrLines, hasLength(1));
+      expect(stderrLines.single, contains("could not verify the active github.com account"));
+      expect(stderrLines.single, isNot(contains("is not authenticated")));
+    });
+
+    test("preserves an empty login for repository validation", () async {
+      processRunner.enqueueResult(result: _ok(stdout: "  \n"));
+
+      expect((await service.getAuthenticatedIdentity())?.rawLogin, "  \n");
+    });
+
+    test("returns null when gh is unavailable", () async {
+      processRunner.enqueueError(
+        error: const ProcessException("gh", <String>["api"], "boom", 1),
+      );
+
+      expect(await service.getAuthenticatedIdentity(), isNull);
+    });
+
+    test("propagates timeout for the caller to handle", () async {
+      processRunner.enqueueError(error: TimeoutException("timed out"));
+
+      await expectLater(
+        service.getAuthenticatedIdentity(),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
+  });
+
   group("GhCliApi.listOpenPrs", () {
     late _FakeProcessRunner processRunner;
     late GhCliApi service;
@@ -166,7 +230,10 @@ void main() {
         ),
       );
 
-      final prs = await service.listOpenPrs(workingDirectory: "/repo");
+      final prs = await service.listOpenPrs(
+        workingDirectory: "/repo",
+        githubRepositoryIdentity: _githubRepositoryIdentity,
+      );
 
       expect(
         prs,
@@ -193,6 +260,8 @@ void main() {
         equals(<String>[
           "pr",
           "list",
+          "--repo",
+          _githubRepositoryIdentity,
           "--state",
           "open",
           "--json",
@@ -207,7 +276,10 @@ void main() {
     test("returns empty list for empty JSON array", () async {
       processRunner.enqueueResult(result: _ok(stdout: "[]"));
 
-      final prs = await service.listOpenPrs(workingDirectory: "/repo");
+      final prs = await service.listOpenPrs(
+        workingDirectory: "/repo",
+        githubRepositoryIdentity: _githubRepositoryIdentity,
+      );
 
       expect(prs, isEmpty);
     });
@@ -216,7 +288,10 @@ void main() {
       processRunner.enqueueResult(result: _ok(stdout: "not-json"));
 
       expect(
-        () => service.listOpenPrs(workingDirectory: "/repo"),
+        () => service.listOpenPrs(
+          workingDirectory: "/repo",
+          githubRepositoryIdentity: _githubRepositoryIdentity,
+        ),
         throwsA(isA<FormatException>()),
       );
     });
@@ -225,7 +300,10 @@ void main() {
       processRunner.enqueueResult(result: _fail(exitCode: 1));
 
       expect(
-        () => service.listOpenPrs(workingDirectory: "/repo"),
+        () => service.listOpenPrs(
+          workingDirectory: "/repo",
+          githubRepositoryIdentity: _githubRepositoryIdentity,
+        ),
         throwsA(isA<Exception>()),
       );
     });
@@ -234,7 +312,10 @@ void main() {
       processRunner.enqueueError(error: TimeoutException("timed out"));
 
       expect(
-        () => service.listOpenPrs(workingDirectory: "/repo"),
+        () => service.listOpenPrs(
+          workingDirectory: "/repo",
+          githubRepositoryIdentity: _githubRepositoryIdentity,
+        ),
         throwsA(isA<TimeoutException>()),
       );
     });
@@ -245,7 +326,10 @@ void main() {
       );
 
       expect(
-        () => service.listOpenPrs(workingDirectory: "/repo"),
+        () => service.listOpenPrs(
+          workingDirectory: "/repo",
+          githubRepositoryIdentity: _githubRepositoryIdentity,
+        ),
         throwsA(isA<ProcessException>()),
       );
     });
@@ -258,7 +342,10 @@ void main() {
         ),
       );
 
-      final prs = await service.listOpenPrs(workingDirectory: "/repo");
+      final prs = await service.listOpenPrs(
+        workingDirectory: "/repo",
+        githubRepositoryIdentity: _githubRepositoryIdentity,
+      );
 
       expect(prs, hasLength(1));
       expect(prs.single.statusCheckRollup, equals(PrCheckStatus.success));
@@ -272,7 +359,10 @@ void main() {
         ),
       );
 
-      final prs = await service.listOpenPrs(workingDirectory: "/repo");
+      final prs = await service.listOpenPrs(
+        workingDirectory: "/repo",
+        githubRepositoryIdentity: _githubRepositoryIdentity,
+      );
 
       expect(prs, hasLength(1));
       expect(prs.single.statusCheckRollup, equals(PrCheckStatus.unknown));
@@ -296,7 +386,11 @@ void main() {
         ),
       );
 
-      final pr = await service.getPrByNumber(number: 12, workingDirectory: "/repo");
+      final pr = await service.getPrByNumber(
+        number: 12,
+        workingDirectory: "/repo",
+        githubRepositoryIdentity: _githubRepositoryIdentity,
+      );
 
       expect(
         pr,
@@ -322,6 +416,8 @@ void main() {
           "pr",
           "view",
           "12",
+          "--repo",
+          _githubRepositoryIdentity,
           "--json",
           "number,url,title,state,headRefName,isCrossRepository,mergeable,reviewDecision,statusCheckRollup",
         ]),
@@ -333,7 +429,11 @@ void main() {
       processRunner.enqueueResult(result: _ok(stdout: "{"));
 
       expect(
-        () => service.getPrByNumber(number: 1, workingDirectory: "/repo"),
+        () => service.getPrByNumber(
+          number: 1,
+          workingDirectory: "/repo",
+          githubRepositoryIdentity: _githubRepositoryIdentity,
+        ),
         throwsA(isA<FormatException>()),
       );
     });
@@ -342,7 +442,11 @@ void main() {
       processRunner.enqueueResult(result: _fail(exitCode: 1));
 
       expect(
-        () => service.getPrByNumber(number: 1, workingDirectory: "/repo"),
+        () => service.getPrByNumber(
+          number: 1,
+          workingDirectory: "/repo",
+          githubRepositoryIdentity: _githubRepositoryIdentity,
+        ),
         throwsA(isA<Exception>()),
       );
     });
@@ -351,7 +455,11 @@ void main() {
       processRunner.enqueueError(error: TimeoutException("timed out"));
 
       expect(
-        () => service.getPrByNumber(number: 1, workingDirectory: "/repo"),
+        () => service.getPrByNumber(
+          number: 1,
+          workingDirectory: "/repo",
+          githubRepositoryIdentity: _githubRepositoryIdentity,
+        ),
         throwsA(isA<TimeoutException>()),
       );
     });
@@ -362,7 +470,11 @@ void main() {
       );
 
       expect(
-        () => service.getPrByNumber(number: 1, workingDirectory: "/repo"),
+        () => service.getPrByNumber(
+          number: 1,
+          workingDirectory: "/repo",
+          githubRepositoryIdentity: _githubRepositoryIdentity,
+        ),
         throwsA(isA<ProcessException>()),
       );
     });

--- a/bridge/app/test/bridge/api/gh_cli_api_test.dart
+++ b/bridge/app/test/bridge/api/gh_cli_api_test.dart
@@ -9,6 +9,7 @@ import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
 const _githubRepositoryIdentity = "sesori-ai/sesori_apps_monorepo";
+const _githubRepositorySelector = "github.com/$_githubRepositoryIdentity";
 
 void main() {
   group("GhCliApi.isAvailable", () {
@@ -175,10 +176,17 @@ void main() {
       expect(processRunner.invocations.single.workingDirectory, isNull);
     });
 
-    test("returns null when the identity command fails", () async {
+    test("throws a process failure when the identity command fails", () async {
       processRunner.enqueueResult(result: _fail(exitCode: 1));
 
-      expect(await service.getAuthenticatedIdentity(), isNull);
+      await expectLater(
+        service.getAuthenticatedIdentity(),
+        throwsA(
+          isA<ProcessException>()
+              .having((error) => error.executable, "executable", "gh")
+              .having((error) => error.errorCode, "errorCode", 1),
+        ),
+      );
     });
 
     test("preserves an empty login for repository validation", () async {
@@ -256,7 +264,7 @@ void main() {
           "pr",
           "list",
           "--repo",
-          _githubRepositoryIdentity,
+          _githubRepositorySelector,
           "--state",
           "open",
           "--json",
@@ -412,7 +420,7 @@ void main() {
           "view",
           "12",
           "--repo",
-          _githubRepositoryIdentity,
+          _githubRepositorySelector,
           "--json",
           "number,url,title,state,headRefName,isCrossRepository,mergeable,reviewDecision,statusCheckRollup",
         ]),

--- a/bridge/app/test/bridge/repositories/pr_source_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/pr_source_repository_test.dart
@@ -1,0 +1,106 @@
+import "dart:collection";
+import "dart:io";
+
+import "package:sesori_bridge/src/bridge/api/gh_cli_api.dart";
+import "package:sesori_bridge/src/bridge/api/git_cli_api.dart";
+import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
+import "package:sesori_bridge/src/bridge/repositories/pr_source_repository.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("PrSourceRepository", () {
+    test("maps the verified gh identity into repository evidence", () async {
+      final repository = _repository(
+        ghResults: [_result(stdout: "  OctoCat\n")],
+        gitResults: const [],
+      );
+
+      final identity = await repository.getAuthenticatedIdentity();
+
+      expect(identity?.login, "octocat");
+    });
+
+    test("rejects an empty gh identity", () async {
+      final repository = _repository(
+        ghResults: [_result(stdout: "  \n")],
+        gitResults: const [],
+      );
+
+      expect(await repository.getAuthenticatedIdentity(), isNull);
+    });
+
+    test("returns a canonical lowercase GitHub owner/repository identity", () async {
+      final repository = _repository(
+        ghResults: const [],
+        gitResults: [
+          _result(stdout: "origin\n"),
+          _result(stdout: "git@GitHub.com:Sesori-AI/Sesori_Apps_Monorepo.git\n"),
+        ],
+      );
+
+      final identity = await repository.getGithubRepositoryIdentity(
+        projectPath: "/repo",
+      );
+
+      expect(identity, "sesori-ai/sesori_apps_monorepo");
+    });
+
+    test("rejects non-GitHub and nested repository identities", () async {
+      for (final remoteUrl in [
+        "https://gitlab.com/sesori-ai/sesori_apps_monorepo.git",
+        "https://github.com/sesori-ai/mobile/sesori_apps_monorepo.git",
+      ]) {
+        final repository = _repository(
+          ghResults: const [],
+          gitResults: [
+            _result(stdout: "origin\n"),
+            _result(stdout: "$remoteUrl\n"),
+          ],
+        );
+
+        expect(
+          await repository.getGithubRepositoryIdentity(projectPath: "/repo"),
+          isNull,
+          reason: remoteUrl,
+        );
+      }
+    });
+  });
+}
+
+PrSourceRepository _repository({
+  required List<ProcessResult> ghResults,
+  required List<ProcessResult> gitResults,
+}) {
+  return PrSourceRepository(
+    ghCli: GhCliApi(processRunner: _QueueProcessRunner(results: ghResults)),
+    gitCli: GitCliApi(
+      processRunner: _QueueProcessRunner(results: gitResults),
+      gitPathExists: ({required String gitPath}) => true,
+    ),
+  );
+}
+
+ProcessResult _result({String stdout = ""}) {
+  return ProcessResult(1, 0, stdout, "");
+}
+
+class _QueueProcessRunner extends ProcessRunner {
+  final Queue<ProcessResult> _results;
+
+  _QueueProcessRunner({required List<ProcessResult> results}) : _results = Queue<ProcessResult>.from(results);
+
+  @override
+  Future<ProcessResult> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    Duration timeout = const Duration(seconds: 15),
+  }) async {
+    if (_results.isEmpty) {
+      throw StateError("Unexpected command: $executable ${arguments.join(" ")}");
+    }
+    return _results.removeFirst();
+  }
+}

--- a/bridge/app/test/bridge/repositories/pr_source_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/pr_source_repository_test.dart
@@ -81,7 +81,7 @@ PrSourceRepository _repository({
   );
 }
 
-ProcessResult _result({String stdout = ""}) {
+ProcessResult _result({required String stdout}) {
   return ProcessResult(1, 0, stdout, "");
 }
 

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -17,6 +17,7 @@ import "package:sesori_bridge/src/bridge/repositories/mappers/pull_request_mappe
 import "package:sesori_bridge/src/bridge/repositories/mappers/stored_session_mapper.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/session_operation.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/stored_session.dart";
+import "package:sesori_bridge/src/bridge/repositories/models/verified_github_login.dart";
 import "package:sesori_bridge/src/bridge/repositories/pr_source_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/pull_request_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
@@ -644,12 +645,20 @@ class _AlwaysReadyPrSource implements PrSourceRepository {
   @override
   Future<bool> isGithubCliAuthenticated() async => true;
   @override
-  Future<bool> hasGitHubRemote({required String projectPath}) async => true;
+  Future<VerifiedGithubLogin?> getAuthenticatedIdentity() async => VerifiedGithubLogin.tryParse(rawLogin: "octocat");
   @override
-  Future<List<GhPullRequest>> listOpenPrs({required String workingDirectory}) async => const <GhPullRequest>[];
+  Future<String?> getGithubRepositoryIdentity({required String projectPath}) async => "sesori-ai/test";
   @override
-  Future<GhPullRequest> getPrByNumber({required int number, required String workingDirectory}) async =>
-      throw StateError("getPrByNumber should not be called");
+  Future<List<GhPullRequest>> listOpenPrs({
+    required String workingDirectory,
+    required String githubRepositoryIdentity,
+  }) async => const <GhPullRequest>[];
+  @override
+  Future<GhPullRequest> getPrByNumber({
+    required int number,
+    required String workingDirectory,
+    required String githubRepositoryIdentity,
+  }) async => throw StateError("getPrByNumber should not be called");
 }
 
 class _NoopPullRequestRepository implements PullRequestRepository {

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:io";
 
 import "package:clock/clock.dart";
 import "package:sesori_bridge/src/api/database/tables/pull_requests_table.dart";
@@ -161,6 +162,47 @@ void main() {
 
       expect(prSource.getAuthenticatedIdentityCallCount, 1);
       expect(prSource.getGithubRepositoryIdentityCalls, isEmpty);
+      expect(prSource.listOpenPrsCallCount, 0);
+    });
+
+    test("shows an actionable warning when identity verification fails", () async {
+      final stderrLines = <String>[];
+      final prSource = _FakePrSource(listOpenPrsResult: const <GhPullRequest>[])..authenticatedIdentityResult = null;
+      final service = PrSyncService(
+        prSource: prSource,
+        pullRequestRepository: _FakePullRequestRepository(),
+        sessionRepository: _FakeSessionRepository(sessionsByProject: const <String, List<StoredSession>>{}),
+        clock: const Clock(),
+      );
+      addTearDown(service.dispose);
+
+      await IOOverrides.runZoned(
+        () => service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1"),
+        stderr: () => _CapturingStdout(stderrLines),
+      );
+
+      expect(stderrLines.join("\n"), contains("metadata cannot be refreshed"));
+      expect(stderrLines.join("\n"), isNot(contains("metadata is hidden")));
+    });
+
+    test("keeps an identity verification timeout visible", () async {
+      final stderrLines = <String>[];
+      final prSource = _FakePrSource(listOpenPrsResult: const <GhPullRequest>[])
+        ..authenticatedIdentityError = TimeoutException("timed out");
+      final service = PrSyncService(
+        prSource: prSource,
+        pullRequestRepository: _FakePullRequestRepository(),
+        sessionRepository: _FakeSessionRepository(sessionsByProject: const <String, List<StoredSession>>{}),
+        clock: const Clock(),
+      );
+      addTearDown(service.dispose);
+
+      await IOOverrides.runZoned(
+        () => service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1"),
+        stderr: () => _CapturingStdout(stderrLines),
+      );
+
+      expect(stderrLines.join("\n"), contains("metadata cannot be refreshed"));
       expect(prSource.listOpenPrsCallCount, 0);
     });
 
@@ -386,6 +428,7 @@ class _FakePrSource implements PrSourceRepository {
   bool isAvailableResult;
   bool isAuthenticatedResult = true;
   VerifiedGithubLogin? authenticatedIdentityResult = _verifiedGithubLogin;
+  Object? authenticatedIdentityError;
   String? githubRepositoryIdentityResult = _githubRepositoryIdentity;
   Completer<void>? availabilityBlock;
   int isAvailableFailuresRemaining = 0;
@@ -428,6 +471,9 @@ class _FakePrSource implements PrSourceRepository {
   @override
   Future<VerifiedGithubLogin?> getAuthenticatedIdentity() async {
     getAuthenticatedIdentityCallCount++;
+    if (authenticatedIdentityError case final error?) {
+      throw error;
+    }
     return authenticatedIdentityResult;
   }
 
@@ -464,6 +510,23 @@ class _FakePrSource implements PrSourceRepository {
     }
     return pr;
   }
+}
+
+class _CapturingStdout implements Stdout {
+  final List<String> lines;
+
+  _CapturingStdout(this.lines);
+
+  @override
+  bool get supportsAnsiEscapes => false;
+
+  @override
+  void writeln([Object? object = ""]) {
+    lines.add(object.toString());
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _FakePullRequestRepository implements PullRequestRepository {

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -161,7 +161,7 @@ void main() {
       await service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
 
       expect(prSource.getAuthenticatedIdentityCallCount, 1);
-      expect(prSource.getGithubRepositoryIdentityCalls, isEmpty);
+      expect(prSource.getGithubRepositoryIdentityCalls, ["/tmp/project-1"]);
       expect(prSource.listOpenPrsCallCount, 0);
     });
 
@@ -218,7 +218,7 @@ void main() {
 
       await service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
 
-      expect(prSource.getAuthenticatedIdentityCallCount, 1);
+      expect(prSource.getAuthenticatedIdentityCallCount, 0);
       expect(prSource.getGithubRepositoryIdentityCalls, ["/tmp/project-1"]);
       expect(prSource.listOpenPrsCallCount, 0);
     });

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -6,6 +6,7 @@ import "package:sesori_bridge/src/bridge/api/gh_pull_request.dart";
 import "package:sesori_bridge/src/bridge/repositories/mappers/plugin_session_mapper.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/session_operation.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/stored_session.dart";
+import "package:sesori_bridge/src/bridge/repositories/models/verified_github_login.dart";
 import "package:sesori_bridge/src/bridge/repositories/pr_source_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/pull_request_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
@@ -13,6 +14,9 @@ import "package:sesori_bridge/src/bridge/services/pr_sync_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
+
+const _githubRepositoryIdentity = "sesori-ai/sesori_apps_monorepo";
+final VerifiedGithubLogin _verifiedGithubLogin = VerifiedGithubLogin.tryParse(rawLogin: "octocat")!;
 
 void main() {
   group("PrSyncService", () {
@@ -49,6 +53,7 @@ void main() {
       expect(prs.single.prNumber, equals(11));
       expect(prs.single.branchName, equals("feature/new-pr"));
       expect(emittedProjectIds, equals(<String>["project-1"]));
+      expect(prSource.listOpenPrsRepositoryIdentities, [_githubRepositoryIdentity]);
     });
 
     test("does not emit when PR data is unchanged", () async {
@@ -139,6 +144,41 @@ void main() {
       final prs = pullRequestRepository.getByProjectId(projectId: "project-1");
       expect(prs.single.state, equals(PrState.merged));
       expect(prSource.getPrByNumberCalls, contains(22));
+      expect(prSource.getPrByNumberRepositoryIdentities, everyElement(_githubRepositoryIdentity));
+    });
+
+    test("skips PR queries when fresh identity verification fails", () async {
+      final prSource = _FakePrSource(listOpenPrsResult: const <GhPullRequest>[])..authenticatedIdentityResult = null;
+      final service = PrSyncService(
+        prSource: prSource,
+        pullRequestRepository: _FakePullRequestRepository(),
+        sessionRepository: _FakeSessionRepository(sessionsByProject: const <String, List<StoredSession>>{}),
+        clock: const Clock(),
+      );
+      addTearDown(service.dispose);
+
+      await service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
+
+      expect(prSource.getAuthenticatedIdentityCallCount, 1);
+      expect(prSource.getGithubRepositoryIdentityCalls, isEmpty);
+      expect(prSource.listOpenPrsCallCount, 0);
+    });
+
+    test("skips PR queries when the canonical GitHub repository is unavailable", () async {
+      final prSource = _FakePrSource(listOpenPrsResult: const <GhPullRequest>[])..githubRepositoryIdentityResult = null;
+      final service = PrSyncService(
+        prSource: prSource,
+        pullRequestRepository: _FakePullRequestRepository(),
+        sessionRepository: _FakeSessionRepository(sessionsByProject: const <String, List<StoredSession>>{}),
+        clock: const Clock(),
+      );
+      addTearDown(service.dispose);
+
+      await service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
+
+      expect(prSource.getAuthenticatedIdentityCallCount, 1);
+      expect(prSource.getGithubRepositoryIdentityCalls, ["/tmp/project-1"]);
+      expect(prSource.listOpenPrsCallCount, 0);
     });
 
     test("caches unavailable gh capability and detects installation after the TTL", () async {
@@ -160,6 +200,7 @@ void main() {
 
       expect(prSource.isAvailableCallCount, equals(1));
       expect(prSource.isAuthenticatedCallCount, equals(0));
+      expect(prSource.getAuthenticatedIdentityCallCount, equals(0));
       expect(prSource.listOpenPrsCallCount, equals(0));
 
       prSource.isAvailableResult = true;
@@ -171,6 +212,7 @@ void main() {
       await service.triggerRefresh(projectId: "project-4", projectPath: "/tmp/project-4");
       expect(prSource.isAvailableCallCount, equals(2));
       expect(prSource.isAuthenticatedCallCount, equals(1));
+      expect(prSource.getAuthenticatedIdentityCallCount, equals(1));
       expect(prSource.listOpenPrsCallCount, equals(1));
     });
 
@@ -195,11 +237,13 @@ void main() {
       capabilityBlock.complete();
       await Future.wait([first, second]);
       expect(prSource.isAuthenticatedCallCount, equals(1));
+      expect(prSource.getAuthenticatedIdentityCallCount, equals(2));
       expect(prSource.listOpenPrsCallCount, equals(2));
 
       await service.triggerRefresh(projectId: "project-3", projectPath: "/tmp/project-3");
       expect(prSource.isAvailableCallCount, equals(1));
       expect(prSource.isAuthenticatedCallCount, equals(1));
+      expect(prSource.getAuthenticatedIdentityCallCount, equals(3));
       expect(prSource.listOpenPrsCallCount, equals(3));
     });
 
@@ -220,6 +264,7 @@ void main() {
       await service.triggerRefresh(projectId: "project-2", projectPath: "/tmp/project-2");
 
       expect(prSource.isAvailableCallCount, equals(2));
+      expect(prSource.getAuthenticatedIdentityCallCount, equals(1));
       expect(prSource.listOpenPrsCallCount, equals(1));
     });
 
@@ -340,13 +385,19 @@ class _FakePrSource implements PrSourceRepository {
   final Future<void> Function()? onListOpenPrs;
   bool isAvailableResult;
   bool isAuthenticatedResult = true;
+  VerifiedGithubLogin? authenticatedIdentityResult = _verifiedGithubLogin;
+  String? githubRepositoryIdentityResult = _githubRepositoryIdentity;
   Completer<void>? availabilityBlock;
   int isAvailableFailuresRemaining = 0;
 
   int isAvailableCallCount = 0;
   int isAuthenticatedCallCount = 0;
+  int getAuthenticatedIdentityCallCount = 0;
   int listOpenPrsCallCount = 0;
+  final List<String> getGithubRepositoryIdentityCalls = <String>[];
+  final List<String> listOpenPrsRepositoryIdentities = <String>[];
   final List<int> getPrByNumberCalls = <int>[];
+  final List<String> getPrByNumberRepositoryIdentities = <String>[];
 
   _FakePrSource({
     required this.listOpenPrsResult,
@@ -375,11 +426,24 @@ class _FakePrSource implements PrSourceRepository {
   }
 
   @override
-  Future<bool> hasGitHubRemote({required String projectPath}) async => true;
+  Future<VerifiedGithubLogin?> getAuthenticatedIdentity() async {
+    getAuthenticatedIdentityCallCount++;
+    return authenticatedIdentityResult;
+  }
 
   @override
-  Future<List<GhPullRequest>> listOpenPrs({required String workingDirectory}) async {
+  Future<String?> getGithubRepositoryIdentity({required String projectPath}) async {
+    getGithubRepositoryIdentityCalls.add(projectPath);
+    return githubRepositoryIdentityResult;
+  }
+
+  @override
+  Future<List<GhPullRequest>> listOpenPrs({
+    required String workingDirectory,
+    required String githubRepositoryIdentity,
+  }) async {
     listOpenPrsCallCount++;
+    listOpenPrsRepositoryIdentities.add(githubRepositoryIdentity);
     if (onListOpenPrs case final callback?) {
       await callback();
     }
@@ -387,8 +451,13 @@ class _FakePrSource implements PrSourceRepository {
   }
 
   @override
-  Future<GhPullRequest> getPrByNumber({required int number, required String workingDirectory}) async {
+  Future<GhPullRequest> getPrByNumber({
+    required int number,
+    required String workingDirectory,
+    required String githubRepositoryIdentity,
+  }) async {
     getPrByNumberCalls.add(number);
+    getPrByNumberRepositoryIdentities.add(githubRepositoryIdentity);
     final pr = prByNumber[number];
     if (pr == null) {
       throw Exception("PR #$number not found");


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this changes API, repository, and service ownership for privacy-sensitive GitHub identity and repository scope, while intentionally leaving persistence and read gating for Steps 2.b and 2.c.

## What

- Add typed raw `gh` account output as a generated Freezed API model and repository-owned verified GitHub login evidence.
- Resolve the preferred local remote into a canonical lowercase GitHub `owner/repo` identity.
- Require request-driven PR refreshes to verify both identities before querying.
- Pin every existing `gh pr list` and `gh pr view` command to `github.com/owner/repo` explicitly.
- Preserve nonzero identity command failures for service-level diagnostics.
- Keep verification failures actionable through an honest user-facing warning, including timeouts.
- Record the approved Step 2 split into source, persistence, and read substeps.

## Why

GitHub CLI defaults such as `GH_REPO` or `GH_HOST` must not redirect PR metadata reads away from the project's canonical GitHub.com remote, and source refreshes must not proceed when the active GitHub account cannot be verified.

## Risk and test focus

The main risk is exposing or caching PR metadata from the wrong account, repository, or GitHub host. Tests focus on raw-to-verified identity ownership, malformed/non-GitHub remotes, fail-closed refresh preflight, verification-failure observability, typed command failures, and exact CLI arguments. User-visible impact is limited to an actionable warning and paused PR metadata refresh when identity verification fails; cached read gating ships in Step 2.c. There is no database, wire, client, timer, settings, or analytics impact.

## Expected result

Existing request-driven PR refreshes query only the canonical GitHub.com repository associated with the project and only after active-account verification succeeds.

## Verification

- `dart analyze --fatal-infos`
- `dart test test/bridge/api/gh_cli_api_test.dart test/bridge/repositories/pr_source_repository_test.dart test/bridge/services/pr_sync_service_test.dart` — 43 tests passed
- `git diff --check`
- 883 changed lines, within the planned 500–900 target
- Aristotle architecture review finding addressed by keeping raw CLI output in the API model and canonicalization exclusively in `PrSourceRepository`
