### PR TITLE
⚙️ Make multi-question prompts reviewable

### DIFF
--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -165,8 +165,9 @@ sealed class BridgePluginApi {
   /// [answers] is a `List<List<String>>` because:
   /// - The outer list contains one entry per question in the prompt
   ///   (a single prompt can ask multiple questions at once).
-  /// - Each inner list contains the selected answers for that question
-  ///   (supports multi-select — one or more values can be chosen).
+  /// - Each inner list contains the selected answers for that question. Multiple
+  ///   values represent multi-select; an empty list means that individual
+  ///   question was explicitly declined without rejecting the whole prompt.
   Future<void> replyToQuestion({
     required String questionId,
     required String sessionId,

--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -166,8 +166,8 @@ sealed class BridgePluginApi {
   /// - The outer list contains one entry per question in the prompt
   ///   (a single prompt can ask multiple questions at once).
   /// - Each inner list contains the selected answers for that question. Multiple
-  ///   values represent multi-select; an empty list means that individual
-  ///   question was explicitly declined without rejecting the whole prompt.
+  ///   values represent multi-select; an empty list means intentionally
+  ///   unanswered, including a client-side decline of only that question.
   Future<void> replyToQuestion({
     required String questionId,
     required String sessionId,

--- a/client/app/lib/features/session_detail/widgets/question_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/question_modal.dart
@@ -206,7 +206,14 @@ class _QuestionModalState extends State<QuestionModal> {
     final draft = _currentDraft;
     draft.customFocus.unfocus();
     setState(() {
-      draft.disposition = draft.isDeclined ? _QuestionDisposition.answer : _QuestionDisposition.declined;
+      if (draft.isDeclined) {
+        draft.disposition = _QuestionDisposition.answer;
+        return;
+      }
+      draft
+        ..disposition = _QuestionDisposition.declined
+        ..customSelected = false
+        ..selectedLabels.clear();
     });
   }
 

--- a/client/app/lib/features/session_detail/widgets/question_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/question_modal.dart
@@ -103,8 +103,8 @@ class _QuestionModalState extends State<QuestionModal> {
     super.initState();
     _drafts = List.generate(_totalQuestions, (index) {
       final draft = _QuestionDraft();
-      draft.customFocus.addListener(() => _onCustomFocusChanged(index));
-      draft.customController.addListener(() => _onCustomTextChanged(index));
+      draft.customFocus.addListener(() => _onCustomFocusChanged(index: index));
+      draft.customController.addListener(() => _onCustomTextChanged(index: index));
       return draft;
     });
   }
@@ -121,7 +121,7 @@ class _QuestionModalState extends State<QuestionModal> {
   // Callbacks
   // ---------------------------------------------------------------------------
 
-  void _onCustomFocusChanged(int index) {
+  void _onCustomFocusChanged({required int index}) {
     if (!mounted || index != _currentIndex) return;
 
     final draft = _drafts[index];
@@ -137,7 +137,7 @@ class _QuestionModalState extends State<QuestionModal> {
     }
   }
 
-  void _onCustomTextChanged(int index) {
+  void _onCustomTextChanged({required int index}) {
     // Rebuild to update submit button enabled state.
     if (mounted && index == _currentIndex && _drafts[index].customSelected) {
       setState(() {});
@@ -165,7 +165,7 @@ class _QuestionModalState extends State<QuestionModal> {
     draft.customFocus.requestFocus();
   }
 
-  void _onOptionTap(String label) {
+  void _onOptionTap({required String label}) {
     final draft = _currentDraft;
     draft.customFocus.unfocus();
     setState(() {
@@ -210,7 +210,7 @@ class _QuestionModalState extends State<QuestionModal> {
     });
   }
 
-  void _navigateTo(int index) {
+  void _navigateTo({required int index}) {
     if (index == _currentIndex || index < 0 || index >= _totalQuestions) return;
 
     _currentDraft.customFocus.unfocus();
@@ -221,7 +221,7 @@ class _QuestionModalState extends State<QuestionModal> {
   }
 
   void _onProceed() {
-    if (!_isLastQuestion) _navigateTo(_currentIndex + 1);
+    if (!_isLastQuestion) _navigateTo(index: _currentIndex + 1);
   }
 
   void _onSubmit() {
@@ -245,6 +245,10 @@ class _QuestionModalState extends State<QuestionModal> {
     }
 
     setState(() => _confirmingRequestDecline = true);
+  }
+
+  void _cancelDeclineRequest() {
+    setState(() => _confirmingRequestDecline = false);
   }
 
   // ---------------------------------------------------------------------------
@@ -272,169 +276,167 @@ class _QuestionModalState extends State<QuestionModal> {
     // instead of overflowing fixed navigator and helper rows.
     final showQuestionNavigator = _isMultiQuestion && maxBody >= 180;
 
-    return PregoBottomSheet(
-      title: _confirmingRequestDecline
-          ? loc.questionModalDeclineAllTitle
-          : (info.header.isNotEmpty ? info.header : loc.questionModalTitle),
-      subtitle: _isMultiQuestion && !_confirmingRequestDecline
-          ? loc.questionModalStepIndicator(
-              _currentIndex + 1,
-              _totalQuestions,
-            )
-          : null,
-      topInset: widget.topInset,
-      onBack: _confirmingRequestDecline
-          ? () => setState(() => _confirmingRequestDecline = false)
-          : (_currentIndex > 0 ? () => _navigateTo(_currentIndex - 1) : null),
-      onClose: _dismissModal,
-      // Full-bleed body; the step indicator, list, and actions pad themselves.
-      contentPadding: EdgeInsetsDirectional.zero,
-      child: ConstrainedBox(
-        constraints: BoxConstraints(maxHeight: math.max(maxBody, screenHeight * 0.3)),
-        child: _confirmingRequestDecline
-            ? _DeclineAllConfirmation(
-                onCancel: () => setState(() => _confirmingRequestDecline = false),
-                onConfirm: _onReject,
+    return PopScope(
+      canPop: !_confirmingRequestDecline,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop && _confirmingRequestDecline) _cancelDeclineRequest();
+      },
+      child: PregoBottomSheet(
+        title: _confirmingRequestDecline
+            ? loc.questionModalDeclineAllTitle
+            : (info.header.isNotEmpty ? info.header : loc.questionModalTitle),
+        subtitle: _isMultiQuestion && !_confirmingRequestDecline
+            ? loc.questionModalStepIndicator(
+                _currentIndex + 1,
+                _totalQuestions,
               )
-            : Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  // Direct question navigation (only when there are multiple questions).
-                  if (showQuestionNavigator)
-                    Padding(
-                      padding: const EdgeInsetsDirectional.fromSTEB(16, 0, 16, 8),
-                      child: _QuestionNavigator(
-                        currentIndex: _currentIndex,
-                        resolutions: _drafts.map((item) => item.resolution).toList(growable: false),
-                        onSelected: _navigateTo,
+            : null,
+        topInset: widget.topInset,
+        onBack: _confirmingRequestDecline
+            ? _cancelDeclineRequest
+            : (_currentIndex > 0 ? () => _navigateTo(index: _currentIndex - 1) : null),
+        onClose: _dismissModal,
+        // Full-bleed body; the step indicator, list, and actions pad themselves.
+        contentPadding: EdgeInsetsDirectional.zero,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(maxHeight: math.max(maxBody, screenHeight * 0.3)),
+          child: _confirmingRequestDecline
+              ? _DeclineAllConfirmation(
+                  onCancel: _cancelDeclineRequest,
+                  onConfirm: _onReject,
+                )
+              : Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    // Direct question navigation (only when there are multiple questions).
+                    if (showQuestionNavigator)
+                      Padding(
+                        padding: const EdgeInsetsDirectional.fromSTEB(16, 0, 16, 8),
+                        child: _QuestionNavigator(
+                          currentIndex: _currentIndex,
+                          resolutions: _drafts.map((item) => item.resolution).toList(growable: false),
+                          onSelected: (index) => _navigateTo(index: index),
+                        ),
+                      ),
+
+                    // Scrollable body — wraps its content (a handful of option tiles,
+                    // so laying them all out is cheap) and scrolls only once the
+                    // sheet hits its cap.
+                    Flexible(
+                      child: TweenAnimationBuilder<double>(
+                        key: ValueKey(_currentIndex),
+                        tween: Tween(begin: 0, end: 1),
+                        duration: const Duration(milliseconds: 180),
+                        curve: Curves.easeOutCubic,
+                        builder: (context, value, child) {
+                          return Opacity(
+                            opacity: value,
+                            child: Transform.translate(
+                              offset: Offset(_navigationDirection * 12 * (1 - value), 0),
+                              child: child,
+                            ),
+                          );
+                        },
+                        child: ListView(
+                          shrinkWrap: true,
+                          padding: const EdgeInsets.all(16),
+                          children: [
+                            // Question text
+                            MarkdownBody(
+                              data: info.question,
+                              selectable: true,
+                              onTapLink: handleMarkdownLinkTap,
+                              styleSheet: buildSessionMarkdownStyleSheet(
+                                prego: prego,
+                                paragraphStyle: prego.textTheme.textSm.medium,
+                              ),
+                            ),
+                            const SizedBox(height: 16),
+
+                            // Option tiles
+                            ...info.options.map(
+                              (option) => _OptionTile(
+                                option: option,
+                                isMultiple: info.multiple,
+                                isSelected: !draft.isDeclined && draft.selectedLabels.contains(option.label),
+                                onTap: () => _onOptionTap(label: option.label),
+                              ),
+                            ),
+
+                            // Custom answer tile
+                            if (info.custom) ...[
+                              const SizedBox(height: 8),
+                              _CustomAnswerTile(
+                                controller: draft.customController,
+                                focusNode: draft.customFocus,
+                                isSelected: !draft.isDeclined && draft.customSelected,
+                                isMultiple: info.multiple,
+                                onTap: _onCustomTileTap,
+                              ),
+                            ],
+
+                            if (_isMultiQuestion) ...[
+                              const SizedBox(height: 8),
+                              _DeclineQuestionTile(
+                                isSelected: draft.isDeclined,
+                                onTap: _onDeclineCurrentQuestion,
+                              ),
+                            ],
+                          ],
+                        ),
                       ),
                     ),
 
-                  // Scrollable body — wraps its content (a handful of option tiles,
-                  // so laying them all out is cheap) and scrolls only once the
-                  // sheet hits its cap.
-                  Flexible(
-                    child: AnimatedSwitcher(
-                      duration: const Duration(milliseconds: 180),
-                      switchInCurve: Curves.easeOutCubic,
-                      switchOutCurve: Curves.easeInCubic,
-                      transitionBuilder: (child, animation) {
-                        final key = child.key;
-                        final isIncoming = key is ValueKey<int> && key.value == _currentIndex;
-                        final horizontalOffset = (isIncoming ? 1 : -1) * _navigationDirection * 0.04;
-                        return IgnorePointer(
-                          ignoring: !isIncoming,
-                          child: ExcludeSemantics(
-                            excluding: !isIncoming,
-                            child: FadeTransition(
-                              opacity: animation,
-                              child: SlideTransition(
-                                position: Tween<Offset>(
-                                  begin: Offset(horizontalOffset, 0),
-                                  end: Offset.zero,
-                                ).animate(animation),
-                                child: child,
+                    if (_isLastQuestion && !_allQuestionsResolved && showQuestionNavigator)
+                      Padding(
+                        padding: const EdgeInsetsDirectional.fromSTEB(16, 0, 16, 8),
+                        child: Text(
+                          loc.questionModalResolveAll,
+                          textAlign: TextAlign.center,
+                          style: prego.textTheme.textXs.regular.copyWith(
+                            color: prego.colors.textSecondary,
+                          ),
+                        ),
+                      ),
+
+                    // Request-wide decline / Submit / Next actions.
+                    Padding(
+                      padding: const EdgeInsetsDirectional.fromSTEB(16, 0, 16, 16),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: OutlinedButton(
+                              key: const Key("decline-question-request"),
+                              style: OutlinedButton.styleFrom(
+                                foregroundColor: prego.colors.fgErrorPrimary,
+                                side: BorderSide(color: prego.colors.fgErrorPrimary),
+                              ),
+                              onPressed: _onDeclineRequest,
+                              child: Text(
+                                _isMultiQuestion ? loc.questionModalDeclineAll : loc.questionModalDecline,
                               ),
                             ),
                           ),
-                        );
-                      },
-                      child: ListView(
-                        key: ValueKey(_currentIndex),
-                        shrinkWrap: true,
-                        padding: const EdgeInsets.all(16),
-                        children: [
-                          // Question text
-                          MarkdownBody(
-                            data: info.question,
-                            selectable: true,
-                            onTapLink: handleMarkdownLinkTap,
-                            styleSheet: buildSessionMarkdownStyleSheet(
-                              prego: prego,
-                              paragraphStyle: prego.textTheme.textSm.medium,
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: FilledButton(
+                              key: const Key("question-primary-action"),
+                              onPressed: _isLastQuestion ? (_allQuestionsResolved ? _onSubmit : null) : _onProceed,
+                              child: Text(
+                                _isLastQuestion
+                                    ? (!_allQuestionsResolved && !showQuestionNavigator
+                                          ? loc.questionModalResolveAllCompact
+                                          : loc.questionModalSubmit)
+                                    : loc.questionModalNext,
+                              ),
                             ),
                           ),
-                          const SizedBox(height: 16),
-
-                          // Option tiles
-                          ...info.options.map(
-                            (option) => _OptionTile(
-                              option: option,
-                              isMultiple: info.multiple,
-                              isSelected: !draft.isDeclined && draft.selectedLabels.contains(option.label),
-                              onTap: () => _onOptionTap(option.label),
-                            ),
-                          ),
-
-                          // Custom answer tile
-                          if (info.custom) ...[
-                            const SizedBox(height: 8),
-                            _CustomAnswerTile(
-                              controller: draft.customController,
-                              focusNode: draft.customFocus,
-                              isSelected: !draft.isDeclined && draft.customSelected,
-                              isMultiple: info.multiple,
-                              onTap: _onCustomTileTap,
-                            ),
-                          ],
-
-                          if (_isMultiQuestion) ...[
-                            const SizedBox(height: 8),
-                            _DeclineQuestionTile(
-                              isSelected: draft.isDeclined,
-                              onTap: _onDeclineCurrentQuestion,
-                            ),
-                          ],
                         ],
                       ),
                     ),
-                  ),
-
-                  if (_isLastQuestion && !_allQuestionsResolved && showQuestionNavigator)
-                    Padding(
-                      padding: const EdgeInsetsDirectional.fromSTEB(16, 0, 16, 8),
-                      child: Text(
-                        loc.questionModalResolveAll,
-                        textAlign: TextAlign.center,
-                        style: prego.textTheme.textXs.regular.copyWith(
-                          color: prego.colors.textSecondary,
-                        ),
-                      ),
-                    ),
-
-                  // Request-wide decline / Submit / Next actions.
-                  Padding(
-                    padding: const EdgeInsetsDirectional.fromSTEB(16, 0, 16, 16),
-                    child: Row(
-                      children: [
-                        Expanded(
-                          child: OutlinedButton(
-                            key: const Key("decline-question-request"),
-                            style: OutlinedButton.styleFrom(
-                              foregroundColor: prego.colors.fgErrorPrimary,
-                              side: BorderSide(color: prego.colors.fgErrorPrimary),
-                            ),
-                            onPressed: _onDeclineRequest,
-                            child: Text(
-                              _isMultiQuestion ? loc.questionModalDeclineAll : loc.questionModalDecline,
-                            ),
-                          ),
-                        ),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: FilledButton(
-                            key: const Key("question-primary-action"),
-                            onPressed: _isLastQuestion ? (_allQuestionsResolved ? _onSubmit : null) : _onProceed,
-                            child: Text(
-                              _isLastQuestion ? loc.questionModalSubmit : loc.questionModalNext,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
+                  ],
+                ),
+        ),
       ),
     );
   }
@@ -465,7 +467,8 @@ class _QuestionDraft {
 
   _QuestionResolution get resolution {
     if (isDeclined) return _QuestionResolution.declined;
-    return answerValues.isEmpty ? _QuestionResolution.unanswered : _QuestionResolution.answered;
+    final hasCustomAnswer = customSelected && customController.text.trim().isNotEmpty;
+    return selectedLabels.isEmpty && !hasCustomAnswer ? _QuestionResolution.unanswered : _QuestionResolution.answered;
   }
 
   void dispose() {
@@ -705,6 +708,7 @@ class _QuestionStep extends StatelessWidget {
       button: true,
       selected: isCurrent,
       label: loc.questionModalStepSemantics(index + 1, total, status),
+      onTap: onTap,
       child: ExcludeSemantics(
         child: SizedBox(
           width: 44,

--- a/client/app/lib/features/session_detail/widgets/question_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/question_modal.dart
@@ -13,8 +13,9 @@ import "pending_request_auto_dismiss.dart";
 /// Bottom sheet that presents all server-driven questions within a single
 /// [SesoriQuestionAsked] event, one at a time.
 ///
-/// The user steps through each [QuestionInfo] sequentially. Answers are
-/// collected locally and only submitted once every question has been answered.
+/// Each question keeps an editable local draft. The user can move freely
+/// between questions, and the request is submitted only after every question
+/// has either been answered or explicitly declined.
 class QuestionModal extends StatefulWidget {
   final SesoriQuestionAsked question;
   final void Function(String requestId, List<ReplyAnswer> answers) onReply;
@@ -75,18 +76,15 @@ class QuestionModal extends StatefulWidget {
 }
 
 class _QuestionModalState extends State<QuestionModal> {
-  final TextEditingController _customController = TextEditingController();
-  final FocusNode _customFocus = FocusNode();
+  late final List<_QuestionDraft> _drafts;
 
   /// Index of the question currently being displayed.
   int _currentIndex = 0;
 
-  /// Answers collected so far — one entry per completed question.
-  final List<ReplyAnswer> _collectedAnswers = [];
+  /// Direction used by the question-page transition: 1 forward, -1 backward.
+  int _navigationDirection = 1;
 
-  /// Selection state for the *current* question.
-  final Set<String> _selectedLabels = {};
-  bool _customSelected = false;
+  bool _confirmingRequestDecline = false;
 
   void _dismissModal() {
     context.pop();
@@ -95,20 +93,27 @@ class _QuestionModalState extends State<QuestionModal> {
   List<QuestionInfo> get _questions => widget.question.questions;
   int get _totalQuestions => _questions.length;
   QuestionInfo get _currentInfo => _questions[_currentIndex];
+  _QuestionDraft get _currentDraft => _drafts[_currentIndex];
   bool get _isLastQuestion => _currentIndex == _totalQuestions - 1;
   bool get _isMultiQuestion => _totalQuestions > 1;
+  bool get _allQuestionsResolved => _drafts.every((draft) => draft.resolution != _QuestionResolution.unanswered);
 
   @override
   void initState() {
     super.initState();
-    _customFocus.addListener(_onCustomFocusChanged);
-    _customController.addListener(_onCustomTextChanged);
+    _drafts = List.generate(_totalQuestions, (index) {
+      final draft = _QuestionDraft();
+      draft.customFocus.addListener(() => _onCustomFocusChanged(index));
+      draft.customController.addListener(() => _onCustomTextChanged(index));
+      return draft;
+    });
   }
 
   @override
   void dispose() {
-    _customFocus.dispose();
-    _customController.dispose();
+    for (final draft in _drafts) {
+      draft.dispose();
+    }
     super.dispose();
   }
 
@@ -116,56 +121,80 @@ class _QuestionModalState extends State<QuestionModal> {
   // Callbacks
   // ---------------------------------------------------------------------------
 
-  void _onCustomFocusChanged() {
-    if (_customFocus.hasFocus && !_customSelected) {
+  void _onCustomFocusChanged(int index) {
+    if (!mounted || index != _currentIndex) return;
+
+    final draft = _drafts[index];
+    if (draft.customFocus.hasFocus && (!draft.customSelected || draft.isDeclined)) {
       setState(() {
-        _customSelected = true;
+        draft
+          ..disposition = _QuestionDisposition.answer
+          ..customSelected = true;
         if (!_currentInfo.multiple) {
-          _selectedLabels.clear();
+          draft.selectedLabels.clear();
         }
       });
     }
   }
 
-  void _onCustomTextChanged() {
+  void _onCustomTextChanged(int index) {
     // Rebuild to update submit button enabled state.
-    if (_customSelected) setState(() {});
+    if (mounted && index == _currentIndex && _drafts[index].customSelected) {
+      setState(() {});
+    }
   }
 
   void _onCustomTileTap() {
-    if (_customSelected) {
-      _customFocus.unfocus();
+    final draft = _currentDraft;
+    if (draft.customSelected && !draft.isDeclined) {
+      draft.customFocus.unfocus();
       setState(() {
-        _customSelected = false;
+        draft.customSelected = false;
       });
       return;
     }
 
     setState(() {
-      _customSelected = true;
+      draft
+        ..disposition = _QuestionDisposition.answer
+        ..customSelected = true;
       if (!_currentInfo.multiple) {
-        _selectedLabels.clear();
+        draft.selectedLabels.clear();
       }
     });
-    _customFocus.requestFocus();
+    draft.customFocus.requestFocus();
   }
 
   void _onOptionTap(String label) {
-    _customFocus.unfocus();
+    final draft = _currentDraft;
+    draft.customFocus.unfocus();
     setState(() {
-      if (_currentInfo.multiple) {
-        if (_selectedLabels.contains(label)) {
-          _selectedLabels.remove(label);
+      final wasDeclined = draft.isDeclined;
+      draft.disposition = _QuestionDisposition.answer;
+      if (wasDeclined) {
+        if (_currentInfo.multiple) {
+          draft.selectedLabels.add(label);
         } else {
-          _selectedLabels.add(label);
+          draft
+            ..customSelected = false
+            ..selectedLabels.clear();
+          draft.selectedLabels.add(label);
+        }
+        return;
+      }
+      if (_currentInfo.multiple) {
+        if (draft.selectedLabels.contains(label)) {
+          draft.selectedLabels.remove(label);
+        } else {
+          draft.selectedLabels.add(label);
         }
       } else {
-        _customSelected = false;
+        draft.customSelected = false;
         // Single-select: toggle — only one at a time.
-        if (_selectedLabels.contains(label)) {
-          _selectedLabels.clear();
+        if (draft.selectedLabels.contains(label)) {
+          draft.selectedLabels.clear();
         } else {
-          _selectedLabels
+          draft.selectedLabels
             ..clear()
             ..add(label);
         }
@@ -173,43 +202,49 @@ class _QuestionModalState extends State<QuestionModal> {
     });
   }
 
-  String get _trimmedCustomAnswer => _customController.text.trim();
-  bool get _hasSelectedCustomAnswer => _customSelected && _trimmedCustomAnswer.isNotEmpty;
-
-  bool get _canProceed {
-    return _selectedLabels.isNotEmpty || _hasSelectedCustomAnswer;
+  void _onDeclineCurrentQuestion() {
+    final draft = _currentDraft;
+    draft.customFocus.unfocus();
+    setState(() {
+      draft.disposition = draft.isDeclined ? _QuestionDisposition.answer : _QuestionDisposition.declined;
+    });
   }
 
-  /// Collects the current answer and either advances to the next question
-  /// or submits all answers if this is the last one.
+  void _navigateTo(int index) {
+    if (index == _currentIndex || index < 0 || index >= _totalQuestions) return;
+
+    _currentDraft.customFocus.unfocus();
+    setState(() {
+      _navigationDirection = index > _currentIndex ? 1 : -1;
+      _currentIndex = index;
+    });
+  }
+
   void _onProceed() {
-    // Build the answer for the current question.
-    final answer = _selectedLabels.toList();
-    if (_hasSelectedCustomAnswer) {
-      answer.add(_trimmedCustomAnswer);
-    }
-    if (answer.isEmpty) return;
+    if (!_isLastQuestion) _navigateTo(_currentIndex + 1);
+  }
 
-    _collectedAnswers.add(ReplyAnswer(values: answer));
+  void _onSubmit() {
+    if (!_allQuestionsResolved) return;
 
-    if (_isLastQuestion) {
-      // All questions answered — submit.
-      widget.onReply(widget.question.id, _collectedAnswers);
-      _dismissModal();
-    } else {
-      // Advance to next question — reset selection state.
-      setState(() {
-        _currentIndex++;
-        _selectedLabels.clear();
-        _customSelected = false;
-        _customController.clear();
-      });
-    }
+    final answers = _drafts.map((draft) => ReplyAnswer(values: draft.answerValues)).toList(growable: false);
+    widget.onReply(widget.question.id, answers);
+    _dismissModal();
   }
 
   void _onReject() {
     widget.onReject(widget.question.id);
     _dismissModal();
+  }
+
+  void _onDeclineRequest() {
+    _currentDraft.customFocus.unfocus();
+    if (!_isMultiQuestion) {
+      _onReject();
+      return;
+    }
+
+    setState(() => _confirmingRequestDecline = true);
   }
 
   // ---------------------------------------------------------------------------
@@ -221,6 +256,7 @@ class _QuestionModalState extends State<QuestionModal> {
     final prego = context.prego;
     final loc = context.loc;
     final info = _currentInfo;
+    final draft = _currentDraft;
     final screenHeight = MediaQuery.heightOf(context);
     final keyboard = MediaQuery.viewInsetsOf(context).bottom;
     // Mirror the inset PregoBottomSheet adds below the body so the cap below
@@ -231,118 +267,469 @@ class _QuestionModalState extends State<QuestionModal> {
     // the sheet's own cap and scrolls inside the Flexible list while the
     // actions stay pinned.
     final maxBody = screenHeight - widget.topInset - PregoBottomSheet.contentTopInset - bottomInset;
+    // In a compact landscape/keyboard viewport, the header still provides Back
+    // navigation. Let the question content keep the limited vertical space
+    // instead of overflowing fixed navigator and helper rows.
+    final showQuestionNavigator = _isMultiQuestion && maxBody >= 180;
 
     return PregoBottomSheet(
-      title: info.header.isNotEmpty ? info.header : loc.questionModalTitle,
+      title: _confirmingRequestDecline
+          ? loc.questionModalDeclineAllTitle
+          : (info.header.isNotEmpty ? info.header : loc.questionModalTitle),
+      subtitle: _isMultiQuestion && !_confirmingRequestDecline
+          ? loc.questionModalStepIndicator(
+              _currentIndex + 1,
+              _totalQuestions,
+            )
+          : null,
       topInset: widget.topInset,
+      onBack: _confirmingRequestDecline
+          ? () => setState(() => _confirmingRequestDecline = false)
+          : (_currentIndex > 0 ? () => _navigateTo(_currentIndex - 1) : null),
       onClose: _dismissModal,
       // Full-bleed body; the step indicator, list, and actions pad themselves.
       contentPadding: EdgeInsetsDirectional.zero,
       child: ConstrainedBox(
         constraints: BoxConstraints(maxHeight: math.max(maxBody, screenHeight * 0.3)),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // Step indicator (only when there are multiple questions)
-            if (_isMultiQuestion)
-              Padding(
-                padding: const EdgeInsetsDirectional.fromSTEB(16, 0, 16, 8),
-                child: Row(
-                  children: [
-                    Text(
-                      loc.questionModalStepIndicator(
-                        _currentIndex + 1,
-                        _totalQuestions,
-                      ),
-                      style: prego.textTheme.textSm.bold.copyWith(
-                        color: prego.colors.textSecondary,
+        child: _confirmingRequestDecline
+            ? _DeclineAllConfirmation(
+                onCancel: () => setState(() => _confirmingRequestDecline = false),
+                onConfirm: _onReject,
+              )
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // Direct question navigation (only when there are multiple questions).
+                  if (showQuestionNavigator)
+                    Padding(
+                      padding: const EdgeInsetsDirectional.fromSTEB(16, 0, 16, 8),
+                      child: _QuestionNavigator(
+                        currentIndex: _currentIndex,
+                        resolutions: _drafts.map((item) => item.resolution).toList(growable: false),
+                        onSelected: _navigateTo,
                       ),
                     ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(4),
-                        child: LinearProgressIndicator(
-                          value: (_currentIndex + 1) / _totalQuestions,
-                          minHeight: 4,
-                          backgroundColor: prego.colors.bgQuaternary,
-                          color: prego.colors.bgBrandSolid,
+
+                  // Scrollable body — wraps its content (a handful of option tiles,
+                  // so laying them all out is cheap) and scrolls only once the
+                  // sheet hits its cap.
+                  Flexible(
+                    child: AnimatedSwitcher(
+                      duration: const Duration(milliseconds: 180),
+                      switchInCurve: Curves.easeOutCubic,
+                      switchOutCurve: Curves.easeInCubic,
+                      transitionBuilder: (child, animation) {
+                        final key = child.key;
+                        final isIncoming = key is ValueKey<int> && key.value == _currentIndex;
+                        final horizontalOffset = (isIncoming ? 1 : -1) * _navigationDirection * 0.04;
+                        return IgnorePointer(
+                          ignoring: !isIncoming,
+                          child: ExcludeSemantics(
+                            excluding: !isIncoming,
+                            child: FadeTransition(
+                              opacity: animation,
+                              child: SlideTransition(
+                                position: Tween<Offset>(
+                                  begin: Offset(horizontalOffset, 0),
+                                  end: Offset.zero,
+                                ).animate(animation),
+                                child: child,
+                              ),
+                            ),
+                          ),
+                        );
+                      },
+                      child: ListView(
+                        key: ValueKey(_currentIndex),
+                        shrinkWrap: true,
+                        padding: const EdgeInsets.all(16),
+                        children: [
+                          // Question text
+                          MarkdownBody(
+                            data: info.question,
+                            selectable: true,
+                            onTapLink: handleMarkdownLinkTap,
+                            styleSheet: buildSessionMarkdownStyleSheet(
+                              prego: prego,
+                              paragraphStyle: prego.textTheme.textSm.medium,
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+
+                          // Option tiles
+                          ...info.options.map(
+                            (option) => _OptionTile(
+                              option: option,
+                              isMultiple: info.multiple,
+                              isSelected: !draft.isDeclined && draft.selectedLabels.contains(option.label),
+                              onTap: () => _onOptionTap(option.label),
+                            ),
+                          ),
+
+                          // Custom answer tile
+                          if (info.custom) ...[
+                            const SizedBox(height: 8),
+                            _CustomAnswerTile(
+                              controller: draft.customController,
+                              focusNode: draft.customFocus,
+                              isSelected: !draft.isDeclined && draft.customSelected,
+                              isMultiple: info.multiple,
+                              onTap: _onCustomTileTap,
+                            ),
+                          ],
+
+                          if (_isMultiQuestion) ...[
+                            const SizedBox(height: 8),
+                            _DeclineQuestionTile(
+                              isSelected: draft.isDeclined,
+                              onTap: _onDeclineCurrentQuestion,
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ),
+
+                  if (_isLastQuestion && !_allQuestionsResolved && showQuestionNavigator)
+                    Padding(
+                      padding: const EdgeInsetsDirectional.fromSTEB(16, 0, 16, 8),
+                      child: Text(
+                        loc.questionModalResolveAll,
+                        textAlign: TextAlign.center,
+                        style: prego.textTheme.textXs.regular.copyWith(
+                          color: prego.colors.textSecondary,
                         ),
                       ),
                     ),
-                  ],
+
+                  // Request-wide decline / Submit / Next actions.
+                  Padding(
+                    padding: const EdgeInsetsDirectional.fromSTEB(16, 0, 16, 16),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: OutlinedButton(
+                            key: const Key("decline-question-request"),
+                            style: OutlinedButton.styleFrom(
+                              foregroundColor: prego.colors.fgErrorPrimary,
+                              side: BorderSide(color: prego.colors.fgErrorPrimary),
+                            ),
+                            onPressed: _onDeclineRequest,
+                            child: Text(
+                              _isMultiQuestion ? loc.questionModalDeclineAll : loc.questionModalDecline,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: FilledButton(
+                            key: const Key("question-primary-action"),
+                            onPressed: _isLastQuestion ? (_allQuestionsResolved ? _onSubmit : null) : _onProceed,
+                            child: Text(
+                              _isLastQuestion ? loc.questionModalSubmit : loc.questionModalNext,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+}
+
+enum _QuestionDisposition { answer, declined }
+
+enum _QuestionResolution { unanswered, answered, declined }
+
+class _QuestionDraft {
+  final TextEditingController customController = TextEditingController();
+  final FocusNode customFocus = FocusNode();
+  final Set<String> selectedLabels = {};
+
+  _QuestionDisposition disposition = _QuestionDisposition.answer;
+  bool customSelected = false;
+
+  bool get isDeclined => disposition == _QuestionDisposition.declined;
+
+  List<String> get answerValues {
+    if (isDeclined) return const [];
+
+    final values = selectedLabels.toList();
+    final custom = customController.text.trim();
+    if (customSelected && custom.isNotEmpty) values.add(custom);
+    return values;
+  }
+
+  _QuestionResolution get resolution {
+    if (isDeclined) return _QuestionResolution.declined;
+    return answerValues.isEmpty ? _QuestionResolution.unanswered : _QuestionResolution.answered;
+  }
+
+  void dispose() {
+    customFocus.dispose();
+    customController.dispose();
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Request-wide decline confirmation
+// -----------------------------------------------------------------------------
+
+class _DeclineAllConfirmation extends StatelessWidget {
+  final VoidCallback onCancel;
+  final VoidCallback onConfirm;
+
+  const _DeclineAllConfirmation({
+    required this.onCancel,
+    required this.onConfirm,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    final loc = context.loc;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsetsDirectional.fromSTEB(16, 0, 16, 16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            loc.questionModalDeclineAllMessage,
+            style: prego.textTheme.textSm.regular.copyWith(
+              color: prego.colors.textSecondary,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: onCancel,
+                  child: Text(loc.questionModalKeepAnswering),
                 ),
               ),
-
-            // Scrollable body — wraps its content (a handful of option tiles,
-            // so laying them all out is cheap) and scrolls only once the
-            // sheet hits its cap.
-            Flexible(
-              child: ListView(
-                shrinkWrap: true,
-                padding: const EdgeInsets.all(16),
-                children: [
-                  // Question text
-                  MarkdownBody(
-                    data: info.question,
-                    selectable: true,
-                    onTapLink: handleMarkdownLinkTap,
-                    styleSheet: buildSessionMarkdownStyleSheet(
-                      prego: prego,
-                      paragraphStyle: prego.textTheme.textSm.medium,
-                    ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: FilledButton(
+                  style: FilledButton.styleFrom(
+                    backgroundColor: prego.colors.fgErrorPrimary,
                   ),
-                  const SizedBox(height: 16),
-
-                  // Option tiles
-                  ...info.options.map(
-                    (option) => _OptionTile(
-                      option: option,
-                      isMultiple: info.multiple,
-                      isSelected: _selectedLabels.contains(option.label),
-                      onTap: () => _onOptionTap(option.label),
-                    ),
-                  ),
-
-                  // Custom answer tile
-                  if (info.custom) ...[
-                    const SizedBox(height: 8),
-                    _CustomAnswerTile(
-                      controller: _customController,
-                      focusNode: _customFocus,
-                      isSelected: _customSelected,
-                      isMultiple: info.multiple,
-                      onTap: _onCustomTileTap,
-                    ),
-                  ],
-                ],
+                  onPressed: onConfirm,
+                  child: Text(loc.questionModalDeclineAll),
+                ),
               ),
-            ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
 
-            // Reject / Submit / Next actions
-            Padding(
-              padding: const EdgeInsetsDirectional.fromSTEB(16, 0, 16, 16),
+// -----------------------------------------------------------------------------
+// Question navigator
+// -----------------------------------------------------------------------------
+
+class _QuestionNavigator extends StatefulWidget {
+  final int currentIndex;
+  final List<_QuestionResolution> resolutions;
+  final ValueChanged<int> onSelected;
+
+  const _QuestionNavigator({
+    required this.currentIndex,
+    required this.resolutions,
+    required this.onSelected,
+  });
+
+  @override
+  State<_QuestionNavigator> createState() => _QuestionNavigatorState();
+}
+
+class _QuestionNavigatorState extends State<_QuestionNavigator> {
+  late List<GlobalKey> _stepKeys;
+
+  @override
+  void initState() {
+    super.initState();
+    _stepKeys = _buildStepKeys();
+  }
+
+  @override
+  void didUpdateWidget(covariant _QuestionNavigator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.resolutions.length != widget.resolutions.length) {
+      _stepKeys = _buildStepKeys();
+    }
+    if (oldWidget.currentIndex != widget.currentIndex) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _revealCurrentStep());
+    }
+  }
+
+  List<GlobalKey> _buildStepKeys() => List.generate(widget.resolutions.length, (_) => GlobalKey());
+
+  void _revealCurrentStep() {
+    if (!mounted) return;
+    final stepContext = _stepKeys[widget.currentIndex].currentContext;
+    if (stepContext == null) return;
+    Scrollable.ensureVisible(
+      stepContext,
+      alignment: 0.5,
+      duration: const Duration(milliseconds: 180),
+      curve: Curves.easeOutCubic,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final children = <Widget>[];
+    for (var index = 0; index < widget.resolutions.length; index++) {
+      if (index > 0) {
+        children.add(
+          Container(
+            width: 20,
+            height: 2,
+            color: context.prego.colors.borderSecondary,
+          ),
+        );
+      }
+      children.add(
+        KeyedSubtree(
+          key: _stepKeys[index],
+          child: _QuestionStep(
+            key: Key("question-step-$index"),
+            index: index,
+            total: widget.resolutions.length,
+            isCurrent: index == widget.currentIndex,
+            resolution: widget.resolutions[index],
+            onTap: () => widget.onSelected(index),
+          ),
+        ),
+      );
+    }
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SizedBox(
+          height: 44,
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minWidth: constraints.maxWidth),
               child: Row(
-                children: [
-                  Expanded(
-                    child: OutlinedButton(
-                      onPressed: _onReject,
-                      child: Text(loc.questionModalReject),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: FilledButton(
-                      onPressed: _canProceed ? _onProceed : null,
-                      child: Text(
-                        _isLastQuestion ? loc.questionModalSubmit : loc.questionModalNext,
-                      ),
-                    ),
-                  ),
-                ],
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: children,
               ),
             ),
-          ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _QuestionStep extends StatelessWidget {
+  final int index;
+  final int total;
+  final bool isCurrent;
+  final _QuestionResolution resolution;
+  final VoidCallback onTap;
+
+  const _QuestionStep({
+    super.key,
+    required this.index,
+    required this.total,
+    required this.isCurrent,
+    required this.resolution,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    final loc = context.loc;
+    final status = switch (resolution) {
+      _QuestionResolution.unanswered => loc.questionModalStatusUnanswered,
+      _QuestionResolution.answered => loc.questionModalStatusAnswered,
+      _QuestionResolution.declined => loc.questionModalStatusDeclined,
+    };
+    final backgroundColor = isCurrent
+        ? prego.colors.bgBrandSolid
+        : switch (resolution) {
+            _QuestionResolution.unanswered => prego.colors.bgSurface1,
+            _QuestionResolution.answered => prego.colors.bgBrandPrimary,
+            _QuestionResolution.declined => prego.colors.bgQuaternary,
+          };
+    final foregroundColor = isCurrent
+        ? prego.colors.textWhite
+        : switch (resolution) {
+            _QuestionResolution.unanswered => prego.colors.textSecondary,
+            _QuestionResolution.answered => prego.colors.textBrandPrimary,
+            _QuestionResolution.declined => prego.colors.textSecondary,
+          };
+    final borderColor = isCurrent
+        ? prego.colors.bgBrandSolid
+        : switch (resolution) {
+            _QuestionResolution.unanswered => prego.colors.borderSecondary,
+            _QuestionResolution.answered => prego.colors.borderBrand,
+            _QuestionResolution.declined => prego.colors.borderPrimary,
+          };
+
+    final child = isCurrent
+        ? Text(
+            "${index + 1}",
+            style: prego.textTheme.textSm.bold.copyWith(color: foregroundColor),
+          )
+        : switch (resolution) {
+            _QuestionResolution.unanswered => Text(
+              "${index + 1}",
+              style: prego.textTheme.textSm.bold.copyWith(color: foregroundColor),
+            ),
+            _QuestionResolution.answered => Icon(
+              TablerRegular.check,
+              size: 16,
+              color: foregroundColor,
+            ),
+            _QuestionResolution.declined => Icon(
+              TablerRegular.minus,
+              size: 16,
+              color: foregroundColor,
+            ),
+          };
+
+    return Semantics(
+      button: true,
+      selected: isCurrent,
+      label: loc.questionModalStepSemantics(index + 1, total, status),
+      child: ExcludeSemantics(
+        child: SizedBox(
+          width: 44,
+          height: 44,
+          child: Material(
+            color: Colors.transparent,
+            child: InkWell(
+              customBorder: const CircleBorder(),
+              onTap: onTap,
+              child: Center(
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 150),
+                  width: 32,
+                  height: 32,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: backgroundColor,
+                    shape: BoxShape.circle,
+                    border: Border.all(color: borderColor),
+                  ),
+                  child: child,
+                ),
+              ),
+            ),
+          ),
         ),
       ),
     );
@@ -410,6 +797,77 @@ class _OptionTile extends StatelessWidget {
                           ),
                         ),
                       ],
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Per-question decline tile
+// -----------------------------------------------------------------------------
+
+class _DeclineQuestionTile extends StatelessWidget {
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _DeclineQuestionTile({
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    final loc = context.loc;
+
+    return Semantics(
+      button: true,
+      selected: isSelected,
+      child: Material(
+        key: const Key("decline-current-question"),
+        color: isSelected ? prego.colors.bgQuaternary : prego.colors.bgSurface1,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+          side: BorderSide(
+            color: isSelected ? prego.colors.borderPrimary : prego.colors.borderSecondary,
+          ),
+        ),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Row(
+              children: [
+                Icon(
+                  TablerRegular.circle_minus,
+                  color: prego.colors.textSecondary,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        isSelected ? loc.questionModalQuestionDeclined : loc.questionModalDeclineQuestion,
+                        style: prego.textTheme.textSm.bold.copyWith(
+                          color: isSelected ? prego.colors.textPrimary : prego.colors.textSecondary,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        isSelected ? loc.questionModalQuestionDeclinedHint : loc.questionModalDeclineQuestionHint,
+                        style: prego.textTheme.textXs.regular.copyWith(
+                          color: prego.colors.textSecondary,
+                        ),
+                      ),
                     ],
                   ),
                 ),

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -417,6 +417,7 @@
   "questionModalSubmit": "Submit answers",
   "questionModalNext": "Next",
   "questionModalResolveAll": "Answer or decline every question to submit.",
+  "questionModalResolveAllCompact": "Answer or decline all",
   "questionModalStatusUnanswered": "unanswered",
   "questionModalStatusAnswered": "answered",
   "questionModalStatusDeclined": "declined",

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -404,10 +404,22 @@
     "description": "Text for the floating pill button that appears when the user scrolls up in the message list, allowing them to jump back to the newest messages."
   },
   "questionModalTitle": "Question",
-  "questionModalReject": "Reject",
+  "questionModalDecline": "Decline",
+  "questionModalDeclineAll": "Decline all",
+  "questionModalDeclineQuestion": "Decline this question",
+  "questionModalDeclineQuestionHint": "The assistant will see it as unanswered.",
+  "questionModalQuestionDeclined": "Question declined",
+  "questionModalQuestionDeclinedHint": "Choose an answer to undo.",
+  "questionModalDeclineAllTitle": "Decline all questions?",
+  "questionModalDeclineAllMessage": "None of your draft answers will be sent. Your coding session will remain active.",
+  "questionModalKeepAnswering": "Keep answering",
   "questionModalCustomHint": "Type your own answer",
-  "questionModalSubmit": "Submit",
+  "questionModalSubmit": "Submit answers",
   "questionModalNext": "Next",
+  "questionModalResolveAll": "Answer or decline every question to submit.",
+  "questionModalStatusUnanswered": "unanswered",
+  "questionModalStatusAnswered": "answered",
+  "questionModalStatusDeclined": "declined",
   "questionModalStepIndicator": "Question {current} of {total}",
   "@questionModalStepIndicator": {
     "placeholders": {
@@ -416,6 +428,20 @@
       },
       "total": {
         "type": "int"
+      }
+    }
+  },
+  "questionModalStepSemantics": "Question {current} of {total}, {status}",
+  "@questionModalStepSemantics": {
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      },
+      "status": {
+        "type": "String"
       }
     }
   },

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -1351,11 +1351,59 @@ abstract class AppLocalizations {
   /// **'Question'**
   String get questionModalTitle;
 
-  /// No description provided for @questionModalReject.
+  /// No description provided for @questionModalDecline.
   ///
   /// In en, this message translates to:
-  /// **'Reject'**
-  String get questionModalReject;
+  /// **'Decline'**
+  String get questionModalDecline;
+
+  /// No description provided for @questionModalDeclineAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Decline all'**
+  String get questionModalDeclineAll;
+
+  /// No description provided for @questionModalDeclineQuestion.
+  ///
+  /// In en, this message translates to:
+  /// **'Decline this question'**
+  String get questionModalDeclineQuestion;
+
+  /// No description provided for @questionModalDeclineQuestionHint.
+  ///
+  /// In en, this message translates to:
+  /// **'The assistant will see it as unanswered.'**
+  String get questionModalDeclineQuestionHint;
+
+  /// No description provided for @questionModalQuestionDeclined.
+  ///
+  /// In en, this message translates to:
+  /// **'Question declined'**
+  String get questionModalQuestionDeclined;
+
+  /// No description provided for @questionModalQuestionDeclinedHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose an answer to undo.'**
+  String get questionModalQuestionDeclinedHint;
+
+  /// No description provided for @questionModalDeclineAllTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Decline all questions?'**
+  String get questionModalDeclineAllTitle;
+
+  /// No description provided for @questionModalDeclineAllMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'None of your draft answers will be sent. Your coding session will remain active.'**
+  String get questionModalDeclineAllMessage;
+
+  /// No description provided for @questionModalKeepAnswering.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep answering'**
+  String get questionModalKeepAnswering;
 
   /// No description provided for @questionModalCustomHint.
   ///
@@ -1366,7 +1414,7 @@ abstract class AppLocalizations {
   /// No description provided for @questionModalSubmit.
   ///
   /// In en, this message translates to:
-  /// **'Submit'**
+  /// **'Submit answers'**
   String get questionModalSubmit;
 
   /// No description provided for @questionModalNext.
@@ -1375,11 +1423,41 @@ abstract class AppLocalizations {
   /// **'Next'**
   String get questionModalNext;
 
+  /// No description provided for @questionModalResolveAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Answer or decline every question to submit.'**
+  String get questionModalResolveAll;
+
+  /// No description provided for @questionModalStatusUnanswered.
+  ///
+  /// In en, this message translates to:
+  /// **'unanswered'**
+  String get questionModalStatusUnanswered;
+
+  /// No description provided for @questionModalStatusAnswered.
+  ///
+  /// In en, this message translates to:
+  /// **'answered'**
+  String get questionModalStatusAnswered;
+
+  /// No description provided for @questionModalStatusDeclined.
+  ///
+  /// In en, this message translates to:
+  /// **'declined'**
+  String get questionModalStatusDeclined;
+
   /// No description provided for @questionModalStepIndicator.
   ///
   /// In en, this message translates to:
   /// **'Question {current} of {total}'**
   String questionModalStepIndicator(int current, int total);
+
+  /// No description provided for @questionModalStepSemantics.
+  ///
+  /// In en, this message translates to:
+  /// **'Question {current} of {total}, {status}'**
+  String questionModalStepSemantics(int current, int total, String status);
 
   /// No description provided for @questionBannerSingle.
   ///

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -1429,6 +1429,12 @@ abstract class AppLocalizations {
   /// **'Answer or decline every question to submit.'**
   String get questionModalResolveAll;
 
+  /// No description provided for @questionModalResolveAllCompact.
+  ///
+  /// In en, this message translates to:
+  /// **'Answer or decline all'**
+  String get questionModalResolveAllCompact;
+
   /// No description provided for @questionModalStatusUnanswered.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -664,20 +664,62 @@ class AppLocalizationsEn extends AppLocalizations {
   String get questionModalTitle => 'Question';
 
   @override
-  String get questionModalReject => 'Reject';
+  String get questionModalDecline => 'Decline';
+
+  @override
+  String get questionModalDeclineAll => 'Decline all';
+
+  @override
+  String get questionModalDeclineQuestion => 'Decline this question';
+
+  @override
+  String get questionModalDeclineQuestionHint => 'The assistant will see it as unanswered.';
+
+  @override
+  String get questionModalQuestionDeclined => 'Question declined';
+
+  @override
+  String get questionModalQuestionDeclinedHint => 'Choose an answer to undo.';
+
+  @override
+  String get questionModalDeclineAllTitle => 'Decline all questions?';
+
+  @override
+  String get questionModalDeclineAllMessage =>
+      'None of your draft answers will be sent. Your coding session will remain active.';
+
+  @override
+  String get questionModalKeepAnswering => 'Keep answering';
 
   @override
   String get questionModalCustomHint => 'Type your own answer';
 
   @override
-  String get questionModalSubmit => 'Submit';
+  String get questionModalSubmit => 'Submit answers';
 
   @override
   String get questionModalNext => 'Next';
 
   @override
+  String get questionModalResolveAll => 'Answer or decline every question to submit.';
+
+  @override
+  String get questionModalStatusUnanswered => 'unanswered';
+
+  @override
+  String get questionModalStatusAnswered => 'answered';
+
+  @override
+  String get questionModalStatusDeclined => 'declined';
+
+  @override
   String questionModalStepIndicator(int current, int total) {
     return 'Question $current of $total';
+  }
+
+  @override
+  String questionModalStepSemantics(int current, int total, String status) {
+    return 'Question $current of $total, $status';
   }
 
   @override

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -704,6 +704,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get questionModalResolveAll => 'Answer or decline every question to submit.';
 
   @override
+  String get questionModalResolveAllCompact => 'Answer or decline all';
+
+  @override
   String get questionModalStatusUnanswered => 'unanswered';
 
   @override

--- a/client/app/test/features/session_detail/widgets/question_modal_test.dart
+++ b/client/app/test/features/session_detail/widgets/question_modal_test.dart
@@ -569,7 +569,7 @@ void main() {
     ]);
   });
 
-  testWidgets("answering a locally declined question restores its multi-select draft", (tester) async {
+  testWidgets("answering a locally declined question starts a fresh answer", (tester) async {
     final capture = _ReplyCapture();
     final router = _createRouter(
       question: _questionAsked(
@@ -617,7 +617,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(capture.answers, [
-      const ReplyAnswer(values: ["Mobile", "Desktop", "Web preview"]),
+      const ReplyAnswer(values: ["Desktop"]),
       const ReplyAnswer(values: ["Gradual"]),
     ]);
   });

--- a/client/app/test/features/session_detail/widgets/question_modal_test.dart
+++ b/client/app/test/features/session_detail/widgets/question_modal_test.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:go_router/go_router.dart";
@@ -9,10 +11,17 @@ import "package:theme_prego/module_prego.dart";
 class _ReplyCapture {
   String? requestId;
   List<ReplyAnswer>? answers;
+  String? rejectedRequestId;
+  Stream<bool> pendingStream = const Stream.empty();
+  bool isPending = true;
 
   void onReply(String requestId, List<ReplyAnswer> answers) {
     this.requestId = requestId;
     this.answers = answers;
+  }
+
+  void onReject(String requestId) {
+    rejectedRequestId = requestId;
   }
 }
 
@@ -34,9 +43,9 @@ GoRouter _createRouter({
                     context,
                     question: question,
                     onReply: capture.onReply,
-                    onReject: (_) {},
-                    isPendingStream: const Stream<bool>.empty(),
-                    isPending: () => true,
+                    onReject: capture.onReject,
+                    isPendingStream: capture.pendingStream,
+                    isPending: () => capture.isPending,
                   );
                 },
                 child: const Text("Open question modal"),
@@ -334,7 +343,7 @@ void main() {
     ]);
   });
 
-  testWidgets("advancing to the next question resets current question state", (tester) async {
+  testWidgets("each question starts with an independent draft", (tester) async {
     final capture = _ReplyCapture();
     final router = _createRouter(
       question: _questionAsked(
@@ -388,5 +397,421 @@ void main() {
         const ReplyAnswer(values: ["Gradual"]),
       ],
     );
+  });
+
+  testWidgets("questions can be visited unanswered and edited in either direction", (tester) async {
+    final capture = _ReplyCapture();
+    final router = _createRouter(
+      question: _questionAsked(
+        questions: const [
+          QuestionInfo(
+            question: "Choose platforms",
+            header: "Platforms",
+            multiple: true,
+            custom: true,
+            options: [
+              QuestionOption(label: "Mobile", description: "Phone app"),
+            ],
+          ),
+          QuestionInfo(
+            question: "Choose rollout speed",
+            header: "Rollout",
+            custom: false,
+            options: [
+              QuestionOption(label: "Gradual", description: "Ramp slowly"),
+            ],
+          ),
+          QuestionInfo(
+            question: "Add release notes",
+            header: "Notes",
+            options: [],
+            custom: true,
+          ),
+        ],
+      ),
+      capture: capture,
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openQuestionModal(tester);
+
+    await tester.tap(find.text("Mobile"));
+    await tester.enterText(find.byType(TextField), "Notify QA");
+    await tester.pump();
+    await tester.tap(find.byKey(const Key("question-primary-action")));
+    await tester.pumpAndSettle();
+
+    expect(find.text("Choose rollout speed"), findsOneWidget);
+    final unansweredNext = tester.widget<FilledButton>(
+      find.byKey(const Key("question-primary-action")),
+    );
+    expect(unansweredNext.onPressed, isNotNull);
+
+    await tester.tap(find.byKey(const Key("question-primary-action")));
+    await tester.pumpAndSettle();
+    expect(find.text("Add release notes"), findsOneWidget);
+
+    await tester.tap(find.byIcon(TablerRegular.arrow_left));
+    await tester.pumpAndSettle();
+    expect(find.text("Choose rollout speed"), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key("question-step-0")));
+    await tester.pumpAndSettle();
+    expect(find.text("Choose platforms"), findsOneWidget);
+    expect(find.text("Notify QA"), findsOneWidget);
+
+    await tester.tap(find.text("Mobile"));
+    await tester.enterText(find.byType(TextField), "Notify QA and Docs");
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key("question-step-1")));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text("Gradual"));
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key("question-step-2")));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), "Include the migration guide");
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key("question-primary-action")));
+    await tester.pumpAndSettle();
+
+    expect(capture.answers, [
+      const ReplyAnswer(values: ["Notify QA and Docs"]),
+      const ReplyAnswer(values: ["Gradual"]),
+      const ReplyAnswer(values: ["Include the migration guide"]),
+    ]);
+  });
+
+  testWidgets("submit requires every question to be answered or explicitly declined", (tester) async {
+    final capture = _ReplyCapture();
+    final router = _createRouter(
+      question: _questionAsked(
+        questions: const [
+          QuestionInfo(
+            question: "Choose a language",
+            header: "Language",
+            custom: false,
+            options: [
+              QuestionOption(label: "Dart", description: "Flutter language"),
+            ],
+          ),
+          QuestionInfo(
+            question: "Choose an IDE",
+            header: "IDE",
+            custom: false,
+            options: [
+              QuestionOption(label: "VS Code", description: "Microsoft editor"),
+            ],
+          ),
+          QuestionInfo(
+            question: "Choose a platform",
+            header: "Platform",
+            custom: false,
+            options: [
+              QuestionOption(label: "Mobile", description: "Phone app"),
+            ],
+          ),
+        ],
+      ),
+      capture: capture,
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openQuestionModal(tester);
+
+    await tester.tap(find.byKey(const Key("question-primary-action")));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key("question-primary-action")));
+    await tester.pumpAndSettle();
+
+    expect(find.text("Answer or decline every question to submit."), findsOneWidget);
+    expect(
+      tester.widget<FilledButton>(find.byKey(const Key("question-primary-action"))).onPressed,
+      isNull,
+    );
+
+    await tester.tap(find.byKey(const Key("question-step-0")));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text("Dart"));
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key("question-step-1")));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key("decline-current-question")));
+    await tester.pump();
+    expect(find.text("Question declined"), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key("question-step-2")));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(TablerRegular.minus), findsOneWidget);
+    await tester.tap(find.text("Mobile"));
+    await tester.pump();
+
+    expect(
+      tester.widget<FilledButton>(find.byKey(const Key("question-primary-action"))).onPressed,
+      isNotNull,
+    );
+    await tester.tap(find.byKey(const Key("question-primary-action")));
+    await tester.pumpAndSettle();
+
+    expect(capture.answers, [
+      const ReplyAnswer(values: ["Dart"]),
+      const ReplyAnswer(values: []),
+      const ReplyAnswer(values: ["Mobile"]),
+    ]);
+  });
+
+  testWidgets("answering a locally declined question restores its multi-select draft", (tester) async {
+    final capture = _ReplyCapture();
+    final router = _createRouter(
+      question: _questionAsked(
+        questions: const [
+          QuestionInfo(
+            question: "Choose targets",
+            header: "Targets",
+            multiple: true,
+            custom: true,
+            options: [
+              QuestionOption(label: "Mobile", description: "Phone app"),
+              QuestionOption(label: "Desktop", description: "Desktop app"),
+            ],
+          ),
+          QuestionInfo(
+            question: "Choose rollout speed",
+            header: "Rollout",
+            custom: false,
+            options: [
+              QuestionOption(label: "Gradual", description: "Ramp slowly"),
+            ],
+          ),
+        ],
+      ),
+      capture: capture,
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openQuestionModal(tester);
+
+    await tester.tap(find.text("Mobile"));
+    await tester.enterText(find.byType(TextField), "Web preview");
+    await tester.pump();
+    await tester.tap(find.byKey(const Key("decline-current-question")));
+    await tester.pump();
+    await tester.tap(find.text("Desktop"));
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key("question-primary-action")));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text("Gradual"));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key("question-primary-action")));
+    await tester.pumpAndSettle();
+
+    expect(capture.answers, [
+      const ReplyAnswer(values: ["Mobile", "Desktop", "Web preview"]),
+      const ReplyAnswer(values: ["Gradual"]),
+    ]);
+  });
+
+  testWidgets("decline all confirms before rejecting the complete request", (tester) async {
+    final capture = _ReplyCapture();
+    final router = _createRouter(
+      question: _questionAsked(
+        questions: const [
+          QuestionInfo(
+            question: "Choose a language",
+            header: "Language",
+            options: [],
+          ),
+          QuestionInfo(
+            question: "Choose a platform",
+            header: "Platform",
+            options: [],
+          ),
+        ],
+      ),
+      capture: capture,
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openQuestionModal(tester);
+
+    await tester.tap(find.byKey(const Key("decline-question-request")));
+    await tester.pumpAndSettle();
+
+    expect(find.text("Decline all questions?"), findsOneWidget);
+    expect(capture.rejectedRequestId, isNull);
+
+    await tester.tap(find.text("Keep answering"));
+    await tester.pumpAndSettle();
+    expect(find.byType(PregoBottomSheet), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key("decline-question-request")));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, "Decline all"));
+    await tester.pumpAndSettle();
+
+    expect(capture.rejectedRequestId, "question-1");
+    expect(capture.answers, isNull);
+    expect(find.byType(PregoBottomSheet), findsNothing);
+  });
+
+  testWidgets("external resolution dismisses an open decline-all confirmation", (tester) async {
+    final capture = _ReplyCapture();
+    final pendingController = StreamController<bool>();
+    capture.pendingStream = pendingController.stream;
+    addTearDown(pendingController.close);
+    final router = _createRouter(
+      question: _questionAsked(
+        questions: const [
+          QuestionInfo(
+            question: "Choose a language",
+            header: "Language",
+            options: [],
+          ),
+          QuestionInfo(
+            question: "Choose a platform",
+            header: "Platform",
+            options: [],
+          ),
+        ],
+      ),
+      capture: capture,
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openQuestionModal(tester);
+    await tester.tap(find.byKey(const Key("decline-question-request")));
+    await tester.pumpAndSettle();
+    expect(find.text("Decline all questions?"), findsOneWidget);
+
+    capture.isPending = false;
+    pendingController.add(false);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(PregoBottomSheet), findsNothing);
+    expect(capture.rejectedRequestId, isNull);
+  });
+
+  testWidgets("question-step semantics announce current resolution", (tester) async {
+    final semantics = tester.ensureSemantics();
+    final capture = _ReplyCapture();
+    final router = _createRouter(
+      question: _questionAsked(
+        questions: const [
+          QuestionInfo(
+            question: "Choose a language",
+            header: "Language",
+            custom: false,
+            options: [
+              QuestionOption(label: "Dart", description: "Flutter language"),
+            ],
+          ),
+          QuestionInfo(
+            question: "Choose a platform",
+            header: "Platform",
+            custom: false,
+            options: [
+              QuestionOption(label: "Mobile", description: "Phone app"),
+            ],
+          ),
+        ],
+      ),
+      capture: capture,
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openQuestionModal(tester);
+
+    expect(find.bySemanticsLabel("Question 1 of 2, unanswered"), findsOneWidget);
+    await tester.tap(find.text("Dart"));
+    await tester.pump();
+    expect(find.bySemanticsLabel("Question 1 of 2, answered"), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key("question-primary-action")));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key("decline-current-question")));
+    await tester.pump();
+    expect(find.bySemanticsLabel("Question 2 of 2, declined"), findsOneWidget);
+    semantics.dispose();
+  });
+
+  testWidgets("compact keyboard viewport keeps the action row overflow-free", (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(700, 300);
+    addTearDown(tester.view.reset);
+    final capture = _ReplyCapture();
+    final router = _createRouter(
+      question: _questionAsked(
+        questions: const [
+          QuestionInfo(
+            question: "Add release notes",
+            header: "Notes",
+            options: [],
+            custom: true,
+          ),
+          QuestionInfo(
+            question: "Choose a platform",
+            header: "Platform",
+            custom: false,
+            options: [
+              QuestionOption(label: "Mobile", description: "Phone app"),
+            ],
+          ),
+        ],
+      ),
+      capture: capture,
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openQuestionModal(tester);
+    await tester.tap(find.byType(TextField));
+    tester.view.viewInsets = const FakeViewPadding(bottom: 180);
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byKey(const Key("question-primary-action")), findsOneWidget);
+    expect(find.byKey(const Key("question-step-0")), findsNothing);
+  });
+
+  testWidgets("single questions expose only the request-level decline", (tester) async {
+    final capture = _ReplyCapture();
+    final router = _createRouter(
+      question: _questionAsked(
+        questions: const [
+          QuestionInfo(
+            question: "Choose a language",
+            header: "Language",
+            custom: false,
+            options: [
+              QuestionOption(label: "Dart", description: "Flutter language"),
+            ],
+          ),
+        ],
+      ),
+      capture: capture,
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openQuestionModal(tester);
+
+    expect(find.byKey(const Key("decline-current-question")), findsNothing);
+    expect(find.widgetWithText(OutlinedButton, "Decline"), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key("decline-question-request")));
+    await tester.pumpAndSettle();
+
+    expect(capture.rejectedRequestId, "question-1");
+    expect(find.byType(PregoBottomSheet), findsNothing);
   });
 }

--- a/client/app/test/features/session_detail/widgets/question_modal_test.dart
+++ b/client/app/test/features/session_detail/widgets/question_modal_test.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:ui" show SemanticsAction;
 
 import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
@@ -15,12 +16,12 @@ class _ReplyCapture {
   Stream<bool> pendingStream = const Stream.empty();
   bool isPending = true;
 
-  void onReply(String requestId, List<ReplyAnswer> answers) {
+  void onReply({required String requestId, required List<ReplyAnswer> answers}) {
     this.requestId = requestId;
     this.answers = answers;
   }
 
-  void onReject(String requestId) {
+  void onReject({required String requestId}) {
     rejectedRequestId = requestId;
   }
 }
@@ -42,8 +43,11 @@ GoRouter _createRouter({
                   QuestionModal.show(
                     context,
                     question: question,
-                    onReply: capture.onReply,
-                    onReject: capture.onReject,
+                    onReply: (requestId, answers) => capture.onReply(
+                      requestId: requestId,
+                      answers: answers,
+                    ),
+                    onReject: (requestId) => capture.onReject(requestId: requestId),
                     isPendingStream: capture.pendingStream,
                     isPending: () => capture.isPending,
                   );
@@ -662,6 +666,49 @@ void main() {
     expect(find.byType(PregoBottomSheet), findsNothing);
   });
 
+  testWidgets("system back cancels decline-all confirmation without dismissing drafts", (tester) async {
+    final capture = _ReplyCapture();
+    final router = _createRouter(
+      question: _questionAsked(
+        questions: const [
+          QuestionInfo(
+            question: "Choose a language",
+            header: "Language",
+            custom: false,
+            options: [
+              QuestionOption(label: "Dart", description: "Flutter language"),
+            ],
+          ),
+          QuestionInfo(
+            question: "Choose a platform",
+            header: "Platform",
+            custom: false,
+            options: [
+              QuestionOption(label: "Mobile", description: "Phone app"),
+            ],
+          ),
+        ],
+      ),
+      capture: capture,
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openQuestionModal(tester);
+    await tester.tap(find.text("Dart"));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key("decline-question-request")));
+    await tester.pumpAndSettle();
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(PregoBottomSheet), findsOneWidget);
+    expect(find.text("Choose a language"), findsOneWidget);
+    expect(find.byIcon(Icons.radio_button_checked), findsOneWidget);
+    expect(capture.rejectedRequestId, isNull);
+  });
+
   testWidgets("external resolution dismisses an open decline-all confirmation", (tester) async {
     final capture = _ReplyCapture();
     final pendingController = StreamController<bool>();
@@ -731,7 +778,12 @@ void main() {
     await tester.pumpWidget(_buildApp(router: router));
     await _openQuestionModal(tester);
 
-    expect(find.bySemanticsLabel("Question 1 of 2, unanswered"), findsOneWidget);
+    final firstStep = find.bySemanticsLabel("Question 1 of 2, unanswered");
+    expect(firstStep, findsOneWidget);
+    expect(
+      tester.getSemantics(firstStep).getSemanticsData().hasAction(SemanticsAction.tap),
+      isTrue,
+    );
     await tester.tap(find.text("Dart"));
     await tester.pump();
     expect(find.bySemanticsLabel("Question 1 of 2, answered"), findsOneWidget);
@@ -742,6 +794,43 @@ void main() {
     await tester.pump();
     expect(find.bySemanticsLabel("Question 2 of 2, declined"), findsOneWidget);
     semantics.dispose();
+  });
+
+  testWidgets("rapid return to a custom question keeps one text field mounted", (tester) async {
+    final capture = _ReplyCapture();
+    final router = _createRouter(
+      question: _questionAsked(
+        questions: const [
+          QuestionInfo(
+            question: "Add release notes",
+            header: "Notes",
+            options: [],
+            custom: true,
+          ),
+          QuestionInfo(
+            question: "Choose a platform",
+            header: "Platform",
+            custom: false,
+            options: [
+              QuestionOption(label: "Mobile", description: "Phone app"),
+            ],
+          ),
+        ],
+      ),
+      capture: capture,
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openQuestionModal(tester);
+
+    await tester.tap(find.byKey(const Key("question-primary-action")));
+    await tester.pump(const Duration(milliseconds: 30));
+    await tester.tap(find.byKey(const Key("question-step-0")));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(TextField), findsOneWidget);
   });
 
   testWidgets("compact keyboard viewport keeps the action row overflow-free", (tester) async {
@@ -774,11 +863,13 @@ void main() {
 
     await tester.pumpWidget(_buildApp(router: router));
     await _openQuestionModal(tester);
-    await tester.tap(find.byType(TextField));
+    await tester.tap(find.byKey(const Key("question-primary-action")));
+    await tester.pumpAndSettle();
     tester.view.viewInsets = const FakeViewPadding(bottom: 180);
     await tester.pumpAndSettle();
 
     expect(tester.takeException(), isNull);
+    expect(find.text("Answer or decline all"), findsOneWidget);
     expect(find.byKey(const Key("question-primary-action")), findsOneWidget);
     expect(find.byKey(const Key("question-step-0")), findsNothing);
   });

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -397,7 +397,7 @@ void main() {
 
     await tester.tap(find.text("Stable"));
     await tester.pump();
-    await tester.tap(find.text("Submit"));
+    await tester.tap(find.text("Submit answers"));
     await tester.pump(const Duration(milliseconds: 250));
     await tester.pumpAndSettle();
 

--- a/shared/sesori_shared/lib/src/models/sesori/reply_to_question_request.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/reply_to_question_request.dart
@@ -31,6 +31,8 @@ sealed class RejectQuestionRequest with _$RejectQuestionRequest {
 
 @Freezed(fromJson: true, toJson: true)
 sealed class ReplyAnswer with _$ReplyAnswer {
+  /// One question's selected values. An empty list means the user explicitly
+  /// declined that question while answering the rest of the request.
   const factory ReplyAnswer({
     required List<String> values,
   }) = _ReplyAnswer;

--- a/shared/sesori_shared/lib/src/models/sesori/reply_to_question_request.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/reply_to_question_request.dart
@@ -31,8 +31,9 @@ sealed class RejectQuestionRequest with _$RejectQuestionRequest {
 
 @Freezed(fromJson: true, toJson: true)
 sealed class ReplyAnswer with _$ReplyAnswer {
-  /// One question's selected values. An empty list means the user explicitly
-  /// declined that question while answering the rest of the request.
+  /// One question's selected values. An empty list means the question was
+  /// intentionally left unanswered, including when the user declines that
+  /// individual question while answering the rest of the request.
   const factory ReplyAnswer({
     required List<String> values,
   }) = _ReplyAnswer;


### PR DESCRIPTION
## Complexity

⚙️ Moderate. This replaces one-way modal state with per-question drafts, direct navigation, explicit resolution states, and request-wide confirmation while preserving the existing reply wire shape.

## What

- Add Prego-styled back and direct step navigation with answered, declined, and unanswered states.
- Preserve option and custom-answer drafts while moving freely between questions.
- Allow moving forward without answering, but gate final submission until every question is answered or explicitly declined.
- Add a per-question decline action that submits an ordered empty answer row, separately from the confirmed `Decline all` request action.
- Keep single-question requests streamlined and adapt the navigator for compact keyboard viewports.
- Add localized copy, semantics, transition behavior, and focused widget coverage.

## Why

Multi-question prompts were one-way: advancing cleared the visible controls and offered no way to revisit or correct an earlier response. The old `Reject` action also looked question-local even though it rejected the complete prompt. Users now need reviewable drafts and explicit local-versus-request decline semantics.

## Risk and test focus

- Preserve answer ordering when navigating non-linearly and when an individual question is declined.
- Keep multi-select and custom drafts intact through decline and undo flows.
- Prevent stale confirmation UI when another surface resolves the pending request.
- Avoid overflow in compact landscape/keyboard layouts and expose useful step semantics.
- User-visible impact: multi-question sheets have new navigation, decline, validation, and confirmation UX.
- Database impact: none.
- Transport impact: no wire-shape change; per-question decline intentionally uses the existing valid empty answer row that older peers already treat as unanswered.

## Expected result

Users can move backward, forward, or directly between questions without losing drafts, intentionally decline an irrelevant question, and submit only after every question is resolved. Declining the complete prompt remains a distinct, confirmed action.

## Verification

- `dart analyze` in `client/app`
- `flutter test test/features/session_detail/widgets/question_modal_test.dart`
- `flutter test test/features/session_detail/widgets/session_detail_body_test.dart`
- `git diff --check`
- Aristotle implementation review: approved
