### PR TITLE
🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]

### DIFF
--- a/.plan/active/relay-request-concurrency/PLAN.md
+++ b/.plan/active/relay-request-concurrency/PLAN.md
@@ -8,12 +8,13 @@
   post-merge correction PR
   [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) and Step 2 PR
   [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) and Step 3 PR
-  [#696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) merged;
-  Step 4 PR [#699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) open
+  [#696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) and Step 4 PR
+  [#699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) merged; Step 5
+  is implemented and ready for review
 - **Plan date:** 2026-08-02
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Current implementation base:** `main` at
-  `95178462b794cb485523a62740b80e8f0206d977`
+  `9ac855a3f64930a118675fa93786476337a987c9`
 - **Delivery:** one plan PR, eight sequential implementation PRs, and one
   plan-retirement PR
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687)

--- a/.plan/active/relay-request-concurrency/PLAN.md
+++ b/.plan/active/relay-request-concurrency/PLAN.md
@@ -10,7 +10,7 @@
   [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) and Step 3 PR
   [#696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) and Step 4 PR
   [#699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) merged; Step 5
-  is implemented and ready for review
+  PR [#700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700) is open
 - **Plan date:** 2026-08-02
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Current implementation base:** `main` at

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -338,5 +338,14 @@
   auto-approval competition, and unique/missing/ambiguous legacy owners.
 - **Step 5/10 architecture review:** `aristotle-impl-review` approved all tracked
   and untracked Step 5 changes from `9ac855a3` with no blocking findings.
+- **Step 5/10 PR review:** three bot findings were applied: the legacy wire path
+  retains its dated compatibility cleanup marker; the abort-pending signal is
+  emitted synchronously after dispatcher acceptance while backend abort remains
+  family-ordered; and the legacy owner callback uses a required named parameter.
+  Three suggestions were declined: pending questions have no authoritative
+  database index and adding one would violate this step's no-schema scope; the
+  fixed legacy OpenCode plugin's root query explicitly includes descendant
+  questions; and timing out its plugin barrier would not cancel owner discovery
+  and would let later same-plugin work violate the required arrival order.
 - **Step 5/10 delivery:** [PR #700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700)
-  is open at 1,484 changed lines.
+  is open at 1,490 changed lines.

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -8,7 +8,8 @@
 - **Series state:** Steps 1–4 merged; Step 4/10
   [#699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) merged as
   `9ac855a3`
-- **Current step:** Step 5/10 implemented on `plan-parallel-requests`
+- **Current step:** Step 5/10 PR
+  [#700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700) open
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged
 - **Next action:** open, review, and merge Step 5; Step 6 remains blocked until then
 
@@ -91,7 +92,7 @@
 | [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | [PR #690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) merged as `fdc8ad67` with 1,552 changed lines |
 | [x] | 3/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]` | 600–1,000 | [PR #696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) merged as `95178462` |
 | [x] | 4/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | [PR #699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) merged as `9ac855a3` with 1,326 changed lines |
-| [ ] | 5/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | Implemented from `9ac855a3`; ready to open |
+| [ ] | 5/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | [PR #700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700) open from `9ac855a3` |
 | [ ] | 6/10 | `relay-request-concurrency-session-lifecycle` | `🚧 [relay-request-concurrency] refactor(bridge): scope session family mutations [step 6/10]` | 750–1,250 | Blocked on Step 5 merge |
 | [ ] | 7/10 | `relay-request-concurrency-session-visibility` | `🚧 [relay-request-concurrency] refactor(bridge): gate new session visibility [step 7/10]` | 600–1,100 | Blocked on Step 6 merge |
 | [ ] | 8/10 | `relay-request-concurrency-project-mutations` | `🚧 [relay-request-concurrency] refactor(bridge): order project path mutations [step 8/10]` | 650–1,100 | Blocked on Step 7 merge |
@@ -337,4 +338,5 @@
   auto-approval competition, and unique/missing/ambiguous legacy owners.
 - **Step 5/10 architecture review:** `aristotle-impl-review` approved all tracked
   and untracked Step 5 changes from `9ac855a3` with no blocking findings.
-- **Step 5/10 delivery:** ready to open at 1,482 changed lines.
+- **Step 5/10 delivery:** [PR #700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700)
+  is open at 1,484 changed lines.

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -3,15 +3,14 @@
 ## Current State
 
 - **Plan slug:** `relay-request-concurrency`
-- **Implementation base:** merged Step 3 at
-  `95178462b794cb485523a62740b80e8f0206d977`
-- **Series state:** Steps 1–3 merged; Step 3/10
-  [#696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) merged as
-  `95178462`
-- **Current step:** Step 4/10 PR
-  [#699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) open
+- **Implementation base:** merged Step 4 at
+  `9ac855a3f64930a118675fa93786476337a987c9`
+- **Series state:** Steps 1–4 merged; Step 4/10
+  [#699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) merged as
+  `9ac855a3`
+- **Current step:** Step 5/10 implemented on `plan-parallel-requests`
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged
-- **Next action:** review and merge Step 4; Step 5 remains blocked until then
+- **Next action:** open, review, and merge Step 5; Step 6 remains blocked until then
 
 ## Incident Evidence
 
@@ -91,8 +90,8 @@
 | [x] | 1/10 | `plan/relay-request-concurrency` | `🌱 [relay-request-concurrency] docs: plan concurrent bridge requests [step 1/10]` | 1,400–1,600; explicitly cap-exempt | [PR #687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged as `c4d42a15`; correction [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) merged as `0e31324a` |
 | [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | [PR #690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) merged as `fdc8ad67` with 1,552 changed lines |
 | [x] | 3/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]` | 600–1,000 | [PR #696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) merged as `95178462` |
-| [ ] | 4/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | [PR #699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) open from `95178462` |
-| [ ] | 5/10 | `relay-request-concurrency-session-actions` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | Blocked on Step 4 merge |
+| [x] | 4/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | [PR #699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) merged as `9ac855a3` with 1,326 changed lines |
+| [ ] | 5/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | Implemented from `9ac855a3`; ready to open |
 | [ ] | 6/10 | `relay-request-concurrency-session-lifecycle` | `🚧 [relay-request-concurrency] refactor(bridge): scope session family mutations [step 6/10]` | 750–1,250 | Blocked on Step 5 merge |
 | [ ] | 7/10 | `relay-request-concurrency-session-visibility` | `🚧 [relay-request-concurrency] refactor(bridge): gate new session visibility [step 7/10]` | 600–1,100 | Blocked on Step 6 merge |
 | [ ] | 8/10 | `relay-request-concurrency-project-mutations` | `🚧 [relay-request-concurrency] refactor(bridge): order project path mutations [step 8/10]` | 650–1,100 | Blocked on Step 7 merge |
@@ -315,4 +314,27 @@
   single-assignment `final` and removed the shutdown future's bang assertion in
   favor of explicit null checking plus promotion.
 - **Step 4/10 delivery:** [PR #699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699)
-  is open at 1,326 changed lines; the owner-provided branch/worktree are reused.
+  merged as `9ac855a3f64930a118675fa93786476337a987c9` at 1,326 changed
+  lines; the owner-provided branch/worktree are reused.
+- **Step 5/10 base and scope:** based directly on merged Step 4 at `9ac855a3`
+  on the owner-provided `plan-parallel-requests` branch. The change adds internal
+  session-family and pending-interaction ordering only: no wire, database,
+  client, UI, analytics, or plugin-interface change; relay routing remains serial.
+- **Step 5/10 implementation:** one lifecycle-owned `SessionOperationDispatcher`
+  assigns monotonic admission, resolves stable root/plugin scope in order, and
+  atomically claims per-family plus permission/question lanes. Prompt/defaults,
+  abort, all pending-choice handlers, and auto approval use it. Legacy sessionless
+  question rejection resolves exactly one owner behind its plugin barrier and
+  returns explicit missing/ambiguous errors. Teardown quiesces plugin-event
+  producers and routes before closing and draining dispatcher acceptance.
+- **Step 5/10 cleanup:** removed direct pending-choice handler repository writes
+  and the repository's sessionless legacy rejection path. Prompt content remains
+  excluded from diagnostics while useful session/request/error context remains.
+- **Step 5/10 verification:** 2,396 full `bridge/app` tests pass, along with
+  strict `dart analyze --fatal-infos` and `git diff --check`. Focused coverage
+  includes family/interaction FIFO, unrelated-family/plugin concurrency,
+  failure release, idle cleanup, repeated drain, prompt/default/abort order,
+  auto-approval competition, and unique/missing/ambiguous legacy owners.
+- **Step 5/10 architecture review:** `aristotle-impl-review` approved all tracked
+  and untracked Step 5 changes from `9ac855a3` with no blocking findings.
+- **Step 5/10 delivery:** ready to open at 1,482 changed lines.

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -347,5 +347,15 @@
   fixed legacy OpenCode plugin's root query explicitly includes descendant
   questions; and timing out its plugin barrier would not cancel owner discovery
   and would let later same-plugin work violate the required arrival order.
+  Follow-up Cubic/Codex findings were valid: every accepted abort now emits one
+  terminal failure even when family admission fails before backend execution,
+  and legacy owner discovery waits for all earlier accepted work on that plugin
+  while continuing to block only later same-plugin admissions. The redundant
+  legacy-barrier bookkeeping was removed; the ticketed resolution and plugin
+  admission lanes own the actual reservation. Cache and concurrent-scan
+  suggestions were declined as speculative machinery for bounded local catalog
+  walks and a compatibility-only path without demonstrated load evidence.
 - **Step 5/10 delivery:** [PR #700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700)
-  is open at 1,490 changed lines.
+  is open at 1,534 changed lines. The 34-line soft-cap overage is directly caused
+  by review-required terminal abort signaling and prior-plugin settlement coverage;
+  splitting it would leave the ordering fix incomplete.

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -122,6 +122,7 @@ import "routing/set_base_branch_handler.dart";
 import "routing/update_session_archive_status_handler.dart";
 import "runtime/plugin_runtime.dart";
 import "services/deleted_session_storage_cleanup_service.dart";
+import "services/pending_interaction_service.dart";
 import "services/permission_auto_approval_service.dart";
 import "services/pr_sync_service.dart";
 import "services/project_activity_service.dart";
@@ -133,6 +134,7 @@ import "services/session_event_dispatcher.dart";
 import "services/session_event_service.dart";
 import "services/session_lifecycle_service.dart";
 import "services/session_mutation_dispatcher.dart";
+import "services/session_operation_dispatcher.dart";
 import "services/session_options_service.dart";
 import "services/session_prompt_service.dart";
 import "services/session_unseen_service.dart";
@@ -276,6 +278,9 @@ class Orchestrator {
       runtime: _pluginRuntime,
     );
     final worktreeService = WorktreeService(worktreeRepository: worktreeRepository);
+    final sessionOperationDispatcher = SessionOperationDispatcher(
+      sessionRepository: sessionRepository,
+    );
     final sessionMutationDispatcher = SessionMutationDispatcher(sessionRepository: sessionRepository);
     final pushTracker = PushSessionStateTracker(now: clock.now);
     final pushRateLimiter = PushRateLimiter(now: clock.now);
@@ -365,8 +370,13 @@ class Orchestrator {
       runtime: _pluginRuntime,
       sessionDao: _database.sessionDao,
       projectsDao: _database.projectsDao,
-      legacyMissingPluginId: _legacyMissingPluginId,
       aggregateSourceDeadline: aggregateSourceDeadline,
+    );
+    final pendingInteractionService = PendingInteractionService(
+      permissionRepository: permissionRepository,
+      questionRepository: questionRepository,
+      dispatcher: sessionOperationDispatcher,
+      legacyMissingPluginId: _legacyMissingPluginId,
     );
     final sessionCreationService = SessionCreationService(
       metadataService: MetadataService(
@@ -416,13 +426,17 @@ class Orchestrator {
     );
     final sessionPromptService = SessionPromptService(
       sessionRepository: sessionRepository,
+      dispatcher: sessionOperationDispatcher,
     );
     final sessionLifecycleService = SessionLifecycleService(
       worktreeService: worktreeService,
       sessionRepository: sessionRepository,
       filesystemRepository: filesystemRepository,
     );
-    final sessionAbortService = SessionAbortService(sessionRepository: sessionRepository);
+    final sessionAbortService = SessionAbortService(
+      sessionRepository: sessionRepository,
+      dispatcher: sessionOperationDispatcher,
+    );
     final sessionDiffService = SessionDiffService(
       sessionRepository: sessionRepository,
       sessionDiffRepository: SessionDiffRepository(
@@ -446,6 +460,7 @@ class Orchestrator {
     final permissionAutoApprovalService = PermissionAutoApprovalService(
       sessionRepository: sessionRepository,
       permissionRepository: permissionRepository,
+      pendingInteractionService: pendingInteractionService,
     );
     final pluginEventListeners = [
       PluginEventListener(source: _pluginRuntime.backendEvents, dispatcher: sessionEventDispatcher),
@@ -522,9 +537,9 @@ class Orchestrator {
         GetSessionQuestionsHandler(questionRepository: questionRepository),
         GetProjectQuestionsHandler(questionRepository: questionRepository),
         GetSessionPermissionsHandler(permissionRepository: permissionRepository),
-        ReplyToQuestionHandler(questionRepository: questionRepository),
-        RejectQuestionHandler(questionRepository: questionRepository),
-        ReplyToPermissionHandler(permissionRepository: permissionRepository),
+        ReplyToQuestionHandler(pendingInteractionService: pendingInteractionService),
+        RejectQuestionHandler(pendingInteractionService: pendingInteractionService),
+        ReplyToPermissionHandler(pendingInteractionService: pendingInteractionService),
         RenameProjectHandler(projectRepository),
         CreateProjectHandler(
           projectInitializationService: projectInitializationService,
@@ -585,7 +600,9 @@ class Orchestrator {
       projectViewTracker: projectViewTracker,
       projectActivityService: projectActivityService,
       permissionAutoApprovalService: permissionAutoApprovalService,
+      pendingInteractionService: pendingInteractionService,
       sessionAbortService: sessionAbortService,
+      sessionOperationDispatcher: sessionOperationDispatcher,
       sessionMutationDispatcher: sessionMutationDispatcher,
       restartDispatcher: restartDispatcher,
       statusNotifier: _statusNotifier,
@@ -653,6 +670,8 @@ class OrchestratorSession {
   final ProjectViewTracker _projectViewTracker;
   final SessionRepository _sessionRepository;
   final PermissionAutoApprovalService _permissionAutoApprovalService;
+  final PendingInteractionService _pendingInteractionService;
+  final SessionOperationDispatcher _sessionOperationDispatcher;
   final SessionMutationDispatcher _sessionMutationDispatcher;
   final SessionAbortService _sessionAbortService;
   final SessionPromptService _sessionPromptService;
@@ -673,8 +692,6 @@ class OrchestratorSession {
   Future<void>? _shutdownRelayCloseFuture;
 
   bool _cancelled = false;
-  Object? _beginShutdownError;
-  StackTrace? _beginShutdownStackTrace;
 
   /// When the first [cancel] was requested. Used only for shutdown timing
   /// diagnostics (the logger emits no timestamps, so durations are explicit).
@@ -724,7 +741,9 @@ class OrchestratorSession {
     required ProjectViewTracker projectViewTracker,
     required ProjectActivityService projectActivityService,
     required PermissionAutoApprovalService permissionAutoApprovalService,
+    required PendingInteractionService pendingInteractionService,
     required SessionAbortService sessionAbortService,
+    required SessionOperationDispatcher sessionOperationDispatcher,
     required SessionMutationDispatcher sessionMutationDispatcher,
     required BridgeRestartDispatcher restartDispatcher,
     required ControlStatusNotifier? statusNotifier,
@@ -758,6 +777,8 @@ class OrchestratorSession {
        _projectViewTracker = projectViewTracker,
        _sessionRepository = sessionRepository,
        _permissionAutoApprovalService = permissionAutoApprovalService,
+       _pendingInteractionService = pendingInteractionService,
+       _sessionOperationDispatcher = sessionOperationDispatcher,
        _sessionMutationDispatcher = sessionMutationDispatcher,
        _sessionAbortService = sessionAbortService,
        _projectActivityService = projectActivityService,
@@ -1003,8 +1024,8 @@ class OrchestratorSession {
   Future<void> _teardown() async {
     _routedRequestDispatcher.beginShutdown();
     final teardownSw = Stopwatch()..start();
-    Object? firstTeardownError = _beginShutdownError;
-    StackTrace? firstTeardownStackTrace = _beginShutdownStackTrace;
+    Object? firstTeardownError;
+    StackTrace? firstTeardownStackTrace;
 
     Future<void> attempt(FutureOr<void> Function() action) async {
       try {
@@ -1028,8 +1049,11 @@ class OrchestratorSession {
       attempt(_subscriptions.cancel),
       attempt(_promptDefaultsSubscriptions.cancel),
       attempt(_catalogImportSubscriptions.cancel),
+      for (final listener in _pluginEventListeners) attempt(listener.dispose),
+      attempt(_sessionBindingCommitListener.dispose),
+      attempt(_sessionDeletionListener.dispose),
     ]);
-    Log.v("[shutdown] subscriptions cancelled (+${teardownSw.elapsedMilliseconds}ms)");
+    Log.v("[shutdown] event producers cancelled (+${teardownSw.elapsedMilliseconds}ms)");
     await Future.wait([
       attempt(() async {
         await Future.wait(_pluginEventProcessingTails.values);
@@ -1037,21 +1061,23 @@ class OrchestratorSession {
       attempt(_routedRequestDispatcher.drain),
     ]);
     Log.v("[shutdown] plugin events and routed requests drained (+${teardownSw.elapsedMilliseconds}ms)");
-    await attempt(_sessionPromptService.dispose);
+    _sessionOperationDispatcher.beginShutdown();
+    await attempt(_sessionOperationDispatcher.dispose);
+    Log.v("[shutdown] session operations drained (+${teardownSw.elapsedMilliseconds}ms)");
     await Future.wait([
-      for (final listener in _pluginEventListeners) attempt(listener.dispose),
-      attempt(_sessionBindingCommitListener.dispose),
-      attempt(_sessionDeletionListener.dispose),
+      attempt(_permissionAutoApprovalService.dispose),
+      attempt(_sessionPromptService.dispose),
+      attempt(_sessionAbortService.dispose),
+    ]);
+    await attempt(_pendingInteractionService.dispose);
+    await Future.wait([
       attempt(_sessionOptionsCreationRefreshListener.dispose),
       attempt(_sessionOptionsChangedRefreshListener.dispose),
     ]);
     await attempt(_sessionEventDispatcher.dispose);
-    await attempt(_permissionAutoApprovalService.dispose);
     await attempt(_sessionMutationDispatcher.dispose);
     await attempt(_projectActivityService.dispose);
     Log.v("[shutdown] project activity service disposed (+${teardownSw.elapsedMilliseconds}ms)");
-    await attempt(_sessionAbortService.dispose);
-    Log.v("[shutdown] session abort service disposed (+${teardownSw.elapsedMilliseconds}ms)");
     await attempt(_completionListener.dispose);
     Log.v("[shutdown] completion listener disposed (+${teardownSw.elapsedMilliseconds}ms)");
     await attempt(_maintenanceListener.dispose);
@@ -1224,12 +1250,6 @@ class OrchestratorSession {
     }
     _shutdownRelayCloseFuture ??= _closeRelayConnection();
     unawaited(_shutdownRelayCloseFuture);
-    try {
-      _permissionAutoApprovalService.dispose();
-    } on Object catch (error, stackTrace) {
-      _beginShutdownError ??= error;
-      _beginShutdownStackTrace ??= stackTrace;
-    }
   }
 
   Future<void> cancel() async {

--- a/bridge/app/lib/src/bridge/repositories/question_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/question_repository.dart
@@ -20,19 +20,16 @@ class QuestionRepository {
   final PluginRuntime _runtime;
   final SessionDao _sessionDao;
   final ProjectsDao _projectsDao;
-  final String _legacyMissingPluginId;
   final Duration _aggregateSourceDeadline;
 
   QuestionRepository({
     required PluginRuntime runtime,
     required SessionDao sessionDao,
     required ProjectsDao projectsDao,
-    required String legacyMissingPluginId,
     required Duration aggregateSourceDeadline,
   }) : _runtime = runtime,
        _sessionDao = sessionDao,
        _projectsDao = projectsDao,
-       _legacyMissingPluginId = legacyMissingPluginId,
        _aggregateSourceDeadline = aggregateSourceDeadline;
 
   /// Pending questions to surface on [sessionId]'s screen (its own plus any
@@ -211,39 +208,57 @@ class QuestionRepository {
     );
   }
 
-  // COMPATIBILITY 2026-06-17 (v1.1.0): Old clients may omit the rejection sessionId. Require it and always run tombstone validation once those clients are unsupported.
   Future<void> rejectQuestion({
     required String questionId,
-    required String? sessionId,
+    required String sessionId,
   }) async {
-    String? backendSessionId;
-    if (sessionId != null) {
-      final binding = await _requireBinding(
-        sessionId: sessionId,
-        operation: SessionOperation.rejectQuestion,
-      );
-      backendSessionId = binding.backendSessionId;
-      return _runtime.use(
-        pluginId: binding.pluginId,
-        operation: SessionOperation.rejectQuestion,
-        body: (plugin) async {
-          await _throwIfMutationTargetTombstoned(
-            questionId: questionId,
-            backendSessionId: backendSessionId!,
-            operation: SessionOperation.rejectQuestion,
-            plugin: plugin,
-          );
-          return plugin.rejectQuestion(questionId: questionId, sessionId: backendSessionId);
-        },
-      );
-    }
-    return _runtime.use(
-      pluginId: _legacyMissingPluginId,
+    final binding = await _requireBinding(
+      sessionId: sessionId,
       operation: SessionOperation.rejectQuestion,
-      body: (plugin) => plugin.rejectQuestion(
-        questionId: questionId,
-        sessionId: backendSessionId,
-      ),
+    );
+    return _runtime.use(
+      pluginId: binding.pluginId,
+      operation: SessionOperation.rejectQuestion,
+      body: (plugin) async {
+        await _throwIfMutationTargetTombstoned(
+          questionId: questionId,
+          backendSessionId: binding.backendSessionId,
+          operation: SessionOperation.rejectQuestion,
+          plugin: plugin,
+        );
+        return plugin.rejectQuestion(
+          questionId: questionId,
+          sessionId: binding.backendSessionId,
+        );
+      },
+    );
+  }
+
+  Future<List<String>> findPendingQuestionOwnerSessionIds({
+    required String pluginId,
+    required String questionId,
+  }) async {
+    final bindings = await _sessionDao.getSessionsForPlugin(pluginId: pluginId);
+    final roots = bindings.values.where((binding) => binding.parentSessionId == null);
+    return _runtime.use(
+      pluginId: pluginId,
+      operation: SessionOperation.rejectQuestion,
+      body: (plugin) async {
+        final tombstoned = plugin is BridgeDerivedProjectsPluginApi
+            ? await _sessionDao.getTombstonedSessionIds(pluginId: pluginId)
+            : const <String>{};
+        final owners = <String>{};
+        for (final root in roots) {
+          if (tombstoned.contains(root.backendSessionId)) continue;
+          final questions = await plugin.getPendingQuestions(sessionId: root.backendSessionId);
+          for (final question in questions) {
+            if (question.id != questionId || !_isVisible(question, tombstoned)) continue;
+            final owner = bindings[question.sessionID];
+            if (owner != null) owners.add(owner.sessionId);
+          }
+        }
+        return owners.toList(growable: false)..sort();
+      },
     );
   }
 

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -61,6 +61,8 @@ typedef SessionBindingsCommitted = ({
   List<String> backendSessionIds,
 });
 
+typedef SessionFamilyScope = ({String rootSessionId, String pluginId});
+
 class SessionRepository {
   static const SessionCatalogMapper _sessionCatalogMapper = SessionCatalogMapper();
 
@@ -99,6 +101,50 @@ class SessionRepository {
        _aggregateSourceDeadline = aggregateSourceDeadline;
 
   Stream<SessionBindingsCommitted> get bindingCommits => _bindingCommitsController.stream;
+
+  Future<SessionFamilyScope> resolveSessionFamily({
+    required String sessionId,
+    required SessionOperation operation,
+  }) async {
+    const maxDepth = 256;
+    final visited = <String>{};
+    String? pluginId;
+    var currentSessionId = sessionId;
+    for (var depth = 0; depth < maxDepth; depth++) {
+      if (!visited.add(currentSessionId)) {
+        throw PluginOperationException(
+          operation.name,
+          statusCode: 409,
+          message: "session $sessionId has cyclic ancestry at $currentSessionId",
+        );
+      }
+      final binding = await _sessionDao.getSession(sessionId: currentSessionId);
+      if (binding == null) {
+        throw PluginOperationException.notFound(
+          operation.name,
+          message: "session $currentSessionId was not found while resolving family for $sessionId",
+        );
+      }
+      pluginId ??= binding.pluginId;
+      if (binding.pluginId != pluginId) {
+        throw PluginOperationException(
+          operation.name,
+          statusCode: 409,
+          message: "session $sessionId has cross-plugin ancestry at $currentSessionId",
+        );
+      }
+      final parentSessionId = binding.parentSessionId;
+      if (parentSessionId == null) {
+        return (rootSessionId: binding.sessionId, pluginId: binding.pluginId);
+      }
+      currentSessionId = parentSessionId;
+    }
+    throw PluginOperationException(
+      operation.name,
+      statusCode: 409,
+      message: "session $sessionId ancestry exceeds $maxDepth entries",
+    );
+  }
 
   Future<List<Session>> getSessionsForProject({
     required String projectId,

--- a/bridge/app/lib/src/bridge/routing/reject_question_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/reject_question_handler.dart
@@ -1,17 +1,18 @@
 import "package:sesori_shared/sesori_shared.dart";
 
-import "../repositories/question_repository.dart";
+import "../services/pending_interaction_service.dart";
 import "request_handler.dart";
 
 /// Handles `POST /question/reject` — rejects a pending question.
 ///
-/// Question IDs are globally unique. Session context is optional for backwards
-/// compatibility with older mobile clients.
+/// Session context scopes modern question IDs. It remains optional for
+/// backwards compatibility with older clients, where the pending owner must
+/// resolve unambiguously before rejection.
 class RejectQuestionHandler extends BodyRequestHandler<RejectQuestionRequest, SuccessEmptyResponse> {
-  final QuestionRepository _questionRepository;
+  final PendingInteractionService _pendingInteractionService;
 
-  RejectQuestionHandler({required QuestionRepository questionRepository})
-    : _questionRepository = questionRepository,
+  RejectQuestionHandler({required PendingInteractionService pendingInteractionService})
+    : _pendingInteractionService = pendingInteractionService,
       super(
         HttpMethod.post,
         "/question/reject",
@@ -31,7 +32,7 @@ class RejectQuestionHandler extends BodyRequestHandler<RejectQuestionRequest, Su
       throw buildErrorResponse(request, 400, "empty request id");
     }
 
-    await _questionRepository.rejectQuestion(
+    await _pendingInteractionService.rejectQuestion(
       questionId: requestId,
       sessionId: body.sessionId,
     );

--- a/bridge/app/lib/src/bridge/routing/reply_to_permission_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/reply_to_permission_handler.dart
@@ -1,16 +1,16 @@
 import "package:sesori_shared/sesori_shared.dart";
 
-import "../repositories/permission_repository.dart";
+import "../services/pending_interaction_service.dart";
 import "request_handler.dart";
 
 /// Handles `POST /permission/reply` — replies to a pending permission request.
 ///
 /// The [reply] field accepts "once", "always", or "reject".
 class ReplyToPermissionHandler extends BodyRequestHandler<ReplyToPermissionRequest, SuccessEmptyResponse> {
-  final PermissionRepository _permissionRepository;
+  final PendingInteractionService _pendingInteractionService;
 
-  ReplyToPermissionHandler({required PermissionRepository permissionRepository})
-    : _permissionRepository = permissionRepository,
+  ReplyToPermissionHandler({required PendingInteractionService pendingInteractionService})
+    : _pendingInteractionService = pendingInteractionService,
       super(
         HttpMethod.post,
         "/permission/reply",
@@ -34,7 +34,7 @@ class ReplyToPermissionHandler extends BodyRequestHandler<ReplyToPermissionReque
       throw buildErrorResponse(request, 400, "empty session id");
     }
 
-    await _permissionRepository.replyToPermission(
+    await _pendingInteractionService.replyToPermission(
       requestId: requestId,
       sessionId: sessionId,
       reply: body.reply,

--- a/bridge/app/lib/src/bridge/routing/reply_to_question_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/reply_to_question_handler.dart
@@ -1,16 +1,14 @@
 import "package:sesori_shared/sesori_shared.dart";
 
-import "../repositories/question_repository.dart";
+import "../services/pending_interaction_service.dart";
 import "request_handler.dart";
 
 /// Handles `POST /question/reply` — replies to a pending question.
-///
-/// Question IDs are globally unique in the backend.
 class ReplyToQuestionHandler extends BodyRequestHandler<ReplyToQuestionRequest, SuccessEmptyResponse> {
-  final QuestionRepository _questionRepository;
+  final PendingInteractionService _pendingInteractionService;
 
-  ReplyToQuestionHandler({required QuestionRepository questionRepository})
-    : _questionRepository = questionRepository,
+  ReplyToQuestionHandler({required PendingInteractionService pendingInteractionService})
+    : _pendingInteractionService = pendingInteractionService,
       super(
         HttpMethod.post,
         "/question/reply",
@@ -34,7 +32,7 @@ class ReplyToQuestionHandler extends BodyRequestHandler<ReplyToQuestionRequest, 
       throw buildErrorResponse(request, 400, "empty session id");
     }
 
-    await _questionRepository.replyToQuestion(
+    await _pendingInteractionService.replyToQuestion(
       questionId: requestId,
       sessionId: sessionId,
       answers: body.answers,

--- a/bridge/app/lib/src/bridge/services/pending_interaction_service.dart
+++ b/bridge/app/lib/src/bridge/services/pending_interaction_service.dart
@@ -76,6 +76,7 @@ class PendingInteractionService {
       );
     }
 
+    // COMPATIBILITY 2026-06-17 (v1.1.0): Released clients may omit the rejection sessionId. Require it and remove legacy owner resolution once those clients are unsupported.
     return _dispatcher.dispatchLegacyQuestion(
       pluginId: _legacyMissingPluginId,
       questionId: questionId,
@@ -100,7 +101,7 @@ class PendingInteractionService {
         }
         return owners.single;
       },
-      body: (ownerSessionId) => _questionRepository.rejectQuestion(
+      body: ({required ownerSessionId}) => _questionRepository.rejectQuestion(
         questionId: questionId,
         sessionId: ownerSessionId,
       ),

--- a/bridge/app/lib/src/bridge/services/pending_interaction_service.dart
+++ b/bridge/app/lib/src/bridge/services/pending_interaction_service.dart
@@ -1,0 +1,118 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginOperationException;
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../repositories/models/session_operation.dart";
+import "../repositories/permission_repository.dart";
+import "../repositories/question_repository.dart";
+import "session_operation_dispatcher.dart";
+
+class PendingInteractionService {
+  final PermissionRepository _permissionRepository;
+  final QuestionRepository _questionRepository;
+  final SessionOperationDispatcher _dispatcher;
+  final String _legacyMissingPluginId;
+  var _disposed = false;
+
+  PendingInteractionService({
+    required PermissionRepository permissionRepository,
+    required QuestionRepository questionRepository,
+    required SessionOperationDispatcher dispatcher,
+    required String legacyMissingPluginId,
+  }) : _permissionRepository = permissionRepository,
+       _questionRepository = questionRepository,
+       _dispatcher = dispatcher,
+       _legacyMissingPluginId = legacyMissingPluginId;
+
+  Future<void> replyToPermission({
+    required String requestId,
+    required String sessionId,
+    required PermissionReply reply,
+  }) {
+    if (_disposed) return _disposedFuture();
+    return _dispatcher.dispatch(
+      sessionId: sessionId,
+      operation: SessionOperation.replyToPermission,
+      interaction: PendingPermissionInteraction(requestId: requestId),
+      body: () => _permissionRepository.replyToPermission(
+        requestId: requestId,
+        sessionId: sessionId,
+        reply: reply,
+      ),
+    );
+  }
+
+  Future<void> replyToQuestion({
+    required String questionId,
+    required String sessionId,
+    required List<ReplyAnswer> answers,
+  }) {
+    if (_disposed) return _disposedFuture();
+    return _dispatcher.dispatch(
+      sessionId: sessionId,
+      operation: SessionOperation.replyToQuestion,
+      interaction: PendingQuestionInteraction(requestId: questionId),
+      body: () => _questionRepository.replyToQuestion(
+        questionId: questionId,
+        sessionId: sessionId,
+        answers: answers,
+      ),
+    );
+  }
+
+  Future<void> rejectQuestion({
+    required String questionId,
+    required String? sessionId,
+  }) {
+    if (_disposed) return _disposedFuture();
+    if (sessionId != null) {
+      return _dispatcher.dispatch(
+        sessionId: sessionId,
+        operation: SessionOperation.rejectQuestion,
+        interaction: PendingQuestionInteraction(requestId: questionId),
+        body: () => _questionRepository.rejectQuestion(
+          questionId: questionId,
+          sessionId: sessionId,
+        ),
+      );
+    }
+
+    return _dispatcher.dispatchLegacyQuestion(
+      pluginId: _legacyMissingPluginId,
+      questionId: questionId,
+      operation: SessionOperation.rejectQuestion,
+      resolveOwnerSessionId: () async {
+        final owners = await _questionRepository.findPendingQuestionOwnerSessionIds(
+          pluginId: _legacyMissingPluginId,
+          questionId: questionId,
+        );
+        if (owners.isEmpty) {
+          throw PluginOperationException.notFound(
+            SessionOperation.rejectQuestion.name,
+            message: "pending question $questionId was not found for legacy rejection",
+          );
+        }
+        if (owners.length > 1) {
+          throw PluginOperationException(
+            SessionOperation.rejectQuestion.name,
+            statusCode: 409,
+            message: "pending question $questionId has multiple owners for legacy rejection",
+          );
+        }
+        return owners.single;
+      },
+      body: (ownerSessionId) => _questionRepository.rejectQuestion(
+        questionId: questionId,
+        sessionId: ownerSessionId,
+      ),
+    );
+  }
+
+  void dispose() {
+    _disposed = true;
+  }
+
+  Future<void> _disposedFuture() => Future<void>.error(
+    StateError("PendingInteractionService is disposed"),
+    StackTrace.current,
+  );
+}

--- a/bridge/app/lib/src/bridge/services/permission_auto_approval_service.dart
+++ b/bridge/app/lib/src/bridge/services/permission_auto_approval_service.dart
@@ -3,10 +3,12 @@ import "package:sesori_shared/sesori_shared.dart" show PendingPermission, Permis
 
 import "../repositories/permission_repository.dart";
 import "../repositories/session_repository.dart";
+import "pending_interaction_service.dart";
 
 class PermissionAutoApprovalService {
   final SessionRepository _sessionRepository;
   final PermissionRepository _permissionRepository;
+  final PendingInteractionService _pendingInteractionService;
   final Set<({String requestId, String sessionId})> _approvedPermissions = {};
 
   bool _disposed = false;
@@ -14,8 +16,10 @@ class PermissionAutoApprovalService {
   PermissionAutoApprovalService({
     required SessionRepository sessionRepository,
     required PermissionRepository permissionRepository,
+    required PendingInteractionService pendingInteractionService,
   }) : _sessionRepository = sessionRepository,
-       _permissionRepository = permissionRepository;
+       _permissionRepository = permissionRepository,
+       _pendingInteractionService = pendingInteractionService;
 
   bool consumeReply({required String requestId, required String sessionId}) {
     return _approvedPermissions.remove((requestId: requestId, sessionId: sessionId));
@@ -28,7 +32,7 @@ class PermissionAutoApprovalService {
 
     Log.i("[permissions] auto-approving request $requestId");
     try {
-      await _permissionRepository.replyToPermission(
+      await _pendingInteractionService.replyToPermission(
         requestId: requestId,
         sessionId: sessionId,
         reply: PermissionReply.once,

--- a/bridge/app/lib/src/bridge/services/session_abort_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_abort_service.dart
@@ -27,17 +27,18 @@ class SessionAbortService {
       operation: SessionOperation.abortSession,
       interaction: null,
       body: () async {
-        try {
-          await _sessionRepository.abortSession(sessionId: sessionId);
-          _abortedSessionsController.add(sessionId);
-        } catch (_) {
-          _abortFailedSessionsController.add(sessionId);
-          rethrow;
-        }
+        await _sessionRepository.abortSession(sessionId: sessionId);
+        _abortedSessionsController.add(sessionId);
       },
     );
     _abortStartedSessionsController.add(sessionId);
-    return operation;
+    return operation.then<void>(
+      (_) {},
+      onError: (Object error, StackTrace stackTrace) {
+        _abortFailedSessionsController.add(sessionId);
+        Error.throwWithStackTrace(error, stackTrace);
+      },
+    );
   }
 
   Future<void> dispose() async {

--- a/bridge/app/lib/src/bridge/services/session_abort_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_abort_service.dart
@@ -1,28 +1,42 @@
 import "dart:async";
 
+import "../repositories/models/session_operation.dart";
 import "../repositories/session_repository.dart";
+import "session_operation_dispatcher.dart";
 
 class SessionAbortService {
   final SessionRepository _sessionRepository;
+  final SessionOperationDispatcher _dispatcher;
   final StreamController<String> _abortStartedSessionsController = StreamController<String>.broadcast(sync: true);
   final StreamController<String> _abortedSessionsController = StreamController<String>.broadcast(sync: true);
   final StreamController<String> _abortFailedSessionsController = StreamController<String>.broadcast(sync: true);
 
-  SessionAbortService({required SessionRepository sessionRepository}) : _sessionRepository = sessionRepository;
+  SessionAbortService({
+    required SessionRepository sessionRepository,
+    required SessionOperationDispatcher dispatcher,
+  }) : _sessionRepository = sessionRepository,
+       _dispatcher = dispatcher;
 
   Stream<String> get abortStartedSessions => _abortStartedSessionsController.stream;
   Stream<String> get abortedSessions => _abortedSessionsController.stream;
   Stream<String> get abortFailedSessions => _abortFailedSessionsController.stream;
 
-  Future<void> abortSession({required String sessionId}) async {
-    _abortStartedSessionsController.add(sessionId);
-    try {
-      await _sessionRepository.abortSession(sessionId: sessionId);
-      _abortedSessionsController.add(sessionId);
-    } catch (_) {
-      _abortFailedSessionsController.add(sessionId);
-      rethrow;
-    }
+  Future<void> abortSession({required String sessionId}) {
+    return _dispatcher.dispatch(
+      sessionId: sessionId,
+      operation: SessionOperation.abortSession,
+      interaction: null,
+      body: () async {
+        _abortStartedSessionsController.add(sessionId);
+        try {
+          await _sessionRepository.abortSession(sessionId: sessionId);
+          _abortedSessionsController.add(sessionId);
+        } catch (_) {
+          _abortFailedSessionsController.add(sessionId);
+          rethrow;
+        }
+      },
+    );
   }
 
   Future<void> dispose() async {

--- a/bridge/app/lib/src/bridge/services/session_abort_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_abort_service.dart
@@ -22,12 +22,11 @@ class SessionAbortService {
   Stream<String> get abortFailedSessions => _abortFailedSessionsController.stream;
 
   Future<void> abortSession({required String sessionId}) {
-    return _dispatcher.dispatch(
+    final operation = _dispatcher.dispatch<void>(
       sessionId: sessionId,
       operation: SessionOperation.abortSession,
       interaction: null,
       body: () async {
-        _abortStartedSessionsController.add(sessionId);
         try {
           await _sessionRepository.abortSession(sessionId: sessionId);
           _abortedSessionsController.add(sessionId);
@@ -37,6 +36,8 @@ class SessionAbortService {
         }
       },
     );
+    _abortStartedSessionsController.add(sessionId);
+    return operation;
   }
 
   Future<void> dispose() async {

--- a/bridge/app/lib/src/bridge/services/session_operation_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/services/session_operation_dispatcher.dart
@@ -1,0 +1,288 @@
+import "dart:async";
+
+import "package:meta/meta.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginOperationException;
+
+import "../repositories/models/session_operation.dart";
+import "../repositories/session_repository.dart";
+
+sealed class PendingInteractionRequest {
+  final String requestId;
+
+  const PendingInteractionRequest({required this.requestId});
+}
+
+final class PendingPermissionInteraction extends PendingInteractionRequest {
+  const PendingPermissionInteraction({required super.requestId});
+}
+
+final class PendingQuestionInteraction extends PendingInteractionRequest {
+  const PendingQuestionInteraction({required super.requestId});
+}
+
+enum _PendingInteractionKind { permission, question }
+
+typedef _FamilyKey = ({String pluginId, String rootSessionId});
+typedef _InteractionKey = ({
+  String pluginId,
+  String ownerSessionId,
+  _PendingInteractionKind kind,
+  String requestId,
+});
+
+/// Admits session work in arrival order, then serializes only shared domains.
+class SessionOperationDispatcher {
+  final SessionRepository _sessionRepository;
+  final Map<_FamilyKey, _LaneToken> _familyLanes = {};
+  final Map<_InteractionKey, _LaneToken> _interactionLanes = {};
+  final Map<String, _LaneToken> _pluginAdmissionLanes = {};
+  final Map<String, Set<int>> _legacyBarriers = {};
+  final Set<Future<void>> _inFlightSettlements = {};
+
+  Future<void> _resolutionTail = Future<void>.value();
+  Future<void>? _drainFuture;
+  var _nextTicket = 0;
+  var _accepting = true;
+  var _disposed = false;
+
+  SessionOperationDispatcher({required SessionRepository sessionRepository}) : _sessionRepository = sessionRepository;
+
+  Future<T> dispatch<T>({
+    required String sessionId,
+    required SessionOperation operation,
+    required PendingInteractionRequest? interaction,
+    required Future<T> Function() body,
+  }) {
+    if (!_accepting) return _closedFuture<T>();
+
+    final ticket = _nextTicket++;
+    final result = Completer<T>();
+    _track(result: result);
+    _enqueueResolution(
+      ticket: ticket,
+      action: () async {
+        final family = await _sessionRepository.resolveSessionFamily(
+          sessionId: sessionId,
+          operation: operation,
+        );
+        _enqueuePluginAdmission(
+          pluginId: family.pluginId,
+          ticket: ticket,
+          action: () {
+            _registerOperation(
+              ticket: ticket,
+              family: family,
+              ownerSessionId: sessionId,
+              interaction: interaction,
+              body: body,
+              result: result,
+            );
+          },
+          onError: result.completeError,
+        );
+      },
+      onError: result.completeError,
+    );
+    return result.future;
+  }
+
+  /// Reserves [pluginId] synchronously while a sessionless question owner is
+  /// unresolved. The global resolver only installs this reservation in ticket
+  /// order; owner discovery itself blocks this plugin's admissions only.
+  Future<T> dispatchLegacyQuestion<T>({
+    required String pluginId,
+    required String questionId,
+    required SessionOperation operation,
+    required Future<String> Function() resolveOwnerSessionId,
+    required Future<T> Function(String ownerSessionId) body,
+  }) {
+    if (!_accepting) return _closedFuture<T>();
+
+    final ticket = _nextTicket++;
+    final result = Completer<T>();
+    (_legacyBarriers[pluginId] ??= <int>{}).add(ticket);
+    _track(result: result);
+    _enqueueResolution(
+      ticket: ticket,
+      action: () {
+        _enqueuePluginAdmission(
+          pluginId: pluginId,
+          ticket: ticket,
+          action: () async {
+            try {
+              final ownerSessionId = await resolveOwnerSessionId();
+              final family = await _sessionRepository.resolveSessionFamily(
+                sessionId: ownerSessionId,
+                operation: operation,
+              );
+              if (family.pluginId != pluginId) {
+                throw PluginOperationException(
+                  operation.name,
+                  statusCode: 409,
+                  message: "question $questionId resolved to plugin ${family.pluginId}, expected $pluginId",
+                );
+              }
+              _registerOperation(
+                ticket: ticket,
+                family: family,
+                ownerSessionId: ownerSessionId,
+                interaction: PendingQuestionInteraction(requestId: questionId),
+                body: () => body(ownerSessionId),
+                result: result,
+              );
+            } finally {
+              final barriers = _legacyBarriers[pluginId];
+              barriers?.remove(ticket);
+              if (barriers?.isEmpty ?? false) _legacyBarriers.remove(pluginId);
+            }
+          },
+          onError: result.completeError,
+        );
+      },
+      onError: (error, stackTrace) {
+        final barriers = _legacyBarriers[pluginId];
+        barriers?.remove(ticket);
+        if (barriers?.isEmpty ?? false) _legacyBarriers.remove(pluginId);
+        result.completeError(error, stackTrace);
+      },
+    );
+    return result.future;
+  }
+
+  void beginShutdown() {
+    _accepting = false;
+  }
+
+  Future<void> drain() => _drainFuture ??= _drain();
+
+  Future<void> dispose() {
+    _disposed = true;
+    return drain();
+  }
+
+  @visibleForTesting
+  int get activeLaneCount =>
+      _familyLanes.length + _interactionLanes.length + _pluginAdmissionLanes.length + _legacyBarriers.length;
+
+  Future<void> _drain() async {
+    beginShutdown();
+    await _resolutionTail;
+    await Future.wait(_inFlightSettlements.toList(growable: false));
+  }
+
+  Future<T> _closedFuture<T>() {
+    final state = _disposed ? "disposed" : "closed";
+    return Future<T>.error(
+      StateError("SessionOperationDispatcher is $state"),
+      StackTrace.current,
+    );
+  }
+
+  void _enqueueResolution({
+    required int ticket,
+    required FutureOr<void> Function() action,
+    required void Function(Object error, StackTrace stackTrace) onError,
+  }) {
+    final previous = _resolutionTail;
+    final release = Completer<void>();
+    _resolutionTail = release.future;
+    unawaited(() async {
+      await previous;
+      try {
+        await action();
+      } on Object catch (error, stackTrace) {
+        onError(error, stackTrace);
+      } finally {
+        release.complete();
+      }
+    }());
+  }
+
+  void _enqueuePluginAdmission({
+    required String pluginId,
+    required int ticket,
+    required FutureOr<void> Function() action,
+    required void Function(Object error, StackTrace stackTrace) onError,
+  }) {
+    final previous = _pluginAdmissionLanes[pluginId]?.completion.future ?? Future<void>.value();
+    final token = _LaneToken(ticket: ticket);
+    _pluginAdmissionLanes[pluginId] = token;
+    unawaited(() async {
+      await previous;
+      try {
+        await action();
+      } on Object catch (error, stackTrace) {
+        onError(error, stackTrace);
+      } finally {
+        token.completion.complete();
+        if (identical(_pluginAdmissionLanes[pluginId], token)) {
+          _pluginAdmissionLanes.remove(pluginId);
+        }
+      }
+    }());
+  }
+
+  void _registerOperation<T>({
+    required int ticket,
+    required SessionFamilyScope family,
+    required String ownerSessionId,
+    required PendingInteractionRequest? interaction,
+    required Future<T> Function() body,
+    required Completer<T> result,
+  }) {
+    final familyKey = (pluginId: family.pluginId, rootSessionId: family.rootSessionId);
+    final predecessors = <Future<void>>[
+      _familyLanes[familyKey]?.completion.future ?? Future<void>.value(),
+    ];
+    final token = _LaneToken(ticket: ticket);
+    _familyLanes[familyKey] = token;
+
+    final interactionKey = interaction == null
+        ? null
+        : (
+            pluginId: family.pluginId,
+            ownerSessionId: ownerSessionId,
+            kind: switch (interaction) {
+              PendingPermissionInteraction() => _PendingInteractionKind.permission,
+              PendingQuestionInteraction() => _PendingInteractionKind.question,
+            },
+            requestId: interaction.requestId,
+          );
+    if (interactionKey != null) {
+      predecessors.add(
+        _interactionLanes[interactionKey]?.completion.future ?? Future<void>.value(),
+      );
+      _interactionLanes[interactionKey] = token;
+    }
+
+    unawaited(() async {
+      await Future.wait(predecessors);
+      try {
+        result.complete(await body());
+      } on Object catch (error, stackTrace) {
+        result.completeError(error, stackTrace);
+      } finally {
+        token.completion.complete();
+        if (identical(_familyLanes[familyKey], token)) _familyLanes.remove(familyKey);
+        if (interactionKey != null && identical(_interactionLanes[interactionKey], token)) {
+          _interactionLanes.remove(interactionKey);
+        }
+      }
+    }());
+  }
+
+  void _track<T>({required Completer<T> result}) {
+    late final Future<void> settlement;
+    settlement = result.future.then<void>((_) {}, onError: (Object _, StackTrace __) {}).whenComplete(() {
+      _inFlightSettlements.remove(settlement);
+    });
+    _inFlightSettlements.add(settlement);
+  }
+}
+
+class _LaneToken {
+  final int ticket;
+  final Completer<void> completion = Completer<void>();
+
+  _LaneToken({required this.ticket});
+}

--- a/bridge/app/lib/src/bridge/services/session_operation_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/services/session_operation_dispatcher.dart
@@ -36,7 +36,7 @@ class SessionOperationDispatcher {
   final Map<_FamilyKey, _LaneToken> _familyLanes = {};
   final Map<_InteractionKey, _LaneToken> _interactionLanes = {};
   final Map<String, _LaneToken> _pluginAdmissionLanes = {};
-  final Map<String, Set<int>> _legacyBarriers = {};
+  final Map<String, Set<Future<void>>> _pluginSettlements = {};
   final Set<Future<void>> _inFlightSettlements = {};
 
   Future<void> _resolutionTail = Future<void>.value();
@@ -86,9 +86,8 @@ class SessionOperationDispatcher {
     return result.future;
   }
 
-  /// Reserves [pluginId] synchronously while a sessionless question owner is
-  /// unresolved. The global resolver only installs this reservation in ticket
-  /// order; owner discovery itself blocks this plugin's admissions only.
+  /// Queues a sessionless question ticket synchronously. Its plugin admission
+  /// waits for prior plugin work, then blocks later admissions while resolving.
   Future<T> dispatchLegacyQuestion<T>({
     required String pluginId,
     required String questionId,
@@ -100,7 +99,6 @@ class SessionOperationDispatcher {
 
     final ticket = _nextTicket++;
     final result = Completer<T>();
-    (_legacyBarriers[pluginId] ??= <int>{}).add(ticket);
     _track(result: result);
     _enqueueResolution(
       ticket: ticket,
@@ -109,42 +107,32 @@ class SessionOperationDispatcher {
           pluginId: pluginId,
           ticket: ticket,
           action: () async {
-            try {
-              final ownerSessionId = await resolveOwnerSessionId();
-              final family = await _sessionRepository.resolveSessionFamily(
-                sessionId: ownerSessionId,
-                operation: operation,
+            await Future.wait(_pluginSettlements[pluginId]?.toList(growable: false) ?? const []);
+            final ownerSessionId = await resolveOwnerSessionId();
+            final family = await _sessionRepository.resolveSessionFamily(
+              sessionId: ownerSessionId,
+              operation: operation,
+            );
+            if (family.pluginId != pluginId) {
+              throw PluginOperationException(
+                operation.name,
+                statusCode: 409,
+                message: "question $questionId resolved to plugin ${family.pluginId}, expected $pluginId",
               );
-              if (family.pluginId != pluginId) {
-                throw PluginOperationException(
-                  operation.name,
-                  statusCode: 409,
-                  message: "question $questionId resolved to plugin ${family.pluginId}, expected $pluginId",
-                );
-              }
-              _registerOperation(
-                ticket: ticket,
-                family: family,
-                ownerSessionId: ownerSessionId,
-                interaction: PendingQuestionInteraction(requestId: questionId),
-                body: () => body(ownerSessionId: ownerSessionId),
-                result: result,
-              );
-            } finally {
-              final barriers = _legacyBarriers[pluginId];
-              barriers?.remove(ticket);
-              if (barriers?.isEmpty ?? false) _legacyBarriers.remove(pluginId);
             }
+            _registerOperation(
+              ticket: ticket,
+              family: family,
+              ownerSessionId: ownerSessionId,
+              interaction: PendingQuestionInteraction(requestId: questionId),
+              body: () => body(ownerSessionId: ownerSessionId),
+              result: result,
+            );
           },
           onError: result.completeError,
         );
       },
-      onError: (error, stackTrace) {
-        final barriers = _legacyBarriers[pluginId];
-        barriers?.remove(ticket);
-        if (barriers?.isEmpty ?? false) _legacyBarriers.remove(pluginId);
-        result.completeError(error, stackTrace);
-      },
+      onError: result.completeError,
     );
     return result.future;
   }
@@ -161,8 +149,7 @@ class SessionOperationDispatcher {
   }
 
   @visibleForTesting
-  int get activeLaneCount =>
-      _familyLanes.length + _interactionLanes.length + _pluginAdmissionLanes.length + _legacyBarriers.length;
+  int get activeLaneCount => _familyLanes.length + _interactionLanes.length + _pluginAdmissionLanes.length;
 
   Future<void> _drain() async {
     beginShutdown();
@@ -251,6 +238,7 @@ class SessionOperationDispatcher {
       );
       _interactionLanes[interactionKey] = token;
     }
+    _trackPlugin(result: result, pluginId: family.pluginId);
 
     unawaited(() async {
       await Future.wait(predecessors);
@@ -274,6 +262,16 @@ class SessionOperationDispatcher {
       _inFlightSettlements.remove(settlement);
     });
     _inFlightSettlements.add(settlement);
+  }
+
+  void _trackPlugin<T>({required Completer<T> result, required String pluginId}) {
+    late final Future<void> settlement;
+    settlement = result.future.then<void>((_) {}, onError: (Object _, StackTrace __) {}).whenComplete(() {
+      final settlements = _pluginSettlements[pluginId];
+      settlements?.remove(settlement);
+      if (settlements?.isEmpty ?? false) _pluginSettlements.remove(pluginId);
+    });
+    (_pluginSettlements[pluginId] ??= {}).add(settlement);
   }
 }
 

--- a/bridge/app/lib/src/bridge/services/session_operation_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/services/session_operation_dispatcher.dart
@@ -53,7 +53,7 @@ class SessionOperationDispatcher {
     required PendingInteractionRequest? interaction,
     required Future<T> Function() body,
   }) {
-    if (!_accepting) return _closedFuture<T>();
+    if (!_accepting) throw _closedError();
 
     final ticket = _nextTicket++;
     final result = Completer<T>();
@@ -94,9 +94,9 @@ class SessionOperationDispatcher {
     required String questionId,
     required SessionOperation operation,
     required Future<String> Function() resolveOwnerSessionId,
-    required Future<T> Function(String ownerSessionId) body,
+    required Future<T> Function({required String ownerSessionId}) body,
   }) {
-    if (!_accepting) return _closedFuture<T>();
+    if (!_accepting) throw _closedError();
 
     final ticket = _nextTicket++;
     final result = Completer<T>();
@@ -127,7 +127,7 @@ class SessionOperationDispatcher {
                 family: family,
                 ownerSessionId: ownerSessionId,
                 interaction: PendingQuestionInteraction(requestId: questionId),
-                body: () => body(ownerSessionId),
+                body: () => body(ownerSessionId: ownerSessionId),
                 result: result,
               );
             } finally {
@@ -170,12 +170,9 @@ class SessionOperationDispatcher {
     await Future.wait(_inFlightSettlements.toList(growable: false));
   }
 
-  Future<T> _closedFuture<T>() {
+  StateError _closedError() {
     final state = _disposed ? "disposed" : "closed";
-    return Future<T>.error(
-      StateError("SessionOperationDispatcher is $state"),
-      StackTrace.current,
-    );
+    return StateError("SessionOperationDispatcher is $state");
   }
 
   void _enqueueResolution({

--- a/bridge/app/lib/src/bridge/services/session_prompt_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_prompt_service.dart
@@ -3,7 +3,9 @@ import "dart:async";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../repositories/models/session_operation.dart";
 import "../repositories/session_repository.dart";
+import "session_operation_dispatcher.dart";
 
 class SessionPromptDefaultsChange {
   final String sessionId;
@@ -17,12 +19,15 @@ class SessionPromptDefaultsChange {
 
 class SessionPromptService {
   final SessionRepository _sessionRepository;
+  final SessionOperationDispatcher _dispatcher;
   final StreamController<SessionPromptDefaultsChange> _promptDefaultsChangesController =
       StreamController<SessionPromptDefaultsChange>.broadcast(sync: true);
 
   SessionPromptService({
     required SessionRepository sessionRepository,
-  }) : _sessionRepository = sessionRepository;
+    required SessionOperationDispatcher dispatcher,
+  }) : _sessionRepository = sessionRepository,
+       _dispatcher = dispatcher;
 
   Stream<SessionPromptDefaultsChange> get promptDefaultsChanges => _promptDefaultsChangesController.stream;
 
@@ -33,8 +38,33 @@ class SessionPromptService {
     required String? agent,
     required PromptModel? model,
     required String? command,
-  }) async {
+  }) {
     final normalizedCommand = command?.trim();
+    return _dispatcher.dispatch(
+      sessionId: sessionId,
+      operation: normalizedCommand == null || normalizedCommand.isEmpty
+          ? SessionOperation.sendPrompt
+          : SessionOperation.sendCommand,
+      interaction: null,
+      body: () => _sendPrompt(
+        sessionId: sessionId,
+        parts: parts,
+        variant: variant,
+        agent: agent,
+        model: model,
+        normalizedCommand: normalizedCommand,
+      ),
+    );
+  }
+
+  Future<void> _sendPrompt({
+    required String sessionId,
+    required List<PromptPart> parts,
+    required SessionVariant? variant,
+    required String? agent,
+    required PromptModel? model,
+    required String? normalizedCommand,
+  }) async {
     if (normalizedCommand == null || normalizedCommand.isEmpty) {
       await _sessionRepository.sendPrompt(
         sessionId: sessionId,

--- a/bridge/app/test/bridge/repositories/question_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/question_repository_test.dart
@@ -163,7 +163,6 @@ void main() {
         runtime: createTestPluginRuntime(plugins: [healthyPlugin, throwingPlugin, timedOutPlugin]),
         sessionDao: db.sessionDao,
         projectsDao: db.projectsDao,
-        legacyMissingPluginId: healthyPlugin.id,
         aggregateSourceDeadline: const Duration(milliseconds: 20),
       );
       final previousLogLevel = Log.level;
@@ -206,7 +205,6 @@ void main() {
         runtime: createTestPluginRuntime(plugins: [emptyPlugin, failedPlugin]),
         sessionDao: db.sessionDao,
         projectsDao: db.projectsDao,
-        legacyMissingPluginId: emptyPlugin.id,
         aggregateSourceDeadline: const Duration(milliseconds: 20),
       );
 
@@ -228,7 +226,6 @@ void main() {
         runtime: createTestPluginRuntime(plugins: [throwingPlugin, timedOutPlugin]),
         sessionDao: db.sessionDao,
         projectsDao: db.projectsDao,
-        legacyMissingPluginId: throwingPlugin.id,
         aggregateSourceDeadline: const Duration(milliseconds: 20),
       );
 

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -7,6 +7,7 @@ import "package:sesori_bridge/src/api/database/tables/projects_table.dart";
 import "package:sesori_bridge/src/api/database/tables/pull_requests_table.dart";
 import "package:sesori_bridge/src/api/database/tables/session_table.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/project_not_found_exception.dart";
+import "package:sesori_bridge/src/bridge/repositories/models/session_operation.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/verified_github_login.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
@@ -27,6 +28,93 @@ void main() {
 
     setUp(() {
       plugin = _FakeBridgePlugin();
+    });
+
+    test("resolves stable root families and rejects malformed ancestry", () async {
+      final db = createTestDatabase();
+      addTearDown(db.close);
+      const projectId = "family-project";
+      await db.projectsDao.insertProjectsIfMissing(projectIds: [projectId]);
+      await db.sessionDao.insertSession(
+        sessionId: "root",
+        backendSessionId: "backend-root",
+        projectId: projectId,
+        isDedicated: false,
+        createdAt: 1,
+        worktreePath: null,
+        branchName: null,
+        baseBranch: null,
+        baseCommit: null,
+        lastAgent: null,
+        lastAgentModel: null,
+        pluginId: plugin.id,
+      );
+      await db.sessionDao.insertObservedChild(
+        sessionId: "child",
+        backendSessionId: "backend-child",
+        projectId: projectId,
+        parentSessionId: "root",
+        directory: projectId,
+        catalogTitle: null,
+        archivedAt: null,
+        createdAt: 1,
+        updatedAt: 1,
+        projectionUpdatedAt: 1,
+        pluginId: plugin.id,
+      );
+      final repository = singlePluginSessionRepository(
+        plugin: plugin,
+        sessionDao: db.sessionDao,
+        projectsDao: db.projectsDao,
+        pullRequestDao: db.pullRequestDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+      );
+
+      expect(
+        await repository.resolveSessionFamily(
+          sessionId: "child",
+          operation: SessionOperation.sendPrompt,
+        ),
+        (rootSessionId: "root", pluginId: plugin.id),
+      );
+      await expectLater(
+        repository.resolveSessionFamily(
+          sessionId: "missing",
+          operation: SessionOperation.sendPrompt,
+        ),
+        throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 404)),
+      );
+
+      await db.sessionDao.insertObservedChild(
+        sessionId: "foreign-child",
+        backendSessionId: "foreign-child",
+        projectId: projectId,
+        parentSessionId: "root",
+        directory: projectId,
+        catalogTitle: null,
+        archivedAt: null,
+        createdAt: 1,
+        updatedAt: 1,
+        projectionUpdatedAt: 1,
+        pluginId: "other",
+      );
+      await expectLater(
+        repository.resolveSessionFamily(
+          sessionId: "foreign-child",
+          operation: SessionOperation.abortSession,
+        ),
+        throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 409)),
+      );
+
+      final root = (await db.sessionDao.getSession(sessionId: "root"))!;
+      await db.sessionDao.upsertSessionRows(rows: [root.copyWith(parentSessionId: "child")]);
+      await expectLater(
+        repository.resolveSessionFamily(
+          sessionId: "child",
+          operation: SessionOperation.sendPrompt,
+        ),
+        throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 409)),
+      );
     });
 
     test("deleteSession records a plugin-scoped tombstone and removes the stored row", () async {

--- a/bridge/app/test/bridge/routing/abort_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/abort_session_handler_test.dart
@@ -1,5 +1,6 @@
 import "package:sesori_bridge/src/bridge/routing/abort_session_handler.dart";
 import "package:sesori_bridge/src/bridge/services/session_abort_service.dart";
+import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -13,7 +14,13 @@ void main() {
 
     setUp(() {
       plugin = FakeBridgePlugin();
-      sessionAbortService = SessionAbortService(sessionRepository: FakeSessionRepository(plugin: plugin));
+      final repository = FakeSessionRepository(plugin: plugin);
+      final dispatcher = SessionOperationDispatcher(sessionRepository: repository);
+      addTearDown(dispatcher.dispose);
+      sessionAbortService = SessionAbortService(
+        sessionRepository: repository,
+        dispatcher: dispatcher,
+      );
       handler = AbortSessionHandler(sessionAbortService: sessionAbortService);
     });
 

--- a/bridge/app/test/bridge/routing/reject_question_handler_test.dart
+++ b/bridge/app/test/bridge/routing/reject_question_handler_test.dart
@@ -1,4 +1,6 @@
+import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/bridge/routing/reject_question_handler.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -8,11 +10,12 @@ import "routing_test_helpers.dart";
 void main() {
   group("RejectQuestionHandler", () {
     late FakeBridgePlugin plugin;
+    late AppDatabase db;
     late RejectQuestionHandler handler;
 
     setUp(() async {
       plugin = FakeBridgePlugin();
-      final db = createTestDatabase();
+      db = createTestDatabase();
       addTearDown(db.close);
       await recordSessionBinding(
         database: db,
@@ -22,13 +25,10 @@ void main() {
         projectId: "/repo",
         parentSessionId: null,
       );
-      handler = RejectQuestionHandler(
-        questionRepository: singlePluginQuestionRepository(
-          plugin: plugin,
-          sessionDao: db.sessionDao,
-          projectsDao: db.projectsDao,
-        ),
-      );
+      final pending = buildTestPendingInteractionService(database: db, plugin: plugin);
+      addTearDown(pending.dispatcher.dispose);
+      addTearDown(pending.service.dispose);
+      handler = RejectQuestionHandler(pendingInteractionService: pending.service);
     });
 
     tearDown(() => plugin.close());
@@ -50,7 +50,15 @@ void main() {
       expect(plugin.lastRejectSessionId, equals("backend-ses-1"));
     });
 
-    test("allows null sessionId for backwards compatibility", () async {
+    test("resolves a null legacy sessionId to its stable owner", () async {
+      plugin.pendingQuestionsResult = const [
+        PluginPendingQuestion(
+          id: "q1",
+          sessionID: "backend-ses-1",
+          displaySessionId: null,
+          questions: [],
+        ),
+      ];
       await handler.handle(
         makeRequest("POST", "/question/reject"),
         body: const RejectQuestionRequest(requestId: "q1", sessionId: null),
@@ -60,7 +68,47 @@ void main() {
       );
 
       expect(plugin.lastRejectQuestionId, equals("q1"));
-      expect(plugin.lastRejectSessionId, isNull);
+      expect(plugin.lastRejectSessionId, equals("backend-ses-1"));
+    });
+
+    test("reports a missing legacy owner as not found", () async {
+      await expectLater(
+        handler.handle(
+          makeRequest("POST", "/question/reject"),
+          body: const RejectQuestionRequest(requestId: "missing", sessionId: null),
+          pathParams: {},
+          queryParams: {},
+          fragment: null,
+        ),
+        throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 404)),
+      );
+    });
+
+    test("reports ambiguous legacy owners as a compatibility conflict", () async {
+      await recordSessionBinding(
+        database: db,
+        sessionId: "ses-2",
+        backendSessionId: "backend-ses-2",
+        pluginId: plugin.id,
+        projectId: "/repo",
+        parentSessionId: null,
+      );
+      plugin.pendingQuestionsResult = const [
+        PluginPendingQuestion(id: "q1", sessionID: "backend-ses-1", displaySessionId: null, questions: []),
+        PluginPendingQuestion(id: "q1", sessionID: "backend-ses-2", displaySessionId: null, questions: []),
+      ];
+
+      await expectLater(
+        handler.handle(
+          makeRequest("POST", "/question/reject"),
+          body: const RejectQuestionRequest(requestId: "q1", sessionId: null),
+          pathParams: {},
+          queryParams: {},
+          fragment: null,
+        ),
+        throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 409)),
+      );
+      expect(plugin.lastRejectQuestionId, isNull);
     });
 
     test("returns 200", () async {

--- a/bridge/app/test/bridge/routing/reply_to_permission_handler_test.dart
+++ b/bridge/app/test/bridge/routing/reply_to_permission_handler_test.dart
@@ -1,5 +1,4 @@
 import "package:sesori_bridge/src/api/database/database.dart";
-import "package:sesori_bridge/src/bridge/repositories/permission_repository.dart";
 import "package:sesori_bridge/src/bridge/routing/reply_to_permission_handler.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -12,7 +11,6 @@ void main() {
   group("ReplyToPermissionHandler", () {
     late FakeBridgePlugin plugin;
     late AppDatabase db;
-    late PermissionRepository permissionRepository;
     late ReplyToPermissionHandler handler;
 
     setUp(() async {
@@ -26,8 +24,10 @@ void main() {
         projectId: "/repo",
         parentSessionId: null,
       );
-      permissionRepository = singlePluginPermissionRepository(plugin: plugin, sessionDao: db.sessionDao);
-      handler = ReplyToPermissionHandler(permissionRepository: permissionRepository);
+      final pending = buildTestPendingInteractionService(database: db, plugin: plugin);
+      addTearDown(pending.dispatcher.dispose);
+      addTearDown(pending.service.dispose);
+      handler = ReplyToPermissionHandler(pendingInteractionService: pending.service);
     });
 
     tearDown(() async {

--- a/bridge/app/test/bridge/routing/reply_to_question_handler_test.dart
+++ b/bridge/app/test/bridge/routing/reply_to_question_handler_test.dart
@@ -22,13 +22,10 @@ void main() {
         projectId: "/repo",
         parentSessionId: null,
       );
-      handler = ReplyToQuestionHandler(
-        questionRepository: singlePluginQuestionRepository(
-          plugin: plugin,
-          sessionDao: db.sessionDao,
-          projectsDao: db.projectsDao,
-        ),
-      );
+      final pending = buildTestPendingInteractionService(database: db, plugin: plugin);
+      addTearDown(pending.dispatcher.dispose);
+      addTearDown(pending.service.dispose);
+      handler = ReplyToQuestionHandler(pendingInteractionService: pending.service);
     });
 
     tearDown(() => plugin.close());

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -23,7 +23,9 @@ import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_repository.dart";
 import "package:sesori_bridge/src/bridge/routing/request_handler.dart";
+import "package:sesori_bridge/src/bridge/services/pending_interaction_service.dart";
 import "package:sesori_bridge/src/bridge/services/pr_sync_service.dart";
+import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
 import "package:sesori_bridge/src/bridge/services/session_unseen_service.dart";
 import "package:sesori_bridge/src/bridge/services/session_view_tracker.dart";
 import "package:sesori_bridge/src/repositories/models/pull_request_selection.dart";
@@ -51,6 +53,37 @@ SessionUnseenService buildTestSessionUnseenService(AppDatabase db, BridgePluginA
       filesystemApi: FakeFilesystemApi(),
     ),
     viewTracker: SessionViewTracker(),
+  );
+}
+
+({PendingInteractionService service, SessionOperationDispatcher dispatcher}) buildTestPendingInteractionService({
+  required AppDatabase database,
+  required BridgePluginApi plugin,
+}) {
+  final dispatcher = SessionOperationDispatcher(
+    sessionRepository: singlePluginSessionRepository(
+      plugin: plugin,
+      sessionDao: database.sessionDao,
+      projectsDao: database.projectsDao,
+      pullRequestDao: database.pullRequestDao,
+      unseenCalculator: const SessionUnseenCalculator(),
+    ),
+  );
+  return (
+    dispatcher: dispatcher,
+    service: PendingInteractionService(
+      permissionRepository: singlePluginPermissionRepository(
+        plugin: plugin,
+        sessionDao: database.sessionDao,
+      ),
+      questionRepository: singlePluginQuestionRepository(
+        plugin: plugin,
+        sessionDao: database.sessionDao,
+        projectsDao: database.projectsDao,
+      ),
+      dispatcher: dispatcher,
+      legacyMissingPluginId: plugin.id,
+    ),
   );
 }
 
@@ -803,6 +836,12 @@ class _NoopSessionRepository implements SessionRepository {
   int captureProjectionTimestamp() => DateTime.now().millisecondsSinceEpoch;
 
   @override
+  Future<SessionFamilyScope> resolveSessionFamily({
+    required String sessionId,
+    required SessionOperation operation,
+  }) async => (rootSessionId: sessionId, pluginId: "fake");
+
+  @override
   Future<void> dispose() async {}
 
   @override
@@ -1069,6 +1108,12 @@ class FakeSessionRepository implements SessionRepository {
        _sessionDao = sessionDao ?? FakeSessionDao(),
        _pullRequestRepository = pullRequestRepository ?? FakePullRequestRepository(),
        _persistenceDatabase = persistenceDatabase;
+
+  @override
+  Future<SessionFamilyScope> resolveSessionFamily({
+    required String sessionId,
+    required SessionOperation operation,
+  }) async => (rootSessionId: sessionId, pluginId: _plugin.id);
 
   @override
   Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async {

--- a/bridge/app/test/bridge/routing/send_prompt_handler_test.dart
+++ b/bridge/app/test/bridge/routing/send_prompt_handler_test.dart
@@ -4,6 +4,7 @@ import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/routing/send_prompt_handler.dart";
+import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
 import "package:sesori_bridge/src/bridge/services/session_prompt_service.dart";
 import "package:sesori_bridge/src/repositories/project_catalog_identity_calculator.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
@@ -32,9 +33,7 @@ void main() {
         unseenCalculator: const SessionUnseenCalculator(),
       );
       handler = SendPromptHandler(
-        sessionPromptService: SessionPromptService(
-          sessionRepository: sessionRepository,
-        ),
+        sessionPromptService: _buildPromptService(sessionRepository),
       );
       for (final sessionId in ["s1", "s42", "s7", "s8", "s10", "s-update-fails", "s9"]) {
         await _insertStoredSession(
@@ -390,7 +389,7 @@ void main() {
         unseenCalculator: const SessionUnseenCalculator(),
       );
       final localHandler = SendPromptHandler(
-        sessionPromptService: SessionPromptService(sessionRepository: localRepository),
+        sessionPromptService: _buildPromptService(localRepository),
       );
 
       await expectLater(
@@ -442,7 +441,7 @@ void main() {
         unseenCalculator: const SessionUnseenCalculator(),
       );
       final localHandler = SendPromptHandler(
-        sessionPromptService: SessionPromptService(sessionRepository: localRepository),
+        sessionPromptService: _buildPromptService(localRepository),
       );
 
       await expectLater(
@@ -478,11 +477,10 @@ void main() {
         database: db,
         unseenCalculator: const SessionUnseenCalculator(),
       );
-      final promptService = SessionPromptService(sessionRepository: throwingRepository);
+      final promptService = _buildPromptService(throwingRepository);
       final changes = <SessionPromptDefaultsChange>[];
       final subscription = promptService.promptDefaultsChanges.listen(changes.add);
       addTearDown(subscription.cancel);
-      addTearDown(promptService.dispose);
       final localHandler = SendPromptHandler(
         sessionPromptService: promptService,
       );
@@ -612,6 +610,17 @@ void main() {
       expect(plugin.lastSendCommandSessionId, isNull);
     });
   });
+}
+
+SessionPromptService _buildPromptService(SessionRepository repository) {
+  final dispatcher = SessionOperationDispatcher(sessionRepository: repository);
+  final service = SessionPromptService(
+    sessionRepository: repository,
+    dispatcher: dispatcher,
+  );
+  addTearDown(dispatcher.dispose);
+  addTearDown(service.dispose);
+  return service;
 }
 
 Future<void> _insertStoredSession({

--- a/bridge/app/test/bridge/services/pending_interaction_service_test.dart
+++ b/bridge/app/test/bridge/services/pending_interaction_service_test.dart
@@ -1,0 +1,159 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/bridge/repositories/models/session_operation.dart";
+import "package:sesori_bridge/src/bridge/repositories/permission_repository.dart";
+import "package:sesori_bridge/src/bridge/repositories/question_repository.dart";
+import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
+import "package:sesori_bridge/src/bridge/services/pending_interaction_service.dart";
+import "package:sesori_bridge/src/bridge/services/permission_auto_approval_service.dart";
+import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("PendingInteractionService", () {
+    late _FamilyRepository sessionRepository;
+    late _PermissionRepository permissionRepository;
+    late _QuestionRepository questionRepository;
+    late SessionOperationDispatcher dispatcher;
+    late PendingInteractionService service;
+    late PermissionAutoApprovalService autoApproval;
+
+    setUp(() {
+      sessionRepository = _FamilyRepository({
+        "session-one": (rootSessionId: "root-one", pluginId: "legacy"),
+        "session-two": (rootSessionId: "root-two", pluginId: "legacy"),
+      });
+      permissionRepository = _PermissionRepository();
+      questionRepository = _QuestionRepository();
+      dispatcher = SessionOperationDispatcher(sessionRepository: sessionRepository);
+      service = PendingInteractionService(
+        permissionRepository: permissionRepository,
+        questionRepository: questionRepository,
+        dispatcher: dispatcher,
+        legacyMissingPluginId: "legacy",
+      );
+      autoApproval = PermissionAutoApprovalService(
+        sessionRepository: sessionRepository,
+        permissionRepository: permissionRepository,
+        pendingInteractionService: service,
+      );
+    });
+
+    tearDown(() async {
+      autoApproval.dispose();
+      await dispatcher.dispose();
+      service.dispose();
+    });
+
+    test("keeps first permission and question responses authoritative", () async {
+      final permissionGate = Completer<void>();
+      final permissionStarted = Completer<void>();
+      permissionRepository.onReply = ({required requestId, required sessionId, required reply}) async {
+        if (permissionRepository.calls.isEmpty) {
+          permissionStarted.complete();
+          await permissionGate.future;
+        }
+        permissionRepository.calls.add(reply);
+      };
+
+      final automatic = autoApproval.approve(requestId: "permission", sessionId: "session-one");
+      await permissionStarted.future;
+      final rejection = service.replyToPermission(
+        requestId: "permission",
+        sessionId: "session-one",
+        reply: PermissionReply.reject,
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(permissionRepository.calls, isEmpty);
+      permissionGate.complete();
+      await Future.wait([automatic, rejection]);
+      expect(permissionRepository.calls, [PermissionReply.once, PermissionReply.reject]);
+
+      final questionGate = Completer<void>();
+      final questionStarted = Completer<void>();
+      questionRepository.onReply = ({required questionId, required sessionId, required answers}) async {
+        questionRepository.calls.add("answer");
+        questionStarted.complete();
+        await questionGate.future;
+      };
+      final answer = service.replyToQuestion(
+        questionId: "question",
+        sessionId: "session-one",
+        answers: const [
+          ReplyAnswer(values: ["yes"]),
+        ],
+      );
+      await questionStarted.future;
+      final reject = service.rejectQuestion(questionId: "question", sessionId: "session-one");
+      await Future<void>.delayed(Duration.zero);
+      expect(questionRepository.calls, ["answer"]);
+      questionGate.complete();
+      await Future.wait([answer, reject]);
+      expect(questionRepository.calls, ["answer", "reject:session-one"]);
+
+      dispatcher.beginShutdown();
+      await expectLater(
+        autoApproval.approve(requestId: "closed", sessionId: "session-one"),
+        throwsStateError,
+      );
+      expect(permissionRepository.calls, hasLength(2));
+    });
+  });
+}
+
+class _FamilyRepository implements SessionRepository {
+  final Map<String, SessionFamilyScope> scopes;
+
+  _FamilyRepository(this.scopes);
+
+  @override
+  Future<SessionFamilyScope> resolveSessionFamily({
+    required String sessionId,
+    required SessionOperation operation,
+  }) async => scopes[sessionId]!;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _PermissionRepository implements PermissionRepository {
+  final List<PermissionReply> calls = [];
+  Future<void> Function({required String requestId, required String sessionId, required PermissionReply reply})?
+  onReply;
+
+  @override
+  Future<void> replyToPermission({
+    required String requestId,
+    required String sessionId,
+    required PermissionReply reply,
+  }) async {
+    await onReply?.call(requestId: requestId, sessionId: sessionId, reply: reply);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _QuestionRepository implements QuestionRepository {
+  final List<String> calls = [];
+  Future<void> Function({required String questionId, required String sessionId, required List<ReplyAnswer> answers})?
+  onReply;
+
+  @override
+  Future<void> replyToQuestion({
+    required String questionId,
+    required String sessionId,
+    required List<ReplyAnswer> answers,
+  }) async {
+    await onReply?.call(questionId: questionId, sessionId: sessionId, answers: answers);
+  }
+
+  @override
+  Future<void> rejectQuestion({required String questionId, required String sessionId}) async {
+    calls.add("reject:$sessionId");
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/bridge/services/session_abort_service_test.dart
+++ b/bridge/app/test/bridge/services/session_abort_service_test.dart
@@ -78,12 +78,28 @@ void main() {
       expect(emittedSessionIds, isEmpty);
       expect(failedSessionIds, equals(["session-1"]));
     });
+
+    test("emits abort failure when family resolution fails before execution", () async {
+      final startedSessionIds = <String>[];
+      final failedSessionIds = <String>[];
+      sessionRepository.resolutionError = StateError("family unavailable");
+      final startedSubscription = service.abortStartedSessions.listen(startedSessionIds.add);
+      final failedSubscription = service.abortFailedSessions.listen(failedSessionIds.add);
+      addTearDown(startedSubscription.cancel);
+      addTearDown(failedSubscription.cancel);
+
+      await expectLater(service.abortSession(sessionId: "missing"), throwsStateError);
+
+      expect(startedSessionIds, ["missing"]);
+      expect(failedSessionIds, ["missing"]);
+    });
   });
 }
 
 class _FakeSessionRepository implements SessionRepository {
   final Completer<void> abortCompleter = Completer<void>();
   Future<void> Function({required String sessionId})? onAbort;
+  Object? resolutionError;
 
   @override
   Future<void> abortSession({required String sessionId}) async {
@@ -94,7 +110,10 @@ class _FakeSessionRepository implements SessionRepository {
   Future<SessionFamilyScope> resolveSessionFamily({
     required String sessionId,
     required SessionOperation operation,
-  }) async => (rootSessionId: sessionId, pluginId: "fake");
+  }) async {
+    if (resolutionError case final error?) throw error;
+    return (rootSessionId: sessionId, pluginId: "fake");
+  }
 
   @override
   Future<void> ensurePluginRoutable({required String pluginId, required SessionOperation operation}) async {}

--- a/bridge/app/test/bridge/services/session_abort_service_test.dart
+++ b/bridge/app/test/bridge/services/session_abort_service_test.dart
@@ -4,6 +4,7 @@ import "package:sesori_bridge/src/bridge/repositories/models/session_operation.d
 import "package:sesori_bridge/src/bridge/repositories/models/stored_session.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/services/session_abort_service.dart";
+import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -11,13 +12,21 @@ void main() {
   group("SessionAbortService", () {
     late _FakeSessionRepository sessionRepository;
     late SessionAbortService service;
+    late SessionOperationDispatcher dispatcher;
 
     setUp(() {
       sessionRepository = _FakeSessionRepository();
-      service = SessionAbortService(sessionRepository: sessionRepository);
+      dispatcher = SessionOperationDispatcher(sessionRepository: sessionRepository);
+      service = SessionAbortService(
+        sessionRepository: sessionRepository,
+        dispatcher: dispatcher,
+      );
     });
 
-    tearDown(() => service.dispose());
+    tearDown(() async {
+      await dispatcher.dispose();
+      await service.dispose();
+    });
 
     test("emits aborted session only after repository abort succeeds", () async {
       final startedSessionIds = <String>[];
@@ -80,6 +89,12 @@ class _FakeSessionRepository implements SessionRepository {
   Future<void> abortSession({required String sessionId}) async {
     await onAbort?.call(sessionId: sessionId);
   }
+
+  @override
+  Future<SessionFamilyScope> resolveSessionFamily({
+    required String sessionId,
+    required SessionOperation operation,
+  }) async => (rootSessionId: sessionId, pluginId: "fake");
 
   @override
   Future<void> ensurePluginRoutable({required String pluginId, required SessionOperation operation}) async {}

--- a/bridge/app/test/bridge/services/session_operation_dispatcher_test.dart
+++ b/bridge/app/test/bridge/services/session_operation_dispatcher_test.dart
@@ -133,7 +133,7 @@ void main() {
           await ownerGate.future;
           return "legacy-owner";
         },
-        body: (_) async {
+        body: ({required String ownerSessionId}) async {
           legacyBodyStarted.complete();
           await legacyBodyGate.future;
         },
@@ -195,8 +195,8 @@ void main() {
       final drain = dispatcher.drain();
       expect(identical(drain, dispatcher.drain()), isTrue);
       expect(identical(drain, dispatcher.dispose()), isTrue);
-      await expectLater(
-        dispatcher.dispatch<void>(
+      expect(
+        () => dispatcher.dispatch<void>(
           sessionId: "second",
           operation: SessionOperation.abortSession,
           interaction: null,

--- a/bridge/app/test/bridge/services/session_operation_dispatcher_test.dart
+++ b/bridge/app/test/bridge/services/session_operation_dispatcher_test.dart
@@ -112,11 +112,14 @@ void main() {
 
     test("legacy owner resolution blocks only later admissions for its plugin", () async {
       final repository = _FamilyRepository({
+        "earlier": (rootSessionId: "earlier", pluginId: "legacy"),
         "legacy-owner": (rootSessionId: "legacy-owner", pluginId: "legacy"),
         "other-plugin": (rootSessionId: "other-plugin", pluginId: "other"),
       });
       final dispatcher = SessionOperationDispatcher(sessionRepository: repository);
       addTearDown(dispatcher.dispose);
+      final earlierGate = Completer<void>();
+      final earlierStarted = Completer<void>();
       final ownerLookupStarted = Completer<void>();
       final ownerGate = Completer<void>();
       final legacyBodyStarted = Completer<void>();
@@ -124,6 +127,16 @@ void main() {
       final laterStarted = Completer<void>();
       final otherPluginStarted = Completer<void>();
 
+      final earlier = dispatcher.dispatch<void>(
+        sessionId: "earlier",
+        operation: SessionOperation.replyToQuestion,
+        interaction: const PendingQuestionInteraction(requestId: "question"),
+        body: () async {
+          earlierStarted.complete();
+          await earlierGate.future;
+        },
+      );
+      await earlierStarted.future;
       final legacy = dispatcher.dispatchLegacyQuestion<void>(
         pluginId: "legacy",
         questionId: "question",
@@ -151,13 +164,16 @@ void main() {
         body: () async => otherPluginStarted.complete(),
       );
 
-      await Future.wait([ownerLookupStarted.future, otherPluginStarted.future]);
+      await otherPluginStarted.future;
+      expect(ownerLookupStarted.isCompleted, isFalse);
       expect(laterStarted.isCompleted, isFalse);
+      earlierGate.complete();
+      await ownerLookupStarted.future;
       ownerGate.complete();
       await legacyBodyStarted.future;
       expect(laterStarted.isCompleted, isFalse);
       legacyBodyGate.complete();
-      await Future.wait([legacy, later, otherPlugin]);
+      await Future.wait([earlier, legacy, later, otherPlugin]);
       expect(laterStarted.isCompleted, isTrue);
       expect(dispatcher.activeLaneCount, isZero);
     });

--- a/bridge/app/test/bridge/services/session_operation_dispatcher_test.dart
+++ b/bridge/app/test/bridge/services/session_operation_dispatcher_test.dart
@@ -1,0 +1,234 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/bridge/repositories/models/session_operation.dart";
+import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
+import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("SessionOperationDispatcher", () {
+    test("orders one family while unrelated families and plugins run", () async {
+      final repository = _FamilyRepository({
+        "root": (rootSessionId: "root", pluginId: "one"),
+        "child": (rootSessionId: "root", pluginId: "one"),
+        "other": (rootSessionId: "other", pluginId: "one"),
+        "plugin-two": (rootSessionId: "plugin-two", pluginId: "two"),
+      });
+      final dispatcher = SessionOperationDispatcher(sessionRepository: repository);
+      addTearDown(dispatcher.dispose);
+      final rootGate = Completer<void>();
+      final rootStarted = Completer<void>();
+      final childStarted = Completer<void>();
+      final otherStarted = Completer<void>();
+      final pluginTwoStarted = Completer<void>();
+
+      final root = dispatcher.dispatch<void>(
+        sessionId: "root",
+        operation: SessionOperation.sendPrompt,
+        interaction: null,
+        body: () async {
+          rootStarted.complete();
+          await rootGate.future;
+        },
+      );
+      final child = dispatcher.dispatch<void>(
+        sessionId: "child",
+        operation: SessionOperation.abortSession,
+        interaction: null,
+        body: () async => childStarted.complete(),
+      );
+      final other = dispatcher.dispatch<void>(
+        sessionId: "other",
+        operation: SessionOperation.sendPrompt,
+        interaction: null,
+        body: () async => otherStarted.complete(),
+      );
+      final pluginTwo = dispatcher.dispatch<void>(
+        sessionId: "plugin-two",
+        operation: SessionOperation.sendPrompt,
+        interaction: null,
+        body: () async => pluginTwoStarted.complete(),
+      );
+
+      await Future.wait([rootStarted.future, otherStarted.future, pluginTwoStarted.future]);
+      expect(childStarted.isCompleted, isFalse);
+      rootGate.complete();
+      await Future.wait([root, child, other, pluginTwo]);
+      expect(childStarted.isCompleted, isTrue);
+      expect(dispatcher.activeLaneCount, isZero);
+    });
+
+    test("isolates reused interaction IDs and releases a failed lane", () async {
+      final repository = _FamilyRepository({
+        "a": (rootSessionId: "a", pluginId: "one"),
+        "b": (rootSessionId: "b", pluginId: "one"),
+        "c": (rootSessionId: "c", pluginId: "two"),
+      });
+      final dispatcher = SessionOperationDispatcher(sessionRepository: repository);
+      addTearDown(dispatcher.dispose);
+      final gate = Completer<void>();
+      final firstStarted = Completer<void>();
+      final sameStarted = Completer<void>();
+      final otherFamilyStarted = Completer<void>();
+      final otherPluginStarted = Completer<void>();
+
+      final first = dispatcher.dispatch<void>(
+        sessionId: "a",
+        operation: SessionOperation.replyToQuestion,
+        interaction: const PendingQuestionInteraction(requestId: "reused"),
+        body: () async {
+          firstStarted.complete();
+          await gate.future;
+          throw StateError("first response failed");
+        },
+      );
+      final same = dispatcher.dispatch<void>(
+        sessionId: "a",
+        operation: SessionOperation.rejectQuestion,
+        interaction: const PendingQuestionInteraction(requestId: "reused"),
+        body: () async => sameStarted.complete(),
+      );
+      final otherFamily = dispatcher.dispatch<void>(
+        sessionId: "b",
+        operation: SessionOperation.rejectQuestion,
+        interaction: const PendingQuestionInteraction(requestId: "reused"),
+        body: () async => otherFamilyStarted.complete(),
+      );
+      final otherPlugin = dispatcher.dispatch<void>(
+        sessionId: "c",
+        operation: SessionOperation.rejectQuestion,
+        interaction: const PendingQuestionInteraction(requestId: "reused"),
+        body: () async => otherPluginStarted.complete(),
+      );
+
+      await Future.wait([firstStarted.future, otherFamilyStarted.future, otherPluginStarted.future]);
+      expect(sameStarted.isCompleted, isFalse);
+      gate.complete();
+      await expectLater(first, throwsStateError);
+      await Future.wait([same, otherFamily, otherPlugin]);
+      expect(sameStarted.isCompleted, isTrue);
+      expect(dispatcher.activeLaneCount, isZero);
+    });
+
+    test("legacy owner resolution blocks only later admissions for its plugin", () async {
+      final repository = _FamilyRepository({
+        "legacy-owner": (rootSessionId: "legacy-owner", pluginId: "legacy"),
+        "other-plugin": (rootSessionId: "other-plugin", pluginId: "other"),
+      });
+      final dispatcher = SessionOperationDispatcher(sessionRepository: repository);
+      addTearDown(dispatcher.dispose);
+      final ownerLookupStarted = Completer<void>();
+      final ownerGate = Completer<void>();
+      final legacyBodyStarted = Completer<void>();
+      final legacyBodyGate = Completer<void>();
+      final laterStarted = Completer<void>();
+      final otherPluginStarted = Completer<void>();
+
+      final legacy = dispatcher.dispatchLegacyQuestion<void>(
+        pluginId: "legacy",
+        questionId: "question",
+        operation: SessionOperation.rejectQuestion,
+        resolveOwnerSessionId: () async {
+          ownerLookupStarted.complete();
+          await ownerGate.future;
+          return "legacy-owner";
+        },
+        body: (_) async {
+          legacyBodyStarted.complete();
+          await legacyBodyGate.future;
+        },
+      );
+      final later = dispatcher.dispatch<void>(
+        sessionId: "legacy-owner",
+        operation: SessionOperation.abortSession,
+        interaction: null,
+        body: () async => laterStarted.complete(),
+      );
+      final otherPlugin = dispatcher.dispatch<void>(
+        sessionId: "other-plugin",
+        operation: SessionOperation.abortSession,
+        interaction: null,
+        body: () async => otherPluginStarted.complete(),
+      );
+
+      await Future.wait([ownerLookupStarted.future, otherPluginStarted.future]);
+      expect(laterStarted.isCompleted, isFalse);
+      ownerGate.complete();
+      await legacyBodyStarted.future;
+      expect(laterStarted.isCompleted, isFalse);
+      legacyBodyGate.complete();
+      await Future.wait([legacy, later, otherPlugin]);
+      expect(laterStarted.isCompleted, isTrue);
+      expect(dispatcher.activeLaneCount, isZero);
+    });
+
+    test("resolves tickets in order and closes acceptance on repeated drain", () async {
+      final firstResolutionGate = Completer<void>();
+      final firstResolutionStarted = Completer<void>();
+      final repository =
+          _FamilyRepository({
+              "first": (rootSessionId: "first", pluginId: "one"),
+              "second": (rootSessionId: "second", pluginId: "one"),
+            })
+            ..beforeResolve = (sessionId) async {
+              if (sessionId == "first") {
+                firstResolutionStarted.complete();
+                await firstResolutionGate.future;
+              }
+            };
+      final dispatcher = SessionOperationDispatcher(sessionRepository: repository);
+      final first = dispatcher.dispatch<void>(
+        sessionId: "first",
+        operation: SessionOperation.sendPrompt,
+        interaction: null,
+        body: () async {},
+      );
+      final second = dispatcher.dispatch<void>(
+        sessionId: "second",
+        operation: SessionOperation.sendPrompt,
+        interaction: null,
+        body: () async {},
+      );
+      await firstResolutionStarted.future;
+      expect(repository.resolutionOrder, ["first"]);
+
+      final drain = dispatcher.drain();
+      expect(identical(drain, dispatcher.drain()), isTrue);
+      expect(identical(drain, dispatcher.dispose()), isTrue);
+      await expectLater(
+        dispatcher.dispatch<void>(
+          sessionId: "second",
+          operation: SessionOperation.abortSession,
+          interaction: null,
+          body: () async {},
+        ),
+        throwsStateError,
+      );
+      firstResolutionGate.complete();
+      await Future.wait([first, second, drain]);
+      expect(repository.resolutionOrder, ["first", "second"]);
+      expect(dispatcher.activeLaneCount, isZero);
+    });
+  });
+}
+
+class _FamilyRepository implements SessionRepository {
+  final Map<String, SessionFamilyScope> scopes;
+  final List<String> resolutionOrder = [];
+  Future<void> Function(String sessionId)? beforeResolve;
+
+  _FamilyRepository(this.scopes);
+
+  @override
+  Future<SessionFamilyScope> resolveSessionFamily({
+    required String sessionId,
+    required SessionOperation operation,
+  }) async {
+    resolutionOrder.add(sessionId);
+    await beforeResolve?.call(sessionId);
+    return scopes[sessionId]!;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/bridge/services/session_prompt_service_test.dart
+++ b/bridge/app/test/bridge/services/session_prompt_service_test.dart
@@ -3,6 +3,8 @@ import "dart:async";
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
+import "package:sesori_bridge/src/bridge/services/session_abort_service.dart";
+import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
 import "package:sesori_bridge/src/bridge/services/session_prompt_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -15,6 +17,7 @@ void main() {
     late FakeBridgePlugin plugin;
     late AppDatabase db;
     late SessionRepository sessionRepository;
+    late SessionOperationDispatcher dispatcher;
     late SessionPromptService service;
 
     setUp(() async {
@@ -27,8 +30,10 @@ void main() {
         pullRequestDao: db.pullRequestDao,
         unseenCalculator: const SessionUnseenCalculator(),
       );
+      dispatcher = SessionOperationDispatcher(sessionRepository: sessionRepository);
       service = SessionPromptService(
         sessionRepository: sessionRepository,
+        dispatcher: dispatcher,
       );
       await sessionRepository.insertStoredSession(
         sessionId: "s1",
@@ -48,6 +53,7 @@ void main() {
 
     tearDown(() async {
       await service.dispose();
+      await dispatcher.dispose();
       await plugin.close();
       await db.close();
     });
@@ -153,6 +159,55 @@ void main() {
       expect(change.promptDefaults.model?.providerID, "openai");
       expect(change.promptDefaults.model?.modelID, "gpt-5");
       expect(change.promptDefaults.model?.variant, "high");
+    });
+
+    test("keeps command defaults, abort, and later defaults in arrival order", () async {
+      final abortService = SessionAbortService(
+        sessionRepository: sessionRepository,
+        dispatcher: dispatcher,
+      );
+      addTearDown(abortService.dispose);
+      final events = <String>[];
+      final defaultsSubscription = service.promptDefaultsChanges.listen(
+        (change) => events.add("defaults:${change.promptDefaults.agent}"),
+      );
+      final abortSubscription = abortService.abortStartedSessions.listen(
+        (_) => events.add("abort"),
+      );
+      addTearDown(defaultsSubscription.cancel);
+      addTearDown(abortSubscription.cancel);
+      final commandGate = Completer<void>();
+      plugin.sendCommandCompleter = commandGate;
+
+      final command = service.sendPrompt(
+        sessionId: "s1",
+        parts: const [PromptPart.text(text: "arguments")],
+        variant: null,
+        agent: "first",
+        model: null,
+        command: "review",
+      );
+      while (plugin.lastSendCommandSessionId == null) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      final abort = abortService.abortSession(sessionId: "s1");
+      final prompt = service.sendPrompt(
+        sessionId: "s1",
+        parts: const [PromptPart.text(text: "later")],
+        variant: null,
+        agent: "second",
+        model: null,
+        command: null,
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(events, isEmpty);
+      expect(plugin.lastAbortSessionId, isNull);
+      expect(plugin.lastSendPromptSessionId, isNull);
+
+      commandGate.complete();
+      await Future.wait([command, abort, prompt]);
+      expect(events, ["defaults:first", "abort", "defaults:second"]);
+      expect((await db.sessionDao.getSession(sessionId: "s1"))!.lastAgent, "second");
     });
 
     test("plain prompts are unaffected and delegate to sendPrompt", () async {

--- a/bridge/app/test/bridge/services/session_prompt_service_test.dart
+++ b/bridge/app/test/bridge/services/session_prompt_service_test.dart
@@ -161,7 +161,7 @@ void main() {
       expect(change.promptDefaults.model?.variant, "high");
     });
 
-    test("keeps command defaults, abort, and later defaults in arrival order", () async {
+    test("suppresses completion immediately while backend actions retain arrival order", () async {
       final abortService = SessionAbortService(
         sessionRepository: sessionRepository,
         dispatcher: dispatcher,
@@ -200,13 +200,13 @@ void main() {
         command: null,
       );
       await Future<void>.delayed(Duration.zero);
-      expect(events, isEmpty);
+      expect(events, ["abort"]);
       expect(plugin.lastAbortSessionId, isNull);
       expect(plugin.lastSendPromptSessionId, isNull);
 
       commandGate.complete();
       await Future.wait([command, abort, prompt]);
-      expect(events, ["defaults:first", "abort", "defaults:second"]);
+      expect(events, ["abort", "defaults:first", "defaults:second"]);
       expect((await db.sessionDao.getSession(sessionId: "s1"))!.lastAgent, "second");
     });
 

--- a/bridge/app/test/helpers/single_plugin_repository_test_support.dart
+++ b/bridge/app/test/helpers/single_plugin_repository_test_support.dart
@@ -90,7 +90,6 @@ QuestionRepository singlePluginQuestionRepository({
     runtime: createTestPluginRuntime(plugins: [plugin]),
     sessionDao: sessionDao,
     projectsDao: projectsDao,
-    legacyMissingPluginId: plugin.id,
     aggregateSourceDeadline: const Duration(seconds: 5),
   );
 }


### PR DESCRIPTION
## Complexity

🚧 Complex — ordered family resolution and atomic pending-interaction admission cross prompt/default, abort, permission/question, auto-approval, and shutdown lifecycles.

## What

- add one lifecycle-owned `SessionOperationDispatcher` with monotonic admission, bounded stable-family resolution, per-family FIFO lanes, and permission/question interaction lanes
- route prompt/default persistence, abort, permission responses, question responses, and auto approval through the shared owner
- resolve legacy sessionless question rejection to exactly one pending owner behind a plugin-scoped barrier, with explicit missing and ambiguous failures
- quiesce plugin-event producers and routed requests before closing and draining session-operation acceptance
- remove direct pending-choice handler writes and the repository's obsolete sessionless rejection path

## Why

The later concurrent relay-dispatch step must not let an abort overtake prompt acceptance/default publication or let a slower validation lookup make the second conflicting permission/question response win. This step makes that domain ordering explicit before transport work is detached.

## Risk and test focus

Risk: high within bridge session-action ordering, with no transport, wire, database-schema, client, or plugin-interface change. Highest-value checks cover root/child FIFO, unrelated-family and plugin concurrency, prompt/default/abort order, conflicting manual and automatic responses, reused request IDs, legacy unique/missing/ambiguous ownership, failure release, idle cleanup, repeated drain, and producer-quiescent shutdown.

## Expected result

- **User-visible:** the first pending choice remains authoritative and prompt/default/abort order is preserved within one session family; unrelated families remain responsive
- **Persisted/database:** no schema or new data change; existing prompt defaults are persisted in FIFO order
- **Internal:** one explicit dispatcher owns session-family and pending-interaction causality; relay request routing remains serial until Step 9

## Verification

- `dart test` from `bridge/app`: 2,396 tests passed
- `dart analyze --fatal-infos` from `bridge/app`: passed
- `git diff --check`: passed
- `aristotle-impl-review`: approved with no blocking findings
- changed-line count: 1,534 (34-line soft-cap overage from review-required abort terminal signaling and prior-plugin settlement coverage)


