### PR TITLE
🌱 [hold-to-talk-height-jitter] Stabilize headerless composer [step 2/3]

### DIFF
--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -767,7 +767,9 @@ class _PromptInputState extends State<PromptInput> {
       };
       child = KeyedSubtree(
         key: ValueKey(widget.stagedCommand == null ? "header" : "staged-command"),
-        child: headerChild ?? const SizedBox(width: double.infinity),
+        // Older bridges can provide no picker header. Reserve its footprint so
+        // the recording helper does not grow the composer when it appears.
+        child: headerChild ?? const SizedBox(width: double.infinity, height: _actionButtonSize),
       );
     }
 

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -789,7 +789,7 @@ class _PromptInputState extends State<PromptInput> {
     return Padding(
       // The design floats the helper spacing-3xl above the pill, less the
       // padding the tap-region below already contributes.
-      padding: const EdgeInsetsDirectional.only(top: PregoSpacing.md, bottom: PregoSpacing.xl),
+      padding: const EdgeInsetsDirectional.only(top: PregoSpacing.xs, bottom: PregoSpacing.xl),
       child: SizedBox(
         width: double.infinity,
         child: ValueListenableBuilder<double>(

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -354,6 +354,9 @@ void main() {
   });
 
   testWidgets("old bridge guidance keeps Create available and Refresh uses legacy routes", (tester) async {
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) async => "");
     when(pluginRepository.listPlugins).thenAnswer(
       (_) async => ApiResponse.success(
         PluginDiscoverySnapshot(
@@ -382,6 +385,7 @@ void main() {
       find.ancestor(of: find.byType(PromptInput), matching: find.byType(IgnorePointer)).first,
     );
     expect(composerPointer.ignoring, isFalse);
+    expect(find.byType(PregoPickerButton), findsNothing);
     verifyNever(
       () => sessionRepository.loadSessionOptions(
         projectId: any(named: "projectId"),
@@ -389,6 +393,14 @@ void main() {
         forceRefresh: any(named: "forceRefresh"),
       ),
     );
+
+    final restingComposerHeight = tester.getSize(find.byType(PromptInput)).height;
+    final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
+    await tester.pump(const Duration(milliseconds: 600));
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(tester.getSize(find.byType(PromptInput)).height, closeTo(restingComposerHeight, 0.01));
+    await gesture.up();
+    await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const Key("new_session_options_refresh")));
     await tester.pumpAndSettle();

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -1064,7 +1064,7 @@ void main() {
     // Let the swap-in transitions finish (bounded: the waveform never settles).
     await tester.pump(const Duration(milliseconds: 300));
 
-    expect(tester.getSize(find.byType(PromptInput)).height, restingComposerHeight);
+    expect(tester.getSize(find.byType(PromptInput)).height, closeTo(restingComposerHeight, 0.01));
     expect(find.byType(VoiceCancelButton), findsOneWidget);
     // The cancel target must keep the full 44pt footprint (a CustomPaint with
     // a child would otherwise shrink to its icon).

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -14,6 +14,7 @@ import "package:mocktail/mocktail.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/capabilities/voice/voice_transcription_service.dart";
 import "package:sesori_mobile/features/session_detail/widgets/prompt_editor_sheet.dart";
+import "package:sesori_mobile/features/session_detail/widgets/prompt_input.dart";
 import "package:sesori_mobile/features/session_detail/widgets/session_detail_body.dart";
 import "package:sesori_mobile/features/session_detail/widgets/voice_cancel_button.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
@@ -1057,11 +1058,13 @@ void main() {
     await tester.pumpWidget(_buildApp(cubit: cubit));
     await tester.pumpAndSettle();
 
+    final restingComposerHeight = tester.getSize(find.byType(PromptInput)).height;
     final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
     await tester.pump(const Duration(milliseconds: 600));
     // Let the swap-in transitions finish (bounded: the waveform never settles).
     await tester.pump(const Duration(milliseconds: 300));
 
+    expect(tester.getSize(find.byType(PromptInput)).height, restingComposerHeight);
     expect(find.byType(VoiceCancelButton), findsOneWidget);
     // The cancel target must keep the full 44pt footprint (a CustomPaint with
     // a child would otherwise shrink to its icon).


### PR DESCRIPTION
## Complexity

🌱 Trivial. This reserves one existing layout footprint and extends focused widget coverage. It has user-visible layout impact for headerless composers only, with no database or wire-contract impact.

## What

- Reserve the standard 44 px composer top slot when an older bridge provides no agent/model picker header.
- Cover the headerless old-bridge recording transition.
- Use the existing tolerant matcher pattern for both composer-height assertions.

## Why

PR #676 fixed the four-pixel recording shift for composers with a picker header, then merged before its automated review follow-up was pushed. The review identified that headerless old-bridge composers could still grow by 44 px when the release helper appeared.

## Risk and test focus

Risk is low and limited to preserving empty top-slot space when picker data is unavailable. Test focus is the old-bridge fallback, the normal session-detail recording transition, and short-viewport/new-session layout behavior.

## Expected result

Hold-to-talk keeps the composer height stable whether or not agent/model picker data is available.

## Verification

- `flutter test test/features/new_session/new_session_screen_test.dart test/features/session_detail/widgets/session_detail_body_test.dart` (72 tests)
- `dart analyze` in `client/app`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hold-to-talk composer height jitter when the picker header is missing. We reserve the standard 44 px top slot so recording doesn’t grow the composer.

- **Bug Fixes**
  - Reserve the 44 px header footprint for headerless (old-bridge) composers.
  - Cover the headerless recording transition to keep composer height stable.
  - Update tests to simulate voice recording and assert height stability with a small tolerance.

<sup>Written for commit b102052393570b698e2e8c0484995f2d130b872b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

