### PR TITLE
🌱 [output-image-support] docs: retire output image support plan [step 13/13]

### DIFF
--- a/.plan/completed/output-image-support/PLAN.md
+++ b/.plan/completed/output-image-support/PLAN.md
@@ -315,7 +315,7 @@ coverage; it does not introduce another interpretation of content.
 | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | Message tracker adopted live/replay; live image materialization. |
 | 11/13 | `output-image-support-acp-tool-images` | `⚙️ [output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | Tool tracker adopted live/replay; live attachment materialization. |
 | 12/13 | `output-image-support-acp-image-replay` | `⚙️ [output-image-support] feat(acp): restore output image replay [step 12/13]` | 900-1,400 | Replay materialization and end-to-end parity proof only. |
-| 13/13 | `output-image-support-retire-plan` | `[output-image-support] docs: retire output image support plan [step 13/13]` | 50-200 | Record completion and move the plan tree from active to completed. |
+| 13/13 | `output-image-support-retire-plan` | `🌱 [output-image-support] docs: retire output image support plan [step 13/13]` | 50-200 | Record completion and move the plan tree from active to completed. |
 
 ## Step Details And Verification
 

--- a/.plan/completed/output-image-support/TRACKER.md
+++ b/.plan/completed/output-image-support/TRACKER.md
@@ -5,10 +5,10 @@
 - **Plan slug:** `output-image-support`
 - **Implementation base:** `origin/main` at
   `dd627325d065d8ac5dfed7118b092f2ea387c3e9`
-- **Series state:** Steps 1-12 merged in order; final retirement Step 13/13 in progress
-- **Current step:** Step 13/13 open as [PR #680](https://github.com/sesori-ai/sesori_apps_monorepo/pull/680)
+- **Series state:** All 13 steps complete; final retirement delivered by [PR #680](https://github.com/sesori-ai/sesori_apps_monorepo/pull/680)
+- **Current step:** Complete
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** monitor final retirement PR #680
+- **Next action:** None
 
 ## Plan Review
 
@@ -38,7 +38,7 @@
 | [x] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666) merged as `e64fb4b5`; 1,138 changed lines |
 | [x] | 11/13 | `output-image-support-acp-tool-images` | `⚙️ [output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | [PR #670](https://github.com/sesori-ai/sesori_apps_monorepo/pull/670) merged as `db7d62c6`; 1,477 changed lines |
 | [x] | 12/13 | `output-image-support-acp-image-replay` | `⚙️ [output-image-support] feat(acp): restore output image replay [step 12/13]` | 900-1,400 | [PR #674](https://github.com/sesori-ai/sesori_apps_monorepo/pull/674) merged as `dd627325`; 1,419 changed lines |
-| [ ] | 13/13 | `output-image-support-retire-plan` | `🌱 [output-image-support] docs: retire output image support plan [step 13/13]` | 50-200 | [PR #680](https://github.com/sesori-ai/sesori_apps_monorepo/pull/680) open |
+| [x] | 13/13 | `output-image-support-retire-plan` | `🌱 [output-image-support] docs: retire output image support plan [step 13/13]` | 50-200 | Final retirement delivered by [PR #680](https://github.com/sesori-ai/sesori_apps_monorepo/pull/680) |
 
 ## Exact PR Titles
 

--- a/.plan/completed/output-image-support/TRACKER.md
+++ b/.plan/completed/output-image-support/TRACKER.md
@@ -6,9 +6,9 @@
 - **Implementation base:** `origin/main` at
   `dd627325d065d8ac5dfed7118b092f2ea387c3e9`
 - **Series state:** Steps 1-12 merged in order; final retirement Step 13/13 in progress
-- **Current step:** Step 13/13 — retire the completed plan
+- **Current step:** Step 13/13 open as [PR #680](https://github.com/sesori-ai/sesori_apps_monorepo/pull/680)
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** commit, push, and open the final documentation-only PR
+- **Next action:** monitor final retirement PR #680
 
 ## Plan Review
 
@@ -38,7 +38,7 @@
 | [x] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666) merged as `e64fb4b5`; 1,138 changed lines |
 | [x] | 11/13 | `output-image-support-acp-tool-images` | `⚙️ [output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | [PR #670](https://github.com/sesori-ai/sesori_apps_monorepo/pull/670) merged as `db7d62c6`; 1,477 changed lines |
 | [x] | 12/13 | `output-image-support-acp-image-replay` | `⚙️ [output-image-support] feat(acp): restore output image replay [step 12/13]` | 900-1,400 | [PR #674](https://github.com/sesori-ai/sesori_apps_monorepo/pull/674) merged as `dd627325`; 1,419 changed lines |
-| [ ] | 13/13 | `output-image-support-retire-plan` | `🌱 [output-image-support] docs: retire output image support plan [step 13/13]` | 50-200 | Final documentation-only retirement in progress |
+| [ ] | 13/13 | `output-image-support-retire-plan` | `🌱 [output-image-support] docs: retire output image support plan [step 13/13]` | 50-200 | [PR #680](https://github.com/sesori-ai/sesori_apps_monorepo/pull/680) open |
 
 ## Exact PR Titles
 

--- a/.plan/completed/output-image-support/TRACKER.md
+++ b/.plan/completed/output-image-support/TRACKER.md
@@ -4,11 +4,11 @@
 
 - **Plan slug:** `output-image-support`
 - **Implementation base:** `origin/main` at
-  `db7d62c666f88a63a05acd28fe6b8816dd6afc56`
-- **Series state:** Step 11/13 merged as [PR #670](https://github.com/sesori-ai/sesori_apps_monorepo/pull/670) (`db7d62c6`)
-- **Current step:** Step 12/13 open as [PR #674](https://github.com/sesori-ai/sesori_apps_monorepo/pull/674)
+  `dd627325d065d8ac5dfed7118b092f2ea387c3e9`
+- **Series state:** Steps 1-12 merged in order; final retirement Step 13/13 in progress
+- **Current step:** Step 13/13 — retire the completed plan
 - **Plan PR:** [#638](https://github.com/sesori-ai/sesori_apps_monorepo/pull/638)
-- **Next action:** monitor PR #674 and address CI or review findings
+- **Next action:** commit, push, and open the final documentation-only PR
 
 ## Plan Review
 
@@ -37,8 +37,8 @@
 | [x] | 9/13 | `output-image-support-acp-content-mapping` | `[output-image-support] refactor(acp): centralize tool content mapping [step 9/13]` | 1,100-1,500 | [PR #661](https://github.com/sesori-ai/sesori_apps_monorepo/pull/661) merged as `f5f24240`; 879 changed lines |
 | [x] | 10/13 | `output-image-support-acp-message-images` | `[output-image-support] feat(acp): surface live message images [step 10/13]` | 1,100-1,500 | [PR #666](https://github.com/sesori-ai/sesori_apps_monorepo/pull/666) merged as `e64fb4b5`; 1,138 changed lines |
 | [x] | 11/13 | `output-image-support-acp-tool-images` | `⚙️ [output-image-support] feat(acp): surface live tool images [step 11/13]` | 1,200-1,500 | [PR #670](https://github.com/sesori-ai/sesori_apps_monorepo/pull/670) merged as `db7d62c6`; 1,477 changed lines |
-| [ ] | 12/13 | `output-image-support-acp-image-replay` | `⚙️ [output-image-support] feat(acp): restore output image replay [step 12/13]` | 900-1,400 | [PR #674](https://github.com/sesori-ai/sesori_apps_monorepo/pull/674) open; architecture review approved |
-| [ ] | 13/13 | `output-image-support-retire-plan` | `[output-image-support] docs: retire output image support plan [step 13/13]` | 50-200 | Blocked on Step 12 merge |
+| [x] | 12/13 | `output-image-support-acp-image-replay` | `⚙️ [output-image-support] feat(acp): restore output image replay [step 12/13]` | 900-1,400 | [PR #674](https://github.com/sesori-ai/sesori_apps_monorepo/pull/674) merged as `dd627325`; 1,419 changed lines |
+| [ ] | 13/13 | `output-image-support-retire-plan` | `🌱 [output-image-support] docs: retire output image support plan [step 13/13]` | 50-200 | Final documentation-only retirement in progress |
 
 ## Exact PR Titles
 
@@ -54,7 +54,7 @@
 10. `[output-image-support] feat(acp): surface live message images [step 10/13]`
 11. `⚙️ [output-image-support] feat(acp): surface live tool images [step 11/13]`
 12. `⚙️ [output-image-support] feat(acp): restore output image replay [step 12/13]`
-13. `[output-image-support] docs: retire output image support plan [step 13/13]`
+13. `🌱 [output-image-support] docs: retire output image support plan [step 13/13]`
 
 ## Execution Rules
 
@@ -268,7 +268,13 @@
   metadata is privacy-sensitive. `git diff --check` passes.
   The exact Step 12 diff is 1,419 changed lines (1,032 additions, 387
   deletions), below the 1,500-line soft cap; this excludes the pre-existing
-  unrelated modified `fetch.sh` and untracked Step 6 test notes.
+  unrelated modified `fetch.sh` and untracked Step 6 test notes. PR #674 merged
+  as `dd627325` on 2026-08-01.
+- Step 13/13 (2026-08-01): confirmed Steps 1-12 merged in numeric order, recorded
+  the final Step 12 merge and verification evidence, and moved the tracked plan
+  tree from `.plan/active/` to `.plan/completed/`. This documentation-only
+  retirement requires no Dart, Flutter, code generation, analytics, or
+  architecture implementation review. `git diff --check` passes.
 
 ## Findings And Plan Deltas
 


### PR DESCRIPTION
## Complexity

🌱 Trivial — records completed delivery evidence and mechanically moves two tracked planning documents.

## What

- Recorded PR #674’s merge and final Step 12 verification.
- Confirmed Steps 1-12 merged in numeric order with the expected merge commits.
- Moved the tracked `output-image-support` plan and tracker from `.plan/active/` to `.plan/completed/`.
- Recorded the required Step 13 complexity-prefixed title.

## Why

All planned Codex and standard ACP output-image implementation steps are merged. The durable plan lifecycle now needs to reflect that the work is complete.

## Risk and test focus

Low risk. Review the recorded PR/merge sequence, Step 12 evidence, and the active-to-completed rename. No production code, generated output, or runtime behavior changed.

## Expected result

No user-visible, database, wire, relay, client, or internal runtime change. The completed plan remains available as durable delivery history and is no longer listed as active tracked work.

## Verification

- PRs #638, #639, #644, #646, #648, #652, #657, #658, #661, #666, #670, and #674 are all merged in order.
- `git diff --check` passes.
- The diff contains two tracked renames with 15 additions and 9 deletions.
- No Dart, Flutter, code generation, analytics, or architecture review was required for this documentation-only retirement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retired the `output-image-support` plan by moving `.plan/active/output-image-support` to `.plan/completed/output-image-support`. Updated `PLAN.md` and `TRACKER.md` to record the Step 12 merge, add the final Step 13 retirement, confirm all 13 steps complete, refresh the base hash and exact titles (🌱), and set next action to none; no code or runtime changes.

<sup>Written for commit 42fb6a9634882ddf029029d2d0c11be61862c173. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

