### PR TITLE
⚙️ [session-pull-request-monitoring] feat(bridge): configure PR refresh cadence [step 6/9]

### DIFF
--- a/.plan/active/session-pull-request-monitoring/TRACKER.md
+++ b/.plan/active/session-pull-request-monitoring/TRACKER.md
@@ -362,10 +362,11 @@
   plugin response publication and bridge-identity failure semantics.
 - **Step 6/9 analytics:** No event; this bridge setting does not answer a current
   activation/retention decision, and the approved plan excludes new analytics.
-- **Step 6/9 verification:** Shared codegen, 18 focused bridge tests added, all
-  357 shared tests, all 2,364 bridge app tests, both fatal-info analyzers, and
-  `git diff --check` pass. The implementation remains within its 1,000–1,500
-  changed-line target.
+- **Step 6/9 verification:** Shared codegen, 20 focused bridge tests added, all
+  357 shared tests, all 2,366 bridge app tests, both fatal-info analyzers, and
+  `git diff --check` pass. Review-requested strict contract and invariant tests
+  raise the final change to 1,554 lines, 54 above the soft target; generated
+  contract output and its coupled boundary tests have no smaller coherent split.
 - **Step 6/9 architecture review:** `aristotle-impl-review` found two issues.
   The service now suppresses unrelated whole-settings changes, and the runtime
   runner now owns repository disposal across early startup exits. Both findings

--- a/.plan/active/session-pull-request-monitoring/TRACKER.md
+++ b/.plan/active/session-pull-request-monitoring/TRACKER.md
@@ -9,7 +9,8 @@
 - **Current step:** Step 6/9 — bridge cadence settings
 - **Plan PR:** [#649](https://github.com/sesori-ai/sesori_apps_monorepo/pull/649) merged
 - **Superseded prototype:** [#659](https://github.com/sesori-ai/sesori_apps_monorepo/pull/659) closed
-- **Next action:** commit and open the verified Step 6 implementation PR
+- **Step PR:** [#693](https://github.com/sesori-ai/sesori_apps_monorepo/pull/693) open
+- **Next action:** monitor Step 6 CI and review feedback until merge
 
 ## Existing Baseline
 
@@ -365,12 +366,18 @@
 - **Step 6/9 verification:** Shared codegen, 20 focused bridge tests added, all
   357 shared tests, all 2,366 bridge app tests, both fatal-info analyzers, and
   `git diff --check` pass. Review-requested strict contract and invariant tests
-  raise the final change to 1,554 lines, 54 above the soft target; generated
-  contract output and its coupled boundary tests have no smaller coherent split.
+  plus the diagnostic-logging follow-up raise the final change to 1,589 lines,
+  89 above the soft target; generated contract output, coupled boundary tests,
+  and directly caused logging-policy cleanup have no smaller coherent split.
 - **Step 6/9 architecture review:** `aristotle-impl-review` found two issues.
   The service now suppresses unrelated whole-settings changes, and the runtime
   runner now owns repository disposal across early startup exits. Both findings
   were applied and, per review rules, were not re-reviewed.
+- **Step 6/9 diagnostic logging follow-up:** All logs introduced or touched by
+  this PR preserve the original error, stack trace, paths, identifiers, and
+  operation context. The prior whole-error privacy wrappers were removed; config
+  repair now captures parse stacks, and range exceptions retain the rejected
+  value and valid range. No prompt or transcript fields occur in these logs.
 
 ## Findings and Plan Deltas
 

--- a/.plan/active/session-pull-request-monitoring/TRACKER.md
+++ b/.plan/active/session-pull-request-monitoring/TRACKER.md
@@ -4,12 +4,12 @@
 
 - **Plan slug:** `session-pull-request-monitoring`
 - **Implementation base:** `main` at
-  `d38d47939e621f60077d75545e00966401e16ccf`
-- **Series state:** Steps 1/9, 2.a–2.c/9, 3/9, and 4/9 merged; Step 5 is in progress
-- **Current step:** Step 5/9 — multi-device view scheduling
+  `42161a53b8b76268d3a94157e200d07418dc880b`
+- **Series state:** Steps 1/9, 2.a–2.c/9, 3/9, 4/9, and 5/9 merged; Step 6 is in progress
+- **Current step:** Step 6/9 — bridge cadence settings
 - **Plan PR:** [#649](https://github.com/sesori-ai/sesori_apps_monorepo/pull/649) merged
 - **Superseded prototype:** [#659](https://github.com/sesori-ai/sesori_apps_monorepo/pull/659) closed
-- **Next action:** commit and open the verified Step 5 implementation PR
+- **Next action:** commit and open the verified Step 6 implementation PR
 
 ## Existing Baseline
 
@@ -45,8 +45,8 @@
 | [x] | 2.c/9 | `session-pull-request-monitoring-scoped-pr-reads` | `🚧 [session-pull-request-monitoring] feat(bridge): gate scoped PR reads [step 2.c/9]` | 1,200–1,700 | [PR #678](https://github.com/sesori-ai/sesori_apps_monorepo/pull/678) merged as `d13cc8ca` |
 | [x] | 3/9 | `session-pull-request-monitoring-graphql-selection` | `🚧 [session-pull-request-monitoring] feat(bridge): batch exact PR selection [step 3/9]` | 3,100–3,500 | [PR #685](https://github.com/sesori-ai/sesori_apps_monorepo/pull/685) merged as `f6ec9e9d` |
 | [x] | 4/9 | `session-pull-request-monitoring-current-branch-refresh` | `🚧 [session-pull-request-monitoring] feat(bridge): refresh current session branches [step 4/9]` | 4,000–4,200 | [PR #686](https://github.com/sesori-ai/sesori_apps_monorepo/pull/686) merged as `3bbb1e8e` |
-| [ ] | 5/9 | `session-pull-request-monitoring-view-scheduler` | `🚧 [session-pull-request-monitoring] feat(bridge): schedule viewed-project PR refresh [step 5/9]` | 900–1,400 | Current and unblocked; implementation complete locally, architecture review/PR pending |
-| [ ] | 6/9 | `session-pull-request-monitoring-bridge-settings` | `⚙️ [session-pull-request-monitoring] feat(bridge): configure PR refresh cadence [step 6/9]` | 1,000–1,500 | Blocked on Step 5 merge |
+| [x] | 5/9 | `session-pull-request-monitoring-view-scheduler` | `🚧 [session-pull-request-monitoring] feat(bridge): schedule viewed-project PR refresh [step 5/9]` | 900–1,400 | [PR #692](https://github.com/sesori-ai/sesori_apps_monorepo/pull/692) merged as `42161a53` |
+| [ ] | 6/9 | `session-pull-request-monitoring-bridge-settings` | `⚙️ [session-pull-request-monitoring] feat(bridge): configure PR refresh cadence [step 6/9]` | 1,000–1,500 | Current; implementation, verification, and architecture review complete |
 | [ ] | 7/9 | `session-pull-request-monitoring-client-presence` | `🚧 [session-pull-request-monitoring] feat(client): declare viewed projects [step 7/9]` | 1,000–1,500 | Blocked on Step 6 merge |
 | [ ] | 8/9 | `session-pull-request-monitoring-client-settings` | `🚧 [session-pull-request-monitoring] feat(client): configure PR refresh cadence [step 8/9]` | 1,000–1,500 | Blocked on Step 7 merge; use current settings owner and merged #647 pattern |
 | [ ] | 9/9 | `session-pull-request-monitoring-retire-plan` | `🌱 [session-pull-request-monitoring] docs: retire current PR monitoring plan [step 9/9]` | 50–200 | Blocked on Step 8 merge |
@@ -89,10 +89,8 @@
 
 ## Current Drift and Open Work
 
-- Latest audited `main`: `d38d4793`, including Step 4 merged as `3bbb1e8e`, the
-  repository-rename hotfix, and unrelated client haptics. The hotfix accepts a
-  redirected canonical GitHub response while retaining local remote scope, and
-  does not overlap connection presence or scheduling ownership.
+- Latest audited `main`: `42161a53`, including Step 5 merged from PR #692. No
+  later drift affects the reviewed Step 6 settings architecture.
 - Drift schema: v13 on `main`; Step 4 leaves the merged schema and migration
   unchanged.
 - Parallel-plugin plan: complete through Stage 9 / PR #497.
@@ -350,6 +348,28 @@
   admitted refresh before `PrSyncService` teardown, and the new tracker moved
   from the legacy nested bridge path to the current top-level service layer.
   Both findings were applied and, per review rules, were not re-reviewed.
+- **Step 6/9 implementation:** `BridgeSettings` now persists a validated
+  15–3,600-second PR refresh interval, repairs missing/invalid startup values to
+  30, and exposes one repository-owned serialized mutation seam and committed
+  settings stream. Plugin writers use that seam. Shared typed GET/PATCH/error
+  contracts back `/settings/pull-request-refresh`; the focused service persists
+  committed values and the viewed-project listener rearms pending timers live.
+- **Step 6/9 compatibility and data:** The route and shared contracts are
+  additive, with no database change. Manual JSON edits remain restart-scoped;
+  older clients do not call the new route.
+- **Step 6/9 cleanup:** Removed the hard-coded listener cadence and direct
+  `saveSettings` writer. The plugin-local tail remains because it also orders
+  plugin response publication and bridge-identity failure semantics.
+- **Step 6/9 analytics:** No event; this bridge setting does not answer a current
+  activation/retention decision, and the approved plan excludes new analytics.
+- **Step 6/9 verification:** Shared codegen, 18 focused bridge tests added, all
+  357 shared tests, all 2,364 bridge app tests, both fatal-info analyzers, and
+  `git diff --check` pass. The implementation remains within its 1,000–1,500
+  changed-line target.
+- **Step 6/9 architecture review:** `aristotle-impl-review` found two issues.
+  The service now suppresses unrelated whole-settings changes, and the runtime
+  runner now owns repository disposal across early startup exits. Both findings
+  were applied and, per review rules, were not re-reviewed.
 
 ## Findings and Plan Deltas
 

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -33,6 +33,7 @@ import "../push/push_notification_client.dart";
 import "../push/push_notification_content_builder.dart";
 import "../push/push_rate_limiter.dart";
 import "../push/push_session_state_tracker.dart";
+import "../repositories/bridge_settings_repository.dart";
 import "../repositories/catalog_import_repository.dart";
 import "../repositories/project_catalog_identity_calculator.dart";
 import "../routing/cancel_catalog_import_handler.dart";
@@ -40,13 +41,16 @@ import "../routing/get_catalog_import_statuses_handler.dart";
 import "../routing/get_plugin_management_handler.dart";
 import "../routing/get_plugin_setup_handler.dart";
 import "../routing/get_plugins_handler.dart";
+import "../routing/get_pull_request_refresh_settings_handler.dart";
 import "../routing/patch_plugin_idle_timeout_handler.dart";
+import "../routing/patch_pull_request_refresh_settings_handler.dart";
 import "../routing/post_plugin_lifecycle_command_handler.dart";
 import "../routing/start_catalog_import_handler.dart";
 import "../server/services/bridge_restart_service.dart";
 import "../services/catalog_import_service.dart";
 import "../services/plugin_lifecycle_service.dart";
 import "../services/project_view_tracker.dart";
+import "../services/pull_request_refresh_settings_service.dart";
 import "../version.dart";
 import "api/filesystem_api.dart";
 import "api/gh_cli_api.dart";
@@ -153,6 +157,7 @@ class Orchestrator {
   final String _legacyMissingPluginId;
   final PluginLifecycleService _pluginLifecycleService;
   final PluginRuntime _pluginRuntime;
+  final BridgeSettingsRepository _bridgeSettingsRepository;
   final ServerClock _clock;
   final AppDatabase _database;
   final http.Client _httpClient;
@@ -171,6 +176,7 @@ class Orchestrator {
     required String legacyMissingPluginId,
     required PluginLifecycleService pluginLifecycleService,
     required PluginRuntime pluginRuntime,
+    required BridgeSettingsRepository bridgeSettingsRepository,
     required ServerClock clock,
     required AppDatabase database,
     required http.Client httpClient,
@@ -188,6 +194,7 @@ class Orchestrator {
        _legacyMissingPluginId = legacyMissingPluginId,
        _pluginLifecycleService = pluginLifecycleService,
        _pluginRuntime = pluginRuntime,
+       _bridgeSettingsRepository = bridgeSettingsRepository,
        _clock = clock,
        _database = database,
        _httpClient = httpClient,
@@ -313,10 +320,13 @@ class Orchestrator {
       sessionRepository: sessionRepository,
       clock: const Clock(),
     );
+    final pullRequestRefreshSettingsService = PullRequestRefreshSettingsService(
+      bridgeSettingsRepository: _bridgeSettingsRepository,
+    );
     final viewedProjectPrRefreshListener = ViewedProjectPrRefreshListener(
       tracker: projectViewTracker,
       prSyncService: prSyncService,
-      refreshInterval: const Duration(seconds: 30),
+      settingsService: pullRequestRefreshSettingsService,
     );
     final projectActivityService = ProjectActivityService(
       projectRepository: projectRepository,
@@ -463,6 +473,8 @@ class Orchestrator {
         HealthCheckHandler(healthRepository: healthRepository),
         GetPluginManagementHandler(lifecycleService: _pluginLifecycleService),
         PatchPluginIdleTimeoutHandler(lifecycleService: _pluginLifecycleService),
+        GetPullRequestRefreshSettingsHandler(settingsService: pullRequestRefreshSettingsService),
+        PatchPullRequestRefreshSettingsHandler(settingsService: pullRequestRefreshSettingsService),
         PostPluginLifecycleCommandHandler(lifecycleService: _pluginLifecycleService),
         GetPluginSetupHandler(lifecycleService: _pluginLifecycleService),
         GetPluginsHandler(lifecycleService: _pluginLifecycleService, bridgeIdProvider: _bridgeRegistrationService),

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -461,6 +461,7 @@ class BridgeRuntimeRunner {
       final BridgeSettings bridgeSettings;
       try {
         bridgeSettingsRepository = BridgeSettingsRepository(api: BridgeSettingsApi());
+        shutdownCoordinator.add(disposable: bridgeSettingsRepository.dispose);
         bridgeSettings = await bridgeSettingsRepository.loadSettings();
       } on Object catch (error, stackTrace) {
         Log.e("Failed to resolve bridge settings", error, stackTrace);
@@ -801,6 +802,7 @@ class BridgeRuntimeRunner {
         legacyMissingPluginId: legacyMissingPluginId,
         pluginLifecycleService: activePluginLifecycleService,
         pluginRuntime: activePluginRuntime,
+        bridgeSettingsRepository: bridgeSettingsRepository,
         clock: serverClock,
         database: database,
         httpClient: httpClient,

--- a/bridge/app/lib/src/listeners/viewed_project_pr_refresh_listener.dart
+++ b/bridge/app/lib/src/listeners/viewed_project_pr_refresh_listener.dart
@@ -38,11 +38,12 @@ class ViewedProjectPrRefreshListener {
     _tracker.changes
         .listen(
           (change) => _handleChange(change: change),
-          onError: (Object error, StackTrace _) {
+          onError: (Object error, StackTrace stackTrace) {
             if (_disposed) return;
             Log.w(
               "Viewed-project change tracking failed unexpectedly",
-              _PrivacySafeViewedProjectRefreshException(cause: error),
+              error,
+              stackTrace,
             );
           },
         )
@@ -50,11 +51,12 @@ class ViewedProjectPrRefreshListener {
     _settingsService.changes
         .listen(
           (settings) => _handleIntervalChange(intervalSeconds: settings.intervalSeconds),
-          onError: (Object error, StackTrace _) {
+          onError: (Object error, StackTrace stackTrace) {
             if (_disposed) return;
             Log.w(
               "Pull request refresh settings changes failed unexpectedly",
-              _PrivacySafePullRequestRefreshSettingsException(cause: error),
+              error,
+              stackTrace,
             );
           },
         )
@@ -107,11 +109,12 @@ class ViewedProjectPrRefreshListener {
         projectIds: projectIds,
         refreshPolicy: PrRefreshPolicy.viewedProject,
       );
-    } on Object catch (error) {
+    } on Object catch (error, stackTrace) {
       if (!_disposed) {
         Log.w(
           "Viewed-project pull request refresh failed unexpectedly; retrying after the configured interval",
-          _PrivacySafeViewedProjectRefreshException(cause: error),
+          error,
+          stackTrace,
         );
       }
     }
@@ -146,22 +149,4 @@ class ViewedProjectPrRefreshListener {
     await _subscriptions.cancel();
     await Future.wait(List<Future<void>>.of(_activeRefreshes));
   }
-}
-
-final class _PrivacySafeViewedProjectRefreshException implements Exception {
-  final Object cause;
-
-  const _PrivacySafeViewedProjectRefreshException({required this.cause});
-
-  @override
-  String toString() => "ViewedProjectRefreshException";
-}
-
-final class _PrivacySafePullRequestRefreshSettingsException implements Exception {
-  final Object cause;
-
-  const _PrivacySafePullRequestRefreshSettingsException({required this.cause});
-
-  @override
-  String toString() => "PullRequestRefreshSettingsException";
 }

--- a/bridge/app/lib/src/listeners/viewed_project_pr_refresh_listener.dart
+++ b/bridge/app/lib/src/listeners/viewed_project_pr_refresh_listener.dart
@@ -1,48 +1,76 @@
 import "dart:async";
 
+import "package:rxdart/rxdart.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
 import "../bridge/services/pr_sync_service.dart";
 import "../services/project_view_tracker.dart";
+import "../services/pull_request_refresh_settings_service.dart";
 
 /// Schedules pull request refreshes while at least one project is being viewed.
 class ViewedProjectPrRefreshListener {
   final ProjectViewTracker _tracker;
   final PrSyncService _prSyncService;
-  final Duration _refreshInterval;
+  final PullRequestRefreshSettingsService _settingsService;
 
-  StreamSubscription<ProjectViewChange>? _subscription;
+  final CompositeSubscription _subscriptions = CompositeSubscription();
   Timer? _timer;
   Future<void>? _disposeFuture;
   final Set<Future<void>> _activeRefreshes = <Future<void>>{};
   int _latestAdmission = 0;
   bool _disposed = false;
+  bool _started = false;
+  late Duration _refreshInterval;
 
   ViewedProjectPrRefreshListener({
     required ProjectViewTracker tracker,
     required PrSyncService prSyncService,
-    required Duration refreshInterval,
+    required PullRequestRefreshSettingsService settingsService,
   }) : _tracker = tracker,
        _prSyncService = prSyncService,
-       _refreshInterval = refreshInterval;
+       _settingsService = settingsService;
 
   void start() {
-    if (_subscription != null || _disposed) return;
+    if (_started || _disposed) return;
+    _started = true;
+    _refreshInterval = Duration(seconds: _settingsService.currentSettings.intervalSeconds);
 
-    _subscription = _tracker.changes.listen(
-      (change) => _handleChange(change: change),
-      onError: (Object error, StackTrace _) {
-        if (_disposed) return;
-        Log.w(
-          "Viewed-project change tracking failed unexpectedly",
-          _PrivacySafeViewedProjectRefreshException(cause: error),
-        );
-      },
-    );
+    _tracker.changes
+        .listen(
+          (change) => _handleChange(change: change),
+          onError: (Object error, StackTrace _) {
+            if (_disposed) return;
+            Log.w(
+              "Viewed-project change tracking failed unexpectedly",
+              _PrivacySafeViewedProjectRefreshException(cause: error),
+            );
+          },
+        )
+        .addTo(_subscriptions);
+    _settingsService.changes
+        .listen(
+          (settings) => _handleIntervalChange(intervalSeconds: settings.intervalSeconds),
+          onError: (Object error, StackTrace stackTrace) {
+            if (_disposed) return;
+            Log.w(
+              "Pull request refresh settings changes failed unexpectedly",
+              _PrivacySafePullRequestRefreshSettingsException(cause: error),
+              stackTrace,
+            );
+          },
+        )
+        .addTo(_subscriptions);
     final activeProjectIds = _tracker.activeProjectIds;
     if (activeProjectIds.isNotEmpty) {
       _admitRefresh(projectIds: activeProjectIds);
     }
+  }
+
+  void _handleIntervalChange({required int intervalSeconds}) {
+    if (_disposed) return;
+    _refreshInterval = Duration(seconds: intervalSeconds);
+    if (_timer == null) return;
+    _armTimer();
   }
 
   void _handleChange({required ProjectViewChange change}) {
@@ -116,8 +144,7 @@ class ViewedProjectPrRefreshListener {
   Future<void> _dispose() async {
     _disposed = true;
     _cancelSchedule();
-    await _subscription?.cancel();
-    _subscription = null;
+    await _subscriptions.cancel();
     await Future.wait(List<Future<void>>.of(_activeRefreshes));
   }
 }
@@ -129,4 +156,13 @@ final class _PrivacySafeViewedProjectRefreshException implements Exception {
 
   @override
   String toString() => "ViewedProjectRefreshException";
+}
+
+final class _PrivacySafePullRequestRefreshSettingsException implements Exception {
+  final Object cause;
+
+  const _PrivacySafePullRequestRefreshSettingsException({required this.cause});
+
+  @override
+  String toString() => "PullRequestRefreshSettingsException";
 }

--- a/bridge/app/lib/src/listeners/viewed_project_pr_refresh_listener.dart
+++ b/bridge/app/lib/src/listeners/viewed_project_pr_refresh_listener.dart
@@ -50,12 +50,11 @@ class ViewedProjectPrRefreshListener {
     _settingsService.changes
         .listen(
           (settings) => _handleIntervalChange(intervalSeconds: settings.intervalSeconds),
-          onError: (Object error, StackTrace stackTrace) {
+          onError: (Object error, StackTrace _) {
             if (_disposed) return;
             Log.w(
               "Pull request refresh settings changes failed unexpectedly",
               _PrivacySafePullRequestRefreshSettingsException(cause: error),
-              stackTrace,
             );
           },
         )

--- a/bridge/app/lib/src/repositories/bridge_settings.dart
+++ b/bridge/app/lib/src/repositories/bridge_settings.dart
@@ -1,6 +1,9 @@
 import '../updater/foundation/release_track.dart';
 
 const int defaultPluginIdleTimeoutMins = 10;
+const int defaultPullRequestRefreshIntervalSeconds = 30;
+const int minimumPullRequestRefreshIntervalSeconds = 15;
+const int maximumPullRequestRefreshIntervalSeconds = 3600;
 
 enum SleepPreventionMode {
   off,
@@ -183,11 +186,15 @@ class BridgeSettings {
   /// Which release channel the auto-updater follows.
   final ReleaseTrack releaseTrack;
 
+  /// Polling cadence while at least one client views a project.
+  final int pullRequestRefreshIntervalSeconds;
+
   const BridgeSettings({
     this.sleepPrevention = SleepPreventionMode.always,
     this.yolo = false,
     this.plugins = const BridgePluginSettings(),
     this.releaseTrack = ReleaseTrack.stable,
+    this.pullRequestRefreshIntervalSeconds = defaultPullRequestRefreshIntervalSeconds,
   });
 
   factory BridgeSettings.fromJson(Map<String, dynamic> json) {
@@ -198,6 +205,10 @@ class BridgeSettings {
           ? BridgePluginSettings.fromJson(rawValue: json['plugins'])
           : const BridgePluginSettings(),
       releaseTrack: _parseReleaseTrack(json['releaseTrack']),
+      pullRequestRefreshIntervalSeconds: _parsePullRequestRefreshInterval(
+        isPresent: json.containsKey('pullRequestRefreshIntervalSeconds'),
+        rawValue: json['pullRequestRefreshIntervalSeconds'],
+      ),
     );
   }
 
@@ -209,6 +220,7 @@ class BridgeSettings {
       },
       'yolo': yolo,
       'releaseTrack': releaseTrack.wireValue,
+      'pullRequestRefreshIntervalSeconds': pullRequestRefreshIntervalSeconds,
       if (!plugins.isEmpty) 'plugins': plugins.toJson(),
     };
   }
@@ -218,12 +230,14 @@ class BridgeSettings {
     bool? yolo,
     BridgePluginSettings? plugins,
     ReleaseTrack? releaseTrack,
+    int? pullRequestRefreshIntervalSeconds,
   }) {
     return BridgeSettings(
       sleepPrevention: sleepPrevention ?? this.sleepPrevention,
       yolo: yolo ?? this.yolo,
       plugins: plugins ?? this.plugins,
       releaseTrack: releaseTrack ?? this.releaseTrack,
+      pullRequestRefreshIntervalSeconds: pullRequestRefreshIntervalSeconds ?? this.pullRequestRefreshIntervalSeconds,
     );
   }
 
@@ -238,6 +252,16 @@ class BridgeSettings {
   static ReleaseTrack _parseReleaseTrack(Object? rawValue) {
     return ReleaseTrack.fromWire(rawValue is String ? rawValue : null);
   }
+
+  static int _parsePullRequestRefreshInterval({required bool isPresent, required Object? rawValue}) {
+    if (!isPresent) return defaultPullRequestRefreshIntervalSeconds;
+    if (rawValue is! int ||
+        rawValue < minimumPullRequestRefreshIntervalSeconds ||
+        rawValue > maximumPullRequestRefreshIntervalSeconds) {
+      throw const PullRequestRefreshIntervalFormatException();
+    }
+    return rawValue;
+  }
 }
 
 class PluginSettingsFormatException extends FormatException {
@@ -249,4 +273,12 @@ class PluginIdleTimeoutFormatException extends PluginSettingsFormatException {
 
   PluginIdleTimeoutFormatException({required this.entryName})
     : super('"plugins.$entryName.idleTimeoutMins" must be an integer');
+}
+
+class PullRequestRefreshIntervalFormatException extends FormatException {
+  const PullRequestRefreshIntervalFormatException()
+    : super(
+        '"pullRequestRefreshIntervalSeconds" must be an integer between '
+        '$minimumPullRequestRefreshIntervalSeconds and $maximumPullRequestRefreshIntervalSeconds',
+      );
 }

--- a/bridge/app/lib/src/repositories/bridge_settings_repository.dart
+++ b/bridge/app/lib/src/repositories/bridge_settings_repository.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Log;
@@ -11,11 +12,19 @@ class BridgeSettingsRepository {
   static const JsonEncoder _jsonEncoder = JsonEncoder.withIndent('  ');
 
   final BridgeSettingsApi _api;
+  final StreamController<BridgeSettingsChange> _settingsChanges = StreamController<BridgeSettingsChange>.broadcast(
+    sync: true,
+  );
   BridgeSettings? _currentSettings;
+  Future<void> _mutationTail = Future<void>.value();
+  Future<void>? _disposeFuture;
+  bool _disposed = false;
 
   BridgeSettingsRepository({required BridgeSettingsApi api}) : _api = api;
 
   String get configFilePath => _api.configFilePath;
+
+  Stream<BridgeSettingsChange> get settingsChanges => _settingsChanges.stream;
 
   BridgeSettings get currentSettings {
     final settings = _currentSettings;
@@ -41,8 +50,8 @@ class BridgeSettingsRepository {
     final json = jsonDecodeMap(storedConfig);
     final parsed = _parseSettings(json);
     final settings = parsed.settings;
-    if (parsed.idleTimeoutErrors.isNotEmpty) {
-      for (final error in parsed.idleTimeoutErrors) {
+    if (parsed.repairErrors.isNotEmpty || parsed.missingPullRequestRefreshInterval) {
+      for (final error in parsed.repairErrors) {
         Log.w('[bridge-settings] invalid config at $configFilePath: $error');
       }
       try {
@@ -55,34 +64,68 @@ class BridgeSettingsRepository {
     return settings;
   }
 
-  Future<void> saveSettings({required BridgeSettings settings}) async {
-    await _api.writeConfig(_jsonEncoder.convert(settings.toJson()));
-    _currentSettings = settings;
+  Future<BridgeSettings> mutateSettings({
+    required BridgeSettings Function({required BridgeSettings current}) mutation,
+  }) {
+    if (_disposed) return Future<BridgeSettings>.error(StateError('Bridge settings repository has been disposed.'));
+
+    final completer = Completer<BridgeSettings>();
+    _mutationTail = _mutationTail.then((_) async {
+      try {
+        final current = _currentSettings ?? await loadSettings();
+        final updated = mutation(current: current);
+        if (identical(updated, current)) {
+          completer.complete(current);
+          return;
+        }
+        await _api.writeConfig(_jsonEncoder.convert(updated.toJson()));
+        _currentSettings = updated;
+        _settingsChanges.add(BridgeSettingsChange(previous: current, current: updated));
+        completer.complete(updated);
+      } on Object catch (error, stackTrace) {
+        completer.completeError(error, stackTrace);
+      }
+    });
+    return completer.future;
   }
 
   Future<void> updateReleaseTrack({required ReleaseTrack track}) async {
-    final current = await loadSettings();
-    await saveSettings(settings: current.copyWith(releaseTrack: track));
+    await mutateSettings(mutation: ({required current}) => current.copyWith(releaseTrack: track));
   }
 
   Future<void> updateYolo({required bool enabled}) async {
-    final current = await loadSettings();
-    await saveSettings(settings: current.copyWith(yolo: enabled));
+    await mutateSettings(mutation: ({required current}) => current.copyWith(yolo: enabled));
   }
 
   Future<BridgeSettings> updatePluginDisabled({required String pluginId, required bool disabled}) async {
-    final current = await loadSettings();
-    final updated = current.copyWith(
-      plugins: current.plugins.withPluginDisabled(pluginId: pluginId, disabled: disabled),
+    return mutateSettings(
+      mutation: ({required current}) => current.copyWith(
+        plugins: current.plugins.withPluginDisabled(pluginId: pluginId, disabled: disabled),
+      ),
     );
-    await saveSettings(settings: updated);
-    return updated;
   }
 
-  ({BridgeSettings settings, List<PluginIdleTimeoutFormatException> idleTimeoutErrors}) _parseSettings(
+  Future<void> dispose() => _disposeFuture ??= _dispose();
+
+  Future<void> _dispose() async {
+    _disposed = true;
+    await _mutationTail;
+    await _settingsChanges.close();
+  }
+
+  ({
+    BridgeSettings settings,
+    List<FormatException> repairErrors,
+    bool missingPullRequestRefreshInterval,
+  })
+  _parseSettings(
     Map<String, dynamic> json,
   ) {
     final repaired = Map<String, dynamic>.of(json);
+    final missingPullRequestRefreshInterval = !repaired.containsKey('pullRequestRefreshIntervalSeconds');
+    if (missingPullRequestRefreshInterval) {
+      repaired['pullRequestRefreshIntervalSeconds'] = defaultPullRequestRefreshIntervalSeconds;
+    }
     final rawPlugins = repaired['plugins'];
     if (rawPlugins is Map) {
       repaired['plugins'] = <String, dynamic>{
@@ -93,10 +136,14 @@ class BridgeSettingsRepository {
                 : entry.value,
       };
     }
-    final errors = <PluginIdleTimeoutFormatException>[];
+    final errors = <FormatException>[];
     while (true) {
       try {
-        return (settings: BridgeSettings.fromJson(repaired), idleTimeoutErrors: List.unmodifiable(errors));
+        return (
+          settings: BridgeSettings.fromJson(repaired),
+          repairErrors: List.unmodifiable(errors),
+          missingPullRequestRefreshInterval: missingPullRequestRefreshInterval,
+        );
       } on PluginIdleTimeoutFormatException catch (error) {
         final plugins = repaired['plugins'];
         if (plugins is! Map<String, dynamic>) rethrow;
@@ -105,7 +152,17 @@ class BridgeSettingsRepository {
         entry.remove('idleTimeoutMins');
         if (entry.isEmpty && error.entryName != 'default') plugins.remove(error.entryName);
         errors.add(error);
+      } on PullRequestRefreshIntervalFormatException catch (error) {
+        repaired['pullRequestRefreshIntervalSeconds'] = defaultPullRequestRefreshIntervalSeconds;
+        errors.add(error);
       }
     }
   }
+}
+
+class BridgeSettingsChange {
+  final BridgeSettings previous;
+  final BridgeSettings current;
+
+  const BridgeSettingsChange({required this.previous, required this.current});
 }

--- a/bridge/app/lib/src/repositories/bridge_settings_repository.dart
+++ b/bridge/app/lib/src/repositories/bridge_settings_repository.dart
@@ -52,7 +52,7 @@ class BridgeSettingsRepository {
     final settings = parsed.settings;
     if (parsed.repairErrors.isNotEmpty || parsed.missingPullRequestRefreshInterval) {
       for (final error in parsed.repairErrors) {
-        Log.w('[bridge-settings] invalid config at $configFilePath: $error');
+        Log.w('[bridge-settings] invalid config at $configFilePath', error);
       }
       try {
         await _api.writeConfig(_jsonEncoder.convert(settings.toJson()));
@@ -77,6 +77,10 @@ class BridgeSettingsRepository {
         if (identical(updated, current)) {
           completer.complete(current);
           return;
+        }
+        if (updated.pullRequestRefreshIntervalSeconds < minimumPullRequestRefreshIntervalSeconds ||
+            updated.pullRequestRefreshIntervalSeconds > maximumPullRequestRefreshIntervalSeconds) {
+          throw const PullRequestRefreshIntervalFormatException();
         }
         await _api.writeConfig(_jsonEncoder.convert(updated.toJson()));
         _currentSettings = updated;

--- a/bridge/app/lib/src/repositories/bridge_settings_repository.dart
+++ b/bridge/app/lib/src/repositories/bridge_settings_repository.dart
@@ -51,8 +51,12 @@ class BridgeSettingsRepository {
     final parsed = _parseSettings(json);
     final settings = parsed.settings;
     if (parsed.repairErrors.isNotEmpty || parsed.missingPullRequestRefreshInterval) {
-      for (final error in parsed.repairErrors) {
-        Log.w('[bridge-settings] invalid config at $configFilePath', error);
+      for (final repairError in parsed.repairErrors) {
+        Log.w(
+          '[bridge-settings] invalid config at $configFilePath',
+          repairError.error,
+          repairError.stackTrace,
+        );
       }
       try {
         await _api.writeConfig(_jsonEncoder.convert(settings.toJson()));
@@ -119,7 +123,7 @@ class BridgeSettingsRepository {
 
   ({
     BridgeSettings settings,
-    List<FormatException> repairErrors,
+    List<({FormatException error, StackTrace stackTrace})> repairErrors,
     bool missingPullRequestRefreshInterval,
   })
   _parseSettings(
@@ -140,7 +144,7 @@ class BridgeSettingsRepository {
                 : entry.value,
       };
     }
-    final errors = <FormatException>[];
+    final errors = <({FormatException error, StackTrace stackTrace})>[];
     while (true) {
       try {
         return (
@@ -148,17 +152,17 @@ class BridgeSettingsRepository {
           repairErrors: List.unmodifiable(errors),
           missingPullRequestRefreshInterval: missingPullRequestRefreshInterval,
         );
-      } on PluginIdleTimeoutFormatException catch (error) {
+      } on PluginIdleTimeoutFormatException catch (error, stackTrace) {
         final plugins = repaired['plugins'];
         if (plugins is! Map<String, dynamic>) rethrow;
         final entry = plugins[error.entryName];
         if (entry is! Map<String, dynamic> || !entry.containsKey('idleTimeoutMins')) rethrow;
         entry.remove('idleTimeoutMins');
         if (entry.isEmpty && error.entryName != 'default') plugins.remove(error.entryName);
-        errors.add(error);
-      } on PullRequestRefreshIntervalFormatException catch (error) {
+        errors.add((error: error, stackTrace: stackTrace));
+      } on PullRequestRefreshIntervalFormatException catch (error, stackTrace) {
         repaired['pullRequestRefreshIntervalSeconds'] = defaultPullRequestRefreshIntervalSeconds;
-        errors.add(error);
+        errors.add((error: error, stackTrace: stackTrace));
       }
     }
   }

--- a/bridge/app/lib/src/routing/get_pull_request_refresh_settings_handler.dart
+++ b/bridge/app/lib/src/routing/get_pull_request_refresh_settings_handler.dart
@@ -1,0 +1,20 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../bridge/routing/request_handler.dart";
+import "../services/pull_request_refresh_settings_service.dart";
+
+class GetPullRequestRefreshSettingsHandler extends GetRequestHandler<PullRequestRefreshSettingsResponse> {
+  GetPullRequestRefreshSettingsHandler({required PullRequestRefreshSettingsService settingsService})
+    : _settingsService = settingsService,
+      super("/settings/pull-request-refresh");
+
+  final PullRequestRefreshSettingsService _settingsService;
+
+  @override
+  Future<PullRequestRefreshSettingsResponse> handle(
+    RelayRequest request, {
+    required Map<String, String> pathParams,
+    required Map<String, String> queryParams,
+    required String? fragment,
+  }) async => _settingsService.currentSettings;
+}

--- a/bridge/app/lib/src/routing/patch_pull_request_refresh_settings_handler.dart
+++ b/bridge/app/lib/src/routing/patch_pull_request_refresh_settings_handler.dart
@@ -1,0 +1,46 @@
+import "dart:convert";
+
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../bridge/routing/request_handler.dart";
+import "../repositories/bridge_settings.dart";
+import "../services/pull_request_refresh_settings_service.dart";
+
+class PatchPullRequestRefreshSettingsHandler
+    extends BodyRequestHandler<PullRequestRefreshSettingsRequest, PullRequestRefreshSettingsResponse> {
+  PatchPullRequestRefreshSettingsHandler({required PullRequestRefreshSettingsService settingsService})
+    : _settingsService = settingsService,
+      super(
+        HttpMethod.patch,
+        "/settings/pull-request-refresh",
+        fromJson: PullRequestRefreshSettingsRequest.fromJson,
+      );
+
+  final PullRequestRefreshSettingsService _settingsService;
+
+  @override
+  Future<PullRequestRefreshSettingsResponse> handle(
+    RelayRequest request, {
+    required PullRequestRefreshSettingsRequest body,
+    required Map<String, String> pathParams,
+    required Map<String, String> queryParams,
+    required String? fragment,
+  }) async {
+    try {
+      return await _settingsService.update(request: body);
+    } on PullRequestRefreshIntervalOutOfRangeException {
+      throw RelayResponse(
+        id: request.id,
+        status: 400,
+        headers: const {"content-type": "application/json"},
+        body: jsonEncode(
+          const PullRequestRefreshSettingsErrorResponse(
+            code: PullRequestRefreshSettingsErrorCode.intervalOutOfRange,
+            minimumIntervalSeconds: minimumPullRequestRefreshIntervalSeconds,
+            maximumIntervalSeconds: maximumPullRequestRefreshIntervalSeconds,
+          ).toJson(),
+        ),
+      );
+    }
+  }
+}

--- a/bridge/app/lib/src/routing/patch_pull_request_refresh_settings_handler.dart
+++ b/bridge/app/lib/src/routing/patch_pull_request_refresh_settings_handler.dart
@@ -3,7 +3,6 @@ import "dart:convert";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../bridge/routing/request_handler.dart";
-import "../repositories/bridge_settings.dart";
 import "../services/pull_request_refresh_settings_service.dart";
 
 class PatchPullRequestRefreshSettingsHandler
@@ -28,16 +27,16 @@ class PatchPullRequestRefreshSettingsHandler
   }) async {
     try {
       return await _settingsService.update(request: body);
-    } on PullRequestRefreshIntervalOutOfRangeException {
+    } on PullRequestRefreshIntervalOutOfRangeException catch (error) {
       throw RelayResponse(
         id: request.id,
         status: 400,
         headers: const {"content-type": "application/json"},
         body: jsonEncode(
-          const PullRequestRefreshSettingsErrorResponse(
+          PullRequestRefreshSettingsErrorResponse(
             code: PullRequestRefreshSettingsErrorCode.intervalOutOfRange,
-            minimumIntervalSeconds: minimumPullRequestRefreshIntervalSeconds,
-            maximumIntervalSeconds: maximumPullRequestRefreshIntervalSeconds,
+            minimumIntervalSeconds: error.minimumIntervalSeconds,
+            maximumIntervalSeconds: error.maximumIntervalSeconds,
           ).toJson(),
         ),
       );

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -324,21 +324,24 @@ class PluginLifecycleService {
     }
     return _withSettingsMutationTail(() async {
       _requireBridgeId();
-      final current = await _bridgeSettingsRepository.loadSettings();
-      final plugins = switch (request) {
-        PluginIdleTimeoutApplyAllRequest(:final idleTimeoutMins) => current.plugins.withDefaultIdleTimeout(
-          idleTimeoutMins: idleTimeoutMins,
-          clearOverridePluginIds: _pluginIdsSupporting(capability: PluginControlCapability.idleTimeout),
-        ),
-        PluginIdleTimeoutSetOverrideRequest(:final pluginId, :final idleTimeoutMins) =>
-          current.plugins.withPluginIdleTimeout(pluginId: pluginId, idleTimeoutMins: idleTimeoutMins),
-        PluginIdleTimeoutClearOverrideRequest(:final pluginId) => current.plugins.withPluginIdleTimeout(
-          pluginId: pluginId,
-          idleTimeoutMins: null,
-        ),
-      };
-      _requireBridgeId();
-      await _bridgeSettingsRepository.saveSettings(settings: current.copyWith(plugins: plugins));
+      await _bridgeSettingsRepository.mutateSettings(
+        mutation: ({required current}) {
+          final plugins = switch (request) {
+            PluginIdleTimeoutApplyAllRequest(:final idleTimeoutMins) => current.plugins.withDefaultIdleTimeout(
+              idleTimeoutMins: idleTimeoutMins,
+              clearOverridePluginIds: _pluginIdsSupporting(capability: PluginControlCapability.idleTimeout),
+            ),
+            PluginIdleTimeoutSetOverrideRequest(:final pluginId, :final idleTimeoutMins) =>
+              current.plugins.withPluginIdleTimeout(pluginId: pluginId, idleTimeoutMins: idleTimeoutMins),
+            PluginIdleTimeoutClearOverrideRequest(:final pluginId) => current.plugins.withPluginIdleTimeout(
+              pluginId: pluginId,
+              idleTimeoutMins: null,
+            ),
+          };
+          _requireBridgeId();
+          return current.copyWith(plugins: plugins);
+        },
+      );
       _syncIdleTimers(_lifecycleRepository.snapshot);
       _publishManagementIfChanged();
       return _managementSnapshotAfterMutation;
@@ -527,12 +530,12 @@ class PluginLifecycleService {
 
   Future<void> _persistPluginDisabled({required String pluginId, required bool disabled}) {
     return _withSettingsMutationTail(() async {
-      final current = await _bridgeSettingsRepository.loadSettings();
-      if (current.plugins.isDisabled(pluginId: pluginId) == disabled) return;
-      await _bridgeSettingsRepository.saveSettings(
-        settings: current.copyWith(
-          plugins: current.plugins.withPluginDisabled(pluginId: pluginId, disabled: disabled),
-        ),
+      await _bridgeSettingsRepository.mutateSettings(
+        mutation: ({required current}) => current.plugins.isDisabled(pluginId: pluginId) == disabled
+            ? current
+            : current.copyWith(
+                plugins: current.plugins.withPluginDisabled(pluginId: pluginId, disabled: disabled),
+              ),
       );
     });
   }

--- a/bridge/app/lib/src/services/pull_request_refresh_settings_service.dart
+++ b/bridge/app/lib/src/services/pull_request_refresh_settings_service.dart
@@ -46,6 +46,10 @@ class PullRequestRefreshIntervalOutOfRangeException implements Exception {
 
   const PullRequestRefreshIntervalOutOfRangeException({required this.intervalSeconds});
 
+  int get minimumIntervalSeconds => minimumPullRequestRefreshIntervalSeconds;
+
+  int get maximumIntervalSeconds => maximumPullRequestRefreshIntervalSeconds;
+
   @override
   String toString() => "PullRequestRefreshIntervalOutOfRangeException";
 }

--- a/bridge/app/lib/src/services/pull_request_refresh_settings_service.dart
+++ b/bridge/app/lib/src/services/pull_request_refresh_settings_service.dart
@@ -51,5 +51,7 @@ class PullRequestRefreshIntervalOutOfRangeException implements Exception {
   int get maximumIntervalSeconds => maximumPullRequestRefreshIntervalSeconds;
 
   @override
-  String toString() => "PullRequestRefreshIntervalOutOfRangeException";
+  String toString() =>
+      "PullRequestRefreshIntervalOutOfRangeException(intervalSeconds: $intervalSeconds, "
+      "validRange: $minimumIntervalSeconds..$maximumIntervalSeconds)";
 }

--- a/bridge/app/lib/src/services/pull_request_refresh_settings_service.dart
+++ b/bridge/app/lib/src/services/pull_request_refresh_settings_service.dart
@@ -1,0 +1,51 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../repositories/bridge_settings.dart";
+import "../repositories/bridge_settings_repository.dart";
+
+class PullRequestRefreshSettingsService {
+  PullRequestRefreshSettingsService({required BridgeSettingsRepository bridgeSettingsRepository})
+    : _bridgeSettingsRepository = bridgeSettingsRepository;
+
+  final BridgeSettingsRepository _bridgeSettingsRepository;
+
+  PullRequestRefreshSettingsResponse get currentSettings =>
+      _response(settings: _bridgeSettingsRepository.currentSettings);
+
+  Stream<PullRequestRefreshSettingsResponse> get changes => _bridgeSettingsRepository.settingsChanges
+      .where(
+        (change) =>
+            change.previous.pullRequestRefreshIntervalSeconds != change.current.pullRequestRefreshIntervalSeconds,
+      )
+      .map((change) => _response(settings: change.current));
+
+  Future<PullRequestRefreshSettingsResponse> update({required PullRequestRefreshSettingsRequest request}) async {
+    final intervalSeconds = request.intervalSeconds;
+    if (intervalSeconds < minimumPullRequestRefreshIntervalSeconds ||
+        intervalSeconds > maximumPullRequestRefreshIntervalSeconds) {
+      throw PullRequestRefreshIntervalOutOfRangeException(intervalSeconds: intervalSeconds);
+    }
+
+    final committed = await _bridgeSettingsRepository.mutateSettings(
+      mutation: ({required current}) => current.pullRequestRefreshIntervalSeconds == intervalSeconds
+          ? current
+          : current.copyWith(pullRequestRefreshIntervalSeconds: intervalSeconds),
+    );
+    return _response(settings: committed);
+  }
+
+  PullRequestRefreshSettingsResponse _response({required BridgeSettings settings}) {
+    return PullRequestRefreshSettingsResponse(
+      intervalSeconds: settings.pullRequestRefreshIntervalSeconds,
+    );
+  }
+}
+
+class PullRequestRefreshIntervalOutOfRangeException implements Exception {
+  final int intervalSeconds;
+
+  const PullRequestRefreshIntervalOutOfRangeException({required this.intervalSeconds});
+
+  @override
+  String toString() => "PullRequestRefreshIntervalOutOfRangeException";
+}

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -57,6 +57,7 @@ Future<_DebugServerHarness> _createDebugServerHarness({
     legacyMissingPluginId: plugin.id,
     pluginLifecycleService: lifecycleService,
     pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
+    bridgeSettingsRepository: settingsRepositoryForLifecycleService(service: lifecycleService),
     clock: const ServerClock(),
     database: db,
     httpClient: httpClient,

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -671,6 +671,7 @@ class _OrchestratorHarness {
       legacyMissingPluginId: "opencode",
       pluginLifecycleService: lifecycleService,
       pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
+      bridgeSettingsRepository: settingsRepositoryForLifecycleService(service: lifecycleService),
       clock: const ServerClock(),
       database: database,
       httpClient: httpClient,

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -26,11 +26,12 @@ void main() {
     final relayServer = await TestRelayServer.start();
     final database = createTestDatabase();
     final pluginRuntime = createRegisteredTestPluginRuntime(pluginIds: const ["opencode"]);
+    final bridgeSettingsRepository = createTestBridgeSettingsRepository();
     final lifecycleService =
         PluginLifecycleService(
             lifecycleRepository: PluginLifecycleRepository(runtime: pluginRuntime),
             preferredDefaultPluginId: legacyMissingPluginId,
-            bridgeSettingsRepository: createTestBridgeSettingsRepository(),
+            bridgeSettingsRepository: bridgeSettingsRepository,
             idleTimerScheduler: const PluginIdleTimerScheduler(),
             bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
           )
@@ -68,6 +69,7 @@ void main() {
       legacyMissingPluginId: "opencode",
       pluginLifecycleService: lifecycleService,
       pluginRuntime: pluginRuntime,
+      bridgeSettingsRepository: bridgeSettingsRepository,
       clock: const ServerClock(),
       database: database,
       httpClient: httpClient,
@@ -141,6 +143,7 @@ void main() {
       legacyMissingPluginId: plugin.id,
       pluginLifecycleService: lifecycleService,
       pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
+      bridgeSettingsRepository: settingsRepositoryForLifecycleService(service: lifecycleService),
       clock: const ServerClock(),
       database: database,
       httpClient: httpClient,
@@ -192,6 +195,7 @@ void main() {
         legacyMissingPluginId: plugin.id,
         pluginLifecycleService: lifecycleService,
         pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
+        bridgeSettingsRepository: settingsRepositoryForLifecycleService(service: lifecycleService),
         clock: const ServerClock(),
         database: database,
         httpClient: httpClient,
@@ -308,6 +312,7 @@ class _TestHarness {
       legacyMissingPluginId: plugin.id,
       pluginLifecycleService: lifecycleService,
       pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
+      bridgeSettingsRepository: settingsRepositoryForLifecycleService(service: lifecycleService),
       clock: const ServerClock(),
       database: database,
       httpClient: httpClient,

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -304,6 +304,7 @@ class _RegistrationHarness {
       legacyMissingPluginId: plugin.id,
       pluginLifecycleService: lifecycleService,
       pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
+      bridgeSettingsRepository: settingsRepositoryForLifecycleService(service: lifecycleService),
       clock: const ServerClock(),
       database: database,
       httpClient: httpClient,

--- a/bridge/app/test/bridge/orchestrator_token_reauth_test.dart
+++ b/bridge/app/test/bridge/orchestrator_token_reauth_test.dart
@@ -331,6 +331,7 @@ class _ReauthHarness {
       legacyMissingPluginId: plugin.id,
       pluginLifecycleService: lifecycleService,
       pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
+      bridgeSettingsRepository: settingsRepositoryForLifecycleService(service: lifecycleService),
       clock: const ServerClock(),
       database: database,
       httpClient: httpClient,

--- a/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
@@ -66,6 +66,7 @@ void main() {
       legacyMissingPluginId: plugin.id,
       pluginLifecycleService: lifecycleService,
       pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
+      bridgeSettingsRepository: settingsRepositoryForLifecycleService(service: lifecycleService),
       clock: const ServerClock(),
       database: database,
       httpClient: httpClient,

--- a/bridge/app/test/bridge_config_service_test.dart
+++ b/bridge/app/test/bridge_config_service_test.dart
@@ -78,6 +78,9 @@ class _FakeBridgeSettingsRepository implements BridgeSettingsRepository {
   BridgeSettings get currentSettings => settings;
 
   @override
+  Stream<BridgeSettingsChange> get settingsChanges => const Stream<BridgeSettingsChange>.empty();
+
+  @override
   Future<void> ensureConfigExists() async {
     ensureConfigExistsCallCount += 1;
   }
@@ -88,9 +91,14 @@ class _FakeBridgeSettingsRepository implements BridgeSettingsRepository {
   }
 
   @override
-  Future<void> saveSettings({required BridgeSettings settings}) async {
-    this.settings = settings;
+  Future<BridgeSettings> mutateSettings({
+    required BridgeSettings Function({required BridgeSettings current}) mutation,
+  }) async {
+    return settings = mutation(current: settings);
   }
+
+  @override
+  Future<void> dispose() async {}
 
   @override
   Future<BridgeSettings> updatePluginDisabled({required String pluginId, required bool disabled}) async {

--- a/bridge/app/test/bridge_settings_repository_test.dart
+++ b/bridge/app/test/bridge_settings_repository_test.dart
@@ -186,6 +186,31 @@ void main() {
       await repository.dispose();
     });
 
+    test('rejects an invalid interval mutation before commit and keeps the tail usable', () async {
+      final api = FakeBridgeSettingsApi(readResult: '{"pullRequestRefreshIntervalSeconds":30}');
+      final repository = BridgeSettingsRepository(api: api);
+      await repository.loadSettings();
+      final changes = <BridgeSettingsChange>[];
+      final subscription = repository.settingsChanges.listen(changes.add);
+
+      await expectLater(
+        repository.mutateSettings(
+          mutation: ({required current}) => current.copyWith(pullRequestRefreshIntervalSeconds: 14),
+        ),
+        throwsA(isA<PullRequestRefreshIntervalFormatException>()),
+      );
+
+      expect(api.writeCount, 0);
+      expect(repository.currentSettings.pullRequestRefreshIntervalSeconds, 30);
+      expect(changes, isEmpty);
+      final recovered = await repository.mutateSettings(
+        mutation: ({required current}) => current.copyWith(pullRequestRefreshIntervalSeconds: 45),
+      );
+      expect(recovered.pullRequestRefreshIntervalSeconds, 45);
+      await subscription.cancel();
+      await repository.dispose();
+    });
+
     test('manual file edits have no live effect but load in a new repository', () async {
       final api = FakeBridgeSettingsApi(readResult: '{"pullRequestRefreshIntervalSeconds":30}');
       final repository = BridgeSettingsRepository(api: api);

--- a/bridge/app/test/bridge_settings_repository_test.dart
+++ b/bridge/app/test/bridge_settings_repository_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:sesori_bridge/src/api/bridge_settings_api.dart';
@@ -15,13 +16,15 @@ void main() {
       final settings = await repository.loadSettings();
 
       expect(settings.plugins.disabledPluginIds, isEmpty);
+      expect(settings.pullRequestRefreshIntervalSeconds, defaultPullRequestRefreshIntervalSeconds);
       expect(repository.currentSettings, same(settings));
       expect(api.lastWrittenConfig, _defaultJson);
     });
 
     test('loads valid plugin settings without rewriting', () async {
       final api = FakeBridgeSettingsApi(
-        readResult: '{"sleepPrevention":"off","plugins":{"disabled":["cursor"]}}',
+        readResult:
+            '{"sleepPrevention":"off","pullRequestRefreshIntervalSeconds":30,"plugins":{"disabled":["cursor"]}}',
       );
       final repository = BridgeSettingsRepository(api: api);
 
@@ -30,6 +33,30 @@ void main() {
       expect(settings.sleepPrevention, SleepPreventionMode.off);
       expect(settings.plugins.disabledPluginIds, {'cursor'});
       expect(api.writeCount, 0);
+    });
+
+    test('writes the default when the PR refresh interval key is missing', () async {
+      final api = FakeBridgeSettingsApi(readResult: '{"sleepPrevention":"off"}');
+      final repository = BridgeSettingsRepository(api: api);
+
+      final settings = await repository.loadSettings();
+
+      expect(settings.pullRequestRefreshIntervalSeconds, defaultPullRequestRefreshIntervalSeconds);
+      expect((jsonDecode(api.lastWrittenConfig!) as Map<String, dynamic>)['pullRequestRefreshIntervalSeconds'], 30);
+    });
+
+    test('repairs malformed and out-of-range PR refresh intervals', () async {
+      for (final rawValue in <Object?>['30', 14, 3601, null]) {
+        final api = FakeBridgeSettingsApi(
+          readResult: jsonEncode({'pullRequestRefreshIntervalSeconds': rawValue}),
+        );
+        final repository = BridgeSettingsRepository(api: api);
+
+        final settings = await repository.loadSettings();
+
+        expect(settings.pullRequestRefreshIntervalSeconds, defaultPullRequestRefreshIntervalSeconds);
+        expect((jsonDecode(api.lastWrittenConfig!) as Map<String, dynamic>)['pullRequestRefreshIntervalSeconds'], 30);
+      }
     });
 
     test('does not replace corrupted JSON with an empty denylist', () async {
@@ -107,18 +134,70 @@ void main() {
       expect(api.writeCount, 0);
     });
 
-    test('saveSettings pretty prints and updates the current snapshot', () async {
+    test('mutateSettings pretty prints, updates, and publishes the current snapshot', () async {
       final api = FakeBridgeSettingsApi(readResult: null);
       final repository = BridgeSettingsRepository(api: api);
-      const settings = BridgeSettings(
-        sleepPrevention: SleepPreventionMode.off,
-        plugins: BridgePluginSettings(disabledPluginIds: {'cursor'}),
-      );
+      await repository.loadSettings();
+      final changes = <BridgeSettingsChange>[];
+      final subscription = repository.settingsChanges.listen(changes.add);
 
-      await repository.saveSettings(settings: settings);
+      final settings = await repository.mutateSettings(
+        mutation: ({required current}) => current.copyWith(
+          sleepPrevention: SleepPreventionMode.off,
+          plugins: const BridgePluginSettings(disabledPluginIds: {'cursor'}),
+        ),
+      );
 
       expect(repository.currentSettings, same(settings));
       expect(api.lastWrittenConfig, contains('"disabled": [\n      "cursor"'));
+      expect(changes, hasLength(1));
+      expect(changes.single.previous.pullRequestRefreshIntervalSeconds, 30);
+      expect(changes.single.current, same(settings));
+      await subscription.cancel();
+      await repository.dispose();
+    });
+
+    test('serializes plugin and PR interval mutations without losing either field', () async {
+      final api = FakeBridgeSettingsApi(
+        readResult: '{"pullRequestRefreshIntervalSeconds":30}',
+      );
+      final repository = BridgeSettingsRepository(api: api);
+      await repository.loadSettings();
+      api.writeGate = Completer<void>();
+
+      final pluginMutation = repository.mutateSettings(
+        mutation: ({required current}) => current.copyWith(
+          plugins: current.plugins.withPluginDisabled(pluginId: 'cursor', disabled: true),
+        ),
+      );
+      await api.writeStarted.future;
+      final intervalMutation = repository.mutateSettings(
+        mutation: ({required current}) => current.copyWith(pullRequestRefreshIntervalSeconds: 45),
+      );
+
+      api.writeGate!.complete();
+      await Future.wait([pluginMutation, intervalMutation]);
+
+      expect(repository.currentSettings.plugins.disabledPluginIds, {'cursor'});
+      expect(repository.currentSettings.pullRequestRefreshIntervalSeconds, 45);
+      final written = jsonDecode(api.lastWrittenConfig!) as Map<String, dynamic>;
+      expect((written['plugins'] as Map)['disabled'], ['cursor']);
+      expect(written['pullRequestRefreshIntervalSeconds'], 45);
+      await repository.dispose();
+    });
+
+    test('manual file edits have no live effect but load in a new repository', () async {
+      final api = FakeBridgeSettingsApi(readResult: '{"pullRequestRefreshIntervalSeconds":30}');
+      final repository = BridgeSettingsRepository(api: api);
+      await repository.loadSettings();
+
+      api.readResult = '{"pullRequestRefreshIntervalSeconds":60}';
+
+      expect(repository.currentSettings.pullRequestRefreshIntervalSeconds, 30);
+      final restartedRepository = BridgeSettingsRepository(api: api);
+      expect((await restartedRepository.loadSettings()).pullRequestRefreshIntervalSeconds, 60);
+      await repository.dispose();
+      await restartedRepository.dispose();
     });
 
     test('updates denylist while preserving plugin objects and dropping abandoned allowlists', () async {
@@ -167,15 +246,18 @@ void main() {
   });
 }
 
-const _defaultJson = '{\n  "sleepPrevention": "always",\n  "yolo": false,\n  "releaseTrack": "stable"\n}';
+const _defaultJson =
+    '{\n  "sleepPrevention": "always",\n  "yolo": false,\n  "releaseTrack": "stable",\n  "pullRequestRefreshIntervalSeconds": 30\n}';
 
 class FakeBridgeSettingsApi implements BridgeSettingsApi {
   @override
   final String configFilePath;
 
-  final String? readResult;
+  String? readResult;
   String? lastWrittenConfig;
   int writeCount = 0;
+  Completer<void>? writeGate;
+  final Completer<void> writeStarted = Completer<void>();
 
   FakeBridgeSettingsApi({
     required this.readResult,
@@ -187,6 +269,8 @@ class FakeBridgeSettingsApi implements BridgeSettingsApi {
 
   @override
   Future<void> writeConfig(String jsonContent) async {
+    if (!writeStarted.isCompleted) writeStarted.complete();
+    await writeGate?.future;
     lastWrittenConfig = jsonContent;
     writeCount += 1;
   }

--- a/bridge/app/test/bridge_settings_test.dart
+++ b/bridge/app/test/bridge_settings_test.dart
@@ -10,12 +10,14 @@ void main() {
       expect(settings.sleepPrevention, SleepPreventionMode.always);
       expect(settings.yolo, isFalse);
       expect(settings.releaseTrack, ReleaseTrack.stable);
+      expect(settings.pullRequestRefreshIntervalSeconds, defaultPullRequestRefreshIntervalSeconds);
       expect(settings.plugins.disabledPluginIds, isEmpty);
       expect(settings.plugins.idleTimeoutMinsFor(pluginId: 'opencode'), defaultPluginIdleTimeoutMins);
       expect(settings.toJson(), {
         'sleepPrevention': 'always',
         'yolo': false,
         'releaseTrack': 'stable',
+        'pullRequestRefreshIntervalSeconds': defaultPullRequestRefreshIntervalSeconds,
       });
     });
 
@@ -24,11 +26,46 @@ void main() {
         'sleepPrevention': 'off',
         'yolo': true,
         'releaseTrack': 'internal',
+        'pullRequestRefreshIntervalSeconds': 45,
       });
 
       expect(settings.sleepPrevention, SleepPreventionMode.off);
       expect(settings.yolo, isTrue);
       expect(settings.releaseTrack, ReleaseTrack.internal);
+      expect(settings.pullRequestRefreshIntervalSeconds, 45);
+    });
+
+    test('uses the default for a missing PR refresh interval', () {
+      final settings = BridgeSettings.fromJson(const {});
+
+      expect(settings.pullRequestRefreshIntervalSeconds, defaultPullRequestRefreshIntervalSeconds);
+    });
+
+    test('accepts PR refresh interval boundaries and round trips the value', () {
+      for (final interval in [
+        minimumPullRequestRefreshIntervalSeconds,
+        maximumPullRequestRefreshIntervalSeconds,
+      ]) {
+        final settings = BridgeSettings.fromJson({'pullRequestRefreshIntervalSeconds': interval});
+
+        expect(settings.pullRequestRefreshIntervalSeconds, interval);
+        expect(settings.toJson()['pullRequestRefreshIntervalSeconds'], interval);
+      }
+    });
+
+    test('rejects malformed and out-of-range PR refresh intervals', () {
+      for (final value in <Object?>[
+        null,
+        '30',
+        30.0,
+        minimumPullRequestRefreshIntervalSeconds - 1,
+        maximumPullRequestRefreshIntervalSeconds + 1,
+      ]) {
+        expect(
+          () => BridgeSettings.fromJson({'pullRequestRefreshIntervalSeconds': value}),
+          throwsA(isA<PullRequestRefreshIntervalFormatException>()),
+        );
+      }
     });
 
     test('invalid legacy scalar values retain their established defaults', () {
@@ -220,6 +257,7 @@ void main() {
       expect(updated.plugins.disabledPluginIds, {'cursor'});
       expect(updated.releaseTrack, ReleaseTrack.internal);
       expect(updated.yolo, isTrue);
+      expect(updated.pullRequestRefreshIntervalSeconds, defaultPullRequestRefreshIntervalSeconds);
     });
   });
 }

--- a/bridge/app/test/helpers/plugin_lifecycle_test_support.dart
+++ b/bridge/app/test/helpers/plugin_lifecycle_test_support.dart
@@ -10,6 +10,7 @@ import "plugin_runtime_test_support.dart";
 import "test_helpers.dart";
 
 final Expando<PluginRuntime> _runtimes = Expando<PluginRuntime>();
+final Expando<BridgeSettingsRepository> _settingsRepositories = Expando<BridgeSettingsRepository>();
 
 const defaultManagementCapabilities = <PluginControlCapability>{
   PluginControlCapability.lifecycle,
@@ -27,11 +28,12 @@ Future<PluginLifecycleService> createPluginLifecycleService({
   required List<BridgePluginApi> plugins,
 }) async {
   final runtime = createTestPluginRuntime(plugins: plugins);
+  final settingsRepository = createTestBridgeSettingsRepository();
   final service =
       PluginLifecycleService(
           lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
           preferredDefaultPluginId: legacyMissingPluginId,
-          bridgeSettingsRepository: createTestBridgeSettingsRepository(),
+          bridgeSettingsRepository: settingsRepository,
           idleTimerScheduler: const PluginIdleTimerScheduler(),
           bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
         )
@@ -52,6 +54,7 @@ Future<PluginLifecycleService> createPluginLifecycleService({
           setupById: {for (final plugin in plugins) plugin.id: const PluginSetupReady()},
         );
   _runtimes[service] = runtime;
+  _settingsRepositories[service] = settingsRepository;
   await Future<void>.delayed(Duration.zero);
   return service;
 }
@@ -59,6 +62,12 @@ Future<PluginLifecycleService> createPluginLifecycleService({
 BridgeSettingsRepository createTestBridgeSettingsRepository({
   BridgeSettings settings = const BridgeSettings(),
 }) => _TestBridgeSettingsRepository(settings: settings);
+
+BridgeSettingsRepository settingsRepositoryForLifecycleService({required PluginLifecycleService service}) {
+  final repository = _settingsRepositories[service];
+  if (repository == null) throw StateError("No test bridge settings repository is registered for this service.");
+  return repository;
+}
 
 Future<void> activateTestPlugin({
   required PluginLifecycleService service,
@@ -88,12 +97,20 @@ class _TestBridgeSettingsRepository implements BridgeSettingsRepository {
   BridgeSettings get currentSettings => settings;
 
   @override
+  Stream<BridgeSettingsChange> get settingsChanges => const Stream<BridgeSettingsChange>.empty();
+
+  @override
   Future<BridgeSettings> loadSettings() async => settings;
 
   @override
-  Future<void> saveSettings({required BridgeSettings settings}) async {
-    this.settings = settings;
+  Future<BridgeSettings> mutateSettings({
+    required BridgeSettings Function({required BridgeSettings current}) mutation,
+  }) async {
+    return settings = mutation(current: settings);
   }
+
+  @override
+  Future<void> dispose() async {}
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/bridge/app/test/listeners/viewed_project_pr_refresh_listener_test.dart
+++ b/bridge/app/test/listeners/viewed_project_pr_refresh_listener_test.dart
@@ -5,7 +5,9 @@ import "package:fake_async/fake_async.dart";
 import "package:sesori_bridge/src/bridge/services/pr_sync_service.dart";
 import "package:sesori_bridge/src/listeners/viewed_project_pr_refresh_listener.dart";
 import "package:sesori_bridge/src/services/project_view_tracker.dart";
+import "package:sesori_bridge/src/services/pull_request_refresh_settings_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log, LogLevel;
+import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
 void main() {
@@ -106,6 +108,44 @@ void main() {
         expect(harness.service.calls, hasLength(2));
         async.elapse(const Duration(seconds: 1));
         expect(harness.service.calls, hasLength(3));
+        _disposeHarness(harness: harness, async: async);
+      });
+    });
+
+    test("a committed interval change cancels and rearms the pending timer", () {
+      fakeAsync((async) {
+        final harness = _Harness();
+        harness.listener.start();
+        harness.tracker.setViewing(connID: 1, projectId: "project-x");
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 10));
+
+        harness.settingsService.setInterval(intervalSeconds: 15);
+        async.elapse(const Duration(seconds: 14));
+        expect(harness.service.calls, hasLength(1));
+
+        async.elapse(const Duration(seconds: 1));
+        expect(harness.service.calls, hasLength(2));
+        _disposeHarness(harness: harness, async: async);
+      });
+    });
+
+    test("an interval change during refresh applies when completion arms the timer", () {
+      fakeAsync((async) {
+        final harness = _Harness()..service.completeImmediately = false;
+        harness.listener.start();
+        harness.tracker.setViewing(connID: 1, projectId: "project-x");
+
+        harness.settingsService.setInterval(intervalSeconds: 15);
+        async.elapse(const Duration(minutes: 1));
+        expect(harness.service.calls, hasLength(1));
+
+        harness.service.complete(callIndex: 0);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 14));
+        expect(harness.service.calls, hasLength(1));
+        async.elapse(const Duration(seconds: 1));
+        expect(harness.service.calls, hasLength(2));
         _disposeHarness(harness: harness, async: async);
       });
     });
@@ -238,6 +278,7 @@ void main() {
       harness.tracker.setViewing(connID: 2, projectId: "project-y");
       await Future<void>.delayed(Duration.zero);
       expect(harness.service.calls, hasLength(1));
+      await harness.settingsService.dispose();
       await harness.tracker.dispose();
     });
   });
@@ -246,16 +287,40 @@ void main() {
 class _Harness {
   final ProjectViewTracker tracker = ProjectViewTracker();
   final _FakePrSyncService service = _FakePrSyncService();
+  final _FakePullRequestRefreshSettingsService settingsService = _FakePullRequestRefreshSettingsService();
   late final ViewedProjectPrRefreshListener listener = ViewedProjectPrRefreshListener(
     tracker: tracker,
     prSyncService: service,
-    refreshInterval: const Duration(seconds: 30),
+    settingsService: settingsService,
   );
 
   Future<void> dispose() async {
     await listener.dispose();
+    await settingsService.dispose();
     await tracker.dispose();
   }
+}
+
+class _FakePullRequestRefreshSettingsService implements PullRequestRefreshSettingsService {
+  final StreamController<PullRequestRefreshSettingsResponse> _changes =
+      StreamController<PullRequestRefreshSettingsResponse>.broadcast(sync: true);
+  PullRequestRefreshSettingsResponse _current = const PullRequestRefreshSettingsResponse(intervalSeconds: 30);
+
+  @override
+  PullRequestRefreshSettingsResponse get currentSettings => _current;
+
+  @override
+  Stream<PullRequestRefreshSettingsResponse> get changes => _changes.stream;
+
+  void setInterval({required int intervalSeconds}) {
+    _current = PullRequestRefreshSettingsResponse(intervalSeconds: intervalSeconds);
+    _changes.add(_current);
+  }
+
+  Future<void> dispose() => _changes.close();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _FakePrSyncService implements PrSyncService {

--- a/bridge/app/test/listeners/viewed_project_pr_refresh_listener_test.dart
+++ b/bridge/app/test/listeners/viewed_project_pr_refresh_listener_test.dart
@@ -239,7 +239,7 @@ void main() {
       });
     });
 
-    test("unexpected errors log without identifiers and retry after the interval", () {
+    test("unexpected errors preserve diagnostics and retry after the interval", () {
       fakeAsync((async) {
         final harness = _Harness()..service.immediateError = StateError("project-x /private/source/path");
         final logOutput = _captureLogOutput(
@@ -251,9 +251,8 @@ void main() {
         );
 
         expect(logOutput, contains("Viewed-project pull request refresh failed unexpectedly"));
-        expect(logOutput, contains("ViewedProjectRefreshException"));
-        expect(logOutput, isNot(contains("project-x")));
-        expect(logOutput, isNot(contains("/private/source/path")));
+        expect(logOutput, contains("project-x /private/source/path"));
+        expect(logOutput, contains("viewed_project_pr_refresh_listener_test.dart"));
 
         async.elapse(const Duration(seconds: 30));
         expect(harness.service.calls, hasLength(2));
@@ -261,7 +260,7 @@ void main() {
       });
     });
 
-    test("settings stream errors log without causes or stack paths", () {
+    test("settings stream errors preserve causes and stack paths", () {
       final harness = _Harness();
       final logOutput = _captureLogOutput(
         action: () {
@@ -274,9 +273,8 @@ void main() {
       );
 
       expect(logOutput, contains("Pull request refresh settings changes failed unexpectedly"));
-      expect(logOutput, contains("PullRequestRefreshSettingsException"));
-      expect(logOutput, isNot(contains("secret settings cause")));
-      expect(logOutput, isNot(contains("/private/settings/source.dart")));
+      expect(logOutput, contains("secret settings cause"));
+      expect(logOutput, contains("/private/settings/source.dart"));
       unawaited(harness.dispose());
     });
 

--- a/bridge/app/test/listeners/viewed_project_pr_refresh_listener_test.dart
+++ b/bridge/app/test/listeners/viewed_project_pr_refresh_listener_test.dart
@@ -261,6 +261,25 @@ void main() {
       });
     });
 
+    test("settings stream errors log without causes or stack paths", () {
+      final harness = _Harness();
+      final logOutput = _captureLogOutput(
+        action: () {
+          harness.listener.start();
+          harness.settingsService.emitError(
+            error: StateError("secret settings cause"),
+            stackTrace: StackTrace.fromString("/private/settings/source.dart"),
+          );
+        },
+      );
+
+      expect(logOutput, contains("Pull request refresh settings changes failed unexpectedly"));
+      expect(logOutput, contains("PullRequestRefreshSettingsException"));
+      expect(logOutput, isNot(contains("secret settings cause")));
+      expect(logOutput, isNot(contains("/private/settings/source.dart")));
+      unawaited(harness.dispose());
+    });
+
     test("dispose drains admitted work and suppresses late completion", () async {
       final harness = _Harness()..service.completeImmediately = false;
       harness.listener.start();
@@ -315,6 +334,10 @@ class _FakePullRequestRefreshSettingsService implements PullRequestRefreshSettin
   void setInterval({required int intervalSeconds}) {
     _current = PullRequestRefreshSettingsResponse(intervalSeconds: intervalSeconds);
     _changes.add(_current);
+  }
+
+  void emitError({required Object error, required StackTrace stackTrace}) {
+    _changes.addError(error, stackTrace);
   }
 
   Future<void> dispose() => _changes.close();

--- a/bridge/app/test/routing/pull_request_refresh_settings_handlers_test.dart
+++ b/bridge/app/test/routing/pull_request_refresh_settings_handlers_test.dart
@@ -1,0 +1,121 @@
+import "dart:convert";
+
+import "package:sesori_bridge/src/api/bridge_settings_api.dart";
+import "package:sesori_bridge/src/repositories/bridge_settings_repository.dart";
+import "package:sesori_bridge/src/routing/get_pull_request_refresh_settings_handler.dart";
+import "package:sesori_bridge/src/routing/patch_pull_request_refresh_settings_handler.dart";
+import "package:sesori_bridge/src/services/pull_request_refresh_settings_service.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "../bridge/routing/routing_test_helpers.dart";
+
+void main() {
+  group("pull request refresh settings handlers", () {
+    late _MemoryBridgeSettingsApi api;
+    late BridgeSettingsRepository repository;
+    late PullRequestRefreshSettingsService service;
+
+    setUp(() async {
+      api = _MemoryBridgeSettingsApi();
+      repository = BridgeSettingsRepository(api: api);
+      await repository.loadSettings();
+      service = PullRequestRefreshSettingsService(bridgeSettingsRepository: repository);
+    });
+
+    tearDown(() => repository.dispose());
+
+    test("GET returns the committed interval", () async {
+      final response = await GetPullRequestRefreshSettingsHandler(settingsService: service).handleInternal(
+        makeRequest("GET", "/settings/pull-request-refresh"),
+        pathParams: const {},
+        queryParams: const {},
+        fragment: null,
+      );
+
+      expect(response.status, 200);
+      expect(
+        PullRequestRefreshSettingsResponse.fromJson(jsonDecodeMap(response.body!)),
+        const PullRequestRefreshSettingsResponse(intervalSeconds: 30),
+      );
+    });
+
+    test("PATCH persists and returns the committed interval", () async {
+      final response = await PatchPullRequestRefreshSettingsHandler(settingsService: service).handleInternal(
+        makeRequest(
+          "PATCH",
+          "/settings/pull-request-refresh",
+          body: jsonEncode(const PullRequestRefreshSettingsRequest(intervalSeconds: 45).toJson()),
+        ),
+        pathParams: const {},
+        queryParams: const {},
+        fragment: null,
+      );
+
+      expect(response.status, 200);
+      expect(
+        PullRequestRefreshSettingsResponse.fromJson(jsonDecodeMap(response.body!)),
+        const PullRequestRefreshSettingsResponse(intervalSeconds: 45),
+      );
+      expect((jsonDecode(api.config!) as Map)["pullRequestRefreshIntervalSeconds"], 45);
+    });
+
+    test("PATCH returns a typed 400 for an out-of-range interval", () async {
+      final response = await PatchPullRequestRefreshSettingsHandler(settingsService: service).handleInternal(
+        makeRequest(
+          "PATCH",
+          "/settings/pull-request-refresh",
+          body: jsonEncode(const PullRequestRefreshSettingsRequest(intervalSeconds: 14).toJson()),
+        ),
+        pathParams: const {},
+        queryParams: const {},
+        fragment: null,
+      );
+
+      expect(response.status, 400);
+      expect(response.headers["content-type"], "application/json");
+      expect(
+        PullRequestRefreshSettingsErrorResponse.fromJson(jsonDecodeMap(response.body!)),
+        const PullRequestRefreshSettingsErrorResponse(
+          code: PullRequestRefreshSettingsErrorCode.intervalOutOfRange,
+          minimumIntervalSeconds: 15,
+          maximumIntervalSeconds: 3600,
+        ),
+      );
+      expect(api.writeCount, 0);
+    });
+
+    test("PATCH rejects non-integer JSON before the service", () async {
+      final response = await PatchPullRequestRefreshSettingsHandler(settingsService: service).handleInternal(
+        makeRequest(
+          "PATCH",
+          "/settings/pull-request-refresh",
+          body: jsonEncode({"intervalSeconds": 30.5}),
+        ),
+        pathParams: const {},
+        queryParams: const {},
+        fragment: null,
+      );
+
+      expect(response.status, 400);
+      expect(api.writeCount, 0);
+    });
+  });
+}
+
+class _MemoryBridgeSettingsApi implements BridgeSettingsApi {
+  String? config = '{"pullRequestRefreshIntervalSeconds":30}';
+  int writeCount = 0;
+
+  @override
+  String get configFilePath => "/tmp/config.json";
+
+  @override
+  Future<String?> readConfig() async => config;
+
+  @override
+  Future<void> writeConfig(String jsonContent) async {
+    config = jsonContent;
+    writeCount++;
+  }
+}

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -2077,12 +2077,16 @@ class _MutableBridgeSettingsRepository implements BridgeSettingsRepository {
   }
 
   @override
-  Future<void> saveSettings({required BridgeSettings settings}) async {
+  Future<BridgeSettings> mutateSettings({
+    required BridgeSettings Function({required BridgeSettings current}) mutation,
+  }) async {
+    loadCalls++;
+    final updated = mutation(current: settings);
     if (!saveStarted.isCompleted) saveStarted.complete();
     await saveGate?.future;
     final error = saveError;
     if (error != null) throw error;
-    this.settings = settings;
+    return settings = updated;
   }
 
   @override

--- a/bridge/app/test/services/pull_request_refresh_settings_service_test.dart
+++ b/bridge/app/test/services/pull_request_refresh_settings_service_test.dart
@@ -1,0 +1,127 @@
+import "dart:convert";
+
+import "package:sesori_bridge/src/api/bridge_settings_api.dart";
+import "package:sesori_bridge/src/repositories/bridge_settings.dart";
+import "package:sesori_bridge/src/repositories/bridge_settings_repository.dart";
+import "package:sesori_bridge/src/services/pull_request_refresh_settings_service.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("PullRequestRefreshSettingsService", () {
+    late _MemoryBridgeSettingsApi api;
+    late BridgeSettingsRepository repository;
+    late PullRequestRefreshSettingsService service;
+
+    setUp(() async {
+      api = _MemoryBridgeSettingsApi(
+        config: '{"pullRequestRefreshIntervalSeconds":30}',
+      );
+      repository = BridgeSettingsRepository(api: api);
+      await repository.loadSettings();
+      service = PullRequestRefreshSettingsService(bridgeSettingsRepository: repository);
+    });
+
+    tearDown(() => repository.dispose());
+
+    test("returns the loaded committed interval", () {
+      expect(service.currentSettings, const PullRequestRefreshSettingsResponse(intervalSeconds: 30));
+    });
+
+    test("persists and publishes accepted boundary values", () async {
+      final changes = <PullRequestRefreshSettingsResponse>[];
+      final subscription = service.changes.listen(changes.add);
+
+      for (final intervalSeconds in [
+        minimumPullRequestRefreshIntervalSeconds,
+        maximumPullRequestRefreshIntervalSeconds,
+      ]) {
+        final response = await service.update(
+          request: PullRequestRefreshSettingsRequest(intervalSeconds: intervalSeconds),
+        );
+
+        expect(response.intervalSeconds, intervalSeconds);
+        expect(repository.currentSettings.pullRequestRefreshIntervalSeconds, intervalSeconds);
+        expect((jsonDecode(api.config!) as Map)["pullRequestRefreshIntervalSeconds"], intervalSeconds);
+      }
+      expect(changes.map((change) => change.intervalSeconds), [15, 3600]);
+      await subscription.cancel();
+    });
+
+    test("rejects out-of-range values without persisting or publishing", () async {
+      final changes = <PullRequestRefreshSettingsResponse>[];
+      final subscription = service.changes.listen(changes.add);
+
+      for (final intervalSeconds in [
+        minimumPullRequestRefreshIntervalSeconds - 1,
+        maximumPullRequestRefreshIntervalSeconds + 1,
+      ]) {
+        await expectLater(
+          service.update(
+            request: PullRequestRefreshSettingsRequest(intervalSeconds: intervalSeconds),
+          ),
+          throwsA(
+            isA<PullRequestRefreshIntervalOutOfRangeException>().having(
+              (error) => error.intervalSeconds,
+              "intervalSeconds",
+              intervalSeconds,
+            ),
+          ),
+        );
+      }
+
+      expect(api.writeCount, 0);
+      expect(changes, isEmpty);
+      expect(service.currentSettings.intervalSeconds, 30);
+      await subscription.cancel();
+    });
+
+    test("an unchanged value does not rewrite or publish", () async {
+      final changes = <PullRequestRefreshSettingsResponse>[];
+      final subscription = service.changes.listen(changes.add);
+
+      final response = await service.update(
+        request: const PullRequestRefreshSettingsRequest(intervalSeconds: 30),
+      );
+
+      expect(response.intervalSeconds, 30);
+      expect(api.writeCount, 0);
+      expect(changes, isEmpty);
+      await subscription.cancel();
+    });
+
+    test("unrelated committed settings do not publish a cadence change", () async {
+      final changes = <PullRequestRefreshSettingsResponse>[];
+      final subscription = service.changes.listen(changes.add);
+
+      await repository.mutateSettings(
+        mutation: ({required current}) => current.copyWith(
+          plugins: current.plugins.withPluginDisabled(pluginId: "cursor", disabled: true),
+        ),
+      );
+
+      expect(changes, isEmpty);
+      expect(service.currentSettings.intervalSeconds, 30);
+      await subscription.cancel();
+    });
+  });
+}
+
+class _MemoryBridgeSettingsApi implements BridgeSettingsApi {
+  _MemoryBridgeSettingsApi({required this.config});
+
+  String? config;
+  int writeCount = 0;
+
+  @override
+  String get configFilePath => "/tmp/config.json";
+
+  @override
+  Future<String?> readConfig() async => config;
+
+  @override
+  Future<void> writeConfig(String jsonContent) async {
+    config = jsonContent;
+    writeCount++;
+  }
+}

--- a/bridge/app/test/services/pull_request_refresh_settings_service_test.dart
+++ b/bridge/app/test/services/pull_request_refresh_settings_service_test.dart
@@ -54,17 +54,22 @@ void main() {
         minimumPullRequestRefreshIntervalSeconds - 1,
         maximumPullRequestRefreshIntervalSeconds + 1,
       ]) {
+        final matcher = isA<PullRequestRefreshIntervalOutOfRangeException>()
+            .having(
+              (error) => error.intervalSeconds,
+              "intervalSeconds",
+              intervalSeconds,
+            )
+            .having(
+              (error) => error.toString(),
+              "diagnostic description",
+              allOf(contains("$intervalSeconds"), contains("15"), contains("3600")),
+            );
         await expectLater(
           service.update(
             request: PullRequestRefreshSettingsRequest(intervalSeconds: intervalSeconds),
           ),
-          throwsA(
-            isA<PullRequestRefreshIntervalOutOfRangeException>().having(
-              (error) => error.intervalSeconds,
-              "intervalSeconds",
-              intervalSeconds,
-            ),
-          ),
+          throwsA(matcher),
         );
       }
 

--- a/bridge/app/test/services/pull_request_refresh_settings_service_test.dart
+++ b/bridge/app/test/services/pull_request_refresh_settings_service_test.dart
@@ -1,5 +1,3 @@
-import "dart:convert";
-
 import "package:sesori_bridge/src/api/bridge_settings_api.dart";
 import "package:sesori_bridge/src/repositories/bridge_settings.dart";
 import "package:sesori_bridge/src/repositories/bridge_settings_repository.dart";
@@ -42,7 +40,7 @@ void main() {
 
         expect(response.intervalSeconds, intervalSeconds);
         expect(repository.currentSettings.pullRequestRefreshIntervalSeconds, intervalSeconds);
-        expect((jsonDecode(api.config!) as Map)["pullRequestRefreshIntervalSeconds"], intervalSeconds);
+        expect(jsonDecodeMap(api.config!)["pullRequestRefreshIntervalSeconds"], intervalSeconds);
       }
       expect(changes.map((change) => change.intervalSeconds), [15, 3600]);
       await subscription.cancel();

--- a/shared/sesori_shared/lib/sesori_shared.dart
+++ b/shared/sesori_shared/lib/sesori_shared.dart
@@ -60,6 +60,7 @@ export "src/models/sesori/project.dart";
 export "src/models/sesori/project_activity_summary.dart";
 export "src/models/sesori/provider_info.dart";
 export "src/models/sesori/pull_request_info.dart";
+export "src/models/sesori/pull_request_refresh_settings.dart";
 export "src/models/sesori/question.dart";
 export "src/models/sesori/rename_project_request.dart";
 export "src/models/sesori/rename_session_request.dart";

--- a/shared/sesori_shared/lib/src/models/sesori/pull_request_refresh_settings.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/pull_request_refresh_settings.dart
@@ -16,7 +16,7 @@ sealed class PullRequestRefreshSettingsRequest with _$PullRequestRefreshSettings
 @Freezed(fromJson: true, toJson: true)
 sealed class PullRequestRefreshSettingsResponse with _$PullRequestRefreshSettingsResponse {
   const factory PullRequestRefreshSettingsResponse({
-    required int intervalSeconds,
+    @JsonKey(fromJson: _strictIntFromJson) required int intervalSeconds,
   }) = _PullRequestRefreshSettingsResponse;
 
   factory PullRequestRefreshSettingsResponse.fromJson(Map<String, dynamic> json) =>
@@ -30,15 +30,16 @@ sealed class PullRequestRefreshSettingsErrorResponse with _$PullRequestRefreshSe
   const factory PullRequestRefreshSettingsErrorResponse({
     @JsonKey(unknownEnumValue: PullRequestRefreshSettingsErrorCode.unknown)
     required PullRequestRefreshSettingsErrorCode code,
-    required int minimumIntervalSeconds,
-    required int maximumIntervalSeconds,
+    @JsonKey(fromJson: _strictIntFromJson) required int minimumIntervalSeconds,
+    @JsonKey(fromJson: _strictIntFromJson) required int maximumIntervalSeconds,
   }) = _PullRequestRefreshSettingsErrorResponse;
 
   factory PullRequestRefreshSettingsErrorResponse.fromJson(Map<String, dynamic> json) =>
       _$PullRequestRefreshSettingsErrorResponseFromJson(json);
 }
 
-int _strictIntFromJson(num value) {
+// ignore: no_slop_linter/prefer_specific_type, JSON converter input must validate the raw value
+int _strictIntFromJson(Object? value) {
   if (value is int) return value;
   throw const FormatException("Expected an integer");
 }

--- a/shared/sesori_shared/lib/src/models/sesori/pull_request_refresh_settings.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/pull_request_refresh_settings.dart
@@ -1,0 +1,44 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "pull_request_refresh_settings.freezed.dart";
+part "pull_request_refresh_settings.g.dart";
+
+@Freezed(fromJson: true, toJson: true)
+sealed class PullRequestRefreshSettingsRequest with _$PullRequestRefreshSettingsRequest {
+  const factory PullRequestRefreshSettingsRequest({
+    @JsonKey(fromJson: _strictIntFromJson) required int intervalSeconds,
+  }) = _PullRequestRefreshSettingsRequest;
+
+  factory PullRequestRefreshSettingsRequest.fromJson(Map<String, dynamic> json) =>
+      _$PullRequestRefreshSettingsRequestFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: true)
+sealed class PullRequestRefreshSettingsResponse with _$PullRequestRefreshSettingsResponse {
+  const factory PullRequestRefreshSettingsResponse({
+    required int intervalSeconds,
+  }) = _PullRequestRefreshSettingsResponse;
+
+  factory PullRequestRefreshSettingsResponse.fromJson(Map<String, dynamic> json) =>
+      _$PullRequestRefreshSettingsResponseFromJson(json);
+}
+
+enum PullRequestRefreshSettingsErrorCode { intervalOutOfRange, unknown }
+
+@Freezed(fromJson: true, toJson: true)
+sealed class PullRequestRefreshSettingsErrorResponse with _$PullRequestRefreshSettingsErrorResponse {
+  const factory PullRequestRefreshSettingsErrorResponse({
+    @JsonKey(unknownEnumValue: PullRequestRefreshSettingsErrorCode.unknown)
+    required PullRequestRefreshSettingsErrorCode code,
+    required int minimumIntervalSeconds,
+    required int maximumIntervalSeconds,
+  }) = _PullRequestRefreshSettingsErrorResponse;
+
+  factory PullRequestRefreshSettingsErrorResponse.fromJson(Map<String, dynamic> json) =>
+      _$PullRequestRefreshSettingsErrorResponseFromJson(json);
+}
+
+int _strictIntFromJson(num value) {
+  if (value is int) return value;
+  throw const FormatException("Expected an integer");
+}

--- a/shared/sesori_shared/lib/src/models/sesori/pull_request_refresh_settings.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/pull_request_refresh_settings.freezed.dart
@@ -1,0 +1,422 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'pull_request_refresh_settings.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PullRequestRefreshSettingsRequest {
+
+@JsonKey(fromJson: _strictIntFromJson) int get intervalSeconds;
+/// Create a copy of PullRequestRefreshSettingsRequest
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PullRequestRefreshSettingsRequestCopyWith<PullRequestRefreshSettingsRequest> get copyWith => _$PullRequestRefreshSettingsRequestCopyWithImpl<PullRequestRefreshSettingsRequest>(this as PullRequestRefreshSettingsRequest, _$identity);
+
+  /// Serializes this PullRequestRefreshSettingsRequest to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PullRequestRefreshSettingsRequest&&(identical(other.intervalSeconds, intervalSeconds) || other.intervalSeconds == intervalSeconds));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,intervalSeconds);
+
+@override
+String toString() {
+  return 'PullRequestRefreshSettingsRequest(intervalSeconds: $intervalSeconds)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PullRequestRefreshSettingsRequestCopyWith<$Res>  {
+  factory $PullRequestRefreshSettingsRequestCopyWith(PullRequestRefreshSettingsRequest value, $Res Function(PullRequestRefreshSettingsRequest) _then) = _$PullRequestRefreshSettingsRequestCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(fromJson: _strictIntFromJson) int intervalSeconds
+});
+
+
+
+
+}
+/// @nodoc
+class _$PullRequestRefreshSettingsRequestCopyWithImpl<$Res>
+    implements $PullRequestRefreshSettingsRequestCopyWith<$Res> {
+  _$PullRequestRefreshSettingsRequestCopyWithImpl(this._self, this._then);
+
+  final PullRequestRefreshSettingsRequest _self;
+  final $Res Function(PullRequestRefreshSettingsRequest) _then;
+
+/// Create a copy of PullRequestRefreshSettingsRequest
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? intervalSeconds = null,}) {
+  return _then(_self.copyWith(
+intervalSeconds: null == intervalSeconds ? _self.intervalSeconds : intervalSeconds // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _PullRequestRefreshSettingsRequest implements PullRequestRefreshSettingsRequest {
+  const _PullRequestRefreshSettingsRequest({@JsonKey(fromJson: _strictIntFromJson) required this.intervalSeconds});
+  factory _PullRequestRefreshSettingsRequest.fromJson(Map<String, dynamic> json) => _$PullRequestRefreshSettingsRequestFromJson(json);
+
+@override@JsonKey(fromJson: _strictIntFromJson) final  int intervalSeconds;
+
+/// Create a copy of PullRequestRefreshSettingsRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PullRequestRefreshSettingsRequestCopyWith<_PullRequestRefreshSettingsRequest> get copyWith => __$PullRequestRefreshSettingsRequestCopyWithImpl<_PullRequestRefreshSettingsRequest>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PullRequestRefreshSettingsRequestToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PullRequestRefreshSettingsRequest&&(identical(other.intervalSeconds, intervalSeconds) || other.intervalSeconds == intervalSeconds));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,intervalSeconds);
+
+@override
+String toString() {
+  return 'PullRequestRefreshSettingsRequest(intervalSeconds: $intervalSeconds)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PullRequestRefreshSettingsRequestCopyWith<$Res> implements $PullRequestRefreshSettingsRequestCopyWith<$Res> {
+  factory _$PullRequestRefreshSettingsRequestCopyWith(_PullRequestRefreshSettingsRequest value, $Res Function(_PullRequestRefreshSettingsRequest) _then) = __$PullRequestRefreshSettingsRequestCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(fromJson: _strictIntFromJson) int intervalSeconds
+});
+
+
+
+
+}
+/// @nodoc
+class __$PullRequestRefreshSettingsRequestCopyWithImpl<$Res>
+    implements _$PullRequestRefreshSettingsRequestCopyWith<$Res> {
+  __$PullRequestRefreshSettingsRequestCopyWithImpl(this._self, this._then);
+
+  final _PullRequestRefreshSettingsRequest _self;
+  final $Res Function(_PullRequestRefreshSettingsRequest) _then;
+
+/// Create a copy of PullRequestRefreshSettingsRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? intervalSeconds = null,}) {
+  return _then(_PullRequestRefreshSettingsRequest(
+intervalSeconds: null == intervalSeconds ? _self.intervalSeconds : intervalSeconds // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$PullRequestRefreshSettingsResponse {
+
+ int get intervalSeconds;
+/// Create a copy of PullRequestRefreshSettingsResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PullRequestRefreshSettingsResponseCopyWith<PullRequestRefreshSettingsResponse> get copyWith => _$PullRequestRefreshSettingsResponseCopyWithImpl<PullRequestRefreshSettingsResponse>(this as PullRequestRefreshSettingsResponse, _$identity);
+
+  /// Serializes this PullRequestRefreshSettingsResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PullRequestRefreshSettingsResponse&&(identical(other.intervalSeconds, intervalSeconds) || other.intervalSeconds == intervalSeconds));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,intervalSeconds);
+
+@override
+String toString() {
+  return 'PullRequestRefreshSettingsResponse(intervalSeconds: $intervalSeconds)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PullRequestRefreshSettingsResponseCopyWith<$Res>  {
+  factory $PullRequestRefreshSettingsResponseCopyWith(PullRequestRefreshSettingsResponse value, $Res Function(PullRequestRefreshSettingsResponse) _then) = _$PullRequestRefreshSettingsResponseCopyWithImpl;
+@useResult
+$Res call({
+ int intervalSeconds
+});
+
+
+
+
+}
+/// @nodoc
+class _$PullRequestRefreshSettingsResponseCopyWithImpl<$Res>
+    implements $PullRequestRefreshSettingsResponseCopyWith<$Res> {
+  _$PullRequestRefreshSettingsResponseCopyWithImpl(this._self, this._then);
+
+  final PullRequestRefreshSettingsResponse _self;
+  final $Res Function(PullRequestRefreshSettingsResponse) _then;
+
+/// Create a copy of PullRequestRefreshSettingsResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? intervalSeconds = null,}) {
+  return _then(_self.copyWith(
+intervalSeconds: null == intervalSeconds ? _self.intervalSeconds : intervalSeconds // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _PullRequestRefreshSettingsResponse implements PullRequestRefreshSettingsResponse {
+  const _PullRequestRefreshSettingsResponse({required this.intervalSeconds});
+  factory _PullRequestRefreshSettingsResponse.fromJson(Map<String, dynamic> json) => _$PullRequestRefreshSettingsResponseFromJson(json);
+
+@override final  int intervalSeconds;
+
+/// Create a copy of PullRequestRefreshSettingsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PullRequestRefreshSettingsResponseCopyWith<_PullRequestRefreshSettingsResponse> get copyWith => __$PullRequestRefreshSettingsResponseCopyWithImpl<_PullRequestRefreshSettingsResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PullRequestRefreshSettingsResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PullRequestRefreshSettingsResponse&&(identical(other.intervalSeconds, intervalSeconds) || other.intervalSeconds == intervalSeconds));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,intervalSeconds);
+
+@override
+String toString() {
+  return 'PullRequestRefreshSettingsResponse(intervalSeconds: $intervalSeconds)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PullRequestRefreshSettingsResponseCopyWith<$Res> implements $PullRequestRefreshSettingsResponseCopyWith<$Res> {
+  factory _$PullRequestRefreshSettingsResponseCopyWith(_PullRequestRefreshSettingsResponse value, $Res Function(_PullRequestRefreshSettingsResponse) _then) = __$PullRequestRefreshSettingsResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ int intervalSeconds
+});
+
+
+
+
+}
+/// @nodoc
+class __$PullRequestRefreshSettingsResponseCopyWithImpl<$Res>
+    implements _$PullRequestRefreshSettingsResponseCopyWith<$Res> {
+  __$PullRequestRefreshSettingsResponseCopyWithImpl(this._self, this._then);
+
+  final _PullRequestRefreshSettingsResponse _self;
+  final $Res Function(_PullRequestRefreshSettingsResponse) _then;
+
+/// Create a copy of PullRequestRefreshSettingsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? intervalSeconds = null,}) {
+  return _then(_PullRequestRefreshSettingsResponse(
+intervalSeconds: null == intervalSeconds ? _self.intervalSeconds : intervalSeconds // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$PullRequestRefreshSettingsErrorResponse {
+
+@JsonKey(unknownEnumValue: PullRequestRefreshSettingsErrorCode.unknown) PullRequestRefreshSettingsErrorCode get code; int get minimumIntervalSeconds; int get maximumIntervalSeconds;
+/// Create a copy of PullRequestRefreshSettingsErrorResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PullRequestRefreshSettingsErrorResponseCopyWith<PullRequestRefreshSettingsErrorResponse> get copyWith => _$PullRequestRefreshSettingsErrorResponseCopyWithImpl<PullRequestRefreshSettingsErrorResponse>(this as PullRequestRefreshSettingsErrorResponse, _$identity);
+
+  /// Serializes this PullRequestRefreshSettingsErrorResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PullRequestRefreshSettingsErrorResponse&&(identical(other.code, code) || other.code == code)&&(identical(other.minimumIntervalSeconds, minimumIntervalSeconds) || other.minimumIntervalSeconds == minimumIntervalSeconds)&&(identical(other.maximumIntervalSeconds, maximumIntervalSeconds) || other.maximumIntervalSeconds == maximumIntervalSeconds));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,code,minimumIntervalSeconds,maximumIntervalSeconds);
+
+@override
+String toString() {
+  return 'PullRequestRefreshSettingsErrorResponse(code: $code, minimumIntervalSeconds: $minimumIntervalSeconds, maximumIntervalSeconds: $maximumIntervalSeconds)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PullRequestRefreshSettingsErrorResponseCopyWith<$Res>  {
+  factory $PullRequestRefreshSettingsErrorResponseCopyWith(PullRequestRefreshSettingsErrorResponse value, $Res Function(PullRequestRefreshSettingsErrorResponse) _then) = _$PullRequestRefreshSettingsErrorResponseCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(unknownEnumValue: PullRequestRefreshSettingsErrorCode.unknown) PullRequestRefreshSettingsErrorCode code, int minimumIntervalSeconds, int maximumIntervalSeconds
+});
+
+
+
+
+}
+/// @nodoc
+class _$PullRequestRefreshSettingsErrorResponseCopyWithImpl<$Res>
+    implements $PullRequestRefreshSettingsErrorResponseCopyWith<$Res> {
+  _$PullRequestRefreshSettingsErrorResponseCopyWithImpl(this._self, this._then);
+
+  final PullRequestRefreshSettingsErrorResponse _self;
+  final $Res Function(PullRequestRefreshSettingsErrorResponse) _then;
+
+/// Create a copy of PullRequestRefreshSettingsErrorResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? code = null,Object? minimumIntervalSeconds = null,Object? maximumIntervalSeconds = null,}) {
+  return _then(_self.copyWith(
+code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as PullRequestRefreshSettingsErrorCode,minimumIntervalSeconds: null == minimumIntervalSeconds ? _self.minimumIntervalSeconds : minimumIntervalSeconds // ignore: cast_nullable_to_non_nullable
+as int,maximumIntervalSeconds: null == maximumIntervalSeconds ? _self.maximumIntervalSeconds : maximumIntervalSeconds // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _PullRequestRefreshSettingsErrorResponse implements PullRequestRefreshSettingsErrorResponse {
+  const _PullRequestRefreshSettingsErrorResponse({@JsonKey(unknownEnumValue: PullRequestRefreshSettingsErrorCode.unknown) required this.code, required this.minimumIntervalSeconds, required this.maximumIntervalSeconds});
+  factory _PullRequestRefreshSettingsErrorResponse.fromJson(Map<String, dynamic> json) => _$PullRequestRefreshSettingsErrorResponseFromJson(json);
+
+@override@JsonKey(unknownEnumValue: PullRequestRefreshSettingsErrorCode.unknown) final  PullRequestRefreshSettingsErrorCode code;
+@override final  int minimumIntervalSeconds;
+@override final  int maximumIntervalSeconds;
+
+/// Create a copy of PullRequestRefreshSettingsErrorResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PullRequestRefreshSettingsErrorResponseCopyWith<_PullRequestRefreshSettingsErrorResponse> get copyWith => __$PullRequestRefreshSettingsErrorResponseCopyWithImpl<_PullRequestRefreshSettingsErrorResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PullRequestRefreshSettingsErrorResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PullRequestRefreshSettingsErrorResponse&&(identical(other.code, code) || other.code == code)&&(identical(other.minimumIntervalSeconds, minimumIntervalSeconds) || other.minimumIntervalSeconds == minimumIntervalSeconds)&&(identical(other.maximumIntervalSeconds, maximumIntervalSeconds) || other.maximumIntervalSeconds == maximumIntervalSeconds));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,code,minimumIntervalSeconds,maximumIntervalSeconds);
+
+@override
+String toString() {
+  return 'PullRequestRefreshSettingsErrorResponse(code: $code, minimumIntervalSeconds: $minimumIntervalSeconds, maximumIntervalSeconds: $maximumIntervalSeconds)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PullRequestRefreshSettingsErrorResponseCopyWith<$Res> implements $PullRequestRefreshSettingsErrorResponseCopyWith<$Res> {
+  factory _$PullRequestRefreshSettingsErrorResponseCopyWith(_PullRequestRefreshSettingsErrorResponse value, $Res Function(_PullRequestRefreshSettingsErrorResponse) _then) = __$PullRequestRefreshSettingsErrorResponseCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(unknownEnumValue: PullRequestRefreshSettingsErrorCode.unknown) PullRequestRefreshSettingsErrorCode code, int minimumIntervalSeconds, int maximumIntervalSeconds
+});
+
+
+
+
+}
+/// @nodoc
+class __$PullRequestRefreshSettingsErrorResponseCopyWithImpl<$Res>
+    implements _$PullRequestRefreshSettingsErrorResponseCopyWith<$Res> {
+  __$PullRequestRefreshSettingsErrorResponseCopyWithImpl(this._self, this._then);
+
+  final _PullRequestRefreshSettingsErrorResponse _self;
+  final $Res Function(_PullRequestRefreshSettingsErrorResponse) _then;
+
+/// Create a copy of PullRequestRefreshSettingsErrorResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? code = null,Object? minimumIntervalSeconds = null,Object? maximumIntervalSeconds = null,}) {
+  return _then(_PullRequestRefreshSettingsErrorResponse(
+code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as PullRequestRefreshSettingsErrorCode,minimumIntervalSeconds: null == minimumIntervalSeconds ? _self.minimumIntervalSeconds : minimumIntervalSeconds // ignore: cast_nullable_to_non_nullable
+as int,maximumIntervalSeconds: null == maximumIntervalSeconds ? _self.maximumIntervalSeconds : maximumIntervalSeconds // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/shared/sesori_shared/lib/src/models/sesori/pull_request_refresh_settings.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/pull_request_refresh_settings.freezed.dart
@@ -149,7 +149,7 @@ as int,
 /// @nodoc
 mixin _$PullRequestRefreshSettingsResponse {
 
- int get intervalSeconds;
+@JsonKey(fromJson: _strictIntFromJson) int get intervalSeconds;
 /// Create a copy of PullRequestRefreshSettingsResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -182,7 +182,7 @@ abstract mixin class $PullRequestRefreshSettingsResponseCopyWith<$Res>  {
   factory $PullRequestRefreshSettingsResponseCopyWith(PullRequestRefreshSettingsResponse value, $Res Function(PullRequestRefreshSettingsResponse) _then) = _$PullRequestRefreshSettingsResponseCopyWithImpl;
 @useResult
 $Res call({
- int intervalSeconds
+@JsonKey(fromJson: _strictIntFromJson) int intervalSeconds
 });
 
 
@@ -214,10 +214,10 @@ as int,
 @JsonSerializable()
 
 class _PullRequestRefreshSettingsResponse implements PullRequestRefreshSettingsResponse {
-  const _PullRequestRefreshSettingsResponse({required this.intervalSeconds});
+  const _PullRequestRefreshSettingsResponse({@JsonKey(fromJson: _strictIntFromJson) required this.intervalSeconds});
   factory _PullRequestRefreshSettingsResponse.fromJson(Map<String, dynamic> json) => _$PullRequestRefreshSettingsResponseFromJson(json);
 
-@override final  int intervalSeconds;
+@override@JsonKey(fromJson: _strictIntFromJson) final  int intervalSeconds;
 
 /// Create a copy of PullRequestRefreshSettingsResponse
 /// with the given fields replaced by the non-null parameter values.
@@ -252,7 +252,7 @@ abstract mixin class _$PullRequestRefreshSettingsResponseCopyWith<$Res> implemen
   factory _$PullRequestRefreshSettingsResponseCopyWith(_PullRequestRefreshSettingsResponse value, $Res Function(_PullRequestRefreshSettingsResponse) _then) = __$PullRequestRefreshSettingsResponseCopyWithImpl;
 @override @useResult
 $Res call({
- int intervalSeconds
+@JsonKey(fromJson: _strictIntFromJson) int intervalSeconds
 });
 
 
@@ -283,7 +283,7 @@ as int,
 /// @nodoc
 mixin _$PullRequestRefreshSettingsErrorResponse {
 
-@JsonKey(unknownEnumValue: PullRequestRefreshSettingsErrorCode.unknown) PullRequestRefreshSettingsErrorCode get code; int get minimumIntervalSeconds; int get maximumIntervalSeconds;
+@JsonKey(unknownEnumValue: PullRequestRefreshSettingsErrorCode.unknown) PullRequestRefreshSettingsErrorCode get code;@JsonKey(fromJson: _strictIntFromJson) int get minimumIntervalSeconds;@JsonKey(fromJson: _strictIntFromJson) int get maximumIntervalSeconds;
 /// Create a copy of PullRequestRefreshSettingsErrorResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -316,7 +316,7 @@ abstract mixin class $PullRequestRefreshSettingsErrorResponseCopyWith<$Res>  {
   factory $PullRequestRefreshSettingsErrorResponseCopyWith(PullRequestRefreshSettingsErrorResponse value, $Res Function(PullRequestRefreshSettingsErrorResponse) _then) = _$PullRequestRefreshSettingsErrorResponseCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(unknownEnumValue: PullRequestRefreshSettingsErrorCode.unknown) PullRequestRefreshSettingsErrorCode code, int minimumIntervalSeconds, int maximumIntervalSeconds
+@JsonKey(unknownEnumValue: PullRequestRefreshSettingsErrorCode.unknown) PullRequestRefreshSettingsErrorCode code,@JsonKey(fromJson: _strictIntFromJson) int minimumIntervalSeconds,@JsonKey(fromJson: _strictIntFromJson) int maximumIntervalSeconds
 });
 
 
@@ -350,12 +350,12 @@ as int,
 @JsonSerializable()
 
 class _PullRequestRefreshSettingsErrorResponse implements PullRequestRefreshSettingsErrorResponse {
-  const _PullRequestRefreshSettingsErrorResponse({@JsonKey(unknownEnumValue: PullRequestRefreshSettingsErrorCode.unknown) required this.code, required this.minimumIntervalSeconds, required this.maximumIntervalSeconds});
+  const _PullRequestRefreshSettingsErrorResponse({@JsonKey(unknownEnumValue: PullRequestRefreshSettingsErrorCode.unknown) required this.code, @JsonKey(fromJson: _strictIntFromJson) required this.minimumIntervalSeconds, @JsonKey(fromJson: _strictIntFromJson) required this.maximumIntervalSeconds});
   factory _PullRequestRefreshSettingsErrorResponse.fromJson(Map<String, dynamic> json) => _$PullRequestRefreshSettingsErrorResponseFromJson(json);
 
 @override@JsonKey(unknownEnumValue: PullRequestRefreshSettingsErrorCode.unknown) final  PullRequestRefreshSettingsErrorCode code;
-@override final  int minimumIntervalSeconds;
-@override final  int maximumIntervalSeconds;
+@override@JsonKey(fromJson: _strictIntFromJson) final  int minimumIntervalSeconds;
+@override@JsonKey(fromJson: _strictIntFromJson) final  int maximumIntervalSeconds;
 
 /// Create a copy of PullRequestRefreshSettingsErrorResponse
 /// with the given fields replaced by the non-null parameter values.
@@ -390,7 +390,7 @@ abstract mixin class _$PullRequestRefreshSettingsErrorResponseCopyWith<$Res> imp
   factory _$PullRequestRefreshSettingsErrorResponseCopyWith(_PullRequestRefreshSettingsErrorResponse value, $Res Function(_PullRequestRefreshSettingsErrorResponse) _then) = __$PullRequestRefreshSettingsErrorResponseCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(unknownEnumValue: PullRequestRefreshSettingsErrorCode.unknown) PullRequestRefreshSettingsErrorCode code, int minimumIntervalSeconds, int maximumIntervalSeconds
+@JsonKey(unknownEnumValue: PullRequestRefreshSettingsErrorCode.unknown) PullRequestRefreshSettingsErrorCode code,@JsonKey(fromJson: _strictIntFromJson) int minimumIntervalSeconds,@JsonKey(fromJson: _strictIntFromJson) int maximumIntervalSeconds
 });
 
 

--- a/shared/sesori_shared/lib/src/models/sesori/pull_request_refresh_settings.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/pull_request_refresh_settings.g.dart
@@ -9,7 +9,7 @@ part of 'pull_request_refresh_settings.dart';
 _PullRequestRefreshSettingsRequest _$PullRequestRefreshSettingsRequestFromJson(
   Map json,
 ) => _PullRequestRefreshSettingsRequest(
-  intervalSeconds: _strictIntFromJson(json['intervalSeconds'] as num),
+  intervalSeconds: _strictIntFromJson(json['intervalSeconds']),
 );
 
 Map<String, dynamic> _$PullRequestRefreshSettingsRequestToJson(
@@ -19,7 +19,7 @@ Map<String, dynamic> _$PullRequestRefreshSettingsRequestToJson(
 _PullRequestRefreshSettingsResponse
 _$PullRequestRefreshSettingsResponseFromJson(Map json) =>
     _PullRequestRefreshSettingsResponse(
-      intervalSeconds: (json['intervalSeconds'] as num).toInt(),
+      intervalSeconds: _strictIntFromJson(json['intervalSeconds']),
     );
 
 Map<String, dynamic> _$PullRequestRefreshSettingsResponseToJson(
@@ -27,16 +27,17 @@ Map<String, dynamic> _$PullRequestRefreshSettingsResponseToJson(
 ) => <String, dynamic>{'intervalSeconds': instance.intervalSeconds};
 
 _PullRequestRefreshSettingsErrorResponse
-_$PullRequestRefreshSettingsErrorResponseFromJson(Map json) =>
-    _PullRequestRefreshSettingsErrorResponse(
-      code: $enumDecode(
-        _$PullRequestRefreshSettingsErrorCodeEnumMap,
-        json['code'],
-        unknownValue: PullRequestRefreshSettingsErrorCode.unknown,
-      ),
-      minimumIntervalSeconds: (json['minimumIntervalSeconds'] as num).toInt(),
-      maximumIntervalSeconds: (json['maximumIntervalSeconds'] as num).toInt(),
-    );
+_$PullRequestRefreshSettingsErrorResponseFromJson(
+  Map json,
+) => _PullRequestRefreshSettingsErrorResponse(
+  code: $enumDecode(
+    _$PullRequestRefreshSettingsErrorCodeEnumMap,
+    json['code'],
+    unknownValue: PullRequestRefreshSettingsErrorCode.unknown,
+  ),
+  minimumIntervalSeconds: _strictIntFromJson(json['minimumIntervalSeconds']),
+  maximumIntervalSeconds: _strictIntFromJson(json['maximumIntervalSeconds']),
+);
 
 Map<String, dynamic> _$PullRequestRefreshSettingsErrorResponseToJson(
   _PullRequestRefreshSettingsErrorResponse instance,

--- a/shared/sesori_shared/lib/src/models/sesori/pull_request_refresh_settings.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/pull_request_refresh_settings.g.dart
@@ -1,0 +1,52 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pull_request_refresh_settings.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PullRequestRefreshSettingsRequest _$PullRequestRefreshSettingsRequestFromJson(
+  Map json,
+) => _PullRequestRefreshSettingsRequest(
+  intervalSeconds: _strictIntFromJson(json['intervalSeconds'] as num),
+);
+
+Map<String, dynamic> _$PullRequestRefreshSettingsRequestToJson(
+  _PullRequestRefreshSettingsRequest instance,
+) => <String, dynamic>{'intervalSeconds': instance.intervalSeconds};
+
+_PullRequestRefreshSettingsResponse
+_$PullRequestRefreshSettingsResponseFromJson(Map json) =>
+    _PullRequestRefreshSettingsResponse(
+      intervalSeconds: (json['intervalSeconds'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$PullRequestRefreshSettingsResponseToJson(
+  _PullRequestRefreshSettingsResponse instance,
+) => <String, dynamic>{'intervalSeconds': instance.intervalSeconds};
+
+_PullRequestRefreshSettingsErrorResponse
+_$PullRequestRefreshSettingsErrorResponseFromJson(Map json) =>
+    _PullRequestRefreshSettingsErrorResponse(
+      code: $enumDecode(
+        _$PullRequestRefreshSettingsErrorCodeEnumMap,
+        json['code'],
+        unknownValue: PullRequestRefreshSettingsErrorCode.unknown,
+      ),
+      minimumIntervalSeconds: (json['minimumIntervalSeconds'] as num).toInt(),
+      maximumIntervalSeconds: (json['maximumIntervalSeconds'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$PullRequestRefreshSettingsErrorResponseToJson(
+  _PullRequestRefreshSettingsErrorResponse instance,
+) => <String, dynamic>{
+  'code': _$PullRequestRefreshSettingsErrorCodeEnumMap[instance.code]!,
+  'minimumIntervalSeconds': instance.minimumIntervalSeconds,
+  'maximumIntervalSeconds': instance.maximumIntervalSeconds,
+};
+
+const _$PullRequestRefreshSettingsErrorCodeEnumMap = {
+  PullRequestRefreshSettingsErrorCode.intervalOutOfRange: 'intervalOutOfRange',
+  PullRequestRefreshSettingsErrorCode.unknown: 'unknown',
+};

--- a/shared/sesori_shared/test/models/pull_request_refresh_settings_test.dart
+++ b/shared/sesori_shared/test/models/pull_request_refresh_settings_test.dart
@@ -1,0 +1,38 @@
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("pull request refresh settings contracts", () {
+    test("request and response round trip", () {
+      const request = PullRequestRefreshSettingsRequest(intervalSeconds: 45);
+      const response = PullRequestRefreshSettingsResponse(intervalSeconds: 45);
+
+      expect(PullRequestRefreshSettingsRequest.fromJson(request.toJson()), request);
+      expect(PullRequestRefreshSettingsResponse.fromJson(response.toJson()), response);
+    });
+
+    test("request rejects a non-integer number", () {
+      expect(
+        () => PullRequestRefreshSettingsRequest.fromJson({"intervalSeconds": 45.5}),
+        throwsFormatException,
+      );
+    });
+
+    test("typed error round trips and unknown codes degrade", () {
+      const error = PullRequestRefreshSettingsErrorResponse(
+        code: PullRequestRefreshSettingsErrorCode.intervalOutOfRange,
+        minimumIntervalSeconds: 15,
+        maximumIntervalSeconds: 3600,
+      );
+
+      expect(PullRequestRefreshSettingsErrorResponse.fromJson(error.toJson()), error);
+      expect(
+        PullRequestRefreshSettingsErrorResponse.fromJson({
+          ...error.toJson(),
+          "code": "futureCode",
+        }).code,
+        PullRequestRefreshSettingsErrorCode.unknown,
+      );
+    });
+  });
+}

--- a/shared/sesori_shared/test/models/pull_request_refresh_settings_test.dart
+++ b/shared/sesori_shared/test/models/pull_request_refresh_settings_test.dart
@@ -11,11 +11,28 @@ void main() {
       expect(PullRequestRefreshSettingsResponse.fromJson(response.toJson()), response);
     });
 
-    test("request rejects a non-integer number", () {
-      expect(
-        () => PullRequestRefreshSettingsRequest.fromJson({"intervalSeconds": 45.5}),
-        throwsFormatException,
-      );
+    test("integer fields reject missing, null, non-numeric, and fractional values", () {
+      for (final json in <Map<String, dynamic>>[
+        const {},
+        const {"intervalSeconds": null},
+        const {"intervalSeconds": "45"},
+        const {"intervalSeconds": 45.5},
+      ]) {
+        expect(() => PullRequestRefreshSettingsRequest.fromJson(json), throwsFormatException);
+        expect(() => PullRequestRefreshSettingsResponse.fromJson(json), throwsFormatException);
+      }
+
+      for (final field in ["minimumIntervalSeconds", "maximumIntervalSeconds"]) {
+        expect(
+          () => PullRequestRefreshSettingsErrorResponse.fromJson({
+            "code": "intervalOutOfRange",
+            "minimumIntervalSeconds": 15,
+            "maximumIntervalSeconds": 3600,
+            field: 15.5,
+          }),
+          throwsFormatException,
+        );
+      }
     });
 
     test("typed error round trips and unknown codes degrade", () {


### PR DESCRIPTION
## Complexity

Moderate (`⚙️`): this changes persisted bridge settings, serialized cross-domain mutation ownership, additive shared contracts, request routing, and a live timer lifecycle.

## What

- Persist `pullRequestRefreshIntervalSeconds` with a 30-second default and startup repair for values outside 15–3,600 seconds.
- Add one repository-owned serialized settings mutation seam, migrate plugin settings writers to it, and publish committed settings changes.
- Add typed shared GET/PATCH/error contracts and bridge handlers for `/settings/pull-request-refresh`.
- Apply committed cadence changes to the viewed-project scheduler without restarting the bridge or creating a second refresh loop.
- Preserve original errors, stack traces, paths, identifiers, and operation context in every log introduced or touched by this PR; no prompt or transcript fields occur in these logs.
- Record the merged Step 5 state and verified Step 6 implementation in the active plan tracker.

## Why

Viewed-project PR refresh currently uses a fixed 30-second cadence. Step 6 makes that cadence safely configurable for the client settings UI planned in Step 8 while preventing concurrent plugin and PR-setting writes from losing each other's fields.

## Risk and test focus

Risk is medium. The highest-value checks cover startup repair, concurrent settings mutations, typed range rejection, persistence, suppression of unrelated settings events, timer rearming during pending and in-flight refreshes, and repository disposal on early startup exits. Existing request-driven refreshes and plugin lifecycle mutation semantics must remain unchanged. Diagnostic failures must retain their original errors and stack traces.

## Expected result

- **User-visible:** No UI change yet. A modern client can read the committed 30-second default and PATCH any integer from 15 through 3,600; the running viewed-project timer adopts a changed value immediately. Invalid ranges receive a typed 400 response.
- **Persisted/database:** The bridge JSON config gains `pullRequestRefreshIntervalSeconds`; missing or invalid startup values are repaired to 30. No database schema or row changes.
- **Internal:** Plugin and PR cadence writes serialize through one repository seam. Unrelated settings writes do not rearm PR polling, and manual JSON edits remain restart-scoped because no file watcher is added. Recover-and-continue logs retain local diagnostic context instead of replacing errors with privacy wrappers.

## Verification

- Shared code generation completed.
- `dart analyze --fatal-infos` in `shared/sesori_shared` — passed.
- `dart test` in `shared/sesori_shared` — 357 passed.
- `dart analyze --fatal-infos` in `bridge/app` — passed.
- `dart test` in `bridge/app` — 2,366 passed before the diagnostic-only follow-up.
- 37 affected settings/listener/service tests after the diagnostic follow-up — passed.
- Focused settings, routing, listener, plugin lifecycle, and orchestrator tests — passed.
- `git diff --check` — passed.
- `aristotle-impl-review` findings applied: PR cadence events now suppress unrelated settings changes, and the runtime runner owns repository disposal across early exits.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the viewed-project PR refresh cadence configurable and applied live without restarting. Adds GET/PATCH routes, a validated, persisted interval in bridge config, and logging that preserves full refresh error diagnostics and stack traces.

- **New Features**
  - Persist `pullRequestRefreshIntervalSeconds` with validation and a 30s default; serialize settings writes and publish committed changes.
  - Add `sesori_shared` typed request/response/error and bridge handlers for `/settings/pull-request-refresh` (GET/PATCH).
  - Use a new settings service and stream to rearm the viewed-project timer on change; no duplicate loops or bridge restart.
  - Preserve refresh diagnostics in logs by passing the original error and stack trace; remove the privacy wrapper.

- **Migration**
  - Valid range: 15–3,600 seconds. Missing/invalid config repairs to 30 on startup. Out-of-range PATCH returns a typed 400.
  - No database changes; manual config edits are picked up on restart only.
  - Unrelated settings commits don’t emit PR cadence change events.

<sup>Written for commit 34ec26d648af4cf2465c3c6a6e7a6aebe9cf3986. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


