### PR TITLE
🌿 Make image dismissal drag free-form

### DIFF
--- a/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
+++ b/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
@@ -108,9 +108,9 @@ class _ImageAttachmentViewerState extends State<ImageAttachmentViewer> with Tick
   Matrix4Tween? _zoomTween;
   Offset? _doubleTapPosition;
   Offset _interactionDelta = Offset.zero;
-  double _dragOffset = 0;
-  double _dragStartOffset = 0;
-  double _dragResetStart = 0;
+  Offset _dragOffset = Offset.zero;
+  Offset _dragStartOffset = Offset.zero;
+  Offset _dragResetStart = Offset.zero;
   bool _canDragToDismiss = false;
   bool _isDismissDrag = false;
   bool _isDismissing = false;
@@ -161,23 +161,24 @@ class _ImageAttachmentViewerState extends State<ImageAttachmentViewer> with Tick
     if (!_canDragToDismiss || _isDismissing) return;
     if (details.pointerCount != 1 || !_isAtBaseScale) {
       _canDragToDismiss = false;
-      if (_dragOffset != 0) _animateDragToOrigin();
+      if (_dragOffset != Offset.zero) _animateDragToOrigin();
       return;
     }
 
     _interactionDelta += details.focalPointDelta;
     if (!_isDismissDrag) {
       if (_interactionDelta.distance < 8) return;
-      if (_interactionDelta.dy.abs() <= _interactionDelta.dx.abs() * 1.2) {
-        _canDragToDismiss = false;
-        if (_dragOffset != 0) _animateDragToOrigin();
-        return;
-      }
       _isDismissDrag = true;
     }
 
-    final height = MediaQuery.sizeOf(context).height;
-    setState(() => _dragOffset = (_dragStartOffset + _interactionDelta.dy).clamp(-height, height));
+    final size = MediaQuery.sizeOf(context);
+    final nextOffset = _dragStartOffset + _interactionDelta;
+    setState(
+      () => _dragOffset = Offset(
+        nextOffset.dx.clamp(-size.width, size.width),
+        nextOffset.dy.clamp(-size.height, size.height),
+      ),
+    );
   }
 
   void _handleInteractionEnd({required ScaleEndDetails details}) {
@@ -185,17 +186,19 @@ class _ImageAttachmentViewerState extends State<ImageAttachmentViewer> with Tick
     _canDragToDismiss = false;
     _isDismissDrag = false;
     if (!wasDismissDrag || _isDismissing) {
-      if (!_isDismissing && _dragOffset != 0 && !_dragResetController.isAnimating) {
+      if (!_isDismissing && _dragOffset != Offset.zero && !_dragResetController.isAnimating) {
         _animateDragToOrigin();
       }
       return;
     }
 
-    final velocity = details.velocity.pixelsPerSecond.dy;
+    final velocity = details.velocity.pixelsPerSecond;
+    final dragDistance = _dragOffset.distance;
+    final outwardVelocity = dragDistance == 0
+        ? velocity.distance
+        : (velocity.dx * _dragOffset.dx + velocity.dy * _dragOffset.dy) / dragDistance;
     final distanceThreshold = (MediaQuery.sizeOf(context).height * 0.15).clamp(96.0, 160.0);
-    final hasDismissVelocity =
-        velocity.abs() >= _dismissVelocity && (_dragOffset == 0 || velocity.sign == _dragOffset.sign);
-    if (_dragOffset.abs() >= distanceThreshold || hasDismissVelocity) {
+    if (dragDistance >= distanceThreshold || outwardVelocity >= _dismissVelocity) {
       _dismiss();
     } else {
       _animateDragToOrigin();
@@ -204,7 +207,7 @@ class _ImageAttachmentViewerState extends State<ImageAttachmentViewer> with Tick
 
   void _animateDragToOrigin() {
     if (context.isReducedMotion) {
-      setState(() => _dragOffset = 0);
+      setState(() => _dragOffset = Offset.zero);
       return;
     }
     _dragResetStart = _dragOffset;
@@ -280,7 +283,7 @@ class _ImageAttachmentViewerState extends State<ImageAttachmentViewer> with Tick
     final displayFilename = widget.filename;
     final isRunningAction = context.watch<ImageAttachmentActionsCubit>().state is ImageAttachmentActionRunning;
     final dismissRange = (MediaQuery.sizeOf(context).height * 0.45).clamp(1.0, double.infinity);
-    final dismissProgress = (_dragOffset.abs() / dismissRange).clamp(0.0, 1.0);
+    final dismissProgress = (_dragOffset.distance / dismissRange).clamp(0.0, 1.0);
     final chromeOpacity = 1 - dismissProgress;
     final backgroundOpacity = 1 - dismissProgress * 0.8;
     return BlocListener<ImageAttachmentActionsCubit, ImageAttachmentActionsState>(
@@ -366,7 +369,7 @@ class _ImageAttachmentViewerState extends State<ImageAttachmentViewer> with Tick
               ),
               Expanded(
                 child: Transform.translate(
-                  offset: Offset(0, _dragOffset),
+                  offset: _dragOffset,
                   child: GestureDetector(
                     behavior: HitTestBehavior.opaque,
                     onDoubleTapDown: (details) => _captureDoubleTapPosition(details: details),

--- a/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
+++ b/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
@@ -195,7 +195,7 @@ class _ImageAttachmentViewerState extends State<ImageAttachmentViewer> with Tick
     final velocity = details.velocity.pixelsPerSecond;
     final dragDistance = _dragOffset.distance;
     final outwardVelocity = dragDistance == 0
-        ? velocity.distance
+        ? 0.0
         : (velocity.dx * _dragOffset.dx + velocity.dy * _dragOffset.dy) / dragDistance;
     final distanceThreshold = (MediaQuery.sizeOf(context).height * 0.15).clamp(96.0, 160.0);
     if (dragDistance >= distanceThreshold || outwardVelocity >= _dismissVelocity) {

--- a/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
+++ b/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
@@ -260,7 +260,7 @@ void main() {
     expect(router.routeInformationProvider.value.uri.path, "/sessions");
   });
 
-  testWidgets("vertical image drag snaps back or dismisses the viewer", (tester) async {
+  testWidgets("free-form image drag follows the pointer, snaps back, or dismisses", (tester) async {
     const attachment = MessageAttachment.inlineImage(
       mime: "image/png",
       base64: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==",
@@ -271,9 +271,19 @@ void main() {
     final viewer = find.byType(ImageAttachmentViewer);
     final initialCenter = tester.getCenter(find.byKey(ImageAttachmentViewer.imageKey));
 
-    await tester.timedDrag(viewer, const Offset(0, 40), const Duration(seconds: 1));
-    await tester.pump(const Duration(milliseconds: 40));
-    await tester.timedDrag(viewer, const Offset(80, 0), const Duration(milliseconds: 400));
+    final gesture = await tester.startGesture(initialCenter);
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(const Offset(20, 15));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(const Offset(20, 15));
+    await tester.pump();
+
+    final draggedCenter = tester.getCenter(find.byKey(ImageAttachmentViewer.imageKey));
+    expect(draggedCenter.dx, greaterThan(initialCenter.dx));
+    expect(draggedCenter.dy, greaterThan(initialCenter.dy));
+
+    await tester.pump(const Duration(seconds: 1));
+    await gesture.up();
     await tester.pumpAndSettle();
 
     expect(viewer, findsOneWidget);
@@ -282,7 +292,7 @@ void main() {
       lessThan(0.01),
     );
 
-    await tester.timedDrag(viewer, const Offset(0, 200), const Duration(milliseconds: 400));
+    await tester.timedDrag(viewer, const Offset(200, 0), const Duration(milliseconds: 400));
     await tester.pumpAndSettle();
 
     expect(viewer, findsNothing);

--- a/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
+++ b/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
@@ -299,6 +299,39 @@ void main() {
     expect(find.byKey(FilePartWidget.previewTapTargetKey), findsOneWidget);
   });
 
+  testWidgets("fast drag back to center does not dismiss the viewer", (tester) async {
+    const attachment = MessageAttachment.inlineImage(
+      mime: "image/png",
+      base64: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==",
+      filename: "image.png",
+    );
+    await tester.pumpWidget(_app(child: const FilePartWidget(attachment: attachment)));
+    await _openImageViewer(tester: tester);
+    final viewer = find.byType(ImageAttachmentViewer);
+    final image = find.byKey(ImageAttachmentViewer.imageKey);
+    final initialCenter = tester.getCenter(image);
+
+    final gesture = await tester.startGesture(initialCenter);
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(const Offset(30, 0), timeStamp: const Duration(milliseconds: 100));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.moveBy(const Offset(30, 0), timeStamp: const Duration(milliseconds: 200));
+    await tester.pump(const Duration(milliseconds: 200));
+    await gesture.moveBy(const Offset(-10, 0), timeStamp: const Duration(milliseconds: 400));
+    await tester.pump(const Duration(milliseconds: 1));
+    await gesture.moveBy(const Offset(-10, 0), timeStamp: const Duration(milliseconds: 401));
+    await tester.pump(const Duration(milliseconds: 1));
+    await gesture.moveBy(const Offset(-10, 0), timeStamp: const Duration(milliseconds: 402));
+    await tester.pump(const Duration(milliseconds: 1));
+
+    expect((tester.getCenter(image) - initialCenter).distance, lessThan(0.01));
+
+    await gesture.up(timeStamp: const Duration(milliseconds: 403));
+    await tester.pumpAndSettle();
+
+    expect(viewer, findsOneWidget);
+  });
+
   testWidgets("double tap toggles zoom and disables drag dismissal while zoomed", (tester) async {
     const attachment = MessageAttachment.inlineImage(
       mime: "image/png",


### PR DESCRIPTION
## Complexity
🌿 Straightforward. This is a localized conversion of image dismissal gesture state from a vertical scalar to a two-dimensional offset.

## What
- Track image drag movement freely across both axes.
- Base snap-back, chrome fading, and dismissal distance on radial movement.
- Project release velocity onto the outward drag direction before velocity-based dismissal.
- Update the widget test to cover diagonal movement, snap-back, and horizontal dismissal.

## Why
The image viewer's drag-to-dismiss gesture only accepted mostly vertical movement, making horizontal and diagonal drags feel constrained even though there is no axis-specific navigation in the viewer.

## Risk and test focus
User-visible impact: images at base zoom now follow one-finger drags in any direction and can be dismissed horizontally or diagonally as well as vertically.

Database impact: none.

Test focus is free-form pointer tracking, below-threshold snap-back, horizontal dismissal, and preserving the existing zoom gate for dismissal.

## Expected result
At base zoom, the image follows a one-finger drag freely. Releasing below the existing threshold returns it to center; dragging far enough or flicking outward dismisses the viewer. Zoomed images remain available for panning without triggering dismissal.

## Verification
- `flutter test test/features/session_detail/widgets/file_part_widget_test.dart`
- `dart analyze` from `client/app`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make image drag-to-dismiss free-form in the image viewer. Images now follow one-finger drags in any direction; horizontal and diagonal dismissal supported; below-threshold drags snap back.

- **New Features**
  - Track drag as a 2D `Offset` and clamp to viewport.
  - Base snap-back and dismissal on radial distance; fade chrome/background from radial progress.
  - Project release velocity onto the outward drag direction for velocity-based dismissal.
  - Preserve the base-zoom gate: zoomed images pan without triggering dismissal.
  - Update widget test to cover diagonal tracking, snap-back, and horizontal dismissal.

- **Bug Fixes**
  - Fix release at center: fast outward-then-back drags no longer dismiss; covered by a new test.

<sup>Written for commit 41091b61ce667824004975e90961f36123d91503. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

