### PR TITLE
🌿 Prevent Android recording startup from freezing the UI

### DIFF
--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -1327,12 +1327,13 @@ packages:
     source: hosted
     version: "7.1.1"
   record_android:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: record_android
-      sha256: "28f1108626a190e249b01ffa9f639070e31e5157474b64a5ae380bf36aec9559"
-      url: "https://pub.dev"
-    source: hosted
+      path: record_android
+      ref: "98dc1e1a856186e613523aaac06264984bedda87"
+      resolved-ref: "98dc1e1a856186e613523aaac06264984bedda87"
+      url: "https://github.com/sesori-ai/record.git"
+    source: git
     version: "2.1.2"
   record_ios:
     dependency: transitive

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -12,3 +12,10 @@ workspace:
   - module_prego
   - module_desktop_core
   - desktop
+
+dependency_overrides:
+  record_android:
+    git:
+      url: https://github.com/sesori-ai/record.git
+      ref: 98dc1e1a856186e613523aaac06264984bedda87
+      path: record_android


### PR DESCRIPTION
## Complexity

Straightforward in this repository: the client workspace pins one exact Android implementation commit. The underlying recorder lifecycle change is moderate and is proposed upstream in [llfbandit/record#620](https://github.com/llfbandit/record/pull/620).

## What

- Override the transitive `record_android` package at the client workspace root.
- Pin `sesori-ai/record` commit `98dc1e1a856186e613523aaac06264984bedda87` and its `record_android` package path.
- Keep the public `record: ^7.1.1` dependency unchanged.

## Why

Android recorder startup synchronously waited for `AudioRecord` initialization on Flutter's platform thread. Physical Pixel profiling measured a 321.9 ms median delay before the first hold-to-talk feedback frame, with 311.2 ms spent in recorder startup.

The pinned implementation runs stateful recorder calls on a per-recorder serial worker while preserving UI-thread channel lifecycle and ordered teardown.

## Risk and test focus

The change is Android-only. Test focus is recorder call ordering, startup/cancel/dispose races, engine teardown, exact dependency resolution, and the real hold-to-talk interaction.

There is no UI code, animation-duration, wire-contract, persisted-data, permission-policy, or database change. The user-visible impact is limited to responsive Android voice startup.

## Expected result

The existing 220 ms hold-to-talk animation begins immediately and remains smooth while Android recorder initialization completes off the platform thread.

## Verification

- `dart pub get` from `client/`
- `dart analyze` from `client/app/`
- `flutter test` from `client/app/` (862 tests)
- `flutter build apk --profile` from `client/app/`
- `flutter analyze record_android` in the fork
- `flutter build apk --debug` from the fork's `record/example/`
- `./gradlew :record_android:testDebugUnitTest` in the fork (4 queue tests)
- Repeated hold/release validation on Pixel 10 Pro, Android 17/API 37; no crashes or recorder errors
- User-confirmed the pinned build starts immediately with no perceptible delay


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Android recorder initialization off the UI thread so hold-to-talk starts immediately and stays smooth on Android. The app code is unchanged; this is handled via dependency wiring.

- **Dependencies**
  - Override transitive `record_android` to a Git-based worker-threaded implementation; keep `record: ^7.1.1` unchanged.

<sup>Written for commit 7d3b0c64f81de11d9c86dc42ceee7bf9c4c4e55f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

