### PR TITLE
⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]

### DIFF
--- a/.plan/active/relay-request-concurrency/PLAN.md
+++ b/.plan/active/relay-request-concurrency/PLAN.md
@@ -9,7 +9,7 @@
   [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) and Step 2 PR
   [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) and Step 3 PR
   [#696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) merged;
-  Step 4 implementation ready for review
+  Step 4 PR [#699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) open
 - **Plan date:** 2026-08-02
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Current implementation base:** `main` at

--- a/.plan/active/relay-request-concurrency/PLAN.md
+++ b/.plan/active/relay-request-concurrency/PLAN.md
@@ -7,12 +7,13 @@
   [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) and
   post-merge correction PR
   [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) and Step 2 PR
-  [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) merged;
-  Step 3 PR [#696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) open
+  [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) and Step 3 PR
+  [#696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) merged;
+  Step 4 implementation ready for review
 - **Plan date:** 2026-08-02
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Current implementation base:** `main` at
-  `fdc8ad67eafe18edb774249329f707bc6394c187`
+  `95178462b794cb485523a62740b80e8f0206d977`
 - **Delivery:** one plan PR, eight sequential implementation PRs, and one
   plan-retirement PR
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687)

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -292,5 +292,8 @@
   one-implementation `RelayConnection` interface under A5. Replacing it with a
   final privately constructed opaque handle applied the valid finding directly;
   per policy, the correction was not re-reviewed.
+- **Step 4/10 PR review:** two Qodo bot findings were valid. Auth setup now reaches
+  a terminal disconnected state without first emitting connected, with regression
+  coverage, and new private connection helpers use required named parameters.
 - **Step 4/10 delivery:** [PR #699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699)
-  is open at 951 changed lines; the owner-provided branch/worktree are reused.
+  is open at 984 changed lines; the owner-provided branch/worktree are reused.

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -311,5 +311,8 @@
   callbacks detach only their exact subscription owner, and ordinary routed
   responses also count bytes only after a successful send. All 30 focused
   registration/routing/SSE tests and strict app analysis pass after these fixes.
+  Owner review also replaced the startup handle's `late` declaration with
+  single-assignment `final` and removed the shutdown future's bang assertion in
+  favor of explicit null checking plus promotion.
 - **Step 4/10 delivery:** [PR #699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699)
-  is open at 1,318 changed lines; the owner-provided branch/worktree are reused.
+  is open at 1,326 changed lines; the owner-provided branch/worktree are reused.

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -306,5 +306,10 @@
   feedback identified two consequences of stale retries: the stale callback now
   detaches its subscriber immediately so a burst cannot consume the poison-event
   budget, and bandwidth accounting occurs only after a successful relay send.
+  Follow-up Kody/Cubic/Codex feedback then closed the remaining exact-ownership
+  gaps: initial-connect cancellation closes its promoted handle, stale SSE
+  callbacks detach only their exact subscription owner, and ordinary routed
+  responses also count bytes only after a successful send. All 30 focused
+  registration/routing/SSE tests and strict app analysis pass after these fixes.
 - **Step 4/10 delivery:** [PR #699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699)
-  is open at 1,154 changed lines; the owner-provided branch/worktree are reused.
+  is open at 1,318 changed lines; the owner-provided branch/worktree are reused.

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -294,6 +294,8 @@
   per policy, the correction was not re-reviewed.
 - **Step 4/10 PR review:** two Qodo bot findings were valid. Auth setup now reaches
   a terminal disconnected state without first emitting connected, with regression
-  coverage, and new private connection helpers use required named parameters.
+  coverage, and new private connection helpers use required named parameters. A
+  valid Cubic finding added a post-registration cancellation gate so shutdown
+  cannot start a successor connection, with a blocked-registration regression test.
 - **Step 4/10 delivery:** [PR #699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699)
-  is open at 984 changed lines; the owner-provided branch/worktree are reused.
+  is open at 1,019 changed lines; the owner-provided branch/worktree are reused.

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -302,6 +302,9 @@
   can stop the close-to-connect transition; and stale SSE sends remain queued for
   replay, including listener turnover while delivery is in flight. Follow-up
   verification passes 50 focused app tests, all 42 shared `EventQueue` tests,
-  strict app/shared analysis, and `git diff --check`.
+  strict app/shared analysis, and `git diff --check`. Subsequent Cubic/Codex
+  feedback identified two consequences of stale retries: the stale callback now
+  detaches its subscriber immediately so a burst cannot consume the poison-event
+  budget, and bandwidth accounting occurs only after a successful relay send.
 - **Step 4/10 delivery:** [PR #699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699)
-  is open at 1,135 changed lines; the owner-provided branch/worktree are reused.
+  is open at 1,154 changed lines; the owner-provided branch/worktree are reused.

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -297,5 +297,11 @@
   coverage, and new private connection helpers use required named parameters. A
   valid Cubic finding added a post-registration cancellation gate so shutdown
   cannot start a successor connection, with a blocked-registration regression test.
+  Three Codex bot findings were also valid: observed socket closure now detaches
+  its epoch immediately; reconnect separates close from connect so cancellation
+  can stop the close-to-connect transition; and stale SSE sends remain queued for
+  replay, including listener turnover while delivery is in flight. Follow-up
+  verification passes 50 focused app tests, all 42 shared `EventQueue` tests,
+  strict app/shared analysis, and `git diff --check`.
 - **Step 4/10 delivery:** [PR #699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699)
-  is open at 1,019 changed lines; the owner-provided branch/worktree are reused.
+  is open at 1,135 changed lines; the owner-provided branch/worktree are reused.

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -3,16 +3,16 @@
 ## Current State
 
 - **Plan slug:** `relay-request-concurrency`
-- **Implementation base:** merged Step 2 at
-  `fdc8ad67eafe18edb774249329f707bc6394c187`
-- **Series state:** Step 1/10 plan PR
-  [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) and correction
-  [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688), plus Step 2/10
-  [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690), merged
-- **Current step:** Step 3/10 PR
-  [#696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) open
+- **Implementation base:** merged Step 3 at
+  `95178462b794cb485523a62740b80e8f0206d977`
+- **Series state:** Steps 1–3 merged; Step 3/10
+  [#696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) merged as
+  `95178462`
+- **Current step:** Step 4/10 implemented and ready for review on
+  `plan-parallel-requests`; PR link pending
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged
-- **Next action:** review and merge Step 3; Step 4 remains blocked until then
+- **Next action:** commit, push, and open the Step 4 PR; Step 5 remains blocked
+  until Step 4 merges
 
 ## Incident Evidence
 
@@ -91,8 +91,8 @@
 |---|---|---|---|---:|---|
 | [x] | 1/10 | `plan/relay-request-concurrency` | `🌱 [relay-request-concurrency] docs: plan concurrent bridge requests [step 1/10]` | 1,400–1,600; explicitly cap-exempt | [PR #687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged as `c4d42a15`; correction [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) merged as `0e31324a` |
 | [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | [PR #690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) merged as `fdc8ad67` with 1,552 changed lines |
-| [ ] | 3/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]` | 600–1,000 | [PR #696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) open from `fdc8ad67` |
-| [ ] | 4/10 | `relay-request-concurrency-relay-epochs` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | Blocked on Step 3 merge |
+| [x] | 3/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]` | 600–1,000 | [PR #696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) merged as `95178462` |
+| [ ] | 4/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | Implemented and verified from `95178462`; PR link pending |
 | [ ] | 5/10 | `relay-request-concurrency-session-actions` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | Blocked on Step 4 merge |
 | [ ] | 6/10 | `relay-request-concurrency-session-lifecycle` | `🚧 [relay-request-concurrency] refactor(bridge): scope session family mutations [step 6/10]` | 750–1,250 | Blocked on Step 5 merge |
 | [ ] | 7/10 | `relay-request-concurrency-session-visibility` | `🚧 [relay-request-concurrency] refactor(bridge): gate new session visibility [step 7/10]` | 600–1,100 | Blocked on Step 6 merge |
@@ -271,4 +271,27 @@
 - **Step 3/10 architecture review:** `aristotle-impl-review` approved all tracked
   and untracked Step 3 changes from `fdc8ad67` with no blocking findings.
 - **Step 3/10 delivery:** [PR #696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696)
-  is open at 680 changed lines; the owner-provided branch/worktree are reused.
+  merged as `95178462b794cb485523a62740b80e8f0206d977` at 680 changed lines.
+- **Step 4/10 base and scope:** based directly on merged Step 3 at `95178462` on
+  the owner-provided clean `plan-parallel-requests` branch. Relay routing remains
+  serial; there is no wire, database, client, UI, analytics, or plugin-interface impact.
+- **Step 4/10 implementation:** successful connect/reconnect returns one final,
+  opaque `RelayConnection` for the exact WebSocket. Reads, auth/close metadata,
+  synchronous sent/stale writes, and closed/stale closes require that handle;
+  current close claims it before awaiting, and stale operations cannot touch a successor.
+  `OrchestratorSession` carries the handle through reconnect, re-auth, response,
+  SSE, and shutdown paths, and closes a successor returned after cancellation.
+- **Step 4/10 cleanup:** removed mutable-current channel reads/sends/metadata/close,
+  the mutable global authed-token value, and all parameterless relay close paths.
+  Tests and benchmarks use genuine returned handles rather than a test-only seam.
+- **Step 4/10 verification:** 80 focused RelayClient, SSE, orchestrator,
+  registration/reconnect, revoke/takeover, token re-auth, event-drain, and shutdown
+  tests pass. Strict `dart analyze --fatal-infos`, `git diff --check`, and minimal
+  event-projection/catalog-soak benchmark runs pass; the catalog smoke passed alone
+  after an initial parallel macOS SQLite native-asset codesign collision.
+- **Step 4/10 architecture review:** `aristotle-impl-review` rejected the initial
+  one-implementation `RelayConnection` interface under A5. Replacing it with a
+  final privately constructed opaque handle applied the valid finding directly;
+  per policy, the correction was not re-reviewed.
+- **Step 4/10 local delivery:** exact change size is 952 lines before recording
+  the PR link; the owner-provided branch/worktree are reused as required.

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -8,11 +8,10 @@
 - **Series state:** Steps 1–3 merged; Step 3/10
   [#696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) merged as
   `95178462`
-- **Current step:** Step 4/10 implemented and ready for review on
-  `plan-parallel-requests`; PR link pending
+- **Current step:** Step 4/10 PR
+  [#699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) open
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged
-- **Next action:** commit, push, and open the Step 4 PR; Step 5 remains blocked
-  until Step 4 merges
+- **Next action:** review and merge Step 4; Step 5 remains blocked until then
 
 ## Incident Evidence
 
@@ -92,7 +91,7 @@
 | [x] | 1/10 | `plan/relay-request-concurrency` | `🌱 [relay-request-concurrency] docs: plan concurrent bridge requests [step 1/10]` | 1,400–1,600; explicitly cap-exempt | [PR #687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged as `c4d42a15`; correction [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) merged as `0e31324a` |
 | [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | [PR #690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) merged as `fdc8ad67` with 1,552 changed lines |
 | [x] | 3/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]` | 600–1,000 | [PR #696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) merged as `95178462` |
-| [ ] | 4/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | Implemented and verified from `95178462`; PR link pending |
+| [ ] | 4/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | [PR #699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) open from `95178462` |
 | [ ] | 5/10 | `relay-request-concurrency-session-actions` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | Blocked on Step 4 merge |
 | [ ] | 6/10 | `relay-request-concurrency-session-lifecycle` | `🚧 [relay-request-concurrency] refactor(bridge): scope session family mutations [step 6/10]` | 750–1,250 | Blocked on Step 5 merge |
 | [ ] | 7/10 | `relay-request-concurrency-session-visibility` | `🚧 [relay-request-concurrency] refactor(bridge): gate new session visibility [step 7/10]` | 600–1,100 | Blocked on Step 6 merge |
@@ -293,5 +292,5 @@
   one-implementation `RelayConnection` interface under A5. Replacing it with a
   final privately constructed opaque handle applied the valid finding directly;
   per policy, the correction was not re-reviewed.
-- **Step 4/10 local delivery:** exact change size is 952 lines before recording
-  the PR link; the owner-provided branch/worktree are reused as required.
+- **Step 4/10 delivery:** [PR #699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699)
+  is open at 951 changed lines; the owner-provided branch/worktree are reused.

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -1168,6 +1168,9 @@ class OrchestratorSession {
 
         try {
           await _bridgeRegistrationService.ensureRegistered();
+          if (_cancelled) {
+            return;
+          }
           final reconnectFuture = _client.reconnect(connection: connection);
           if (identical(_relayConnection, connection)) {
             _relayConnection = null;

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -890,7 +890,14 @@ class OrchestratorSession {
       relayConnection = await _client.connect();
       _relayConnection = relayConnection;
       Log.d("relay connected");
-      if (_cancelled) return;
+      if (_cancelled) {
+        final closeFuture = _client.closeIfCurrent(connection: relayConnection);
+        if (identical(_relayConnection, relayConnection)) {
+          _relayConnection = null;
+        }
+        await closeFuture;
+        return;
+      }
 
       _sessionAbortService.abortStartedSessions
           .listen(_completionListener.markSessionAbortPending)
@@ -2065,16 +2072,19 @@ class OrchestratorSession {
     final respJson = jsonEncode(message.toJson());
     final jsonBytes = utf8.encode(respJson);
     Log.v("[response] sending ${jsonBytes.length} bytes to connID=$connID");
-    _bytesSentController.add(jsonBytes.length);
     final cryptoService = RelayCryptoService();
     final encryptionKey = SecretKey(List<int>.from(_roomKey));
     final encryptor = cryptoService.createSessionEncryptor(encryptionKey);
     final framed = await frame(jsonBytes, encryptor: encryptor);
-    return _sendIfCurrent(
+    final outcome = _sendIfCurrent(
       connection: connection,
       connID: connID,
       payload: framed,
     );
+    if (outcome == RelaySendOutcome.sent) {
+      _bytesSentController.add(jsonBytes.length);
+    }
+    return outcome;
   }
 
   RelaySendOutcome _sendIfCurrent({

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -669,6 +669,8 @@ class OrchestratorSession {
   Future<void> _projectsSummaryTail = Future<void>.value();
   final Random _backoffJitter = Random();
   Future<void>? _lifecycleFuture;
+  RelayConnection? _relayConnection;
+  Future<void>? _shutdownRelayCloseFuture;
 
   bool _cancelled = false;
   Object? _beginShutdownError;
@@ -882,9 +884,11 @@ class OrchestratorSession {
     Log.d("bridge registered");
     if (_cancelled) return;
 
+    late RelayConnection relayConnection;
     try {
       Log.d("connecting to relay...");
-      await _client.connect();
+      relayConnection = await _client.connect();
+      _relayConnection = relayConnection;
       Log.d("relay connected");
       if (_cancelled) return;
 
@@ -983,6 +987,7 @@ class OrchestratorSession {
 
     await _serveRelayConnections(
       readiness: readiness,
+      initialConnection: relayConnection,
       kxManager: kxManager,
       activePhones: activePhones,
     );
@@ -1061,7 +1066,8 @@ class OrchestratorSession {
     ]);
     await attempt(() async {
       Log.v("closing relay client...");
-      await _client.close();
+      _shutdownRelayCloseFuture ??= _closeRelayConnection();
+      await _shutdownRelayCloseFuture!;
       Log.v("relay client closed (+${teardownSw.elapsedMilliseconds}ms)");
     });
     Log.d("[shutdown] session teardown complete (${teardownSw.elapsedMilliseconds}ms total)");
@@ -1072,11 +1078,15 @@ class OrchestratorSession {
 
   Future<void> _serveRelayConnections({
     required Completer<OrchestratorSessionStartResult> readiness,
+    required RelayConnection initialConnection,
     required KeyExchangeManager kxManager,
     required Map<int, bool> activePhones,
   }) async {
+    var connection = initialConnection;
     while (!_cancelled) {
-      final iterator = StreamIterator<RelayClientMessage>(_client.read());
+      final iterator = StreamIterator<RelayClientMessage>(
+        _client.read(connection: connection),
+      );
       final firstRead = iterator.moveNext();
       if (!readiness.isCompleted) {
         readiness.complete(OrchestratorSessionStartResult.ready);
@@ -1087,6 +1097,7 @@ class OrchestratorSession {
           await _runRelayLoop(
             iterator: iterator,
             firstRead: firstRead,
+            connection: connection,
             roomKey: _roomKey,
             kxManager: kxManager,
             activePhones: activePhones,
@@ -1116,7 +1127,7 @@ class OrchestratorSession {
       _sessionViewTracker.clearAll();
       _projectViewTracker.clearAll();
 
-      if (_client.closeCode == RelayCloseCodes.bridgeRevoked) {
+      if (_client.closeCode(connection: connection) == RelayCloseCodes.bridgeRevoked) {
         Log.w("Relay reports this bridge as revoked — re-registering with a fresh bridge id");
         await _bridgeRegistrationService.handleBridgeRevoked();
       }
@@ -1128,8 +1139,8 @@ class OrchestratorSession {
       // ControlStatusNotifier (it observes the same replaced-close on the
       // connection-state stream); this loop owns only the backoff policy.
       final takenOver = RelayCloseCodes.isBridgeReplaced(
-        closeCode: _client.closeCode,
-        closeReason: _client.closeReason,
+        closeCode: _client.closeCode(connection: connection),
+        closeReason: _client.closeReason(connection: connection),
       );
       if (takenOver) {
         Console.warning(
@@ -1157,7 +1168,17 @@ class OrchestratorSession {
 
         try {
           await _bridgeRegistrationService.ensureRegistered();
-          await _client.reconnect();
+          final reconnectFuture = _client.reconnect(connection: connection);
+          if (identical(_relayConnection, connection)) {
+            _relayConnection = null;
+          }
+          final reconnected = await reconnectFuture;
+          if (_cancelled) {
+            await _client.closeIfCurrent(connection: reconnected);
+            return;
+          }
+          connection = reconnected;
+          _relayConnection = reconnected;
         } on Object catch (error, stackTrace) {
           Log.w("Reconnect failed (retrying in $backoff)", error, stackTrace);
           backoff = _nextBackoff(backoff, takenOver: takenOver);
@@ -1186,7 +1207,8 @@ class OrchestratorSession {
     if (!_shutdownCompleter.isCompleted) {
       _shutdownCompleter.complete();
     }
-    unawaited(_client.close());
+    _shutdownRelayCloseFuture ??= _closeRelayConnection();
+    unawaited(_shutdownRelayCloseFuture);
     try {
       _permissionAutoApprovalService.dispose();
     } on Object catch (error, stackTrace) {
@@ -1198,8 +1220,21 @@ class OrchestratorSession {
   Future<void> cancel() async {
     beginShutdown();
     final sw = Stopwatch()..start();
-    await _client.close();
+    await _shutdownRelayCloseFuture!;
     Log.d("[shutdown] cancel(): relay client closed in ${sw.elapsedMilliseconds}ms");
+  }
+
+  Future<void> _closeRelayConnection() async {
+    final connection = _relayConnection;
+    if (connection == null) {
+      await _client.cancelPendingConnection();
+      return;
+    }
+    final closeFuture = _client.closeIfCurrent(connection: connection);
+    if (identical(_relayConnection, connection)) {
+      _relayConnection = null;
+    }
+    await closeFuture;
   }
 
   Future<void> _processPluginEventInOrder(NormalizedSourcedBridgeEvent source) {
@@ -1561,7 +1596,8 @@ class OrchestratorSession {
   /// only when the socket's authenticated identity no longer matches the token
   /// the provider now holds:
   ///
-  /// - the last connect sent no auth at all ([RelayClient.lastAuthedToken] is
+  /// - the last connect sent no auth at all (its connection-scoped
+  ///   [RelayClient.lastAuthedToken] is
   ///   null — also covers a push landing in the gap between connect() and this
   ///   subscription on a never-authed socket);
   /// - the `userId` claim differs (supervised account switch, standalone
@@ -1573,7 +1609,9 @@ class OrchestratorSession {
   /// force-pull re-emitting the token it just authenticated with) never
   /// re-auths.
   bool _requiresRelayReauth(String token) {
-    final String? lastAuthed = _client.lastAuthedToken;
+    final connection = _relayConnection;
+    if (connection == null) return false;
+    final String? lastAuthed = _client.lastAuthedToken(connection: connection);
     if (lastAuthed == null) return true;
     if (token == lastAuthed) return false;
     final String? newUserId = parseJwtUserId(token);
@@ -1590,18 +1628,20 @@ class OrchestratorSession {
   /// so a token emit during shutdown can't fight teardown.
   Future<void> _reauthenticateRelay() async {
     if (_cancelled) return;
+    final connection = _relayConnection;
+    if (connection == null) return;
     // If the socket has already closed (closeCode is set), the read loop is
     // about to end on its own and the reconnect block will inspect the close
-    // code. Don't call close() here: it nulls the channel and discards that code,
-    // which would mask a bridgeRevoked close and skip re-registration. Let the
-    // natural drop path handle it; the fresh token is picked up on reconnect.
-    if (_client.closeCode != null) {
+    // code. Don't deliberately detach it here, which would mask a bridgeRevoked
+    // close and skip re-registration. Let the natural drop path handle it; the
+    // fresh token is picked up on reconnect.
+    if (_client.closeCode(connection: connection) != null) {
       Log.d("Token updated while the relay was already closing — letting the drop path reconnect");
       return;
     }
     Log.i("Access token updated while connected — re-authenticating relay");
     try {
-      await _client.close();
+      await _closeRelayConnection();
     } on Object catch (error, stackTrace) {
       // Best-effort: if the close fails the read loop still ends on the broken
       // socket and the reconnect block recovers, so log and continue.
@@ -1612,6 +1652,7 @@ class OrchestratorSession {
   Future<void> _runRelayLoop({
     required StreamIterator<RelayClientMessage> iterator,
     required Future<bool> firstRead,
+    required RelayConnection connection,
     required List<int> roomKey,
     required KeyExchangeManager kxManager,
     required Map<int, bool> activePhones,
@@ -1700,7 +1741,14 @@ class OrchestratorSession {
           }
 
           try {
-            _client.send(connID, encrypted);
+            final outcome = _sendIfCurrent(
+              connection: connection,
+              connID: connID,
+              payload: encrypted,
+            );
+            if (outcome == RelaySendOutcome.stale) {
+              throw StateError("relay connection changed before key exchange completed");
+            }
             Log.d("ready sent to connID=$connID");
           } catch (e) {
             if (_cancelled) {
@@ -1737,7 +1785,11 @@ class OrchestratorSession {
               break processMessage;
             }
             Log.v("decrypted OK from connID=$connID, handling...");
-            await _handleDecryptedMessage(connID, decrypted);
+            await _handleDecryptedMessage(
+              connection: connection,
+              connID: connID,
+              decrypted: decrypted,
+            );
             Log.v("handled message from connID=$connID");
             break processMessage;
           }
@@ -1748,7 +1800,11 @@ class OrchestratorSession {
               const RelayMessage.rekeyRequired().toJson(),
             );
             try {
-              _client.send(connID, utf8.encode(rekeyRequired));
+              _sendIfCurrent(
+                connection: connection,
+                connID: connID,
+                payload: utf8.encode(rekeyRequired),
+              );
             } catch (_) {
               if (_cancelled) {
                 throw StateError("cancelled");
@@ -1781,7 +1837,14 @@ class OrchestratorSession {
           }
 
           try {
-            _client.send(connID, encryptedAck);
+            final outcome = _sendIfCurrent(
+              connection: connection,
+              connID: connID,
+              payload: encryptedAck,
+            );
+            if (outcome == RelaySendOutcome.stale) {
+              throw StateError("relay connection changed before resume completed");
+            }
           } catch (e) {
             if (_cancelled) {
               throw StateError("cancelled");
@@ -1804,7 +1867,11 @@ class OrchestratorSession {
     Log.d("phone $connID is now active");
   }
 
-  Future<void> _handleDecryptedMessage(int connID, List<int> decrypted) async {
+  Future<void> _handleDecryptedMessage({
+    required RelayConnection connection,
+    required int connID,
+    required List<int> decrypted,
+  }) async {
     RelayMessage msg;
     try {
       msg = RelayMessage.fromJson(
@@ -1823,7 +1890,11 @@ class OrchestratorSession {
         if (dispatch case final RoutedRequestShutdownRejected rejected) {
           if (!_cancelled) {
             try {
-              await _encryptAndSend(connID: connID, message: rejected.response);
+              await _encryptAndSend(
+                connection: connection,
+                connID: connID,
+                message: rejected.response,
+              );
             } on Object catch (error, stackTrace) {
               Log.w("failed to send shutdown rejection to connId $connID", error, stackTrace);
             }
@@ -1860,8 +1931,16 @@ class OrchestratorSession {
           }
           Log.v("response: status=${response.status}");
           try {
-            await _encryptAndSend(connID: connID, message: response);
-            Log.v("response sent to connID=$connID");
+            final sendOutcome = await _encryptAndSend(
+              connection: connection,
+              connID: connID,
+              message: response,
+            );
+            if (sendOutcome == RelaySendOutcome.sent) {
+              Log.v("response sent to connID=$connID");
+            } else {
+              Log.v("response dropped because its relay connection is stale");
+            }
           } finally {
             if (!_cancelled) {
               switch (outcome) {
@@ -1896,7 +1975,12 @@ class OrchestratorSession {
       case final RelaySseSubscribe subscribe:
         Log.v("SseSubscribe: path=${subscribe.path}");
         try {
-          _sseManager.subscribePath(connID, subscribe.path, _client);
+          _sseManager.subscribePath(
+            connID: connID,
+            path: subscribe.path,
+            client: _client,
+            connection: connection,
+          );
           final projSummary = await _buildProjectsSummary();
           if (projSummary != null) {
             _enqueueWireEvent(projSummary);
@@ -1965,7 +2049,8 @@ class OrchestratorSession {
     return base + Duration(milliseconds: extra);
   }
 
-  Future<void> _encryptAndSend({
+  Future<RelaySendOutcome> _encryptAndSend({
+    required RelayConnection connection,
     required int connID,
     required RelayMessage message,
   }) async {
@@ -1977,7 +2062,39 @@ class OrchestratorSession {
     final encryptionKey = SecretKey(List<int>.from(_roomKey));
     final encryptor = cryptoService.createSessionEncryptor(encryptionKey);
     final framed = await frame(jsonBytes, encryptor: encryptor);
-    _client.send(connID, framed);
+    return _sendIfCurrent(
+      connection: connection,
+      connID: connID,
+      payload: framed,
+    );
+  }
+
+  RelaySendOutcome _sendIfCurrent({
+    required RelayConnection connection,
+    required int connID,
+    required List<int> payload,
+  }) {
+    try {
+      return _client.sendIfCurrent(
+        connection: connection,
+        connID: connID,
+        payload: payload,
+      );
+    } on Object {
+      final closeFuture = _client.closeIfCurrent(connection: connection);
+      if (identical(_relayConnection, connection)) {
+        _relayConnection = null;
+      }
+      unawaited(
+        closeFuture.then<void>(
+          (_) {},
+          onError: (Object error, StackTrace stackTrace) {
+            Log.w("Failed to close relay after send failure", error, stackTrace);
+          },
+        ),
+      );
+      rethrow;
+    }
   }
 }
 

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -884,7 +884,7 @@ class OrchestratorSession {
     Log.d("bridge registered");
     if (_cancelled) return;
 
-    late RelayConnection relayConnection;
+    final RelayConnection relayConnection;
     try {
       Log.d("connecting to relay...");
       relayConnection = await _client.connect();
@@ -1235,7 +1235,11 @@ class OrchestratorSession {
   Future<void> cancel() async {
     beginShutdown();
     final sw = Stopwatch()..start();
-    await _shutdownRelayCloseFuture!;
+    final shutdownRelayCloseFuture = _shutdownRelayCloseFuture;
+    if (shutdownRelayCloseFuture == null) {
+      throw StateError("Relay shutdown was not started");
+    }
+    await shutdownRelayCloseFuture;
     Log.d("[shutdown] cancel(): relay client closed in ${sw.elapsedMilliseconds}ms");
   }
 

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -1171,10 +1171,15 @@ class OrchestratorSession {
           if (_cancelled) {
             return;
           }
-          final reconnectFuture = _client.reconnect(connection: connection);
+          final closeFuture = _client.closeIfCurrent(connection: connection);
           if (identical(_relayConnection, connection)) {
             _relayConnection = null;
           }
+          await closeFuture;
+          if (_cancelled) {
+            return;
+          }
+          final reconnectFuture = _client.connect();
           final reconnected = await reconnectFuture;
           if (_cancelled) {
             await _client.closeIfCurrent(connection: reconnected);

--- a/bridge/app/lib/src/bridge/relay_client.dart
+++ b/bridge/app/lib/src/bridge/relay_client.dart
@@ -207,6 +207,7 @@ class RelayClient {
 
   void _handleConnectionDone({required RelayConnection connection}) {
     if (!identical(_connection, connection)) return;
+    _connection = null;
     _connectionState.add(
       RelayDisconnected(
         closeCode: connection._channel.closeCode,

--- a/bridge/app/lib/src/bridge/relay_client.dart
+++ b/bridge/app/lib/src/bridge/relay_client.dart
@@ -19,13 +19,28 @@ class RelayClientMessage {
   const RelayClientMessage({required this.isText, required this.data});
 }
 
+/// Opaque handle for one exact relay WebSocket generation.
+///
+/// Callers can retain and pass the handle back to [RelayClient], but cannot
+/// inspect the underlying socket.
+final class RelayConnection {
+  RelayConnection._({required IOWebSocketChannel channel}) : _channel = channel;
+
+  final IOWebSocketChannel _channel;
+  String? _lastAuthedToken;
+}
+
+enum RelaySendOutcome { sent, stale }
+
+enum RelayCloseOutcome { closed, stale }
+
 /// Live connection state of the relay WebSocket, emitted on
 /// [RelayClient.connectionState].
 ///
 /// This is internal lifecycle state, NOT a wire-protocol type. A remote drop
 /// carries the WebSocket [RelayDisconnected.closeCode] so observers can key on
 /// close semantics (e.g. revoked/replaced) without racing the reconnect loop's
-/// own [RelayClient.closeCode] read.
+/// own connection-scoped close-code read.
 sealed class RelayConnectionState {
   const RelayConnectionState();
 }
@@ -63,8 +78,7 @@ class RelayClient {
   final Duration _connectTimeout;
   final StreamController<RelayConnectionState> _connectionState = StreamController<RelayConnectionState>.broadcast();
   _RelayConnectionAttempt? _pendingConnection;
-  IOWebSocketChannel? _channel;
-  String? _lastAuthedToken;
+  RelayConnection? _connection;
 
   RelayClient({
     required String relayURL,
@@ -78,29 +92,28 @@ class RelayClient {
        _pingInterval = pingInterval,
        _connectTimeout = connectTimeout;
 
-  /// The WebSocket close code of the current connection, available once the
-  /// connection has closed and until [close] or [reconnect] discards it.
-  int? get closeCode => _channel?.closeCode;
+  /// The WebSocket close code of [connection], available once it has closed.
+  int? closeCode({required RelayConnection connection}) => connection._channel.closeCode;
 
-  /// The WebSocket close reason of the current connection, paired with
+  /// The WebSocket close reason of [connection], paired with
   /// [closeCode]. Only meaningful for the bridge-replaced rollout fallback
   /// (`1000 + "replaced"`); close reason strings are fragile, so close-code
   /// semantics are authoritative everywhere else.
-  String? get closeReason => _channel?.closeReason;
+  String? closeReason({required RelayConnection connection}) => connection._channel.closeReason;
 
-  /// The access token most recently sent in an auth message by [connect], or
-  /// `null` if the last connect sent no auth (empty token). Lets a live re-auth
+  /// The access token sent in [connection]'s auth message, or `null` if that
+  /// connect sent no auth (empty token). Lets a live re-auth
   /// trigger compare a freshly emitted token against the one this socket is
   /// actually authenticated with, so it re-auths only on a real change.
-  String? get lastAuthedToken => _lastAuthedToken;
+  String? lastAuthedToken({required RelayConnection connection}) => connection._lastAuthedToken;
 
   /// Live connection-state transitions of the relay socket.
   ///
   /// A connect attempt emits [RelayConnecting] then [RelayConnected] on
   /// success or [RelayDisconnected] on failure; a remote drop emits
-  /// [RelayDisconnected] with the socket's close code. A deliberate [close]
-  /// emits nothing — a clean shutdown is not an outage (same contract as the
-  /// control channel's connection-state stream).
+  /// [RelayDisconnected] with the socket's close code. A deliberate
+  /// [closeIfCurrent] emits nothing — a clean shutdown is not an outage (same
+  /// contract as the control channel's connection-state stream).
   ///
   /// Remote-drop detection rides on the socket's close handshake, which
   /// `dart:io` only processes while the inbound message stream is being
@@ -108,12 +121,12 @@ class RelayClient {
   /// (it always drains [read] on a live connection).
   Stream<RelayConnectionState> get connectionState => _connectionState.stream;
 
-  Future<void> connect() async {
+  Future<RelayConnection> connect() async {
     // Build (and thereby validate) the URL before announcing the attempt: a
     // throwing parse must not leave observers stuck on a connecting state
     // that never resolves to a terminal one.
     final wsURL = _buildWebSocketURL(_relayURL);
-    if (_pendingConnection != null || _channel != null) {
+    if (_pendingConnection != null || _connection != null) {
       throw StateError("Relay connection already exists or is in progress");
     }
     _connectionState.add(const RelayConnecting());
@@ -129,8 +142,8 @@ class RelayClient {
     try {
       await channel.ready.timeout(_connectTimeout);
     } on Object catch (error, stackTrace) {
-      // A detached attempt belongs to deliberate close(); only a still-owned
-      // failure reports disconnected and cleans up here.
+      // A detached attempt belongs to deliberate cancellation; only a
+      // still-owned failure reports disconnected and cleans up here.
       if (identical(_pendingConnection, attempt)) {
         _pendingConnection = null;
         _connectionState.add(const RelayDisconnected(closeCode: null, closeReason: null));
@@ -150,60 +163,67 @@ class RelayClient {
     }
     _pendingConnection = null;
     httpClient.close();
-    _channel = channel;
-    _watchChannelDone(channel);
+    final connection = RelayConnection._(channel: channel);
+    _connection = connection;
+    _watchConnectionDone(connection);
     _connectionState.add(const RelayConnected());
 
-    if (_accessTokenProvider.accessToken case final String token when token.isNotEmpty) {
-      final authMessage = RelayMessage.auth(
-        token: token,
-        role: _bridgeRole,
-        bridgeId: _bridgeIdProvider.bridgeId,
-      );
-      channel.sink.add(jsonEncode(authMessage.toJson()));
-      _lastAuthedToken = token;
-    } else {
-      _lastAuthedToken = null;
+    try {
+      if (_accessTokenProvider.accessToken case final String token when token.isNotEmpty) {
+        final authMessage = RelayMessage.auth(
+          token: token,
+          role: _bridgeRole,
+          bridgeId: _bridgeIdProvider.bridgeId,
+        );
+        channel.sink.add(jsonEncode(authMessage.toJson()));
+        connection._lastAuthedToken = token;
+      } else {
+        connection._lastAuthedToken = null;
+      }
+    } on Object catch (error, stackTrace) {
+      await closeIfCurrent(connection: connection);
+      Error.throwWithStackTrace(error, stackTrace);
     }
+    return connection;
   }
 
-  /// Emits [RelayDisconnected] when [channel]'s socket closes while it is
-  /// still the current channel. A deliberate [close] (or [reconnect]) nulls
-  /// [_channel] before the sink-done future settles, so this watcher stays
-  /// silent for intentional teardown and only surfaces genuine drops.
-  void _watchChannelDone(IOWebSocketChannel channel) {
+  /// Emits [RelayDisconnected] when [connection]'s socket closes while it is
+  /// still current. A deliberate close detaches the handle before the
+  /// sink-done future settles, so this watcher stays silent for intentional
+  /// teardown and only surfaces genuine drops.
+  void _watchConnectionDone(RelayConnection connection) {
     unawaited(
-      channel.sink.done.then<void>(
-        (_) => _handleChannelDone(channel),
+      connection._channel.sink.done.then<void>(
+        (_) => _handleConnectionDone(connection),
         onError: (Object error) {
           Log.w("relay socket closed with error", error);
-          _handleChannelDone(channel);
+          _handleConnectionDone(connection);
         },
       ),
     );
   }
 
-  void _handleChannelDone(IOWebSocketChannel channel) {
-    if (!identical(_channel, channel)) return;
+  void _handleConnectionDone(RelayConnection connection) {
+    if (!identical(_connection, connection)) return;
     _connectionState.add(
-      RelayDisconnected(closeCode: channel.closeCode, closeReason: channel.closeReason),
+      RelayDisconnected(
+        closeCode: connection._channel.closeCode,
+        closeReason: connection._channel.closeReason,
+      ),
     );
   }
 
-  Future<void> reconnect() async {
+  Future<RelayConnection> reconnect({required RelayConnection connection}) async {
     try {
-      await close();
-    } catch (e) {
-      Log.d("reconnect: close failed (ignored): $e");
+      await closeIfCurrent(connection: connection);
+    } on Object catch (error, stackTrace) {
+      Log.w("reconnect: close failed; continuing with a fresh connection", error, stackTrace);
     }
-    await connect();
+    return connect();
   }
 
-  Stream<RelayClientMessage> read() {
-    final channel = _channel;
-    if (channel == null) {
-      throw StateError("WebSocket connection is not established");
-    }
+  Stream<RelayClientMessage> read({required RelayConnection connection}) {
+    final channel = connection._channel;
 
     return channel.stream.map((dynamic message) {
       if (message is String) {
@@ -234,46 +254,71 @@ class RelayClient {
     });
   }
 
-  void send(int connID, List<int> payload) {
+  RelaySendOutcome sendIfCurrent({
+    required RelayConnection connection,
+    required int connID,
+    required List<int> payload,
+  }) {
     if (connID < 0 || connID > 0xFFFF) {
       throw RangeError.range(connID, 0, 0xFFFF, "connID");
     }
 
-    final channel = _channel;
-    if (channel == null) {
-      throw StateError("WebSocket connection is not established");
-    }
+    final current = _connection;
+    if (!identical(current, connection)) return RelaySendOutcome.stale;
 
     final framed = Uint8List(2 + payload.length);
     final byteData = ByteData.sublistView(framed);
     byteData.setUint16(0, connID, Endian.big);
     framed.setRange(2, framed.length, payload);
 
-    channel.sink.add(framed);
+    try {
+      current!._channel.sink.add(framed);
+    } on Object {
+      // This call claims the exact handle before returning its close future.
+      // An obsolete send can therefore never close a successor connection.
+      unawaited(closeIfCurrent(connection: connection));
+      rethrow;
+    }
+    return RelaySendOutcome.sent;
   }
 
-  Future<void> close() async {
+  /// Closes a pending handshake that has not produced a [RelayConnection].
+  ///
+  /// Detachment is synchronous so a cancelled attempt cannot be promoted by a
+  /// later `ready` completion.
+  Future<void> cancelPendingConnection() {
     final pendingConnection = _pendingConnection;
     _pendingConnection = null;
     pendingConnection?.httpClient.close(force: true);
-    final channel = _channel;
-    _channel = null;
-    await Future.wait([
-      if (pendingConnection != null)
-        _closeChannel(
-          channel: pendingConnection.channel,
-          timeout: const Duration(seconds: 3),
-          timeoutMessage: "Pending WebSocket close timed out — connection abandoned",
-          failureMessage: "Pending WebSocket close failed — connection abandoned",
-        ),
-      if (channel != null)
-        _closeChannel(
-          channel: channel,
-          timeout: const Duration(seconds: 3),
-          timeoutMessage: "WebSocket close handshake timed out — connection abandoned",
-          failureMessage: "WebSocket close failed — connection abandoned",
-        ),
-    ]);
+    if (pendingConnection == null) return Future<void>.value();
+    return _closeChannel(
+      channel: pendingConnection.channel,
+      timeout: const Duration(seconds: 3),
+      timeoutMessage: "Pending WebSocket close timed out — connection abandoned",
+      failureMessage: "Pending WebSocket close failed — connection abandoned",
+    );
+  }
+
+  /// Claims and detaches [connection] synchronously, then closes its socket.
+  ///
+  /// A stale handle is a typed no-op and can never close the current socket.
+  Future<RelayCloseOutcome> closeIfCurrent({required RelayConnection connection}) {
+    final current = _connection;
+    if (!identical(current, connection)) {
+      return Future<RelayCloseOutcome>.value(RelayCloseOutcome.stale);
+    }
+    _connection = null;
+    return _closeClaimedConnection(current!);
+  }
+
+  Future<RelayCloseOutcome> _closeClaimedConnection(RelayConnection connection) async {
+    await _closeChannel(
+      channel: connection._channel,
+      timeout: const Duration(seconds: 3),
+      timeoutMessage: "WebSocket close handshake timed out — connection abandoned",
+      failureMessage: "WebSocket close failed — connection abandoned",
+    );
+    return RelayCloseOutcome.closed;
   }
 
   Future<void> _closeChannel({

--- a/bridge/app/lib/src/bridge/relay_client.dart
+++ b/bridge/app/lib/src/bridge/relay_client.dart
@@ -165,8 +165,6 @@ class RelayClient {
     httpClient.close();
     final connection = RelayConnection._(channel: channel);
     _connection = connection;
-    _watchConnectionDone(connection);
-    _connectionState.add(const RelayConnected());
 
     try {
       if (_accessTokenProvider.accessToken case final String token when token.isNotEmpty) {
@@ -181,9 +179,13 @@ class RelayClient {
         connection._lastAuthedToken = null;
       }
     } on Object catch (error, stackTrace) {
-      await closeIfCurrent(connection: connection);
+      final closeFuture = closeIfCurrent(connection: connection);
+      _connectionState.add(const RelayDisconnected(closeCode: null, closeReason: null));
+      await closeFuture;
       Error.throwWithStackTrace(error, stackTrace);
     }
+    _watchConnectionDone(connection: connection);
+    _connectionState.add(const RelayConnected());
     return connection;
   }
 
@@ -191,19 +193,19 @@ class RelayClient {
   /// still current. A deliberate close detaches the handle before the
   /// sink-done future settles, so this watcher stays silent for intentional
   /// teardown and only surfaces genuine drops.
-  void _watchConnectionDone(RelayConnection connection) {
+  void _watchConnectionDone({required RelayConnection connection}) {
     unawaited(
       connection._channel.sink.done.then<void>(
-        (_) => _handleConnectionDone(connection),
+        (_) => _handleConnectionDone(connection: connection),
         onError: (Object error) {
           Log.w("relay socket closed with error", error);
-          _handleConnectionDone(connection);
+          _handleConnectionDone(connection: connection);
         },
       ),
     );
   }
 
-  void _handleConnectionDone(RelayConnection connection) {
+  void _handleConnectionDone({required RelayConnection connection}) {
     if (!identical(_connection, connection)) return;
     _connectionState.add(
       RelayDisconnected(
@@ -308,10 +310,10 @@ class RelayClient {
       return Future<RelayCloseOutcome>.value(RelayCloseOutcome.stale);
     }
     _connection = null;
-    return _closeClaimedConnection(current!);
+    return _closeClaimedConnection(connection: current!);
   }
 
-  Future<RelayCloseOutcome> _closeClaimedConnection(RelayConnection connection) async {
+  Future<RelayCloseOutcome> _closeClaimedConnection({required RelayConnection connection}) async {
     await _closeChannel(
       channel: connection._channel,
       timeout: const Duration(seconds: 3),

--- a/bridge/app/lib/src/bridge/sse/sse_manager.dart
+++ b/bridge/app/lib/src/bridge/sse/sse_manager.dart
@@ -46,12 +46,21 @@ class SSEManager {
   ///
   /// [path] is accepted for API compatibility with call sites but is not used
   /// by this manager.
-  void subscribePath(int connID, String path, RelayClient client) {
+  void subscribePath({
+    required int connID,
+    required String path,
+    required RelayClient client,
+    required RelayConnection connection,
+  }) {
     final orphan = _popValidOrphan();
 
     if (orphan != null) {
       _subscriptions[connID] = orphan.listen(
-        _createSendFunction(connID, client),
+        _createSendFunction(
+          connID: connID,
+          client: client,
+          connection: connection,
+        ),
         onError: _createErrorHandler(connID),
       );
       _subscribers[connID] = orphan;
@@ -60,7 +69,11 @@ class SSEManager {
 
     final queue = EventQueue<SesoriSseEvent>(maxSize: maxQueueSize);
     _subscriptions[connID] = queue.listen(
-      _createSendFunction(connID, client),
+      _createSendFunction(
+        connID: connID,
+        client: client,
+        connection: connection,
+      ),
       onError: _createErrorHandler(connID),
     );
     _subscribers[connID] = queue;
@@ -166,10 +179,11 @@ class SSEManager {
     };
   }
 
-  Future<void> Function(SesoriSseEvent) _createSendFunction(
-    int connID,
-    RelayClient client,
-  ) {
+  Future<void> Function(SesoriSseEvent) _createSendFunction({
+    required int connID,
+    required RelayClient client,
+    required RelayConnection connection,
+  }) {
     SessionEncryptor? encryptor;
 
     return (SesoriSseEvent event) async {
@@ -192,7 +206,14 @@ class SSEManager {
       Log.v("[sse] sending ${payloadBytes.length} bytes to connID=$connID");
       _onBytesSent(payloadBytes.length);
       final framed = await frame(payloadBytes, encryptor: encryptor!);
-      client.send(connID, framed);
+      final outcome = client.sendIfCurrent(
+        connection: connection,
+        connID: connID,
+        payload: framed,
+      );
+      if (outcome == RelaySendOutcome.stale) {
+        Log.v("[sse] dropping event for connID=$connID on a stale relay connection");
+      }
     };
   }
 

--- a/bridge/app/lib/src/bridge/sse/sse_manager.dart
+++ b/bridge/app/lib/src/bridge/sse/sse_manager.dart
@@ -25,6 +25,7 @@ class SSEManager {
 
   final Map<int, EventQueue<SesoriSseEvent>> _subscribers = {};
   final Map<int, EventQueueSubscription<SesoriSseEvent>> _subscriptions = {};
+  final Map<int, Object> _subscriptionOwners = {};
   final Queue<({EventQueue<SesoriSseEvent> queue, DateTime expiry})> _orphanQueues =
       Queue<({EventQueue<SesoriSseEvent> queue, DateTime expiry})>();
 
@@ -53,30 +54,41 @@ class SSEManager {
     required RelayConnection connection,
   }) {
     final orphan = _popValidOrphan();
+    final subscriptionOwner = Object();
+    _subscriptionOwners[connID] = subscriptionOwner;
 
-    if (orphan != null) {
-      _subscriptions[connID] = orphan.listen(
+    try {
+      if (orphan != null) {
+        _subscriptions[connID] = orphan.listen(
+          _createSendFunction(
+            connID: connID,
+            client: client,
+            connection: connection,
+            subscriptionOwner: subscriptionOwner,
+          ),
+          onError: _createErrorHandler(connID),
+        );
+        _subscribers[connID] = orphan;
+        return;
+      }
+
+      final queue = EventQueue<SesoriSseEvent>(maxSize: maxQueueSize);
+      _subscriptions[connID] = queue.listen(
         _createSendFunction(
           connID: connID,
           client: client,
           connection: connection,
+          subscriptionOwner: subscriptionOwner,
         ),
         onError: _createErrorHandler(connID),
       );
-      _subscribers[connID] = orphan;
-      return;
+      _subscribers[connID] = queue;
+    } on Object {
+      if (identical(_subscriptionOwners[connID], subscriptionOwner)) {
+        _subscriptionOwners.remove(connID);
+      }
+      rethrow;
     }
-
-    final queue = EventQueue<SesoriSseEvent>(maxSize: maxQueueSize);
-    _subscriptions[connID] = queue.listen(
-      _createSendFunction(
-        connID: connID,
-        client: client,
-        connection: connection,
-      ),
-      onError: _createErrorHandler(connID),
-    );
-    _subscribers[connID] = queue;
   }
 
   /// Removes [connID] from active subscribers.
@@ -85,6 +97,7 @@ class SSEManager {
   /// [replayWindow]. If the phone reconnects within that window, the orphan
   /// is resumed via [subscribePath] and all buffered events are delivered.
   void unsubscribe(int connID) {
+    _subscriptionOwners.remove(connID);
     final queue = _subscribers.remove(connID);
     _subscriptions.remove(connID)?.cancel();
     if (queue == null) return;
@@ -112,6 +125,7 @@ class SSEManager {
       ));
     }
     _subscribers.clear();
+    _subscriptionOwners.clear();
   }
 
   /// Clears all subscribers and orphan state.
@@ -121,6 +135,7 @@ class SSEManager {
       sub.dispose();
     }
     _subscribers.clear();
+    _subscriptionOwners.clear();
     _disposeOrphans();
   }
 
@@ -187,6 +202,7 @@ class SSEManager {
     required int connID,
     required RelayClient client,
     required RelayConnection connection,
+    required Object subscriptionOwner,
   }) {
     SessionEncryptor? encryptor;
 
@@ -215,11 +231,16 @@ class SSEManager {
         payload: framed,
       );
       if (outcome == RelaySendOutcome.stale) {
-        unsubscribe(connID);
+        _unsubscribeIfOwned(connID: connID, subscriptionOwner: subscriptionOwner);
         throw const _StaleRelayConnectionException();
       }
       _onBytesSent(payloadBytes.length);
     };
+  }
+
+  void _unsubscribeIfOwned({required int connID, required Object subscriptionOwner}) {
+    if (!identical(_subscriptionOwners[connID], subscriptionOwner)) return;
+    unsubscribe(connID);
   }
 
   /// Converts a [SesoriSseEvent] to the OpenCode wire format expected by the

--- a/bridge/app/lib/src/bridge/sse/sse_manager.dart
+++ b/bridge/app/lib/src/bridge/sse/sse_manager.dart
@@ -163,6 +163,10 @@ class SSEManager {
 
   void Function(SesoriSseEvent, Object) _createErrorHandler(int connID) {
     return (event, error) {
+      if (error is _StaleRelayConnectionException) {
+        Log.v("[sse] retaining event ${event.runtimeType} for connID=$connID after relay turnover");
+        return;
+      }
       Log.w("[sse] failed to send event ${event.runtimeType} to connID=$connID: $error");
       unawaited(
         _failureReporter
@@ -212,7 +216,7 @@ class SSEManager {
         payload: framed,
       );
       if (outcome == RelaySendOutcome.stale) {
-        Log.v("[sse] dropping event for connID=$connID on a stale relay connection");
+        throw const _StaleRelayConnectionException();
       }
     };
   }
@@ -240,4 +244,8 @@ class SSEManager {
       _orphanQueues.remove(orphan);
     }
   }
+}
+
+final class _StaleRelayConnectionException implements Exception {
+  const _StaleRelayConnectionException();
 }

--- a/bridge/app/lib/src/bridge/sse/sse_manager.dart
+++ b/bridge/app/lib/src/bridge/sse/sse_manager.dart
@@ -208,7 +208,6 @@ class SSEManager {
       final relayMessage = RelayMessage.sseEvent(data: eventData);
       final payloadBytes = utf8.encode(jsonEncode(relayMessage.toJson()));
       Log.v("[sse] sending ${payloadBytes.length} bytes to connID=$connID");
-      _onBytesSent(payloadBytes.length);
       final framed = await frame(payloadBytes, encryptor: encryptor!);
       final outcome = client.sendIfCurrent(
         connection: connection,
@@ -216,8 +215,10 @@ class SSEManager {
         payload: framed,
       );
       if (outcome == RelaySendOutcome.stale) {
+        unsubscribe(connID);
         throw const _StaleRelayConnectionException();
       }
+      _onBytesSent(payloadBytes.length);
     };
   }
 

--- a/bridge/app/test/bridge/client_test.dart
+++ b/bridge/app/test/bridge/client_test.dart
@@ -14,8 +14,8 @@ void main() {
       final (server, messageStream) = await startTestRelayServer();
       addTearDown(server.close);
 
-      final client = await connectTestRelayClient(server);
-      addTearDown(client.close);
+      final (:client, :connection) = await connectTestRelayClient(server);
+      _closeAfterTest(client: client, connection: connection);
 
       const tests = [
         (connID: 0, hi: 0x00, lo: 0x00),
@@ -27,7 +27,14 @@ void main() {
       final payload = "test-payload".codeUnits;
 
       for (final tt in tests) {
-        client.send(tt.connID, payload);
+        expect(
+          client.sendIfCurrent(
+            connection: connection,
+            connID: tt.connID,
+            payload: payload,
+          ),
+          RelaySendOutcome.sent,
+        );
 
         final msg = await messageStream.first.timeout(
           const Duration(seconds: 2),
@@ -44,16 +51,25 @@ void main() {
       }
     });
 
-    test("send throws when websocket is not connected", () {
+    test("send returns stale when its connection is not current", () async {
+      final server = await TestRelayServer.start();
+      addTearDown(server.close);
       final client = RelayClient(
-        relayURL: "ws://localhost:9999",
+        relayURL: "ws://127.0.0.1:${server.port}",
         accessTokenProvider: FakeAccessTokenProvider(""),
         bridgeIdProvider: FakeBridgeIdProvider(),
       );
+      final connection = await client.connect();
+      await server.nextClient();
+      await client.closeIfCurrent(connection: connection);
 
       expect(
-        () => client.send(0, "hello".codeUnits),
-        throwsA(isA<StateError>()),
+        client.sendIfCurrent(
+          connection: connection,
+          connID: 0,
+          payload: "hello".codeUnits,
+        ),
+        RelaySendOutcome.stale,
       );
     });
   });
@@ -68,8 +84,8 @@ void main() {
         accessTokenProvider: FakeAccessTokenProvider("jwt-token"),
         bridgeIdProvider: FakeBridgeIdProvider("br_abc12345"),
       );
-      await client.connect();
-      addTearDown(client.close);
+      final connection = await client.connect();
+      _closeAfterTest(client: client, connection: connection);
 
       final serverWs = await server.nextClient();
       final authJson = await _firstTextFrame(serverWs);
@@ -94,8 +110,8 @@ void main() {
         accessTokenProvider: FakeAccessTokenProvider("jwt-token"),
         bridgeIdProvider: FakeBridgeIdProvider(),
       );
-      await client.connect();
-      addTearDown(client.close);
+      final connection = await client.connect();
+      _closeAfterTest(client: client, connection: connection);
 
       final serverWs = await server.nextClient();
       final authJson = await _firstTextFrame(serverWs);
@@ -117,18 +133,18 @@ void main() {
         accessTokenProvider: FakeAccessTokenProvider(""),
         bridgeIdProvider: FakeBridgeIdProvider(),
       );
-      await client.connect();
-      addTearDown(client.close);
+      final connection = await client.connect();
+      _closeAfterTest(client: client, connection: connection);
 
       final serverWs = await server.nextClient();
-      expect(client.closeCode, isNull);
+      expect(client.closeCode(connection: connection), isNull);
 
       final streamDone = Completer<void>();
-      client.read().listen((_) {}, onDone: streamDone.complete);
+      client.read(connection: connection).listen((_) {}, onDone: streamDone.complete);
       await serverWs.close(RelayCloseCodes.bridgeRevoked);
       await streamDone.future.timeout(const Duration(seconds: 5));
 
-      expect(client.closeCode, equals(RelayCloseCodes.bridgeRevoked));
+      expect(client.closeCode(connection: connection), equals(RelayCloseCodes.bridgeRevoked));
     });
 
     test("exposes the server's close reason (bridge-replaced rollout fallback)", () async {
@@ -140,17 +156,17 @@ void main() {
         accessTokenProvider: FakeAccessTokenProvider(""),
         bridgeIdProvider: FakeBridgeIdProvider(),
       );
-      await client.connect();
-      addTearDown(client.close);
+      final connection = await client.connect();
+      _closeAfterTest(client: client, connection: connection);
 
       final serverWs = await server.nextClient();
       final streamDone = Completer<void>();
-      client.read().listen((_) {}, onDone: streamDone.complete);
+      client.read(connection: connection).listen((_) {}, onDone: streamDone.complete);
       await serverWs.close(1000, "replaced");
       await streamDone.future.timeout(const Duration(seconds: 5));
 
-      expect(client.closeCode, equals(1000));
-      expect(client.closeReason, equals("replaced"));
+      expect(client.closeCode(connection: connection), equals(1000));
+      expect(client.closeReason(connection: connection), equals("replaced"));
     });
   });
 
@@ -167,8 +183,8 @@ void main() {
       final states = <RelayConnectionState>[];
       client.connectionState.listen(states.add);
 
-      await client.connect();
-      addTearDown(client.close);
+      final connection = await client.connect();
+      _closeAfterTest(client: client, connection: connection);
       await Future<void>.delayed(const Duration(milliseconds: 50));
 
       expect(states, hasLength(2));
@@ -187,13 +203,13 @@ void main() {
       );
       final states = <RelayConnectionState>[];
       client.connectionState.listen(states.add);
-      await client.connect();
-      addTearDown(client.close);
+      final connection = await client.connect();
+      _closeAfterTest(client: client, connection: connection);
 
       final serverWs = await server.nextClient();
       // Drop detection requires the inbound stream to be consumed, exactly
       // like the orchestrator's relay loop does on a live connection.
-      client.read().listen((_) {});
+      client.read(connection: connection).listen((_) {});
       final disconnected = client.connectionState.firstWhere((state) => state is RelayDisconnected);
       await serverWs.close(RelayCloseCodes.bridgeRevoked);
 
@@ -212,11 +228,11 @@ void main() {
       );
       final states = <RelayConnectionState>[];
       client.connectionState.listen(states.add);
-      await client.connect();
-      addTearDown(client.close);
+      final connection = await client.connect();
+      _closeAfterTest(client: client, connection: connection);
 
       final serverWs = await server.nextClient();
-      client.read().listen((_) {});
+      client.read(connection: connection).listen((_) {});
       final disconnected = client.connectionState.firstWhere((state) => state is RelayDisconnected);
       await serverWs.close(1000, "replaced");
 
@@ -236,10 +252,13 @@ void main() {
       );
       final states = <RelayConnectionState>[];
       client.connectionState.listen(states.add);
-      await client.connect();
+      final connection = await client.connect();
       await server.nextClient();
 
-      await client.close();
+      expect(
+        await client.closeIfCurrent(connection: connection),
+        RelayCloseOutcome.closed,
+      );
       // Give the sink-done watcher time to fire if it (incorrectly) would.
       await Future<void>.delayed(const Duration(milliseconds: 200));
 
@@ -277,7 +296,7 @@ void main() {
       await accepted.future.timeout(const Duration(seconds: 2));
 
       final stopwatch = Stopwatch()..start();
-      await client.close().timeout(const Duration(seconds: 5));
+      await client.cancelPendingConnection().timeout(const Duration(seconds: 5));
       stopwatch.stop();
 
       await expectLater(connectFuture, throwsA(anything));
@@ -285,7 +304,6 @@ void main() {
       expect(stopwatch.elapsed, lessThan(const Duration(seconds: 5)));
       expect(states.whereType<RelayConnected>(), isEmpty);
       expect(states.whereType<RelayDisconnected>(), isEmpty);
-      expect(() => client.send(1, const [1]), throwsA(isA<StateError>()));
     });
 
     test("failed connect emits disconnected with no close code", () async {
@@ -352,19 +370,19 @@ void main() {
       );
       final states = <RelayConnectionState>[];
       client.connectionState.listen(states.add);
-      await client.connect();
-      addTearDown(client.close);
+      var connection = await client.connect();
+      addTearDown(() => client.closeIfCurrent(connection: connection));
 
       final serverWs1 = await server.nextClient();
       // Drop detection requires the inbound stream to be consumed, exactly
       // like the orchestrator's relay loop does on a live connection.
-      client.read().listen((_) {});
+      client.read(connection: connection).listen((_) {});
       final disconnected = client.connectionState.firstWhere((state) => state is RelayDisconnected);
       await serverWs1.close();
       await disconnected.timeout(const Duration(seconds: 5));
 
       final serverWs2Future = server.nextClient();
-      await client.reconnect();
+      connection = await client.reconnect(connection: connection);
       await serverWs2Future;
       await Future<void>.delayed(const Duration(milliseconds: 50));
 
@@ -385,19 +403,21 @@ void main() {
         accessTokenProvider: FakeAccessTokenProvider(""),
         bridgeIdProvider: FakeBridgeIdProvider(),
       );
-      await client.connect();
-      addTearDown(client.close);
+      final connection = await client.connect();
+      _closeAfterTest(client: client, connection: connection);
 
       final serverWs = await server.nextClient();
 
       final messages = <RelayClientMessage>[];
       final done = Completer<void>();
 
-      client.read().listen(
-        messages.add,
-        onDone: done.complete,
-        onError: done.completeError,
-      );
+      client
+          .read(connection: connection)
+          .listen(
+            messages.add,
+            onDone: done.complete,
+            onError: done.completeError,
+          );
 
       // Send a message and verify receipt.
       serverWs.add("hello");
@@ -425,8 +445,8 @@ void main() {
         accessTokenProvider: FakeAccessTokenProvider(""),
         bridgeIdProvider: FakeBridgeIdProvider(),
       );
-      await client.connect();
-      addTearDown(client.close);
+      final connection = await client.connect();
+      _closeAfterTest(client: client, connection: connection);
 
       final serverWs = await server.nextClient();
 
@@ -435,7 +455,7 @@ void main() {
 
       unawaited(
         (() async {
-          await for (final _ in client.read()) {
+          await for (final _ in client.read(connection: connection)) {
             messageCount++;
           }
           loopExited.complete();
@@ -469,14 +489,14 @@ void main() {
         accessTokenProvider: FakeAccessTokenProvider(""),
         bridgeIdProvider: FakeBridgeIdProvider(),
       );
-      await client.connect();
-      addTearDown(client.close);
+      var connection = await client.connect();
+      addTearDown(() => client.closeIfCurrent(connection: connection));
 
       final serverWs1 = await server.nextClient();
 
       // Verify the first connection works.
       final msgs1 = <RelayClientMessage>[];
-      final sub1 = client.read().listen(msgs1.add);
+      final sub1 = client.read(connection: connection).listen(msgs1.add);
 
       serverWs1.add("first");
       await Future<void>.delayed(const Duration(milliseconds: 100));
@@ -489,12 +509,12 @@ void main() {
 
       // Reconnect — the server will accept a new WebSocket.
       final serverWs2Future = server.nextClient();
-      await client.reconnect();
+      connection = await client.reconnect(connection: connection);
       final serverWs2 = await serverWs2Future;
 
       // Verify the second connection works.
       final msgs2 = <RelayClientMessage>[];
-      final sub2 = client.read().listen(msgs2.add);
+      final sub2 = client.read(connection: connection).listen(msgs2.add);
 
       serverWs2.add("second");
       await Future<void>.delayed(const Duration(milliseconds: 100));
@@ -511,8 +531,8 @@ void main() {
         accessTokenProvider: FakeAccessTokenProvider(""),
         bridgeIdProvider: FakeBridgeIdProvider(),
       );
-      await client.connect();
-      addTearDown(client.close);
+      var connection = await client.connect();
+      addTearDown(() => client.closeIfCurrent(connection: connection));
 
       final serverWs1 = await server.nextClient();
 
@@ -520,7 +540,14 @@ void main() {
       final received1 = <dynamic>[];
       serverWs1.listen(received1.add);
 
-      client.send(1, "before".codeUnits);
+      expect(
+        client.sendIfCurrent(
+          connection: connection,
+          connID: 1,
+          payload: "before".codeUnits,
+        ),
+        RelaySendOutcome.sent,
+      );
       await Future<void>.delayed(const Duration(milliseconds: 100));
       expect(received1, hasLength(1));
 
@@ -530,15 +557,96 @@ void main() {
 
       // Reconnect.
       final serverWs2Future = server.nextClient();
-      await client.reconnect();
+      connection = await client.reconnect(connection: connection);
       final serverWs2 = await serverWs2Future;
 
       final received2 = <dynamic>[];
       serverWs2.listen(received2.add);
 
-      client.send(2, "after".codeUnits);
+      expect(
+        client.sendIfCurrent(
+          connection: connection,
+          connID: 2,
+          payload: "after".codeUnits,
+        ),
+        RelaySendOutcome.sent,
+      );
       await Future<void>.delayed(const Duration(milliseconds: 100));
       expect(received2, hasLength(1));
+    });
+
+    test("stale send and close cannot affect a successor connection", () async {
+      final server = await TestRelayServer.start();
+      addTearDown(server.close);
+      final client = RelayClient(
+        relayURL: "ws://127.0.0.1:${server.port}",
+        accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
+      );
+      final firstConnection = await client.connect();
+      final firstSocket = await server.nextClient();
+      final firstDone = Completer<void>();
+      client.read(connection: firstConnection).listen((_) {}, onDone: firstDone.complete);
+      await firstSocket.close();
+      await firstDone.future.timeout(const Duration(seconds: 5));
+
+      final secondSocketFuture = server.nextClient();
+      final secondConnection = await client.reconnect(connection: firstConnection);
+      _closeAfterTest(client: client, connection: secondConnection);
+      final secondSocket = await secondSocketFuture;
+      final received = <dynamic>[];
+      secondSocket.listen(received.add);
+
+      expect(
+        client.sendIfCurrent(
+          connection: firstConnection,
+          connID: 1,
+          payload: const [1],
+        ),
+        RelaySendOutcome.stale,
+      );
+      expect(
+        await client.closeIfCurrent(connection: firstConnection),
+        RelayCloseOutcome.stale,
+      );
+      expect(
+        client.sendIfCurrent(
+          connection: secondConnection,
+          connID: 2,
+          payload: const [2],
+        ),
+        RelaySendOutcome.sent,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(received, hasLength(1));
+    });
+
+    test("closeIfCurrent detaches synchronously before its handshake", () async {
+      final server = await TestRelayServer.start();
+      addTearDown(server.close);
+      final client = RelayClient(
+        relayURL: "ws://127.0.0.1:${server.port}",
+        accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
+      );
+      final firstConnection = await client.connect();
+      await server.nextClient();
+
+      final closeFuture = client.closeIfCurrent(connection: firstConnection);
+      expect(
+        client.sendIfCurrent(
+          connection: firstConnection,
+          connID: 1,
+          payload: const [1],
+        ),
+        RelaySendOutcome.stale,
+      );
+      final secondSocketFuture = server.nextClient();
+      final secondConnection = await client.connect();
+      _closeAfterTest(client: client, connection: secondConnection);
+      await secondSocketFuture;
+
+      expect(await closeFuture, RelayCloseOutcome.closed);
     });
 
     test("TestRelayServer.close rejects pending nextClient waiters", () async {
@@ -576,4 +684,11 @@ void main() {
 Future<Map<String, dynamic>> _firstTextFrame(WebSocket socket) async {
   final message = await socket.firstWhere((dynamic data) => data is String).timeout(const Duration(seconds: 5));
   return jsonDecodeMap(message as String);
+}
+
+void _closeAfterTest({
+  required RelayClient client,
+  required RelayConnection connection,
+}) {
+  addTearDown(() => client.closeIfCurrent(connection: connection));
 }

--- a/bridge/app/test/bridge/client_test.dart
+++ b/bridge/app/test/bridge/client_test.dart
@@ -611,6 +611,15 @@ void main() {
       await firstSocket.close();
       await firstDone.future.timeout(const Duration(seconds: 5));
 
+      expect(
+        client.sendIfCurrent(
+          connection: firstConnection,
+          connID: 1,
+          payload: const [1],
+        ),
+        RelaySendOutcome.stale,
+      );
+
       final secondSocketFuture = server.nextClient();
       final secondConnection = await client.reconnect(connection: firstConnection);
       _closeAfterTest(client: client, connection: secondConnection);

--- a/bridge/app/test/bridge/client_test.dart
+++ b/bridge/app/test/bridge/client_test.dart
@@ -192,6 +192,27 @@ void main() {
       expect(states[1], isA<RelayConnected>());
     });
 
+    test("auth setup failure emits disconnected without a false connected state", () async {
+      final server = await TestRelayServer.start();
+      addTearDown(server.close);
+
+      final client = RelayClient(
+        relayURL: "ws://127.0.0.1:${server.port}",
+        accessTokenProvider: _ThrowingAccessTokenProvider(),
+        bridgeIdProvider: FakeBridgeIdProvider(),
+      );
+      final states = <RelayConnectionState>[];
+      client.connectionState.listen(states.add);
+
+      await expectLater(client.connect(), throwsA(isA<StateError>()));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(states, hasLength(2));
+      expect(states[0], isA<RelayConnecting>());
+      expect(states[1], isA<RelayDisconnected>());
+      expect(states.whereType<RelayConnected>(), isEmpty);
+    });
+
     test("remote close emits disconnected carrying the close code", () async {
       final server = await TestRelayServer.start();
       addTearDown(server.close);
@@ -679,6 +700,11 @@ void main() {
       await expectLater(client.connect(), throwsA(isA<TimeoutException>()));
     });
   });
+}
+
+class _ThrowingAccessTokenProvider extends FakeAccessTokenProvider {
+  @override
+  String get accessToken => throw StateError("auth token unavailable");
 }
 
 Future<Map<String, dynamic>> _firstTextFrame(WebSocket socket) async {

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -555,7 +555,7 @@ class _ThrowingConnectRelayClient extends RelayClient {
       );
 
   @override
-  Future<void> connect() async {
+  Future<RelayConnection> connect() async {
     throw StateError("connect failed");
   }
 }

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -148,6 +148,32 @@ void main() {
       expect(repository.registeredBridgeIds.length, greaterThanOrEqualTo(3));
       expect(authMessage["bridgeId"], equals("br_second002"));
     });
+
+    test("cancellation during re-registration does not open a successor relay connection", () async {
+      final repository = FakeBridgeRegistrationRepository()..nextBridgeId = "br_first001";
+      final harness = await _RegistrationHarness.start(repository: repository);
+      addTearDown(harness.close);
+
+      final firstSocket = await harness.relayServer.nextClient();
+      await _firstTextMessage(firstSocket);
+
+      final registrationGate = Completer<void>();
+      repository
+        ..nextBridgeId = "br_second002"
+        ..registerDelay = registrationGate.future;
+      await firstSocket.close(RelayCloseCodes.bridgeRevoked);
+      await _waitFor(
+        () => repository.registeredBridgeIds.length >= 2,
+        reason: "blocked re-registration",
+      );
+
+      final cancelFuture = harness.session.cancel();
+      registrationGate.complete();
+      await cancelFuture;
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(harness.relayServer.connectedClientCount, equals(1));
+    });
   });
 
   group("OrchestratorSession routed request boundaries", () {

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -185,6 +185,31 @@ void main() {
       await harness.runFuture.timeout(const Duration(seconds: 5));
     });
 
+    test("a current response send failure closes that handle and reconnects", () async {
+      final repository = FakeBridgeRegistrationRepository()..nextBridgeId = "br_sendfail01";
+      final harness = await _RegistrationHarness.start(repository: repository);
+      addTearDown(harness.close);
+      final phone = await _activatePhone(harness: harness, connId: 8);
+      harness.relayClient.failNextSend = true;
+
+      await _sendEncrypted(
+        socket: phone.socket,
+        connId: 8,
+        encryptor: phone.encryptor,
+        message: const RelayMessage.request(
+          id: "send-failure-request",
+          method: "GET",
+          path: "/global/health",
+          headers: {},
+          body: null,
+        ),
+      );
+
+      final successor = await harness.relayServer.nextClient(timeout: const Duration(seconds: 5));
+      final authMessage = await _firstTextMessage(successor);
+      expect(authMessage["bridgeId"], "br_sendfail01");
+    });
+
     test("routed and control diagnostics retain useful local context", () async {
       late _RegistrationHarness harness;
       final output = await _captureLogOutput(() async {
@@ -465,12 +490,27 @@ class _RecordingRelayClient extends RelayClient {
 
   int sendCount = 0;
   int? lastConnId;
+  bool failNextSend = false;
 
   @override
-  void send(int connID, List<int> payload) {
-    super.send(connID, payload);
+  RelaySendOutcome sendIfCurrent({
+    required RelayConnection connection,
+    required int connID,
+    required List<int> payload,
+  }) {
+    if (failNextSend) {
+      failNextSend = false;
+      throw StateError("send failed intentionally");
+    }
+    final outcome = super.sendIfCurrent(
+      connection: connection,
+      connID: connID,
+      payload: payload,
+    );
+    if (outcome == RelaySendOutcome.stale) return outcome;
     sendCount++;
     lastConnId = connID;
+    return outcome;
   }
 }
 

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -195,6 +195,33 @@ void main() {
 
       expect(harness.relayServer.connectedClientCount, equals(1));
     });
+
+    test("cancellation while initial connect returns closes the promoted connection", () async {
+      final connectReturnGate = Completer<void>();
+      final harness = await _RegistrationHarness.start(
+        repository: FakeBridgeRegistrationRepository()..nextBridgeId = "br_first001",
+        connectReturnDelay: connectReturnGate.future,
+      );
+      addTearDown(harness.close);
+
+      final firstSocket = await harness.relayServer.nextClient();
+      await _firstTextMessage(firstSocket);
+      await harness.relayClient.connectPromoted.future;
+
+      final cancelFuture = harness.session.cancel();
+      connectReturnGate.complete();
+      await cancelFuture;
+      await harness.runFuture.timeout(const Duration(seconds: 5));
+
+      expect(
+        harness.relayClient.sendIfCurrent(
+          connection: harness.relayClient.promotedConnection!,
+          connID: 1,
+          payload: const [1],
+        ),
+        RelaySendOutcome.stale,
+      );
+    });
   });
 
   group("OrchestratorSession routed request boundaries", () {
@@ -255,6 +282,34 @@ void main() {
       final successor = await harness.relayServer.nextClient(timeout: const Duration(seconds: 5));
       final authMessage = await _firstTextMessage(successor);
       expect(authMessage["bridgeId"], "br_sendfail01");
+    });
+
+    test("a stale routed response does not count unsent bandwidth", () async {
+      final harness = await _RegistrationHarness.start(
+        repository: FakeBridgeRegistrationRepository()..nextBridgeId = "br_stale001",
+      );
+      addTearDown(harness.close);
+      final phone = await _activatePhone(harness: harness, connId: 10);
+      final sentByteCounts = <int>[];
+      final subscription = harness.session.bytesSent.listen(sentByteCounts.add);
+      addTearDown(subscription.cancel);
+      harness.relayClient.staleNextSend = true;
+
+      await _sendEncrypted(
+        socket: phone.socket,
+        connId: 10,
+        encryptor: phone.encryptor,
+        message: const RelayMessage.request(
+          id: "stale-response-request",
+          method: "GET",
+          path: "/global/health",
+          headers: {},
+          body: null,
+        ),
+      );
+      await _waitFor(() => !harness.relayClient.staleNextSend, reason: "stale response attempt");
+
+      expect(sentByteCounts, isEmpty);
     });
 
     test("routed and control diagnostics retain useful local context", () async {
@@ -439,6 +494,7 @@ class _RegistrationHarness {
 
   static Future<_RegistrationHarness> start({
     required FakeBridgeRegistrationRepository repository,
+    Future<void>? connectReturnDelay,
   }) async {
     final relayServer = await _CountingRelayServer.start();
     final database = createTestDatabase();
@@ -457,6 +513,7 @@ class _RegistrationHarness {
       relayURL: "ws://127.0.0.1:${relayServer.port}",
       accessTokenProvider: FakeAccessTokenProvider(),
       bridgeIdProvider: registrationService,
+      connectReturnDelay: connectReturnDelay,
     );
     final restartService = _RecordingRestartService(relayClient: relayClient);
 
@@ -533,13 +590,29 @@ class _RecordingRelayClient extends RelayClient {
     required super.relayURL,
     required super.accessTokenProvider,
     required super.bridgeIdProvider,
+    required this.connectReturnDelay,
   });
 
   int sendCount = 0;
   int? lastConnId;
   bool failNextSend = false;
+  bool staleNextSend = false;
+  final Future<void>? connectReturnDelay;
+  final Completer<void> connectPromoted = Completer<void>();
+  RelayConnection? promotedConnection;
   Future<void>? closeDelay;
   final Completer<void> closeStarted = Completer<void>();
+
+  @override
+  Future<RelayConnection> connect() async {
+    final connection = await super.connect();
+    promotedConnection = connection;
+    if (!connectPromoted.isCompleted) {
+      connectPromoted.complete();
+    }
+    await connectReturnDelay;
+    return connection;
+  }
 
   @override
   Future<RelayCloseOutcome> closeIfCurrent({required RelayConnection connection}) async {
@@ -560,6 +633,10 @@ class _RecordingRelayClient extends RelayClient {
     if (failNextSend) {
       failNextSend = false;
       throw StateError("send failed intentionally");
+    }
+    if (staleNextSend) {
+      staleNextSend = false;
+      return RelaySendOutcome.stale;
     }
     final outcome = super.sendIfCurrent(
       connection: connection,

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -174,6 +174,27 @@ void main() {
 
       expect(harness.relayServer.connectedClientCount, equals(1));
     });
+
+    test("cancellation while the old relay closes does not open a successor connection", () async {
+      final repository = FakeBridgeRegistrationRepository()..nextBridgeId = "br_first001";
+      final harness = await _RegistrationHarness.start(repository: repository);
+      addTearDown(harness.close);
+
+      final firstSocket = await harness.relayServer.nextClient();
+      await _firstTextMessage(firstSocket);
+
+      final closeGate = Completer<void>();
+      harness.relayClient.closeDelay = closeGate.future;
+      await firstSocket.close();
+      await harness.relayClient.closeStarted.future;
+
+      final cancelFuture = harness.session.cancel();
+      closeGate.complete();
+      await cancelFuture;
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(harness.relayServer.connectedClientCount, equals(1));
+    });
   });
 
   group("OrchestratorSession routed request boundaries", () {
@@ -517,6 +538,18 @@ class _RecordingRelayClient extends RelayClient {
   int sendCount = 0;
   int? lastConnId;
   bool failNextSend = false;
+  Future<void>? closeDelay;
+  final Completer<void> closeStarted = Completer<void>();
+
+  @override
+  Future<RelayCloseOutcome> closeIfCurrent({required RelayConnection connection}) async {
+    final closeFuture = super.closeIfCurrent(connection: connection);
+    if (!closeStarted.isCompleted) {
+      closeStarted.complete();
+    }
+    await closeDelay;
+    return closeFuture;
+  }
 
   @override
   RelaySendOutcome sendIfCurrent({

--- a/bridge/app/test/bridge/sse_manager_test.dart
+++ b/bridge/app/test/bridge/sse_manager_test.dart
@@ -299,6 +299,30 @@ void main() {
       expect(manager.pendingReplayCount, equals(0));
     });
 
+    test("stale relay delivery remains buffered for replay", () async {
+      final client = _RecordingRelayClient()..nextOutcome = RelaySendOutcome.stale;
+      final reporter = CapturingFailureReporter();
+      final manager = SSEManager(
+        replayWindow: SSEManager.defaultReplayWindow,
+        onBytesSent: (_) {},
+        failureReporter: reporter,
+      );
+      manager.setRoomKey(makeRoomKey());
+      addTearDown(manager.stop);
+
+      manager.subscribeForTest(1, client);
+      manager.enqueueEvent(_event("relay-turnover"));
+      await _waitForSendCount(client, 1);
+      manager.orphanAll();
+
+      client.nextOutcome = RelaySendOutcome.sent;
+      manager.subscribeForTest(2, client);
+      await _waitForSendCount(client, 2);
+
+      expect(client.sentConnIDs, [1, 2]);
+      expect(reporter.recordedIdentifiers, isEmpty);
+    });
+
     test("stop clears subscribers and orphan queues", () {
       final manager = SSEManager(
         replayWindow: SSEManager.defaultReplayWindow,
@@ -390,6 +414,7 @@ Future<void> _pumpEventLoop() => Future<void>.delayed(const Duration(millisecond
 class _RecordingRelayClient extends RelayClient {
   final List<int> sentConnIDs = <int>[];
   final List<List<int>> sentPayloads = <List<int>>[];
+  RelaySendOutcome nextOutcome = RelaySendOutcome.sent;
 
   _RecordingRelayClient()
     : super(
@@ -406,7 +431,7 @@ class _RecordingRelayClient extends RelayClient {
   }) {
     sentConnIDs.add(connID);
     sentPayloads.add(List<int>.from(payload));
-    return RelaySendOutcome.sent;
+    return nextOutcome;
   }
 }
 

--- a/bridge/app/test/bridge/sse_manager_test.dart
+++ b/bridge/app/test/bridge/sse_manager_test.dart
@@ -302,9 +302,10 @@ void main() {
     test("stale relay delivery remains buffered for replay", () async {
       final client = _RecordingRelayClient()..nextOutcome = RelaySendOutcome.stale;
       final reporter = CapturingFailureReporter();
+      final sentByteCounts = <int>[];
       final manager = SSEManager(
         replayWindow: SSEManager.defaultReplayWindow,
-        onBytesSent: (_) {},
+        onBytesSent: sentByteCounts.add,
         failureReporter: reporter,
       );
       manager.setRoomKey(makeRoomKey());
@@ -313,13 +314,19 @@ void main() {
       manager.subscribeForTest(1, client);
       manager.enqueueEvent(_event("relay-turnover"));
       await _waitForSendCount(client, 1);
-      manager.orphanAll();
+      expect(manager.subscriberCount, 0);
+      expect(manager.pendingReplayCount, 1);
+
+      for (var index = 0; index < 5; index++) {
+        manager.enqueueEvent(_event("buffered-$index"));
+      }
 
       client.nextOutcome = RelaySendOutcome.sent;
       manager.subscribeForTest(2, client);
-      await _waitForSendCount(client, 2);
+      await _waitForSendCount(client, 7);
 
-      expect(client.sentConnIDs, [1, 2]);
+      expect(client.sentConnIDs, [1, 2, 2, 2, 2, 2, 2]);
+      expect(sentByteCounts, hasLength(6), reason: "the rejected stale attempt must not count bandwidth");
       expect(reporter.recordedIdentifiers, isEmpty);
     });
 

--- a/bridge/app/test/bridge/sse_manager_test.dart
+++ b/bridge/app/test/bridge/sse_manager_test.dart
@@ -11,6 +11,25 @@ import "package:test/test.dart";
 import "../helpers/test_helpers.dart";
 
 void main() {
+  late TestRelayServer connectionServer;
+  late RelayClient connectionOwner;
+
+  setUpAll(() async {
+    connectionServer = await TestRelayServer.start();
+    connectionOwner = RelayClient(
+      relayURL: "ws://127.0.0.1:${connectionServer.port}",
+      accessTokenProvider: FakeAccessTokenProvider(""),
+      bridgeIdProvider: FakeBridgeIdProvider(),
+    );
+    _testRelayConnection = await connectionOwner.connect();
+    await connectionServer.nextClient();
+  });
+
+  tearDownAll(() async {
+    await connectionOwner.closeIfCurrent(connection: _testRelayConnection);
+    await connectionServer.close();
+  });
+
   group("SSEManager", () {
     test("subscribe registers subscribers", () {
       final manager = SSEManager(
@@ -24,8 +43,8 @@ void main() {
         bridgeIdProvider: FakeBridgeIdProvider(),
       );
 
-      manager.subscribePath(1, "/global/event", relayClient);
-      manager.subscribePath(2, "/global/event", relayClient);
+      manager.subscribeForTest(1, relayClient);
+      manager.subscribeForTest(2, relayClient);
       addTearDown(manager.stop);
 
       expect(manager.subscriberCount, equals(2));
@@ -57,8 +76,8 @@ void main() {
       manager.setRoomKey(roomKey);
       addTearDown(manager.stop);
 
-      manager.subscribePath(1, "/global/event", client);
-      manager.subscribePath(2, "/global/event", client);
+      manager.subscribeForTest(1, client);
+      manager.subscribeForTest(2, client);
 
       final event = _event("repo-a");
       manager.enqueueEvent(event);
@@ -98,7 +117,7 @@ void main() {
       );
       addTearDown(manager.stop);
 
-      manager.subscribePath(7, "/global/event", client);
+      manager.subscribeForTest(7, client);
       manager.enqueueEvent(_event("repo-x"));
       await _pumpEventLoop();
 
@@ -118,8 +137,8 @@ void main() {
       );
       addTearDown(manager.stop);
 
-      manager.subscribePath(1, "/global/event", relayClient);
-      manager.subscribePath(2, "/global/event", relayClient);
+      manager.subscribeForTest(1, relayClient);
+      manager.subscribeForTest(2, relayClient);
       manager.unsubscribe(1);
 
       expect(manager.subscriberCount, equals(1));
@@ -139,7 +158,7 @@ void main() {
       );
       addTearDown(manager.stop);
 
-      manager.subscribePath(1, "/global/event", relayClient);
+      manager.subscribeForTest(1, relayClient);
       manager.unsubscribe(1);
 
       expect(manager.subscriberCount, equals(0));
@@ -158,7 +177,7 @@ void main() {
       addTearDown(manager.stop);
 
       // Phone connects and receives one event.
-      manager.subscribePath(1, "/global/event", client);
+      manager.subscribeForTest(1, client);
       manager.enqueueEvent(_event("event-a"));
       await _waitForSendCount(client, 1);
       expect(client.sentConnIDs, [1]);
@@ -172,7 +191,7 @@ void main() {
       manager.enqueueEvent(_event("event-c"));
 
       // Phone reconnects with a new connID (relay assigns fresh IDs).
-      manager.subscribePath(5, "/global/event", client);
+      manager.subscribeForTest(5, client);
       await _waitForSendCount(client, 3);
 
       // The two buffered events were replayed to the new connID.
@@ -192,8 +211,8 @@ void main() {
       manager.setRoomKey(roomKey);
       addTearDown(manager.stop);
 
-      manager.subscribePath(1, "/global/event", client);
-      manager.subscribePath(2, "/global/event", client);
+      manager.subscribeForTest(1, client);
+      manager.subscribeForTest(2, client);
 
       manager.enqueueEvent(_event("event-a"));
       await _waitForSendCount(client, 2);
@@ -202,7 +221,7 @@ void main() {
       manager.enqueueEvent(_event("event-b"));
       await _waitForSendCount(client, 3);
 
-      manager.subscribePath(3, "/global/event", client);
+      manager.subscribeForTest(3, client);
       await _waitForSendCount(client, 4);
 
       expect(client.sentConnIDs[3], equals(3));
@@ -224,8 +243,8 @@ void main() {
         manager.setRoomKey(roomKey);
         addTearDown(manager.stop);
 
-        manager.subscribePath(1, "/global/event", client);
-        manager.subscribePath(2, "/global/event", client);
+        manager.subscribeForTest(1, client);
+        manager.subscribeForTest(2, client);
 
         manager.unsubscribe(1);
         manager.enqueueEvent(_event("queued-for-orphan"));
@@ -234,7 +253,7 @@ void main() {
         now = now.add(SSEManager.defaultReplayWindow + const Duration(seconds: 1));
         final sendsBefore = client.sentConnIDs.length;
 
-        manager.subscribePath(3, "/global/event", client);
+        manager.subscribeForTest(3, client);
         await _pumpEventLoop();
 
         expect(client.sentConnIDs.length, equals(sendsBefore));
@@ -253,8 +272,8 @@ void main() {
       manager.setRoomKey(roomKey);
       addTearDown(manager.stop);
 
-      manager.subscribePath(1, "/global/event", client);
-      manager.subscribePath(2, "/global/event", client);
+      manager.subscribeForTest(1, client);
+      manager.subscribeForTest(2, client);
 
       manager.enqueueEvent(_event("before-orphan"));
       await _waitForSendCount(client, 2);
@@ -268,13 +287,13 @@ void main() {
       manager.enqueueEvent(_event("during-reconnect"));
 
       // First phone reconnects — picks up orphan with buffered event.
-      manager.subscribePath(3, "/global/event", client);
+      manager.subscribeForTest(3, client);
       await _waitForSendCount(client, 3);
       expect(client.sentConnIDs[2], equals(3));
       expect(manager.pendingReplayCount, equals(1));
 
       // Second phone reconnects.
-      manager.subscribePath(4, "/global/event", client);
+      manager.subscribeForTest(4, client);
       await _waitForSendCount(client, 4);
       expect(client.sentConnIDs[3], equals(4));
       expect(manager.pendingReplayCount, equals(0));
@@ -292,8 +311,8 @@ void main() {
         bridgeIdProvider: FakeBridgeIdProvider(),
       );
 
-      manager.subscribePath(1, "/global/event", relayClient);
-      manager.subscribePath(2, "/global/event", relayClient);
+      manager.subscribeForTest(1, relayClient);
+      manager.subscribeForTest(2, relayClient);
       manager.unsubscribe(1);
 
       manager.stop();
@@ -314,7 +333,7 @@ void main() {
       manager.setRoomKey(roomKey);
       addTearDown(manager.stop);
 
-      manager.subscribePath(42, "/global/event", throwingClient);
+      manager.subscribeForTest(42, throwingClient);
       manager.enqueueEvent(_event("repo-err"));
 
       // Wait for the send function to throw and the onError callback to fire.
@@ -380,9 +399,14 @@ class _RecordingRelayClient extends RelayClient {
       );
 
   @override
-  void send(int connID, List<int> payload) {
+  RelaySendOutcome sendIfCurrent({
+    required RelayConnection connection,
+    required int connID,
+    required List<int> payload,
+  }) {
     sentConnIDs.add(connID);
     sentPayloads.add(List<int>.from(payload));
+    return RelaySendOutcome.sent;
   }
 }
 
@@ -395,7 +419,24 @@ class _ThrowingRelayClient extends RelayClient {
       );
 
   @override
-  void send(int connID, List<int> payload) {
+  RelaySendOutcome sendIfCurrent({
+    required RelayConnection connection,
+    required int connID,
+    required List<int> payload,
+  }) {
     throw Exception("send failed intentionally");
   }
 }
+
+extension on SSEManager {
+  void subscribeForTest(int connID, RelayClient client) {
+    subscribePath(
+      connID: connID,
+      path: "/global/event",
+      client: client,
+      connection: _testRelayConnection,
+    );
+  }
+}
+
+late RelayConnection _testRelayConnection;

--- a/bridge/app/test/bridge/sse_manager_test.dart
+++ b/bridge/app/test/bridge/sse_manager_test.dart
@@ -330,6 +330,31 @@ void main() {
       expect(reporter.recordedIdentifiers, isEmpty);
     });
 
+    test("stale callback cannot unsubscribe a successor reusing the connection id", () async {
+      final client = _RecordingRelayClient()..nextOutcome = RelaySendOutcome.stale;
+      final manager = SSEManager(
+        replayWindow: SSEManager.defaultReplayWindow,
+        onBytesSent: (_) {},
+        failureReporter: FakeFailureReporter(),
+      );
+      manager.setRoomKey(makeRoomKey());
+      addTearDown(manager.stop);
+
+      manager.subscribeForTest(1, client);
+      client.onNextSend = () {
+        client.onNextSend = null;
+        manager.orphanAll();
+        manager.subscribeForTest(1, client);
+        client.nextOutcome = RelaySendOutcome.sent;
+      };
+      manager.enqueueEvent(_event("reused-connection-id"));
+      await _waitForSendCount(client, 2);
+
+      expect(manager.subscriberCount, 1);
+      expect(manager.pendingReplayCount, 0);
+      expect(client.sentConnIDs, [1, 1]);
+    });
+
     test("stop clears subscribers and orphan queues", () {
       final manager = SSEManager(
         replayWindow: SSEManager.defaultReplayWindow,
@@ -422,6 +447,7 @@ class _RecordingRelayClient extends RelayClient {
   final List<int> sentConnIDs = <int>[];
   final List<List<int>> sentPayloads = <List<int>>[];
   RelaySendOutcome nextOutcome = RelaySendOutcome.sent;
+  void Function()? onNextSend;
 
   _RecordingRelayClient()
     : super(
@@ -438,7 +464,9 @@ class _RecordingRelayClient extends RelayClient {
   }) {
     sentConnIDs.add(connID);
     sentPayloads.add(List<int>.from(payload));
-    return nextOutcome;
+    final outcome = nextOutcome;
+    onNextSend?.call();
+    return outcome;
   }
 }
 

--- a/bridge/app/test/helpers/test_helpers.dart
+++ b/bridge/app/test/helpers/test_helpers.dart
@@ -215,14 +215,14 @@ Future<(HttpServer, Stream<List<int>>)> startTestRelayServer() async {
   return (server, controller.stream);
 }
 
-Future<RelayClient> connectTestRelayClient(HttpServer server) async {
+Future<({RelayClient client, RelayConnection connection})> connectTestRelayClient(HttpServer server) async {
   final client = RelayClient(
     relayURL: "ws://127.0.0.1:${server.port}",
     accessTokenProvider: FakeAccessTokenProvider(),
     bridgeIdProvider: FakeBridgeIdProvider(),
   );
-  await client.connect();
-  return client;
+  final connection = await client.connect();
+  return (client: client, connection: connection);
 }
 
 /// A test relay server that exposes individual server-side [WebSocket]

--- a/bridge/app/test/helpers/test_helpers.dart
+++ b/bridge/app/test/helpers/test_helpers.dart
@@ -86,6 +86,9 @@ class FakeBridgeRegistrationRepository implements BridgeRegistrationRepository {
   /// When non-null, [register] throws this error instead of succeeding.
   Object? registerError;
 
+  /// When non-null, [register] waits for this future before settling.
+  Future<void>? registerDelay;
+
   /// The id returned from successful [register] calls.
   String nextBridgeId = "br_test1234";
 
@@ -97,6 +100,7 @@ class FakeBridgeRegistrationRepository implements BridgeRegistrationRepository {
     required String accessToken,
   }) async {
     registeredBridgeIds.add(bridgeId);
+    await registerDelay;
     if (registerError != null) {
       throw registerError!;
     }

--- a/bridge/app/tool/benchmarks/benchmark_relay_fixture.dart
+++ b/bridge/app/tool/benchmarks/benchmark_relay_fixture.dart
@@ -1,0 +1,79 @@
+import "dart:async";
+import "dart:io";
+
+import "package:rxdart/rxdart.dart";
+import "package:sesori_bridge/src/auth/access_token_provider.dart";
+import "package:sesori_bridge/src/auth/bridge_id_provider.dart";
+import "package:sesori_bridge/src/bridge/relay_client.dart";
+
+final class BenchmarkRelayFixture {
+  BenchmarkRelayFixture._({
+    required this.client,
+    required this.connection,
+    required HttpServer server,
+    required _BenchmarkAccessTokenProvider accessTokenProvider,
+  }) : _server = server,
+       _accessTokenProvider = accessTokenProvider;
+
+  final RelayClient client;
+  final RelayConnection connection;
+  final HttpServer _server;
+  final _BenchmarkAccessTokenProvider _accessTokenProvider;
+
+  static Future<BenchmarkRelayFixture> start() async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    server.listen((request) async {
+      if (!WebSocketTransformer.isUpgradeRequest(request)) {
+        request.response.statusCode = HttpStatus.notFound;
+        await request.response.close();
+        return;
+      }
+      final socket = await WebSocketTransformer.upgrade(request);
+      socket.listen((_) {});
+    });
+    final accessTokenProvider = _BenchmarkAccessTokenProvider();
+    final client = RelayClient(
+      relayURL: "ws://127.0.0.1:${server.port}",
+      accessTokenProvider: accessTokenProvider,
+      bridgeIdProvider: const _BenchmarkBridgeIdProvider(),
+    );
+    try {
+      final connection = await client.connect();
+      return BenchmarkRelayFixture._(
+        client: client,
+        connection: connection,
+        server: server,
+        accessTokenProvider: accessTokenProvider,
+      );
+    } on Object {
+      await accessTokenProvider.dispose();
+      await server.close(force: true);
+      rethrow;
+    }
+  }
+
+  Future<void> dispose() async {
+    await client.closeIfCurrent(connection: connection);
+    await _accessTokenProvider.dispose();
+    await _server.close(force: true);
+  }
+}
+
+final class _BenchmarkAccessTokenProvider implements AccessTokenProvider {
+  final BehaviorSubject<String> _tokens = BehaviorSubject.seeded("");
+
+  @override
+  String get accessToken => "";
+
+  @override
+  ValueStream<String> get tokenStream => _tokens;
+
+  Future<void> dispose() => _tokens.close();
+}
+
+final class _BenchmarkBridgeIdProvider implements BridgeIdProvider {
+  const _BenchmarkBridgeIdProvider();
+
+  @override
+  String? get bridgeId => null;
+}

--- a/bridge/app/tool/benchmarks/catalog_import_event_soak.dart
+++ b/bridge/app/tool/benchmarks/catalog_import_event_soak.dart
@@ -11,7 +11,6 @@ import "package:sesori_bridge/src/api/database/tables/session_table.dart";
 import "package:sesori_bridge/src/bridge/api/filesystem_api.dart";
 import "package:sesori_bridge/src/bridge/api/git_cli_api.dart";
 import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
-import "package:sesori_bridge/src/bridge/relay_client.dart";
 import "package:sesori_bridge/src/bridge/repositories/mappers/session_event_mapper.dart";
 import "package:sesori_bridge/src/bridge/repositories/project_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
@@ -27,6 +26,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "benchmark_plugin_runtime.dart";
+import "benchmark_relay_fixture.dart";
 
 const _defaultProjectCount = 2000;
 const _defaultSessionCount = 50000;
@@ -177,8 +177,18 @@ class _CatalogImportEventSoak {
       );
       final bridgeEventMapper = BridgeEventMapper(failureReporter: failureReporter);
       sseManager = _CountingSSEManager(failureReporter: failureReporter);
-      sseManager.subscribePath(1, "/global/event", _BenchmarkRelayClient());
-      sseManager.unsubscribe(1);
+      final relay = await BenchmarkRelayFixture.start();
+      try {
+        sseManager.subscribePath(
+          connID: 1,
+          path: "/global/event",
+          client: relay.client,
+          connection: relay.connection,
+        );
+        sseManager.unsubscribe(1);
+      } finally {
+        await relay.dispose();
+      }
       if (sseManager.pendingReplayCount != 1) {
         throw StateError("benchmark relay replay queue was not created");
       }
@@ -884,11 +894,6 @@ class _ExistingFilesystemApi implements FilesystemApi {
   @override
   bool directoryExists(String path) => true;
 
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
-class _BenchmarkRelayClient implements RelayClient {
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/bridge/app/tool/benchmarks/event_projection_benchmark.dart
+++ b/bridge/app/tool/benchmarks/event_projection_benchmark.dart
@@ -5,7 +5,6 @@ import "dart:io";
 import "package:args/args.dart";
 import "package:path/path.dart" as p;
 import "package:sesori_bridge/src/api/database/database.dart";
-import "package:sesori_bridge/src/bridge/relay_client.dart";
 import "package:sesori_bridge/src/bridge/repositories/mappers/session_event_mapper.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
@@ -18,6 +17,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "benchmark_plugin_runtime.dart";
+import "benchmark_relay_fixture.dart";
 
 const _defaultWarmupCount = 25;
 const _defaultSampleCount = 2000;
@@ -175,8 +175,18 @@ class _EventProjectionBenchmark {
     required BridgeEventMapper bridgeEventMapper,
     required SSEManager sseManager,
   }) async {
-    sseManager.subscribePath(1, "/global/event", _BenchmarkRelayClient());
-    sseManager.unsubscribe(1);
+    final relay = await BenchmarkRelayFixture.start();
+    try {
+      sseManager.subscribePath(
+        connID: 1,
+        path: "/global/event",
+        client: relay.client,
+        connection: relay.connection,
+      );
+      sseManager.unsubscribe(1);
+    } finally {
+      await relay.dispose();
+    }
     if (sseManager.pendingReplayCount != 1) {
       throw StateError("benchmark relay replay queue was not created");
     }
@@ -400,11 +410,6 @@ class _BenchmarkPlugin implements NativeProjectsPluginApi {
     required PluginSessionOptionsDiscoveryMode discoveryMode,
   }) => throw UnimplementedError();
 
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
-class _BenchmarkRelayClient implements RelayClient {
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/shared/sesori_shared/lib/src/concurrency/event_queue.dart
+++ b/shared/sesori_shared/lib/src/concurrency/event_queue.dart
@@ -194,6 +194,7 @@ class EventQueue<T extends Object> {
 
         final onData = _onData;
         if (onData == null) break;
+        final activeSubscription = _activeSubscription;
 
         final event = _buffer.first;
         try {
@@ -201,6 +202,12 @@ class EventQueue<T extends Object> {
           _buffer.removeFirst();
           _headAttempts = 0;
         } catch (e) {
+          // A detached listener no longer owns the in-flight delivery. Keep
+          // the head untouched so a replacement listener can retry it without
+          // charging the obsolete attempt against the poison-event limit.
+          if (!identical(_activeSubscription, activeSubscription)) {
+            continue;
+          }
           _headAttempts++;
           _onError(event, e);
 

--- a/shared/sesori_shared/test/concurrency/event_queue_test.dart
+++ b/shared/sesori_shared/test/concurrency/event_queue_test.dart
@@ -403,6 +403,34 @@ void main() {
         queue.dispose();
       });
 
+      test("detached in-flight failure is retried by the replacement listener", () async {
+        final firstDelivery = Completer<void>();
+        final firstStarted = Completer<void>();
+        final errors = <Object>[];
+        final processed = <String>[];
+        final queue = EventQueue<String>();
+        final firstSubscription = queue.listen(
+          (event) async {
+            firstStarted.complete();
+            await firstDelivery.future;
+            throw StateError("obsolete delivery");
+          },
+          onError: (_, error) => errors.add(error),
+        );
+
+        queue.enqueue("retained");
+        await firstStarted.future;
+        firstSubscription.cancel();
+        queue.listen((event) async => processed.add(event));
+        firstDelivery.complete();
+        await pumpEventQueue();
+
+        expect(processed, ["retained"]);
+        expect(errors, isEmpty);
+        expect(queue.length, 0);
+        queue.dispose();
+      });
+
       test("default onError does not throw", () async {
         final queue = EventQueue<String>();
         queue.listen((e) async => throw Exception("oops"));


### PR DESCRIPTION
## Complexity

Moderate: this threads an opaque exact-WebSocket handle through Layer-0 relay connect, read, metadata, send, close, reconnect, SSE, and orchestrator shutdown paths without changing request concurrency.

## What

- Return an opaque `RelayConnection` from successful connect and reconnect operations.
- Require that exact handle for relay reads, auth/close metadata, sends, and closes.
- Add closed sent/stale and closed/stale outcomes.
- Make `closeIfCurrent` detach the exact current handle synchronously before awaiting its close handshake.
- Prevent stale send/close operations from affecting a successor connection.
- Emit connected state only after auth setup succeeds; auth failure terminates as disconnected.
- Prevent cancellation during token refresh or registration from starting a successor socket.
- Update orchestrator, SSE, tests, helpers, and existing relay benchmarks in lockstep.

## Why

A session-owned epoch check followed by a send through mutable current socket state leaves a reconnect race. Enforcing socket identity inside `RelayClient` creates the final exact-generation seam needed before route responses can complete independently.

## Risk and test focus

Risk centers on an old handle reading/sending through or closing its successor, losing authoritative close metadata, leaving observers in a false connected state, starting a successor after cancellation, changing connection-state emissions, or regressing reconnect, revoke, takeover, re-auth, and shutdown behavior. Tests cover stale/current send and close outcomes, synchronous detachment, auth setup failure, cancellation during re-registration, remote close metadata, pending handshake cancellation, successor protection, current send failure recovery, reconnect, revoke/takeover, token re-auth, SSE delivery, and shutdown races.

## Expected result

- **User-visible:** No behavior change; reconnect, takeover, revoke, and token re-auth continue as before.
- **Persisted/database:** None.
- **Internal:** Every relay operation is explicitly bound to one WebSocket generation. Request routing remains serial.

## Verification

- 80 focused RelayClient, SSE, orchestrator, reconnect, re-auth, revoke/takeover, and shutdown tests passed; 23 RelayClient tests and 13 registration/reconnect tests passed after review fixes.
- `dart analyze --fatal-infos` from `bridge/app` passed.
- Minimal event-projection and catalog-import benchmark smoke runs passed.
- `git diff --check` passed.
- `aristotle-impl-review` rejected an initial one-implementation handle interface; it was replaced with a final privately constructed opaque handle. Per policy, that direct fix was not re-reviewed.
- 1,019 changed lines, below the 1,500-line soft cap.
