### PR TITLE
🌿 Exclude Codex projectless chats from project discovery

### DIFF
--- a/bridge/sesori_plugin_codex/lib/src/api/codex_rollout_api.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/codex_rollout_api.dart
@@ -6,6 +6,7 @@ import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show res
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart" show jsonDecodeMap;
 
+import "models/codex_desktop_state_dto.dart";
 import "models/codex_rollout_dto.dart";
 
 typedef CodexSessionIndexLine = ({CodexSessionIndexEntryDto? entry, String raw});
@@ -32,7 +33,7 @@ class CodexRolloutTailPosition {
   final List<int> trailingBytes;
 }
 
-/// Layer-1 filesystem boundary for Codex's on-disk rollout history.
+/// Layer-1 filesystem boundary for Codex's on-disk local state and rollout history.
 class CodexRolloutApi {
   CodexRolloutApi({Map<String, String>? environment}) : _environment = environment ?? Platform.environment;
 
@@ -54,6 +55,30 @@ class CodexRolloutApi {
   String? get sessionsDirectory {
     final home = codexHome;
     return home == null ? null : p.join(home, "sessions");
+  }
+
+  String? get desktopStatePath {
+    final home = codexHome;
+    return home == null ? null : p.join(home, ".codex-global-state.json");
+  }
+
+  String? get documentsCodexDirectory {
+    final home = resolveUserHomeDirectory(environment: _environment);
+    return home == null ? null : p.join(home, "Documents", "Codex");
+  }
+
+  CodexDesktopStateDto readDesktopState() {
+    final path = desktopStatePath;
+    if (path == null) {
+      return const CodexDesktopStateDto(projectlessThreadIds: {});
+    }
+    final file = File(path);
+    if (!file.existsSync()) {
+      return const CodexDesktopStateDto(projectlessThreadIds: {});
+    }
+    return CodexDesktopStateDto.fromJson(
+      jsonDecodeMap(file.readAsStringSync()),
+    );
   }
 
   List<CodexSessionIndexEntryDto> readSessionIndex() => [

--- a/bridge/sesori_plugin_codex/lib/src/api/codex_rollout_api.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/codex_rollout_api.dart
@@ -33,6 +33,15 @@ class CodexRolloutTailPosition {
   final List<int> trailingBytes;
 }
 
+class CodexDesktopStateReadException implements Exception {
+  const CodexDesktopStateReadException({required this.cause});
+
+  final Object cause;
+
+  @override
+  String toString() => "Codex Desktop state read failed (${cause.runtimeType})";
+}
+
 /// Layer-1 filesystem boundary for Codex's on-disk local state and rollout history.
 class CodexRolloutApi {
   CodexRolloutApi({Map<String, String>? environment}) : _environment = environment ?? Platform.environment;
@@ -67,18 +76,23 @@ class CodexRolloutApi {
     return home == null ? null : p.join(home, "Documents", "Codex");
   }
 
-  CodexDesktopStateDto readDesktopState() {
+  Future<CodexDesktopStateDto> readDesktopState() async {
     final path = desktopStatePath;
     if (path == null) {
       return const CodexDesktopStateDto(projectlessThreadIds: {});
     }
-    final file = File(path);
-    if (!file.existsSync()) {
+    try {
+      return CodexDesktopStateDto.fromJson(
+        jsonDecodeMap(await File(path).readAsString()),
+      );
+    } on PathNotFoundException {
       return const CodexDesktopStateDto(projectlessThreadIds: {});
+    } on Object catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        CodexDesktopStateReadException(cause: error),
+        stackTrace,
+      );
     }
-    return CodexDesktopStateDto.fromJson(
-      jsonDecodeMap(file.readAsStringSync()),
-    );
   }
 
   List<CodexSessionIndexEntryDto> readSessionIndex() => [

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_desktop_state_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_desktop_state_dto.dart
@@ -1,0 +1,33 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "codex_desktop_state_dto.freezed.dart";
+part "codex_desktop_state_dto.g.dart";
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CodexDesktopStateDto with _$CodexDesktopStateDto {
+  const factory CodexDesktopStateDto({
+    @JsonKey(name: "projectless-thread-ids")
+    @CodexProjectlessThreadIdsConverter()
+    required Set<String> projectlessThreadIds,
+  }) = _CodexDesktopStateDto;
+
+  factory CodexDesktopStateDto.fromJson(Map<String, dynamic> json) => _$CodexDesktopStateDtoFromJson(json);
+}
+
+/// Reads only useful string ids from Codex Desktop's independently-versioned
+/// state while ignoring missing, malformed, and future-shaped entries.
+class CodexProjectlessThreadIdsConverter implements JsonConverter<Set<String>, Object?> {
+  const CodexProjectlessThreadIdsConverter();
+
+  @override
+  Set<String> fromJson(Object? json) {
+    if (json is! List) return const {};
+    return {
+      for (final value in json)
+        if (value is String && value.trim().isNotEmpty) value.trim(),
+    };
+  }
+
+  @override
+  Object toJson(Set<String> object) => object.toList(growable: false);
+}

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_desktop_state_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_desktop_state_dto.freezed.dart
@@ -1,0 +1,149 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'codex_desktop_state_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$CodexDesktopStateDto {
+
+@JsonKey(name: "projectless-thread-ids")@CodexProjectlessThreadIdsConverter() Set<String> get projectlessThreadIds;
+/// Create a copy of CodexDesktopStateDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexDesktopStateDtoCopyWith<CodexDesktopStateDto> get copyWith => _$CodexDesktopStateDtoCopyWithImpl<CodexDesktopStateDto>(this as CodexDesktopStateDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexDesktopStateDto&&const DeepCollectionEquality().equals(other.projectlessThreadIds, projectlessThreadIds));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(projectlessThreadIds));
+
+@override
+String toString() {
+  return 'CodexDesktopStateDto(projectlessThreadIds: $projectlessThreadIds)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexDesktopStateDtoCopyWith<$Res>  {
+  factory $CodexDesktopStateDtoCopyWith(CodexDesktopStateDto value, $Res Function(CodexDesktopStateDto) _then) = _$CodexDesktopStateDtoCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: "projectless-thread-ids")@CodexProjectlessThreadIdsConverter() Set<String> projectlessThreadIds
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexDesktopStateDtoCopyWithImpl<$Res>
+    implements $CodexDesktopStateDtoCopyWith<$Res> {
+  _$CodexDesktopStateDtoCopyWithImpl(this._self, this._then);
+
+  final CodexDesktopStateDto _self;
+  final $Res Function(CodexDesktopStateDto) _then;
+
+/// Create a copy of CodexDesktopStateDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? projectlessThreadIds = null,}) {
+  return _then(_self.copyWith(
+projectlessThreadIds: null == projectlessThreadIds ? _self.projectlessThreadIds : projectlessThreadIds // ignore: cast_nullable_to_non_nullable
+as Set<String>,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexDesktopStateDto implements CodexDesktopStateDto {
+  const _CodexDesktopStateDto({@JsonKey(name: "projectless-thread-ids")@CodexProjectlessThreadIdsConverter() required final  Set<String> projectlessThreadIds}): _projectlessThreadIds = projectlessThreadIds;
+  factory _CodexDesktopStateDto.fromJson(Map<String, dynamic> json) => _$CodexDesktopStateDtoFromJson(json);
+
+ final  Set<String> _projectlessThreadIds;
+@override@JsonKey(name: "projectless-thread-ids")@CodexProjectlessThreadIdsConverter() Set<String> get projectlessThreadIds {
+  if (_projectlessThreadIds is EqualUnmodifiableSetView) return _projectlessThreadIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableSetView(_projectlessThreadIds);
+}
+
+
+/// Create a copy of CodexDesktopStateDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexDesktopStateDtoCopyWith<_CodexDesktopStateDto> get copyWith => __$CodexDesktopStateDtoCopyWithImpl<_CodexDesktopStateDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexDesktopStateDto&&const DeepCollectionEquality().equals(other._projectlessThreadIds, _projectlessThreadIds));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_projectlessThreadIds));
+
+@override
+String toString() {
+  return 'CodexDesktopStateDto(projectlessThreadIds: $projectlessThreadIds)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexDesktopStateDtoCopyWith<$Res> implements $CodexDesktopStateDtoCopyWith<$Res> {
+  factory _$CodexDesktopStateDtoCopyWith(_CodexDesktopStateDto value, $Res Function(_CodexDesktopStateDto) _then) = __$CodexDesktopStateDtoCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: "projectless-thread-ids")@CodexProjectlessThreadIdsConverter() Set<String> projectlessThreadIds
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexDesktopStateDtoCopyWithImpl<$Res>
+    implements _$CodexDesktopStateDtoCopyWith<$Res> {
+  __$CodexDesktopStateDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexDesktopStateDto _self;
+  final $Res Function(_CodexDesktopStateDto) _then;
+
+/// Create a copy of CodexDesktopStateDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? projectlessThreadIds = null,}) {
+  return _then(_CodexDesktopStateDto(
+projectlessThreadIds: null == projectlessThreadIds ? _self._projectlessThreadIds : projectlessThreadIds // ignore: cast_nullable_to_non_nullable
+as Set<String>,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_desktop_state_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_desktop_state_dto.g.dart
@@ -1,0 +1,14 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'codex_desktop_state_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_CodexDesktopStateDto _$CodexDesktopStateDtoFromJson(Map json) =>
+    _CodexDesktopStateDto(
+      projectlessThreadIds: const CodexProjectlessThreadIdsConverter().fromJson(
+        json['projectless-thread-ids'],
+      ),
+    );

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -566,11 +566,11 @@ class CodexPlugin implements CodexManagedApi {
   /// project list from these sessions. Each carries its real rollout cwd as its
   /// directory so the bridge groups it under the right project.
   ///
-  /// [knownDirectories] is unused: codex's rollout index already enumerates
-  /// every session globally, so the bridge's directory hints add nothing.
+  /// [knownDirectories] preserves sessions already attributed to stored
+  /// projects while discovery excludes new Codex Desktop projectless chats.
   @override
   Future<List<PluginSession>> listAllSessions({required Set<String> knownDirectories}) async =>
-      _sessionService.listAllSessions();
+      _sessionService.listAllSessions(knownDirectories: knownDirectories);
 
   @override
   String get launchDirectory => _projectCwd;

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_catalog_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_catalog_repository.dart
@@ -68,8 +68,12 @@ class CodexCatalogRepository {
 
   Future<List<CodexSessionRecord>> listSessionRecordsInIsolate() => Isolate.run(listSessionRecords);
 
-  Future<List<PluginSession>> listAllSessions() async {
-    final projectlessThreadIds = _readProjectlessThreadIds();
+  Future<List<PluginSession>> listAllSessions({required Set<String> knownDirectories}) async {
+    final projectlessThreadIds = await _readProjectlessThreadIds();
+    final normalizedKnownDirectories = {
+      for (final directory in knownDirectories)
+        if (directory.trim().isNotEmpty) normalizeProjectDirectory(directory: directory),
+    };
     final documentsCodexDirectory = _rolloutApi.documentsCodexDirectory;
     final excludedDirectory = documentsCodexDirectory == null
         ? null
@@ -81,6 +85,7 @@ class CodexCatalogRepository {
             record: record,
             projectlessThreadIds: projectlessThreadIds,
             documentsCodexDirectory: excludedDirectory,
+            knownDirectories: normalizedKnownDirectories,
           ),
         )
         .map(_toPluginSession)
@@ -179,12 +184,14 @@ class CodexCatalogRepository {
     }
   }
 
-  Set<String> _readProjectlessThreadIds() {
+  Future<Set<String>> _readProjectlessThreadIds() async {
     try {
-      return _rolloutApi.readDesktopState().projectlessThreadIds;
-    } on Object {
-      Log.d(
+      return (await _rolloutApi.readDesktopState()).projectlessThreadIds;
+    } on CodexDesktopStateReadException catch (error, stackTrace) {
+      Log.w(
         "[codex] Codex Desktop state is unreadable; continuing discovery without its projectless thread ids",
+        error,
+        stackTrace,
       );
       return const {};
     }
@@ -194,13 +201,16 @@ class CodexCatalogRepository {
     required CodexSessionRecord record,
     required Set<String> projectlessThreadIds,
     required String? documentsCodexDirectory,
+    required Set<String> knownDirectories,
   }) {
-    if (projectlessThreadIds.contains(record.id)) return true;
     final cwd = record.cwd?.trim();
-    if (documentsCodexDirectory == null || cwd == null || cwd.isEmpty) {
-      return false;
+    String? directory;
+    if (cwd != null && cwd.isNotEmpty) {
+      directory = normalizeProjectDirectory(directory: cwd);
+      if (knownDirectories.contains(directory)) return false;
     }
-    final directory = normalizeProjectDirectory(directory: cwd);
+    if (projectlessThreadIds.contains(record.id)) return true;
+    if (documentsCodexDirectory == null || directory == null) return false;
     return p.equals(directory, documentsCodexDirectory) || p.isWithin(documentsCodexDirectory, directory);
   }
 

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_catalog_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_catalog_repository.dart
@@ -69,8 +69,23 @@ class CodexCatalogRepository {
   Future<List<CodexSessionRecord>> listSessionRecordsInIsolate() => Isolate.run(listSessionRecords);
 
   Future<List<PluginSession>> listAllSessions() async {
+    final projectlessThreadIds = _readProjectlessThreadIds();
+    final documentsCodexDirectory = _rolloutApi.documentsCodexDirectory;
+    final excludedDirectory = documentsCodexDirectory == null
+        ? null
+        : normalizeProjectDirectory(directory: documentsCodexDirectory);
     final records = await listSessionRecordsInIsolate();
-    return records.map(_toPluginSession).nonNulls.toList(growable: false);
+    return records
+        .where(
+          (record) => !_isExcludedFromDiscovery(
+            record: record,
+            projectlessThreadIds: projectlessThreadIds,
+            documentsCodexDirectory: excludedDirectory,
+          ),
+        )
+        .map(_toPluginSession)
+        .nonNulls
+        .toList(growable: false);
   }
 
   /// Filters by normalized rollout CWD before applying pagination.
@@ -162,6 +177,31 @@ class CodexCatalogRepository {
       Log.w("[codex] failed to read the session index", error, stackTrace);
       return const [];
     }
+  }
+
+  Set<String> _readProjectlessThreadIds() {
+    try {
+      return _rolloutApi.readDesktopState().projectlessThreadIds;
+    } on Object {
+      Log.d(
+        "[codex] Codex Desktop state is unreadable; continuing discovery without its projectless thread ids",
+      );
+      return const {};
+    }
+  }
+
+  bool _isExcludedFromDiscovery({
+    required CodexSessionRecord record,
+    required Set<String> projectlessThreadIds,
+    required String? documentsCodexDirectory,
+  }) {
+    if (projectlessThreadIds.contains(record.id)) return true;
+    final cwd = record.cwd?.trim();
+    if (documentsCodexDirectory == null || cwd == null || cwd.isEmpty) {
+      return false;
+    }
+    final directory = normalizeProjectDirectory(directory: cwd);
+    return p.equals(directory, documentsCodexDirectory) || p.isWithin(documentsCodexDirectory, directory);
   }
 
   _CodexSessionMetadata? _readMetadata(String rolloutPath) {

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
@@ -61,7 +61,8 @@ class CodexSessionService {
     _threadModels.clear();
   }
 
-  Future<List<PluginSession>> listAllSessions() => _catalogRepository.listAllSessions();
+  Future<List<PluginSession>> listAllSessions({required Set<String> knownDirectories}) =>
+      _catalogRepository.listAllSessions(knownDirectories: knownDirectories);
 
   Future<List<PluginSession>> getSessions({
     required String projectId,

--- a/bridge/sesori_plugin_codex/test/codex_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_catalog_repository_test.dart
@@ -39,7 +39,7 @@ void main() {
         ],
       );
 
-      final sessions = await repository.listAllSessions();
+      final sessions = await repository.listAllSessions(knownDirectories: const {});
 
       expect(sessions, hasLength(1));
       expect(sessions[0].id, "session-with-cwd");
@@ -113,30 +113,40 @@ void main() {
       final userHome = p.join(Directory.systemTemp.path, "codex-discovery-user");
       final documentsCodex = p.join(userHome, "Documents", "Codex");
       final generatedChat = p.join(documentsCodex, "2026-08-01", "new-chat-2");
+      final existingGeneratedChat = p.join(documentsCodex, "2026-08-01", "existing-chat");
       final normalProject = p.join(userHome, "repos", "app");
+      final existingStateProject = p.join(userHome, "repos", "existing-projectless");
       final dateShapedProject = p.join(userHome, "repos", "2026-08-01", "small-slug");
       final similarlyNamedProject = p.join(userHome, "Documents", "Codexical", "app");
       final repository = _DiscoveryStubCodexCatalogRepository(
         rolloutApi: _DiscoveryRolloutApi(
           documentsCodexDirectory: documentsCodex,
-          projectlessThreadIds: const {"state-filtered"},
+          projectlessThreadIds: const {"state-filtered", "existing-state-filtered"},
           desktopStateError: null,
         ),
         records: [
           _record(id: "generated-root", cwd: documentsCodex, title: "Generated root"),
           _record(id: "generated-child", cwd: generatedChat, title: "Generated child"),
+          _record(id: "existing-generated", cwd: existingGeneratedChat, title: "Existing generated"),
           _record(id: "state-filtered", cwd: normalProject, title: "Projectless elsewhere"),
+          _record(
+            id: "existing-state-filtered",
+            cwd: existingStateProject,
+            title: "Existing projectless elsewhere",
+          ),
           _record(id: "normal", cwd: normalProject, title: "Normal"),
           _record(id: "date-shaped", cwd: dateShapedProject, title: "Date shaped"),
           _record(id: "similar-name", cwd: similarlyNamedProject, title: "Similar name"),
         ],
       );
 
-      final discovered = await repository.listAllSessions();
+      final discovered = await repository.listAllSessions(
+        knownDirectories: {existingGeneratedChat, existingStateProject},
+      );
 
       expect(
         discovered.map((session) => session.id),
-        ["normal", "date-shaped", "similar-name"],
+        ["existing-generated", "existing-state-filtered", "normal", "date-shaped", "similar-name"],
       );
       expect(
         (await repository.getSessions(projectId: generatedChat, start: null, limit: null)).map(
@@ -166,7 +176,7 @@ void main() {
         ],
       );
 
-      final discovered = await repository.listAllSessions();
+      final discovered = await repository.listAllSessions(knownDirectories: const {});
 
       expect(discovered.map((session) => session.id), ["normal"]);
     });
@@ -236,9 +246,11 @@ class _DiscoveryRolloutApi extends CodexRolloutApi {
   final Object? desktopStateError;
 
   @override
-  CodexDesktopStateDto readDesktopState() {
+  Future<CodexDesktopStateDto> readDesktopState() async {
     final error = desktopStateError;
-    if (error != null) throw error;
+    if (error != null) {
+      throw CodexDesktopStateReadException(cause: error);
+    }
     return CodexDesktopStateDto(
       projectlessThreadIds: projectlessThreadIds,
     );

--- a/bridge/sesori_plugin_codex/test/codex_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_catalog_repository_test.dart
@@ -1,9 +1,11 @@
 import "dart:io";
 
 import "package:codex_plugin/src/api/codex_rollout_api.dart";
+import "package:codex_plugin/src/api/models/codex_desktop_state_dto.dart";
 import "package:codex_plugin/src/api/models/codex_rollout_dto.dart";
 import "package:codex_plugin/src/repositories/codex_catalog_repository.dart";
 import "package:codex_plugin/src/repositories/models/codex_session_record.dart";
+import "package:path/path.dart" as p;
 import "package:test/test.dart";
 
 void main() {
@@ -107,6 +109,68 @@ void main() {
       );
     });
 
+    test("discovery excludes projectless ids and every session under Documents/Codex", () async {
+      final userHome = p.join(Directory.systemTemp.path, "codex-discovery-user");
+      final documentsCodex = p.join(userHome, "Documents", "Codex");
+      final generatedChat = p.join(documentsCodex, "2026-08-01", "new-chat-2");
+      final normalProject = p.join(userHome, "repos", "app");
+      final dateShapedProject = p.join(userHome, "repos", "2026-08-01", "small-slug");
+      final similarlyNamedProject = p.join(userHome, "Documents", "Codexical", "app");
+      final repository = _DiscoveryStubCodexCatalogRepository(
+        rolloutApi: _DiscoveryRolloutApi(
+          documentsCodexDirectory: documentsCodex,
+          projectlessThreadIds: const {"state-filtered"},
+          desktopStateError: null,
+        ),
+        records: [
+          _record(id: "generated-root", cwd: documentsCodex, title: "Generated root"),
+          _record(id: "generated-child", cwd: generatedChat, title: "Generated child"),
+          _record(id: "state-filtered", cwd: normalProject, title: "Projectless elsewhere"),
+          _record(id: "normal", cwd: normalProject, title: "Normal"),
+          _record(id: "date-shaped", cwd: dateShapedProject, title: "Date shaped"),
+          _record(id: "similar-name", cwd: similarlyNamedProject, title: "Similar name"),
+        ],
+      );
+
+      final discovered = await repository.listAllSessions();
+
+      expect(
+        discovered.map((session) => session.id),
+        ["normal", "date-shaped", "similar-name"],
+      );
+      expect(
+        (await repository.getSessions(projectId: generatedChat, start: null, limit: null)).map(
+          (session) => session.id,
+        ),
+        ["generated-child"],
+        reason: "discovery filtering must not remove direct access to an already-known session",
+      );
+    });
+
+    test("discovery keeps using the Documents/Codex filter when desktop state is unreadable", () async {
+      final userHome = p.join(Directory.systemTemp.path, "codex-unreadable-state-user");
+      final documentsCodex = p.join(userHome, "Documents", "Codex");
+      final repository = _DiscoveryStubCodexCatalogRepository(
+        rolloutApi: _DiscoveryRolloutApi(
+          documentsCodexDirectory: documentsCodex,
+          projectlessThreadIds: const {},
+          desktopStateError: const FormatException("malformed state"),
+        ),
+        records: [
+          _record(
+            id: "generated",
+            cwd: p.join(documentsCodex, "2026-08-01", "chat"),
+            title: "Generated",
+          ),
+          _record(id: "normal", cwd: p.join(userHome, "repos", "app"), title: "Normal"),
+        ],
+      );
+
+      final discovered = await repository.listAllSessions();
+
+      expect(discovered.map((session) => session.id), ["normal"]);
+    });
+
     test("keeps the index entry when rollout deletion fails", () {
       final rolloutApi = _DeleteFailingRolloutApi();
       final repository = CodexCatalogRepository(rolloutApi: rolloutApi);
@@ -145,6 +209,40 @@ class _StubCodexCatalogRepository extends CodexCatalogRepository {
 
   @override
   Future<List<CodexSessionRecord>> listSessionRecordsInIsolate() async => records;
+}
+
+class _DiscoveryStubCodexCatalogRepository extends CodexCatalogRepository {
+  _DiscoveryStubCodexCatalogRepository({
+    required super.rolloutApi,
+    required this.records,
+  });
+
+  final List<CodexSessionRecord> records;
+
+  @override
+  Future<List<CodexSessionRecord>> listSessionRecordsInIsolate() async => records;
+}
+
+class _DiscoveryRolloutApi extends CodexRolloutApi {
+  _DiscoveryRolloutApi({
+    required this.documentsCodexDirectory,
+    required this.projectlessThreadIds,
+    required this.desktopStateError,
+  }) : super(environment: const {});
+
+  @override
+  final String? documentsCodexDirectory;
+  final Set<String> projectlessThreadIds;
+  final Object? desktopStateError;
+
+  @override
+  CodexDesktopStateDto readDesktopState() {
+    final error = desktopStateError;
+    if (error != null) throw error;
+    return CodexDesktopStateDto(
+      projectlessThreadIds: projectlessThreadIds,
+    );
+  }
 }
 
 class _DeleteFailingRolloutApi extends CodexRolloutApi {

--- a/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
@@ -47,6 +47,57 @@ void main() {
       expect(rolloutApi.readSessionIndex(), isEmpty);
     });
 
+    test("desktop state tolerantly extracts only non-empty projectless thread ids", () {
+      File(p.join(codexHome.path, ".codex-global-state.json")).writeAsStringSync(
+        jsonEncode({
+          "future-field": {"nested": true},
+          "projectless-thread-ids": [
+            " projectless-one ",
+            42,
+            null,
+            "",
+            {"future": "shape"},
+            "projectless-two",
+            "projectless-one",
+          ],
+        }),
+      );
+
+      expect(
+        rolloutApi.readDesktopState().projectlessThreadIds,
+        {"projectless-one", "projectless-two"},
+      );
+    });
+
+    test("desktop state treats a missing or future-shaped projectless field as empty", () {
+      final state = File(p.join(codexHome.path, ".codex-global-state.json"));
+      for (final contents in [
+        jsonEncode({"future-field": true}),
+        jsonEncode({
+          "projectless-thread-ids": {"future": "shape"},
+        }),
+      ]) {
+        state.writeAsStringSync(contents);
+        expect(rolloutApi.readDesktopState().projectlessThreadIds, isEmpty);
+      }
+    });
+
+    test("resolves the generated Codex chats directory from the user home", () {
+      final userHome = p.join(codexHome.path, "user-home");
+      final api = CodexRolloutApi(
+        environment: {
+          "CODEX_HOME": codexHome.path,
+          "HOME": userHome,
+          "USERPROFILE": userHome,
+        },
+      );
+
+      expect(
+        api.documentsCodexDirectory,
+        p.join(userHome, "Documents", "Codex"),
+      );
+    });
+
     test("readIndex decodes JSON lines and skips malformed JSON", () {
       final index = File(p.join(codexHome.path, "session_index.jsonl"))
         ..writeAsStringSync(

--- a/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
@@ -47,7 +47,7 @@ void main() {
       expect(rolloutApi.readSessionIndex(), isEmpty);
     });
 
-    test("desktop state tolerantly extracts only non-empty projectless thread ids", () {
+    test("desktop state tolerantly extracts only non-empty projectless thread ids", () async {
       File(p.join(codexHome.path, ".codex-global-state.json")).writeAsStringSync(
         jsonEncode({
           "future-field": {"nested": true},
@@ -64,12 +64,13 @@ void main() {
       );
 
       expect(
-        rolloutApi.readDesktopState().projectlessThreadIds,
+        (await rolloutApi.readDesktopState()).projectlessThreadIds,
         {"projectless-one", "projectless-two"},
       );
     });
 
-    test("desktop state treats a missing or future-shaped projectless field as empty", () {
+    test("desktop state treats a missing or future-shaped projectless field as empty", () async {
+      expect((await rolloutApi.readDesktopState()).projectlessThreadIds, isEmpty);
       final state = File(p.join(codexHome.path, ".codex-global-state.json"));
       for (final contents in [
         jsonEncode({"future-field": true}),
@@ -78,8 +79,27 @@ void main() {
         }),
       ]) {
         state.writeAsStringSync(contents);
-        expect(rolloutApi.readDesktopState().projectlessThreadIds, isEmpty);
+        expect((await rolloutApi.readDesktopState()).projectlessThreadIds, isEmpty);
       }
+    });
+
+    test("desktop state read failures retain a privacy-safe cause", () async {
+      File(p.join(codexHome.path, ".codex-global-state.json")).writeAsStringSync(
+        '{"projectless-thread-ids":["private-thread-id"',
+      );
+
+      await expectLater(
+        rolloutApi.readDesktopState(),
+        throwsA(
+          isA<CodexDesktopStateReadException>()
+              .having((error) => error.cause, "cause", isA<FormatException>())
+              .having(
+                (error) => error.toString(),
+                "presentation",
+                isNot(contains("private-thread-id")),
+              ),
+        ),
+      );
     });
 
     test("resolves the generated Codex chats directory from the user home", () {


### PR DESCRIPTION
## Complexity

🌿 Straightforward plugin-local discovery filtering with a tolerant external-state decoder.

## What

- Read Codex Desktop's `projectless-thread-ids` from `$CODEX_HOME/.codex-global-state.json` through a narrow typed DTO that ignores missing, mixed, and future-shaped values.
- Exclude those thread IDs and every session rooted at or below the resolved user's `Documents/Codex` directory from `listAllSessions()` project discovery.
- Keep `getSessions()`, direct transcript access, resume, rename, and deletion behavior unchanged.

## Why

Codex Desktop now creates standalone chats in generated `Documents/Codex/<date>/<slug>` workspaces. Sesori derives Codex projects from rollout working directories, so each standalone chat was incorrectly imported as a separate project.

## Risk and test focus

- The `Documents/Codex` exclusion is intentionally broad; legitimate projects stored there are not newly discovered.
- Missing or malformed Desktop state fails open for the ID filter without exposing JSON contents or thread IDs in logs.
- Date-shaped directories outside `Documents/Codex` remain discoverable.
- There is no database migration, projection-version bump, catalog pruning, or retroactive hiding. Existing persisted projects and sessions remain unchanged.

## Expected result

New Codex catalog discoveries no longer create Sesori projects for standalone Codex chats, while already-known sessions remain directly accessible and existing catalog rows remain untouched.

## Verification

- `dart pub get` from `bridge/`
- `dart test` from `bridge/sesori_plugin_codex/` (237 tests)
- `dart analyze --fatal-infos` from `bridge/sesori_plugin_codex/`
- Architecture implementation review: approved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop importing standalone Codex Desktop chats as projects by excluding projectless thread IDs and anything under the `Documents/Codex` directory during discovery, while preserving sessions already linked to known project directories. Existing sessions remain accessible and catalog entries stay unchanged.

- **Bug Fixes**
  - Read `projectless-thread-ids` from `$CODEX_HOME/.codex-global-state.json` using a tolerant DTO that ignores missing or future-shaped values.
  - Update `listAllSessions()` to exclude sessions under the user's `Documents/Codex` and any listed projectless thread IDs, and accept `knownDirectories` to keep already-attributed sessions visible.
  - Continue discovery if Desktop state is unreadable and still apply the `Documents/Codex` filter; keep `getSessions()`, direct transcript access, resume, rename, and deletion unchanged.

<sup>Written for commit 49ef3fd1bf23030996def4ffd4c5ef2414c6bd11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

