### PR TITLE
⚙️ Keep composer surface borders in sync

### DIFF
--- a/client/app/lib/core/widgets/agent_model_buttons.dart
+++ b/client/app/lib/core/widgets/agent_model_buttons.dart
@@ -16,6 +16,7 @@ import "model_picker_sheet.dart";
 /// The widget owns the menu contents, so it receives the selectable data and
 /// the selection callbacks directly rather than a "open picker" callback.
 class AgentModelButtons extends StatefulWidget {
+  final PregoComposerSurfaceStyle surfaceStyle;
   final List<AgentInfo> agents;
   final String? selectedAgent;
   final ValueChanged<String> onAgentSelected;
@@ -29,6 +30,7 @@ class AgentModelButtons extends StatefulWidget {
 
   const AgentModelButtons({
     super.key,
+    required this.surfaceStyle,
     required this.agents,
     required this.selectedAgent,
     required this.onAgentSelected,
@@ -89,6 +91,7 @@ class _AgentModelButtonsState extends State<AgentModelButtons> {
           if (hasAgentSelection) ...[
             Expanded(
               child: _AgentMenu(
+                surfaceStyle: widget.surfaceStyle,
                 agents: widget.agents,
                 selectedAgent: selectedAgent,
                 onAgentSelected: widget.onAgentSelected,
@@ -98,6 +101,7 @@ class _AgentModelButtonsState extends State<AgentModelButtons> {
           ],
           Expanded(
             child: _ModelMenu(
+              surfaceStyle: widget.surfaceStyle,
               sections: _modelSections,
               selected: selected,
               providers: widget.providers,
@@ -109,6 +113,7 @@ class _AgentModelButtonsState extends State<AgentModelButtons> {
             const SizedBox(width: 8),
             Expanded(
               child: _VariantMenu(
+                surfaceStyle: widget.surfaceStyle,
                 availableVariants: widget.availableVariants,
                 selectedVariant: selected?.variant,
                 onVariantSelected: widget.onVariantSelected,
@@ -146,11 +151,13 @@ class _AgentModelButtonsState extends State<AgentModelButtons> {
 /// Agent-selection pill + its popup. Extracted as a widget (rather than a build
 /// method) so it gets its own element subtree and only rebuilds with its inputs.
 class _AgentMenu extends StatelessWidget {
+  final PregoComposerSurfaceStyle surfaceStyle;
   final List<AgentInfo> agents;
   final String selectedAgent;
   final ValueChanged<String> onAgentSelected;
 
   const _AgentMenu({
+    required this.surfaceStyle,
     required this.agents,
     required this.selectedAgent,
     required this.onAgentSelected,
@@ -166,6 +173,7 @@ class _AgentMenu extends StatelessWidget {
       triggerBuilder: (context, toggle) => PregoPickerButton(
         leadingIcon: Icons.smart_toy_outlined,
         label: selectedAgent,
+        surfaceStyle: surfaceStyle,
         onPressed: toggle,
       ),
       entriesBuilder: () => [
@@ -185,6 +193,7 @@ class _AgentMenu extends StatelessWidget {
 /// Model-selection pill + its quick-pick popup (search affordance pinned at the
 /// top, then each provider's representative models).
 class _ModelMenu extends StatelessWidget {
+  final PregoComposerSurfaceStyle surfaceStyle;
   final List<ModelPickerSection> sections;
   final AgentModel? selected;
   final List<ProviderInfo> providers;
@@ -192,6 +201,7 @@ class _ModelMenu extends StatelessWidget {
   final VoidCallback onSearchTap;
 
   const _ModelMenu({
+    required this.surfaceStyle,
     required this.sections,
     required this.selected,
     required this.providers,
@@ -238,6 +248,7 @@ class _ModelMenu extends StatelessWidget {
       triggerBuilder: (context, toggle) => PregoPickerButton(
         leadingIcon: Icons.memory_outlined,
         label: _resolveModelName(context, providers: providers, selected: selected),
+        surfaceStyle: surfaceStyle,
         onPressed: toggle,
       ),
       entriesBuilder: () => entries,
@@ -247,11 +258,13 @@ class _ModelMenu extends StatelessWidget {
 
 /// Variant-selection pill + its popup.
 class _VariantMenu extends StatelessWidget {
+  final PregoComposerSurfaceStyle surfaceStyle;
   final List<SessionVariant> availableVariants;
   final String? selectedVariant;
   final ValueChanged<SessionVariant?> onVariantSelected;
 
   const _VariantMenu({
+    required this.surfaceStyle,
     required this.availableVariants,
     required this.selectedVariant,
     required this.onVariantSelected,
@@ -267,6 +280,7 @@ class _VariantMenu extends StatelessWidget {
       triggerBuilder: (context, toggle) => PregoPickerButton(
         leadingIcon: Icons.speed_outlined,
         label: selectedVariant ?? loc.sessionDetailVariantDefault,
+        surfaceStyle: surfaceStyle,
         onPressed: toggle,
       ),
       entriesBuilder: () => [

--- a/client/app/lib/core/widgets/composer_surface_style.dart
+++ b/client/app/lib/core/widgets/composer_surface_style.dart
@@ -1,0 +1,14 @@
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_prego/module_prego.dart";
+
+PregoComposerSurfaceStyle resolveInitialComposerSurfaceStyle({
+  required ChatInputMode inputMode,
+  required ComposerDraft draft,
+  required CommandInfo? stagedCommand,
+}) {
+  if (inputMode == ChatInputMode.textFirst || draft.text.trim().isNotEmpty || stagedCommand != null) {
+    return PregoComposerSurfaceStyle.emphasized;
+  }
+  return PregoComposerSurfaceStyle.subtle;
+}

--- a/client/app/lib/core/widgets/composer_surface_style.dart
+++ b/client/app/lib/core/widgets/composer_surface_style.dart
@@ -2,13 +2,35 @@ import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/module_prego.dart";
 
+/// The composer's three visual layouts and their shared surface treatment.
+enum ComposerSurfaceLayout {
+  holdToTalk(surfaceStyle: PregoComposerSurfaceStyle.subtle),
+  compact(surfaceStyle: PregoComposerSurfaceStyle.emphasized),
+  typing(surfaceStyle: PregoComposerSurfaceStyle.emphasized);
+
+  const ComposerSurfaceLayout({required this.surfaceStyle});
+
+  final PregoComposerSurfaceStyle surfaceStyle;
+}
+
+ComposerSurfaceLayout resolveComposerSurfaceLayout({
+  required ChatInputMode inputMode,
+  required bool showsTypingLayout,
+}) {
+  if (showsTypingLayout) return ComposerSurfaceLayout.typing;
+  return switch (inputMode) {
+    ChatInputMode.voiceFirst => ComposerSurfaceLayout.holdToTalk,
+    ChatInputMode.textFirst => ComposerSurfaceLayout.compact,
+  };
+}
+
 PregoComposerSurfaceStyle resolveInitialComposerSurfaceStyle({
   required ChatInputMode inputMode,
   required ComposerDraft draft,
   required CommandInfo? stagedCommand,
 }) {
-  if (inputMode == ChatInputMode.textFirst || draft.text.trim().isNotEmpty || stagedCommand != null) {
-    return PregoComposerSurfaceStyle.emphasized;
-  }
-  return PregoComposerSurfaceStyle.subtle;
+  return resolveComposerSurfaceLayout(
+    inputMode: inputMode,
+    showsTypingLayout: draft.text.trim().isNotEmpty || stagedCommand != null,
+  ).surfaceStyle;
 }

--- a/client/app/lib/features/new_session/new_session_screen.dart
+++ b/client/app/lib/features/new_session/new_session_screen.dart
@@ -61,6 +61,9 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
   bool _dedicatedWorktree = true;
   bool _navigatingToCreatedSession = false;
   bool _isSending = false;
+  final ValueNotifier<PregoComposerSurfaceStyle> _composerSurfaceStyle = ValueNotifier(
+    PregoComposerSurfaceStyle.subtle,
+  );
   late ScaffoldMessengerState _scaffoldMessenger;
   late String _launchingInBackgroundMessage;
 
@@ -83,6 +86,7 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
         );
       });
     }
+    _composerSurfaceStyle.dispose();
     super.dispose();
   }
 
@@ -119,15 +123,19 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
     if (data == null || (data.agents.isEmpty && data.providers.isEmpty)) return null;
 
     final cubit = context.read<NewSessionCubit>();
-    return AgentModelButtons(
-      agents: data.agents,
-      selectedAgent: selectedAgent,
-      onAgentSelected: cubit.selectAgent,
-      providers: data.providers,
-      selectedAgentModel: data.agentModel,
-      onModelSelected: cubit.selectModel,
-      availableVariants: data.availableVariants,
-      onVariantSelected: cubit.selectVariant,
+    return ValueListenableBuilder<PregoComposerSurfaceStyle>(
+      valueListenable: _composerSurfaceStyle,
+      builder: (context, surfaceStyle, _) => AgentModelButtons(
+        surfaceStyle: surfaceStyle,
+        agents: data.agents,
+        selectedAgent: selectedAgent,
+        onAgentSelected: cubit.selectAgent,
+        providers: data.providers,
+        selectedAgentModel: data.agentModel,
+        onModelSelected: cubit.selectModel,
+        availableVariants: data.availableVariants,
+        onVariantSelected: cubit.selectVariant,
+      ),
     );
   }
 
@@ -336,6 +344,7 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
                             ),
                             onDraftCleared: context.read<NewSessionCubit>().clearComposerDraft,
                             onAbort: _dismissScreen,
+                            onSurfaceStyleChanged: (style) => _composerSurfaceStyle.value = style,
                             header: _buildErrorBanner(state),
                             composerHeader: _buildComposerHeader(state),
                             availableCommands: composerData?.commands ?? const [],

--- a/client/app/lib/features/new_session/new_session_screen.dart
+++ b/client/app/lib/features/new_session/new_session_screen.dart
@@ -10,6 +10,7 @@ import "../../core/extensions/build_context_x.dart";
 import "../../core/extensions/remote_failure_x.dart";
 import "../../core/routing/app_router.dart";
 import "../../core/widgets/agent_model_buttons.dart";
+import "../../core/widgets/composer_surface_style.dart";
 import "../../core/widgets/connection_banner.dart";
 import "../session_detail/widgets/prompt_input.dart";
 import "new_session_loading_overlay.dart";
@@ -61,11 +62,22 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
   bool _dedicatedWorktree = true;
   bool _navigatingToCreatedSession = false;
   bool _isSending = false;
-  final ValueNotifier<PregoComposerSurfaceStyle> _composerSurfaceStyle = ValueNotifier(
-    PregoComposerSurfaceStyle.subtle,
-  );
+  late final ValueNotifier<PregoComposerSurfaceStyle> _composerSurfaceStyle;
   late ScaffoldMessengerState _scaffoldMessenger;
   late String _launchingInBackgroundMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    final cubit = context.read<NewSessionCubit>();
+    _composerSurfaceStyle = ValueNotifier(
+      resolveInitialComposerSurfaceStyle(
+        inputMode: context.read<ChatInputModeCubit>().state,
+        draft: cubit.composerDraft,
+        stagedCommand: cubit.state.agentModelData?.stagedCommand,
+      ),
+    );
+  }
 
   @override
   void didChangeDependencies() {
@@ -344,7 +356,7 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
                             ),
                             onDraftCleared: context.read<NewSessionCubit>().clearComposerDraft,
                             onAbort: _dismissScreen,
-                            onSurfaceStyleChanged: (style) => _composerSurfaceStyle.value = style,
+                            surfaceStyleController: _composerSurfaceStyle,
                             header: _buildErrorBanner(state),
                             composerHeader: _buildComposerHeader(state),
                             availableCommands: composerData?.commands ?? const [],

--- a/client/app/lib/features/session_detail/widgets/background_tasks_bar.dart
+++ b/client/app/lib/features/session_detail/widgets/background_tasks_bar.dart
@@ -21,12 +21,14 @@ import "background_tasks_list.dart";
 /// Running tasks are always shown first. Completed tasks are hidden behind a
 /// "Show N completed" toggle.
 class BackgroundTasksBar extends StatefulWidget {
+  final PregoComposerSurfaceStyle surfaceStyle;
   final String? projectId;
   final List<Session> children;
   final Map<String, SessionStatus> childStatuses;
 
   const BackgroundTasksBar({
     super.key,
+    required this.surfaceStyle,
     required this.projectId,
     required this.children,
     required this.childStatuses,
@@ -132,6 +134,7 @@ class _BackgroundTasksBarState extends State<BackgroundTasksBar> {
 
   Widget _buildCard(BuildContext context, {required bool expanded}) {
     return PregoCard(
+      surfaceStyle: widget.surfaceStyle,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -350,13 +350,18 @@ class _PromptInputState extends State<PromptInput> {
   @override
   void didUpdateWidget(covariant PromptInput oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.draftIdentity != widget.draftIdentity) {
+    final draftChanged = oldWidget.draftIdentity != widget.draftIdentity;
+    final stagedCommandChanged = oldWidget.stagedCommand?.name != widget.stagedCommand?.name;
+    if (draftChanged) {
       // The state was reused for another session without initState/dispose.
       // The owning Cubit already persisted each edit, so only restore the new
       // immutable snapshot here.
       _restoreDraft(draft: widget.initialDraft);
     }
-    if (oldWidget.stagedCommand?.name != widget.stagedCommand?.name && widget.stagedCommand != null) {
+    if (oldWidget.surfaceStyleController != widget.surfaceStyleController || draftChanged || stagedCommandChanged) {
+      _syncSurfaceStyle();
+    }
+    if (stagedCommandChanged && widget.stagedCommand != null) {
       _focusComposerField();
     }
   }

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -17,16 +17,12 @@ import "../../../core/constants.dart";
 import "../../../core/di/injection.dart";
 import "../../../core/extensions/build_context_x.dart";
 import "../../../core/widgets/command_picker_sheet.dart";
+import "../../../core/widgets/composer_surface_style.dart";
 import "composer_options_accordion.dart";
 import "prompt_editor_sheet.dart";
 import "voice_cancel_button.dart";
 
 enum _VoiceState { idle, recording, transcribing }
-
-/// The composer's three visual states: the hold-to-talk pill (voice-first
-/// resting state), the compact tap-to-type pill (text-first resting state),
-/// and the expanded typing container.
-enum _ComposerLayout { holdToTalk, compact, typing }
 
 typedef PromptSubmitCallback =
     void Function({
@@ -121,7 +117,7 @@ class _PromptInputState extends State<PromptInput> {
   /// composer's slots for the recording/transcribing chrome must not relayout
   /// the composer mid-hold — the gesture-owning elements would be reparented
   /// and never receive the release.
-  _ComposerLayout? _pinnedVoiceLayout;
+  ComposerSurfaceLayout? _pinnedVoiceLayout;
 
   /// Set when the hold is released while [_startRecording] is still awaiting
   /// the recorder, so the start path discards the incomplete recording once
@@ -168,6 +164,7 @@ class _PromptInputState extends State<PromptInput> {
       _updateComposerState(update: () => _chatInputMode = inputMode);
     });
     _restoreDraft(draft: widget.initialDraft);
+    _syncSurfaceStyle();
     _hasText = _controller.text.trim().isNotEmpty;
     _controller.addListener(_handleTextChanged);
     _focusNode.addListener(_handleFocusChanged);
@@ -258,17 +255,14 @@ class _PromptInputState extends State<PromptInput> {
 
   /// The layout the composer would rest in right now, ignoring any pinned
   /// voice interaction.
-  _ComposerLayout get _restingLayout {
-    if (_showsTypingLayout) return _ComposerLayout.typing;
-    return _isVoiceFirst ? _ComposerLayout.holdToTalk : _ComposerLayout.compact;
-  }
+  ComposerSurfaceLayout get _restingLayout => resolveComposerSurfaceLayout(
+    inputMode: _chatInputMode,
+    showsTypingLayout: _showsTypingLayout,
+  );
 
-  _ComposerLayout get _layout => _pinnedVoiceLayout ?? _restingLayout;
+  ComposerSurfaceLayout get _layout => _pinnedVoiceLayout ?? _restingLayout;
 
-  PregoComposerSurfaceStyle get _surfaceStyle => switch (_layout) {
-    _ComposerLayout.holdToTalk => PregoComposerSurfaceStyle.subtle,
-    _ComposerLayout.compact || _ComposerLayout.typing => PregoComposerSurfaceStyle.emphasized,
-  };
+  PregoComposerSurfaceStyle get _surfaceStyle => _layout.surfaceStyle;
 
   void _updateComposerState({required VoidCallback update}) {
     setState(update);
@@ -768,9 +762,9 @@ class _PromptInputState extends State<PromptInput> {
                     // [_layout], so a switch never happens mid-hold.
                     key: ValueKey(_layout),
                     child: switch (_layout) {
-                      _ComposerLayout.typing => _buildTypingComposer(context),
-                      _ComposerLayout.compact => _buildCompactComposer(context),
-                      _ComposerLayout.holdToTalk => _buildHoldToTalkComposer(context),
+                      ComposerSurfaceLayout.typing => _buildTypingComposer(context),
+                      ComposerSurfaceLayout.compact => _buildCompactComposer(context),
+                      ComposerSurfaceLayout.holdToTalk => _buildHoldToTalkComposer(context),
                     },
                   ),
                 ),

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -47,6 +47,7 @@ class PromptInput extends StatefulWidget {
   final ValueChanged<ComposerDraft> onDraftChanged;
   final VoidCallback onDraftCleared;
   final VoidCallback onAbort;
+  final ValueChanged<PregoComposerSurfaceStyle> onSurfaceStyleChanged;
   final Widget? composerHeader;
   final List<CommandInfo> availableCommands;
   final CommandInfo? stagedCommand;
@@ -70,6 +71,7 @@ class PromptInput extends StatefulWidget {
     required this.onDraftChanged,
     required this.onDraftCleared,
     required this.onAbort,
+    required this.onSurfaceStyleChanged,
     required this.composerHeader,
     required this.availableCommands,
     required this.stagedCommand,
@@ -112,6 +114,11 @@ class _PromptInputState extends State<PromptInput> {
   /// composer only rebuilds when emptiness flips (layout + send/stop swap),
   /// not on every keystroke.
   bool _hasText = false;
+
+  /// Last style queued for the parent-owned sibling surfaces. Reporting after
+  /// the frame keeps this child authoritative without rebuilding an ancestor
+  /// while the composer itself is building.
+  PregoComposerSurfaceStyle? _lastReportedSurfaceStyle;
 
   /// Layout pinned for the duration of a voice interaction. Swapping the
   /// composer's slots for the recording/transcribing chrome must not relayout
@@ -251,6 +258,11 @@ class _PromptInputState extends State<PromptInput> {
   }
 
   _ComposerLayout get _layout => _pinnedVoiceLayout ?? _restingLayout;
+
+  PregoComposerSurfaceStyle get _surfaceStyle => switch (_layout) {
+    _ComposerLayout.holdToTalk => PregoComposerSurfaceStyle.subtle,
+    _ComposerLayout.compact || _ComposerLayout.typing => PregoComposerSurfaceStyle.emphasized,
+  };
 
   /// Acknowledges the hold immediately while the recorder starts without
   /// claiming that the underlying recording lifecycle has advanced yet.
@@ -649,11 +661,22 @@ class _PromptInputState extends State<PromptInput> {
   static const Duration _morphDuration = Duration(milliseconds: 220);
   static const Curve _morphCurve = Curves.easeOutCubic;
 
+  void _reportSurfaceStyleAfterBuild(PregoComposerSurfaceStyle surfaceStyle) {
+    if (_lastReportedSurfaceStyle == surfaceStyle) return;
+    _lastReportedSurfaceStyle = surfaceStyle;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _surfaceStyle != surfaceStyle) return;
+      widget.onSurfaceStyleChanged(surfaceStyle);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     // The resting layout follows the settings choice live.
     context.watch<ChatInputModeCubit>();
     final prego = context.prego;
+    final surfaceStyle = _surfaceStyle;
+    _reportSurfaceStyleAfterBuild(surfaceStyle);
 
     return DecoratedBox(
       // Floating composer: no bar surface, no separator line. The scaffold
@@ -820,21 +843,6 @@ class _PromptInputState extends State<PromptInput> {
   // Composer layouts
   // ---------------------------------------------------------------------------
 
-  BoxDecoration _containerDecoration(
-    PregoDesignSystem prego, {
-    required Color borderColor,
-    required BorderRadius borderRadius,
-  }) {
-    return BoxDecoration(
-      color: prego.colors.bgSurface2,
-      borderRadius: borderRadius,
-      border: Border.all(color: borderColor),
-      boxShadow: [
-        BoxShadow(color: prego.colors.shadowXs, offset: const Offset(0, 1), blurRadius: 2),
-      ],
-    );
-  }
-
   /// A resting pill surface with the destructive drag-to-cancel gradient
   /// sandwiched between its background and [child]. The gradient layer is
   /// always mounted (invisible at zero progress) so entering the recording
@@ -845,7 +853,7 @@ class _PromptInputState extends State<PromptInput> {
   /// end inset eases down so the waveform ends the spec's 12pt from the edge.
   Widget _buildVoicePillSurface(
     BuildContext context, {
-    required Color borderColor,
+    required PregoComposerSurfaceStyle surfaceStyle,
     required Widget child,
     bool tightensTrailingWhileRecording = false,
   }) {
@@ -854,7 +862,11 @@ class _PromptInputState extends State<PromptInput> {
     final tightenEnd = tightensTrailingWhileRecording && _displayedVoiceState == _VoiceState.recording;
 
     return DecoratedBox(
-      decoration: _containerDecoration(prego, borderColor: borderColor, borderRadius: radius),
+      decoration: pregoComposerSurfaceDecoration(
+        prego: prego,
+        style: surfaceStyle,
+        borderRadius: radius,
+      ),
       child: Stack(
         children: [
           Positioned.fill(child: _buildCancelGradient(context, borderRadius: radius)),
@@ -911,7 +923,7 @@ class _PromptInputState extends State<PromptInput> {
 
     return _buildVoicePillSurface(
       context,
-      borderColor: prego.colors.borderSecondary,
+      surfaceStyle: PregoComposerSurfaceStyle.subtle,
       tightensTrailingWhileRecording: true,
       child: Row(
         spacing: PregoSpacing.md,
@@ -963,7 +975,7 @@ class _PromptInputState extends State<PromptInput> {
 
     return _buildVoicePillSurface(
       context,
-      borderColor: prego.colors.borderPrimary,
+      surfaceStyle: PregoComposerSurfaceStyle.emphasized,
       child: Row(
         spacing: PregoSpacing.md,
         children: [
@@ -1027,9 +1039,9 @@ class _PromptInputState extends State<PromptInput> {
 
     return Container(
       padding: const EdgeInsets.all(PregoSpacing.sm),
-      decoration: _containerDecoration(
-        prego,
-        borderColor: prego.colors.borderPrimary,
+      decoration: pregoComposerSurfaceDecoration(
+        prego: prego,
+        style: PregoComposerSurfaceStyle.emphasized,
         borderRadius: borderRadius,
       ),
       child: Column(
@@ -1106,7 +1118,7 @@ class _PromptInputState extends State<PromptInput> {
 
     return _buildVoicePillSurface(
       context,
-      borderColor: prego.colors.borderSecondary,
+      surfaceStyle: PregoComposerSurfaceStyle.subtle,
       tightensTrailingWhileRecording: true,
       child: Row(
         spacing: PregoSpacing.md,

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -47,7 +47,7 @@ class PromptInput extends StatefulWidget {
   final ValueChanged<ComposerDraft> onDraftChanged;
   final VoidCallback onDraftCleared;
   final VoidCallback onAbort;
-  final ValueChanged<PregoComposerSurfaceStyle> onSurfaceStyleChanged;
+  final ValueNotifier<PregoComposerSurfaceStyle> surfaceStyleController;
   final Widget? composerHeader;
   final List<CommandInfo> availableCommands;
   final CommandInfo? stagedCommand;
@@ -71,7 +71,7 @@ class PromptInput extends StatefulWidget {
     required this.onDraftChanged,
     required this.onDraftCleared,
     required this.onAbort,
-    required this.onSurfaceStyleChanged,
+    required this.surfaceStyleController,
     required this.composerHeader,
     required this.availableCommands,
     required this.stagedCommand,
@@ -97,6 +97,7 @@ class _PromptInputState extends State<PromptInput> {
   bool _isApplyingDraft = false;
   _VoiceState _voiceState = _VoiceState.idle;
   StreamSubscription<void>? _maxDurationSub;
+  StreamSubscription<ChatInputMode>? _chatInputModeSub;
   Timer? _minimumRecordingDurationTimer;
   bool _minimumRecordingDurationReached = false;
 
@@ -114,11 +115,7 @@ class _PromptInputState extends State<PromptInput> {
   /// composer only rebuilds when emptiness flips (layout + send/stop swap),
   /// not on every keystroke.
   bool _hasText = false;
-
-  /// Last style queued for the parent-owned sibling surfaces. Reporting after
-  /// the frame keeps this child authoritative without rebuilding an ancestor
-  /// while the composer itself is building.
-  PregoComposerSurfaceStyle? _lastReportedSurfaceStyle;
+  late ChatInputMode _chatInputMode;
 
   /// Layout pinned for the duration of a voice interaction. Swapping the
   /// composer's slots for the recording/transcribing chrome must not relayout
@@ -164,6 +161,12 @@ class _PromptInputState extends State<PromptInput> {
   @override
   void initState() {
     super.initState();
+    final chatInputModeCubit = context.read<ChatInputModeCubit>();
+    _chatInputMode = chatInputModeCubit.state;
+    _chatInputModeSub = chatInputModeCubit.stream.listen((inputMode) {
+      if (!mounted || _chatInputMode == inputMode) return;
+      _updateComposerState(update: () => _chatInputMode = inputMode);
+    });
     _restoreDraft(draft: widget.initialDraft);
     _hasText = _controller.text.trim().isNotEmpty;
     _controller.addListener(_handleTextChanged);
@@ -180,6 +183,7 @@ class _PromptInputState extends State<PromptInput> {
   @override
   void dispose() {
     _maxDurationSub?.cancel();
+    _chatInputModeSub?.cancel();
     _minimumRecordingDurationTimer?.cancel();
     // Fire-and-forget cancel if the widget is disposed mid-recording or mid-transcription.
     if (_voiceState != _VoiceState.idle) {
@@ -227,7 +231,7 @@ class _PromptInputState extends State<PromptInput> {
     _previousEditingValue = currentValue;
     final hasText = currentValue.text.trim().isNotEmpty;
     if (hasText != _hasText && mounted) {
-      setState(() => _hasText = hasText);
+      _updateComposerState(update: () => _hasText = hasText);
     }
   }
 
@@ -236,15 +240,17 @@ class _PromptInputState extends State<PromptInput> {
     // Rebuild on both edges: gaining focus keeps the typing layout up via the
     // focus check; losing it (with nothing to show) collapses back to the
     // resting pill.
-    setState(() {
-      if (!_focusNode.hasFocus) _typingRequested = false;
-    });
+    _updateComposerState(
+      update: () {
+        if (!_focusNode.hasFocus) _typingRequested = false;
+      },
+    );
   }
 
   /// Whether the session composer leads with hold-to-talk voice input (the
   /// default) or with the tap-to-type field. Chosen in settings; the cubit
   /// lives above the router, so flipping it re-shapes this composer live.
-  bool get _isVoiceFirst => context.read<ChatInputModeCubit>().state == ChatInputMode.voiceFirst;
+  bool get _isVoiceFirst => _chatInputMode == ChatInputMode.voiceFirst;
 
   /// Whether the expanded typing container is showing (vs. the resting
   /// hold-to-talk / compact pills).
@@ -263,6 +269,18 @@ class _PromptInputState extends State<PromptInput> {
     _ComposerLayout.holdToTalk => PregoComposerSurfaceStyle.subtle,
     _ComposerLayout.compact || _ComposerLayout.typing => PregoComposerSurfaceStyle.emphasized,
   };
+
+  void _updateComposerState({required VoidCallback update}) {
+    setState(update);
+    _syncSurfaceStyle();
+  }
+
+  void _syncSurfaceStyle() {
+    final surfaceStyle = _surfaceStyle;
+    if (widget.surfaceStyleController.value != surfaceStyle) {
+      widget.surfaceStyleController.value = surfaceStyle;
+    }
+  }
 
   /// Acknowledges the hold immediately while the recorder starts without
   /// claiming that the underlying recording lifecycle has advanced yet.
@@ -283,12 +301,14 @@ class _PromptInputState extends State<PromptInput> {
   /// and lands its transcript in the now-focused field.
   void _enterTypingMode() {
     if (_voiceState == _VoiceState.recording || _isRecordStartInFlight) return;
-    setState(() {
-      _typingRequested = true;
-      // Safe to unpin while transcribing: no gesture is in flight once the
-      // hold has been released.
-      _pinnedVoiceLayout = null;
-    });
+    _updateComposerState(
+      update: () {
+        _typingRequested = true;
+        // Safe to unpin while transcribing: no gesture is in flight once the
+        // hold has been released.
+        _pinnedVoiceLayout = null;
+      },
+    );
     _focusComposerField();
   }
 
@@ -348,12 +368,14 @@ class _PromptInputState extends State<PromptInput> {
     _minimumRecordingDurationTimer?.cancel();
     _minimumRecordingDurationTimer = null;
     _cancelDragProgress.value = 0;
-    setState(() {
-      _isRecordStartInFlight = true;
-      _releaseRequestedDuringStart = false;
-      _minimumRecordingDurationReached = false;
-      _pinnedVoiceLayout = pinnedVoiceLayout;
-    });
+    _updateComposerState(
+      update: () {
+        _isRecordStartInFlight = true;
+        _releaseRequestedDuringStart = false;
+        _minimumRecordingDurationReached = false;
+        _pinnedVoiceLayout = pinnedVoiceLayout;
+      },
+    );
     await _startRecording();
     _isRecordStartInFlight = false;
     if (!mounted) {
@@ -365,7 +387,7 @@ class _PromptInputState extends State<PromptInput> {
     if (_voiceState == _VoiceState.idle) {
       // Recording never started (permission denied / recorder error), so no
       // later transition will release the pin.
-      setState(() => _pinnedVoiceLayout = null);
+      _updateComposerState(update: () => _pinnedVoiceLayout = null);
     } else if (_releaseRequestedDuringStart) {
       // The hold ended while the recorder was still starting up, leaving no
       // meaningful captured duration to transcribe.
@@ -420,7 +442,7 @@ class _PromptInputState extends State<PromptInput> {
     if (_voiceState == _VoiceState.idle) {
       // A release can race a recorder that is still starting up.
       if (_isRecordStartInFlight) {
-        setState(() => _releaseRequestedDuringStart = true);
+        _updateComposerState(update: () => _releaseRequestedDuringStart = true);
         _cancelDragProgress.value = 0;
       }
       return;
@@ -455,7 +477,7 @@ class _PromptInputState extends State<PromptInput> {
       await _voiceService.startRecording();
       if (!mounted) return;
       final interactionId = _voiceInteractionId;
-      setState(() => _voiceState = _VoiceState.recording);
+      _updateComposerState(update: () => _voiceState = _VoiceState.recording);
       // Startup can finish after the user has already dragged toward cancel.
       // Reapply the latest position once the newly mounted target has layout.
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -495,10 +517,12 @@ class _PromptInputState extends State<PromptInput> {
     final interactionId = _voiceInteractionId;
     _minimumRecordingDurationTimer?.cancel();
     _minimumRecordingDurationTimer = null;
-    setState(() {
-      _voiceState = _VoiceState.transcribing;
-      _cancelDragProgress.value = 0;
-    });
+    _updateComposerState(
+      update: () {
+        _voiceState = _VoiceState.transcribing;
+        _cancelDragProgress.value = 0;
+      },
+    );
 
     bool stale() => !mounted || interactionId != _voiceInteractionId;
 
@@ -536,11 +560,13 @@ class _PromptInputState extends State<PromptInput> {
       _showVoiceError(context.loc.voiceErrorTranscription);
     } finally {
       if (!stale()) {
-        setState(() {
-          _voiceState = _VoiceState.idle;
-          _pinnedVoiceLayout = null;
-          _cancelDragProgress.value = 0;
-        });
+        _updateComposerState(
+          update: () {
+            _voiceState = _VoiceState.idle;
+            _pinnedVoiceLayout = null;
+            _cancelDragProgress.value = 0;
+          },
+        );
       }
     }
   }
@@ -573,7 +599,7 @@ class _PromptInputState extends State<PromptInput> {
       // Cancelling the service before its start future settles can let native
       // startup continue after cleanup. Mark the release now and let the start
       // path cancel once the recorder has reached a stable state.
-      setState(() => _releaseRequestedDuringStart = true);
+      _updateComposerState(update: () => _releaseRequestedDuringStart = true);
       _cancelDragProgress.value = 0;
       return;
     }
@@ -586,11 +612,13 @@ class _PromptInputState extends State<PromptInput> {
     _minimumRecordingDurationTimer?.cancel();
     _minimumRecordingDurationTimer = null;
     _minimumRecordingDurationReached = false;
-    setState(() {
-      _voiceState = _VoiceState.idle;
-      _pinnedVoiceLayout = null;
-      _cancelDragProgress.value = 0;
-    });
+    _updateComposerState(
+      update: () {
+        _voiceState = _VoiceState.idle;
+        _pinnedVoiceLayout = null;
+        _cancelDragProgress.value = 0;
+      },
+    );
     _isCancelInFlight = true;
     try {
       await _voiceService.cancelRecording();
@@ -661,22 +689,9 @@ class _PromptInputState extends State<PromptInput> {
   static const Duration _morphDuration = Duration(milliseconds: 220);
   static const Curve _morphCurve = Curves.easeOutCubic;
 
-  void _reportSurfaceStyleAfterBuild(PregoComposerSurfaceStyle surfaceStyle) {
-    if (_lastReportedSurfaceStyle == surfaceStyle) return;
-    _lastReportedSurfaceStyle = surfaceStyle;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || _surfaceStyle != surfaceStyle) return;
-      widget.onSurfaceStyleChanged(surfaceStyle);
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
-    // The resting layout follows the settings choice live.
-    context.watch<ChatInputModeCubit>();
     final prego = context.prego;
-    final surfaceStyle = _surfaceStyle;
-    _reportSurfaceStyleAfterBuild(surfaceStyle);
 
     return DecoratedBox(
       // Floating composer: no bar surface, no separator line. The scaffold

--- a/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
@@ -57,10 +57,14 @@ class _SessionDetailLoadedViewState extends State<SessionDetailLoadedView> {
   /// message list — not rebuild the whole view including the very composer
   /// being measured.
   final ValueNotifier<double> _bottomControlsHeight = ValueNotifier<double>(0);
+  final ValueNotifier<PregoComposerSurfaceStyle> _composerSurfaceStyle = ValueNotifier(
+    PregoComposerSurfaceStyle.subtle,
+  );
 
   @override
   void dispose() {
     _bottomControlsHeight.dispose();
+    _composerSurfaceStyle.dispose();
     super.dispose();
   }
 
@@ -168,10 +172,14 @@ class _SessionDetailLoadedViewState extends State<SessionDetailLoadedView> {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   if (state.children.isNotEmpty)
-                    BackgroundTasksBar(
-                      projectId: widget.projectId,
-                      children: state.children,
-                      childStatuses: state.childStatuses,
+                    ValueListenableBuilder<PregoComposerSurfaceStyle>(
+                      valueListenable: _composerSurfaceStyle,
+                      builder: (context, surfaceStyle, _) => BackgroundTasksBar(
+                        surfaceStyle: surfaceStyle,
+                        projectId: widget.projectId,
+                        children: state.children,
+                        childStatuses: state.childStatuses,
+                      ),
                     ),
                   if (state.queuedMessages.isNotEmpty)
                     SessionDetailQueuedMessagesSection(messages: state.queuedMessages),
@@ -202,16 +210,21 @@ class _SessionDetailLoadedViewState extends State<SessionDetailLoadedView> {
                       ),
                       onDraftCleared: context.read<SessionDetailCubit>().clearComposerDraft,
                       onAbort: () => context.read<SessionDetailCubit>().abort(),
+                      onSurfaceStyleChanged: (style) => _composerSurfaceStyle.value = style,
                       header: null,
-                      composerHeader: AgentModelButtons(
-                        agents: state.availableAgents,
-                        selectedAgent: state.selectedAgent,
-                        onAgentSelected: context.read<SessionDetailCubit>().selectAgent,
-                        providers: state.availableProviders,
-                        selectedAgentModel: state.selectedAgentModel,
-                        onModelSelected: context.read<SessionDetailCubit>().selectModel,
-                        availableVariants: state.availableVariants,
-                        onVariantSelected: context.read<SessionDetailCubit>().selectVariant,
+                      composerHeader: ValueListenableBuilder<PregoComposerSurfaceStyle>(
+                        valueListenable: _composerSurfaceStyle,
+                        builder: (context, surfaceStyle, _) => AgentModelButtons(
+                          surfaceStyle: surfaceStyle,
+                          agents: state.availableAgents,
+                          selectedAgent: state.selectedAgent,
+                          onAgentSelected: context.read<SessionDetailCubit>().selectAgent,
+                          providers: state.availableProviders,
+                          selectedAgentModel: state.selectedAgentModel,
+                          onModelSelected: context.read<SessionDetailCubit>().selectModel,
+                          availableVariants: state.availableVariants,
+                          onVariantSelected: context.read<SessionDetailCubit>().selectVariant,
+                        ),
                       ),
                       availableCommands: state.availableCommands,
                       stagedCommand: state.stagedCommand,

--- a/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
@@ -7,6 +7,7 @@ import "package:theme_prego/module_prego.dart";
 
 import "../../../core/extensions/build_context_x.dart";
 import "../../../core/widgets/agent_model_buttons.dart";
+import "../../../core/widgets/composer_surface_style.dart";
 import "background_tasks_bar.dart";
 import "prompt_input.dart";
 import "session_detail_message_list.dart";
@@ -57,9 +58,19 @@ class _SessionDetailLoadedViewState extends State<SessionDetailLoadedView> {
   /// message list — not rebuild the whole view including the very composer
   /// being measured.
   final ValueNotifier<double> _bottomControlsHeight = ValueNotifier<double>(0);
-  final ValueNotifier<PregoComposerSurfaceStyle> _composerSurfaceStyle = ValueNotifier(
-    PregoComposerSurfaceStyle.subtle,
-  );
+  late final ValueNotifier<PregoComposerSurfaceStyle> _composerSurfaceStyle;
+
+  @override
+  void initState() {
+    super.initState();
+    _composerSurfaceStyle = ValueNotifier(
+      resolveInitialComposerSurfaceStyle(
+        inputMode: context.read<ChatInputModeCubit>().state,
+        draft: context.read<SessionDetailCubit>().composerDraft,
+        stagedCommand: widget.state.stagedCommand,
+      ),
+    );
+  }
 
   @override
   void dispose() {
@@ -210,7 +221,7 @@ class _SessionDetailLoadedViewState extends State<SessionDetailLoadedView> {
                       ),
                       onDraftCleared: context.read<SessionDetailCubit>().clearComposerDraft,
                       onAbort: () => context.read<SessionDetailCubit>().abort(),
-                      onSurfaceStyleChanged: (style) => _composerSurfaceStyle.value = style,
+                      surfaceStyleController: _composerSurfaceStyle,
                       header: null,
                       composerHeader: ValueListenableBuilder<PregoComposerSurfaceStyle>(
                         valueListenable: _composerSurfaceStyle,

--- a/client/app/test/core/widgets/agent_model_buttons_test.dart
+++ b/client/app/test/core/widgets/agent_model_buttons_test.dart
@@ -33,6 +33,7 @@ Widget _buildApp({required List<AgentInfo> agents, required void Function(String
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
           AgentModelButtons(
+            surfaceStyle: PregoComposerSurfaceStyle.subtle,
             agents: agents,
             selectedAgent: "sesori-plan-worker",
             onAgentSelected: onAgentSelected,

--- a/client/app/test/features/session_detail/widgets/adaptive_child_session_navigation_test.dart
+++ b/client/app/test/features/session_detail/widgets/adaptive_child_session_navigation_test.dart
@@ -149,6 +149,7 @@ void main() {
         _buildApp(
           child: Scaffold(
             body: BackgroundTasksBar(
+              surfaceStyle: PregoComposerSurfaceStyle.subtle,
               projectId: "project-1",
               children: [child],
               childStatuses: const {},
@@ -178,6 +179,7 @@ void main() {
             body: SessionSplitScope(
               isSplit: true,
               child: BackgroundTasksBar(
+                surfaceStyle: PregoComposerSurfaceStyle.subtle,
                 projectId: "project-1",
                 children: [child],
                 childStatuses: const {},

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -87,6 +87,8 @@ SessionDetailLoaded _loadedState({
   required List<SesoriQuestionAsked> pendingQuestions,
   required List<SesoriPermissionAsked> pendingPermissions,
   List<MessageWithParts> messages = const [],
+  List<Session> children = const [],
+  Map<String, SessionStatus> childStatuses = const {},
   SessionStatus sessionStatus = const SessionStatus.idle(),
 }) {
   final provider = testProviderListResponse().items.first;
@@ -99,8 +101,8 @@ SessionDetailLoaded _loadedState({
     sessionTitle: "Session",
     agent: null,
     assistantAgentModel: null,
-    children: const [],
-    childStatuses: const {},
+    children: children,
+    childStatuses: childStatuses,
     isRootSession: true,
     isArchived: false,
     queuedMessages: const [],
@@ -457,6 +459,15 @@ void main() {
   // design.
   FocusNode composerFocus(WidgetTester tester) => tester.widget<EditableText>(find.byType(EditableText)).focusNode;
 
+  Color composerSurfaceBorderColor(WidgetTester tester, Finder surface) {
+    final decoration = tester
+        .widgetList<DecoratedBox>(find.descendant(of: surface, matching: find.byType(DecoratedBox)))
+        .map((widget) => widget.decoration)
+        .whereType<BoxDecoration>()
+        .singleWhere((decoration) => decoration.color == PregoColorsLight.bgSurface2);
+    return (decoration.border! as Border).top.color;
+  }
+
   // A fresh session rests in the hold-to-talk pill, which hosts no text field;
   // the keyboard button switches the composer to its typing layout and focuses
   // the field (focus lands post-frame).
@@ -601,6 +612,40 @@ void main() {
     // of the text-first mic button.
     expect(find.byIcon(TablerRegular.microphone), findsNothing);
     expect(find.text("Hold to talk"), findsOneWidget);
+  });
+
+  testWidgets("picker pills and task card follow the composer surface style", (tester) async {
+    final state = _loadedState(
+      pendingQuestions: const [],
+      pendingPermissions: const [],
+      children: [testSession(id: "child-1", title: "Child task", parentID: "session-1")],
+    );
+    when(() => cubit.state).thenReturn(state);
+    whenListen(cubit, const Stream<SessionDetailState>.empty(), initialState: state);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    final picker = find.byType(PregoPickerButton).first;
+    final taskCard = find.byType(PregoCard);
+    expect(composerSurfaceBorderColor(tester, picker), PregoColorsLight.borderSecondary);
+    expect(composerSurfaceBorderColor(tester, taskCard), PregoColorsLight.borderSecondary);
+
+    await enterTypingMode(tester);
+    await tester.enterText(find.byType(EditableText), "draft");
+    composerFocus(tester).unfocus();
+    await tester.pumpAndSettle();
+
+    expect(composerSurfaceBorderColor(tester, picker), PregoColorsLight.borderPrimary);
+    expect(composerSurfaceBorderColor(tester, taskCard), PregoColorsLight.borderPrimary);
+
+    await tester.tap(find.text("draft"));
+    await tester.enterText(find.byType(EditableText), "");
+    composerFocus(tester).unfocus();
+    await tester.pumpAndSettle();
+
+    expect(composerSurfaceBorderColor(tester, picker), PregoColorsLight.borderSecondary);
+    expect(composerSurfaceBorderColor(tester, taskCard), PregoColorsLight.borderSecondary);
   });
 
   testWidgets("voice-first session with messages still rests in hold-to-talk", (tester) async {
@@ -1284,6 +1329,10 @@ void main() {
     await tester.pumpWidget(_buildApp(cubit: cubit, chatInputModeCubit: modeCubit));
     await tester.pumpAndSettle();
     expect(find.text("Hold to talk"), findsOneWidget);
+    expect(
+      composerSurfaceBorderColor(tester, find.byType(PregoPickerButton).first),
+      PregoColorsLight.borderSecondary,
+    );
 
     await modeCubit.select(mode: ChatInputMode.textFirst);
     await tester.pumpAndSettle();
@@ -1291,6 +1340,10 @@ void main() {
     expect(find.text("Hold to talk"), findsNothing);
     expect(find.text("Ask anything..."), findsOneWidget);
     expect(find.byIcon(TablerRegular.microphone), findsOneWidget);
+    expect(
+      composerSurfaceBorderColor(tester, find.byType(PregoPickerButton).first),
+      PregoColorsLight.borderPrimary,
+    );
   });
 
   testWidgets("holding the typing container's voice pill records while the text stays", (tester) async {

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -13,6 +13,7 @@ import "package:go_router/go_router.dart";
 import "package:mocktail/mocktail.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/capabilities/voice/voice_transcription_service.dart";
+import "package:sesori_mobile/features/session_detail/widgets/background_tasks_bar.dart";
 import "package:sesori_mobile/features/session_detail/widgets/prompt_editor_sheet.dart";
 import "package:sesori_mobile/features/session_detail/widgets/session_detail_body.dart";
 import "package:sesori_mobile/features/session_detail/widgets/voice_cancel_button.dart";
@@ -459,13 +460,13 @@ void main() {
   // design.
   FocusNode composerFocus(WidgetTester tester) => tester.widget<EditableText>(find.byType(EditableText)).focusNode;
 
-  Color composerSurfaceBorderColor(WidgetTester tester, Finder surface) {
-    final decoration = tester
-        .widgetList<DecoratedBox>(find.descendant(of: surface, matching: find.byType(DecoratedBox)))
-        .map((widget) => widget.decoration)
-        .whereType<BoxDecoration>()
-        .singleWhere((decoration) => decoration.color == PregoColorsLight.bgSurface2);
-    return (decoration.border! as Border).top.color;
+  Color composerSurfaceBorderColor({required WidgetTester tester, required Finder surface}) {
+    expect(surface, findsOneWidget);
+    final decoratedBox = find.descendant(of: surface, matching: find.byType(DecoratedBox)).first;
+    final decoration = tester.widget<DecoratedBox>(decoratedBox).decoration as BoxDecoration;
+    final border = decoration.border;
+    if (border is! Border) throw TestFailure("Expected a solid composer surface border");
+    return border.top.color;
   }
 
   // A fresh session rests in the hold-to-talk pill, which hosts no text field;
@@ -627,25 +628,60 @@ void main() {
     await tester.pumpAndSettle();
 
     final picker = find.byType(PregoPickerButton).first;
-    final taskCard = find.byType(PregoCard);
-    expect(composerSurfaceBorderColor(tester, picker), PregoColorsLight.borderSecondary);
-    expect(composerSurfaceBorderColor(tester, taskCard), PregoColorsLight.borderSecondary);
+    final taskCard = find.descendant(
+      of: find.byType(BackgroundTasksBar),
+      matching: find.byType(PregoCard),
+    );
+    expect(
+      composerSurfaceBorderColor(tester: tester, surface: picker),
+      PregoColorsLight.borderSecondary,
+    );
+    expect(
+      composerSurfaceBorderColor(tester: tester, surface: taskCard),
+      PregoColorsLight.borderSecondary,
+    );
 
-    await enterTypingMode(tester);
+    await tester.tap(find.byIcon(TablerRegular.keyboard));
+    await tester.pump();
+
+    // Adjacent surfaces switch in the same frame as the composer rather than
+    // briefly retaining the previous outline treatment.
+    expect(
+      composerSurfaceBorderColor(tester: tester, surface: picker),
+      PregoColorsLight.borderPrimary,
+    );
+    expect(
+      composerSurfaceBorderColor(tester: tester, surface: taskCard),
+      PregoColorsLight.borderPrimary,
+    );
+
+    await tester.pumpAndSettle();
     await tester.enterText(find.byType(EditableText), "draft");
     composerFocus(tester).unfocus();
     await tester.pumpAndSettle();
 
-    expect(composerSurfaceBorderColor(tester, picker), PregoColorsLight.borderPrimary);
-    expect(composerSurfaceBorderColor(tester, taskCard), PregoColorsLight.borderPrimary);
+    expect(
+      composerSurfaceBorderColor(tester: tester, surface: picker),
+      PregoColorsLight.borderPrimary,
+    );
+    expect(
+      composerSurfaceBorderColor(tester: tester, surface: taskCard),
+      PregoColorsLight.borderPrimary,
+    );
 
     await tester.tap(find.text("draft"));
     await tester.enterText(find.byType(EditableText), "");
     composerFocus(tester).unfocus();
     await tester.pumpAndSettle();
 
-    expect(composerSurfaceBorderColor(tester, picker), PregoColorsLight.borderSecondary);
-    expect(composerSurfaceBorderColor(tester, taskCard), PregoColorsLight.borderSecondary);
+    expect(
+      composerSurfaceBorderColor(tester: tester, surface: picker),
+      PregoColorsLight.borderSecondary,
+    );
+    expect(
+      composerSurfaceBorderColor(tester: tester, surface: taskCard),
+      PregoColorsLight.borderSecondary,
+    );
   });
 
   testWidgets("voice-first session with messages still rests in hold-to-talk", (tester) async {
@@ -689,6 +725,10 @@ void main() {
 
   testWidgets("text-first fresh session rests as a tap-to-type field with the mic alongside", (tester) async {
     await tester.pumpWidget(_buildApp(cubit: cubit, chatInputMode: ChatInputMode.textFirst));
+    expect(
+      composerSurfaceBorderColor(tester: tester, surface: find.byType(PregoPickerButton).first),
+      PregoColorsLight.borderPrimary,
+    );
     await tester.pumpAndSettle();
 
     expect(find.text("Hold to talk"), findsNothing);
@@ -1330,7 +1370,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text("Hold to talk"), findsOneWidget);
     expect(
-      composerSurfaceBorderColor(tester, find.byType(PregoPickerButton).first),
+      composerSurfaceBorderColor(tester: tester, surface: find.byType(PregoPickerButton).first),
       PregoColorsLight.borderSecondary,
     );
 
@@ -1341,7 +1381,7 @@ void main() {
     expect(find.text("Ask anything..."), findsOneWidget);
     expect(find.byIcon(TablerRegular.microphone), findsOneWidget);
     expect(
-      composerSurfaceBorderColor(tester, find.byType(PregoPickerButton).first),
+      composerSurfaceBorderColor(tester: tester, surface: find.byType(PregoPickerButton).first),
       PregoColorsLight.borderPrimary,
     );
   });

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -684,6 +684,62 @@ void main() {
     );
   });
 
+  testWidgets("parent-driven staged command changes update adjacent surface styles", (tester) async {
+    var state = _loadedState(
+      pendingQuestions: const [],
+      pendingPermissions: const [],
+      children: [testSession(id: "child-1", title: "Child task", parentID: "session-1")],
+    );
+    final stateController = StreamController<SessionDetailState>.broadcast();
+    addTearDown(stateController.close);
+    when(() => cubit.state).thenAnswer((_) => state);
+    when(() => cubit.stream).thenAnswer((_) => stateController.stream);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    final picker = find.byType(PregoPickerButton).first;
+    final taskCard = find.descendant(
+      of: find.byType(BackgroundTasksBar),
+      matching: find.byType(PregoCard),
+    );
+    expect(
+      composerSurfaceBorderColor(tester: tester, surface: picker),
+      PregoColorsLight.borderSecondary,
+    );
+    expect(
+      composerSurfaceBorderColor(tester: tester, surface: taskCard),
+      PregoColorsLight.borderSecondary,
+    );
+
+    state = state.copyWith(stagedCommand: testCommandInfo());
+    stateController.add(state);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(EditableText), findsOneWidget);
+    expect(
+      composerSurfaceBorderColor(tester: tester, surface: taskCard),
+      PregoColorsLight.borderPrimary,
+    );
+
+    composerFocus(tester).unfocus();
+    await tester.pumpAndSettle();
+
+    state = state.copyWith(stagedCommand: null);
+    stateController.add(state);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(EditableText), findsNothing);
+    expect(
+      composerSurfaceBorderColor(tester: tester, surface: picker),
+      PregoColorsLight.borderSecondary,
+    );
+    expect(
+      composerSurfaceBorderColor(tester: tester, surface: taskCard),
+      PregoColorsLight.borderSecondary,
+    );
+  });
+
   testWidgets("voice-first session with messages still rests in hold-to-talk", (tester) async {
     final state = _loadedState(
       pendingQuestions: const [],

--- a/client/module_prego/lib/components/buttons/prego_picker_button.dart
+++ b/client/module_prego/lib/components/buttons/prego_picker_button.dart
@@ -1,12 +1,13 @@
 import "package:flutter/material.dart";
 
 import "../../theme/prego_theme.dart";
+import "../surfaces/prego_surfaces.dart";
 
 /// A solid pill that opens a picker: leading glyph, one-line [label], and a
 /// trailing unfold caret signalling the popup.
 ///
-/// Its surface matches the prompt composer's background, border, and elevation
-/// on every platform, while its press feedback uses the same Material ripple.
+/// Its surface matches the composer's background, border, and elevation on
+/// every platform, while its press feedback uses the same Material ripple.
 /// The pill fills its parent's width and ellipsizes long labels.
 ///
 /// Usage:
@@ -14,6 +15,7 @@ import "../../theme/prego_theme.dart";
 /// PregoPickerButton(
 ///   leadingIcon: Icons.smart_toy_outlined,
 ///   label: selectedAgent,
+///   surfaceStyle: PregoComposerSurfaceStyle.subtle,
 ///   onPressed: toggle,
 /// )
 /// ```
@@ -22,6 +24,7 @@ class PregoPickerButton extends StatelessWidget {
     super.key,
     required this.leadingIcon,
     required this.label,
+    required this.surfaceStyle,
     required this.onPressed,
   });
 
@@ -30,6 +33,9 @@ class PregoPickerButton extends StatelessWidget {
 
   /// One-line button text; ellipsizes when it doesn't fit.
   final String label;
+
+  /// Outline emphasis shared with the current composer state.
+  final PregoComposerSurfaceStyle surfaceStyle;
 
   /// Called when the pill is tapped. Wire this to the menu's open callback.
   final VoidCallback onPressed;
@@ -43,11 +49,10 @@ class PregoPickerButton extends StatelessWidget {
       width: double.infinity,
       height: 36,
       child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: prego.colors.bgSurface2,
+        decoration: pregoComposerSurfaceDecoration(
+          prego: prego,
+          style: surfaceStyle,
           borderRadius: borderRadius,
-          border: Border.all(color: prego.colors.borderPrimary),
-          boxShadow: prego.shadows.xs,
         ),
         child: Padding(
           padding: const EdgeInsets.all(1),

--- a/client/module_prego/lib/components/surfaces/prego_surfaces.dart
+++ b/client/module_prego/lib/components/surfaces/prego_surfaces.dart
@@ -14,18 +14,41 @@ import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "../../theme/prego_glass.dart";
 import "../../theme/prego_theme.dart";
 
+/// The two outline treatments used by the composer and its adjacent surfaces.
+enum PregoComposerSurfaceStyle { subtle, emphasized }
+
+/// Builds the shared solid decoration used by the composer, picker pills, and
+/// background-task card.
+BoxDecoration pregoComposerSurfaceDecoration({
+  required PregoDesignSystem prego,
+  required PregoComposerSurfaceStyle style,
+  required BorderRadius borderRadius,
+}) {
+  final borderColor = switch (style) {
+    PregoComposerSurfaceStyle.subtle => prego.colors.borderSecondary,
+    PregoComposerSurfaceStyle.emphasized => prego.colors.borderPrimary,
+  };
+  return BoxDecoration(
+    color: prego.colors.bgSurface2,
+    borderRadius: borderRadius,
+    border: Border.all(color: borderColor),
+    boxShadow: prego.shadows.xs,
+  );
+}
+
 /// A rounded, elevated surface that hosts grouped content.
 ///
-/// Uses the same fill, border, and elevation as the prompt composer on every
-/// platform.
+/// Uses the same fill, border, and elevation as the composer on every platform.
 class PregoCard extends StatelessWidget {
   const PregoCard({
     super.key,
     required this.child,
+    required this.surfaceStyle,
     this.borderRadius = 20,
   });
 
   final Widget child;
+  final PregoComposerSurfaceStyle surfaceStyle;
 
   /// Corner radius of the card.
   final double borderRadius;
@@ -35,11 +58,10 @@ class PregoCard extends StatelessWidget {
     final prego = context.prego;
     final radius = BorderRadius.circular(borderRadius);
     return DecoratedBox(
-      decoration: BoxDecoration(
-        color: prego.colors.bgSurface2,
+      decoration: pregoComposerSurfaceDecoration(
+        prego: prego,
+        style: surfaceStyle,
         borderRadius: radius,
-        border: Border.all(color: prego.colors.borderPrimary),
-        boxShadow: prego.shadows.xs,
       ),
       child: ClipRRect(
         borderRadius: radius,

--- a/client/module_prego/test/components/prego_picker_button_test.dart
+++ b/client/module_prego/test/components/prego_picker_button_test.dart
@@ -17,6 +17,7 @@ void main() {
         PregoPickerButton(
           leadingIcon: Icons.smart_toy_outlined,
           label: "Agent",
+          surfaceStyle: PregoComposerSurfaceStyle.subtle,
           onPressed: () => taps++,
         ),
       ),
@@ -41,6 +42,7 @@ void main() {
           PregoPickerButton(
             leadingIcon: Icons.memory_outlined,
             label: "Model",
+            surfaceStyle: PregoComposerSurfaceStyle.subtle,
             onPressed: () {},
           ),
         ),
@@ -59,7 +61,7 @@ void main() {
       final surface = decorations.singleWhere(
         (decoration) => decoration.color == PregoColorsLight.bgSurface2,
       );
-      expect(surface.border, Border.all(color: PregoColorsLight.borderPrimary));
+      expect(surface.border, Border.all(color: PregoColorsLight.borderSecondary));
       expect(
         surface.boxShadow,
         [
@@ -83,6 +85,7 @@ void main() {
               child: PregoPickerButton(
                 leadingIcon: Icons.memory_outlined,
                 label: "An extremely long model name that cannot possibly fit in one pill" * 3,
+                surfaceStyle: PregoComposerSurfaceStyle.subtle,
                 onPressed: () {},
               ),
             ),

--- a/client/module_prego/test/components/prego_surfaces_test.dart
+++ b/client/module_prego/test/components/prego_surfaces_test.dart
@@ -15,7 +15,14 @@ void main() {
     testWidgets(
       "PregoCard matches the composer surface on Android and iOS",
       (tester) async {
-        await tester.pumpWidget(_harness(const PregoCard(child: Text("Body"))));
+        await tester.pumpWidget(
+          _harness(
+            const PregoCard(
+              surfaceStyle: PregoComposerSurfaceStyle.subtle,
+              child: Text("Body"),
+            ),
+          ),
+        );
 
         expect(find.byType(GlassContainer), findsNothing);
         final decorations = tester
@@ -27,7 +34,7 @@ void main() {
         final surface = decorations.singleWhere(
           (decoration) => decoration.color == PregoColorsLight.bgSurface2,
         );
-        expect(surface.border, Border.all(color: PregoColorsLight.borderPrimary));
+        expect(surface.border, Border.all(color: PregoColorsLight.borderSecondary));
         expect(
           surface.boxShadow,
           [
@@ -49,6 +56,7 @@ void main() {
         await tester.pumpWidget(
           _harness(
             PregoCard(
+              surfaceStyle: PregoComposerSurfaceStyle.subtle,
               child: PregoListTile(
                 leading: const Icon(Icons.task_alt),
                 title: const Text("Alpha"),
@@ -77,6 +85,7 @@ void main() {
         await tester.pumpWidget(
           _harness(
             const PregoCard(
+              surfaceStyle: PregoComposerSurfaceStyle.subtle,
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [


### PR DESCRIPTION
## Complexity
Moderate. This centralizes the shared composer surface decoration and propagates the composer's private visual state to sibling controls without lifting its text or focus state.

## What
- Add subtle and emphasized composer surface styles backed by one Prego decoration helper.
- Make picker pills and the background-task card follow the authoritative `PromptInput` surface style.
- Keep rebuilds scoped to the affected controls.
- Cover text, empty, and live input-mode transitions in widget tests.

## Why
PR #672 gave the controls the same fill and shadow as the composer, but left them on the stronger border used by the typing container. The empty voice-first composer uses a milder border, so adjacent surfaces looked outlined differently and did not follow later composer state changes.

## Risk and test focus
This is a user-visible presentation change limited to the mobile composer controls. Focus review on empty voice-first, typing or retained-text, text-first, staged-command, and task-card states. There is no database, transport, authentication, or analytics impact.

## Expected result
The task card and agent/model/variant pills use the subtle outline beside the empty voice-first input, switch to the emphasized outline whenever the main composer does, and switch back when an empty unfocused composer collapses.

## Verification
- `dart analyze` in `client/module_prego`
- `dart analyze` in `client/app`
- Focused Prego picker and surface widget tests
- Agent picker and background-task navigation widget tests
- Full session-detail composer widget suite
- Full new-session widget suite
- iOS simulator debug build and visual review in empty and retained-text states
- Aristotle implementation review: approved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps composer-adjacent surfaces in perfect sync with the composer, with same-frame border updates. Picker pills and the background task card switch between subtle and emphasized outlines exactly in step with `PromptInput`.

- **Bug Fixes**
  - Removed one-frame lag by publishing the style via `surfaceStyleController` on every `setState`.
  - Synced external changes immediately: `ChatInputMode` flips and parent-driven `stagedCommand` updates.
  - Chose the correct initial style with `resolveInitialComposerSurfaceStyle(...)` in New Session and Session Detail.
  - Expanded tests to verify same-frame transitions, input-mode flips, and staged-command updates.

- **Refactors**
  - Centralized layout and styling: added `ComposerSurfaceLayout`, `resolveComposerSurfaceLayout(...)`, and shared `PregoComposerSurfaceStyle` + `pregoComposerSurfaceDecoration(...)`.
  - `PromptInput` now drives style via a `ValueNotifier`, subscribes to `ChatInputModeCubit`, and uses the shared decoration.
  - `AgentModelButtons`, `BackgroundTasksBar`, `PregoPickerButton`, and `PregoCard` accept/forward `surfaceStyle`.

<sup>Written for commit eacab6d8d530bd79a3987bcfc13aa53bc138ad21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

