### PR TITLE
🌱 Keep voice transcripts scrolled to the end

### DIFF
--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -88,6 +88,7 @@ class _PromptInputState extends State<PromptInput> {
   static const _draftCalculator = ComposerDraftCalculator();
   static const _minimumRecordingDuration = Duration(milliseconds: 200);
   final _controller = TextEditingController();
+  final _textScrollController = ScrollController();
   final _focusNode = FocusNode();
   late ComposerDraft _draft;
   late TextEditingValue _previousEditingValue;
@@ -178,6 +179,7 @@ class _PromptInputState extends State<PromptInput> {
     }
     _cancelDragProgress.dispose();
     _controller.dispose();
+    _textScrollController.dispose();
     _focusNode.dispose();
     super.dispose();
   }
@@ -497,6 +499,7 @@ class _PromptInputState extends State<PromptInput> {
         transcript: transcript,
       );
       _applyDraft(draft: nextDraft);
+      _scrollToDraftEndAfterLayout();
       widget.onVoiceTranscriptionCompleted();
       // Text-first raises the keyboard so the transcript can be extended
       // right away. Voice-first rests the transcript in the typing container
@@ -541,6 +544,13 @@ class _PromptInputState extends State<PromptInput> {
     _isApplyingDraft = false;
     _hasText = draft.text.trim().isNotEmpty;
     widget.onDraftChanged(draft);
+  }
+
+  void _scrollToDraftEndAfterLayout() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_textScrollController.hasClients) return;
+      _textScrollController.jumpTo(_textScrollController.position.maxScrollExtent);
+    });
   }
 
   /// Discards the running voice interaction: a drag released on the cancel
@@ -1040,6 +1050,7 @@ class _PromptInputState extends State<PromptInput> {
                   },
                   child: TextField(
                     controller: _controller,
+                    scrollController: _textScrollController,
                     focusNode: _focusNode,
                     minLines: 1,
                     maxLines: 6,

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -1346,4 +1346,26 @@ void main() {
     expect(composerFocus(tester).hasFocus, isFalse);
     expect(find.text("Hold to talk more"), findsOneWidget);
   });
+
+  testWidgets("long voice-first transcript rests scrolled to its end without focus", (tester) async {
+    final transcript = List.generate(80, (index) => "dictated phrase $index").join(" ");
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) async => transcript);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
+    await tester.pump(const Duration(milliseconds: 600));
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    final editable = tester.widget<EditableText>(find.byType(EditableText));
+    final scrollController = editable.scrollController!;
+    expect(editable.focusNode.hasFocus, isFalse);
+    expect(editable.controller.selection, TextSelection.collapsed(offset: transcript.length));
+    expect(scrollController.position.maxScrollExtent, greaterThan(0));
+    expect(scrollController.offset, scrollController.position.maxScrollExtent);
+  });
 }


### PR DESCRIPTION
## Complexity

🌱 Trivial. This is a localized Flutter composer viewport change.

## What

- Give the multiline composer field an owned scroll controller.
- Move its viewport to the bottom after a completed voice transcript has laid out.
- Add a widget regression test covering a long, unfocused voice-first transcript.

## Why

Voice-first transcripts are inserted while the text field is not mounted. Although the selection is already placed at the end, Flutter initially presents the beginning when the unfocused field mounts, hiding the newest dictated words.

## Risk and test focus

Risk is low and limited to the composer text viewport. The regression test verifies that a long transcript has overflow, rests at the bottom with its selection at the end, and does not focus the field. New-session and existing-session composers share this widget. There is no database or wire-contract impact.

## Expected result

After speech transcription completes, the composer previews the end of the message where further typing or dictation will append, while voice-first mode continues to keep the keyboard hidden.

## Verification

- `flutter test test/features/session_detail/widgets/session_detail_body_test.dart`
- `dart analyze` in `client/app`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep voice-first transcripts scrolled to the end in the composer so the latest dictated words are visible without focusing the field.

- **Bug Fixes**
  - Added a dedicated `ScrollController` to the multiline `TextField` and scroll to max extent after layout when transcription completes.
  - Ensures selection is at the end and the field stays unfocused (keyboard remains hidden).
  - Added a widget test for long, unfocused voice-first transcripts.

<sup>Written for commit 57eee3f11b84061acde0671e023e60a2b0c83fbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

