### PR TITLE
🌿 fix(bridge): follow GitHub repository renames in PR queries

### DIFF
--- a/bridge/app/lib/src/bridge/api/gh_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/gh_cli_api.dart
@@ -112,7 +112,7 @@ class GhCliApi {
       ]);
       selections.add(
         """
-        target$index: repository(owner: \$owner$index, name: \$name$index) {
+        target$index: repository(owner: \$owner$index, name: \$name$index, followRenames: true) {
           nameWithOwner
           open: pullRequests(
             headRefName: \$branch$index
@@ -161,7 +161,7 @@ class GhCliApi {
       };
       selections.add(
         """
-        target$index: repository(owner: \$owner$index, name: \$name$index) {
+        target$index: repository(owner: \$owner$index, name: \$name$index, followRenames: true) {
           nameWithOwner
           page: pullRequests(
             headRefName: \$branch$index

--- a/bridge/app/lib/src/bridge/repositories/pr_source_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/pr_source_repository.dart
@@ -304,8 +304,8 @@ final class _PullRequestTargetSelection {
   }
 
   void _consume({required GhPullRequestCandidatePage page}) {
-    if (page.repositoryIdentity.toLowerCase() != target.githubRepositoryIdentity) {
-      throw const FormatException("GitHub pull request query returned a different repository");
+    if (page.repositoryIdentity.isEmpty) {
+      throw const FormatException("GitHub pull request query returned an empty repository identity");
     }
 
     _eligibleCandidates.addAll(

--- a/bridge/app/test/bridge/api/gh_cli_api_test.dart
+++ b/bridge/app/test/bridge/api/gh_cli_api_test.dart
@@ -270,7 +270,10 @@ void main() {
       expect(invocation.workingDirectory, isNull);
       expect(invocation.arguments.take(4), ["api", "graphql", "--hostname", "github.com"]);
       final queryArgument = invocation.arguments.singleWhere((argument) => argument.startsWith("query="));
-      expect(queryArgument, contains(r"target0: repository(owner: $owner0, name: $name0)"));
+      expect(
+        queryArgument,
+        contains(r"target0: repository(owner: $owner0, name: $name0, followRenames: true)"),
+      );
       expect(queryArgument, contains("states: [OPEN]"));
       expect(queryArgument, contains("states: [MERGED, CLOSED]"));
       expect(queryArgument, contains("createdAt"));
@@ -304,6 +307,10 @@ void main() {
       expect(response.pages.single.stateGroup, GhPullRequestStateGroup.terminal);
       final arguments = processRunner.invocations.single.arguments;
       final queryArgument = arguments.singleWhere((argument) => argument.startsWith("query="));
+      expect(
+        queryArgument,
+        contains(r"target0: repository(owner: $owner0, name: $name0, followRenames: true)"),
+      );
       expect(queryArgument, contains("states: [MERGED, CLOSED]"));
       expect(queryArgument, contains(r"after: $cursor0"));
       expect(arguments, contains("cursor0=cursor-1"));

--- a/bridge/app/test/bridge/repositories/pr_source_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/pr_source_repository_test.dart
@@ -295,6 +295,107 @@ void main() {
       expect(ghCli.cursorCalls.map((requests) => requests.single.cursor), ["open-1", "open-2"]);
     });
 
+    test("accepts a canonical repository identity for a historical target", () async {
+      const historicalTarget = (
+        githubRepositoryIdentity: "sesori-ai/historical-name",
+        branchName: "feature/current",
+      );
+      const canonicalIdentity = "sesori-ai/current-name";
+      final createdAt = DateTime.utc(2026, 8, 1);
+      final ghCli = _FakeGhCliApi(
+        initialResponses: [
+          _batchResponse(
+            pages: [
+              _page(
+                repositoryIdentity: canonicalIdentity,
+                stateGroup: GhPullRequestStateGroup.open,
+                pullRequests: [
+                  _pullRequest(
+                    number: 30,
+                    createdAt: createdAt,
+                    state: PrState.open,
+                    isCrossRepository: true,
+                  ),
+                ],
+                hasNextPage: true,
+                endCursor: "open-1",
+              ),
+              _page(
+                repositoryIdentity: canonicalIdentity,
+                stateGroup: GhPullRequestStateGroup.terminal,
+                pullRequests: const [],
+              ),
+            ],
+          ),
+        ],
+        cursorResponses: [
+          _batchResponse(
+            pages: [
+              _page(
+                repositoryIdentity: canonicalIdentity,
+                stateGroup: GhPullRequestStateGroup.open,
+                pullRequests: [
+                  _pullRequest(
+                    number: 40,
+                    branch: "feature/other",
+                    createdAt: createdAt,
+                    state: PrState.open,
+                  ),
+                  _pullRequest(number: 7, createdAt: createdAt, state: PrState.open),
+                ],
+              ),
+            ],
+          ),
+        ],
+      );
+      final repository = _selectionRepository(ghCli: ghCli);
+
+      final outcome = await repository.selectPullRequests(
+        targets: const [historicalTarget],
+        expectedGithubLogin: _verifiedGithubLogin,
+      );
+
+      final selected = (outcome as PullRequestSelectionCompleted).selections.single as PullRequestTargetSelected;
+      expect(selected.target, historicalTarget);
+      expect(selected.number, 7);
+      final cursorTarget = ghCli.cursorCalls.single.single.target;
+      expect(cursorTarget.repositoryOwner, "sesori-ai");
+      expect(cursorTarget.repositoryName, "historical-name");
+      expect(cursorTarget.branchName, "feature/current");
+    });
+
+    test("rejects an empty returned repository identity", () async {
+      final ghCli = _FakeGhCliApi(
+        initialResponses: [
+          _batchResponse(
+            pages: [
+              _page(
+                repositoryIdentity: "",
+                stateGroup: GhPullRequestStateGroup.open,
+                pullRequests: const [],
+              ),
+              _page(stateGroup: GhPullRequestStateGroup.terminal, pullRequests: const []),
+            ],
+          ),
+        ],
+      );
+      final repository = _selectionRepository(ghCli: ghCli);
+
+      await expectLater(
+        repository.selectPullRequests(
+          targets: const [_selectionTarget],
+          expectedGithubLogin: _verifiedGithubLogin,
+        ),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            "message",
+            contains("repository identity"),
+          ),
+        ),
+      );
+    });
+
     test("rejects a repeated GraphQL cursor instead of looping", () async {
       final ghCli = _FakeGhCliApi(
         initialResponses: [
@@ -536,6 +637,7 @@ GhPullRequestBatchResponse _batchResponse({
 
 GhPullRequestCandidatePage _page({
   int requestIndex = 0,
+  String repositoryIdentity = _repositoryIdentity,
   required GhPullRequestStateGroup stateGroup,
   required List<GhPullRequest> pullRequests,
   bool hasNextPage = false,
@@ -544,7 +646,7 @@ GhPullRequestCandidatePage _page({
   return GhPullRequestCandidatePage(
     requestIndex: requestIndex,
     stateGroup: stateGroup,
-    repositoryIdentity: _repositoryIdentity,
+    repositoryIdentity: repositoryIdentity,
     connection: GhPullRequestConnection(
       nodes: pullRequests,
       pageInfo: GhPullRequestPageInfo(


### PR DESCRIPTION
## Complexity

🌿 Straightforward — localized GraphQL query and response-validation changes with focused redirect regressions.

## What

- explicitly requests GitHub repository rename following for initial and cursor PR queries
- accepts a non-empty canonical `nameWithOwner` that differs from a historical Git remote slug
- preserves alias/request-index association, exact branch matching, fork filtering, and login fencing
- retains the historical normalized remote identity for persisted cache scope

## Why

GitHub keeps old repository URLs working after renames or transfers and GraphQL resolves those historical names to the current canonical repository. The bridge treated that legitimate canonical response as a different repository and aborted the entire batched PR refresh.

## Risk and test focus

Risk is medium because this relaxes one repository-response guard. The query alias and request index still bind every response page to the exact requested target, while non-empty identity validation, branch matching, cross-repository filtering, and account checks remain intact. Highest-value checks cover initial/cursor query shape, historical-to-canonical redirects, exact branch selection, and malformed empty identities.

## Expected result

Repositories with unchanged historical Git remote URLs continue receiving current PR and CI metadata after a GitHub rename or transfer. No user-visible behavior changes for repositories without redirects. No wire-contract or database-schema change.

## Verification

- `dart test test/bridge/api/gh_cli_api_test.dart test/bridge/repositories/pr_source_repository_test.dart` — 36 passed
- `dart analyze --fatal-infos`
- `dart format` on changed Dart files
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix PR refresh to follow GitHub repository renames. The bridge now keeps fetching PRs after a repo is renamed or transferred instead of aborting.

- **Bug Fixes**
  - Add `followRenames: true` to repository GraphQL queries for both initial and cursor requests.
  - Accept canonical `nameWithOwner` even if it differs from the historical remote slug; still reject empty identities.
  - Update tests to cover rename redirects and empty identity handling.

<sup>Written for commit 6f031defdc6b9ef6f98d86e8236dd755991b8ae0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

