### PR TITLE
🌱 Silence expected permission reconciliation warnings

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -538,7 +538,7 @@ class OpenCodeService {
       );
     } on OpenCodeApiException catch (e) {
       if (e.statusCode != 404) rethrow;
-      Log.w("permission already resolved upstream (404), reconciling tracker: ${e.endpoint}", e);
+      Log.d("permission already resolved upstream (404), reconciling tracker: ${e.endpoint}");
     }
     return tracker.clearPendingPermission(sessionId: sessionId, requestId: requestId);
   }

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -1777,6 +1777,35 @@ void main() {
       expect(tracker.lastClearedPermissionSessionId, equals("ses-1"));
     });
 
+    test("replyToPermission 404 clears tracker without warning", () async {
+      final originalLogLevel = Log.level;
+      addTearDown(() => Log.level = originalLogLevel);
+      Log.level = LogLevel.info;
+      final logLines = <String>[];
+      final repository = FakeOpenCodeRepository(
+        replyToPermissionError: OpenCodeApiException("POST /permission/perm-1/reply", 404),
+      );
+      final tracker = FakeActiveSessionTracker(
+        sessionDirectories: const {"ses-1": "/repo"},
+        clearPendingPermissionChanged: true,
+      );
+      final service = OpenCodeService(repository, tracker);
+
+      final result = await io.IOOverrides.runZoned(
+        () => service.replyToPermission(
+          requestId: "perm-1",
+          sessionId: "ses-1",
+          reply: PluginPermissionReply.once,
+        ),
+        stderr: () => _CapturingStdout(logLines),
+      );
+
+      expect(logLines, isEmpty, reason: "an expected reconciliation must not emit a warning");
+      expect(result.summaryChanged, isTrue);
+      expect(tracker.lastClearedPermissionRequestId, equals("perm-1"));
+      expect(tracker.lastClearedPermissionSessionId, equals("ses-1"));
+    });
+
     test("replyToPermission 400 does not clear and rethrows", () async {
       final error = OpenCodeApiException("POST /permission/perm-1/reply", 400);
       final repository = FakeOpenCodeRepository(replyToPermissionError: error);
@@ -2406,6 +2435,18 @@ class FakeOpenCodeRepository extends OpenCodeRepository {
     pendingPermissionDirectories.add(directory);
     return _pendingPermissionsByDirectory[directory] ?? const [];
   }
+}
+
+class _CapturingStdout implements io.Stdout {
+  final List<String> lines;
+
+  _CapturingStdout(this.lines);
+
+  @override
+  void writeln([Object? object = ""]) => lines.add(object.toString());
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class FakeActiveSessionTracker extends ActiveSessionTracker {


### PR DESCRIPTION
## Complexity

🌱 Trivial: one log-level adjustment with focused regression coverage.

## What

- Log an already-resolved OpenCode permission reply at debug instead of warning severity.
- Verify a permission `404` still clears local pending state without logging at the normal info threshold.

## Why

OpenCode can report that a permission disappeared before the bridge reply reached it. The plugin already treats this as successful idempotent reconciliation, so warning severity and the attached exception dump falsely suggested that YOLO auto-approval failed.

## Risk and test focus

Low risk. Non-404 permission failures still propagate unchanged, while the handled `404` remains visible at debug verbosity. There is no wire-contract or database impact; the only user-visible impact is cleaner diagnostic output.

## Expected result

YOLO permission auto-approval no longer emits a warning/error block when OpenCode reports that the request was already resolved, and local pending state is still reconciled.

## Verification

- `dart test test/opencode_service_test.dart`
- `dart analyze --fatal-infos`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Demoted the 404 "permission already resolved" log in `OpenCodeService.replyToPermission` from warning to debug to stop false warning/error blocks. 404s still clear the local pending permission; non-404 failures are unchanged.

<sup>Written for commit e6db5ca0e9f6f86c8642a9f1e976536fc381d732. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

