### PR TITLE
🌿 Cache temporary directory before voice recording

### DIFF
--- a/client/app/lib/capabilities/voice/recording_file_provider.dart
+++ b/client/app/lib/capabilities/voice/recording_file_provider.dart
@@ -9,16 +9,19 @@ import "audio_format_config.dart";
 class RecordingFileProvider {
   final AudioFormatConfig _audioFormat;
   final TemporaryDirectoryClient _temporaryDirectoryClient;
+  final Future<void> _warmUp;
 
   RecordingFileProvider({
     required AudioFormatConfig audioFormat,
     required TemporaryDirectoryClient temporaryDirectoryClient,
   }) : _audioFormat = audioFormat,
-       _temporaryDirectoryClient = temporaryDirectoryClient {
-    unawaited(_temporaryDirectoryClient.warmUp());
+       _temporaryDirectoryClient = temporaryDirectoryClient,
+       _warmUp = temporaryDirectoryClient.warmUp() {
+    unawaited(_warmUp);
   }
 
   Future<String> createRecordingPath() async {
+    await _warmUp;
     final tempDir = await _temporaryDirectoryClient.directory;
     final timestamp = DateTime.now().millisecondsSinceEpoch;
     return "${tempDir.path}/sesori_voice_$timestamp.${_audioFormat.fileExtension}";

--- a/client/app/lib/capabilities/voice/recording_file_provider.dart
+++ b/client/app/lib/capabilities/voice/recording_file_provider.dart
@@ -1,16 +1,25 @@
-import "package:injectable/injectable.dart";
-import "package:path_provider/path_provider.dart";
+import "dart:async";
 
+import "package:injectable/injectable.dart";
+
+import "../../core/platform/temporary_directory_client.dart";
 import "audio_format_config.dart";
 
 @lazySingleton
 class RecordingFileProvider {
   final AudioFormatConfig _audioFormat;
+  final TemporaryDirectoryClient _temporaryDirectoryClient;
 
-  RecordingFileProvider(AudioFormatConfig audioFormat) : _audioFormat = audioFormat;
+  RecordingFileProvider({
+    required AudioFormatConfig audioFormat,
+    required TemporaryDirectoryClient temporaryDirectoryClient,
+  }) : _audioFormat = audioFormat,
+       _temporaryDirectoryClient = temporaryDirectoryClient {
+    unawaited(_temporaryDirectoryClient.warmUp());
+  }
 
   Future<String> createRecordingPath() async {
-    final tempDir = await getTemporaryDirectory();
+    final tempDir = await _temporaryDirectoryClient.directory;
     final timestamp = DateTime.now().millisecondsSinceEpoch;
     return "${tempDir.path}/sesori_voice_$timestamp.${_audioFormat.fileExtension}";
   }

--- a/client/app/lib/capabilities/voice/voice_transcription_service.dart
+++ b/client/app/lib/capabilities/voice/voice_transcription_service.dart
@@ -19,51 +19,6 @@ const _amplitudeInterval = Duration(milliseconds: 100);
 /// so using -160 (the technical floor) would make the bars barely move.
 const double _amplitudeFloor = -60.0;
 
-const _voiceStartupTimingEnabled = bool.fromEnvironment("SESORI_VOICE_STARTUP_TIMING");
-
-String _elapsedMilliseconds({required Stopwatch stopwatch}) =>
-    (stopwatch.elapsedMicroseconds / Duration.microsecondsPerMillisecond).toStringAsFixed(3);
-
-void _logVoiceStartupStage({
-  required int attempt,
-  required String stage,
-  required Stopwatch stageStopwatch,
-  required Stopwatch totalStopwatch,
-}) {
-  if (!_voiceStartupTimingEnabled) return;
-  logd(
-    "[voice.start.timing] attempt=$attempt stage=$stage "
-    "elapsed_ms=${_elapsedMilliseconds(stopwatch: stageStopwatch)} "
-    "total_ms=${_elapsedMilliseconds(stopwatch: totalStopwatch)}",
-  );
-}
-
-void _logVoiceStartupEvent({
-  required int attempt,
-  required String event,
-  required Stopwatch totalStopwatch,
-}) {
-  if (!_voiceStartupTimingEnabled) return;
-  logd(
-    "[voice.start.timing] attempt=$attempt event=$event "
-    "total_ms=${_elapsedMilliseconds(stopwatch: totalStopwatch)}",
-  );
-}
-
-void _logVoiceStartupFailure({
-  required int attempt,
-  required String stage,
-  required Stopwatch stageStopwatch,
-  required Stopwatch totalStopwatch,
-}) {
-  if (!_voiceStartupTimingEnabled) return;
-  logd(
-    "[voice.start.timing] attempt=$attempt event=failed stage=$stage "
-    "elapsed_ms=${_elapsedMilliseconds(stopwatch: stageStopwatch)} "
-    "total_ms=${_elapsedMilliseconds(stopwatch: totalStopwatch)}",
-  );
-}
-
 @lazySingleton
 class VoiceTranscriptionService {
   final VoiceApi _voiceApi;
@@ -73,7 +28,6 @@ class VoiceTranscriptionService {
   final AudioFormatConfig _audioFormat;
   bool _isRecording = false;
   bool _isBusy = false;
-  int _recordingStartAttempt = 0;
   int _transcriptionGeneration = 0;
   String? _currentRecordingPath;
   StreamSubscription<Amplitude>? _amplitudeSub;
@@ -111,15 +65,6 @@ class VoiceTranscriptionService {
       return;
     }
 
-    final attempt = ++_recordingStartAttempt;
-    final totalStopwatch = Stopwatch()..start();
-    final stageStopwatch = Stopwatch()..start();
-    var currentStage = "permission_check";
-    _logVoiceStartupEvent(
-      attempt: attempt,
-      event: "requested",
-      totalStopwatch: totalStopwatch,
-    );
     _isBusy = true;
 
     try {
@@ -130,29 +75,13 @@ class VoiceTranscriptionService {
         loge("Failed to check microphone permission", error, stackTrace);
         throw VoiceTranscriptionError.microphonePermissionDenied();
       }
-      _logVoiceStartupStage(
-        attempt: attempt,
-        stage: currentStage,
-        stageStopwatch: stageStopwatch,
-        totalStopwatch: totalStopwatch,
-      );
       if (!hasPermission) {
         throw VoiceTranscriptionError.microphonePermissionDenied();
       }
 
-      currentStage = "temporary_directory_and_path";
-      stageStopwatch.reset();
       final path = await _fileProvider.createRecordingPath();
       _currentRecordingPath = path;
-      _logVoiceStartupStage(
-        attempt: attempt,
-        stage: currentStage,
-        stageStopwatch: stageStopwatch,
-        totalStopwatch: totalStopwatch,
-      );
 
-      currentStage = "record_config";
-      stageStopwatch.reset();
       final config = RecordConfig(
         encoder: _audioFormat.encoder,
         sampleRate: _audioFormat.sampleRate,
@@ -161,47 +90,18 @@ class VoiceTranscriptionService {
         noiseSuppress: true,
         audioInterruption: AudioInterruptionMode.none,
       );
-      _logVoiceStartupStage(
-        attempt: attempt,
-        stage: currentStage,
-        stageStopwatch: stageStopwatch,
-        totalStopwatch: totalStopwatch,
-      );
       logt(
         "[voice] starting recorder — encoder=${config.encoder.name} "
         "sampleRate=${config.sampleRate} channels=${config.numChannels} "
         "path=$path",
       );
 
-      currentStage = "native_recorder_start";
-      stageStopwatch.reset();
       try {
         await _recorder.start(config, path: path);
-        _logVoiceStartupStage(
-          attempt: attempt,
-          stage: currentStage,
-          stageStopwatch: stageStopwatch,
-          totalStopwatch: totalStopwatch,
-        );
-
-        currentStage = "post_start_setup";
-        stageStopwatch.reset();
         _isRecording = true;
         _startAmplitudeMonitoring(_recorder);
         _startMaxDurationTimer();
         unawaited(_wakeLockService.enable());
-        _logVoiceStartupStage(
-          attempt: attempt,
-          stage: currentStage,
-          stageStopwatch: stageStopwatch,
-          totalStopwatch: totalStopwatch,
-        );
-        totalStopwatch.stop();
-        _logVoiceStartupEvent(
-          attempt: attempt,
-          event: "ready",
-          totalStopwatch: totalStopwatch,
-        );
       } catch (error, stackTrace) {
         loge("Failed to start recording", error, stackTrace);
         await _cleanupFile(path);
@@ -209,13 +109,6 @@ class VoiceTranscriptionService {
         throw VoiceTranscriptionError.recordingFailed();
       }
     } catch (_) {
-      totalStopwatch.stop();
-      _logVoiceStartupFailure(
-        attempt: attempt,
-        stage: currentStage,
-        stageStopwatch: stageStopwatch,
-        totalStopwatch: totalStopwatch,
-      );
       // Release the busy lock on any error — if recording started
       // successfully, _isBusy stays true until stop/cancel.
       if (!_isRecording) _isBusy = false;

--- a/client/app/lib/capabilities/voice/voice_transcription_service.dart
+++ b/client/app/lib/capabilities/voice/voice_transcription_service.dart
@@ -19,6 +19,51 @@ const _amplitudeInterval = Duration(milliseconds: 100);
 /// so using -160 (the technical floor) would make the bars barely move.
 const double _amplitudeFloor = -60.0;
 
+const _voiceStartupTimingEnabled = bool.fromEnvironment("SESORI_VOICE_STARTUP_TIMING");
+
+String _elapsedMilliseconds({required Stopwatch stopwatch}) =>
+    (stopwatch.elapsedMicroseconds / Duration.microsecondsPerMillisecond).toStringAsFixed(3);
+
+void _logVoiceStartupStage({
+  required int attempt,
+  required String stage,
+  required Stopwatch stageStopwatch,
+  required Stopwatch totalStopwatch,
+}) {
+  if (!_voiceStartupTimingEnabled) return;
+  logd(
+    "[voice.start.timing] attempt=$attempt stage=$stage "
+    "elapsed_ms=${_elapsedMilliseconds(stopwatch: stageStopwatch)} "
+    "total_ms=${_elapsedMilliseconds(stopwatch: totalStopwatch)}",
+  );
+}
+
+void _logVoiceStartupEvent({
+  required int attempt,
+  required String event,
+  required Stopwatch totalStopwatch,
+}) {
+  if (!_voiceStartupTimingEnabled) return;
+  logd(
+    "[voice.start.timing] attempt=$attempt event=$event "
+    "total_ms=${_elapsedMilliseconds(stopwatch: totalStopwatch)}",
+  );
+}
+
+void _logVoiceStartupFailure({
+  required int attempt,
+  required String stage,
+  required Stopwatch stageStopwatch,
+  required Stopwatch totalStopwatch,
+}) {
+  if (!_voiceStartupTimingEnabled) return;
+  logd(
+    "[voice.start.timing] attempt=$attempt event=failed stage=$stage "
+    "elapsed_ms=${_elapsedMilliseconds(stopwatch: stageStopwatch)} "
+    "total_ms=${_elapsedMilliseconds(stopwatch: totalStopwatch)}",
+  );
+}
+
 @lazySingleton
 class VoiceTranscriptionService {
   final VoiceApi _voiceApi;
@@ -28,6 +73,7 @@ class VoiceTranscriptionService {
   final AudioFormatConfig _audioFormat;
   bool _isRecording = false;
   bool _isBusy = false;
+  int _recordingStartAttempt = 0;
   int _transcriptionGeneration = 0;
   String? _currentRecordingPath;
   StreamSubscription<Amplitude>? _amplitudeSub;
@@ -65,6 +111,15 @@ class VoiceTranscriptionService {
       return;
     }
 
+    final attempt = ++_recordingStartAttempt;
+    final totalStopwatch = Stopwatch()..start();
+    final stageStopwatch = Stopwatch()..start();
+    var currentStage = "permission_check";
+    _logVoiceStartupEvent(
+      attempt: attempt,
+      event: "requested",
+      totalStopwatch: totalStopwatch,
+    );
     _isBusy = true;
 
     try {
@@ -75,13 +130,29 @@ class VoiceTranscriptionService {
         loge("Failed to check microphone permission", error, stackTrace);
         throw VoiceTranscriptionError.microphonePermissionDenied();
       }
+      _logVoiceStartupStage(
+        attempt: attempt,
+        stage: currentStage,
+        stageStopwatch: stageStopwatch,
+        totalStopwatch: totalStopwatch,
+      );
       if (!hasPermission) {
         throw VoiceTranscriptionError.microphonePermissionDenied();
       }
 
+      currentStage = "temporary_directory_and_path";
+      stageStopwatch.reset();
       final path = await _fileProvider.createRecordingPath();
       _currentRecordingPath = path;
+      _logVoiceStartupStage(
+        attempt: attempt,
+        stage: currentStage,
+        stageStopwatch: stageStopwatch,
+        totalStopwatch: totalStopwatch,
+      );
 
+      currentStage = "record_config";
+      stageStopwatch.reset();
       final config = RecordConfig(
         encoder: _audioFormat.encoder,
         sampleRate: _audioFormat.sampleRate,
@@ -90,18 +161,47 @@ class VoiceTranscriptionService {
         noiseSuppress: true,
         audioInterruption: AudioInterruptionMode.none,
       );
+      _logVoiceStartupStage(
+        attempt: attempt,
+        stage: currentStage,
+        stageStopwatch: stageStopwatch,
+        totalStopwatch: totalStopwatch,
+      );
       logt(
         "[voice] starting recorder — encoder=${config.encoder.name} "
         "sampleRate=${config.sampleRate} channels=${config.numChannels} "
         "path=$path",
       );
 
+      currentStage = "native_recorder_start";
+      stageStopwatch.reset();
       try {
         await _recorder.start(config, path: path);
+        _logVoiceStartupStage(
+          attempt: attempt,
+          stage: currentStage,
+          stageStopwatch: stageStopwatch,
+          totalStopwatch: totalStopwatch,
+        );
+
+        currentStage = "post_start_setup";
+        stageStopwatch.reset();
         _isRecording = true;
         _startAmplitudeMonitoring(_recorder);
         _startMaxDurationTimer();
         unawaited(_wakeLockService.enable());
+        _logVoiceStartupStage(
+          attempt: attempt,
+          stage: currentStage,
+          stageStopwatch: stageStopwatch,
+          totalStopwatch: totalStopwatch,
+        );
+        totalStopwatch.stop();
+        _logVoiceStartupEvent(
+          attempt: attempt,
+          event: "ready",
+          totalStopwatch: totalStopwatch,
+        );
       } catch (error, stackTrace) {
         loge("Failed to start recording", error, stackTrace);
         await _cleanupFile(path);
@@ -109,6 +209,13 @@ class VoiceTranscriptionService {
         throw VoiceTranscriptionError.recordingFailed();
       }
     } catch (_) {
+      totalStopwatch.stop();
+      _logVoiceStartupFailure(
+        attempt: attempt,
+        stage: currentStage,
+        stageStopwatch: stageStopwatch,
+        totalStopwatch: totalStopwatch,
+      );
       // Release the busy lock on any error — if recording started
       // successfully, _isBusy stays true until stop/cancel.
       if (!_isRecording) _isBusy = false;

--- a/client/app/lib/core/di/injection.config.dart
+++ b/client/app/lib/core/di/injection.config.dart
@@ -60,6 +60,8 @@ import 'package:sesori_mobile/core/platform/go_router_route_source.dart'
     as _i597;
 import 'package:sesori_mobile/core/platform/pasteboard_client.dart' as _i748;
 import 'package:sesori_mobile/core/platform/share_plus_client.dart' as _i1019;
+import 'package:sesori_mobile/core/platform/temporary_directory_client.dart'
+    as _i908;
 import 'package:sesori_mobile/core/routing/deep_link_service.dart' as _i901;
 import 'package:sesori_mobile/core/routing/deep_link_source.dart' as _i919;
 import 'package:sesori_shared/sesori_shared.dart' as _i553;
@@ -96,6 +98,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i227.GalClient>(() => _i227.GalClient());
     gh.lazySingleton<_i748.PasteboardClient>(() => _i748.PasteboardClient());
     gh.lazySingleton<_i1019.SharePlusClient>(() => _i1019.SharePlusClient());
+    gh.lazySingleton<_i908.TemporaryDirectoryClient>(
+      () => _i908.TemporaryDirectoryClient(),
+    );
     gh.singleton<_i948.LifecycleSource>(() => _i875.AppLifecycleObserver());
     gh.singleton<_i948.RouteSource>(() => _i597.GoRouterRouteSource());
     gh.lazySingleton<_i948.LocalNotificationClient>(
@@ -113,9 +118,6 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i948.DeepLinkSource>(
       () => _i919.AppLinksDeepLinkSource(),
-    );
-    gh.lazySingleton<_i62.RecordingFileProvider>(
-      () => _i62.RecordingFileProvider(gh<_i430.AudioFormatConfig>()),
     );
     gh.lazySingleton<_i948.SecureStorage>(
       () => _i816.FlutterSecureStorageAdapter(gh<_i558.FlutterSecureStorage>()),
@@ -154,20 +156,16 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i833.DeviceInfoPlugin>(),
       ),
     );
-    gh.lazySingleton<_i1038.VoiceTranscriptionService>(
-      () => _i1038.VoiceTranscriptionService(
-        gh<_i948.VoiceApi>(),
-        gh<_i1039.AudioRecorder>(),
-        gh<_i62.RecordingFileProvider>(),
-        gh<_i511.WakeLockService>(),
-        gh<_i430.AudioFormatConfig>(),
-      ),
-      dispose: (i) => i.dispose(),
-    );
     gh.lazySingleton<_i948.ImageSaver>(
       () => registerModule.imageSaver(
         galClient: gh<_i227.GalClient>(),
         fileSaveClient: gh<_i223.FileSaveClient>(),
+      ),
+    );
+    gh.lazySingleton<_i62.RecordingFileProvider>(
+      () => _i62.RecordingFileProvider(
+        audioFormat: gh<_i430.AudioFormatConfig>(),
+        temporaryDirectoryClient: gh<_i908.TemporaryDirectoryClient>(),
       ),
     );
     gh.lazySingleton<_i948.ImageClipboard>(
@@ -216,6 +214,16 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i553.FailureReporter>(
       () => _i534.CrashlyticsFailureReporter(gh<_i141.FirebaseCrashlytics>()),
+    );
+    gh.lazySingleton<_i1038.VoiceTranscriptionService>(
+      () => _i1038.VoiceTranscriptionService(
+        gh<_i948.VoiceApi>(),
+        gh<_i1039.AudioRecorder>(),
+        gh<_i62.RecordingFileProvider>(),
+        gh<_i511.WakeLockService>(),
+        gh<_i430.AudioFormatConfig>(),
+      ),
+      dispose: (i) => i.dispose(),
     );
     return this;
   }

--- a/client/app/lib/core/platform/temporary_directory_client.dart
+++ b/client/app/lib/core/platform/temporary_directory_client.dart
@@ -1,0 +1,36 @@
+import "dart:io";
+
+import "package:flutter/foundation.dart" show visibleForTesting;
+import "package:injectable/injectable.dart";
+import "package:path_provider/path_provider.dart" as path_provider;
+import "package:sesori_dart_core/logging.dart";
+
+typedef TemporaryDirectoryLoader = Future<Directory> Function();
+
+/// App-wide cached seam around path_provider's temporary-directory lookup.
+///
+/// Voice starts warming this client when its dependency graph is constructed as
+/// the composer mounts, so the platform call normally finishes before the
+/// user's first recording gesture.
+@lazySingleton
+class TemporaryDirectoryClient {
+  final TemporaryDirectoryLoader _load;
+  Future<Directory>? _directory;
+
+  TemporaryDirectoryClient() : this.forTesting(load: path_provider.getTemporaryDirectory);
+
+  @visibleForTesting
+  TemporaryDirectoryClient.forTesting({required TemporaryDirectoryLoader load}) : _load = load;
+
+  Future<Directory> get directory => _directory ??= _load();
+
+  Future<void> warmUp() async {
+    final resolution = directory;
+    try {
+      await resolution;
+    } catch (error, stackTrace) {
+      if (identical(_directory, resolution)) _directory = null;
+      logw("Failed to warm the temporary-directory cache", error, stackTrace);
+    }
+  }
+}

--- a/client/app/lib/core/platform/temporary_directory_client.dart
+++ b/client/app/lib/core/platform/temporary_directory_client.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:io";
 
 import "package:flutter/foundation.dart" show visibleForTesting;
@@ -22,14 +23,27 @@ class TemporaryDirectoryClient {
   @visibleForTesting
   TemporaryDirectoryClient.forTesting({required TemporaryDirectoryLoader load}) : _load = load;
 
-  Future<Directory> get directory => _directory ??= _load();
+  Future<Directory> get directory {
+    final cached = _directory;
+    if (cached != null) return cached;
+
+    final completer = Completer<Directory>();
+    final resolution = completer.future;
+    _directory = resolution;
+    Future<Directory>.sync(_load).then(
+      completer.complete,
+      onError: (Object error, StackTrace stackTrace) {
+        if (identical(_directory, resolution)) _directory = null;
+        completer.completeError(error, stackTrace);
+      },
+    );
+    return resolution;
+  }
 
   Future<void> warmUp() async {
-    final resolution = directory;
     try {
-      await resolution;
+      await directory;
     } catch (error, stackTrace) {
-      if (identical(_directory, resolution)) _directory = null;
       logw("Failed to warm the temporary-directory cache", error, stackTrace);
     }
   }

--- a/client/app/test/capabilities/voice/recording_file_provider_test.dart
+++ b/client/app/test/capabilities/voice/recording_file_provider_test.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:io";
 
 import "package:flutter_test/flutter_test.dart";
@@ -26,5 +27,27 @@ void main() {
     expect(firstPath, endsWith(".m4a"));
     expect(secondPath, startsWith("/tmp/sesori-recording-file-provider-test/sesori_voice_"));
     expect(directoryLoads, 1);
+  });
+
+  test("retries when recording starts as eager warm-up fails", () async {
+    final firstLoad = Completer<Directory>();
+    final recoveredDirectory = Directory("/tmp/sesori-recording-file-provider-recovered");
+    var directoryLoads = 0;
+    final temporaryDirectoryClient = TemporaryDirectoryClient.forTesting(
+      load: () {
+        directoryLoads++;
+        return directoryLoads == 1 ? firstLoad.future : Future.value(recoveredDirectory);
+      },
+    );
+    final provider = RecordingFileProvider(
+      audioFormat: AudioFormatConfig.forPlatform(isWeb: false),
+      temporaryDirectoryClient: temporaryDirectoryClient,
+    );
+
+    final path = provider.createRecordingPath();
+    firstLoad.completeError(StateError("temporary directory unavailable"));
+
+    expect(await path, startsWith("${recoveredDirectory.path}/sesori_voice_"));
+    expect(directoryLoads, 2);
   });
 }

--- a/client/app/test/capabilities/voice/recording_file_provider_test.dart
+++ b/client/app/test/capabilities/voice/recording_file_provider_test.dart
@@ -1,0 +1,30 @@
+import "dart:io";
+
+import "package:flutter_test/flutter_test.dart";
+import "package:sesori_mobile/capabilities/voice/audio_format_config.dart";
+import "package:sesori_mobile/capabilities/voice/recording_file_provider.dart";
+import "package:sesori_mobile/core/platform/temporary_directory_client.dart";
+
+void main() {
+  test("reuses the app-wide cached temporary directory", () async {
+    var directoryLoads = 0;
+    final temporaryDirectoryClient = TemporaryDirectoryClient.forTesting(
+      load: () async {
+        directoryLoads++;
+        return Directory("/tmp/sesori-recording-file-provider-test");
+      },
+    );
+    final provider = RecordingFileProvider(
+      audioFormat: AudioFormatConfig.forPlatform(isWeb: false),
+      temporaryDirectoryClient: temporaryDirectoryClient,
+    );
+
+    final firstPath = await provider.createRecordingPath();
+    final secondPath = await provider.createRecordingPath();
+
+    expect(firstPath, startsWith("/tmp/sesori-recording-file-provider-test/sesori_voice_"));
+    expect(firstPath, endsWith(".m4a"));
+    expect(secondPath, startsWith("/tmp/sesori-recording-file-provider-test/sesori_voice_"));
+    expect(directoryLoads, 1);
+  });
+}

--- a/client/app/test/core/platform/temporary_directory_client_test.dart
+++ b/client/app/test/core/platform/temporary_directory_client_test.dart
@@ -46,4 +46,44 @@ void main() {
     expect(await client.directory, same(recoveredDirectory));
     expect(loadCalls, 2);
   });
+
+  test("retries after a direct lookup failure", () async {
+    final recoveredDirectory = Directory("/tmp/sesori-temporary-directory-client-direct-retry");
+    var loadCalls = 0;
+
+    final client = TemporaryDirectoryClient.forTesting(
+      load: () {
+        loadCalls++;
+        if (loadCalls == 1) {
+          return Future.error(StateError("temporary directory unavailable"));
+        }
+        return Future.value(recoveredDirectory);
+      },
+    );
+
+    await expectLater(client.directory, throwsA(isA<StateError>()));
+
+    expect(await client.directory, same(recoveredDirectory));
+    expect(loadCalls, 2);
+  });
+
+  test("contains a synchronous warm-up failure", () async {
+    final recoveredDirectory = Directory("/tmp/sesori-temporary-directory-client-sync-retry");
+    var loadCalls = 0;
+
+    final client = TemporaryDirectoryClient.forTesting(
+      load: () {
+        loadCalls++;
+        if (loadCalls == 1) {
+          throw StateError("temporary directory unavailable");
+        }
+        return Future.value(recoveredDirectory);
+      },
+    );
+
+    await client.warmUp();
+
+    expect(await client.directory, same(recoveredDirectory));
+    expect(loadCalls, 2);
+  });
 }

--- a/client/app/test/core/platform/temporary_directory_client_test.dart
+++ b/client/app/test/core/platform/temporary_directory_client_test.dart
@@ -1,0 +1,49 @@
+import "dart:async";
+import "dart:io";
+
+import "package:flutter_test/flutter_test.dart";
+import "package:sesori_mobile/core/platform/temporary_directory_client.dart";
+
+void main() {
+  test("warms once and shares the result", () async {
+    final directory = Directory("/tmp/sesori-temporary-directory-client-test");
+    final loadCompleter = Completer<Directory>();
+    var loadCalls = 0;
+
+    final client = TemporaryDirectoryClient.forTesting(
+      load: () {
+        loadCalls++;
+        return loadCompleter.future;
+      },
+    );
+
+    final warmUp = client.warmUp();
+    expect(loadCalls, 1);
+    expect(identical(client.directory, client.directory), isTrue);
+
+    loadCompleter.complete(directory);
+    await warmUp;
+    expect(await client.directory, same(directory));
+    expect(loadCalls, 1);
+  });
+
+  test("retries after an eager lookup failure", () async {
+    final firstLoad = Completer<Directory>();
+    final recoveredDirectory = Directory("/tmp/sesori-temporary-directory-client-recovered");
+    var loadCalls = 0;
+
+    final client = TemporaryDirectoryClient.forTesting(
+      load: () {
+        loadCalls++;
+        return loadCalls == 1 ? firstLoad.future : Future.value(recoveredDirectory);
+      },
+    );
+
+    final warmUp = client.warmUp();
+    firstLoad.completeError(StateError("temporary directory unavailable"));
+    await warmUp;
+
+    expect(await client.directory, same(recoveredDirectory));
+    expect(loadCalls, 2);
+  });
+}


### PR DESCRIPTION
## Complexity

🌿 Straightforward: adds one app-wide platform client and wires it into the existing recording file provider.

## What

- Cache `path_provider`'s temporary-directory lookup in an injectable app-wide client.
- Eagerly warm the cache when the voice composer dependency graph is constructed.
- Clear failed synchronous or asynchronous lookups so later access can retry.
- Let a recording that races a failed warm-up retry directory resolution immediately.
- Cover cache sharing, failure recovery, and recording path reuse.

## Why

Temporary profiling found that the first voice recording spent 99.647 ms resolving the temporary directory before entering the native recorder. That avoidable platform call accounted for roughly one third of the measured first-start latency.

## Risk and test focus

The main risk is changing temporary-directory failure handling or recording path construction. Tests verify shared in-flight resolution, retries after warm-up and direct failures, synchronous-failure containment, and unchanged recording filename behavior. There is no database impact. The only intended user-visible impact is faster first voice recording startup.

The residual cold cost remains in native recorder startup and is intentionally out of scope here.

## Expected result

When the composer has mounted, recording path creation uses the already-resolved directory. In the simulator measurement, the first path stage dropped from 99.647 ms to 0.206 ms and total readiness dropped from 295.413 ms to 205.669 ms.

## Verification

- `flutter test test/capabilities/voice/voice_transcription_service_test.dart test/capabilities/voice/recording_file_provider_test.dart test/core/platform/temporary_directory_client_test.dart`
- `dart analyze`
