### PR TITLE
🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]

### DIFF
--- a/.plan/active/relay-request-concurrency/PLAN.md
+++ b/.plan/active/relay-request-concurrency/PLAN.md
@@ -7,7 +7,7 @@
   [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) and
   post-merge correction PR
   [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) merged;
-  Step 2 implementation ready for review
+  Step 2 PR [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open
 - **Plan date:** 2026-08-02
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Current implementation base:** `main` at

--- a/.plan/active/relay-request-concurrency/PLAN.md
+++ b/.plan/active/relay-request-concurrency/PLAN.md
@@ -4,13 +4,14 @@
 
 - **Plan slug:** `relay-request-concurrency`
 - **Status:** Active — Step 1 PR
-  [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged;
+  [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) and
   post-merge correction PR
-  [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) open before Step 2
+  [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) merged;
+  Step 2 implementation ready for review
 - **Plan date:** 2026-08-02
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
-- **Implementation base:** `main` at
-  `f6ec9e9dc66782197a46261de3bcc002e261a5bd`
+- **Current implementation base:** `main` at
+  `0e31324a9ec3cbd08d53394d7a1c6e9e3b133b0e`
 - **Delivery:** one plan PR, eight sequential implementation PRs, and one
   plan-retirement PR
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687)

--- a/.plan/active/relay-request-concurrency/PLAN.md
+++ b/.plan/active/relay-request-concurrency/PLAN.md
@@ -93,10 +93,11 @@ long-running testing.
     another surface cannot mutate a partially initialized binding.
 11. Create/open/hide and Git initialization for one canonical project path
     preserve arrival order, while unrelated paths remain independent.
-12. Slow work is observable while it is still running through privacy-safe route
-   templates; logs never include request bodies, headers, query values, source
-   paths, prompts, session IDs, relay-control values, or other raw entity
-   identifiers.
+12. Slow work is observable while it is still running through stable route
+    templates, while local diagnostics retain useful errors, stack traces,
+    paths, connection/session identifiers, and relay-control context. Known
+    prompt/transcript content and other user data with no debugging value stays
+    selectively omitted.
 13. There is no wire-contract, database-schema, persisted-data, client API, or
      analytics change.
 
@@ -293,19 +294,16 @@ RoutedRequestOutcome
 
 The synchronous phase first parses the raw external method into the existing
 closed `HttpMethod` enum, excluding handler-only `any`. Unsupported or malformed
-method text becomes fixed `InvalidMethod` identity and never survives into a
-log label. A known method with an invalid URI uses `InvalidTarget(HttpMethod)`;
+method text becomes fixed `InvalidMethod` identity for routing decisions. A
+known method with an invalid URI uses `InvalidTarget(HttpMethod)`;
 a valid request with no handler uses `Unmatched(HttpMethod)`. A match exposes
-only the handler's declared template, never concrete path parameters or query
-values. No consumer repeats matching or retains a raw method/path for
-diagnostics.
+only the handler's declared template for bounded route categorization. Transport
+consumers may still log the concrete request/control context when diagnostically
+useful; they never log request bodies, headers, prompts, or transcripts.
 
 Step 2 audits every existing route log, not only the new slow timer. Receipt,
-ordinary handler failures, shutdown completion/drain, and debug diagnostics use
-the selected identity; matched handlers may format their own declared
-`HttpMethod` and path template directly. Raw request method/path remains
-available only for protocol parsing, parameter extraction, and response
-construction, never as diagnostic text.
+ordinary handler failures and shutdown completion/drain use the selected identity
+for stable categorization while preserving caught errors and stack traces.
 
 The asynchronous completion preserves current handler/error mapping. Ordinary
 successes, router errors, handler errors, restart preflight failures, unmatched
@@ -597,15 +595,11 @@ settles.
 - A disconnected write can still complete. The client retains its existing
   typed response-loss/uncertain-outcome behavior rather than receiving a false
   cancellation claim.
-- Every router, handler, relay, and debug request diagnostic uses the selected
-  closed method plus handler template (or a fixed message), not raw transport
-  method/path text. Relay-control diagnostics omit client-provided SSE paths and
-  session-view IDs. Each domain-ordering PR also audits all diagnostics reachable
-  from its routed/control inputs, including creation/mutation/auto-approval and
-  project initialization/repository failures; fixed operation labels replace raw
-  paths and identifiers. Logs never include body, headers, query/fragment values,
-  concrete path parameters, prompts, source paths, branch/repository names, or
-  raw identifiers.
+- Local bridge diagnostics preserve useful caught errors, stack traces, concrete
+  request/control paths, connection/session identifiers, and operation context;
+  users decide whether to inspect, anonymize, and share those logs. Audits remove
+  only known user data with no debugging value, such as prompt/transcript content,
+  and do so selectively rather than suppressing whole errors or categories.
 - This is internal reliability work, not a new user action or product-adoption
   question, so no analytics event is added.
 
@@ -736,9 +730,9 @@ concurrency.
 - Parse the external method once into a closed internal `HttpMethod` value, then
   make router matching synchronous and return a pending route with a typed
   matched/unmatched/invalid privacy-safe identity plus asynchronous completion.
-- Audit relay control branches as well as routed work: remove client-provided
-  `RelaySseSubscribe.path` and `RelaySessionView.sessionId` from diagnostics and
-  retain only fixed control-message labels.
+- Audit relay control branches as well as routed work: retain diagnostically
+  useful paths, connection/session identifiers, caught errors, and stack traces
+  while selectively excluding request bodies, headers, prompts, and transcripts.
 - Add sealed `ResponseOnly` and `RestartAccepted` completion variants; the latter
   constructs only the fixed successful restart response from its request ID.
 - Let the restart handler return `RestartAccepted` only for a successful preflight.
@@ -763,8 +757,8 @@ makes concurrent request completion unable to steal or suppress a restart.
 
 Risk is representing restart with an error response, acting before response
 enqueue/HTTP close, acting after a failed preflight, acting twice, losing the
-shutdown signal, disposing its dispatcher under a debug request, exposing raw
-methods/paths, or changing ordinary response/error mapping. Focus on sealed
+shutdown signal, disposing its dispatcher under a debug request, losing useful
+diagnostic context, or changing ordinary response/error mapping. Focus on sealed
 outcome construction, direct shared-dispatcher injection, duplicate handoffs,
 successful/failed handoff signal behavior and disposal, supported/unsupported
 methods, matched/unmatched/invalid-target route identity, concurrent debug
@@ -923,8 +917,8 @@ handlers, auto approval, lifecycle, failure, cleanup, and shutdown.
   intake closes, cancel plugin-event producers, await both the route barrier and
   `_pluginEventProcessingTails`, close acceptance, drain/dispose once, then
   dispose consumers and repositories.
-- Replace raw session/request identifiers in every diagnostic reachable through
-  prompt/abort/pending-choice/auto-approval with fixed operation labels.
+- Preserve useful session/request context and caught failures in these diagnostics;
+  selectively omit prompt/transcript content itself.
 
 ### Why
 
@@ -985,8 +979,8 @@ multi-service shutdown.
   writes, and worktree restoration on that family lane.
 - Preserve cleanup rejection without deletion and remove settled family/backend
   mutation state after failure or completion.
-- Replace raw session/path identifiers in mutation, lifecycle, and repository
-  diagnostics reached by these routes with fixed operation labels.
+- Preserve useful session/path identifiers and caught failures in mutation,
+  lifecycle, and repository diagnostics.
 - Replace direct-session/global-order tests with both root/child arrival orders,
   archive/delete inversion, and unrelated-root parallelism.
 
@@ -1045,8 +1039,8 @@ failure, exactly-once publication, and restart recovery.
   failure paths, before returning or rethrowing the current route outcome.
 - On process restart, treat committed rows as visible recovery state; add no
   schema field, backfill, callback, or wire change.
-- Replace raw session/path identifiers in creation/repository diagnostics reached
-  by this workflow with fixed operation labels.
+- Preserve useful session/path identifiers and caught failures in creation and
+  repository diagnostics while omitting prompt content.
 
 ### Why
 
@@ -1101,8 +1095,8 @@ cleanup, and shutdown.
 - Preserve existing typed HTTP outcomes and project IDs, remove idle lanes, and
   assign acceptance/drain/disposal to `OrchestratorSession` after the shared
   route barrier.
-- Replace raw project paths/IDs in every diagnostic reachable through the three
-  workflows with fixed operation labels.
+- Preserve useful project paths/IDs and caught failures in diagnostics reachable
+  through these workflows.
 - Do not add symlink-wide filesystem canonicalization without evidence.
 
 ### Why
@@ -1165,10 +1159,10 @@ draining on top of the already-landed route, ordering, and relay-epoch contracts
 - Detach and track initial SSE summary construction after synchronous subscribe,
   but enqueue it on the existing summary-ordering tail before building so an
   older snapshot cannot broadcast after a newer one.
-- Add ongoing privacy-safe slow-route diagnostics and honest multi-operation
-  shutdown diagnostics.
-- Run a final diagnostic audit proving routed/control values cannot reach raw
-  logging in the touched request, session, or project call graphs.
+- Add ongoing stable slow-route diagnostics and honest multi-operation shutdown
+  diagnostics without discarding useful local context.
+- Run a final diagnostic audit that preserves errors, stack traces, paths, and
+  identifiers while selectively omitting known prompt/transcript content.
 - Drain session-owned completion work plus the shared dispatcher barrier before
   route-owned dependencies are disposed.
 
@@ -1282,7 +1276,7 @@ product suite applies.
 | Same-path Git setup overlaps | Keep directory/Git setup inside the canonical project-path lane. |
 | Overlapping initial summaries regress client activity | Put initial builds and broadcasts on the existing summary-ordering tail while detaching that tracked work from frame ingestion. |
 | Concurrent mutation corrupts session order | Keep explicit root-family lanes, whole-workflow reservation, and transactional repository writes. |
-| Raw request/control input reaches local logs | Parse methods to a closed enum and use only fixed identities/templates; omit SSE paths and session-view IDs from control diagnostics. |
+| Diagnostics lose useful request/control context | Keep closed route categorization while retaining errors, stacks, paths, and identifiers; selectively omit known prompt/transcript content. |
 | Synchronous plugin code blocks the isolate | Keep synchronous work bounded; isolate/process redesign requires separate evidence and plan. |
 | PR #686 changes adjacent code | Rebase every step on current `main`, audit overlap, and keep this implementation out of the feature PR. |
 

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -89,7 +89,7 @@
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
 | [x] | 1/10 | `plan/relay-request-concurrency` | `🌱 [relay-request-concurrency] docs: plan concurrent bridge requests [step 1/10]` | 1,400–1,600; explicitly cap-exempt | [PR #687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged as `c4d42a15`; correction [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) merged as `0e31324a` |
-| [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | [PR #690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open at 1,432 changed lines |
+| [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | [PR #690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open at 1,523 changed lines |
 | [ ] | 3/10 | `relay-request-concurrency-route-lifecycle` | `🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]` | 600–1,000 | Blocked on Step 2 merge |
 | [ ] | 4/10 | `relay-request-concurrency-relay-epochs` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | Blocked on Step 3 merge |
 | [ ] | 5/10 | `relay-request-concurrency-session-actions` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | Blocked on Step 4 merge |
@@ -124,8 +124,8 @@
 - Restart handoff becomes a sealed valid-only outcome belonging to its exact
   route; only successful acceptance can construct the fixed restart response.
 - Route identity is selected synchronously by `RequestRouter` before completion;
-  external methods parse to a closed enum and no route diagnostic retains raw
-  method/path text. Relay-control logs also omit SSE paths and session-view IDs.
+  external methods parse to a closed enum for decisions while local diagnostics
+  retain useful request/control context, errors, stack traces, and identifiers.
 - Relay and debug routing share one dispatcher acceptance/drain barrier before
   shared dependencies are disposed.
 - Layer-0 relay reads/sends/closes use an opaque exact-connection handle; final
@@ -178,22 +178,20 @@
 ## Cleanup Outcomes Planned
 
 - **Step 2:** remove global restart-request flag, forwarded handoff callback,
-  serial-routing comments, and every request/control diagnostic that formats raw
-  transport method/path/session text.
+  serial-routing comments, and diagnostics that discarded useful caught errors.
 - **Step 3:** replace separate relay/debug route completion ownership with one
   shared lifecycle barrier.
 - **Step 4:** replace mutable-current-channel relay operations with explicit
   exact-connection handles.
 - **Step 5:** replace accidental relay-loop prompt/default/abort and pending-choice
-  ordering with one explicit plugin-scoped family/interaction owner; sanitize
-  diagnostics in that call graph.
+  ordering with one explicit plugin-scoped family/interaction owner; omit prompt
+  content selectively while preserving useful diagnostics.
 - **Step 6:** remove global session mutation tails and individual-session scope;
-  reserve complete family lifecycle workflows and sanitize touched diagnostics.
+  reserve complete family lifecycle workflows and retain useful diagnostics.
 - **Step 7:** replace eager visibility with a repository-owned unpublished token
-  and atomic reveal; sanitize creation diagnostics.
+  and atomic reveal; retain useful creation diagnostics.
 - **Step 8:** replace handler-level project workflow coordination and direct hide
-  persistence with one canonical-path service/dispatcher; sanitize touched
-  diagnostics.
+  persistence with one canonical-path service/dispatcher; retain useful diagnostics.
 - **Step 9:** remove the single in-flight request label and completion-only,
   shutdown-mislabeled slow-route diagnostic.
 - **No cleanup:** wire fields, database data, plugin leases/generations, request
@@ -226,15 +224,22 @@
 - **Step 2/10 verification:** 87 focused router/restart/service/dispatcher,
   debug, encrypted relay ordering/graceful-close, runtime-composition, and
   diagnostic capture tests passed. `dart analyze --fatal-infos` from `bridge/app` and
-  `git diff --check` passed. Actual change size: 1,432 lines; PR
+  `git diff --check` passed. Actual change size: 1,523 lines; PR
   [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open.
 - **Step 2/10 architecture review:** `aristotle-impl-review` rejected one valid
   service-to-routing dependency. Moving `BridgeRestartDispatcher` and its test
   beside the routing outcome applied the finding directly; per policy, the fix
   was not re-reviewed.
 - **Step 2/10 PR review:** five bot threads produced two valid corrections:
-  new routing APIs now use required named parameters, and handler diagnostics
-  retain only the closed route label rather than forwarding caught errors.
+  new routing APIs now use required named parameters, and route labels remain
+  closed for stable categorization.
   Two duplicate send-failure threads were declined because accepted restart
   explicitly survives delivery failure; the dispatcher-disposal race was
   declined because runtime disposal starts only after relay/debug route drains.
+- **Step 2/10 owner logging direction:** local logs now retain useful caught
+  errors, stack traces, paths, and connection/session/control identifiers. The
+  plan and root `AGENTS.md` require selective removal only for known user data
+  without debugging value; broad precautionary suppression is no longer allowed.
+- **Step 2/10 cap exception:** the owner's review-requested repo-wide logging
+  rule and matching plan/code corrections raised the PR 23 lines above the soft
+  cap; splitting them would leave this PR governed by contradictory diagnostics.

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -89,7 +89,7 @@
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
 | [x] | 1/10 | `plan/relay-request-concurrency` | `🌱 [relay-request-concurrency] docs: plan concurrent bridge requests [step 1/10]` | 1,400–1,600; explicitly cap-exempt | [PR #687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged as `c4d42a15`; correction [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) merged as `0e31324a` |
-| [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | [PR #690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open at 1,523 changed lines |
+| [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | [PR #690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open at 1,547 changed lines |
 | [ ] | 3/10 | `relay-request-concurrency-route-lifecycle` | `🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]` | 600–1,000 | Blocked on Step 2 merge |
 | [ ] | 4/10 | `relay-request-concurrency-relay-epochs` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | Blocked on Step 3 merge |
 | [ ] | 5/10 | `relay-request-concurrency-session-actions` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | Blocked on Step 4 merge |
@@ -224,7 +224,7 @@
 - **Step 2/10 verification:** 87 focused router/restart/service/dispatcher,
   debug, encrypted relay ordering/graceful-close, runtime-composition, and
   diagnostic capture tests passed. `dart analyze --fatal-infos` from `bridge/app` and
-  `git diff --check` passed. Actual change size: 1,523 lines; PR
+  `git diff --check` passed. Actual change size: 1,547 lines; PR
   [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open.
 - **Step 2/10 architecture review:** `aristotle-impl-review` rejected one valid
   service-to-routing dependency. Moving `BridgeRestartDispatcher` and its test
@@ -239,7 +239,8 @@
 - **Step 2/10 owner logging direction:** local logs now retain useful caught
   errors, stack traces, paths, and connection/session/control identifiers. The
   plan and root `AGENTS.md` require selective removal only for known user data
-  without debugging value; broad precautionary suppression is no longer allowed.
+  without debugging value; the bridge logger now emits attached errors/stacks at
+  its default info threshold rather than hiding them below debug verbosity.
 - **Step 2/10 cap exception:** the owner's review-requested repo-wide logging
-  rule and matching plan/code corrections raised the PR 23 lines above the soft
+  rule and matching plan/code corrections raised the PR 47 lines above the soft
   cap; splitting them would leave this PR governed by contradictory diagnostics.

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -89,7 +89,7 @@
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
 | [x] | 1/10 | `plan/relay-request-concurrency` | `🌱 [relay-request-concurrency] docs: plan concurrent bridge requests [step 1/10]` | 1,400–1,600; explicitly cap-exempt | [PR #687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged as `c4d42a15`; correction [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) merged as `0e31324a` |
-| [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | [PR #690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open at 1,418 changed lines |
+| [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | [PR #690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open at 1,432 changed lines |
 | [ ] | 3/10 | `relay-request-concurrency-route-lifecycle` | `🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]` | 600–1,000 | Blocked on Step 2 merge |
 | [ ] | 4/10 | `relay-request-concurrency-relay-epochs` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | Blocked on Step 3 merge |
 | [ ] | 5/10 | `relay-request-concurrency-session-actions` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | Blocked on Step 4 merge |
@@ -226,9 +226,15 @@
 - **Step 2/10 verification:** 87 focused router/restart/service/dispatcher,
   debug, encrypted relay ordering/graceful-close, runtime-composition, and
   diagnostic capture tests passed. `dart analyze --fatal-infos` from `bridge/app` and
-  `git diff --check` passed. Actual change size: 1,418 lines; PR
+  `git diff --check` passed. Actual change size: 1,432 lines; PR
   [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open.
 - **Step 2/10 architecture review:** `aristotle-impl-review` rejected one valid
   service-to-routing dependency. Moving `BridgeRestartDispatcher` and its test
   beside the routing outcome applied the finding directly; per policy, the fix
   was not re-reviewed.
+- **Step 2/10 PR review:** five bot threads produced two valid corrections:
+  new routing APIs now use required named parameters, and handler diagnostics
+  retain only the closed route label rather than forwarding caught errors.
+  Two duplicate send-failure threads were declined because accepted restart
+  explicitly survives delivery failure; the dispatcher-disposal race was
+  declined because runtime disposal starts only after relay/debug route drains.

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -8,9 +8,10 @@
 - **Series state:** Step 1/10 plan PR
   [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) and correction
   [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) merged
-- **Current step:** Step 2/10 implemented and ready for review; PR link pending
+- **Current step:** Step 2/10 PR
+  [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged
-- **Next action:** commit, push, and open the Step 2 PR
+- **Next action:** review and merge Step 2, then start Step 3 from current `main`
 
 ## Incident Evidence
 
@@ -88,7 +89,7 @@
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
 | [x] | 1/10 | `plan/relay-request-concurrency` | `🌱 [relay-request-concurrency] docs: plan concurrent bridge requests [step 1/10]` | 1,400–1,600; explicitly cap-exempt | [PR #687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged as `c4d42a15`; correction [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) merged as `0e31324a` |
-| [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | Implementation complete at 1,416 changed lines; PR link pending |
+| [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | [PR #690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open at 1,418 changed lines |
 | [ ] | 3/10 | `relay-request-concurrency-route-lifecycle` | `🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]` | 600–1,000 | Blocked on Step 2 merge |
 | [ ] | 4/10 | `relay-request-concurrency-relay-epochs` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | Blocked on Step 3 merge |
 | [ ] | 5/10 | `relay-request-concurrency-session-actions` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | Blocked on Step 4 merge |
@@ -225,7 +226,8 @@
 - **Step 2/10 verification:** 87 focused router/restart/service/dispatcher,
   debug, encrypted relay ordering/graceful-close, runtime-composition, and
   diagnostic capture tests passed. `dart analyze --fatal-infos` from `bridge/app` and
-  `git diff --check` passed. Actual change size: 1,416 lines; PR link pending.
+  `git diff --check` passed. Actual change size: 1,418 lines; PR
+  [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open.
 - **Step 2/10 architecture review:** `aristotle-impl-review` rejected one valid
   service-to-routing dependency. Moving `BridgeRestartDispatcher` and its test
   beside the routing outcome applied the finding directly; per policy, the fix

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -4,15 +4,13 @@
 
 - **Plan slug:** `relay-request-concurrency`
 - **Implementation base:** `main` at
-  `f6ec9e9dc66782197a46261de3bcc002e261a5bd`
+  `0e31324a9ec3cbd08d53394d7a1c6e9e3b133b0e`
 - **Series state:** Step 1/10 plan PR
-  [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged
-  as `c4d42a152d52d6aa2e3479b8f445d622bbe4b9a5`; post-merge correction
-  [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) open
-- **Current step:** Post-merge plan correction PR #688 before Step 2/10
+  [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) and correction
+  [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) merged
+- **Current step:** Step 2/10 implemented and ready for review; PR link pending
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged
-- **Next action:** merge the post-review correction, then start Step 2 from
-  current `main`
+- **Next action:** commit, push, and open the Step 2 PR
 
 ## Incident Evidence
 
@@ -82,15 +80,15 @@
   sent/stale/send-failure disposition rather than suppressing it with delivery
 - **Delivery impact:** no fixed step title, denominator, branch, or line budget
   changes; documentation-only correction
-  [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) must merge
-  before Step 2 begins
+  [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) merged as
+  `0e31324a9ec3cbd08d53394d7a1c6e9e3b133b0e`
 
 ## Delivery Steps
 
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
-| [x] | 1/10 | `plan/relay-request-concurrency` | `🌱 [relay-request-concurrency] docs: plan concurrent bridge requests [step 1/10]` | 1,400–1,600; explicitly cap-exempt | [PR #687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged as `c4d42a15`; correction [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) open |
-| [ ] | 2/10 | `relay-request-concurrency-route-outcomes` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | Blocked on post-merge plan correction |
+| [x] | 1/10 | `plan/relay-request-concurrency` | `🌱 [relay-request-concurrency] docs: plan concurrent bridge requests [step 1/10]` | 1,400–1,600; explicitly cap-exempt | [PR #687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged as `c4d42a15`; correction [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) merged as `0e31324a` |
+| [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | Implementation complete at 1,416 changed lines; PR link pending |
 | [ ] | 3/10 | `relay-request-concurrency-route-lifecycle` | `🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]` | 600–1,000 | Blocked on Step 2 merge |
 | [ ] | 4/10 | `relay-request-concurrency-relay-epochs` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | Blocked on Step 3 merge |
 | [ ] | 5/10 | `relay-request-concurrency-session-actions` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | Blocked on Step 4 merge |
@@ -215,3 +213,20 @@
   changed lines and 10/10 checks passing. Exact titles/branches/step totals and
   `git diff --check` passed; the user explicitly exempted this first
   plan-containing PR from the 1,500-line soft cap.
+- **Step 2/10 base and overlap:** based on `main` at `0e31324a`; adjacent PR
+  #686 was already merged at `3bbb1e8e`, so its orchestrator changes were part
+  of the base and no open overlap remained. The session-provided dedicated
+  `plan-parallel-requests` branch replaced the originally planned branch name.
+- **Step 2/10 implementation:** synchronous typed route selection now exposes
+  closed matched/unmatched/invalid identities and sealed asynchronous ordinary
+  or valid-only restart outcomes. One shared restart dispatcher owns duplicate
+  handoff suppression, service invocation, typed shutdown emission, and runtime
+  disposal after relay/debug drains; the flag and callback wiring are removed.
+- **Step 2/10 verification:** 87 focused router/restart/service/dispatcher,
+  debug, encrypted relay ordering/graceful-close, runtime-composition, and
+  diagnostic capture tests passed. `dart analyze --fatal-infos` from `bridge/app` and
+  `git diff --check` passed. Actual change size: 1,416 lines; PR link pending.
+- **Step 2/10 architecture review:** `aristotle-impl-review` rejected one valid
+  service-to-routing dependency. Moving `BridgeRestartDispatcher` and its test
+  beside the routing outcome applied the finding directly; per policy, the fix
+  was not re-reviewed.

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -89,7 +89,7 @@
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
 | [x] | 1/10 | `plan/relay-request-concurrency` | `🌱 [relay-request-concurrency] docs: plan concurrent bridge requests [step 1/10]` | 1,400–1,600; explicitly cap-exempt | [PR #687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged as `c4d42a15`; correction [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) merged as `0e31324a` |
-| [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | [PR #690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open at 1,547 changed lines |
+| [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | [PR #690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open at 1,552 changed lines |
 | [ ] | 3/10 | `relay-request-concurrency-route-lifecycle` | `🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]` | 600–1,000 | Blocked on Step 2 merge |
 | [ ] | 4/10 | `relay-request-concurrency-relay-epochs` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | Blocked on Step 3 merge |
 | [ ] | 5/10 | `relay-request-concurrency-session-actions` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | Blocked on Step 4 merge |
@@ -224,7 +224,7 @@
 - **Step 2/10 verification:** 87 focused router/restart/service/dispatcher,
   debug, encrypted relay ordering/graceful-close, runtime-composition, and
   diagnostic capture tests passed. `dart analyze --fatal-infos` from `bridge/app` and
-  `git diff --check` passed. Actual change size: 1,547 lines; PR
+  `git diff --check` passed. Actual change size: 1,552 lines; PR
   [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open.
 - **Step 2/10 architecture review:** `aristotle-impl-review` rejected one valid
   service-to-routing dependency. Moving `BridgeRestartDispatcher` and its test
@@ -242,5 +242,5 @@
   without debugging value; the bridge logger now emits attached errors/stacks at
   its default info threshold rather than hiding them below debug verbosity.
 - **Step 2/10 cap exception:** the owner's review-requested repo-wide logging
-  rule and matching plan/code corrections raised the PR 47 lines above the soft
+  rule and matching plan/code corrections raised the PR 52 lines above the soft
   cap; splitting them would leave this PR governed by contradictory diagnostics.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,12 @@ eagerly "just in case."
   internal contracts; update every in-repository consumer in lockstep instead.
 - A recovered failure that continues must remain observable. Do not add a
   redundant log when the error is rethrown or returned as an explicit failure.
+- Preserve diagnostically useful errors, stack traces, paths, identifiers, and
+  operation context in local bridge and client logs. Logs are not submitted
+  automatically; users choose whether to inspect, anonymize, and share them.
+  Strip only known user data that has no debugging value (for example prompt or
+  transcript content), and remove that field selectively rather than suppressing
+  an entire error or category because it might contain sensitive data.
 - When translating a caught error into another error, retain the original in a
   typed `innerError` or `cause` field instead of discarding it. Keep the
   wrapper's presentation privacy-safe when the original may contain sensitive

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,8 @@ eagerly "just in case."
   internal contracts; update every in-repository consumer in lockstep instead.
 - A recovered failure that continues must remain observable. Do not add a
   redundant log when the error is rethrown or returned as an explicit failure.
+- A failure response sent to a remote client does not replace a useful local log
+  when only that log retains the original error, stack trace, or operation context.
 - Preserve diagnostically useful errors, stack traces, paths, identifiers, and
   operation context in local bridge and client logs. Logs are not submitted
   automatically; users choose whether to inspect, anonymize, and share them.

--- a/bridge/app/lib/src/bridge/debug_server.dart
+++ b/bridge/app/lib/src/bridge/debug_server.dart
@@ -6,15 +6,15 @@ import "package:rxdart/rxdart.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Console, Log;
 import "package:sesori_shared/sesori_shared.dart";
 
-import "../server/services/bridge_restart_service.dart";
+import "routing/bridge_restart_dispatcher.dart";
 import "routing/request_router.dart";
+import "routing/routed_request.dart";
 
 class DebugServer {
   final Stream<SesoriSseEvent> _localWireEvents;
   final RequestRouter _router;
   final FailureReporter _failureReporter;
-  final BridgeRestartService _restartService;
-  final Future<void> Function() _restartHandoff;
+  final BridgeRestartDispatcher _restartDispatcher;
   final Future<void> Function() _drainRoutedMutations;
   final int port;
   final List<HttpResponse> _sseClients = [];
@@ -36,14 +36,12 @@ class DebugServer {
     required RequestRouter router,
     required this.port,
     required FailureReporter failureReporter,
-    required BridgeRestartService restartService,
-    required Future<void> Function() restartHandoff,
+    required BridgeRestartDispatcher restartDispatcher,
     required Future<void> Function() drainRoutedMutations,
   }) : _localWireEvents = localWireEvents,
        _router = router,
        _failureReporter = failureReporter,
-       _restartService = restartService,
-       _restartHandoff = restartHandoff,
+       _restartDispatcher = restartDispatcher,
        _drainRoutedMutations = drainRoutedMutations;
 
   int? get boundPort => _server?.port;
@@ -128,11 +126,8 @@ class DebugServer {
   }
 
   Future<void> _handleHTTP(HttpRequest request) async {
-    // Whether the request just routed armed a bridge restart. Consumed
-    // synchronously right after routing so a concurrently-handled relay request
-    // cannot steal the shared flag before this handler triggers the handoff.
-    bool restartRequested = false;
-    Future<RelayResponse>? routeToDrain;
+    RoutedRequestOutcome? completedOutcome;
+    Future<RoutedRequestOutcome>? routeToDrain;
     try {
       final rawBody = await utf8.decoder.bind(request).join();
       final body = rawBody.isEmpty ? null : rawBody;
@@ -152,17 +147,17 @@ class DebugServer {
               )
               as RelayRequest;
 
-      final route = _router.route(relayRequest);
-      final message = await Future.any<RelayResponse?>([
+      final pendingRoute = _router.route(relayRequest);
+      final route = pendingRoute.completion;
+      final outcome = await Future.any<RoutedRequestOutcome?>([
         route,
-        _shutdownSignal.future.then<RelayResponse?>((_) => null),
+        _shutdownSignal.future.then<RoutedRequestOutcome?>((_) => null),
       ]);
-      if (message == null) {
+      if (outcome == null) {
         routeToDrain = route;
       } else {
-        // The RestartBridgeHandler arms the shared restart flag during routing;
-        // consume it now, attributed to this request, mirroring the relay path.
-        restartRequested = _restartService.consumeRestartRequest();
+        completedOutcome = outcome;
+        final message = outcome.response;
         request.response.statusCode = message.status;
         // Skip hop-by-hop and length headers — dart:io sets them
         // automatically based on the actual response body written.
@@ -178,11 +173,19 @@ class DebugServer {
           request.response.add(utf8.encode(message.body!));
         }
       }
-    } catch (e) {
-      request.response.statusCode = HttpStatus.badGateway;
-      request.response.add(utf8.encode("Debug server proxy error: $e"));
+    } on Object catch (error, stackTrace) {
+      if (completedOutcome is RestartAccepted) {
+        Log.w("debug restart response write failed", error, stackTrace);
+      } else {
+        request.response.statusCode = HttpStatus.badGateway;
+        request.response.add(utf8.encode("Debug server proxy error: $error"));
+      }
     } finally {
-      await request.response.close();
+      try {
+        await request.response.close();
+      } on Object catch (error, stackTrace) {
+        Log.w("debug HTTP response close failed", error, stackTrace);
+      }
     }
 
     if (routeToDrain != null) {
@@ -190,19 +193,15 @@ class DebugServer {
       return;
     }
 
-    // Drive the handoff only after the `{restarting:true}` reply has been
-    // flushed and closed, so the debug client receives the response before this
-    // process spawns its successor and shuts down. The handoff itself is owned
-    // by the orchestrator and injected as an action, so a debug
-    // `POST /global/restart` behaves identically to a phone-triggered restart.
-    if (restartRequested) {
-      // The response is already closed, so a handoff failure has nowhere to go —
-      // log it instead of letting it escape this listen callback unhandled.
-      try {
-        await _restartHandoff();
-      } on Object catch (error, stackTrace) {
-        Log.w("debug server restart handoff failed: $error", error, stackTrace);
-      }
+    switch (completedOutcome) {
+      case null || ResponseOnly():
+        break;
+      case final RestartAccepted accepted:
+        try {
+          await _restartDispatcher.dispatch(restart: accepted);
+        } on Object catch (error, stackTrace) {
+          Log.w("debug server restart handoff failed", error, stackTrace);
+        }
     }
   }
 

--- a/bridge/app/lib/src/bridge/debug_server.dart
+++ b/bridge/app/lib/src/bridge/debug_server.dart
@@ -147,7 +147,7 @@ class DebugServer {
               )
               as RelayRequest;
 
-      final pendingRoute = _router.route(relayRequest);
+      final pendingRoute = _router.route(request: relayRequest);
       final route = pendingRoute.completion;
       final outcome = await Future.any<RoutedRequestOutcome?>([
         route,

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -75,6 +75,7 @@ import "repositories/session_unseen_repository.dart";
 import "repositories/trackers/session_event_tracker.dart";
 import "repositories/worktree_repository.dart";
 import "routing/abort_session_handler.dart";
+import "routing/bridge_restart_dispatcher.dart";
 import "routing/create_directory_handler.dart";
 import "routing/create_project_handler.dart";
 import "routing/create_session_handler.dart";
@@ -108,6 +109,7 @@ import "routing/reply_to_permission_handler.dart";
 import "routing/reply_to_question_handler.dart";
 import "routing/request_router.dart";
 import "routing/restart_bridge_handler.dart";
+import "routing/routed_request.dart";
 import "routing/send_prompt_handler.dart";
 import "routing/set_base_branch_handler.dart";
 import "routing/update_session_archive_status_handler.dart";
@@ -137,6 +139,7 @@ typedef OrchestratorComposition = ({
   CatalogImportService catalogImportService,
   PluginCatalogHydrationListener catalogHydrationListener,
   DeletedSessionStorageCleanupService deletedSessionStorageCleanupService,
+  BridgeRestartDispatcher restartDispatcher,
   SessionRepository sessionRepository,
   SessionUnseenService sessionUnseenService,
   SessionViewTracker sessionViewTracker,
@@ -449,6 +452,7 @@ class Orchestrator {
       sessionBindingCommitListener.start();
       sessionDeletionListener.start();
     });
+    final restartDispatcher = BridgeRestartDispatcher(restartService: _restartService);
     final router = RequestRouter(
       handlers: [
         HealthCheckHandler(healthRepository: healthRepository),
@@ -557,7 +561,7 @@ class Orchestrator {
       permissionAutoApprovalService: permissionAutoApprovalService,
       sessionAbortService: sessionAbortService,
       sessionMutationDispatcher: sessionMutationDispatcher,
-      restartService: _restartService,
+      restartDispatcher: restartDispatcher,
       statusNotifier: _statusNotifier,
     );
     return (
@@ -565,6 +569,7 @@ class Orchestrator {
       catalogImportService: catalogImportService,
       catalogHydrationListener: catalogHydrationListener,
       deletedSessionStorageCleanupService: deletedSessionStorageCleanupService,
+      restartDispatcher: restartDispatcher,
       sessionRepository: sessionRepository,
       sessionUnseenService: sessionUnseenService,
       sessionViewTracker: sessionViewTracker,
@@ -626,7 +631,7 @@ class OrchestratorSession {
   // ignore: cancel_subscriptions - cancelled by the failure-isolated session drain.
   final CompositeSubscription _catalogImportSubscriptions = CompositeSubscription();
   final ProjectActivityService _projectActivityService;
-  final BridgeRestartService _restartService;
+  final BridgeRestartDispatcher _restartDispatcher;
   final ControlStatusNotifier? _statusNotifier;
   // ignore: cancel_subscriptions - cancelled by the failure-isolated session drain.
   final CompositeSubscription _subscriptions = CompositeSubscription();
@@ -639,18 +644,12 @@ class OrchestratorSession {
   Object? _beginShutdownError;
   StackTrace? _beginShutdownStackTrace;
 
-  /// Guards [handleRestartHandoff] so concurrent relay + debug restart triggers
-  /// spawn at most one successor.
-  bool _restartHandoffStarted = false;
-
   /// When the first [cancel] was requested. Used only for shutdown timing
   /// diagnostics (the logger emits no timestamps, so durations are explicit).
   DateTime? _cancelRequestedAt;
 
-  /// Label ("METHOD path") of the relay request currently being routed, or
-  /// `null` when the read loop is idle. Surfaces which in-flight request is
-  /// blocking the read loop when a shutdown is requested mid-route.
-  String? _inFlightRequestLabel;
+  /// Privacy-safe identity of the relay request currently being routed.
+  RouteIdentity? _inFlightRouteIdentity;
 
   /// Completes when [cancel] is first called. Allows in-flight request routing
   /// to abandon a response instead of awaiting an OpenCode HTTP call that has
@@ -693,7 +692,7 @@ class OrchestratorSession {
     required PermissionAutoApprovalService permissionAutoApprovalService,
     required SessionAbortService sessionAbortService,
     required SessionMutationDispatcher sessionMutationDispatcher,
-    required BridgeRestartService restartService,
+    required BridgeRestartDispatcher restartDispatcher,
     required ControlStatusNotifier? statusNotifier,
   }) : _client = client,
        _pluginEvents = pluginEvents,
@@ -726,8 +725,20 @@ class OrchestratorSession {
        _sessionMutationDispatcher = sessionMutationDispatcher,
        _sessionAbortService = sessionAbortService,
        _projectActivityService = projectActivityService,
-       _restartService = restartService,
+       _restartDispatcher = restartDispatcher,
        _statusNotifier = statusNotifier {
+    _restartDispatcher.shutdownRequests
+        .listen((request) {
+          switch (request) {
+            case BridgeShutdownRequest.restart:
+              unawaited(
+                cancel().catchError((Object error, StackTrace stackTrace) {
+                  Log.w("[restart] failed to cancel the session", error, stackTrace);
+                }),
+              );
+          }
+        })
+        .addTo(_subscriptions);
     catalogImportProgress
         .listen((progress) {
           _enqueueWireEvent(SesoriSseEvent.catalogImportProgress(progress: progress));
@@ -964,7 +975,7 @@ class OrchestratorSession {
     Log.d(
       "[shutdown] session teardown begin "
       "(${sinceCancelMs == null ? "no cancel timestamp" : "${sinceCancelMs}ms since cancel()"}"
-      "${_inFlightRequestLabel == null ? "" : ", in-flight request: $_inFlightRequestLabel"})",
+      "${_inFlightRouteIdentity == null ? "" : ", in-flight request: ${_inFlightRouteIdentity!.diagnosticLabel}"})",
     );
     await Future.wait([
       attempt(_subscriptions.cancel),
@@ -1125,7 +1136,7 @@ class OrchestratorSession {
       _cancelRequestedAt = DateTime.now();
       Log.d(
         "[shutdown] cancel() requested"
-        "${_inFlightRequestLabel == null ? "" : " — in-flight request: $_inFlightRequestLabel"}",
+        "${_inFlightRouteIdentity == null ? "" : " — in-flight request: ${_inFlightRouteIdentity!.diagnosticLabel}"}",
       );
     } else {
       Log.v("[shutdown] cancel() again (already shutting down)");
@@ -1148,48 +1159,6 @@ class OrchestratorSession {
     final sw = Stopwatch()..start();
     await _client.close();
     Log.d("[shutdown] cancel(): relay client closed in ${sw.elapsedMilliseconds}ms");
-  }
-
-  /// Performs the restart handoff after the `{restarting:true}` reply has been
-  /// enqueued: delegates the run-mode strategy to [BridgeRestartService]
-  /// (standalone spawns a successor; supervised records the GUI-respawn intent),
-  /// then drives the normal graceful shutdown ([cancel]) — which flushes the
-  /// queued reply by closing the relay and lets this process exit. A standalone
-  /// successor waits for this pid to exit before it enforces single-live-bridge,
-  /// so the handoff is clean; the supervised exit code is applied by the
-  /// composition root once the session ends.
-  ///
-  /// Public because both restart triggers drive the same handoff: the relay
-  /// request loop (below) and the local [DebugServer], which reuses this
-  /// session's [RequestRouter] and so reaches the same `RestartBridgeHandler`.
-  Future<void> handleRestartHandoff() async {
-    // Single-flight: the relay and debug-server triggers share the same restart
-    // flag but run independently, so without this guard two near-simultaneous
-    // `POST /global/restart` requests could each spawn a successor. The flag is
-    // set synchronously (no await before it), so the check-and-set is atomic on
-    // the event loop. It is reset only when the spawn fails and we keep running,
-    // so a later restart can retry.
-    if (_restartHandoffStarted) {
-      Log.v("[restart] handoff already in progress; ignoring duplicate trigger");
-      return;
-    }
-    _restartHandoffStarted = true;
-    Log.i("[restart] restart requested");
-    // The restart service owns the run-mode strategy: standalone spawns a
-    // successor process; supervised records the intent so the composition root
-    // exits with the GUI-respawn sentinel (no successor spawn). A `false` return
-    // means the standalone successor could not be started, so we keep running.
-    final bool proceed = await _restartService.performRestartHandoff();
-    if (!proceed) {
-      _restartHandoffStarted = false;
-      Console.error(
-        "Restart requested but a new bridge could not be started; continuing to run. "
-        "Re-run the install script if this persists: https://sesori.com/",
-      );
-      return;
-    }
-    Log.i("[restart] handing off; shutting down");
-    await cancel();
   }
 
   Future<void> _processPluginEventInOrder(NormalizedSourcedBridgeEvent source) {
@@ -1621,24 +1590,23 @@ class OrchestratorSession {
           Map<String, dynamic> control;
           try {
             control = jsonDecodeMap(utf8.decode(msg.data));
-          } catch (e) {
-            Log.e("failed to parse control message: $e");
+          } catch (_) {
+            Log.v("failed to parse relay control message");
             break processMessage;
           }
 
           final type = control["type"] as String?;
           final connID = control["connId"] as int?;
-          Log.v("control: type=$type connID=$connID");
           if (type == null || connID == null) {
-            Log.v("dropping control: null type or connID");
+            Log.v("dropping relay control message with missing fields");
             break processMessage;
           }
 
           switch (type) {
             case "phone_connected":
-              Log.v("phone_connected connID=$connID");
+              Log.v("RelayPhoneConnected");
             case "phone_disconnected":
-              Log.v("phone_disconnected connID=$connID");
+              Log.v("RelayPhoneDisconnected");
               activePhones.remove(connID);
               _sseManager.removeSubscriber(connID);
               _sessionViewTracker.releaseConnection(connID: connID);
@@ -1799,8 +1767,8 @@ class OrchestratorSession {
       msg = RelayMessage.fromJson(
         jsonDecodeMap(utf8.decode(decrypted)),
       );
-    } catch (e) {
-      Log.v("failed to parse decrypted msg from connID=$connID: $e");
+    } catch (_) {
+      Log.v("failed to parse encrypted relay message");
       return;
     }
 
@@ -1808,52 +1776,51 @@ class OrchestratorSession {
 
     switch (msg) {
       case final RelayRequest req:
-        Log.v("RelayRequest: ${req.method} ${req.path}");
-        _inFlightRequestLabel = "${req.method} ${req.path}";
+        final pendingRoute = _router.route(req);
+        final routeIdentity = pendingRoute.routeIdentity;
+        Log.v("RelayRequest: ${routeIdentity.diagnosticLabel}");
+        _inFlightRouteIdentity = routeIdentity;
         final routeSw = Stopwatch()..start();
-        // Defensively discard any restart flag left armed before routing this
-        // relay request. The local DebugServer reuses this RequestRouter but
-        // consumes and acts on its own restart flag synchronously right after it
-        // routes, so it should never leak one here; this clear still guarantees
-        // that only a restart requested during THIS relay request can trigger a
-        // handoff from the relay path.
-        _restartService.consumeRestartRequest();
         // If shutdown wins the race below, this future keeps running in the
         // background. ignore() marks any later failure as handled so it can
         // never surface as an unhandled async exception after abandonment.
-        final routeFuture = _router.route(req)..ignore();
+        final routeFuture = pendingRoute.completion..ignore();
         try {
-          final response = await Future.any<RelayResponse>([
+          final outcome = await Future.any<RoutedRequestOutcome>([
             routeFuture,
             _shutdownCompleter.future.then((_) => throw const _ShutdownInProgressException()),
           ]);
-          // Consume the restart flag now — it was set (if at all) by THIS
-          // request during routing. Tying consumption to this request means a
-          // failed/abandoned response can never leave the flag armed to trigger
-          // a delayed, unintended restart on a later request.
-          final bool restartRequested = _restartService.consumeRestartRequest();
+          final response = outcome.response;
           if (_cancelled) {
             Log.v(
-              "[shutdown] route ${req.method} ${req.path} completed after cancel — "
+              "[shutdown] route ${routeIdentity.diagnosticLabel} completed after cancel — "
               "dropping response (status=${response.status})",
             );
             return;
           }
           if (routeSw.elapsedMilliseconds > 1000) {
             Log.d(
-              "[shutdown] slow route ${req.method} ${req.path} for connId $connID "
+              "[shutdown] slow route ${routeIdentity.diagnosticLabel} for connId $connID "
               "took ${routeSw.elapsedMilliseconds}ms (cancelled=$_cancelled)",
             );
           }
           Log.v("response: status=${response.status}");
-          await _encryptAndSend(connID: connID, message: response);
-          Log.v("response sent to connID=$connID");
-          if (restartRequested) {
-            await handleRestartHandoff();
+          try {
+            await _encryptAndSend(connID: connID, message: response);
+            Log.v("response sent to connID=$connID");
+          } finally {
+            if (!_cancelled) {
+              switch (outcome) {
+                case ResponseOnly():
+                  break;
+                case final RestartAccepted accepted:
+                  await _restartDispatcher.dispatch(restart: accepted);
+              }
+            }
           }
         } on _ShutdownInProgressException {
           Log.v(
-            "[shutdown] route ${req.method} ${req.path} will finish without sending a response",
+            "[shutdown] route ${routeIdentity.diagnosticLabel} will finish without sending a response",
           );
           // Keep route-owned services and plugin APIs alive until the operation
           // settles. The shutdown coordinator's process backstop bounds this
@@ -1861,19 +1828,19 @@ class OrchestratorSession {
           try {
             await routeFuture;
           } on Object catch (error, stackTrace) {
-            Log.w("[shutdown] route ${req.method} ${req.path} failed while draining", error, stackTrace);
+            Log.w("[shutdown] route ${routeIdentity.diagnosticLabel} failed while draining", error, stackTrace);
           }
-        } catch (e) {
+        } on Object catch (error, stackTrace) {
           if (_cancelled) {
-            Log.v("[shutdown] route ${req.method} ${req.path} failed during shutdown: $e");
+            Log.w("[shutdown] route ${routeIdentity.diagnosticLabel} failed during shutdown", error, stackTrace);
           } else {
-            Log.e("request routing failed for connId $connID: $e");
+            Log.e("route ${routeIdentity.diagnosticLabel} failed for connId $connID", error, stackTrace);
           }
         } finally {
-          _inFlightRequestLabel = null;
+          _inFlightRouteIdentity = null;
         }
       case final RelaySseSubscribe subscribe:
-        Log.v("SseSubscribe: path=${subscribe.path}");
+        Log.v("RelaySseSubscribe");
         try {
           _sseManager.subscribePath(connID, subscribe.path, _client);
           final projSummary = await _buildProjectsSummary();
@@ -1882,14 +1849,14 @@ class OrchestratorSession {
             _completionListener.handleSseEvent(projSummary);
           }
           Log.v("initial projectsSummary enqueued");
-        } catch (e) {
-          Log.e("sse subscribe failed for connId $connID: $e");
+        } on Object catch (error, stackTrace) {
+          Log.e("RelaySseSubscribe failed", error, stackTrace);
         }
       case RelaySseUnsubscribe():
-        Log.v("SseUnsubscribe connID=$connID");
+        Log.v("RelaySseUnsubscribe");
         _sseManager.unsubscribe(connID);
       case RelaySessionView(:final sessionId):
-        Log.v("SessionView connID=$connID sessionId=$sessionId");
+        Log.v("RelaySessionView");
         _sessionViewTracker.setViewing(connID: connID, sessionId: sessionId);
       default:
         Log.v("unhandled msg type: ${msg.runtimeType}");

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -1776,7 +1776,7 @@ class OrchestratorSession {
 
     switch (msg) {
       case final RelayRequest req:
-        final pendingRoute = _router.route(req);
+        final pendingRoute = _router.route(request: req);
         final routeIdentity = pendingRoute.routeIdentity;
         Log.v("RelayRequest: ${routeIdentity.diagnosticLabel}");
         _inFlightRouteIdentity = routeIdentity;

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -1590,13 +1590,14 @@ class OrchestratorSession {
           Map<String, dynamic> control;
           try {
             control = jsonDecodeMap(utf8.decode(msg.data));
-          } catch (_) {
-            Log.v("failed to parse relay control message");
+          } on Object catch (error, stackTrace) {
+            Log.w("failed to parse relay control message", error, stackTrace);
             break processMessage;
           }
 
           final type = control["type"] as String?;
           final connID = control["connId"] as int?;
+          Log.v("control: type=$type connID=$connID");
           if (type == null || connID == null) {
             Log.v("dropping relay control message with missing fields");
             break processMessage;
@@ -1604,9 +1605,9 @@ class OrchestratorSession {
 
           switch (type) {
             case "phone_connected":
-              Log.v("RelayPhoneConnected");
+              Log.v("phone_connected connID=$connID");
             case "phone_disconnected":
-              Log.v("RelayPhoneDisconnected");
+              Log.v("phone_disconnected connID=$connID");
               activePhones.remove(connID);
               _sseManager.removeSubscriber(connID);
               _sessionViewTracker.releaseConnection(connID: connID);
@@ -1767,8 +1768,8 @@ class OrchestratorSession {
       msg = RelayMessage.fromJson(
         jsonDecodeMap(utf8.decode(decrypted)),
       );
-    } catch (_) {
-      Log.v("failed to parse encrypted relay message");
+    } on Object catch (error, stackTrace) {
+      Log.w("failed to parse encrypted relay message from connID=$connID", error, stackTrace);
       return;
     }
 
@@ -1778,7 +1779,7 @@ class OrchestratorSession {
       case final RelayRequest req:
         final pendingRoute = _router.route(request: req);
         final routeIdentity = pendingRoute.routeIdentity;
-        Log.v("RelayRequest: ${routeIdentity.diagnosticLabel}");
+        Log.v("RelayRequest: ${req.method} ${req.path}");
         _inFlightRouteIdentity = routeIdentity;
         final routeSw = Stopwatch()..start();
         // If shutdown wins the race below, this future keeps running in the
@@ -1840,7 +1841,7 @@ class OrchestratorSession {
           _inFlightRouteIdentity = null;
         }
       case final RelaySseSubscribe subscribe:
-        Log.v("RelaySseSubscribe");
+        Log.v("SseSubscribe: path=${subscribe.path}");
         try {
           _sseManager.subscribePath(connID, subscribe.path, _client);
           final projSummary = await _buildProjectsSummary();
@@ -1850,13 +1851,13 @@ class OrchestratorSession {
           }
           Log.v("initial projectsSummary enqueued");
         } on Object catch (error, stackTrace) {
-          Log.e("RelaySseSubscribe failed", error, stackTrace);
+          Log.e("sse subscribe failed for connId $connID", error, stackTrace);
         }
       case RelaySseUnsubscribe():
-        Log.v("RelaySseUnsubscribe");
+        Log.v("SseUnsubscribe connID=$connID");
         _sseManager.unsubscribe(connID);
       case RelaySessionView(:final sessionId):
-        Log.v("RelaySessionView");
+        Log.v("SessionView connID=$connID sessionId=$sessionId");
         _sessionViewTracker.setViewing(connID: connID, sessionId: sessionId);
       default:
         Log.v("unhandled msg type: ${msg.runtimeType}");

--- a/bridge/app/lib/src/bridge/routing/bridge_restart_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/routing/bridge_restart_dispatcher.dart
@@ -1,0 +1,62 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Console, Log;
+
+import "../../server/services/bridge_restart_service.dart";
+import "routed_request.dart";
+
+enum BridgeShutdownRequest { restart }
+
+/// Owns the single restart handoff shared by relay and debug route consumers.
+class BridgeRestartDispatcher {
+  BridgeRestartDispatcher({required BridgeRestartService restartService}) : _restartService = restartService;
+
+  final BridgeRestartService _restartService;
+  final StreamController<BridgeShutdownRequest> _shutdownRequests = StreamController<BridgeShutdownRequest>.broadcast(
+    sync: true,
+  );
+  Future<void>? _handoff;
+  bool _handoffSucceeded = false;
+  bool _disposed = false;
+
+  Stream<BridgeShutdownRequest> get shutdownRequests => _shutdownRequests.stream;
+
+  Future<void> dispatch({required RestartAccepted restart}) {
+    if (_disposed) {
+      return Future<void>.error(StateError("BridgeRestartDispatcher is disposed"), StackTrace.current);
+    }
+    final activeHandoff = _handoff;
+    if (activeHandoff != null) return activeHandoff;
+
+    final handoff = _performHandoff();
+    _handoff = handoff;
+    handoff.whenComplete(() {
+      if (!_handoffSucceeded && identical(_handoff, handoff)) {
+        _handoff = null;
+      }
+    }).ignore();
+    return handoff;
+  }
+
+  Future<void> _performHandoff() async {
+    Log.i("[restart] restart requested");
+    final proceed = await _restartService.performRestartHandoff();
+    if (!proceed) {
+      Console.error(
+        "Restart requested but a new bridge could not be started; continuing to run. "
+        "Re-run the install script if this persists: https://sesori.com/",
+      );
+      return;
+    }
+
+    _handoffSucceeded = true;
+    Log.i("[restart] handing off; requesting shutdown");
+    _shutdownRequests.add(BridgeShutdownRequest.restart);
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await _shutdownRequests.close();
+  }
+}

--- a/bridge/app/lib/src/bridge/routing/http_method.dart
+++ b/bridge/app/lib/src/bridge/routing/http_method.dart
@@ -9,7 +9,7 @@ enum HttpMethod {
   /// Handler-only wildcard; external method parsing never produces this value.
   any;
 
-  static HttpMethod? parseExternal(String rawMethod) => switch (rawMethod.toUpperCase()) {
+  static HttpMethod? parseExternal({required String rawMethod}) => switch (rawMethod.toUpperCase()) {
     "GET" => get,
     "POST" => post,
     "PUT" => put,
@@ -20,5 +20,5 @@ enum HttpMethod {
 
   String get diagnosticLabel => this == any ? "ANY" : name.toUpperCase();
 
-  bool matches(HttpMethod requestMethod) => this == any || this == requestMethod;
+  bool matches({required HttpMethod requestMethod}) => this == any || this == requestMethod;
 }

--- a/bridge/app/lib/src/bridge/routing/http_method.dart
+++ b/bridge/app/lib/src/bridge/routing/http_method.dart
@@ -1,0 +1,24 @@
+/// HTTP methods accepted from routed relay and debug requests.
+enum HttpMethod {
+  get,
+  post,
+  put,
+  patch,
+  delete,
+
+  /// Handler-only wildcard; external method parsing never produces this value.
+  any;
+
+  static HttpMethod? parseExternal(String rawMethod) => switch (rawMethod.toUpperCase()) {
+    "GET" => get,
+    "POST" => post,
+    "PUT" => put,
+    "PATCH" => patch,
+    "DELETE" => delete,
+    _ => null,
+  };
+
+  String get diagnosticLabel => this == any ? "ANY" : name.toUpperCase();
+
+  bool matches(HttpMethod requestMethod) => this == any || this == requestMethod;
+}

--- a/bridge/app/lib/src/bridge/routing/request_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/request_handler.dart
@@ -39,8 +39,8 @@ abstract class GetRequestHandler<RES extends Object> extends RequestHandlerBase 
       return buildOkJsonResponse(request, result);
     } on ProjectNotFoundException {
       return buildErrorResponse(request, 404, "project not found");
-    } on PluginOperationException catch (err) {
-      Log.w("$diagnosticLabel: upstream failure");
+    } on PluginOperationException catch (err, stackTrace) {
+      Log.w("$diagnosticLabel: upstream failure", err, stackTrace);
       return buildErrorResponse(request, err.statusCode ?? 502, err.toString());
     } on RelayResponse catch (err) {
       if (err.status >= 200 && err.status < 300) {
@@ -51,8 +51,8 @@ abstract class GetRequestHandler<RES extends Object> extends RequestHandlerBase 
         // just return the error response
         return err;
       }
-    } catch (err) {
-      Log.w("$diagnosticLabel: handler failed");
+    } catch (err, stackTrace) {
+      Log.w("$diagnosticLabel: handler failed", err, stackTrace);
       return buildErrorResponse(request, 500, "Internal Server Error: $err");
     }
   }
@@ -102,8 +102,8 @@ abstract class BodyRequestHandler<REQ, RES extends Object> extends RequestHandle
       return buildOkJsonResponse(request, result);
     } on ProjectNotFoundException {
       return buildErrorResponse(request, 404, "project not found");
-    } on PluginOperationException catch (err) {
-      Log.w("$diagnosticLabel: upstream failure");
+    } on PluginOperationException catch (err, stackTrace) {
+      Log.w("$diagnosticLabel: upstream failure", err, stackTrace);
       return buildErrorResponse(request, err.statusCode ?? 502, err.toString());
     } on RelayResponse catch (err) {
       if (err.status >= 200 && err.status < 300) {
@@ -114,8 +114,8 @@ abstract class BodyRequestHandler<REQ, RES extends Object> extends RequestHandle
         // just return the error response
         return err;
       }
-    } catch (err) {
-      Log.w("$diagnosticLabel: handler failed");
+    } catch (err, stackTrace) {
+      Log.w("$diagnosticLabel: handler failed", err, stackTrace);
       return buildErrorResponse(request, 500, "Internal Server Error: $err");
     }
   }

--- a/bridge/app/lib/src/bridge/routing/request_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/request_handler.dart
@@ -39,8 +39,8 @@ abstract class GetRequestHandler<RES extends Object> extends RequestHandlerBase 
       return buildOkJsonResponse(request, result);
     } on ProjectNotFoundException {
       return buildErrorResponse(request, 404, "project not found");
-    } on PluginOperationException catch (err, stackTrace) {
-      Log.w("$diagnosticLabel: upstream failure", err, stackTrace);
+    } on PluginOperationException catch (err) {
+      Log.w("$diagnosticLabel: upstream failure");
       return buildErrorResponse(request, err.statusCode ?? 502, err.toString());
     } on RelayResponse catch (err) {
       if (err.status >= 200 && err.status < 300) {
@@ -51,8 +51,8 @@ abstract class GetRequestHandler<RES extends Object> extends RequestHandlerBase 
         // just return the error response
         return err;
       }
-    } catch (err, stackTrace) {
-      Log.w("$diagnosticLabel: handler failed", err, stackTrace);
+    } catch (err) {
+      Log.w("$diagnosticLabel: handler failed");
       return buildErrorResponse(request, 500, "Internal Server Error: $err");
     }
   }
@@ -102,8 +102,8 @@ abstract class BodyRequestHandler<REQ, RES extends Object> extends RequestHandle
       return buildOkJsonResponse(request, result);
     } on ProjectNotFoundException {
       return buildErrorResponse(request, 404, "project not found");
-    } on PluginOperationException catch (err, stackTrace) {
-      Log.w("$diagnosticLabel: upstream failure", err, stackTrace);
+    } on PluginOperationException catch (err) {
+      Log.w("$diagnosticLabel: upstream failure");
       return buildErrorResponse(request, err.statusCode ?? 502, err.toString());
     } on RelayResponse catch (err) {
       if (err.status >= 200 && err.status < 300) {
@@ -114,8 +114,8 @@ abstract class BodyRequestHandler<REQ, RES extends Object> extends RequestHandle
         // just return the error response
         return err;
       }
-    } catch (err, stackTrace) {
-      Log.w("$diagnosticLabel: handler failed", err, stackTrace);
+    } catch (err) {
+      Log.w("$diagnosticLabel: handler failed");
       return buildErrorResponse(request, 500, "Internal Server Error: $err");
     }
   }
@@ -160,7 +160,7 @@ abstract class RequestHandlerBase {
 
   /// Matches the router's parsed method and target against this declaration.
   bool matches({required HttpMethod requestMethod, required Uri target}) {
-    if (!method.matches(requestMethod)) return false;
+    if (!method.matches(requestMethod: requestMethod)) return false;
     if (path == "*") return true;
     return _matchPathParams(target.path, path) != null;
   }
@@ -196,8 +196,8 @@ abstract class RequestHandlerBase {
     required String? fragment,
   });
 
-  Future<RoutedRequestOutcome> routeInternal(
-    RelayRequest request, {
+  Future<RoutedRequestOutcome> routeInternal({
+    required RelayRequest request,
     required Map<String, String> pathParams,
     required Map<String, String> queryParams,
     required String? fragment,

--- a/bridge/app/lib/src/bridge/routing/request_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/request_handler.dart
@@ -4,25 +4,10 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../repositories/models/project_not_found_exception.dart";
+import "http_method.dart";
+import "routed_request.dart";
 
-/// HTTP methods supported by [RequestHandler].
-enum HttpMethod {
-  get,
-  post,
-  put,
-  patch,
-  delete,
-
-  /// Matches any HTTP method.
-  any
-  ;
-
-  /// Returns `true` when this matches the raw method string from a request.
-  bool matches(String rawMethod) {
-    if (this == any) return true;
-    return name.toUpperCase() == rawMethod.toUpperCase();
-  }
-}
+export "http_method.dart";
 
 abstract class GetRequestHandler<RES extends Object> extends RequestHandlerBase {
   GetRequestHandler(
@@ -54,8 +39,8 @@ abstract class GetRequestHandler<RES extends Object> extends RequestHandlerBase 
       return buildOkJsonResponse(request, result);
     } on ProjectNotFoundException {
       return buildErrorResponse(request, 404, "project not found");
-    } on PluginOperationException catch (err) {
-      Log.w("${request.method} ${request.path}: upstream failure: $err");
+    } on PluginOperationException catch (err, stackTrace) {
+      Log.w("$diagnosticLabel: upstream failure", err, stackTrace);
       return buildErrorResponse(request, err.statusCode ?? 502, err.toString());
     } on RelayResponse catch (err) {
       if (err.status >= 200 && err.status < 300) {
@@ -67,7 +52,7 @@ abstract class GetRequestHandler<RES extends Object> extends RequestHandlerBase 
         return err;
       }
     } catch (err, stackTrace) {
-      Log.w("${request.method} ${request.path}: handler failed: $err\n$stackTrace");
+      Log.w("$diagnosticLabel: handler failed", err, stackTrace);
       return buildErrorResponse(request, 500, "Internal Server Error: $err");
     }
   }
@@ -117,8 +102,8 @@ abstract class BodyRequestHandler<REQ, RES extends Object> extends RequestHandle
       return buildOkJsonResponse(request, result);
     } on ProjectNotFoundException {
       return buildErrorResponse(request, 404, "project not found");
-    } on PluginOperationException catch (err) {
-      Log.w("${request.method} ${request.path}: upstream failure: $err");
+    } on PluginOperationException catch (err, stackTrace) {
+      Log.w("$diagnosticLabel: upstream failure", err, stackTrace);
       return buildErrorResponse(request, err.statusCode ?? 502, err.toString());
     } on RelayResponse catch (err) {
       if (err.status >= 200 && err.status < 300) {
@@ -130,7 +115,7 @@ abstract class BodyRequestHandler<REQ, RES extends Object> extends RequestHandle
         return err;
       }
     } catch (err, stackTrace) {
-      Log.w("${request.method} ${request.path}: handler failed: $err\n$stackTrace");
+      Log.w("$diagnosticLabel: handler failed", err, stackTrace);
       return buildErrorResponse(request, 500, "Internal Server Error: $err");
     }
   }
@@ -147,9 +132,8 @@ abstract class BodyRequestHandler<REQ, RES extends Object> extends RequestHandle
 /// A single interceptor in the request routing chain.
 ///
 /// Subclasses declare their [method] and [path] pattern in the constructor.
-/// [canHandle] is implemented here and never needs to be overridden — it
-/// compares the incoming request against [method] and [path], resolving
-/// `:param` placeholders automatically.
+/// [RequestRouter] compares the parsed request method and target against
+/// [method] and [path], resolving `:param` placeholders automatically.
 ///
 /// Example:
 /// ```dart
@@ -170,28 +154,25 @@ abstract class RequestHandlerBase {
 
   const RequestHandlerBase(this.method, this.path);
 
+  String get diagnosticLabel => "${method.diagnosticLabel} $path";
+
   // ── Matching ────────────────────────────────────────────────────────────────
 
-  /// Returns `true` if this handler is responsible for [request].
-  ///
-  /// Matches on [method] and the [path] pattern. Subclasses must NOT override
-  /// this — declare [method] and [path] in the constructor instead.
-  bool canHandle(RelayRequest request) {
-    if (!method.matches(request.method)) return false;
+  /// Matches the router's parsed method and target against this declaration.
+  bool matches({required HttpMethod requestMethod, required Uri target}) {
+    if (!method.matches(requestMethod)) return false;
     if (path == "*") return true;
-    return _matchPathParams(Uri.parse(request.path).path, path) != null;
+    return _matchPathParams(target.path, path) != null;
   }
 
-  /// Extracts path params, query params, and URL fragment from [request].
-  ///
-  /// Only call this after [canHandle] returned `true` for the same request.
+  /// Extracts route values from the target parsed once by [RequestRouter].
   ({
     Map<String, String> pathParams,
     Map<String, String> queryParams,
     String? fragment,
   })
-  extractParams(RelayRequest request) {
-    final uri = Uri.parse(request.path);
+  extractTargetParams({required Uri target}) {
+    final uri = target;
     final pathParams = path == "*" ? <String, String>{} : (_matchPathParams(uri.path, path) ?? {});
     final queryParams = Map<String, String>.from(uri.queryParameters);
     final fragment = uri.fragment.isEmpty ? null : uri.fragment;
@@ -202,7 +183,7 @@ abstract class RequestHandlerBase {
 
   /// Produces a [RelayResponse] for [request].
   ///
-  /// Only called when [canHandle] returned `true` for the same request.
+  /// Only called when [matches] returned `true` for the same request.
   ///
   /// - [pathParams] — values extracted from `:param` placeholders in [path],
   ///   e.g. `"/session/:id/message"` yields `{"id": "abc"}`.
@@ -214,6 +195,22 @@ abstract class RequestHandlerBase {
     required Map<String, String> queryParams,
     required String? fragment,
   });
+
+  Future<RoutedRequestOutcome> routeInternal(
+    RelayRequest request, {
+    required Map<String, String> pathParams,
+    required Map<String, String> queryParams,
+    required String? fragment,
+  }) async {
+    return ResponseOnly(
+      response: await handleInternal(
+        request,
+        pathParams: pathParams,
+        queryParams: queryParams,
+        fragment: fragment,
+      ),
+    );
+  }
 
   // ── Shared helpers ──────────────────────────────────────────────────────────
 

--- a/bridge/app/lib/src/bridge/routing/request_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/request_handler.dart
@@ -40,7 +40,7 @@ abstract class GetRequestHandler<RES extends Object> extends RequestHandlerBase 
     } on ProjectNotFoundException {
       return buildErrorResponse(request, 404, "project not found");
     } on PluginOperationException catch (err, stackTrace) {
-      Log.w("$diagnosticLabel: upstream failure", err, stackTrace);
+      Log.w("${request.method} ${request.path}: upstream failure", err, stackTrace);
       return buildErrorResponse(request, err.statusCode ?? 502, err.toString());
     } on RelayResponse catch (err) {
       if (err.status >= 200 && err.status < 300) {
@@ -52,7 +52,7 @@ abstract class GetRequestHandler<RES extends Object> extends RequestHandlerBase 
         return err;
       }
     } catch (err, stackTrace) {
-      Log.w("$diagnosticLabel: handler failed", err, stackTrace);
+      Log.w("${request.method} ${request.path}: handler failed", err, stackTrace);
       return buildErrorResponse(request, 500, "Internal Server Error: $err");
     }
   }
@@ -103,7 +103,7 @@ abstract class BodyRequestHandler<REQ, RES extends Object> extends RequestHandle
     } on ProjectNotFoundException {
       return buildErrorResponse(request, 404, "project not found");
     } on PluginOperationException catch (err, stackTrace) {
-      Log.w("$diagnosticLabel: upstream failure", err, stackTrace);
+      Log.w("${request.method} ${request.path}: upstream failure", err, stackTrace);
       return buildErrorResponse(request, err.statusCode ?? 502, err.toString());
     } on RelayResponse catch (err) {
       if (err.status >= 200 && err.status < 300) {
@@ -115,7 +115,7 @@ abstract class BodyRequestHandler<REQ, RES extends Object> extends RequestHandle
         return err;
       }
     } catch (err, stackTrace) {
-      Log.w("$diagnosticLabel: handler failed", err, stackTrace);
+      Log.w("${request.method} ${request.path}: handler failed", err, stackTrace);
       return buildErrorResponse(request, 500, "Internal Server Error: $err");
     }
   }

--- a/bridge/app/lib/src/bridge/routing/request_router.dart
+++ b/bridge/app/lib/src/bridge/routing/request_router.dart
@@ -19,8 +19,8 @@ class RequestRouter {
   }) : _handlers = List<RequestHandlerBase>.unmodifiable(handlers);
 
   /// Selects a route synchronously and returns its asynchronous completion.
-  PendingRoutedRequest route(RelayRequest request) {
-    final requestMethod = HttpMethod.parseExternal(request.method);
+  PendingRoutedRequest route({required RelayRequest request}) {
+    final requestMethod = HttpMethod.parseExternal(rawMethod: request.method);
     if (requestMethod == null) {
       return PendingRoutedRequest(
         routeIdentity: const InvalidMethodRoute(),
@@ -72,7 +72,7 @@ class RequestRouter {
     try {
       final (:pathParams, :queryParams, :fragment) = handler.extractTargetParams(target: target);
       return await handler.routeInternal(
-        request,
+        request: request,
         pathParams: pathParams,
         queryParams: queryParams,
         fragment: fragment,

--- a/bridge/app/lib/src/bridge/routing/request_router.dart
+++ b/bridge/app/lib/src/bridge/routing/request_router.dart
@@ -87,7 +87,12 @@ class RequestRouter {
           body: error.toString(),
         ),
       );
-    } on Object catch (error) {
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        "${identity.diagnosticLabel}: routing failed for ${request.method} ${request.path}",
+        error,
+        stackTrace,
+      );
       return ResponseOnly(
         response: _failed(request: request, error: error),
       );

--- a/bridge/app/lib/src/bridge/routing/request_router.dart
+++ b/bridge/app/lib/src/bridge/routing/request_router.dart
@@ -2,8 +2,9 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "request_handler.dart";
+import "routed_request.dart";
 
-/// Routes incoming [RelayRequest]s to the first matching [RequestHandler].
+/// Routes incoming [RelayRequest]s to the first matching [RequestHandlerBase].
 ///
 /// Handlers are checked in registration order. The first matching handler wins.
 ///
@@ -17,41 +18,95 @@ class RequestRouter {
     required List<RequestHandlerBase> handlers,
   }) : _handlers = List<RequestHandlerBase>.unmodifiable(handlers);
 
-  /// Routes [request] to the first matching handler and returns its response.
-  Future<RelayResponse> route(RelayRequest request) async {
-    try {
-      for (final handler in _handlers) {
-        if (handler.canHandle(request)) {
-          final (:pathParams, :queryParams, :fragment) = handler.extractParams(request);
-          return await handler.handleInternal(
-            request,
-            pathParams: pathParams,
-            queryParams: queryParams,
-            fragment: fragment,
-          );
-        }
-      }
-      return RelayResponse(
-        id: request.id,
-        status: 404,
-        headers: {},
-        body: "no handler found for ${request.method} ${request.path}",
-      );
-    } on PluginOperationException catch (e) {
-      Log.w("upstream error: $e");
-      return RelayResponse(
-        id: request.id,
-        status: e.statusCode ?? 502,
-        headers: {},
-        body: e.toString(),
-      );
-    } catch (e) {
-      return RelayResponse(
-        id: request.id,
-        status: 502,
-        headers: {},
-        body: "request failed: $e",
+  /// Selects a route synchronously and returns its asynchronous completion.
+  PendingRoutedRequest route(RelayRequest request) {
+    final requestMethod = HttpMethod.parseExternal(request.method);
+    if (requestMethod == null) {
+      return PendingRoutedRequest(
+        routeIdentity: const InvalidMethodRoute(),
+        completion: Future<RoutedRequestOutcome>.value(ResponseOnly(response: _notFound(request))),
       );
     }
+
+    final Uri target;
+    try {
+      target = Uri.parse(request.path);
+    } on Object catch (error) {
+      return PendingRoutedRequest(
+        routeIdentity: InvalidTargetRoute(method: requestMethod),
+        completion: Future<RoutedRequestOutcome>.value(
+          ResponseOnly(
+            response: _failed(request: request, error: error),
+          ),
+        ),
+      );
+    }
+
+    for (final handler in _handlers) {
+      if (handler.matches(requestMethod: requestMethod, target: target)) {
+        final identity = MatchedRoute(method: requestMethod, pathTemplate: handler.path);
+        return PendingRoutedRequest(
+          routeIdentity: identity,
+          completion: _complete(
+            request: request,
+            target: target,
+            handler: handler,
+            identity: identity,
+          ),
+        );
+      }
+    }
+
+    return PendingRoutedRequest(
+      routeIdentity: UnmatchedRoute(method: requestMethod),
+      completion: Future<RoutedRequestOutcome>.value(ResponseOnly(response: _notFound(request))),
+    );
+  }
+
+  Future<RoutedRequestOutcome> _complete({
+    required RelayRequest request,
+    required Uri target,
+    required RequestHandlerBase handler,
+    required MatchedRoute identity,
+  }) async {
+    try {
+      final (:pathParams, :queryParams, :fragment) = handler.extractTargetParams(target: target);
+      return await handler.routeInternal(
+        request,
+        pathParams: pathParams,
+        queryParams: queryParams,
+        fragment: fragment,
+      );
+    } on PluginOperationException catch (error, stackTrace) {
+      Log.w("${identity.diagnosticLabel}: upstream error", error, stackTrace);
+      return ResponseOnly(
+        response: RelayResponse(
+          id: request.id,
+          status: error.statusCode ?? 502,
+          headers: const {},
+          body: error.toString(),
+        ),
+      );
+    } on Object catch (error) {
+      return ResponseOnly(
+        response: _failed(request: request, error: error),
+      );
+    }
+  }
+
+  RelayResponse _notFound(RelayRequest request) => RelayResponse(
+    id: request.id,
+    status: 404,
+    headers: const {},
+    body: "no handler found for ${request.method} ${request.path}",
+  );
+
+  RelayResponse _failed({required RelayRequest request, required Object error}) {
+    return RelayResponse(
+      id: request.id,
+      status: 502,
+      headers: const {},
+      body: "request failed: $error",
+    );
   }
 }

--- a/bridge/app/lib/src/bridge/routing/restart_bridge_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/restart_bridge_handler.dart
@@ -17,8 +17,8 @@ class RestartBridgeHandler extends RequestHandlerBase {
   final BridgeRestartService _restartService;
 
   @override
-  Future<RoutedRequestOutcome> routeInternal(
-    RelayRequest request, {
+  Future<RoutedRequestOutcome> routeInternal({
+    required RelayRequest request,
     required Map<String, String> pathParams,
     required Map<String, String> queryParams,
     required String? fragment,
@@ -45,7 +45,7 @@ class RestartBridgeHandler extends RequestHandlerBase {
     required String? fragment,
   }) async {
     return (await routeInternal(
-      request,
+      request: request,
       pathParams: pathParams,
       queryParams: queryParams,
       fragment: fragment,

--- a/bridge/app/lib/src/bridge/routing/restart_bridge_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/restart_bridge_handler.dart
@@ -1,16 +1,14 @@
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../../server/services/bridge_restart_service.dart";
-import "models/restart_bridge_response.dart";
 import "request_handler.dart";
+import "routed_request.dart";
 
 /// Handles `POST /global/restart` — an explicit, user-triggered bridge restart.
 ///
-/// It validates that a restart can be delivered, replies `{restarting:true}`,
-/// and flags the restart. The orchestrator performs the actual handoff (spawn a
-/// successor in standalone, or exit for GUI respawn in supervised mode) + graceful
-/// shutdown *after* this reply has been flushed to the phone, so the response is
-/// never lost to the handoff.
+/// It validates that a restart can be delivered and returns a typed acceptance.
+/// The transport closes or enqueues the fixed response before dispatching the
+/// handoff.
 class RestartBridgeHandler extends RequestHandlerBase {
   RestartBridgeHandler({required BridgeRestartService restartService})
     : _restartService = restartService,
@@ -19,7 +17,7 @@ class RestartBridgeHandler extends RequestHandlerBase {
   final BridgeRestartService _restartService;
 
   @override
-  Future<RelayResponse> handleInternal(
+  Future<RoutedRequestOutcome> routeInternal(
     RelayRequest request, {
     required Map<String, String> pathParams,
     required Map<String, String> queryParams,
@@ -27,14 +25,30 @@ class RestartBridgeHandler extends RequestHandlerBase {
   }) async {
     final bool canRestart = await _restartService.canRestart();
     if (!canRestart) {
-      return buildErrorResponse(
-        request,
-        503,
-        "Cannot restart: the managed bridge binary is unavailable. Re-run the install script: https://sesori.com/",
+      return ResponseOnly(
+        response: buildErrorResponse(
+          request,
+          503,
+          "Cannot restart: the managed bridge binary is unavailable. Re-run the install script: https://sesori.com/",
+        ),
       );
     }
 
-    _restartService.requestRestart();
-    return buildOkJsonResponse(request, const RestartBridgeResponse(restarting: true));
+    return RestartAccepted(requestId: request.id);
+  }
+
+  @override
+  Future<RelayResponse> handleInternal(
+    RelayRequest request, {
+    required Map<String, String> pathParams,
+    required Map<String, String> queryParams,
+    required String? fragment,
+  }) async {
+    return (await routeInternal(
+      request,
+      pathParams: pathParams,
+      queryParams: queryParams,
+      fragment: fragment,
+    )).response;
   }
 }

--- a/bridge/app/lib/src/bridge/routing/routed_request.dart
+++ b/bridge/app/lib/src/bridge/routing/routed_request.dart
@@ -1,0 +1,74 @@
+import "dart:convert";
+
+import "package:sesori_shared/sesori_shared.dart";
+
+import "http_method.dart";
+import "models/restart_bridge_response.dart";
+
+class PendingRoutedRequest {
+  final RouteIdentity routeIdentity;
+  final Future<RoutedRequestOutcome> completion;
+
+  const PendingRoutedRequest({required this.routeIdentity, required this.completion});
+}
+
+sealed class RouteIdentity {
+  const RouteIdentity();
+
+  String get diagnosticLabel => switch (this) {
+    MatchedRoute(:final method, :final pathTemplate) => "${method.diagnosticLabel} $pathTemplate",
+    UnmatchedRoute(:final method) => "${method.diagnosticLabel} unmatched route",
+    InvalidMethodRoute() => "invalid method",
+    InvalidTargetRoute(:final method) => "${method.diagnosticLabel} invalid target",
+  };
+}
+
+final class MatchedRoute extends RouteIdentity {
+  final HttpMethod method;
+  final String pathTemplate;
+
+  const MatchedRoute({required this.method, required this.pathTemplate});
+}
+
+final class UnmatchedRoute extends RouteIdentity {
+  final HttpMethod method;
+
+  const UnmatchedRoute({required this.method});
+}
+
+final class InvalidMethodRoute extends RouteIdentity {
+  const InvalidMethodRoute();
+}
+
+final class InvalidTargetRoute extends RouteIdentity {
+  final HttpMethod method;
+
+  const InvalidTargetRoute({required this.method});
+}
+
+sealed class RoutedRequestOutcome {
+  const RoutedRequestOutcome();
+
+  RelayResponse get response;
+}
+
+final class ResponseOnly extends RoutedRequestOutcome {
+  @override
+  final RelayResponse response;
+
+  const ResponseOnly({required this.response});
+}
+
+final class RestartAccepted extends RoutedRequestOutcome {
+  final String requestId;
+
+  const RestartAccepted({required this.requestId});
+
+  @override
+  RelayResponse get response => RelayResponse(
+    id: requestId,
+    status: 200,
+    headers: const {"content-type": "application/json"},
+    body: jsonEncode(const RestartBridgeResponse(restarting: true)),
+  );
+}

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
@@ -7,27 +7,26 @@ import "package:sesori_shared/sesori_shared.dart" show FailureReporter;
 
 import "../../api/database/database.dart";
 import "../../listeners/plugin_catalog_hydration_listener.dart";
-import "../../server/services/bridge_restart_service.dart";
 import "../../services/catalog_import_service.dart";
 import "../bandwidth_tracker.dart";
 import "../debug_server.dart";
 import "../orchestrator.dart";
+import "../routing/bridge_restart_dispatcher.dart";
 import "bridge_shutdown_coordinator.dart";
 
 class BridgeRuntime {
   BridgeRuntime({
     required AppDatabase database,
     required FailureReporter failureReporter,
-    required BridgeRestartService restartService,
     required OrchestratorComposition composition,
   }) : _database = database,
        _failureReporter = failureReporter,
-       _restartService = restartService,
+       _restartDispatcher = composition.restartDispatcher,
        _composition = composition;
 
   final AppDatabase _database;
   final FailureReporter _failureReporter;
-  final BridgeRestartService _restartService;
+  final BridgeRestartDispatcher _restartDispatcher;
   final OrchestratorComposition _composition;
   Future<void>? _closeFuture;
 
@@ -49,8 +48,7 @@ class BridgeRuntime {
       router: session.router,
       port: port,
       failureReporter: _failureReporter,
-      restartService: _restartService,
-      restartHandoff: session.handleRestartHandoff,
+      restartDispatcher: _restartDispatcher,
       drainRoutedMutations: session.drainRoutedMutations,
     );
   }
@@ -70,6 +68,7 @@ class BridgeRuntime {
       }
     }
 
+    await step(_restartDispatcher.dispose);
     await step(_composition.sessionUnseenService.dispose);
     await step(_composition.sessionViewTracker.dispose);
     await step(_composition.sessionRepository.dispose);

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -816,7 +816,6 @@ class BridgeRuntimeRunner {
       runtime = BridgeRuntime(
         database: database,
         failureReporter: failureReporter,
-        restartService: restartService,
         composition: composition,
       );
       final activeRuntime = runtime;

--- a/bridge/app/lib/src/server/services/bridge_restart_service.dart
+++ b/bridge/app/lib/src/server/services/bridge_restart_service.dart
@@ -24,10 +24,10 @@ import '../repositories/process_repository.dart';
 ///   `--control-url` into a detached child with no off-argv secret and fail
 ///   closed, so supervised mode must never call [spawnSuccessor].
 ///
-/// It deliberately does NOT shut the current process down — the consumer
-/// (orchestrator) drives the existing graceful-shutdown path after the
-/// `{restarting:true}` reply has been flushed to the phone, so the relay
-/// disconnect → reconnect carries the handoff.
+/// It deliberately does NOT shut the current process down. The restart
+/// dispatcher emits a shutdown request only after the debug response closes or
+/// the relay response is synchronously enqueued. Relay delivery remains
+/// best-effort through the existing graceful close.
 class BridgeRestartService {
   BridgeRestartService({
     required ProcessRepository processRepository,
@@ -50,7 +50,6 @@ class BridgeRestartService {
   final int _currentPid;
   final bool _isSupervised;
 
-  bool _restartRequested = false;
   bool _supervisedRestartRequested = false;
 
   /// Whether a supervised restart handoff has been performed, so the composition
@@ -58,19 +57,6 @@ class BridgeRestartService {
   /// ever set in supervised mode; standalone spawns a successor and leaves this
   /// false.
   bool get supervisedRestartRequested => _supervisedRestartRequested;
-
-  /// Marks that a restart has been accepted (after the handler validates it),
-  /// so the consumer performs the handoff once the response is sent.
-  void requestRestart() {
-    _restartRequested = true;
-  }
-
-  /// Returns whether a restart was requested and clears the flag.
-  bool consumeRestartRequest() {
-    final bool requested = _restartRequested;
-    _restartRequested = false;
-    return requested;
-  }
 
   /// Whether an explicit restart can be delivered right now, so the handler only
   /// promises a restart it can actually carry out.
@@ -109,8 +95,7 @@ class BridgeRestartService {
   }
 
   /// Performs the restart handoff for the active run mode and reports whether the
-  /// caller should now proceed to shut down (flush the queued reply, then cancel
-  /// the session).
+  /// caller should now request graceful shutdown.
   ///
   /// - **supervised:** records [supervisedRestartRequested] and returns `true`
   ///   without spawning a successor — the desktop GUI respawns this process after

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -12,6 +12,10 @@ import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
 import "package:sesori_bridge/src/bridge/models/bridge_config.dart";
 import "package:sesori_bridge/src/bridge/orchestrator.dart";
 import "package:sesori_bridge/src/bridge/relay_client.dart";
+import "package:sesori_bridge/src/bridge/routing/bridge_restart_dispatcher.dart";
+import "package:sesori_bridge/src/bridge/routing/request_router.dart";
+import "package:sesori_bridge/src/bridge/routing/restart_bridge_handler.dart";
+import "package:sesori_bridge/src/bridge/routing/routed_request.dart";
 import "package:sesori_bridge/src/bridge/runtime/bridge_runtime.dart";
 import "package:sesori_bridge/src/bridge/runtime/bridge_shutdown_coordinator.dart";
 import "package:sesori_bridge/src/repositories/bridge_settings.dart";
@@ -72,7 +76,6 @@ Future<_DebugServerHarness> _createDebugServerHarness({
   final runtime = BridgeRuntime(
     database: db,
     failureReporter: failureReporter,
-    restartService: effectiveRestartService,
     composition: composition,
   );
   final running = await startTestOrchestratorSession(session: composition.session);
@@ -566,6 +569,45 @@ void main() {
   });
 
   group("DebugServer restart", () {
+    test("closes the HTTP response before awaiting restart dispatch and drains the dispatch", () async {
+      final dispatcher = _BlockingRestartDispatcher();
+      final debugServer = DebugServer(
+        localWireEvents: const Stream<SesoriSseEvent>.empty(),
+        router: RequestRouter(
+          handlers: [RestartBridgeHandler(restartService: _AlwaysRestartableService())],
+        ),
+        port: 0,
+        failureReporter: FakeFailureReporter(),
+        restartDispatcher: dispatcher,
+        drainRoutedMutations: () async {},
+      );
+      await debugServer.start();
+      addTearDown(() async {
+        dispatcher.release();
+        await debugServer.stop();
+      });
+
+      final client = HttpClient();
+      addTearDown(client.close);
+      final request = await client.postUrl(
+        Uri.parse("http://127.0.0.1:${debugServer.boundPort!}/global/restart"),
+      );
+      final responseFuture = request.close();
+
+      await dispatcher.started.timeout(const Duration(seconds: 2));
+      final response = await responseFuture.timeout(const Duration(seconds: 2));
+      final body = await utf8.decoder.bind(response).join().timeout(const Duration(seconds: 2));
+      expect(response.statusCode, HttpStatus.ok);
+      expect(body, contains('"restarting":true'));
+
+      var stopped = false;
+      final stop = debugServer.stop().whenComplete(() => stopped = true);
+      await Future<void>.delayed(Duration.zero);
+      expect(stopped, isFalse);
+      dispatcher.release();
+      await stop.timeout(const Duration(seconds: 2));
+    });
+
     test("POST /global/restart replies and spawns a successor", () async {
       final plugin = _FakeBridgePlugin();
       addTearDown(plugin.close);
@@ -647,12 +689,21 @@ void main() {
       );
       addTearDown(harness.close);
 
-      // Both the relay and debug triggers funnel into handleRestartHandoff;
-      // fire two concurrently and assert the single-flight guard holds.
-      await Future.wait<void>([
-        harness.runtime.session.handleRestartHandoff(),
-        harness.runtime.session.handleRestartHandoff(),
-      ]);
+      final debugServer = harness.debugServer;
+      await debugServer.start();
+      final client = HttpClient();
+      addTearDown(client.close);
+
+      Future<void> restart() async {
+        final request = await client.postUrl(
+          Uri.parse("http://127.0.0.1:${debugServer.boundPort!}/global/restart"),
+        );
+        final response = await request.close();
+        expect(response.statusCode, HttpStatus.ok);
+        await utf8.decoder.bind(response).join();
+      }
+
+      await Future.wait([restart(), restart()]);
 
       expect(processRunner.startDetachedCount, equals(1));
     });
@@ -695,6 +746,46 @@ void main() {
       expect(processRunner.startDetachedCount, equals(0));
     });
   });
+}
+
+class _BlockingRestartDispatcher implements BridgeRestartDispatcher {
+  final Completer<void> _started = Completer<void>();
+  final Completer<void> _release = Completer<void>();
+
+  Future<void> get started => _started.future;
+
+  @override
+  Stream<BridgeShutdownRequest> get shutdownRequests => const Stream<BridgeShutdownRequest>.empty();
+
+  @override
+  Future<void> dispatch({required RestartAccepted restart}) async {
+    if (!_started.isCompleted) _started.complete();
+    await _release.future;
+  }
+
+  void release() {
+    if (!_release.isCompleted) _release.complete();
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+class _AlwaysRestartableService implements BridgeRestartService {
+  @override
+  bool get supervisedRestartRequested => false;
+
+  @override
+  Future<bool> canRestart() async => true;
+
+  @override
+  Future<bool> canSpawnSuccessor() async => true;
+
+  @override
+  Future<bool> performRestartHandoff() async => true;
+
+  @override
+  Future<bool> spawnSuccessor() async => true;
 }
 
 BridgeRestartService _spawnableRestartService({

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -26,7 +26,8 @@ void main() {
     final harness = await _OrchestratorHarness.create(pluginIds: const ["one", "two"]);
     addTearDown(harness.close);
 
-    final response = await harness.composition.session.router.route(makeRequest("GET", "/plugin"));
+    final response =
+        (await harness.composition.session.router.route(makeRequest("GET", "/plugin")).completion).response;
     final plugins = PluginListResponse.fromJson(jsonDecodeMap(response.body!)).plugins;
 
     expect(response.status, 200);
@@ -55,15 +56,19 @@ void main() {
     final harness = await _OrchestratorHarness.create(pluginIds: const ["one"]);
     addTearDown(harness.close);
 
-    final response = await harness.composition.session.router.route(
-      makeRequest(
-        "PATCH",
-        "/plugin/idle-timeout",
-        body: jsonEncode(
-          const PluginIdleTimeoutUpdateRequest.setOverride(pluginId: "one", idleTimeoutMins: 25).toJson(),
-        ),
-      ),
-    );
+    final response =
+        (await harness.composition.session.router
+                .route(
+                  makeRequest(
+                    "PATCH",
+                    "/plugin/idle-timeout",
+                    body: jsonEncode(
+                      const PluginIdleTimeoutUpdateRequest.setOverride(pluginId: "one", idleTimeoutMins: 25).toJson(),
+                    ),
+                  ),
+                )
+                .completion)
+            .response;
     final management = PluginManagementResponse.fromJson(jsonDecodeMap(response.body!));
 
     expect(response.status, 200);
@@ -75,13 +80,17 @@ void main() {
     final harness = await _OrchestratorHarness.create(pluginIds: const ["one"]);
     addTearDown(harness.close);
 
-    final response = await harness.composition.session.router.route(
-      makeRequest(
-        "POST",
-        "/plugin/missing/command",
-        body: jsonEncode(const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe).toJson()),
-      ),
-    );
+    final response =
+        (await harness.composition.session.router
+                .route(
+                  makeRequest(
+                    "POST",
+                    "/plugin/missing/command",
+                    body: jsonEncode(const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe).toJson()),
+                  ),
+                )
+                .completion)
+            .response;
 
     expect(response.status, 404);
     expect(response.body, "plugin not found");
@@ -453,7 +462,6 @@ class _OrchestratorHarness {
     final runtime = BridgeRuntime(
       database: database,
       failureReporter: failureReporter,
-      restartService: restartService,
       composition: composition,
     );
     return _OrchestratorHarness(

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -27,7 +27,7 @@ void main() {
     addTearDown(harness.close);
 
     final response =
-        (await harness.composition.session.router.route(makeRequest("GET", "/plugin")).completion).response;
+        (await harness.composition.session.router.route(request: makeRequest("GET", "/plugin")).completion).response;
     final plugins = PluginListResponse.fromJson(jsonDecodeMap(response.body!)).plugins;
 
     expect(response.status, 200);
@@ -59,7 +59,7 @@ void main() {
     final response =
         (await harness.composition.session.router
                 .route(
-                  makeRequest(
+                  request: makeRequest(
                     "PATCH",
                     "/plugin/idle-timeout",
                     body: jsonEncode(
@@ -83,7 +83,7 @@ void main() {
     final response =
         (await harness.composition.session.router
                 .route(
-                  makeRequest(
+                  request: makeRequest(
                     "POST",
                     "/plugin/missing/command",
                     body: jsonEncode(const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe).toJson()),

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -185,7 +185,7 @@ void main() {
       await harness.runFuture.timeout(const Duration(seconds: 5));
     });
 
-    test("routed and control diagnostics retain only closed identities", () async {
+    test("routed and control diagnostics retain useful local context", () async {
       late _RegistrationHarness harness;
       final output = await _captureLogOutput(() async {
         harness = await _RegistrationHarness.start(
@@ -229,12 +229,9 @@ void main() {
         }
       });
 
-      expect(output, contains("RelaySessionView"));
-      expect(output, contains("RelaySseSubscribe"));
-      expect(output, contains("GET /global/health"));
-      expect(output, isNot(contains("private-session-view")));
-      expect(output, isNot(contains("private-subscription-path")));
-      expect(output, isNot(contains("private-route-query")));
+      expect(output, contains("SessionView connID=9 sessionId=private-session-view"));
+      expect(output, contains("SseSubscribe: path=/events/private-subscription-path"));
+      expect(output, contains("GET /global/health?private-route-query=yes"));
     });
   });
 

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -2,6 +2,7 @@ import "dart:async";
 import "dart:convert";
 import "dart:io";
 
+import "package:cryptography/cryptography.dart";
 import "package:http/http.dart" as http;
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/auth/bridge_registration_api.dart";
@@ -10,13 +11,14 @@ import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
 import "package:sesori_bridge/src/bridge/models/bridge_config.dart";
 import "package:sesori_bridge/src/bridge/orchestrator.dart";
 import "package:sesori_bridge/src/bridge/relay_client.dart";
+import "package:sesori_bridge/src/bridge/routing/bridge_restart_dispatcher.dart";
+import "package:sesori_bridge/src/server/services/bridge_restart_service.dart";
 import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show ServerClock;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log, LogLevel, ServerClock;
 import "package:sesori_shared/sesori_shared.dart" hide PermissionReply;
 import "package:test/test.dart";
 
 import "../helpers/plugin_lifecycle_test_support.dart";
-import "../helpers/restart_test_support.dart";
 import "../helpers/test_database.dart";
 import "../helpers/test_helpers.dart";
 import "routing/routing_test_helpers.dart";
@@ -148,6 +150,94 @@ void main() {
     });
   });
 
+  group("OrchestratorSession routed request boundaries", () {
+    test("enqueues the correlated restart response before handoff and graceful close", () async {
+      final repository = FakeBridgeRegistrationRepository()..nextBridgeId = "br_restart001";
+      final harness = await _RegistrationHarness.start(repository: repository);
+      addTearDown(harness.close);
+      harness.restartService.restartable = true;
+      final phone = await _activatePhone(harness: harness, connId: 7);
+      final sendsBeforeRestart = harness.relayClient.sendCount;
+
+      await _sendEncrypted(
+        socket: phone.socket,
+        connId: 7,
+        encryptor: phone.encryptor,
+        message: const RelayMessage.request(
+          id: "restart-request",
+          method: "POST",
+          path: "/global/restart",
+          headers: {},
+          body: null,
+        ),
+      );
+
+      final response = await _nextResponse(
+        messages: phone.messages,
+        encryptor: phone.encryptor,
+        requestId: "restart-request",
+      );
+      expect(response.status, 200);
+      expect(jsonDecodeMap(response.body!)["restarting"], isTrue);
+      expect(harness.restartService.handoffCalls, 1);
+      expect(harness.restartService.sendCountAtHandoff, sendsBeforeRestart + 1);
+      expect(harness.restartService.connIdAtHandoff, 7);
+      await harness.runFuture.timeout(const Duration(seconds: 5));
+    });
+
+    test("routed and control diagnostics retain only closed identities", () async {
+      late _RegistrationHarness harness;
+      final output = await _captureLogOutput(() async {
+        harness = await _RegistrationHarness.start(
+          repository: FakeBridgeRegistrationRepository()..nextBridgeId = "br_logs001",
+        );
+        try {
+          final phone = await _activatePhone(harness: harness, connId: 9);
+          await _sendEncrypted(
+            socket: phone.socket,
+            connId: 9,
+            encryptor: phone.encryptor,
+            message: const RelayMessage.sessionView(sessionId: "private-session-view"),
+          );
+          await _sendEncrypted(
+            socket: phone.socket,
+            connId: 9,
+            encryptor: phone.encryptor,
+            message: const RelayMessage.sseSubscribe(path: "/events/private-subscription-path"),
+          );
+          await _sendEncrypted(
+            socket: phone.socket,
+            connId: 9,
+            encryptor: phone.encryptor,
+            message: const RelayMessage.request(
+              id: "health-request",
+              method: "GET",
+              path: "/global/health?private-route-query=yes",
+              headers: {},
+              body: null,
+            ),
+          );
+
+          final response = await _nextResponse(
+            messages: phone.messages,
+            encryptor: phone.encryptor,
+            requestId: "health-request",
+          );
+          expect(response.status, 200);
+        } finally {
+          await harness.close();
+        }
+      });
+
+      expect(output, contains("RelaySessionView"));
+      expect(output, contains("RelaySseSubscribe"));
+      expect(output, contains("GET /global/health"));
+      expect(output, isNot(contains("private-session-view")));
+      expect(output, isNot(contains("private-subscription-path")));
+      expect(output, isNot(contains("private-route-query")));
+    });
+  });
+
   group("OrchestratorSession relay takeover (ADR A22)", () {
     test("a 4007 replaced-close does not reconnect within the war window", () async {
       final repository = FakeBridgeRegistrationRepository()..nextBridgeId = "br_first001";
@@ -259,6 +349,9 @@ class _RegistrationHarness {
   final AppDatabase database;
   final PluginLifecycleService lifecycleService;
   final http.Client httpClient;
+  final _RecordingRelayClient relayClient;
+  final _RecordingRestartService restartService;
+  final BridgeRestartDispatcher restartDispatcher;
 
   _RegistrationHarness._({
     required this.plugin,
@@ -270,6 +363,9 @@ class _RegistrationHarness {
     required this.database,
     required this.lifecycleService,
     required this.httpClient,
+    required this.relayClient,
+    required this.restartService,
+    required this.restartDispatcher,
   });
 
   static Future<_RegistrationHarness> start({
@@ -288,6 +384,12 @@ class _RegistrationHarness {
     );
     final lifecycleService = await createSinglePluginLifecycleService(plugin: plugin);
     final httpClient = http.Client();
+    final relayClient = _RecordingRelayClient(
+      relayURL: "ws://127.0.0.1:${relayServer.port}",
+      accessTokenProvider: FakeAccessTokenProvider(),
+      bridgeIdProvider: registrationService,
+    );
+    final restartService = _RecordingRestartService(relayClient: relayClient);
 
     final orchestrator = Orchestrator(
       config: BridgeConfig(
@@ -296,11 +398,7 @@ class _RegistrationHarness {
         sseReplayWindow: const Duration(minutes: 1),
         yolo: false,
       ),
-      client: RelayClient(
-        relayURL: "ws://127.0.0.1:${relayServer.port}",
-        accessTokenProvider: FakeAccessTokenProvider(),
-        bridgeIdProvider: registrationService,
-      ),
+      client: relayClient,
       legacyMissingPluginId: plugin.id,
       pluginLifecycleService: lifecycleService,
       pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
@@ -312,12 +410,13 @@ class _RegistrationHarness {
       tokenRefresher: FakeTokenRefresher(),
       bridgeRegistrationService: registrationService,
       failureReporter: FakeFailureReporter(),
-      restartService: buildTestRestartService(),
+      restartService: restartService,
       filesystemAccessOk: true,
       statusNotifier: null,
     );
 
-    final session = orchestrator.create().session;
+    final composition = orchestrator.create();
+    final session = composition.session;
     final startFuture = session.start();
     final runFuture = session.waitUntilStopped();
     startFuture.ignore();
@@ -333,6 +432,9 @@ class _RegistrationHarness {
       database: database,
       lifecycleService: lifecycleService,
       httpClient: httpClient,
+      relayClient: relayClient,
+      restartService: restartService,
+      restartDispatcher: composition.restartDispatcher,
     );
   }
 
@@ -349,9 +451,152 @@ class _RegistrationHarness {
       // The lifecycle may have already completed with the error under test.
     }
     await lifecycleService.dispose();
+    await restartDispatcher.dispose();
     httpClient.close();
     await database.close();
     await relayServer.close();
+  }
+}
+
+class _RecordingRelayClient extends RelayClient {
+  _RecordingRelayClient({
+    required super.relayURL,
+    required super.accessTokenProvider,
+    required super.bridgeIdProvider,
+  });
+
+  int sendCount = 0;
+  int? lastConnId;
+
+  @override
+  void send(int connID, List<int> payload) {
+    super.send(connID, payload);
+    sendCount++;
+    lastConnId = connID;
+  }
+}
+
+class _RecordingRestartService implements BridgeRestartService {
+  _RecordingRestartService({required this.relayClient});
+
+  final _RecordingRelayClient relayClient;
+  bool restartable = false;
+  int handoffCalls = 0;
+  int? sendCountAtHandoff;
+  int? connIdAtHandoff;
+
+  @override
+  bool get supervisedRestartRequested => false;
+
+  @override
+  Future<bool> canRestart() async => restartable;
+
+  @override
+  Future<bool> canSpawnSuccessor() async => restartable;
+
+  @override
+  Future<bool> performRestartHandoff() async {
+    handoffCalls++;
+    sendCountAtHandoff = relayClient.sendCount;
+    connIdAtHandoff = relayClient.lastConnId;
+    return true;
+  }
+
+  @override
+  Future<bool> spawnSuccessor() async => true;
+}
+
+Future<({WebSocket socket, StreamIterator<dynamic> messages, SessionEncryptor encryptor})> _activatePhone({
+  required _RegistrationHarness harness,
+  required int connId,
+}) async {
+  final socket = await harness.relayServer.nextClient();
+  final messages = StreamIterator<dynamic>(socket);
+  expect(await messages.moveNext(), isTrue);
+  expect(jsonDecodeMap(messages.current as String)["type"], "auth");
+
+  final crypto = RelayCryptoService();
+  final phoneKeyPair = await crypto.generateKeyPair();
+  final phonePublicKey = await phoneKeyPair.extractPublicKey();
+  socket.add(<int>[
+    0,
+    connId,
+    ...utf8.encode(
+      jsonEncode(
+        RelayMessage.keyExchange(
+          publicKey: base64Url.encode(phonePublicKey.bytes).replaceAll("=", ""),
+        ).toJson(),
+      ),
+    ),
+  ]);
+
+  expect(await messages.moveNext(), isTrue);
+  final readyFrame = messages.current as List<int>;
+  expect(readyFrame.sublist(0, 2), [0, connId]);
+  final ready = await _decryptReady(response: readyFrame.sublist(2), phoneKeyPair: phoneKeyPair);
+  final roomKey = SecretKey(base64Url.decode(base64Url.normalize(ready.roomKey)));
+  await harness.session.firstPhoneConnected.timeout(const Duration(seconds: 2));
+  return (socket: socket, messages: messages, encryptor: crypto.createSessionEncryptor(roomKey));
+}
+
+Future<RelayReady> _decryptReady({required List<int> response, required SimpleKeyPair phoneKeyPair}) async {
+  final crypto = RelayCryptoService();
+  final bridgePublicKey = SimplePublicKey(response.sublist(0, 32), type: KeyPairType.x25519);
+  final secret = await crypto.deriveSharedSecret(phoneKeyPair, peerPublicKey: bridgePublicKey);
+  final encryptor = crypto.createSessionEncryptor(await crypto.deriveEncryptionKey(secret));
+  final decrypted = await unframe(response.sublist(32), encryptor: encryptor);
+  return RelayMessage.fromJson(jsonDecodeMap(utf8.decode(decrypted))) as RelayReady;
+}
+
+Future<void> _sendEncrypted({
+  required WebSocket socket,
+  required int connId,
+  required SessionEncryptor encryptor,
+  required RelayMessage message,
+}) async {
+  final payload = await frame(utf8.encode(jsonEncode(message.toJson())), encryptor: encryptor);
+  socket.add(<int>[0, connId, ...payload]);
+}
+
+Future<RelayResponse> _nextResponse({
+  required StreamIterator<dynamic> messages,
+  required SessionEncryptor encryptor,
+  required String requestId,
+}) async {
+  while (await messages.moveNext()) {
+    final wire = messages.current;
+    if (wire is! List<int> || wire.length < 3) continue;
+    final decrypted = await unframe(wire.sublist(2), encryptor: encryptor);
+    final message = RelayMessage.fromJson(jsonDecodeMap(utf8.decode(decrypted)));
+    if (message case final RelayResponse response when response.id == requestId) return response;
+  }
+  throw StateError("relay closed before response $requestId");
+}
+
+class _BufferingStdout implements Stdout {
+  final StringBuffer _buffer = StringBuffer();
+
+  String get text => _buffer.toString();
+
+  @override
+  void write(Object? object) => _buffer.write(object);
+
+  @override
+  void writeln([Object? object = ""]) => _buffer.writeln(object);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+Future<String> _captureLogOutput(Future<void> Function() action) async {
+  final stderrBuffer = _BufferingStdout();
+  final previousLevel = Log.level;
+  try {
+    Log.level = LogLevel.verbose;
+    await IOOverrides.runZoned(action, stderr: () => stderrBuffer);
+    return stderrBuffer.text;
+  } finally {
+    Log.level = previousLevel;
   }
 }
 

--- a/bridge/app/test/bridge/routing/bridge_restart_dispatcher_test.dart
+++ b/bridge/app/test/bridge/routing/bridge_restart_dispatcher_test.dart
@@ -1,0 +1,110 @@
+import "dart:async";
+import "dart:collection";
+
+import "package:sesori_bridge/src/bridge/routing/bridge_restart_dispatcher.dart";
+import "package:sesori_bridge/src/bridge/routing/routed_request.dart";
+import "package:sesori_bridge/src/server/services/bridge_restart_service.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("BridgeRestartDispatcher", () {
+    test("shares one successful handoff and emits one synchronous shutdown request", () async {
+      final gate = Completer<bool>();
+      final service = _FakeRestartService(handoffs: Queue.of([() => gate.future]));
+      final dispatcher = BridgeRestartDispatcher(restartService: service);
+      addTearDown(dispatcher.dispose);
+      final shutdownRequests = <BridgeShutdownRequest>[];
+      dispatcher.shutdownRequests.listen(shutdownRequests.add);
+
+      final first = dispatcher.dispatch(restart: const RestartAccepted(requestId: "one"));
+      final duplicate = dispatcher.dispatch(restart: const RestartAccepted(requestId: "two"));
+
+      expect(service.handoffCalls, 1);
+      expect(shutdownRequests, isEmpty);
+      gate.complete(true);
+      await Future.wait([first, duplicate]);
+      expect(shutdownRequests, [BridgeShutdownRequest.restart]);
+
+      await dispatcher.dispatch(restart: const RestartAccepted(requestId: "three"));
+      expect(service.handoffCalls, 1);
+      expect(shutdownRequests, [BridgeShutdownRequest.restart]);
+    });
+
+    test("failed handoff emits nothing and permits a later retry", () async {
+      final service = _FakeRestartService(
+        handoffs: Queue.of([
+          () async => false,
+          () async => true,
+        ]),
+      );
+      final dispatcher = BridgeRestartDispatcher(restartService: service);
+      addTearDown(dispatcher.dispose);
+      final shutdownRequests = <BridgeShutdownRequest>[];
+      dispatcher.shutdownRequests.listen(shutdownRequests.add);
+
+      await dispatcher.dispatch(restart: const RestartAccepted(requestId: "first"));
+      expect(shutdownRequests, isEmpty);
+
+      await dispatcher.dispatch(restart: const RestartAccepted(requestId: "retry"));
+      expect(service.handoffCalls, 2);
+      expect(shutdownRequests, [BridgeShutdownRequest.restart]);
+    });
+
+    test("handoff errors remain observable and do not poison retries", () async {
+      final service = _FakeRestartService(
+        handoffs: Queue.of([
+          () => Future<bool>.error(StateError("handoff failed")),
+          () async => true,
+        ]),
+      );
+      final dispatcher = BridgeRestartDispatcher(restartService: service);
+      addTearDown(dispatcher.dispose);
+
+      await expectLater(
+        dispatcher.dispatch(restart: const RestartAccepted(requestId: "first")),
+        throwsA(isA<StateError>()),
+      );
+      await dispatcher.dispatch(restart: const RestartAccepted(requestId: "retry"));
+      expect(service.handoffCalls, 2);
+    });
+
+    test("dispose closes output and rejects later dispatch", () async {
+      final service = _FakeRestartService(handoffs: Queue<Future<bool> Function()>());
+      final dispatcher = BridgeRestartDispatcher(restartService: service);
+      final done = dispatcher.shutdownRequests.drain<void>();
+
+      await dispatcher.dispose();
+      await done;
+
+      await expectLater(
+        dispatcher.dispatch(restart: const RestartAccepted(requestId: "late")),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+}
+
+class _FakeRestartService implements BridgeRestartService {
+  _FakeRestartService({required this.handoffs});
+
+  final Queue<Future<bool> Function()> handoffs;
+  int handoffCalls = 0;
+
+  @override
+  bool get supervisedRestartRequested => false;
+
+  @override
+  Future<bool> canRestart() async => true;
+
+  @override
+  Future<bool> canSpawnSuccessor() async => true;
+
+  @override
+  Future<bool> performRestartHandoff() {
+    handoffCalls++;
+    return handoffs.removeFirst()();
+  }
+
+  @override
+  Future<bool> spawnSuccessor() async => true;
+}

--- a/bridge/app/test/bridge/routing/request_handler_test.dart
+++ b/bridge/app/test/bridge/routing/request_handler_test.dart
@@ -39,30 +39,28 @@ class _ThrowingGetHandler extends GetRequestHandler<Object> {
 }
 
 void main() {
-  group("HttpMethod.matches", () {
-    test("each method matches its own name (uppercase)", () {
-      expect(HttpMethod.get.matches("GET"), isTrue);
-      expect(HttpMethod.post.matches("POST"), isTrue);
-      expect(HttpMethod.put.matches("PUT"), isTrue);
-      expect(HttpMethod.patch.matches("PATCH"), isTrue);
-      expect(HttpMethod.delete.matches("DELETE"), isTrue);
+  group("HttpMethod", () {
+    test("parses supported external methods case-insensitively", () {
+      expect(HttpMethod.parseExternal("GET"), HttpMethod.get);
+      expect(HttpMethod.parseExternal("Post"), HttpMethod.post);
+      expect(HttpMethod.parseExternal("put"), HttpMethod.put);
+      expect(HttpMethod.parseExternal("PATCH"), HttpMethod.patch);
+      expect(HttpMethod.parseExternal("DELETE"), HttpMethod.delete);
     });
 
-    test("matching is case-insensitive", () {
-      expect(HttpMethod.get.matches("get"), isTrue);
-      expect(HttpMethod.post.matches("Post"), isTrue);
-      expect(HttpMethod.delete.matches("delete"), isTrue);
+    test("does not parse unsupported methods or the handler wildcard", () {
+      expect(HttpMethod.parseExternal("OPTIONS"), isNull);
+      expect(HttpMethod.parseExternal("ANY"), isNull);
     });
 
-    test("method mismatch returns false", () {
-      expect(HttpMethod.get.matches("POST"), isFalse);
-      expect(HttpMethod.post.matches("GET"), isFalse);
-      expect(HttpMethod.put.matches("PATCH"), isFalse);
+    test("matches typed methods", () {
+      expect(HttpMethod.get.matches(HttpMethod.get), isTrue);
+      expect(HttpMethod.get.matches(HttpMethod.post), isFalse);
     });
 
-    test("any matches every method string", () {
-      for (final raw in ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]) {
-        expect(HttpMethod.any.matches(raw), isTrue, reason: raw);
+    test("any matches every parsed method", () {
+      for (final method in HttpMethod.values.where((method) => method != HttpMethod.any)) {
+        expect(HttpMethod.any.matches(method), isTrue, reason: method.name);
       }
     });
   });

--- a/bridge/app/test/bridge/routing/request_handler_test.dart
+++ b/bridge/app/test/bridge/routing/request_handler_test.dart
@@ -41,26 +41,26 @@ class _ThrowingGetHandler extends GetRequestHandler<Object> {
 void main() {
   group("HttpMethod", () {
     test("parses supported external methods case-insensitively", () {
-      expect(HttpMethod.parseExternal("GET"), HttpMethod.get);
-      expect(HttpMethod.parseExternal("Post"), HttpMethod.post);
-      expect(HttpMethod.parseExternal("put"), HttpMethod.put);
-      expect(HttpMethod.parseExternal("PATCH"), HttpMethod.patch);
-      expect(HttpMethod.parseExternal("DELETE"), HttpMethod.delete);
+      expect(HttpMethod.parseExternal(rawMethod: "GET"), HttpMethod.get);
+      expect(HttpMethod.parseExternal(rawMethod: "Post"), HttpMethod.post);
+      expect(HttpMethod.parseExternal(rawMethod: "put"), HttpMethod.put);
+      expect(HttpMethod.parseExternal(rawMethod: "PATCH"), HttpMethod.patch);
+      expect(HttpMethod.parseExternal(rawMethod: "DELETE"), HttpMethod.delete);
     });
 
     test("does not parse unsupported methods or the handler wildcard", () {
-      expect(HttpMethod.parseExternal("OPTIONS"), isNull);
-      expect(HttpMethod.parseExternal("ANY"), isNull);
+      expect(HttpMethod.parseExternal(rawMethod: "OPTIONS"), isNull);
+      expect(HttpMethod.parseExternal(rawMethod: "ANY"), isNull);
     });
 
     test("matches typed methods", () {
-      expect(HttpMethod.get.matches(HttpMethod.get), isTrue);
-      expect(HttpMethod.get.matches(HttpMethod.post), isFalse);
+      expect(HttpMethod.get.matches(requestMethod: HttpMethod.get), isTrue);
+      expect(HttpMethod.get.matches(requestMethod: HttpMethod.post), isFalse);
     });
 
     test("any matches every parsed method", () {
       for (final method in HttpMethod.values.where((method) => method != HttpMethod.any)) {
-        expect(HttpMethod.any.matches(method), isTrue, reason: method.name);
+        expect(HttpMethod.any.matches(requestMethod: method), isTrue, reason: method.name);
       }
     });
   });

--- a/bridge/app/test/bridge/routing/request_router_test.dart
+++ b/bridge/app/test/bridge/routing/request_router_test.dart
@@ -1,5 +1,8 @@
+import "dart:async";
+
 import "package:sesori_bridge/src/bridge/routing/request_handler.dart";
 import "package:sesori_bridge/src/bridge/routing/request_router.dart";
+import "package:sesori_bridge/src/bridge/routing/routed_request.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -32,8 +35,19 @@ void main() {
         ],
       );
 
-      final response = await router.route(_request(method: "GET", path: "/session/s1?view=full#messages"));
+      final pending = router.route(_request(method: "GET", path: "/session/s1?view=full#messages"));
 
+      expect(
+        pending.routeIdentity,
+        isA<MatchedRoute>()
+            .having((identity) => identity.method, "method", HttpMethod.get)
+            .having((identity) => identity.pathTemplate, "pathTemplate", "/session/:id"),
+      );
+      expect(pending.routeIdentity.diagnosticLabel, "GET /session/:id");
+      final outcome = await pending.completion;
+      final response = outcome.response;
+
+      expect(outcome, isA<ResponseOnly>());
       expect(response.status, 201);
       expect(response.body, "first");
       expect(calls, ["first"]);
@@ -62,17 +76,62 @@ void main() {
           ),
         );
 
-      expect((await router.route(_request(method: "GET", path: "/original"))).status, 200);
-      expect((await router.route(_request(method: "GET", path: "/replacement"))).status, 404);
+      expect((await _route(router, _request(method: "GET", path: "/original"))).status, 200);
+      expect((await _route(router, _request(method: "GET", path: "/replacement"))).status, 404);
     });
 
     test("returns 404 when no handler matches", () async {
       final router = RequestRouter(handlers: const []);
 
-      final response = await router.route(_request(method: "GET", path: "/unknown"));
+      final pending = router.route(_request(method: "GET", path: "/unknown?secret=value"));
+      final response = (await pending.completion).response;
 
+      expect(pending.routeIdentity, isA<UnmatchedRoute>());
+      expect(pending.routeIdentity.diagnosticLabel, "GET unmatched route");
+      expect(pending.routeIdentity.diagnosticLabel, isNot(contains("secret")));
       expect(response.status, 404);
-      expect(response.body, "no handler found for GET /unknown");
+      expect(response.body, "no handler found for GET /unknown?secret=value");
+    });
+
+    test("returns closed identities for invalid methods and targets", () async {
+      final router = RequestRouter(handlers: const []);
+
+      final invalidMethod = router.route(_request(method: "CUSTOM-secret", path: "/private/path"));
+      expect(invalidMethod.routeIdentity, isA<InvalidMethodRoute>());
+      expect(invalidMethod.routeIdentity.diagnosticLabel, "invalid method");
+      expect((await invalidMethod.completion).response.status, 404);
+
+      final invalidTarget = router.route(_request(method: "GET", path: "http://[target-secret"));
+      expect(invalidTarget.routeIdentity, isA<InvalidTargetRoute>());
+      expect(invalidTarget.routeIdentity.diagnosticLabel, "GET invalid target");
+      expect((await invalidTarget.completion).response.status, 502);
+    });
+
+    test("returns route identity before asynchronous completion", () async {
+      final responseGate = Completer<RelayResponse>();
+      final router = RequestRouter(
+        handlers: [
+          _TestHandler(
+            method: HttpMethod.get,
+            path: "/session/:id",
+            handle: ({required request, required pathParams, required queryParams, required fragment}) {
+              return responseGate.future;
+            },
+          ),
+        ],
+      );
+
+      final pending = router.route(_request(method: "get", path: "/session/private-id"));
+
+      expect(pending.routeIdentity.diagnosticLabel, "GET /session/:id");
+      responseGate.complete(
+        _response(
+          request: _request(method: "GET", path: "/"),
+          status: 200,
+          body: "ok",
+        ),
+      );
+      expect((await pending.completion).response.body, "ok");
     });
 
     test("maps plugin operation failures to their status", () async {
@@ -88,7 +147,7 @@ void main() {
         ],
       );
 
-      final response = await router.route(_request(method: "GET", path: "/plugin-failure"));
+      final response = await _route(router, _request(method: "GET", path: "/plugin-failure"));
 
       expect(response.status, 404);
       expect(response.body, contains("PluginOperationException"));
@@ -107,7 +166,7 @@ void main() {
         ],
       );
 
-      final response = await router.route(_request(method: "GET", path: "/failure"));
+      final response = await _route(router, _request(method: "GET", path: "/failure"));
 
       expect(response.status, 502);
       expect(response.body, contains("boom"));
@@ -167,4 +226,8 @@ RelayResponse _response({required RelayRequest request, required int status, req
     headers: const {},
     body: body,
   );
+}
+
+Future<RelayResponse> _route(RequestRouter router, RelayRequest request) async {
+  return (await router.route(request).completion).response;
 }

--- a/bridge/app/test/bridge/routing/request_router_test.dart
+++ b/bridge/app/test/bridge/routing/request_router_test.dart
@@ -35,7 +35,7 @@ void main() {
         ],
       );
 
-      final pending = router.route(_request(method: "GET", path: "/session/s1?view=full#messages"));
+      final pending = router.route(request: _request(method: "GET", path: "/session/s1?view=full#messages"));
 
       expect(
         pending.routeIdentity,
@@ -83,7 +83,7 @@ void main() {
     test("returns 404 when no handler matches", () async {
       final router = RequestRouter(handlers: const []);
 
-      final pending = router.route(_request(method: "GET", path: "/unknown?secret=value"));
+      final pending = router.route(request: _request(method: "GET", path: "/unknown?secret=value"));
       final response = (await pending.completion).response;
 
       expect(pending.routeIdentity, isA<UnmatchedRoute>());
@@ -96,12 +96,12 @@ void main() {
     test("returns closed identities for invalid methods and targets", () async {
       final router = RequestRouter(handlers: const []);
 
-      final invalidMethod = router.route(_request(method: "CUSTOM-secret", path: "/private/path"));
+      final invalidMethod = router.route(request: _request(method: "CUSTOM-secret", path: "/private/path"));
       expect(invalidMethod.routeIdentity, isA<InvalidMethodRoute>());
       expect(invalidMethod.routeIdentity.diagnosticLabel, "invalid method");
       expect((await invalidMethod.completion).response.status, 404);
 
-      final invalidTarget = router.route(_request(method: "GET", path: "http://[target-secret"));
+      final invalidTarget = router.route(request: _request(method: "GET", path: "http://[target-secret"));
       expect(invalidTarget.routeIdentity, isA<InvalidTargetRoute>());
       expect(invalidTarget.routeIdentity.diagnosticLabel, "GET invalid target");
       expect((await invalidTarget.completion).response.status, 502);
@@ -121,7 +121,7 @@ void main() {
         ],
       );
 
-      final pending = router.route(_request(method: "get", path: "/session/private-id"));
+      final pending = router.route(request: _request(method: "get", path: "/session/private-id"));
 
       expect(pending.routeIdentity.diagnosticLabel, "GET /session/:id");
       responseGate.complete(
@@ -229,5 +229,5 @@ RelayResponse _response({required RelayRequest request, required int status, req
 }
 
 Future<RelayResponse> _route(RequestRouter router, RelayRequest request) async {
-  return (await router.route(request).completion).response;
+  return (await router.route(request: request).completion).response;
 }

--- a/bridge/app/test/bridge/routing/restart_bridge_handler_test.dart
+++ b/bridge/app/test/bridge/routing/restart_bridge_handler_test.dart
@@ -85,7 +85,7 @@ void main() {
     final handler = RestartBridgeHandler(restartService: service);
 
     final outcome = await handler.routeInternal(
-      makeRequest('POST', '/global/restart'),
+      request: makeRequest('POST', '/global/restart'),
       pathParams: const {},
       queryParams: const {},
       fragment: null,
@@ -102,7 +102,7 @@ void main() {
     final handler = RestartBridgeHandler(restartService: service);
 
     final outcome = await handler.routeInternal(
-      makeRequest('POST', '/global/restart'),
+      request: makeRequest('POST', '/global/restart'),
       pathParams: const {},
       queryParams: const {},
       fragment: null,
@@ -120,7 +120,7 @@ void main() {
     final handler = RestartBridgeHandler(restartService: service);
 
     final outcome = await handler.routeInternal(
-      makeRequest('POST', '/global/restart'),
+      request: makeRequest('POST', '/global/restart'),
       pathParams: const {},
       queryParams: const {},
       fragment: null,

--- a/bridge/app/test/bridge/routing/restart_bridge_handler_test.dart
+++ b/bridge/app/test/bridge/routing/restart_bridge_handler_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:sesori_bridge/src/bridge/foundation/process_runner.dart';
 import 'package:sesori_bridge/src/bridge/routing/restart_bridge_handler.dart';
+import 'package:sesori_bridge/src/bridge/routing/routed_request.dart';
 import 'package:sesori_bridge/src/server/api/system_process_api.dart';
 import 'package:sesori_bridge/src/server/foundation/bridge_restart_command_builder.dart';
 import 'package:sesori_bridge/src/server/repositories/process_repository.dart';
@@ -74,7 +75,7 @@ void main() {
     expect(handler.canHandle(makeRequest('POST', '/global/health')), isFalse);
   });
 
-  test('replies {restarting:true} and flags the restart when spawnable', () async {
+  test('returns a fixed RestartAccepted outcome when spawnable', () async {
     final binaryPath = p.join(tempDir.path, 'sesori-bridge');
     File(binaryPath).writeAsStringSync('binary');
     if (!Platform.isWindows) {
@@ -83,32 +84,33 @@ void main() {
     final service = buildService(binaryPath: binaryPath);
     final handler = RestartBridgeHandler(restartService: service);
 
-    final response = await handler.handleInternal(
+    final outcome = await handler.routeInternal(
       makeRequest('POST', '/global/restart'),
       pathParams: const {},
       queryParams: const {},
       fragment: null,
     );
 
-    expect(response.status, 200);
-    expect(response.body, contains('"restarting":true'));
-    expect(service.consumeRestartRequest(), isTrue);
+    expect(outcome, isA<RestartAccepted>());
+    expect((outcome as RestartAccepted).requestId, 'test-id');
+    expect(outcome.response.status, 200);
+    expect(outcome.response.body, contains('"restarting":true'));
   });
 
-  test('returns 503 without flagging a restart when the binary is unavailable', () async {
+  test('returns ResponseOnly 503 when the binary is unavailable', () async {
     final service = buildService(binaryPath: p.join(tempDir.path, 'missing'));
     final handler = RestartBridgeHandler(restartService: service);
 
-    final response = await handler.handleInternal(
+    final outcome = await handler.routeInternal(
       makeRequest('POST', '/global/restart'),
       pathParams: const {},
       queryParams: const {},
       fragment: null,
     );
 
-    expect(response.status, 503);
-    expect(response.body, contains('sesori.com'));
-    expect(service.consumeRestartRequest(), isFalse);
+    expect(outcome, isA<ResponseOnly>());
+    expect(outcome.response.status, 503);
+    expect(outcome.response.body, contains('sesori.com'));
   });
 
   test('supervised restart proceeds even when the managed binary is unavailable', () async {
@@ -117,15 +119,15 @@ void main() {
     final service = buildService(binaryPath: p.join(tempDir.path, 'missing'), isSupervised: true);
     final handler = RestartBridgeHandler(restartService: service);
 
-    final response = await handler.handleInternal(
+    final outcome = await handler.routeInternal(
       makeRequest('POST', '/global/restart'),
       pathParams: const {},
       queryParams: const {},
       fragment: null,
     );
 
-    expect(response.status, 200);
-    expect(response.body, contains('"restarting":true'));
-    expect(service.consumeRestartRequest(), isTrue);
+    expect(outcome, isA<RestartAccepted>());
+    expect(outcome.response.status, 200);
+    expect(outcome.response.body, contains('"restarting":true'));
   });
 }

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -72,7 +72,7 @@ RelayRequest makeRequest(
 
 extension RequestHandlerTestMatching on RequestHandlerBase {
   bool canHandle(RelayRequest request) {
-    final method = HttpMethod.parseExternal(request.method);
+    final method = HttpMethod.parseExternal(rawMethod: request.method);
     if (method == null) return false;
     return matches(requestMethod: method, target: Uri.parse(request.path));
   }

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -22,6 +22,7 @@ import "package:sesori_bridge/src/bridge/repositories/pull_request_repository.da
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_repository.dart";
+import "package:sesori_bridge/src/bridge/routing/request_handler.dart";
 import "package:sesori_bridge/src/bridge/services/pr_sync_service.dart";
 import "package:sesori_bridge/src/bridge/services/session_unseen_service.dart";
 import "package:sesori_bridge/src/bridge/services/session_view_tracker.dart";
@@ -68,6 +69,21 @@ RelayRequest makeRequest(
           body: body,
         )
         as RelayRequest;
+
+extension RequestHandlerTestMatching on RequestHandlerBase {
+  bool canHandle(RelayRequest request) {
+    final method = HttpMethod.parseExternal(request.method);
+    if (method == null) return false;
+    return matches(requestMethod: method, target: Uri.parse(request.path));
+  }
+
+  ({
+    Map<String, String> pathParams,
+    Map<String, String> queryParams,
+    String? fragment,
+  })
+  extractParams(RelayRequest request) => extractTargetParams(target: Uri.parse(request.path));
+}
 
 /// Hand-written fake [BridgePluginApi] used across routing handler tests.
 class FakeBridgePlugin implements NativeProjectsPluginApi {

--- a/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
@@ -89,7 +89,7 @@ void main() {
     final routed =
         (await debugServer.router
                 .route(
-                  makeRequest(
+                  request: makeRequest(
                     "POST",
                     "/session/options",
                     body: jsonEncode(PluginProjectIdRequest(projectId: "missing", pluginId: plugin.id).toJson()),

--- a/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
@@ -81,19 +81,22 @@ void main() {
     final runtime = BridgeRuntime(
       database: database,
       failureReporter: failureReporter,
-      restartService: restartService,
       composition: composition,
     );
     final debugServer = runtime.createDebugServer(port: 0);
 
     expect(identical(debugServer.router, runtime.session.router), isTrue);
-    final routed = await debugServer.router.route(
-      makeRequest(
-        "POST",
-        "/session/options",
-        body: jsonEncode(PluginProjectIdRequest(projectId: "missing", pluginId: plugin.id).toJson()),
-      ),
-    );
+    final routed =
+        (await debugServer.router
+                .route(
+                  makeRequest(
+                    "POST",
+                    "/session/options",
+                    body: jsonEncode(PluginProjectIdRequest(projectId: "missing", pluginId: plugin.id).toJson()),
+                  ),
+                )
+                .completion)
+            .response;
     expect(routed.status, 404);
     expect(routed.headers, containsPair("content-type", "application/json"));
     expect(

--- a/bridge/app/test/server/services/bridge_restart_service_test.dart
+++ b/bridge/app/test/server/services/bridge_restart_service_test.dart
@@ -78,15 +78,6 @@ void main() {
     );
   }
 
-  test('requestRestart is consumed exactly once', () {
-    final service = buildService(binaryPath: '/x');
-
-    expect(service.consumeRestartRequest(), isFalse);
-    service.requestRestart();
-    expect(service.consumeRestartRequest(), isTrue);
-    expect(service.consumeRestartRequest(), isFalse);
-  });
-
   test('canSpawnSuccessor reflects whether the binary exists and is executable', () async {
     final existing = p.join(tempDir.path, 'sesori-bridge');
     File(existing).writeAsStringSync('binary');

--- a/bridge/sesori_plugin_interface/lib/src/log.dart
+++ b/bridge/sesori_plugin_interface/lib/src/log.dart
@@ -62,11 +62,12 @@ class Log {
       }
     }
     buffer.write(rawMessage);
-    if (error != null && level.index < LogLevel.info.index) {
-      buffer.write("\n -- Error on next line(s)");
+    if (error != null) {
+      buffer.write("\n -- Error on next line(s)\n");
       buffer.write(error.toString());
     }
-    if (st != null && level.index < LogLevel.info.index) {
+    if (st != null) {
+      buffer.write("\n");
       buffer.write(st.toString());
     }
 

--- a/bridge/sesori_plugin_interface/test/log_test.dart
+++ b/bridge/sesori_plugin_interface/test/log_test.dart
@@ -88,6 +88,20 @@ void main() {
       expect(err.single, equals("from-caller"));
     });
 
+    test("warning retains attached error and stack trace at the default info level", () {
+      Log.level = LogLevel.info;
+      final err = <String>[];
+
+      IOOverrides.runZoned(
+        () => Log.w("operation failed", StateError("useful failure"), StackTrace.fromString("useful stack")),
+        stdout: () => _CapturingStdout(<String>[]),
+        stderr: () => _CapturingStdout(err),
+      );
+
+      expect(err.single, contains("Bad state: useful failure"));
+      expect(err.single, contains("useful stack"));
+    });
+
     test("warning and error are not colorized when stderr is not a terminal", () {
       Log.level = LogLevel.verbose;
       final err = <String>[];


### PR DESCRIPTION
## Complexity

Complex: this changes the internal routing contract and restart lifecycle ownership across relay, debug HTTP, orchestrator, runtime composition, and the shared bridge logger while preserving current serial request execution.

## What

- Select routes synchronously with closed matched/unmatched/invalid identities and asynchronous sealed outcomes.
- Represent successful restart acceptance as a valid-only outcome tied to its originating request.
- Add one shared restart dispatcher for duplicate suppression, process handoff, and typed shutdown signaling.
- Remove the global restart flag and the callback forwarded through `BridgeRuntime`.
- Preserve useful local errors, stack traces, paths, identifiers, and request/control context while selectively excluding known prompt/transcript content.
- Emit attached bridge errors/stacks at the default info threshold instead of hiding them below debug verbosity.
- Preserve response enqueue/debug close before restart handoff.

## Why

The shared restart flag assumes one route completes at a time. Scoping restart acceptance to the exact routed request removes that hidden serialization dependency before relay requests are made concurrent in later steps.

## Risk and test focus

Risk is high around restart sequencing, shutdown ownership, and diagnostic behavior: an error response must never trigger restart, duplicate requests must not spawn multiple successors, debug/relay responses must settle before handoff, and local logs must retain enough context to diagnose failures without logging known prompt/transcript content. Tests focus on route identity and error mapping, successful and failed restart preflight, duplicate handoffs, synchronous shutdown emission, debug response ordering, encrypted relay enqueue and graceful close ordering, runtime composition/disposal, and default-level diagnostic capture.

## Expected result

- **User-visible:** Restart keeps its existing best-effort acknowledgement followed by reconnect; ordinary routes are unchanged.
- **Persisted/database:** None.
- **Internal:** Restart acceptance belongs to one sealed route outcome, and one concrete dispatcher replaces the global flag and cross-layer callback. Relay request execution remains serial until Step 9. Repo-wide logging guidance and bridge logger behavior preserve useful bridge/client diagnostic context.

## Verification

- 87 focused bridge routing, restart, debug, relay, and runtime tests passed; 47 focused routing/composition tests passed after the first review fixes; 36 focused routing/relay diagnostic tests passed after the owner-requested logging correction; 6 logger tests and 7 focused router tests passed after restoring default-level error details.
- `dart analyze --fatal-infos` passed in `bridge/app` and `bridge/sesori_plugin_interface`.
- `git diff --check` passed.
- `aristotle-impl-review` identified one routing-layer placement issue; the dispatcher and its test were moved beside the routing outcome. Per repository policy, that direct fix was not re-reviewed.
- 1,552 changed lines. This is 52 lines above the soft cap because the owner requested a repo-wide logging rule plus matching plan/code/logger corrections during review; splitting those corrections would leave this PR governed by contradictory diagnostics.
