### PR TITLE
⚙️ [output-image-support] feat(acp): surface live tool images [step 11/13]

### DIFF
--- a/.plan/active/output-image-support/PLAN.md
+++ b/.plan/active/output-image-support/PLAN.md
@@ -313,7 +313,7 @@ coverage; it does not introduce another interpretation of content.
 | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | Content DTO/mapper, explicit composition, and live/replay text consumers. |
 | 9/13 | `output-image-support-acp-content-mapping` | `[output-image-support] refactor(acp): centralize tool content mapping [step 9/13]` | 1,100-1,500 | Tool DTOs and one shared behavior-preserving content policy. |
 | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | Message tracker adopted live/replay; live image materialization. |
-| 11/13 | `output-image-support-acp-tool-images` | `[output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | Tool tracker adopted live/replay; live attachment materialization. |
+| 11/13 | `output-image-support-acp-tool-images` | `⚙️ [output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | Tool tracker adopted live/replay; live attachment materialization. |
 | 12/13 | `output-image-support-acp-image-replay` | `[output-image-support] feat(acp): restore output image replay [step 12/13]` | 900-1,400 | Replay materialization and end-to-end parity proof only. |
 | 13/13 | `output-image-support-retire-plan` | `[output-image-support] docs: retire output image support plan [step 13/13]` | 50-200 | Record completion and move the plan tree from active to completed. |
 

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -231,7 +231,10 @@
   explicit diff content with no known status after `952cc30f` introduced terminal
   gating. The five new regressions failed before the fixes. All 204 ACP
   tests and all 109 Cursor tests pass, fatal analysis passes in both packages,
-  and `git diff --check` passes. The final 1,344-line PR diff
+  and `git diff --check` passes. Follow-up review centralized the shared
+  four-image candidate limit; the status-less diff exception remains unchanged
+  because it is established compatibility behavior for backends that provide no
+  later status event. The final 1,346-line PR diff
   is below the 1,500-line soft cap; no neighboring scope was combined.
 
 ## Findings And Plan Deltas

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -229,15 +229,19 @@
   completion while retaining the mutation; and unused tool snapshot counters
   were removed. The diff fix preserves PR #414's later `7b2d21dc` exception for
   explicit diff content with no known status after `952cc30f` introduced terminal
-  gating. The five new regressions failed before the fixes. All 204 ACP
-  tests and all 109 Cursor tests pass, fatal analysis passes in both packages,
-  and `git diff --check` passes. Follow-up review centralized the shared
-  four-image candidate limit; the status-less diff exception remains unchanged
-  because it is established compatibility behavior for backends that provide no
-  later status event. Malformed raw-output-only updates now preserve prior tool
-  state while explicit empty output still clears it; valid sibling fields remain
-  usable and malformed nested content is rejected. The final 1,375-line PR diff
-  is below the 1,500-line soft cap; no neighboring scope was combined.
+  gating. The five earlier regressions failed before their fixes. Follow-up review
+  centralized the shared four-image candidate limit; status-less diff compatibility
+  remains unchanged. Malformed raw-output-only updates preserve prior state while
+  explicit empty output clears; valid siblings remain usable and malformed nested
+  content is rejected. The three latest boundary/security fixes map only recognized
+  statuses as explicit in live/replay, strip inline payloads from retained replay
+  tool state while preserving safe metadata and replacement/output/diff boundaries,
+  and treat malformed top-level content as unchanged while String/List/Map forms and
+  empty collections still replace. The live/replay status and mapper regressions
+  failed first; payload-free retained state has tracker coverage. All 207 ACP and
+  all 109 Cursor tests pass; fatal analysis passes in both packages, and focused
+  tests plus `git diff --check` pass. The final 1,474-line PR diff remains below the
+  1,500-line soft cap; no neighboring scope was combined.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -240,11 +240,14 @@
   empty collections still replace. The live/replay status and mapper regressions
   failed first; payload-free retained state has tracker coverage. All 207 ACP and
   all 109 Cursor tests pass; fatal analysis passes in both packages, and focused
-  tests plus `git diff --check` pass. The final 1,474-line PR diff remains below the
+  tests plus `git diff --check` pass. The final 1,477-line PR diff remains below the
   1,500-line soft cap; no neighboring scope was combined.
 
 ## Findings And Plan Deltas
 
+- **2026-08-01 — Live aggregate budget declined:** Retain the per-tool 5 MiB
+  bound and turn cleanup; the user declined additional cross-tool mutable
+  accounting as disproportionate for the edge case.
 - **2026-07-31 — Automatic continuation:** After each merged PR, proceed with
   the next numbered step without waiting for another explicit user request.
 - **2026-07-31 — Lifecycle and line budget:** Set a 1,500 changed-line soft cap,

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -234,7 +234,7 @@
   and `git diff --check` passes. Follow-up review centralized the shared
   four-image candidate limit; the status-less diff exception remains unchanged
   because it is established compatibility behavior for backends that provide no
-  later status event. The final 1,346-line PR diff
+  later status event. The final 1,345-line PR diff
   is below the 1,500-line soft cap; no neighboring scope was combined.
 
 ## Findings And Plan Deltas

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -6,9 +6,9 @@
 - **Implementation base:** `origin/main` at
   `e64fb4b5d6daeee55447efdf0177318daece5932`
 - **Series state:** Step 10/13 merged as [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666)
-- **Current step:** Step 11/13 — implemented and verified; preparing PR
+- **Current step:** Step 11/13 — [PR #670](https://github.com/sesori-ai/sesori_apps_monorepo/pull/670) open; local review fixes verified
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** commit, push, and open the Step 11 PR
+- **Next action:** review and publish the local PR feedback fixes
 
 ## Plan Review
 
@@ -36,7 +36,7 @@
 | [x] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | [PR #658](https://github.com/sesori-ai/sesori_apps_monorepo/pull/658) merged as `a973796c`; 1,119 changed lines |
 | [x] | 9/13 | `output-image-support-acp-content-mapping` | `[output-image-support] refactor(acp): centralize tool content mapping [step 9/13]` | 1,100-1,500 | [PR #661](https://github.com/sesori-ai/sesori_apps_monorepo/pull/661) merged as `f5f24240`; 879 changed lines |
 | [x] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666) merged as `e64fb4b5`; 1,138 changed lines |
-| [ ] | 11/13 | `output-image-support-acp-tool-images` | `⚙️ [output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | Implemented and verified; preparing PR |
+| [ ] | 11/13 | `output-image-support-acp-tool-images` | `⚙️ [output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | [PR #670](https://github.com/sesori-ai/sesori_apps_monorepo/pull/670) open; local review fixes verified |
 | [ ] | 12/13 | `output-image-support-acp-image-replay` | `[output-image-support] feat(acp): restore output image replay [step 12/13]` | 900-1,400 | Blocked on Step 11 merge |
 | [ ] | 13/13 | `output-image-support-retire-plan` | `[output-image-support] docs: retire output image support plan [step 13/13]` | 50-200 | Blocked on Step 12 merge |
 
@@ -221,8 +221,18 @@
   degradation, and one-shot diff signaling have focused coverage. All 199 ACP
   tests and all 109 Cursor tests pass; fatal analysis passes in both packages;
   `aristotle-impl-review` approved with no findings. No code generation was
-  required. The 963-line implementation is below the 1,500-line soft cap; no
-  neighboring scope was combined.
+  required. PR #670 review found four valid root issues across eight duplicate
+  bot threads: reordered late `tool_call`s now retain newer live/replay content,
+  status, and diff state while filling missing metadata; tool mapping stops
+  normalizing image candidates after the four-item prefix while still scanning
+  trailing text/diff entries; explicit non-terminal diff content now waits for
+  completion while retaining the mutation; and unused tool snapshot counters
+  were removed. The diff fix preserves PR #414's later `7b2d21dc` exception for
+  explicit diff content with no known status after `952cc30f` introduced terminal
+  gating. The five new regressions failed before the fixes. All 204 ACP
+  tests and all 109 Cursor tests pass, fatal analysis passes in both packages,
+  and `git diff --check` passes. The final 1,344-line PR diff
+  is below the 1,500-line soft cap; no neighboring scope was combined.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -234,7 +234,8 @@
   and `git diff --check` passes. Follow-up review centralized the shared
   four-image candidate limit; the status-less diff exception remains unchanged
   because it is established compatibility behavior for backends that provide no
-  later status event. The final 1,345-line PR diff
+  later status event. Malformed raw-output-only updates now preserve prior tool
+  state while explicit empty output still clears it. The final 1,364-line PR diff
   is below the 1,500-line soft cap; no neighboring scope was combined.
 
 ## Findings And Plan Deltas

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -235,7 +235,8 @@
   four-image candidate limit; the status-less diff exception remains unchanged
   because it is established compatibility behavior for backends that provide no
   later status event. Malformed raw-output-only updates now preserve prior tool
-  state while explicit empty output still clears it. The final 1,364-line PR diff
+  state while explicit empty output still clears it; valid sibling fields remain
+  usable and malformed nested content is rejected. The final 1,375-line PR diff
   is below the 1,500-line soft cap; no neighboring scope was combined.
 
 ## Findings And Plan Deltas

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -4,11 +4,11 @@
 
 - **Plan slug:** `output-image-support`
 - **Implementation base:** `origin/main` at
-  `f5f24240bb49be17313f7f2748720f8399523e23`
-- **Series state:** Step 10/13 open as [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666)
-- **Current step:** Step 10/13 — surface live ACP message images
+  `e64fb4b5d6daeee55447efdf0177318daece5932`
+- **Series state:** Step 10/13 merged as [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666)
+- **Current step:** Step 11/13 — implemented and verified; preparing PR
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** monitor PR #666 and address CI or review findings
+- **Next action:** commit, push, and open the Step 11 PR
 
 ## Plan Review
 
@@ -35,8 +35,8 @@
 | [x] | 7/13 | `output-image-support-codex-image-history` | `[output-image-support] feat(codex): restore output image history [step 7/13]` | 1,100-1,500 | [PR #657](https://github.com/sesori-ai/sesori_apps_monorepo/pull/657) merged as `4ca1cb90`; 589 changed lines |
 | [x] | 8/13 | `output-image-support-acp-content-blocks` | `[output-image-support] refactor(acp): type content blocks [step 8/13]` | 1,300-1,500 | [PR #658](https://github.com/sesori-ai/sesori_apps_monorepo/pull/658) merged as `a973796c`; 1,119 changed lines |
 | [x] | 9/13 | `output-image-support-acp-content-mapping` | `[output-image-support] refactor(acp): centralize tool content mapping [step 9/13]` | 1,100-1,500 | [PR #661](https://github.com/sesori-ai/sesori_apps_monorepo/pull/661) merged as `f5f24240`; 879 changed lines |
-| [ ] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666) open; 1,138 changed lines |
-| [ ] | 11/13 | `output-image-support-acp-tool-images` | `[output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | Blocked on Step 10 merge |
+| [x] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666) merged as `e64fb4b5`; 1,138 changed lines |
+| [ ] | 11/13 | `output-image-support-acp-tool-images` | `⚙️ [output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | Implemented and verified; preparing PR |
 | [ ] | 12/13 | `output-image-support-acp-image-replay` | `[output-image-support] feat(acp): restore output image replay [step 12/13]` | 900-1,400 | Blocked on Step 11 merge |
 | [ ] | 13/13 | `output-image-support-retire-plan` | `[output-image-support] docs: retire output image support plan [step 13/13]` | 50-200 | Blocked on Step 12 merge |
 
@@ -52,7 +52,7 @@
 8. `[output-image-support] refactor(acp): type content blocks [step 8/13]`
 9. `[output-image-support] refactor(acp): centralize tool content mapping [step 9/13]`
 10. `[output-image-support] feat(acp): surface live message images [step 10/13]`
-11. `[output-image-support] feat(acp): surface live tool images [step 11/13]`
+11. `⚙️ [output-image-support] feat(acp): surface live tool images [step 11/13]`
 12. `[output-image-support] feat(acp): restore output image replay [step 12/13]`
 13. `[output-image-support] docs: retire output image support plan [step 13/13]`
 
@@ -208,7 +208,21 @@
   content in both live and replay, and resets unrendered id-less tracker state at
   message boundaries. All 90 focused ACP tests, 8 Cursor mapper tests, and fatal
   analysis in both packages pass. The 1,138 changed-line diff is below the
-  1,500-line soft cap; no neighboring scope was combined.
+  1,500-line soft cap; no neighboring scope was combined. PR #666 merged as
+  `e64fb4b5` on 2026-08-01.
+- Step 11/13 (2026-08-01): added the zero-collaborator
+  `AcpToolContentTracker`; changed `AcpContentMapper` to emit sealed replace,
+  update-output, and unchanged mutations; and made both `_LiveTool` and
+  replay `_ToolDraft` retain and apply that tracker. Live tool cards now render
+  bounded standard ACP image attachments, while replay retains the same
+  normalized final attachment state but deliberately renders none until Step
+  12. Omission preservation, complete replacement, empty clearing, image-only
+  replacement, raw-output fallback, count/aggregate limits, privacy-safe
+  degradation, and one-shot diff signaling have focused coverage. All 199 ACP
+  tests and all 109 Cursor tests pass; fatal analysis passes in both packages;
+  `aristotle-impl-review` approved with no findings. No code generation was
+  required. The 961-line implementation is below the 1,500-line soft cap; no
+  neighboring scope was combined.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/output-image-support/TRACKER.md
+++ b/.plan/active/output-image-support/TRACKER.md
@@ -221,7 +221,7 @@
   degradation, and one-shot diff signaling have focused coverage. All 199 ACP
   tests and all 109 Cursor tests pass; fatal analysis passes in both packages;
   `aristotle-impl-review` approved with no findings. No code generation was
-  required. The 961-line implementation is below the 1,500-line soft cap; no
+  required. The 963-line implementation is below the 1,500-line soft cap; no
   neighboring scope was combined.
 
 ## Findings And Plan Deltas

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -638,6 +638,7 @@ class AcpEventMapper {
     final contentTracker = prior?.contentTracker ?? AcpToolContentTracker();
     contentTracker.applyInitial(mutation: contentMutation);
     final hasKind = update["kind"] is String && (update["kind"] as String).isNotEmpty;
+    final mappedStatus = _contentMapper.toolStatus(status: update["status"]);
     final useCallTool = prior == null || (!prior.hasExplicitKind && (hasKind || prior.tool == "tool"));
     final state = _LiveTool(
       // Fail-soft like the tool name and `_toolCallUpdate`'s title: a non-string
@@ -645,7 +646,7 @@ class AcpEventMapper {
       // throwing and aborting the notification.
       tool: useCallTool ? _contentMapper.toolName(update: update) : prior.tool,
       title: prior?.title ?? (update["title"] is String ? update["title"] as String? : null),
-      status: prior?.hasExplicitStatus ?? false ? prior!.status : _contentMapper.toolStatus(status: update["status"]),
+      status: prior?.hasExplicitStatus ?? false ? prior!.status : mappedStatus ?? PluginToolStatus.pending,
       contentTracker: contentTracker,
       isFileMutation:
           (prior?.isFileMutation ?? false) ||
@@ -655,7 +656,7 @@ class AcpEventMapper {
           ),
       diffEmitted: prior?.diffEmitted ?? false,
       hasExplicitKind: (prior?.hasExplicitKind ?? false) || hasKind,
-      hasExplicitStatus: (prior?.hasExplicitStatus ?? false) || update.containsKey("status"),
+      hasExplicitStatus: (prior?.hasExplicitStatus ?? false) || mappedStatus != null,
     );
     (_liveTools[sessionId] ??= {})[toolCallId] = state;
     final events = <BridgeSseEvent>[
@@ -695,14 +696,13 @@ class AcpEventMapper {
     final contentMutation = _contentMapper.toolContent(update: update);
     final contentTracker = prior?.contentTracker ?? AcpToolContentTracker();
     contentTracker.apply(mutation: contentMutation);
+    final mappedStatus = _contentMapper.toolStatus(status: update["status"]);
     final state = _LiveTool(
       tool: hasKind
           ? _contentMapper.toolName(update: update)
           : (prior?.tool ?? _contentMapper.toolName(update: update)),
       title: update.containsKey("title") && update["title"] is String ? update["title"] as String? : prior?.title,
-      status: update.containsKey("status")
-          ? _contentMapper.toolStatus(status: update["status"])
-          : (prior?.status ?? PluginToolStatus.pending),
+      status: mappedStatus ?? prior?.status ?? PluginToolStatus.pending,
       contentTracker: contentTracker,
       isFileMutation:
           (prior?.isFileMutation ?? false) ||
@@ -712,7 +712,7 @@ class AcpEventMapper {
           ),
       diffEmitted: prior?.diffEmitted ?? false,
       hasExplicitKind: (prior?.hasExplicitKind ?? false) || hasKind,
-      hasExplicitStatus: (prior?.hasExplicitStatus ?? false) || update.containsKey("status"),
+      hasExplicitStatus: (prior?.hasExplicitStatus ?? false) || mappedStatus != null,
     );
     final events = <BridgeSseEvent>[
       // ACP events can be reordered (reconnect / resume / replay), so a

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -7,6 +7,7 @@ import "acp_session_configuration_tracker.dart";
 import "acp_stdio_client.dart";
 import "repositories/mappers/acp_content_mapper.dart";
 import "repositories/trackers/acp_content_tracker.dart";
+import "repositories/trackers/acp_tool_content_tracker.dart";
 
 /// A backend "halt notice": the agent ended a turn without doing the requested
 /// work and instead streamed a terminal notice telling the user to change
@@ -174,7 +175,7 @@ class AcpEventMapper {
 
   /// sessionId -> (toolCallId -> last-rendered live tool state). ACP
   /// `tool_call_update` notifications are partial, so this preserves the tool's
-  /// name/title/status/output across updates that omit them. Nested (not a
+  /// name/title/status/content across updates that omit them. Nested (not a
   /// composite "sessionId:toolCallId" key) so cleanup is exact regardless of
   /// characters in the opaque agent-supplied ids.
   final Map<String, Map<String, _LiveTool>> _liveTools = {};
@@ -632,7 +633,8 @@ class AcpEventMapper {
       _closeCurrentIdlessAssistantContent(sessionId: sessionId);
     }
     final messageId = "$sessionId-tool-$toolCallId";
-    final content = _contentMapper.toolContent(update: update);
+    final contentMutation = _contentMapper.toolContent(update: update);
+    final contentTracker = AcpToolContentTracker()..apply(mutation: contentMutation);
     final state = _LiveTool(
       // Fail-soft like the tool name and `_toolCallUpdate`'s title: a non-string
       // title (schema drift / malformed agent data) renders as null rather than
@@ -640,8 +642,11 @@ class AcpEventMapper {
       tool: _contentMapper.toolName(update: update),
       title: update["title"] is String ? update["title"] as String? : null,
       status: _contentMapper.toolStatus(status: update["status"]),
-      output: content.output,
-      isFileMutation: _isFileMutation(update: update, content: content),
+      contentTracker: contentTracker,
+      isFileMutation: _isFileMutation(
+        update: update,
+        contentMutation: contentMutation,
+      ),
       diffEmitted: false,
     );
     (_liveTools[sessionId] ??= {})[toolCallId] = state;
@@ -653,7 +658,7 @@ class AcpEventMapper {
       events: events,
       sessionId: sessionId,
       state: state,
-      mutationAvailable: content.mutation == AcpToolContentMutation.diff,
+      mutationAvailable: _reportsDiff(mutation: contentMutation),
     );
     return events;
   }
@@ -667,7 +672,7 @@ class AcpEventMapper {
     final messageId = "$sessionId-tool-$toolCallId";
     // A `tool_call_update` is a PARTIAL update: an agent may send only the
     // changed fields (e.g. `{status: completed}`). Merge onto the tool's prior
-    // state so an omitted name/title/output/status isn't reset to a default,
+    // state so omitted name/title/content/status fields aren't reset to defaults,
     // which would blank an existing tool card. Mirrors the replay collector,
     // which already merges — keeping live and history renderings consistent.
     final prior = _liveTools[sessionId]?[toolCallId];
@@ -679,7 +684,9 @@ class AcpEventMapper {
     // the title text (`title` lives separately in PluginToolState.title). This
     // matches the replay collector, which preserves the original tool name.
     final hasKind = update["kind"] is String && (update["kind"] as String).isNotEmpty;
-    final content = _contentMapper.toolContent(update: update);
+    final contentMutation = _contentMapper.toolContent(update: update);
+    final contentTracker = prior?.contentTracker ?? AcpToolContentTracker();
+    contentTracker.apply(mutation: contentMutation);
     final state = _LiveTool(
       tool: hasKind
           ? _contentMapper.toolName(update: update)
@@ -688,8 +695,13 @@ class AcpEventMapper {
       status: update.containsKey("status")
           ? _contentMapper.toolStatus(status: update["status"])
           : (prior?.status ?? PluginToolStatus.pending),
-      output: content.output ?? prior?.output,
-      isFileMutation: (prior?.isFileMutation ?? false) || _isFileMutation(update: update, content: content),
+      contentTracker: contentTracker,
+      isFileMutation:
+          (prior?.isFileMutation ?? false) ||
+          _isFileMutation(
+            update: update,
+            contentMutation: contentMutation,
+          ),
       diffEmitted: prior?.diffEmitted ?? false,
     );
     final events = <BridgeSseEvent>[
@@ -709,7 +721,7 @@ class AcpEventMapper {
       events: events,
       sessionId: sessionId,
       state: state,
-      mutationAvailable: content.mutation == AcpToolContentMutation.diff,
+      mutationAvailable: _reportsDiff(mutation: contentMutation),
     );
     return events;
   }
@@ -748,6 +760,7 @@ class AcpEventMapper {
     required String messageId,
     required _LiveTool state,
   }) {
+    final content = state.contentTracker.snapshot;
     return BridgeSseMessagePartUpdated(
       part: _toolPart(
         partId: "$messageId-call",
@@ -757,9 +770,9 @@ class AcpEventMapper {
         state: PluginToolState(
           status: state.status,
           title: state.title,
-          output: state.output,
-          error: state.status == PluginToolStatus.error ? state.output : null,
-          attachments: const [],
+          output: content.output,
+          error: state.status == PluginToolStatus.error ? content.output : null,
+          attachments: content.attachments,
         ),
       ),
     );
@@ -881,11 +894,18 @@ class AcpEventMapper {
   /// shape, with a non-mutating or absent kind).
   bool _isFileMutation({
     required Map<String, dynamic> update,
-    required AcpMappedToolContent content,
+    required AcpToolContentMutation contentMutation,
   }) {
     final kind = update["kind"];
     if (kind == "edit" || kind == "delete" || kind == "move") return true;
-    return content.mutation == AcpToolContentMutation.diff;
+    return _reportsDiff(mutation: contentMutation);
+  }
+
+  bool _reportsDiff({required AcpToolContentMutation mutation}) {
+    return switch (mutation) {
+      AcpReplaceToolContentMutation(:final hasDiff) => hasDiff,
+      AcpUpdateToolOutputMutation() || AcpUnchangedToolContentMutation() => false,
+    };
   }
 
   void _appendCompletedMutationDiff({
@@ -934,7 +954,7 @@ class _LiveTool {
     required this.tool,
     required this.title,
     required this.status,
-    required this.output,
+    required this.contentTracker,
     required this.isFileMutation,
     required this.diffEmitted,
   });
@@ -942,7 +962,7 @@ class _LiveTool {
   final String tool;
   final String? title;
   final PluginToolStatus status;
-  final String? output;
+  final AcpToolContentTracker contentTracker;
   final bool isFileMutation;
   bool diffEmitted;
 }

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -629,29 +629,37 @@ class AcpEventMapper {
   }) {
     final toolCallId = update["toolCallId"] as String?;
     if (toolCallId == null || toolCallId.isEmpty) return const [];
-    if (_liveTools[sessionId]?[toolCallId] == null) {
+    final prior = _liveTools[sessionId]?[toolCallId];
+    if (prior == null) {
       _closeCurrentIdlessAssistantContent(sessionId: sessionId);
     }
     final messageId = "$sessionId-tool-$toolCallId";
     final contentMutation = _contentMapper.toolContent(update: update);
-    final contentTracker = AcpToolContentTracker()..apply(mutation: contentMutation);
+    final contentTracker = prior?.contentTracker ?? AcpToolContentTracker();
+    contentTracker.applyInitial(mutation: contentMutation);
+    final hasKind = update["kind"] is String && (update["kind"] as String).isNotEmpty;
+    final useCallTool = prior == null || (!prior.hasExplicitKind && (hasKind || prior.tool == "tool"));
     final state = _LiveTool(
       // Fail-soft like the tool name and `_toolCallUpdate`'s title: a non-string
       // title (schema drift / malformed agent data) renders as null rather than
       // throwing and aborting the notification.
-      tool: _contentMapper.toolName(update: update),
-      title: update["title"] is String ? update["title"] as String? : null,
-      status: _contentMapper.toolStatus(status: update["status"]),
+      tool: useCallTool ? _contentMapper.toolName(update: update) : prior.tool,
+      title: prior?.title ?? (update["title"] is String ? update["title"] as String? : null),
+      status: prior?.hasExplicitStatus ?? false ? prior!.status : _contentMapper.toolStatus(status: update["status"]),
       contentTracker: contentTracker,
-      isFileMutation: _isFileMutation(
-        update: update,
-        contentMutation: contentMutation,
-      ),
-      diffEmitted: false,
+      isFileMutation:
+          (prior?.isFileMutation ?? false) ||
+          _isFileMutation(
+            update: update,
+            contentMutation: contentMutation,
+          ),
+      diffEmitted: prior?.diffEmitted ?? false,
+      hasExplicitKind: (prior?.hasExplicitKind ?? false) || hasKind,
+      hasExplicitStatus: (prior?.hasExplicitStatus ?? false) || update.containsKey("status"),
     );
     (_liveTools[sessionId] ??= {})[toolCallId] = state;
     final events = <BridgeSseEvent>[
-      _toolEnvelope(sessionId: sessionId, messageId: messageId),
+      if (prior == null) _toolEnvelope(sessionId: sessionId, messageId: messageId),
       _toolPartEvent(sessionId: sessionId, messageId: messageId, state: state),
     ];
     _appendCompletedMutationDiff(
@@ -703,6 +711,8 @@ class AcpEventMapper {
             contentMutation: contentMutation,
           ),
       diffEmitted: prior?.diffEmitted ?? false,
+      hasExplicitKind: (prior?.hasExplicitKind ?? false) || hasKind,
+      hasExplicitStatus: (prior?.hasExplicitStatus ?? false) || update.containsKey("status"),
     );
     final events = <BridgeSseEvent>[
       // ACP events can be reordered (reconnect / resume / replay), so a
@@ -917,7 +927,7 @@ class AcpEventMapper {
     if (!state.isFileMutation || state.diffEmitted) {
       return;
     }
-    if (!mutationAvailable && !_isTerminalToolStatus(state.status)) {
+    if (!_isTerminalToolStatus(state.status) && (!mutationAvailable || state.hasExplicitStatus)) {
       return;
     }
     state.diffEmitted = true;
@@ -957,6 +967,8 @@ class _LiveTool {
     required this.contentTracker,
     required this.isFileMutation,
     required this.diffEmitted,
+    required this.hasExplicitKind,
+    required this.hasExplicitStatus,
   });
 
   final String tool;
@@ -965,4 +977,6 @@ class _LiveTool {
   final AcpToolContentTracker contentTracker;
   final bool isFileMutation;
   bool diffEmitted;
+  final bool hasExplicitKind;
+  final bool hasExplicitStatus;
 }

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -64,18 +64,37 @@ class AcpReplayCollector {
       case "tool_call":
         final id = update["toolCallId"] as String?;
         if (id == null) return;
-        final contentTracker = AcpToolContentTracker()..apply(mutation: _contentMapper.toolContent(update: update));
-        _assistantForTool().tools[id] = _ToolDraft(
-          tool: _contentMapper.toolName(update: update),
-          title: _toolTitle(update),
-          status: _contentMapper.toolStatus(status: update["status"]),
-          contentTracker: contentTracker,
-        );
+        final contentMutation = _contentMapper.toolContent(update: update);
+        final draft = _findTool(id);
+        final hasKind = update["kind"] is String && (update["kind"] as String).isNotEmpty;
+        if (draft == null) {
+          final contentTracker = AcpToolContentTracker()..applyInitial(mutation: contentMutation);
+          _assistantForTool().tools[id] = _ToolDraft(
+            tool: _contentMapper.toolName(update: update),
+            title: _toolTitle(update),
+            status: _contentMapper.toolStatus(status: update["status"]),
+            contentTracker: contentTracker,
+            hasExplicitKind: hasKind,
+            hasExplicitStatus: update.containsKey("status"),
+          );
+        } else {
+          if (!draft.hasExplicitKind && (hasKind || draft.tool == "tool")) {
+            draft.tool = _contentMapper.toolName(update: update);
+          }
+          draft.title ??= _toolTitle(update);
+          if (!draft.hasExplicitStatus) {
+            draft.status = _contentMapper.toolStatus(status: update["status"]);
+          }
+          draft.contentTracker.applyInitial(mutation: contentMutation);
+          draft.hasExplicitKind = draft.hasExplicitKind || hasKind;
+          draft.hasExplicitStatus = draft.hasExplicitStatus || update.containsKey("status");
+        }
       case "tool_call_update":
         final id = update["toolCallId"] as String?;
         if (id == null) return;
         final contentMutation = _contentMapper.toolContent(update: update);
         final draft = _findTool(id);
+        final hasKind = update["kind"] is String && (update["kind"] as String).isNotEmpty;
         if (draft == null) {
           // No prior `tool_call` was replayed for this id (loaded history can
           // carry only the update). Seed a tool draft from the update payload so
@@ -87,6 +106,8 @@ class AcpReplayCollector {
             title: _toolTitle(update),
             status: _contentMapper.toolStatus(status: update["status"]),
             contentTracker: contentTracker,
+            hasExplicitKind: hasKind,
+            hasExplicitStatus: update.containsKey("status"),
           );
           return;
         }
@@ -97,6 +118,11 @@ class AcpReplayCollector {
         // replayed history matches live rendering.
         if (update.containsKey("status")) {
           draft.status = _contentMapper.toolStatus(status: update["status"]);
+          draft.hasExplicitStatus = true;
+        }
+        if (hasKind) {
+          draft.tool = _contentMapper.toolName(update: update);
+          draft.hasExplicitKind = true;
         }
         if (update.containsKey("title")) draft.title = _toolTitle(update);
         draft.contentTracker.apply(mutation: contentMutation);
@@ -414,11 +440,15 @@ class _ToolDraft {
     required this.title,
     required this.status,
     required this.contentTracker,
+    required this.hasExplicitKind,
+    required this.hasExplicitStatus,
   });
 
-  final String tool;
+  String tool;
   // Reassigned as later tool_call_update notifications arrive during replay.
   String? title;
   PluginToolStatus status;
   final AcpToolContentTracker contentTracker;
+  bool hasExplicitKind;
+  bool hasExplicitStatus;
 }

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -64,37 +64,39 @@ class AcpReplayCollector {
       case "tool_call":
         final id = update["toolCallId"] as String?;
         if (id == null) return;
-        final contentMutation = _contentMapper.toolContent(update: update);
+        final contentMutation = _contentMapper.toolContent(update: update).withoutImagePayload();
         final draft = _findTool(id);
         final hasKind = update["kind"] is String && (update["kind"] as String).isNotEmpty;
+        final mappedStatus = _contentMapper.toolStatus(status: update["status"]);
         if (draft == null) {
           final contentTracker = AcpToolContentTracker()..applyInitial(mutation: contentMutation);
           _assistantForTool().tools[id] = _ToolDraft(
             tool: _contentMapper.toolName(update: update),
             title: _toolTitle(update),
-            status: _contentMapper.toolStatus(status: update["status"]),
+            status: mappedStatus ?? PluginToolStatus.pending,
             contentTracker: contentTracker,
             hasExplicitKind: hasKind,
-            hasExplicitStatus: update.containsKey("status"),
+            hasExplicitStatus: mappedStatus != null,
           );
         } else {
           if (!draft.hasExplicitKind && (hasKind || draft.tool == "tool")) {
             draft.tool = _contentMapper.toolName(update: update);
           }
           draft.title ??= _toolTitle(update);
-          if (!draft.hasExplicitStatus) {
-            draft.status = _contentMapper.toolStatus(status: update["status"]);
+          if (!draft.hasExplicitStatus && mappedStatus != null) {
+            draft.status = mappedStatus;
           }
           draft.contentTracker.applyInitial(mutation: contentMutation);
           draft.hasExplicitKind = draft.hasExplicitKind || hasKind;
-          draft.hasExplicitStatus = draft.hasExplicitStatus || update.containsKey("status");
+          draft.hasExplicitStatus = draft.hasExplicitStatus || mappedStatus != null;
         }
       case "tool_call_update":
         final id = update["toolCallId"] as String?;
         if (id == null) return;
-        final contentMutation = _contentMapper.toolContent(update: update);
+        final contentMutation = _contentMapper.toolContent(update: update).withoutImagePayload();
         final draft = _findTool(id);
         final hasKind = update["kind"] is String && (update["kind"] as String).isNotEmpty;
+        final mappedStatus = _contentMapper.toolStatus(status: update["status"]);
         if (draft == null) {
           // No prior `tool_call` was replayed for this id (loaded history can
           // carry only the update). Seed a tool draft from the update payload so
@@ -104,10 +106,10 @@ class AcpReplayCollector {
           _assistantForTool().tools[id] = _ToolDraft(
             tool: _contentMapper.toolName(update: update),
             title: _toolTitle(update),
-            status: _contentMapper.toolStatus(status: update["status"]),
+            status: mappedStatus ?? PluginToolStatus.pending,
             contentTracker: contentTracker,
             hasExplicitKind: hasKind,
-            hasExplicitStatus: update.containsKey("status"),
+            hasExplicitStatus: mappedStatus != null,
           );
           return;
         }
@@ -116,8 +118,8 @@ class AcpReplayCollector {
         // completed/failed replayed tool card back to pending (status) or drop a
         // separately-sent display title. Mirrors the live mapper's merge so
         // replayed history matches live rendering.
-        if (update.containsKey("status")) {
-          draft.status = _contentMapper.toolStatus(status: update["status"]);
+        if (mappedStatus != null) {
+          draft.status = mappedStatus;
           draft.hasExplicitStatus = true;
         }
         if (hasKind) {

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -3,6 +3,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "acp_event_mapper.dart" show AcpHaltNotice;
 import "repositories/mappers/acp_content_mapper.dart";
 import "repositories/trackers/acp_content_tracker.dart";
+import "repositories/trackers/acp_tool_content_tracker.dart";
 
 /// Accumulates the `session/update` notifications replayed by `session/load`
 /// into ordered [PluginMessageWithParts] for `getSessionMessages`.
@@ -63,28 +64,29 @@ class AcpReplayCollector {
       case "tool_call":
         final id = update["toolCallId"] as String?;
         if (id == null) return;
-        final content = _contentMapper.toolContent(update: update);
+        final contentTracker = AcpToolContentTracker()..apply(mutation: _contentMapper.toolContent(update: update));
         _assistantForTool().tools[id] = _ToolDraft(
           tool: _contentMapper.toolName(update: update),
           title: _toolTitle(update),
           status: _contentMapper.toolStatus(status: update["status"]),
-          output: content.output,
+          contentTracker: contentTracker,
         );
       case "tool_call_update":
         final id = update["toolCallId"] as String?;
         if (id == null) return;
-        final content = _contentMapper.toolContent(update: update);
+        final contentMutation = _contentMapper.toolContent(update: update);
         final draft = _findTool(id);
         if (draft == null) {
           // No prior `tool_call` was replayed for this id (loaded history can
           // carry only the update). Seed a tool draft from the update payload so
           // the card still renders, mirroring the live mapper which emits a tool
           // part unconditionally.
+          final contentTracker = AcpToolContentTracker()..apply(mutation: contentMutation);
           _assistantForTool().tools[id] = _ToolDraft(
             tool: _contentMapper.toolName(update: update),
             title: _toolTitle(update),
             status: _contentMapper.toolStatus(status: update["status"]),
-            output: content.output,
+            contentTracker: contentTracker,
           );
           return;
         }
@@ -97,7 +99,7 @@ class AcpReplayCollector {
           draft.status = _contentMapper.toolStatus(status: update["status"]);
         }
         if (update.containsKey("title")) draft.title = _toolTitle(update);
-        if (content.output != null) draft.output = content.output;
+        draft.contentTracker.apply(mutation: contentMutation);
     }
   }
 
@@ -187,6 +189,7 @@ class AcpReplayCollector {
       parts.add(_textPart(draft, entry.key, PluginMessagePartType.text, entry.value));
     }
     draft.tools.forEach((toolId, tool) {
+      final content = tool.contentTracker.snapshot;
       parts.add(
         PluginMessagePart(
           id: "${draft.id}-tool-$toolId",
@@ -198,8 +201,8 @@ class AcpReplayCollector {
           state: PluginToolState(
             status: tool.status,
             title: tool.title,
-            output: tool.output,
-            error: tool.status == PluginToolStatus.error ? tool.output : null,
+            output: content.output,
+            error: tool.status == PluginToolStatus.error ? content.output : null,
             attachments: const [],
           ),
           prompt: null,
@@ -410,12 +413,12 @@ class _ToolDraft {
     required this.tool,
     required this.title,
     required this.status,
-    required this.output,
+    required this.contentTracker,
   });
 
   final String tool;
   // Reassigned as later tool_call_update notifications arrive during replay.
   String? title;
   PluginToolStatus status;
-  String? output;
+  final AcpToolContentTracker contentTracker;
 }

--- a/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
@@ -152,6 +152,9 @@ final class AcpContentMapper {
       if (!update.containsKey("rawOutput")) {
         return const AcpUnchangedToolContentMutation();
       }
+      if (!_isValidRawOutput(raw: update["rawOutput"])) {
+        return const AcpUnchangedToolContentMutation();
+      }
       return AcpUpdateToolOutputMutation(
         output: _boundedToolOutput(
           text: _rawOutputText(raw: update["rawOutput"]),
@@ -390,6 +393,17 @@ final class AcpContentMapper {
     final exitCode = raw["exitCode"];
     if (exitCode is int && exitCode != 0) return "exited with code $exitCode";
     return null;
+  }
+
+  bool _isValidRawOutput({required Object? raw}) {
+    if (raw is String) return true;
+    if (raw is! Map) return false;
+    if (raw.isEmpty) return true;
+    if (raw.containsKey("stdout") && raw["stdout"] is! String) return false;
+    if (raw.containsKey("stderr") && raw["stderr"] is! String) return false;
+    if (raw.containsKey("exitCode") && raw["exitCode"] is! int) return false;
+    if (raw.containsKey("content")) return true;
+    return raw.containsKey("stdout") || raw.containsKey("stderr") || raw.containsKey("exitCode");
   }
 
   List<AcpMappedContentBlock> _legacyMapContent({

--- a/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
@@ -55,19 +55,30 @@ enum AcpImageDegradationReason {
   oversized,
 }
 
-enum AcpToolContentMutation {
-  none,
-  diff,
+sealed class AcpToolContentMutation {
+  const AcpToolContentMutation();
 }
 
-final class AcpMappedToolContent {
-  const AcpMappedToolContent({
+final class AcpReplaceToolContentMutation extends AcpToolContentMutation {
+  const AcpReplaceToolContentMutation({
     required this.output,
-    required this.mutation,
+    required this.imageCandidates,
+    required this.hasDiff,
   });
 
   final String? output;
-  final AcpToolContentMutation mutation;
+  final List<AcpMappedImageContentBlock> imageCandidates;
+  final bool hasDiff;
+}
+
+final class AcpUpdateToolOutputMutation extends AcpToolContentMutation {
+  const AcpUpdateToolOutputMutation({required this.output});
+
+  final String? output;
+}
+
+final class AcpUnchangedToolContentMutation extends AcpToolContentMutation {
+  const AcpUnchangedToolContentMutation();
 }
 
 /// Deduplicates privacy-safe mapping warnings across chunks of one logical
@@ -79,9 +90,9 @@ final class AcpContentMappingScope {
 /// Maps standard ACP content blocks into backend-neutral, individually
 /// validated content while retaining no URI or source-path data.
 ///
-/// Message-level ordering, count, and aggregate-byte state belong to the
-/// per-message tracker introduced with image materialization. This mapper owns
-/// only one candidate's typed decoding and transport-safe normalization.
+/// Message/tool ordering, count, and aggregate-byte state belong to their
+/// respective trackers. This mapper owns only one candidate's typed decoding,
+/// transport-safe normalization, and tool mutation selection.
 final class AcpContentMapper {
   const AcpContentMapper();
 
@@ -130,23 +141,43 @@ final class AcpContentMapper {
     };
   }
 
-  AcpMappedToolContent toolContent({required Map<String, dynamic> update}) {
+  AcpToolContentMutation toolContent({required Map<String, dynamic> update}) {
+    if (!update.containsKey("content")) {
+      if (!update.containsKey("rawOutput")) {
+        return const AcpUnchangedToolContentMutation();
+      }
+      return AcpUpdateToolOutputMutation(
+        output: _boundedToolOutput(
+          text: _rawOutputText(raw: update["rawOutput"]),
+        ),
+      );
+    }
+
     final warned = <_AcpContentWarning>{};
     final buffer = StringBuffer();
-    var mutation = AcpToolContentMutation.none;
+    final imageCandidates = <AcpMappedImageContentBlock>[];
+    var hasDiff = false;
     for (final item in _mapToolValue(content: update["content"], warned: warned)) {
       switch (item) {
-        case _AcpMappedToolText(:final text):
-          buffer.write(text);
+        case _AcpMappedToolBlock(:final block):
+          switch (block) {
+            case AcpMappedTextContentBlock(:final text):
+              buffer.write(text);
+            case AcpMappedImageContentBlock():
+              imageCandidates.add(block);
+            case AcpMappedUnsupportedContentBlock() || AcpMappedUnknownContentBlock():
+              continue;
+          }
         case _AcpMappedToolDiff():
-          mutation = AcpToolContentMutation.diff;
+          hasDiff = true;
       }
     }
     final contentText = buffer.toString();
     final text = contentText.isNotEmpty ? contentText : _rawOutputText(raw: update["rawOutput"]);
-    return AcpMappedToolContent(
+    return AcpReplaceToolContentMutation(
       output: _boundedToolOutput(text: text),
-      mutation: mutation,
+      imageCandidates: List.unmodifiable(imageCandidates),
+      hasDiff: hasDiff,
     );
   }
 
@@ -234,8 +265,9 @@ final class AcpContentMapper {
       return;
     }
     if (content is! Map) {
-      final text = _textFromMappedBlocks(_mapValue(content: content, warned: warned));
-      if (text != null) yield _AcpMappedToolText(text: text);
+      for (final block in _mapValue(content: content, warned: warned)) {
+        yield _AcpMappedToolBlock(block: block);
+      }
       return;
     }
 
@@ -247,22 +279,25 @@ final class AcpContentMapper {
         yield const _AcpMappedToolDiff();
         return;
       }
-      final text = _textFromMappedBlocks(_mapValue(content: content, warned: warned));
-      if (text != null) yield _AcpMappedToolText(text: text);
+      for (final block in _mapValue(content: content, warned: warned)) {
+        yield _AcpMappedToolBlock(block: block);
+      }
       return;
     }
 
     switch (dto) {
       case AcpStandardToolContentDto():
-        final text = _textFromMappedBlocks(_mapValue(content: content["content"], warned: warned));
-        if (text != null) yield _AcpMappedToolText(text: text);
+        for (final block in _mapValue(content: content["content"], warned: warned)) {
+          yield _AcpMappedToolBlock(block: block);
+        }
       case AcpDiffToolContentDto():
         yield const _AcpMappedToolDiff();
       case AcpTerminalToolContentDto():
         return;
       case AcpUnknownToolContentDto():
-        final text = _textFromMappedBlocks(_mapValue(content: content, warned: warned));
-        if (text != null) yield _AcpMappedToolText(text: text);
+        for (final block in _mapValue(content: content, warned: warned)) {
+          yield _AcpMappedToolBlock(block: block);
+        }
     }
   }
 
@@ -443,10 +478,10 @@ sealed class _AcpMappedToolItem {
   const _AcpMappedToolItem();
 }
 
-final class _AcpMappedToolText extends _AcpMappedToolItem {
-  const _AcpMappedToolText({required this.text});
+final class _AcpMappedToolBlock extends _AcpMappedToolItem {
+  const _AcpMappedToolBlock({required this.block});
 
-  final String text;
+  final AcpMappedContentBlock block;
 }
 
 final class _AcpMappedToolDiff extends _AcpMappedToolItem {

--- a/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
@@ -59,6 +59,9 @@ enum AcpImageDegradationReason {
 
 sealed class AcpToolContentMutation {
   const AcpToolContentMutation();
+
+  /// Retains mutation boundaries and safe metadata without inline image data.
+  AcpToolContentMutation withoutImagePayload();
 }
 
 final class AcpReplaceToolContentMutation extends AcpToolContentMutation {
@@ -71,16 +74,29 @@ final class AcpReplaceToolContentMutation extends AcpToolContentMutation {
   final String? output;
   final List<AcpMappedImageContentBlock> imageCandidates;
   final bool hasDiff;
+
+  @override
+  AcpToolContentMutation withoutImagePayload() => AcpReplaceToolContentMutation(
+    output: output,
+    imageCandidates: imageCandidates.whereType<AcpMappedMetadataImageContentBlock>().toList(growable: false),
+    hasDiff: hasDiff,
+  );
 }
 
 final class AcpUpdateToolOutputMutation extends AcpToolContentMutation {
   const AcpUpdateToolOutputMutation({required this.output});
 
   final String? output;
+
+  @override
+  AcpToolContentMutation withoutImagePayload() => this;
 }
 
 final class AcpUnchangedToolContentMutation extends AcpToolContentMutation {
   const AcpUnchangedToolContentMutation();
+
+  @override
+  AcpToolContentMutation withoutImagePayload() => this;
 }
 
 /// Deduplicates privacy-safe mapping warnings across chunks of one logical
@@ -137,13 +153,13 @@ final class AcpContentMapper {
     return "tool";
   }
 
-  PluginToolStatus toolStatus({required Object? status}) {
+  PluginToolStatus? toolStatus({required Object? status}) {
     return switch (status) {
       "pending" => PluginToolStatus.pending,
       "in_progress" => PluginToolStatus.running,
       "completed" => PluginToolStatus.completed,
       "failed" => PluginToolStatus.error,
-      _ => PluginToolStatus.pending,
+      _ => null,
     };
   }
 
@@ -162,13 +178,21 @@ final class AcpContentMapper {
       );
     }
 
+    final content = update["content"];
+    if (content is! String && content is! List && content is! Map) {
+      _warnOnce(
+        reason: _AcpContentWarning.malformed,
+        warned: <_AcpContentWarning>{},
+      );
+      return const AcpUnchangedToolContentMutation();
+    }
     final warned = <_AcpContentWarning>{};
     final buffer = StringBuffer();
     final imageCandidates = <AcpMappedImageContentBlock>[];
     final toolImagePrefix = _AcpToolImagePrefix();
     var hasDiff = false;
     for (final item in _mapToolValue(
-      content: update["content"],
+      content: content,
       warned: warned,
       toolImagePrefix: toolImagePrefix,
     )) {

--- a/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
@@ -120,7 +120,11 @@ final class AcpContentMapper {
     required Object? content,
     required AcpContentMappingScope scope,
   }) {
-    return _mapValue(content: content, warned: scope._warned).toList(growable: false);
+    return _mapValue(
+      content: content,
+      warned: scope._warned,
+      toolImagePrefix: null,
+    ).toList(growable: false);
   }
 
   String toolName({required Map<String, dynamic> update}) {
@@ -156,8 +160,13 @@ final class AcpContentMapper {
     final warned = <_AcpContentWarning>{};
     final buffer = StringBuffer();
     final imageCandidates = <AcpMappedImageContentBlock>[];
+    final toolImagePrefix = _AcpToolImagePrefix();
     var hasDiff = false;
-    for (final item in _mapToolValue(content: update["content"], warned: warned)) {
+    for (final item in _mapToolValue(
+      content: update["content"],
+      warned: warned,
+      toolImagePrefix: toolImagePrefix,
+    )) {
       switch (item) {
         case _AcpMappedToolBlock(:final block):
           switch (block) {
@@ -202,6 +211,7 @@ final class AcpContentMapper {
   Iterable<AcpMappedContentBlock> _mapValue({
     required Object? content,
     required Set<_AcpContentWarning> warned,
+    required _AcpToolImagePrefix? toolImagePrefix,
   }) sync* {
     if (content == null) return;
     if (content is String) {
@@ -210,7 +220,11 @@ final class AcpContentMapper {
     }
     if (content is List) {
       for (final entry in content) {
-        yield* _mapValue(content: entry, warned: warned);
+        yield* _mapValue(
+          content: entry,
+          warned: warned,
+          toolImagePrefix: toolImagePrefix,
+        );
       }
       return;
     }
@@ -225,7 +239,11 @@ final class AcpContentMapper {
       dto = AcpContentBlockDto.fromJson(content.cast<String, dynamic>());
     } on Object {
       _warnOnce(reason: _AcpContentWarning.malformed, warned: warned);
-      final fallback = _legacyMapContent(content: content, warned: warned);
+      final fallback = _legacyMapContent(
+        content: content,
+        warned: warned,
+        toolImagePrefix: toolImagePrefix,
+      );
       if (fallback.isEmpty) {
         yield const AcpMappedUnknownContentBlock();
       } else {
@@ -238,13 +256,24 @@ final class AcpContentMapper {
       case AcpTextContentBlockDto(:final text):
         yield AcpMappedTextContentBlock(text: text);
       case AcpImageContentBlockDto(:final data, :final mimeType, :final uri):
+        if (toolImagePrefix != null && !toolImagePrefix.take()) {
+          _warnOnce(
+            reason: _AcpContentWarning.toolImageCountOverflow,
+            warned: warned,
+          );
+          return;
+        }
         yield _mapImage(data: data, mime: mimeType, uri: uri);
       case AcpUnsupportedAudioContentBlockDto() ||
           AcpUnsupportedResourceContentBlockDto() ||
           AcpUnsupportedResourceLinkContentBlockDto():
         yield const AcpMappedUnsupportedContentBlock();
       case AcpUnknownContentBlockDto():
-        final fallback = _legacyMapContent(content: content, warned: warned);
+        final fallback = _legacyMapContent(
+          content: content,
+          warned: warned,
+          toolImagePrefix: toolImagePrefix,
+        );
         if (fallback.isEmpty) {
           yield const AcpMappedUnknownContentBlock();
         } else {
@@ -256,16 +285,25 @@ final class AcpContentMapper {
   Iterable<_AcpMappedToolItem> _mapToolValue({
     required Object? content,
     required Set<_AcpContentWarning> warned,
+    required _AcpToolImagePrefix toolImagePrefix,
   }) sync* {
     if (content == null) return;
     if (content is List) {
       for (final entry in content) {
-        yield* _mapToolValue(content: entry, warned: warned);
+        yield* _mapToolValue(
+          content: entry,
+          warned: warned,
+          toolImagePrefix: toolImagePrefix,
+        );
       }
       return;
     }
     if (content is! Map) {
-      for (final block in _mapValue(content: content, warned: warned)) {
+      for (final block in _mapValue(
+        content: content,
+        warned: warned,
+        toolImagePrefix: toolImagePrefix,
+      )) {
         yield _AcpMappedToolBlock(block: block);
       }
       return;
@@ -279,7 +317,11 @@ final class AcpContentMapper {
         yield const _AcpMappedToolDiff();
         return;
       }
-      for (final block in _mapValue(content: content, warned: warned)) {
+      for (final block in _mapValue(
+        content: content,
+        warned: warned,
+        toolImagePrefix: toolImagePrefix,
+      )) {
         yield _AcpMappedToolBlock(block: block);
       }
       return;
@@ -287,7 +329,11 @@ final class AcpContentMapper {
 
     switch (dto) {
       case AcpStandardToolContentDto():
-        for (final block in _mapValue(content: content["content"], warned: warned)) {
+        for (final block in _mapValue(
+          content: content["content"],
+          warned: warned,
+          toolImagePrefix: toolImagePrefix,
+        )) {
           yield _AcpMappedToolBlock(block: block);
         }
       case AcpDiffToolContentDto():
@@ -295,7 +341,11 @@ final class AcpContentMapper {
       case AcpTerminalToolContentDto():
         return;
       case AcpUnknownToolContentDto():
-        for (final block in _mapValue(content: content, warned: warned)) {
+        for (final block in _mapValue(
+          content: content,
+          warned: warned,
+          toolImagePrefix: toolImagePrefix,
+        )) {
           yield _AcpMappedToolBlock(block: block);
         }
     }
@@ -328,7 +378,11 @@ final class AcpContentMapper {
       return buffer.toString();
     }
     final content = _textFromMappedBlocks(
-      _mapValue(content: raw["content"], warned: <_AcpContentWarning>{}),
+      _mapValue(
+        content: raw["content"],
+        warned: <_AcpContentWarning>{},
+        toolImagePrefix: null,
+      ),
     )?.trimRight();
     if (content != null && content.isNotEmpty) return content;
     final exitCode = raw["exitCode"];
@@ -339,6 +393,7 @@ final class AcpContentMapper {
   List<AcpMappedContentBlock> _legacyMapContent({
     required Map<dynamic, dynamic> content,
     required Set<_AcpContentWarning> warned,
+    required _AcpToolImagePrefix? toolImagePrefix,
   }) {
     final text = content["text"];
     if (text is String && text.isNotEmpty) {
@@ -346,7 +401,11 @@ final class AcpContentMapper {
     }
     final nested = content["content"];
     if (nested == null) return const [];
-    return _mapValue(content: nested, warned: warned).toList(growable: false);
+    return _mapValue(
+      content: nested,
+      warned: warned,
+      toolImagePrefix: toolImagePrefix,
+    ).toList(growable: false);
   }
 
   AcpMappedImageContentBlock _mapImage({
@@ -466,12 +525,31 @@ final class AcpContentMapper {
     required Set<_AcpContentWarning> warned,
   }) {
     if (!warned.add(reason)) return;
-    Log.w("[acp] skipping malformed content block");
+    Log.w(
+      switch (reason) {
+        _AcpContentWarning.malformed => "[acp] skipping malformed content block",
+        _AcpContentWarning.toolImageCountOverflow =>
+          "[acp] tool image attachment collection exceeds the count limit; dropping excess candidates",
+      },
+    );
   }
 }
 
 enum _AcpContentWarning {
   malformed,
+  toolImageCountOverflow,
+}
+
+final class _AcpToolImagePrefix {
+  static const int _maxCandidates = 4;
+
+  int _candidateCount = 0;
+
+  bool take() {
+    if (_candidateCount >= _maxCandidates) return false;
+    _candidateCount++;
+    return true;
+  }
 }
 
 sealed class _AcpMappedToolItem {

--- a/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
@@ -7,6 +7,8 @@ import "package:sesori_shared/sesori_shared.dart"
 import "../../api/models/acp_content_block_dto.dart";
 import "../../api/models/acp_tool_content_dto.dart";
 
+const int acpToolImageCandidateLimit = 4;
+
 sealed class AcpMappedContentBlock {
   const AcpMappedContentBlock();
 }
@@ -541,12 +543,10 @@ enum _AcpContentWarning {
 }
 
 final class _AcpToolImagePrefix {
-  static const int _maxCandidates = 4;
-
   int _candidateCount = 0;
 
   bool take() {
-    if (_candidateCount >= _maxCandidates) return false;
+    if (_candidateCount >= acpToolImageCandidateLimit) return false;
     _candidateCount++;
     return true;
   }

--- a/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
@@ -399,11 +399,9 @@ final class AcpContentMapper {
     if (raw is String) return true;
     if (raw is! Map) return false;
     if (raw.isEmpty) return true;
-    if (raw.containsKey("stdout") && raw["stdout"] is! String) return false;
-    if (raw.containsKey("stderr") && raw["stderr"] is! String) return false;
-    if (raw.containsKey("exitCode") && raw["exitCode"] is! int) return false;
-    if (raw.containsKey("content")) return true;
-    return raw.containsKey("stdout") || raw.containsKey("stderr") || raw.containsKey("exitCode");
+    if (raw["stdout"] is String || raw["stderr"] is String || raw["exitCode"] is int) return true;
+    final content = raw["content"];
+    return content is String || content is List || content is Map;
   }
 
   List<AcpMappedContentBlock> _legacyMapContent({

--- a/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_tool_content_tracker.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_tool_content_tracker.dart
@@ -17,8 +17,6 @@ final class AcpToolContentSnapshot {
 /// tool call. Callers apply only mapper-produced mutations, so live and replay
 /// share collection replacement and partial-update semantics.
 final class AcpToolContentTracker {
-  static const int _maxImageCandidates = 4;
-
   String? _output;
   List<PluginMessageAttachment> _attachments = const [];
   bool _hasReplacement = false;
@@ -74,7 +72,7 @@ final class AcpToolContentTracker {
     var decodedImageBytes = 0;
     for (var index = 0; index < candidates.length; index++) {
       final candidate = candidates[index];
-      if (index >= _maxImageCandidates) {
+      if (index >= acpToolImageCandidateLimit) {
         _warnOnce(
           reason: _AcpToolContentWarning.countOverflow,
           warned: warned,

--- a/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_tool_content_tracker.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_tool_content_tracker.dart
@@ -7,14 +7,10 @@ final class AcpToolContentSnapshot {
   const AcpToolContentSnapshot({
     required this.output,
     required this.attachments,
-    required this.imageCandidateCount,
-    required this.decodedImageBytes,
   });
 
   final String? output;
   final List<PluginMessageAttachment> attachments;
-  final int imageCandidateCount;
-  final int decodedImageBytes;
 }
 
 /// Owns the normalized output and bounded attachment collection for one ACP
@@ -25,14 +21,12 @@ final class AcpToolContentTracker {
 
   String? _output;
   List<PluginMessageAttachment> _attachments = const [];
-  int _imageCandidateCount = 0;
-  int _decodedImageBytes = 0;
+  bool _hasReplacement = false;
+  bool _hasOutputUpdate = false;
 
   AcpToolContentSnapshot get snapshot => AcpToolContentSnapshot(
     output: _output,
     attachments: _attachments,
-    imageCandidateCount: _imageCandidateCount,
-    decodedImageBytes: _decodedImageBytes,
   );
 
   void apply({required AcpToolContentMutation mutation}) {
@@ -41,10 +35,32 @@ final class AcpToolContentTracker {
         :final output,
         :final imageCandidates,
       ):
+        _hasReplacement = true;
         _output = output;
         _replaceAttachments(candidates: imageCandidates);
       case AcpUpdateToolOutputMutation(:final output):
+        _hasOutputUpdate = true;
         _output = output;
+      case AcpUnchangedToolContentMutation():
+        return;
+    }
+  }
+
+  /// Applies a reordered base call beneath any newer updates seen first.
+  void applyInitial({required AcpToolContentMutation mutation}) {
+    switch (mutation) {
+      case AcpReplaceToolContentMutation(
+        :final output,
+        :final imageCandidates,
+      ):
+        if (_hasReplacement) return;
+        if (!_hasOutputUpdate) _output = output;
+        _replaceAttachments(candidates: imageCandidates);
+        _hasReplacement = true;
+      case AcpUpdateToolOutputMutation(:final output):
+        if (_hasReplacement || _hasOutputUpdate) return;
+        _output = output;
+        _hasOutputUpdate = true;
       case AcpUnchangedToolContentMutation():
         return;
     }
@@ -97,8 +113,6 @@ final class AcpToolContentTracker {
       }
     }
     _attachments = List.unmodifiable(attachments);
-    _imageCandidateCount = candidates.length;
-    _decodedImageBytes = decodedImageBytes;
   }
 
   _AcpToolContentWarning _warningFor({

--- a/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_tool_content_tracker.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_tool_content_tracker.dart
@@ -1,0 +1,139 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" show maxInlineMessageAttachmentBytes;
+
+import "../mappers/acp_content_mapper.dart";
+
+final class AcpToolContentSnapshot {
+  const AcpToolContentSnapshot({
+    required this.output,
+    required this.attachments,
+    required this.imageCandidateCount,
+    required this.decodedImageBytes,
+  });
+
+  final String? output;
+  final List<PluginMessageAttachment> attachments;
+  final int imageCandidateCount;
+  final int decodedImageBytes;
+}
+
+/// Owns the normalized output and bounded attachment collection for one ACP
+/// tool call. Callers apply only mapper-produced mutations, so live and replay
+/// share collection replacement and partial-update semantics.
+final class AcpToolContentTracker {
+  static const int _maxImageCandidates = 4;
+
+  String? _output;
+  List<PluginMessageAttachment> _attachments = const [];
+  int _imageCandidateCount = 0;
+  int _decodedImageBytes = 0;
+
+  AcpToolContentSnapshot get snapshot => AcpToolContentSnapshot(
+    output: _output,
+    attachments: _attachments,
+    imageCandidateCount: _imageCandidateCount,
+    decodedImageBytes: _decodedImageBytes,
+  );
+
+  void apply({required AcpToolContentMutation mutation}) {
+    switch (mutation) {
+      case AcpReplaceToolContentMutation(
+        :final output,
+        :final imageCandidates,
+      ):
+        _output = output;
+        _replaceAttachments(candidates: imageCandidates);
+      case AcpUpdateToolOutputMutation(:final output):
+        _output = output;
+      case AcpUnchangedToolContentMutation():
+        return;
+    }
+  }
+
+  void _replaceAttachments({
+    required List<AcpMappedImageContentBlock> candidates,
+  }) {
+    final attachments = <PluginMessageAttachment>[];
+    final warned = <_AcpToolContentWarning>{};
+    var decodedImageBytes = 0;
+    for (var index = 0; index < candidates.length; index++) {
+      final candidate = candidates[index];
+      if (index >= _maxImageCandidates) {
+        _warnOnce(
+          reason: _AcpToolContentWarning.countOverflow,
+          warned: warned,
+        );
+        continue;
+      }
+      switch (candidate) {
+        case AcpMappedInlineImageContentBlock(
+          :final attachment,
+          :final decodedBytes,
+        ):
+          if (decodedImageBytes + decodedBytes > maxInlineMessageAttachmentBytes) {
+            _warnOnce(
+              reason: _AcpToolContentWarning.aggregateOverflow,
+              warned: warned,
+            );
+            attachments.add(
+              PluginMessageAttachment.metadata(
+                mime: attachment.mime,
+                filename: attachment.filename,
+              ),
+            );
+            continue;
+          }
+          decodedImageBytes += decodedBytes;
+          attachments.add(attachment);
+        case AcpMappedMetadataImageContentBlock(
+          :final attachment,
+          :final reason,
+        ):
+          _warnOnce(
+            reason: _warningFor(reason: reason),
+            warned: warned,
+          );
+          attachments.add(attachment);
+      }
+    }
+    _attachments = List.unmodifiable(attachments);
+    _imageCandidateCount = candidates.length;
+    _decodedImageBytes = decodedImageBytes;
+  }
+
+  _AcpToolContentWarning _warningFor({
+    required AcpImageDegradationReason reason,
+  }) {
+    return switch (reason) {
+      AcpImageDegradationReason.invalid => _AcpToolContentWarning.invalid,
+      AcpImageDegradationReason.unsupported => _AcpToolContentWarning.unsupported,
+      AcpImageDegradationReason.oversized => _AcpToolContentWarning.oversized,
+    };
+  }
+
+  void _warnOnce({
+    required _AcpToolContentWarning reason,
+    required Set<_AcpToolContentWarning> warned,
+  }) {
+    if (!warned.add(reason)) return;
+    Log.w(
+      switch (reason) {
+        _AcpToolContentWarning.invalid => "[acp] invalid tool image attachment; forwarding metadata only",
+        _AcpToolContentWarning.unsupported => "[acp] unsupported tool image attachment; forwarding metadata only",
+        _AcpToolContentWarning.oversized => "[acp] oversized tool image attachment; forwarding metadata only",
+        _AcpToolContentWarning.aggregateOverflow =>
+          "[acp] tool image attachments exceed the aggregate transport limit; forwarding metadata only",
+        _AcpToolContentWarning.countOverflow =>
+          "[acp] tool image attachment collection exceeds the count limit; dropping excess candidates",
+      },
+    );
+  }
+}
+
+enum _AcpToolContentWarning {
+  invalid,
+  unsupported,
+  oversized,
+  aggregateOverflow,
+  countOverflow,
+}

--- a/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
@@ -206,7 +206,7 @@ void main() {
       expect(mapper.toolStatus(status: "in_progress"), PluginToolStatus.running);
       expect(mapper.toolStatus(status: "completed"), PluginToolStatus.completed);
       expect(mapper.toolStatus(status: "failed"), PluginToolStatus.error);
-      expect(mapper.toolStatus(status: "future"), PluginToolStatus.pending);
+      expect(mapper.toolStatus(status: "future"), isNull);
     });
 
     test("maps typed tool content text and diff while ignoring terminal and unknown variants", () {
@@ -415,6 +415,25 @@ void main() {
               as AcpReplaceToolContentMutation;
       expect(imageOnly.output, isNull);
       expect(imageOnly.imageCandidates, hasLength(1));
+    });
+
+    test("rejects malformed top-level tool content but preserves legacy containers", () {
+      expect(
+        mapper.toolContent(update: {"content": 42}),
+        isA<AcpUnchangedToolContentMutation>(),
+      );
+      for (final content in <Object>[
+        "legacy",
+        {"text": "legacy"},
+        [
+          {"text": "legacy"},
+        ],
+      ]) {
+        expect(
+          (mapper.toolContent(update: {"content": content}) as AcpReplaceToolContentMutation).output,
+          "legacy",
+        );
+      }
     });
 
     test("uses raw output only when replacement content has no text", () {

--- a/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
@@ -254,6 +254,47 @@ void main() {
       expect(mapped.toString(), isNot(contains("secret")));
     });
 
+    test("bounds tool images before scanning trailing text and diff content", () {
+      late AcpReplaceToolContentMutation replacement;
+      final output = _captureWarnings(() {
+        replacement =
+            mapper.toolContent(
+                  update: {
+                    "content": [
+                      for (var index = 0; index < 5; index++)
+                        {
+                          "type": "content",
+                          "content": {
+                            "type": "image",
+                            "data": "AA==",
+                            "mimeType": "image/png",
+                            "uri": "file:///private/image-$index.png",
+                          },
+                        },
+                      {
+                        "type": "content",
+                        "content": {"type": "text", "text": "after images"},
+                      },
+                      {
+                        "type": "diff",
+                        "path": "/private/source.dart",
+                        "oldText": "old",
+                        "newText": "new",
+                      },
+                    ],
+                  },
+                )
+                as AcpReplaceToolContentMutation;
+      });
+
+      expect(replacement.imageCandidates, hasLength(4));
+      expect(replacement.output, "after images");
+      expect(replacement.hasDiff, isTrue);
+      expect("exceeds the count limit".allMatches(output), hasLength(1));
+      expect(output, isNot(contains("source.dart")));
+      expect(output, isNot(contains("image-4.png")));
+    });
+
     test("preserves legacy tool text and bounded raw-output fallbacks", () {
       expect(
         mapper.toolContent(

--- a/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
@@ -243,8 +243,12 @@ void main() {
         },
       );
 
-      expect(mapped.output, "one two");
-      expect(mapped.mutation, AcpToolContentMutation.diff);
+      expect(mapped, isA<AcpReplaceToolContentMutation>());
+      final replacement = mapped as AcpReplaceToolContentMutation;
+      expect(replacement.output, "one two");
+      expect(replacement.hasDiff, isTrue);
+      expect(replacement.imageCandidates, hasLength(1));
+      expect(replacement.imageCandidates.single, isA<AcpMappedInlineImageContentBlock>());
       expect(mapped.toString(), isNot(contains("private-terminal")));
       expect(mapped.toString(), isNot(contains("source.dart")));
       expect(mapped.toString(), isNot(contains("secret")));
@@ -260,54 +264,137 @@ void main() {
             ],
           },
         ),
-        isA<AcpMappedToolContent>()
+        isA<AcpReplaceToolContentMutation>()
             .having((content) => content.output, "output", "legacy")
-            .having((content) => content.mutation, "mutation", AcpToolContentMutation.diff),
+            .having((content) => content.hasDiff, "hasDiff", isTrue),
       );
       expect(
-        mapper
-            .toolContent(
-              update: {
-                "rawOutput": {"stdout": "out\n", "stderr": "error\n"},
-              },
-            )
+        (mapper.toolContent(
+                  update: {
+                    "rawOutput": {"stdout": "out\n", "stderr": "error\n"},
+                  },
+                )
+                as AcpUpdateToolOutputMutation)
             .output,
         "out\nerror",
       );
       expect(
-        mapper
-            .toolContent(
-              update: {
-                "rawOutput": {
-                  "content": {"type": "text", "text": "nested\n"},
-                },
-              },
-            )
+        (mapper.toolContent(
+                  update: {
+                    "rawOutput": {
+                      "content": {"type": "text", "text": "nested\n"},
+                    },
+                  },
+                )
+                as AcpUpdateToolOutputMutation)
             .output,
         "nested",
       );
       expect(
-        mapper
-            .toolContent(
-              update: {
-                "rawOutput": {"exitCode": 7},
-              },
-            )
+        (mapper.toolContent(
+                  update: {
+                    "rawOutput": {"exitCode": 7},
+                  },
+                )
+                as AcpUpdateToolOutputMutation)
             .output,
         "exited with code 7",
       );
 
       final oversized = "x" * (maxToolOutputLength + 1);
       expect(
-        mapper.toolContent(update: {"rawOutput": oversized}).output,
+        (mapper.toolContent(update: {"rawOutput": oversized}) as AcpUpdateToolOutputMutation).output,
         "${"x" * maxToolOutputLength}…",
       );
 
       final unicode = "${"x" * (maxToolOutputLength - 1)}😀z";
       expect(
-        mapper.toolContent(update: {"rawOutput": unicode}).output,
+        (mapper.toolContent(update: {"rawOutput": unicode}) as AcpUpdateToolOutputMutation).output,
         "${"x" * (maxToolOutputLength - 1)}😀…",
       );
+    });
+
+    test("distinguishes replacement, raw-output update, and omission", () {
+      expect(
+        mapper.toolContent(update: const {}),
+        isA<AcpUnchangedToolContentMutation>(),
+      );
+      expect(
+        mapper.toolContent(update: {"rawOutput": ""}),
+        isA<AcpUpdateToolOutputMutation>().having(
+          (mutation) => mutation.output,
+          "output",
+          isNull,
+        ),
+      );
+      expect(
+        mapper.toolContent(update: {"content": const <Object?>[]}),
+        isA<AcpReplaceToolContentMutation>()
+            .having((mutation) => mutation.output, "output", isNull)
+            .having(
+              (mutation) => mutation.imageCandidates,
+              "imageCandidates",
+              isEmpty,
+            )
+            .having((mutation) => mutation.hasDiff, "hasDiff", isFalse),
+      );
+
+      final imageOnly =
+          mapper.toolContent(
+                update: {
+                  "content": [
+                    {
+                      "type": "content",
+                      "content": {
+                        "type": "image",
+                        "data": "AA==",
+                        "mimeType": "image/png",
+                        "uri": null,
+                      },
+                    },
+                  ],
+                },
+              )
+              as AcpReplaceToolContentMutation;
+      expect(imageOnly.output, isNull);
+      expect(imageOnly.imageCandidates, hasLength(1));
+    });
+
+    test("uses raw output only when replacement content has no text", () {
+      final withText =
+          mapper.toolContent(
+                update: {
+                  "content": [
+                    {
+                      "type": "content",
+                      "content": {"type": "text", "text": "standard"},
+                    },
+                  ],
+                  "rawOutput": "fallback",
+                },
+              )
+              as AcpReplaceToolContentMutation;
+      final imageOnly =
+          mapper.toolContent(
+                update: {
+                  "content": [
+                    {
+                      "type": "content",
+                      "content": {
+                        "type": "image",
+                        "data": "AA==",
+                        "mimeType": "image/png",
+                        "uri": null,
+                      },
+                    },
+                  ],
+                  "rawOutput": "fallback",
+                },
+              )
+              as AcpReplaceToolContentMutation;
+
+      expect(withText.output, "standard");
+      expect(imageOnly.output, "fallback");
     });
   });
 }

--- a/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
@@ -369,6 +369,10 @@ void main() {
         ),
       );
       expect(
+        mapper.toolContent(update: {"rawOutput": {"stdout": 42}}),
+        isA<AcpUnchangedToolContentMutation>(),
+      );
+      expect(
         mapper.toolContent(update: {"content": const <Object?>[]}),
         isA<AcpReplaceToolContentMutation>()
             .having((mutation) => mutation.output, "output", isNull)

--- a/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
@@ -373,6 +373,18 @@ void main() {
         isA<AcpUnchangedToolContentMutation>(),
       );
       expect(
+        mapper.toolContent(update: {"rawOutput": {"content": 42}}),
+        isA<AcpUnchangedToolContentMutation>(),
+      );
+      expect(
+        mapper.toolContent(update: {"rawOutput": {"stdout": 42, "stderr": "usable"}}),
+        isA<AcpUpdateToolOutputMutation>().having(
+          (mutation) => mutation.output,
+          "output",
+          "usable",
+        ),
+      );
+      expect(
         mapper.toolContent(update: {"content": const <Object?>[]}),
         isA<AcpReplaceToolContentMutation>()
             .having((mutation) => mutation.output, "output", isNull)

--- a/bridge/sesori_plugin_acp/test/acp_tool_content_integration_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_tool_content_integration_test.dart
@@ -207,6 +207,18 @@ void main() {
       expect(completed.whereType<BridgeSseSessionDiff>(), hasLength(1));
     });
 
+    test("malformed status lets a later tool_call supply live status", () {
+      mapper.map(
+        update({"sessionUpdate": "tool_call_update", "toolCallId": "t1", "status": 42}),
+      );
+
+      final call = mapper.map(
+        update({"sessionUpdate": "tool_call", "toolCallId": "t1", "status": "completed"}),
+      );
+
+      expect(_liveState(events: call).status, PluginToolStatus.completed);
+    });
+
     test("a late tool_call enriches without clobbering a first-seen update", () {
       final firstSeen = mapper.map(
         update({
@@ -373,6 +385,18 @@ void main() {
       final state = _replayState(collector: collector);
       expect(state.output, isNull);
       expect(state.attachments, isEmpty);
+    });
+
+    test("malformed status lets a later tool_call supply replay status", () {
+      final collector = _collector()
+        ..consume(
+          update({"sessionUpdate": "tool_call_update", "toolCallId": "t1", "status": 42}),
+        )
+        ..consume(
+          update({"sessionUpdate": "tool_call", "toolCallId": "t1", "status": "completed"}),
+        );
+
+      expect(_replayState(collector: collector).status, PluginToolStatus.completed);
     });
 
     test("a late tool_call enriches without clobbering a first-seen replay update", () {

--- a/bridge/sesori_plugin_acp/test/acp_tool_content_integration_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_tool_content_integration_test.dart
@@ -167,7 +167,7 @@ void main() {
       );
       expect(_liveState(events: replacement).output, isNull);
       expect(_liveState(events: replacement).attachments, isEmpty);
-      expect(replacement.whereType<BridgeSseSessionDiff>(), hasLength(1));
+      expect(replacement.whereType<BridgeSseSessionDiff>(), isEmpty);
 
       final completed = mapper.map(
         update({
@@ -176,7 +176,101 @@ void main() {
           "status": "completed",
         }),
       );
-      expect(completed.whereType<BridgeSseSessionDiff>(), isEmpty);
+      expect(completed.whereType<BridgeSseSessionDiff>(), hasLength(1));
+    });
+
+    test("explicit non-terminal diff content waits for completion", () {
+      final running = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "t1",
+          "status": "in_progress",
+          "content": [
+            {
+              "type": "diff",
+              "path": "/private/source.dart",
+              "oldText": "old",
+              "newText": "new",
+            },
+          ],
+        }),
+      );
+      expect(running.whereType<BridgeSseSessionDiff>(), isEmpty);
+
+      final completed = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "t1",
+          "status": "completed",
+        }),
+      );
+      expect(completed.whereType<BridgeSseSessionDiff>(), hasLength(1));
+    });
+
+    test("a late tool_call enriches without clobbering a first-seen update", () {
+      final firstSeen = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "t1",
+          "status": "completed",
+          "content": [
+            {
+              "type": "content",
+              "content": {"type": "text", "text": "new output"},
+            },
+            {
+              "type": "content",
+              "content": {
+                "type": "image",
+                "data": "AA==",
+                "mimeType": "image/png",
+                "uri": "file:///private/new.png",
+              },
+            },
+            {
+              "type": "diff",
+              "path": "/private/source.dart",
+              "oldText": "old",
+              "newText": "new",
+            },
+          ],
+        }),
+      );
+      expect(firstSeen.whereType<BridgeSseSessionDiff>(), hasLength(1));
+
+      final lateCall = mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "t1",
+          "kind": "edit",
+          "title": "Edit source.dart",
+          "status": "pending",
+          "content": [
+            {
+              "type": "content",
+              "content": {"type": "text", "text": "stale output"},
+            },
+            {
+              "type": "content",
+              "content": {
+                "type": "image",
+                "data": "AQ==",
+                "mimeType": "image/png",
+                "uri": "file:///private/stale.png",
+              },
+            },
+          ],
+        }),
+      );
+
+      expect(lateCall.whereType<BridgeSseMessageUpdated>(), isEmpty);
+      final state = _liveState(events: lateCall);
+      expect(lateCall.whereType<BridgeSseMessagePartUpdated>().single.part.tool, "edit");
+      expect(state.title, "Edit source.dart");
+      expect(state.status, PluginToolStatus.completed);
+      expect(state.output, "new output");
+      expect(state.attachments.single.filename, "new.png");
+      expect(lateCall.whereType<BridgeSseSessionDiff>(), isEmpty);
     });
   });
 
@@ -279,6 +373,54 @@ void main() {
       final state = _replayState(collector: collector);
       expect(state.output, isNull);
       expect(state.attachments, isEmpty);
+    });
+
+    test("a late tool_call enriches without clobbering a first-seen replay update", () {
+      final collector = _collector()
+        ..consume(
+          update({
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": "t1",
+            "status": "completed",
+            "content": [
+              {
+                "type": "content",
+                "content": {"type": "text", "text": "new output"},
+              },
+              {
+                "type": "content",
+                "content": {
+                  "type": "image",
+                  "data": "AA==",
+                  "mimeType": "image/png",
+                  "uri": "file:///private/new.png",
+                },
+              },
+            ],
+          }),
+        )
+        ..consume(
+          update({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "t1",
+            "kind": "read",
+            "title": "Read source.dart",
+            "status": "pending",
+            "content": [
+              {
+                "type": "content",
+                "content": {"type": "text", "text": "stale output"},
+              },
+            ],
+          }),
+        );
+
+      final part = collector.build().single.parts.single;
+      expect(part.tool, "read");
+      expect(part.state?.title, "Read source.dart");
+      expect(part.state?.status, PluginToolStatus.completed);
+      expect(part.state?.output, "new output");
+      expect(part.state?.attachments, isEmpty);
     });
   });
 }

--- a/bridge/sesori_plugin_acp/test/acp_tool_content_integration_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_tool_content_integration_test.dart
@@ -1,0 +1,297 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("live ACP tool content", () {
+    late AcpEventMapper mapper;
+
+    setUp(() {
+      mapper = AcpEventMapper(
+        launchDirectory: "/repo",
+        agentId: "acp",
+        pluginId: "acp",
+        configurationTracker: AcpSessionConfigurationTracker(),
+        contentMapper: const AcpContentMapper(),
+      );
+    });
+
+    AcpNotification update(Map<String, dynamic> body) => AcpNotification(
+      method: "session/update",
+      params: {"sessionId": "s1", "update": body},
+    );
+
+    test("omission and raw output preserve attachments while empty content clears", () {
+      final initial = mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "t1",
+          "kind": "read",
+          "status": "in_progress",
+          "content": [
+            {
+              "type": "content",
+              "content": {"type": "text", "text": "standard output"},
+            },
+            {
+              "type": "content",
+              "content": {
+                "type": "image",
+                "data": "AA==",
+                "mimeType": "image/png",
+                "uri": "file:///private/first.png",
+              },
+            },
+          ],
+        }),
+      );
+      final initialState = _liveState(events: initial);
+      expect(initialState.output, "standard output");
+      expect(initialState.attachments.single, isA<PluginMessageAttachmentInlineImage>());
+      expect(initialState.attachments.single.filename, "first.png");
+
+      final omitted = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "t1",
+          "status": "completed",
+        }),
+      );
+      expect(_liveState(events: omitted).output, "standard output");
+      expect(_liveState(events: omitted).attachments.single.filename, "first.png");
+
+      final rawOutput = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "t1",
+          "rawOutput": {"stdout": "fallback output\n"},
+        }),
+      );
+      expect(_liveState(events: rawOutput).output, "fallback output");
+      expect(_liveState(events: rawOutput).attachments.single.filename, "first.png");
+
+      final cleared = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "t1",
+          "content": const <Object?>[],
+        }),
+      );
+      expect(_liveState(events: cleared).output, isNull);
+      expect(_liveState(events: cleared).attachments, isEmpty);
+    });
+
+    test("image-only content replaces prior output and attachments", () {
+      mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "t1",
+          "kind": "read",
+          "status": "in_progress",
+          "content": [
+            {
+              "type": "content",
+              "content": {"type": "text", "text": "old output"},
+            },
+            {
+              "type": "content",
+              "content": {
+                "type": "image",
+                "data": "AA==",
+                "mimeType": "image/png",
+                "uri": "file:///private/old.png",
+              },
+            },
+          ],
+        }),
+      );
+
+      final replacement = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "t1",
+          "content": [
+            {
+              "type": "content",
+              "content": {
+                "type": "image",
+                "data": "AQ==",
+                "mimeType": "image/png",
+                "uri": "file:///private/new.png",
+              },
+            },
+          ],
+        }),
+      );
+
+      final state = _liveState(events: replacement);
+      expect(state.output, isNull);
+      expect(state.attachments, hasLength(1));
+      expect(state.attachments.single.filename, "new.png");
+    });
+
+    test("diff content replaces attachments and keeps one-shot diff signaling", () {
+      mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "t1",
+          "kind": "read",
+          "status": "in_progress",
+          "content": [
+            {
+              "type": "content",
+              "content": {
+                "type": "image",
+                "data": "AA==",
+                "mimeType": "image/png",
+                "uri": null,
+              },
+            },
+          ],
+        }),
+      );
+
+      final replacement = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "t1",
+          "content": [
+            {
+              "type": "diff",
+              "path": "/private/source.dart",
+              "oldText": "old",
+              "newText": "new",
+            },
+          ],
+        }),
+      );
+      expect(_liveState(events: replacement).output, isNull);
+      expect(_liveState(events: replacement).attachments, isEmpty);
+      expect(replacement.whereType<BridgeSseSessionDiff>(), hasLength(1));
+
+      final completed = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "t1",
+          "status": "completed",
+        }),
+      );
+      expect(completed.whereType<BridgeSseSessionDiff>(), isEmpty);
+    });
+  });
+
+  group("replayed ACP tool content", () {
+    Map<String, dynamic> update(Map<String, dynamic> body) => {"update": body};
+
+    test("applies the same replacement state while deferring attachments", () {
+      final collector = _collector()
+        ..consume(
+          update({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "t1",
+            "kind": "read",
+            "status": "in_progress",
+            "content": [
+              {
+                "type": "content",
+                "content": {"type": "text", "text": "standard output"},
+              },
+              {
+                "type": "content",
+                "content": {
+                  "type": "image",
+                  "data": "AA==",
+                  "mimeType": "image/png",
+                  "uri": "file:///private/output.png",
+                },
+              },
+            ],
+          }),
+        );
+
+      expect(_replayState(collector: collector).output, "standard output");
+      expect(_replayState(collector: collector).attachments, isEmpty);
+
+      collector.consume(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "t1",
+          "status": "completed",
+        }),
+      );
+      expect(_replayState(collector: collector).output, "standard output");
+
+      collector.consume(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "t1",
+          "rawOutput": {"stdout": "fallback output\n"},
+        }),
+      );
+      expect(_replayState(collector: collector).output, "fallback output");
+      expect(_replayState(collector: collector).attachments, isEmpty);
+
+      collector.consume(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "t1",
+          "content": const <Object?>[],
+        }),
+      );
+      expect(_replayState(collector: collector).output, isNull);
+      expect(_replayState(collector: collector).attachments, isEmpty);
+    });
+
+    test("image-only content replaces prior replay output without rendering", () {
+      final collector = _collector()
+        ..consume(
+          update({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "t1",
+            "kind": "read",
+            "status": "in_progress",
+            "content": [
+              {
+                "type": "content",
+                "content": {"type": "text", "text": "old output"},
+              },
+            ],
+          }),
+        )
+        ..consume(
+          update({
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": "t1",
+            "content": [
+              {
+                "type": "content",
+                "content": {
+                  "type": "image",
+                  "data": "AA==",
+                  "mimeType": "image/png",
+                  "uri": null,
+                },
+              },
+            ],
+          }),
+        );
+
+      final state = _replayState(collector: collector);
+      expect(state.output, isNull);
+      expect(state.attachments, isEmpty);
+    });
+  });
+}
+
+PluginToolState _liveState({required List<BridgeSseEvent> events}) =>
+    events.whereType<BridgeSseMessagePartUpdated>().single.part.state!;
+
+AcpReplayCollector _collector() => AcpReplayCollector(
+  sessionId: "s1",
+  agentId: "ACP",
+  initialUserMessageId: null,
+  haltClassifier: null,
+  contentMapper: const AcpContentMapper(),
+);
+
+PluginToolState _replayState({required AcpReplayCollector collector}) => collector.build().single.parts.single.state!;

--- a/bridge/sesori_plugin_acp/test/repositories/trackers/acp_tool_content_tracker_test.dart
+++ b/bridge/sesori_plugin_acp/test/repositories/trackers/acp_tool_content_tracker_test.dart
@@ -1,0 +1,190 @@
+import "dart:io";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/src/repositories/trackers/acp_tool_content_tracker.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" show maxInlineMessageAttachmentBytes;
+import "package:test/test.dart";
+
+void main() {
+  group("AcpToolContentTracker", () {
+    test("applies replacement, output-only, and unchanged mutations", () {
+      final tracker = AcpToolContentTracker()
+        ..apply(
+          mutation: AcpReplaceToolContentMutation(
+            output: "first",
+            imageCandidates: [_inline(filename: "first.png", decodedBytes: 1)],
+            hasDiff: false,
+          ),
+        );
+
+      expect(tracker.snapshot.output, "first");
+      expect(tracker.snapshot.attachments.single.filename, "first.png");
+
+      tracker.apply(mutation: const AcpUnchangedToolContentMutation());
+      expect(tracker.snapshot.output, "first");
+      expect(tracker.snapshot.attachments.single.filename, "first.png");
+
+      tracker.apply(
+        mutation: const AcpUpdateToolOutputMutation(output: "updated"),
+      );
+      expect(tracker.snapshot.output, "updated");
+      expect(tracker.snapshot.attachments.single.filename, "first.png");
+    });
+
+    test("present empty and image-only collections replace the whole state", () {
+      final tracker = AcpToolContentTracker()
+        ..apply(
+          mutation: AcpReplaceToolContentMutation(
+            output: "old",
+            imageCandidates: [_inline(filename: "old.png", decodedBytes: 1)],
+            hasDiff: false,
+          ),
+        )
+        ..apply(
+          mutation: AcpReplaceToolContentMutation(
+            output: null,
+            imageCandidates: [_inline(filename: "new.png", decodedBytes: 1)],
+            hasDiff: false,
+          ),
+        );
+
+      expect(tracker.snapshot.output, isNull);
+      expect(tracker.snapshot.attachments, hasLength(1));
+      expect(tracker.snapshot.attachments.single.filename, "new.png");
+
+      tracker.apply(
+        mutation: const AcpReplaceToolContentMutation(
+          output: null,
+          imageCandidates: [],
+          hasDiff: false,
+        ),
+      );
+      expect(tracker.snapshot.output, isNull);
+      expect(tracker.snapshot.attachments, isEmpty);
+      expect(tracker.snapshot.imageCandidateCount, 0);
+      expect(tracker.snapshot.decodedImageBytes, 0);
+    });
+
+    test("enforces count and aggregate budgets for each replacement", () {
+      final tracker = AcpToolContentTracker()
+        ..apply(
+          mutation: AcpReplaceToolContentMutation(
+            output: null,
+            imageCandidates: [
+              _inline(
+                filename: "one.png",
+                decodedBytes: maxInlineMessageAttachmentBytes,
+              ),
+              _inline(filename: "two.png", decodedBytes: 1),
+              _metadata(),
+              _inline(filename: "four.png", decodedBytes: 0),
+              _inline(filename: "five.png", decodedBytes: 0),
+            ],
+            hasDiff: false,
+          ),
+        );
+
+      expect(tracker.snapshot.attachments, hasLength(4));
+      expect(
+        tracker.snapshot.attachments.map((attachment) => attachment.runtimeType),
+        [
+          PluginMessageAttachmentInlineImage,
+          PluginMessageAttachmentMetadata,
+          PluginMessageAttachmentMetadata,
+          PluginMessageAttachmentInlineImage,
+        ],
+      );
+      expect(tracker.snapshot.imageCandidateCount, 5);
+      expect(
+        tracker.snapshot.decodedImageBytes,
+        maxInlineMessageAttachmentBytes,
+      );
+
+      tracker.apply(
+        mutation: AcpReplaceToolContentMutation(
+          output: null,
+          imageCandidates: [_inline(filename: "reset.png", decodedBytes: 1)],
+          hasDiff: false,
+        ),
+      );
+      expect(tracker.snapshot.attachments.single.filename, "reset.png");
+      expect(tracker.snapshot.imageCandidateCount, 1);
+      expect(tracker.snapshot.decodedImageBytes, 1);
+    });
+
+    test("deduplicates privacy-safe warnings within each collection", () {
+      final output = _captureWarnings(() {
+        AcpToolContentTracker().apply(
+          mutation: AcpReplaceToolContentMutation(
+            output: null,
+            imageCandidates: [
+              _metadata(),
+              _metadata(),
+              _metadata(),
+              _metadata(),
+              _metadata(),
+            ],
+            hasDiff: false,
+          ),
+        );
+      });
+
+      expect("invalid tool image attachment".allMatches(output), hasLength(1));
+      expect("exceeds the count limit".allMatches(output), hasLength(1));
+      expect(output, isNot(contains("private.png")));
+    });
+  });
+}
+
+AcpMappedInlineImageContentBlock _inline({
+  required String filename,
+  required int decodedBytes,
+}) {
+  return AcpMappedInlineImageContentBlock(
+    attachment:
+        PluginMessageAttachment.inlineImage(
+              mime: "image/png",
+              base64: "AA==",
+              filename: filename,
+            )
+            as PluginMessageAttachmentInlineImage,
+    decodedBytes: decodedBytes,
+  );
+}
+
+AcpMappedMetadataImageContentBlock _metadata() {
+  return const AcpMappedMetadataImageContentBlock(
+    attachment:
+        PluginMessageAttachment.metadata(
+              mime: "image/png",
+              filename: "private.png",
+            )
+            as PluginMessageAttachmentMetadata,
+    reason: AcpImageDegradationReason.invalid,
+  );
+}
+
+String _captureWarnings(void Function() action) {
+  final previousLevel = Log.level;
+  final stderr = _BufferingStdout();
+  try {
+    Log.level = LogLevel.warning;
+    IOOverrides.runZoned(action, stderr: () => stderr);
+  } finally {
+    Log.level = previousLevel;
+  }
+  return stderr.text;
+}
+
+class _BufferingStdout implements Stdout {
+  final StringBuffer _buffer = StringBuffer();
+
+  String get text => _buffer.toString();
+
+  @override
+  void writeln([Object? object = ""]) => _buffer.writeln(object);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}

--- a/bridge/sesori_plugin_acp/test/repositories/trackers/acp_tool_content_tracker_test.dart
+++ b/bridge/sesori_plugin_acp/test/repositories/trackers/acp_tool_content_tracker_test.dart
@@ -32,6 +32,23 @@ void main() {
       expect(tracker.snapshot.attachments.single.filename, "first.png");
     });
 
+    test("layers late initial attachments below an earlier output update", () {
+      final tracker = AcpToolContentTracker()
+        ..apply(
+          mutation: const AcpUpdateToolOutputMutation(output: "new output"),
+        )
+        ..applyInitial(
+          mutation: AcpReplaceToolContentMutation(
+            output: "initial output",
+            imageCandidates: [_inline(filename: "initial.png", decodedBytes: 1)],
+            hasDiff: false,
+          ),
+        );
+
+      expect(tracker.snapshot.output, "new output");
+      expect(tracker.snapshot.attachments.single.filename, "initial.png");
+    });
+
     test("present empty and image-only collections replace the whole state", () {
       final tracker = AcpToolContentTracker()
         ..apply(
@@ -62,8 +79,6 @@ void main() {
       );
       expect(tracker.snapshot.output, isNull);
       expect(tracker.snapshot.attachments, isEmpty);
-      expect(tracker.snapshot.imageCandidateCount, 0);
-      expect(tracker.snapshot.decodedImageBytes, 0);
     });
 
     test("enforces count and aggregate budgets for each replacement", () {
@@ -95,11 +110,6 @@ void main() {
           PluginMessageAttachmentInlineImage,
         ],
       );
-      expect(tracker.snapshot.imageCandidateCount, 5);
-      expect(
-        tracker.snapshot.decodedImageBytes,
-        maxInlineMessageAttachmentBytes,
-      );
 
       tracker.apply(
         mutation: AcpReplaceToolContentMutation(
@@ -109,8 +119,6 @@ void main() {
         ),
       );
       expect(tracker.snapshot.attachments.single.filename, "reset.png");
-      expect(tracker.snapshot.imageCandidateCount, 1);
-      expect(tracker.snapshot.decodedImageBytes, 1);
     });
 
     test("deduplicates privacy-safe warnings within each collection", () {

--- a/bridge/sesori_plugin_acp/test/repositories/trackers/acp_tool_content_tracker_test.dart
+++ b/bridge/sesori_plugin_acp/test/repositories/trackers/acp_tool_content_tracker_test.dart
@@ -8,7 +8,7 @@ import "package:test/test.dart";
 
 void main() {
   group("AcpToolContentTracker", () {
-    test("applies replacement, output-only, and unchanged mutations", () {
+    test("applies replacement, output-only, unchanged, and payload-free mutations", () {
       final tracker = AcpToolContentTracker()
         ..apply(
           mutation: AcpReplaceToolContentMutation(
@@ -30,6 +30,16 @@ void main() {
       );
       expect(tracker.snapshot.output, "updated");
       expect(tracker.snapshot.attachments.single.filename, "first.png");
+
+      tracker.apply(
+        mutation: AcpReplaceToolContentMutation(
+          output: "payload-free",
+          imageCandidates: [_inline(filename: "stripped.png", decodedBytes: 1), _metadata()],
+          hasDiff: true,
+        ).withoutImagePayload(),
+      );
+      expect(tracker.snapshot.output, "payload-free");
+      expect(tracker.snapshot.attachments.single, isA<PluginMessageAttachmentMetadata>());
     });
 
     test("layers late initial attachments below an earlier output update", () {


### PR DESCRIPTION
## Complexity

⚙️ Moderate — introduces shared stateful tool-content normalization across live and replay paths with bounded attachment handling.

## What

- Added `AcpToolContentTracker` as the single owner of normalized ACP tool output and attachments.
- Changed `AcpContentMapper` to emit sealed replace, output-update, and unchanged mutations.
- Adopted the tracker in live `_LiveTool` and replay `_ToolDraft` state.
- Materialized bounded standard ACP image attachments on live tool cards while retaining replay attachment state for Step 12.
- Added mapper, tracker, and live/replay integration coverage for replacement and limit behavior.

## Why

Standard ACP tool results can contain images. Live and replay processing need one content policy so omitted updates preserve prior state, explicit content replaces it, and image limits cannot diverge between paths.

## Risk and test focus

Medium risk. Review tool-call partial updates, explicit empty-content clearing, image-only results, raw-output fallback, diff signaling, attachment count/aggregate-byte limits, and Cursor inheritance. Replay intentionally does not render retained tool attachments until Step 12.

## Expected result

Live standard ACP tool cards display validated image attachments alongside normalized output. Omitted updates preserve prior content; present content replaces it. No database or shared-wire change. Replay user-visible behavior is unchanged in this step.

## Verification

- All 207 `sesori_plugin_acp` tests pass.
- All 109 `sesori_plugin_cursor` tests pass.
- `dart analyze --fatal-infos` passes in both packages.
- `git diff --check` passes.
- `aristotle-impl-review` approved the architecture with no findings.
- The complete 1,477-line diff is below the 1,500-line soft cap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces live ACP tool images on tool cards and unifies tool content behavior across live and replay. Adds `AcpToolContentTracker` and sealed mutations to handle replace/omit/raw-output updates, preserve state on reorders, validate update boundaries, and gate diff signaling.

- **New Features**
  - Added `AcpToolContentTracker` to own normalized tool output and attachments; enforces shared `acpToolImageCandidateLimit` of 4 and aggregate byte limits.
  - Live tool cards render validated image attachments; replay keeps the same final state but defers image rendering to Step 12.
  - Update semantics: omitted updates keep prior content/attachments; explicit empty content clears both; raw-output updates are fail-soft and change text without touching attachments—invalid fields are ignored, valid siblings are used, and malformed-only updates preserve prior state.

- **Refactors**
  - `AcpContentMapper` now emits sealed mutations: `AcpReplaceToolContentMutation`, `AcpUpdateToolOutputMutation`, `AcpUnchangedToolContentMutation`.
  - Integrated the tracker into live `_LiveTool` and replay `_ToolDraft`; file-mutation detection derives from mutation; diff emission waits for terminal status with the established exception for status-less diff producers; reordered late `tool_call`s enrich without clobbering newer content/status/diff.
  - Validated tool update boundaries: only recognized statuses are treated as explicit in live/replay, malformed top-level content is unchanged, and replay strips inline image payloads while preserving safe metadata and replacement/output/diff boundaries.

<sup>Written for commit 43289f2186b8eaa65a12b1922ee2b0860a68a27b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

