### PR TITLE
[output-image-support] feat(acp): surface live message images [step 10/13]

### DIFF
--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -35,7 +35,7 @@
 | [x] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | [PR #657](https://github.com/sesori-ai/sesori_apps_monorepo/pull/657) merged as `4ca1cb90`; 589 changed lines |
 | [x] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | [PR #658](https://github.com/sesori-ai/sesori_apps_monorepo/pull/658) merged as `a973796c`; 1,119 changed lines |
 | [x] | 9/13 | `output-image-support-acp-content-mapping` | `[output-image-support] refactor(acp): centralize tool content mapping [step 9/13]` | 1,100-1,500 | [PR #661](https://github.com/sesori-ai/sesori_apps_monorepo/pull/661) merged as `f5f24240`; 879 changed lines |
-| [ ] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666) open; 714 changed lines |
+| [ ] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666) open; 951 changed lines |
 | [ ] | 11/13 | `output-image-support-acp-tool-images` | `[output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | Blocked on Step 10 merge |
 | [ ] | 12/13 | `output-image-support-acp-image-replay` | `[output-image-support] feat(acp): restore output image replay [step 12/13]` | 900-1,400 | Blocked on Step 11 merge |
 | [ ] | 13/13 | `output-image-support-retire-plan` | `[output-image-support] docs: retire output image support plan [step 13/13]` | 50-200 | Blocked on Step 12 merge |
@@ -194,8 +194,15 @@
   `dart pub get`, fatal analysis in both packages, and
   `git diff --cached --check` pass. `aristotle-impl-review` approved with no
   findings. Analytics remain excluded because passive image rendering has no
-  authoritative user action or product-decision event. The 714 changed-line
-  diff is below the 1,500-line soft cap; no neighboring scope was combined.
+  authoritative user action or product-decision event. PR review added
+  message-scoped malformed-warning deduplication, skips unrenderable replay
+  drafts, stores payload-free replay image boundaries until Step 12, and aligned
+  new helper signatures with named-parameter rules. A second architecture pass
+  found replay was not sharing that mapping scope; replay now retains a pending
+  tracker scope without creating a draft until renderable content arrives. All
+  84 focused ACP tests, 8 Cursor mapper tests, and fatal analysis in both
+  packages pass. The 951 changed-line diff is below the 1,500-line soft cap; no
+  neighboring scope was combined.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -5,10 +5,10 @@
 - **Plan slug:** `output-image-support`
 - **Implementation base:** `origin/main` at
   `f5f24240bb49be17313f7f2748720f8399523e23`
-- **Series state:** Step 10/13 ready for PR
+- **Series state:** Step 10/13 open as [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666)
 - **Current step:** Step 10/13 — surface live ACP message images
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** raise Step 10/13 for review
+- **Next action:** monitor PR #666 and address CI or review findings
 
 ## Plan Review
 
@@ -35,7 +35,7 @@
 | [x] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | [PR #657](https://github.com/sesori-ai/sesori_apps_monorepo/pull/657) merged as `4ca1cb90`; 589 changed lines |
 | [x] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | [PR #658](https://github.com/sesori-ai/sesori_apps_monorepo/pull/658) merged as `a973796c`; 1,119 changed lines |
 | [x] | 9/13 | `output-image-support-acp-content-mapping` | `[output-image-support] refactor(acp): centralize tool content mapping [step 9/13]` | 1,100-1,500 | [PR #661](https://github.com/sesori-ai/sesori_apps_monorepo/pull/661) merged as `f5f24240`; 879 changed lines |
-| [ ] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | Ready for PR; 714 changed lines |
+| [ ] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666) open; 714 changed lines |
 | [ ] | 11/13 | `output-image-support-acp-tool-images` | `[output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | Blocked on Step 10 merge |
 | [ ] | 12/13 | `output-image-support-acp-image-replay` | `[output-image-support] feat(acp): restore output image replay [step 12/13]` | 900-1,400 | Blocked on Step 11 merge |
 | [ ] | 13/13 | `output-image-support-retire-plan` | `[output-image-support] docs: retire output image support plan [step 13/13]` | 50-200 | Blocked on Step 12 merge |

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -35,7 +35,7 @@
 | [x] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | [PR #657](https://github.com/sesori-ai/sesori_apps_monorepo/pull/657) merged as `4ca1cb90`; 589 changed lines |
 | [x] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | [PR #658](https://github.com/sesori-ai/sesori_apps_monorepo/pull/658) merged as `a973796c`; 1,119 changed lines |
 | [x] | 9/13 | `output-image-support-acp-content-mapping` | `[output-image-support] refactor(acp): centralize tool content mapping [step 9/13]` | 1,100-1,500 | [PR #661](https://github.com/sesori-ai/sesori_apps_monorepo/pull/661) merged as `f5f24240`; 879 changed lines |
-| [ ] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666) open; 1,096 changed lines |
+| [ ] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666) open; 1,138 changed lines |
 | [ ] | 11/13 | `output-image-support-acp-tool-images` | `[output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | Blocked on Step 10 merge |
 | [ ] | 12/13 | `output-image-support-acp-image-replay` | `[output-image-support] feat(acp): restore output image replay [step 12/13]` | 900-1,400 | Blocked on Step 11 merge |
 | [ ] | 13/13 | `output-image-support-retire-plan` | `[output-image-support] docs: retire output image support plan [step 13/13]` | 50-200 | Blocked on Step 12 merge |
@@ -190,8 +190,8 @@
   Step 12. Mixed order, stable suffixes, count/aggregate limits, privacy-safe
   warning deduplication, message/turn identity, id-less tool boundaries, halt
   behavior, and Cursor standard-versus-extension behavior have focused coverage.
-  All 71 focused ACP tests, all 179 ACP tests, all 109 Cursor tests,
-  `dart pub get`, fatal analysis in both packages, and
+  Initial verification included the focused ACP suite, all 179 ACP tests, all
+  109 Cursor tests, `dart pub get`, fatal analysis in both packages, and
   `git diff --cached --check` pass. `aristotle-impl-review` approved with no
   findings. Analytics remain excluded because passive image rendering has no
   authoritative user action or product-decision event. PR review added
@@ -199,15 +199,16 @@
   drafts, stores payload-free replay image boundaries until Step 12, and aligned
   new helper signatures with named-parameter rules. A second architecture pass
   found replay was not sharing that mapping scope; replay now retains a pending
-  tracker scope without creating a draft until renderable content arrives. All
-  review also made explicit messages close prior id-less envelopes, limited
+  tracker scope without creating a draft until renderable content arrives.
+  Further review also made explicit messages close prior id-less envelopes, limited
   atomic live halt recognition to id-less backend notices that cannot receive a
   later image chunk, and tracks text-only versus mixed composition symmetrically
   for replay halt decisions. The latest review also made malformed replay
-  discriminators fail-soft and keeps identified halt-like messages as assistant
-  content in both live and replay. All 89 focused ACP tests, 8 Cursor mapper
-  tests, and fatal analysis in both packages pass. The 1,096 changed-line diff is
-  below the 1,500-line soft cap; no neighboring scope was combined.
+  discriminators fail-soft, keeps identified halt-like messages as assistant
+  content in both live and replay, and resets unrendered id-less tracker state at
+  message boundaries. All 90 focused ACP tests, 8 Cursor mapper tests, and fatal
+  analysis in both packages pass. The 1,138 changed-line diff is below the
+  1,500-line soft cap; no neighboring scope was combined.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -35,7 +35,7 @@
 | [x] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | [PR #657](https://github.com/sesori-ai/sesori_apps_monorepo/pull/657) merged as `4ca1cb90`; 589 changed lines |
 | [x] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | [PR #658](https://github.com/sesori-ai/sesori_apps_monorepo/pull/658) merged as `a973796c`; 1,119 changed lines |
 | [x] | 9/13 | `output-image-support-acp-content-mapping` | `[output-image-support] refactor(acp): centralize tool content mapping [step 9/13]` | 1,100-1,500 | [PR #661](https://github.com/sesori-ai/sesori_apps_monorepo/pull/661) merged as `f5f24240`; 879 changed lines |
-| [ ] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666) open; 951 changed lines |
+| [ ] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666) open; 1,059 changed lines |
 | [ ] | 11/13 | `output-image-support-acp-tool-images` | `[output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | Blocked on Step 10 merge |
 | [ ] | 12/13 | `output-image-support-acp-image-replay` | `[output-image-support] feat(acp): restore output image replay [step 12/13]` | 900-1,400 | Blocked on Step 11 merge |
 | [ ] | 13/13 | `output-image-support-retire-plan` | `[output-image-support] docs: retire output image support plan [step 13/13]` | 50-200 | Blocked on Step 12 merge |
@@ -200,9 +200,12 @@
   new helper signatures with named-parameter rules. A second architecture pass
   found replay was not sharing that mapping scope; replay now retains a pending
   tracker scope without creating a draft until renderable content arrives. All
-  84 focused ACP tests, 8 Cursor mapper tests, and fatal analysis in both
-  packages pass. The 951 changed-line diff is below the 1,500-line soft cap; no
-  neighboring scope was combined.
+  review also made explicit messages close prior id-less envelopes, limited
+  atomic live halt recognition to id-less backend notices that cannot receive a
+  later image chunk, and tracks text-only versus mixed composition symmetrically
+  for replay halt decisions. All 87 focused ACP tests, 8 Cursor mapper tests,
+  and fatal analysis in both packages pass. The 1,059 changed-line diff is below
+  the 1,500-line soft cap; no neighboring scope was combined.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -35,7 +35,7 @@
 | [x] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | [PR #657](https://github.com/sesori-ai/sesori_apps_monorepo/pull/657) merged as `4ca1cb90`; 589 changed lines |
 | [x] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | [PR #658](https://github.com/sesori-ai/sesori_apps_monorepo/pull/658) merged as `a973796c`; 1,119 changed lines |
 | [x] | 9/13 | `output-image-support-acp-content-mapping` | `[output-image-support] refactor(acp): centralize tool content mapping [step 9/13]` | 1,100-1,500 | [PR #661](https://github.com/sesori-ai/sesori_apps_monorepo/pull/661) merged as `f5f24240`; 879 changed lines |
-| [ ] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666) open; 1,059 changed lines |
+| [ ] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666) open; 1,096 changed lines |
 | [ ] | 11/13 | `output-image-support-acp-tool-images` | `[output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | Blocked on Step 10 merge |
 | [ ] | 12/13 | `output-image-support-acp-image-replay` | `[output-image-support] feat(acp): restore output image replay [step 12/13]` | 900-1,400 | Blocked on Step 11 merge |
 | [ ] | 13/13 | `output-image-support-retire-plan` | `[output-image-support] docs: retire output image support plan [step 13/13]` | 50-200 | Blocked on Step 12 merge |
@@ -203,9 +203,11 @@
   review also made explicit messages close prior id-less envelopes, limited
   atomic live halt recognition to id-less backend notices that cannot receive a
   later image chunk, and tracks text-only versus mixed composition symmetrically
-  for replay halt decisions. All 87 focused ACP tests, 8 Cursor mapper tests,
-  and fatal analysis in both packages pass. The 1,059 changed-line diff is below
-  the 1,500-line soft cap; no neighboring scope was combined.
+  for replay halt decisions. The latest review also made malformed replay
+  discriminators fail-soft and keeps identified halt-like messages as assistant
+  content in both live and replay. All 89 focused ACP tests, 8 Cursor mapper
+  tests, and fatal analysis in both packages pass. The 1,096 changed-line diff is
+  below the 1,500-line soft cap; no neighboring scope was combined.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -4,11 +4,11 @@
 
 - **Plan slug:** `output-image-support`
 - **Implementation base:** `origin/main` at
-  `a973796cc337f37370921f4c85428b3965472ddb`
-- **Series state:** Step 9/13 open as [PR #661](https://github.com/sesori-ai/sesori_apps_monorepo/pull/661)
-- **Current step:** Step 9/13 — centralize ACP tool content mapping
+  `f5f24240bb49be17313f7f2748720f8399523e23`
+- **Series state:** Step 10/13 ready for PR
+- **Current step:** Step 10/13 — surface live ACP message images
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** monitor PR #661 and address CI or review findings
+- **Next action:** raise Step 10/13 for review
 
 ## Plan Review
 
@@ -34,8 +34,8 @@
 | [x] | 6/13 | `output-image-support-codex-live-images` | `[output-image-support] feat(codex): surface live output images [step 6/13]` | 900-1,400 | [PR #652](https://github.com/sesori-ai/sesori_apps_monorepo/pull/652) merged as `737226d8`; 830 changed lines |
 | [x] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | [PR #657](https://github.com/sesori-ai/sesori_apps_monorepo/pull/657) merged as `4ca1cb90`; 589 changed lines |
 | [x] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | [PR #658](https://github.com/sesori-ai/sesori_apps_monorepo/pull/658) merged as `a973796c`; 1,119 changed lines |
-| [ ] | 9/13 | `output-image-support-acp-content-mapping` | `[output-image-support] refactor(acp): centralize tool content mapping [step 9/13]` | 1,100-1,500 | [PR #661](https://github.com/sesori-ai/sesori_apps_monorepo/pull/661) open; 879 changed lines |
-| [ ] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | Blocked on Step 9 merge |
+| [x] | 9/13 | `output-image-support-acp-content-mapping` | `[output-image-support] refactor(acp): centralize tool content mapping [step 9/13]` | 1,100-1,500 | [PR #661](https://github.com/sesori-ai/sesori_apps_monorepo/pull/661) merged as `f5f24240`; 879 changed lines |
+| [ ] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | Ready for PR; 714 changed lines |
 | [ ] | 11/13 | `output-image-support-acp-tool-images` | `[output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | Blocked on Step 10 merge |
 | [ ] | 12/13 | `output-image-support-acp-image-replay` | `[output-image-support] feat(acp): restore output image replay [step 12/13]` | 900-1,400 | Blocked on Step 11 merge |
 | [ ] | 13/13 | `output-image-support-retire-plan` | `[output-image-support] docs: retire output image support plan [step 13/13]` | 50-200 | Blocked on Step 12 merge |
@@ -182,7 +182,20 @@
   neighboring scope was combined. PR review refreshed the tracker state and
   made output clipping Unicode-safe without changing the established diff
   timing; all 73 focused ACP tests, 7 Cursor mapper tests, and fatal analysis in
-  both packages pass.
+  both packages pass. PR #661 merged as `f5f24240` on 2026-08-01.
+- Step 10/13 (2026-08-01): added the zero-collaborator `AcpContentTracker` and
+  adopted its ordered text/image mutations in live and replay assistant message
+  flows. Live standard ACP images now materialize as bounded file parts while
+  replay records the same segmentation and budgets without image parts until
+  Step 12. Mixed order, stable suffixes, count/aggregate limits, privacy-safe
+  warning deduplication, message/turn identity, id-less tool boundaries, halt
+  behavior, and Cursor standard-versus-extension behavior have focused coverage.
+  All 71 focused ACP tests, all 179 ACP tests, all 109 Cursor tests,
+  `dart pub get`, fatal analysis in both packages, and
+  `git diff --cached --check` pass. `aristotle-impl-review` approved with no
+  findings. Analytics remain excluded because passive image rendering has no
+  authoritative user action or product-decision event. The 714 changed-line
+  diff is below the 1,500-line soft cap; no neighboring scope was combined.
 
 ## Findings And Plan Deltas
 

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -429,7 +429,7 @@ class AcpEventMapper {
       (block) => block is AcpMappedImageContentBlock || (block is AcpMappedTextContentBlock && block.text.isNotEmpty),
     );
     if (identity.hasAcpMessageId && hasTrackableContent) {
-      _closeIdlessAssistantEnvelope(sessionId);
+      _closeCurrentIdlessAssistantContent(sessionId: sessionId);
     }
 
     if (!identity.hasAcpMessageId &&
@@ -605,7 +605,7 @@ class AcpEventMapper {
     // message id and opens a new envelope rather than appending a delta to the
     // abandoned one. (The dedupe return above runs first, so a repeated halt
     // chunk can't double-bump the sequence.)
-    _closeIdlessAssistantEnvelope(sessionId);
+    _closeCurrentIdlessAssistantContent(sessionId: sessionId);
     return [
       BridgeSseMessageUpdated(
         info: shared.Message.error(
@@ -629,7 +629,7 @@ class AcpEventMapper {
     final toolCallId = update["toolCallId"] as String?;
     if (toolCallId == null || toolCallId.isEmpty) return const [];
     if (_liveTools[sessionId]?[toolCallId] == null) {
-      _closeIdlessAssistantEnvelope(sessionId);
+      _closeCurrentIdlessAssistantContent(sessionId: sessionId);
     }
     final messageId = "$sessionId-tool-$toolCallId";
     final content = _contentMapper.toolContent(update: update);
@@ -672,7 +672,7 @@ class AcpEventMapper {
     // which already merges — keeping live and history renderings consistent.
     final prior = _liveTools[sessionId]?[toolCallId];
     if (prior == null) {
-      _closeIdlessAssistantEnvelope(sessionId);
+      _closeCurrentIdlessAssistantContent(sessionId: sessionId);
     }
     // Only re-resolve the tool identifier when `kind` is explicitly present; a
     // title-only update must NOT overwrite the canonical id (e.g. "edit") with
@@ -717,6 +717,15 @@ class AcpEventMapper {
   void _closeIdlessAssistantEnvelope(String sessionId) {
     if (!_openIdlessAssistant.remove(sessionId)) return;
     _idlessAssistantSeq[sessionId] = (_idlessAssistantSeq[sessionId] ?? 0) + 1;
+  }
+
+  void _closeCurrentIdlessAssistantContent({required String sessionId}) {
+    final messageId =
+        "$sessionId-t${_turn(sessionId)}-${_ChunkRole.assistant.name}-a${_idlessAssistantSeq[sessionId] ?? 0}";
+    final sessionTrackers = _contentTrackers[sessionId];
+    sessionTrackers?.remove(messageId);
+    if (sessionTrackers?.isEmpty ?? false) _contentTrackers.remove(sessionId);
+    _closeIdlessAssistantEnvelope(sessionId);
   }
 
   BridgeSseMessageUpdated _toolEnvelope({required String sessionId, required String messageId}) {

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -425,8 +425,16 @@ class AcpEventMapper {
       scope: tracker.mappingScope,
     );
     if (blocks.isEmpty) return const [];
+    final hasTrackableContent = blocks.any(
+      (block) => block is AcpMappedImageContentBlock || (block is AcpMappedTextContentBlock && block.text.isNotEmpty),
+    );
+    if (identity.hasAcpMessageId && hasTrackableContent) {
+      _closeIdlessAssistantEnvelope(sessionId);
+    }
 
-    if (tracker.snapshot.imageCandidateCount == 0 && blocks.every((block) => block is AcpMappedTextContentBlock)) {
+    if (!identity.hasAcpMessageId &&
+        tracker.snapshot.composition != AcpContentComposition.mixed &&
+        blocks.every((block) => block is AcpMappedTextContentBlock)) {
       final text = blocks.whereType<AcpMappedTextContentBlock>().map((block) => block.text).join();
       if (text.isNotEmpty) {
         final halt = classifyHaltNotice(text: text);

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -6,6 +6,7 @@ import "acp_protocol.dart";
 import "acp_session_configuration_tracker.dart";
 import "acp_stdio_client.dart";
 import "repositories/mappers/acp_content_mapper.dart";
+import "repositories/trackers/acp_content_tracker.dart";
 
 /// A backend "halt notice": the agent ended a turn without doing the requested
 /// work and instead streamed a terminal notice telling the user to change
@@ -161,6 +162,7 @@ class AcpEventMapper {
     _sessionSnapshots.remove(sessionId);
     _turnSeq.remove(sessionId);
     _startedParts.remove(sessionId);
+    _contentTrackers.remove(sessionId);
     _sentUserSeq.remove(sessionId);
     _idlessAssistantSeq.remove(sessionId);
     _openIdlessAssistant.remove(sessionId);
@@ -185,6 +187,10 @@ class AcpEventMapper {
   /// grow without bound across a long-running session.
   final Map<String, Set<String>> _startedParts = {};
 
+  /// Per-session, per-message ordered content state. Nested keys keep cleanup
+  /// exact for opaque session and ACP message identifiers.
+  final Map<String, Map<String, AcpContentTracker>> _contentTrackers = {};
+
   /// Sequence for user messages accepted by this plugin. These are emitted
   /// locally because ACP agents do not reliably echo `user_message_chunk`.
   final Map<String, int> _sentUserSeq = {};
@@ -202,6 +208,7 @@ class AcpEventMapper {
     // The new turn uses fresh (turn-numbered) part ids, so the prior turn's are
     // dead weight — drop them to bound memory in long sessions.
     _startedParts.remove(sessionId);
+    _contentTrackers.remove(sessionId);
     _idlessAssistantSeq.remove(sessionId);
     _openIdlessAssistant.remove(sessionId);
     // Tool state is retained across a turn (so a reordered late `tool_call_update`
@@ -234,6 +241,7 @@ class AcpEventMapper {
           sessionId: sessionId,
           type: PluginMessagePartType.text,
           text: text,
+          attachment: null,
         ),
       ),
     ];
@@ -262,6 +270,7 @@ class AcpEventMapper {
             sessionId: sessionId,
             type: PluginMessagePartType.text,
             text: textParts[index].text,
+            attachment: null,
           ),
         ),
     ];
@@ -308,13 +317,7 @@ class AcpEventMapper {
 
     switch (update["sessionUpdate"] as String?) {
       case "agent_message_chunk":
-        return _textChunk(
-          sessionId: sessionId,
-          update: update,
-          role: _ChunkRole.assistant,
-          partSuffix: "text",
-          partType: PluginMessagePartType.text,
-        );
+        return _assistantContentChunk(sessionId: sessionId, update: update);
       case "agent_thought_chunk":
         return _textChunk(
           sessionId: sessionId,
@@ -404,6 +407,88 @@ class AcpEventMapper {
   /// way it did live.
   AcpHaltNotice? classifyHaltNotice({required String text}) => null;
 
+  List<BridgeSseEvent> _assistantContentChunk({
+    required String sessionId,
+    required Map<String, dynamic> update,
+  }) {
+    final blocks = _contentMapper.map(content: update["content"]);
+    if (blocks.isEmpty) return const [];
+    final identity = _chunkIdentity(
+      sessionId: sessionId,
+      update: update,
+      role: _ChunkRole.assistant,
+    );
+    final tracker = (_contentTrackers[sessionId] ??= {}).putIfAbsent(
+      identity.messageId,
+      AcpContentTracker.new,
+    );
+
+    if (tracker.snapshot.imageCandidateCount == 0 && blocks.every((block) => block is AcpMappedTextContentBlock)) {
+      final text = blocks.whereType<AcpMappedTextContentBlock>().map((block) => block.text).join();
+      if (text.isNotEmpty) {
+        final halt = classifyHaltNotice(text: text);
+        if (halt != null) return _haltNoticeEvents(sessionId: sessionId, notice: halt);
+      }
+    }
+
+    final mutations = tracker.append(blocks: blocks);
+    if (mutations.isEmpty) return const [];
+    final events = <BridgeSseEvent>[];
+    final started = _startedParts.putIfAbsent(sessionId, () => <String>{});
+    if (started.add(identity.messageId)) {
+      events.add(
+        BridgeSseMessageUpdated(
+          info: _messageFor(_ChunkRole.assistant, identity.messageId, sessionId).toJson(),
+        ),
+      );
+    }
+    for (final mutation in mutations) {
+      final partId = "${identity.messageId}-${mutation.partIdSuffix}";
+      switch (mutation) {
+        case AcpTextDeltaMutation(:final delta):
+          if (started.add(partId)) {
+            events.add(
+              BridgeSseMessagePartUpdated(
+                part: _part(
+                  partId: partId,
+                  messageId: identity.messageId,
+                  sessionId: sessionId,
+                  type: PluginMessagePartType.text,
+                  text: "",
+                  attachment: null,
+                ),
+              ),
+            );
+          }
+          events.add(
+            BridgeSseMessagePartDelta(
+              sessionID: sessionId,
+              messageID: identity.messageId,
+              partID: partId,
+              field: "text",
+              delta: delta,
+            ),
+          );
+        case AcpImageMutation(:final attachment):
+          started.add(partId);
+          events.add(
+            BridgeSseMessagePartUpdated(
+              part: _part(
+                partId: partId,
+                messageId: identity.messageId,
+                sessionId: sessionId,
+                type: PluginMessagePartType.file,
+                text: null,
+                attachment: attachment,
+              ),
+            ),
+          );
+      }
+    }
+    if (!identity.hasAcpMessageId) _openIdlessAssistant.add(sessionId);
+    return events;
+  }
+
   List<BridgeSseEvent> _textChunk({
     required String sessionId,
     required Map<String, dynamic> update,
@@ -433,20 +518,18 @@ class AcpEventMapper {
     // role stays in the id so a pathological cross-role id reuse can't merge a
     // user chunk into an assistant envelope. Absent (Cursor today) → the
     // synthesized per-turn id.
-    final acpMessageId = update["messageId"];
-    final hasAcpMessageId = acpMessageId is String && acpMessageId.isNotEmpty;
-    final fallbackSuffix = role == _ChunkRole.assistant ? "-a${_idlessAssistantSeq[sessionId] ?? 0}" : "";
-    final messageId = hasAcpMessageId
-        ? "$sessionId-m$acpMessageId-${role.name}"
-        : "$sessionId-t${_turn(sessionId)}-${role.name}$fallbackSuffix";
+    final identity = _chunkIdentity(sessionId: sessionId, update: update, role: role);
+    final messageId = identity.messageId;
     final partId = "$messageId-$partSuffix";
 
     final events = <BridgeSseEvent>[];
     final started = _startedParts.putIfAbsent(sessionId, () => <String>{});
     if (started.add(partId)) {
-      events.add(
-        BridgeSseMessageUpdated(info: _messageFor(role, messageId, sessionId).toJson()),
-      );
+      if (started.add(messageId)) {
+        events.add(
+          BridgeSseMessageUpdated(info: _messageFor(role, messageId, sessionId).toJson()),
+        );
+      }
       events.add(
         BridgeSseMessagePartUpdated(
           part: _part(
@@ -455,6 +538,7 @@ class AcpEventMapper {
             sessionId: sessionId,
             type: partType,
             text: "",
+            attachment: null,
           ),
         ),
       );
@@ -468,10 +552,26 @@ class AcpEventMapper {
         delta: text,
       ),
     );
-    if (role == _ChunkRole.assistant && !hasAcpMessageId) {
+    if (role == _ChunkRole.assistant && !identity.hasAcpMessageId) {
       _openIdlessAssistant.add(sessionId);
     }
     return events;
+  }
+
+  ({String messageId, bool hasAcpMessageId}) _chunkIdentity({
+    required String sessionId,
+    required Map<String, dynamic> update,
+    required _ChunkRole role,
+  }) {
+    final acpMessageId = update["messageId"];
+    final hasAcpMessageId = acpMessageId is String && acpMessageId.isNotEmpty;
+    final fallbackSuffix = role == _ChunkRole.assistant ? "-a${_idlessAssistantSeq[sessionId] ?? 0}" : "";
+    return (
+      messageId: hasAcpMessageId
+          ? "$sessionId-m$acpMessageId-${role.name}"
+          : "$sessionId-t${_turn(sessionId)}-${role.name}$fallbackSuffix",
+      hasAcpMessageId: hasAcpMessageId,
+    );
   }
 
   /// Emits a backend halt [notice] (see [classifyHaltNotice]) as a single
@@ -707,7 +807,8 @@ class AcpEventMapper {
     required String messageId,
     required String sessionId,
     required PluginMessagePartType type,
-    required String text,
+    required String? text,
+    required PluginMessageAttachment? attachment,
   }) {
     return PluginMessagePart(
       id: partId,
@@ -723,7 +824,7 @@ class AcpEventMapper {
       agentName: null,
       attempt: null,
       retryError: null,
-      attachment: null,
+      attachment: attachment,
     );
   }
 

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -411,8 +411,6 @@ class AcpEventMapper {
     required String sessionId,
     required Map<String, dynamic> update,
   }) {
-    final blocks = _contentMapper.map(content: update["content"]);
-    if (blocks.isEmpty) return const [];
     final identity = _chunkIdentity(
       sessionId: sessionId,
       update: update,
@@ -422,6 +420,11 @@ class AcpEventMapper {
       identity.messageId,
       AcpContentTracker.new,
     );
+    final blocks = _contentMapper.mapScoped(
+      content: update["content"],
+      scope: tracker.mappingScope,
+    );
+    if (blocks.isEmpty) return const [];
 
     if (tracker.snapshot.imageCandidateCount == 0 && blocks.every((block) => block is AcpMappedTextContentBlock)) {
       final text = blocks.whereType<AcpMappedTextContentBlock>().map((block) => block.text).join();
@@ -483,6 +486,8 @@ class AcpEventMapper {
               ),
             ),
           );
+        case AcpImageBoundaryMutation():
+          continue;
       }
     }
     if (!identity.hasAcpMessageId) _openIdlessAssistant.add(sessionId);

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -46,7 +46,8 @@ class AcpReplayCollector {
   void consume(Map<String, dynamic> params) {
     final update = _asMap(params["update"]);
     if (update == null) return;
-    final sessionUpdate = update["sessionUpdate"] as String?;
+    final rawSessionUpdate = update["sessionUpdate"];
+    final sessionUpdate = rawSessionUpdate is String ? rawSessionUpdate : null;
     if (sessionUpdate != "agent_message_chunk") {
       _pendingAssistantContent = null;
     }
@@ -152,6 +153,7 @@ class AcpReplayCollector {
     // qualifies — no reasoning, no tools — matching the shape the backend emits.
     final assistantText = _assistantText(draft: draft);
     if (draft.role == "assistant" &&
+        draft.acpMessageId == null &&
         draft.reasoning.isEmpty &&
         draft.tools.isEmpty &&
         !_hasAssistantImageCandidate(draft: draft) &&

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -124,6 +124,7 @@ class AcpReplayCollector {
       content: update["content"],
       scope: tracker.mappingScope,
     );
+    final mutations = tracker.append(blocks: blocks);
     if (!_hasTrackableAssistantContent(blocks: blocks)) return;
     final draft =
         existing ??
@@ -134,7 +135,7 @@ class AcpReplayCollector {
         );
     _pendingAssistantContent = null;
     draft.contentMutations.addAll(
-      tracker.append(blocks: blocks).map((mutation) => mutation.withoutImagePayload()),
+      mutations.map((mutation) => mutation.withoutImagePayload()),
     );
   }
 
@@ -154,6 +155,7 @@ class AcpReplayCollector {
         draft.reasoning.isEmpty &&
         draft.tools.isEmpty &&
         !_hasAssistantImageCandidate(draft: draft) &&
+        draft.contentTracker.snapshot.composition == AcpContentComposition.textOnly &&
         assistantText.isNotEmpty) {
       final halt = haltClassifier?.call(text: assistantText);
       if (halt != null) {

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -2,6 +2,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "acp_event_mapper.dart" show AcpHaltNotice;
 import "repositories/mappers/acp_content_mapper.dart";
+import "repositories/trackers/acp_content_tracker.dart";
 
 /// Accumulates the `session/update` notifications replayed by `session/load`
 /// into ordered [PluginMessageWithParts] for `getSessionMessages`.
@@ -46,8 +47,12 @@ class AcpReplayCollector {
     if (update == null) return;
     switch (update["sessionUpdate"] as String?) {
       case "agent_message_chunk":
-        final t = _contentMapper.text(content: update["content"]);
-        if (t != null) _assistant(messageId: _chunkMessageId(update)).text.write(t);
+        final draft = _assistant(messageId: _chunkMessageId(update));
+        draft.contentMutations.addAll(
+          draft.contentTracker.append(
+            blocks: _contentMapper.map(content: update["content"]),
+          ),
+        );
       case "agent_thought_chunk":
         final t = _contentMapper.text(content: update["content"]);
         if (t != null) _assistant(messageId: _chunkMessageId(update)).reasoning.write(t);
@@ -106,8 +111,13 @@ class AcpReplayCollector {
     // lone assistant message) is surfaced as an error message so a reloaded
     // session matches the live rendering. Only a pure-text terminal notice
     // qualifies — no reasoning, no tools — matching the shape the backend emits.
-    if (draft.role == "assistant" && draft.reasoning.isEmpty && draft.tools.isEmpty && draft.text.isNotEmpty) {
-      final halt = haltClassifier?.call(text: draft.text.toString());
+    final assistantText = _assistantText(draft);
+    if (draft.role == "assistant" &&
+        draft.reasoning.isEmpty &&
+        draft.tools.isEmpty &&
+        !_hasAssistantImageCandidate(draft) &&
+        assistantText.isNotEmpty) {
+      final halt = haltClassifier?.call(text: assistantText);
       if (halt != null) {
         return PluginMessageWithParts(
           info: PluginMessage.error(
@@ -130,6 +140,9 @@ class AcpReplayCollector {
     }
     if (draft.text.isNotEmpty) {
       parts.add(_textPart(draft, "text", PluginMessagePartType.text, draft.text.toString()));
+    }
+    for (final entry in _assistantTextParts(draft).entries) {
+      parts.add(_textPart(draft, entry.key, PluginMessagePartType.text, entry.value));
     }
     draft.tools.forEach((toolId, tool) {
       parts.add(
@@ -158,6 +171,26 @@ class AcpReplayCollector {
       );
     });
     return PluginMessageWithParts(info: _message(draft), parts: parts);
+  }
+
+  String _assistantText(_Draft draft) {
+    final buffer = StringBuffer();
+    for (final mutation in draft.contentMutations) {
+      if (mutation case AcpTextDeltaMutation(:final delta)) buffer.write(delta);
+    }
+    return buffer.toString();
+  }
+
+  bool _hasAssistantImageCandidate(_Draft draft) => draft.contentTracker.snapshot.imageCandidateCount > 0;
+
+  Map<String, String> _assistantTextParts(_Draft draft) {
+    final buffers = <String, StringBuffer>{};
+    for (final mutation in draft.contentMutations) {
+      if (mutation case AcpTextDeltaMutation(:final partIdSuffix, :final delta)) {
+        buffers.putIfAbsent(partIdSuffix, StringBuffer.new).write(delta);
+      }
+    }
+    return {for (final entry in buffers.entries) entry.key: entry.value.toString()};
   }
 
   PluginMessage _message(_Draft draft) {
@@ -211,7 +244,7 @@ class AcpReplayCollector {
   _Draft _assistantForTool() {
     if (_drafts.isNotEmpty && _drafts.last.role == "assistant") {
       final last = _drafts.last;
-      if (last.acpMessageId != null || (last.text.isEmpty && last.reasoning.isEmpty)) {
+      if (last.acpMessageId != null || (last.text.isEmpty && last.reasoning.isEmpty && last.contentMutations.isEmpty)) {
         return last;
       }
     }
@@ -285,6 +318,8 @@ class _Draft {
   String? acpMessageId;
   final StringBuffer text = StringBuffer();
   final StringBuffer reasoning = StringBuffer();
+  final AcpContentTracker contentTracker = AcpContentTracker();
+  final List<AcpContentMutation> contentMutations = [];
   final Map<String, _ToolDraft> tools = {};
 }
 

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -41,18 +41,18 @@ class AcpReplayCollector {
   final List<_Draft> _drafts = [];
   int _seq = 0;
   bool _hasUserDraft = false;
+  _PendingAssistantContent? _pendingAssistantContent;
 
   void consume(Map<String, dynamic> params) {
     final update = _asMap(params["update"]);
     if (update == null) return;
-    switch (update["sessionUpdate"] as String?) {
+    final sessionUpdate = update["sessionUpdate"] as String?;
+    if (sessionUpdate != "agent_message_chunk") {
+      _pendingAssistantContent = null;
+    }
+    switch (sessionUpdate) {
       case "agent_message_chunk":
-        final draft = _assistant(messageId: _chunkMessageId(update));
-        draft.contentMutations.addAll(
-          draft.contentTracker.append(
-            blocks: _contentMapper.map(content: update["content"]),
-          ),
-        );
+        _consumeAssistantContent(update: update);
       case "agent_thought_chunk":
         final t = _contentMapper.text(content: update["content"]);
         if (t != null) _assistant(messageId: _chunkMessageId(update)).reasoning.write(t);
@@ -100,6 +100,44 @@ class AcpReplayCollector {
     }
   }
 
+  void _consumeAssistantContent({required Map<String, dynamic> update}) {
+    final messageId = _chunkMessageId(update);
+    final existing = _matchingRole(role: "assistant", messageId: messageId);
+    final AcpContentTracker tracker;
+    if (existing != null) {
+      tracker = existing.contentTracker;
+      _pendingAssistantContent = null;
+    } else {
+      final pending = _pendingAssistantContent;
+      if (pending != null && pending.messageId == messageId) {
+        tracker = pending.tracker;
+      } else {
+        tracker = AcpContentTracker();
+        _pendingAssistantContent = _PendingAssistantContent(
+          messageId: messageId,
+          tracker: tracker,
+        );
+      }
+    }
+
+    final blocks = _contentMapper.mapScoped(
+      content: update["content"],
+      scope: tracker.mappingScope,
+    );
+    if (!_hasTrackableAssistantContent(blocks: blocks)) return;
+    final draft =
+        existing ??
+        _newDraft(
+          role: "assistant",
+          messageId: messageId,
+          contentTracker: tracker,
+        );
+    _pendingAssistantContent = null;
+    draft.contentMutations.addAll(
+      tracker.append(blocks: blocks).map((mutation) => mutation.withoutImagePayload()),
+    );
+  }
+
   List<PluginMessageWithParts> build() {
     return [
       for (final draft in _drafts) _buildMessage(draft),
@@ -111,11 +149,11 @@ class AcpReplayCollector {
     // lone assistant message) is surfaced as an error message so a reloaded
     // session matches the live rendering. Only a pure-text terminal notice
     // qualifies — no reasoning, no tools — matching the shape the backend emits.
-    final assistantText = _assistantText(draft);
+    final assistantText = _assistantText(draft: draft);
     if (draft.role == "assistant" &&
         draft.reasoning.isEmpty &&
         draft.tools.isEmpty &&
-        !_hasAssistantImageCandidate(draft) &&
+        !_hasAssistantImageCandidate(draft: draft) &&
         assistantText.isNotEmpty) {
       final halt = haltClassifier?.call(text: assistantText);
       if (halt != null) {
@@ -141,7 +179,7 @@ class AcpReplayCollector {
     if (draft.text.isNotEmpty) {
       parts.add(_textPart(draft, "text", PluginMessagePartType.text, draft.text.toString()));
     }
-    for (final entry in _assistantTextParts(draft).entries) {
+    for (final entry in _assistantTextParts(draft: draft).entries) {
       parts.add(_textPart(draft, entry.key, PluginMessagePartType.text, entry.value));
     }
     draft.tools.forEach((toolId, tool) {
@@ -173,7 +211,15 @@ class AcpReplayCollector {
     return PluginMessageWithParts(info: _message(draft), parts: parts);
   }
 
-  String _assistantText(_Draft draft) {
+  bool _hasTrackableAssistantContent({
+    required List<AcpMappedContentBlock> blocks,
+  }) {
+    return blocks.any(
+      (block) => block is AcpMappedImageContentBlock || (block is AcpMappedTextContentBlock && block.text.isNotEmpty),
+    );
+  }
+
+  String _assistantText({required _Draft draft}) {
     final buffer = StringBuffer();
     for (final mutation in draft.contentMutations) {
       if (mutation case AcpTextDeltaMutation(:final delta)) buffer.write(delta);
@@ -181,9 +227,9 @@ class AcpReplayCollector {
     return buffer.toString();
   }
 
-  bool _hasAssistantImageCandidate(_Draft draft) => draft.contentTracker.snapshot.imageCandidateCount > 0;
+  bool _hasAssistantImageCandidate({required _Draft draft}) => draft.contentTracker.snapshot.imageCandidateCount > 0;
 
-  Map<String, String> _assistantTextParts(_Draft draft) {
+  Map<String, String> _assistantTextParts({required _Draft draft}) {
     final buffers = <String, StringBuffer>{};
     for (final mutation in draft.contentMutations) {
       if (mutation case AcpTextDeltaMutation(:final partIdSuffix, :final delta)) {
@@ -248,7 +294,11 @@ class AcpReplayCollector {
         return last;
       }
     }
-    return _newDraft("assistant", messageId: null);
+    return _newDraft(
+      role: "assistant",
+      messageId: null,
+      contentTracker: null,
+    );
   }
 
   /// The draft the next chunk belongs to. ACP v1: chunks of one message share
@@ -258,16 +308,28 @@ class AcpReplayCollector {
   /// [_assistantForTool] because ACP does not stamp them. Comparison is against
   /// the last draft only, matching the spec's sequential semantics.
   _Draft _ensureRole(String role, {String? messageId}) {
-    if (_drafts.isNotEmpty && _drafts.last.role == role) {
-      final last = _drafts.last;
-      if (last.acpMessageId == messageId && !(messageId == null && last.tools.isNotEmpty)) {
-        return last;
-      }
-    }
-    return _newDraft(role, messageId: messageId);
+    return _matchingRole(role: role, messageId: messageId) ??
+        _newDraft(
+          role: role,
+          messageId: messageId,
+          contentTracker: null,
+        );
   }
 
-  _Draft _newDraft(String role, {required String? messageId}) {
+  _Draft? _matchingRole({required String role, required String? messageId}) {
+    if (_drafts.isEmpty || _drafts.last.role != role) return null;
+    final last = _drafts.last;
+    if (last.acpMessageId != messageId || (messageId == null && last.tools.isNotEmpty)) {
+      return null;
+    }
+    return last;
+  }
+
+  _Draft _newDraft({
+    required String role,
+    required String? messageId,
+    required AcpContentTracker? contentTracker,
+  }) {
     final isFirstUser = role == "user" && !_hasUserDraft;
     if (role == "user") _hasUserDraft = true;
     final defaultId = messageId != null && messageId.isNotEmpty
@@ -277,6 +339,7 @@ class AcpReplayCollector {
       role: role,
       id: isFirstUser && initialUserMessageId != null ? initialUserMessageId! : defaultId,
       acpMessageId: messageId,
+      contentTracker: contentTracker ?? AcpContentTracker(),
     );
     _drafts.add(draft);
     return draft;
@@ -309,7 +372,12 @@ class AcpReplayCollector {
 }
 
 class _Draft {
-  _Draft({required this.role, required this.id, required this.acpMessageId});
+  _Draft({
+    required this.role,
+    required this.id,
+    required this.acpMessageId,
+    required this.contentTracker,
+  });
 
   final String role;
   final String id;
@@ -318,9 +386,19 @@ class _Draft {
   String? acpMessageId;
   final StringBuffer text = StringBuffer();
   final StringBuffer reasoning = StringBuffer();
-  final AcpContentTracker contentTracker = AcpContentTracker();
+  final AcpContentTracker contentTracker;
   final List<AcpContentMutation> contentMutations = [];
   final Map<String, _ToolDraft> tools = {};
+}
+
+final class _PendingAssistantContent {
+  const _PendingAssistantContent({
+    required this.messageId,
+    required this.tracker,
+  });
+
+  final String? messageId;
+  final AcpContentTracker tracker;
 }
 
 class _ToolDraft {

--- a/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
@@ -70,6 +70,12 @@ final class AcpMappedToolContent {
   final AcpToolContentMutation mutation;
 }
 
+/// Deduplicates privacy-safe mapping warnings across chunks of one logical
+/// message while retaining no payload values.
+final class AcpContentMappingScope {
+  final Set<_AcpContentWarning> _warned = {};
+}
+
 /// Maps standard ACP content blocks into backend-neutral, individually
 /// validated content while retaining no URI or source-path data.
 ///
@@ -96,8 +102,14 @@ final class AcpContentMapper {
   };
 
   List<AcpMappedContentBlock> map({required Object? content}) {
-    final warned = <_AcpContentWarning>{};
-    return _mapValue(content: content, warned: warned).toList(growable: false);
+    return mapScoped(content: content, scope: AcpContentMappingScope());
+  }
+
+  List<AcpMappedContentBlock> mapScoped({
+    required Object? content,
+    required AcpContentMappingScope scope,
+  }) {
+    return _mapValue(content: content, warned: scope._warned).toList(growable: false);
   }
 
   String toolName({required Map<String, dynamic> update}) {
@@ -132,7 +144,10 @@ final class AcpContentMapper {
     }
     final contentText = buffer.toString();
     final text = contentText.isNotEmpty ? contentText : _rawOutputText(raw: update["rawOutput"]);
-    return AcpMappedToolContent(output: _boundedToolOutput(text: text), mutation: mutation);
+    return AcpMappedToolContent(
+      output: _boundedToolOutput(text: text),
+      mutation: mutation,
+    );
   }
 
   String? _boundedToolOutput({required String? text}) {

--- a/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_content_tracker.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_content_tracker.dart
@@ -50,12 +50,20 @@ final class AcpContentSnapshot {
     required this.activeTextPartIdSuffix,
     required this.imageCandidateCount,
     required this.decodedImageBytes,
+    required this.composition,
   });
 
   final int textPartCount;
   final String? activeTextPartIdSuffix;
   final int imageCandidateCount;
   final int decodedImageBytes;
+  final AcpContentComposition composition;
+}
+
+enum AcpContentComposition {
+  empty,
+  textOnly,
+  mixed,
 }
 
 /// Owns ordered text/image segmentation and bounded image budgets for one
@@ -69,12 +77,14 @@ final class AcpContentTracker {
   String? _activeTextPartIdSuffix;
   int _imageCandidateCount = 0;
   int _decodedImageBytes = 0;
+  AcpContentComposition _composition = AcpContentComposition.empty;
 
   AcpContentSnapshot get snapshot => AcpContentSnapshot(
     textPartCount: _textPartCount,
     activeTextPartIdSuffix: _activeTextPartIdSuffix,
     imageCandidateCount: _imageCandidateCount,
     decodedImageBytes: _decodedImageBytes,
+    composition: _composition,
   );
 
   List<AcpContentMutation> append({required Iterable<AcpMappedContentBlock> blocks}) {
@@ -82,10 +92,14 @@ final class AcpContentTracker {
     for (final block in blocks) {
       switch (block) {
         case AcpMappedTextContentBlock(:final text):
+          if (_composition == AcpContentComposition.empty) {
+            _composition = AcpContentComposition.textOnly;
+          }
           if (text.isEmpty) continue;
           final suffix = _activeTextPartIdSuffix ??= _nextTextPartIdSuffix();
           mutations.add(AcpTextDeltaMutation(partIdSuffix: suffix, delta: text));
         case AcpMappedInlineImageContentBlock(:final attachment, :final decodedBytes):
+          _composition = AcpContentComposition.mixed;
           _activeTextPartIdSuffix = null;
           final imageIndex = ++_imageCandidateCount;
           if (imageIndex > _maxImageCandidates) {
@@ -113,6 +127,7 @@ final class AcpContentTracker {
             ),
           );
         case AcpMappedMetadataImageContentBlock(:final attachment, :final reason):
+          _composition = AcpContentComposition.mixed;
           _activeTextPartIdSuffix = null;
           final imageIndex = ++_imageCandidateCount;
           if (imageIndex > _maxImageCandidates) {
@@ -127,6 +142,7 @@ final class AcpContentTracker {
             ),
           );
         case AcpMappedUnsupportedContentBlock() || AcpMappedUnknownContentBlock():
+          _composition = AcpContentComposition.mixed;
           continue;
       }
     }

--- a/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_content_tracker.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_content_tracker.dart
@@ -1,0 +1,153 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" show maxInlineMessageAttachmentBytes;
+
+import "../mappers/acp_content_mapper.dart";
+
+sealed class AcpContentMutation {
+  const AcpContentMutation({required this.partIdSuffix});
+
+  final String partIdSuffix;
+}
+
+final class AcpTextDeltaMutation extends AcpContentMutation {
+  const AcpTextDeltaMutation({
+    required super.partIdSuffix,
+    required this.delta,
+  });
+
+  final String delta;
+}
+
+final class AcpImageMutation extends AcpContentMutation {
+  const AcpImageMutation({
+    required super.partIdSuffix,
+    required this.attachment,
+  });
+
+  final PluginMessageAttachment attachment;
+}
+
+final class AcpContentSnapshot {
+  const AcpContentSnapshot({
+    required this.textPartCount,
+    required this.activeTextPartIdSuffix,
+    required this.imageCandidateCount,
+    required this.decodedImageBytes,
+  });
+
+  final int textPartCount;
+  final String? activeTextPartIdSuffix;
+  final int imageCandidateCount;
+  final int decodedImageBytes;
+}
+
+/// Owns ordered text/image segmentation and bounded image budgets for one
+/// logical ACP assistant message.
+final class AcpContentTracker {
+  static const int _maxImageCandidates = 4;
+
+  final Set<_AcpContentWarning> _warned = {};
+  int _textPartCount = 0;
+  String? _activeTextPartIdSuffix;
+  int _imageCandidateCount = 0;
+  int _decodedImageBytes = 0;
+
+  AcpContentSnapshot get snapshot => AcpContentSnapshot(
+    textPartCount: _textPartCount,
+    activeTextPartIdSuffix: _activeTextPartIdSuffix,
+    imageCandidateCount: _imageCandidateCount,
+    decodedImageBytes: _decodedImageBytes,
+  );
+
+  List<AcpContentMutation> append({required Iterable<AcpMappedContentBlock> blocks}) {
+    final mutations = <AcpContentMutation>[];
+    for (final block in blocks) {
+      switch (block) {
+        case AcpMappedTextContentBlock(:final text):
+          if (text.isEmpty) continue;
+          final suffix = _activeTextPartIdSuffix ??= _nextTextPartIdSuffix();
+          mutations.add(AcpTextDeltaMutation(partIdSuffix: suffix, delta: text));
+        case AcpMappedInlineImageContentBlock(:final attachment, :final decodedBytes):
+          _activeTextPartIdSuffix = null;
+          final imageIndex = ++_imageCandidateCount;
+          if (imageIndex > _maxImageCandidates) {
+            _warnOnce(reason: _AcpContentWarning.countOverflow);
+            continue;
+          }
+          if (_decodedImageBytes + decodedBytes > maxInlineMessageAttachmentBytes) {
+            _warnOnce(reason: _AcpContentWarning.aggregateOverflow);
+            mutations.add(
+              AcpImageMutation(
+                partIdSuffix: "image-$imageIndex",
+                attachment: PluginMessageAttachment.metadata(
+                  mime: attachment.mime,
+                  filename: attachment.filename,
+                ),
+              ),
+            );
+            continue;
+          }
+          _decodedImageBytes += decodedBytes;
+          mutations.add(
+            AcpImageMutation(
+              partIdSuffix: "image-$imageIndex",
+              attachment: attachment,
+            ),
+          );
+        case AcpMappedMetadataImageContentBlock(:final attachment, :final reason):
+          _activeTextPartIdSuffix = null;
+          final imageIndex = ++_imageCandidateCount;
+          if (imageIndex > _maxImageCandidates) {
+            _warnOnce(reason: _AcpContentWarning.countOverflow);
+            continue;
+          }
+          _warnOnce(reason: _warningFor(reason: reason));
+          mutations.add(
+            AcpImageMutation(
+              partIdSuffix: "image-$imageIndex",
+              attachment: attachment,
+            ),
+          );
+        case AcpMappedUnsupportedContentBlock() || AcpMappedUnknownContentBlock():
+          continue;
+      }
+    }
+    return mutations;
+  }
+
+  String _nextTextPartIdSuffix() {
+    final index = _textPartCount++;
+    return index == 0 ? "text" : "text-$index";
+  }
+
+  _AcpContentWarning _warningFor({required AcpImageDegradationReason reason}) {
+    return switch (reason) {
+      AcpImageDegradationReason.invalid => _AcpContentWarning.invalid,
+      AcpImageDegradationReason.unsupported => _AcpContentWarning.unsupported,
+      AcpImageDegradationReason.oversized => _AcpContentWarning.oversized,
+    };
+  }
+
+  void _warnOnce({required _AcpContentWarning reason}) {
+    if (!_warned.add(reason)) return;
+    Log.w(
+      switch (reason) {
+        _AcpContentWarning.invalid => "[acp] invalid image attachment; forwarding metadata only",
+        _AcpContentWarning.unsupported => "[acp] unsupported image attachment; forwarding metadata only",
+        _AcpContentWarning.oversized => "[acp] oversized image attachment; forwarding metadata only",
+        _AcpContentWarning.aggregateOverflow =>
+          "[acp] image attachments exceed the aggregate transport limit; forwarding metadata only",
+        _AcpContentWarning.countOverflow =>
+          "[acp] image attachment collection exceeds the count limit; dropping excess candidates",
+      },
+    );
+  }
+}
+
+enum _AcpContentWarning {
+  invalid,
+  unsupported,
+  oversized,
+  aggregateOverflow,
+  countOverflow,
+}

--- a/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_content_tracker.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_content_tracker.dart
@@ -7,6 +7,8 @@ sealed class AcpContentMutation {
   const AcpContentMutation({required this.partIdSuffix});
 
   final String partIdSuffix;
+
+  AcpContentMutation withoutImagePayload();
 }
 
 final class AcpTextDeltaMutation extends AcpContentMutation {
@@ -16,6 +18,9 @@ final class AcpTextDeltaMutation extends AcpContentMutation {
   });
 
   final String delta;
+
+  @override
+  AcpContentMutation withoutImagePayload() => this;
 }
 
 final class AcpImageMutation extends AcpContentMutation {
@@ -25,6 +30,18 @@ final class AcpImageMutation extends AcpContentMutation {
   });
 
   final PluginMessageAttachment attachment;
+
+  @override
+  AcpContentMutation withoutImagePayload() => AcpImageBoundaryMutation(
+    partIdSuffix: partIdSuffix,
+  );
+}
+
+final class AcpImageBoundaryMutation extends AcpContentMutation {
+  const AcpImageBoundaryMutation({required super.partIdSuffix});
+
+  @override
+  AcpContentMutation withoutImagePayload() => this;
 }
 
 final class AcpContentSnapshot {
@@ -47,6 +64,7 @@ final class AcpContentTracker {
   static const int _maxImageCandidates = 4;
 
   final Set<_AcpContentWarning> _warned = {};
+  final AcpContentMappingScope mappingScope = AcpContentMappingScope();
   int _textPartCount = 0;
   String? _activeTextPartIdSuffix;
   int _imageCandidateCount = 0;

--- a/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
@@ -182,6 +182,21 @@ void main() {
       expect(output, isNot(contains("type cast")));
     });
 
+    test("a mapping scope deduplicates malformed warnings across chunks", () {
+      final scope = AcpContentMappingScope();
+      final output = _captureWarnings(() {
+        for (var index = 0; index < 2; index++) {
+          mapper.mapScoped(
+            content: {"type": "text", "text": 42, "private": "secret"},
+            scope: scope,
+          );
+        }
+      });
+
+      expect("malformed content block".allMatches(output), hasLength(1));
+      expect(output, isNot(contains("secret")));
+    });
+
     test("maps tool identity and status with fail-soft defaults", () {
       expect(mapper.toolName(update: {"kind": "read", "title": "Read file"}), "read");
       expect(mapper.toolName(update: {"kind": "", "title": "Read file"}), "Read file");

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -229,6 +229,37 @@ void main() {
       );
     });
 
+    test("an explicit assistant message closes the prior id-less envelope", () {
+      mapper.beginTurn("s1");
+      final before = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "before"},
+      }));
+      mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "m1",
+        "content": {"type": "text", "text": "explicit"},
+      }));
+      final after = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {
+          "type": "image",
+          "data": "AA==",
+          "mimeType": "image/png",
+          "uri": null,
+        },
+      }));
+
+      final beforeId = shared.Message.fromJson(
+        before.whereType<BridgeSseMessageUpdated>().single.info,
+      ).id;
+      final afterId = shared.Message.fromJson(
+        after.whereType<BridgeSseMessageUpdated>().single.info,
+      ).id;
+      expect(afterId, isNot(beforeId));
+      expect(after.whereType<BridgeSseMessagePartUpdated>().single.part.type, PluginMessagePartType.file);
+    });
+
     test("tool_call maps to an assistant message with a tool part", () {
       final events = mapper.map(update({
         "sessionUpdate": "tool_call",
@@ -939,6 +970,33 @@ void main() {
         PluginMessagePartType.file,
         PluginMessagePartType.text,
       ]);
+    });
+
+    test("an identified halt-like text chunk can receive a later image", () {
+      mapper.beginTurn("s1");
+      final text = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "mixed",
+        "content": {"type": "text", "text": "HALT: fix it"},
+      }));
+      final image = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "mixed",
+        "content": {
+          "type": "image",
+          "data": "AA==",
+          "mimeType": "image/png",
+          "uri": null,
+        },
+      }));
+
+      expect(
+        shared.Message.fromJson(text.whereType<BridgeSseMessageUpdated>().single.info),
+        isA<shared.MessageAssistant>(),
+      );
+      expect(text.whereType<BridgeSseMessagePartDelta>().single.delta, "HALT: fix it");
+      expect(image.whereType<BridgeSseMessageUpdated>(), isEmpty);
+      expect(image.whereType<BridgeSseMessagePartUpdated>().single.part.type, PluginMessagePartType.file);
     });
 
     test("ordinary assistant text still streams as an assistant message", () {

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -60,27 +60,77 @@ void main() {
       expect(second.whereType<BridgeSseMessagePartDelta>().single.delta, "lo");
     });
 
-    test("validated image chunks remain unmaterialized until the content tracker lands", () {
+    test("agent message content preserves mixed text and image order", () {
       mapper.beginTurn("s1");
-      final imageEvents = mapper.map(update({
+      final events = mapper.map(update({
         "sessionUpdate": "agent_message_chunk",
         "messageId": "mixed",
+        "content": [
+          {"type": "text", "text": "before"},
+          {
+            "type": "image",
+            "data": "AA==",
+            "mimeType": "image/png",
+            "uri": "file:///private/output.png",
+          },
+          {"type": "text", "text": "after"},
+        ],
+      }));
+
+      expect(events.whereType<BridgeSseMessageUpdated>(), hasLength(1));
+      final parts = events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part).toList();
+      expect(
+        parts.map((part) => part.id),
+        ["s1-mmixed-assistant-text", "s1-mmixed-assistant-image-1", "s1-mmixed-assistant-text-1"],
+      );
+      expect(parts.map((part) => part.type), [
+        PluginMessagePartType.text,
+        PluginMessagePartType.file,
+        PluginMessagePartType.text,
+      ]);
+      expect(parts[1].attachment, isA<PluginMessageAttachmentInlineImage>());
+      expect(parts[1].attachment?.filename, "output.png");
+      expect(events.whereType<BridgeSseMessagePartDelta>().map((event) => event.delta), ["before", "after"]);
+    });
+
+    test("message trackers persist across chunks and reset at turn boundaries", () {
+      mapper.beginTurn("s1");
+      mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "m1",
         "content": {
           "type": "image",
           "data": "AA==",
           "mimeType": "image/png",
-          "uri": "file:///private/output.png",
+          "uri": null,
         },
       }));
-      final textEvents = mapper.map(update({
+      final text = mapper.map(update({
         "sessionUpdate": "agent_message_chunk",
-        "messageId": "mixed",
-        "content": {"type": "text", "text": "visible"},
+        "messageId": "m1",
+        "content": {"type": "text", "text": "after"},
       }));
+      expect(text.whereType<BridgeSseMessageUpdated>(), isEmpty);
+      expect(
+        text.whereType<BridgeSseMessagePartUpdated>().single.part.id,
+        "s1-mm1-assistant-text",
+      );
 
-      expect(imageEvents, isEmpty);
-      expect(textEvents.whereType<BridgeSseMessageUpdated>(), hasLength(1));
-      expect(textEvents.whereType<BridgeSseMessagePartDelta>().single.delta, "visible");
+      mapper.beginTurn("s1");
+      final reset = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "m1",
+        "content": {
+          "type": "image",
+          "data": "AA==",
+          "mimeType": "image/png",
+          "uri": null,
+        },
+      }));
+      expect(
+        reset.whereType<BridgeSseMessagePartUpdated>().single.part.id,
+        "s1-mm1-assistant-image-1",
+      );
     });
 
     test("agent_thought_chunk maps to a reasoning part", () {
@@ -144,11 +194,16 @@ void main() {
       expect(events, isEmpty);
     });
 
-    test("id-less assistant text after a tool opens a later envelope", () {
+    test("id-less assistant content after a tool opens a later envelope", () {
       mapper.beginTurn("s1");
       final beforeTool = mapper.map(update({
         "sessionUpdate": "agent_message_chunk",
-        "content": {"type": "text", "text": "Before"},
+        "content": {
+          "type": "image",
+          "data": "AA==",
+          "mimeType": "image/png",
+          "uri": null,
+        },
       }));
       mapper.map(update({
         "sessionUpdate": "tool_call",
@@ -859,6 +914,31 @@ void main() {
         events.whereType<BridgeSseMessagePartUpdated>().single.part.type,
         PluginMessagePartType.reasoning,
       );
+    });
+
+    test("an image-bearing halt-like message remains an assistant message", () {
+      mapper.beginTurn("s1");
+      final events = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": [
+          {
+            "type": "image",
+            "data": "AA==",
+            "mimeType": "image/png",
+            "uri": null,
+          },
+          {"type": "text", "text": "HALT: fix it"},
+        ],
+      }));
+
+      final message = shared.Message.fromJson(
+        events.whereType<BridgeSseMessageUpdated>().single.info,
+      );
+      expect(message, isA<shared.MessageAssistant>());
+      expect(events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part.type), [
+        PluginMessagePartType.file,
+        PluginMessagePartType.text,
+      ]);
     });
 
     test("ordinary assistant text still streams as an assistant message", () {

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -907,6 +907,32 @@ void main() {
       expect(again, isEmpty);
     });
 
+    test("a tool clears unrendered id-less state before a later halt", () {
+      mapper.beginTurn("s1");
+      expect(
+        mapper.map(update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "audio", "data": "private", "mimeType": "audio/wav"},
+        })),
+        isEmpty,
+      );
+      mapper.map(update({
+        "sessionUpdate": "tool_call",
+        "toolCallId": "t1",
+        "kind": "read",
+        "status": "completed",
+      }));
+      final halt = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "HALT: fix it"},
+      }));
+
+      expect(
+        shared.Message.fromJson(halt.whereType<BridgeSseMessageUpdated>().single.info),
+        isA<shared.MessageError>(),
+      );
+    });
+
     test("id-less assistant text after a halt opens a fresh envelope", () {
       mapper.beginTurn("s1");
       final before = mapper.map(update({

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -316,6 +316,22 @@ void main() {
       expect(collector.build(), isEmpty);
     });
 
+    test("a non-string session update discriminator is ignored", () {
+      final collector = AcpReplayCollector(
+        sessionId: "s1",
+        agentId: "Cursor",
+        initialUserMessageId: null,
+        haltClassifier: null,
+        contentMapper: const AcpContentMapper(),
+      );
+
+      expect(
+        () => collector.consume(upd({"sessionUpdate": 42})),
+        returnsNormally,
+      );
+      expect(collector.build(), isEmpty);
+    });
+
     test("malformed replay chunks share warning state without creating a message", () {
       final collector = AcpReplayCollector(
         sessionId: "s1",
@@ -509,6 +525,23 @@ void main() {
       expect(message.info, isA<PluginMessageError>());
       expect((message.info as PluginMessageError).errorMessage, "Check your settings to continue");
       expect(message.parts, isEmpty);
+    });
+
+    test("an identified halt-like message remains assistant content", () {
+      final collector = AcpReplayCollector(
+        sessionId: "s1",
+        agentId: "Cursor",
+        initialUserMessageId: null,
+        haltClassifier: ({required text}) =>
+            const AcpHaltNotice(errorName: "cursor_gate", message: "gate"),
+        contentMapper: const AcpContentMapper(),
+      )..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "m1",
+          "content": {"type": "text", "text": "Check your settings to continue"},
+        }));
+
+      expect(collector.build().single.info, isA<PluginMessageAssistant>());
     });
 
     test("an image-bearing halt-like message remains an assistant message", () {

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -1,3 +1,5 @@
+import "dart:io";
+
 import "package:acp_plugin/acp_plugin.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
@@ -294,6 +296,49 @@ void main() {
       expect(collector.build().single.parts.single.text, "one flow");
     });
 
+    test("unrenderable assistant chunks do not create empty replay messages", () {
+      final collector = AcpReplayCollector(
+        sessionId: "s1",
+        agentId: "Cursor",
+        initialUserMessageId: null,
+        haltClassifier: null,
+        contentMapper: const AcpContentMapper(),
+      )
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": ""},
+        }))
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "audio", "data": "private", "mimeType": "audio/wav"},
+        }));
+
+      expect(collector.build(), isEmpty);
+    });
+
+    test("malformed replay chunks share warning state without creating a message", () {
+      final collector = AcpReplayCollector(
+        sessionId: "s1",
+        agentId: "Cursor",
+        initialUserMessageId: null,
+        haltClassifier: null,
+        contentMapper: const AcpContentMapper(),
+      );
+      final output = _captureWarnings(() {
+        for (var index = 0; index < 2; index++) {
+          collector.consume(upd({
+            "sessionUpdate": "agent_message_chunk",
+            "messageId": "m1",
+            "content": {"type": "text", "text": 42, "private": "secret"},
+          }));
+        }
+      });
+
+      expect("malformed content block".allMatches(output), hasLength(1));
+      expect(output, isNot(contains("secret")));
+      expect(collector.build(), isEmpty);
+    });
+
     test("replay records image boundaries while deferring image materialization", () {
       final collector = AcpReplayCollector(
         sessionId: "s1",
@@ -509,4 +554,28 @@ void main() {
       expect(message.parts, isNotEmpty);
     });
   });
+}
+
+String _captureWarnings(void Function() action) {
+  final previousLevel = Log.level;
+  final stderr = _BufferingStdout();
+  try {
+    Log.level = LogLevel.warning;
+    IOOverrides.runZoned(action, stderr: () => stderr);
+  } finally {
+    Log.level = previousLevel;
+  }
+  return stderr.text;
+}
+
+class _BufferingStdout implements Stdout {
+  final StringBuffer _buffer = StringBuffer();
+
+  String get text => _buffer.toString();
+
+  @override
+  void writeln([Object? object = ""]) => _buffer.writeln(object);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
 }

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -294,7 +294,7 @@ void main() {
       expect(collector.build().single.parts.single.text, "one flow");
     });
 
-    test("validated replay images remain unmaterialized without changing text grouping", () {
+    test("replay records image boundaries while deferring image materialization", () {
       final collector = AcpReplayCollector(
         sessionId: "s1",
         agentId: "Cursor",
@@ -324,10 +324,43 @@ void main() {
         }));
 
       final message = collector.build().single;
-      expect(message.parts, hasLength(1));
-      expect(message.parts.single.type, PluginMessagePartType.text);
-      expect(message.parts.single.text, "beforeafter");
-      expect(message.parts.single.attachment, isNull);
+      expect(message.parts, hasLength(2));
+      expect(
+        message.parts.map((part) => part.id),
+        ["s1-mmixed-assistant-text", "s1-mmixed-assistant-text-1"],
+      );
+      expect(message.parts.map((part) => part.text), ["before", "after"]);
+      expect(message.parts, everyElement(isA<PluginMessagePart>().having((part) => part.attachment, "attachment", isNull)));
+    });
+
+    test("an id-less image closes its replay draft before a following tool", () {
+      final collector = AcpReplayCollector(
+        sessionId: "s1",
+        agentId: "Cursor",
+        initialUserMessageId: null,
+        haltClassifier: null,
+        contentMapper: const AcpContentMapper(),
+      )
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {
+            "type": "image",
+            "data": "AA==",
+            "mimeType": "image/png",
+            "uri": null,
+          },
+        }))
+        ..consume(upd({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "t1",
+          "kind": "read",
+          "status": "completed",
+        }));
+
+      final messages = collector.build();
+      expect(messages, hasLength(2));
+      expect(messages.first.parts, isEmpty);
+      expect(messages.last.parts.single.type, PluginMessagePartType.tool);
     });
 
     test("an explicit messageId after id-less text starts a new message", () {
@@ -431,6 +464,32 @@ void main() {
       expect(message.info, isA<PluginMessageError>());
       expect((message.info as PluginMessageError).errorMessage, "Check your settings to continue");
       expect(message.parts, isEmpty);
+    });
+
+    test("an image-bearing halt-like message remains an assistant message", () {
+      final collector = AcpReplayCollector(
+        sessionId: "s1",
+        agentId: "Cursor",
+        initialUserMessageId: null,
+        haltClassifier: ({required text}) =>
+            const AcpHaltNotice(errorName: "cursor_gate", message: "gate"),
+        contentMapper: const AcpContentMapper(),
+      )..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "content": [
+            {
+              "type": "image",
+              "data": "AA==",
+              "mimeType": "image/png",
+              "uri": null,
+            },
+            {"type": "text", "text": "Check your settings to continue"},
+          ],
+        }));
+
+      final message = collector.build().single;
+      expect(message.info, isA<PluginMessageAssistant>());
+      expect(message.parts.single.text, "Check your settings to continue");
     });
 
     test("without a halt classifier the same chunk stays assistant text", () {

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -537,6 +537,27 @@ void main() {
       expect(message.parts.single.text, "Check your settings to continue");
     });
 
+    test("unsupported content keeps halt-like replay text as an assistant message", () {
+      final collector = AcpReplayCollector(
+        sessionId: "s1",
+        agentId: "Cursor",
+        initialUserMessageId: null,
+        haltClassifier: ({required text}) =>
+            const AcpHaltNotice(errorName: "cursor_gate", message: "gate"),
+        contentMapper: const AcpContentMapper(),
+      )..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "content": [
+            {"type": "text", "text": "Check your settings to continue"},
+            {"type": "audio", "data": "private", "mimeType": "audio/wav"},
+          ],
+        }));
+
+      final message = collector.build().single;
+      expect(message.info, isA<PluginMessageAssistant>());
+      expect(message.parts.single.text, "Check your settings to continue");
+    });
+
     test("without a halt classifier the same chunk stays assistant text", () {
       final collector = AcpReplayCollector(
         sessionId: "s1",

--- a/bridge/sesori_plugin_acp/test/repositories/trackers/acp_content_tracker_test.dart
+++ b/bridge/sesori_plugin_acp/test/repositories/trackers/acp_content_tracker_test.dart
@@ -50,6 +50,10 @@ void main() {
         mutations.map((mutation) => mutation.partIdSuffix),
         ["image-1", "text"],
       );
+      final boundary = mutations.first.withoutImagePayload();
+      expect(boundary, isA<AcpImageBoundaryMutation>());
+      expect(boundary.partIdSuffix, "image-1");
+      expect(boundary.toString(), isNot(contains("AA==")));
     });
 
     test("enforces count and aggregate budgets without retaining overflow bytes", () {

--- a/bridge/sesori_plugin_acp/test/repositories/trackers/acp_content_tracker_test.dart
+++ b/bridge/sesori_plugin_acp/test/repositories/trackers/acp_content_tracker_test.dart
@@ -1,0 +1,144 @@
+import "dart:io";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/src/repositories/trackers/acp_content_tracker.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" show maxInlineMessageAttachmentBytes;
+import "package:test/test.dart";
+
+void main() {
+  group("AcpContentTracker", () {
+    test("preserves mixed order with stable text and image suffixes", () {
+      final tracker = AcpContentTracker();
+
+      final mutations = tracker.append(
+        blocks: [
+          const AcpMappedTextContentBlock(text: "before"),
+          _inline(decodedBytes: 1),
+          const AcpMappedTextContentBlock(text: "after "),
+          const AcpMappedTextContentBlock(text: "continued"),
+          const AcpMappedUnsupportedContentBlock(),
+          _metadata(),
+          const AcpMappedTextContentBlock(text: "last"),
+        ],
+      );
+
+      expect(
+        mutations.map((mutation) => mutation.partIdSuffix),
+        ["text", "image-1", "text-1", "text-1", "image-2", "text-2"],
+      );
+      expect(
+        mutations.whereType<AcpTextDeltaMutation>().map((mutation) => mutation.delta),
+        ["before", "after ", "continued", "last"],
+      );
+      expect(tracker.snapshot.textPartCount, 3);
+      expect(tracker.snapshot.imageCandidateCount, 2);
+      expect(tracker.snapshot.decodedImageBytes, 1);
+    });
+
+    test("uses text for the first segment after a leading image", () {
+      final tracker = AcpContentTracker();
+
+      final mutations = tracker.append(
+        blocks: [
+          _inline(decodedBytes: 1),
+          const AcpMappedTextContentBlock(text: "text"),
+        ],
+      );
+
+      expect(
+        mutations.map((mutation) => mutation.partIdSuffix),
+        ["image-1", "text"],
+      );
+    });
+
+    test("enforces count and aggregate budgets without retaining overflow bytes", () {
+      final tracker = AcpContentTracker();
+      final mutations = tracker.append(
+        blocks: [
+          _inline(decodedBytes: maxInlineMessageAttachmentBytes),
+          _inline(decodedBytes: 1),
+          _metadata(),
+          _inline(decodedBytes: 0),
+          const AcpMappedTextContentBlock(text: "before dropped image"),
+          _inline(decodedBytes: 0),
+          const AcpMappedTextContentBlock(text: "after dropped image"),
+        ],
+      );
+
+      final images = mutations.whereType<AcpImageMutation>().toList();
+      expect(images, hasLength(4));
+      expect(images[0].attachment, isA<PluginMessageAttachmentInlineImage>());
+      expect(images[1].attachment, isA<PluginMessageAttachmentMetadata>());
+      expect(images[2].attachment, isA<PluginMessageAttachmentMetadata>());
+      expect(images[3].attachment, isA<PluginMessageAttachmentInlineImage>());
+      expect(mutations.whereType<AcpTextDeltaMutation>().map((mutation) => mutation.partIdSuffix), [
+        "text",
+        "text-1",
+      ]);
+      expect(tracker.snapshot.imageCandidateCount, 5);
+      expect(tracker.snapshot.decodedImageBytes, maxInlineMessageAttachmentBytes);
+    });
+
+    test("deduplicates privacy-safe warnings per message tracker", () {
+      final output = _captureWarnings(() {
+        AcpContentTracker().append(
+          blocks: [_metadata(), _metadata(), _metadata(), _metadata(), _metadata()],
+        );
+      });
+
+      expect("invalid image attachment".allMatches(output), hasLength(1));
+      expect("exceeds the count limit".allMatches(output), hasLength(1));
+      expect(output, isNot(contains("image.png")));
+    });
+  });
+}
+
+String _captureWarnings(void Function() action) {
+  final previousLevel = Log.level;
+  final stderr = _BufferingStdout();
+  try {
+    Log.level = LogLevel.warning;
+    IOOverrides.runZoned(action, stderr: () => stderr);
+  } finally {
+    Log.level = previousLevel;
+  }
+  return stderr.text;
+}
+
+class _BufferingStdout implements Stdout {
+  final StringBuffer _buffer = StringBuffer();
+
+  String get text => _buffer.toString();
+
+  @override
+  void writeln([Object? object = ""]) => _buffer.writeln(object);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+AcpMappedInlineImageContentBlock _inline({required int decodedBytes}) {
+  return AcpMappedInlineImageContentBlock(
+    attachment:
+        const PluginMessageAttachment.inlineImage(
+              mime: "image/png",
+              base64: "AA==",
+              filename: "image.png",
+            )
+            as PluginMessageAttachmentInlineImage,
+    decodedBytes: decodedBytes,
+  );
+}
+
+AcpMappedMetadataImageContentBlock _metadata() {
+  return const AcpMappedMetadataImageContentBlock(
+    attachment:
+        PluginMessageAttachment.metadata(
+              mime: "image/png",
+              filename: "image.png",
+            )
+            as PluginMessageAttachmentMetadata,
+    reason: AcpImageDegradationReason.invalid,
+  );
+}

--- a/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
@@ -48,6 +48,41 @@ void main() {
       expect(events.whereType<BridgeSseMessagePartDelta>().single.delta, "hi");
     });
 
+    test("standard ACP images are inherited while cursor image extensions stay dropped", () {
+      mapper.beginTurn("s-image");
+      final standard = mapper.map(
+        const AcpNotification(
+          method: "session/update",
+          params: {
+            "sessionId": "s-image",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": {
+                "type": "image",
+                "data": "AA==",
+                "mimeType": "image/png",
+                "uri": null,
+              },
+            },
+          },
+        ),
+      );
+      expect(
+        standard.whereType<BridgeSseMessagePartUpdated>().single.part.type,
+        PluginMessagePartType.file,
+      );
+
+      expect(
+        mapper.map(
+          const AcpNotification(
+            method: "cursor/generate_image",
+            params: {"sessionId": "s-image", "path": "/private/output.png"},
+          ),
+        ),
+        isEmpty,
+      );
+    });
+
     test("an account/plan gate notice becomes an error message, not assistant text", () {
       mapper.beginTurn("sg");
       final events = mapper.map(


### PR DESCRIPTION
## Complexity

🚧 Complex — introduces per-message ordering and security-budget state shared across live and replay lifecycle paths.

## What

- add an internal zero-collaborator `AcpContentTracker` for ordered text/image segmentation, four-candidate limits, and the 5 MiB aggregate decoded budget
- materialize standard ACP assistant images live as backend-neutral file parts while preserving mixed order and stable part identities
- adopt the same tracker mutations in replay now, segmenting text around deferred images without materializing replay image parts before Step 12
- preserve id-less/tool boundaries, explicit message IDs, turn/session cleanup, and halt classification
- prove Cursor inherits standard ACP images while continuing to drop `cursor/generate_image`

## Why

ACP content can interleave text and images across chunks. A single per-message state owner is required so live and replay share ordering, suffix, count, and byte-budget decisions before tool images and replay materialization are added in later steps.

## Risk and test focus

Risk is high around message ordering, duplicate or orphan parts, stale tracker state, aggregate payload limits, source-location privacy, id-less envelope boundaries, and incorrectly converting image-bearing gate messages into errors. Tests cover mixed and multi-chunk order, exact suffixes, count and aggregate overflow, metadata degradation, warning deduplication, turn resets, replay segmentation, tool chronology, halt behavior, and Cursor standard/extension separation.

There is no database, shared-wire, relay, or analytics change.

## Expected result

Standard ACP and Cursor assistant image blocks render live in their original position with text. Invalid, unsupported, oversized, aggregate-overflow, and excess images degrade or drop under the existing transport policy. Replay preserves identical segmentation internally but remains text-only until Step 12.

## Verification

- focused ACP mapper/tracker/live/replay tests (90 tests)
- focused Cursor event mapper tests (8 tests)
- full ACP suite (179 tests)
- full Cursor suite (109 tests)
- `dart pub get`
- `dart analyze --fatal-infos` in ACP and Cursor
- `git diff --cached --check`
- `aristotle-impl-review` — approved with no findings

## Plan

Step 10/13 of `.plan/active/output-image-support/PLAN.md`. The complete 1,138-line diff is below the 1,500-line soft cap; no adjacent scope was combined.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces live ACP assistant message images next to text with stable ordering and part IDs. Adds per-message `AcpContentTracker` so live and replay share segmentation and enforce image count/byte budgets; replay defers image payloads while preserving boundaries and aligns halt handling to live.

- **New Features**
  - Added `AcpContentTracker` to segment text/images in order and enforce limits (max 4 images, 5 MiB aggregate decoded bytes).
  - Live: materialize standard ACP images as `file` parts with stable suffixes; text streams into separate parts around images.
  - Replay: apply the same segmentation; emit text parts around deferred images and record payload-free image boundaries (no image parts yet).
  - Mapping scope: deduplicate privacy-safe malformed-content warnings per message; explicit assistant messages close prior id-less envelopes. `sesori_plugin_cursor` inherits standard ACP images and still drops `cursor/generate_image`.

- **Bug Fixes**
  - Preserve mixed-message chronology: trackers persist across chunks and reset at turn boundaries; text parts pick up correctly after images.
  - Bound replay image state: skip unrenderable chunks, avoid empty assistant drafts via pending tracker scope, record image boundaries only, and ignore non-string discriminators.
  - Align halt handling with live: only id-less, pure-text assistant messages become errors; identified or image-bearing messages remain assistant content.
  - Reset hidden id-less tracker state at message boundaries so tools or later messages don’t inherit stale content state.

<sup>Written for commit 89e3d574dbb9f6b509b99883dbae192fb9668c89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

