### PR TITLE
🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]

### DIFF
--- a/.plan/active/relay-request-concurrency/PLAN.md
+++ b/.plan/active/relay-request-concurrency/PLAN.md
@@ -6,12 +6,13 @@
 - **Status:** Active — Step 1 PR
   [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) and
   post-merge correction PR
-  [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) merged;
-  Step 2 PR [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open
+  [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) and Step 2 PR
+  [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) merged;
+  Step 3 implementation ready for review
 - **Plan date:** 2026-08-02
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Current implementation base:** `main` at
-  `0e31324a9ec3cbd08d53394d7a1c6e9e3b133b0e`
+  `fdc8ad67eafe18edb774249329f707bc6394c187`
 - **Delivery:** one plan PR, eight sequential implementation PRs, and one
   plan-retirement PR
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687)

--- a/.plan/active/relay-request-concurrency/PLAN.md
+++ b/.plan/active/relay-request-concurrency/PLAN.md
@@ -8,7 +8,7 @@
   post-merge correction PR
   [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) and Step 2 PR
   [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) merged;
-  Step 3 implementation ready for review
+  Step 3 PR [#696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) open
 - **Plan date:** 2026-08-02
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Current implementation base:** `main` at

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -3,15 +3,17 @@
 ## Current State
 
 - **Plan slug:** `relay-request-concurrency`
-- **Implementation base:** `main` at
-  `0e31324a9ec3cbd08d53394d7a1c6e9e3b133b0e`
+- **Implementation base:** merged Step 2 at
+  `fdc8ad67eafe18edb774249329f707bc6394c187`
 - **Series state:** Step 1/10 plan PR
   [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) and correction
-  [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) merged
-- **Current step:** Step 2/10 PR
-  [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open
+  [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688), plus Step 2/10
+  [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690), merged
+- **Current step:** Step 3/10 implemented and ready for review on
+  `plan-parallel-requests`; PR link pending
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged
-- **Next action:** review and merge Step 2, then start Step 3 from current `main`
+- **Next action:** commit, push, and open the Step 3 PR; Step 4 remains blocked
+  until Step 3 is delivered and merged
 
 ## Incident Evidence
 
@@ -89,8 +91,8 @@
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
 | [x] | 1/10 | `plan/relay-request-concurrency` | `🌱 [relay-request-concurrency] docs: plan concurrent bridge requests [step 1/10]` | 1,400–1,600; explicitly cap-exempt | [PR #687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged as `c4d42a15`; correction [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) merged as `0e31324a` |
-| [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | [PR #690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open at 1,552 changed lines |
-| [ ] | 3/10 | `relay-request-concurrency-route-lifecycle` | `🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]` | 600–1,000 | Blocked on Step 2 merge |
+| [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | [PR #690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) merged as `fdc8ad67` with 1,552 changed lines |
+| [ ] | 3/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]` | 600–1,000 | Implemented and verified from `fdc8ad67`; PR link pending |
 | [ ] | 4/10 | `relay-request-concurrency-relay-epochs` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | Blocked on Step 3 merge |
 | [ ] | 5/10 | `relay-request-concurrency-session-actions` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | Blocked on Step 4 merge |
 | [ ] | 6/10 | `relay-request-concurrency-session-lifecycle` | `🚧 [relay-request-concurrency] refactor(bridge): scope session family mutations [step 6/10]` | 750–1,250 | Blocked on Step 5 merge |
@@ -225,7 +227,8 @@
   debug, encrypted relay ordering/graceful-close, runtime-composition, and
   diagnostic capture tests passed. `dart analyze --fatal-infos` from `bridge/app` and
   `git diff --check` passed. Actual change size: 1,552 lines; PR
-  [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) open.
+  [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) merged as
+  `fdc8ad67eafe18edb774249329f707bc6394c187`.
 - **Step 2/10 architecture review:** `aristotle-impl-review` rejected one valid
   service-to-routing dependency. Moving `BridgeRestartDispatcher` and its test
   beside the routing outcome applied the finding directly; per policy, the fix
@@ -244,3 +247,29 @@
 - **Step 2/10 cap exception:** the owner's review-requested repo-wide logging
   rule and matching plan/code corrections raised the PR 52 lines above the soft
   cap; splitting them would leave this PR governed by contradictory diagnostics.
+- **Step 3/10 base and scope:** based directly on merged Step 2 at `fdc8ad67` on
+  the owner-provided `plan-parallel-requests` branch. The change is internal
+  bridge routing lifecycle work only: no wire, database, client, UI, analytics,
+  or plugin-interface impact, and relay request execution remains serial.
+- **Step 3/10 implementation:** one concrete `RoutedRequestDispatcher` owns the
+  sole `RequestRouter`, synchronously returns sealed accepted/shutdown-rejected
+  results, registers every accepted relay/debug route completion, fixes shutdown
+  rejection to 503, and memoizes one drain barrier. Composition constructs one
+  instance for `OrchestratorSession` and `DebugServer`; both shutdown entries
+  close acceptance and both drains await the same barrier before session route
+  collaborators are disposed. Debug full-request tracking and the current serial
+  relay lifecycle remain transport-owned.
+- **Step 3/10 cleanup:** removed direct router injection from both transports and
+  the debug-to-session mutation-drain callback. Shared route completion ownership
+  now has one lifecycle owner; domain dispatcher disposal still drains its own
+  detached backend tail through normal session teardown.
+- **Step 3/10 verification:** 63 focused dispatcher, router, debug HTTP/SSE and
+  cross-transport shutdown, runtime composition, orchestrator shutdown/restart,
+  registration, and shutdown-coordinator tests pass. The integration gate overlaps
+  one encrypted relay route with one debug route, observes a post-stop debug 503,
+  and proves both drains wait for the same route barrier. Strict
+  `dart analyze --fatal-infos` from `bridge/app` and `git diff --check` pass.
+- **Step 3/10 architecture review:** `aristotle-impl-review` approved all tracked
+  and untracked Step 3 changes from `fdc8ad67` with no blocking findings.
+- **Step 3/10 local delivery:** actual change size is 681 lines before recording
+  the PR link; the owner-provided branch/worktree are reused as required.

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -9,11 +9,10 @@
   [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) and correction
   [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688), plus Step 2/10
   [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690), merged
-- **Current step:** Step 3/10 implemented and ready for review on
-  `plan-parallel-requests`; PR link pending
+- **Current step:** Step 3/10 PR
+  [#696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) open
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged
-- **Next action:** commit, push, and open the Step 3 PR; Step 4 remains blocked
-  until Step 3 is delivered and merged
+- **Next action:** review and merge Step 3; Step 4 remains blocked until then
 
 ## Incident Evidence
 
@@ -92,7 +91,7 @@
 |---|---|---|---|---:|---|
 | [x] | 1/10 | `plan/relay-request-concurrency` | `🌱 [relay-request-concurrency] docs: plan concurrent bridge requests [step 1/10]` | 1,400–1,600; explicitly cap-exempt | [PR #687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged as `c4d42a15`; correction [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) merged as `0e31324a` |
 | [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | [PR #690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) merged as `fdc8ad67` with 1,552 changed lines |
-| [ ] | 3/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]` | 600–1,000 | Implemented and verified from `fdc8ad67`; PR link pending |
+| [ ] | 3/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]` | 600–1,000 | [PR #696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) open from `fdc8ad67` |
 | [ ] | 4/10 | `relay-request-concurrency-relay-epochs` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | Blocked on Step 3 merge |
 | [ ] | 5/10 | `relay-request-concurrency-session-actions` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | Blocked on Step 4 merge |
 | [ ] | 6/10 | `relay-request-concurrency-session-lifecycle` | `🚧 [relay-request-concurrency] refactor(bridge): scope session family mutations [step 6/10]` | 750–1,250 | Blocked on Step 5 merge |
@@ -271,5 +270,5 @@
   `dart analyze --fatal-infos` from `bridge/app` and `git diff --check` pass.
 - **Step 3/10 architecture review:** `aristotle-impl-review` approved all tracked
   and untracked Step 3 changes from `fdc8ad67` with no blocking findings.
-- **Step 3/10 local delivery:** actual change size is 681 lines before recording
-  the PR link; the owner-provided branch/worktree are reused as required.
+- **Step 3/10 delivery:** [PR #696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696)
+  is open at 680 changed lines; the owner-provided branch/worktree are reused.

--- a/bridge/app/lib/src/bridge/debug_server.dart
+++ b/bridge/app/lib/src/bridge/debug_server.dart
@@ -7,15 +7,14 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Conso
 import "package:sesori_shared/sesori_shared.dart";
 
 import "routing/bridge_restart_dispatcher.dart";
-import "routing/request_router.dart";
 import "routing/routed_request.dart";
+import "routing/routed_request_dispatcher.dart";
 
 class DebugServer {
   final Stream<SesoriSseEvent> _localWireEvents;
-  final RequestRouter _router;
+  final RoutedRequestDispatcher _routedRequestDispatcher;
   final FailureReporter _failureReporter;
   final BridgeRestartDispatcher _restartDispatcher;
-  final Future<void> Function() _drainRoutedMutations;
   final int port;
   final List<HttpResponse> _sseClients = [];
   // ignore: cancel_subscriptions - cancelled by the failure-isolated drain.
@@ -33,19 +32,17 @@ class DebugServer {
 
   DebugServer({
     required Stream<SesoriSseEvent> localWireEvents,
-    required RequestRouter router,
+    required RoutedRequestDispatcher routedRequestDispatcher,
     required this.port,
     required FailureReporter failureReporter,
     required BridgeRestartDispatcher restartDispatcher,
-    required Future<void> Function() drainRoutedMutations,
   }) : _localWireEvents = localWireEvents,
-       _router = router,
+       _routedRequestDispatcher = routedRequestDispatcher,
        _failureReporter = failureReporter,
-       _restartDispatcher = restartDispatcher,
-       _drainRoutedMutations = drainRoutedMutations;
+       _restartDispatcher = restartDispatcher;
 
   int? get boundPort => _server?.port;
-  RequestRouter get router => _router;
+  RoutedRequestDispatcher get routedRequestDispatcher => _routedRequestDispatcher;
 
   Future<void> start() async {
     if (_server != null) {
@@ -71,13 +68,17 @@ class DebugServer {
   }
 
   void beginShutdown() {
+    _routedRequestDispatcher.beginShutdown();
     if (!_shutdownSignal.isCompleted) _shutdownSignal.complete();
     final server = _server;
     _server = null;
     _serverClose ??= server?.close() ?? Future<void>.value();
   }
 
-  Future<void> drain() => _drainFuture ??= _drain();
+  Future<void> drain() {
+    beginShutdown();
+    return _drainFuture ??= _drain();
+  }
 
   Future<void> stop() {
     beginShutdown();
@@ -110,7 +111,7 @@ class DebugServer {
         await _serverClose;
       }),
     ]);
-    await attempt(_drainRoutedMutations);
+    await attempt(_routedRequestDispatcher.drain);
     if (firstError != null) {
       Error.throwWithStackTrace(firstError!, firstStackTrace!);
     }
@@ -127,6 +128,7 @@ class DebugServer {
 
   Future<void> _handleHTTP(HttpRequest request) async {
     RoutedRequestOutcome? completedOutcome;
+    RelayResponse? rejectedResponse;
     Future<RoutedRequestOutcome>? routeToDrain;
     try {
       final rawBody = await utf8.decoder.bind(request).join();
@@ -147,17 +149,24 @@ class DebugServer {
               )
               as RelayRequest;
 
-      final pendingRoute = _router.route(request: relayRequest);
-      final route = pendingRoute.completion;
-      final outcome = await Future.any<RoutedRequestOutcome?>([
-        route,
-        _shutdownSignal.future.then<RoutedRequestOutcome?>((_) => null),
-      ]);
-      if (outcome == null) {
-        routeToDrain = route;
-      } else {
-        completedOutcome = outcome;
-        final message = outcome.response;
+      final dispatch = _routedRequestDispatcher.dispatch(request: relayRequest);
+      switch (dispatch) {
+        case final RoutedRequestShutdownRejected rejected:
+          rejectedResponse = rejected.response;
+        case final RoutedRequestAccepted accepted:
+          final route = accepted.pendingRequest.completion;
+          final outcome = await Future.any<RoutedRequestOutcome?>([
+            route,
+            _shutdownSignal.future.then<RoutedRequestOutcome?>((_) => null),
+          ]);
+          if (outcome == null) {
+            routeToDrain = route;
+          } else {
+            completedOutcome = outcome;
+          }
+      }
+      final message = completedOutcome?.response ?? rejectedResponse;
+      if (message != null) {
         request.response.statusCode = message.status;
         // Skip hop-by-hop and length headers — dart:io sets them
         // automatically based on the actual response body written.

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -116,6 +116,7 @@ import "routing/reply_to_question_handler.dart";
 import "routing/request_router.dart";
 import "routing/restart_bridge_handler.dart";
 import "routing/routed_request.dart";
+import "routing/routed_request_dispatcher.dart";
 import "routing/send_prompt_handler.dart";
 import "routing/set_base_branch_handler.dart";
 import "routing/update_session_archive_status_handler.dart";
@@ -146,6 +147,7 @@ typedef OrchestratorComposition = ({
   PluginCatalogHydrationListener catalogHydrationListener,
   DeletedSessionStorageCleanupService deletedSessionStorageCleanupService,
   BridgeRestartDispatcher restartDispatcher,
+  RoutedRequestDispatcher routedRequestDispatcher,
   SessionRepository sessionRepository,
   SessionUnseenService sessionUnseenService,
   SessionViewTracker sessionViewTracker,
@@ -546,6 +548,7 @@ class Orchestrator {
         ),
       ],
     );
+    final routedRequestDispatcher = RoutedRequestDispatcher(router: router);
 
     final session = OrchestratorSession._(
       config: config,
@@ -566,7 +569,7 @@ class Orchestrator {
       bridgeRegistrationService: _bridgeRegistrationService,
       roomKey: roomKey,
       sseManager: sseManager,
-      router: router,
+      routedRequestDispatcher: routedRequestDispatcher,
       mapper: BridgeEventMapper(failureReporter: _failureReporter),
       sessionPromptService: sessionPromptService,
       catalogImportProgress: catalogImportService.progress,
@@ -593,6 +596,7 @@ class Orchestrator {
       catalogHydrationListener: catalogHydrationListener,
       deletedSessionStorageCleanupService: deletedSessionStorageCleanupService,
       restartDispatcher: restartDispatcher,
+      routedRequestDispatcher: routedRequestDispatcher,
       sessionRepository: sessionRepository,
       sessionUnseenService: sessionUnseenService,
       sessionViewTracker: sessionViewTracker,
@@ -631,7 +635,7 @@ class OrchestratorSession {
   final PluginRuntime _pluginRuntime;
   final List<int> _roomKey;
   final SSEManager _sseManager;
-  final RequestRouter _router;
+  final RoutedRequestDispatcher _routedRequestDispatcher;
   final BridgeEventMapper _mapper;
   final PushDispatcher _pushDispatcher;
   final CompletionPushListener _completionListener;
@@ -702,7 +706,7 @@ class OrchestratorSession {
     required BridgeRegistrationService bridgeRegistrationService,
     required List<int> roomKey,
     required SSEManager sseManager,
-    required RequestRouter router,
+    required RoutedRequestDispatcher routedRequestDispatcher,
     required BridgeEventMapper mapper,
     required SessionPromptService sessionPromptService,
     required Stream<CatalogImportProgress> catalogImportProgress,
@@ -739,7 +743,7 @@ class OrchestratorSession {
        _bridgeRegistrationService = bridgeRegistrationService,
        _roomKey = roomKey,
        _sseManager = sseManager,
-       _router = router,
+       _routedRequestDispatcher = routedRequestDispatcher,
        _mapper = mapper,
        _sessionPromptService = sessionPromptService,
        _bytesSentController = bytesSentController,
@@ -801,8 +805,7 @@ class OrchestratorSession {
   /// Completes after the first phone finishes key exchange or resume and can
   /// send encrypted bridge traffic.
   Future<void> get firstPhoneConnected => _firstPhoneConnectedCompleter.future;
-  RequestRouter get router => _router;
-  Future<void> drainRoutedMutations() => _sessionMutationDispatcher.drain();
+  RoutedRequestDispatcher get routedRequestDispatcher => _routedRequestDispatcher;
 
   Future<OrchestratorSessionStartResult> start() {
     if (_lifecycleFuture != null) {
@@ -986,6 +989,7 @@ class OrchestratorSession {
   }
 
   Future<void> _teardown() async {
+    _routedRequestDispatcher.beginShutdown();
     final teardownSw = Stopwatch()..start();
     Object? firstTeardownError = _beginShutdownError;
     StackTrace? firstTeardownStackTrace = _beginShutdownStackTrace;
@@ -1014,10 +1018,13 @@ class OrchestratorSession {
       attempt(_catalogImportSubscriptions.cancel),
     ]);
     Log.v("[shutdown] subscriptions cancelled (+${teardownSw.elapsedMilliseconds}ms)");
-    await attempt(() async {
-      await Future.wait(_pluginEventProcessingTails.values);
-    });
-    Log.v("[shutdown] plugin event processing drained (+${teardownSw.elapsedMilliseconds}ms)");
+    await Future.wait([
+      attempt(() async {
+        await Future.wait(_pluginEventProcessingTails.values);
+      }),
+      attempt(_routedRequestDispatcher.drain),
+    ]);
+    Log.v("[shutdown] plugin events and routed requests drained (+${teardownSw.elapsedMilliseconds}ms)");
     await attempt(_sessionPromptService.dispose);
     await Future.wait([
       for (final listener in _pluginEventListeners) attempt(listener.dispose),
@@ -1165,6 +1172,7 @@ class OrchestratorSession {
   }
 
   void beginShutdown() {
+    _routedRequestDispatcher.beginShutdown();
     if (_cancelRequestedAt == null) {
       _cancelRequestedAt = DateTime.now();
       Log.d(
@@ -1811,7 +1819,18 @@ class OrchestratorSession {
 
     switch (msg) {
       case final RelayRequest req:
-        final pendingRoute = _router.route(request: req);
+        final dispatch = _routedRequestDispatcher.dispatch(request: req);
+        if (dispatch case final RoutedRequestShutdownRejected rejected) {
+          if (!_cancelled) {
+            try {
+              await _encryptAndSend(connID: connID, message: rejected.response);
+            } on Object catch (error, stackTrace) {
+              Log.w("failed to send shutdown rejection to connId $connID", error, stackTrace);
+            }
+          }
+          return;
+        }
+        final pendingRoute = (dispatch as RoutedRequestAccepted).pendingRequest;
         final routeIdentity = pendingRoute.routeIdentity;
         Log.v("RelayRequest: ${req.method} ${req.path}");
         _inFlightRouteIdentity = routeIdentity;

--- a/bridge/app/lib/src/bridge/routing/routed_request_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/routing/routed_request_dispatcher.dart
@@ -1,0 +1,69 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+import "request_router.dart";
+import "routed_request.dart";
+
+sealed class RoutedRequestDispatchResult {
+  const RoutedRequestDispatchResult();
+}
+
+final class RoutedRequestAccepted extends RoutedRequestDispatchResult {
+  final PendingRoutedRequest pendingRequest;
+
+  const RoutedRequestAccepted({required this.pendingRequest});
+}
+
+final class RoutedRequestShutdownRejected extends RoutedRequestDispatchResult {
+  final String requestId;
+
+  const RoutedRequestShutdownRejected({required this.requestId});
+
+  RelayResponse get response => RelayResponse(
+    id: requestId,
+    status: 503,
+    headers: const {},
+    body: "bridge is shutting down",
+  );
+}
+
+/// Owns route acceptance and the completion barrier shared by every transport.
+class RoutedRequestDispatcher {
+  final RequestRouter _router;
+  final Set<Future<RoutedRequestOutcome>> _inFlightRoutes = <Future<RoutedRequestOutcome>>{};
+
+  bool _accepting = true;
+  Future<void>? _drainFuture;
+
+  RoutedRequestDispatcher({required RequestRouter router}) : _router = router;
+
+  RoutedRequestDispatchResult dispatch({required RelayRequest request}) {
+    if (!_accepting) {
+      return RoutedRequestShutdownRejected(requestId: request.id);
+    }
+
+    final pendingRequest = _router.route(request: request);
+    late final Future<RoutedRequestOutcome> trackedCompletion;
+    trackedCompletion = pendingRequest.completion.whenComplete(() {
+      _inFlightRoutes.remove(trackedCompletion);
+    });
+    _inFlightRoutes.add(trackedCompletion);
+
+    return RoutedRequestAccepted(
+      pendingRequest: PendingRoutedRequest(
+        routeIdentity: pendingRequest.routeIdentity,
+        completion: trackedCompletion,
+      ),
+    );
+  }
+
+  void beginShutdown() {
+    _accepting = false;
+  }
+
+  Future<void> drain() => _drainFuture ??= _drain();
+
+  Future<void> _drain() async {
+    beginShutdown();
+    await Future.wait(_inFlightRoutes.toList(growable: false));
+  }
+}

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
@@ -12,6 +12,7 @@ import "../bandwidth_tracker.dart";
 import "../debug_server.dart";
 import "../orchestrator.dart";
 import "../routing/bridge_restart_dispatcher.dart";
+import "../routing/routed_request_dispatcher.dart";
 import "bridge_shutdown_coordinator.dart";
 
 class BridgeRuntime {
@@ -22,11 +23,13 @@ class BridgeRuntime {
   }) : _database = database,
        _failureReporter = failureReporter,
        _restartDispatcher = composition.restartDispatcher,
+       _routedRequestDispatcher = composition.routedRequestDispatcher,
        _composition = composition;
 
   final AppDatabase _database;
   final FailureReporter _failureReporter;
   final BridgeRestartDispatcher _restartDispatcher;
+  final RoutedRequestDispatcher _routedRequestDispatcher;
   final OrchestratorComposition _composition;
   Future<void>? _closeFuture;
 
@@ -45,11 +48,10 @@ class BridgeRuntime {
   DebugServer createDebugServer({required int port}) {
     return DebugServer(
       localWireEvents: session.localWireEvents,
-      router: session.router,
+      routedRequestDispatcher: _routedRequestDispatcher,
       port: port,
       failureReporter: _failureReporter,
       restartDispatcher: _restartDispatcher,
-      drainRoutedMutations: session.drainRoutedMutations,
     );
   }
 

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -2,6 +2,7 @@ import "dart:async";
 import "dart:convert";
 import "dart:io";
 
+import "package:cryptography/cryptography.dart";
 import "package:http/http.dart" as http;
 import "package:path/path.dart" as p;
 import "package:sesori_bridge/src/api/database/database.dart";
@@ -16,6 +17,7 @@ import "package:sesori_bridge/src/bridge/routing/bridge_restart_dispatcher.dart"
 import "package:sesori_bridge/src/bridge/routing/request_router.dart";
 import "package:sesori_bridge/src/bridge/routing/restart_bridge_handler.dart";
 import "package:sesori_bridge/src/bridge/routing/routed_request.dart";
+import "package:sesori_bridge/src/bridge/routing/routed_request_dispatcher.dart";
 import "package:sesori_bridge/src/bridge/runtime/bridge_runtime.dart";
 import "package:sesori_bridge/src/bridge/runtime/bridge_shutdown_coordinator.dart";
 import "package:sesori_bridge/src/repositories/bridge_settings.dart";
@@ -81,7 +83,7 @@ Future<_DebugServerHarness> _createDebugServerHarness({
   );
   final running = await startTestOrchestratorSession(session: composition.session);
   final runFuture = running.stopped;
-  await relayServer.nextClient();
+  final bridgeSocket = await relayServer.nextClient();
   await activateTestPlugin(service: lifecycleService, pluginId: plugin.id);
   if (plugin case final _SubscriptionAwarePlugin subscriptionAware) {
     await subscriptionAware.eventsSubscribed.timeout(const Duration(seconds: 2));
@@ -93,6 +95,7 @@ Future<_DebugServerHarness> _createDebugServerHarness({
     httpClient: httpClient,
     lifecycleService: lifecycleService,
     relayServer: relayServer,
+    bridgeSocket: bridgeSocket,
     runFuture: runFuture,
   );
 }
@@ -489,6 +492,99 @@ void main() {
   });
 
   group("DebugServer shutdown", () {
+    test("session and debug drains share one relay and debug route barrier", () async {
+      final db = createTestDatabase();
+      final plugin = _BlockingRoutesPlugin();
+      await db.projectsDao.insertProjectsIfMissing(projectIds: ["/tmp/test"]);
+      await db.sessionDao.insertSession(
+        pluginId: plugin.id,
+        sessionId: "s1",
+        backendSessionId: "backend-s1",
+        projectId: "/tmp/test",
+        isDedicated: false,
+        createdAt: 1,
+        worktreePath: null,
+        branchName: null,
+        baseBranch: null,
+        baseCommit: null,
+        lastAgent: null,
+        lastAgentModel: null,
+      );
+      final harness = await _createDebugServerHarness(
+        plugin: plugin,
+        db: db,
+        port: 0,
+        failureReporter: FakeFailureReporter(),
+      );
+      addTearDown(plugin.close);
+      addTearDown(harness.close);
+      addTearDown(() {
+        plugin
+          ..releaseAbort()
+          ..releaseMessages();
+      });
+      final debugServer = harness.debugServer;
+      await debugServer.start();
+      final phone = await _activatePhone(harness: harness, connId: 7);
+
+      await _sendEncryptedRelayMessage(
+        socket: harness.bridgeSocket,
+        connId: 7,
+        encryptor: phone.encryptor,
+        message: RelayMessage.request(
+          id: "relay-route",
+          method: "POST",
+          path: "/session/messages",
+          headers: const {"content-type": "application/json"},
+          body: jsonEncode(const SessionIdRequest(sessionId: "s1").toJson()),
+        ),
+      );
+      await plugin.messagesStarted.timeout(const Duration(seconds: 2));
+
+      final client = HttpClient();
+      addTearDown(client.close);
+      final abortRequest = await client.postUrl(
+        Uri.parse("http://127.0.0.1:${debugServer.boundPort!}/session/abort"),
+      );
+      abortRequest.headers.contentType = ContentType.json;
+      abortRequest.write(jsonEncode(const SessionIdRequest(sessionId: "s1").toJson()));
+      final abortResponseFuture = abortRequest.close();
+      await plugin.abortStarted.timeout(const Duration(seconds: 2));
+
+      var sessionStopped = false;
+      unawaited(harness.runFuture.whenComplete(() => sessionStopped = true));
+      await harness.runtime.session.cancel();
+
+      final rejectedRequest = await client.getUrl(
+        Uri.parse("http://127.0.0.1:${debugServer.boundPort!}/global/health"),
+      );
+      final rejectedResponse = await rejectedRequest.close();
+      expect(rejectedResponse.statusCode, HttpStatus.serviceUnavailable);
+      expect(await utf8.decoder.bind(rejectedResponse).join(), "bridge is shutting down");
+      await Future<void>.delayed(Duration.zero);
+      expect(sessionStopped, isFalse);
+
+      plugin.releaseAbort();
+      final abortResponse = await abortResponseFuture.timeout(const Duration(seconds: 2));
+      await utf8.decoder.bind(abortResponse).join().timeout(const Duration(seconds: 2));
+      expect(abortResponse.statusCode, HttpStatus.ok);
+
+      debugServer.beginShutdown();
+      var debugDrained = false;
+      final debugDrain = debugServer.drain().whenComplete(() => debugDrained = true);
+      await Future<void>.delayed(Duration.zero);
+      expect(sessionStopped, isFalse);
+      expect(debugDrained, isFalse);
+
+      plugin.releaseMessages();
+      await Future.wait([
+        harness.runFuture.timeout(const Duration(seconds: 2)),
+        debugDrain.timeout(const Duration(seconds: 2)),
+      ]);
+      expect(sessionStopped, isTrue);
+      expect(debugDrained, isTrue);
+    });
+
     test("drains and persists a routed mutation before disposing its plugin API", () async {
       final db = createTestDatabase();
       String? persistedTitleAtDispose;
@@ -529,7 +625,15 @@ void main() {
             )
             ..addPhase(
               phase: BridgeShutdownPhase.signal,
+              action: harness.runtime.session.beginShutdown,
+            )
+            ..addPhase(
+              phase: BridgeShutdownPhase.signal,
               action: debugServer.beginShutdown,
+            )
+            ..addPhase(
+              phase: BridgeShutdownPhase.drain,
+              action: () => harness.runFuture,
             )
             ..addPhase(
               phase: BridgeShutdownPhase.drain,
@@ -574,13 +678,14 @@ void main() {
       final dispatcher = _BlockingRestartDispatcher();
       final debugServer = DebugServer(
         localWireEvents: const Stream<SesoriSseEvent>.empty(),
-        router: RequestRouter(
-          handlers: [RestartBridgeHandler(restartService: _AlwaysRestartableService())],
+        routedRequestDispatcher: RoutedRequestDispatcher(
+          router: RequestRouter(
+            handlers: [RestartBridgeHandler(restartService: _AlwaysRestartableService())],
+          ),
         ),
         port: 0,
         failureReporter: FakeFailureReporter(),
         restartDispatcher: dispatcher,
-        drainRoutedMutations: () async {},
       );
       await debugServer.start();
       addTearDown(() async {
@@ -695,17 +800,19 @@ void main() {
       final client = HttpClient();
       addTearDown(client.close);
 
-      Future<void> restart() async {
+      Future<int> restart() async {
         final request = await client.postUrl(
           Uri.parse("http://127.0.0.1:${debugServer.boundPort!}/global/restart"),
         );
         final response = await request.close();
-        expect(response.statusCode, HttpStatus.ok);
         await utf8.decoder.bind(response).join();
+        return response.statusCode;
       }
 
-      await Future.wait([restart(), restart()]);
+      final statuses = await Future.wait([restart(), restart()]);
 
+      expect(statuses, contains(HttpStatus.ok));
+      expect(statuses, everyElement(anyOf(HttpStatus.ok, HttpStatus.serviceUnavailable)));
       expect(processRunner.startDetachedCount, equals(1));
     });
 
@@ -747,6 +854,66 @@ void main() {
       expect(processRunner.startDetachedCount, equals(0));
     });
   });
+}
+
+Future<({StreamIterator<dynamic> messages, SessionEncryptor encryptor})> _activatePhone({
+  required _DebugServerHarness harness,
+  required int connId,
+}) async {
+  final messages = StreamIterator<dynamic>(harness.bridgeSocket);
+  expect(await messages.moveNext(), isTrue);
+  expect(jsonDecodeMap(messages.current as String)["type"], "auth");
+
+  final crypto = RelayCryptoService();
+  final phoneKeyPair = await crypto.generateKeyPair();
+  final phonePublicKey = await phoneKeyPair.extractPublicKey();
+  harness.bridgeSocket.add(<int>[
+    0,
+    connId,
+    ...utf8.encode(
+      jsonEncode(
+        RelayMessage.keyExchange(
+          publicKey: base64Url.encode(phonePublicKey.bytes).replaceAll("=", ""),
+        ).toJson(),
+      ),
+    ),
+  ]);
+
+  expect(await messages.moveNext(), isTrue);
+  final readyFrame = messages.current as List<int>;
+  expect(readyFrame.sublist(0, 2), [0, connId]);
+  final ready = await _decryptReady(
+    response: readyFrame.sublist(2),
+    phoneKeyPair: phoneKeyPair,
+  );
+  final roomKey = SecretKey(base64Url.decode(base64Url.normalize(ready.roomKey)));
+  await harness.runtime.session.firstPhoneConnected.timeout(const Duration(seconds: 2));
+  return (messages: messages, encryptor: crypto.createSessionEncryptor(roomKey));
+}
+
+Future<RelayReady> _decryptReady({
+  required List<int> response,
+  required SimpleKeyPair phoneKeyPair,
+}) async {
+  final crypto = RelayCryptoService();
+  final bridgePublicKey = SimplePublicKey(response.sublist(0, 32), type: KeyPairType.x25519);
+  final secret = await crypto.deriveSharedSecret(phoneKeyPair, peerPublicKey: bridgePublicKey);
+  final encryptor = crypto.createSessionEncryptor(await crypto.deriveEncryptionKey(secret));
+  final decrypted = await unframe(response.sublist(32), encryptor: encryptor);
+  return RelayMessage.fromJson(jsonDecodeMap(utf8.decode(decrypted))) as RelayReady;
+}
+
+Future<void> _sendEncryptedRelayMessage({
+  required WebSocket socket,
+  required int connId,
+  required SessionEncryptor encryptor,
+  required RelayMessage message,
+}) async {
+  final payload = await frame(
+    utf8.encode(jsonEncode(message.toJson())),
+    encryptor: encryptor,
+  );
+  socket.add(<int>[0, connId, ...payload]);
 }
 
 class _BlockingRestartDispatcher implements BridgeRestartDispatcher {
@@ -850,6 +1017,7 @@ class _DebugServerHarness {
   final http.Client httpClient;
   final PluginLifecycleService lifecycleService;
   final TestRelayServer relayServer;
+  final WebSocket bridgeSocket;
   final Future<void> runFuture;
 
   const _DebugServerHarness({
@@ -858,6 +1026,7 @@ class _DebugServerHarness {
     required this.httpClient,
     required this.lifecycleService,
     required this.relayServer,
+    required this.bridgeSocket,
     required this.runFuture,
   });
 
@@ -1095,6 +1264,37 @@ class _BlockingMutationPlugin extends _FakeBridgePlugin {
   Future<void> dispose() async {
     disposeCalls++;
     await onDispose();
+  }
+}
+
+class _BlockingRoutesPlugin extends _FakeBridgePlugin {
+  final Completer<void> _messagesStarted = Completer<void>();
+  final Completer<void> _messagesRelease = Completer<void>();
+  final Completer<void> _abortStarted = Completer<void>();
+  final Completer<void> _abortRelease = Completer<void>();
+
+  Future<void> get messagesStarted => _messagesStarted.future;
+  Future<void> get abortStarted => _abortStarted.future;
+
+  void releaseMessages() {
+    if (!_messagesRelease.isCompleted) _messagesRelease.complete();
+  }
+
+  void releaseAbort() {
+    if (!_abortRelease.isCompleted) _abortRelease.complete();
+  }
+
+  @override
+  Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId) async {
+    _messagesStarted.complete();
+    await _messagesRelease.future;
+    return [];
+  }
+
+  @override
+  Future<void> abortSession({required String sessionId}) async {
+    _abortStarted.complete();
+    await _abortRelease.future;
   }
 }
 

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -8,6 +8,7 @@ import "package:sesori_bridge/src/auth/token_refresher.dart";
 import "package:sesori_bridge/src/bridge/models/bridge_config.dart";
 import "package:sesori_bridge/src/bridge/orchestrator.dart";
 import "package:sesori_bridge/src/bridge/relay_client.dart";
+import "package:sesori_bridge/src/bridge/routing/routed_request_dispatcher.dart";
 import "package:sesori_bridge/src/bridge/runtime/bridge_runtime.dart";
 import "package:sesori_bridge/src/bridge/runtime/plugin_runtime.dart" as runtime show PluginRuntimeState;
 import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
@@ -27,8 +28,10 @@ void main() {
     final harness = await _OrchestratorHarness.create(pluginIds: const ["one", "two"]);
     addTearDown(harness.close);
 
-    final response =
-        (await harness.composition.session.router.route(request: makeRequest("GET", "/plugin")).completion).response;
+    final response = await _dispatch(
+      dispatcher: harness.composition.routedRequestDispatcher,
+      request: makeRequest("GET", "/plugin"),
+    );
     final plugins = PluginListResponse.fromJson(jsonDecodeMap(response.body!)).plugins;
 
     expect(response.status, 200);
@@ -57,19 +60,16 @@ void main() {
     final harness = await _OrchestratorHarness.create(pluginIds: const ["one"]);
     addTearDown(harness.close);
 
-    final response =
-        (await harness.composition.session.router
-                .route(
-                  request: makeRequest(
-                    "PATCH",
-                    "/plugin/idle-timeout",
-                    body: jsonEncode(
-                      const PluginIdleTimeoutUpdateRequest.setOverride(pluginId: "one", idleTimeoutMins: 25).toJson(),
-                    ),
-                  ),
-                )
-                .completion)
-            .response;
+    final response = await _dispatch(
+      dispatcher: harness.composition.routedRequestDispatcher,
+      request: makeRequest(
+        "PATCH",
+        "/plugin/idle-timeout",
+        body: jsonEncode(
+          const PluginIdleTimeoutUpdateRequest.setOverride(pluginId: "one", idleTimeoutMins: 25).toJson(),
+        ),
+      ),
+    );
     final management = PluginManagementResponse.fromJson(jsonDecodeMap(response.body!));
 
     expect(response.status, 200);
@@ -81,17 +81,14 @@ void main() {
     final harness = await _OrchestratorHarness.create(pluginIds: const ["one"]);
     addTearDown(harness.close);
 
-    final response =
-        (await harness.composition.session.router
-                .route(
-                  request: makeRequest(
-                    "POST",
-                    "/plugin/missing/command",
-                    body: jsonEncode(const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe).toJson()),
-                  ),
-                )
-                .completion)
-            .response;
+    final response = await _dispatch(
+      dispatcher: harness.composition.routedRequestDispatcher,
+      request: makeRequest(
+        "POST",
+        "/plugin/missing/command",
+        body: jsonEncode(const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe).toJson()),
+      ),
+    );
 
     expect(response.status, 404);
     expect(response.body, "plugin not found");
@@ -491,6 +488,17 @@ void main() {
     }
     await runFuture.timeout(const Duration(seconds: 5));
   });
+}
+
+Future<RelayResponse> _dispatch({
+  required RoutedRequestDispatcher dispatcher,
+  required RelayRequest request,
+}) async {
+  final result = dispatcher.dispatch(request: request);
+  if (result case final RoutedRequestAccepted accepted) {
+    return (await accepted.pendingRequest.completion).response;
+  }
+  throw StateError("route was rejected during test setup");
 }
 
 void _configureBlockingProjectSummary({

--- a/bridge/app/test/bridge/routing/routed_request_dispatcher_test.dart
+++ b/bridge/app/test/bridge/routing/routed_request_dispatcher_test.dart
@@ -1,0 +1,151 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/bridge/routing/request_handler.dart";
+import "package:sesori_bridge/src/bridge/routing/request_router.dart";
+import "package:sesori_bridge/src/bridge/routing/routed_request_dispatcher.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("RoutedRequestDispatcher", () {
+    test("closes acceptance synchronously and drains every accepted route once", () async {
+      final firstGate = Completer<void>();
+      final secondGate = Completer<void>();
+      final firstStarted = Completer<void>();
+      final secondStarted = Completer<void>();
+      final dispatcher = RoutedRequestDispatcher(
+        router: RequestRouter(
+          handlers: [
+            _GatedHandler(path: "/first", started: firstStarted, gate: firstGate),
+            _GatedHandler(path: "/second", started: secondStarted, gate: secondGate),
+          ],
+        ),
+      );
+
+      final first = dispatcher.dispatch(
+        request: _request(id: "first", path: "/first"),
+      );
+      final second = dispatcher.dispatch(
+        request: _request(id: "second", path: "/second"),
+      );
+
+      expect(first, isA<RoutedRequestAccepted>());
+      expect(second, isA<RoutedRequestAccepted>());
+      expect(firstStarted.isCompleted, isTrue);
+      expect(secondStarted.isCompleted, isTrue);
+
+      dispatcher
+        ..beginShutdown()
+        ..beginShutdown();
+      final rejected = dispatcher.dispatch(
+        request: _request(id: "rejected", path: "/first"),
+      );
+      expect(rejected, isA<RoutedRequestShutdownRejected>());
+      expect(
+        (rejected as RoutedRequestShutdownRejected).response,
+        isA<RelayResponse>()
+            .having((response) => response.id, "id", "rejected")
+            .having((response) => response.status, "status", 503),
+      );
+
+      final firstDrain = dispatcher.drain();
+      final secondDrain = dispatcher.drain();
+      expect(identical(firstDrain, secondDrain), isTrue);
+      var drained = false;
+      unawaited(firstDrain.whenComplete(() => drained = true));
+
+      secondGate.complete();
+      await Future<void>.delayed(Duration.zero);
+      expect(drained, isFalse);
+
+      firstGate.complete();
+      await firstDrain;
+      expect(drained, isTrue);
+      expect(
+        (await (first as RoutedRequestAccepted).pendingRequest.completion).response.status,
+        200,
+      );
+      expect(
+        (await (second as RoutedRequestAccepted).pendingRequest.completion).response.status,
+        200,
+      );
+    });
+
+    test("mapped route failure settles the shared drain", () async {
+      final dispatcher = RoutedRequestDispatcher(
+        router: RequestRouter(
+          handlers: [
+            _FailingHandler(),
+          ],
+        ),
+      );
+
+      final dispatch = dispatcher.dispatch(
+        request: _request(id: "failure", path: "/failure"),
+      );
+      expect(dispatch, isA<RoutedRequestAccepted>());
+
+      final drain = dispatcher.drain();
+      final response = (await (dispatch as RoutedRequestAccepted).pendingRequest.completion).response;
+
+      expect(response.status, 502);
+      expect(response.body, contains("route failed"));
+      await drain;
+    });
+  });
+}
+
+class _GatedHandler extends RequestHandlerBase {
+  final Completer<void> _started;
+  final Completer<void> _gate;
+
+  _GatedHandler({
+    required String path,
+    required Completer<void> started,
+    required Completer<void> gate,
+  }) : _started = started,
+       _gate = gate,
+       super(HttpMethod.get, path);
+
+  @override
+  Future<RelayResponse> handleInternal(
+    RelayRequest request, {
+    required Map<String, String> pathParams,
+    required Map<String, String> queryParams,
+    required String? fragment,
+  }) async {
+    _started.complete();
+    await _gate.future;
+    return RelayResponse(
+      id: request.id,
+      status: 200,
+      headers: const {},
+      body: "ok",
+    );
+  }
+}
+
+class _FailingHandler extends RequestHandlerBase {
+  _FailingHandler() : super(HttpMethod.get, "/failure");
+
+  @override
+  Future<RelayResponse> handleInternal(
+    RelayRequest request, {
+    required Map<String, String> pathParams,
+    required Map<String, String> queryParams,
+    required String? fragment,
+  }) async {
+    throw StateError("route failed");
+  }
+}
+
+RelayRequest _request({required String id, required String path}) {
+  return RelayMessage.request(
+        id: id,
+        method: "GET",
+        path: path,
+        headers: const {},
+        body: null,
+      )
+      as RelayRequest;
+}

--- a/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
@@ -7,6 +7,7 @@ import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
 import "package:sesori_bridge/src/bridge/models/bridge_config.dart";
 import "package:sesori_bridge/src/bridge/orchestrator.dart";
 import "package:sesori_bridge/src/bridge/relay_client.dart";
+import "package:sesori_bridge/src/bridge/routing/routed_request_dispatcher.dart";
 import "package:sesori_bridge/src/bridge/runtime/bridge_runtime.dart";
 import "package:sesori_bridge/src/push/completion_notifier.dart";
 import "package:sesori_bridge/src/push/completion_push_listener.dart";
@@ -44,7 +45,7 @@ void main() {
     });
   });
 
-  test("runtime-created debug server reuses the session router", () async {
+  test("runtime-created debug server reuses the composed routed request dispatcher", () async {
     final plugin = FakeBridgePlugin();
     final database = createTestDatabase();
     final httpClient = http.Client();
@@ -86,18 +87,16 @@ void main() {
     );
     final debugServer = runtime.createDebugServer(port: 0);
 
-    expect(identical(debugServer.router, runtime.session.router), isTrue);
-    final routed =
-        (await debugServer.router
-                .route(
-                  request: makeRequest(
-                    "POST",
-                    "/session/options",
-                    body: jsonEncode(PluginProjectIdRequest(projectId: "missing", pluginId: plugin.id).toJson()),
-                  ),
-                )
-                .completion)
-            .response;
+    expect(identical(debugServer.routedRequestDispatcher, runtime.session.routedRequestDispatcher), isTrue);
+    final dispatch = debugServer.routedRequestDispatcher.dispatch(
+      request: makeRequest(
+        "POST",
+        "/session/options",
+        body: jsonEncode(PluginProjectIdRequest(projectId: "missing", pluginId: plugin.id).toJson()),
+      ),
+    );
+    expect(dispatch, isA<RoutedRequestAccepted>());
+    final routed = (await (dispatch as RoutedRequestAccepted).pendingRequest.completion).response;
     expect(routed.status, 404);
     expect(routed.headers, containsPair("content-type", "application/json"));
     expect(
@@ -105,7 +104,13 @@ void main() {
       SessionOptionsErrorCode.projectNotFound,
     );
 
-    await debugServer.stop();
+    debugServer.beginShutdown();
+    final rejected = runtime.session.routedRequestDispatcher.dispatch(
+      request: makeRequest("GET", "/global/health"),
+    );
+    expect(rejected, isA<RoutedRequestShutdownRejected>());
+    expect((rejected as RoutedRequestShutdownRejected).response.status, 503);
+    await debugServer.drain();
     await runtime.close();
     await lifecycleService.dispose();
     httpClient.close();


### PR DESCRIPTION
## Complexity

Complex: this introduces one cross-transport lifecycle owner whose acceptance and drain barrier must protect shared routing collaborators across relay, debug HTTP, session teardown, and runtime composition.

## What

- Add a concrete `RoutedRequestDispatcher` around the sole `RequestRouter`.
- Register every accepted relay/debug route completion synchronously.
- Stop route acceptance idempotently during shutdown and return a typed 503 rejection afterward.
- Make session and debug drains await the same memoized route barrier.
- Keep debug HTTP lifecycle tracking and serial relay response handling with their transport owners.
- Remove direct router injection and the debug-to-session mutation-drain callback.

## Why

Relay and debug routes share repositories and services that session teardown currently owns. A debug request can still be routing while session teardown disposes those collaborators. The shared barrier closes that ownership gap before relay request completion becomes concurrent in later steps.

## Risk and test focus

Risk is high around accepting work after a drain snapshot, missing a transport's route, deadlocking repeated drains, returning the wrong shutdown response, or disposing route collaborators before debug and relay work settles. Tests cover synchronous acceptance closure, repeated begin/drain calls, mapped route failure, overlapping encrypted relay and debug routes, post-stop debug 503 behavior, release in either order, runtime identity wiring, and teardown ordering.

## Expected result

- **User-visible:** No ordinary behavior change. A request racing after shutdown begins receives 503 rather than entering shared routing work.
- **Persisted/database:** None.
- **Internal:** One dispatcher owns route acceptance and completion lifetime for both transports. Relay request execution remains serial.

## Verification

- 63 focused dispatcher, router, debug, relay, runtime, and shutdown tests passed.
- `dart analyze --fatal-infos` from `bridge/app` passed.
- `git diff --check` passed.
- `aristotle-impl-review` approved the Step 3 changes with no blocking findings.
- 680 changed lines, below the 1,500-line soft cap.
