### PR TITLE
🌱 [hold-to-talk-height-jitter] Keep composer height stable [step 1/3]

### DIFF
--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -789,7 +789,7 @@ class _PromptInputState extends State<PromptInput> {
     return Padding(
       // The design floats the helper spacing-3xl above the pill, less the
       // padding the tap-region below already contributes.
-      padding: const EdgeInsetsDirectional.only(top: PregoSpacing.md, bottom: PregoSpacing.xl),
+      padding: const EdgeInsetsDirectional.only(top: PregoSpacing.xs, bottom: PregoSpacing.xl),
       child: SizedBox(
         width: double.infinity,
         child: ValueListenableBuilder<double>(

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -14,6 +14,7 @@ import "package:mocktail/mocktail.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/capabilities/voice/voice_transcription_service.dart";
 import "package:sesori_mobile/features/session_detail/widgets/prompt_editor_sheet.dart";
+import "package:sesori_mobile/features/session_detail/widgets/prompt_input.dart";
 import "package:sesori_mobile/features/session_detail/widgets/session_detail_body.dart";
 import "package:sesori_mobile/features/session_detail/widgets/voice_cancel_button.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
@@ -1057,11 +1058,13 @@ void main() {
     await tester.pumpWidget(_buildApp(cubit: cubit));
     await tester.pumpAndSettle();
 
+    final restingComposerHeight = tester.getSize(find.byType(PromptInput)).height;
     final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
     await tester.pump(const Duration(milliseconds: 600));
     // Let the swap-in transitions finish (bounded: the waveform never settles).
     await tester.pump(const Duration(milliseconds: 300));
 
+    expect(tester.getSize(find.byType(PromptInput)).height, restingComposerHeight);
     expect(find.byType(VoiceCancelButton), findsOneWidget);
     // The cancel target must keep the full 44pt footprint (a CustomPaint with
     // a child would otherwise shrink to its icon).


### PR DESCRIPTION
## Complexity

🌱 Trivial. This adjusts one spacing token and adds focused widget coverage. It has user-visible layout impact only, with no database or wire-contract impact.

## What

- Align the recording release helper's top-slot height with the resting agent/model header.
- Assert that the full composer height remains unchanged when hold-to-talk enters recording.

## Why

The resting header was 44 px tall while the recording helper was 48 px tall. The floating controls measurement propagated that four-pixel increase into the message-list inset, making surrounding content move during a recording hold.

## Risk and test focus

Risk is low and limited to the release helper's vertical position. The designed 24 px helper-to-pill gap remains unchanged; test focus is the idle-to-recording height transition and existing recording chrome behavior.

## Expected result

Starting and stopping hold-to-talk no longer shifts the composer or surrounding screen content vertically.

## Verification

- `flutter test test/features/session_detail/widgets/session_detail_body_test.dart`
- `dart analyze` in `client/app`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed vertical jitter in the hold-to-talk composer by aligning the recording helper spacing with the resting header so the composer height stays constant while recording.

- **Bug Fixes**
  - Reduced `PromptInput` top padding from `PregoSpacing.md` to `PregoSpacing.xs` to match the 44px header.
  - Added a widget test that asserts the composer height does not change during recording.

<sup>Written for commit 7eb4edd5d6bb082317a15b5c772bd9c7b8fce226. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

