### PR TITLE
🌿 fix(client): preserve PR status across session events

### DIFF
--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -292,6 +292,7 @@ class SessionListCubit extends Cubit<SessionListState> {
 
     _allSessions = _sessionListService.applySessionUpdatedEvent(
       sessions: _allSessions,
+      existingSession: _allSessions[index],
       session: session,
     );
     logt("[SessionList] session.updated updated id=${session.id}");

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -290,7 +290,10 @@ class SessionListCubit extends Cubit<SessionListState> {
       return;
     }
 
-    _allSessions = _sessionListService.upsertSession(sessions: _allSessions, session: session);
+    _allSessions = _sessionListService.applySessionUpdatedEvent(
+      sessions: _allSessions,
+      session: session,
+    );
     logt("[SessionList] session.updated updated id=${session.id}");
     _emitFiltered();
   }

--- a/client/module_core/lib/src/services/session_list_service.dart
+++ b/client/module_core/lib/src/services/session_list_service.dart
@@ -64,27 +64,21 @@ class SessionListService {
   /// identity-gated PR fields as authoritative absence.
   ///
   /// Project-scoped `sessions.updated` events trigger a REST refresh that owns
-  /// replacing or clearing PR metadata. Ordinary session updates may omit that
-  /// metadata, so they retain the last identity-gated snapshot instead.
+  /// replacing or clearing PR metadata. Ordinary session updates may omit
+  /// either field, so each omitted value retains its last identity-gated
+  /// snapshot instead.
   List<Session> applySessionUpdatedEvent({
     required Iterable<Session> sessions,
+    required Session existingSession,
     required Session session,
   }) {
-    final currentSessions = sessions.toList();
-    Session? existing;
-    for (final candidate in currentSessions) {
-      if (candidate.id == session.id) {
-        existing = candidate;
-        break;
-      }
-    }
-    final merged = existing == null || session.pullRequest != null
-        ? session
-        : session.copyWith(
-            pullRequest: existing.pullRequest,
-            pullRequestHistory: existing.pullRequestHistory,
-          );
-    return upsertSession(sessions: currentSessions, session: merged);
+    final merged = session.copyWith(
+      pullRequest: session.pullRequest ?? existingSession.pullRequest,
+      pullRequestHistory: session.pullRequestHistory.isEmpty
+          ? existingSession.pullRequestHistory
+          : session.pullRequestHistory,
+    );
+    return upsertSession(sessions: sessions, session: merged);
   }
 
   List<Session> removeSession({required Iterable<Session> sessions, required String sessionId}) {

--- a/client/module_core/lib/src/services/session_list_service.dart
+++ b/client/module_core/lib/src/services/session_list_service.dart
@@ -60,6 +60,33 @@ class SessionListService {
     ]);
   }
 
+  /// Applies a `session.updated` catalog projection without treating its
+  /// identity-gated PR fields as authoritative absence.
+  ///
+  /// Project-scoped `sessions.updated` events trigger a REST refresh that owns
+  /// replacing or clearing PR metadata. Ordinary session updates may omit that
+  /// metadata, so they retain the last identity-gated snapshot instead.
+  List<Session> applySessionUpdatedEvent({
+    required Iterable<Session> sessions,
+    required Session session,
+  }) {
+    final currentSessions = sessions.toList();
+    Session? existing;
+    for (final candidate in currentSessions) {
+      if (candidate.id == session.id) {
+        existing = candidate;
+        break;
+      }
+    }
+    final merged = existing == null || session.pullRequest != null
+        ? session
+        : session.copyWith(
+            pullRequest: existing.pullRequest,
+            pullRequestHistory: existing.pullRequestHistory,
+          );
+    return upsertSession(sessions: currentSessions, session: merged);
+  }
+
   List<Session> removeSession({required Iterable<Session> sessions, required String sessionId}) {
     return _sortSessions(sessions.where((session) => session.id != sessionId));
   }

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -1243,6 +1243,60 @@ void main() {
       ],
     );
 
+    test("PR-free session.updated preserves REST PR data until sessions.updated refreshes it", () async {
+      const mergedPullRequest = PullRequestInfo(
+        number: 690,
+        url: "https://github.com/sesori-ai/sesori_apps_monorepo/pull/690",
+        title: "Merged pull request",
+        state: PrState.merged,
+        mergeableStatus: PrMergeableStatus.unknown,
+        reviewDecision: PrReviewDecision.unknown,
+        checkStatus: PrCheckStatus.success,
+      );
+      final withPullRequest = testSession(id: "s1", title: "Original").copyWith(
+        pullRequest: mergedPullRequest,
+      );
+      final withoutPullRequest = testSession(id: "s1", title: "Updated");
+      final responses = <SessionListResponse>[
+        SessionListResponse(items: [withPullRequest]),
+        SessionListResponse(items: [withoutPullRequest]),
+      ];
+      mockRouteSource = MockRouteSource(initialRoute: AppRouteDef.sessions);
+      when(
+        () => mockProjectRepository.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
+      ).thenAnswer((_) async => ApiResponse.success(responses.removeAt(0)));
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+
+      await cubit.stream.firstWhere(
+        (state) => state is SessionListLoaded && state.sessions.single.pullRequest == mergedPullRequest,
+      );
+      eventController.add(
+        SseEvent(
+          data: SesoriSseEvent.sessionUpdated(info: withoutPullRequest),
+        ),
+      );
+      final afterSessionUpdate =
+          await cubit.stream.firstWhere(
+                (state) => state is SessionListLoaded && state.sessions.single.title == "Updated",
+              )
+              as SessionListLoaded;
+      expect(afterSessionUpdate.sessions.single.pullRequest, mergedPullRequest);
+
+      eventController.add(
+        SseEvent(data: const SesoriSessionsUpdated(projectID: projectId)),
+      );
+      final afterAuthoritativeRefresh =
+          await cubit.stream.firstWhere(
+                (state) => state is SessionListLoaded && state.sessions.single.pullRequest == null,
+              )
+              as SessionListLoaded;
+      expect(afterAuthoritativeRefresh.sessions.single.pullRequest, isNull);
+    });
+
     blocTest<SessionListCubit, SessionListState>(
       "SSE session.updated timestamp reorders sessions",
       build: () {

--- a/client/module_core/test/services/session_list_service_test.dart
+++ b/client/module_core/test/services/session_list_service_test.dart
@@ -35,6 +35,46 @@ void main() {
       ["running-a", "running-z", "waiting-a", "inactive-b"],
     );
   });
+
+  test("session updates preserve REST PR history when the event omits it", () {
+    final service = SessionListService(
+      repository: _MockProjectRepository(),
+      activityCalculator: const SessionActivityCalculator(),
+    );
+    const existingHistory = PullRequestInfo(
+      number: 690,
+      url: "https://github.com/sesori-ai/sesori_apps_monorepo/pull/690",
+      title: "Merged pull request",
+      state: PrState.merged,
+      mergeableStatus: PrMergeableStatus.unknown,
+      reviewDecision: PrReviewDecision.unknown,
+      checkStatus: PrCheckStatus.success,
+    );
+    const incomingPullRequest = PullRequestInfo(
+      number: 698,
+      url: "https://github.com/sesori-ai/sesori_apps_monorepo/pull/698",
+      title: "Open pull request",
+      state: PrState.open,
+      mergeableStatus: PrMergeableStatus.mergeable,
+      reviewDecision: PrReviewDecision.unknown,
+      checkStatus: PrCheckStatus.pending,
+    );
+    final existing = _session(id: "session", title: "Original", updatedAt: 1).copyWith(
+      pullRequestHistory: const [existingHistory],
+    );
+    final incoming = _session(id: "session", title: "Updated", updatedAt: 2).copyWith(
+      pullRequest: incomingPullRequest,
+    );
+
+    final result = service.applySessionUpdatedEvent(
+      sessions: [existing],
+      existingSession: existing,
+      session: incoming,
+    );
+
+    expect(result.single.pullRequest, incomingPullRequest);
+    expect(result.single.pullRequestHistory, const [existingHistory]);
+  });
 }
 
 Session _session({required String id, required String title, required int updatedAt}) {


### PR DESCRIPTION
## Complexity

Straightforward — this is a localized client-side merge rule with one regression test and no contract or persistence changes.

## What

- Preserve the last identity-gated pull-request snapshot when an ordinary `session.updated` SSE payload omits PR metadata.
- Keep project-scoped `sessions.updated` REST refreshes authoritative for replacing or clearing PR metadata.
- Add a regression test covering both preservation during a live update and later authoritative removal.

## Why

Prompt activity emits a catalog-derived `session.updated` payload that does not contain identity-gated GitHub data. Replacing the whole REST-derived session with that payload made a valid merged/open PR indicator disappear until the next refresh.

## Risk and test focus

Risk is low and localized to session-list event merging. The highest-value checks are that ordinary session updates still apply fields such as title and ordering, omitted PR metadata remains visible, and an authoritative REST refresh can still clear stale PR data.

## Expected result

PR status remains visible across prompt and other live session updates, while `sessions.updated` refreshes can still replace or remove it. There is no database or wire-contract change.

## Verification

- `dart test test/cubits/session_list/session_list_cubit_test.dart test/services/session_list_service_test.dart`
- `dart analyze --fatal-infos` (`client/module_core`)
- `dart analyze --fatal-infos` (`client/app`)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PR status disappearing after live updates. We now keep the last PR snapshot (metadata and history) on `session.updated` events and only change it on project-scoped `sessions.updated` refreshes.

- **Bug Fixes**
  - Preserve PR metadata and `pullRequestHistory` when `session.updated` omits them; only `sessions.updated` refresh can replace or clear.
  - Route updates through `SessionListService.applySessionUpdatedEvent` in the cubit; add tests for preservation and later authoritative removal.

<sup>Written for commit 9ad629f93c8bd8be8997aa676efd3149e5a3b841. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

