### PR TITLE
🌿 Make Markdown images open in the image viewer

### DIFF
--- a/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
+++ b/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
@@ -10,11 +10,20 @@ import "../../../core/di/injection.dart";
 import "../../../core/extensions/build_context_x.dart";
 import "../../../core/external_link.dart";
 
-final class LoadedMessageImage {
+sealed class MessageImageViewerImage {
+  ImageProvider get provider;
+  Uri? get originalUri;
+
+  const MessageImageViewerImage();
+}
+
+final class LoadedMessageImage extends MessageImageViewerImage {
   final Uint8List bytes;
+  @override
   final ImageProvider provider;
   final String mime;
   final String actionFilename;
+  @override
   final Uri? originalUri;
 
   const LoadedMessageImage({
@@ -23,12 +32,24 @@ final class LoadedMessageImage {
     required this.mime,
     required this.actionFilename,
     required this.originalUri,
-  });
+  }) : super();
+}
+
+final class ViewOnlyMessageImage extends MessageImageViewerImage {
+  @override
+  final ImageProvider provider;
+  @override
+  final Uri? originalUri;
+
+  const ViewOnlyMessageImage({
+    required this.provider,
+    required this.originalUri,
+  }) : super();
 }
 
 Future<void> showImageAttachmentViewer({
   required BuildContext context,
-  required LoadedMessageImage image,
+  required MessageImageViewerImage image,
   required String? filename,
   required Key heroTag,
 }) {
@@ -40,23 +61,29 @@ Future<void> showImageAttachmentViewer({
     opaque: false,
     transitionDuration: const Duration(milliseconds: 260),
     reverseTransitionDuration: const Duration(milliseconds: 220),
-    pageBuilder: (_, _, _) => BlocProvider(
-      create: (_) => ImageAttachmentActionsCubit(
-        imageSaver: getIt<ImageSaver>(),
-        imageClipboard: getIt<ImageClipboard>(),
-        imageSharer: getIt<ImageSharer>(),
-        bytes: image.bytes,
-        mime: image.mime,
-        actionFilename: image.actionFilename,
-      ),
-      child: ScaffoldMessenger(
+    pageBuilder: (_, _, _) {
+      final viewer = ScaffoldMessenger(
         child: ImageAttachmentViewer(
           image: image,
           filename: filename,
           heroTag: heroTag,
         ),
-      ),
-    ),
+      );
+      return switch (image) {
+        LoadedMessageImage() => BlocProvider(
+          create: (_) => ImageAttachmentActionsCubit(
+            imageSaver: getIt<ImageSaver>(),
+            imageClipboard: getIt<ImageClipboard>(),
+            imageSharer: getIt<ImageSharer>(),
+            bytes: image.bytes,
+            mime: image.mime,
+            actionFilename: image.actionFilename,
+          ),
+          child: viewer,
+        ),
+        ViewOnlyMessageImage() => viewer,
+      };
+    },
     transitionsBuilder: (_, animation, _, child) => FadeTransition(opacity: animation, child: child),
   );
   var shouldDismissViewerWithHistory = true;
@@ -80,7 +107,7 @@ Future<void> showImageAttachmentViewer({
 class ImageAttachmentViewer extends StatefulWidget {
   static const imageKey = ValueKey("imageAttachmentViewer.image");
 
-  final LoadedMessageImage image;
+  final MessageImageViewerImage image;
   final String? filename;
   final Key heroTag;
 
@@ -276,67 +303,69 @@ class _ImageAttachmentViewerState extends State<ImageAttachmentViewer> with Tick
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
+    final image = widget.image;
     final originalUri = widget.image.originalUri;
     final displayFilename = widget.filename;
-    final isRunningAction = context.watch<ImageAttachmentActionsCubit>().state is ImageAttachmentActionRunning;
+    final hasAttachmentActions = image is LoadedMessageImage;
+    final isRunningAction =
+        hasAttachmentActions && context.watch<ImageAttachmentActionsCubit>().state is ImageAttachmentActionRunning;
     final dismissRange = (MediaQuery.sizeOf(context).height * 0.45).clamp(1.0, double.infinity);
     final dismissProgress = (_dragOffset.abs() / dismissRange).clamp(0.0, 1.0);
     final chromeOpacity = 1 - dismissProgress;
     final backgroundOpacity = 1 - dismissProgress * 0.8;
-    return BlocListener<ImageAttachmentActionsCubit, ImageAttachmentActionsState>(
-      listener: _handleActionState,
-      child: Scaffold(
-        backgroundColor: prego.colors.bgSurface1.withValues(alpha: backgroundOpacity),
-        body: SafeArea(
-          child: Column(
-            children: [
-              IgnorePointer(
-                ignoring: _isDismissDrag,
-                child: Opacity(
-                  opacity: chromeOpacity,
-                  child: Padding(
-                    padding: EdgeInsets.symmetric(horizontal: prego.spacing.sm),
-                    child: Row(
-                      children: [
-                        IconButton(
-                          tooltip: context.loc.sessionDetailImageClose,
-                          onPressed: _dismiss,
-                          icon: Icon(Icons.close, color: prego.colors.textPrimary),
-                        ),
-                        SizedBox(width: prego.spacing.xs),
-                        Expanded(
-                          child: displayFilename == null
-                              ? const SizedBox.shrink()
-                              : Text(
-                                  displayFilename,
-                                  style: prego.textTheme.textSm.bold,
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                ),
-                        ),
-                        if (isRunningAction)
-                          Padding(
-                            padding: EdgeInsets.all(prego.spacing.md),
-                            child: SizedBox.square(
-                              dimension: prego.spacing.x2l,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                                color: prego.colors.fgBrandPrimary,
+    final viewer = Scaffold(
+      backgroundColor: prego.colors.bgSurface1.withValues(alpha: backgroundOpacity),
+      body: SafeArea(
+        child: Column(
+          children: [
+            IgnorePointer(
+              ignoring: _isDismissDrag,
+              child: Opacity(
+                opacity: chromeOpacity,
+                child: Padding(
+                  padding: EdgeInsets.symmetric(horizontal: prego.spacing.sm),
+                  child: Row(
+                    children: [
+                      IconButton(
+                        tooltip: context.loc.sessionDetailImageClose,
+                        onPressed: _dismiss,
+                        icon: Icon(Icons.close, color: prego.colors.textPrimary),
+                      ),
+                      SizedBox(width: prego.spacing.xs),
+                      Expanded(
+                        child: displayFilename == null
+                            ? const SizedBox.shrink()
+                            : Text(
+                                displayFilename,
+                                style: prego.textTheme.textSm.bold,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
                               ),
+                      ),
+                      if (isRunningAction)
+                        Padding(
+                          padding: EdgeInsets.all(prego.spacing.md),
+                          child: SizedBox.square(
+                            dimension: prego.spacing.x2l,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: prego.colors.fgBrandPrimary,
                             ),
-                          )
-                        else ...[
-                          if (originalUri != null)
-                            IconButton(
-                              tooltip: context.loc.sessionDetailImageOpenOriginal,
-                              onPressed: () => unawaited(
-                                openExternalLink(
-                                  url: originalUri,
-                                  mode: UrlLaunchMode.externalApp,
-                                ).then<void>((_) {}),
-                              ),
-                              icon: Icon(Icons.open_in_new, color: prego.colors.textPrimary),
+                          ),
+                        )
+                      else ...[
+                        if (originalUri != null)
+                          IconButton(
+                            tooltip: context.loc.sessionDetailImageOpenOriginal,
+                            onPressed: () => unawaited(
+                              openExternalLink(
+                                url: originalUri,
+                                mode: UrlLaunchMode.externalApp,
+                              ).then<void>((_) {}),
                             ),
+                            icon: Icon(Icons.open_in_new, color: prego.colors.textPrimary),
+                          ),
+                        if (hasAttachmentActions) ...[
                           IconButton(
                             tooltip: context.loc.sessionDetailImageCopy,
                             onPressed: () => unawaited(context.read<ImageAttachmentActionsCubit>().copy()),
@@ -360,37 +389,37 @@ class _ImageAttachmentViewerState extends State<ImageAttachmentViewer> with Tick
                           ),
                         ],
                       ],
-                    ),
+                    ],
                   ),
                 ),
               ),
-              Expanded(
-                child: Transform.translate(
-                  offset: Offset(0, _dragOffset),
-                  child: GestureDetector(
-                    behavior: HitTestBehavior.opaque,
-                    onDoubleTapDown: (details) => _captureDoubleTapPosition(details: details),
-                    onDoubleTap: _toggleZoom,
-                    child: InteractiveViewer(
-                      transformationController: _transformationController,
-                      minScale: 0.8,
-                      maxScale: 5,
-                      onInteractionStart: (details) => _handleInteractionStart(details: details),
-                      onInteractionUpdate: (details) => _handleInteractionUpdate(details: details),
-                      onInteractionEnd: (details) => _handleInteractionEnd(details: details),
-                      child: Hero(
-                        tag: widget.heroTag,
-                        child: SizedBox.expand(
-                          child: Image(
-                            key: ImageAttachmentViewer.imageKey,
-                            image: widget.image.provider,
-                            fit: BoxFit.contain,
-                            semanticLabel: widget.filename,
-                            errorBuilder: (_, _, _) => Icon(
-                              Icons.broken_image,
-                              size: prego.spacing.x6l,
-                              color: prego.colors.textTertiary,
-                            ),
+            ),
+            Expanded(
+              child: Transform.translate(
+                offset: Offset(0, _dragOffset),
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onDoubleTapDown: (details) => _captureDoubleTapPosition(details: details),
+                  onDoubleTap: _toggleZoom,
+                  child: InteractiveViewer(
+                    transformationController: _transformationController,
+                    minScale: 0.8,
+                    maxScale: 5,
+                    onInteractionStart: (details) => _handleInteractionStart(details: details),
+                    onInteractionUpdate: (details) => _handleInteractionUpdate(details: details),
+                    onInteractionEnd: (details) => _handleInteractionEnd(details: details),
+                    child: Hero(
+                      tag: widget.heroTag,
+                      child: SizedBox.expand(
+                        child: Image(
+                          key: ImageAttachmentViewer.imageKey,
+                          image: image.provider,
+                          fit: BoxFit.contain,
+                          semanticLabel: widget.filename,
+                          errorBuilder: (_, _, _) => Icon(
+                            Icons.broken_image,
+                            size: prego.spacing.x6l,
+                            color: prego.colors.textTertiary,
                           ),
                         ),
                       ),
@@ -398,10 +427,15 @@ class _ImageAttachmentViewerState extends State<ImageAttachmentViewer> with Tick
                   ),
                 ),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
+    );
+    if (!hasAttachmentActions) return viewer;
+    return BlocListener<ImageAttachmentActionsCubit, ImageAttachmentActionsState>(
+      listener: _handleActionState,
+      child: viewer,
     );
   }
 }

--- a/client/app/lib/features/session_detail/widgets/text_part_widget.dart
+++ b/client/app/lib/features/session_detail/widgets/text_part_widget.dart
@@ -1,9 +1,12 @@
+import "dart:async";
+
 import "package:flutter/material.dart";
 import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
 import "package:theme_prego/module_prego.dart";
 
 import "../../../core/extensions/build_context_x.dart";
 import "../../../core/widgets/markdown_styles.dart";
+import "image_attachment_viewer.dart";
 
 class TextPartWidget extends StatelessWidget {
   final String text;
@@ -25,10 +28,137 @@ class TextPartWidget extends StatelessWidget {
         data: text,
         selectable: false,
         onTapLink: handleMarkdownLinkTap,
+        imageBuilder: (uri, title, alt) => MarkdownMessageImage(
+          uri: uri,
+          semanticLabel: alt,
+        ),
         styleSheet: buildSessionMarkdownStyleSheet(prego: context.prego),
         builders: buildSessionMarkdownBuilders(
           highlightEnabled: !isStreaming,
           copyTooltip: context.loc.sessionDetailCopy,
+        ),
+      ),
+    );
+  }
+}
+
+class MarkdownMessageImage extends StatefulWidget {
+  final Uri uri;
+  final String? semanticLabel;
+
+  const MarkdownMessageImage({
+    super.key,
+    required this.uri,
+    required this.semanticLabel,
+  });
+
+  @override
+  State<MarkdownMessageImage> createState() => _MarkdownMessageImageState();
+}
+
+class _MarkdownMessageImageState extends State<MarkdownMessageImage> {
+  final _heroTag = UniqueKey();
+  late ImageProvider? _provider;
+  bool _isDecoded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _provider = _imageProvider(uri: widget.uri);
+  }
+
+  @override
+  void didUpdateWidget(covariant MarkdownMessageImage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.uri != widget.uri) {
+      _provider = _imageProvider(uri: widget.uri);
+      _isDecoded = false;
+    }
+  }
+
+  ImageProvider? _imageProvider({required Uri uri}) {
+    final scheme = uri.scheme.toLowerCase();
+    if ((scheme == "http" || scheme == "https") && uri.host.isNotEmpty && uri.userInfo.isEmpty) {
+      return NetworkImage(uri.toString());
+    }
+    if (scheme == "resource" && uri.path.isNotEmpty) return AssetImage(uri.path);
+    if (scheme != "data") return null;
+
+    try {
+      final data = uri.data;
+      if (data == null || !data.mimeType.toLowerCase().startsWith("image/")) return null;
+      return MemoryImage(data.contentAsBytes());
+    } on FormatException {
+      return null;
+    }
+  }
+
+  void _markDecoded() {
+    if (_isDecoded) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && !_isDecoded) setState(() => _isDecoded = true);
+    });
+  }
+
+  String? get _displayFilename {
+    final scheme = widget.uri.scheme.toLowerCase();
+    if (scheme != "http" && scheme != "https") return null;
+    final segments = widget.uri.pathSegments;
+    if (segments.isEmpty) return null;
+    final filename = segments.last.trim();
+    if (filename.isEmpty) return null;
+    return String.fromCharCodes(filename.runes.take(255));
+  }
+
+  Uri? get _originalUri {
+    final scheme = widget.uri.scheme.toLowerCase();
+    return scheme == "http" || scheme == "https" ? widget.uri : null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = _provider;
+    if (provider == null) {
+      return Icon(
+        Icons.broken_image,
+        size: context.prego.spacing.x6l,
+        color: context.prego.colors.textTertiary,
+      );
+    }
+
+    return Semantics(
+      button: _isDecoded,
+      label: context.loc.sessionDetailImageOpen,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: !_isDecoded
+            ? null
+            : () => unawaited(
+                showImageAttachmentViewer(
+                  context: context,
+                  image: ViewOnlyMessageImage(
+                    provider: provider,
+                    originalUri: _originalUri,
+                  ),
+                  filename: _displayFilename,
+                  heroTag: _heroTag,
+                ),
+              ),
+        child: Hero(
+          tag: _heroTag,
+          child: Image(
+            image: provider,
+            semanticLabel: widget.semanticLabel,
+            frameBuilder: (_, child, frame, _) {
+              if (frame != null) _markDecoded();
+              return child;
+            },
+            errorBuilder: (_, _, _) => Icon(
+              Icons.broken_image,
+              size: context.prego.spacing.x6l,
+              color: context.prego.colors.textTertiary,
+            ),
+          ),
         ),
       ),
     );

--- a/client/app/lib/features/session_detail/widgets/text_part_widget.dart
+++ b/client/app/lib/features/session_detail/widgets/text_part_widget.dart
@@ -59,6 +59,8 @@ class MarkdownMessageImage extends StatefulWidget {
 }
 
 class _MarkdownMessageImageState extends State<MarkdownMessageImage> {
+  static const _maxDecodedImageDimension = 2048;
+
   final _heroTag = UniqueKey();
   late ImageProvider? _provider;
   bool _isDecoded = false;
@@ -81,9 +83,11 @@ class _MarkdownMessageImageState extends State<MarkdownMessageImage> {
   ImageProvider? _imageProvider({required Uri uri}) {
     final scheme = uri.scheme.toLowerCase();
     if ((scheme == "http" || scheme == "https") && uri.host.isNotEmpty && uri.userInfo.isEmpty) {
-      return NetworkImage(uri.toString());
+      return _boundedProvider(provider: NetworkImage(uri.toString()));
     }
-    if (scheme == "resource" && uri.path.isNotEmpty) return AssetImage(uri.path);
+    if (scheme == "resource" && uri.path.isNotEmpty) {
+      return _boundedProvider(provider: AssetImage(uri.path));
+    }
     if (scheme != "data") return null;
 
     try {
@@ -100,10 +104,19 @@ class _MarkdownMessageImageState extends State<MarkdownMessageImage> {
 
       final bytes = data.contentAsBytes();
       if (bytes.length > maxInlineMessageAttachmentBytes) return null;
-      return MemoryImage(bytes);
+      return _boundedProvider(provider: MemoryImage(bytes));
     } on FormatException {
       return null;
     }
+  }
+
+  ImageProvider _boundedProvider({required ImageProvider provider}) {
+    return ResizeImage(
+      provider,
+      width: _maxDecodedImageDimension,
+      height: _maxDecodedImageDimension,
+      policy: ResizeImagePolicy.fit,
+    );
   }
 
   void _markDecoded() {

--- a/client/app/lib/features/session_detail/widgets/text_part_widget.dart
+++ b/client/app/lib/features/session_detail/widgets/text_part_widget.dart
@@ -2,6 +2,8 @@ import "dart:async";
 
 import "package:flutter/material.dart";
 import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
+import "package:sesori_shared/sesori_shared.dart"
+    show isInlineMessageAttachmentWithinSizeLimit, maxInlineMessageAttachmentBytes;
 import "package:theme_prego/module_prego.dart";
 
 import "../../../core/extensions/build_context_x.dart";
@@ -87,7 +89,18 @@ class _MarkdownMessageImageState extends State<MarkdownMessageImage> {
     try {
       final data = uri.data;
       if (data == null || !data.mimeType.toLowerCase().startsWith("image/")) return null;
-      return MemoryImage(data.contentAsBytes());
+      final encoded = uri.toString();
+      final separator = encoded.indexOf(",");
+      if (separator < 0) return null;
+      final encodedDataLength = encoded.length - separator - 1;
+      final isWithinEncodedLimit = data.isBase64
+          ? isInlineMessageAttachmentWithinSizeLimit(base64Length: encodedDataLength)
+          : encodedDataLength <= maxInlineMessageAttachmentBytes * 3;
+      if (!isWithinEncodedLimit) return null;
+
+      final bytes = data.contentAsBytes();
+      if (bytes.length > maxInlineMessageAttachmentBytes) return null;
+      return MemoryImage(bytes);
     } on FormatException {
       return null;
     }

--- a/client/app/test/features/session_detail/widgets/assistant_message_card_test.dart
+++ b/client/app/test/features/session_detail/widgets/assistant_message_card_test.dart
@@ -1,3 +1,6 @@
+import "dart:typed_data";
+import "dart:ui" show SemanticsAction;
+
 import "package:flutter/material.dart";
 import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
 import "package:flutter_test/flutter_test.dart";
@@ -217,6 +220,7 @@ void main() {
   });
 
   testWidgets("opens a decoded Markdown image in the full-screen viewer", (tester) async {
+    final semantics = tester.ensureSemantics();
     const imageData =
         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==";
 
@@ -244,6 +248,10 @@ void main() {
       find.descendant(of: markdownImage, matching: find.byType(GestureDetector)),
     );
     expect(tapTarget.onTap, isNotNull);
+    expect(
+      tester.getSemantics(markdownImage).getSemanticsData().hasAction(SemanticsAction.tap),
+      isTrue,
+    );
 
     tapTarget.onTap!();
     await tester.pumpAndSettle();
@@ -255,6 +263,32 @@ void main() {
     expect(find.byIcon(Icons.download_outlined), findsNothing);
     final fullscreen = tester.widget<Image>(find.byKey(ImageAttachmentViewer.imageKey));
     expect(identical(fullscreen.image, preview.image), isTrue);
+    semantics.dispose();
+  });
+
+  testWidgets("rejects oversized Markdown data images before decoding", (tester) async {
+    final oversizedUri = Uri.dataFromBytes(
+      Uint8List(maxInlineMessageAttachmentBytes + 1),
+      mimeType: "image/png",
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(extensions: [PregoDesignSystem.light]),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: MarkdownMessageImage(
+            uri: oversizedUri,
+            semanticLabel: "Oversized image",
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(Image), findsNothing);
+    expect(find.byIcon(Icons.broken_image), findsOneWidget);
+    expect(find.byType(GestureDetector), findsNothing);
   });
 
   testWidgets("renders normalized assistant file attachments", (tester) async {

--- a/client/app/test/features/session_detail/widgets/assistant_message_card_test.dart
+++ b/client/app/test/features/session_detail/widgets/assistant_message_card_test.dart
@@ -7,6 +7,8 @@ import "package:http/testing.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/features/session_detail/widgets/assistant_message_card.dart";
 import "package:sesori_mobile/features/session_detail/widgets/file_part_widget.dart";
+import "package:sesori_mobile/features/session_detail/widgets/image_attachment_viewer.dart";
+import "package:sesori_mobile/features/session_detail/widgets/text_part_widget.dart";
 import "package:sesori_mobile/features/session_detail/widgets/tool_part_widget.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -212,6 +214,47 @@ void main() {
     expect(tester.takeException(), isNull);
     expect(find.byType(SelectionArea), findsOneWidget);
     expect(tester.widget<MarkdownBody>(find.byType(MarkdownBody)).data, "updated draft text");
+  });
+
+  testWidgets("opens a decoded Markdown image in the full-screen viewer", (tester) async {
+    const imageData =
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==";
+
+    await tester.pumpWidget(
+      _AssistantMessageCardHarness(
+        message: _assistantMessage(
+          parts: [_textPart(id: "image-part", text: "![Test image]($imageData)")],
+        ),
+        streamingText: const {},
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final markdownImage = find.byType(MarkdownMessageImage);
+    expect(markdownImage, findsOneWidget);
+    final preview = tester.widget<Image>(find.descendant(of: markdownImage, matching: find.byType(Image)));
+    await tester.runAsync(
+      () => precacheImage(
+        preview.image,
+        tester.element(markdownImage),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final tapTarget = tester.widget<GestureDetector>(
+      find.descendant(of: markdownImage, matching: find.byType(GestureDetector)),
+    );
+    expect(tapTarget.onTap, isNotNull);
+
+    tapTarget.onTap!();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ImageAttachmentViewer), findsOneWidget);
+    expect(find.byType(InteractiveViewer), findsOneWidget);
+    expect(find.byIcon(Icons.content_copy), findsNothing);
+    expect(find.byIcon(Icons.share_outlined), findsNothing);
+    expect(find.byIcon(Icons.download_outlined), findsNothing);
+    final fullscreen = tester.widget<Image>(find.byKey(ImageAttachmentViewer.imageKey));
+    expect(identical(fullscreen.image, preview.image), isTrue);
   });
 
   testWidgets("renders normalized assistant file attachments", (tester) async {

--- a/client/app/test/features/session_detail/widgets/assistant_message_card_test.dart
+++ b/client/app/test/features/session_detail/widgets/assistant_message_card_test.dart
@@ -237,6 +237,8 @@ void main() {
     final markdownImage = find.byType(MarkdownMessageImage);
     expect(markdownImage, findsOneWidget);
     final preview = tester.widget<Image>(find.descendant(of: markdownImage, matching: find.byType(Image)));
+    expect(preview.image, isA<ResizeImage>());
+    expect((preview.image as ResizeImage).imageProvider, isA<MemoryImage>());
     await tester.runAsync(
       () => precacheImage(
         preview.image,
@@ -264,6 +266,32 @@ void main() {
     final fullscreen = tester.widget<Image>(find.byKey(ImageAttachmentViewer.imageKey));
     expect(identical(fullscreen.image, preview.image), isTrue);
     semantics.dispose();
+  });
+
+  testWidgets("bounds remote Markdown image decode dimensions", (tester) async {
+    const uri = "https://example.com/image.png";
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(extensions: [PregoDesignSystem.light]),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: MarkdownMessageImage(
+            uri: Uri.parse(uri),
+            semanticLabel: "Remote image",
+          ),
+        ),
+      ),
+    );
+
+    final image = tester.widget<Image>(find.byType(Image));
+    expect(image.image, isA<ResizeImage>());
+    final provider = image.image as ResizeImage;
+    expect(provider.width, 2048);
+    expect(provider.height, 2048);
+    expect(provider.policy, ResizeImagePolicy.fit);
+    expect(provider.imageProvider, isA<NetworkImage>());
+    expect((provider.imageProvider as NetworkImage).url, uri);
   });
 
   testWidgets("rejects oversized Markdown data images before decoding", (tester) async {


### PR DESCRIPTION
## Complexity

🌿 Straightforward. This reuses the existing image viewer and models Markdown images as a view-only source instead of adding another viewer or fetching unverified bytes for attachment actions.

## What

- Make decoded images in assistant Markdown tappable.
- Open them through the existing full-screen Hero viewer with zoom, drag dismissal, and back handling.
- Split viewer inputs into action-capable loaded images and view-only rendered images.
- Preserve copy, share, and save controls for byte-backed attachments while offering open-original for remote Markdown images.
- Add focused regression coverage for the Markdown image route.

## Why

Markdown images rendered inline but could not be opened like image attachments, making them harder to inspect on mobile.

## Risk and test focus

The user-visible impact is limited to enabling taps on successfully decoded session Markdown images. Byte-backed attachment behavior remains unchanged, and view-only Markdown images do not expose actions that require trusted encoded bytes.

There is no database, transport, bridge, or persisted-state impact. Test focus is the shared viewer boundary, absence of attachment-only actions for Markdown images, and preservation of existing attachment navigation and gestures.

## Expected result

Tapping a rendered Markdown image opens it full-screen with the same navigation and gestures as an attachment. Remote Markdown images can still open their original URL; copy, share, and save remain available only for actual attachments.

## Verification

- `flutter test test/features/session_detail/widgets/assistant_message_card_test.dart`
- `flutter test test/features/session_detail/widgets/assistant_message_card_test.dart test/features/session_detail/widgets/file_part_widget_test.dart`
- `flutter analyze`
- Aristotle implementation review: approved with no findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Markdown images in assistant messages open in the full-screen viewer with zoom, drag-to-dismiss, and back handling. Images are view-only (attachment actions stay on trusted bytes, remote images get “open original”) and decoding is bounded; oversized data URIs are rejected.

- **New Features**
  - Markdown images rendered via `flutter_markdown_plus` open in the Hero viewer; remote images include “open original”.
  - Added tests for the tap-to-view flow.

- **Bug Fixes**
  - Bound Markdown image decoding to 2048px via `ResizeImage` for network, asset, and data images to limit memory use.
  - Reject oversized `data:` images before decoding using shared size limits; show a broken-image fallback and no tap target. Added a test.

<sup>Written for commit 792b723a74cff5cf42b1e407cd731ed75134a484. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

