### PR TITLE
🌱 Pin keyboard visibility Android API 24 fix

### DIFF
--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -90,7 +90,7 @@ dependencies:
   flutter_keyboard_visibility:
     git:
       url: https://github.com/vespr-wallet/flutter_keyboard_visibility.git
-      ref: d8d628478d35687e3373735a377c663b19586fa0
+      ref: a640afe883868faf2709c41daa391e2cd6f1fc7b
       path: flutter_keyboard_visibility
 
 dev_dependencies:

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -610,8 +610,8 @@ packages:
     dependency: transitive
     description:
       path: flutter_keyboard_visibility
-      ref: d8d628478d35687e3373735a377c663b19586fa0
-      resolved-ref: d8d628478d35687e3373735a377c663b19586fa0
+      ref: a640afe883868faf2709c41daa391e2cd6f1fc7b
+      resolved-ref: a640afe883868faf2709c41daa391e2cd6f1fc7b
       url: "https://github.com/vespr-wallet/flutter_keyboard_visibility.git"
     source: git
     version: "6.0.2"


### PR DESCRIPTION
## Complexity

Trivial dependency pin update.

## What

- Pin `flutter_keyboard_visibility` to fork commit `a640afe883868faf2709c41daa391e2cd6f1fc7b`.
- Regenerate the client lockfile for the new revision.

## Why

The prior fork revision declared Android API 26 even though the plugin implementation supports the app's API 24 minimum. That declaration caused the Android internal release build to fail during manifest merging. The new fork commit restores API 24 support in both the plugin and its example app.

## Risk and test focus

Low risk. The dependency implementation is unchanged; only its declared Android minimum SDK is lowered from 26 to 24. Focus CI on Android manifest merging and app bundle compilation at API 24.

There is no database impact and no intended user-visible behavior change.

## Expected result

Android release builds complete without the `flutter_keyboard_visibility` minimum-SDK manifest conflict while Sesori continues supporting Android API 24.

## Verification

- `dart pub get` from `client/`
- `dart analyze` from `client/app/`
- `flutter build appbundle --debug` from `client/app/` after `flutter clean`
- Fork package: `flutter test`
- Fork example: `flutter build apk --debug`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `flutter_keyboard_visibility` to a fork revision that restores Android minSdk 24, fixing manifest merge failures in release builds. Regenerated the client lockfile with no user-visible changes.

<sup>Written for commit 4c5aff464aaced4a65076c332011ade1d772516f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

