### PR TITLE
🌿 fix(client): disable empty send and unmute voice haptics on iOS

### DIFF
--- a/client/app/ios/Runner/RecorderPrewarmService.swift
+++ b/client/app/ios/Runner/RecorderPrewarmService.swift
@@ -98,7 +98,9 @@ final class RecorderPrewarmService {
       options: [.defaultToSpeaker, .allowBluetooth, .allowBluetoothA2DP]
     )
     if #available(iOS 13.0, *) {
-      try session.setAllowHapticsAndSystemSoundsDuringRecording(false)
+      // Mirrors the recorder's own session configuration, where haptics stay
+      // allowed so the hold-to-speak feedback is not silenced while recording.
+      try session.setAllowHapticsAndSystemSoundsDuringRecording(true)
     }
 
     var settings: [String: Any] = [

--- a/client/app/lib/capabilities/voice/voice_transcription_service.dart
+++ b/client/app/lib/capabilities/voice/voice_transcription_service.dart
@@ -139,6 +139,10 @@ class VoiceTranscriptionService {
         autoGain: true,
         noiseSuppress: true,
         audioInterruption: AudioInterruptionMode.none,
+        // iOS silences every haptic and system sound while an audio session is
+        // recording unless the session opts in, which mutes the whole
+        // hold-to-speak feedback (cancel-target ticks included) on device.
+        iosConfig: const IosRecordConfig(allowHapticsAndSystemSoundsDuringRecording: true),
       );
       logt(
         "[voice] starting recorder — encoder=${config.encoder.name} "

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -1436,7 +1436,9 @@ class _PromptInputState extends State<PromptInput> {
         leadingIcon: TablerRegular.arrow_up,
         hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
         size: PregoButtonsSolidSize.lg,
-        onPressed: _handleSend,
+        // An empty composer has nothing to send: show the action as genuinely
+        // unavailable instead of accepting a tap that does nothing.
+        onPressed: _hasSendableContent ? _handleSend : null,
       ),
     );
   }

--- a/client/app/test/core/widgets/session_split/session_split_shell_test.dart
+++ b/client/app/test/core/widgets/session_split/session_split_shell_test.dart
@@ -256,10 +256,9 @@ void main() {
       await tester.tap(find.descendant(of: newSession, matching: find.byIcon(TablerRegular.keyboard)));
       await tester.pumpAndSettle();
       await tester.enterText(find.descendant(of: newSession, matching: find.byType(EditableText)), "do the thing");
-      await tester.tap(
-        find.descendant(of: newSession, matching: find.byIcon(TablerRegular.arrow_up)),
-        warnIfMissed: false,
-      );
+      // Send only accepts taps once the composer has rebuilt around its text.
+      await tester.pump();
+      await tester.tap(find.descendant(of: newSession, matching: find.byIcon(TablerRegular.arrow_up)));
       await tester.pump();
       expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
 

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -107,6 +107,14 @@ Future<void> enterTypingMode(WidgetTester tester) async {
   await tester.pumpAndSettle();
 }
 
+/// Types a prompt and sends it. The pump in between lets the composer rebuild
+/// around the new text — send only accepts taps once the field has content.
+Future<void> enterTextAndSend(WidgetTester tester, String text) async {
+  await tester.enterText(find.byType(EditableText), text);
+  await tester.pump();
+  await tester.tap(find.byIcon(TablerRegular.arrow_up));
+}
+
 void main() {
   late MockSessionService sessionService;
   late MockSessionRepository sessionRepository;
@@ -441,8 +449,7 @@ void main() {
     expect(find.text(loc.newSessionOptionsUnavailable), findsOneWidget);
 
     await enterTypingMode(tester);
-    await tester.enterText(find.byType(EditableText), "use backend defaults");
-    await tester.tap(find.byIcon(TablerRegular.arrow_up), warnIfMissed: false);
+    await enterTextAndSend(tester, "use backend defaults");
     await tester.pumpAndSettle();
 
     verify(
@@ -1186,8 +1193,7 @@ void main() {
     final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
 
     await enterTypingMode(tester);
-    await tester.enterText(find.byType(EditableText), "test message");
-    await tester.tap(find.byIcon(TablerRegular.arrow_up), warnIfMissed: false);
+    await enterTextAndSend(tester, "test message");
     await tester.pump();
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
@@ -1216,8 +1222,7 @@ void main() {
     await tester.pumpAndSettle();
 
     await enterTypingMode(tester);
-    await tester.enterText(find.byType(EditableText), "test message");
-    await tester.tap(find.byIcon(TablerRegular.arrow_up), warnIfMissed: false);
+    await enterTextAndSend(tester, "test message");
     await tester.pump();
 
     final absorbingFinder = find.byWidgetPredicate(
@@ -1267,8 +1272,7 @@ void main() {
     final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
 
     await enterTypingMode(tester);
-    await tester.enterText(find.byType(EditableText), "test message");
-    await tester.tap(find.byIcon(TablerRegular.arrow_up), warnIfMissed: false);
+    await enterTextAndSend(tester, "test message");
     await tester.pump();
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
@@ -1311,8 +1315,7 @@ void main() {
     final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
 
     await enterTypingMode(tester);
-    await tester.enterText(find.byType(EditableText), "test message");
-    await tester.tap(find.byIcon(TablerRegular.arrow_up), warnIfMissed: false);
+    await enterTextAndSend(tester, "test message");
     await tester.pump();
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
@@ -1358,8 +1361,7 @@ void main() {
     await tester.pumpAndSettle();
 
     await enterTypingMode(tester);
-    await tester.enterText(find.byType(EditableText), "test message");
-    await tester.tap(find.byIcon(TablerRegular.arrow_up));
+    await enterTextAndSend(tester, "test message");
     await tester.pump();
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
@@ -1398,8 +1400,7 @@ void main() {
     final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
 
     await enterTypingMode(tester);
-    await tester.enterText(find.byType(EditableText), "test message");
-    await tester.tap(find.byIcon(TablerRegular.arrow_up));
+    await enterTextAndSend(tester, "test message");
     await tester.pump();
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
@@ -1432,8 +1433,7 @@ void main() {
     await tester.pumpAndSettle();
 
     await enterTypingMode(tester);
-    await tester.enterText(find.byType(EditableText), "test message");
-    await tester.tap(find.byIcon(TablerRegular.arrow_up));
+    await enterTextAndSend(tester, "test message");
     await tester.pump();
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -109,7 +109,7 @@ Future<void> enterTypingMode(WidgetTester tester) async {
 
 /// Types a prompt and sends it. The pump in between lets the composer rebuild
 /// around the new text — send only accepts taps once the field has content.
-Future<void> enterTextAndSend(WidgetTester tester, String text) async {
+Future<void> enterTextAndSend({required WidgetTester tester, required String text}) async {
   await tester.enterText(find.byType(EditableText), text);
   await tester.pump();
   await tester.tap(find.byIcon(TablerRegular.arrow_up));
@@ -449,7 +449,7 @@ void main() {
     expect(find.text(loc.newSessionOptionsUnavailable), findsOneWidget);
 
     await enterTypingMode(tester);
-    await enterTextAndSend(tester, "use backend defaults");
+    await enterTextAndSend(tester: tester, text: "use backend defaults");
     await tester.pumpAndSettle();
 
     verify(
@@ -1193,7 +1193,7 @@ void main() {
     final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
 
     await enterTypingMode(tester);
-    await enterTextAndSend(tester, "test message");
+    await enterTextAndSend(tester: tester, text: "test message");
     await tester.pump();
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
@@ -1222,7 +1222,7 @@ void main() {
     await tester.pumpAndSettle();
 
     await enterTypingMode(tester);
-    await enterTextAndSend(tester, "test message");
+    await enterTextAndSend(tester: tester, text: "test message");
     await tester.pump();
 
     final absorbingFinder = find.byWidgetPredicate(
@@ -1272,7 +1272,7 @@ void main() {
     final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
 
     await enterTypingMode(tester);
-    await enterTextAndSend(tester, "test message");
+    await enterTextAndSend(tester: tester, text: "test message");
     await tester.pump();
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
@@ -1315,7 +1315,7 @@ void main() {
     final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
 
     await enterTypingMode(tester);
-    await enterTextAndSend(tester, "test message");
+    await enterTextAndSend(tester: tester, text: "test message");
     await tester.pump();
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
@@ -1361,7 +1361,7 @@ void main() {
     await tester.pumpAndSettle();
 
     await enterTypingMode(tester);
-    await enterTextAndSend(tester, "test message");
+    await enterTextAndSend(tester: tester, text: "test message");
     await tester.pump();
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
@@ -1400,7 +1400,7 @@ void main() {
     final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
 
     await enterTypingMode(tester);
-    await enterTextAndSend(tester, "test message");
+    await enterTextAndSend(tester: tester, text: "test message");
     await tester.pump();
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
@@ -1433,7 +1433,7 @@ void main() {
     await tester.pumpAndSettle();
 
     await enterTypingMode(tester);
-    await enterTextAndSend(tester, "test message");
+    await enterTextAndSend(tester: tester, text: "test message");
     await tester.pump();
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -21,6 +21,7 @@ import "package:sesori_mobile/features/session_detail/widgets/session_detail_bod
 import "package:sesori_mobile/features/session_detail/widgets/voice_cancel_button.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
 import "package:theme_prego/module_prego.dart";
 
 import "../../../helpers/test_helpers.dart";
@@ -496,6 +497,14 @@ void main() {
   }
 
   testWidgets("pressing send keeps the composer field focused", (tester) async {
+    when(
+      () => cubit.sendMessage(
+        text: "ship it",
+        command: null,
+        inputMode: ComposerInputMode.typed,
+      ),
+    ).thenAnswer((_) async {});
+
     await tester.pumpWidget(_buildApp(cubit: cubit));
     await tester.pumpAndSettle();
 
@@ -503,12 +512,35 @@ void main() {
     await enterTypingMode(tester);
     expect(composerFocus(tester).hasFocus, isTrue);
 
-    // Send with an empty field: `_handleSend` is a no-op that does not
-    // re-request focus, so focus retention here proves the tap itself didn't
-    // unfocus the field (which is what produced the hide/re-show flicker).
+    await tester.enterText(find.byType(EditableText), "ship it");
+    await tester.pump();
+
+    // Focus retention here proves the tap itself didn't unfocus the field
+    // (which is what produced the hide/re-show flicker).
     await tester.tap(find.byIcon(TablerRegular.arrow_up));
     await tester.pump();
     expect(composerFocus(tester).hasFocus, isTrue, reason: "send must not dismiss the keyboard");
+  });
+
+  testWidgets("send stays disabled until the composer holds text", (tester) async {
+    VoidCallback? sendAction() => tester
+        .widget<PregoButtonsSolid>(find.widgetWithIcon(PregoButtonsSolid, TablerRegular.arrow_up))
+        .onPressed;
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    await enterTypingMode(tester);
+    expect(sendAction(), isNull, reason: "an empty composer has nothing to send");
+
+    await tester.enterText(find.byType(EditableText), "ship it");
+    await tester.pump();
+    expect(sendAction(), isNotNull);
+
+    // Whitespace alone is not sendable content either.
+    await tester.enterText(find.byType(EditableText), "   ");
+    await tester.pump();
+    expect(sendAction(), isNull);
   });
 
   testWidgets("system back dismisses the composer keyboard before popping the route", (tester) async {


### PR DESCRIPTION
## Complexity

Straightforward. Two localized fixes in the composer: a disabled state for the
send button, and one audio-session flag that unblocks the existing voice
haptics on iOS.

## What

- The composer's send button is now disabled (design-system disabled styling)
  whenever there is no sendable content — an empty or whitespace-only field
  with no staged command. It was previously always enabled and swallowed the
  tap in `_handleSend`.
- The recorder now starts with
  `IosRecordConfig(allowHapticsAndSystemSoundsDuringRecording: true)`, and the
  iOS prewarm service mirrors that same setting instead of forcing `false`.

## Why

`AVAudioSession` silences all haptics and system sounds while a session is
recording unless the session explicitly opts in, and `record`'s default for
that flag is `false`. Every haptic that fires during a hold-to-speak gesture —
the tick when the finger reaches the cancel target and the tick when it leaves
again — was therefore muted on real iOS devices, which matches the internal
report. Simulators have no Taptic Engine, so the gap never showed locally.

The four voice haptics themselves are wired correctly and unchanged:
touch-down (`lightImpact`), each crossing of the cancel-target boundary in
either direction (`selectionClick`), and the two-pulse success cue that fires
when the transcript lands (not on finger lift).

## Risk and test focus

- No database impact. No wire-contract impact.
- User-visible: the send button now renders in its grayed disabled state on an
  empty composer, in both the session-detail and new-session composers.
- Allowing haptics during recording also lets an incoming call ring without
  immediately interrupting the recording (the interruption starts only if the
  call is answered), and the mic can pick up the Taptic Engine on a hard
  surface. Both are acceptable for short dictation clips.
- Haptics cannot be verified in a simulator; the flag needs a device check.

## Expected result

Send is tappable only when the composer has something to send. On an iOS
device, holding to speak buzzes on touch-down, ticks when the finger reaches
the delete/cancel target and again when it leaves, and gives the two-pulse
reward when the transcription lands.

## Verification

- `flutter test test/features/session_detail/ test/capabilities/voice/` — 253 passing
- `flutter test test/features/new_session/` — 29 passing
- `flutter analyze lib test` — clean
- New test: `send stays disabled until the composer holds text`

https://claude.ai/code/session_01Vdve2sYeEBSx9RnqfvBGdx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the send button when the composer is empty and restore hold‑to‑speak haptics on iOS by allowing system haptics during recording.

- **Bug Fixes**
  - Composer: disable send when empty or whitespace; tests pump before tapping and cover the disabled state.
  - iOS voice: allow haptics during recording in the recorder and prewarm session so touch‑down, cancel‑boundary, and success cues work on device.

<sup>Written for commit c12403ef59bd378d513e3c8684a8286a40ae0510. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

