### PR TITLE
🌱 Use released PR monitor package

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@sesori/pr-monitor-opencode@0.2.0"],
+  "plugin": ["@sesori/pr-monitor-opencode"],
   "mcp": {
     "mobile-mcp": {
       "type": "local",

--- a/opencode.json
+++ b/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["github:sesori-ai/opencode-pr-monitor#v0.1.6"],
+  "plugin": ["@sesori/pr-monitor-opencode"],
   "mcp": {
     "mobile-mcp": {
       "type": "local",

--- a/opencode.json
+++ b/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@sesori/pr-monitor-opencode"],
+  "plugin": ["@sesori/pr-monitor-opencode@0.2.0"],
   "mcp": {
     "mobile-mcp": {
       "type": "local",


### PR DESCRIPTION
## Complexity
Trivial

## What
- Replace the Git-based OpenCode PR monitor reference with `@sesori/pr-monitor-opencode`.

## Why
- Use the released package instead of pinning the monitor to a repository tag.

## Risk and test focus
- No user-visible or database impact.
- OpenCode must resolve the released package when loading the project config.

## Expected result
- Project OpenCode sessions load the PR monitor through the released npm package.

## Verification
- `OPENCODE_PURE=1 opencode debug config`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch OpenCode PR monitor to the released `@sesori/pr-monitor-opencode`, replacing the Git-tagged repo reference. Leave the package unpinned for simpler npm resolution and latest-version usage.

<sup>Written for commit 6b3bd5d2373fe0dc43e05f1104265a86c3b11651. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

