### PR TITLE
🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]

### DIFF
--- a/.plan/active/session-pull-request-monitoring/PLAN.md
+++ b/.plan/active/session-pull-request-monitoring/PLAN.md
@@ -528,8 +528,10 @@ settings screen analytics continue unchanged.
   refresh state machine atomically: shipping only local resolution would retain
   the known same-project post-seal request drop while presenting the result as
   current. Roughly 1,000 changed lines delete obsolete service tests/fakes and
-  roughly 700 replace persistence/service coverage around the new invariants, so
-  the evidence-based target is 3,100–3,400 changed lines including deletions.
+  roughly 700 replace persistence/service coverage around the new invariants.
+  Review hardening added exact directory and checkout-race fences, explicit
+  refresh policy, isolated batched-write failures, and their regressions, so the
+  final evidence-based target is 3,600–3,900 changed lines including deletions.
 - Never hand-edit generated files. Internal Dart contracts update every
   in-repository consumer in lockstep.
 - Run `aristotle-impl-review` for Steps 2.a–8 because they alter production
@@ -545,7 +547,7 @@ settings screen analytics continue unchanged.
 | 2.b/9 | `session-pull-request-monitoring-scoped-pr-persistence` | `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2.b/9]` | Drift migration, generated artifacts, transactional writer ownership, and scoped cache joins. | 9,800–10,800 | Migrate current branch/repository/login scope and the repository-keyed ephemeral PR cache while preserving request-driven behavior. |
 | 2.c/9 | `session-pull-request-monitoring-scoped-pr-reads` | `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]` | Fresh request identity gating, list/detail failure behavior, and privacy-sensitive regressions. | 1,200–1,700 | Require fresh login evidence for every PR-bearing read and fail closed without blocking session/catalog data. |
 | 3/9 | `session-pull-request-monitoring-graphql-selection` | `🚧 [session-pull-request-monitoring] feat(bridge): batch exact PR selection [step 3/9]` | Typed dynamic GraphQL batching/pagination, identity fencing, and deterministic selection. | 3,100–3,500 | Replace repository-wide open-list CLI reads with typed exact-target GraphQL batching and open/terminal selection. |
-| 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | Git/process resolution, persisted scope, cache races, and cross-layer rendering. | 3,100–3,400 | Resolve every root's current branch/repository on each request refresh, scope selected cache, and map the live branch. |
+| 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | Git/process resolution, persisted scope, cache races, and cross-layer rendering. | 3,600–3,900 | Resolve every root's current branch/repository on each request refresh, scope selected cache, and map the live branch. |
 | 5/9 | `session-pull-request-monitoring-view-scheduler` | `🚧 [session-pull-request-monitoring] feat(bridge): schedule viewed-project PR refresh [step 5/9]` | Multi-device connection lifecycle and serialized add-during-flight scheduling. | 900–1,400 | Route per-connection project presence and run one fixed 30-second aggregate scheduler. |
 | 6/9 | `session-pull-request-monitoring-bridge-settings` | `⚙️ [session-pull-request-monitoring] feat(bridge): configure PR refresh cadence [step 6/9]` | Localized persisted settings flow with concurrent writes and live timer updates. | 1,000–1,500 | Persist/validate interval settings, expose GET/PATCH, serialize settings writes, and rearm the live timer. |
 | 7/9 | `session-pull-request-monitoring-client-presence` | `🚧 [session-pull-request-monitoring] feat(client): declare viewed projects [step 7/9]` | Shared list/detail lifecycle, reconnect ordering, and multi-device bridge behavior. | 1,000–1,500 | Add layered client project presence with list/detail, lifecycle, reconnect, and multi-device-safe bridge behavior. |

--- a/.plan/active/session-pull-request-monitoring/PLAN.md
+++ b/.plan/active/session-pull-request-monitoring/PLAN.md
@@ -531,7 +531,9 @@ settings screen analytics continue unchanged.
   roughly 700 replace persistence/service coverage around the new invariants.
   Review hardening added exact directory and checkout-race fences, explicit
   refresh policy, isolated batched-write failures, and their regressions, so the
-  final evidence-based target is 3,600–3,900 changed lines including deletions.
+  later review hardening also bounded refresh/fallback work and coalesced
+  background requests, so the final evidence-based target is 4,000–4,200
+  changed lines including deletions.
 - Never hand-edit generated files. Internal Dart contracts update every
   in-repository consumer in lockstep.
 - Run `aristotle-impl-review` for Steps 2.a–8 because they alter production
@@ -547,7 +549,7 @@ settings screen analytics continue unchanged.
 | 2.b/9 | `session-pull-request-monitoring-scoped-pr-persistence` | `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2.b/9]` | Drift migration, generated artifacts, transactional writer ownership, and scoped cache joins. | 9,800–10,800 | Migrate current branch/repository/login scope and the repository-keyed ephemeral PR cache while preserving request-driven behavior. |
 | 2.c/9 | `session-pull-request-monitoring-scoped-pr-reads` | `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]` | Fresh request identity gating, list/detail failure behavior, and privacy-sensitive regressions. | 1,200–1,700 | Require fresh login evidence for every PR-bearing read and fail closed without blocking session/catalog data. |
 | 3/9 | `session-pull-request-monitoring-graphql-selection` | `🚧 [session-pull-request-monitoring] feat(bridge): batch exact PR selection [step 3/9]` | Typed dynamic GraphQL batching/pagination, identity fencing, and deterministic selection. | 3,100–3,500 | Replace repository-wide open-list CLI reads with typed exact-target GraphQL batching and open/terminal selection. |
-| 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | Git/process resolution, persisted scope, cache races, and cross-layer rendering. | 3,600–3,900 | Resolve every root's current branch/repository on each request refresh, scope selected cache, and map the live branch. |
+| 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | Git/process resolution, persisted scope, cache races, and cross-layer rendering. | 4,000–4,200 | Resolve every root's current branch/repository on each request refresh, scope selected cache, and map the live branch. |
 | 5/9 | `session-pull-request-monitoring-view-scheduler` | `🚧 [session-pull-request-monitoring] feat(bridge): schedule viewed-project PR refresh [step 5/9]` | Multi-device connection lifecycle and serialized add-during-flight scheduling. | 900–1,400 | Route per-connection project presence and run one fixed 30-second aggregate scheduler. |
 | 6/9 | `session-pull-request-monitoring-bridge-settings` | `⚙️ [session-pull-request-monitoring] feat(bridge): configure PR refresh cadence [step 6/9]` | Localized persisted settings flow with concurrent writes and live timer updates. | 1,000–1,500 | Persist/validate interval settings, expose GET/PATCH, serialize settings writes, and rearm the live timer. |
 | 7/9 | `session-pull-request-monitoring-client-presence` | `🚧 [session-pull-request-monitoring] feat(client): declare viewed projects [step 7/9]` | Shared list/detail lifecycle, reconnect ordering, and multi-device bridge behavior. | 1,000–1,500 | Add layered client project presence with list/detail, lifecycle, reconnect, and multi-device-safe bridge behavior. |

--- a/.plan/active/session-pull-request-monitoring/PLAN.md
+++ b/.plan/active/session-pull-request-monitoring/PLAN.md
@@ -523,6 +523,13 @@ settings screen analytics continue unchanged.
   fakes. Splitting before integration would either ship unused GraphQL machinery
   or retain both source paths, so the evidence-based target is 3,100–3,500
   changed lines including generated output and deletions.
+- Step 4 is expected to exceed 1,500 because current-branch persistence and the
+  request-generation drain must replace the old creation-branch/per-project
+  refresh state machine atomically: shipping only local resolution would retain
+  the known same-project post-seal request drop while presenting the result as
+  current. Roughly 1,000 changed lines delete obsolete service tests/fakes and
+  roughly 700 replace persistence/service coverage around the new invariants, so
+  the evidence-based target is 3,100–3,400 changed lines including deletions.
 - Never hand-edit generated files. Internal Dart contracts update every
   in-repository consumer in lockstep.
 - Run `aristotle-impl-review` for Steps 2.a–8 because they alter production
@@ -538,7 +545,7 @@ settings screen analytics continue unchanged.
 | 2.b/9 | `session-pull-request-monitoring-scoped-pr-persistence` | `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2.b/9]` | Drift migration, generated artifacts, transactional writer ownership, and scoped cache joins. | 9,800–10,800 | Migrate current branch/repository/login scope and the repository-keyed ephemeral PR cache while preserving request-driven behavior. |
 | 2.c/9 | `session-pull-request-monitoring-scoped-pr-reads` | `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]` | Fresh request identity gating, list/detail failure behavior, and privacy-sensitive regressions. | 1,200–1,700 | Require fresh login evidence for every PR-bearing read and fail closed without blocking session/catalog data. |
 | 3/9 | `session-pull-request-monitoring-graphql-selection` | `🚧 [session-pull-request-monitoring] feat(bridge): batch exact PR selection [step 3/9]` | Typed dynamic GraphQL batching/pagination, identity fencing, and deterministic selection. | 3,100–3,500 | Replace repository-wide open-list CLI reads with typed exact-target GraphQL batching and open/terminal selection. |
-| 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | Git/process resolution, persisted scope, cache races, and cross-layer rendering. | 1,100–1,500 | Resolve every root's current branch/repository on each request refresh, scope selected cache, and map the live branch. |
+| 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | Git/process resolution, persisted scope, cache races, and cross-layer rendering. | 3,100–3,400 | Resolve every root's current branch/repository on each request refresh, scope selected cache, and map the live branch. |
 | 5/9 | `session-pull-request-monitoring-view-scheduler` | `🚧 [session-pull-request-monitoring] feat(bridge): schedule viewed-project PR refresh [step 5/9]` | Multi-device connection lifecycle and serialized add-during-flight scheduling. | 900–1,400 | Route per-connection project presence and run one fixed 30-second aggregate scheduler. |
 | 6/9 | `session-pull-request-monitoring-bridge-settings` | `⚙️ [session-pull-request-monitoring] feat(bridge): configure PR refresh cadence [step 6/9]` | Localized persisted settings flow with concurrent writes and live timer updates. | 1,000–1,500 | Persist/validate interval settings, expose GET/PATCH, serialize settings writes, and rearm the live timer. |
 | 7/9 | `session-pull-request-monitoring-client-presence` | `🚧 [session-pull-request-monitoring] feat(client): declare viewed projects [step 7/9]` | Shared list/detail lifecycle, reconnect ordering, and multi-device bridge behavior. | 1,000–1,500 | Add layered client project presence with list/detail, lifecycle, reconnect, and multi-device-safe bridge behavior. |

--- a/.plan/active/session-pull-request-monitoring/TRACKER.md
+++ b/.plan/active/session-pull-request-monitoring/TRACKER.md
@@ -293,7 +293,7 @@
   persisted login and exact current targets.
 - **Step 4/9 cleanup and size:** Removed creation-branch target generation,
   project-path/session-directory fallback routing, the per-project active-return
-  refresh path, and their obsolete tests/fakes. The 3,707-line
+  refresh path, and their obsolete tests/fakes. The approximately 3,700-line
   change replaces roughly 1,000 lines of old service coverage and roughly 700
   lines of persistence/service tests, then adds review-requested checkout and
   directory race fences, explicit-refresh debounce policy, per-project write

--- a/.plan/active/session-pull-request-monitoring/TRACKER.md
+++ b/.plan/active/session-pull-request-monitoring/TRACKER.md
@@ -43,7 +43,7 @@
 | [x] | 2.b/9 | `session-pull-request-monitoring-scoped-pr-persistence` | `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2.b/9]` | 9,800–10,800 | [PR #671](https://github.com/sesori-ai/sesori_apps_monorepo/pull/671) merged as `e6001fdc` |
 | [x] | 2.c/9 | `session-pull-request-monitoring-scoped-pr-reads` | `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]` | 1,200–1,700 | [PR #678](https://github.com/sesori-ai/sesori_apps_monorepo/pull/678) merged as `d13cc8ca` |
 | [x] | 3/9 | `session-pull-request-monitoring-graphql-selection` | `🚧 [session-pull-request-monitoring] feat(bridge): batch exact PR selection [step 3/9]` | 3,100–3,500 | [PR #685](https://github.com/sesori-ai/sesori_apps_monorepo/pull/685) merged as `f6ec9e9d` |
-| [ ] | 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | 3,600–3,900 | [PR #686](https://github.com/sesori-ai/sesori_apps_monorepo/pull/686) open; all review feedback addressed with no unresolved threads |
+| [ ] | 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | 4,000–4,200 | [PR #686](https://github.com/sesori-ai/sesori_apps_monorepo/pull/686) open; all valid feedback addressed, with rejected bot threads left for reviewer follow-up |
 | [ ] | 5/9 | `session-pull-request-monitoring-view-scheduler` | `🚧 [session-pull-request-monitoring] feat(bridge): schedule viewed-project PR refresh [step 5/9]` | 900–1,400 | Blocked on Step 4 merge |
 | [ ] | 6/9 | `session-pull-request-monitoring-bridge-settings` | `⚙️ [session-pull-request-monitoring] feat(bridge): configure PR refresh cadence [step 6/9]` | 1,000–1,500 | Blocked on Step 5 merge |
 | [ ] | 7/9 | `session-pull-request-monitoring-client-presence` | `🚧 [session-pull-request-monitoring] feat(client): declare viewed projects [step 7/9]` | 1,000–1,500 | Blocked on Step 6 merge |
@@ -293,13 +293,16 @@
   persisted login and exact current targets.
 - **Step 4/9 cleanup and size:** Removed creation-branch target generation,
   project-path/session-directory fallback routing, the per-project active-return
-  refresh path, and their obsolete tests/fakes. The approximately 3,700-line
+  refresh path, and their obsolete tests/fakes. The approximately 4,100-line
   change replaces roughly 1,000 lines of old service coverage and roughly 700
   lines of persistence/service tests, then adds review-requested checkout and
   directory race fences, explicit-refresh debounce policy, per-project write
   failure isolation, and focused regressions. Splitting local resolution from
   the drain would ship current-branch presentation with the known post-seal
-  request-drop race, so the coherent final target is 3,600–3,900 changed lines.
+  request-drop race. Later review hardening bounded directory concurrency and
+  request fallback time, preserved locally committed branches on failed waits,
+  and coalesced background refreshes, so the coherent final target is
+  4,000–4,200 changed lines.
 - **Step 4/9 verification and review:** Fatal-info analysis, 79 focused
   Git/source/persistence/service/routing/integration tests, all 2,311 bridge app
   tests, formatting, and `git diff --check` pass. `aristotle-impl-review`

--- a/.plan/active/session-pull-request-monitoring/TRACKER.md
+++ b/.plan/active/session-pull-request-monitoring/TRACKER.md
@@ -43,7 +43,7 @@
 | [x] | 2.b/9 | `session-pull-request-monitoring-scoped-pr-persistence` | `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2.b/9]` | 9,800–10,800 | [PR #671](https://github.com/sesori-ai/sesori_apps_monorepo/pull/671) merged as `e6001fdc` |
 | [x] | 2.c/9 | `session-pull-request-monitoring-scoped-pr-reads` | `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]` | 1,200–1,700 | [PR #678](https://github.com/sesori-ai/sesori_apps_monorepo/pull/678) merged as `d13cc8ca` |
 | [x] | 3/9 | `session-pull-request-monitoring-graphql-selection` | `🚧 [session-pull-request-monitoring] feat(bridge): batch exact PR selection [step 3/9]` | 3,100–3,500 | [PR #685](https://github.com/sesori-ai/sesori_apps_monorepo/pull/685) merged as `f6ec9e9d` |
-| [ ] | 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | 3,100–3,400 | [PR #686](https://github.com/sesori-ai/sesori_apps_monorepo/pull/686) open; implementation, focused/full verification, and architecture review complete |
+| [ ] | 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | 3,600–3,900 | [PR #686](https://github.com/sesori-ai/sesori_apps_monorepo/pull/686) open; all review feedback addressed with no unresolved threads |
 | [ ] | 5/9 | `session-pull-request-monitoring-view-scheduler` | `🚧 [session-pull-request-monitoring] feat(bridge): schedule viewed-project PR refresh [step 5/9]` | 900–1,400 | Blocked on Step 4 merge |
 | [ ] | 6/9 | `session-pull-request-monitoring-bridge-settings` | `⚙️ [session-pull-request-monitoring] feat(bridge): configure PR refresh cadence [step 6/9]` | 1,000–1,500 | Blocked on Step 5 merge |
 | [ ] | 7/9 | `session-pull-request-monitoring-client-presence` | `🚧 [session-pull-request-monitoring] feat(client): declare viewed projects [step 7/9]` | 1,000–1,500 | Blocked on Step 6 merge |
@@ -293,15 +293,22 @@
   persisted login and exact current targets.
 - **Step 4/9 cleanup and size:** Removed creation-branch target generation,
   project-path/session-directory fallback routing, the per-project active-return
-  refresh path, and their obsolete tests/fakes. The approximately 3,300-line
+  refresh path, and their obsolete tests/fakes. The 3,707-line
   change replaces roughly 1,000 lines of old service coverage and roughly 700
-  lines of persistence/service tests. Splitting local resolution from the drain
-  would ship current-branch presentation with the known post-seal request-drop
-  race, so the coherent target is 3,100–3,400 changed lines.
+  lines of persistence/service tests, then adds review-requested checkout and
+  directory race fences, explicit-refresh debounce policy, per-project write
+  failure isolation, and focused regressions. Splitting local resolution from
+  the drain would ship current-branch presentation with the known post-seal
+  request-drop race, so the coherent final target is 3,600–3,900 changed lines.
 - **Step 4/9 verification and review:** Fatal-info analysis, 79 focused
   Git/source/persistence/service/routing/integration tests, all 2,311 bridge app
   tests, formatting, and `git diff --check` pass. `aristotle-impl-review`
-  approved the complete working-tree architecture with no findings.
+  approved the initial complete working-tree architecture with no findings. A
+  follow-up review of the architecture-bearing feedback changes identified two
+  contract-shape corrections: use a closed semantic refresh policy and model a
+  checkout change as its own typed target variant. Both were applied; per review
+  rules, those corrections were not re-reviewed. All 13 bot threads were
+  addressed in `a4016fa9` and resolved.
 
 ## Findings and Plan Deltas
 

--- a/.plan/active/session-pull-request-monitoring/TRACKER.md
+++ b/.plan/active/session-pull-request-monitoring/TRACKER.md
@@ -5,11 +5,11 @@
 - **Plan slug:** `session-pull-request-monitoring`
 - **Implementation base:** `main` at
   `f6ec9e9dc66782197a46261de3bcc002e261a5bd`
-- **Series state:** Steps 1/9, 2.a–2.c/9, and 3/9 merged; Step 4 is in progress
+- **Series state:** Steps 1/9, 2.a–2.c/9, and 3/9 merged; Step 4 is in review
 - **Current step:** Step 4/9 — current-branch request refresh
 - **Plan PR:** [#649](https://github.com/sesori-ai/sesori_apps_monorepo/pull/649) merged
 - **Superseded prototype:** [#659](https://github.com/sesori-ai/sesori_apps_monorepo/pull/659) closed
-- **Next action:** commit, push, and raise Step 4/9
+- **Next action:** monitor Step 4 PR #686 and address CI/review feedback
 
 ## Existing Baseline
 
@@ -43,7 +43,7 @@
 | [x] | 2.b/9 | `session-pull-request-monitoring-scoped-pr-persistence` | `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2.b/9]` | 9,800–10,800 | [PR #671](https://github.com/sesori-ai/sesori_apps_monorepo/pull/671) merged as `e6001fdc` |
 | [x] | 2.c/9 | `session-pull-request-monitoring-scoped-pr-reads` | `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]` | 1,200–1,700 | [PR #678](https://github.com/sesori-ai/sesori_apps_monorepo/pull/678) merged as `d13cc8ca` |
 | [x] | 3/9 | `session-pull-request-monitoring-graphql-selection` | `🚧 [session-pull-request-monitoring] feat(bridge): batch exact PR selection [step 3/9]` | 3,100–3,500 | [PR #685](https://github.com/sesori-ai/sesori_apps_monorepo/pull/685) merged as `f6ec9e9d` |
-| [ ] | 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | 3,100–3,400 | Implementation, focused/full verification, and architecture review complete |
+| [ ] | 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | 3,100–3,400 | [PR #686](https://github.com/sesori-ai/sesori_apps_monorepo/pull/686) open; implementation, focused/full verification, and architecture review complete |
 | [ ] | 5/9 | `session-pull-request-monitoring-view-scheduler` | `🚧 [session-pull-request-monitoring] feat(bridge): schedule viewed-project PR refresh [step 5/9]` | 900–1,400 | Blocked on Step 4 merge |
 | [ ] | 6/9 | `session-pull-request-monitoring-bridge-settings` | `⚙️ [session-pull-request-monitoring] feat(bridge): configure PR refresh cadence [step 6/9]` | 1,000–1,500 | Blocked on Step 5 merge |
 | [ ] | 7/9 | `session-pull-request-monitoring-client-presence` | `🚧 [session-pull-request-monitoring] feat(client): declare viewed projects [step 7/9]` | 1,000–1,500 | Blocked on Step 6 merge |

--- a/.plan/active/session-pull-request-monitoring/TRACKER.md
+++ b/.plan/active/session-pull-request-monitoring/TRACKER.md
@@ -4,12 +4,12 @@
 
 - **Plan slug:** `session-pull-request-monitoring`
 - **Implementation base:** `main` at
-  `d13cc8ca8ae137fb0db57a359bc8429e378af0de`
-- **Series state:** Steps 1/9 and 2.a–2.c/9 merged; Step 3 is in review
-- **Current step:** Step 3/9 — exact GraphQL selection
+  `f6ec9e9dc66782197a46261de3bcc002e261a5bd`
+- **Series state:** Steps 1/9, 2.a–2.c/9, and 3/9 merged; Step 4 is in progress
+- **Current step:** Step 4/9 — current-branch request refresh
 - **Plan PR:** [#649](https://github.com/sesori-ai/sesori_apps_monorepo/pull/649) merged
 - **Superseded prototype:** [#659](https://github.com/sesori-ai/sesori_apps_monorepo/pull/659) closed
-- **Next action:** monitor Step 3 PR #685 and address CI/review feedback
+- **Next action:** commit, push, and raise Step 4/9
 
 ## Existing Baseline
 
@@ -42,8 +42,8 @@
 | [x] | 2.a/9 | `session-pull-request-monitoring-scoped-source` | `⚙️ [session-pull-request-monitoring] feat(bridge): scope GitHub PR queries [step 2.a/9]` | 500–900 | [PR #662](https://github.com/sesori-ai/sesori_apps_monorepo/pull/662) merged as `057e4c24` |
 | [x] | 2.b/9 | `session-pull-request-monitoring-scoped-pr-persistence` | `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2.b/9]` | 9,800–10,800 | [PR #671](https://github.com/sesori-ai/sesori_apps_monorepo/pull/671) merged as `e6001fdc` |
 | [x] | 2.c/9 | `session-pull-request-monitoring-scoped-pr-reads` | `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]` | 1,200–1,700 | [PR #678](https://github.com/sesori-ai/sesori_apps_monorepo/pull/678) merged as `d13cc8ca` |
-| [ ] | 3/9 | `session-pull-request-monitoring-graphql-selection` | `🚧 [session-pull-request-monitoring] feat(bridge): batch exact PR selection [step 3/9]` | 3,100–3,500 | [PR #685](https://github.com/sesori-ai/sesori_apps_monorepo/pull/685) open; implementation, focused/full verification, and architecture correction complete |
-| [ ] | 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | 1,100–1,500 | Blocked on Step 3 merge |
+| [x] | 3/9 | `session-pull-request-monitoring-graphql-selection` | `🚧 [session-pull-request-monitoring] feat(bridge): batch exact PR selection [step 3/9]` | 3,100–3,500 | [PR #685](https://github.com/sesori-ai/sesori_apps_monorepo/pull/685) merged as `f6ec9e9d` |
+| [ ] | 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | 3,100–3,400 | Implementation, focused/full verification, and architecture review complete |
 | [ ] | 5/9 | `session-pull-request-monitoring-view-scheduler` | `🚧 [session-pull-request-monitoring] feat(bridge): schedule viewed-project PR refresh [step 5/9]` | 900–1,400 | Blocked on Step 4 merge |
 | [ ] | 6/9 | `session-pull-request-monitoring-bridge-settings` | `⚙️ [session-pull-request-monitoring] feat(bridge): configure PR refresh cadence [step 6/9]` | 1,000–1,500 | Blocked on Step 5 merge |
 | [ ] | 7/9 | `session-pull-request-monitoring-client-presence` | `🚧 [session-pull-request-monitoring] feat(client): declare viewed projects [step 7/9]` | 1,000–1,500 | Blocked on Step 6 merge |
@@ -88,10 +88,10 @@
 
 ## Current Drift and Open Work
 
-- Latest audited `main`: Step 3 branched from merged Step 2.c at `d13cc8ca`.
-  Intervening client and ACP/output-image work does not overlap this bridge PR
-  source/selection scope.
-- Drift schema: v13 on `main`; Step 3 leaves the merged schema and migration
+- Latest audited `main`: Step 4 branched from merged Step 3 at `f6ec9e9d`.
+  Intervening image-viewer work does not overlap this bridge current-branch
+  refresh scope.
+- Drift schema: v13 on `main`; Step 4 leaves the merged schema and migration
   unchanged.
 - Parallel-plugin plan: complete through Stage 9 / PR #497.
 - PR #647 is merged and consolidates Harness settings into one screen. Its
@@ -280,6 +280,28 @@
   change exceeds the soft cap because roughly 700 lines are generated DTO output
   and roughly 900 are required deletion of the replaced path. A smaller split
   would ship unused GraphQL machinery or retain two competing source paths.
+- **Step 3/9 merge:** PR #685 merged as `f6ec9e9d` with all 11 checks passing,
+  Cubic approval, and no unresolved review threads. Review follow-up added
+  repeated-cursor termination, privacy-safe typed diagnostics, and the required
+  named query-size parameter before merge.
+- **Step 4/9 implementation:** Request refresh now resolves every captured root
+  session's exact persisted directory through typed named/detached/missing/
+  unsupported/failure outcomes, commits current branch/repository scope before
+  GitHub work, and maps `Session.branchName` only from current scope. One global
+  generation drain batches project sets, queues post-seal same-project requests,
+  serializes local/network/write phases, and gates replacement against the
+  persisted login and exact current targets.
+- **Step 4/9 cleanup and size:** Removed creation-branch target generation,
+  project-path/session-directory fallback routing, the per-project active-return
+  refresh path, and their obsolete tests/fakes. The approximately 3,300-line
+  change replaces roughly 1,000 lines of old service coverage and roughly 700
+  lines of persistence/service tests. Splitting local resolution from the drain
+  would ship current-branch presentation with the known post-seal request-drop
+  race, so the coherent target is 3,100–3,400 changed lines.
+- **Step 4/9 verification and review:** Fatal-info analysis, 79 focused
+  Git/source/persistence/service/routing/integration tests, all 2,311 bridge app
+  tests, formatting, and `git diff --check` pass. `aristotle-impl-review`
+  approved the complete working-tree architecture with no findings.
 
 ## Findings and Plan Deltas
 

--- a/bridge/app/lib/src/api/database/daos/pull_request_dao.dart
+++ b/bridge/app/lib/src/api/database/daos/pull_request_dao.dart
@@ -7,6 +7,11 @@ import "../tables/session_table.dart";
 
 part "pull_request_dao.g.dart";
 
+typedef PullRequestPersistedTarget = ({
+  String githubRepositoryIdentity,
+  String branchName,
+});
+
 @DriftAccessor(tables: [ProjectsTable, PullRequestsTable, SessionTable])
 class PullRequestDao extends DatabaseAccessor<AppDatabase> with _$PullRequestDaoMixin {
   PullRequestDao(super.attachedDatabase);
@@ -83,22 +88,31 @@ class PullRequestDao extends DatabaseAccessor<AppDatabase> with _$PullRequestDao
     return groupedBySessionId;
   }
 
-  Future<void> deletePrsOutsideScope({
+  Future<void> deletePrsOutsideTargets({
     required String projectId,
-    required String githubRepositoryIdentity,
-    required String githubLogin,
-    required Set<String> branchNames,
+    required Set<PullRequestPersistedTarget> targets,
   }) async {
+    Expression<bool> matchesTarget = const Constant(false);
+    for (final target in targets) {
+      matchesTarget =
+          matchesTarget |
+          (pullRequestsTable.githubRepositoryIdentity.equals(target.githubRepositoryIdentity) &
+              pullRequestsTable.branchName.equals(target.branchName));
+    }
     await (delete(pullRequestsTable)..where(
           (table) {
-            final branchIsOutsideScope = branchNames.isEmpty
-                ? const Constant(true)
-                : table.branchName.isIn(branchNames).not();
-            return table.projectId.equals(projectId) &
-                (table.githubRepositoryIdentity.equals(githubRepositoryIdentity).not() |
-                    table.githubLogin.equals(githubLogin).not() |
-                    branchIsOutsideScope);
+            return table.projectId.equals(projectId) & matchesTarget.not();
           },
+        ))
+        .go();
+  }
+
+  Future<void> deletePrsForOtherGithubLogins({
+    required String projectId,
+    required String githubLogin,
+  }) async {
+    await (delete(pullRequestsTable)..where(
+          (table) => table.projectId.equals(projectId) & table.githubLogin.equals(githubLogin).not(),
         ))
         .go();
   }

--- a/bridge/app/lib/src/bridge/api/git_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/git_cli_api.dart
@@ -70,7 +70,12 @@ class GitCliApi {
     const arguments = ["symbolic-ref", "--quiet", "--short", "HEAD"];
     final ProcessResult result;
     try {
-      result = await runGit(projectPath: projectPath, arguments: arguments);
+      result = await _processRunner.run(
+        "git",
+        arguments,
+        workingDirectory: projectPath,
+        environment: const {"LC_ALL": "C"},
+      );
     } on ProcessException {
       if (!_gitPathExists(gitPath: projectPath)) {
         return const GitCurrentBranchMissingDirectory();
@@ -78,7 +83,12 @@ class GitCliApi {
       rethrow;
     }
     if (result.exitCode == 0) {
-      final branchName = result.stdout.toString().trim();
+      var branchName = result.stdout.toString();
+      if (branchName.endsWith("\r\n")) {
+        branchName = branchName.substring(0, branchName.length - 2);
+      } else if (branchName.endsWith("\n")) {
+        branchName = branchName.substring(0, branchName.length - 1);
+      }
       if (branchName.isEmpty) {
         throw const FormatException("git returned an empty current branch");
       }

--- a/bridge/app/lib/src/bridge/api/git_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/git_cli_api.dart
@@ -88,6 +88,8 @@ class GitCliApi {
         branchName = branchName.substring(0, branchName.length - 2);
       } else if (branchName.endsWith("\n")) {
         branchName = branchName.substring(0, branchName.length - 1);
+      } else if (branchName.endsWith("\r")) {
+        branchName = branchName.substring(0, branchName.length - 1);
       }
       if (branchName.isEmpty) {
         throw const FormatException("git returned an empty current branch");

--- a/bridge/app/lib/src/bridge/api/git_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/git_cli_api.dart
@@ -7,6 +7,28 @@ import "../foundation/process_runner.dart";
 
 typedef GitPathExistsChecker = bool Function({required String gitPath});
 
+sealed class GitCurrentBranchResult {
+  const GitCurrentBranchResult();
+}
+
+final class GitCurrentBranchNamed extends GitCurrentBranchResult {
+  final String branchName;
+
+  const GitCurrentBranchNamed({required this.branchName});
+}
+
+final class GitCurrentBranchDetached extends GitCurrentBranchResult {
+  const GitCurrentBranchDetached();
+}
+
+final class GitCurrentBranchMissingDirectory extends GitCurrentBranchResult {
+  const GitCurrentBranchMissingDirectory();
+}
+
+final class GitCurrentBranchNotRepository extends GitCurrentBranchResult {
+  const GitCurrentBranchNotRepository();
+}
+
 class GitWorktreeSafetySnapshot {
   final bool worktreeExists;
   final bool hasUnstagedChanges;
@@ -39,6 +61,38 @@ class GitCliApi {
       arguments: const ["rev-parse", "--is-inside-work-tree"],
     );
     return result.exitCode == 0 && result.stdout.toString().trim() == "true";
+  }
+
+  Future<GitCurrentBranchResult> getCurrentBranch({required String projectPath}) async {
+    if (!_gitPathExists(gitPath: projectPath)) {
+      return const GitCurrentBranchMissingDirectory();
+    }
+    const arguments = ["symbolic-ref", "--quiet", "--short", "HEAD"];
+    final ProcessResult result;
+    try {
+      result = await runGit(projectPath: projectPath, arguments: arguments);
+    } on ProcessException {
+      if (!_gitPathExists(gitPath: projectPath)) {
+        return const GitCurrentBranchMissingDirectory();
+      }
+      rethrow;
+    }
+    if (result.exitCode == 0) {
+      final branchName = result.stdout.toString().trim();
+      if (branchName.isEmpty) {
+        throw const FormatException("git returned an empty current branch");
+      }
+      return GitCurrentBranchNamed(branchName: branchName);
+    }
+
+    final stderr = result.stderr.toString();
+    if (stderr.toLowerCase().contains("not a git repository")) {
+      return const GitCurrentBranchNotRepository();
+    }
+    if (result.exitCode == 1 && stderr.trim().isEmpty) {
+      return const GitCurrentBranchDetached();
+    }
+    throw ProcessException("git", arguments, stderr, result.exitCode);
   }
 
   /// Initializes a new git repository at [path]. Returns `true` on success.

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -894,9 +894,9 @@ class OrchestratorSession {
           )
           .addTo(_subscriptions);
       Log.d("plugin event stream subscribed");
-      _prSyncService.prChanges
-          .listen((String projectId) {
-            _enqueueWireEvent(SesoriSseEvent.sessionsUpdated(projectID: projectId));
+      _prSyncService.renderedChanges
+          .listen((change) {
+            _enqueueWireEvent(SesoriSseEvent.sessionsUpdated(projectID: change.projectId));
           })
           .addTo(_subscriptions);
       _sessionUnseenService.unseenChanges

--- a/bridge/app/lib/src/bridge/repositories/mappers/plugin_session_mapper.dart
+++ b/bridge/app/lib/src/bridge/repositories/mappers/plugin_session_mapper.dart
@@ -46,8 +46,7 @@ Session enrichSharedSession({
   required SessionUnseenCalculator unseenCalculator,
   required bool adoptStoredProjectId,
 }) {
-  // The stored row carries the branch created with a dedicated worktree.
-  var result = session.copyWith(branchName: session.branchName ?? storedSession?.branchName);
+  var result = session.copyWith(branchName: storedSession?.currentBranchName);
 
   if (storedSession != null) {
     final currentTime = session.time;

--- a/bridge/app/lib/src/bridge/repositories/mappers/session_catalog_mapper.dart
+++ b/bridge/app/lib/src/bridge/repositories/mappers/session_catalog_mapper.dart
@@ -11,7 +11,10 @@ class SessionCatalogMapper {
     required bool unseen,
   }) {
     return Session(
-      branchName: row.branchName,
+      // COMPATIBILITY 2026-08-02 (v1.6.1): Older bridges map the creation
+      // branch to Session.branchName. Modern bridges map current_branch_name;
+      // remove this comment when bridge versions before v1.6.1 are unsupported.
+      branchName: row.currentBranchName,
       id: row.sessionId,
       pluginId: row.pluginId,
       projectID: row.projectId,

--- a/bridge/app/lib/src/bridge/repositories/pr_source_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/pr_source_repository.dart
@@ -28,11 +28,12 @@ class PrSourceRepository {
     required Iterable<String> directories,
   }) async {
     final uniqueDirectories = directories.toSet().toList(growable: false)..sort();
-    final targets = <String, PullRequestDirectoryTarget>{};
-    for (final directory in uniqueDirectories) {
-      targets[directory] = await _resolvePullRequestTarget(directory: directory);
-    }
-    return targets;
+    final resolutions = await Future.wait([
+      for (final directory in uniqueDirectories) _resolvePullRequestTarget(directory: directory),
+    ]);
+    return {
+      for (var index = 0; index < uniqueDirectories.length; index++) uniqueDirectories[index]: resolutions[index],
+    };
   }
 
   Future<PullRequestDirectoryTarget> _resolvePullRequestTarget({required String directory}) async {
@@ -81,6 +82,22 @@ class PrSourceRepository {
         ),
       );
     }
+
+    final GitCurrentBranchResult confirmedBranch;
+    try {
+      confirmedBranch = await _gitCli.getCurrentBranch(projectPath: directory);
+    } on Object catch (error, stackTrace) {
+      return PullRequestBranchResolutionFailed(
+        error: PullRequestTargetResolutionException(
+          innerError: error,
+          innerStackTrace: stackTrace,
+        ),
+      );
+    }
+    if (confirmedBranch is! GitCurrentBranchNamed || confirmedBranch.branchName != branchName) {
+      return const PullRequestBranchChangedDuringResolution();
+    }
+
     final identity = remoteUrl == null ? null : _remoteIdentityParser.parse(remoteUrl: remoteUrl);
     final segments = identity?.slug.split("/") ?? const <String>[];
     if (identity == null ||

--- a/bridge/app/lib/src/bridge/repositories/pr_source_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/pr_source_repository.dart
@@ -1,5 +1,6 @@
 import "../../api/gh_pull_request_batch.dart";
 import "../../repositories/models/pull_request_selection.dart";
+import "../../repositories/models/pull_request_target.dart";
 import "../api/gh_cli_api.dart";
 import "../api/gh_pull_request.dart";
 import "../api/git_cli_api.dart";
@@ -23,20 +24,77 @@ class PrSourceRepository {
     return VerifiedGithubLogin.tryParse(rawLogin: identity.rawLogin);
   }
 
-  Future<String?> getGithubRepositoryIdentity({required String projectPath}) async {
-    final remoteUrl = await _gitCli.getRemoteUrl(projectPath: projectPath);
-    if (remoteUrl == null) {
-      return null;
+  Future<Map<String, PullRequestDirectoryTarget>> resolvePullRequestTargets({
+    required Iterable<String> directories,
+  }) async {
+    final uniqueDirectories = directories.toSet().toList(growable: false)..sort();
+    final targets = <String, PullRequestDirectoryTarget>{};
+    for (final directory in uniqueDirectories) {
+      targets[directory] = await _resolvePullRequestTarget(directory: directory);
     }
-    final identity = _remoteIdentityParser.parse(remoteUrl: remoteUrl);
-    if (identity == null || identity.host != "github.com") {
-      return null;
+    return targets;
+  }
+
+  Future<PullRequestDirectoryTarget> _resolvePullRequestTarget({required String directory}) async {
+    final GitCurrentBranchResult currentBranch;
+    try {
+      currentBranch = await _gitCli.getCurrentBranch(projectPath: directory);
+    } on Object catch (error, stackTrace) {
+      return PullRequestBranchResolutionFailed(
+        error: PullRequestTargetResolutionException(
+          innerError: error,
+          innerStackTrace: stackTrace,
+        ),
+      );
     }
-    final segments = identity.slug.split("/");
-    if (segments.length != 2 || segments.any((segment) => segment.isEmpty)) {
-      return null;
+
+    return switch (currentBranch) {
+      GitCurrentBranchMissingDirectory() => const PullRequestNoBranchDirectoryTarget(
+        reason: PullRequestNoBranchReason.missingDirectory,
+      ),
+      GitCurrentBranchNotRepository() => const PullRequestNoBranchDirectoryTarget(
+        reason: PullRequestNoBranchReason.notGitRepository,
+      ),
+      GitCurrentBranchDetached() => const PullRequestNoBranchDirectoryTarget(
+        reason: PullRequestNoBranchReason.detachedHead,
+      ),
+      GitCurrentBranchNamed(:final branchName) => await _resolveNamedBranchTarget(
+        directory: directory,
+        branchName: branchName,
+      ),
+    };
+  }
+
+  Future<PullRequestDirectoryTarget> _resolveNamedBranchTarget({
+    required String directory,
+    required String branchName,
+  }) async {
+    final String? remoteUrl;
+    try {
+      remoteUrl = await _gitCli.getRemoteUrl(projectPath: directory);
+    } on Object catch (error, stackTrace) {
+      return PullRequestRepositoryResolutionFailed(
+        branchName: branchName,
+        error: PullRequestTargetResolutionException(
+          innerError: error,
+          innerStackTrace: stackTrace,
+        ),
+      );
     }
-    return identity.slug.toLowerCase();
+    final identity = remoteUrl == null ? null : _remoteIdentityParser.parse(remoteUrl: remoteUrl);
+    final segments = identity?.slug.split("/") ?? const <String>[];
+    if (identity == null ||
+        identity.host.toLowerCase() != "github.com" ||
+        segments.length != 2 ||
+        segments.any((segment) => segment.isEmpty)) {
+      return PullRequestLocalBranchDirectoryTarget(branchName: branchName);
+    }
+    return PullRequestGithubDirectoryTarget(
+      target: (
+        githubRepositoryIdentity: identity.slug.toLowerCase(),
+        branchName: branchName,
+      ),
+    );
   }
 
   Future<PullRequestSelectionOutcome> selectPullRequests({

--- a/bridge/app/lib/src/bridge/repositories/pr_source_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/pr_source_repository.dart
@@ -9,6 +9,7 @@ import "models/verified_github_login.dart";
 
 class PrSourceRepository {
   static const GitRemoteIdentityParser _remoteIdentityParser = GitRemoteIdentityParser();
+  static const int _maxConcurrentDirectoryResolutions = 8;
 
   final GhCliApi _ghCli;
   final GitCliApi _gitCli;
@@ -28,9 +29,17 @@ class PrSourceRepository {
     required Iterable<String> directories,
   }) async {
     final uniqueDirectories = directories.toSet().toList(growable: false)..sort();
-    final resolutions = await Future.wait([
-      for (final directory in uniqueDirectories) _resolvePullRequestTarget(directory: directory),
-    ]);
+    final resolutions = <PullRequestDirectoryTarget>[];
+    for (final directoryChunk in _chunks(
+      values: uniqueDirectories,
+      size: _maxConcurrentDirectoryResolutions,
+    )) {
+      resolutions.addAll(
+        await Future.wait([
+          for (final directory in directoryChunk) _resolvePullRequestTarget(directory: directory),
+        ]),
+      );
+    }
     return {
       for (var index = 0; index < uniqueDirectories.length; index++) uniqueDirectories[index]: resolutions[index],
     };

--- a/bridge/app/lib/src/bridge/repositories/pull_request_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/pull_request_repository.dart
@@ -44,8 +44,20 @@ class PullRequestRepository {
           final current = currentById[captured.id];
           if (current == null ||
               current.projectId != captured.projectId ||
-              current.parentSessionId != captured.parentSessionId ||
-              current.directory != captured.directory) {
+              current.parentSessionId != captured.parentSessionId) {
+            continue;
+          }
+          if (current.directory != captured.directory) {
+            if (current.currentBranchName != null) {
+              renderedBranchChanged = true;
+            }
+            if (current.currentBranchName != null || current.currentGithubRepositoryIdentity != null) {
+              updates.add((
+                sessionId: captured.id,
+                currentBranchName: null,
+                currentGithubRepositoryIdentity: null,
+              ));
+            }
             continue;
           }
 
@@ -68,7 +80,7 @@ class PullRequestRepository {
                 branchName: branchName,
                 repositoryIdentity: null,
               ),
-              PullRequestBranchResolutionFailed() || null => (
+              PullRequestBranchResolutionFailed() || PullRequestBranchChangedDuringResolution() || null => (
                 branchName: current.currentBranchName,
                 repositoryIdentity: current.currentGithubRepositoryIdentity,
               ),
@@ -143,6 +155,7 @@ class PullRequestRepository {
   Future<PullRequestReplacementOutcome> replaceScopedPullRequests({
     required String projectId,
     required VerifiedGithubLogin verifiedGithubLogin,
+    required Map<String, String> capturedRootDirectoriesBySessionId,
     required List<PullRequestTargetSelection> targetSelections,
     required int lastCheckedAt,
   }) async {
@@ -177,6 +190,10 @@ class PullRequestRepository {
       final project = await _projectsDao.getProject(projectId: projectId);
       final currentSessions = await _sessionDao.getSessionsByProject(projectId: projectId);
       if (project?.prCacheGithubLogin != verifiedGithubLogin.login ||
+          !_sameRootDirectories(
+            first: _rootDirectoriesBySessionId(sessions: currentSessions),
+            second: capturedRootDirectoriesBySessionId,
+          ) ||
           !_sameTargets(
             first: _currentSelectionTargets(sessions: currentSessions),
             second: targets,
@@ -265,5 +282,20 @@ class PullRequestRepository {
     required Set<PullRequestSelectionTarget> second,
   }) {
     return first.length == second.length && first.containsAll(second);
+  }
+
+  Map<String, String> _rootDirectoriesBySessionId({required Iterable<SessionDto> sessions}) {
+    return {
+      for (final session in sessions)
+        if (session.parentSessionId == null) session.sessionId: session.directory,
+    };
+  }
+
+  bool _sameRootDirectories({
+    required Map<String, String> first,
+    required Map<String, String> second,
+  }) {
+    if (first.length != second.length) return false;
+    return first.entries.every((entry) => second[entry.key] == entry.value);
   }
 }

--- a/bridge/app/lib/src/bridge/repositories/pull_request_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/pull_request_repository.dart
@@ -3,7 +3,9 @@ import "../../api/database/daos/pull_request_dao.dart";
 import "../../api/database/daos/session_dao.dart";
 import "../../api/database/database.dart";
 import "../../api/database/tables/pull_requests_table.dart";
+import "../../api/database/tables/session_table.dart" show SessionDto;
 import "../../repositories/models/pull_request_selection.dart";
+import "../../repositories/models/pull_request_target.dart";
 import "models/stored_session.dart";
 import "models/verified_github_login.dart";
 
@@ -23,65 +25,122 @@ class PullRequestRepository {
        _projectsDao = projectsDao,
        _sessionDao = sessionDao;
 
-  Future<bool> prepareScopedRefresh({
-    required String projectId,
-    required String githubRepositoryIdentity,
+  Future<Set<String>> applyResolvedTargets({
+    required Map<String, List<StoredSession>> sessionsByProject,
+    required Map<String, PullRequestDirectoryTarget> targetsByDirectory,
+  }) {
+    return _database.transaction(() async {
+      final changedProjectIds = <String>{};
+      final sortedProjectIds = sessionsByProject.keys.toList(growable: false)..sort();
+      for (final projectId in sortedProjectIds) {
+        final capturedSessions = sessionsByProject[projectId] ?? const <StoredSession>[];
+        final sessionIds = capturedSessions.map((session) => session.id).toList(growable: false);
+        final currentById = await _sessionDao.getSessionsByIds(sessionIds: sessionIds);
+        final before = await _pullRequestDao.getPrsByPersistedScopeSessionIds(sessionIds: sessionIds);
+        final updates = <SessionPullRequestScopeUpdate>[];
+        var renderedBranchChanged = false;
+
+        for (final captured in capturedSessions) {
+          final current = currentById[captured.id];
+          if (current == null ||
+              current.projectId != captured.projectId ||
+              current.parentSessionId != captured.parentSessionId ||
+              current.directory != captured.directory) {
+            continue;
+          }
+
+          final ({String? branchName, String? repositoryIdentity}) desiredScope;
+          if (captured.parentSessionId != null) {
+            desiredScope = (branchName: null, repositoryIdentity: null);
+          } else {
+            final resolution = targetsByDirectory[captured.directory];
+            desiredScope = switch (resolution) {
+              PullRequestGithubDirectoryTarget(:final target) => (
+                branchName: target.branchName,
+                repositoryIdentity: target.githubRepositoryIdentity,
+              ),
+              PullRequestLocalBranchDirectoryTarget(:final branchName) => (
+                branchName: branchName,
+                repositoryIdentity: null,
+              ),
+              PullRequestNoBranchDirectoryTarget() => (branchName: null, repositoryIdentity: null),
+              PullRequestRepositoryResolutionFailed(:final branchName) => (
+                branchName: branchName,
+                repositoryIdentity: null,
+              ),
+              PullRequestBranchResolutionFailed() || null => (
+                branchName: current.currentBranchName,
+                repositoryIdentity: current.currentGithubRepositoryIdentity,
+              ),
+            };
+          }
+
+          if (current.currentBranchName != desiredScope.branchName) {
+            renderedBranchChanged = true;
+          }
+          if (current.currentBranchName != desiredScope.branchName ||
+              current.currentGithubRepositoryIdentity != desiredScope.repositoryIdentity) {
+            updates.add((
+              sessionId: captured.id,
+              currentBranchName: desiredScope.branchName,
+              currentGithubRepositoryIdentity: desiredScope.repositoryIdentity,
+            ));
+          }
+        }
+
+        await _sessionDao.updatePullRequestScopes(updates: updates);
+        final currentSessions = await _sessionDao.getSessionsByProject(projectId: projectId);
+        final currentTargets = _currentSelectionTargets(sessions: currentSessions);
+        await _pullRequestDao.deletePrsOutsideTargets(
+          projectId: projectId,
+          targets: currentTargets,
+        );
+        if (currentTargets.isEmpty) {
+          await _projectsDao.setPrCacheGithubLogin(projectId: projectId, githubLogin: null);
+        }
+        final after = await _pullRequestDao.getPrsByPersistedScopeSessionIds(sessionIds: sessionIds);
+        if (renderedBranchChanged || !_sameVisiblePullRequests(before: before, after: after)) {
+          changedProjectIds.add(projectId);
+        }
+      }
+      return changedProjectIds;
+    });
+  }
+
+  Future<Set<String>> prepareScopedRefresh({
+    required Set<String> projectIds,
     required VerifiedGithubLogin verifiedGithubLogin,
-    required List<StoredSession> sessions,
-  }) async {
+  }) {
     return _database.transaction(() async {
-      final sessionIds = sessions.map((session) => session.id).toList(growable: false);
-      final before = await _pullRequestDao.getPrsByPersistedScopeSessionIds(sessionIds: sessionIds);
-      await _projectsDao.setPrCacheGithubLogin(
-        projectId: projectId,
-        githubLogin: verifiedGithubLogin.login,
-      );
-      await _sessionDao.updatePullRequestScopes(
-        updates: [
-          for (final session in sessions)
-            (
-              sessionId: session.id,
-              currentBranchName: session.parentSessionId == null ? session.branchName : null,
-              currentGithubRepositoryIdentity: session.parentSessionId == null ? githubRepositoryIdentity : null,
-            ),
-        ],
-      );
-      await _pullRequestDao.deletePrsOutsideScope(
-        projectId: projectId,
-        githubRepositoryIdentity: githubRepositoryIdentity,
-        githubLogin: verifiedGithubLogin.login,
-        branchNames: _rootBranchNames(sessions: sessions),
-      );
-      final after = await _pullRequestDao.getPrsByPersistedScopeSessionIds(sessionIds: sessionIds);
-      return !_sameVisiblePullRequests(before: before, after: after);
+      final changedProjectIds = <String>{};
+      final sortedProjectIds = projectIds.toList(growable: false)..sort();
+      for (final projectId in sortedProjectIds) {
+        if (await _projectsDao.getProject(projectId: projectId) == null) continue;
+        final sessions = await _sessionDao.getSessionsByProject(projectId: projectId);
+        final sessionIds = sessions.map((session) => session.sessionId).toList(growable: false);
+        final before = await _pullRequestDao.getPrsByPersistedScopeSessionIds(sessionIds: sessionIds);
+        await _projectsDao.setPrCacheGithubLogin(
+          projectId: projectId,
+          githubLogin: verifiedGithubLogin.login,
+        );
+        await _pullRequestDao.deletePrsOutsideTargets(
+          projectId: projectId,
+          targets: _currentSelectionTargets(sessions: sessions),
+        );
+        await _pullRequestDao.deletePrsForOtherGithubLogins(
+          projectId: projectId,
+          githubLogin: verifiedGithubLogin.login,
+        );
+        final after = await _pullRequestDao.getPrsByPersistedScopeSessionIds(sessionIds: sessionIds);
+        if (!_sameVisiblePullRequests(before: before, after: after)) {
+          changedProjectIds.add(projectId);
+        }
+      }
+      return changedProjectIds;
     });
   }
 
-  Future<bool> clearScopedRefresh({
-    required String projectId,
-    required List<StoredSession> sessions,
-  }) async {
-    return _database.transaction(() async {
-      final before = await _pullRequestDao.getPrsByPersistedScopeSessionIds(
-        sessionIds: sessions.map((session) => session.id).toList(growable: false),
-      );
-      await _projectsDao.setPrCacheGithubLogin(projectId: projectId, githubLogin: null);
-      await _sessionDao.updatePullRequestScopes(
-        updates: [
-          for (final session in sessions)
-            (
-              sessionId: session.id,
-              currentBranchName: null,
-              currentGithubRepositoryIdentity: null,
-            ),
-        ],
-      );
-      await _pullRequestDao.deletePrsByProjectId(projectId: projectId);
-      return before.values.any((pullRequests) => pullRequests.isNotEmpty);
-    });
-  }
-
-  Future<bool> replaceScopedPullRequests({
+  Future<PullRequestReplacementOutcome> replaceScopedPullRequests({
     required String projectId,
     required VerifiedGithubLogin verifiedGithubLogin,
     required List<PullRequestTargetSelection> targetSelections,
@@ -114,14 +173,23 @@ class PullRequestRepository {
             createdAt: pullRequest.createdAt.millisecondsSinceEpoch,
           ),
     ];
-    return _database.transaction(() async {
+    return _database.transaction<PullRequestReplacementOutcome>(() async {
+      final project = await _projectsDao.getProject(projectId: projectId);
+      final currentSessions = await _sessionDao.getSessionsByProject(projectId: projectId);
+      if (project?.prCacheGithubLogin != verifiedGithubLogin.login ||
+          !_sameTargets(
+            first: _currentSelectionTargets(sessions: currentSessions),
+            second: targets,
+          )) {
+        return const PullRequestReplacementScopeChanged();
+      }
       final previous = await _pullRequestDao.getPrsByProjectId(projectId: projectId);
       final changed = !_sameSelectedPullRequests(previous: previous, replacements: replacements);
       await _pullRequestDao.deletePrsByProjectId(projectId: projectId);
       for (final replacement in replacements) {
         await _pullRequestDao.upsertPr(pullRequest: replacement);
       }
-      return changed;
+      return PullRequestReplacementApplied(changed: changed);
     });
   }
 
@@ -175,11 +243,27 @@ class PullRequestRepository {
     };
   }
 
-  Set<String> _rootBranchNames({required List<StoredSession> sessions}) {
+  Set<PullRequestSelectionTarget> _currentSelectionTargets({
+    required Iterable<SessionDto> sessions,
+  }) {
     return {
       for (final session in sessions)
         if (session.parentSessionId == null)
-          if (session.branchName case final branchName? when branchName.isNotEmpty) branchName,
+          if ((session.currentGithubRepositoryIdentity, session.currentBranchName) case (
+            final repositoryIdentity?,
+            final branchName?,
+          ) when repositoryIdentity.isNotEmpty && branchName.isNotEmpty)
+            (
+              githubRepositoryIdentity: repositoryIdentity,
+              branchName: branchName,
+            ),
     };
+  }
+
+  bool _sameTargets({
+    required Set<PullRequestSelectionTarget> first,
+    required Set<PullRequestSelectionTarget> second,
+  }) {
+    return first.length == second.length && first.containsAll(second);
   }
 }

--- a/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
@@ -88,7 +88,10 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
       Log.w("GetSessionsHandler: post-publication enrichment failed", error, stackTrace);
     }
 
-    final prRefreshFuture = _triggerPrRefresh(projectId: projectId);
+    final prRefreshFuture = _triggerPrRefresh(
+      projectId: projectId,
+      refreshPolicy: waitForPrData ? PrRefreshPolicy.explicit : PrRefreshPolicy.background,
+    );
     if (!waitForPrData) {
       // COMPATIBILITY 2026-08-01 (v1.6.1): Released clients rely on the
       // non-waiting request to trigger background PR refresh. Remove this path
@@ -99,7 +102,11 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
 
     final refreshOutcome = await prRefreshFuture;
     if (refreshOutcome != PrRefreshOutcome.completed) {
-      return SessionListResponse(items: sessionsWithoutPullRequestData);
+      final currentSessionsWithoutPullRequestData = await _sessionRepository.enrichSessions(
+        sessions: sessionsWithoutPullRequestData,
+        verifiedGithubLogin: null,
+      );
+      return SessionListResponse(items: currentSessionsWithoutPullRequestData);
     }
 
     // Refresh succeeded within the shared request deadline. Verify identity
@@ -114,9 +121,13 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
 
   Future<PrRefreshOutcome> _triggerPrRefresh({
     required String projectId,
+    required PrRefreshPolicy refreshPolicy,
   }) async {
     try {
-      return await _prSyncService.triggerRefresh(projectIds: {projectId});
+      return await _prSyncService.triggerRefresh(
+        projectIds: {projectId},
+        refreshPolicy: refreshPolicy,
+      );
     } on Object catch (e, st) {
       Log.w("[GetSessionsHandler] PR refresh trigger failed", e, st);
       return PrRefreshOutcome.failed;

--- a/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
@@ -68,9 +68,12 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
         projectId: projectId,
         sessionsWithoutPullRequestData: sessionsWithoutPullRequestData,
         waitForPrData: body.waitForPrData,
-        timeoutStopwatch: timeoutStopwatch,
-        mainDeadline: mainDeadline,
       ).timeout(mainDeadline);
+    } on _PrRefreshFailedException {
+      return _buildPrFreeFallbackResponse(
+        sessionsWithoutPullRequestData: sessionsWithoutPullRequestData,
+        timeoutStopwatch: timeoutStopwatch,
+      );
     } on Object catch (error, stackTrace) {
       Log.w(
         "PR identity-gated read or refresh work failed after waiting up to "
@@ -78,18 +81,9 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
         error,
         stackTrace,
       );
-      final fallbackBudget = _remainingBudget(
+      return _buildPrFreeFallbackResponse(
+        sessionsWithoutPullRequestData: sessionsWithoutPullRequestData,
         timeoutStopwatch: timeoutStopwatch,
-        deadline: _prRefreshTimeout,
-      );
-      if (fallbackBudget == Duration.zero) {
-        return SessionListResponse(items: sessionsWithoutPullRequestData);
-      }
-      return SessionListResponse(
-        items: await _reEnrichWithoutPullRequestData(
-          sessionsWithoutPullRequestData: sessionsWithoutPullRequestData,
-          timeout: fallbackBudget,
-        ),
       );
     }
   }
@@ -98,8 +92,6 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
     required String projectId,
     required List<Session> sessionsWithoutPullRequestData,
     required bool waitForPrData,
-    required Stopwatch timeoutStopwatch,
-    required Duration mainDeadline,
   }) async {
     final prRefreshFuture = _triggerPrRefresh(
       projectId: projectId,
@@ -126,19 +118,7 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
 
     final refreshOutcome = await prRefreshFuture;
     if (refreshOutcome != PrRefreshOutcome.completed) {
-      final fallbackBudget = _remainingBudget(
-        timeoutStopwatch: timeoutStopwatch,
-        deadline: mainDeadline,
-      );
-      if (fallbackBudget == Duration.zero) {
-        return SessionListResponse(items: sessionsWithoutPullRequestData);
-      }
-      return SessionListResponse(
-        items: await _reEnrichWithoutPullRequestData(
-          sessionsWithoutPullRequestData: sessionsWithoutPullRequestData,
-          timeout: fallbackBudget,
-        ),
-      );
+      throw const _PrRefreshFailedException();
     }
 
     // Refresh succeeded within the shared request deadline. Verify identity
@@ -149,6 +129,25 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
       verifiedGithubLogin: refreshedGithubLogin,
     );
     return SessionListResponse(items: enrichedSessions);
+  }
+
+  Future<SessionListResponse> _buildPrFreeFallbackResponse({
+    required List<Session> sessionsWithoutPullRequestData,
+    required Stopwatch timeoutStopwatch,
+  }) async {
+    final fallbackBudget = _remainingBudget(
+      timeoutStopwatch: timeoutStopwatch,
+      deadline: _prRefreshTimeout,
+    );
+    if (fallbackBudget == Duration.zero) {
+      return SessionListResponse(items: sessionsWithoutPullRequestData);
+    }
+    return SessionListResponse(
+      items: await _reEnrichWithoutPullRequestData(
+        sessionsWithoutPullRequestData: sessionsWithoutPullRequestData,
+        timeout: fallbackBudget,
+      ),
+    );
   }
 
   Future<List<Session>> _reEnrichWithoutPullRequestData({
@@ -195,4 +194,8 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
       return PrRefreshOutcome.failed;
     }
   }
+}
+
+final class _PrRefreshFailedException implements Exception {
+  const _PrRefreshFailedException();
 }

--- a/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
@@ -68,7 +68,11 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
         error,
         stackTrace,
       );
-      return SessionListResponse(items: sessionsWithoutPullRequestData);
+      return SessionListResponse(
+        items: await _reEnrichWithoutPullRequestData(
+          sessionsWithoutPullRequestData: sessionsWithoutPullRequestData,
+        ),
+      );
     }
   }
 
@@ -77,6 +81,10 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
     required List<Session> sessionsWithoutPullRequestData,
     required bool waitForPrData,
   }) async {
+    final prRefreshFuture = _triggerPrRefresh(
+      projectId: projectId,
+      refreshPolicy: waitForPrData ? PrRefreshPolicy.explicit : PrRefreshPolicy.background,
+    );
     var sessions = sessionsWithoutPullRequestData;
     final verifiedGithubLogin = await _prSyncService.verifyGithubIdentity();
     try {
@@ -88,10 +96,6 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
       Log.w("GetSessionsHandler: post-publication enrichment failed", error, stackTrace);
     }
 
-    final prRefreshFuture = _triggerPrRefresh(
-      projectId: projectId,
-      refreshPolicy: waitForPrData ? PrRefreshPolicy.explicit : PrRefreshPolicy.background,
-    );
     if (!waitForPrData) {
       // COMPATIBILITY 2026-08-01 (v1.6.1): Released clients rely on the
       // non-waiting request to trigger background PR refresh. Remove this path
@@ -102,11 +106,11 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
 
     final refreshOutcome = await prRefreshFuture;
     if (refreshOutcome != PrRefreshOutcome.completed) {
-      final currentSessionsWithoutPullRequestData = await _sessionRepository.enrichSessions(
-        sessions: sessionsWithoutPullRequestData,
-        verifiedGithubLogin: null,
+      return SessionListResponse(
+        items: await _reEnrichWithoutPullRequestData(
+          sessionsWithoutPullRequestData: sessionsWithoutPullRequestData,
+        ),
       );
-      return SessionListResponse(items: currentSessionsWithoutPullRequestData);
     }
 
     // Refresh succeeded within the shared request deadline. Verify identity
@@ -117,6 +121,24 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
       verifiedGithubLogin: refreshedGithubLogin,
     );
     return SessionListResponse(items: enrichedSessions);
+  }
+
+  Future<List<Session>> _reEnrichWithoutPullRequestData({
+    required List<Session> sessionsWithoutPullRequestData,
+  }) async {
+    try {
+      return await _sessionRepository.enrichSessions(
+        sessions: sessionsWithoutPullRequestData,
+        verifiedGithubLogin: null,
+      );
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        "GetSessionsHandler: PR-free fallback enrichment failed; returning the original snapshot",
+        error,
+        stackTrace,
+      );
+      return sessionsWithoutPullRequestData;
+    }
   }
 
   Future<PrRefreshOutcome> _triggerPrRefresh({

--- a/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
@@ -88,7 +88,7 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
       Log.w("GetSessionsHandler: post-publication enrichment failed", error, stackTrace);
     }
 
-    final prRefreshFuture = _triggerPrRefresh(projectId: projectId, sessions: sessions);
+    final prRefreshFuture = _triggerPrRefresh(projectId: projectId);
     if (!waitForPrData) {
       // COMPATIBILITY 2026-08-01 (v1.6.1): Released clients rely on the
       // non-waiting request to trigger background PR refresh. Remove this path
@@ -114,19 +114,9 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
 
   Future<PrRefreshOutcome> _triggerPrRefresh({
     required String projectId,
-    required List<Session> sessions,
   }) async {
     try {
-      final projectPath = await _sessionRepository.getProjectPath(projectId: projectId);
-      if (projectPath != null) {
-        return await _prSyncService.triggerRefresh(projectId: projectId, projectPath: projectPath);
-      }
-
-      final fallbackDirectory = sessions.firstOrNull?.directory;
-      if (fallbackDirectory == null || fallbackDirectory.isEmpty) {
-        return PrRefreshOutcome.failed;
-      }
-      return await _prSyncService.triggerRefresh(projectId: projectId, projectPath: fallbackDirectory);
+      return await _prSyncService.triggerRefresh(projectIds: {projectId});
     } on Object catch (e, st) {
       Log.w("[GetSessionsHandler] PR refresh trigger failed", e, st);
       return PrRefreshOutcome.failed;

--- a/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
@@ -11,6 +11,8 @@ import "request_handler.dart";
 ///
 /// Reads the durable catalog and applies bridge-owned enrichment.
 class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionListResponse> {
+  static const _maximumFallbackReserve = Duration(milliseconds: 100);
+
   final SessionRepository _sessionRepository;
   final PrSyncService _prSyncService;
   final Duration _prRefreshTimeout;
@@ -54,13 +56,21 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
       limit: limit,
       verifiedGithubLogin: null,
     );
+    final timeoutStopwatch = Stopwatch()..start();
+    final halfRefreshTimeout = Duration(microseconds: _prRefreshTimeout.inMicroseconds ~/ 2);
+    final fallbackReserve = halfRefreshTimeout.compareTo(_maximumFallbackReserve) < 0
+        ? halfRefreshTimeout
+        : _maximumFallbackReserve;
+    final mainDeadline = _prRefreshTimeout - fallbackReserve;
 
     try {
       return await _readIdentityGatedPullRequestData(
         projectId: projectId,
         sessionsWithoutPullRequestData: sessionsWithoutPullRequestData,
         waitForPrData: body.waitForPrData,
-      ).timeout(_prRefreshTimeout);
+        timeoutStopwatch: timeoutStopwatch,
+        mainDeadline: mainDeadline,
+      ).timeout(mainDeadline);
     } on Object catch (error, stackTrace) {
       Log.w(
         "PR identity-gated read or refresh work failed after waiting up to "
@@ -68,9 +78,17 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
         error,
         stackTrace,
       );
+      final fallbackBudget = _remainingBudget(
+        timeoutStopwatch: timeoutStopwatch,
+        deadline: _prRefreshTimeout,
+      );
+      if (fallbackBudget == Duration.zero) {
+        return SessionListResponse(items: sessionsWithoutPullRequestData);
+      }
       return SessionListResponse(
         items: await _reEnrichWithoutPullRequestData(
           sessionsWithoutPullRequestData: sessionsWithoutPullRequestData,
+          timeout: fallbackBudget,
         ),
       );
     }
@@ -80,6 +98,8 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
     required String projectId,
     required List<Session> sessionsWithoutPullRequestData,
     required bool waitForPrData,
+    required Stopwatch timeoutStopwatch,
+    required Duration mainDeadline,
   }) async {
     final prRefreshFuture = _triggerPrRefresh(
       projectId: projectId,
@@ -106,9 +126,17 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
 
     final refreshOutcome = await prRefreshFuture;
     if (refreshOutcome != PrRefreshOutcome.completed) {
+      final fallbackBudget = _remainingBudget(
+        timeoutStopwatch: timeoutStopwatch,
+        deadline: mainDeadline,
+      );
+      if (fallbackBudget == Duration.zero) {
+        return SessionListResponse(items: sessionsWithoutPullRequestData);
+      }
       return SessionListResponse(
         items: await _reEnrichWithoutPullRequestData(
           sessionsWithoutPullRequestData: sessionsWithoutPullRequestData,
+          timeout: fallbackBudget,
         ),
       );
     }
@@ -125,12 +153,15 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
 
   Future<List<Session>> _reEnrichWithoutPullRequestData({
     required List<Session> sessionsWithoutPullRequestData,
+    required Duration timeout,
   }) async {
     try {
-      return await _sessionRepository.enrichSessions(
-        sessions: sessionsWithoutPullRequestData,
-        verifiedGithubLogin: null,
-      );
+      return await _sessionRepository
+          .enrichSessions(
+            sessions: sessionsWithoutPullRequestData,
+            verifiedGithubLogin: null,
+          )
+          .timeout(timeout);
     } on Object catch (error, stackTrace) {
       Log.w(
         "GetSessionsHandler: PR-free fallback enrichment failed; returning the original snapshot",
@@ -139,6 +170,15 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
       );
       return sessionsWithoutPullRequestData;
     }
+  }
+
+  Duration _remainingBudget({
+    required Stopwatch timeoutStopwatch,
+    required Duration deadline,
+  }) {
+    final remainingMicroseconds = deadline.inMicroseconds - timeoutStopwatch.elapsedMicroseconds;
+    if (remainingMicroseconds <= 0) return Duration.zero;
+    return Duration(microseconds: remainingMicroseconds);
   }
 
   Future<PrRefreshOutcome> _triggerPrRefresh({

--- a/bridge/app/lib/src/bridge/services/pr_sync_service.dart
+++ b/bridge/app/lib/src/bridge/services/pr_sync_service.dart
@@ -4,13 +4,16 @@ import "package:clock/clock.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Console, Log;
 
 import "../../repositories/models/pull_request_selection.dart";
+import "../../repositories/models/pull_request_target.dart";
 import "../repositories/models/stored_session.dart";
 import "../repositories/models/verified_github_login.dart";
 import "../repositories/pr_source_repository.dart";
 import "../repositories/pull_request_repository.dart";
 import "../repositories/session_repository.dart";
 
-enum PrRefreshOutcome { completed, inProgress, failed }
+enum PrRefreshOutcome { completed, failed }
+
+typedef PullRequestRenderedChange = ({String projectId});
 
 class PrSyncService {
   final PrSourceRepository _prSource;
@@ -18,13 +21,19 @@ class PrSyncService {
   final SessionRepository _sessionRepository;
   final Clock _clock;
   final Duration _debounceWindow;
-  final StreamController<String> _prChangesController = StreamController<String>.broadcast();
+  final StreamController<PullRequestRenderedChange> _renderedChangesController =
+      StreamController<PullRequestRenderedChange>.broadcast();
 
   final Map<String, DateTime> _lastRefreshTimes = <String, DateTime>{};
-  final Set<String> _activeRefreshes = <String>{};
+  final Map<String, int> _nextRequestGenerations = <String, int>{};
+  final Map<String, int> _pendingProjectGenerations = <String, int>{};
+  Map<String, int> _activeProjectGenerations = const <String, int>{};
+  final List<_PrRefreshWaiter> _refreshWaiters = <_PrRefreshWaiter>[];
   ({bool capable, DateTime checkedAt})? _githubCliCapabilityCache;
   Future<bool>? _githubCliCapabilityCheck;
   bool _identityVerificationFailureReported = false;
+  bool _isDraining = false;
+  bool _disposed = false;
 
   static const _githubCliCapabilityCacheTtl = Duration(seconds: 30);
 
@@ -40,7 +49,7 @@ class PrSyncService {
        _clock = clock,
        _debounceWindow = debounceWindow;
 
-  Stream<String> get prChanges => _prChangesController.stream;
+  Stream<PullRequestRenderedChange> get renderedChanges => _renderedChangesController.stream;
 
   Future<VerifiedGithubLogin?> verifyGithubIdentity() async {
     try {
@@ -72,67 +81,82 @@ class PrSyncService {
     );
   }
 
-  Future<PrRefreshOutcome> triggerRefresh({required String projectId, required String projectPath}) async {
-    if (_activeRefreshes.contains(projectId)) {
-      return PrRefreshOutcome.inProgress;
+  Future<PrRefreshOutcome> triggerRefresh({required Set<String> projectIds}) {
+    if (_disposed) return Future.value(PrRefreshOutcome.failed);
+
+    final requiredGenerations = <String, int>{};
+    final sortedProjectIds = projectIds.where((projectId) => projectId.isNotEmpty).toList(growable: false)..sort();
+    for (final projectId in sortedProjectIds) {
+      final hasOutstandingRequest =
+          _activeProjectGenerations.containsKey(projectId) || _pendingProjectGenerations.containsKey(projectId);
+      final lastRefreshAt = _lastRefreshTimes[projectId];
+      if (!hasOutstandingRequest && lastRefreshAt != null && _clock.now().difference(lastRefreshAt) < _debounceWindow) {
+        continue;
+      }
+      final generation = (_nextRequestGenerations[projectId] ?? 0) + 1;
+      _nextRequestGenerations[projectId] = generation;
+      _pendingProjectGenerations[projectId] = generation;
+      requiredGenerations[projectId] = generation;
+    }
+    if (requiredGenerations.isEmpty) {
+      return Future.value(PrRefreshOutcome.completed);
     }
 
-    final lastRefreshAt = _lastRefreshTimes[projectId];
-    if (lastRefreshAt != null && _clock.now().difference(lastRefreshAt) < _debounceWindow) {
-      return PrRefreshOutcome.completed;
-    }
+    final waiter = _PrRefreshWaiter(requiredGenerations: requiredGenerations);
+    _refreshWaiters.add(waiter);
+    _ensureDrainStarted();
+    return waiter.future;
+  }
 
-    // Claim the project before the first async gap so concurrent requests for
-    // one project cannot start duplicate preflight or refresh work.
-    _activeRefreshes.add(projectId);
+  void _ensureDrainStarted() {
+    if (_isDraining || _disposed) return;
+    _isDraining = true;
+    unawaited(_drainRefreshCycles());
+  }
+
+  Future<void> _drainRefreshCycles() async {
     try {
-      if (!await _hasGithubCliCapability()) {
-        return PrRefreshOutcome.failed;
-      }
+      while (_pendingProjectGenerations.isNotEmpty && !_disposed) {
+        final sealedGenerations = Map<String, int>.from(_pendingProjectGenerations);
+        _pendingProjectGenerations.clear();
+        _activeProjectGenerations = sealedGenerations;
 
-      final githubRepositoryIdentity = await _prSource.getGithubRepositoryIdentity(
-        projectPath: projectPath,
-      );
-      if (githubRepositoryIdentity == null) {
-        final scopeChanged = await _pullRequestRepository.clearScopedRefresh(
-          projectId: projectId,
-          sessions: await _sessionRepository.getStoredSessionsByProjectId(
-            projectId: projectId,
-          ),
-        );
-        if (scopeChanged) {
-          _prChangesController.add(projectId);
+        Map<String, PrRefreshOutcome> outcomes;
+        try {
+          outcomes = await _runRefreshCycle(projectIds: sealedGenerations.keys.toSet());
+        } on Object catch (error, stackTrace) {
+          Log.e("[PrSync] refresh cycle failed", error, stackTrace);
+          outcomes = {
+            for (final projectId in sealedGenerations.keys) projectId: PrRefreshOutcome.failed,
+          };
+        } finally {
+          _activeProjectGenerations = const <String, int>{};
         }
-        _lastRefreshTimes[projectId] = _clock.now();
-        return PrRefreshOutcome.completed;
+        _settleWaiters(
+          sealedGenerations: sealedGenerations,
+          outcomes: outcomes,
+        );
       }
-
-      final verifiedGithubLogin = await verifyGithubIdentity();
-      if (verifiedGithubLogin == null) {
-        return PrRefreshOutcome.failed;
-      }
-
-      final storedSessions = await _sessionRepository.getStoredSessionsByProjectId(
-        projectId: projectId,
-      );
-      final scopeChanged = await _pullRequestRepository.prepareScopedRefresh(
-        projectId: projectId,
-        githubRepositoryIdentity: githubRepositoryIdentity,
-        verifiedGithubLogin: verifiedGithubLogin,
-        sessions: storedSessions,
-      );
-      if (scopeChanged) {
-        _prChangesController.add(projectId);
-      }
-
-      return await _refresh(
-        projectId: projectId,
-        githubRepositoryIdentity: githubRepositoryIdentity,
-        verifiedGithubLogin: verifiedGithubLogin,
-        storedSessions: storedSessions,
-      );
     } finally {
-      _activeRefreshes.remove(projectId);
+      _isDraining = false;
+      if (_pendingProjectGenerations.isNotEmpty && !_disposed) {
+        _ensureDrainStarted();
+      }
+    }
+  }
+
+  void _settleWaiters({
+    required Map<String, int> sealedGenerations,
+    required Map<String, PrRefreshOutcome> outcomes,
+  }) {
+    for (final waiter in List<_PrRefreshWaiter>.from(_refreshWaiters)) {
+      waiter.settle(
+        sealedGenerations: sealedGenerations,
+        outcomes: outcomes,
+      );
+      if (waiter.isSettled) {
+        _refreshWaiters.remove(waiter);
+      }
     }
   }
 
@@ -163,19 +187,85 @@ class PrSyncService {
     return capable;
   }
 
-  Future<PrRefreshOutcome> _refresh({
-    required String projectId,
-    required String githubRepositoryIdentity,
-    required VerifiedGithubLogin verifiedGithubLogin,
-    required List<StoredSession> storedSessions,
+  Future<Map<String, PrRefreshOutcome>> _runRefreshCycle({
+    required Set<String> projectIds,
   }) async {
-    var completed = false;
+    final outcomes = {
+      for (final projectId in projectIds) projectId: PrRefreshOutcome.failed,
+    };
+    final sessionsByProject = <String, List<StoredSession>>{};
+    final sortedProjectIds = projectIds.toList(growable: false)..sort();
+    for (final projectId in sortedProjectIds) {
+      sessionsByProject[projectId] = await _sessionRepository.getStoredSessionsByProjectId(
+        projectId: projectId,
+      );
+    }
+    final rootSessions = [
+      for (final sessions in sessionsByProject.values)
+        for (final session in sessions)
+          if (session.parentSessionId == null) session,
+    ];
+    final targetsByDirectory = await _prSource.resolvePullRequestTargets(
+      directories: rootSessions.map((session) => session.directory),
+    );
+    final failedProjectIds = <String>{};
+    for (final entry in targetsByDirectory.entries) {
+      switch (entry.value) {
+        case PullRequestBranchResolutionFailed(:final error) || PullRequestRepositoryResolutionFailed(:final error):
+          failedProjectIds.addAll(
+            rootSessions.where((session) => session.directory == entry.key).map((session) => session.projectId),
+          );
+          Log.w("[PrSync] local pull request target resolution failed", error, error.innerStackTrace);
+        default:
+          break;
+      }
+    }
+
+    final localChanges = await _pullRequestRepository.applyResolvedTargets(
+      sessionsByProject: sessionsByProject,
+      targetsByDirectory: targetsByDirectory,
+    );
+    _emitRenderedChanges(projectIds: localChanges);
+
+    final githubTargetsByProject = <String, Set<PullRequestSelectionTarget>>{};
+    for (final projectId in sortedProjectIds) {
+      final targets = <PullRequestSelectionTarget>{
+        for (final session in sessionsByProject[projectId] ?? const <StoredSession>[])
+          if (session.parentSessionId == null)
+            if (targetsByDirectory[session.directory] case PullRequestGithubDirectoryTarget(:final target)) target,
+      };
+      githubTargetsByProject[projectId] = targets;
+      if (!failedProjectIds.contains(projectId) && targets.isEmpty) {
+        outcomes[projectId] = PrRefreshOutcome.completed;
+      }
+    }
+    final networkProjectIds = {
+      for (final projectId in sortedProjectIds)
+        if (!failedProjectIds.contains(projectId) && githubTargetsByProject[projectId]!.isNotEmpty) projectId,
+    };
+    if (networkProjectIds.isEmpty) {
+      return _finishCycle(outcomes: outcomes);
+    }
+
     try {
+      if (!await _hasGithubCliCapability()) {
+        return _finishCycle(outcomes: outcomes);
+      }
+      final verifiedGithubLogin = await verifyGithubIdentity();
+      if (verifiedGithubLogin == null) {
+        return _finishCycle(outcomes: outcomes);
+      }
+      final preparedChanges = await _pullRequestRepository.prepareScopedRefresh(
+        projectIds: networkProjectIds,
+        verifiedGithubLogin: verifiedGithubLogin,
+      );
+      _emitRenderedChanges(projectIds: preparedChanges);
+
+      final uniqueTargets = {
+        for (final projectId in networkProjectIds) ...githubTargetsByProject[projectId]!,
+      }.toList(growable: false)..sort(_compareTargets);
       final selectionOutcome = await _prSource.selectPullRequests(
-        targets: _selectionTargets(
-          githubRepositoryIdentity: githubRepositoryIdentity,
-          sessions: storedSessions,
-        ),
+        targets: uniqueTargets,
         expectedGithubLogin: verifiedGithubLogin,
       );
       final PullRequestSelectionCompleted completedSelection;
@@ -183,46 +273,110 @@ class PrSyncService {
         case PullRequestSelectionCompleted():
           completedSelection = selectionOutcome;
         case PullRequestSelectionIdentityChanged():
-          return PrRefreshOutcome.failed;
-      }
-      final hasChanges = await _pullRequestRepository.replaceScopedPullRequests(
-        projectId: projectId,
-        verifiedGithubLogin: verifiedGithubLogin,
-        targetSelections: completedSelection.selections,
-        lastCheckedAt: _clock.now().millisecondsSinceEpoch,
-      );
-      if (hasChanges) {
-        _prChangesController.add(projectId);
+          return _finishCycle(outcomes: outcomes);
       }
 
-      completed = true;
-      return PrRefreshOutcome.completed;
-    } catch (e, st) {
-      Log.e("[PrSync] refresh failed", e, st);
-      return PrRefreshOutcome.failed;
-    } finally {
-      if (completed) {
-        _lastRefreshTimes[projectId] = _clock.now();
+      final selectionsByTarget = {
+        for (final selection in completedSelection.selections) selection.target: selection,
+      };
+      for (final projectId in networkProjectIds) {
+        final targets = githubTargetsByProject[projectId]!.toList(growable: false)..sort(_compareTargets);
+        final targetSelections = <PullRequestTargetSelection>[];
+        for (final target in targets) {
+          final selection = selectionsByTarget[target];
+          if (selection == null) {
+            throw const FormatException("GitHub pull request selection omitted a requested target");
+          }
+          targetSelections.add(selection);
+        }
+        final replacement = await _pullRequestRepository.replaceScopedPullRequests(
+          projectId: projectId,
+          verifiedGithubLogin: verifiedGithubLogin,
+          targetSelections: targetSelections,
+          lastCheckedAt: _clock.now().millisecondsSinceEpoch,
+        );
+        switch (replacement) {
+          case PullRequestReplacementApplied(:final changed):
+            if (changed) _emitRenderedChanges(projectIds: {projectId});
+            outcomes[projectId] = PrRefreshOutcome.completed;
+          case PullRequestReplacementScopeChanged():
+            outcomes[projectId] = PrRefreshOutcome.failed;
+        }
       }
+    } on Object catch (error, stackTrace) {
+      Log.e("[PrSync] GitHub pull request refresh failed", error, stackTrace);
+    }
+    return _finishCycle(outcomes: outcomes);
+  }
+
+  Map<String, PrRefreshOutcome> _finishCycle({
+    required Map<String, PrRefreshOutcome> outcomes,
+  }) {
+    final completedAt = _clock.now();
+    for (final entry in outcomes.entries) {
+      if (entry.value == PrRefreshOutcome.completed) {
+        _lastRefreshTimes[entry.key] = completedAt;
+      }
+    }
+    return outcomes;
+  }
+
+  int _compareTargets(PullRequestSelectionTarget first, PullRequestSelectionTarget second) {
+    final repositoryComparison = first.githubRepositoryIdentity.compareTo(second.githubRepositoryIdentity);
+    return repositoryComparison != 0 ? repositoryComparison : first.branchName.compareTo(second.branchName);
+  }
+
+  void _emitRenderedChanges({required Iterable<String> projectIds}) {
+    if (_disposed) return;
+    final sortedProjectIds = projectIds.toSet().toList(growable: false)..sort();
+    for (final projectId in sortedProjectIds) {
+      _renderedChangesController.add((projectId: projectId));
     }
   }
 
   void dispose() {
-    _prChangesController.close();
+    if (_disposed) return;
+    _disposed = true;
+    _pendingProjectGenerations.clear();
+    for (final waiter in _refreshWaiters) {
+      waiter.fail();
+    }
+    _refreshWaiters.clear();
+    _renderedChangesController.close();
+  }
+}
+
+final class _PrRefreshWaiter {
+  final Map<String, int> _remainingGenerations;
+  final Completer<PrRefreshOutcome> _completer = Completer<PrRefreshOutcome>();
+  bool _failed = false;
+
+  _PrRefreshWaiter({required Map<String, int> requiredGenerations})
+    : _remainingGenerations = Map<String, int>.from(requiredGenerations);
+
+  Future<PrRefreshOutcome> get future => _completer.future;
+  bool get isSettled => _completer.isCompleted;
+
+  void settle({
+    required Map<String, int> sealedGenerations,
+    required Map<String, PrRefreshOutcome> outcomes,
+  }) {
+    for (final entry in Map<String, int>.from(_remainingGenerations).entries) {
+      final sealedGeneration = sealedGenerations[entry.key];
+      if (sealedGeneration == null || sealedGeneration < entry.value) continue;
+      if (outcomes[entry.key] != PrRefreshOutcome.completed) {
+        _failed = true;
+      }
+      _remainingGenerations.remove(entry.key);
+    }
+    if (_remainingGenerations.isEmpty && !_completer.isCompleted) {
+      _completer.complete(_failed ? PrRefreshOutcome.failed : PrRefreshOutcome.completed);
+    }
   }
 
-  List<PullRequestSelectionTarget> _selectionTargets({
-    required String githubRepositoryIdentity,
-    required List<StoredSession> sessions,
-  }) {
-    return {
-      for (final session in sessions)
-        if (session.parentSessionId == null)
-          if (session.branchName case final branchName? when branchName.isNotEmpty)
-            (
-              githubRepositoryIdentity: githubRepositoryIdentity,
-              branchName: branchName,
-            ),
-    }.toList(growable: false);
+  void fail() {
+    if (!_completer.isCompleted) {
+      _completer.complete(PrRefreshOutcome.failed);
+    }
   }
 }

--- a/bridge/app/lib/src/bridge/services/pr_sync_service.dart
+++ b/bridge/app/lib/src/bridge/services/pr_sync_service.dart
@@ -96,9 +96,8 @@ class PrSyncService {
           _activeProjectGenerations.containsKey(projectId) || _pendingProjectGenerations.containsKey(projectId);
       final lastRefreshAt = _lastRefreshTimes[projectId];
       if (refreshPolicy == PrRefreshPolicy.background &&
-          !hasOutstandingRequest &&
-          lastRefreshAt != null &&
-          _clock.now().difference(lastRefreshAt) < _debounceWindow) {
+          (hasOutstandingRequest ||
+              lastRefreshAt != null && _clock.now().difference(lastRefreshAt) < _debounceWindow)) {
         continue;
       }
       final generation = (_nextRequestGenerations[projectId] ?? 0) + 1;
@@ -275,7 +274,7 @@ class PrSyncService {
 
       final uniqueTargets = {
         for (final projectId in networkProjectIds) ...githubTargetsByProject[projectId]!,
-      }.toList(growable: false)..sort(_compareTargets);
+      }.toList(growable: false)..sort((first, second) => _compareTargets(first: first, second: second));
       final selectionOutcome = await _prSource.selectPullRequests(
         targets: uniqueTargets,
         expectedGithubLogin: verifiedGithubLogin,
@@ -292,7 +291,8 @@ class PrSyncService {
         for (final selection in completedSelection.selections) selection.target: selection,
       };
       for (final projectId in networkProjectIds) {
-        final targets = githubTargetsByProject[projectId]!.toList(growable: false)..sort(_compareTargets);
+        final targets = githubTargetsByProject[projectId]!.toList(growable: false)
+          ..sort((first, second) => _compareTargets(first: first, second: second));
         final targetSelections = <PullRequestTargetSelection>[];
         for (final target in targets) {
           final selection = selectionsByTarget[target];
@@ -345,7 +345,10 @@ class PrSyncService {
     return outcomes;
   }
 
-  int _compareTargets(PullRequestSelectionTarget first, PullRequestSelectionTarget second) {
+  int _compareTargets({
+    required PullRequestSelectionTarget first,
+    required PullRequestSelectionTarget second,
+  }) {
     final repositoryComparison = first.githubRepositoryIdentity.compareTo(second.githubRepositoryIdentity);
     return repositoryComparison != 0 ? repositoryComparison : first.branchName.compareTo(second.branchName);
   }

--- a/bridge/app/lib/src/bridge/services/pr_sync_service.dart
+++ b/bridge/app/lib/src/bridge/services/pr_sync_service.dart
@@ -13,6 +13,8 @@ import "../repositories/session_repository.dart";
 
 enum PrRefreshOutcome { completed, failed }
 
+enum PrRefreshPolicy { background, explicit }
+
 typedef PullRequestRenderedChange = ({String projectId});
 
 class PrSyncService {
@@ -81,7 +83,10 @@ class PrSyncService {
     );
   }
 
-  Future<PrRefreshOutcome> triggerRefresh({required Set<String> projectIds}) {
+  Future<PrRefreshOutcome> triggerRefresh({
+    required Set<String> projectIds,
+    required PrRefreshPolicy refreshPolicy,
+  }) {
     if (_disposed) return Future.value(PrRefreshOutcome.failed);
 
     final requiredGenerations = <String, int>{};
@@ -90,7 +95,10 @@ class PrSyncService {
       final hasOutstandingRequest =
           _activeProjectGenerations.containsKey(projectId) || _pendingProjectGenerations.containsKey(projectId);
       final lastRefreshAt = _lastRefreshTimes[projectId];
-      if (!hasOutstandingRequest && lastRefreshAt != null && _clock.now().difference(lastRefreshAt) < _debounceWindow) {
+      if (refreshPolicy == PrRefreshPolicy.background &&
+          !hasOutstandingRequest &&
+          lastRefreshAt != null &&
+          _clock.now().difference(lastRefreshAt) < _debounceWindow) {
         continue;
       }
       final generation = (_nextRequestGenerations[projectId] ?? 0) + 1;
@@ -216,6 +224,10 @@ class PrSyncService {
             rootSessions.where((session) => session.directory == entry.key).map((session) => session.projectId),
           );
           Log.w("[PrSync] local pull request target resolution failed", error, error.innerStackTrace);
+        case PullRequestBranchChangedDuringResolution():
+          failedProjectIds.addAll(
+            rootSessions.where((session) => session.directory == entry.key).map((session) => session.projectId),
+          );
         default:
           break;
       }
@@ -289,18 +301,30 @@ class PrSyncService {
           }
           targetSelections.add(selection);
         }
-        final replacement = await _pullRequestRepository.replaceScopedPullRequests(
-          projectId: projectId,
-          verifiedGithubLogin: verifiedGithubLogin,
-          targetSelections: targetSelections,
-          lastCheckedAt: _clock.now().millisecondsSinceEpoch,
-        );
-        switch (replacement) {
-          case PullRequestReplacementApplied(:final changed):
-            if (changed) _emitRenderedChanges(projectIds: {projectId});
-            outcomes[projectId] = PrRefreshOutcome.completed;
-          case PullRequestReplacementScopeChanged():
-            outcomes[projectId] = PrRefreshOutcome.failed;
+        try {
+          final replacement = await _pullRequestRepository.replaceScopedPullRequests(
+            projectId: projectId,
+            verifiedGithubLogin: verifiedGithubLogin,
+            capturedRootDirectoriesBySessionId: {
+              for (final session in sessionsByProject[projectId] ?? const <StoredSession>[])
+                if (session.parentSessionId == null) session.id: session.directory,
+            },
+            targetSelections: targetSelections,
+            lastCheckedAt: _clock.now().millisecondsSinceEpoch,
+          );
+          switch (replacement) {
+            case PullRequestReplacementApplied(:final changed):
+              if (changed) _emitRenderedChanges(projectIds: {projectId});
+              outcomes[projectId] = PrRefreshOutcome.completed;
+            case PullRequestReplacementScopeChanged():
+              outcomes[projectId] = PrRefreshOutcome.failed;
+          }
+        } on Object catch (error, stackTrace) {
+          Log.e(
+            "[PrSync] scoped pull request replacement failed; continuing remaining projects",
+            error,
+            stackTrace,
+          );
         }
       }
     } on Object catch (error, stackTrace) {

--- a/bridge/app/lib/src/repositories/models/pull_request_target.dart
+++ b/bridge/app/lib/src/repositories/models/pull_request_target.dart
@@ -30,6 +30,10 @@ final class PullRequestBranchResolutionFailed extends PullRequestDirectoryTarget
   const PullRequestBranchResolutionFailed({required this.error});
 }
 
+final class PullRequestBranchChangedDuringResolution extends PullRequestDirectoryTarget {
+  const PullRequestBranchChangedDuringResolution();
+}
+
 final class PullRequestRepositoryResolutionFailed extends PullRequestDirectoryTarget {
   final String branchName;
   final PullRequestTargetResolutionException error;

--- a/bridge/app/lib/src/repositories/models/pull_request_target.dart
+++ b/bridge/app/lib/src/repositories/models/pull_request_target.dart
@@ -1,0 +1,68 @@
+import "pull_request_selection.dart";
+
+enum PullRequestNoBranchReason { missingDirectory, notGitRepository, detachedHead }
+
+sealed class PullRequestDirectoryTarget {
+  const PullRequestDirectoryTarget();
+}
+
+final class PullRequestGithubDirectoryTarget extends PullRequestDirectoryTarget {
+  final PullRequestSelectionTarget target;
+
+  const PullRequestGithubDirectoryTarget({required this.target});
+}
+
+final class PullRequestLocalBranchDirectoryTarget extends PullRequestDirectoryTarget {
+  final String branchName;
+
+  const PullRequestLocalBranchDirectoryTarget({required this.branchName});
+}
+
+final class PullRequestNoBranchDirectoryTarget extends PullRequestDirectoryTarget {
+  final PullRequestNoBranchReason reason;
+
+  const PullRequestNoBranchDirectoryTarget({required this.reason});
+}
+
+final class PullRequestBranchResolutionFailed extends PullRequestDirectoryTarget {
+  final PullRequestTargetResolutionException error;
+
+  const PullRequestBranchResolutionFailed({required this.error});
+}
+
+final class PullRequestRepositoryResolutionFailed extends PullRequestDirectoryTarget {
+  final String branchName;
+  final PullRequestTargetResolutionException error;
+
+  const PullRequestRepositoryResolutionFailed({
+    required this.branchName,
+    required this.error,
+  });
+}
+
+final class PullRequestTargetResolutionException implements Exception {
+  final Object innerError;
+  final StackTrace innerStackTrace;
+
+  const PullRequestTargetResolutionException({
+    required this.innerError,
+    required this.innerStackTrace,
+  });
+
+  @override
+  String toString() => "Local pull request target resolution failed while handling ${innerError.runtimeType}";
+}
+
+sealed class PullRequestReplacementOutcome {
+  const PullRequestReplacementOutcome();
+}
+
+final class PullRequestReplacementApplied extends PullRequestReplacementOutcome {
+  final bool changed;
+
+  const PullRequestReplacementApplied({required this.changed});
+}
+
+final class PullRequestReplacementScopeChanged extends PullRequestReplacementOutcome {
+  const PullRequestReplacementScopeChanged();
+}

--- a/bridge/app/test/bridge/api/git_cli_api_test.dart
+++ b/bridge/app/test/bridge/api/git_cli_api_test.dart
@@ -50,6 +50,7 @@ void main() {
     for (final testCase in [
       (stdout: "Feature/Current\n", expected: "Feature/Current"),
       (stdout: "\u2003Feature/Current\u2003\r\n", expected: "\u2003Feature/Current\u2003"),
+      (stdout: "Feature/Current\r", expected: "Feature/Current"),
       (stdout: "Feature/Current\n\n", expected: "Feature/Current\n"),
     ]) {
       final processRunner = _RecordingProcessRunner(stdout: testCase.stdout);

--- a/bridge/app/test/bridge/api/git_cli_api_test.dart
+++ b/bridge/app/test/bridge/api/git_cli_api_test.dart
@@ -46,18 +46,25 @@ void main() {
     expect(processRunner.arguments, ["rev-parse", "--is-inside-work-tree"]);
   });
 
-  test("getCurrentBranch returns the exact named branch", () async {
-    final processRunner = _RecordingProcessRunner(stdout: "Feature/Current\n");
-    final api = GitCliApi(
-      processRunner: processRunner,
-      gitPathExists: ({required String gitPath}) => true,
-    );
+  test("getCurrentBranch removes one line ending without trimming the branch", () async {
+    for (final testCase in [
+      (stdout: "Feature/Current\n", expected: "Feature/Current"),
+      (stdout: "\u2003Feature/Current\u2003\r\n", expected: "\u2003Feature/Current\u2003"),
+      (stdout: "Feature/Current\n\n", expected: "Feature/Current\n"),
+    ]) {
+      final processRunner = _RecordingProcessRunner(stdout: testCase.stdout);
+      final api = GitCliApi(
+        processRunner: processRunner,
+        gitPathExists: ({required String gitPath}) => true,
+      );
 
-    final result = await api.getCurrentBranch(projectPath: "/project");
+      final result = await api.getCurrentBranch(projectPath: "/project");
 
-    expect(result, isA<GitCurrentBranchNamed>());
-    expect((result as GitCurrentBranchNamed).branchName, "Feature/Current");
-    expect(processRunner.arguments, ["symbolic-ref", "--quiet", "--short", "HEAD"]);
+      expect(result, isA<GitCurrentBranchNamed>());
+      expect((result as GitCurrentBranchNamed).branchName, testCase.expected);
+      expect(processRunner.arguments, ["symbolic-ref", "--quiet", "--short", "HEAD"]);
+      expect(processRunner.environment, const {"LC_ALL": "C"});
+    }
   });
 
   test("getCurrentBranch distinguishes detached, non-git, and missing directories", () async {
@@ -103,6 +110,7 @@ class _RecordingProcessRunner implements ProcessRunner {
   final int exitCode;
   List<String>? arguments;
   String? workingDirectory;
+  Map<String, String>? environment;
 
   _RecordingProcessRunner({this.stdout = "", this.stderr = "", this.exitCode = 0});
 
@@ -117,6 +125,7 @@ class _RecordingProcessRunner implements ProcessRunner {
     expect(executable, "git");
     this.arguments = arguments;
     this.workingDirectory = workingDirectory;
+    this.environment = environment;
     return ProcessResult(1, exitCode, stdout, stderr);
   }
 

--- a/bridge/app/test/bridge/api/git_cli_api_test.dart
+++ b/bridge/app/test/bridge/api/git_cli_api_test.dart
@@ -45,14 +45,66 @@ void main() {
     expect(processRunner.workingDirectory, "/project/child");
     expect(processRunner.arguments, ["rev-parse", "--is-inside-work-tree"]);
   });
+
+  test("getCurrentBranch returns the exact named branch", () async {
+    final processRunner = _RecordingProcessRunner(stdout: "Feature/Current\n");
+    final api = GitCliApi(
+      processRunner: processRunner,
+      gitPathExists: ({required String gitPath}) => true,
+    );
+
+    final result = await api.getCurrentBranch(projectPath: "/project");
+
+    expect(result, isA<GitCurrentBranchNamed>());
+    expect((result as GitCurrentBranchNamed).branchName, "Feature/Current");
+    expect(processRunner.arguments, ["symbolic-ref", "--quiet", "--short", "HEAD"]);
+  });
+
+  test("getCurrentBranch distinguishes detached, non-git, and missing directories", () async {
+    final detachedApi = GitCliApi(
+      processRunner: _RecordingProcessRunner(exitCode: 1),
+      gitPathExists: ({required String gitPath}) => true,
+    );
+    final nonGitApi = GitCliApi(
+      processRunner: _RecordingProcessRunner(exitCode: 128, stderr: "fatal: not a git repository"),
+      gitPathExists: ({required String gitPath}) => true,
+    );
+    final missingRunner = _RecordingProcessRunner();
+    final missingApi = GitCliApi(
+      processRunner: missingRunner,
+      gitPathExists: ({required String gitPath}) => false,
+    );
+
+    expect(await detachedApi.getCurrentBranch(projectPath: "/detached"), isA<GitCurrentBranchDetached>());
+    expect(await nonGitApi.getCurrentBranch(projectPath: "/plain"), isA<GitCurrentBranchNotRepository>());
+    expect(
+      await missingApi.getCurrentBranch(projectPath: "/missing"),
+      isA<GitCurrentBranchMissingDirectory>(),
+    );
+    expect(missingRunner.arguments, isNull);
+  });
+
+  test("getCurrentBranch preserves unexpected git failures", () async {
+    final api = GitCliApi(
+      processRunner: _RecordingProcessRunner(exitCode: 2, stderr: "unexpected failure"),
+      gitPathExists: ({required String gitPath}) => true,
+    );
+
+    await expectLater(
+      api.getCurrentBranch(projectPath: "/project"),
+      throwsA(isA<ProcessException>()),
+    );
+  });
 }
 
 class _RecordingProcessRunner implements ProcessRunner {
   final String stdout;
+  final String stderr;
+  final int exitCode;
   List<String>? arguments;
   String? workingDirectory;
 
-  _RecordingProcessRunner({this.stdout = ""});
+  _RecordingProcessRunner({this.stdout = "", this.stderr = "", this.exitCode = 0});
 
   @override
   Future<ProcessResult> run(
@@ -65,7 +117,7 @@ class _RecordingProcessRunner implements ProcessRunner {
     expect(executable, "git");
     this.arguments = arguments;
     this.workingDirectory = workingDirectory;
-    return ProcessResult(1, 0, stdout, "");
+    return ProcessResult(1, exitCode, stdout, stderr);
   }
 
   @override

--- a/bridge/app/test/bridge/repositories/mappers/catalog_mappers_test.dart
+++ b/bridge/app/test/bridge/repositories/mappers/catalog_mappers_test.dart
@@ -90,7 +90,7 @@ void main() {
     expect(session.parentID, "parent-id");
     expect(session.title, "Observed title");
     expect(session.promptDefaults?.agent, "build");
-    expect(session.branchName, "feature");
+    expect(session.branchName, "current-feature");
     expect(session.hasWorktree, isTrue);
     expect(session.unseen, isTrue);
   });

--- a/bridge/app/test/bridge/repositories/pr_source_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/pr_source_repository_test.dart
@@ -117,14 +117,15 @@ void main() {
       );
     });
 
-    test("resolves deduplicated directories concurrently in sorted result order", () async {
-      final first = Completer<GitCurrentBranchResult>();
-      final second = Completer<GitCurrentBranchResult>();
+    test("bounds concurrent deduplicated directory resolution and preserves sorted output", () async {
+      final sortedDirectories = [
+        for (var index = 0; index < 9; index++) "/directory-${index.toString().padLeft(2, "0")}",
+      ];
+      final branchResults = {
+        for (final directory in sortedDirectories) directory: Completer<GitCurrentBranchResult>(),
+      };
       final gitCli = _CompletingGitCliApi(
-        branchResults: {
-          "/a": first,
-          "/z": second,
-        },
+        branchResults: branchResults,
       );
       final repository = PrSourceRepository(
         ghCli: _FakeGhCliApi(initialResponses: const []),
@@ -132,23 +133,26 @@ void main() {
       );
 
       final resolution = repository.resolvePullRequestTargets(
-        directories: const ["/z", "/a", "/z"],
+        directories: [...sortedDirectories.reversed, sortedDirectories.last],
       );
-      await Future<void>.delayed(Duration.zero);
+      await gitCli.resolutionLimitReached.future;
 
-      expect(gitCli.branchCalls, ["/a", "/z"]);
-      second.complete(const GitCurrentBranchDetached());
-      first.complete(const GitCurrentBranchNotRepository());
+      expect(gitCli.branchCalls, sortedDirectories.take(8));
+      expect(gitCli.nextChunkStarted.isCompleted, isFalse);
+      for (final directory in sortedDirectories.take(8)) {
+        branchResults[directory]!.complete(const GitCurrentBranchDetached());
+      }
+
+      await gitCli.nextChunkStarted.future;
+      expect(gitCli.branchCalls, sortedDirectories);
+      branchResults[sortedDirectories.last]!.complete(const GitCurrentBranchNotRepository());
 
       final targets = await resolution;
-      expect(targets.keys, ["/a", "/z"]);
+      expect(targets.keys, sortedDirectories);
+      expect(targets, hasLength(9));
       expect(
-        (targets["/a"]! as PullRequestNoBranchDirectoryTarget).reason,
+        (targets[sortedDirectories.last]! as PullRequestNoBranchDirectoryTarget).reason,
         PullRequestNoBranchReason.notGitRepository,
-      );
-      expect(
-        (targets["/z"]! as PullRequestNoBranchDirectoryTarget).reason,
-        PullRequestNoBranchReason.detachedHead,
       );
     });
 
@@ -657,12 +661,19 @@ class _QueueProcessRunner extends ProcessRunner {
 final class _CompletingGitCliApi implements GitCliApi {
   final Map<String, Completer<GitCurrentBranchResult>> branchResults;
   final List<String> branchCalls = <String>[];
+  final Completer<void> resolutionLimitReached = Completer<void>();
+  final Completer<void> nextChunkStarted = Completer<void>();
 
   _CompletingGitCliApi({required this.branchResults});
 
   @override
   Future<GitCurrentBranchResult> getCurrentBranch({required String projectPath}) {
     branchCalls.add(projectPath);
+    if (branchCalls.length == 8) {
+      resolutionLimitReached.complete();
+    } else if (branchCalls.length == 9) {
+      nextChunkStarted.complete();
+    }
     return branchResults[projectPath]!.future;
   }
 

--- a/bridge/app/test/bridge/repositories/pr_source_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/pr_source_repository_test.dart
@@ -10,6 +10,7 @@ import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/verified_github_login.dart";
 import "package:sesori_bridge/src/bridge/repositories/pr_source_repository.dart";
 import "package:sesori_bridge/src/repositories/models/pull_request_selection.dart";
+import "package:sesori_bridge/src/repositories/models/pull_request_target.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -35,24 +36,27 @@ void main() {
       expect(await repository.getAuthenticatedIdentity(), isNull);
     });
 
-    test("returns a canonical lowercase GitHub owner/repository identity", () async {
+    test("resolves a named branch and canonical GitHub repository target", () async {
       final repository = _repository(
         ghResults: const [],
         gitResults: [
+          _result(stdout: "Feature/Current\n"),
           _result(stdout: "true\n"),
           _result(stdout: "origin\n"),
           _result(stdout: "git@GitHub.com:Sesori-AI/Sesori_Apps_Monorepo.git\n"),
         ],
       );
 
-      final identity = await repository.getGithubRepositoryIdentity(
-        projectPath: "/repo",
+      final targets = await repository.resolvePullRequestTargets(
+        directories: const ["/repo"],
       );
 
-      expect(identity, "sesori-ai/sesori_apps_monorepo");
+      final target = targets["/repo"]! as PullRequestGithubDirectoryTarget;
+      expect(target.target.githubRepositoryIdentity, "sesori-ai/sesori_apps_monorepo");
+      expect(target.target.branchName, "Feature/Current");
     });
 
-    test("rejects non-GitHub and nested repository identities", () async {
+    test("keeps named branches without a supported GitHub remote", () async {
       for (final remoteUrl in [
         "https://gitlab.com/sesori-ai/sesori_apps_monorepo.git",
         "https://github.com/sesori-ai/mobile/sesori_apps_monorepo.git",
@@ -60,18 +64,88 @@ void main() {
         final repository = _repository(
           ghResults: const [],
           gitResults: [
+            _result(stdout: "feature/current\n"),
             _result(stdout: "true\n"),
             _result(stdout: "origin\n"),
             _result(stdout: "$remoteUrl\n"),
           ],
         );
 
-        expect(
-          await repository.getGithubRepositoryIdentity(projectPath: "/repo"),
-          isNull,
-          reason: remoteUrl,
+        final targets = await repository.resolvePullRequestTargets(
+          directories: const ["/repo"],
         );
+        expect(targets["/repo"], isA<PullRequestLocalBranchDirectoryTarget>(), reason: remoteUrl);
       }
+    });
+
+    test("deduplicates exact directories and classifies branch absence", () async {
+      final detachedAndPlain = _repository(
+        ghResults: const [],
+        gitResults: [
+          ProcessResult(1, 1, "", ""),
+          ProcessResult(2, 128, "", "fatal: not a git repository"),
+        ],
+      );
+
+      final targets = await detachedAndPlain.resolvePullRequestTargets(
+        directories: const ["/plain", "/detached", "/detached"],
+      );
+
+      expect(
+        (targets["/detached"]! as PullRequestNoBranchDirectoryTarget).reason,
+        PullRequestNoBranchReason.detachedHead,
+      );
+      expect(
+        (targets["/plain"]! as PullRequestNoBranchDirectoryTarget).reason,
+        PullRequestNoBranchReason.notGitRepository,
+      );
+
+      final missing = _repository(
+        ghResults: const [],
+        gitResults: const [],
+        gitPathExists: false,
+      );
+      final missingTargets = await missing.resolvePullRequestTargets(
+        directories: const ["/missing"],
+      );
+      expect(
+        (missingTargets["/missing"]! as PullRequestNoBranchDirectoryTarget).reason,
+        PullRequestNoBranchReason.missingDirectory,
+      );
+    });
+
+    test("retains a named branch when repository resolution fails", () async {
+      final repository = _repository(
+        ghResults: const [],
+        gitResults: [
+          _result(stdout: "feature/current\n"),
+          ProcessResult(2, 2, "", "unexpected remote failure"),
+        ],
+      );
+
+      final targets = await repository.resolvePullRequestTargets(
+        directories: const ["/repo"],
+      );
+
+      final failed = targets["/repo"]! as PullRequestRepositoryResolutionFailed;
+      expect(failed.branchName, "feature/current");
+      expect(failed.error.innerError, isA<ProcessException>());
+      expect(failed.error.toString(), isNot(contains("unexpected remote failure")));
+    });
+
+    test("returns a typed failure when the current branch command fails", () async {
+      final repository = _repository(
+        ghResults: const [],
+        gitResults: [ProcessResult(1, 2, "", "unexpected branch failure")],
+      );
+
+      final targets = await repository.resolvePullRequestTargets(
+        directories: const ["/repo"],
+      );
+
+      final failed = targets["/repo"]! as PullRequestBranchResolutionFailed;
+      expect(failed.error.innerError, isA<ProcessException>());
+      expect(failed.error.toString(), isNot(contains("unexpected branch failure")));
     });
 
     test("selects newest open by creation time and number before terminal", () async {
@@ -446,12 +520,13 @@ GhPullRequest _pullRequest({
 PrSourceRepository _repository({
   required List<ProcessResult> ghResults,
   required List<ProcessResult> gitResults,
+  bool gitPathExists = true,
 }) {
   return PrSourceRepository(
     ghCli: GhCliApi(processRunner: _QueueProcessRunner(results: ghResults)),
     gitCli: GitCliApi(
       processRunner: _QueueProcessRunner(results: gitResults),
-      gitPathExists: ({required String gitPath}) => true,
+      gitPathExists: ({required String gitPath}) => gitPathExists,
     ),
   );
 }

--- a/bridge/app/test/bridge/repositories/pr_source_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/pr_source_repository_test.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:collection";
 import "dart:io";
 
@@ -44,6 +45,7 @@ void main() {
           _result(stdout: "true\n"),
           _result(stdout: "origin\n"),
           _result(stdout: "git@GitHub.com:Sesori-AI/Sesori_Apps_Monorepo.git\n"),
+          _result(stdout: "Feature/Current\n"),
         ],
       );
 
@@ -68,6 +70,7 @@ void main() {
             _result(stdout: "true\n"),
             _result(stdout: "origin\n"),
             _result(stdout: "$remoteUrl\n"),
+            _result(stdout: "feature/current\n"),
           ],
         );
 
@@ -112,6 +115,58 @@ void main() {
         (missingTargets["/missing"]! as PullRequestNoBranchDirectoryTarget).reason,
         PullRequestNoBranchReason.missingDirectory,
       );
+    });
+
+    test("resolves deduplicated directories concurrently in sorted result order", () async {
+      final first = Completer<GitCurrentBranchResult>();
+      final second = Completer<GitCurrentBranchResult>();
+      final gitCli = _CompletingGitCliApi(
+        branchResults: {
+          "/a": first,
+          "/z": second,
+        },
+      );
+      final repository = PrSourceRepository(
+        ghCli: _FakeGhCliApi(initialResponses: const []),
+        gitCli: gitCli,
+      );
+
+      final resolution = repository.resolvePullRequestTargets(
+        directories: const ["/z", "/a", "/z"],
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(gitCli.branchCalls, ["/a", "/z"]);
+      second.complete(const GitCurrentBranchDetached());
+      first.complete(const GitCurrentBranchNotRepository());
+
+      final targets = await resolution;
+      expect(targets.keys, ["/a", "/z"]);
+      expect(
+        (targets["/a"]! as PullRequestNoBranchDirectoryTarget).reason,
+        PullRequestNoBranchReason.notGitRepository,
+      );
+      expect(
+        (targets["/z"]! as PullRequestNoBranchDirectoryTarget).reason,
+        PullRequestNoBranchReason.detachedHead,
+      );
+    });
+
+    test("returns a typed branch failure when checkout changes during resolution", () async {
+      final gitCli = _BranchChangingGitCliApi();
+      final repository = PrSourceRepository(
+        ghCli: _FakeGhCliApi(initialResponses: const []),
+        gitCli: gitCli,
+      );
+
+      final resolution = repository.resolvePullRequestTargets(
+        directories: const ["/repo"],
+      );
+      await gitCli.remoteReadStarted.future;
+      gitCli.allowRemoteRead.complete();
+
+      expect((await resolution)["/repo"], isA<PullRequestBranchChangedDuringResolution>());
+      expect(gitCli.branchCalls, 2);
     });
 
     test("retains a named branch when repository resolution fails", () async {
@@ -597,4 +652,44 @@ class _QueueProcessRunner extends ProcessRunner {
     }
     return _results.removeFirst();
   }
+}
+
+final class _CompletingGitCliApi implements GitCliApi {
+  final Map<String, Completer<GitCurrentBranchResult>> branchResults;
+  final List<String> branchCalls = <String>[];
+
+  _CompletingGitCliApi({required this.branchResults});
+
+  @override
+  Future<GitCurrentBranchResult> getCurrentBranch({required String projectPath}) {
+    branchCalls.add(projectPath);
+    return branchResults[projectPath]!.future;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+final class _BranchChangingGitCliApi implements GitCliApi {
+  final Completer<void> remoteReadStarted = Completer<void>();
+  final Completer<void> allowRemoteRead = Completer<void>();
+  int branchCalls = 0;
+
+  @override
+  Future<GitCurrentBranchResult> getCurrentBranch({required String projectPath}) async {
+    branchCalls++;
+    return GitCurrentBranchNamed(
+      branchName: branchCalls == 1 ? "feature/old" : "feature/new",
+    );
+  }
+
+  @override
+  Future<String?> getRemoteUrl({required String projectPath}) async {
+    remoteReadStarted.complete();
+    await allowRemoteRead.future;
+    return "git@github.com:sesori-ai/sesori_apps_monorepo.git";
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/bridge/app/test/bridge/repositories/pull_request_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/pull_request_repository_test.dart
@@ -2,9 +2,11 @@ import "package:sesori_bridge/src/api/database/daos/pull_request_dao.dart";
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/api/database/tables/pull_requests_table.dart";
 import "package:sesori_bridge/src/bridge/repositories/mappers/stored_session_mapper.dart";
+import "package:sesori_bridge/src/bridge/repositories/models/stored_session.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/verified_github_login.dart";
 import "package:sesori_bridge/src/bridge/repositories/pull_request_repository.dart";
 import "package:sesori_bridge/src/repositories/models/pull_request_selection.dart";
+import "package:sesori_bridge/src/repositories/models/pull_request_target.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -12,194 +14,45 @@ import "../../helpers/test_database.dart";
 
 void main() {
   group("PullRequestRepository", () {
-    const githubLogin = "octocat";
-    const githubRepositoryIdentity = "sesori-ai/sesori_apps_monorepo";
-    final verifiedGithubLogin = VerifiedGithubLogin.tryParse(rawLogin: githubLogin)!;
-    final previousVerifiedGithubLogin = VerifiedGithubLogin.tryParse(
-      rawLogin: "previous-account",
-    )!;
+    const projectId = "X";
+    const repositoryIdentity = "sesori-ai/sesori_apps_monorepo";
+    final verifiedGithubLogin = VerifiedGithubLogin.tryParse(rawLogin: "octocat")!;
     late AppDatabase db;
     late PullRequestRepository repository;
 
-    setUp(() {
+    setUp(() async {
       db = createTestDatabase();
-      repository = PullRequestRepository(
-        database: db,
-        pullRequestDao: db.pullRequestDao,
-        projectsDao: db.projectsDao,
-        sessionDao: db.sessionDao,
+      await db.projectsDao.recordOpenedProject(
+        projectId: projectId,
+        path: "/project",
+        displayName: null,
+        createdAt: 1,
+        updatedAt: 1,
       );
+      repository = _repository(database: db, pullRequestDao: db.pullRequestDao);
     });
 
     tearDown(() => db.close());
 
-    PullRequestTargetSelected selectedPullRequest({required int number, required String branchName}) {
-      return PullRequestTargetSelected(
-        target: (
-          githubRepositoryIdentity: githubRepositoryIdentity,
-          branchName: branchName,
-        ),
-        number: number,
-        url: "https://github.com/$githubRepositoryIdentity/pull/$number",
-        title: "Test PR $number",
-        createdAt: DateTime.fromMillisecondsSinceEpoch(number, isUtc: true),
-        state: PrState.open,
-        mergeableStatus: PrMergeableStatus.mergeable,
-        reviewDecision: PrReviewDecision.reviewRequired,
-        checkStatus: PrCheckStatus.success,
+    test("applies exact root-directory scopes and clears child scope", () async {
+      await _insertRoot(
+        database: db,
+        sessionId: "project-root",
+        worktreePath: null,
+        creationBranch: "created-main",
       );
-    }
-
-    Future<void> insertRootSession({required String branchName}) async {
-      await db.projectsDao.insertProjectsIfMissing(projectIds: ["X"]);
-      await db.sessionDao.insertSession(
-        pluginId: "opencode",
-        sessionId: "root",
-        backendSessionId: "root",
-        projectId: "X",
-        isDedicated: true,
-        createdAt: 1,
-        worktreePath: "/tmp/root",
-        branchName: branchName,
-        baseBranch: "main",
-        baseCommit: "abc123",
-        lastAgent: null,
-        lastAgentModel: null,
+      await _insertRoot(
+        database: db,
+        sessionId: "worktree-root",
+        worktreePath: "/worktree",
+        creationBranch: "created-worktree",
       );
-    }
-
-    Future<void> insertPullRequest({
-      required String repositoryIdentity,
-      required String login,
-      required int number,
-      required String branchName,
-    }) {
-      return db.pullRequestDao.upsertPr(
-        pullRequest: PullRequestDto(
-          projectId: "X",
-          githubRepositoryIdentity: repositoryIdentity,
-          githubLogin: login,
-          prNumber: number,
-          branchName: branchName,
-          url: "https://github.com/$repositoryIdentity/pull/$number",
-          title: "Test PR $number",
-          state: PrState.open,
-          mergeableStatus: PrMergeableStatus.mergeable,
-          reviewDecision: PrReviewDecision.reviewRequired,
-          checkStatus: PrCheckStatus.success,
-          lastCheckedAt: number,
-          createdAt: number,
-        ),
-      );
-    }
-
-    test("replaceScopedPullRequests persists selected PR scope", () async {
-      await db.projectsDao.insertProjectsIfMissing(projectIds: ["X"]);
-      final changed = await repository.replaceScopedPullRequests(
-        projectId: "X",
-        verifiedGithubLogin: verifiedGithubLogin,
-        targetSelections: [selectedPullRequest(number: 42, branchName: "feature-branch")],
-        lastCheckedAt: 2,
-      );
-
-      final projectRows = await db.select(db.projectsTable).get();
-      expect(projectRows.map((row) => row.projectId), contains("X"));
-
-      final prRows = await db.pullRequestDao.getPrsByProjectId(projectId: "X");
-      expect(prRows, hasLength(1));
-      expect(prRows.single.prNumber, 42);
-      expect(prRows.single.githubRepositoryIdentity, githubRepositoryIdentity);
-      expect(prRows.single.githubLogin, githubLogin);
-      expect(prRows.single.createdAt, 42);
-      expect(changed, isTrue);
-    });
-
-    test("replaceScopedPullRequests does not fabricate a missing catalog project", () async {
-      await expectLater(
-        repository.replaceScopedPullRequests(
-          projectId: "missing",
-          verifiedGithubLogin: verifiedGithubLogin,
-          targetSelections: [selectedPullRequest(number: 42, branchName: "feature-branch")],
-          lastCheckedAt: 2,
-        ),
-        throwsA(anything),
-      );
-
-      expect(await db.projectsDao.getProject(projectId: "missing"), isNull);
-    });
-
-    test("replaceScopedPullRequests reports visible changes and clears complete no-match", () async {
-      await db.projectsDao.insertProjectsIfMissing(projectIds: ["X"]);
-      await insertPullRequest(
-        repositoryIdentity: githubRepositoryIdentity,
-        login: verifiedGithubLogin.login,
-        number: 42,
-        branchName: "feature-branch",
-      );
-
-      final unchanged = await repository.replaceScopedPullRequests(
-        projectId: "X",
-        verifiedGithubLogin: verifiedGithubLogin,
-        targetSelections: [selectedPullRequest(number: 42, branchName: "feature-branch")],
-        lastCheckedAt: 100,
-      );
-      final cleared = await repository.replaceScopedPullRequests(
-        projectId: "X",
-        verifiedGithubLogin: verifiedGithubLogin,
-        targetSelections: const [
-          PullRequestTargetUnmatched(
-            target: (
-              githubRepositoryIdentity: githubRepositoryIdentity,
-              branchName: "feature-branch",
-            ),
-          ),
-        ],
-        lastCheckedAt: 101,
-      );
-
-      expect(unchanged, isFalse);
-      expect(cleared, isTrue);
-      expect(await db.pullRequestDao.getPrsByProjectId(projectId: "X"), isEmpty);
-    });
-
-    test("replaceScopedPullRequests rejects duplicate target outcomes", () async {
-      await db.projectsDao.insertProjectsIfMissing(projectIds: ["X"]);
-      final selected = selectedPullRequest(number: 42, branchName: "feature-branch");
-
-      await expectLater(
-        repository.replaceScopedPullRequests(
-          projectId: "X",
-          verifiedGithubLogin: verifiedGithubLogin,
-          targetSelections: [
-            selected,
-            PullRequestTargetUnmatched(target: selected.target),
-          ],
-          lastCheckedAt: 2,
-        ),
-        throwsArgumentError,
-      );
-    });
-
-    test("prepareScopedRefresh does not fabricate a missing catalog project", () async {
-      final changed = await repository.prepareScopedRefresh(
-        projectId: "missing",
-        githubRepositoryIdentity: githubRepositoryIdentity,
-        verifiedGithubLogin: verifiedGithubLogin,
-        sessions: const [],
-      );
-
-      expect(changed, isFalse);
-      expect(await db.projectsDao.getProject(projectId: "missing"), isNull);
-    });
-
-    test("prepareScopedRefresh establishes account and root repository scope", () async {
-      await insertRootSession(branchName: "feature/root");
       await db.sessionDao.insertObservedChild(
         sessionId: "child",
         backendSessionId: "child",
-        projectId: "X",
-        parentSessionId: "root",
-        directory: "/tmp/root/child",
+        projectId: projectId,
+        parentSessionId: "project-root",
+        directory: "/project/child",
         catalogTitle: null,
         archivedAt: null,
         createdAt: 2,
@@ -207,157 +60,442 @@ void main() {
         projectionUpdatedAt: 2,
         pluginId: "opencode",
       );
-      await db.projectsDao.setPrCacheGithubLogin(
-        projectId: "X",
-        githubLogin: "previous-account",
-      );
       await db.sessionDao.updatePullRequestScopes(
         updates: const [
-          (
-            sessionId: "root",
-            currentBranchName: "stale-root",
-            currentGithubRepositoryIdentity: "previous/repository",
-          ),
           (
             sessionId: "child",
             currentBranchName: "stale-child",
-            currentGithubRepositoryIdentity: "previous/repository",
+            currentGithubRepositoryIdentity: "stale/repository",
           ),
         ],
       );
-      await insertPullRequest(
-        repositoryIdentity: "previous/repository",
-        login: previousVerifiedGithubLogin.login,
-        number: 1,
-        branchName: "stale-root",
-      );
-      await insertPullRequest(
-        repositoryIdentity: githubRepositoryIdentity,
-        login: verifiedGithubLogin.login,
-        number: 2,
-        branchName: "feature/root",
-      );
-      await insertPullRequest(
-        repositoryIdentity: githubRepositoryIdentity,
-        login: previousVerifiedGithubLogin.login,
-        number: 3,
-        branchName: "feature/root",
-      );
-      await insertPullRequest(
-        repositoryIdentity: githubRepositoryIdentity,
-        login: verifiedGithubLogin.login,
-        number: 4,
-        branchName: "departed-branch",
-      );
-      final storedSessions = (await db.sessionDao.getSessionsByProject(
-        projectId: "X",
-      )).map((row) => row.toStoredSession()).toList(growable: false);
 
-      final changed = await repository.prepareScopedRefresh(
-        projectId: "X",
-        githubRepositoryIdentity: githubRepositoryIdentity,
-        verifiedGithubLogin: verifiedGithubLogin,
-        sessions: storedSessions,
+      final changed = await repository.applyResolvedTargets(
+        sessionsByProject: {projectId: await _storedSessions(database: db)},
+        targetsByDirectory: const {
+          "/project": PullRequestGithubDirectoryTarget(
+            target: (githubRepositoryIdentity: repositoryIdentity, branchName: "main"),
+          ),
+          "/worktree": PullRequestGithubDirectoryTarget(
+            target: (githubRepositoryIdentity: repositoryIdentity, branchName: "feature/current"),
+          ),
+        },
       );
 
-      final project = await db.projectsDao.getProject(projectId: "X");
-      final root = await db.sessionDao.getSession(sessionId: "root");
+      final projectRoot = await db.sessionDao.getSession(sessionId: "project-root");
+      final worktreeRoot = await db.sessionDao.getSession(sessionId: "worktree-root");
       final child = await db.sessionDao.getSession(sessionId: "child");
-      final prs = await db.pullRequestDao.getPrsByProjectId(projectId: "X");
-      expect(project?.prCacheGithubLogin, githubLogin);
-      expect(root?.currentBranchName, "feature/root");
-      expect(root?.currentGithubRepositoryIdentity, githubRepositoryIdentity);
+      expect(projectRoot?.branchName, "created-main");
+      expect(projectRoot?.currentBranchName, "main");
+      expect(projectRoot?.currentGithubRepositoryIdentity, repositoryIdentity);
+      expect(worktreeRoot?.branchName, "created-worktree");
+      expect(worktreeRoot?.currentBranchName, "feature/current");
       expect(child?.currentBranchName, isNull);
       expect(child?.currentGithubRepositoryIdentity, isNull);
-      expect(prs.map((pr) => pr.prNumber), [2]);
-      expect(changed, isTrue);
+      expect(changed, {projectId});
     });
 
-    test("prepareScopedRefresh rolls back account and session scope on failure", () async {
-      await insertRootSession(branchName: "feature/root");
-      await db.projectsDao.setPrCacheGithubLogin(
-        projectId: "X",
+    test("branch-only and detached targets clear stale selected PRs", () async {
+      await _insertRoot(
+        database: db,
+        sessionId: "project-root",
+        worktreePath: null,
+        creationBranch: "created-main",
+      );
+      await _setScopeAndLogin(
+        database: db,
+        branchName: "previous",
+        repositoryIdentity: repositoryIdentity,
+        githubLogin: verifiedGithubLogin.login,
+      );
+      await _insertPullRequest(
+        database: db,
+        repositoryIdentity: repositoryIdentity,
+        githubLogin: verifiedGithubLogin.login,
+        branchName: "previous",
+        number: 1,
+      );
+
+      final branchOnlyChanged = await repository.applyResolvedTargets(
+        sessionsByProject: {projectId: await _storedSessions(database: db)},
+        targetsByDirectory: const {
+          "/project": PullRequestLocalBranchDirectoryTarget(branchName: "local-only"),
+        },
+      );
+      final branchOnly = await db.sessionDao.getSession(sessionId: "project-root");
+      expect(branchOnly?.currentBranchName, "local-only");
+      expect(branchOnly?.currentGithubRepositoryIdentity, isNull);
+      expect(await db.pullRequestDao.getPrsByProjectId(projectId: projectId), isEmpty);
+      expect(branchOnlyChanged, {projectId});
+
+      final detachedChanged = await repository.applyResolvedTargets(
+        sessionsByProject: {projectId: await _storedSessions(database: db)},
+        targetsByDirectory: const {
+          "/project": PullRequestNoBranchDirectoryTarget(
+            reason: PullRequestNoBranchReason.detachedHead,
+          ),
+        },
+      );
+      final detached = await db.sessionDao.getSession(sessionId: "project-root");
+      expect(detached?.currentBranchName, isNull);
+      expect(detached?.branchName, "created-main");
+      expect(detachedChanged, {projectId});
+      expect((await db.projectsDao.getProject(projectId: projectId))?.prCacheGithubLogin, isNull);
+    });
+
+    test("branch resolution failure preserves the captured current scope", () async {
+      await _insertRoot(
+        database: db,
+        sessionId: "project-root",
+        worktreePath: null,
+        creationBranch: "created-main",
+      );
+      await _setScopeAndLogin(
+        database: db,
+        branchName: "preserved",
+        repositoryIdentity: repositoryIdentity,
+        githubLogin: verifiedGithubLogin.login,
+      );
+      await _insertPullRequest(
+        database: db,
+        repositoryIdentity: repositoryIdentity,
+        githubLogin: verifiedGithubLogin.login,
+        branchName: "preserved",
+        number: 1,
+      );
+
+      final changed = await repository.applyResolvedTargets(
+        sessionsByProject: {projectId: await _storedSessions(database: db)},
+        targetsByDirectory: {
+          "/project": PullRequestBranchResolutionFailed(
+            error: PullRequestTargetResolutionException(
+              innerError: StateError("failed"),
+              innerStackTrace: StackTrace.current,
+            ),
+          ),
+        },
+      );
+
+      final session = await db.sessionDao.getSession(sessionId: "project-root");
+      expect(session?.currentBranchName, "preserved");
+      expect(session?.currentGithubRepositoryIdentity, repositoryIdentity);
+      expect(await db.pullRequestDao.getPrsByProjectId(projectId: projectId), hasLength(1));
+      expect(changed, isEmpty);
+    });
+
+    test("does not apply a target captured before the session directory moved", () async {
+      await _insertRoot(
+        database: db,
+        sessionId: "project-root",
+        worktreePath: null,
+        creationBranch: "created-main",
+      );
+      final captured = await _storedSessions(database: db);
+      await db.sessionDao.updateObservedSessionProjection(
+        sessionId: "project-root",
+        directory: "/moved",
+        catalogTitle: null,
+        updateCatalogTitle: false,
+        updatedAt: 2,
+        projectionUpdatedAt: 2,
+      );
+
+      final changed = await repository.applyResolvedTargets(
+        sessionsByProject: {projectId: captured},
+        targetsByDirectory: const {
+          "/project": PullRequestGithubDirectoryTarget(
+            target: (githubRepositoryIdentity: repositoryIdentity, branchName: "stale"),
+          ),
+        },
+      );
+
+      final session = await db.sessionDao.getSession(sessionId: "project-root");
+      expect(session?.directory, "/moved");
+      expect(session?.currentBranchName, isNull);
+      expect(changed, isEmpty);
+    });
+
+    test("prepares the verified account without fabricating missing projects", () async {
+      await _insertRoot(
+        database: db,
+        sessionId: "project-root",
+        worktreePath: null,
+        creationBranch: "created-main",
+      );
+      await _setScopeAndLogin(
+        database: db,
+        branchName: "main",
+        repositoryIdentity: repositoryIdentity,
         githubLogin: "previous-account",
       );
+      await _insertPullRequest(
+        database: db,
+        repositoryIdentity: repositoryIdentity,
+        githubLogin: "previous-account",
+        branchName: "main",
+        number: 1,
+      );
+      await _insertPullRequest(
+        database: db,
+        repositoryIdentity: repositoryIdentity,
+        githubLogin: verifiedGithubLogin.login,
+        branchName: "main",
+        number: 2,
+      );
+
+      final changed = await repository.prepareScopedRefresh(
+        projectIds: {projectId, "missing"},
+        verifiedGithubLogin: verifiedGithubLogin,
+      );
+
+      final rows = await db.pullRequestDao.getPrsByProjectId(projectId: projectId);
+      expect(rows.map((row) => row.prNumber), [2]);
+      expect((await db.projectsDao.getProject(projectId: projectId))?.prCacheGithubLogin, "octocat");
+      expect(await db.projectsDao.getProject(projectId: "missing"), isNull);
+      expect(changed, {projectId});
+    });
+
+    test("replacement applies only while account and exact target scope match", () async {
+      await _insertRoot(
+        database: db,
+        sessionId: "project-root",
+        worktreePath: null,
+        creationBranch: "created-main",
+      );
+      await _setScopeAndLogin(
+        database: db,
+        branchName: "main",
+        repositoryIdentity: repositoryIdentity,
+        githubLogin: verifiedGithubLogin.login,
+      );
+      final selected = _selectedPullRequest(
+        repositoryIdentity: repositoryIdentity,
+        branchName: "main",
+        number: 42,
+      );
+
+      final applied = await repository.replaceScopedPullRequests(
+        projectId: projectId,
+        verifiedGithubLogin: verifiedGithubLogin,
+        targetSelections: [selected],
+        lastCheckedAt: 2,
+      );
+      expect(applied, isA<PullRequestReplacementApplied>());
+      expect((applied as PullRequestReplacementApplied).changed, isTrue);
+      expect(await db.pullRequestDao.getPrsByProjectId(projectId: projectId), hasLength(1));
+
       await db.sessionDao.updatePullRequestScopes(
         updates: const [
           (
-            sessionId: "root",
-            currentBranchName: "previous-branch",
-            currentGithubRepositoryIdentity: "previous/repository",
+            sessionId: "project-root",
+            currentBranchName: "switched",
+            currentGithubRepositoryIdentity: repositoryIdentity,
           ),
         ],
       );
-      final storedSession = (await db.sessionDao.getSession(
-        sessionId: "root",
-      ))!.toStoredSession();
-      final failingRepository = PullRequestRepository(
+      final stale = await repository.replaceScopedPullRequests(
+        projectId: projectId,
+        verifiedGithubLogin: verifiedGithubLogin,
+        targetSelections: [selected],
+        lastCheckedAt: 3,
+      );
+      expect(stale, isA<PullRequestReplacementScopeChanged>());
+      expect((await db.pullRequestDao.getPrsByProjectId(projectId: projectId)).single.prNumber, 42);
+    });
+
+    test("complete no-match clears and duplicate target outcomes are rejected", () async {
+      await _insertRoot(
         database: db,
-        pullRequestDao: _FailingScopeCleanupPullRequestDao(db),
-        projectsDao: db.projectsDao,
-        sessionDao: db.sessionDao,
+        sessionId: "project-root",
+        worktreePath: null,
+        creationBranch: "created-main",
+      );
+      await _setScopeAndLogin(
+        database: db,
+        branchName: "main",
+        repositoryIdentity: repositoryIdentity,
+        githubLogin: verifiedGithubLogin.login,
+      );
+      final selected = _selectedPullRequest(
+        repositoryIdentity: repositoryIdentity,
+        branchName: "main",
+        number: 42,
+      );
+      await repository.replaceScopedPullRequests(
+        projectId: projectId,
+        verifiedGithubLogin: verifiedGithubLogin,
+        targetSelections: [selected],
+        lastCheckedAt: 2,
+      );
+
+      final cleared = await repository.replaceScopedPullRequests(
+        projectId: projectId,
+        verifiedGithubLogin: verifiedGithubLogin,
+        targetSelections: [PullRequestTargetUnmatched(target: selected.target)],
+        lastCheckedAt: 3,
+      );
+      expect((cleared as PullRequestReplacementApplied).changed, isTrue);
+      expect(await db.pullRequestDao.getPrsByProjectId(projectId: projectId), isEmpty);
+
+      await expectLater(
+        repository.replaceScopedPullRequests(
+          projectId: projectId,
+          verifiedGithubLogin: verifiedGithubLogin,
+          targetSelections: [
+            selected,
+            PullRequestTargetUnmatched(target: selected.target),
+          ],
+          lastCheckedAt: 4,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test("local target application rolls back session scope when cleanup fails", () async {
+      await _insertRoot(
+        database: db,
+        sessionId: "project-root",
+        worktreePath: null,
+        creationBranch: "created-main",
+      );
+      final failingRepository = _repository(
+        database: db,
+        pullRequestDao: _FailingPullRequestDao(db),
       );
 
       await expectLater(
-        failingRepository.prepareScopedRefresh(
-          projectId: "X",
-          githubRepositoryIdentity: githubRepositoryIdentity,
-          verifiedGithubLogin: verifiedGithubLogin,
-          sessions: [storedSession],
+        failingRepository.applyResolvedTargets(
+          sessionsByProject: {projectId: await _storedSessions(database: db)},
+          targetsByDirectory: const {
+            "/project": PullRequestGithubDirectoryTarget(
+              target: (githubRepositoryIdentity: repositoryIdentity, branchName: "main"),
+            ),
+          },
         ),
         throwsStateError,
       );
 
-      final project = await db.projectsDao.getProject(projectId: "X");
-      final session = await db.sessionDao.getSession(sessionId: "root");
-      expect(project?.prCacheGithubLogin, "previous-account");
-      expect(session?.currentBranchName, "previous-branch");
-      expect(session?.currentGithubRepositoryIdentity, "previous/repository");
-    });
-
-    test("clearScopedRefresh clears scope and cached rows atomically", () async {
-      await insertRootSession(branchName: "feature/root");
-      final storedSession = (await db.sessionDao.getSession(
-        sessionId: "root",
-      ))!.toStoredSession();
-      await repository.prepareScopedRefresh(
-        projectId: "X",
-        githubRepositoryIdentity: githubRepositoryIdentity,
-        verifiedGithubLogin: verifiedGithubLogin,
-        sessions: [storedSession],
-      );
-      await insertPullRequest(
-        repositoryIdentity: githubRepositoryIdentity,
-        login: verifiedGithubLogin.login,
-        number: 7,
-        branchName: "feature/root",
-      );
-
-      final changed = await repository.clearScopedRefresh(
-        projectId: "X",
-        sessions: [storedSession],
-      );
-
-      final project = await db.projectsDao.getProject(projectId: "X");
-      final session = await db.sessionDao.getSession(sessionId: "root");
-      expect(project?.prCacheGithubLogin, isNull);
+      final session = await db.sessionDao.getSession(sessionId: "project-root");
       expect(session?.currentBranchName, isNull);
       expect(session?.currentGithubRepositoryIdentity, isNull);
-      expect(await db.pullRequestDao.getPrsByProjectId(projectId: "X"), isEmpty);
-      expect(changed, isTrue);
     });
   });
 }
 
-class _FailingScopeCleanupPullRequestDao extends PullRequestDao {
-  _FailingScopeCleanupPullRequestDao(super.database);
+PullRequestRepository _repository({
+  required AppDatabase database,
+  required PullRequestDao pullRequestDao,
+}) {
+  return PullRequestRepository(
+    database: database,
+    pullRequestDao: pullRequestDao,
+    projectsDao: database.projectsDao,
+    sessionDao: database.sessionDao,
+  );
+}
+
+Future<void> _insertRoot({
+  required AppDatabase database,
+  required String sessionId,
+  required String? worktreePath,
+  required String creationBranch,
+}) {
+  return database.sessionDao.insertSession(
+    pluginId: "opencode",
+    sessionId: sessionId,
+    backendSessionId: sessionId,
+    projectId: "X",
+    isDedicated: worktreePath != null,
+    createdAt: 1,
+    worktreePath: worktreePath,
+    branchName: creationBranch,
+    baseBranch: "main",
+    baseCommit: "abc123",
+    lastAgent: null,
+    lastAgentModel: null,
+  );
+}
+
+Future<List<StoredSession>> _storedSessions({required AppDatabase database}) async {
+  final rows = await database.sessionDao.getSessionsByProject(projectId: "X");
+  return rows.map((row) => row.toStoredSession()).toList(growable: false);
+}
+
+Future<void> _setScopeAndLogin({
+  required AppDatabase database,
+  required String branchName,
+  required String repositoryIdentity,
+  required String githubLogin,
+}) async {
+  await database.sessionDao.updatePullRequestScopes(
+    updates: [
+      (
+        sessionId: "project-root",
+        currentBranchName: branchName,
+        currentGithubRepositoryIdentity: repositoryIdentity,
+      ),
+    ],
+  );
+  await database.projectsDao.setPrCacheGithubLogin(
+    projectId: "X",
+    githubLogin: githubLogin,
+  );
+}
+
+Future<void> _insertPullRequest({
+  required AppDatabase database,
+  required String repositoryIdentity,
+  required String githubLogin,
+  required String branchName,
+  required int number,
+}) {
+  return database.pullRequestDao.upsertPr(
+    pullRequest: PullRequestDto(
+      projectId: "X",
+      githubRepositoryIdentity: repositoryIdentity,
+      githubLogin: githubLogin,
+      prNumber: number,
+      branchName: branchName,
+      url: "https://github.com/$repositoryIdentity/pull/$number",
+      title: "Test PR $number",
+      state: PrState.open,
+      mergeableStatus: PrMergeableStatus.mergeable,
+      reviewDecision: PrReviewDecision.reviewRequired,
+      checkStatus: PrCheckStatus.success,
+      lastCheckedAt: number,
+      createdAt: number,
+    ),
+  );
+}
+
+PullRequestTargetSelected _selectedPullRequest({
+  required String repositoryIdentity,
+  required String branchName,
+  required int number,
+}) {
+  return PullRequestTargetSelected(
+    target: (
+      githubRepositoryIdentity: repositoryIdentity,
+      branchName: branchName,
+    ),
+    number: number,
+    url: "https://github.com/$repositoryIdentity/pull/$number",
+    title: "Test PR $number",
+    createdAt: DateTime.fromMillisecondsSinceEpoch(number, isUtc: true),
+    state: PrState.open,
+    mergeableStatus: PrMergeableStatus.mergeable,
+    reviewDecision: PrReviewDecision.reviewRequired,
+    checkStatus: PrCheckStatus.success,
+  );
+}
+
+final class _FailingPullRequestDao extends PullRequestDao {
+  _FailingPullRequestDao(super.database);
 
   @override
-  Future<void> deletePrsOutsideScope({
+  Future<void> deletePrsOutsideTargets({
     required String projectId,
-    required String githubRepositoryIdentity,
-    required String githubLogin,
-    required Set<String> branchNames,
+    required Set<PullRequestPersistedTarget> targets,
   }) {
     throw StateError("scope cleanup failed");
   }

--- a/bridge/app/test/bridge/repositories/pull_request_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/pull_request_repository_test.dart
@@ -183,12 +183,25 @@ void main() {
       expect(changed, isEmpty);
     });
 
-    test("does not apply a target captured before the session directory moved", () async {
+    test("clears stale scope when a captured session otherwise matches but its directory moved", () async {
       await _insertRoot(
         database: db,
         sessionId: "project-root",
         worktreePath: null,
         creationBranch: "created-main",
+      );
+      await _setScopeAndLogin(
+        database: db,
+        branchName: "preserved",
+        repositoryIdentity: repositoryIdentity,
+        githubLogin: verifiedGithubLogin.login,
+      );
+      await _insertPullRequest(
+        database: db,
+        repositoryIdentity: repositoryIdentity,
+        githubLogin: verifiedGithubLogin.login,
+        branchName: "preserved",
+        number: 1,
       );
       final captured = await _storedSessions(database: db);
       await db.sessionDao.updateObservedSessionProjection(
@@ -204,7 +217,7 @@ void main() {
         sessionsByProject: {projectId: captured},
         targetsByDirectory: const {
           "/project": PullRequestGithubDirectoryTarget(
-            target: (githubRepositoryIdentity: repositoryIdentity, branchName: "stale"),
+            target: (githubRepositoryIdentity: repositoryIdentity, branchName: "preserved"),
           ),
         },
       );
@@ -212,7 +225,9 @@ void main() {
       final session = await db.sessionDao.getSession(sessionId: "project-root");
       expect(session?.directory, "/moved");
       expect(session?.currentBranchName, isNull);
-      expect(changed, isEmpty);
+      expect(session?.currentGithubRepositoryIdentity, isNull);
+      expect(await db.pullRequestDao.getPrsByProjectId(projectId: projectId), isEmpty);
+      expect(changed, {projectId});
     });
 
     test("prepares the verified account without fabricating missing projects", () async {
@@ -277,6 +292,7 @@ void main() {
       final applied = await repository.replaceScopedPullRequests(
         projectId: projectId,
         verifiedGithubLogin: verifiedGithubLogin,
+        capturedRootDirectoriesBySessionId: const {"project-root": "/project"},
         targetSelections: [selected],
         lastCheckedAt: 2,
       );
@@ -296,11 +312,58 @@ void main() {
       final stale = await repository.replaceScopedPullRequests(
         projectId: projectId,
         verifiedGithubLogin: verifiedGithubLogin,
+        capturedRootDirectoriesBySessionId: const {"project-root": "/project"},
         targetSelections: [selected],
         lastCheckedAt: 3,
       );
       expect(stale, isA<PullRequestReplacementScopeChanged>());
       expect((await db.pullRequestDao.getPrsByProjectId(projectId: projectId)).single.prNumber, 42);
+    });
+
+    test("replacement rejects a query captured before a root directory moved", () async {
+      await _insertRoot(
+        database: db,
+        sessionId: "project-root",
+        worktreePath: null,
+        creationBranch: "created-main",
+      );
+      await _setScopeAndLogin(
+        database: db,
+        branchName: "main",
+        repositoryIdentity: repositoryIdentity,
+        githubLogin: verifiedGithubLogin.login,
+      );
+      await _insertPullRequest(
+        database: db,
+        repositoryIdentity: repositoryIdentity,
+        githubLogin: verifiedGithubLogin.login,
+        branchName: "main",
+        number: 1,
+      );
+      final selected = _selectedPullRequest(
+        repositoryIdentity: repositoryIdentity,
+        branchName: "main",
+        number: 42,
+      );
+      await db.sessionDao.updateObservedSessionProjection(
+        sessionId: "project-root",
+        directory: "/moved",
+        catalogTitle: null,
+        updateCatalogTitle: false,
+        updatedAt: 2,
+        projectionUpdatedAt: 2,
+      );
+
+      final stale = await repository.replaceScopedPullRequests(
+        projectId: projectId,
+        verifiedGithubLogin: verifiedGithubLogin,
+        capturedRootDirectoriesBySessionId: const {"project-root": "/project"},
+        targetSelections: [selected],
+        lastCheckedAt: 3,
+      );
+
+      expect(stale, isA<PullRequestReplacementScopeChanged>());
+      expect((await db.pullRequestDao.getPrsByProjectId(projectId: projectId)).single.prNumber, 1);
     });
 
     test("complete no-match clears and duplicate target outcomes are rejected", () async {
@@ -324,6 +387,7 @@ void main() {
       await repository.replaceScopedPullRequests(
         projectId: projectId,
         verifiedGithubLogin: verifiedGithubLogin,
+        capturedRootDirectoriesBySessionId: const {"project-root": "/project"},
         targetSelections: [selected],
         lastCheckedAt: 2,
       );
@@ -331,6 +395,7 @@ void main() {
       final cleared = await repository.replaceScopedPullRequests(
         projectId: projectId,
         verifiedGithubLogin: verifiedGithubLogin,
+        capturedRootDirectoriesBySessionId: const {"project-root": "/project"},
         targetSelections: [PullRequestTargetUnmatched(target: selected.target)],
         lastCheckedAt: 3,
       );
@@ -341,6 +406,7 @@ void main() {
         repository.replaceScopedPullRequests(
           projectId: projectId,
           verifiedGithubLogin: verifiedGithubLogin,
+          capturedRootDirectoriesBySessionId: const {"project-root": "/project"},
           targetSelections: [
             selected,
             PullRequestTargetUnmatched(target: selected.target),

--- a/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
@@ -1158,6 +1158,56 @@ void main() {
       }
     });
 
+    test("returns the original snapshot when timeout fallback enrichment stalls", () async {
+      plugin.sessionsResult = const [
+        PluginSession(
+          id: "s1",
+          projectID: "p1",
+          directory: "/tmp",
+          parentID: null,
+          title: "session one",
+          time: null,
+        ),
+      ];
+      sessionDao.setSession(_storedSession(currentBranchName: "feature/a"));
+      final fallbackBlockingRepository = _FallbackBlockingSessionRepository(
+        plugin: plugin,
+        sessionDao: sessionDao,
+        pullRequestRepository: pullRequestRepository,
+        persistenceDatabase: db,
+        initialBranchName: "feature/a",
+      );
+      final branchPersisted = Completer<void>();
+      final stalledRefresh = Completer<void>();
+      final timeoutHandler = GetSessionsHandler(
+        sessionRepository: fallbackBlockingRepository,
+        prSyncService: FakePrSyncService(
+          refreshAction: () async {
+            sessionDao.setSession(_storedSession(currentBranchName: "feature/b"));
+            branchPersisted.complete();
+            await stalledRefresh.future;
+          },
+        ),
+        prRefreshTimeout: const Duration(milliseconds: 40),
+      );
+
+      final result = await timeoutHandler
+          .handle(
+            makeRequest("POST", "/sessions"),
+            body: const SessionListRequest(projectId: "p1", start: null, limit: null, waitForPrData: true),
+            pathParams: {},
+            queryParams: {},
+            fragment: null,
+          )
+          .timeout(const Duration(milliseconds: 500));
+
+      expect(branchPersisted.isCompleted, isTrue);
+      expect(fallbackBlockingRepository.fallbackEnrichmentStarted.isCompleted, isTrue);
+      expect(result.items.single.branchName, "feature/a");
+      expect(result.items.single.pullRequest, isNull);
+      expect(result.items.single.pullRequestHistory, isEmpty);
+    });
+
     test("returns the original PR-free snapshot when timeout fallback enrichment fails", () async {
       plugin.sessionsResult = const [
         PluginSession(
@@ -1462,6 +1512,53 @@ final class _FallbackFailingSessionRepository extends FakeSessionRepository {
     enrichmentAttempts++;
     if (enrichmentAttempts == 2) {
       throw StateError("fallback enrichment failed");
+    }
+    return super.enrichSessions(
+      sessions: sessions,
+      verifiedGithubLogin: verifiedGithubLogin,
+    );
+  }
+}
+
+final class _FallbackBlockingSessionRepository extends FakeSessionRepository {
+  final String initialBranchName;
+  final Completer<void> fallbackEnrichmentStarted = Completer<void>();
+  final Completer<List<Session>> _stalledFallback = Completer<List<Session>>();
+
+  _FallbackBlockingSessionRepository({
+    required super.plugin,
+    required super.sessionDao,
+    required super.pullRequestRepository,
+    required super.persistenceDatabase,
+    required this.initialBranchName,
+  });
+
+  @override
+  Future<List<Session>> getSessionsForProject({
+    required String projectId,
+    required int? start,
+    required int? limit,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) async {
+    final sessions = await super.getSessionsForProject(
+      projectId: projectId,
+      start: start,
+      limit: limit,
+      verifiedGithubLogin: verifiedGithubLogin,
+    );
+    return [
+      for (final session in sessions) session.copyWith(branchName: initialBranchName),
+    ];
+  }
+
+  @override
+  Future<List<Session>> enrichSessions({
+    required List<Session> sessions,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) {
+    if (verifiedGithubLogin == null) {
+      fallbackEnrichmentStarted.complete();
+      return _stalledFallback.future;
     }
     return super.enrichSessions(
       sessions: sessions,

--- a/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
@@ -990,7 +990,8 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       expect(prSyncService.calls, hasLength(1));
-      expect(prSyncService.calls.single, {"project-1"});
+      expect(prSyncService.calls.single.projectIds, {"project-1"});
+      expect(prSyncService.calls.single.refreshPolicy, PrRefreshPolicy.background);
     });
 
     test("bounds initial identity verification and returns PR-free sessions", () async {
@@ -1055,7 +1056,8 @@ void main() {
       );
 
       expect(prSyncService.calls, hasLength(1));
-      expect(prSyncService.calls.single, {"project-1"});
+      expect(prSyncService.calls.single.projectIds, {"project-1"});
+      expect(prSyncService.calls.single.refreshPolicy, PrRefreshPolicy.explicit);
       expect(plugin.lastGetCurrentProjectProjectId, isNull);
     });
 
@@ -1111,6 +1113,35 @@ void main() {
     });
 
     test("strips cached PR metadata when a waited refresh fails", () async {
+      SessionDto storedSession({required String currentBranchName}) {
+        return SessionDto(
+          pluginId: "fake",
+          sessionId: "s1",
+          backendSessionId: "s1",
+          projectId: "p1",
+          parentSessionId: null,
+          directory: "/tmp",
+          worktreePath: null,
+          branchName: null,
+          currentBranchName: currentBranchName,
+          currentGithubRepositoryIdentity: "org/repo",
+          isDedicated: false,
+          archivedAt: null,
+          baseBranch: null,
+          baseCommit: null,
+          lastAgent: null,
+          lastAgentModel: null,
+          createdAt: 1,
+          updatedAt: 1,
+          projectionUpdatedAt: 1,
+          lastActivityAt: null,
+          lastSeenAt: null,
+          lastUserMessageAt: null,
+          title: null,
+          catalogTitle: null,
+        );
+      }
+
       plugin.sessionsResult = const [
         PluginSession(
           id: "s1",
@@ -1121,6 +1152,7 @@ void main() {
           time: null,
         ),
       ];
+      sessionDao.setSession(storedSession(currentBranchName: "feature/old"));
       pullRequestRepository.setPr(
         sessionId: "s1",
         pullRequest: const PullRequestDto(
@@ -1139,9 +1171,15 @@ void main() {
           createdAt: 1,
         ),
       );
+      final failedRefresh = FakePrSyncService(
+        refreshOutcome: PrRefreshOutcome.failed,
+        refreshAction: () {
+          sessionDao.setSession(storedSession(currentBranchName: "feature/new"));
+        },
+      );
       final failingHandler = GetSessionsHandler(
         sessionRepository: sessionRepository,
-        prSyncService: FakePrSyncService(refreshOutcome: PrRefreshOutcome.failed),
+        prSyncService: failedRefresh,
       );
 
       final result = await failingHandler.handle(
@@ -1152,8 +1190,12 @@ void main() {
         fragment: null,
       );
 
+      expect(result.items.single.branchName, "feature/new");
       expect(result.items.single.pullRequest, isNull);
       expect(result.items.single.pullRequestHistory, isEmpty);
+      expect(sessionRepository.getSessionsCallCount, 1);
+      expect(sessionRepository.enrichSessionsCallCount, 2);
+      expect(failedRefresh.calls.single.refreshPolicy, PrRefreshPolicy.explicit);
     });
     test("keeps final identity verification inside the waited deadline", () async {
       plugin.sessionsResult = const [

--- a/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
@@ -990,7 +990,7 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       expect(prSyncService.calls, hasLength(1));
-      expect(prSyncService.calls.single, equals((projectId: "project-1", projectPath: "/tmp/project")));
+      expect(prSyncService.calls.single, {"project-1"});
     });
 
     test("bounds initial identity verification and returns PR-free sessions", () async {
@@ -1044,7 +1044,7 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 110));
     });
 
-    test("triggers PR refresh with the stored catalog project path", () async {
+    test("triggers PR refresh with the stable project id", () async {
       sessionRepository.projectPathResult = "/tmp/project";
       await handler.handle(
         makeRequest("POST", "/sessions"),
@@ -1055,32 +1055,8 @@ void main() {
       );
 
       expect(prSyncService.calls, hasLength(1));
-      expect(prSyncService.calls.single, equals((projectId: "project-1", projectPath: "/tmp/project")));
+      expect(prSyncService.calls.single, {"project-1"});
       expect(plugin.lastGetCurrentProjectProjectId, isNull);
-    });
-
-    test("falls back to session directory when the catalog project path is missing", () async {
-      plugin.sessionsResult = const [
-        PluginSession(
-          id: "s1",
-          projectID: "project-1",
-          directory: "/tmp/fallback-project",
-          parentID: null,
-          title: null,
-          time: null,
-        ),
-      ];
-
-      await handler.handle(
-        makeRequest("POST", "/sessions"),
-        body: const SessionListRequest(projectId: "project-1", start: null, limit: null, waitForPrData: true),
-        pathParams: {},
-        queryParams: {},
-        fragment: null,
-      );
-
-      expect(prSyncService.calls, hasLength(1));
-      expect(prSyncService.calls.single, equals((projectId: "project-1", projectPath: "/tmp/fallback-project")));
     });
 
     test("returns sessions without cached PR metadata when a waited refresh times out", () async {
@@ -1179,95 +1155,6 @@ void main() {
       expect(result.items.single.pullRequest, isNull);
       expect(result.items.single.pullRequestHistory, isEmpty);
     });
-
-    test("strips cached PR metadata when another refresh is in progress", () async {
-      plugin.sessionsResult = const [
-        PluginSession(
-          id: "s1",
-          projectID: "p1",
-          directory: "/tmp",
-          parentID: null,
-          title: "session one",
-          time: null,
-        ),
-      ];
-      pullRequestRepository.setPr(
-        sessionId: "s1",
-        pullRequest: const PullRequestDto(
-          projectId: "p1",
-          githubRepositoryIdentity: "org/repo",
-          githubLogin: "octocat",
-          prNumber: 101,
-          branchName: "feature/in-progress",
-          url: "https://github.com/org/repo/pull/101",
-          title: "In-progress refresh PR",
-          state: PrState.open,
-          mergeableStatus: PrMergeableStatus.mergeable,
-          reviewDecision: PrReviewDecision.approved,
-          checkStatus: PrCheckStatus.success,
-          lastCheckedAt: 1,
-          createdAt: 1,
-        ),
-      );
-      final inProgressHandler = GetSessionsHandler(
-        sessionRepository: sessionRepository,
-        prSyncService: FakePrSyncService(refreshOutcome: PrRefreshOutcome.inProgress),
-      );
-
-      final result = await inProgressHandler.handle(
-        makeRequest("POST", "/sessions"),
-        body: const SessionListRequest(projectId: "p1", start: null, limit: null, waitForPrData: true),
-        pathParams: {},
-        queryParams: {},
-        fragment: null,
-      );
-
-      expect(result.items.single.pullRequest, isNull);
-      expect(result.items.single.pullRequestHistory, isEmpty);
-    });
-
-    test("strips cached PR metadata when no refresh source is available", () async {
-      plugin.sessionsResult = const [
-        PluginSession(
-          id: "s1",
-          projectID: "p1",
-          directory: "",
-          parentID: null,
-          title: "session one",
-          time: null,
-        ),
-      ];
-      pullRequestRepository.setPr(
-        sessionId: "s1",
-        pullRequest: const PullRequestDto(
-          projectId: "p1",
-          githubRepositoryIdentity: "org/repo",
-          githubLogin: "octocat",
-          prNumber: 103,
-          branchName: "feature/no-source",
-          url: "https://github.com/org/repo/pull/103",
-          title: "Unavailable refresh source PR",
-          state: PrState.open,
-          mergeableStatus: PrMergeableStatus.mergeable,
-          reviewDecision: PrReviewDecision.approved,
-          checkStatus: PrCheckStatus.success,
-          lastCheckedAt: 1,
-          createdAt: 1,
-        ),
-      );
-
-      final result = await handler.handle(
-        makeRequest("POST", "/sessions"),
-        body: const SessionListRequest(projectId: "p1", start: null, limit: null, waitForPrData: true),
-        pathParams: {},
-        queryParams: {},
-        fragment: null,
-      );
-
-      expect(result.items.single.pullRequest, isNull);
-      expect(result.items.single.pullRequestHistory, isEmpty);
-    });
-
     test("keeps final identity verification inside the waited deadline", () async {
       plugin.sessionsResult = const [
         PluginSession(

--- a/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
@@ -1262,7 +1262,7 @@ void main() {
       }
     });
 
-    test("strips cached PR metadata when a waited refresh fails", () async {
+    test("returns the latest PR-free branch when a refresh fails near the main deadline", () async {
       plugin.sessionsResult = const [
         PluginSession(
           id: "s1",
@@ -1294,28 +1294,40 @@ void main() {
       );
       final failedRefresh = FakePrSyncService(
         refreshOutcome: PrRefreshOutcome.failed,
-        refreshAction: () {
+        refreshAction: () async {
           sessionDao.setSession(_storedSession(currentBranchName: "feature/new"));
+          await Future<void>.delayed(const Duration(milliseconds: 150));
         },
       );
+      final delayedFallbackRepository = _DelayedPrFreeEnrichmentSessionRepository(
+        plugin: plugin,
+        sessionDao: sessionDao,
+        pullRequestRepository: pullRequestRepository,
+        persistenceDatabase: db,
+        delay: const Duration(milliseconds: 75),
+      );
+      const prRefreshTimeout = Duration(milliseconds: 300);
       final failingHandler = GetSessionsHandler(
-        sessionRepository: sessionRepository,
+        sessionRepository: delayedFallbackRepository,
         prSyncService: failedRefresh,
+        prRefreshTimeout: prRefreshTimeout,
       );
 
-      final result = await failingHandler.handle(
-        makeRequest("POST", "/sessions"),
-        body: const SessionListRequest(projectId: "p1", start: null, limit: null, waitForPrData: true),
-        pathParams: {},
-        queryParams: {},
-        fragment: null,
-      );
+      final result = await failingHandler
+          .handle(
+            makeRequest("POST", "/sessions"),
+            body: const SessionListRequest(projectId: "p1", start: null, limit: null, waitForPrData: true),
+            pathParams: {},
+            queryParams: {},
+            fragment: null,
+          )
+          .timeout(prRefreshTimeout);
 
       expect(result.items.single.branchName, "feature/new");
       expect(result.items.single.pullRequest, isNull);
       expect(result.items.single.pullRequestHistory, isEmpty);
-      expect(sessionRepository.getSessionsCallCount, 1);
-      expect(sessionRepository.enrichSessionsCallCount, 2);
+      expect(delayedFallbackRepository.getSessionsCallCount, 1);
+      expect(delayedFallbackRepository.enrichSessionsCallCount, 2);
       expect(failedRefresh.calls.single.refreshPolicy, PrRefreshPolicy.explicit);
     });
     test("keeps final identity verification inside the waited deadline", () async {
@@ -1512,6 +1524,32 @@ final class _FallbackFailingSessionRepository extends FakeSessionRepository {
     enrichmentAttempts++;
     if (enrichmentAttempts == 2) {
       throw StateError("fallback enrichment failed");
+    }
+    return super.enrichSessions(
+      sessions: sessions,
+      verifiedGithubLogin: verifiedGithubLogin,
+    );
+  }
+}
+
+final class _DelayedPrFreeEnrichmentSessionRepository extends FakeSessionRepository {
+  final Duration delay;
+
+  _DelayedPrFreeEnrichmentSessionRepository({
+    required super.plugin,
+    required super.sessionDao,
+    required super.pullRequestRepository,
+    required super.persistenceDatabase,
+    required this.delay,
+  });
+
+  @override
+  Future<List<Session>> enrichSessions({
+    required List<Session> sessions,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) async {
+    if (verifiedGithubLogin == null) {
+      await Future<void>.delayed(delay);
     }
     return super.enrichSessions(
       sessions: sessions,

--- a/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:convert";
 
 import "package:sesori_bridge/src/api/database/database.dart";
@@ -994,6 +995,32 @@ void main() {
       expect(prSyncService.calls.single.refreshPolicy, PrRefreshPolicy.background);
     });
 
+    test("starts explicit PR refresh before awaiting initial GitHub identity", () async {
+      final identityBlockingService = _IdentityBlockingPrSyncService();
+      final orderingHandler = GetSessionsHandler(
+        sessionRepository: sessionRepository,
+        prSyncService: identityBlockingService,
+      );
+
+      final response = orderingHandler.handle(
+        makeRequest("POST", "/sessions"),
+        body: const SessionListRequest(projectId: "p1", start: null, limit: null, waitForPrData: true),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+      await identityBlockingService.identityVerificationStarted.future;
+      final callsBeforeIdentityCompleted = List.of(identityBlockingService.calls);
+      identityBlockingService.identityVerification.complete(
+        VerifiedGithubLogin.tryParse(rawLogin: "octocat"),
+      );
+      await response;
+
+      expect(callsBeforeIdentityCompleted, hasLength(1));
+      expect(callsBeforeIdentityCompleted.single.projectIds, {"p1"});
+      expect(callsBeforeIdentityCompleted.single.refreshPolicy, PrRefreshPolicy.explicit);
+    });
+
     test("bounds initial identity verification and returns PR-free sessions", () async {
       plugin.sessionsResult = const [
         PluginSession(
@@ -1061,7 +1088,7 @@ void main() {
       expect(plugin.lastGetCurrentProjectProjectId, isNull);
     });
 
-    test("returns sessions without cached PR metadata when a waited refresh times out", () async {
+    test("returns the latest PR-free branch when a waited refresh times out", () async {
       plugin.sessionsResult = const [
         PluginSession(
           id: "s1",
@@ -1072,6 +1099,7 @@ void main() {
           time: null,
         ),
       ];
+      sessionDao.setSession(_storedSession(currentBranchName: "feature/a"));
       pullRequestRepository.setPr(
         sessionId: "s1",
         pullRequest: const PullRequestDto(
@@ -1090,58 +1118,47 @@ void main() {
           createdAt: 1,
         ),
       );
-      final slowPrSyncService = FakePrSyncService(delay: const Duration(seconds: 10));
+      final branchPersisted = Completer<void>();
+      final refreshBlocker = Completer<void>();
+      final refreshReleased = Completer<void>();
+      final slowPrSyncService = FakePrSyncService(
+        refreshAction: () async {
+          sessionDao.setSession(_storedSession(currentBranchName: "feature/b"));
+          branchPersisted.complete();
+          await refreshBlocker.future;
+          refreshReleased.complete();
+        },
+      );
       final timeoutHandler = GetSessionsHandler(
         sessionRepository: sessionRepository,
         prSyncService: slowPrSyncService,
-        prRefreshTimeout: const Duration(milliseconds: 50),
+        prRefreshTimeout: const Duration(milliseconds: 20),
       );
 
-      final result = await timeoutHandler.handle(
+      final response = timeoutHandler.handle(
         makeRequest("POST", "/sessions"),
         body: const SessionListRequest(projectId: "p1", start: null, limit: null, waitForPrData: true),
         pathParams: {},
         queryParams: {},
         fragment: null,
       );
+      await branchPersisted.future;
 
-      expect(result.items, hasLength(1));
-      expect(result.items.single.title, equals("session one"));
-      expect(result.items.single.pullRequest, isNull);
-      expect(result.items.single.pullRequestHistory, isEmpty);
-      expect(sessionRepository.getSessionsCallCount, equals(1));
+      try {
+        final result = await response;
+        expect(result.items, hasLength(1));
+        expect(result.items.single.branchName, "feature/b");
+        expect(result.items.single.pullRequest, isNull);
+        expect(result.items.single.pullRequestHistory, isEmpty);
+        expect(sessionRepository.getSessionsCallCount, equals(1));
+      } finally {
+        refreshBlocker.complete();
+        await refreshReleased.future;
+        await Future<void>.delayed(Duration.zero);
+      }
     });
 
-    test("strips cached PR metadata when a waited refresh fails", () async {
-      SessionDto storedSession({required String currentBranchName}) {
-        return SessionDto(
-          pluginId: "fake",
-          sessionId: "s1",
-          backendSessionId: "s1",
-          projectId: "p1",
-          parentSessionId: null,
-          directory: "/tmp",
-          worktreePath: null,
-          branchName: null,
-          currentBranchName: currentBranchName,
-          currentGithubRepositoryIdentity: "org/repo",
-          isDedicated: false,
-          archivedAt: null,
-          baseBranch: null,
-          baseCommit: null,
-          lastAgent: null,
-          lastAgentModel: null,
-          createdAt: 1,
-          updatedAt: 1,
-          projectionUpdatedAt: 1,
-          lastActivityAt: null,
-          lastSeenAt: null,
-          lastUserMessageAt: null,
-          title: null,
-          catalogTitle: null,
-        );
-      }
-
+    test("returns the original PR-free snapshot when timeout fallback enrichment fails", () async {
       plugin.sessionsResult = const [
         PluginSession(
           id: "s1",
@@ -1152,7 +1169,61 @@ void main() {
           time: null,
         ),
       ];
-      sessionDao.setSession(storedSession(currentBranchName: "feature/old"));
+      final fallbackFailingRepository = _FallbackFailingSessionRepository(
+        plugin: plugin,
+        sessionDao: sessionDao,
+        pullRequestRepository: pullRequestRepository,
+        persistenceDatabase: db,
+      );
+      final refreshStarted = Completer<void>();
+      final refreshBlocker = Completer<void>();
+      final refreshReleased = Completer<void>();
+      final timeoutHandler = GetSessionsHandler(
+        sessionRepository: fallbackFailingRepository,
+        prSyncService: FakePrSyncService(
+          refreshAction: () async {
+            refreshStarted.complete();
+            await refreshBlocker.future;
+            refreshReleased.complete();
+          },
+        ),
+        prRefreshTimeout: const Duration(milliseconds: 20),
+      );
+
+      final response = timeoutHandler.handle(
+        makeRequest("POST", "/sessions"),
+        body: const SessionListRequest(projectId: "p1", start: null, limit: null, waitForPrData: true),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+      await refreshStarted.future;
+
+      try {
+        final result = await response;
+        expect(result.items.single.title, "session one");
+        expect(result.items.single.pullRequest, isNull);
+        expect(result.items.single.pullRequestHistory, isEmpty);
+        expect(fallbackFailingRepository.enrichmentAttempts, 2);
+      } finally {
+        refreshBlocker.complete();
+        await refreshReleased.future;
+        await Future<void>.delayed(Duration.zero);
+      }
+    });
+
+    test("strips cached PR metadata when a waited refresh fails", () async {
+      plugin.sessionsResult = const [
+        PluginSession(
+          id: "s1",
+          projectID: "p1",
+          directory: "/tmp",
+          parentID: null,
+          title: "session one",
+          time: null,
+        ),
+      ];
+      sessionDao.setSession(_storedSession(currentBranchName: "feature/old"));
       pullRequestRepository.setPr(
         sessionId: "s1",
         pullRequest: const PullRequestDto(
@@ -1174,7 +1245,7 @@ void main() {
       final failedRefresh = FakePrSyncService(
         refreshOutcome: PrRefreshOutcome.failed,
         refreshAction: () {
-          sessionDao.setSession(storedSession(currentBranchName: "feature/new"));
+          sessionDao.setSession(_storedSession(currentBranchName: "feature/new"));
         },
       );
       final failingHandler = GetSessionsHandler(
@@ -1329,4 +1400,72 @@ void main() {
       expect(sessionRepository.getSessionsCallCount, equals(1));
     });
   });
+}
+
+SessionDto _storedSession({required String currentBranchName}) {
+  return SessionDto(
+    pluginId: "fake",
+    sessionId: "s1",
+    backendSessionId: "s1",
+    projectId: "p1",
+    parentSessionId: null,
+    directory: "/tmp",
+    worktreePath: null,
+    branchName: null,
+    currentBranchName: currentBranchName,
+    currentGithubRepositoryIdentity: "org/repo",
+    isDedicated: false,
+    archivedAt: null,
+    baseBranch: null,
+    baseCommit: null,
+    lastAgent: null,
+    lastAgentModel: null,
+    createdAt: 1,
+    updatedAt: 1,
+    projectionUpdatedAt: 1,
+    lastActivityAt: null,
+    lastSeenAt: null,
+    lastUserMessageAt: null,
+    title: null,
+    catalogTitle: null,
+  );
+}
+
+final class _IdentityBlockingPrSyncService extends FakePrSyncService {
+  final Completer<void> identityVerificationStarted = Completer<void>();
+  final Completer<VerifiedGithubLogin?> identityVerification = Completer<VerifiedGithubLogin?>();
+
+  @override
+  Future<VerifiedGithubLogin?> verifyGithubIdentity() {
+    if (!identityVerificationStarted.isCompleted) {
+      identityVerificationStarted.complete();
+    }
+    return identityVerification.future;
+  }
+}
+
+final class _FallbackFailingSessionRepository extends FakeSessionRepository {
+  int enrichmentAttempts = 0;
+
+  _FallbackFailingSessionRepository({
+    required super.plugin,
+    required super.sessionDao,
+    required super.pullRequestRepository,
+    required super.persistenceDatabase,
+  });
+
+  @override
+  Future<List<Session>> enrichSessions({
+    required List<Session> sessions,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) {
+    enrichmentAttempts++;
+    if (enrichmentAttempts == 2) {
+      throw StateError("fallback enrichment failed");
+    }
+    return super.enrichSessions(
+      sessions: sessions,
+      verifiedGithubLogin: verifiedGithubLogin,
+    );
+  }
 }

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -26,6 +26,7 @@ import "package:sesori_bridge/src/bridge/services/pr_sync_service.dart";
 import "package:sesori_bridge/src/bridge/services/session_unseen_service.dart";
 import "package:sesori_bridge/src/bridge/services/session_view_tracker.dart";
 import "package:sesori_bridge/src/repositories/models/pull_request_selection.dart";
+import "package:sesori_bridge/src/repositories/models/pull_request_target.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" hide PermissionReply;
 
@@ -561,7 +562,7 @@ class FakePullRequestRepository implements PullRequestRepository {
   }
 
   @override
-  Future<bool> replaceScopedPullRequests({
+  Future<PullRequestReplacementOutcome> replaceScopedPullRequests({
     required String projectId,
     required VerifiedGithubLogin verifiedGithubLogin,
     required List<PullRequestTargetSelection> targetSelections,
@@ -593,7 +594,7 @@ class FakePullRequestRepository implements PullRequestRepository {
           )] =
           record;
     }
-    return true;
+    return const PullRequestReplacementApplied(changed: true);
   }
 
   String _key({
@@ -605,22 +606,20 @@ class FakePullRequestRepository implements PullRequestRepository {
   }
 
   @override
-  Future<bool> prepareScopedRefresh({
-    required String projectId,
-    required String githubRepositoryIdentity,
+  Future<Set<String>> prepareScopedRefresh({
+    required Set<String> projectIds,
     required VerifiedGithubLogin verifiedGithubLogin,
-    required List<StoredSession> sessions,
-  }) async => false;
+  }) async => const <String>{};
 
   @override
-  Future<bool> clearScopedRefresh({
-    required String projectId,
-    required List<StoredSession> sessions,
-  }) async => false;
+  Future<Set<String>> applyResolvedTargets({
+    required Map<String, List<StoredSession>> sessionsByProject,
+    required Map<String, PullRequestDirectoryTarget> targetsByDirectory,
+  }) async => const <String>{};
 }
 
 class FakePrSyncService extends PrSyncService {
-  final List<({String projectId, String projectPath})> calls = <({String projectId, String projectPath})>[];
+  final List<Set<String>> calls = <Set<String>>[];
   final Duration? delay;
   final Object? refreshError;
   final PrRefreshOutcome refreshOutcome;
@@ -646,8 +645,8 @@ class FakePrSyncService extends PrSyncService {
        );
 
   @override
-  Future<PrRefreshOutcome> triggerRefresh({required String projectId, required String projectPath}) async {
-    calls.add((projectId: projectId, projectPath: projectPath));
+  Future<PrRefreshOutcome> triggerRefresh({required Set<String> projectIds}) async {
+    calls.add(Set<String>.from(projectIds));
     if (delay != null) {
       await Future<void>.delayed(delay!);
     }
@@ -676,7 +675,14 @@ class _AlwaysReadyPrSource implements PrSourceRepository {
   @override
   Future<VerifiedGithubLogin?> getAuthenticatedIdentity() async => VerifiedGithubLogin.tryParse(rawLogin: "octocat");
   @override
-  Future<String?> getGithubRepositoryIdentity({required String projectPath}) async => "sesori-ai/test";
+  Future<Map<String, PullRequestDirectoryTarget>> resolvePullRequestTargets({
+    required Iterable<String> directories,
+  }) async => {
+    for (final directory in directories)
+      directory: const PullRequestGithubDirectoryTarget(
+        target: (githubRepositoryIdentity: "sesori-ai/test", branchName: "main"),
+      ),
+  };
   @override
   Future<PullRequestSelectionOutcome> selectPullRequests({
     required List<PullRequestSelectionTarget> targets,
@@ -688,26 +694,24 @@ class _AlwaysReadyPrSource implements PrSourceRepository {
 
 class _NoopPullRequestRepository implements PullRequestRepository {
   @override
-  Future<bool> replaceScopedPullRequests({
+  Future<PullRequestReplacementOutcome> replaceScopedPullRequests({
     required String projectId,
     required VerifiedGithubLogin verifiedGithubLogin,
     required List<PullRequestTargetSelection> targetSelections,
     required int lastCheckedAt,
-  }) async => false;
+  }) async => const PullRequestReplacementApplied(changed: false);
 
   @override
-  Future<bool> prepareScopedRefresh({
-    required String projectId,
-    required String githubRepositoryIdentity,
+  Future<Set<String>> prepareScopedRefresh({
+    required Set<String> projectIds,
     required VerifiedGithubLogin verifiedGithubLogin,
-    required List<StoredSession> sessions,
-  }) async => false;
+  }) async => const <String>{};
 
   @override
-  Future<bool> clearScopedRefresh({
-    required String projectId,
-    required List<StoredSession> sessions,
-  }) async => false;
+  Future<Set<String>> applyResolvedTargets({
+    required Map<String, List<StoredSession>> sessionsByProject,
+    required Map<String, PullRequestDirectoryTarget> targetsByDirectory,
+  }) async => const <String>{};
 }
 
 Session _deletedSession(String sessionId) => Session(

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -565,6 +565,7 @@ class FakePullRequestRepository implements PullRequestRepository {
   Future<PullRequestReplacementOutcome> replaceScopedPullRequests({
     required String projectId,
     required VerifiedGithubLogin verifiedGithubLogin,
+    required Map<String, String> capturedRootDirectoriesBySessionId,
     required List<PullRequestTargetSelection> targetSelections,
     required int lastCheckedAt,
   }) async {
@@ -619,11 +620,12 @@ class FakePullRequestRepository implements PullRequestRepository {
 }
 
 class FakePrSyncService extends PrSyncService {
-  final List<Set<String>> calls = <Set<String>>[];
+  final List<({Set<String> projectIds, PrRefreshPolicy refreshPolicy})> calls = [];
   final Duration? delay;
   final Object? refreshError;
   final PrRefreshOutcome refreshOutcome;
   final List<Duration> identityVerificationDelays;
+  final FutureOr<void> Function()? refreshAction;
   VerifiedGithubLogin? verifiedGithubLogin;
   int identityVerificationCallCount = 0;
 
@@ -632,6 +634,7 @@ class FakePrSyncService extends PrSyncService {
     this.refreshError,
     this.refreshOutcome = PrRefreshOutcome.completed,
     this.identityVerificationDelays = const <Duration>[],
+    this.refreshAction,
     VerifiedGithubLogin? verifiedGithubLogin,
     PrSourceRepository? prSource,
     PullRequestRepository? pullRequestRepository,
@@ -645,14 +648,21 @@ class FakePrSyncService extends PrSyncService {
        );
 
   @override
-  Future<PrRefreshOutcome> triggerRefresh({required Set<String> projectIds}) async {
-    calls.add(Set<String>.from(projectIds));
+  Future<PrRefreshOutcome> triggerRefresh({
+    required Set<String> projectIds,
+    required PrRefreshPolicy refreshPolicy,
+  }) async {
+    calls.add((
+      projectIds: Set<String>.from(projectIds),
+      refreshPolicy: refreshPolicy,
+    ));
     if (delay != null) {
       await Future<void>.delayed(delay!);
     }
     if (refreshError case final error?) {
       throw error;
     }
+    await refreshAction?.call();
     return refreshOutcome;
   }
 
@@ -697,6 +707,7 @@ class _NoopPullRequestRepository implements PullRequestRepository {
   Future<PullRequestReplacementOutcome> replaceScopedPullRequests({
     required String projectId,
     required VerifiedGithubLogin verifiedGithubLogin,
+    required Map<String, String> capturedRootDirectoriesBySessionId,
     required List<PullRequestTargetSelection> targetSelections,
     required int lastCheckedAt,
   }) async => const PullRequestReplacementApplied(changed: false);
@@ -1027,6 +1038,7 @@ class FakeSessionRepository implements SessionRepository {
   final FakePullRequestRepository _pullRequestRepository;
   final AppDatabase? _persistenceDatabase;
   int getSessionsCallCount = 0;
+  int enrichSessionsCallCount = 0;
   ({String projectId, int? start, int? limit})? lastGetSessionsArgs;
   VerifiedGithubLogin? lastVerifiedGithubLogin;
   String? projectPathResult;
@@ -1214,6 +1226,7 @@ class FakeSessionRepository implements SessionRepository {
     required List<Session> sessions,
     required VerifiedGithubLogin? verifiedGithubLogin,
   }) async {
+    enrichSessionsCallCount++;
     lastVerifiedGithubLogin = verifiedGithubLogin;
     final sessionIds = sessions.map((session) => session.id).toList(growable: false);
     final dbSessions = await _sessionDao.getSessionsByIds(sessionIds: sessionIds);

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -287,6 +287,42 @@ void main() {
       expect(await second, PrRefreshOutcome.completed);
     });
 
+    test("coalesces repeated background requests into an active project refresh", () async {
+      final firstSelection = Completer<void>();
+      final source = _FakePrSource(
+        targetsByDirectory: {"/one": _githubTarget(branchName: "branch-a")},
+        selectionBlocks: [firstSelection],
+      );
+      final service = _service(
+        source: source,
+        pullRequests: _FakePullRequestRepository(),
+        sessionsByProject: {
+          "one": [_session(id: "one", projectId: "one", directory: "/one")],
+        },
+      );
+      addTearDown(service.dispose);
+
+      final first = service.triggerRefresh(
+        projectIds: {"one"},
+        refreshPolicy: PrRefreshPolicy.explicit,
+      );
+      await _waitFor(() => source.selectionCalls.length == 1);
+      final backgroundRequests = [
+        for (var i = 0; i < 3; i++)
+          service.triggerRefresh(
+            projectIds: {"one"},
+            refreshPolicy: PrRefreshPolicy.background,
+          ),
+      ];
+
+      firstSelection.complete();
+
+      expect(await first, PrRefreshOutcome.completed);
+      expect(await Future.wait(backgroundRequests), everyElement(PrRefreshOutcome.completed));
+      expect(source.selectionCalls, hasLength(1));
+      expect(source.resolveCalls, hasLength(1));
+    });
+
     test("coalesces pending projects into one immediate follow-up cycle", () async {
       final firstSelection = Completer<void>();
       final source = _FakePrSource(

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -1,11 +1,6 @@
 import "dart:async";
-import "dart:io";
 
 import "package:clock/clock.dart";
-import "package:sesori_bridge/src/api/database/tables/pull_requests_table.dart";
-import "package:sesori_bridge/src/bridge/api/gh_pull_request.dart";
-import "package:sesori_bridge/src/bridge/repositories/mappers/plugin_session_mapper.dart";
-import "package:sesori_bridge/src/bridge/repositories/models/session_operation.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/stored_session.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/verified_github_login.dart";
 import "package:sesori_bridge/src/bridge/repositories/pr_source_repository.dart";
@@ -13,699 +8,461 @@ import "package:sesori_bridge/src/bridge/repositories/pull_request_repository.da
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/services/pr_sync_service.dart";
 import "package:sesori_bridge/src/repositories/models/pull_request_selection.dart";
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
-import "package:sesori_shared/sesori_shared.dart";
+import "package:sesori_bridge/src/repositories/models/pull_request_target.dart";
 import "package:test/test.dart";
 
-const _githubRepositoryIdentity = "sesori-ai/sesori_apps_monorepo";
+const _repositoryIdentity = "sesori-ai/sesori_apps_monorepo";
 final VerifiedGithubLogin _verifiedGithubLogin = VerifiedGithubLogin.tryParse(rawLogin: "octocat")!;
 
 void main() {
   group("PrSyncService", () {
-    test("emits project id when a new matched PR is found", () async {
-      final prSource = _FakePrSource(
-        selectedPullRequestsResult: <GhPullRequest>[
-          _ghPr(number: 11, branch: "feature/new-pr", title: "New PR"),
-        ],
-      );
-      final pullRequestRepository = _FakePullRequestRepository();
-      final sessionRepository = _FakeSessionRepository(
-        sessionsByProject: <String, List<StoredSession>>{
-          "project-1": [_storedSession(id: "session-1", branchName: "feature/new-pr")],
+    test("batches multiple projects through one serialized GitHub selection", () async {
+      final source = _FakePrSource(
+        targetsByDirectory: {
+          "/one": _githubTarget(branchName: "feature/one"),
+          "/two": _githubTarget(branchName: "feature/two"),
         },
       );
-      final service = PrSyncService(
-        prSource: prSource,
-        pullRequestRepository: pullRequestRepository,
-        sessionRepository: sessionRepository,
-        clock: const Clock(),
-        debounceWindow: const Duration(milliseconds: 1),
+      final pullRequests = _FakePullRequestRepository();
+      final service = _service(
+        source: source,
+        pullRequests: pullRequests,
+        sessionsByProject: {
+          "one": [_session(id: "one", projectId: "one", directory: "/one")],
+          "two": [_session(id: "two", projectId: "two", directory: "/two")],
+        },
       );
       addTearDown(service.dispose);
 
-      final emittedProjectIds = <String>[];
-      final sub = service.prChanges.listen(emittedProjectIds.add);
-      addTearDown(sub.cancel);
+      final outcome = await service.triggerRefresh(projectIds: {"one", "two"});
 
-      await service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
-      await _waitFor(() => pullRequestRepository.upsertCalls == 1);
-
-      final prs = pullRequestRepository.getByProjectId(projectId: "project-1");
-      expect(prs, hasLength(1));
-      expect(prs.single.prNumber, equals(11));
-      expect(prs.single.branchName, equals("feature/new-pr"));
-      expect(prs.single.githubRepositoryIdentity, _githubRepositoryIdentity);
-      expect(prs.single.githubLogin, _verifiedGithubLogin.login);
-      expect(emittedProjectIds, equals(<String>["project-1"]));
-      expect(prSource.selectionTargets.single.single.githubRepositoryIdentity, _githubRepositoryIdentity);
-      expect(pullRequestRepository.prepareScopedRefreshCalls, hasLength(1));
+      expect(outcome, PrRefreshOutcome.completed);
+      expect(source.resolveCalls, hasLength(1));
+      expect(source.selectionCalls, hasLength(1));
+      expect(source.selectionCalls.single.map((target) => target.branchName), ["feature/one", "feature/two"]);
+      expect(pullRequests.prepareCalls, hasLength(1));
+      expect(pullRequests.prepareCalls.single.projectIds, {"one", "two"});
+      expect(pullRequests.prepareCalls.single.githubLogin, "octocat");
+      expect(pullRequests.replaceCalls.map((call) => call.projectId).toSet(), {"one", "two"});
+      expect(source.maxConcurrentSelections, 1);
     });
 
-    test("does not cache PRs matched only to child-session branches", () async {
-      final prSource = _FakePrSource(
-        selectedPullRequestsResult: <GhPullRequest>[
-          _ghPr(number: 12, branch: "child-branch", title: "Child PR"),
-        ],
+    test("commits and emits local branch changes before unavailable GitHub work", () async {
+      final source = _FakePrSource(
+        targetsByDirectory: {"/one": _githubTarget(branchName: "feature/current")},
+      )..isAvailableResult = false;
+      final pullRequests = _FakePullRequestRepository()..localChangedProjectIds = {"one"};
+      final service = _service(
+        source: source,
+        pullRequests: pullRequests,
+        sessionsByProject: {
+          "one": [_session(id: "one", projectId: "one", directory: "/one")],
+        },
       );
-      final pullRequestRepository = _FakePullRequestRepository();
-      final sessionRepository = _FakeSessionRepository(
-        sessionsByProject: <String, List<StoredSession>>{
-          "project-1": [
-            _storedSession(id: "root", branchName: "root-branch"),
-            const StoredSession(
+      addTearDown(service.dispose);
+      final changes = <String>[];
+      final subscription = service.renderedChanges.listen((change) => changes.add(change.projectId));
+      addTearDown(subscription.cancel);
+
+      final outcome = await service.triggerRefresh(projectIds: {"one"});
+
+      expect(outcome, PrRefreshOutcome.failed);
+      expect(pullRequests.applyCalls, hasLength(1));
+      expect(changes, ["one"]);
+      expect(source.selectionCalls, isEmpty);
+      expect(pullRequests.prepareCalls, isEmpty);
+    });
+
+    test("completes local-only and detached projects without requiring gh", () async {
+      final source = _FakePrSource(
+        targetsByDirectory: const {
+          "/local": PullRequestLocalBranchDirectoryTarget(branchName: "feature/local"),
+          "/detached": PullRequestNoBranchDirectoryTarget(
+            reason: PullRequestNoBranchReason.detachedHead,
+          ),
+        },
+      )..isAvailableResult = false;
+      final service = _service(
+        source: source,
+        pullRequests: _FakePullRequestRepository(),
+        sessionsByProject: {
+          "local": [_session(id: "local", projectId: "local", directory: "/local")],
+          "detached": [_session(id: "detached", projectId: "detached", directory: "/detached")],
+        },
+      );
+      addTearDown(service.dispose);
+
+      final outcome = await service.triggerRefresh(projectIds: {"local", "detached"});
+
+      expect(outcome, PrRefreshOutcome.completed);
+      expect(source.isAvailableCallCount, 0);
+      expect(source.selectionCalls, isEmpty);
+    });
+
+    test("resolves shared root directories once and excludes child directories", () async {
+      final source = _FakePrSource(
+        targetsByDirectory: const {
+          "/shared": PullRequestLocalBranchDirectoryTarget(branchName: "shared"),
+        },
+      );
+      final service = _service(
+        source: source,
+        pullRequests: _FakePullRequestRepository(),
+        sessionsByProject: {
+          "one": [
+            _session(id: "root-a", projectId: "one", directory: "/shared"),
+            _session(id: "root-b", projectId: "one", directory: "/shared"),
+            _session(
               id: "child",
-              backendSessionId: "child",
-              pluginId: "fake",
-              projectId: "project-1",
-              parentSessionId: "root",
-              directory: "/tmp/project-1",
-              worktreePath: null,
-              branchName: "child-branch",
-              isDedicated: false,
-              archivedAt: null,
-              baseBranch: null,
-              baseCommit: null,
+              projectId: "one",
+              directory: "/child",
+              parentSessionId: "root-a",
             ),
           ],
         },
       );
-      final service = PrSyncService(
-        prSource: prSource,
-        pullRequestRepository: pullRequestRepository,
-        sessionRepository: sessionRepository,
-        clock: const Clock(),
-      );
       addTearDown(service.dispose);
 
-      await service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
-
-      expect(pullRequestRepository.upsertCalls, 0);
+      expect(await service.triggerRefresh(projectIds: {"one"}), PrRefreshOutcome.completed);
+      expect(source.resolveCalls.single, ["/shared"]);
     });
 
-    test("does not emit when PR data is unchanged", () async {
-      final prSource = _FakePrSource(
-        selectedPullRequestsResult: <GhPullRequest>[
-          _ghPr(
-            number: 33,
-            branch: "feature/no-change",
-            title: "No changes",
-            reviewDecision: PrReviewDecision.approved,
-          ),
-        ],
+    test("emits identity-preparation and selected-PR rendered changes", () async {
+      final source = _FakePrSource(
+        targetsByDirectory: {"/one": _githubTarget(branchName: "feature/current")},
       );
-      final pullRequestRepository = _FakePullRequestRepository(
-        seed: <PullRequestDto>[
-          _dto(
-            projectId: "project-1",
-            githubRepositoryIdentity: _githubRepositoryIdentity,
-            githubLogin: "octocat",
-            branchName: "feature/no-change",
-            prNumber: 33,
-            title: "No changes",
-            state: PrState.open,
-            mergeableStatus: PrMergeableStatus.mergeable,
-            reviewDecision: PrReviewDecision.approved,
-            checkStatus: PrCheckStatus.success,
-          ),
-        ],
-      );
-      final sessionRepository = _FakeSessionRepository(
-        sessionsByProject: <String, List<StoredSession>>{
-          "project-1": [_storedSession(id: "session-1", branchName: "feature/no-change")],
+      final pullRequests = _FakePullRequestRepository()
+        ..preparedChangedProjectIds = {"one"}
+        ..replacementOutcomes["one"] = const PullRequestReplacementApplied(changed: true);
+      final service = _service(
+        source: source,
+        pullRequests: pullRequests,
+        sessionsByProject: {
+          "one": [_session(id: "one", projectId: "one", directory: "/one")],
         },
       );
-      final service = PrSyncService(
-        prSource: prSource,
-        pullRequestRepository: pullRequestRepository,
-        sessionRepository: sessionRepository,
-        clock: const Clock(),
-      );
       addTearDown(service.dispose);
+      final changes = <String>[];
+      final subscription = service.renderedChanges.listen((change) => changes.add(change.projectId));
+      addTearDown(subscription.cancel);
 
-      final emittedProjectIds = <String>[];
-      final sub = service.prChanges.listen(emittedProjectIds.add);
-      addTearDown(sub.cancel);
-
-      await service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
-      await _waitFor(() => pullRequestRepository.upsertCalls == 1);
-
-      expect(emittedProjectIds, isEmpty);
+      expect(await service.triggerRefresh(projectIds: {"one"}), PrRefreshOutcome.completed);
+      expect(changes, ["one", "one"]);
     });
 
-    test("reports a failed outcome when the PR source query fails", () async {
-      final prSource = _FakePrSource(
-        selectedPullRequestsResult: const <GhPullRequest>[],
-        onSelection: () async => throw StateError("query failed"),
+    test("fails a project with a typed local resolution error after applying safe local state", () async {
+      final resolutionError = PullRequestTargetResolutionException(
+        innerError: StateError("private path must not be rendered"),
+        innerStackTrace: StackTrace.current,
       );
-      final service = PrSyncService(
-        prSource: prSource,
-        pullRequestRepository: _FakePullRequestRepository(),
-        sessionRepository: _FakeSessionRepository(
-          sessionsByProject: const <String, List<StoredSession>>{},
-        ),
-        clock: const Clock(),
-      );
-      addTearDown(service.dispose);
-
-      final outcome = await service.triggerRefresh(
-        projectId: "project-1",
-        projectPath: "/tmp/project-1",
-      );
-
-      expect(outcome, PrRefreshOutcome.failed);
-    });
-
-    test("does not replace scoped rows when query identity changes", () async {
-      final prSource = _FakePrSource(selectedPullRequestsResult: const <GhPullRequest>[])
-        ..selectionOutcome = const PullRequestSelectionIdentityChanged();
-      final pullRequestRepository = _FakePullRequestRepository();
-      final service = PrSyncService(
-        prSource: prSource,
-        pullRequestRepository: pullRequestRepository,
-        sessionRepository: _FakeSessionRepository(
-          sessionsByProject: <String, List<StoredSession>>{
-            "project-1": [_storedSession(id: "session-1", branchName: "feature/identity")],
-          },
-        ),
-        clock: const Clock(),
-      );
-      addTearDown(service.dispose);
-
-      final outcome = await service.triggerRefresh(
-        projectId: "project-1",
-        projectPath: "/tmp/project-1",
-      );
-
-      expect(outcome, PrRefreshOutcome.failed);
-      expect(pullRequestRepository.replaceCalls, 0);
-    });
-
-    test("clears a prior selection after a complete exact no-match", () async {
-      final pullRequestRepository = _FakePullRequestRepository(
-        seed: [
-          _dto(
-            projectId: "project-1",
-            githubRepositoryIdentity: _githubRepositoryIdentity,
-            githubLogin: "octocat",
-            branchName: "feature/gone",
-            prNumber: 20,
-            title: "Gone PR",
-            state: PrState.open,
-            mergeableStatus: PrMergeableStatus.mergeable,
-            reviewDecision: PrReviewDecision.unknown,
-            checkStatus: PrCheckStatus.success,
+      final source = _FakePrSource(
+        targetsByDirectory: {
+          "/one": PullRequestRepositoryResolutionFailed(
+            branchName: "feature/current",
+            error: resolutionError,
           ),
-        ],
-      );
-      final service = PrSyncService(
-        prSource: _FakePrSource(selectedPullRequestsResult: const <GhPullRequest>[]),
-        pullRequestRepository: pullRequestRepository,
-        sessionRepository: _FakeSessionRepository(
-          sessionsByProject: <String, List<StoredSession>>{
-            "project-1": [_storedSession(id: "session-1", branchName: "feature/gone")],
-          },
-        ),
-        clock: const Clock(),
-      );
-      addTearDown(service.dispose);
-      final emittedProjectIds = <String>[];
-      final sub = service.prChanges.listen(emittedProjectIds.add);
-      addTearDown(sub.cancel);
-
-      final outcome = await service.triggerRefresh(
-        projectId: "project-1",
-        projectPath: "/tmp/project-1",
-      );
-      await _waitFor(() => emittedProjectIds.isNotEmpty);
-
-      expect(outcome, PrRefreshOutcome.completed);
-      expect(pullRequestRepository.getByProjectId(projectId: "project-1"), isEmpty);
-      expect(emittedProjectIds, ["project-1"]);
-    });
-
-    test("replaces an open selection with the exact terminal selection", () async {
-      final prSource = _FakePrSource(
-        selectedPullRequestsResult: <GhPullRequest>[
-          _ghPr(number: 22, branch: "feature/merged", title: "Merged PR", state: PrState.merged),
-        ],
-      );
-      final pullRequestRepository = _FakePullRequestRepository(
-        seed: <PullRequestDto>[
-          _dto(
-            projectId: "project-1",
-            githubRepositoryIdentity: _githubRepositoryIdentity,
-            githubLogin: "octocat",
-            branchName: "feature/merged",
-            prNumber: 22,
-            title: "Merged PR",
-            state: PrState.open,
-            mergeableStatus: PrMergeableStatus.mergeable,
-            reviewDecision: PrReviewDecision.unknown,
-            checkStatus: PrCheckStatus.pending,
-          ),
-        ],
-      );
-      final sessionRepository = _FakeSessionRepository(
-        sessionsByProject: <String, List<StoredSession>>{
-          "project-1": [_storedSession(id: "session-1", branchName: "feature/merged")],
         },
       );
-      final service = PrSyncService(
-        prSource: prSource,
-        pullRequestRepository: pullRequestRepository,
-        sessionRepository: sessionRepository,
-        clock: const Clock(),
+      final pullRequests = _FakePullRequestRepository()..localChangedProjectIds = {"one"};
+      final service = _service(
+        source: source,
+        pullRequests: pullRequests,
+        sessionsByProject: {
+          "one": [_session(id: "one", projectId: "one", directory: "/one")],
+        },
       );
       addTearDown(service.dispose);
 
-      await service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
-      await _waitFor(() => pullRequestRepository.upsertCalls == 1);
-
-      final prs = pullRequestRepository.getByProjectId(projectId: "project-1");
-      expect(prs.single.state, equals(PrState.merged));
-      expect(prSource.selectPullRequestsCallCount, 1);
-    });
-
-    test("skips PR queries when fresh identity verification fails", () async {
-      final prSource = _FakePrSource(selectedPullRequestsResult: const <GhPullRequest>[])
-        ..authenticatedIdentityResult = null;
-      final service = PrSyncService(
-        prSource: prSource,
-        pullRequestRepository: _FakePullRequestRepository(),
-        sessionRepository: _FakeSessionRepository(sessionsByProject: const <String, List<StoredSession>>{}),
-        clock: const Clock(),
-      );
-      addTearDown(service.dispose);
-
-      final outcome = await service.triggerRefresh(
-        projectId: "project-1",
-        projectPath: "/tmp/project-1",
-      );
+      final outcome = await service.triggerRefresh(projectIds: {"one"});
 
       expect(outcome, PrRefreshOutcome.failed);
-      expect(prSource.getAuthenticatedIdentityCallCount, 1);
-      expect(prSource.getGithubRepositoryIdentityCalls, ["/tmp/project-1"]);
-      expect(prSource.selectPullRequestsCallCount, 0);
+      expect(pullRequests.applyCalls, hasLength(1));
+      expect(source.selectionCalls, isEmpty);
+      expect(resolutionError.toString(), isNot(contains("private path")));
     });
 
-    test("shows an actionable warning when identity verification fails", () async {
-      final stderrLines = <String>[];
-      final prSource = _FakePrSource(selectedPullRequestsResult: const <GhPullRequest>[])
-        ..authenticatedIdentityResult = null;
-      final service = PrSyncService(
-        prSource: prSource,
-        pullRequestRepository: _FakePullRequestRepository(),
-        sessionRepository: _FakeSessionRepository(sessionsByProject: const <String, List<StoredSession>>{}),
-        clock: const Clock(),
+    test("does not replace rows when the query identity or persisted scope changes", () async {
+      final source = _FakePrSource(
+        targetsByDirectory: {"/one": _githubTarget(branchName: "feature/current")},
+      )..selectionOutcome = const PullRequestSelectionIdentityChanged();
+      final pullRequests = _FakePullRequestRepository();
+      final service = _service(
+        source: source,
+        pullRequests: pullRequests,
+        sessionsByProject: {
+          "one": [_session(id: "one", projectId: "one", directory: "/one")],
+        },
       );
       addTearDown(service.dispose);
 
-      await IOOverrides.runZoned(
-        () => service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1"),
-        stderr: () => _CapturingStdout(stderrLines),
-      );
+      expect(await service.triggerRefresh(projectIds: {"one"}), PrRefreshOutcome.failed);
+      expect(pullRequests.replaceCalls, isEmpty);
 
-      expect(stderrLines.join("\n"), contains("metadata cannot be refreshed"));
-      expect(stderrLines.join("\n"), isNot(contains("metadata is hidden")));
+      source.selectionOutcome = null;
+      pullRequests.replacementOutcomes["one"] = const PullRequestReplacementScopeChanged();
+      expect(await service.triggerRefresh(projectIds: {"one"}), PrRefreshOutcome.failed);
+      expect(pullRequests.replaceCalls, hasLength(1));
     });
 
-    test("keeps an identity verification timeout visible", () async {
-      final stderrLines = <String>[];
-      final prSource = _FakePrSource(selectedPullRequestsResult: const <GhPullRequest>[])
-        ..authenticatedIdentityError = TimeoutException("timed out");
-      final service = PrSyncService(
-        prSource: prSource,
-        pullRequestRepository: _FakePullRequestRepository(),
-        sessionRepository: _FakeSessionRepository(sessionsByProject: const <String, List<StoredSession>>{}),
-        clock: const Clock(),
+    test("a same-project request after sealing waits for a follow-up generation", () async {
+      final firstSelection = Completer<void>();
+      final secondSelection = Completer<void>();
+      final source = _FakePrSource(
+        resolutionResults: [
+          {"/one": _githubTarget(branchName: "branch-a")},
+          {"/one": _githubTarget(branchName: "branch-b")},
+        ],
+        selectionBlocks: [firstSelection, secondSelection],
+      );
+      final service = _service(
+        source: source,
+        pullRequests: _FakePullRequestRepository(),
+        sessionsByProject: {
+          "one": [_session(id: "one", projectId: "one", directory: "/one")],
+        },
       );
       addTearDown(service.dispose);
 
-      await IOOverrides.runZoned(
-        () => service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1"),
-        stderr: () => _CapturingStdout(stderrLines),
-      );
+      final first = service.triggerRefresh(projectIds: {"one"});
+      await _waitFor(() => source.selectionCalls.length == 1);
+      var secondCompleted = false;
+      final second = service.triggerRefresh(projectIds: {"one"});
+      unawaited(second.then((_) => secondCompleted = true));
 
-      expect(stderrLines.join("\n"), contains("metadata cannot be refreshed"));
-      expect(prSource.selectPullRequestsCallCount, 0);
+      firstSelection.complete();
+      expect(await first, PrRefreshOutcome.completed);
+      await _waitFor(() => source.selectionCalls.length == 2);
+      expect(secondCompleted, isFalse);
+      expect(source.selectionCalls[0].single.branchName, "branch-a");
+      expect(source.selectionCalls[1].single.branchName, "branch-b");
+      expect(source.maxConcurrentSelections, 1);
+
+      secondSelection.complete();
+      expect(await second, PrRefreshOutcome.completed);
     });
 
-    test("skips PR queries when the canonical GitHub repository is unavailable", () async {
-      final prSource = _FakePrSource(selectedPullRequestsResult: const <GhPullRequest>[])
-        ..githubRepositoryIdentityResult = null;
-      final pullRequestRepository = _FakePullRequestRepository();
-      final service = PrSyncService(
-        prSource: prSource,
-        pullRequestRepository: pullRequestRepository,
-        sessionRepository: _FakeSessionRepository(sessionsByProject: const <String, List<StoredSession>>{}),
-        clock: const Clock(),
+    test("coalesces pending projects into one immediate follow-up cycle", () async {
+      final firstSelection = Completer<void>();
+      final source = _FakePrSource(
+        targetsByDirectory: {
+          "/one": _githubTarget(branchName: "one"),
+          "/two": _githubTarget(branchName: "two"),
+          "/three": _githubTarget(branchName: "three"),
+        },
+        selectionBlocks: [firstSelection],
+      );
+      final service = _service(
+        source: source,
+        pullRequests: _FakePullRequestRepository(),
+        sessionsByProject: {
+          "one": [_session(id: "one", projectId: "one", directory: "/one")],
+          "two": [_session(id: "two", projectId: "two", directory: "/two")],
+          "three": [_session(id: "three", projectId: "three", directory: "/three")],
+        },
       );
       addTearDown(service.dispose);
 
-      await service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
+      final first = service.triggerRefresh(projectIds: {"one"});
+      await _waitFor(() => source.selectionCalls.length == 1);
+      final second = service.triggerRefresh(projectIds: {"two"});
+      final third = service.triggerRefresh(projectIds: {"three"});
+      firstSelection.complete();
 
-      expect(prSource.getAuthenticatedIdentityCallCount, 0);
-      expect(prSource.getGithubRepositoryIdentityCalls, ["/tmp/project-1"]);
-      expect(prSource.selectPullRequestsCallCount, 0);
-      expect(pullRequestRepository.clearScopedRefreshCalls, [
-        (projectId: "project-1", sessions: const <StoredSession>[]),
-      ]);
+      await Future.wait([first, second, third]);
+      expect(source.selectionCalls, hasLength(2));
+      expect(source.selectionCalls[1].map((target) => target.branchName).toSet(), {"two", "three"});
+      expect(source.maxConcurrentSelections, 1);
     });
 
-    test("emits and debounces a scope clear that hides cached PR metadata", () async {
-      final prSource = _FakePrSource(selectedPullRequestsResult: const <GhPullRequest>[])
-        ..githubRepositoryIdentityResult = null;
-      final pullRequestRepository = _FakePullRequestRepository()..clearScopedRefreshChanged = true;
-      final service = PrSyncService(
-        prSource: prSource,
-        pullRequestRepository: pullRequestRepository,
-        sessionRepository: _FakeSessionRepository(
-          sessionsByProject: const <String, List<StoredSession>>{},
-        ),
-        clock: const Clock(),
-        debounceWindow: const Duration(hours: 1),
+    test("debounces completed projects but retries failed projects", () async {
+      var now = DateTime.utc(2026, 8, 2);
+      final source = _FakePrSource(
+        targetsByDirectory: const {
+          "/local": PullRequestLocalBranchDirectoryTarget(branchName: "local"),
+        },
       );
-      addTearDown(service.dispose);
-      final emittedProjectIds = <String>[];
-      final sub = service.prChanges.listen(emittedProjectIds.add);
-      addTearDown(sub.cancel);
-
-      await service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
-      await service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
-
-      expect(pullRequestRepository.clearScopedRefreshCalls, hasLength(1));
-      expect(emittedProjectIds, ["project-1"]);
-    });
-
-    test("emits when scope preparation hides cached PR metadata", () async {
-      final listBlock = Completer<void>();
-      addTearDown(() {
-        if (!listBlock.isCompleted) {
-          listBlock.complete();
-        }
-      });
-      final pullRequestRepository = _FakePullRequestRepository()..prepareScopedRefreshChanged = true;
-      final service = PrSyncService(
-        prSource: _FakePrSource(
-          selectedPullRequestsResult: const <GhPullRequest>[],
-          onSelection: () => listBlock.future,
-        ),
-        pullRequestRepository: pullRequestRepository,
-        sessionRepository: _FakeSessionRepository(
-          sessionsByProject: const <String, List<StoredSession>>{},
-        ),
-        clock: const Clock(),
-      );
-      addTearDown(service.dispose);
-      final emittedProjectIds = <String>[];
-      final sub = service.prChanges.listen(emittedProjectIds.add);
-      addTearDown(sub.cancel);
-
-      final refresh = service.triggerRefresh(
-        projectId: "project-1",
-        projectPath: "/tmp/project-1",
-      );
-      await _waitFor(() => pullRequestRepository.prepareScopedRefreshCalls.isNotEmpty);
-      await _waitFor(() => emittedProjectIds.isNotEmpty);
-
-      expect(emittedProjectIds, ["project-1"]);
-      listBlock.complete();
-      await refresh;
-      expect(emittedProjectIds, ["project-1"]);
-    });
-
-    test("preserves scoped cache when repository resolution fails", () async {
-      final prSource = _FakePrSource(selectedPullRequestsResult: const <GhPullRequest>[])
-        ..githubRepositoryIdentityError = const ProcessException(
-          "git",
-          ["remote"],
-          "temporary failure",
-          -1,
-        );
-      final pullRequestRepository = _FakePullRequestRepository();
-      final service = PrSyncService(
-        prSource: prSource,
-        pullRequestRepository: pullRequestRepository,
-        sessionRepository: _FakeSessionRepository(
-          sessionsByProject: const <String, List<StoredSession>>{},
-        ),
-        clock: const Clock(),
-      );
-      addTearDown(service.dispose);
-
-      await expectLater(
-        service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1"),
-        throwsA(isA<ProcessException>()),
-      );
-
-      expect(pullRequestRepository.clearScopedRefreshCalls, isEmpty);
-    });
-
-    test("caches unavailable gh capability and detects installation after the TTL", () async {
-      var now = DateTime.utc(2026, 7, 13);
-      final prSource = _FakePrSource(
-        selectedPullRequestsResult: <GhPullRequest>[],
-        isAvailableResult: false,
-      );
-      final service = PrSyncService(
-        prSource: prSource,
-        pullRequestRepository: _FakePullRequestRepository(),
-        sessionRepository: _FakeSessionRepository(sessionsByProject: const <String, List<StoredSession>>{}),
+      final service = _service(
+        source: source,
+        pullRequests: _FakePullRequestRepository(),
+        sessionsByProject: {
+          "local": [_session(id: "local", projectId: "local", directory: "/local")],
+        },
         clock: Clock(() => now),
+        debounceWindow: const Duration(minutes: 1),
       );
       addTearDown(service.dispose);
 
-      await service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
-      await service.triggerRefresh(projectId: "project-2", projectPath: "/tmp/project-2");
+      await service.triggerRefresh(projectIds: {"local"});
+      await service.triggerRefresh(projectIds: {"local"});
+      expect(source.resolveCalls, hasLength(1));
 
-      expect(prSource.isAvailableCallCount, equals(1));
-      expect(prSource.isAuthenticatedCallCount, equals(0));
-      expect(prSource.getAuthenticatedIdentityCallCount, equals(0));
-      expect(prSource.selectPullRequestsCallCount, equals(0));
+      now = now.add(const Duration(minutes: 1));
+      await service.triggerRefresh(projectIds: {"local"});
+      expect(source.resolveCalls, hasLength(2));
 
-      prSource.isAvailableResult = true;
-      now = now.add(const Duration(seconds: 29));
-      await service.triggerRefresh(projectId: "project-3", projectPath: "/tmp/project-3");
-      expect(prSource.isAvailableCallCount, equals(1));
-
-      now = now.add(const Duration(seconds: 1));
-      await service.triggerRefresh(projectId: "project-4", projectPath: "/tmp/project-4");
-      expect(prSource.isAvailableCallCount, equals(2));
-      expect(prSource.isAuthenticatedCallCount, equals(1));
-      expect(prSource.getAuthenticatedIdentityCallCount, equals(1));
-      expect(prSource.selectPullRequestsCallCount, equals(1));
+      source.targetsByDirectory["/local"] = PullRequestBranchResolutionFailed(
+        error: PullRequestTargetResolutionException(
+          innerError: StateError("failed"),
+          innerStackTrace: StackTrace.current,
+        ),
+      );
+      now = now.add(const Duration(minutes: 1));
+      await service.triggerRefresh(projectIds: {"local"});
+      await service.triggerRefresh(projectIds: {"local"});
+      expect(source.resolveCalls, hasLength(4));
     });
 
-    test("shares one in-flight gh capability check across projects", () async {
-      final capabilityBlock = Completer<void>();
-      final prSource = _FakePrSource(selectedPullRequestsResult: <GhPullRequest>[])
-        ..availabilityBlock = capabilityBlock;
-      final service = PrSyncService(
-        prSource: prSource,
-        pullRequestRepository: _FakePullRequestRepository(),
-        sessionRepository: _FakeSessionRepository(sessionsByProject: const <String, List<StoredSession>>{}),
-        clock: const Clock(),
+    test("shares and expires the gh capability cache", () async {
+      var now = DateTime.utc(2026, 8, 2);
+      final source = _FakePrSource(
+        targetsByDirectory: {
+          "/one": _githubTarget(branchName: "one"),
+          "/two": _githubTarget(branchName: "two"),
+        },
+      )..isAvailableResult = false;
+      final service = _service(
+        source: source,
+        pullRequests: _FakePullRequestRepository(),
+        sessionsByProject: {
+          "one": [_session(id: "one", projectId: "one", directory: "/one")],
+          "two": [_session(id: "two", projectId: "two", directory: "/two")],
+        },
+        clock: Clock(() => now),
         debounceWindow: Duration.zero,
       );
       addTearDown(service.dispose);
 
-      final first = service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
-      await _waitFor(() => prSource.isAvailableCallCount == 1);
-      final second = service.triggerRefresh(projectId: "project-2", projectPath: "/tmp/project-2");
-      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await service.triggerRefresh(projectIds: {"one"});
+      await service.triggerRefresh(projectIds: {"two"});
+      expect(source.isAvailableCallCount, 1);
 
-      expect(prSource.isAvailableCallCount, equals(1));
-      capabilityBlock.complete();
-      await Future.wait([first, second]);
-      expect(prSource.isAuthenticatedCallCount, equals(1));
-      expect(prSource.getAuthenticatedIdentityCallCount, equals(2));
-      expect(prSource.selectPullRequestsCallCount, equals(2));
-
-      await service.triggerRefresh(projectId: "project-3", projectPath: "/tmp/project-3");
-      expect(prSource.isAvailableCallCount, equals(1));
-      expect(prSource.isAuthenticatedCallCount, equals(1));
-      expect(prSource.getAuthenticatedIdentityCallCount, equals(3));
-      expect(prSource.selectPullRequestsCallCount, equals(3));
+      now = now.add(const Duration(seconds: 30));
+      source.isAvailableResult = true;
+      await service.triggerRefresh(projectIds: {"one"});
+      expect(source.isAvailableCallCount, 2);
+      expect(source.selectionCalls, hasLength(1));
     });
 
-    test("retries a gh capability check after an unexpected failure", () async {
-      final prSource = _FakePrSource(selectedPullRequestsResult: <GhPullRequest>[])..isAvailableFailuresRemaining = 1;
-      final service = PrSyncService(
-        prSource: prSource,
-        pullRequestRepository: _FakePullRequestRepository(),
-        sessionRepository: _FakeSessionRepository(sessionsByProject: const <String, List<StoredSession>>{}),
-        clock: const Clock(),
+    test("dispose fails queued waiters without starting another cycle", () async {
+      final selectionBlock = Completer<void>();
+      final source = _FakePrSource(
+        targetsByDirectory: {"/one": _githubTarget(branchName: "one")},
+        selectionBlocks: [selectionBlock],
       );
-      addTearDown(service.dispose);
-
-      await expectLater(
-        service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1"),
-        throwsStateError,
-      );
-      await service.triggerRefresh(projectId: "project-2", projectPath: "/tmp/project-2");
-
-      expect(prSource.isAvailableCallCount, equals(2));
-      expect(prSource.getAuthenticatedIdentityCallCount, equals(1));
-      expect(prSource.selectPullRequestsCallCount, equals(1));
-    });
-
-    test("debounces repeated refreshes for same project", () async {
-      var now = DateTime.utc(2026, 7, 13);
-      final prSource = _FakePrSource(selectedPullRequestsResult: <GhPullRequest>[]);
-      final service = PrSyncService(
-        prSource: prSource,
-        pullRequestRepository: _FakePullRequestRepository(),
-        sessionRepository: _FakeSessionRepository(sessionsByProject: const <String, List<StoredSession>>{}),
-        clock: Clock(() => now),
-        debounceWindow: const Duration(hours: 1),
-      );
-      addTearDown(service.dispose);
-
-      await service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
-      await _waitFor(() => prSource.selectPullRequestsCallCount == 1);
-      now = now.add(const Duration(seconds: 31));
-      await service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
-
-      await Future<void>.delayed(const Duration(milliseconds: 50));
-      expect(prSource.selectPullRequestsCallCount, equals(1));
-      expect(prSource.isAvailableCallCount, equals(1));
-      expect(prSource.isAuthenticatedCallCount, equals(1));
-    });
-
-    test("skips concurrent refresh while one is already active", () async {
-      final block = Completer<void>();
-      final prSource = _FakePrSource(
-        selectedPullRequestsResult: <GhPullRequest>[],
-        onSelection: () => block.future,
-      );
-      final service = PrSyncService(
-        prSource: prSource,
-        pullRequestRepository: _FakePullRequestRepository(),
-        sessionRepository: _FakeSessionRepository(sessionsByProject: const <String, List<StoredSession>>{}),
-        clock: const Clock(),
-        debounceWindow: Duration.zero,
-      );
-      addTearDown(service.dispose);
-
-      // Start first refresh without awaiting so we can test concurrent behavior.
-      final firstRefresh = service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
-      await _waitFor(() => prSource.selectPullRequestsCallCount == 1);
-
-      // Second refresh should report that the first is still active rather than
-      // representing unfinished work as completed.
-      final secondOutcome = await service.triggerRefresh(
-        projectId: "project-1",
-        projectPath: "/tmp/project-1",
+      final service = _service(
+        source: source,
+        pullRequests: _FakePullRequestRepository(),
+        sessionsByProject: {
+          "one": [_session(id: "one", projectId: "one", directory: "/one")],
+        },
       );
 
-      expect(secondOutcome, PrRefreshOutcome.inProgress);
-      expect(prSource.selectPullRequestsCallCount, equals(1));
-      expect(prSource.isAvailableCallCount, equals(1));
-      expect(prSource.isAuthenticatedCallCount, equals(1));
+      final first = service.triggerRefresh(projectIds: {"one"});
+      await _waitFor(() => source.selectionCalls.isNotEmpty);
+      final queued = service.triggerRefresh(projectIds: {"one"});
+      service.dispose();
 
-      block.complete();
-      await firstRefresh;
+      expect(await queued, PrRefreshOutcome.failed);
+      selectionBlock.complete();
+      expect(await first, PrRefreshOutcome.failed);
+      expect(source.selectionCalls, hasLength(1));
     });
   });
+}
+
+PrSyncService _service({
+  required _FakePrSource source,
+  required _FakePullRequestRepository pullRequests,
+  required Map<String, List<StoredSession>> sessionsByProject,
+  Clock clock = const Clock(),
+  Duration debounceWindow = Duration.zero,
+}) {
+  return PrSyncService(
+    prSource: source,
+    pullRequestRepository: pullRequests,
+    sessionRepository: _FakeSessionRepository(sessionsByProject: sessionsByProject),
+    clock: clock,
+    debounceWindow: debounceWindow,
+  );
+}
+
+PullRequestGithubDirectoryTarget _githubTarget({required String branchName}) {
+  return PullRequestGithubDirectoryTarget(
+    target: (
+      githubRepositoryIdentity: _repositoryIdentity,
+      branchName: branchName,
+    ),
+  );
+}
+
+StoredSession _session({
+  required String id,
+  required String projectId,
+  required String directory,
+  String? parentSessionId,
+}) {
+  return StoredSession(
+    id: id,
+    backendSessionId: id,
+    pluginId: "fake",
+    projectId: projectId,
+    parentSessionId: parentSessionId,
+    directory: directory,
+    worktreePath: directory,
+    branchName: "creation-branch",
+    isDedicated: true,
+    archivedAt: null,
+    baseBranch: null,
+    baseCommit: null,
+  );
 }
 
 Future<void> _waitFor(bool Function() condition) async {
   final timeout = DateTime.now().add(const Duration(seconds: 2));
   while (!condition()) {
-    if (DateTime.now().isAfter(timeout)) {
-      fail("Timed out waiting for condition");
-    }
+    if (DateTime.now().isAfter(timeout)) fail("Timed out waiting for condition");
     await Future<void>.delayed(const Duration(milliseconds: 10));
   }
 }
 
-GhPullRequest _ghPr({
-  required int number,
-  required String branch,
-  required String title,
-  PrState state = PrState.open,
-  PrMergeableStatus mergeable = PrMergeableStatus.mergeable,
-  PrReviewDecision? reviewDecision,
-  PrCheckStatus statusCheckRollup = PrCheckStatus.success,
-}) {
-  return GhPullRequest(
-    number: number,
-    url: "https://github.com/org/repo/pull/$number",
-    title: title,
-    createdAt: DateTime.fromMillisecondsSinceEpoch(number, isUtc: true),
-    state: state,
-    headRefName: branch,
-    mergeable: mergeable,
-    reviewDecision: reviewDecision ?? PrReviewDecision.unknown,
-    statusCheckRollup: statusCheckRollup,
-  );
-}
-
-PullRequestDto _dto({
-  required String projectId,
-  required String githubRepositoryIdentity,
-  required String githubLogin,
-  required String branchName,
-  required int prNumber,
-  required String title,
-  required PrState state,
-  required PrMergeableStatus mergeableStatus,
-  required PrReviewDecision reviewDecision,
-  required PrCheckStatus checkStatus,
-}) {
-  return PullRequestDto(
-    projectId: projectId,
-    githubRepositoryIdentity: githubRepositoryIdentity,
-    githubLogin: githubLogin,
-    prNumber: prNumber,
-    branchName: branchName,
-    url: "https://github.com/org/repo/pull/$prNumber",
-    title: title,
-    state: state,
-    mergeableStatus: mergeableStatus,
-    reviewDecision: reviewDecision,
-    checkStatus: checkStatus,
-    lastCheckedAt: 1,
-    createdAt: prNumber,
-  );
-}
-
-class _FakePrSource implements PrSourceRepository {
-  final List<GhPullRequest> selectedPullRequestsResult;
-  final Future<void> Function()? onSelection;
+final class _FakePrSource implements PrSourceRepository {
+  final List<Map<String, PullRequestDirectoryTarget>> resolutionResults;
+  final List<Completer<void>> selectionBlocks;
+  final List<List<String>> resolveCalls = <List<String>>[];
+  final List<List<PullRequestSelectionTarget>> selectionCalls = <List<PullRequestSelectionTarget>>[];
+  Map<String, PullRequestDirectoryTarget> targetsByDirectory;
   PullRequestSelectionOutcome? selectionOutcome;
-  bool isAvailableResult;
+  bool isAvailableResult = true;
   bool isAuthenticatedResult = true;
-  VerifiedGithubLogin? authenticatedIdentityResult = _verifiedGithubLogin;
-  Object? authenticatedIdentityError;
-  String? githubRepositoryIdentityResult = _githubRepositoryIdentity;
-  Object? githubRepositoryIdentityError;
-  Completer<void>? availabilityBlock;
-  int isAvailableFailuresRemaining = 0;
-
+  VerifiedGithubLogin? authenticatedIdentity = _verifiedGithubLogin;
   int isAvailableCallCount = 0;
   int isAuthenticatedCallCount = 0;
-  int getAuthenticatedIdentityCallCount = 0;
-  int selectPullRequestsCallCount = 0;
-  final List<String> getGithubRepositoryIdentityCalls = <String>[];
-  final List<List<PullRequestSelectionTarget>> selectionTargets = <List<PullRequestSelectionTarget>>[];
+  int identityCallCount = 0;
+  int _activeSelections = 0;
+  int maxConcurrentSelections = 0;
 
   _FakePrSource({
-    required this.selectedPullRequestsResult,
-    this.onSelection,
-    this.isAvailableResult = true,
-  });
+    Map<String, PullRequestDirectoryTarget> targetsByDirectory = const {},
+    this.resolutionResults = const [],
+    this.selectionBlocks = const [],
+  }) : targetsByDirectory = Map<String, PullRequestDirectoryTarget>.from(targetsByDirectory);
+
+  @override
+  Future<Map<String, PullRequestDirectoryTarget>> resolvePullRequestTargets({
+    required Iterable<String> directories,
+  }) async {
+    final uniqueDirectories = directories.toSet().toList(growable: false)..sort();
+    resolveCalls.add(uniqueDirectories);
+    final resultIndex = resolveCalls.length - 1;
+    final configured = resultIndex < resolutionResults.length ? resolutionResults[resultIndex] : targetsByDirectory;
+    return {
+      for (final directory in uniqueDirectories) directory: ?configured[directory],
+    };
+  }
 
   @override
   Future<bool> isGithubCliAvailable() async {
     isAvailableCallCount++;
-    if (availabilityBlock case final block?) {
-      await block.future;
-    }
-    if (isAvailableFailuresRemaining > 0) {
-      isAvailableFailuresRemaining--;
-      throw StateError("gh availability failed");
-    }
     return isAvailableResult;
   }
 
@@ -717,20 +474,8 @@ class _FakePrSource implements PrSourceRepository {
 
   @override
   Future<VerifiedGithubLogin?> getAuthenticatedIdentity() async {
-    getAuthenticatedIdentityCallCount++;
-    if (authenticatedIdentityError case final error?) {
-      throw error;
-    }
-    return authenticatedIdentityResult;
-  }
-
-  @override
-  Future<String?> getGithubRepositoryIdentity({required String projectPath}) async {
-    getGithubRepositoryIdentityCalls.add(projectPath);
-    if (githubRepositoryIdentityError case final error?) {
-      throw error;
-    }
-    return githubRepositoryIdentityResult;
+    identityCallCount++;
+    return authenticatedIdentity;
   }
 
   @override
@@ -738,266 +483,76 @@ class _FakePrSource implements PrSourceRepository {
     required List<PullRequestSelectionTarget> targets,
     required VerifiedGithubLogin expectedGithubLogin,
   }) async {
-    selectPullRequestsCallCount++;
-    selectionTargets.add(List<PullRequestSelectionTarget>.from(targets));
-    if (onSelection case final callback?) {
-      await callback();
+    selectionCalls.add(List<PullRequestSelectionTarget>.from(targets));
+    _activeSelections++;
+    if (_activeSelections > maxConcurrentSelections) maxConcurrentSelections = _activeSelections;
+    try {
+      final blockIndex = selectionCalls.length - 1;
+      if (blockIndex < selectionBlocks.length) {
+        await selectionBlocks[blockIndex].future;
+      }
+      if (selectionOutcome case final outcome?) return outcome;
+      return PullRequestSelectionCompleted(
+        selections: [for (final target in targets) PullRequestTargetUnmatched(target: target)],
+      );
+    } finally {
+      _activeSelections--;
     }
-    if (selectionOutcome case final outcome?) return outcome;
-    return PullRequestSelectionCompleted(
-      selections: [for (final target in targets) _selectionFor(target: target)],
-    );
-  }
-
-  PullRequestTargetSelection _selectionFor({required PullRequestSelectionTarget target}) {
-    final pullRequest = selectedPullRequestsResult
-        .where((candidate) => candidate.headRefName == target.branchName)
-        .firstOrNull;
-    if (pullRequest == null) return PullRequestTargetUnmatched(target: target);
-    return PullRequestTargetSelected(
-      target: target,
-      number: pullRequest.number,
-      url: pullRequest.url,
-      title: pullRequest.title,
-      createdAt: pullRequest.createdAt,
-      state: pullRequest.state,
-      mergeableStatus: pullRequest.mergeable,
-      reviewDecision: pullRequest.reviewDecision,
-      checkStatus: pullRequest.statusCheckRollup,
-    );
-  }
-}
-
-class _CapturingStdout implements Stdout {
-  final List<String> lines;
-
-  _CapturingStdout(this.lines);
-
-  @override
-  bool get supportsAnsiEscapes => false;
-
-  @override
-  void writeln([Object? object = ""]) {
-    lines.add(object.toString());
   }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-class _FakePullRequestRepository implements PullRequestRepository {
-  final Map<String, List<PullRequestDto>> _recordsByProject = <String, List<PullRequestDto>>{};
-  int upsertCalls = 0;
-  int replaceCalls = 0;
-  final List<
-    ({
-      String projectId,
-      String githubRepositoryIdentity,
-      String githubLogin,
-      List<StoredSession> sessions,
-    })
-  >
-  prepareScopedRefreshCalls = [];
-  final List<({String projectId, List<StoredSession> sessions})> clearScopedRefreshCalls = [];
-  bool prepareScopedRefreshChanged = false;
-  bool clearScopedRefreshChanged = false;
+final class _FakePullRequestRepository implements PullRequestRepository {
+  Set<String> localChangedProjectIds = const <String>{};
+  Set<String> preparedChangedProjectIds = const <String>{};
+  final Map<String, PullRequestReplacementOutcome> replacementOutcomes = <String, PullRequestReplacementOutcome>{};
+  final List<({Map<String, List<StoredSession>> sessionsByProject, Map<String, PullRequestDirectoryTarget> targets})>
+  applyCalls = [];
+  final List<({Set<String> projectIds, String githubLogin})> prepareCalls = [];
+  final List<({String projectId, List<PullRequestTargetSelection> selections})> replaceCalls = [];
 
-  _FakePullRequestRepository({List<PullRequestDto> seed = const <PullRequestDto>[]}) {
-    for (final record in seed) {
-      _recordsByProject.putIfAbsent(record.projectId, () => <PullRequestDto>[]).add(record);
-    }
+  @override
+  Future<Set<String>> applyResolvedTargets({
+    required Map<String, List<StoredSession>> sessionsByProject,
+    required Map<String, PullRequestDirectoryTarget> targetsByDirectory,
+  }) async {
+    applyCalls.add((
+      sessionsByProject: Map<String, List<StoredSession>>.from(sessionsByProject),
+      targets: Map<String, PullRequestDirectoryTarget>.from(targetsByDirectory),
+    ));
+    return localChangedProjectIds;
   }
 
   @override
-  Future<bool> replaceScopedPullRequests({
+  Future<Set<String>> prepareScopedRefresh({
+    required Set<String> projectIds,
+    required VerifiedGithubLogin verifiedGithubLogin,
+  }) async {
+    prepareCalls.add((projectIds: Set<String>.from(projectIds), githubLogin: verifiedGithubLogin.login));
+    return preparedChangedProjectIds;
+  }
+
+  @override
+  Future<PullRequestReplacementOutcome> replaceScopedPullRequests({
     required String projectId,
     required VerifiedGithubLogin verifiedGithubLogin,
     required List<PullRequestTargetSelection> targetSelections,
     required int lastCheckedAt,
   }) async {
-    replaceCalls++;
-    final previous = _recordsByProject[projectId] ?? const <PullRequestDto>[];
-    final replacements = [
-      for (final selection in targetSelections)
-        if (selection case final PullRequestTargetSelected pullRequest)
-          PullRequestDto(
-            projectId: projectId,
-            githubRepositoryIdentity: pullRequest.target.githubRepositoryIdentity,
-            githubLogin: verifiedGithubLogin.login,
-            prNumber: pullRequest.number,
-            branchName: pullRequest.target.branchName,
-            url: pullRequest.url,
-            title: pullRequest.title,
-            state: pullRequest.state,
-            mergeableStatus: pullRequest.mergeableStatus,
-            reviewDecision: pullRequest.reviewDecision,
-            checkStatus: pullRequest.checkStatus,
-            lastCheckedAt: lastCheckedAt,
-            createdAt: pullRequest.createdAt.millisecondsSinceEpoch,
-          ),
-    ];
-    final changed =
-        previous.length != replacements.length ||
-        replacements.any((replacement) {
-          final existing = previous.where((record) => record.prNumber == replacement.prNumber).firstOrNull;
-          return existing == null ||
-              existing.githubRepositoryIdentity != replacement.githubRepositoryIdentity ||
-              existing.githubLogin != replacement.githubLogin ||
-              existing.branchName != replacement.branchName ||
-              existing.title != replacement.title ||
-              existing.state != replacement.state ||
-              existing.mergeableStatus != replacement.mergeableStatus ||
-              existing.reviewDecision != replacement.reviewDecision ||
-              existing.checkStatus != replacement.checkStatus ||
-              existing.createdAt != replacement.createdAt;
-        });
-    _recordsByProject[projectId] = replacements;
-    upsertCalls += replacements.length;
-    return changed;
-  }
-
-  List<PullRequestDto> getByProjectId({required String projectId}) {
-    return List<PullRequestDto>.from(_recordsByProject[projectId] ?? const <PullRequestDto>[]);
+    replaceCalls.add((projectId: projectId, selections: List<PullRequestTargetSelection>.from(targetSelections)));
+    return replacementOutcomes[projectId] ?? const PullRequestReplacementApplied(changed: false);
   }
 
   @override
-  Future<bool> prepareScopedRefresh({
-    required String projectId,
-    required String githubRepositoryIdentity,
-    required VerifiedGithubLogin verifiedGithubLogin,
-    required List<StoredSession> sessions,
-  }) async {
-    prepareScopedRefreshCalls.add((
-      projectId: projectId,
-      githubRepositoryIdentity: githubRepositoryIdentity,
-      githubLogin: verifiedGithubLogin.login,
-      sessions: sessions,
-    ));
-    _recordsByProject[projectId]?.removeWhere(
-      (record) =>
-          record.githubRepositoryIdentity != githubRepositoryIdentity ||
-          record.githubLogin != verifiedGithubLogin.login,
-    );
-    return prepareScopedRefreshChanged;
-  }
-
-  @override
-  Future<bool> clearScopedRefresh({
-    required String projectId,
-    required List<StoredSession> sessions,
-  }) async {
-    clearScopedRefreshCalls.add((projectId: projectId, sessions: sessions));
-    _recordsByProject.remove(projectId);
-    return clearScopedRefreshChanged;
-  }
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-class _FakeSessionRepository implements SessionRepository {
-  @override
-  Stream<SessionBindingsCommitted> get bindingCommits => const Stream.empty();
-
-  @override
-  int captureProjectionTimestamp() => DateTime.now().millisecondsSinceEpoch;
-
-  @override
-  Future<void> dispose() async {}
-
-  @override
-  Future<bool> setSessionTitleIfStored({required String sessionId, required String? title}) async => true;
-
-  @override
-  Future<Session> deleteSession({required String sessionId}) async => Session(
-    branchName: null,
-    id: sessionId,
-    pluginId: "fake",
-    projectID: "",
-    directory: "",
-    parentID: null,
-    title: null,
-    time: null,
-    pullRequest: null,
-    promptDefaults: null,
-  );
-
-  @override
-  Future<bool> isSessionTombstoned({required String sessionId}) async => false;
-
-  @override
-  Future<List<String>> get persistedSessionCleanupPluginIds async => const [];
-
-  @override
-  Future<Set<String>> getTombstonedBackendSessionIdsForCleanup({required String pluginId}) async => const {};
-
-  @override
-  Future<void> deletePersistedSession({required String pluginId, required String backendSessionId}) async {}
-
-  @override
-  Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async => const [];
-
-  @override
-  Future<List<ProjectActivitySummary>> getProjectActivitySummaries() async => const [];
-
+final class _FakeSessionRepository implements SessionRepository {
   final Map<String, List<StoredSession>> sessionsByProject;
 
   _FakeSessionRepository({required this.sessionsByProject});
-
-  @override
-  Future<Session> createSession({
-    required String pluginId,
-    required String projectId,
-    required String directory,
-    required String? parentSessionId,
-    required List<PromptPart> parts,
-    required String? userVisibleText,
-    required SessionVariant? variant,
-    required String? agent,
-    required PromptModel? model,
-    required bool isDedicated,
-    required String? worktreePath,
-    required String? branchName,
-    required String? baseBranch,
-    required String? baseCommit,
-    required String? lastAgent,
-    required AgentModel? lastAgentModel,
-  }) async => const Session(
-    branchName: null,
-    id: "",
-    pluginId: "fake",
-    projectID: "",
-    directory: "",
-    parentID: null,
-    title: null,
-    time: null,
-    pullRequest: null,
-    promptDefaults: null,
-  );
-
-  @override
-  Future<List<Session>> getSessionsForProject({
-    required String projectId,
-    required int? start,
-    required int? limit,
-    required VerifiedGithubLogin? verifiedGithubLogin,
-  }) async => const <Session>[];
-
-  @override
-  Future<Session> enrichSession({
-    required Session session,
-    required VerifiedGithubLogin? verifiedGithubLogin,
-  }) async => session;
-
-  @override
-  Future<Session> enrichPluginSession({required String pluginId, required PluginSession pluginSession}) async =>
-      pluginSession.toSharedSession(pluginId: pluginId);
-
-  @override
-  Future<List<Session>> enrichSessions({
-    required List<Session> sessions,
-    required VerifiedGithubLogin? verifiedGithubLogin,
-  }) async => sessions;
-
-  @override
-  Future<List<Session>> getChildSessions({required String sessionId}) async => const <Session>[];
 
   @override
   Future<List<StoredSession>> getStoredSessionsByProjectId({required String projectId}) async {
@@ -1005,172 +560,5 @@ class _FakeSessionRepository implements SessionRepository {
   }
 
   @override
-  Future<bool> hasOtherActiveSessionsSharing({
-    required String sessionId,
-    required String projectId,
-    required String? worktreePath,
-    required String? branchName,
-  }) async => false;
-
-  @override
-  Future<String?> getProjectPath({required String projectId}) async => null;
-
-  @override
-  Future<StoredSession?> getStoredSession({required String sessionId}) async => null;
-
-  @override
-  Future<StoredSession?> getStoredSessionByBackendId({
-    required String pluginId,
-    required String backendSessionId,
-  }) async => null;
-
-  @override
-  Future<Map<String, StoredSession>> getStoredSessionsByBackendIds({
-    required String pluginId,
-    required List<String> backendSessionIds,
-  }) async => const {};
-
-  @override
-  Future<StoredSession?> updateObservedSessionProjection({
-    required String pluginId,
-    required int generation,
-    required Session observed,
-    required bool updateCatalogTitle,
-    required int projectionUpdatedAt,
-  }) async => null;
-
-  @override
-  Future<StoredSession?> insertObservedChild({
-    required String pluginId,
-    required int generation,
-    required Session observed,
-    required StoredSession parent,
-    required int projectionUpdatedAt,
-  }) async => null;
-
-  @override
-  Future<void> archiveStoredSession({
-    required String sessionId,
-    required int archivedAt,
-  }) async {}
-
-  @override
-  Future<void> unarchiveStoredSession({required String sessionId}) async {}
-
-  @override
-  Future<void> insertStoredSession({
-    required String sessionId,
-    required String backendSessionId,
-    required String pluginId,
-    required String projectId,
-    required bool isDedicated,
-    required int createdAt,
-    required String? worktreePath,
-    required String? branchName,
-    required String? baseBranch,
-    required String? baseCommit,
-    required String? agent,
-    required AgentModel? agentModel,
-  }) async {}
-
-  @override
-  Future<void> updatePromptDefaults({
-    required String sessionId,
-    required String? agent,
-    required AgentModel? agentModel,
-  }) async {}
-
-  @override
-  Future<String?> findProjectIdForSession({required String sessionId}) async => null;
-
-  @override
-  Future<Session?> getSessionForProject({
-    required String projectId,
-    required String sessionId,
-    required VerifiedGithubLogin? verifiedGithubLogin,
-  }) async => null;
-
-  @override
-  Future<void> abortSession({required String sessionId}) async {}
-
-  @override
-  Future<void> notifySessionArchived({required String sessionId}) async {}
-
-  @override
-  Future<void> sendCommand({
-    required String sessionId,
-    required String command,
-    required String arguments,
-    required String? userVisibleArguments,
-    required SessionVariant? variant,
-    required String? agent,
-    required PromptModel? model,
-  }) async {}
-
-  @override
-  Future<CommandListResponse> getCommands({required String? projectId, required String pluginId}) async =>
-      const CommandListResponse(items: []);
-
-  @override
-  Future<void> sendPrompt({
-    required String sessionId,
-    required List<PromptPart> parts,
-    required SessionVariant? variant,
-    required String? agent,
-    required PromptModel? model,
-  }) async {}
-
-  @override
-  Future<Session> renameSession({required String sessionId, required String title}) async => const Session(
-    branchName: null,
-    id: "",
-    pluginId: "fake",
-    projectID: "",
-    directory: "",
-    parentID: null,
-    title: null,
-    time: null,
-    pullRequest: null,
-    promptDefaults: null,
-  );
-
-  @override
-  Future<String> resolveProjectDirectory({required String projectId}) async => projectId;
-
-  @override
-  Future<void> ensurePluginRoutable({required String pluginId, required SessionOperation operation}) async {}
-
-  @override
-  Future<Session?> getCatalogSession({required String sessionId}) async => null;
-
-  @override
-  Future<SessionStatusResponse> getSessionStatuses() async => const SessionStatusResponse(statuses: {});
-
-  @override
-  Future<StoredSession> requireRoutableStoredSession({
-    required String sessionId,
-    required SessionOperation operation,
-  }) async {
-    throw StateError("No stored session configured for $sessionId");
-  }
-}
-
-StoredSession _storedSession({
-  required String id,
-  required String? branchName,
-}) {
-  return StoredSession(
-    id: id,
-    backendSessionId: id,
-    pluginId: "fake",
-    projectId: "project-1",
-    parentSessionId: null,
-    directory: "/tmp/project-1",
-    worktreePath: null,
-    branchName: branchName,
-    isDedicated: false,
-    archivedAt: null,
-    baseBranch: null,
-    baseCommit: null,
-  );
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -34,7 +34,10 @@ void main() {
       );
       addTearDown(service.dispose);
 
-      final outcome = await service.triggerRefresh(projectIds: {"one", "two"});
+      final outcome = await service.triggerRefresh(
+        projectIds: {"one", "two"},
+        refreshPolicy: PrRefreshPolicy.explicit,
+      );
 
       expect(outcome, PrRefreshOutcome.completed);
       expect(source.resolveCalls, hasLength(1));
@@ -44,6 +47,10 @@ void main() {
       expect(pullRequests.prepareCalls.single.projectIds, {"one", "two"});
       expect(pullRequests.prepareCalls.single.githubLogin, "octocat");
       expect(pullRequests.replaceCalls.map((call) => call.projectId).toSet(), {"one", "two"});
+      expect(
+        pullRequests.replaceCalls.singleWhere((call) => call.projectId == "one").capturedRootDirectories,
+        {"one": "/one"},
+      );
       expect(source.maxConcurrentSelections, 1);
     });
 
@@ -64,7 +71,10 @@ void main() {
       final subscription = service.renderedChanges.listen((change) => changes.add(change.projectId));
       addTearDown(subscription.cancel);
 
-      final outcome = await service.triggerRefresh(projectIds: {"one"});
+      final outcome = await service.triggerRefresh(
+        projectIds: {"one"},
+        refreshPolicy: PrRefreshPolicy.explicit,
+      );
 
       expect(outcome, PrRefreshOutcome.failed);
       expect(pullRequests.applyCalls, hasLength(1));
@@ -92,7 +102,10 @@ void main() {
       );
       addTearDown(service.dispose);
 
-      final outcome = await service.triggerRefresh(projectIds: {"local", "detached"});
+      final outcome = await service.triggerRefresh(
+        projectIds: {"local", "detached"},
+        refreshPolicy: PrRefreshPolicy.explicit,
+      );
 
       expect(outcome, PrRefreshOutcome.completed);
       expect(source.isAvailableCallCount, 0);
@@ -123,7 +136,13 @@ void main() {
       );
       addTearDown(service.dispose);
 
-      expect(await service.triggerRefresh(projectIds: {"one"}), PrRefreshOutcome.completed);
+      expect(
+        await service.triggerRefresh(
+          projectIds: {"one"},
+          refreshPolicy: PrRefreshPolicy.explicit,
+        ),
+        PrRefreshOutcome.completed,
+      );
       expect(source.resolveCalls.single, ["/shared"]);
     });
 
@@ -146,7 +165,13 @@ void main() {
       final subscription = service.renderedChanges.listen((change) => changes.add(change.projectId));
       addTearDown(subscription.cancel);
 
-      expect(await service.triggerRefresh(projectIds: {"one"}), PrRefreshOutcome.completed);
+      expect(
+        await service.triggerRefresh(
+          projectIds: {"one"},
+          refreshPolicy: PrRefreshPolicy.explicit,
+        ),
+        PrRefreshOutcome.completed,
+      );
       expect(changes, ["one", "one"]);
     });
 
@@ -173,7 +198,10 @@ void main() {
       );
       addTearDown(service.dispose);
 
-      final outcome = await service.triggerRefresh(projectIds: {"one"});
+      final outcome = await service.triggerRefresh(
+        projectIds: {"one"},
+        refreshPolicy: PrRefreshPolicy.explicit,
+      );
 
       expect(outcome, PrRefreshOutcome.failed);
       expect(pullRequests.applyCalls, hasLength(1));
@@ -195,12 +223,24 @@ void main() {
       );
       addTearDown(service.dispose);
 
-      expect(await service.triggerRefresh(projectIds: {"one"}), PrRefreshOutcome.failed);
+      expect(
+        await service.triggerRefresh(
+          projectIds: {"one"},
+          refreshPolicy: PrRefreshPolicy.explicit,
+        ),
+        PrRefreshOutcome.failed,
+      );
       expect(pullRequests.replaceCalls, isEmpty);
 
       source.selectionOutcome = null;
       pullRequests.replacementOutcomes["one"] = const PullRequestReplacementScopeChanged();
-      expect(await service.triggerRefresh(projectIds: {"one"}), PrRefreshOutcome.failed);
+      expect(
+        await service.triggerRefresh(
+          projectIds: {"one"},
+          refreshPolicy: PrRefreshPolicy.explicit,
+        ),
+        PrRefreshOutcome.failed,
+      );
       expect(pullRequests.replaceCalls, hasLength(1));
     });
 
@@ -223,10 +263,16 @@ void main() {
       );
       addTearDown(service.dispose);
 
-      final first = service.triggerRefresh(projectIds: {"one"});
+      final first = service.triggerRefresh(
+        projectIds: {"one"},
+        refreshPolicy: PrRefreshPolicy.explicit,
+      );
       await _waitFor(() => source.selectionCalls.length == 1);
       var secondCompleted = false;
-      final second = service.triggerRefresh(projectIds: {"one"});
+      final second = service.triggerRefresh(
+        projectIds: {"one"},
+        refreshPolicy: PrRefreshPolicy.explicit,
+      );
       unawaited(second.then((_) => secondCompleted = true));
 
       firstSelection.complete();
@@ -262,10 +308,19 @@ void main() {
       );
       addTearDown(service.dispose);
 
-      final first = service.triggerRefresh(projectIds: {"one"});
+      final first = service.triggerRefresh(
+        projectIds: {"one"},
+        refreshPolicy: PrRefreshPolicy.explicit,
+      );
       await _waitFor(() => source.selectionCalls.length == 1);
-      final second = service.triggerRefresh(projectIds: {"two"});
-      final third = service.triggerRefresh(projectIds: {"three"});
+      final second = service.triggerRefresh(
+        projectIds: {"two"},
+        refreshPolicy: PrRefreshPolicy.explicit,
+      );
+      final third = service.triggerRefresh(
+        projectIds: {"three"},
+        refreshPolicy: PrRefreshPolicy.explicit,
+      );
       firstSelection.complete();
 
       await Future.wait([first, second, third]);
@@ -274,7 +329,7 @@ void main() {
       expect(source.maxConcurrentSelections, 1);
     });
 
-    test("debounces completed projects but retries failed projects", () async {
+    test("debounces background refreshes, allows bypass, and retries failures", () async {
       var now = DateTime.utc(2026, 8, 2);
       final source = _FakePrSource(
         targetsByDirectory: const {
@@ -292,13 +347,28 @@ void main() {
       );
       addTearDown(service.dispose);
 
-      await service.triggerRefresh(projectIds: {"local"});
-      await service.triggerRefresh(projectIds: {"local"});
+      await service.triggerRefresh(
+        projectIds: {"local"},
+        refreshPolicy: PrRefreshPolicy.background,
+      );
+      await service.triggerRefresh(
+        projectIds: {"local"},
+        refreshPolicy: PrRefreshPolicy.background,
+      );
       expect(source.resolveCalls, hasLength(1));
 
-      now = now.add(const Duration(minutes: 1));
-      await service.triggerRefresh(projectIds: {"local"});
+      await service.triggerRefresh(
+        projectIds: {"local"},
+        refreshPolicy: PrRefreshPolicy.explicit,
+      );
       expect(source.resolveCalls, hasLength(2));
+
+      now = now.add(const Duration(minutes: 1));
+      await service.triggerRefresh(
+        projectIds: {"local"},
+        refreshPolicy: PrRefreshPolicy.background,
+      );
+      expect(source.resolveCalls, hasLength(3));
 
       source.targetsByDirectory["/local"] = PullRequestBranchResolutionFailed(
         error: PullRequestTargetResolutionException(
@@ -307,9 +377,15 @@ void main() {
         ),
       );
       now = now.add(const Duration(minutes: 1));
-      await service.triggerRefresh(projectIds: {"local"});
-      await service.triggerRefresh(projectIds: {"local"});
-      expect(source.resolveCalls, hasLength(4));
+      await service.triggerRefresh(
+        projectIds: {"local"},
+        refreshPolicy: PrRefreshPolicy.background,
+      );
+      await service.triggerRefresh(
+        projectIds: {"local"},
+        refreshPolicy: PrRefreshPolicy.background,
+      );
+      expect(source.resolveCalls, hasLength(5));
     });
 
     test("shares and expires the gh capability cache", () async {
@@ -332,15 +408,64 @@ void main() {
       );
       addTearDown(service.dispose);
 
-      await service.triggerRefresh(projectIds: {"one"});
-      await service.triggerRefresh(projectIds: {"two"});
+      await service.triggerRefresh(
+        projectIds: {"one"},
+        refreshPolicy: PrRefreshPolicy.explicit,
+      );
+      await service.triggerRefresh(
+        projectIds: {"two"},
+        refreshPolicy: PrRefreshPolicy.explicit,
+      );
       expect(source.isAvailableCallCount, 1);
 
       now = now.add(const Duration(seconds: 30));
       source.isAvailableResult = true;
-      await service.triggerRefresh(projectIds: {"one"});
+      await service.triggerRefresh(
+        projectIds: {"one"},
+        refreshPolicy: PrRefreshPolicy.explicit,
+      );
       expect(source.isAvailableCallCount, 2);
       expect(source.selectionCalls, hasLength(1));
+    });
+
+    test("isolates replacement exceptions and continues later projects", () async {
+      final source = _FakePrSource(
+        targetsByDirectory: {
+          "/one": _githubTarget(branchName: "one"),
+          "/two": _githubTarget(branchName: "two"),
+        },
+      );
+      final pullRequests = _FakePullRequestRepository()..replacementErrors["one"] = StateError("replacement failed");
+      final service = _service(
+        source: source,
+        pullRequests: pullRequests,
+        sessionsByProject: {
+          "one": [_session(id: "one", projectId: "one", directory: "/one")],
+          "two": [_session(id: "two", projectId: "two", directory: "/two")],
+        },
+        debounceWindow: const Duration(minutes: 1),
+      );
+      addTearDown(service.dispose);
+
+      final outcome = await service.triggerRefresh(
+        projectIds: {"one", "two"},
+        refreshPolicy: PrRefreshPolicy.explicit,
+      );
+
+      expect(outcome, PrRefreshOutcome.failed);
+      expect(pullRequests.replaceCalls.map((call) => call.projectId), ["one", "two"]);
+
+      await service.triggerRefresh(
+        projectIds: {"two"},
+        refreshPolicy: PrRefreshPolicy.background,
+      );
+      expect(pullRequests.replaceCalls, hasLength(2));
+
+      await service.triggerRefresh(
+        projectIds: {"one"},
+        refreshPolicy: PrRefreshPolicy.background,
+      );
+      expect(pullRequests.replaceCalls.map((call) => call.projectId), ["one", "two", "one"]);
     });
 
     test("dispose fails queued waiters without starting another cycle", () async {
@@ -357,9 +482,15 @@ void main() {
         },
       );
 
-      final first = service.triggerRefresh(projectIds: {"one"});
+      final first = service.triggerRefresh(
+        projectIds: {"one"},
+        refreshPolicy: PrRefreshPolicy.explicit,
+      );
       await _waitFor(() => source.selectionCalls.isNotEmpty);
-      final queued = service.triggerRefresh(projectIds: {"one"});
+      final queued = service.triggerRefresh(
+        projectIds: {"one"},
+        refreshPolicy: PrRefreshPolicy.explicit,
+      );
       service.dispose();
 
       expect(await queued, PrRefreshOutcome.failed);
@@ -508,10 +639,18 @@ final class _FakePullRequestRepository implements PullRequestRepository {
   Set<String> localChangedProjectIds = const <String>{};
   Set<String> preparedChangedProjectIds = const <String>{};
   final Map<String, PullRequestReplacementOutcome> replacementOutcomes = <String, PullRequestReplacementOutcome>{};
+  final Map<String, Object> replacementErrors = <String, Object>{};
   final List<({Map<String, List<StoredSession>> sessionsByProject, Map<String, PullRequestDirectoryTarget> targets})>
   applyCalls = [];
   final List<({Set<String> projectIds, String githubLogin})> prepareCalls = [];
-  final List<({String projectId, List<PullRequestTargetSelection> selections})> replaceCalls = [];
+  final List<
+    ({
+      String projectId,
+      Map<String, String> capturedRootDirectories,
+      List<PullRequestTargetSelection> selections,
+    })
+  >
+  replaceCalls = [];
 
   @override
   Future<Set<String>> applyResolvedTargets({
@@ -538,10 +677,16 @@ final class _FakePullRequestRepository implements PullRequestRepository {
   Future<PullRequestReplacementOutcome> replaceScopedPullRequests({
     required String projectId,
     required VerifiedGithubLogin verifiedGithubLogin,
+    required Map<String, String> capturedRootDirectoriesBySessionId,
     required List<PullRequestTargetSelection> targetSelections,
     required int lastCheckedAt,
   }) async {
-    replaceCalls.add((projectId: projectId, selections: List<PullRequestTargetSelection>.from(targetSelections)));
+    replaceCalls.add((
+      projectId: projectId,
+      capturedRootDirectories: Map<String, String>.from(capturedRootDirectoriesBySessionId),
+      selections: List<PullRequestTargetSelection>.from(targetSelections),
+    ));
+    if (replacementErrors[projectId] case final error?) throw error;
     return replacementOutcomes[projectId] ?? const PullRequestReplacementApplied(changed: false);
   }
 

--- a/bridge/app/test/integration/pr_sync_fk_regression_test.dart
+++ b/bridge/app/test/integration/pr_sync_fk_regression_test.dart
@@ -13,8 +13,9 @@
 ///   PullRequestRepository.replaceScopedPullRequests succeeds without FK exception.
 ///
 /// Scenario B — Missing catalog path:
-///   PullRequestRepository.replaceScopedPullRequests preserves the FK failure instead of
-///   fabricating a project row whose path would be inferred from its id.
+///   PullRequestRepository.replaceScopedPullRequests returns a scope-changed
+///   outcome instead of fabricating a project row whose path would be inferred
+///   from its id.
 ///
 /// Scenario C — GetSessions path:
 ///   SessionRepository.getSessionsForProject reads imported bindings without FK
@@ -25,6 +26,7 @@ import "package:sesori_bridge/src/bridge/repositories/models/verified_github_log
 import "package:sesori_bridge/src/bridge/repositories/pull_request_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/repositories/models/pull_request_selection.dart";
+import "package:sesori_bridge/src/repositories/models/pull_request_target.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -71,6 +73,33 @@ void main() {
           updatedAt: 100,
         );
         await projectRepo.getProjects();
+        await db.sessionDao.insertSession(
+          sessionId: "session-X",
+          backendSessionId: "session-X",
+          projectId: "proj-X",
+          isDedicated: false,
+          createdAt: 1,
+          worktreePath: null,
+          branchName: "created-branch",
+          baseBranch: null,
+          baseCommit: null,
+          lastAgent: null,
+          lastAgentModel: null,
+          pluginId: "opencode",
+        );
+        await db.sessionDao.updatePullRequestScopes(
+          updates: const [
+            (
+              sessionId: "session-X",
+              currentBranchName: "feature-branch",
+              currentGithubRepositoryIdentity: _githubRepositoryIdentity,
+            ),
+          ],
+        );
+        await db.projectsDao.setPrCacheGithubLogin(
+          projectId: "proj-X",
+          githubLogin: _githubLogin,
+        );
 
         final projectRows = await db.select(db.projectsTable).get();
         expect(
@@ -82,12 +111,13 @@ void main() {
         // Now scoped replacement must succeed — project row already exists.
         // Direct await (not expectLater) to ensure the future is fully resolved
         // before querying the DB.
-        await prRepo.replaceScopedPullRequests(
+        final outcome = await prRepo.replaceScopedPullRequests(
           projectId: "proj-X",
           verifiedGithubLogin: _verifiedGithubLogin,
           targetSelections: [_selectedPullRequest()],
           lastCheckedAt: 2,
         );
+        expect(outcome, isA<PullRequestReplacementApplied>());
 
         final prRows = await db.pullRequestDao.getPrsByProjectId(projectId: "proj-X");
         expect(
@@ -120,15 +150,13 @@ void main() {
         final emptyRows = await db.select(db.projectsTable).get();
         expect(emptyRows, isEmpty, reason: "projects_table must be empty before the call");
 
-        await expectLater(
-          prRepo.replaceScopedPullRequests(
-            projectId: "ghost",
-            verifiedGithubLogin: _verifiedGithubLogin,
-            targetSelections: [_selectedPullRequest()],
-            lastCheckedAt: 2,
-          ),
-          throwsA(anything),
+        final outcome = await prRepo.replaceScopedPullRequests(
+          projectId: "ghost",
+          verifiedGithubLogin: _verifiedGithubLogin,
+          targetSelections: [_selectedPullRequest()],
+          lastCheckedAt: 2,
         );
+        expect(outcome, isA<PullRequestReplacementScopeChanged>());
 
         final projectRows = await db.select(db.projectsTable).get();
         expect(projectRows, isEmpty);

--- a/bridge/app/test/integration/pr_sync_fk_regression_test.dart
+++ b/bridge/app/test/integration/pr_sync_fk_regression_test.dart
@@ -114,6 +114,7 @@ void main() {
         final outcome = await prRepo.replaceScopedPullRequests(
           projectId: "proj-X",
           verifiedGithubLogin: _verifiedGithubLogin,
+          capturedRootDirectoriesBySessionId: const {"session-X": "proj-X"},
           targetSelections: [_selectedPullRequest()],
           lastCheckedAt: 2,
         );
@@ -153,6 +154,7 @@ void main() {
         final outcome = await prRepo.replaceScopedPullRequests(
           projectId: "ghost",
           verifiedGithubLogin: _verifiedGithubLogin,
+          capturedRootDirectoriesBySessionId: const {},
           targetSelections: [_selectedPullRequest()],
           lastCheckedAt: 2,
         );


### PR DESCRIPTION
## Complexity

🚧 Complex — this changes Git process interpretation, persisted session/PR scope, authenticated cache replacement, and the lifecycle of serialized multi-project refresh generations.

## What

- Resolve each root session's exact persisted directory into typed named-GitHub, named-local, detached, non-git, missing, or failed current-target outcomes; shared directories are resolved once and child sessions receive no independent target.
- Commit current branch/repository scope and invalidate stale selected PR rows atomically before GitHub work, while preserving creation `branch_name` for worktree cleanup.
- Map `Session.branchName` exclusively from persisted current-branch state and retain the existing request-driven cache-first/five-second compatibility behavior.
- Replace per-project active-refresh skipping with one set-based generation drain that batches projects, serializes local/network/write phases, queues post-seal same-project requests, and completes waiters only after a covering generation.
- Fence selected-cache replacement against the persisted exact target set and verified GitHub login, and emit typed rendered changes from both local and network phases.
- Remove creation-branch target generation, project-path/session-directory fallback routing, per-project `inProgress` behavior, and obsolete tests/fakes.

The 3,291 changed lines exceed the soft cap because roughly 1,000 lines delete obsolete per-project/creation-branch service coverage and roughly 700 replace persistence/service tests around the new invariants. Splitting local resolution from the generation drain would ship current-branch presentation with the known post-seal request-drop race.

## Why

PR monitoring must follow the branch currently checked out in each root session directory, not the branch originally created for cleanup. Local state must become visible and stale PR metadata must disappear before a slow or unavailable GitHub query, while concurrent explicit refreshes must not lose a branch switch that occurs after a cycle is sealed.

## Risk and test focus

Risk is high around source-path privacy, detached/missing/non-Git repositories, branch or project-path races, GitHub account changes, atomic cache invalidation, and refresh-generation ordering. Highest-value checks cover dedicated/non-dedicated roots, shared directories, child exclusion, branch-only/detached targets, path movement, account/target replacement fencing, local changes before GitHub failure, multi-project batching, post-seal same-project follow-up, pending-project coalescing, no overlapping selections, debounce behavior, waited request deadlines, and foreign keys.

There is no wire-contract or database-schema change. No scheduler, presence listener, settings API, client UI, or analytics event ships in this step.

## Expected result

- **User-visible:** Request-driven session refreshes display the exact current named branch. Switching branch A to B clears A's PR immediately; detached, missing, or non-git directories display no branch/PR, while a named branch without a GitHub remote still displays its branch. Child sessions have no independent branch/PR association.
- **Persisted/database:** Existing `current_branch_name` and `current_github_repository_identity` fields are updated from exact root directories, stale PR rows are pruned atomically, and selected rows are replaced only while account and target scope still match. Creation `branch_name` and schema v13 remain unchanged.
- **Internal:** Refreshes accept project sets, run one non-overlapping generation drain, batch shared GitHub targets, and emit typed project-rendered changes. Obsolete project-path fallback and active-refresh skipping are removed.

## Verification

- `dart analyze --fatal-infos`
- 79 focused Git API, source, persistence, service, routing, mapper, and integration tests
- `dart test` — all 2,311 bridge app tests passed
- Formatting and `git diff --check` passed

## Architecture review

`aristotle-impl-review` approved the complete working-tree architecture with no findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes session PRs from the exact checked-out branch per root directory, with immediate local persistence and target-based pruning, and emits typed UI updates. Adds explicit/background refresh policies, strict target-scoped cache replacement, caps branch resolution concurrency, bounds the session refresh fallback window, and coalesces background refreshes.

- **New Features**
  - Resolve current branch per root dir with typed results; show local-only branches, hide detached/missing/non-git.
  - Persist `current_branch_name` and repo identity; prune via `deletePrsOutsideTargets` using `{repo, branch}` targets.
  - Replace PRs only within captured targets and verified login; fence writes by captured root directories; emit typed `renderedChanges`.
  - Support `PrRefreshPolicy` (background vs explicit); `get_sessions` triggers explicit refresh while waiting, uses a bounded fallback to re-enrich, and coalesces background refreshes.
  - Standardize outcomes to completed/failed; map `Session.branchName` only from `current_branch_name`.
  - Bound concurrent directory resolutions to 8; cap the refresh fallback reserve to 100ms.

<sup>Written for commit 0579dfd743fa8d0bf21c47fbe76b391000207264. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

