### PR TITLE
⚙️ Fix image viewer navigation and gestures

### DIFF
--- a/client/app/lib/features/session_detail/widgets/file_part_widget.dart
+++ b/client/app/lib/features/session_detail/widgets/file_part_widget.dart
@@ -209,7 +209,6 @@ class _LoadedImageAttachmentState extends State<_LoadedImageAttachment> {
   final _heroTag = UniqueKey();
   late LoadedMessageImage _image;
   bool _isDecoded = false;
-  bool _isViewerOpen = false;
 
   @override
   void initState() {
@@ -251,25 +250,10 @@ class _LoadedImageAttachmentState extends State<_LoadedImageAttachment> {
     });
   }
 
-  Future<void> _openViewer() async {
-    if (_isViewerOpen) return;
-    setState(() => _isViewerOpen = true);
-    try {
-      await showImageAttachmentViewer(
-        context: context,
-        image: _image,
-        filename: widget.filename,
-        heroTag: _heroTag,
-      );
-    } finally {
-      if (mounted) setState(() => _isViewerOpen = false);
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
-    final preview = Padding(
+    return Padding(
       padding: EdgeInsets.symmetric(vertical: prego.spacing.md),
       child: Semantics(
         button: _isDecoded,
@@ -277,7 +261,16 @@ class _LoadedImageAttachmentState extends State<_LoadedImageAttachment> {
         child: GestureDetector(
           key: FilePartWidget.previewTapTargetKey,
           behavior: HitTestBehavior.opaque,
-          onTap: !_isDecoded || _isViewerOpen ? null : () => unawaited(_openViewer()),
+          onTap: !_isDecoded
+              ? null
+              : () => unawaited(
+                  showImageAttachmentViewer(
+                    context: context,
+                    image: _image,
+                    filename: widget.filename,
+                    heroTag: _heroTag,
+                  ),
+                ),
           child: Hero(
             tag: _heroTag,
             child: ClipRRect(
@@ -308,12 +301,6 @@ class _LoadedImageAttachmentState extends State<_LoadedImageAttachment> {
           ),
         ),
       ),
-    );
-    return PopScope(
-      // Keep repeated back events off the session route while the root viewer
-      // is completing its reverse transition.
-      canPop: !_isViewerOpen,
-      child: preview,
     );
   }
 }

--- a/client/app/lib/features/session_detail/widgets/file_part_widget.dart
+++ b/client/app/lib/features/session_detail/widgets/file_part_widget.dart
@@ -209,6 +209,7 @@ class _LoadedImageAttachmentState extends State<_LoadedImageAttachment> {
   final _heroTag = UniqueKey();
   late LoadedMessageImage _image;
   bool _isDecoded = false;
+  bool _isViewerOpen = false;
 
   @override
   void initState() {
@@ -250,10 +251,25 @@ class _LoadedImageAttachmentState extends State<_LoadedImageAttachment> {
     });
   }
 
+  Future<void> _openViewer() async {
+    if (_isViewerOpen) return;
+    setState(() => _isViewerOpen = true);
+    try {
+      await showImageAttachmentViewer(
+        context: context,
+        image: _image,
+        filename: widget.filename,
+        heroTag: _heroTag,
+      );
+    } finally {
+      if (mounted) setState(() => _isViewerOpen = false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
-    return Padding(
+    final preview = Padding(
       padding: EdgeInsets.symmetric(vertical: prego.spacing.md),
       child: Semantics(
         button: _isDecoded,
@@ -261,16 +277,7 @@ class _LoadedImageAttachmentState extends State<_LoadedImageAttachment> {
         child: GestureDetector(
           key: FilePartWidget.previewTapTargetKey,
           behavior: HitTestBehavior.opaque,
-          onTap: !_isDecoded
-              ? null
-              : () => unawaited(
-                  showImageAttachmentViewer(
-                    context: context,
-                    image: _image,
-                    filename: widget.filename,
-                    heroTag: _heroTag,
-                  ),
-                ),
+          onTap: !_isDecoded || _isViewerOpen ? null : () => unawaited(_openViewer()),
           child: Hero(
             tag: _heroTag,
             child: ClipRRect(
@@ -301,6 +308,12 @@ class _LoadedImageAttachmentState extends State<_LoadedImageAttachment> {
           ),
         ),
       ),
+    );
+    return PopScope(
+      // Keep repeated back events off the session route while the root viewer
+      // is completing its reverse transition.
+      canPop: !_isViewerOpen,
+      child: preview,
     );
   }
 }

--- a/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
+++ b/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
@@ -3,7 +3,6 @@ import "dart:typed_data";
 
 import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
-import "package:go_router/go_router.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:theme_prego/module_prego.dart";
 
@@ -33,33 +32,52 @@ Future<void> showImageAttachmentViewer({
   required String? filename,
   required Key heroTag,
 }) {
-  // ignore: no_slop_linter/avoid_navigator_of, no_slop_linter/avoid_raw_go_router, this transient Hero route carries an in-memory ImageProvider that cannot be represented in a URL
-  return Navigator.of(context).push<void>(
-    PageRouteBuilder<void>(
-      opaque: true,
-      transitionDuration: const Duration(milliseconds: 260),
-      reverseTransitionDuration: const Duration(milliseconds: 220),
-      pageBuilder: (_, _, _) => BlocProvider(
-        create: (_) => ImageAttachmentActionsCubit(
-          imageSaver: getIt<ImageSaver>(),
-          imageClipboard: getIt<ImageClipboard>(),
-          imageSharer: getIt<ImageSharer>(),
-          bytes: image.bytes,
-          mime: image.mime,
-          actionFilename: image.actionFilename,
-        ),
+  // ignore: no_slop_linter/avoid_navigator_of, the transient viewer must cover the split shell
+  final rootNavigator = Navigator.of(context, rootNavigator: true);
+  final sourceRoute = ModalRoute.of(context);
+  if (sourceRoute == null) throw StateError("Image attachment viewer requires a source route");
+  final viewerRoute = PageRouteBuilder<void>(
+    opaque: false,
+    transitionDuration: const Duration(milliseconds: 260),
+    reverseTransitionDuration: const Duration(milliseconds: 220),
+    pageBuilder: (_, _, _) => BlocProvider(
+      create: (_) => ImageAttachmentActionsCubit(
+        imageSaver: getIt<ImageSaver>(),
+        imageClipboard: getIt<ImageClipboard>(),
+        imageSharer: getIt<ImageSharer>(),
+        bytes: image.bytes,
+        mime: image.mime,
+        actionFilename: image.actionFilename,
+      ),
+      child: ScaffoldMessenger(
         child: ImageAttachmentViewer(
           image: image,
           filename: filename,
           heroTag: heroTag,
         ),
       ),
-      transitionsBuilder: (_, animation, _, child) => FadeTransition(opacity: animation, child: child),
     ),
+    transitionsBuilder: (_, animation, _, child) => FadeTransition(opacity: animation, child: child),
   );
+  var shouldDismissViewerWithHistory = true;
+  // Mirror the root viewer in the session route's local history so Android
+  // back dismisses the viewer whichever navigator receives the event first.
+  final historyEntry = LocalHistoryEntry(
+    impliesAppBarDismissal: false,
+    onRemove: () {
+      if (shouldDismissViewerWithHistory && viewerRoute.isCurrent) rootNavigator.pop();
+    },
+  );
+  // ignore: no_slop_linter/avoid_raw_go_router, this transient Hero route carries an in-memory ImageProvider that cannot be represented in a URL
+  final result = rootNavigator.push<void>(viewerRoute);
+  sourceRoute.addLocalHistoryEntry(historyEntry);
+  return result.whenComplete(() {
+    shouldDismissViewerWithHistory = false;
+    historyEntry.remove();
+  });
 }
 
-class ImageAttachmentViewer extends StatelessWidget {
+class ImageAttachmentViewer extends StatefulWidget {
   static const imageKey = ValueKey("imageAttachmentViewer.image");
 
   final LoadedMessageImage image;
@@ -72,6 +90,150 @@ class ImageAttachmentViewer extends StatelessWidget {
     required this.filename,
     required this.heroTag,
   });
+
+  @override
+  State<ImageAttachmentViewer> createState() => _ImageAttachmentViewerState();
+}
+
+class _ImageAttachmentViewerState extends State<ImageAttachmentViewer> with TickerProviderStateMixin {
+  static const _doubleTapScale = 2.5;
+  static const _baseScaleTolerance = 0.01;
+  static const _dismissVelocity = 900.0;
+  static const _dragResetDuration = Duration(milliseconds: 180);
+  static const _zoomDuration = Duration(milliseconds: 220);
+
+  final _transformationController = TransformationController();
+  late final AnimationController _dragResetController;
+  late final AnimationController _zoomController;
+  Matrix4Tween? _zoomTween;
+  Offset? _doubleTapPosition;
+  Offset _interactionDelta = Offset.zero;
+  double _dragOffset = 0;
+  double _dragResetStart = 0;
+  bool _canDragToDismiss = false;
+  bool _isDismissDrag = false;
+  bool _isDismissing = false;
+
+  bool get _isAtBaseScale => (_transformationController.value.getMaxScaleOnAxis() - 1).abs() <= _baseScaleTolerance;
+
+  @override
+  void initState() {
+    super.initState();
+    _dragResetController = AnimationController(vsync: this, duration: _dragResetDuration)
+      ..addListener(_updateDragReset);
+    _zoomController = AnimationController(vsync: this, duration: _zoomDuration)..addListener(_updateZoom);
+  }
+
+  @override
+  void dispose() {
+    _dragResetController.dispose();
+    _zoomController.dispose();
+    _transformationController.dispose();
+    super.dispose();
+  }
+
+  void _updateDragReset() {
+    final progress = Curves.easeOutCubic.transform(_dragResetController.value);
+    setState(() => _dragOffset = _dragResetStart * (1 - progress));
+  }
+
+  void _updateZoom() {
+    final tween = _zoomTween;
+    if (tween == null) return;
+    final progress = Curves.easeOutCubic.transform(_zoomController.value);
+    final transform = tween.transform(progress);
+    _transformationController.value = transform;
+  }
+
+  void _handleInteractionStart({required ScaleStartDetails details}) {
+    _zoomController.stop();
+    _dragResetController.stop();
+    _interactionDelta = Offset.zero;
+    _canDragToDismiss = details.pointerCount == 1 && _isAtBaseScale;
+    _isDismissDrag = false;
+  }
+
+  void _handleInteractionUpdate({required ScaleUpdateDetails details}) {
+    if (!_canDragToDismiss || _isDismissing) return;
+    if (details.pointerCount != 1 || !_isAtBaseScale) {
+      _canDragToDismiss = false;
+      if (_dragOffset != 0) _animateDragToOrigin();
+      return;
+    }
+
+    _interactionDelta += details.focalPointDelta;
+    if (!_isDismissDrag) {
+      if (_interactionDelta.distance < 8) return;
+      if (_interactionDelta.dy.abs() <= _interactionDelta.dx.abs() * 1.2) {
+        _canDragToDismiss = false;
+        return;
+      }
+      _isDismissDrag = true;
+    }
+
+    final height = MediaQuery.sizeOf(context).height;
+    setState(() => _dragOffset = _interactionDelta.dy.clamp(-height, height));
+  }
+
+  void _handleInteractionEnd({required ScaleEndDetails details}) {
+    final wasDismissDrag = _isDismissDrag;
+    _canDragToDismiss = false;
+    _isDismissDrag = false;
+    if (!wasDismissDrag || _isDismissing) return;
+
+    final velocity = details.velocity.pixelsPerSecond.dy;
+    final distanceThreshold = (MediaQuery.sizeOf(context).height * 0.15).clamp(96.0, 160.0);
+    final hasDismissVelocity =
+        velocity.abs() >= _dismissVelocity && (_dragOffset == 0 || velocity.sign == _dragOffset.sign);
+    if (_dragOffset.abs() >= distanceThreshold || hasDismissVelocity) {
+      _dismiss();
+    } else {
+      _animateDragToOrigin();
+    }
+  }
+
+  void _animateDragToOrigin() {
+    if (context.isReducedMotion) {
+      setState(() => _dragOffset = 0);
+      return;
+    }
+    _dragResetStart = _dragOffset;
+    _dragResetController.forward(from: 0);
+  }
+
+  void _captureDoubleTapPosition({required TapDownDetails details}) {
+    _doubleTapPosition = details.localPosition;
+  }
+
+  void _toggleZoom() {
+    if (_isDismissing) return;
+    final target = _isAtBaseScale ? _zoomedTransform() : Matrix4.identity();
+    if (context.isReducedMotion) {
+      _transformationController.value = target;
+      return;
+    }
+    _zoomTween = Matrix4Tween(begin: _transformationController.value.clone(), end: target);
+    _zoomController.forward(from: 0);
+  }
+
+  Matrix4 _zoomedTransform() {
+    final position = _doubleTapPosition ?? Offset.zero;
+    return Matrix4.identity()
+      ..translateByDouble(
+        -position.dx * (_doubleTapScale - 1),
+        -position.dy * (_doubleTapScale - 1),
+        0,
+        1,
+      )
+      ..scaleByDouble(_doubleTapScale, _doubleTapScale, _doubleTapScale, 1);
+  }
+
+  void _dismiss() {
+    if (_isDismissing) return;
+    _isDismissing = true;
+    // ignore: no_slop_linter/avoid_navigator_of, dismisses the transient route that owns this viewer
+    Navigator.of(context).pop();
+  }
 
   ImageShareOrigin? _shareOrigin({required BuildContext originContext}) {
     final renderObject = originContext.findRenderObject();
@@ -104,97 +266,122 @@ class ImageAttachmentViewer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
-    final originalUri = image.originalUri;
-    final displayFilename = filename;
+    final originalUri = widget.image.originalUri;
+    final displayFilename = widget.filename;
     final isRunningAction = context.watch<ImageAttachmentActionsCubit>().state is ImageAttachmentActionRunning;
+    final dismissRange = (MediaQuery.sizeOf(context).height * 0.45).clamp(1.0, double.infinity);
+    final dismissProgress = (_dragOffset.abs() / dismissRange).clamp(0.0, 1.0);
+    final chromeOpacity = 1 - dismissProgress;
+    final backgroundOpacity = 1 - dismissProgress * 0.8;
     return BlocListener<ImageAttachmentActionsCubit, ImageAttachmentActionsState>(
       listener: _handleActionState,
       child: Scaffold(
-        backgroundColor: prego.colors.bgSurface1,
+        backgroundColor: prego.colors.bgSurface1.withValues(alpha: backgroundOpacity),
         body: SafeArea(
           child: Column(
             children: [
-              Padding(
-                padding: EdgeInsets.symmetric(horizontal: prego.spacing.sm),
-                child: Row(
-                  children: [
-                    IconButton(
-                      tooltip: context.loc.sessionDetailImageClose,
-                      onPressed: context.pop,
-                      icon: Icon(Icons.close, color: prego.colors.textPrimary),
-                    ),
-                    SizedBox(width: prego.spacing.xs),
-                    Expanded(
-                      child: displayFilename == null
-                          ? const SizedBox.shrink()
-                          : Text(
-                              displayFilename,
-                              style: prego.textTheme.textSm.bold,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                    ),
-                    if (isRunningAction)
-                      Padding(
-                        padding: EdgeInsets.all(prego.spacing.md),
-                        child: SizedBox.square(
-                          dimension: prego.spacing.x2l,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            color: prego.colors.fgBrandPrimary,
-                          ),
-                        ),
-                      )
-                    else ...[
-                      if (originalUri != null)
+              IgnorePointer(
+                ignoring: _isDismissDrag,
+                child: Opacity(
+                  opacity: chromeOpacity,
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: prego.spacing.sm),
+                    child: Row(
+                      children: [
                         IconButton(
-                          tooltip: context.loc.sessionDetailImageOpenOriginal,
-                          onPressed: () => unawaited(
-                            openExternalLink(url: originalUri, mode: UrlLaunchMode.externalApp).then<void>((_) {}),
-                          ),
-                          icon: Icon(Icons.open_in_new, color: prego.colors.textPrimary),
+                          tooltip: context.loc.sessionDetailImageClose,
+                          onPressed: _dismiss,
+                          icon: Icon(Icons.close, color: prego.colors.textPrimary),
                         ),
-                      IconButton(
-                        tooltip: context.loc.sessionDetailImageCopy,
-                        onPressed: () => unawaited(context.read<ImageAttachmentActionsCubit>().copy()),
-                        icon: Icon(Icons.content_copy, color: prego.colors.textPrimary),
-                      ),
-                      Builder(
-                        builder: (buttonContext) => IconButton(
-                          tooltip: context.loc.sessionDetailImageShare,
-                          onPressed: () => unawaited(
-                            context.read<ImageAttachmentActionsCubit>().share(
-                              origin: _shareOrigin(originContext: buttonContext),
+                        SizedBox(width: prego.spacing.xs),
+                        Expanded(
+                          child: displayFilename == null
+                              ? const SizedBox.shrink()
+                              : Text(
+                                  displayFilename,
+                                  style: prego.textTheme.textSm.bold,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                        ),
+                        if (isRunningAction)
+                          Padding(
+                            padding: EdgeInsets.all(prego.spacing.md),
+                            child: SizedBox.square(
+                              dimension: prego.spacing.x2l,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: prego.colors.fgBrandPrimary,
+                              ),
+                            ),
+                          )
+                        else ...[
+                          if (originalUri != null)
+                            IconButton(
+                              tooltip: context.loc.sessionDetailImageOpenOriginal,
+                              onPressed: () => unawaited(
+                                openExternalLink(
+                                  url: originalUri,
+                                  mode: UrlLaunchMode.externalApp,
+                                ).then<void>((_) {}),
+                              ),
+                              icon: Icon(Icons.open_in_new, color: prego.colors.textPrimary),
+                            ),
+                          IconButton(
+                            tooltip: context.loc.sessionDetailImageCopy,
+                            onPressed: () => unawaited(context.read<ImageAttachmentActionsCubit>().copy()),
+                            icon: Icon(Icons.content_copy, color: prego.colors.textPrimary),
+                          ),
+                          Builder(
+                            builder: (buttonContext) => IconButton(
+                              tooltip: context.loc.sessionDetailImageShare,
+                              onPressed: () => unawaited(
+                                context.read<ImageAttachmentActionsCubit>().share(
+                                  origin: _shareOrigin(originContext: buttonContext),
+                                ),
+                              ),
+                              icon: Icon(Icons.share_outlined, color: prego.colors.textPrimary),
                             ),
                           ),
-                          icon: Icon(Icons.share_outlined, color: prego.colors.textPrimary),
-                        ),
-                      ),
-                      IconButton(
-                        tooltip: context.loc.sessionDetailImageSave,
-                        onPressed: () => unawaited(context.read<ImageAttachmentActionsCubit>().save()),
-                        icon: Icon(Icons.download_outlined, color: prego.colors.textPrimary),
-                      ),
-                    ],
-                  ],
+                          IconButton(
+                            tooltip: context.loc.sessionDetailImageSave,
+                            onPressed: () => unawaited(context.read<ImageAttachmentActionsCubit>().save()),
+                            icon: Icon(Icons.download_outlined, color: prego.colors.textPrimary),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
                 ),
               ),
               Expanded(
-                child: InteractiveViewer(
-                  minScale: 0.8,
-                  maxScale: 5,
-                  child: Hero(
-                    tag: heroTag,
-                    child: SizedBox.expand(
-                      child: Image(
-                        key: ImageAttachmentViewer.imageKey,
-                        image: image.provider,
-                        fit: BoxFit.contain,
-                        semanticLabel: filename,
-                        errorBuilder: (_, _, _) => Icon(
-                          Icons.broken_image,
-                          size: prego.spacing.x6l,
-                          color: prego.colors.textTertiary,
+                child: Transform.translate(
+                  offset: Offset(0, _dragOffset),
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onDoubleTapDown: (details) => _captureDoubleTapPosition(details: details),
+                    onDoubleTap: _toggleZoom,
+                    child: InteractiveViewer(
+                      transformationController: _transformationController,
+                      minScale: 0.8,
+                      maxScale: 5,
+                      onInteractionStart: (details) => _handleInteractionStart(details: details),
+                      onInteractionUpdate: (details) => _handleInteractionUpdate(details: details),
+                      onInteractionEnd: (details) => _handleInteractionEnd(details: details),
+                      child: Hero(
+                        tag: widget.heroTag,
+                        child: SizedBox.expand(
+                          child: Image(
+                            key: ImageAttachmentViewer.imageKey,
+                            image: widget.image.provider,
+                            fit: BoxFit.contain,
+                            semanticLabel: widget.filename,
+                            errorBuilder: (_, _, _) => Icon(
+                              Icons.broken_image,
+                              size: prego.spacing.x6l,
+                              color: prego.colors.textTertiary,
+                            ),
+                          ),
                         ),
                       ),
                     ),

--- a/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
+++ b/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
@@ -33,30 +33,30 @@ Future<void> showImageAttachmentViewer({
   required String? filename,
   required Key heroTag,
 }) {
-  // ignore: no_slop_linter/avoid_navigator_of, no_slop_linter/avoid_raw_go_router, this transient root Hero route carries an in-memory ImageProvider that cannot be represented in a URL
-  return Navigator.of(context, rootNavigator: true).push<void>(
-    PageRouteBuilder<void>(
-      opaque: true,
-      transitionDuration: const Duration(milliseconds: 260),
-      reverseTransitionDuration: const Duration(milliseconds: 220),
-      pageBuilder: (_, _, _) => BlocProvider(
-        create: (_) => ImageAttachmentActionsCubit(
-          imageSaver: getIt<ImageSaver>(),
-          imageClipboard: getIt<ImageClipboard>(),
-          imageSharer: getIt<ImageSharer>(),
-          bytes: image.bytes,
-          mime: image.mime,
-          actionFilename: image.actionFilename,
-        ),
-        child: ImageAttachmentViewer(
-          image: image,
-          filename: filename,
-          heroTag: heroTag,
-        ),
+  final route = PageRouteBuilder<void>(
+    opaque: true,
+    transitionDuration: const Duration(milliseconds: 260),
+    reverseTransitionDuration: const Duration(milliseconds: 220),
+    pageBuilder: (_, _, _) => BlocProvider(
+      create: (_) => ImageAttachmentActionsCubit(
+        imageSaver: getIt<ImageSaver>(),
+        imageClipboard: getIt<ImageClipboard>(),
+        imageSharer: getIt<ImageSharer>(),
+        bytes: image.bytes,
+        mime: image.mime,
+        actionFilename: image.actionFilename,
       ),
-      transitionsBuilder: (_, animation, _, child) => FadeTransition(opacity: animation, child: child),
+      child: ImageAttachmentViewer(
+        image: image,
+        filename: filename,
+        heroTag: heroTag,
+      ),
     ),
+    transitionsBuilder: (_, animation, _, child) => FadeTransition(opacity: animation, child: child),
   );
+  // ignore: no_slop_linter/avoid_navigator_of, no_slop_linter/avoid_raw_go_router, this transient root Hero route carries an in-memory ImageProvider that cannot be represented in a URL
+  unawaited(Navigator.of(context, rootNavigator: true).push<void>(route));
+  return route.completed;
 }
 
 class ImageAttachmentViewer extends StatelessWidget {

--- a/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
+++ b/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
@@ -109,6 +109,7 @@ class _ImageAttachmentViewerState extends State<ImageAttachmentViewer> with Tick
   Offset? _doubleTapPosition;
   Offset _interactionDelta = Offset.zero;
   double _dragOffset = 0;
+  double _dragStartOffset = 0;
   double _dragResetStart = 0;
   bool _canDragToDismiss = false;
   bool _isDismissDrag = false;
@@ -147,10 +148,13 @@ class _ImageAttachmentViewerState extends State<ImageAttachmentViewer> with Tick
 
   void _handleInteractionStart({required ScaleStartDetails details}) {
     _zoomController.stop();
-    _dragResetController.stop();
     _interactionDelta = Offset.zero;
     _canDragToDismiss = details.pointerCount == 1 && _isAtBaseScale;
     _isDismissDrag = false;
+    if (_canDragToDismiss) {
+      _dragStartOffset = _dragOffset;
+      _dragResetController.stop();
+    }
   }
 
   void _handleInteractionUpdate({required ScaleUpdateDetails details}) {
@@ -166,20 +170,26 @@ class _ImageAttachmentViewerState extends State<ImageAttachmentViewer> with Tick
       if (_interactionDelta.distance < 8) return;
       if (_interactionDelta.dy.abs() <= _interactionDelta.dx.abs() * 1.2) {
         _canDragToDismiss = false;
+        if (_dragOffset != 0) _animateDragToOrigin();
         return;
       }
       _isDismissDrag = true;
     }
 
     final height = MediaQuery.sizeOf(context).height;
-    setState(() => _dragOffset = _interactionDelta.dy.clamp(-height, height));
+    setState(() => _dragOffset = (_dragStartOffset + _interactionDelta.dy).clamp(-height, height));
   }
 
   void _handleInteractionEnd({required ScaleEndDetails details}) {
     final wasDismissDrag = _isDismissDrag;
     _canDragToDismiss = false;
     _isDismissDrag = false;
-    if (!wasDismissDrag || _isDismissing) return;
+    if (!wasDismissDrag || _isDismissing) {
+      if (!_isDismissing && _dragOffset != 0 && !_dragResetController.isAnimating) {
+        _animateDragToOrigin();
+      }
+      return;
+    }
 
     final velocity = details.velocity.pixelsPerSecond.dy;
     final distanceThreshold = (MediaQuery.sizeOf(context).height * 0.15).clamp(96.0, 160.0);

--- a/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
+++ b/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
@@ -33,30 +33,30 @@ Future<void> showImageAttachmentViewer({
   required String? filename,
   required Key heroTag,
 }) {
-  final route = PageRouteBuilder<void>(
-    opaque: true,
-    transitionDuration: const Duration(milliseconds: 260),
-    reverseTransitionDuration: const Duration(milliseconds: 220),
-    pageBuilder: (_, _, _) => BlocProvider(
-      create: (_) => ImageAttachmentActionsCubit(
-        imageSaver: getIt<ImageSaver>(),
-        imageClipboard: getIt<ImageClipboard>(),
-        imageSharer: getIt<ImageSharer>(),
-        bytes: image.bytes,
-        mime: image.mime,
-        actionFilename: image.actionFilename,
+  // ignore: no_slop_linter/avoid_navigator_of, no_slop_linter/avoid_raw_go_router, this transient Hero route carries an in-memory ImageProvider that cannot be represented in a URL
+  return Navigator.of(context).push<void>(
+    PageRouteBuilder<void>(
+      opaque: true,
+      transitionDuration: const Duration(milliseconds: 260),
+      reverseTransitionDuration: const Duration(milliseconds: 220),
+      pageBuilder: (_, _, _) => BlocProvider(
+        create: (_) => ImageAttachmentActionsCubit(
+          imageSaver: getIt<ImageSaver>(),
+          imageClipboard: getIt<ImageClipboard>(),
+          imageSharer: getIt<ImageSharer>(),
+          bytes: image.bytes,
+          mime: image.mime,
+          actionFilename: image.actionFilename,
+        ),
+        child: ImageAttachmentViewer(
+          image: image,
+          filename: filename,
+          heroTag: heroTag,
+        ),
       ),
-      child: ImageAttachmentViewer(
-        image: image,
-        filename: filename,
-        heroTag: heroTag,
-      ),
+      transitionsBuilder: (_, animation, _, child) => FadeTransition(opacity: animation, child: child),
     ),
-    transitionsBuilder: (_, animation, _, child) => FadeTransition(opacity: animation, child: child),
   );
-  // ignore: no_slop_linter/avoid_navigator_of, no_slop_linter/avoid_raw_go_router, this transient root Hero route carries an in-memory ImageProvider that cannot be represented in a URL
-  unawaited(Navigator.of(context, rootNavigator: true).push<void>(route));
-  return route.completed;
 }
 
 class ImageAttachmentViewer extends StatelessWidget {

--- a/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
+++ b/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
@@ -5,6 +5,7 @@ import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:get_it/get_it.dart";
+import "package:go_router/go_router.dart";
 import "package:http/http.dart" as http;
 import "package:http/testing.dart";
 import "package:mocktail/mocktail.dart";
@@ -158,6 +159,76 @@ void main() {
 
     expect(identical(imageClipboard.copiedBytes, memoryImage.bytes), isTrue);
     expect(find.text("Image copied to clipboard"), findsOneWidget);
+  });
+
+  testWidgets("repeated system back closes the image viewer without leaving the session", (tester) async {
+    const attachment = MessageAttachment.inlineImage(
+      mime: "image/png",
+      base64: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==",
+      filename: "image.png",
+    );
+    final router = GoRouter(
+      initialLocation: "/sessions/chat",
+      routes: [
+        ShellRoute(
+          builder: (_, _, child) => child,
+          routes: [
+            GoRoute(
+              path: "/sessions",
+              builder: (_, _) => const Scaffold(body: Text("Session list")),
+              routes: [
+                GoRoute(
+                  path: "chat",
+                  builder: (_, _) => const Scaffold(body: FilePartWidget(attachment: attachment)),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+    await tester.pumpWidget(
+      MaterialApp.router(
+        routerConfig: router,
+        theme: ThemeData(extensions: [PregoDesignSystem.light]),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+      ),
+    );
+    await _finishAsyncDecode(tester: tester);
+    final preview = tester.widget<Image>(find.byKey(FilePartWidget.previewImageKey));
+    await tester.runAsync(
+      () => precacheImage(
+        preview.image,
+        tester.element(find.byKey(FilePartWidget.previewImageKey)),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(
+      tester.widget<GestureDetector>(find.byKey(FilePartWidget.previewTapTargetKey)).onTap,
+      isNotNull,
+    );
+    await tester.tap(find.byKey(FilePartWidget.previewTapTargetKey));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ImageAttachmentViewer), findsOneWidget);
+    expect(router.routeInformationProvider.value.uri.path, "/sessions/chat");
+
+    await tester.binding.handlePopRoute();
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ImageAttachmentViewer), findsNothing);
+    expect(find.byKey(FilePartWidget.previewTapTargetKey), findsOneWidget);
+    expect(router.routeInformationProvider.value.uri.path, "/sessions/chat");
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(find.text("Session list"), findsOneWidget);
+    expect(router.routeInformationProvider.value.uri.path, "/sessions");
   });
 
   testWidgets("omits the image title when attachment metadata has no filename", (tester) async {

--- a/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
+++ b/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
@@ -20,6 +20,15 @@ import "package:theme_prego/module_prego.dart";
 
 class _MockUrlLauncher extends Mock implements UrlLauncher {}
 
+class _RecordingNavigatorObserver extends NavigatorObserver {
+  final pushedRoutes = <Route<dynamic>>[];
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    pushedRoutes.add(route);
+  }
+}
+
 class _FakeImageSaver implements ImageSaver {
   Uint8List? savedBytes;
   String? savedFilename;
@@ -161,16 +170,22 @@ void main() {
     expect(find.text("Image copied to clipboard"), findsOneWidget);
   });
 
-  testWidgets("repeated system back closes the image viewer without leaving the session", (tester) async {
+  testWidgets("system back closes the image viewer on the session navigator", (tester) async {
     const attachment = MessageAttachment.inlineImage(
       mime: "image/png",
       base64: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==",
       filename: "image.png",
     );
+    final rootNavigatorKey = GlobalKey<NavigatorState>();
+    final sessionNavigatorKey = GlobalKey<NavigatorState>();
+    final sessionObserver = _RecordingNavigatorObserver();
     final router = GoRouter(
+      navigatorKey: rootNavigatorKey,
       initialLocation: "/sessions/chat",
       routes: [
         ShellRoute(
+          navigatorKey: sessionNavigatorKey,
+          observers: [sessionObserver],
           builder: (_, _, child) => child,
           routes: [
             GoRoute(
@@ -209,14 +224,18 @@ void main() {
       tester.widget<GestureDetector>(find.byKey(FilePartWidget.previewTapTargetKey)).onTap,
       isNotNull,
     );
+    sessionObserver.pushedRoutes.clear();
     await tester.tap(find.byKey(FilePartWidget.previewTapTargetKey));
     await tester.pumpAndSettle();
 
     expect(find.byType(ImageAttachmentViewer), findsOneWidget);
     expect(router.routeInformationProvider.value.uri.path, "/sessions/chat");
+    expect(sessionObserver.pushedRoutes, hasLength(1));
+    final viewerRoute = sessionObserver.pushedRoutes.single;
+    expect(viewerRoute, isA<PageRouteBuilder<void>>());
+    expect(viewerRoute.navigator, same(sessionNavigatorKey.currentState));
+    expect(viewerRoute.navigator, isNot(same(rootNavigatorKey.currentState)));
 
-    await tester.binding.handlePopRoute();
-    await tester.pump(const Duration(milliseconds: 100));
     await tester.binding.handlePopRoute();
     await tester.pumpAndSettle();
 

--- a/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
+++ b/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
@@ -20,15 +20,6 @@ import "package:theme_prego/module_prego.dart";
 
 class _MockUrlLauncher extends Mock implements UrlLauncher {}
 
-class _RecordingNavigatorObserver extends NavigatorObserver {
-  final pushedRoutes = <Route<dynamic>>[];
-
-  @override
-  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    pushedRoutes.add(route);
-  }
-}
-
 class _FakeImageSaver implements ImageSaver {
   Uint8List? savedBytes;
   String? savedFilename;
@@ -75,6 +66,28 @@ Widget _app({required Widget child}) {
 
 Future<void> _finishAsyncDecode({required WidgetTester tester}) async {
   await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 50)));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _openImageViewer({required WidgetTester tester}) async {
+  await _finishAsyncDecode(tester: tester);
+  final preview = tester.widget<Image>(find.byKey(FilePartWidget.previewImageKey));
+  await tester.runAsync(
+    () => precacheImage(
+      preview.image,
+      tester.element(find.byKey(FilePartWidget.previewImageKey)),
+    ),
+  );
+  await tester.pumpAndSettle();
+  await tester.tap(find.byKey(FilePartWidget.previewTapTargetKey));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _doubleTap({required WidgetTester tester, required Finder finder}) async {
+  final position = tester.getCenter(finder);
+  await tester.tapAt(position);
+  await tester.pump(const Duration(milliseconds: 100));
+  await tester.tapAt(position);
   await tester.pumpAndSettle();
 }
 
@@ -170,7 +183,9 @@ void main() {
     expect(find.text("Image copied to clipboard"), findsOneWidget);
   });
 
-  testWidgets("system back closes the image viewer on the session navigator", (tester) async {
+  testWidgets("session back closes the root image viewer without leaving the session", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1024, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
     const attachment = MessageAttachment.inlineImage(
       mime: "image/png",
       base64: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==",
@@ -178,19 +193,27 @@ void main() {
     );
     final rootNavigatorKey = GlobalKey<NavigatorState>();
     final sessionNavigatorKey = GlobalKey<NavigatorState>();
-    final sessionObserver = _RecordingNavigatorObserver();
     final router = GoRouter(
       navigatorKey: rootNavigatorKey,
       initialLocation: "/sessions/chat",
       routes: [
         ShellRoute(
           navigatorKey: sessionNavigatorKey,
-          observers: [sessionObserver],
-          builder: (_, _, child) => child,
+          builder: (_, _, child) => Scaffold(
+            body: Row(
+              children: [
+                const SizedBox(
+                  width: 300,
+                  child: Center(child: Text("Session list pane")),
+                ),
+                Expanded(child: child),
+              ],
+            ),
+          ),
           routes: [
             GoRoute(
               path: "/sessions",
-              builder: (_, _) => const Scaffold(body: Text("Session list")),
+              builder: (_, _) => const Scaffold(body: Text("Session list route")),
               routes: [
                 GoRoute(
                   path: "chat",
@@ -211,43 +234,84 @@ void main() {
         supportedLocales: AppLocalizations.supportedLocales,
       ),
     );
-    await _finishAsyncDecode(tester: tester);
-    final preview = tester.widget<Image>(find.byKey(FilePartWidget.previewImageKey));
-    await tester.runAsync(
-      () => precacheImage(
-        preview.image,
-        tester.element(find.byKey(FilePartWidget.previewImageKey)),
-      ),
-    );
-    await tester.pumpAndSettle();
-    expect(
-      tester.widget<GestureDetector>(find.byKey(FilePartWidget.previewTapTargetKey)).onTap,
-      isNotNull,
-    );
-    sessionObserver.pushedRoutes.clear();
-    await tester.tap(find.byKey(FilePartWidget.previewTapTargetKey));
-    await tester.pumpAndSettle();
+    await _openImageViewer(tester: tester);
+    final sessionRoute = ModalRoute.of(tester.element(find.byKey(FilePartWidget.previewTapTargetKey)))!;
 
     expect(find.byType(ImageAttachmentViewer), findsOneWidget);
     expect(router.routeInformationProvider.value.uri.path, "/sessions/chat");
-    expect(sessionObserver.pushedRoutes, hasLength(1));
-    final viewerRoute = sessionObserver.pushedRoutes.single;
-    expect(viewerRoute, isA<PageRouteBuilder<void>>());
-    expect(viewerRoute.navigator, same(sessionNavigatorKey.currentState));
-    expect(viewerRoute.navigator, isNot(same(rootNavigatorKey.currentState)));
+    final viewerRoute = ModalRoute.of(tester.element(find.byType(ImageAttachmentViewer)))!;
+    expect(viewerRoute.navigator, same(rootNavigatorKey.currentState));
+    expect(viewerRoute.opaque, isFalse);
+    expect(tester.getSize(find.byType(ImageAttachmentViewer)), const Size(1024, 800));
+    expect(sessionRoute.willHandlePopInternally, isTrue);
 
-    await tester.binding.handlePopRoute();
+    expect(await sessionNavigatorKey.currentState!.maybePop(), isTrue);
     await tester.pumpAndSettle();
 
     expect(find.byType(ImageAttachmentViewer), findsNothing);
     expect(find.byKey(FilePartWidget.previewTapTargetKey), findsOneWidget);
     expect(router.routeInformationProvider.value.uri.path, "/sessions/chat");
+    expect(sessionRoute.willHandlePopInternally, isFalse);
 
-    await tester.binding.handlePopRoute();
+    expect(await sessionNavigatorKey.currentState!.maybePop(), isTrue);
     await tester.pumpAndSettle();
 
-    expect(find.text("Session list"), findsOneWidget);
+    expect(find.text("Session list route"), findsOneWidget);
     expect(router.routeInformationProvider.value.uri.path, "/sessions");
+  });
+
+  testWidgets("vertical image drag snaps back or dismisses the viewer", (tester) async {
+    const attachment = MessageAttachment.inlineImage(
+      mime: "image/png",
+      base64: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==",
+      filename: "image.png",
+    );
+    await tester.pumpWidget(_app(child: const FilePartWidget(attachment: attachment)));
+    await _openImageViewer(tester: tester);
+    final viewer = find.byType(ImageAttachmentViewer);
+    final initialCenter = tester.getCenter(find.byKey(ImageAttachmentViewer.imageKey));
+
+    await tester.timedDrag(viewer, const Offset(0, 40), const Duration(seconds: 1));
+    await tester.pumpAndSettle();
+
+    expect(viewer, findsOneWidget);
+    expect(
+      (tester.getCenter(find.byKey(ImageAttachmentViewer.imageKey)) - initialCenter).distance,
+      lessThan(0.01),
+    );
+
+    await tester.timedDrag(viewer, const Offset(0, 200), const Duration(milliseconds: 400));
+    await tester.pumpAndSettle();
+
+    expect(viewer, findsNothing);
+    expect(find.byKey(FilePartWidget.previewTapTargetKey), findsOneWidget);
+  });
+
+  testWidgets("double tap toggles zoom and disables drag dismissal while zoomed", (tester) async {
+    const attachment = MessageAttachment.inlineImage(
+      mime: "image/png",
+      base64: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==",
+      filename: "image.png",
+    );
+    await tester.pumpWidget(_app(child: const FilePartWidget(attachment: attachment)));
+    await _openImageViewer(tester: tester);
+    final viewer = find.byType(ImageAttachmentViewer);
+    final interactiveViewer = tester.widget<InteractiveViewer>(find.byType(InteractiveViewer));
+    final transformationController = interactiveViewer.transformationController!;
+
+    await _doubleTap(tester: tester, finder: viewer);
+
+    expect(transformationController.value.getMaxScaleOnAxis(), closeTo(2.5, 0.01));
+    await tester.timedDrag(viewer, const Offset(0, 200), const Duration(milliseconds: 400));
+    await tester.pumpAndSettle();
+    expect(viewer, findsOneWidget);
+
+    await _doubleTap(tester: tester, finder: viewer);
+
+    expect(transformationController.value.getMaxScaleOnAxis(), closeTo(1, 0.01));
+    await tester.timedDrag(viewer, const Offset(0, 200), const Duration(milliseconds: 400));
+    await tester.pumpAndSettle();
+    expect(viewer, findsNothing);
   });
 
   testWidgets("omits the image title when attachment metadata has no filename", (tester) async {

--- a/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
+++ b/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
@@ -272,6 +272,8 @@ void main() {
     final initialCenter = tester.getCenter(find.byKey(ImageAttachmentViewer.imageKey));
 
     await tester.timedDrag(viewer, const Offset(0, 40), const Duration(seconds: 1));
+    await tester.pump(const Duration(milliseconds: 40));
+    await tester.timedDrag(viewer, const Offset(80, 0), const Duration(milliseconds: 400));
     await tester.pumpAndSettle();
 
     expect(viewer, findsOneWidget);


### PR DESCRIPTION
## Complexity

⚙️ Moderate Flutter navigation and gesture lifecycle change.

## What

- Keep the in-memory image viewer on the root navigator so it remains globally full-screen across split layouts.
- Mirror the open viewer in the originating session route with `LocalHistoryEntry`, ensuring one Android active-session back dismisses the viewer instead of the chat.
- Add vertical drag-to-dismiss with backdrop/chrome fading and snap-back below the dismissal threshold.
- Add animated double-tap zoom at the tapped position; a second double tap resets zoom.
- Keep drag dismissal disabled while zoomed so one-finger movement continues to pan the image.

## Why

The viewer carries an already-loaded in-memory image and Hero tag, so it cannot be represented safely in a URL and project rules prohibit `state.extra`. A root route preserves full-screen presentation, while local history gives the nested session stack an honest viewer entry for Android back handling. The gallery gestures make image inspection and dismissal match familiar mobile behavior.

## Risk and test focus

Risk is limited to image-viewer navigation, gesture arbitration, and its transient presentation. Tests verify root ownership and full-screen sizing in a 1024 px split layout, one session-stack back returning to the same chat, normal later back navigation, drag snap-back/dismissal, double-tap zoom toggling, and suppression of drag dismissal while zoomed. There is no database or persisted-data impact.

## Expected result

One back button press or gesture dismisses the full-screen viewer and returns to the same chat. At base zoom, users can drag vertically to dismiss; while zoomed, dragging pans the image. Double tap toggles between base scale and 2.5× zoom.

## Verification

- `flutter test test/features/session_detail/widgets/file_part_widget_test.dart` (15 tests)
- `dart analyze` in `client/app`
- Android API 36 emulator: back, short/long drag, double-tap zoom/reset, and zoomed pan verified interactively
- Aristotle architecture implementation review: approved
