### PR TITLE
🚧 [session-pull-request-monitoring] feat(bridge): schedule viewed-project PR refresh [step 5/9]

### DIFF
--- a/.plan/active/session-pull-request-monitoring/TRACKER.md
+++ b/.plan/active/session-pull-request-monitoring/TRACKER.md
@@ -4,12 +4,12 @@
 
 - **Plan slug:** `session-pull-request-monitoring`
 - **Implementation base:** `main` at
-  `f6ec9e9dc66782197a46261de3bcc002e261a5bd`
-- **Series state:** Steps 1/9, 2.a–2.c/9, and 3/9 merged; Step 4 is in review
-- **Current step:** Step 4/9 — current-branch request refresh
+  `d38d47939e621f60077d75545e00966401e16ccf`
+- **Series state:** Steps 1/9, 2.a–2.c/9, 3/9, and 4/9 merged; Step 5 is in progress
+- **Current step:** Step 5/9 — multi-device view scheduling
 - **Plan PR:** [#649](https://github.com/sesori-ai/sesori_apps_monorepo/pull/649) merged
 - **Superseded prototype:** [#659](https://github.com/sesori-ai/sesori_apps_monorepo/pull/659) closed
-- **Next action:** monitor Step 4 PR #686 and address CI/review feedback
+- **Next action:** commit and open the verified Step 5 implementation PR
 
 ## Existing Baseline
 
@@ -31,8 +31,9 @@
 - **Post-review drift:** `main` advanced through Harness settings, output-image
   plugin work, analytics documentation, bridge `--data-dir` expansion, and plan
   archival. The current tip is audited at `10c7afb9`; none changes this feature's
-  architecture or requested agent guidance, so metadata/path refresh did not
-  trigger another architecture review.
+  architecture or requested agent guidance. The implementation base is now the
+  repository-rename hotfix and unrelated client haptics at `d38d4793`; no plan
+  architecture changed.
 
 ## Delivery Steps
 
@@ -43,8 +44,8 @@
 | [x] | 2.b/9 | `session-pull-request-monitoring-scoped-pr-persistence` | `🚧 [session-pull-request-monitoring] feat(bridge): persist scoped PR selections [step 2.b/9]` | 9,800–10,800 | [PR #671](https://github.com/sesori-ai/sesori_apps_monorepo/pull/671) merged as `e6001fdc` |
 | [x] | 2.c/9 | `session-pull-request-monitoring-scoped-pr-reads` | `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]` | 1,200–1,700 | [PR #678](https://github.com/sesori-ai/sesori_apps_monorepo/pull/678) merged as `d13cc8ca` |
 | [x] | 3/9 | `session-pull-request-monitoring-graphql-selection` | `🚧 [session-pull-request-monitoring] feat(bridge): batch exact PR selection [step 3/9]` | 3,100–3,500 | [PR #685](https://github.com/sesori-ai/sesori_apps_monorepo/pull/685) merged as `f6ec9e9d` |
-| [ ] | 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | 4,000–4,200 | [PR #686](https://github.com/sesori-ai/sesori_apps_monorepo/pull/686) open; all valid feedback addressed, with rejected bot threads left for reviewer follow-up |
-| [ ] | 5/9 | `session-pull-request-monitoring-view-scheduler` | `🚧 [session-pull-request-monitoring] feat(bridge): schedule viewed-project PR refresh [step 5/9]` | 900–1,400 | Blocked on Step 4 merge |
+| [x] | 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | 4,000–4,200 | [PR #686](https://github.com/sesori-ai/sesori_apps_monorepo/pull/686) merged as `3bbb1e8e` |
+| [ ] | 5/9 | `session-pull-request-monitoring-view-scheduler` | `🚧 [session-pull-request-monitoring] feat(bridge): schedule viewed-project PR refresh [step 5/9]` | 900–1,400 | Current and unblocked; implementation complete locally, architecture review/PR pending |
 | [ ] | 6/9 | `session-pull-request-monitoring-bridge-settings` | `⚙️ [session-pull-request-monitoring] feat(bridge): configure PR refresh cadence [step 6/9]` | 1,000–1,500 | Blocked on Step 5 merge |
 | [ ] | 7/9 | `session-pull-request-monitoring-client-presence` | `🚧 [session-pull-request-monitoring] feat(client): declare viewed projects [step 7/9]` | 1,000–1,500 | Blocked on Step 6 merge |
 | [ ] | 8/9 | `session-pull-request-monitoring-client-settings` | `🚧 [session-pull-request-monitoring] feat(client): configure PR refresh cadence [step 8/9]` | 1,000–1,500 | Blocked on Step 7 merge; use current settings owner and merged #647 pattern |
@@ -88,9 +89,10 @@
 
 ## Current Drift and Open Work
 
-- Latest audited `main`: Step 4 branched from merged Step 3 at `f6ec9e9d`.
-  Intervening image-viewer work does not overlap this bridge current-branch
-  refresh scope.
+- Latest audited `main`: `d38d4793`, including Step 4 merged as `3bbb1e8e`, the
+  repository-rename hotfix, and unrelated client haptics. The hotfix accepts a
+  redirected canonical GitHub response while retaining local remote scope, and
+  does not overlap connection presence or scheduling ownership.
 - Drift schema: v13 on `main`; Step 4 leaves the merged schema and migration
   unchanged.
 - Parallel-plugin plan: complete through Stage 9 / PR #497.
@@ -312,6 +314,42 @@
   checkout change as its own typed target variant. Both were applied; per review
   rules, those corrections were not re-reviewed. All 13 bot threads were
   addressed in `a4016fa9` and resolved.
+- **Step 4/9 merge:** PR #686 merged as `3bbb1e8e`. Step 5 starts from current
+  `main` at `d38d4793`, which also contains the merged repository-rename hotfix
+  and unrelated client haptics.
+- **Step 5/9 implementation:** `ProjectViewTracker` owns full-state declarations
+  per physical relay connection, aggregate counts, immutable active-set changes,
+  release-one, relay-wide clear, empty/null normalization, and disposal fencing.
+  `ViewedProjectPrRefreshListener` immediately submits additions with the new
+  `viewedProject` policy, invalidates older completion admissions, and runs one
+  completion-based 30-second timer that snapshots the full active union. Empty
+  state cancels rearm; removal-only changes preserve the schedule; failed and
+  thrown refreshes retry after the interval, with thrown causes retained behind
+  a privacy-safe presentation.
+- **Step 5/9 lifecycle and policy:** `Orchestrator` accepts encrypted
+  `RelayProjectView`, releases one claim on `phone_disconnected`, clears all on
+  relay loss, and owns listener startup/teardown. `BridgeRuntime` disposes the
+  tracker. `PrRefreshPolicy.viewedProject` bypasses completed/background debounce
+  and receives a serialized covering follow-up under active work; existing
+  background coalescing and explicit behavior remain unchanged.
+- **Step 5/9 cleanup:** Keep both old-client request-driven refresh triggers and
+  `SessionViewTracker`: the former is required transport fallback and the latter
+  independently owns mark-seen/unseen semantics. No obsolete production path or
+  competing scheduler remains after routing the previously ignored shipped
+  project-view declaration.
+- **Step 5/9 analytics:** No event. This is passive freshness behavior, and its
+  project/repository identifiers are sensitive and unsuitable for analytics.
+- **Step 5/9 verification:** Dart formatting is applied. The tracker, listener,
+  sync-service, and encrypted orchestrator suites pass 48 focused tests; the
+  complete bridge app suite passes all 2,346 tests. `dart analyze --fatal-infos`
+  and `git diff --check` pass. The 1,113 changed lines, including
+  untracked files, remain within the planned 900–1,400 target, so `PLAN.md` is
+  unchanged.
+- **Step 5/9 architecture review:** `aristotle-impl-review` rejected the initial
+  working-tree scope with two findings. The listener now owns and drains every
+  admitted refresh before `PrSyncService` teardown, and the new tracker moved
+  from the legacy nested bridge path to the current top-level service layer.
+  Both findings were applied and, per review rules, were not re-reviewed.
 
 ## Findings and Plan Deltas
 

--- a/.plan/active/session-pull-request-monitoring/TRACKER.md
+++ b/.plan/active/session-pull-request-monitoring/TRACKER.md
@@ -342,7 +342,7 @@
 - **Step 5/9 verification:** Dart formatting is applied. The tracker, listener,
   sync-service, and encrypted orchestrator suites pass 48 focused tests; the
   complete bridge app suite passes all 2,346 tests. `dart analyze --fatal-infos`
-  and `git diff --check` pass. The 1,113 changed lines, including
+  and `git diff --check` pass. The 1,116 changed lines, including
   untracked files, remain within the planned 900–1,400 target, so `PLAN.md` is
   unchanged.
 - **Step 5/9 architecture review:** `aristotle-impl-review` rejected the initial

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -23,6 +23,7 @@ import "../listeners/session_binding_commit_listener.dart";
 import "../listeners/session_deletion_listener.dart";
 import "../listeners/session_options_changed_refresh_listener.dart";
 import "../listeners/session_options_creation_refresh_listener.dart";
+import "../listeners/viewed_project_pr_refresh_listener.dart";
 import "../push/completion_notifier.dart";
 import "../push/completion_push_listener.dart";
 import "../push/maintenance_push_listener.dart";
@@ -45,6 +46,7 @@ import "../routing/start_catalog_import_handler.dart";
 import "../server/services/bridge_restart_service.dart";
 import "../services/catalog_import_service.dart";
 import "../services/plugin_lifecycle_service.dart";
+import "../services/project_view_tracker.dart";
 import "../version.dart";
 import "api/filesystem_api.dart";
 import "api/gh_cli_api.dart";
@@ -140,6 +142,7 @@ typedef OrchestratorComposition = ({
   SessionRepository sessionRepository,
   SessionUnseenService sessionUnseenService,
   SessionViewTracker sessionViewTracker,
+  ProjectViewTracker projectViewTracker,
 });
 
 /// Factory that creates [OrchestratorSession] instances with all runtime
@@ -241,6 +244,7 @@ class Orchestrator {
       projectCatalogIdentityCalculator: projectCatalogIdentityCalculator,
     );
     final sessionViewTracker = SessionViewTracker();
+    final projectViewTracker = ProjectViewTracker();
     final sessionUnseenService = SessionUnseenService(
       unseenRepository: SessionUnseenRepository(
         sessionDao: _database.sessionDao,
@@ -308,6 +312,11 @@ class Orchestrator {
       pullRequestRepository: pullRequestRepository,
       sessionRepository: sessionRepository,
       clock: const Clock(),
+    );
+    final viewedProjectPrRefreshListener = ViewedProjectPrRefreshListener(
+      tracker: projectViewTracker,
+      prSyncService: prSyncService,
+      refreshInterval: const Duration(seconds: 30),
     );
     final projectActivityService = ProjectActivityService(
       projectRepository: projectRepository,
@@ -551,8 +560,10 @@ class Orchestrator {
       failureReporter: _failureReporter,
       sessionRepository: sessionRepository,
       prSyncService: prSyncService,
+      viewedProjectPrRefreshListener: viewedProjectPrRefreshListener,
       sessionUnseenService: sessionUnseenService,
       sessionViewTracker: sessionViewTracker,
+      projectViewTracker: projectViewTracker,
       projectActivityService: projectActivityService,
       permissionAutoApprovalService: permissionAutoApprovalService,
       sessionAbortService: sessionAbortService,
@@ -568,6 +579,7 @@ class Orchestrator {
       sessionRepository: sessionRepository,
       sessionUnseenService: sessionUnseenService,
       sessionViewTracker: sessionViewTracker,
+      projectViewTracker: projectViewTracker,
     );
   }
 
@@ -614,8 +626,10 @@ class OrchestratorSession {
   final StreamController<SesoriSseEvent> _localWireEventsController;
   final FailureReporter _failureReporter;
   final PrSyncService _prSyncService;
+  final ViewedProjectPrRefreshListener _viewedProjectPrRefreshListener;
   final SessionUnseenService _sessionUnseenService;
   final SessionViewTracker _sessionViewTracker;
+  final ProjectViewTracker _projectViewTracker;
   final SessionRepository _sessionRepository;
   final PermissionAutoApprovalService _permissionAutoApprovalService;
   final SessionMutationDispatcher _sessionMutationDispatcher;
@@ -687,8 +701,10 @@ class OrchestratorSession {
     required FailureReporter failureReporter,
     required SessionRepository sessionRepository,
     required PrSyncService prSyncService,
+    required ViewedProjectPrRefreshListener viewedProjectPrRefreshListener,
     required SessionUnseenService sessionUnseenService,
     required SessionViewTracker sessionViewTracker,
+    required ProjectViewTracker projectViewTracker,
     required ProjectActivityService projectActivityService,
     required PermissionAutoApprovalService permissionAutoApprovalService,
     required SessionAbortService sessionAbortService,
@@ -719,8 +735,10 @@ class OrchestratorSession {
        _localWireEventsController = localWireEventsController,
        _failureReporter = failureReporter,
        _prSyncService = prSyncService,
+       _viewedProjectPrRefreshListener = viewedProjectPrRefreshListener,
        _sessionUnseenService = sessionUnseenService,
        _sessionViewTracker = sessionViewTracker,
+       _projectViewTracker = projectViewTracker,
        _sessionRepository = sessionRepository,
        _permissionAutoApprovalService = permissionAutoApprovalService,
        _sessionMutationDispatcher = sessionMutationDispatcher,
@@ -770,6 +788,7 @@ class OrchestratorSession {
 
     _sessionOptionsCreationRefreshListener.start();
     _sessionOptionsChangedRefreshListener.start();
+    _viewedProjectPrRefreshListener.start();
     final readiness = Completer<OrchestratorSessionStartResult>();
     final lifecycleFuture = Future<void>.microtask(
       () => _runLifecycle(readiness: readiness),
@@ -994,6 +1013,7 @@ class OrchestratorSession {
     await attempt(_completionListener.dispose);
     Log.v("[shutdown] completion listener disposed (+${teardownSw.elapsedMilliseconds}ms)");
     await attempt(_maintenanceListener.dispose);
+    await attempt(_viewedProjectPrRefreshListener.dispose);
     await attempt(_prSyncService.dispose);
     Log.v("[shutdown] maintenance + pr-sync listeners disposed (+${teardownSw.elapsedMilliseconds}ms)");
     // Plugin teardown is owned by BridgePlugin.shutdown(), run as the
@@ -1064,6 +1084,7 @@ class OrchestratorSession {
       // declarations so no session stays "watched" by a ghost connection.
       // Phones re-assert their current view on reconnect.
       _sessionViewTracker.clearAll();
+      _projectViewTracker.clearAll();
 
       if (_client.closeCode == RelayCloseCodes.bridgeRevoked) {
         Log.w("Relay reports this bridge as revoked — re-registering with a fresh bridge id");
@@ -1642,6 +1663,7 @@ class OrchestratorSession {
               activePhones.remove(connID);
               _sseManager.removeSubscriber(connID);
               _sessionViewTracker.releaseConnection(connID: connID);
+              _projectViewTracker.releaseConnection(connID: connID);
           }
           break processMessage;
         }
@@ -1891,6 +1913,8 @@ class OrchestratorSession {
       case RelaySessionView(:final sessionId):
         Log.v("SessionView connID=$connID sessionId=$sessionId");
         _sessionViewTracker.setViewing(connID: connID, sessionId: sessionId);
+      case RelayProjectView(:final projectId):
+        _projectViewTracker.setViewing(connID: connID, projectId: projectId);
       default:
         Log.v("unhandled msg type: ${msg.runtimeType}");
     }

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
@@ -72,6 +72,7 @@ class BridgeRuntime {
 
     await step(_composition.sessionUnseenService.dispose);
     await step(_composition.sessionViewTracker.dispose);
+    await step(_composition.projectViewTracker.dispose);
     await step(_composition.sessionRepository.dispose);
     await step(_composition.catalogHydrationListener.dispose);
     await step(_composition.catalogImportService.dispose);

--- a/bridge/app/lib/src/bridge/services/pr_sync_service.dart
+++ b/bridge/app/lib/src/bridge/services/pr_sync_service.dart
@@ -13,7 +13,7 @@ import "../repositories/session_repository.dart";
 
 enum PrRefreshOutcome { completed, failed }
 
-enum PrRefreshPolicy { background, explicit }
+enum PrRefreshPolicy { background, explicit, viewedProject }
 
 typedef PullRequestRenderedChange = ({String projectId});
 

--- a/bridge/app/lib/src/listeners/viewed_project_pr_refresh_listener.dart
+++ b/bridge/app/lib/src/listeners/viewed_project_pr_refresh_listener.dart
@@ -30,7 +30,7 @@ class ViewedProjectPrRefreshListener {
     if (_subscription != null || _disposed) return;
 
     _subscription = _tracker.changes.listen(
-      _handleChange,
+      (change) => _handleChange(change: change),
       onError: (Object error, StackTrace _) {
         if (_disposed) return;
         Log.w(
@@ -45,7 +45,7 @@ class ViewedProjectPrRefreshListener {
     }
   }
 
-  void _handleChange(ProjectViewChange change) {
+  void _handleChange({required ProjectViewChange change}) {
     if (_disposed) return;
     if (change.activeProjectIds.isEmpty) {
       _cancelSchedule();

--- a/bridge/app/lib/src/listeners/viewed_project_pr_refresh_listener.dart
+++ b/bridge/app/lib/src/listeners/viewed_project_pr_refresh_listener.dart
@@ -1,0 +1,132 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
+import "../bridge/services/pr_sync_service.dart";
+import "../services/project_view_tracker.dart";
+
+/// Schedules pull request refreshes while at least one project is being viewed.
+class ViewedProjectPrRefreshListener {
+  final ProjectViewTracker _tracker;
+  final PrSyncService _prSyncService;
+  final Duration _refreshInterval;
+
+  StreamSubscription<ProjectViewChange>? _subscription;
+  Timer? _timer;
+  Future<void>? _disposeFuture;
+  final Set<Future<void>> _activeRefreshes = <Future<void>>{};
+  int _latestAdmission = 0;
+  bool _disposed = false;
+
+  ViewedProjectPrRefreshListener({
+    required ProjectViewTracker tracker,
+    required PrSyncService prSyncService,
+    required Duration refreshInterval,
+  }) : _tracker = tracker,
+       _prSyncService = prSyncService,
+       _refreshInterval = refreshInterval;
+
+  void start() {
+    if (_subscription != null || _disposed) return;
+
+    _subscription = _tracker.changes.listen(
+      _handleChange,
+      onError: (Object error, StackTrace _) {
+        if (_disposed) return;
+        Log.w(
+          "Viewed-project change tracking failed unexpectedly",
+          _PrivacySafeViewedProjectRefreshException(cause: error),
+        );
+      },
+    );
+    final activeProjectIds = _tracker.activeProjectIds;
+    if (activeProjectIds.isNotEmpty) {
+      _admitRefresh(projectIds: activeProjectIds);
+    }
+  }
+
+  void _handleChange(ProjectViewChange change) {
+    if (_disposed) return;
+    if (change.activeProjectIds.isEmpty) {
+      _cancelSchedule();
+      return;
+    }
+    if (change.newlyAddedProjectIds.isEmpty) return;
+
+    _timer?.cancel();
+    _timer = null;
+    _admitRefresh(projectIds: change.newlyAddedProjectIds);
+  }
+
+  void _admitRefresh({required Set<String> projectIds}) {
+    if (_disposed || projectIds.isEmpty) return;
+
+    final admission = ++_latestAdmission;
+    late final Future<void> refresh;
+    refresh = _refresh(
+      projectIds: projectIds,
+      admission: admission,
+    ).whenComplete(() => _activeRefreshes.remove(refresh));
+    _activeRefreshes.add(refresh);
+    unawaited(refresh);
+  }
+
+  Future<void> _refresh({
+    required Set<String> projectIds,
+    required int admission,
+  }) async {
+    try {
+      await _prSyncService.triggerRefresh(
+        projectIds: projectIds,
+        refreshPolicy: PrRefreshPolicy.viewedProject,
+      );
+    } on Object catch (error) {
+      if (!_disposed) {
+        Log.w(
+          "Viewed-project pull request refresh failed unexpectedly; retrying after the configured interval",
+          _PrivacySafeViewedProjectRefreshException(cause: error),
+        );
+      }
+    }
+
+    if (_disposed || admission != _latestAdmission || _tracker.activeProjectIds.isEmpty) return;
+    _armTimer();
+  }
+
+  void _armTimer() {
+    _timer?.cancel();
+    _timer = Timer(_refreshInterval, () {
+      _timer = null;
+      if (_disposed) return;
+
+      final activeProjectIds = _tracker.activeProjectIds;
+      if (activeProjectIds.isEmpty) return;
+      _admitRefresh(projectIds: activeProjectIds);
+    });
+  }
+
+  void _cancelSchedule() {
+    _latestAdmission++;
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  Future<void> dispose() => _disposeFuture ??= _dispose();
+
+  Future<void> _dispose() async {
+    _disposed = true;
+    _cancelSchedule();
+    await _subscription?.cancel();
+    _subscription = null;
+    await Future.wait(List<Future<void>>.of(_activeRefreshes));
+  }
+}
+
+final class _PrivacySafeViewedProjectRefreshException implements Exception {
+  final Object cause;
+
+  const _PrivacySafeViewedProjectRefreshException({required this.cause});
+
+  @override
+  String toString() => "ViewedProjectRefreshException";
+}

--- a/bridge/app/lib/src/services/project_view_tracker.dart
+++ b/bridge/app/lib/src/services/project_view_tracker.dart
@@ -1,0 +1,103 @@
+import "dart:async";
+
+/// An immutable aggregate change to the projects currently viewed by phones.
+final class ProjectViewChange {
+  final Set<String> activeProjectIds;
+  final Set<String> newlyAddedProjectIds;
+
+  ProjectViewChange({
+    required Set<String> activeProjectIds,
+    required Set<String> newlyAddedProjectIds,
+  }) : activeProjectIds = Set<String>.unmodifiable(activeProjectIds),
+       newlyAddedProjectIds = Set<String>.unmodifiable(newlyAddedProjectIds);
+}
+
+/// Tracks one full-state project-view declaration per relay connection and
+/// publishes only changes to their aggregate union.
+class ProjectViewTracker {
+  final Map<int, String> _viewedByConnection = <int, String>{};
+  final Map<String, int> _viewerCountByProject = <String, int>{};
+  final StreamController<ProjectViewChange> _changes = StreamController<ProjectViewChange>.broadcast(sync: true);
+
+  Future<void>? _disposeFuture;
+  bool _disposed = false;
+
+  Set<String> get activeProjectIds => Set<String>.unmodifiable(_viewerCountByProject.keys);
+  Stream<ProjectViewChange> get changes => _changes.stream;
+
+  /// Declares the complete project-view state for [connID]. Null and empty
+  /// external identifiers both mean that the connection has no project claim.
+  void setViewing({required int connID, required String? projectId}) {
+    if (_disposed) return;
+
+    final normalizedProjectId = projectId == null || projectId.isEmpty ? null : projectId;
+    final previousProjectId = _viewedByConnection[connID];
+    if (previousProjectId == normalizedProjectId) return;
+
+    final previousActiveProjectIds = _viewerCountByProject.keys.toSet();
+    if (previousProjectId != null) {
+      _decrementViewerCount(projectId: previousProjectId);
+    }
+
+    if (normalizedProjectId == null) {
+      _viewedByConnection.remove(connID);
+    } else {
+      _viewedByConnection[connID] = normalizedProjectId;
+      _viewerCountByProject[normalizedProjectId] = (_viewerCountByProject[normalizedProjectId] ?? 0) + 1;
+    }
+    _emitAggregateChange(previousActiveProjectIds: previousActiveProjectIds);
+  }
+
+  void releaseConnection({required int connID}) {
+    if (_disposed) return;
+
+    final previousProjectId = _viewedByConnection.remove(connID);
+    if (previousProjectId == null) return;
+
+    final previousActiveProjectIds = _viewerCountByProject.keys.toSet();
+    _decrementViewerCount(projectId: previousProjectId);
+    _emitAggregateChange(previousActiveProjectIds: previousActiveProjectIds);
+  }
+
+  void clearAll() {
+    if (_disposed || _viewerCountByProject.isEmpty) return;
+
+    final previousActiveProjectIds = _viewerCountByProject.keys.toSet();
+    _viewedByConnection.clear();
+    _viewerCountByProject.clear();
+    _emitAggregateChange(previousActiveProjectIds: previousActiveProjectIds);
+  }
+
+  void _decrementViewerCount({required String projectId}) {
+    final nextViewerCount = (_viewerCountByProject[projectId] ?? 0) - 1;
+    if (nextViewerCount <= 0) {
+      _viewerCountByProject.remove(projectId);
+    } else {
+      _viewerCountByProject[projectId] = nextViewerCount;
+    }
+  }
+
+  void _emitAggregateChange({required Set<String> previousActiveProjectIds}) {
+    final activeProjectIds = _viewerCountByProject.keys.toSet();
+    if (activeProjectIds.length == previousActiveProjectIds.length &&
+        activeProjectIds.containsAll(previousActiveProjectIds)) {
+      return;
+    }
+
+    _changes.add(
+      ProjectViewChange(
+        activeProjectIds: activeProjectIds,
+        newlyAddedProjectIds: activeProjectIds.difference(previousActiveProjectIds),
+      ),
+    );
+  }
+
+  Future<void> dispose() => _disposeFuture ??= _dispose();
+
+  Future<void> _dispose() async {
+    _disposed = true;
+    _viewedByConnection.clear();
+    _viewerCountByProject.clear();
+    await _changes.close();
+  }
+}

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -1,9 +1,10 @@
 import "dart:async";
 import "dart:convert";
+import "dart:io";
 
+import "package:cryptography/cryptography.dart";
 import "package:http/http.dart" as http;
 import "package:sesori_bridge/src/auth/token_refresher.dart";
-import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
 import "package:sesori_bridge/src/bridge/models/bridge_config.dart";
 import "package:sesori_bridge/src/bridge/orchestrator.dart";
 import "package:sesori_bridge/src/bridge/relay_client.dart";
@@ -85,6 +86,133 @@ void main() {
 
     expect(response.status, 404);
     expect(response.body, "plugin not found");
+  });
+
+  test("orchestrator owns encrypted project-view claims across relay lifecycles", () async {
+    final relayServer = await TestRelayServer.start();
+    final harness = await _OrchestratorHarness.create(
+      pluginIds: const ["one"],
+      relayUrl: "ws://127.0.0.1:${relayServer.port}",
+    );
+    addTearDown(() async {
+      await harness.close();
+      await relayServer.close();
+    });
+
+    final running = await startTestOrchestratorSession(session: harness.composition.session);
+    final runFuture = running.stopped;
+    final firstSocket = await relayServer.nextClient();
+    final firstMessages = StreamIterator<dynamic>(firstSocket);
+    const firstConnection = 101;
+    const secondConnection = 202;
+    const firstProject = "test-project-x";
+    const secondProject = "test-project-y";
+
+    final roomKey = await _exchangeRoomKey(
+      socket: firstSocket,
+      messages: firstMessages,
+      connID: firstConnection,
+    );
+    await _sendEncryptedRelayMessage(
+      socket: firstSocket,
+      connID: firstConnection,
+      roomKey: roomKey,
+      message: const RelayMessage.projectView(projectId: firstProject),
+    );
+    await _resumePhone(
+      socket: firstSocket,
+      messages: firstMessages,
+      connID: secondConnection,
+      roomKey: roomKey,
+    );
+    await _sendEncryptedRelayMessage(
+      socket: firstSocket,
+      connID: secondConnection,
+      roomKey: roomKey,
+      message: const RelayMessage.projectView(projectId: secondProject),
+    );
+
+    await _waitFor(
+      () => harness.composition.projectViewTracker.activeProjectIds.length == 2,
+      reason: "both project-view claims",
+    );
+    expect(harness.composition.projectViewTracker.activeProjectIds, {firstProject, secondProject});
+
+    await _sendEncryptedRelayMessage(
+      socket: firstSocket,
+      connID: secondConnection,
+      roomKey: roomKey,
+      message: const RelayMessage.projectView(projectId: null),
+    );
+    await _waitFor(
+      () => harness.composition.projectViewTracker.activeProjectIds.length == 1,
+      reason: "null project-view declaration",
+    );
+    expect(harness.composition.projectViewTracker.activeProjectIds, {firstProject});
+
+    await _sendEncryptedRelayMessage(
+      socket: firstSocket,
+      connID: secondConnection,
+      roomKey: roomKey,
+      message: const RelayMessage.projectView(projectId: secondProject),
+    );
+    await _waitFor(
+      () => harness.composition.projectViewTracker.activeProjectIds.length == 2,
+      reason: "project-view reassertion",
+    );
+    firstSocket.add(jsonEncode({"type": "phone_disconnected", "connId": firstConnection}));
+    await _waitFor(
+      () => harness.composition.projectViewTracker.activeProjectIds.length == 1,
+      reason: "single phone disconnect",
+    );
+    expect(harness.composition.projectViewTracker.activeProjectIds, {secondProject});
+
+    await firstSocket.close();
+    await _waitFor(
+      () => harness.composition.projectViewTracker.activeProjectIds.isEmpty,
+      reason: "relay-drop project-view cleanup",
+    );
+    await firstMessages.cancel();
+
+    final secondSocket = await relayServer.nextClient();
+    final secondMessages = StreamIterator<dynamic>(secondSocket);
+    const reconnectedConnection = 303;
+    await _resumePhone(
+      socket: secondSocket,
+      messages: secondMessages,
+      connID: reconnectedConnection,
+      roomKey: roomKey,
+    );
+    await _sendEncryptedRelayMessage(
+      socket: secondSocket,
+      connID: reconnectedConnection,
+      roomKey: roomKey,
+      message: const RelayMessage.projectView(projectId: firstProject),
+    );
+    await _waitFor(
+      () => harness.composition.projectViewTracker.activeProjectIds.isNotEmpty,
+      reason: "reconnected project-view reassertion",
+    );
+    expect(harness.composition.projectViewTracker.activeProjectIds, {firstProject});
+
+    secondSocket.add(jsonEncode({"type": "phone_disconnected", "connId": secondConnection}));
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(harness.composition.projectViewTracker.activeProjectIds, {firstProject});
+
+    await _sendEncryptedRelayMessage(
+      socket: secondSocket,
+      connID: reconnectedConnection,
+      roomKey: roomKey,
+      message: const RelayMessage.projectView(projectId: null),
+    );
+    await _waitFor(
+      () => harness.composition.projectViewTracker.activeProjectIds.isEmpty,
+      reason: "reconnected null declaration",
+    );
+
+    await harness.composition.session.cancel();
+    await runFuture.timeout(const Duration(seconds: 5));
+    await secondMessages.cancel();
   });
 
   test("a sourced reconnect reconciles its active plugin and local events are already mapped", () async {
@@ -398,6 +526,111 @@ Future<void> _waitFor(
   }
 }
 
+Future<List<int>> _exchangeRoomKey({
+  required WebSocket socket,
+  required StreamIterator<dynamic> messages,
+  required int connID,
+}) async {
+  final crypto = RelayCryptoService();
+  final phoneKeyPair = await crypto.generateKeyPair();
+  final phonePublicKey = await phoneKeyPair.extractPublicKey();
+  _sendRelayPayload(
+    socket: socket,
+    connID: connID,
+    payload: utf8.encode(
+      jsonEncode(
+        RelayMessage.keyExchange(
+          publicKey: base64Url.encode(phonePublicKey.bytes).replaceAll("=", ""),
+        ).toJson(),
+      ),
+    ),
+  );
+
+  final response = await _nextRelayPayload(messages: messages, connID: connID);
+  expect(response, hasLength(greaterThan(32)));
+  final bridgePublicKey = SimplePublicKey(
+    response.sublist(0, 32),
+    type: KeyPairType.x25519,
+  );
+  final sharedSecret = await crypto.deriveSharedSecret(
+    phoneKeyPair,
+    peerPublicKey: bridgePublicKey,
+  );
+  final ephemeralKey = await crypto.deriveEncryptionKey(sharedSecret);
+  final ready = await _decryptRelayMessage(
+    payload: response.sublist(32),
+    key: ephemeralKey,
+  );
+  expect(ready, isA<RelayReady>());
+  return base64Url.decode(base64Url.normalize((ready as RelayReady).roomKey));
+}
+
+Future<void> _resumePhone({
+  required WebSocket socket,
+  required StreamIterator<dynamic> messages,
+  required int connID,
+  required List<int> roomKey,
+}) async {
+  await _sendEncryptedRelayMessage(
+    socket: socket,
+    connID: connID,
+    roomKey: roomKey,
+    message: const RelayMessage.resume(),
+  );
+  final response = await _nextRelayPayload(messages: messages, connID: connID);
+  final acknowledgement = await _decryptRelayMessage(
+    payload: response,
+    key: SecretKey(List<int>.from(roomKey)),
+  );
+  expect(acknowledgement, isA<RelayResumeAck>());
+}
+
+Future<void> _sendEncryptedRelayMessage({
+  required WebSocket socket,
+  required int connID,
+  required List<int> roomKey,
+  required RelayMessage message,
+}) async {
+  final encryptor = RelayCryptoService().createSessionEncryptor(
+    SecretKey(List<int>.from(roomKey)),
+  );
+  final payload = await frame(
+    utf8.encode(jsonEncode(message.toJson())),
+    encryptor: encryptor,
+  );
+  _sendRelayPayload(socket: socket, connID: connID, payload: payload);
+}
+
+Future<RelayMessage> _decryptRelayMessage({
+  required List<int> payload,
+  required SecretKey key,
+}) async {
+  final decryptor = RelayCryptoService().createSessionEncryptor(key);
+  final decrypted = await unframe(payload, encryptor: decryptor);
+  return RelayMessage.fromJson(jsonDecodeMap(utf8.decode(decrypted)));
+}
+
+void _sendRelayPayload({
+  required WebSocket socket,
+  required int connID,
+  required List<int> payload,
+}) {
+  socket.add(<int>[connID >> 8, connID & 0xFF, ...payload]);
+}
+
+Future<List<int>> _nextRelayPayload({
+  required StreamIterator<dynamic> messages,
+  required int connID,
+}) async {
+  while (await messages.moveNext().timeout(const Duration(seconds: 5))) {
+    final message = messages.current;
+    if (message is! List<int> || message.length < 2) continue;
+    final messageConnID = message[0] << 8 | message[1];
+    if (messageConnID == connID) return message.sublist(2);
+  }
+  throw StateError("Relay socket closed before the expected bridge payload");
+}
+
 class _OrchestratorHarness {
   final List<_SourcedPlugin> plugins;
   final PluginLifecycleService lifecycleService;
@@ -441,7 +674,7 @@ class _OrchestratorHarness {
       clock: const ServerClock(),
       database: database,
       httpClient: httpClient,
-      processRunner: ProcessRunner(),
+      processRunner: NoopProcessRunner(),
       accessTokenProvider: FakeAccessTokenProvider(),
       tokenRefresher: _FakeTokenRefresher(),
       bridgeRegistrationService: createFakeBridgeRegistrationService(),

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -54,6 +54,35 @@ void main() {
       expect(source.maxConcurrentSelections, 1);
     });
 
+    test("deduplicates one GitHub target shared by multiple viewed projects", () async {
+      final source = _FakePrSource(
+        targetsByDirectory: {
+          "/one": _githubTarget(branchName: "shared-branch"),
+          "/two": _githubTarget(branchName: "shared-branch"),
+        },
+      );
+      final pullRequests = _FakePullRequestRepository();
+      final service = _service(
+        source: source,
+        pullRequests: pullRequests,
+        sessionsByProject: {
+          "one": [_session(id: "one", projectId: "one", directory: "/one")],
+          "two": [_session(id: "two", projectId: "two", directory: "/two")],
+        },
+      );
+      addTearDown(service.dispose);
+
+      final outcome = await service.triggerRefresh(
+        projectIds: {"one", "two"},
+        refreshPolicy: PrRefreshPolicy.viewedProject,
+      );
+
+      expect(outcome, PrRefreshOutcome.completed);
+      expect(source.selectionCalls, hasLength(1));
+      expect(source.selectionCalls.single, hasLength(1));
+      expect(pullRequests.replaceCalls.map((call) => call.projectId).toSet(), {"one", "two"});
+    });
+
     test("commits and emits local branch changes before unavailable GitHub work", () async {
       final source = _FakePrSource(
         targetsByDirectory: {"/one": _githubTarget(branchName: "feature/current")},
@@ -287,6 +316,38 @@ void main() {
       expect(await second, PrRefreshOutcome.completed);
     });
 
+    test("a viewed-project request after sealing gets a serialized covering follow-up", () async {
+      final firstSelection = Completer<void>();
+      final source = _FakePrSource(
+        targetsByDirectory: {"/one": _githubTarget(branchName: "branch-a")},
+        selectionBlocks: [firstSelection],
+      );
+      final service = _service(
+        source: source,
+        pullRequests: _FakePullRequestRepository(),
+        sessionsByProject: {
+          "one": [_session(id: "one", projectId: "one", directory: "/one")],
+        },
+      );
+      addTearDown(service.dispose);
+
+      final first = service.triggerRefresh(
+        projectIds: {"one"},
+        refreshPolicy: PrRefreshPolicy.viewedProject,
+      );
+      await _waitFor(() => source.selectionCalls.length == 1);
+      final followUp = service.triggerRefresh(
+        projectIds: {"one"},
+        refreshPolicy: PrRefreshPolicy.viewedProject,
+      );
+      firstSelection.complete();
+
+      expect(await first, PrRefreshOutcome.completed);
+      expect(await followUp, PrRefreshOutcome.completed);
+      expect(source.selectionCalls, hasLength(2));
+      expect(source.maxConcurrentSelections, 1);
+    });
+
     test("coalesces repeated background requests into an active project refresh", () async {
       final firstSelection = Completer<void>();
       final source = _FakePrSource(
@@ -422,6 +483,38 @@ void main() {
         refreshPolicy: PrRefreshPolicy.background,
       );
       expect(source.resolveCalls, hasLength(5));
+    });
+
+    test("viewed-project refresh bypasses the completed background debounce window", () async {
+      final source = _FakePrSource(
+        targetsByDirectory: const {
+          "/local": PullRequestLocalBranchDirectoryTarget(branchName: "local"),
+        },
+      );
+      final service = _service(
+        source: source,
+        pullRequests: _FakePullRequestRepository(),
+        sessionsByProject: {
+          "local": [_session(id: "local", projectId: "local", directory: "/local")],
+        },
+        debounceWindow: const Duration(minutes: 1),
+      );
+      addTearDown(service.dispose);
+
+      await service.triggerRefresh(
+        projectIds: {"local"},
+        refreshPolicy: PrRefreshPolicy.background,
+      );
+      await service.triggerRefresh(
+        projectIds: {"local"},
+        refreshPolicy: PrRefreshPolicy.background,
+      );
+      await service.triggerRefresh(
+        projectIds: {"local"},
+        refreshPolicy: PrRefreshPolicy.viewedProject,
+      );
+
+      expect(source.resolveCalls, hasLength(2));
     });
 
     test("shares and expires the gh capability cache", () async {

--- a/bridge/app/test/listeners/viewed_project_pr_refresh_listener_test.dart
+++ b/bridge/app/test/listeners/viewed_project_pr_refresh_listener_test.dart
@@ -1,0 +1,326 @@
+import "dart:async";
+import "dart:io";
+
+import "package:fake_async/fake_async.dart";
+import "package:sesori_bridge/src/bridge/services/pr_sync_service.dart";
+import "package:sesori_bridge/src/listeners/viewed_project_pr_refresh_listener.dart";
+import "package:sesori_bridge/src/services/project_view_tracker.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log, LogLevel;
+import "package:test/test.dart";
+
+void main() {
+  group("ViewedProjectPrRefreshListener", () {
+    test("is passive until start and immediately refreshes existing active projects", () {
+      fakeAsync((async) {
+        final harness = _Harness();
+        harness.tracker.setViewing(connID: 1, projectId: "project-x");
+
+        async.elapse(const Duration(minutes: 1));
+        expect(harness.service.calls, isEmpty);
+
+        harness.listener.start();
+        harness.listener.start();
+
+        expect(harness.service.calls, hasLength(1));
+        expect(harness.service.calls.single.projectIds, {"project-x"});
+        expect(harness.service.calls.single.refreshPolicy, PrRefreshPolicy.viewedProject);
+        _disposeHarness(harness: harness, async: async);
+      });
+    });
+
+    test("starts the interval only after the admitted refresh completes", () {
+      fakeAsync((async) {
+        final harness = _Harness()..service.completeImmediately = false;
+        harness.listener.start();
+        harness.tracker.setViewing(connID: 1, projectId: "project-x");
+
+        async.elapse(const Duration(minutes: 1));
+        expect(harness.service.calls, hasLength(1));
+
+        harness.service.complete(callIndex: 0);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 29));
+        expect(harness.service.calls, hasLength(1));
+
+        async.elapse(const Duration(seconds: 1));
+        expect(harness.service.calls, hasLength(2));
+        _disposeHarness(harness: harness, async: async);
+      });
+    });
+
+    test("timer refreshes the full active project union", () {
+      fakeAsync((async) {
+        final harness = _Harness();
+        harness.listener.start();
+        harness.tracker.setViewing(connID: 1, projectId: "project-x");
+        harness.tracker.setViewing(connID: 2, projectId: "project-y");
+        async.flushMicrotasks();
+
+        expect(harness.service.calls, hasLength(2));
+        async.elapse(const Duration(seconds: 30));
+
+        expect(harness.service.calls, hasLength(3));
+        expect(harness.service.calls.last.projectIds, {"project-x", "project-y"});
+        _disposeHarness(harness: harness, async: async);
+      });
+    });
+
+    test("submits a newly added project while prior work is in flight", () {
+      fakeAsync((async) {
+        final harness = _Harness()..service.completeImmediately = false;
+        harness.listener.start();
+        harness.tracker.setViewing(connID: 1, projectId: "project-x");
+        harness.tracker.setViewing(connID: 2, projectId: "project-y");
+
+        expect(harness.service.calls, hasLength(2));
+        expect(harness.service.calls[0].projectIds, {"project-x"});
+        expect(harness.service.calls[1].projectIds, {"project-y"});
+
+        harness.service.complete(callIndex: 0);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 30));
+        expect(harness.service.calls, hasLength(2), reason: "an older completion must not arm the timer");
+
+        harness.service.complete(callIndex: 1);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 30));
+        expect(harness.service.calls, hasLength(3));
+        expect(harness.service.calls.last.projectIds, {"project-x", "project-y"});
+        _disposeHarness(harness: harness, async: async);
+      });
+    });
+
+    test("a new activation cancels and restarts a pending completion-based timer", () {
+      fakeAsync((async) {
+        final harness = _Harness();
+        harness.listener.start();
+        harness.tracker.setViewing(connID: 1, projectId: "project-x");
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 20));
+
+        harness.tracker.setViewing(connID: 2, projectId: "project-y");
+        async.flushMicrotasks();
+        expect(harness.service.calls, hasLength(2));
+
+        async.elapse(const Duration(seconds: 29));
+        expect(harness.service.calls, hasLength(2));
+        async.elapse(const Duration(seconds: 1));
+        expect(harness.service.calls, hasLength(3));
+        _disposeHarness(harness: harness, async: async);
+      });
+    });
+
+    test("duplicate viewers neither refresh nor disturb the pending timer", () {
+      fakeAsync((async) {
+        final harness = _Harness();
+        harness.listener.start();
+        harness.tracker.setViewing(connID: 1, projectId: "project-x");
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 10));
+
+        harness.tracker.setViewing(connID: 2, projectId: "project-x");
+        expect(harness.service.calls, hasLength(1));
+
+        async.elapse(const Duration(seconds: 20));
+        expect(harness.service.calls, hasLength(2));
+        expect(harness.service.calls.last.projectIds, {"project-x"});
+        _disposeHarness(harness: harness, async: async);
+      });
+    });
+
+    test("removal-only changes preserve scheduling while the union is nonempty", () {
+      fakeAsync((async) {
+        final harness = _Harness();
+        harness.listener.start();
+        harness.tracker.setViewing(connID: 1, projectId: "project-x");
+        harness.tracker.setViewing(connID: 2, projectId: "project-y");
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 10));
+
+        harness.tracker.releaseConnection(connID: 1);
+        async.elapse(const Duration(seconds: 19));
+        expect(harness.service.calls, hasLength(2));
+
+        async.elapse(const Duration(seconds: 1));
+        expect(harness.service.calls, hasLength(3));
+        expect(harness.service.calls.last.projectIds, {"project-y"});
+        _disposeHarness(harness: harness, async: async);
+      });
+    });
+
+    test("final clear cancels timers and suppresses in-flight completion rearm", () {
+      fakeAsync((async) {
+        final harness = _Harness()..service.completeImmediately = false;
+        harness.listener.start();
+        harness.tracker.setViewing(connID: 1, projectId: "project-x");
+        harness.tracker.clearAll();
+
+        harness.service.complete(callIndex: 0);
+        async.flushMicrotasks();
+        async.elapse(const Duration(minutes: 1));
+
+        expect(harness.service.calls, hasLength(1));
+        _disposeHarness(harness: harness, async: async);
+      });
+    });
+
+    test("final clear cancels an already armed timer", () {
+      fakeAsync((async) {
+        final harness = _Harness();
+        harness.listener.start();
+        harness.tracker.setViewing(connID: 1, projectId: "project-x");
+        async.flushMicrotasks();
+        harness.tracker.clearAll();
+
+        async.elapse(const Duration(minutes: 1));
+
+        expect(harness.service.calls, hasLength(1));
+        _disposeHarness(harness: harness, async: async);
+      });
+    });
+
+    test("failed outcomes retry without redundant listener logging", () {
+      fakeAsync((async) {
+        final harness = _Harness()..service.immediateOutcome = PrRefreshOutcome.failed;
+        final logOutput = _captureLogOutput(
+          action: () {
+            harness.listener.start();
+            harness.tracker.setViewing(connID: 1, projectId: "project-x");
+            async.flushMicrotasks();
+          },
+        );
+
+        expect(logOutput, isNot(contains("Viewed-project pull request refresh failed unexpectedly")));
+        async.elapse(const Duration(seconds: 29));
+        expect(harness.service.calls, hasLength(1));
+        async.elapse(const Duration(seconds: 1));
+        expect(harness.service.calls, hasLength(2));
+        _disposeHarness(harness: harness, async: async);
+      });
+    });
+
+    test("unexpected errors log without identifiers and retry after the interval", () {
+      fakeAsync((async) {
+        final harness = _Harness()..service.immediateError = StateError("project-x /private/source/path");
+        final logOutput = _captureLogOutput(
+          action: () {
+            harness.listener.start();
+            harness.tracker.setViewing(connID: 1, projectId: "project-x");
+            async.flushMicrotasks();
+          },
+        );
+
+        expect(logOutput, contains("Viewed-project pull request refresh failed unexpectedly"));
+        expect(logOutput, contains("ViewedProjectRefreshException"));
+        expect(logOutput, isNot(contains("project-x")));
+        expect(logOutput, isNot(contains("/private/source/path")));
+
+        async.elapse(const Duration(seconds: 30));
+        expect(harness.service.calls, hasLength(2));
+        _disposeHarness(harness: harness, async: async);
+      });
+    });
+
+    test("dispose drains admitted work and suppresses late completion", () async {
+      final harness = _Harness()..service.completeImmediately = false;
+      harness.listener.start();
+      harness.tracker.setViewing(connID: 1, projectId: "project-x");
+
+      var disposed = false;
+      final disposeFuture = harness.listener.dispose().then((_) => disposed = true);
+      await Future<void>.delayed(Duration.zero);
+      expect(disposed, isFalse);
+
+      harness.service.complete(callIndex: 0);
+      await disposeFuture.timeout(const Duration(seconds: 1));
+      expect(disposed, isTrue);
+
+      harness.tracker.setViewing(connID: 2, projectId: "project-y");
+      await Future<void>.delayed(Duration.zero);
+      expect(harness.service.calls, hasLength(1));
+      await harness.tracker.dispose();
+    });
+  });
+}
+
+class _Harness {
+  final ProjectViewTracker tracker = ProjectViewTracker();
+  final _FakePrSyncService service = _FakePrSyncService();
+  late final ViewedProjectPrRefreshListener listener = ViewedProjectPrRefreshListener(
+    tracker: tracker,
+    prSyncService: service,
+    refreshInterval: const Duration(seconds: 30),
+  );
+
+  Future<void> dispose() async {
+    await listener.dispose();
+    await tracker.dispose();
+  }
+}
+
+class _FakePrSyncService implements PrSyncService {
+  final List<({Set<String> projectIds, PrRefreshPolicy refreshPolicy})> calls = [];
+  final List<Completer<PrRefreshOutcome>> completions = [];
+  bool completeImmediately = true;
+  PrRefreshOutcome immediateOutcome = PrRefreshOutcome.completed;
+  Object? immediateError;
+
+  @override
+  Future<PrRefreshOutcome> triggerRefresh({
+    required Set<String> projectIds,
+    required PrRefreshPolicy refreshPolicy,
+  }) {
+    calls.add((projectIds: Set<String>.from(projectIds), refreshPolicy: refreshPolicy));
+    final completion = Completer<PrRefreshOutcome>();
+    completions.add(completion);
+    if (completeImmediately) {
+      final error = immediateError;
+      immediateError = null;
+      if (error == null) {
+        completion.complete(immediateOutcome);
+      } else {
+        completion.completeError(error, StackTrace.current);
+      }
+    }
+    return completion.future;
+  }
+
+  void complete({required int callIndex, PrRefreshOutcome outcome = PrRefreshOutcome.completed}) {
+    completions[callIndex].complete(outcome);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void _disposeHarness({required _Harness harness, required FakeAsync async}) {
+  unawaited(harness.dispose());
+  async.flushMicrotasks();
+}
+
+String _captureLogOutput({required void Function() action}) {
+  final output = _BufferingStdout();
+  final previousLevel = Log.level;
+  try {
+    Log.level = LogLevel.debug;
+    IOOverrides.runZoned(action, stderr: () => output);
+  } finally {
+    Log.level = previousLevel;
+  }
+  return output.text;
+}
+
+class _BufferingStdout implements Stdout {
+  final StringBuffer _buffer = StringBuffer();
+
+  String get text => _buffer.toString();
+
+  @override
+  void write(Object? object) => _buffer.write(object);
+
+  @override
+  void writeln([Object? object = ""]) => _buffer.writeln(object);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}

--- a/bridge/app/test/services/project_view_tracker_test.dart
+++ b/bridge/app/test/services/project_view_tracker_test.dart
@@ -1,0 +1,138 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/services/project_view_tracker.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ProjectViewTracker", () {
+    late ProjectViewTracker tracker;
+    late List<ProjectViewChange> changes;
+    late StreamSubscription<ProjectViewChange> subscription;
+
+    setUp(() {
+      tracker = ProjectViewTracker();
+      changes = <ProjectViewChange>[];
+      subscription = tracker.changes.listen(changes.add);
+    });
+
+    tearDown(() async {
+      await subscription.cancel();
+      await tracker.dispose();
+    });
+
+    test("unions projects viewed by different connections", () {
+      tracker.setViewing(connID: 1, projectId: "project-x");
+      tracker.setViewing(connID: 2, projectId: "project-y");
+
+      expect(tracker.activeProjectIds, {"project-x", "project-y"});
+      expect(changes, hasLength(2));
+      expect(changes[0].activeProjectIds, {"project-x"});
+      expect(changes[0].newlyAddedProjectIds, {"project-x"});
+      expect(changes[1].activeProjectIds, {"project-x", "project-y"});
+      expect(changes[1].newlyAddedProjectIds, {"project-y"});
+    });
+
+    test("switching a connection updates both sides of the aggregate", () {
+      tracker.setViewing(connID: 1, projectId: "project-x");
+      changes.clear();
+
+      tracker.setViewing(connID: 1, projectId: "project-y");
+
+      expect(tracker.activeProjectIds, {"project-y"});
+      expect(changes, hasLength(1));
+      expect(changes.single.activeProjectIds, {"project-y"});
+      expect(changes.single.newlyAddedProjectIds, {"project-y"});
+    });
+
+    test("duplicate viewers do not emit duplicate activation", () {
+      tracker.setViewing(connID: 1, projectId: "project-x");
+      changes.clear();
+
+      tracker.setViewing(connID: 2, projectId: "project-x");
+      tracker.setViewing(connID: 2, projectId: "project-x");
+      tracker.releaseConnection(connID: 1);
+
+      expect(tracker.activeProjectIds, {"project-x"});
+      expect(changes, isEmpty);
+
+      tracker.releaseConnection(connID: 2);
+      expect(changes.single.activeProjectIds, isEmpty);
+      expect(changes.single.newlyAddedProjectIds, isEmpty);
+    });
+
+    test("releaseConnection removes only that connection claim", () {
+      tracker.setViewing(connID: 1, projectId: "project-x");
+      tracker.setViewing(connID: 2, projectId: "project-y");
+      changes.clear();
+
+      tracker.releaseConnection(connID: 1);
+
+      expect(tracker.activeProjectIds, {"project-y"});
+      expect(changes.single.activeProjectIds, {"project-y"});
+      expect(changes.single.newlyAddedProjectIds, isEmpty);
+    });
+
+    test("clearAll releases every claim with one aggregate change", () {
+      tracker.setViewing(connID: 1, projectId: "project-x");
+      tracker.setViewing(connID: 2, projectId: "project-y");
+      changes.clear();
+
+      tracker.clearAll();
+      tracker.clearAll();
+
+      expect(tracker.activeProjectIds, isEmpty);
+      expect(changes, hasLength(1));
+      expect(changes.single.activeProjectIds, isEmpty);
+      expect(changes.single.newlyAddedProjectIds, isEmpty);
+    });
+
+    test("a late release after clearAll cannot clear a reasserted claim", () {
+      tracker.setViewing(connID: 1, projectId: "project-x");
+      tracker.clearAll();
+      tracker.setViewing(connID: 2, projectId: "project-x");
+      changes.clear();
+
+      tracker.releaseConnection(connID: 1);
+
+      expect(tracker.activeProjectIds, {"project-x"});
+      expect(changes, isEmpty);
+    });
+
+    test("normalizes null and empty declarations to no claim", () {
+      tracker.setViewing(connID: 1, projectId: "project-x");
+      tracker.setViewing(connID: 1, projectId: "");
+      tracker.setViewing(connID: 1, projectId: null);
+
+      expect(tracker.activeProjectIds, isEmpty);
+      expect(changes, hasLength(2));
+    });
+
+    test("getters and emitted changes are immutable snapshots", () {
+      tracker.setViewing(connID: 1, projectId: "project-x");
+      final activeSnapshot = tracker.activeProjectIds;
+      final changeSnapshot = changes.single;
+
+      expect(() => activeSnapshot.add("mutation"), throwsUnsupportedError);
+      expect(changeSnapshot.activeProjectIds.clear, throwsUnsupportedError);
+      expect(() => changeSnapshot.newlyAddedProjectIds.add("mutation"), throwsUnsupportedError);
+
+      tracker.setViewing(connID: 2, projectId: "project-y");
+      expect(activeSnapshot, {"project-x"});
+      expect(changeSnapshot.activeProjectIds, {"project-x"});
+      expect(changeSnapshot.newlyAddedProjectIds, {"project-x"});
+    });
+
+    test("does not mutate or emit after disposal", () async {
+      tracker.setViewing(connID: 1, projectId: "project-x");
+      changes.clear();
+
+      await tracker.dispose();
+      tracker.setViewing(connID: 2, projectId: "project-y");
+      tracker.releaseConnection(connID: 1);
+      tracker.clearAll();
+
+      expect(tracker.activeProjectIds, isEmpty);
+      expect(changes, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Complexity

🚧 Complex — adds multi-connection lifecycle state, completion-based timer ownership, relay reconnect cleanup, and serialized add-during-flight refresh behavior across tracker, listener, service, and orchestration layers.

## What

- tracks the aggregate projects viewed by each physical relay connection
- routes the shipped encrypted `RelayProjectView` declaration through `Orchestrator`
- immediately refreshes newly active projects and schedules one completion-based 30-second refresh for the active union
- feeds projects added during in-flight work into `PrSyncService`'s serialized pending-generation drain
- releases one claim on phone disconnect, clears all claims on relay loss, and drains listener-owned refreshes during teardown
- preserves request-driven refreshes for older clients

## Why

PR and CI metadata should stay current while a project is actively visible on any connected device. One aggregate scheduler avoids per-device/per-project timers, duplicate GraphQL targets, overlapping cycles, and ghost polling after disconnects.

## Risk and test focus

Risk is medium-high around lifecycle ordering and stale timer rearming. Highest-value checks cover multi-device union/count ownership, encrypted relay routing, disconnect and relay-drop cleanup, activation during in-flight work, completion-based interval timing, failure/disposal behavior, serialized service generations, and strict separation from unseen/push state.

## Expected result

A project-view declaration triggers immediate branch/PR refresh; while any device continues viewing projects, one 30-second completion-based schedule refreshes their deduplicated union. New projects are covered immediately, disconnected claims stop contributing, and an empty union schedules no work. The normal ephemeral PR cache/current-branch fields may refresh; there is no database-schema or wire-contract change. Existing clients retain request-driven behavior, and there is no unrelated user-visible UI change in this step.

## Verification

- 48 focused tracker/listener/sync/orchestrator tests passed
- all 2,346 bridge app tests passed
- `dart analyze --fatal-infos`
- Dart formatting
- `git diff --check`
- architecture review findings applied: listener work is drained before downstream teardown, and the new tracker uses the current top-level service layer
