### PR TITLE
🌿 Retune hold-to-speak feedback

### DIFF
--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -103,8 +103,8 @@ class _PromptInputState extends State<PromptInput> {
   int? _recordingPointer;
   Offset? _recordingPointerPosition;
 
-  /// Keeps the cancel commitment from buzzing repeatedly as pointer updates
-  /// continue inside the target.
+  /// Keeps the cancel commitment from buzzing repeatedly while the pointer
+  /// remains inside the target. Cleared when the pointer leaves.
   bool _dismissFeedbackPlayed = false;
 
   /// Keeps the typing layout mounted after the keyboard affordance was tapped
@@ -369,7 +369,7 @@ class _PromptInputState extends State<PromptInput> {
     if (_voiceState != _VoiceState.idle || _isRecordStartInFlight || _isCancelInFlight) return;
     _dismissFeedbackPlayed = false;
     // Fire before recorder startup or rebuilding so touch-down feels immediate.
-    unawaited(HapticFeedback.lightImpact());
+    unawaited(_playHapticFeedback(play: HapticFeedback.lightImpact));
     final pinnedVoiceLayout = _restingLayout;
     _voiceInteractionId++;
     _minimumRecordingDurationTimer?.cancel();
@@ -428,7 +428,11 @@ class _PromptInputState extends State<PromptInput> {
   void _handleRecordDragUpdate({required Offset globalPosition}) {
     if (_displayedVoiceState != _VoiceState.recording) return;
     final progress = _cancelProgressFor(globalPosition: globalPosition);
-    if (progress >= 1) _playDismissFeedback();
+    if (progress >= 1) {
+      _playDismissFeedback();
+    } else {
+      _dismissFeedbackPlayed = false;
+    }
     _cancelDragProgress.value = progress;
   }
 
@@ -451,7 +455,6 @@ class _PromptInputState extends State<PromptInput> {
     if (_voiceState == _VoiceState.idle) {
       // A release can race a recorder that is still starting up.
       if (_isRecordStartInFlight) {
-        _playDismissFeedback();
         _updateComposerState(update: () => _releaseRequestedDuringStart = true);
         _cancelDragProgress.value = 0;
       }
@@ -521,11 +524,12 @@ class _PromptInputState extends State<PromptInput> {
   }
 
   Future<void> _stopAndTranscribe() async {
-    unawaited(_playCompletionFeedback());
     // The upload can outlive this interaction (a cancel settles the state
     // long before a slow upload errors out); every continuation below is a
     // no-op once a newer interaction owns the composer.
     final interactionId = _voiceInteractionId;
+    _dismissFeedbackPlayed = false;
+    unawaited(_playCompletionFeedback(interactionId: interactionId));
     _minimumRecordingDurationTimer?.cancel();
     _minimumRecordingDurationTimer = null;
     _updateComposerState(
@@ -605,8 +609,12 @@ class _PromptInputState extends State<PromptInput> {
 
   /// Discards the running voice interaction: a drag released on the cancel
   /// target, a tap on it mid-recording, or a tap on the X while transcribing.
-  Future<void> _cancelVoiceInteraction() async {
+  Future<void> _cancelVoiceInteractionWithFeedback() async {
     _playDismissFeedback();
+    await _cancelVoiceInteraction();
+  }
+
+  Future<void> _cancelVoiceInteraction() async {
     if (_isRecordStartInFlight) {
       // Cancelling the service before its start future settles can let native
       // startup continue after cleanup. Mark the release now and let the start
@@ -644,13 +652,22 @@ class _PromptInputState extends State<PromptInput> {
   void _playDismissFeedback() {
     if (_dismissFeedbackPlayed) return;
     _dismissFeedbackPlayed = true;
-    unawaited(HapticFeedback.selectionClick());
+    unawaited(_playHapticFeedback(play: HapticFeedback.selectionClick));
   }
 
-  static Future<void> _playCompletionFeedback() async {
-    await HapticFeedback.lightImpact();
+  Future<void> _playCompletionFeedback({required int interactionId}) async {
+    await _playHapticFeedback(play: HapticFeedback.lightImpact);
     await Future<void>.delayed(_completionFeedbackPulseDelay);
-    await HapticFeedback.heavyImpact();
+    if (!mounted || interactionId != _voiceInteractionId) return;
+    await _playHapticFeedback(play: HapticFeedback.heavyImpact);
+  }
+
+  static Future<void> _playHapticFeedback({required Future<void> Function() play}) async {
+    try {
+      await play();
+    } on Object catch (error, stackTrace) {
+      logw("Failed to play voice haptic feedback", error, stackTrace);
+    }
   }
 
   void _showVoiceError(String message) {
@@ -1244,7 +1261,7 @@ class _PromptInputState extends State<PromptInput> {
         child: VoiceCancelButton(
           key: _cancelTargetKey,
           progress: _cancelDragProgress,
-          onCancel: _cancelVoiceInteraction,
+          onCancel: _cancelVoiceInteractionWithFeedback,
         ),
       ),
       _VoiceState.transcribing => KeyedSubtree(
@@ -1255,7 +1272,7 @@ class _PromptInputState extends State<PromptInput> {
             leadingIcon: TablerRegular.x,
             hierarchy: PregoButtonsSolidHierarchy.secondary,
             size: PregoButtonsSolidSize.lg,
-            onPressed: _cancelVoiceInteraction,
+            onPressed: _cancelVoiceInteractionWithFeedback,
           ),
         ),
       ),

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -85,6 +85,7 @@ class PromptInput extends StatefulWidget {
 class _PromptInputState extends State<PromptInput> {
   static const _draftCalculator = ComposerDraftCalculator();
   static const _minimumRecordingDuration = Duration(milliseconds: 200);
+  static const _completionFeedbackPulseDelay = Duration(milliseconds: 100);
   final _controller = TextEditingController();
   final _textScrollController = ScrollController();
   final _focusNode = FocusNode();
@@ -101,6 +102,10 @@ class _PromptInputState extends State<PromptInput> {
   /// recorder on touch-down without Flutter's long-press recognition delay.
   int? _recordingPointer;
   Offset? _recordingPointerPosition;
+
+  /// Keeps the cancel commitment from buzzing repeatedly as pointer updates
+  /// continue inside the target.
+  bool _dismissFeedbackPlayed = false;
 
   /// Keeps the typing layout mounted after the keyboard affordance was tapped
   /// while the field wasn't in the tree yet (hold-to-talk / compact layouts),
@@ -362,6 +367,9 @@ class _PromptInputState extends State<PromptInput> {
 
   Future<void> _handleRecordStart() async {
     if (_voiceState != _VoiceState.idle || _isRecordStartInFlight || _isCancelInFlight) return;
+    _dismissFeedbackPlayed = false;
+    // Fire before recorder startup or rebuilding so touch-down feels immediate.
+    unawaited(HapticFeedback.lightImpact());
     final pinnedVoiceLayout = _restingLayout;
     _voiceInteractionId++;
     _minimumRecordingDurationTimer?.cancel();
@@ -419,7 +427,9 @@ class _PromptInputState extends State<PromptInput> {
   /// toward the cancel target.
   void _handleRecordDragUpdate({required Offset globalPosition}) {
     if (_displayedVoiceState != _VoiceState.recording) return;
-    _cancelDragProgress.value = _cancelProgressFor(globalPosition: globalPosition);
+    final progress = _cancelProgressFor(globalPosition: globalPosition);
+    if (progress >= 1) _playDismissFeedback();
+    _cancelDragProgress.value = progress;
   }
 
   /// The finger starts engaging the cancel affordance within this distance of
@@ -441,6 +451,7 @@ class _PromptInputState extends State<PromptInput> {
     if (_voiceState == _VoiceState.idle) {
       // A release can race a recorder that is still starting up.
       if (_isRecordStartInFlight) {
+        _playDismissFeedback();
         _updateComposerState(update: () => _releaseRequestedDuringStart = true);
         _cancelDragProgress.value = 0;
       }
@@ -510,6 +521,7 @@ class _PromptInputState extends State<PromptInput> {
   }
 
   Future<void> _stopAndTranscribe() async {
+    unawaited(_playCompletionFeedback());
     // The upload can outlive this interaction (a cancel settles the state
     // long before a slow upload errors out); every continuation below is a
     // no-op once a newer interaction owns the composer.
@@ -594,6 +606,7 @@ class _PromptInputState extends State<PromptInput> {
   /// Discards the running voice interaction: a drag released on the cancel
   /// target, a tap on it mid-recording, or a tap on the X while transcribing.
   Future<void> _cancelVoiceInteraction() async {
+    _playDismissFeedback();
     if (_isRecordStartInFlight) {
       // Cancelling the service before its start future settles can let native
       // startup continue after cleanup. Mark the release now and let the start
@@ -626,6 +639,18 @@ class _PromptInputState extends State<PromptInput> {
     } finally {
       _isCancelInFlight = false;
     }
+  }
+
+  void _playDismissFeedback() {
+    if (_dismissFeedbackPlayed) return;
+    _dismissFeedbackPlayed = true;
+    unawaited(HapticFeedback.selectionClick());
+  }
+
+  static Future<void> _playCompletionFeedback() async {
+    await HapticFeedback.lightImpact();
+    await Future<void>.delayed(_completionFeedbackPulseDelay);
+    await HapticFeedback.heavyImpact();
   }
 
   void _showVoiceError(String message) {

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -85,7 +85,7 @@ class PromptInput extends StatefulWidget {
 class _PromptInputState extends State<PromptInput> {
   static const _draftCalculator = ComposerDraftCalculator();
   static const _minimumRecordingDuration = Duration(milliseconds: 200);
-  static const _completionFeedbackPulseDelay = Duration(milliseconds: 100);
+  static const _successFeedbackPulseDelay = Duration(milliseconds: 100);
   final _controller = TextEditingController();
   final _textScrollController = ScrollController();
   final _focusNode = FocusNode();
@@ -103,9 +103,9 @@ class _PromptInputState extends State<PromptInput> {
   int? _recordingPointer;
   Offset? _recordingPointerPosition;
 
-  /// Keeps the cancel commitment from buzzing repeatedly while the pointer
-  /// remains inside the target. Cleared when the pointer leaves.
-  bool _dismissFeedbackPlayed = false;
+  /// Whether release currently commits cancellation. The transition in either
+  /// direction receives one tactile tick.
+  bool _cancelTargetEngaged = false;
 
   /// Keeps the typing layout mounted after the keyboard affordance was tapped
   /// while the field wasn't in the tree yet (hold-to-talk / compact layouts),
@@ -367,7 +367,7 @@ class _PromptInputState extends State<PromptInput> {
 
   Future<void> _handleRecordStart() async {
     if (_voiceState != _VoiceState.idle || _isRecordStartInFlight || _isCancelInFlight) return;
-    _dismissFeedbackPlayed = false;
+    _cancelTargetEngaged = false;
     // Fire before recorder startup or rebuilding so touch-down feels immediate.
     unawaited(_playHapticFeedback(play: HapticFeedback.lightImpact));
     final pinnedVoiceLayout = _restingLayout;
@@ -428,26 +428,29 @@ class _PromptInputState extends State<PromptInput> {
   void _handleRecordDragUpdate({required Offset globalPosition}) {
     if (_displayedVoiceState != _VoiceState.recording) return;
     final progress = _cancelProgressFor(globalPosition: globalPosition);
-    if (progress >= 1) {
-      _playDismissFeedback();
-    } else {
-      _dismissFeedbackPlayed = false;
+    final cancelTargetEngaged = progress >= 1;
+    if (cancelTargetEngaged != _cancelTargetEngaged) {
+      _cancelTargetEngaged = cancelTargetEngaged;
+      unawaited(_playHapticFeedback(play: HapticFeedback.selectionClick));
     }
     _cancelDragProgress.value = progress;
   }
 
   /// The finger starts engaging the cancel affordance within this distance of
   /// the target's centre, and is committed to cancelling within
-  /// [_cancelCommitRadius] — roughly the 44pt button plus touch slop.
+  /// [_cancelCommitRadius] — roughly the 44pt button plus touch slop. Once
+  /// committed, the wider disengage radius prevents chatter at the boundary.
   static const double _cancelReachRadius = 170;
   static const double _cancelCommitRadius = 44;
+  static const double _cancelDisengageRadius = 56;
 
   double _cancelProgressFor({required Offset globalPosition}) {
     final target = _cancelTargetKey.currentContext?.findRenderObject();
     if (target is! RenderBox || !target.hasSize || !target.attached) return 0;
     final center = target.localToGlobal(target.size.center(Offset.zero));
     final distance = (globalPosition - center).distance;
-    final fraction = (distance - _cancelCommitRadius) / (_cancelReachRadius - _cancelCommitRadius);
+    final thresholdRadius = _cancelTargetEngaged ? _cancelDisengageRadius : _cancelCommitRadius;
+    final fraction = (distance - thresholdRadius) / (_cancelReachRadius - thresholdRadius);
     return (1 - fraction).clamp(0.0, 1.0);
   }
 
@@ -528,8 +531,7 @@ class _PromptInputState extends State<PromptInput> {
     // long before a slow upload errors out); every continuation below is a
     // no-op once a newer interaction owns the composer.
     final interactionId = _voiceInteractionId;
-    _dismissFeedbackPlayed = false;
-    unawaited(_playCompletionFeedback(interactionId: interactionId));
+    _cancelTargetEngaged = false;
     _minimumRecordingDurationTimer?.cancel();
     _minimumRecordingDurationTimer = null;
     _updateComposerState(
@@ -551,6 +553,8 @@ class _PromptInputState extends State<PromptInput> {
         transcript: transcript,
       );
       _applyDraft(draft: nextDraft);
+      // Reward the completed outcome, not release that merely starts transcription.
+      unawaited(_playSuccessFeedback(interactionId: interactionId));
       _scrollToDraftEndAfterLayout();
       widget.onVoiceTranscriptionCompleted();
       // Text-first raises the keyboard so the transcript can be extended
@@ -650,14 +654,13 @@ class _PromptInputState extends State<PromptInput> {
   }
 
   void _playDismissFeedback() {
-    if (_dismissFeedbackPlayed) return;
-    _dismissFeedbackPlayed = true;
+    if (_cancelTargetEngaged) return;
     unawaited(_playHapticFeedback(play: HapticFeedback.selectionClick));
   }
 
-  Future<void> _playCompletionFeedback({required int interactionId}) async {
+  Future<void> _playSuccessFeedback({required int interactionId}) async {
     await _playHapticFeedback(play: HapticFeedback.lightImpact);
-    await Future<void>.delayed(_completionFeedbackPulseDelay);
+    await Future<void>.delayed(_successFeedbackPulseDelay);
     if (!mounted || interactionId != _voiceInteractionId) return;
     await _playHapticFeedback(play: HapticFeedback.heavyImpact);
   }

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -858,7 +858,7 @@ void main() {
     verify(() => voiceTranscriptionService.prewarmRecording()).called(1);
   });
 
-  testWidgets("voice hold gives immediate start and completion feedback", (tester) async {
+  testWidgets("voice hold acknowledges touch-down and stays silent for an empty transcript", (tester) async {
     final feedback = _captureHapticFeedback(throwsPlatformException: false);
     when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
     when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
@@ -872,6 +872,33 @@ void main() {
 
     await tester.pump(const Duration(milliseconds: 250));
     await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(feedback, ["HapticFeedbackType.lightImpact"]);
+  });
+
+  testWidgets("a successful transcript gives feedback when its text is inserted", (tester) async {
+    final feedback = _captureHapticFeedback(throwsPlatformException: false);
+    final stopCompleter = Completer<String>();
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) => stopCompleter.future);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
+    expect(feedback, ["HapticFeedbackType.lightImpact"]);
+
+    await tester.pump(const Duration(milliseconds: 250));
+    await gesture.up();
+    await tester.pump();
+    expect(feedback, ["HapticFeedbackType.lightImpact"]);
+
+    stopCompleter.complete("dictated words");
+    await tester.pump();
+
+    expect(find.text("dictated words"), findsOneWidget);
     expect(feedback, ["HapticFeedbackType.lightImpact", "HapticFeedbackType.lightImpact"]);
 
     await tester.pump();
@@ -883,31 +910,8 @@ void main() {
     ]);
   });
 
-  testWidgets("entering the cancel target gives one dismiss feedback tick", (tester) async {
+  testWidgets("crossing into and out of the cancel target gives one tick at each boundary", (tester) async {
     final feedback = _captureHapticFeedback(throwsPlatformException: false);
-    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
-    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
-    when(() => voiceTranscriptionService.cancelRecording()).thenAnswer((_) async {});
-
-    await tester.pumpWidget(_buildApp(cubit: cubit));
-    await tester.pumpAndSettle();
-
-    final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
-    expect(feedback, ["HapticFeedbackType.lightImpact"]);
-    await tester.pump(const Duration(milliseconds: 250));
-
-    final cancelCenter = tester.getCenter(find.byType(VoiceCancelButton));
-    await gesture.moveTo(cancelCenter);
-    expect(feedback, ["HapticFeedbackType.lightImpact", "HapticFeedbackType.selectionClick"]);
-
-    await gesture.moveTo(cancelCenter + const Offset(1, 0));
-    await gesture.up();
-    await tester.pumpAndSettle();
-    expect(feedback, ["HapticFeedbackType.lightImpact", "HapticFeedbackType.selectionClick"]);
-  });
-
-  testWidgets("haptic platform failures do not interrupt voice recording", (tester) async {
-    _captureHapticFeedback(throwsPlatformException: true);
     when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
     when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
     when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) async => "");
@@ -915,17 +919,59 @@ void main() {
     await tester.pumpWidget(_buildApp(cubit: cubit));
     await tester.pumpAndSettle();
 
+    final holdCenter = tester.getCenter(find.text("Hold to talk"));
+    final gesture = await tester.startGesture(holdCenter);
+    expect(feedback, ["HapticFeedbackType.lightImpact"]);
+    await tester.pump(const Duration(milliseconds: 250));
+
+    final cancelCenter = tester.getCenter(find.byType(VoiceCancelButton));
+    await gesture.moveTo(cancelCenter);
+    expect(feedback, ["HapticFeedbackType.lightImpact", "HapticFeedbackType.selectionClick"]);
+
+    // A small retreat remains armed so finger tremor cannot chatter across the
+    // cancel boundary.
+    await gesture.moveTo(cancelCenter + const Offset(50, 0));
+    await tester.pump();
+    expect(find.text("Release to cancel"), findsOneWidget);
+    expect(feedback, ["HapticFeedbackType.lightImpact", "HapticFeedbackType.selectionClick"]);
+
+    await gesture.moveTo(holdCenter);
+    expect(feedback, [
+      "HapticFeedbackType.lightImpact",
+      "HapticFeedbackType.selectionClick",
+      "HapticFeedbackType.selectionClick",
+    ]);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+    verify(() => voiceTranscriptionService.stopAndTranscribe()).called(1);
+    expect(feedback, [
+      "HapticFeedbackType.lightImpact",
+      "HapticFeedbackType.selectionClick",
+      "HapticFeedbackType.selectionClick",
+    ]);
+  });
+
+  testWidgets("haptic platform failures do not interrupt voice recording", (tester) async {
+    _captureHapticFeedback(throwsPlatformException: true);
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) async => "dictated words");
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
     final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
     await tester.pump(const Duration(milliseconds: 250));
     await gesture.up();
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pumpAndSettle();
 
     expect(tester.takeException(), isNull);
     verify(() => voiceTranscriptionService.stopAndTranscribe()).called(1);
+    expect(find.text("dictated words"), findsOneWidget);
   });
 
-  testWidgets("transcription cancel replaces a pending completion pulse with a dismiss tick", (tester) async {
+  testWidgets("transcription cancel after a recovered drag gives a fresh dismiss tick", (tester) async {
     final feedback = _captureHapticFeedback(throwsPlatformException: false);
     final stopCompleter = Completer<String>();
     when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
@@ -946,17 +992,23 @@ void main() {
 
     await tester.tap(find.byTooltip("Cancel transcription"));
     await tester.pump();
-    await tester.pump(const Duration(milliseconds: 100));
 
     expect(feedback, [
       "HapticFeedbackType.lightImpact",
       "HapticFeedbackType.selectionClick",
-      "HapticFeedbackType.lightImpact",
+      "HapticFeedbackType.selectionClick",
       "HapticFeedbackType.selectionClick",
     ]);
 
-    stopCompleter.complete("");
+    stopCompleter.complete("stale words");
     await tester.pump();
+    expect(find.textContaining("stale words"), findsNothing);
+    expect(feedback, [
+      "HapticFeedbackType.lightImpact",
+      "HapticFeedbackType.selectionClick",
+      "HapticFeedbackType.selectionClick",
+      "HapticFeedbackType.selectionClick",
+    ]);
   });
 
   testWidgets("a very short tap starts recording immediately but never transcribes", (tester) async {

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -5,6 +5,7 @@ import "package:bloc_test/bloc_test.dart";
 import "package:flutter/foundation.dart";
 import "package:flutter/gestures.dart" show kSecondaryButton;
 import "package:flutter/material.dart";
+import "package:flutter/services.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart";
 import "package:flutter_test/flutter_test.dart";
@@ -149,6 +150,19 @@ Finder _pickerMenuItem(String label) => find.descendant(
   of: find.byType(SingleChildScrollView),
   matching: find.widgetWithText(InkWell, label),
 );
+
+List<Object?> _captureHapticFeedback() {
+  final feedback = <Object?>[];
+  final messenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
+    if (call.method == "HapticFeedback.vibrate") feedback.add(call.arguments);
+    return null;
+  });
+  addTearDown(() {
+    messenger.setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+  return feedback;
+}
 
 void main() {
   late MockSessionDetailCubit cubit;
@@ -839,6 +853,54 @@ void main() {
     await tester.pumpAndSettle();
 
     verify(() => voiceTranscriptionService.prewarmRecording()).called(1);
+  });
+
+  testWidgets("voice hold gives immediate start and completion feedback", (tester) async {
+    final feedback = _captureHapticFeedback();
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) async => "");
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
+    expect(feedback, ["HapticFeedbackType.lightImpact"]);
+
+    await tester.pump(const Duration(milliseconds: 250));
+    await gesture.up();
+    expect(feedback, ["HapticFeedbackType.lightImpact", "HapticFeedbackType.lightImpact"]);
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(feedback, [
+      "HapticFeedbackType.lightImpact",
+      "HapticFeedbackType.lightImpact",
+      "HapticFeedbackType.heavyImpact",
+    ]);
+  });
+
+  testWidgets("entering the cancel target gives one dismiss feedback tick", (tester) async {
+    final feedback = _captureHapticFeedback();
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.cancelRecording()).thenAnswer((_) async {});
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
+    expect(feedback, ["HapticFeedbackType.lightImpact"]);
+    await tester.pump(const Duration(milliseconds: 250));
+
+    final cancelCenter = tester.getCenter(find.byType(VoiceCancelButton));
+    await gesture.moveTo(cancelCenter);
+    expect(feedback, ["HapticFeedbackType.lightImpact", "HapticFeedbackType.selectionClick"]);
+
+    await gesture.moveTo(cancelCenter + const Offset(1, 0));
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(feedback, ["HapticFeedbackType.lightImpact", "HapticFeedbackType.selectionClick"]);
   });
 
   testWidgets("a very short tap starts recording immediately but never transcribes", (tester) async {

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -151,11 +151,14 @@ Finder _pickerMenuItem(String label) => find.descendant(
   matching: find.widgetWithText(InkWell, label),
 );
 
-List<Object?> _captureHapticFeedback() {
+List<Object?> _captureHapticFeedback({required bool throwsPlatformException}) {
   final feedback = <Object?>[];
   final messenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
   messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
-    if (call.method == "HapticFeedback.vibrate") feedback.add(call.arguments);
+    if (call.method == "HapticFeedback.vibrate") {
+      feedback.add(call.arguments);
+      if (throwsPlatformException) throw PlatformException(code: "haptics-unavailable");
+    }
     return null;
   });
   addTearDown(() {
@@ -856,7 +859,7 @@ void main() {
   });
 
   testWidgets("voice hold gives immediate start and completion feedback", (tester) async {
-    final feedback = _captureHapticFeedback();
+    final feedback = _captureHapticFeedback(throwsPlatformException: false);
     when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
     when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
     when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) async => "");
@@ -881,7 +884,7 @@ void main() {
   });
 
   testWidgets("entering the cancel target gives one dismiss feedback tick", (tester) async {
-    final feedback = _captureHapticFeedback();
+    final feedback = _captureHapticFeedback(throwsPlatformException: false);
     when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
     when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
     when(() => voiceTranscriptionService.cancelRecording()).thenAnswer((_) async {});
@@ -903,7 +906,61 @@ void main() {
     expect(feedback, ["HapticFeedbackType.lightImpact", "HapticFeedbackType.selectionClick"]);
   });
 
+  testWidgets("haptic platform failures do not interrupt voice recording", (tester) async {
+    _captureHapticFeedback(throwsPlatformException: true);
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) async => "");
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    final gesture = await tester.startGesture(tester.getCenter(find.text("Hold to talk")));
+    await tester.pump(const Duration(milliseconds: 250));
+    await gesture.up();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(tester.takeException(), isNull);
+    verify(() => voiceTranscriptionService.stopAndTranscribe()).called(1);
+  });
+
+  testWidgets("transcription cancel replaces a pending completion pulse with a dismiss tick", (tester) async {
+    final feedback = _captureHapticFeedback(throwsPlatformException: false);
+    final stopCompleter = Completer<String>();
+    when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
+    when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
+    when(() => voiceTranscriptionService.stopAndTranscribe()).thenAnswer((_) => stopCompleter.future);
+    when(() => voiceTranscriptionService.cancelRecording()).thenAnswer((_) async {});
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    final holdCenter = tester.getCenter(find.text("Hold to talk"));
+    final gesture = await tester.startGesture(holdCenter);
+    await tester.pump(const Duration(milliseconds: 250));
+    await gesture.moveTo(tester.getCenter(find.byType(VoiceCancelButton)));
+    await gesture.moveTo(holdCenter);
+    await gesture.up();
+    await tester.pump();
+
+    await tester.tap(find.byTooltip("Cancel transcription"));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(feedback, [
+      "HapticFeedbackType.lightImpact",
+      "HapticFeedbackType.selectionClick",
+      "HapticFeedbackType.lightImpact",
+      "HapticFeedbackType.selectionClick",
+    ]);
+
+    stopCompleter.complete("");
+    await tester.pump();
+  });
+
   testWidgets("a very short tap starts recording immediately but never transcribes", (tester) async {
+    final feedback = _captureHapticFeedback(throwsPlatformException: false);
     when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
     when(() => voiceTranscriptionService.amplitudeStream).thenAnswer((_) => const Stream<double>.empty());
     when(() => voiceTranscriptionService.cancelRecording()).thenAnswer((_) async {});
@@ -920,6 +977,7 @@ void main() {
 
     verify(() => voiceTranscriptionService.cancelRecording()).called(1);
     verifyNever(() => voiceTranscriptionService.stopAndTranscribe());
+    expect(feedback, ["HapticFeedbackType.lightImpact"]);
   });
 
   testWidgets("a secondary pointer button does not start recording", (tester) async {


### PR DESCRIPTION
## Complexity

🌿 Straightforward. This retimes a localized haptic sequence and adds cancel-boundary feedback with focused widget coverage.

## What

- Keep the immediate light touch-down acknowledgement.
- Keep release itself silent while transcription is pending.
- Play the Vesper-style light-then-heavy success pair, 100 ms apart, only after a non-empty transcript is inserted.
- Emit one selection tick when entering the cancel target and another when leaving it.
- Add a 12 pt cancel-boundary hysteresis so finger tremor cannot produce tactile chatter.
- Cover success timing, empty/stale outcomes, reversible cancel feedback, and unavailable haptics.

## Why

The original release-time pair felt disconnected from success because release only begins transcription. Moving that reward to visible transcript insertion makes it earned and causal. Physical Pixel testing also found the single native `CONFIRM` effect too weak, while the Vesper double tap felt better at the successful outcome.

The cancel interaction also needs feedback in both directions so users know when release has returned from discard to transcribe.

## Risk and test focus

Review should focus on repeated-use comfort, the 100 ms success rhythm, and cancel-threshold stability. There is deliberately no Android-version detection or legacy fallback.

There is no transport, persisted-data, database, analytics, or visible layout impact.

## Expected result

Touch-down still feels immediate. Release is quiet while work is pending. Successful transcript insertion receives a distinct double-tap reward, while moving into and out of cancellation feels reversible and precise.

## Verification

- `dart analyze` in `client/app`
- `flutter test test/features/session_detail/widgets/session_detail_body_test.dart` in `client/app` (50 passed)
- `flutter run -d 56211FDCH00366 --debug --no-resident` on a physical Pixel 10 Pro running Android 17
- Physically tested and approved on the connected Pixel after enabling system touch haptics


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retimed hold-to-speak haptics for clearer feedback. Touch-down acknowledges immediately, release stays silent, and success haptics play only after text is inserted; the cancel boundary now ticks when entering and leaving.

- New Features
  - Play success pair (light then heavy, 100 ms apart) only on non-empty transcript insertion.
  - Emit one selection tick on cancel enter and another on exit; add 12 pt hysteresis (44 pt commit, 56 pt disengage) to prevent boundary chatter.
  - Handle empty/stale outcomes and unavailable haptics; tests updated to cover timing and cancel flow.

<sup>Written for commit 5133e5176d72574346791e9e13003ca3a6100790. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

