### PR TITLE
🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]

### DIFF
--- a/.plan/active/session-pull-request-monitoring/TRACKER.md
+++ b/.plan/active/session-pull-request-monitoring/TRACKER.md
@@ -41,7 +41,7 @@
 | [x] | 1/9 | `plan/session-pull-request-monitoring/replan-current-pr-only` | `🌿 [session-pull-request-monitoring] docs: plan current PR monitoring [step 1/9]` | 4,000–7,000 | [PR #649](https://github.com/sesori-ai/sesori_apps_monorepo/pull/649) merged as `f969754b` |
 | [x] | 2.a/9 | `session-pull-request-monitoring-scoped-source` | `⚙️ [session-pull-request-monitoring] feat(bridge): scope GitHub PR queries [step 2.a/9]` | 500–900 | [PR #662](https://github.com/sesori-ai/sesori_apps_monorepo/pull/662) merged as `057e4c24` |
 | [x] | 2.b/9 | `session-pull-request-monitoring-scoped-pr-persistence` | `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2.b/9]` | 9,800–10,800 | [PR #671](https://github.com/sesori-ai/sesori_apps_monorepo/pull/671) merged as `e6001fdc` |
-| [ ] | 2.c/9 | `session-pull-request-monitoring-scoped-pr-reads` | `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]` | 1,200–1,700 | [PR #678](https://github.com/sesori-ai/sesori_apps_monorepo/pull/678) open; implementation, verification, and architecture correction complete |
+| [ ] | 2.c/9 | `session-pull-request-monitoring-scoped-pr-reads` | `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]` | 1,200–1,700 | [PR #678](https://github.com/sesori-ai/sesori_apps_monorepo/pull/678) open; implementation, verification, architecture correction, and review fixes complete |
 | [ ] | 3/9 | `session-pull-request-monitoring-graphql-selection` | `🚧 [session-pull-request-monitoring] feat(bridge): batch exact PR selection [step 3/9]` | 1,000–1,500 | Blocked on Step 2.c merge |
 | [ ] | 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | 1,100–1,500 | Blocked on Step 3 merge |
 | [ ] | 5/9 | `session-pull-request-monitoring-view-scheduler` | `🚧 [session-pull-request-monitoring] feat(bridge): schedule viewed-project PR refresh [step 5/9]` | 900–1,400 | Blocked on Step 4 merge |
@@ -231,13 +231,18 @@
   switched identity yields sessions without PR metadata, and enrichment clears
   incoming PR/history data before applying the selected row. Waited refresh
   failures and timeouts return the original PR-free catalog snapshot.
-- **Step 2.c/9 verification and review:** Fatal-info analysis and all 2,309 bridge
-  app tests pass. Focused DAO/repository, identity-gated list/detail, refresh,
-  mutation-response, SSE, integration, and benchmark contract suites also pass,
-  as does `git diff --check`. `aristotle-impl-review` rejected handler-owned
+- **Step 2.c/9 verification and review:** Fatal-info analysis and the pre-review
+  full bridge app suite of 2,309 tests pass. Focused DAO/repository,
+  identity-gated list/detail, refresh, mutation-response, SSE, integration, and
+  benchmark contract suites also pass, as does `git diff --check`.
+  `aristotle-impl-review` rejected handler-owned
   response mapping; the valid finding was applied by keeping authoritative
   PR/history clearing solely in `SessionRepository`, with no policy re-review.
-  The 809-line change is below estimate because it reuses the Step 2.b
+  Automated review follow-up placed initial/final identity and mapping inside one
+  five-second deadline, converts asynchronous refresh errors into explicit
+  failure, and distinguishes an active refresh from completion. Post-follow-up
+  fatal-info analysis and 54 focused handler/service tests pass. The approximately
+  1,050-line change remains below estimate because it reuses the Step 2.b
   persistence seams and has no generated artifacts.
 - **Step 2.c/9 cleanup assessment:** Removed the unused PR-repository session
   read API and made non-list/detail mapping explicitly PR-free. No persisted,

--- a/.plan/active/session-pull-request-monitoring/TRACKER.md
+++ b/.plan/active/session-pull-request-monitoring/TRACKER.md
@@ -240,10 +240,14 @@
   PR/history clearing solely in `SessionRepository`, with no policy re-review.
   Automated review follow-up placed initial/final identity and mapping inside one
   five-second deadline, converts asynchronous refresh errors into explicit
-  failure, and distinguishes an active refresh from completion. Post-follow-up
-  fatal-info analysis and 54 focused handler/service tests pass. The approximately
-  1,050-line change remains below estimate because it reuses the Step 2.b
-  persistence seams and has no generated artifacts.
+  failure, and distinguishes an active refresh from completion. A later round
+  bounded detail-read identity checks and made an unavailable waited-refresh
+  source fail closed; the non-waiting list deadline remains intentional because
+  it bounds the fresh identity gate rather than waiting for background refresh.
+  Post-follow-up fatal-info analysis and the latest 59 focused
+  handler/service tests pass. The approximately 1,170-line change remains below
+  estimate because it reuses the Step 2.b persistence seams and has no generated
+  artifacts.
 - **Step 2.c/9 cleanup assessment:** Removed the unused PR-repository session
   read API and made non-list/detail mapping explicitly PR-free. No persisted,
   wire, job, listener, setting, or compatibility artifact became obsolete.

--- a/.plan/active/session-pull-request-monitoring/TRACKER.md
+++ b/.plan/active/session-pull-request-monitoring/TRACKER.md
@@ -9,7 +9,7 @@
 - **Current step:** Step 2.c/9 — fresh scoped PR reads
 - **Plan PR:** [#649](https://github.com/sesori-ai/sesori_apps_monorepo/pull/649) merged
 - **Superseded prototype:** [#659](https://github.com/sesori-ai/sesori_apps_monorepo/pull/659) closed
-- **Next action:** commit, raise, and monitor the Step 2.c/9 PR
+- **Next action:** monitor CI/review and merge Step 2.c/9 [PR #678](https://github.com/sesori-ai/sesori_apps_monorepo/pull/678)
 
 ## Existing Baseline
 
@@ -41,7 +41,7 @@
 | [x] | 1/9 | `plan/session-pull-request-monitoring/replan-current-pr-only` | `🌿 [session-pull-request-monitoring] docs: plan current PR monitoring [step 1/9]` | 4,000–7,000 | [PR #649](https://github.com/sesori-ai/sesori_apps_monorepo/pull/649) merged as `f969754b` |
 | [x] | 2.a/9 | `session-pull-request-monitoring-scoped-source` | `⚙️ [session-pull-request-monitoring] feat(bridge): scope GitHub PR queries [step 2.a/9]` | 500–900 | [PR #662](https://github.com/sesori-ai/sesori_apps_monorepo/pull/662) merged as `057e4c24` |
 | [x] | 2.b/9 | `session-pull-request-monitoring-scoped-pr-persistence` | `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2.b/9]` | 9,800–10,800 | [PR #671](https://github.com/sesori-ai/sesori_apps_monorepo/pull/671) merged as `e6001fdc` |
-| [ ] | 2.c/9 | `session-pull-request-monitoring-scoped-pr-reads` | `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]` | 1,200–1,700 | Implementation, focused verification, and architecture correction complete; PR pending |
+| [ ] | 2.c/9 | `session-pull-request-monitoring-scoped-pr-reads` | `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]` | 1,200–1,700 | [PR #678](https://github.com/sesori-ai/sesori_apps_monorepo/pull/678) open; implementation, verification, and architecture correction complete |
 | [ ] | 3/9 | `session-pull-request-monitoring-graphql-selection` | `🚧 [session-pull-request-monitoring] feat(bridge): batch exact PR selection [step 3/9]` | 1,000–1,500 | Blocked on Step 2.c merge |
 | [ ] | 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | 1,100–1,500 | Blocked on Step 3 merge |
 | [ ] | 5/9 | `session-pull-request-monitoring-view-scheduler` | `🚧 [session-pull-request-monitoring] feat(bridge): schedule viewed-project PR refresh [step 5/9]` | 900–1,400 | Blocked on Step 4 merge |
@@ -231,15 +231,14 @@
   switched identity yields sessions without PR metadata, and enrichment clears
   incoming PR/history data before applying the selected row. Waited refresh
   failures and timeouts return the original PR-free catalog snapshot.
-- **Step 2.c/9 verification and review:** Fatal-info analysis, DAO/repository,
-  identity-gated list/detail, refresh, mutation-response, SSE, and benchmark
-  contract suites pass. One full app run had 2,301 passes and four stale
-  assertions expecting ungated mutation/SSE PR data; all four affected suites
-  pass after those expectations were corrected. `aristotle-impl-review` rejected
-  handler-owned response mapping; the valid finding was applied by keeping
-  authoritative PR/history clearing solely in `SessionRepository`, with no
-  policy re-review. The 810-line change is below estimate because it reuses the
-  Step 2.b persistence seams and has no generated artifacts.
+- **Step 2.c/9 verification and review:** Fatal-info analysis and all 2,309 bridge
+  app tests pass. Focused DAO/repository, identity-gated list/detail, refresh,
+  mutation-response, SSE, integration, and benchmark contract suites also pass,
+  as does `git diff --check`. `aristotle-impl-review` rejected handler-owned
+  response mapping; the valid finding was applied by keeping authoritative
+  PR/history clearing solely in `SessionRepository`, with no policy re-review.
+  The 809-line change is below estimate because it reuses the Step 2.b
+  persistence seams and has no generated artifacts.
 - **Step 2.c/9 cleanup assessment:** Removed the unused PR-repository session
   read API and made non-list/detail mapping explicitly PR-free. No persisted,
   wire, job, listener, setting, or compatibility artifact became obsolete.

--- a/.plan/active/session-pull-request-monitoring/TRACKER.md
+++ b/.plan/active/session-pull-request-monitoring/TRACKER.md
@@ -4,12 +4,12 @@
 
 - **Plan slug:** `session-pull-request-monitoring`
 - **Implementation base:** `main` at
-  `3f9a2980f35ca3e8d3f0456af937743036be9bae`
-- **Series state:** Steps 1/9 and 2.a/9 merged; Step 2 continues through 2.b–2.c
-- **Current step:** Step 2.b/9 — scoped PR persistence
+  `e6001fdc3bbfe610414ab10c73f141a48c33efa3`
+- **Series state:** Steps 1/9 and 2.a–2.b/9 merged; Step 2.c is in progress
+- **Current step:** Step 2.c/9 — fresh scoped PR reads
 - **Plan PR:** [#649](https://github.com/sesori-ai/sesori_apps_monorepo/pull/649) merged
 - **Superseded prototype:** [#659](https://github.com/sesori-ai/sesori_apps_monorepo/pull/659) closed
-- **Next action:** monitor CI/review and merge Step 2.b/9 [PR #671](https://github.com/sesori-ai/sesori_apps_monorepo/pull/671)
+- **Next action:** commit, raise, and monitor the Step 2.c/9 PR
 
 ## Existing Baseline
 
@@ -40,8 +40,8 @@
 |---|---|---|---|---:|---|
 | [x] | 1/9 | `plan/session-pull-request-monitoring/replan-current-pr-only` | `🌿 [session-pull-request-monitoring] docs: plan current PR monitoring [step 1/9]` | 4,000–7,000 | [PR #649](https://github.com/sesori-ai/sesori_apps_monorepo/pull/649) merged as `f969754b` |
 | [x] | 2.a/9 | `session-pull-request-monitoring-scoped-source` | `⚙️ [session-pull-request-monitoring] feat(bridge): scope GitHub PR queries [step 2.a/9]` | 500–900 | [PR #662](https://github.com/sesori-ai/sesori_apps_monorepo/pull/662) merged as `057e4c24` |
-| [ ] | 2.b/9 | `session-pull-request-monitoring-scoped-pr-persistence` | `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2.b/9]` | 9,800–10,800 | [PR #671](https://github.com/sesori-ai/sesori_apps_monorepo/pull/671) open; schema v13, scoped writer/joins, generated artifacts, tests, and architecture review complete |
-| [ ] | 2.c/9 | `session-pull-request-monitoring-scoped-pr-reads` | `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]` | 1,200–1,700 | Blocked on Step 2.b |
+| [x] | 2.b/9 | `session-pull-request-monitoring-scoped-pr-persistence` | `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2.b/9]` | 9,800–10,800 | [PR #671](https://github.com/sesori-ai/sesori_apps_monorepo/pull/671) merged as `e6001fdc` |
+| [ ] | 2.c/9 | `session-pull-request-monitoring-scoped-pr-reads` | `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]` | 1,200–1,700 | Implementation, focused verification, and architecture correction complete; PR pending |
 | [ ] | 3/9 | `session-pull-request-monitoring-graphql-selection` | `🚧 [session-pull-request-monitoring] feat(bridge): batch exact PR selection [step 3/9]` | 1,000–1,500 | Blocked on Step 2.c merge |
 | [ ] | 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | 1,100–1,500 | Blocked on Step 3 merge |
 | [ ] | 5/9 | `session-pull-request-monitoring-view-scheduler` | `🚧 [session-pull-request-monitoring] feat(bridge): schedule viewed-project PR refresh [step 5/9]` | 900–1,400 | Blocked on Step 4 merge |
@@ -88,9 +88,10 @@
 
 ## Current Drift and Open Work
 
-- Latest audited `main`: `3f9a2980f35ca3e8d3f0456af937743036be9bae`.
-- Drift schema: v12 on `main`; Step 2.b allocates v13 and leaves every merged
-  schema/migration intact.
+- Latest audited `main`: Step 2.c branched from `e6001fdc`; later client-only
+  drift through `0b1e6072` does not overlap this bridge scope.
+- Drift schema: v13 on `main`; Step 2.c leaves the merged schema and migration
+  unchanged.
 - Parallel-plugin plan: complete through Stage 9 / PR #497.
 - PR #647 is merged and consolidates Harness settings into one screen. Its
   numeric-input/mutation pattern is current evidence for Step 8; PR cadence
@@ -221,6 +222,27 @@
   violate authoritative scope ownership. The previous 2,301-test full suite,
   latest 51 focused tests, fatal-info analysis, and `git diff --check` pass; the
   final 10,743-line PR contains 8,754 generated and 1,989 hand-authored lines.
+- **Step 2.b/9 merge:** PR #671 merged as `e6001fdc` with all 12 checks passing
+  and no unresolved review threads. Step 2.c started immediately from that
+  merged `main` tip.
+- **Step 2.c/9 implementation:** List and detail reads now obtain fresh typed
+  GitHub identity evidence before PR enrichment; DAO joins require that login
+  alongside persisted project, row, repository, and branch scope. Unknown or
+  switched identity yields sessions without PR metadata, and enrichment clears
+  incoming PR/history data before applying the selected row. Waited refresh
+  failures and timeouts return the original PR-free catalog snapshot.
+- **Step 2.c/9 verification and review:** Fatal-info analysis, DAO/repository,
+  identity-gated list/detail, refresh, mutation-response, SSE, and benchmark
+  contract suites pass. One full app run had 2,301 passes and four stale
+  assertions expecting ungated mutation/SSE PR data; all four affected suites
+  pass after those expectations were corrected. `aristotle-impl-review` rejected
+  handler-owned response mapping; the valid finding was applied by keeping
+  authoritative PR/history clearing solely in `SessionRepository`, with no
+  policy re-review. The 810-line change is below estimate because it reuses the
+  Step 2.b persistence seams and has no generated artifacts.
+- **Step 2.c/9 cleanup assessment:** Removed the unused PR-repository session
+  read API and made non-list/detail mapping explicitly PR-free. No persisted,
+  wire, job, listener, setting, or compatibility artifact became obsolete.
 
 ## Findings and Plan Deltas
 

--- a/bridge/app/lib/src/api/database/daos/pull_request_dao.dart
+++ b/bridge/app/lib/src/api/database/daos/pull_request_dao.dart
@@ -24,26 +24,53 @@ class PullRequestDao extends DatabaseAccessor<AppDatabase> with _$PullRequestDao
 
   Future<Map<String, List<PullRequestDto>>> getPrsBySessionIds({
     required List<String> sessionIds,
+    required String verifiedGithubLogin,
+  }) {
+    return _getPrsBySessionIds(
+      sessionIds: sessionIds,
+      verifiedGithubLogin: verifiedGithubLogin,
+    );
+  }
+
+  Future<Map<String, List<PullRequestDto>>> getPrsByPersistedScopeSessionIds({
+    required List<String> sessionIds,
+  }) {
+    return _getPrsBySessionIds(
+      sessionIds: sessionIds,
+      verifiedGithubLogin: null,
+    );
+  }
+
+  Future<Map<String, List<PullRequestDto>>> _getPrsBySessionIds({
+    required List<String> sessionIds,
+    required String? verifiedGithubLogin,
   }) async {
     if (sessionIds.isEmpty) {
       return <String, List<PullRequestDto>>{};
     }
 
-    final query = select(pullRequestsTable).join([
-      innerJoin(
-        sessionTable,
-        pullRequestsTable.projectId.equalsExp(sessionTable.projectId) &
-            pullRequestsTable.githubRepositoryIdentity.equalsExp(
-              sessionTable.currentGithubRepositoryIdentity,
-            ) &
-            pullRequestsTable.branchName.equalsExp(sessionTable.currentBranchName),
-      ),
-      innerJoin(
-        projectsTable,
-        projectsTable.projectId.equalsExp(sessionTable.projectId) &
-            projectsTable.prCacheGithubLogin.equalsExp(pullRequestsTable.githubLogin),
-      ),
-    ])..where(sessionTable.sessionId.isIn(sessionIds) & sessionTable.parentSessionId.isNull());
+    final readLoginScope = verifiedGithubLogin == null
+        ? const Constant(true)
+        : pullRequestsTable.githubLogin.equals(verifiedGithubLogin) &
+              projectsTable.prCacheGithubLogin.equals(verifiedGithubLogin);
+    final query =
+        select(pullRequestsTable).join([
+          innerJoin(
+            sessionTable,
+            pullRequestsTable.projectId.equalsExp(sessionTable.projectId) &
+                pullRequestsTable.githubRepositoryIdentity.equalsExp(
+                  sessionTable.currentGithubRepositoryIdentity,
+                ) &
+                pullRequestsTable.branchName.equalsExp(sessionTable.currentBranchName),
+          ),
+          innerJoin(
+            projectsTable,
+            projectsTable.projectId.equalsExp(sessionTable.projectId) &
+                projectsTable.prCacheGithubLogin.equalsExp(pullRequestsTable.githubLogin),
+          ),
+        ])..where(
+          sessionTable.sessionId.isIn(sessionIds) & sessionTable.parentSessionId.isNull() & readLoginScope,
+        );
 
     final joinedRows = await query.get();
     final groupedBySessionId = <String, List<PullRequestDto>>{};

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -467,7 +467,10 @@ class Orchestrator {
         GetCommandsHandler(sessionRepository: sessionRepository),
         GetSessionStatusesHandler(sessionRepository: sessionRepository),
         GetChildSessionsHandler(sessionRepository: sessionRepository),
-        GetSessionHandler(sessionRepository),
+        GetSessionHandler(
+          sessionRepository: sessionRepository,
+          prSyncService: prSyncService,
+        ),
         GetSessionMessagesHandler(sessionRepository: sessionRepository),
         GetSessionsHandler(
           sessionRepository: sessionRepository,

--- a/bridge/app/lib/src/bridge/repositories/pull_request_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/pull_request_repository.dart
@@ -35,10 +35,6 @@ class PullRequestRepository {
     );
   }
 
-  Future<Map<String, List<PullRequestDto>>> getPrsBySessionIds({required List<String> sessionIds}) {
-    return _pullRequestDao.getPrsBySessionIds(sessionIds: sessionIds);
-  }
-
   Future<bool> prepareScopedRefresh({
     required String projectId,
     required String githubRepositoryIdentity,
@@ -47,7 +43,7 @@ class PullRequestRepository {
   }) async {
     return _database.transaction(() async {
       final sessionIds = sessions.map((session) => session.id).toList(growable: false);
-      final before = await _pullRequestDao.getPrsBySessionIds(sessionIds: sessionIds);
+      final before = await _pullRequestDao.getPrsByPersistedScopeSessionIds(sessionIds: sessionIds);
       await _projectsDao.setPrCacheGithubLogin(
         projectId: projectId,
         githubLogin: verifiedGithubLogin.login,
@@ -68,7 +64,7 @@ class PullRequestRepository {
         githubLogin: verifiedGithubLogin.login,
         branchNames: _rootBranchNames(sessions: sessions),
       );
-      final after = await _pullRequestDao.getPrsBySessionIds(sessionIds: sessionIds);
+      final after = await _pullRequestDao.getPrsByPersistedScopeSessionIds(sessionIds: sessionIds);
       return !_sameVisiblePullRequests(before: before, after: after);
     });
   }
@@ -78,7 +74,7 @@ class PullRequestRepository {
     required List<StoredSession> sessions,
   }) async {
     return _database.transaction(() async {
-      final before = await _pullRequestDao.getPrsBySessionIds(
+      final before = await _pullRequestDao.getPrsByPersistedScopeSessionIds(
         sessionIds: sessions.map((session) => session.id).toList(growable: false),
       );
       await _projectsDao.setPrCacheGithubLogin(projectId: projectId, githubLogin: null);

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -48,6 +48,7 @@ import "mappers/stored_session_mapper.dart";
 import "models/project_not_found_exception.dart";
 import "models/session_operation.dart";
 import "models/stored_session.dart";
+import "models/verified_github_login.dart";
 import "session_unseen_calculator.dart";
 
 enum SessionBindingCommitKind { sessionCreation, catalogSync }
@@ -103,6 +104,7 @@ class SessionRepository {
     required String projectId,
     required int? start,
     required int? limit,
+    required VerifiedGithubLogin? verifiedGithubLogin,
   }) async {
     if (await _projectsDao.getProject(projectId: projectId) == null) {
       throw ProjectNotFoundException(projectId: projectId);
@@ -114,16 +116,26 @@ class SessionRepository {
         offset: start ?? 0,
         limit: effectiveLimit,
       ),
+      verifiedGithubLogin: verifiedGithubLogin,
     );
   }
 
-  Future<Session> enrichSession({required Session session}) async {
-    final enrichedSessions = await enrichSessions(sessions: [session]);
+  Future<Session> enrichSession({
+    required Session session,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) async {
+    final enrichedSessions = await enrichSessions(
+      sessions: [session],
+      verifiedGithubLogin: verifiedGithubLogin,
+    );
     return enrichedSessions.single;
   }
 
   Future<Session> enrichPluginSession({required String pluginId, required PluginSession pluginSession}) {
-    return enrichSession(session: pluginSession.toSharedSession(pluginId: pluginId));
+    return enrichSession(
+      session: pluginSession.toSharedSession(pluginId: pluginId),
+      verifiedGithubLogin: null,
+    );
   }
 
   Future<Session> createSession({
@@ -442,7 +454,10 @@ class SessionRepository {
       operation: SessionOperation.deleteSession,
     );
     final subtree = await _getSessionSubtree(root: binding);
-    final deletionSnapshot = (await _mapCatalogSessions(rows: [binding])).single;
+    final deletionSnapshot = (await _mapCatalogSessions(
+      rows: [binding],
+      verifiedGithubLogin: null,
+    )).single;
     await _runtime.use(
       pluginId: binding.pluginId,
       operation: SessionOperation.deleteSession,
@@ -817,10 +832,17 @@ class SessionRepository {
     };
   }
 
-  Future<Session?> getSessionForProject({required String projectId, required String sessionId}) async {
+  Future<Session?> getSessionForProject({
+    required String projectId,
+    required String sessionId,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) async {
     final row = await _sessionDao.getSession(sessionId: sessionId);
     if (row == null || row.projectId != projectId) return null;
-    return (await _mapCatalogSessions(rows: [row])).single;
+    return (await _mapCatalogSessions(
+      rows: [row],
+      verifiedGithubLogin: verifiedGithubLogin,
+    )).single;
   }
 
   Future<String?> findProjectIdForSession({required String sessionId}) async {
@@ -894,12 +916,18 @@ class SessionRepository {
     );
   }
 
-  Future<List<Session>> enrichSessions({required List<Session> sessions}) async {
+  Future<List<Session>> enrichSessions({
+    required List<Session> sessions,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) async {
     final sessionIds = sessions.map((session) => session.id).toList(growable: false);
 
     final (dbSessions, prsBySessionId) = await (
       _sessionDao.getSessionsByIds(sessionIds: sessionIds),
-      _pullRequestDao.getPrsBySessionIds(sessionIds: sessionIds),
+      _getVisiblePrsBySessionIds(
+        sessionIds: sessionIds,
+        verifiedGithubLogin: verifiedGithubLogin,
+      ),
     ).wait;
 
     final pullRequestsBySessionId = <String, PullRequestInfo>{};
@@ -913,7 +941,10 @@ class SessionRepository {
     return [
       for (final session in sessions)
         enrichSharedSession(
-          session: session,
+          session: session.copyWith(
+            pullRequest: null,
+            pullRequestHistory: const <PullRequestInfo>[],
+          ),
           storedSession: dbSessions[session.id],
           pullRequest: pullRequestsBySessionId[session.id],
           unseenCalculator: _unseenCalculator,
@@ -926,9 +957,15 @@ class SessionRepository {
     ];
   }
 
-  Future<List<Session>> _mapCatalogSessions({required List<SessionDto> rows}) async {
+  Future<List<Session>> _mapCatalogSessions({
+    required List<SessionDto> rows,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) async {
     final sessionIds = [for (final row in rows) row.sessionId];
-    final prsBySessionId = await _pullRequestDao.getPrsBySessionIds(sessionIds: sessionIds);
+    final prsBySessionId = await _getVisiblePrsBySessionIds(
+      sessionIds: sessionIds,
+      verifiedGithubLogin: verifiedGithubLogin,
+    );
     return [
       for (final row in rows)
         _sessionCatalogMapper.map(
@@ -944,6 +981,19 @@ class SessionRepository {
           ),
         ),
     ];
+  }
+
+  Future<Map<String, List<PullRequestDto>>> _getVisiblePrsBySessionIds({
+    required List<String> sessionIds,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) {
+    if (verifiedGithubLogin == null) {
+      return Future.value(<String, List<PullRequestDto>>{});
+    }
+    return _pullRequestDao.getPrsBySessionIds(
+      sessionIds: sessionIds,
+      verifiedGithubLogin: verifiedGithubLogin.login,
+    );
   }
 
   /// Selects the most relevant PR from a list of candidates.
@@ -983,6 +1033,7 @@ class SessionRepository {
     }
     return _mapCatalogSessions(
       rows: await _sessionDao.getChildCatalogSessions(parentSessionId: sessionId),
+      verifiedGithubLogin: null,
     );
   }
 
@@ -1205,7 +1256,10 @@ class SessionRepository {
   Future<Session?> getCatalogSession({required String sessionId}) async {
     final row = await _sessionDao.getSession(sessionId: sessionId);
     if (row == null) return null;
-    return (await _mapCatalogSessions(rows: [row])).single;
+    return (await _mapCatalogSessions(
+      rows: [row],
+      verifiedGithubLogin: null,
+    )).single;
   }
 
   Future<void> archiveStoredSession({

--- a/bridge/app/lib/src/bridge/routing/get_session_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_session_handler.dart
@@ -1,3 +1,6 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../repositories/session_repository.dart";
@@ -8,12 +11,15 @@ import "request_handler.dart";
 class GetSessionHandler extends BodyRequestHandler<SessionIdRequest, Session> {
   final SessionRepository _sessionRepository;
   final PrSyncService _prSyncService;
+  final Duration _identityVerificationTimeout;
 
   GetSessionHandler({
     required SessionRepository sessionRepository,
     required PrSyncService prSyncService,
+    Duration identityVerificationTimeout = const Duration(seconds: 5),
   }) : _sessionRepository = sessionRepository,
        _prSyncService = prSyncService,
+       _identityVerificationTimeout = identityVerificationTimeout,
        super(
          HttpMethod.post,
          "/session/detail",
@@ -38,7 +44,21 @@ class GetSessionHandler extends BodyRequestHandler<SessionIdRequest, Session> {
       throw buildErrorResponse(request, 404, "session not found");
     }
 
-    final verifiedGithubLogin = await _prSyncService.verifyGithubIdentity();
+    final verifiedGithubLogin = await _prSyncService.verifyGithubIdentity().timeout(
+      _identityVerificationTimeout,
+      onTimeout: () {
+        final error = TimeoutException(
+          "GitHub identity verification exceeded ${_identityVerificationTimeout.inSeconds}s",
+          _identityVerificationTimeout,
+        );
+        Log.w(
+          "Session detail identity verification timed out; returning PR-free data",
+          error,
+          StackTrace.current,
+        );
+        return null;
+      },
+    );
     final session = await _sessionRepository.getSessionForProject(
       projectId: projectId,
       sessionId: sessionId,

--- a/bridge/app/lib/src/bridge/routing/get_session_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_session_handler.dart
@@ -1,18 +1,24 @@
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../repositories/session_repository.dart";
+import "../services/pr_sync_service.dart";
 import "request_handler.dart";
 
 /// Handles `POST /session/detail` — returns a single enriched session by ID.
 class GetSessionHandler extends BodyRequestHandler<SessionIdRequest, Session> {
   final SessionRepository _sessionRepository;
+  final PrSyncService _prSyncService;
 
-  GetSessionHandler(this._sessionRepository)
-    : super(
-        HttpMethod.post,
-        "/session/detail",
-        fromJson: SessionIdRequest.fromJson,
-      );
+  GetSessionHandler({
+    required SessionRepository sessionRepository,
+    required PrSyncService prSyncService,
+  }) : _sessionRepository = sessionRepository,
+       _prSyncService = prSyncService,
+       super(
+         HttpMethod.post,
+         "/session/detail",
+         fromJson: SessionIdRequest.fromJson,
+       );
 
   @override
   Future<Session> handle(
@@ -32,9 +38,11 @@ class GetSessionHandler extends BodyRequestHandler<SessionIdRequest, Session> {
       throw buildErrorResponse(request, 404, "session not found");
     }
 
+    final verifiedGithubLogin = await _prSyncService.verifyGithubIdentity();
     final session = await _sessionRepository.getSessionForProject(
       projectId: projectId,
       sessionId: sessionId,
+      verifiedGithubLogin: verifiedGithubLogin,
     );
     if (session == null) {
       throw buildErrorResponse(request, 404, "session not found");

--- a/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
@@ -124,7 +124,7 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
 
       final fallbackDirectory = sessions.firstOrNull?.directory;
       if (fallbackDirectory == null || fallbackDirectory.isEmpty) {
-        return PrRefreshOutcome.completed;
+        return PrRefreshOutcome.failed;
       }
       return await _prSyncService.triggerRefresh(projectId: projectId, projectPath: fallbackDirectory);
     } on Object catch (e, st) {

--- a/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
@@ -48,64 +48,78 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
     final start = body.start;
     final limit = body.limit;
 
-    var sessions = await _sessionRepository.getSessionsForProject(
+    final sessionsWithoutPullRequestData = await _sessionRepository.getSessionsForProject(
       projectId: projectId,
       start: start,
       limit: limit,
+      verifiedGithubLogin: null,
     );
 
+    var sessions = sessionsWithoutPullRequestData;
+    final verifiedGithubLogin = await _prSyncService.verifyGithubIdentity();
     try {
-      sessions = await _sessionRepository.enrichSessions(sessions: sessions);
+      sessions = await _sessionRepository.enrichSessions(
+        sessions: sessions,
+        verifiedGithubLogin: verifiedGithubLogin,
+      );
     } on Object catch (e, st) {
-      Log.w("GetSessionsHandler: post-publication enrichment failed for projectId=$projectId", e, st);
+      Log.w("GetSessionsHandler: post-publication enrichment failed", e, st);
     }
 
     final prRefreshFuture = _triggerPrRefresh(projectId: projectId, sessions: sessions);
 
     if (body.waitForPrData) {
       try {
-        await prRefreshFuture.timeout(_prRefreshTimeout);
+        final refreshOutcome = await prRefreshFuture.timeout(_prRefreshTimeout);
+        if (refreshOutcome == PrRefreshOutcome.failed) {
+          return SessionListResponse(items: sessionsWithoutPullRequestData);
+        }
         // Refresh succeeded within timeout — enrich the already-fetched sessions
         // with updated PR/CI metadata from the database (no extra plugin round-trip).
+        final refreshedGithubLogin = await _prSyncService.verifyGithubIdentity();
         final enrichedSessions = await _sessionRepository.enrichSessions(
           sessions: sessions,
+          verifiedGithubLogin: refreshedGithubLogin,
         );
         return SessionListResponse(items: enrichedSessions);
       } catch (err, st) {
         Log.w(
-          "PR refresh timed out after "
-          "${_prRefreshTimeout.inSeconds}s for $projectId — "
-          "returning current data; SSE will deliver updates when ready",
+          "PR refresh or final identity-gated mapping failed after waiting up to "
+          "${_prRefreshTimeout.inSeconds}s — "
+          "returning sessions without cached PR data; SSE will deliver updates when ready",
           err,
           st,
         );
+        return SessionListResponse(items: sessionsWithoutPullRequestData);
       }
     } else {
-      // Fire-and-forget: PR data will be available for the next request.
+      // COMPATIBILITY 2026-08-01 (v1.6.1): Released clients rely on the
+      // non-waiting request to trigger background PR refresh. Remove this path
+      // only after those client versions are no longer supported.
       unawaited(prRefreshFuture);
     }
 
     return SessionListResponse(items: sessions);
   }
 
-  Future<void> _triggerPrRefresh({
+  Future<PrRefreshOutcome> _triggerPrRefresh({
     required String projectId,
     required List<Session> sessions,
   }) async {
     try {
       final projectPath = await _sessionRepository.getProjectPath(projectId: projectId);
       if (projectPath != null) {
-        await _prSyncService.triggerRefresh(projectId: projectId, projectPath: projectPath);
-        return;
+        return _prSyncService.triggerRefresh(projectId: projectId, projectPath: projectPath);
       }
 
       final fallbackDirectory = sessions.firstOrNull?.directory;
       if (fallbackDirectory == null || fallbackDirectory.isEmpty) {
-        return;
+        return PrRefreshOutcome.completed;
       }
-      await _prSyncService.triggerRefresh(projectId: projectId, projectPath: fallbackDirectory);
+      return _prSyncService.triggerRefresh(projectId: projectId, projectPath: fallbackDirectory);
     } on Object catch (e, st) {
-      Log.w("[GetSessionsHandler] PR refresh trigger failed for $projectId: $e\n$st");
+      Log.w("[GetSessionsHandler] PR refresh trigger failed", e, st);
+      return PrRefreshOutcome.failed;
     }
   }
 }

--- a/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
@@ -55,6 +55,28 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
       verifiedGithubLogin: null,
     );
 
+    try {
+      return await _readIdentityGatedPullRequestData(
+        projectId: projectId,
+        sessionsWithoutPullRequestData: sessionsWithoutPullRequestData,
+        waitForPrData: body.waitForPrData,
+      ).timeout(_prRefreshTimeout);
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        "PR identity-gated read or refresh work failed after waiting up to "
+        "${_prRefreshTimeout.inSeconds}s — returning sessions without cached PR data",
+        error,
+        stackTrace,
+      );
+      return SessionListResponse(items: sessionsWithoutPullRequestData);
+    }
+  }
+
+  Future<SessionListResponse> _readIdentityGatedPullRequestData({
+    required String projectId,
+    required List<Session> sessionsWithoutPullRequestData,
+    required bool waitForPrData,
+  }) async {
     var sessions = sessionsWithoutPullRequestData;
     final verifiedGithubLogin = await _prSyncService.verifyGithubIdentity();
     try {
@@ -62,44 +84,32 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
         sessions: sessions,
         verifiedGithubLogin: verifiedGithubLogin,
       );
-    } on Object catch (e, st) {
-      Log.w("GetSessionsHandler: post-publication enrichment failed", e, st);
+    } on Object catch (error, stackTrace) {
+      Log.w("GetSessionsHandler: post-publication enrichment failed", error, stackTrace);
     }
 
     final prRefreshFuture = _triggerPrRefresh(projectId: projectId, sessions: sessions);
-
-    if (body.waitForPrData) {
-      try {
-        final refreshOutcome = await prRefreshFuture.timeout(_prRefreshTimeout);
-        if (refreshOutcome == PrRefreshOutcome.failed) {
-          return SessionListResponse(items: sessionsWithoutPullRequestData);
-        }
-        // Refresh succeeded within timeout — enrich the already-fetched sessions
-        // with updated PR/CI metadata from the database (no extra plugin round-trip).
-        final refreshedGithubLogin = await _prSyncService.verifyGithubIdentity();
-        final enrichedSessions = await _sessionRepository.enrichSessions(
-          sessions: sessions,
-          verifiedGithubLogin: refreshedGithubLogin,
-        );
-        return SessionListResponse(items: enrichedSessions);
-      } catch (err, st) {
-        Log.w(
-          "PR refresh or final identity-gated mapping failed after waiting up to "
-          "${_prRefreshTimeout.inSeconds}s — "
-          "returning sessions without cached PR data; SSE will deliver updates when ready",
-          err,
-          st,
-        );
-        return SessionListResponse(items: sessionsWithoutPullRequestData);
-      }
-    } else {
+    if (!waitForPrData) {
       // COMPATIBILITY 2026-08-01 (v1.6.1): Released clients rely on the
       // non-waiting request to trigger background PR refresh. Remove this path
       // only after those client versions are no longer supported.
       unawaited(prRefreshFuture);
+      return SessionListResponse(items: sessions);
     }
 
-    return SessionListResponse(items: sessions);
+    final refreshOutcome = await prRefreshFuture;
+    if (refreshOutcome != PrRefreshOutcome.completed) {
+      return SessionListResponse(items: sessionsWithoutPullRequestData);
+    }
+
+    // Refresh succeeded within the shared request deadline. Verify identity
+    // again before mapping updated PR/CI metadata from the database.
+    final refreshedGithubLogin = await _prSyncService.verifyGithubIdentity();
+    final enrichedSessions = await _sessionRepository.enrichSessions(
+      sessions: sessions,
+      verifiedGithubLogin: refreshedGithubLogin,
+    );
+    return SessionListResponse(items: enrichedSessions);
   }
 
   Future<PrRefreshOutcome> _triggerPrRefresh({
@@ -109,14 +119,14 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
     try {
       final projectPath = await _sessionRepository.getProjectPath(projectId: projectId);
       if (projectPath != null) {
-        return _prSyncService.triggerRefresh(projectId: projectId, projectPath: projectPath);
+        return await _prSyncService.triggerRefresh(projectId: projectId, projectPath: projectPath);
       }
 
       final fallbackDirectory = sessions.firstOrNull?.directory;
       if (fallbackDirectory == null || fallbackDirectory.isEmpty) {
         return PrRefreshOutcome.completed;
       }
-      return _prSyncService.triggerRefresh(projectId: projectId, projectPath: fallbackDirectory);
+      return await _prSyncService.triggerRefresh(projectId: projectId, projectPath: fallbackDirectory);
     } on Object catch (e, st) {
       Log.w("[GetSessionsHandler] PR refresh trigger failed", e, st);
       return PrRefreshOutcome.failed;

--- a/bridge/app/lib/src/bridge/services/pr_sync_service.dart
+++ b/bridge/app/lib/src/bridge/services/pr_sync_service.dart
@@ -9,7 +9,7 @@ import "../repositories/pr_source_repository.dart";
 import "../repositories/pull_request_repository.dart";
 import "../repositories/session_repository.dart";
 
-enum PrRefreshOutcome { completed, failed }
+enum PrRefreshOutcome { completed, inProgress, failed }
 
 class PrSyncService {
   final PrSourceRepository _prSource;
@@ -73,7 +73,7 @@ class PrSyncService {
 
   Future<PrRefreshOutcome> triggerRefresh({required String projectId, required String projectPath}) async {
     if (_activeRefreshes.contains(projectId)) {
-      return PrRefreshOutcome.completed;
+      return PrRefreshOutcome.inProgress;
     }
 
     final lastRefreshAt = _lastRefreshTimes[projectId];

--- a/bridge/app/lib/src/bridge/services/pr_sync_service.dart
+++ b/bridge/app/lib/src/bridge/services/pr_sync_service.dart
@@ -9,6 +9,8 @@ import "../repositories/pr_source_repository.dart";
 import "../repositories/pull_request_repository.dart";
 import "../repositories/session_repository.dart";
 
+enum PrRefreshOutcome { completed, failed }
+
 class PrSyncService {
   final PrSourceRepository _prSource;
   final PullRequestRepository _pullRequestRepository;
@@ -39,7 +41,7 @@ class PrSyncService {
 
   Stream<String> get prChanges => _prChangesController.stream;
 
-  Future<VerifiedGithubLogin?> _verifyGithubIdentity() async {
+  Future<VerifiedGithubLogin?> verifyGithubIdentity() async {
     try {
       final identity = await _prSource.getAuthenticatedIdentity();
       if (identity == null) {
@@ -69,14 +71,14 @@ class PrSyncService {
     );
   }
 
-  Future<void> triggerRefresh({required String projectId, required String projectPath}) async {
+  Future<PrRefreshOutcome> triggerRefresh({required String projectId, required String projectPath}) async {
     if (_activeRefreshes.contains(projectId)) {
-      return;
+      return PrRefreshOutcome.completed;
     }
 
     final lastRefreshAt = _lastRefreshTimes[projectId];
     if (lastRefreshAt != null && _clock.now().difference(lastRefreshAt) < _debounceWindow) {
-      return;
+      return PrRefreshOutcome.completed;
     }
 
     // Claim the project before the first async gap so concurrent requests for
@@ -84,7 +86,7 @@ class PrSyncService {
     _activeRefreshes.add(projectId);
     try {
       if (!await _hasGithubCliCapability()) {
-        return;
+        return PrRefreshOutcome.failed;
       }
 
       final githubRepositoryIdentity = await _prSource.getGithubRepositoryIdentity(
@@ -101,12 +103,12 @@ class PrSyncService {
           _prChangesController.add(projectId);
         }
         _lastRefreshTimes[projectId] = _clock.now();
-        return;
+        return PrRefreshOutcome.completed;
       }
 
-      final verifiedGithubLogin = await _verifyGithubIdentity();
+      final verifiedGithubLogin = await verifyGithubIdentity();
       if (verifiedGithubLogin == null) {
-        return;
+        return PrRefreshOutcome.failed;
       }
 
       final storedSessions = await _sessionRepository.getStoredSessionsByProjectId(
@@ -122,7 +124,7 @@ class PrSyncService {
         _prChangesController.add(projectId);
       }
 
-      await _refresh(
+      return await _refresh(
         projectId: projectId,
         projectPath: projectPath,
         githubRepositoryIdentity: githubRepositoryIdentity,
@@ -161,7 +163,7 @@ class PrSyncService {
     return capable;
   }
 
-  Future<void> _refresh({
+  Future<PrRefreshOutcome> _refresh({
     required String projectId,
     required String projectPath,
     required String githubRepositoryIdentity,
@@ -250,8 +252,10 @@ class PrSyncService {
       }
 
       completed = true;
+      return PrRefreshOutcome.completed;
     } catch (e, st) {
-      Log.e("[PrSync] refresh failed for $projectId: $e\n$st");
+      Log.e("[PrSync] refresh failed", e, st);
+      return PrRefreshOutcome.failed;
     } finally {
       if (hasChanges) {
         _prChangesController.add(projectId);

--- a/bridge/app/lib/src/bridge/services/session_creation_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_creation_service.dart
@@ -92,6 +92,7 @@ class SessionCreationService {
     // phone and the bridge key on — mirroring project-scoped session fetches.
     return _sessionRepository.enrichSession(
       session: finalSession.copyWith(projectID: request.projectId),
+      verifiedGithubLogin: null,
     );
   }
 

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -228,10 +228,7 @@ void main() {
 
       expect(firstEvent["type"], equals("session.created"));
       expect(secondEvent["type"], equals("session.diff"));
-      expect(
-        ((firstEvent["info"] as Map<String, dynamic>)["pullRequest"] as Map<String, dynamic>)["number"],
-        equals(11),
-      );
+      expect((firstEvent["info"] as Map<String, dynamic>)["pullRequest"], isNull);
     });
 
     test("debug client disconnect does not tear down the orchestrator plugin listeners", () async {

--- a/bridge/app/test/bridge/persistence/pull_request_dao_test.dart
+++ b/bridge/app/test/bridge/persistence/pull_request_dao_test.dart
@@ -176,6 +176,7 @@ void main() {
 
       final result = await dao.getPrsBySessionIds(
         sessionIds: ["session-1"],
+        verifiedGithubLogin: githubLogin,
       );
       expect(result["session-1"]?.map((pr) => pr.prNumber), unorderedEquals([100, 101]));
     });
@@ -215,8 +216,15 @@ void main() {
 
       final matchingAccount = await dao.getPrsBySessionIds(
         sessionIds: ["session-1"],
+        verifiedGithubLogin: githubLogin,
       );
       expect(matchingAccount["session-1"]?.map((pr) => pr.prNumber), [100]);
+
+      final unverifiedSwitch = await dao.getPrsBySessionIds(
+        sessionIds: ["session-1"],
+        verifiedGithubLogin: "hubot",
+      );
+      expect(unverifiedSwitch, isEmpty);
 
       await db.projectsDao.setPrCacheGithubLogin(
         projectId: "proj-1",
@@ -224,6 +232,7 @@ void main() {
       );
       final switchedAccount = await dao.getPrsBySessionIds(
         sessionIds: ["session-1"],
+        verifiedGithubLogin: "hubot",
       );
       expect(switchedAccount["session-1"]?.map((pr) => pr.prNumber), [102]);
     });

--- a/bridge/app/test/bridge/repositories/session_repository_persistence_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_persistence_test.dart
@@ -37,16 +37,19 @@ void main() {
         projectId: "project-X",
         start: 0,
         limit: 2,
+        verifiedGithubLogin: null,
       );
       final unboundedTail = await repository.getSessionsForProject(
         projectId: "project-X",
         start: 1,
         limit: null,
+        verifiedGithubLogin: null,
       );
       final zeroLimit = await repository.getSessionsForProject(
         projectId: "project-X",
         start: 0,
         limit: 0,
+        verifiedGithubLogin: null,
       );
 
       expect(firstPage.map((session) => session.id), ["root-c", "root-b"]);
@@ -77,10 +80,12 @@ void main() {
         projectId: "project-X",
         start: null,
         limit: null,
+        verifiedGithubLogin: null,
       );
       final detail = await repository.getSessionForProject(
         projectId: "project-X",
         sessionId: "stable-id",
+        verifiedGithubLogin: null,
       );
 
       expect(listed.single.id, "stable-id");
@@ -124,10 +129,19 @@ void main() {
       await _insertRoot(database: database, sessionId: "root", updatedAt: 1);
 
       final roots = await repository
-          .getSessionsForProject(projectId: "project-X", start: null, limit: null)
+          .getSessionsForProject(
+            projectId: "project-X",
+            start: null,
+            limit: null,
+            verifiedGithubLogin: null,
+          )
           .timeout(const Duration(seconds: 1));
       final detail = await repository
-          .getSessionForProject(projectId: "project-X", sessionId: "root")
+          .getSessionForProject(
+            projectId: "project-X",
+            sessionId: "root",
+            verifiedGithubLogin: null,
+          )
           .timeout(const Duration(seconds: 1));
       final children = await repository.getChildSessions(sessionId: "root").timeout(const Duration(seconds: 1));
 
@@ -142,11 +156,20 @@ void main() {
       addTearDown(repository.dispose);
 
       await expectLater(
-        repository.getSessionsForProject(projectId: "missing", start: null, limit: null),
+        repository.getSessionsForProject(
+          projectId: "missing",
+          start: null,
+          limit: null,
+          verifiedGithubLogin: null,
+        ),
         throwsA(isA<ProjectNotFoundException>()),
       );
       expect(
-        await repository.getSessionForProject(projectId: "project-X", sessionId: "missing"),
+        await repository.getSessionForProject(
+          projectId: "project-X",
+          sessionId: "missing",
+          verifiedGithubLogin: null,
+        ),
         isNull,
       );
       await expectLater(

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -7,6 +7,7 @@ import "package:sesori_bridge/src/api/database/tables/projects_table.dart";
 import "package:sesori_bridge/src/api/database/tables/pull_requests_table.dart";
 import "package:sesori_bridge/src/api/database/tables/session_table.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/project_not_found_exception.dart";
+import "package:sesori_bridge/src/bridge/repositories/models/verified_github_login.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/repositories/project_catalog_identity_calculator.dart";
@@ -16,6 +17,9 @@ import "package:test/test.dart";
 
 import "../../helpers/plugin_runtime_test_support.dart";
 import "../../helpers/test_database.dart";
+
+final _octocatLogin = VerifiedGithubLogin.tryParse(rawLogin: "octocat")!;
+final _hubotLogin = VerifiedGithubLogin.tryParse(rawLogin: "hubot")!;
 
 void main() {
   group("SessionRepository", () {
@@ -311,6 +315,7 @@ void main() {
           pullRequest: null,
           promptDefaults: null,
         ),
+        verifiedGithubLogin: _octocatLogin,
       );
 
       expect(result.time?.created, equals(1));
@@ -370,10 +375,64 @@ void main() {
           pullRequest: null,
           promptDefaults: null,
         ),
+        verifiedGithubLogin: null,
       );
 
       expect(result.promptDefaults, isNull);
       expect(result.hasWorktree, isFalse);
+    });
+
+    test("enrichSessions clears incoming PR data without a freshly visible selection", () async {
+      final db = createTestDatabase();
+      addTearDown(db.close);
+      final repository = singlePluginSessionRepository(
+        plugin: plugin,
+        sessionDao: db.sessionDao,
+        projectsDao: db.projectsDao,
+        pullRequestDao: db.pullRequestDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+      );
+      const staleSession = Session(
+        branchName: "feature/private",
+        id: "stale-session",
+        pluginId: "fake",
+        projectID: "p1",
+        directory: "/tmp/project",
+        parentID: null,
+        title: "Session",
+        time: null,
+        pullRequest: PullRequestInfo(
+          number: 17,
+          url: "https://github.com/org/repo/pull/17",
+          title: "Stale PR",
+          state: PrState.open,
+          mergeableStatus: PrMergeableStatus.mergeable,
+          reviewDecision: PrReviewDecision.approved,
+          checkStatus: PrCheckStatus.success,
+        ),
+        pullRequestHistory: [
+          PullRequestInfo(
+            number: 16,
+            url: "https://github.com/org/repo/pull/16",
+            title: "Stale history",
+            state: PrState.merged,
+            mergeableStatus: PrMergeableStatus.unknown,
+            reviewDecision: PrReviewDecision.approved,
+            checkStatus: PrCheckStatus.success,
+          ),
+        ],
+        promptDefaults: null,
+      );
+
+      for (final verifiedGithubLogin in <VerifiedGithubLogin?>[null, _hubotLogin]) {
+        final result = await repository.enrichSessions(
+          sessions: const [staleSession],
+          verifiedGithubLogin: verifiedGithubLogin,
+        );
+
+        expect(result.single.pullRequest, isNull);
+        expect(result.single.pullRequestHistory, isEmpty);
+      }
     });
 
     test("enrichSessions applies stored data only to matching sessions", () async {
@@ -469,6 +528,7 @@ void main() {
             promptDefaults: null,
           ),
         ],
+        verifiedGithubLogin: _octocatLogin,
       );
 
       expect(result, hasLength(2));
@@ -554,6 +614,7 @@ void main() {
             promptDefaults: null,
           ),
         ],
+        verifiedGithubLogin: null,
       );
 
       expect(result[0].projectID, "native-reported-project");
@@ -1063,6 +1124,7 @@ void main() {
           projectId: "/projects/a",
           start: null,
           limit: null,
+          verifiedGithubLogin: null,
         );
         final binding = await db.sessionDao.getSession(sessionId: "stable-live");
 
@@ -1750,7 +1812,12 @@ void main() {
       );
       await recordWorktreeSession(db, parent: parent, worktree: worktree, sessionId: "w1");
 
-      final sessions = await repository.getSessionsForProject(projectId: parent, start: null, limit: null);
+      final sessions = await repository.getSessionsForProject(
+        projectId: parent,
+        start: null,
+        limit: null,
+        verifiedGithubLogin: null,
+      );
 
       expect(sessions.map((s) => s.id).toSet(), {"w1"});
       // Enrichment adopts the stored attribution as projectID (the plugin
@@ -2016,7 +2083,12 @@ void main() {
 
       // The next enumeration keeps serving the rename, not the backend's
       // auto-title: the stored copy wins for derived plugins.
-      final sessions = await repository.getSessionsForProject(projectId: parent, start: null, limit: null);
+      final sessions = await repository.getSessionsForProject(
+        projectId: parent,
+        start: null,
+        limit: null,
+        verifiedGithubLogin: null,
+      );
       expect(sessions.single.title, "My rename");
       expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "My rename");
     });
@@ -2141,6 +2213,7 @@ void main() {
       final childDetail = await repository.getSessionForProject(
         projectId: "/repo",
         sessionId: "stable-child",
+        verifiedGithubLogin: null,
       );
       expect(childDetail?.id, "stable-child");
       expect(childDetail?.parentID, "stable-parent");
@@ -2148,6 +2221,7 @@ void main() {
         await repository.getSessionForProject(
           projectId: "/other",
           sessionId: "stable-child",
+          verifiedGithubLogin: null,
         ),
         isNull,
       );
@@ -2243,7 +2317,12 @@ void main() {
       );
       await db.projectsDao.insertProjectsIfMissing(projectIds: [parent]);
 
-      final sessions = await repository.getSessionsForProject(projectId: parent, start: null, limit: null);
+      final sessions = await repository.getSessionsForProject(
+        projectId: parent,
+        start: null,
+        limit: null,
+        verifiedGithubLogin: null,
+      );
       expect(sessions, isEmpty);
 
       expect(await repository.findProjectIdForSession(sessionId: "deleted-s"), isNull);
@@ -2271,7 +2350,12 @@ void main() {
       await recordWorktreeSession(db, parent: parent, worktree: worktree, sessionId: "w1");
 
       await expectLater(
-        repository.getSessionsForProject(projectId: worktree, start: null, limit: null),
+        repository.getSessionsForProject(
+          projectId: worktree,
+          start: null,
+          limit: null,
+          verifiedGithubLogin: null,
+        ),
         throwsA(isA<ProjectNotFoundException>()),
       );
     });

--- a/bridge/app/test/bridge/routing/catalog_read_handlers_test.dart
+++ b/bridge/app/test/bridge/routing/catalog_read_handlers_test.dart
@@ -177,6 +177,59 @@ void main() {
       expect(plugin.calls, 0);
     });
 
+    test("session detail bounds identity verification and returns PR-free data", () async {
+      await database.projectsDao.setPrCacheGithubLogin(
+        projectId: "project",
+        githubLogin: "octocat",
+      );
+      await database.sessionDao.updatePullRequestScopes(
+        updates: const [
+          (
+            sessionId: "root",
+            currentBranchName: "feature/private",
+            currentGithubRepositoryIdentity: "org/repo",
+          ),
+        ],
+      );
+      await database.pullRequestDao.upsertPr(
+        pullRequest: const PullRequestDto(
+          projectId: "project",
+          githubRepositoryIdentity: "org/repo",
+          githubLogin: "octocat",
+          prNumber: 45,
+          branchName: "feature/private",
+          url: "https://github.com/org/repo/pull/45",
+          title: "Private PR",
+          state: PrState.open,
+          mergeableStatus: PrMergeableStatus.mergeable,
+          reviewDecision: PrReviewDecision.approved,
+          checkStatus: PrCheckStatus.success,
+          lastCheckedAt: 1,
+          createdAt: 1,
+        ),
+      );
+      final detailHandler = GetSessionHandler(
+        sessionRepository: repository,
+        prSyncService: FakePrSyncService(
+          identityVerificationDelays: const [Duration(milliseconds: 100)],
+        ),
+        identityVerificationTimeout: const Duration(milliseconds: 10),
+      );
+
+      final detail = await detailHandler.handle(
+        makeRequest("POST", "/session/detail"),
+        body: const SessionIdRequest(sessionId: "root"),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(detail.id, "root");
+      expect(detail.pullRequest, isNull);
+      expect(detail.pullRequestHistory, isEmpty);
+      await Future<void>.delayed(const Duration(milliseconds: 110));
+    });
+
     test("unknown detail and parent ids remain 404s without plugin calls", () async {
       final detailHandler = GetSessionHandler(
         sessionRepository: repository,

--- a/bridge/app/test/bridge/routing/catalog_read_handlers_test.dart
+++ b/bridge/app/test/bridge/routing/catalog_read_handlers_test.dart
@@ -2,6 +2,8 @@ import "dart:async";
 import "dart:convert";
 
 import "package:sesori_bridge/src/api/database/database.dart";
+import "package:sesori_bridge/src/api/database/tables/pull_requests_table.dart";
+import "package:sesori_bridge/src/bridge/repositories/models/verified_github_login.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/routing/get_child_sessions_handler.dart";
@@ -76,7 +78,10 @@ void main() {
         sessionRepository: repository,
         prSyncService: FakePrSyncService(),
       );
-      final detailHandler = GetSessionHandler(repository);
+      final detailHandler = GetSessionHandler(
+        sessionRepository: repository,
+        prSyncService: FakePrSyncService(),
+      );
       final childrenHandler = GetChildSessionsHandler(sessionRepository: repository);
 
       final roots = await sessionsHandler
@@ -113,8 +118,70 @@ void main() {
       expect(plugin.calls, 0);
     });
 
+    test("session detail gates cached PR metadata with a fresh identity", () async {
+      await database.projectsDao.setPrCacheGithubLogin(
+        projectId: "project",
+        githubLogin: "octocat",
+      );
+      await database.sessionDao.updatePullRequestScopes(
+        updates: const [
+          (
+            sessionId: "root",
+            currentBranchName: "feature/private",
+            currentGithubRepositoryIdentity: "org/repo",
+          ),
+        ],
+      );
+      await database.pullRequestDao.upsertPr(
+        pullRequest: const PullRequestDto(
+          projectId: "project",
+          githubRepositoryIdentity: "org/repo",
+          githubLogin: "octocat",
+          prNumber: 44,
+          branchName: "feature/private",
+          url: "https://github.com/org/repo/pull/44",
+          title: "Private PR",
+          state: PrState.open,
+          mergeableStatus: PrMergeableStatus.mergeable,
+          reviewDecision: PrReviewDecision.approved,
+          checkStatus: PrCheckStatus.success,
+          lastCheckedAt: 1,
+          createdAt: 1,
+        ),
+      );
+      final prSyncService = FakePrSyncService();
+      final detailHandler = GetSessionHandler(
+        sessionRepository: repository,
+        prSyncService: prSyncService,
+      );
+
+      Future<Session> readDetail() {
+        return detailHandler.handle(
+          makeRequest("POST", "/session/detail"),
+          body: const SessionIdRequest(sessionId: "root"),
+          pathParams: {},
+          queryParams: {},
+          fragment: null,
+        );
+      }
+
+      final matching = await readDetail();
+      prSyncService.verifiedGithubLogin = VerifiedGithubLogin.tryParse(rawLogin: "hubot");
+      final switched = await readDetail();
+      prSyncService.verifiedGithubLogin = null;
+      final unknown = await readDetail();
+
+      expect(matching.pullRequest?.number, 44);
+      expect(switched.pullRequest, isNull);
+      expect(unknown.pullRequest, isNull);
+      expect(plugin.calls, 0);
+    });
+
     test("unknown detail and parent ids remain 404s without plugin calls", () async {
-      final detailHandler = GetSessionHandler(repository);
+      final detailHandler = GetSessionHandler(
+        sessionRepository: repository,
+        prSyncService: FakePrSyncService(),
+      );
       final childrenHandler = GetChildSessionsHandler(sessionRepository: repository);
 
       final detail = await detailHandler.handleInternal(

--- a/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
@@ -993,6 +993,57 @@ void main() {
       expect(prSyncService.calls.single, equals((projectId: "project-1", projectPath: "/tmp/project")));
     });
 
+    test("bounds initial identity verification and returns PR-free sessions", () async {
+      plugin.sessionsResult = const [
+        PluginSession(
+          id: "s1",
+          projectID: "p1",
+          directory: "/tmp",
+          parentID: null,
+          title: "session one",
+          time: null,
+        ),
+      ];
+      pullRequestRepository.setPr(
+        sessionId: "s1",
+        pullRequest: const PullRequestDto(
+          projectId: "p1",
+          githubRepositoryIdentity: "org/repo",
+          githubLogin: "octocat",
+          prNumber: 97,
+          branchName: "feature/slow-identity",
+          url: "https://github.com/org/repo/pull/97",
+          title: "Slow identity PR",
+          state: PrState.open,
+          mergeableStatus: PrMergeableStatus.mergeable,
+          reviewDecision: PrReviewDecision.approved,
+          checkStatus: PrCheckStatus.success,
+          lastCheckedAt: 1,
+          createdAt: 1,
+        ),
+      );
+      final slowIdentityService = FakePrSyncService(
+        identityVerificationDelays: const [Duration(milliseconds: 100)],
+      );
+      final boundedHandler = GetSessionsHandler(
+        sessionRepository: sessionRepository,
+        prSyncService: slowIdentityService,
+        prRefreshTimeout: const Duration(milliseconds: 10),
+      );
+
+      final result = await boundedHandler.handle(
+        makeRequest("POST", "/sessions"),
+        body: const SessionListRequest(projectId: "p1", start: null, limit: null),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(result.items.single.pullRequest, isNull);
+      expect(result.items.single.pullRequestHistory, isEmpty);
+      await Future<void>.delayed(const Duration(milliseconds: 110));
+    });
+
     test("triggers PR refresh with the stored catalog project path", () async {
       sessionRepository.projectPathResult = "/tmp/project";
       await handler.handle(
@@ -1115,6 +1166,134 @@ void main() {
       final failingHandler = GetSessionsHandler(
         sessionRepository: sessionRepository,
         prSyncService: FakePrSyncService(refreshOutcome: PrRefreshOutcome.failed),
+      );
+
+      final result = await failingHandler.handle(
+        makeRequest("POST", "/sessions"),
+        body: const SessionListRequest(projectId: "p1", start: null, limit: null, waitForPrData: true),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(result.items.single.pullRequest, isNull);
+      expect(result.items.single.pullRequestHistory, isEmpty);
+    });
+
+    test("strips cached PR metadata when another refresh is in progress", () async {
+      plugin.sessionsResult = const [
+        PluginSession(
+          id: "s1",
+          projectID: "p1",
+          directory: "/tmp",
+          parentID: null,
+          title: "session one",
+          time: null,
+        ),
+      ];
+      pullRequestRepository.setPr(
+        sessionId: "s1",
+        pullRequest: const PullRequestDto(
+          projectId: "p1",
+          githubRepositoryIdentity: "org/repo",
+          githubLogin: "octocat",
+          prNumber: 101,
+          branchName: "feature/in-progress",
+          url: "https://github.com/org/repo/pull/101",
+          title: "In-progress refresh PR",
+          state: PrState.open,
+          mergeableStatus: PrMergeableStatus.mergeable,
+          reviewDecision: PrReviewDecision.approved,
+          checkStatus: PrCheckStatus.success,
+          lastCheckedAt: 1,
+          createdAt: 1,
+        ),
+      );
+      final inProgressHandler = GetSessionsHandler(
+        sessionRepository: sessionRepository,
+        prSyncService: FakePrSyncService(refreshOutcome: PrRefreshOutcome.inProgress),
+      );
+
+      final result = await inProgressHandler.handle(
+        makeRequest("POST", "/sessions"),
+        body: const SessionListRequest(projectId: "p1", start: null, limit: null, waitForPrData: true),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(result.items.single.pullRequest, isNull);
+      expect(result.items.single.pullRequestHistory, isEmpty);
+    });
+
+    test("keeps final identity verification inside the waited deadline", () async {
+      plugin.sessionsResult = const [
+        PluginSession(
+          id: "s1",
+          projectID: "p1",
+          directory: "/tmp",
+          parentID: null,
+          title: "session one",
+          time: null,
+        ),
+      ];
+      pullRequestRepository.setPr(
+        sessionId: "s1",
+        pullRequest: const PullRequestDto(
+          projectId: "p1",
+          githubRepositoryIdentity: "org/repo",
+          githubLogin: "octocat",
+          prNumber: 102,
+          branchName: "feature/final-identity",
+          url: "https://github.com/org/repo/pull/102",
+          title: "Final identity PR",
+          state: PrState.open,
+          mergeableStatus: PrMergeableStatus.mergeable,
+          reviewDecision: PrReviewDecision.approved,
+          checkStatus: PrCheckStatus.success,
+          lastCheckedAt: 1,
+          createdAt: 1,
+        ),
+      );
+      final slowFinalIdentityService = FakePrSyncService(
+        identityVerificationDelays: const [
+          Duration.zero,
+          Duration(milliseconds: 100),
+        ],
+      );
+      final boundedHandler = GetSessionsHandler(
+        sessionRepository: sessionRepository,
+        prSyncService: slowFinalIdentityService,
+        prRefreshTimeout: const Duration(milliseconds: 10),
+      );
+
+      final result = await boundedHandler.handle(
+        makeRequest("POST", "/sessions"),
+        body: const SessionListRequest(projectId: "p1", start: null, limit: null, waitForPrData: true),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(result.items.single.pullRequest, isNull);
+      expect(result.items.single.pullRequestHistory, isEmpty);
+      await Future<void>.delayed(const Duration(milliseconds: 110));
+    });
+
+    test("converts asynchronous refresh errors to a PR-free response", () async {
+      plugin.sessionsResult = const [
+        PluginSession(
+          id: "s1",
+          projectID: "p1",
+          directory: "/tmp",
+          parentID: null,
+          title: "session one",
+          time: null,
+        ),
+      ];
+      final failingHandler = GetSessionsHandler(
+        sessionRepository: sessionRepository,
+        prSyncService: FakePrSyncService(refreshError: StateError("refresh failed")),
       );
 
       final result = await failingHandler.handle(

--- a/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
@@ -3,8 +3,10 @@ import "dart:convert";
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/api/database/tables/pull_requests_table.dart";
 import "package:sesori_bridge/src/api/database/tables/session_table.dart";
+import "package:sesori_bridge/src/bridge/repositories/models/verified_github_login.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/routing/get_sessions_handler.dart";
+import "package:sesori_bridge/src/bridge/services/pr_sync_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -734,6 +736,66 @@ void main() {
       expect(pr?.checkStatus, equals(PrCheckStatus.success));
     });
 
+    test("fresh identity changes hide another login's cached PR", () async {
+      plugin.sessionsResult = const [
+        PluginSession(
+          id: "s1",
+          projectID: "p1",
+          directory: "/tmp",
+          parentID: null,
+          title: "session with private PR",
+          time: null,
+        ),
+      ];
+      pullRequestRepository.setPr(
+        sessionId: "s1",
+        pullRequest: const PullRequestDto(
+          projectId: "p1",
+          githubRepositoryIdentity: "org/repo",
+          githubLogin: "octocat",
+          prNumber: 43,
+          branchName: "feature/private",
+          url: "https://github.com/org/repo/pull/43",
+          title: "Private PR",
+          state: PrState.open,
+          mergeableStatus: PrMergeableStatus.mergeable,
+          reviewDecision: PrReviewDecision.approved,
+          checkStatus: PrCheckStatus.success,
+          lastCheckedAt: 1,
+          createdAt: 1,
+        ),
+      );
+
+      final first = await handler.handle(
+        makeRequest("POST", "/sessions"),
+        body: const SessionListRequest(projectId: "p1", start: null, limit: null),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+      prSyncService.verifiedGithubLogin = VerifiedGithubLogin.tryParse(rawLogin: "hubot");
+      final switched = await handler.handle(
+        makeRequest("POST", "/sessions"),
+        body: const SessionListRequest(projectId: "p1", start: null, limit: null),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+      prSyncService.verifiedGithubLogin = null;
+      final unknown = await handler.handle(
+        makeRequest("POST", "/sessions"),
+        body: const SessionListRequest(projectId: "p1", start: null, limit: null),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(first.items.single.pullRequest?.number, 43);
+      expect(switched.items.single.pullRequest, isNull);
+      expect(unknown.items.single.pullRequest, isNull);
+      expect(prSyncService.identityVerificationCallCount, 3);
+    });
+
     test("reads catalog fields while preserving stored worktree and pull request metadata", () async {
       final realRepository = singlePluginSessionRepository(
         plugin: plugin,
@@ -970,7 +1032,7 @@ void main() {
       expect(prSyncService.calls.single, equals((projectId: "project-1", projectPath: "/tmp/fallback-project")));
     });
 
-    test("returns original sessions when PR refresh times out", () async {
+    test("returns sessions without cached PR metadata when a waited refresh times out", () async {
       plugin.sessionsResult = const [
         PluginSession(
           id: "s1",
@@ -981,6 +1043,24 @@ void main() {
           time: null,
         ),
       ];
+      pullRequestRepository.setPr(
+        sessionId: "s1",
+        pullRequest: const PullRequestDto(
+          projectId: "p1",
+          githubRepositoryIdentity: "org/repo",
+          githubLogin: "octocat",
+          prNumber: 98,
+          branchName: "feature/timeout",
+          url: "https://github.com/org/repo/pull/98",
+          title: "Timed out PR",
+          state: PrState.open,
+          mergeableStatus: PrMergeableStatus.mergeable,
+          reviewDecision: PrReviewDecision.approved,
+          checkStatus: PrCheckStatus.success,
+          lastCheckedAt: 1,
+          createdAt: 1,
+        ),
+      );
       final slowPrSyncService = FakePrSyncService(delay: const Duration(seconds: 10));
       final timeoutHandler = GetSessionsHandler(
         sessionRepository: sessionRepository,
@@ -998,7 +1078,55 @@ void main() {
 
       expect(result.items, hasLength(1));
       expect(result.items.single.title, equals("session one"));
+      expect(result.items.single.pullRequest, isNull);
+      expect(result.items.single.pullRequestHistory, isEmpty);
       expect(sessionRepository.getSessionsCallCount, equals(1));
+    });
+
+    test("strips cached PR metadata when a waited refresh fails", () async {
+      plugin.sessionsResult = const [
+        PluginSession(
+          id: "s1",
+          projectID: "p1",
+          directory: "/tmp",
+          parentID: null,
+          title: "session one",
+          time: null,
+        ),
+      ];
+      pullRequestRepository.setPr(
+        sessionId: "s1",
+        pullRequest: const PullRequestDto(
+          projectId: "p1",
+          githubRepositoryIdentity: "org/repo",
+          githubLogin: "octocat",
+          prNumber: 100,
+          branchName: "feature/failed-refresh",
+          url: "https://github.com/org/repo/pull/100",
+          title: "Stale PR",
+          state: PrState.open,
+          mergeableStatus: PrMergeableStatus.mergeable,
+          reviewDecision: PrReviewDecision.approved,
+          checkStatus: PrCheckStatus.success,
+          lastCheckedAt: 1,
+          createdAt: 1,
+        ),
+      );
+      final failingHandler = GetSessionsHandler(
+        sessionRepository: sessionRepository,
+        prSyncService: FakePrSyncService(refreshOutcome: PrRefreshOutcome.failed),
+      );
+
+      final result = await failingHandler.handle(
+        makeRequest("POST", "/sessions"),
+        body: const SessionListRequest(projectId: "p1", start: null, limit: null, waitForPrData: true),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(result.items.single.pullRequest, isNull);
+      expect(result.items.single.pullRequestHistory, isEmpty);
     });
 
     test("enriches sessions when PR refresh succeeds within timeout", () async {

--- a/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
@@ -1226,6 +1226,48 @@ void main() {
       expect(result.items.single.pullRequestHistory, isEmpty);
     });
 
+    test("strips cached PR metadata when no refresh source is available", () async {
+      plugin.sessionsResult = const [
+        PluginSession(
+          id: "s1",
+          projectID: "p1",
+          directory: "",
+          parentID: null,
+          title: "session one",
+          time: null,
+        ),
+      ];
+      pullRequestRepository.setPr(
+        sessionId: "s1",
+        pullRequest: const PullRequestDto(
+          projectId: "p1",
+          githubRepositoryIdentity: "org/repo",
+          githubLogin: "octocat",
+          prNumber: 103,
+          branchName: "feature/no-source",
+          url: "https://github.com/org/repo/pull/103",
+          title: "Unavailable refresh source PR",
+          state: PrState.open,
+          mergeableStatus: PrMergeableStatus.mergeable,
+          reviewDecision: PrReviewDecision.approved,
+          checkStatus: PrCheckStatus.success,
+          lastCheckedAt: 1,
+          createdAt: 1,
+        ),
+      );
+
+      final result = await handler.handle(
+        makeRequest("POST", "/sessions"),
+        body: const SessionListRequest(projectId: "p1", start: null, limit: null, waitForPrData: true),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(result.items.single.pullRequest, isNull);
+      expect(result.items.single.pullRequestHistory, isEmpty);
+    });
+
     test("keeps final identity verification inside the waited deadline", () async {
       plugin.sessionsResult = const [
         PluginSession(

--- a/bridge/app/test/bridge/routing/rename_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/rename_session_handler_test.dart
@@ -94,7 +94,7 @@ void main() {
       expect(plugin.lastRenameSessionTitle, equals("New Title"));
     });
 
-    test("returns the authoritative catalog Session", () async {
+    test("returns the authoritative catalog Session without ungated PR metadata", () async {
       await db.projectsDao.insertProjectsIfMissing(projectIds: ["p1"]);
       await db.sessionDao.insertSession(
         pluginId: "fake",
@@ -167,8 +167,7 @@ void main() {
       expect(result.time?.created, equals(1));
       expect(result.time?.updated, greaterThan(1));
       expect(result.time?.archived, isNull);
-      expect(result.pullRequest?.number, equals(13));
-      expect(result.pullRequest?.title, equals("Rename PR"));
+      expect(result.pullRequest, isNull);
       await sessionMutationDispatcher.dispose();
       expect(plugin.lastRenameSessionId, equals("backend-s1"));
     });

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -682,6 +682,7 @@ class FakePrSyncService extends PrSyncService {
   final Duration? delay;
   final Object? refreshError;
   final PrRefreshOutcome refreshOutcome;
+  final List<Duration> identityVerificationDelays;
   VerifiedGithubLogin? verifiedGithubLogin;
   int identityVerificationCallCount = 0;
 
@@ -689,6 +690,7 @@ class FakePrSyncService extends PrSyncService {
     this.delay,
     this.refreshError,
     this.refreshOutcome = PrRefreshOutcome.completed,
+    this.identityVerificationDelays = const <Duration>[],
     VerifiedGithubLogin? verifiedGithubLogin,
     PrSourceRepository? prSource,
     PullRequestRepository? pullRequestRepository,
@@ -716,6 +718,10 @@ class FakePrSyncService extends PrSyncService {
   @override
   Future<VerifiedGithubLogin?> verifyGithubIdentity() async {
     identityVerificationCallCount++;
+    final delayIndex = identityVerificationCallCount - 1;
+    if (delayIndex < identityVerificationDelays.length) {
+      await Future<void>.delayed(identityVerificationDelays[delayIndex]);
+    }
     return verifiedGithubLogin;
   }
 }

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -548,11 +548,15 @@ class FakePullRequestRepository implements PullRequestRepository {
         pullRequest;
   }
 
-  @override
-  Future<Map<String, List<PullRequestDto>>> getPrsBySessionIds({required List<String> sessionIds}) async {
+  Future<Map<String, List<PullRequestDto>>> getPrsBySessionIds({
+    required List<String> sessionIds,
+    required VerifiedGithubLogin verifiedGithubLogin,
+  }) async {
     return <String, List<PullRequestDto>>{
       for (final sessionId in sessionIds)
-        if (_prsBySessionId.containsKey(sessionId)) sessionId: _prsBySessionId[sessionId]!,
+        if (_prsBySessionId[sessionId]?.where((pr) => pr.githubLogin == verifiedGithubLogin.login).toList()
+            case final matching? when matching.isNotEmpty)
+          sessionId: matching,
     };
   }
 
@@ -676,13 +680,21 @@ class FakePullRequestRepository implements PullRequestRepository {
 class FakePrSyncService extends PrSyncService {
   final List<({String projectId, String projectPath})> calls = <({String projectId, String projectPath})>[];
   final Duration? delay;
+  final Object? refreshError;
+  final PrRefreshOutcome refreshOutcome;
+  VerifiedGithubLogin? verifiedGithubLogin;
+  int identityVerificationCallCount = 0;
 
   FakePrSyncService({
     this.delay,
+    this.refreshError,
+    this.refreshOutcome = PrRefreshOutcome.completed,
+    VerifiedGithubLogin? verifiedGithubLogin,
     PrSourceRepository? prSource,
     PullRequestRepository? pullRequestRepository,
     SessionRepository? sessionRepository,
-  }) : super(
+  }) : verifiedGithubLogin = verifiedGithubLogin ?? VerifiedGithubLogin.tryParse(rawLogin: "octocat"),
+       super(
          prSource: prSource ?? _AlwaysReadyPrSource(),
          pullRequestRepository: pullRequestRepository ?? _NoopPullRequestRepository(),
          sessionRepository: sessionRepository ?? _NoopSessionRepository(),
@@ -690,11 +702,21 @@ class FakePrSyncService extends PrSyncService {
        );
 
   @override
-  Future<void> triggerRefresh({required String projectId, required String projectPath}) async {
+  Future<PrRefreshOutcome> triggerRefresh({required String projectId, required String projectPath}) async {
     calls.add((projectId: projectId, projectPath: projectPath));
     if (delay != null) {
       await Future<void>.delayed(delay!);
     }
+    if (refreshError case final error?) {
+      throw error;
+    }
+    return refreshOutcome;
+  }
+
+  @override
+  Future<VerifiedGithubLogin?> verifyGithubIdentity() async {
+    identityVerificationCallCount++;
+    return verifiedGithubLogin;
   }
 }
 
@@ -727,11 +749,6 @@ class _NoopPullRequestRepository implements PullRequestRepository {
     required String githubRepositoryIdentity,
     required VerifiedGithubLogin verifiedGithubLogin,
   }) async => const <PullRequestDto>[];
-
-  @override
-  Future<Map<String, List<PullRequestDto>>> getPrsBySessionIds({required List<String> sessionIds}) async {
-    return <String, List<PullRequestDto>>{};
-  }
 
   @override
   bool hasChangedFromExisting({required PullRequestDto? existing, required GhPullRequest pr}) => true;
@@ -894,14 +911,21 @@ class _NoopSessionRepository implements SessionRepository {
     required String projectId,
     required int? start,
     required int? limit,
+    required VerifiedGithubLogin? verifiedGithubLogin,
   }) async => const <Session>[];
   @override
-  Future<Session> enrichSession({required Session session}) async => session;
+  Future<Session> enrichSession({
+    required Session session,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) async => session;
   @override
   Future<Session> enrichPluginSession({required String pluginId, required PluginSession pluginSession}) async =>
       pluginSession.toSharedSession(pluginId: pluginId);
   @override
-  Future<List<Session>> enrichSessions({required List<Session> sessions}) async => sessions;
+  Future<List<Session>> enrichSessions({
+    required List<Session> sessions,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) async => sessions;
   @override
   Future<List<Session>> getChildSessions({required String sessionId}) async => const <Session>[];
   @override
@@ -1005,7 +1029,11 @@ class _NoopSessionRepository implements SessionRepository {
   Future<String?> findProjectIdForSession({required String sessionId}) async => null;
 
   @override
-  Future<Session?> getSessionForProject({required String projectId, required String sessionId}) async => null;
+  Future<Session?> getSessionForProject({
+    required String projectId,
+    required String sessionId,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) async => null;
 
   @override
   Future<void> abortSession({required String sessionId}) async {}
@@ -1074,6 +1102,7 @@ class FakeSessionRepository implements SessionRepository {
   final AppDatabase? _persistenceDatabase;
   int getSessionsCallCount = 0;
   ({String projectId, int? start, int? limit})? lastGetSessionsArgs;
+  VerifiedGithubLogin? lastVerifiedGithubLogin;
   String? projectPathResult;
   Object? publicationError;
 
@@ -1171,8 +1200,10 @@ class FakeSessionRepository implements SessionRepository {
     required String projectId,
     required int? start,
     required int? limit,
+    required VerifiedGithubLogin? verifiedGithubLogin,
   }) async {
     getSessionsCallCount++;
+    lastVerifiedGithubLogin = verifiedGithubLogin;
     lastGetSessionsArgs = (projectId: projectId, start: start, limit: limit);
     final pluginSessions = await _plugin.getSessions(
       projectId,
@@ -1196,7 +1227,12 @@ class FakeSessionRepository implements SessionRepository {
       }
       return session;
     }).toList();
-    final prsBySessionId = await _pullRequestRepository.getPrsBySessionIds(sessionIds: sessionIds);
+    final prsBySessionId = verifiedGithubLogin == null
+        ? <String, List<PullRequestDto>>{}
+        : await _pullRequestRepository.getPrsBySessionIds(
+            sessionIds: sessionIds,
+            verifiedGithubLogin: verifiedGithubLogin,
+          );
     final result = mergedSessions.map((session) {
       final prs = prsBySessionId[session.id];
       final pr = _selectBestPr(prs);
@@ -1228,27 +1264,51 @@ class FakeSessionRepository implements SessionRepository {
   }
 
   @override
-  Future<Session> enrichSession({required Session session}) async {
-    final sessions = await enrichSessions(sessions: [session]);
+  Future<Session> enrichSession({
+    required Session session,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) async {
+    final sessions = await enrichSessions(
+      sessions: [session],
+      verifiedGithubLogin: verifiedGithubLogin,
+    );
     return sessions.single;
   }
 
   @override
   Future<Session> enrichPluginSession({required String pluginId, required PluginSession pluginSession}) async {
-    return enrichSession(session: pluginSession.toSharedSession(pluginId: pluginId));
+    return enrichSession(
+      session: pluginSession.toSharedSession(pluginId: pluginId),
+      verifiedGithubLogin: null,
+    );
   }
 
   @override
-  Future<List<Session>> enrichSessions({required List<Session> sessions}) async {
+  Future<List<Session>> enrichSessions({
+    required List<Session> sessions,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) async {
+    lastVerifiedGithubLogin = verifiedGithubLogin;
     final sessionIds = sessions.map((session) => session.id).toList(growable: false);
     final dbSessions = await _sessionDao.getSessionsByIds(sessionIds: sessionIds);
-    final prsBySessionId = await _pullRequestRepository.getPrsBySessionIds(sessionIds: sessionIds);
+    final prsBySessionId = verifiedGithubLogin == null
+        ? <String, List<PullRequestDto>>{}
+        : await _pullRequestRepository.getPrsBySessionIds(
+            sessionIds: sessionIds,
+            verifiedGithubLogin: verifiedGithubLogin,
+          );
     final pullRequestsBySessionId = <String, PullRequestInfo>{
       for (final session in sessions)
         if (_selectBestPr(prsBySessionId[session.id]) case final pr?) session.id: pullRequestInfoFromDto(pr),
     };
     return enrichSharedSessions(
-      sessions: sessions,
+      sessions: [
+        for (final session in sessions)
+          session.copyWith(
+            pullRequest: null,
+            pullRequestHistory: const <PullRequestInfo>[],
+          ),
+      ],
       storedSessionsById: dbSessions,
       pullRequestsBySessionId: pullRequestsBySessionId,
       unseenCalculator: const SessionUnseenCalculator(),
@@ -1427,8 +1487,17 @@ class FakeSessionRepository implements SessionRepository {
   Future<String?> findProjectIdForSession({required String sessionId}) async => null;
 
   @override
-  Future<Session?> getSessionForProject({required String projectId, required String sessionId}) async {
-    final sessions = await getSessionsForProject(projectId: projectId, start: null, limit: null);
+  Future<Session?> getSessionForProject({
+    required String projectId,
+    required String sessionId,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) async {
+    final sessions = await getSessionsForProject(
+      projectId: projectId,
+      start: null,
+      limit: null,
+      verifiedGithubLogin: verifiedGithubLogin,
+    );
     for (final session in sessions) {
       if (session.id == sessionId) {
         return session;

--- a/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
+++ b/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
@@ -148,7 +148,7 @@ void main() {
       expect(persisted?.archivedAt, isNotNull);
       expect(result.id, equals("s1"));
       expect(result.time?.archived, equals(persisted?.archivedAt));
-      expect(result.pullRequest?.number, equals(21));
+      expect(result.pullRequest, isNull);
     });
 
     test("archiving an already-archived session emits no unseen change", () async {
@@ -426,7 +426,7 @@ void main() {
       final persisted = await db.sessionDao.getSession(sessionId: "s1");
       expect(persisted?.archivedAt, isNull);
       expect(result.time?.archived, isNull);
-      expect(result.pullRequest?.number, equals(22));
+      expect(result.pullRequest, isNull);
     });
 
     test("unarchive with deleted worktree restores worktree", () async {

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -151,6 +151,29 @@ void main() {
       expect(emittedProjectIds, isEmpty);
     });
 
+    test("reports a failed outcome when the PR source query fails", () async {
+      final prSource = _FakePrSource(
+        listOpenPrsResult: const <GhPullRequest>[],
+        onListOpenPrs: () async => throw StateError("list failed"),
+      );
+      final service = PrSyncService(
+        prSource: prSource,
+        pullRequestRepository: _FakePullRequestRepository(),
+        sessionRepository: _FakeSessionRepository(
+          sessionsByProject: const <String, List<StoredSession>>{},
+        ),
+        clock: const Clock(),
+      );
+      addTearDown(service.dispose);
+
+      final outcome = await service.triggerRefresh(
+        projectId: "project-1",
+        projectPath: "/tmp/project-1",
+      );
+
+      expect(outcome, PrRefreshOutcome.failed);
+    });
+
     test("fetches final PR state for disappeared active PR", () async {
       final prSource = _FakePrSource(
         listOpenPrsResult: <GhPullRequest>[],
@@ -206,8 +229,12 @@ void main() {
       );
       addTearDown(service.dispose);
 
-      await service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
+      final outcome = await service.triggerRefresh(
+        projectId: "project-1",
+        projectPath: "/tmp/project-1",
+      );
 
+      expect(outcome, PrRefreshOutcome.failed);
       expect(prSource.getAuthenticatedIdentityCallCount, 1);
       expect(prSource.getGithubRepositoryIdentityCalls, ["/tmp/project-1"]);
       expect(prSource.listOpenPrsCallCount, 0);
@@ -715,11 +742,6 @@ class _FakePullRequestRepository implements PullRequestRepository {
   }
 
   @override
-  Future<Map<String, List<PullRequestDto>>> getPrsBySessionIds({required List<String> sessionIds}) async {
-    return <String, List<PullRequestDto>>{};
-  }
-
-  @override
   bool hasChangedFromExisting({required PullRequestDto? existing, required GhPullRequest pr}) {
     if (existing == null) return true;
     return existing.prNumber != pr.number ||
@@ -913,17 +935,24 @@ class _FakeSessionRepository implements SessionRepository {
     required String projectId,
     required int? start,
     required int? limit,
+    required VerifiedGithubLogin? verifiedGithubLogin,
   }) async => const <Session>[];
 
   @override
-  Future<Session> enrichSession({required Session session}) async => session;
+  Future<Session> enrichSession({
+    required Session session,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) async => session;
 
   @override
   Future<Session> enrichPluginSession({required String pluginId, required PluginSession pluginSession}) async =>
       pluginSession.toSharedSession(pluginId: pluginId);
 
   @override
-  Future<List<Session>> enrichSessions({required List<Session> sessions}) async => sessions;
+  Future<List<Session>> enrichSessions({
+    required List<Session> sessions,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) async => sessions;
 
   @override
   Future<List<Session>> getChildSessions({required String sessionId}) async => const <Session>[];
@@ -1013,7 +1042,11 @@ class _FakeSessionRepository implements SessionRepository {
   Future<String?> findProjectIdForSession({required String sessionId}) async => null;
 
   @override
-  Future<Session?> getSessionForProject({required String projectId, required String sessionId}) async => null;
+  Future<Session?> getSessionForProject({
+    required String projectId,
+    required String sessionId,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) async => null;
 
   @override
   Future<void> abortSession({required String sessionId}) async {}

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -519,9 +519,14 @@ void main() {
       final firstRefresh = service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
       await _waitFor(() => prSource.listOpenPrsCallCount == 1);
 
-      // Second refresh should be skipped because first is still active.
-      await service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
+      // Second refresh should report that the first is still active rather than
+      // representing unfinished work as completed.
+      final secondOutcome = await service.triggerRefresh(
+        projectId: "project-1",
+        projectPath: "/tmp/project-1",
+      );
 
+      expect(secondOutcome, PrRefreshOutcome.inProgress);
       expect(prSource.listOpenPrsCallCount, equals(1));
       expect(prSource.isAvailableCallCount, equals(1));
       expect(prSource.isAuthenticatedCallCount, equals(1));

--- a/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
+++ b/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
@@ -8,6 +8,7 @@ import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
 import "package:sesori_bridge/src/bridge/repositories/filesystem_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/session_operation.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/stored_session.dart";
+import "package:sesori_bridge/src/bridge/repositories/models/verified_github_login.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/services/session_lifecycle_service.dart";
@@ -540,10 +541,16 @@ class _FakeSessionRepository implements SessionRepository {
   int hasSharingCallCount = 0;
 
   @override
-  Future<Session> enrichSession({required Session session}) async => session;
+  Future<Session> enrichSession({
+    required Session session,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) async => session;
 
   @override
-  Future<List<Session>> enrichSessions({required List<Session> sessions}) async => sessions;
+  Future<List<Session>> enrichSessions({
+    required List<Session> sessions,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) async => sessions;
 
   @override
   Future<bool> hasOtherActiveSessionsSharing({

--- a/bridge/app/test/integration/pr_sync_fk_regression_test.dart
+++ b/bridge/app/test/integration/pr_sync_fk_regression_test.dart
@@ -200,6 +200,7 @@ void main() {
           projectId: "sess-proj",
           start: null,
           limit: null,
+          verifiedGithubLogin: null,
         );
 
         // projects_table has "sess-proj".

--- a/bridge/app/tool/benchmarks/catalog_import_event_soak.dart
+++ b/bridge/app/tool/benchmarks/catalog_import_event_soak.dart
@@ -522,6 +522,7 @@ class _CatalogImportEventSoak {
       projectId: sentinelProjectId,
       start: null,
       limit: null,
+      verifiedGithubLogin: null,
     );
     if (sessions.length != 1 || sessions.single.id != _sentinelSessionId) {
       throw StateError("last-committed sentinel was not readable while import was blocked");

--- a/bridge/app/tool/benchmarks/live_list_baseline.dart
+++ b/bridge/app/tool/benchmarks/live_list_baseline.dart
@@ -310,6 +310,7 @@ class _LiveListBenchmark {
             final session = await sessionRepository.getSessionForProject(
               projectId: _projectDirectory,
               sessionId: detailSessionId,
+              verifiedGithubLogin: null,
             );
             if (session?.id != detailSessionId) {
               throw StateError("session detail returned ${session?.id}; expected $detailSessionId");
@@ -464,8 +465,12 @@ class _LiveListBenchmark {
       projectId: projectId,
       start: start,
       limit: limit,
+      verifiedGithubLogin: null,
     );
-    sessions = await repository.enrichSessions(sessions: sessions);
+    sessions = await repository.enrichSessions(
+      sessions: sessions,
+      verifiedGithubLogin: null,
+    );
     _verifyBoundaries(
       name: "session catalog for $projectId",
       expectedFirst: expectedFirstSessionId,


### PR DESCRIPTION
## Complexity

🚧 Complex — this threads privacy-sensitive identity evidence through handler, service, repository, and DAO boundaries, changes refresh state, and gates every cached PR presentation path.

## What

- Adds a fresh `VerifiedGithubLogin` gate to session list and detail reads before cached PR metadata can be mapped.
- Requires the read-scoped login to match persisted project, PR row, repository, and branch scope.
- Makes `SessionRepository` the authoritative owner for clearing and applying PR/history enrichment.
- Bounds list PR work and detail identity verification to five seconds with PR-free fallback.
- Distinguishes completed, active, and failed refresh outcomes; asynchronous refresh errors and unavailable refresh sources fail closed.
- Keeps mutation, child, creation, deletion, catalog-only, and SSE mappings PR-free without fresh request evidence.
- Removes the unused pull-request repository session-read API and updates tests/fakes in lockstep.

## Why

The v13 cache from Step 2.b is durably scoped, but an out-of-band `gh auth switch` can happen between writes and later reads. Fresh request-time identity evidence prevents exposing cached metadata from the previous account. Bounded and explicit refresh outcomes ensure this privacy-safe behavior does not block catalog data or misrepresent unfinished work as successful.

## Risk and test focus

High privacy-sensitive read risk with moderate persistence-query and failure-path impact. Focus on same-login visibility, switched/unknown/stalled identity behavior, project/row scope agreement, list/detail parity, concurrent or unavailable refreshes, asynchronous failures, waited deadlines, and continued availability of non-PR session data. The change is approximately 1,170 lines with no generated output.

## Expected result

- **User-visible:** Session list/detail responses show cached PR metadata only when fresh local GitHub identity matches persisted cache scope. Account switches, unverifiable or stalled identity, unfinished/unavailable/failed refreshes, and timeouts still return sessions without PR/history metadata. No new screen, endpoint, setting, timer, or client behavior.
- **Persisted/database:** No schema, migration, or stored-data change. Existing v13 rows remain available for a later matching identity.
- **Internal:** Required nullable identity evidence flows into PR-bearing reads; DAO joins enforce scope; `SessionRepository` owns mapping; refresh completion/in-progress/failure is typed. No wire-contract change.

## Verification

- `dart analyze --fatal-infos` — passes with no issues after review fixes
- Pre-review `dart test` — all 2,309 bridge app tests pass
- Latest post-review focused handler/service suites — all 59 tests pass
- Focused DAO, repository, list/detail routing, refresh, mutation-response, SSE, integration, and benchmark contract suites — pass
- `dart format` and `git diff --check` — pass
- `aristotle-impl-review` initially rejected handler-owned response clearing; the finding was applied by keeping authoritative clearing/mapping exclusively in `SessionRepository`. Per policy, the direct correction was not re-reviewed.
