### PR TITLE
🚧 [relay-request-concurrency] refactor(bridge): scope session family mutations [step 6/10]

### DIFF
--- a/.plan/active/relay-request-concurrency/PLAN.md
+++ b/.plan/active/relay-request-concurrency/PLAN.md
@@ -11,7 +11,7 @@
   [#696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) and Step 4 PR
   [#699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) and Step 5 PR
   [#700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700) merged; Step 6
-  is implemented and ready for review
+  PR [#703](https://github.com/sesori-ai/sesori_apps_monorepo/pull/703) is open
 - **Plan date:** 2026-08-02
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Current implementation base:** `main` at

--- a/.plan/active/relay-request-concurrency/PLAN.md
+++ b/.plan/active/relay-request-concurrency/PLAN.md
@@ -9,12 +9,13 @@
   [#688](https://github.com/sesori-ai/sesori_apps_monorepo/pull/688) and Step 2 PR
   [#690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) and Step 3 PR
   [#696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) and Step 4 PR
-  [#699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) merged; Step 5
-  PR [#700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700) is open
+  [#699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) and Step 5 PR
+  [#700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700) merged; Step 6
+  is implemented and ready for review
 - **Plan date:** 2026-08-02
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Current implementation base:** `main` at
-  `9ac855a3f64930a118675fa93786476337a987c9`
+  `5ba0d3a6029cdb699120e6254bd248c806fa2f95`
 - **Delivery:** one plan PR, eight sequential implementation PRs, and one
   plan-retirement PR
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687)

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -3,15 +3,14 @@
 ## Current State
 
 - **Plan slug:** `relay-request-concurrency`
-- **Implementation base:** merged Step 4 at
-  `9ac855a3f64930a118675fa93786476337a987c9`
-- **Series state:** Steps 1–4 merged; Step 4/10
-  [#699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) merged as
-  `9ac855a3`
-- **Current step:** Step 5/10 PR
-  [#700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700) open
+- **Implementation base:** merged Step 5 at
+  `5ba0d3a6029cdb699120e6254bd248c806fa2f95`
+- **Series state:** Steps 1–5 merged; Step 5/10
+  [#700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700) merged as
+  `5ba0d3a6`
+- **Current step:** Step 6/10 implemented on `plan-parallel-requests`
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged
-- **Next action:** open, review, and merge Step 5; Step 6 remains blocked until then
+- **Next action:** open, review, and merge Step 6; Step 7 remains blocked until then
 
 ## Incident Evidence
 
@@ -92,8 +91,8 @@
 | [x] | 2/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope restart handoffs [step 2/10]` | 900–1,300 | [PR #690](https://github.com/sesori-ai/sesori_apps_monorepo/pull/690) merged as `fdc8ad67` with 1,552 changed lines |
 | [x] | 3/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]` | 600–1,000 | [PR #696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) merged as `95178462` |
 | [x] | 4/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | [PR #699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) merged as `9ac855a3` with 1,326 changed lines |
-| [ ] | 5/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | [PR #700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700) open from `9ac855a3` |
-| [ ] | 6/10 | `relay-request-concurrency-session-lifecycle` | `🚧 [relay-request-concurrency] refactor(bridge): scope session family mutations [step 6/10]` | 750–1,250 | Blocked on Step 5 merge |
+| [x] | 5/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | [PR #700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700) merged as `5ba0d3a6` with 1,534 changed lines |
+| [ ] | 6/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope session family mutations [step 6/10]` | 750–1,250 | Implemented from `5ba0d3a6`; ready to open |
 | [ ] | 7/10 | `relay-request-concurrency-session-visibility` | `🚧 [relay-request-concurrency] refactor(bridge): gate new session visibility [step 7/10]` | 600–1,100 | Blocked on Step 6 merge |
 | [ ] | 8/10 | `relay-request-concurrency-project-mutations` | `🚧 [relay-request-concurrency] refactor(bridge): order project path mutations [step 8/10]` | 650–1,100 | Blocked on Step 7 merge |
 | [ ] | 9/10 | `relay-request-concurrency-dispatch` | `🚧 [relay-request-concurrency] fix(bridge): route client requests concurrently [step 9/10]` | 950–1,450 | Blocked on Step 8 merge |
@@ -356,6 +355,30 @@
   suggestions were declined as speculative machinery for bounded local catalog
   walks and a compatibility-only path without demonstrated load evidence.
 - **Step 5/10 delivery:** [PR #700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700)
-  is open at 1,534 changed lines. The 34-line soft-cap overage is directly caused
+  merged as `5ba0d3a6029cdb699120e6254bd248c806fa2f95` at 1,534 changed
+  lines. The 34-line soft-cap overage was directly caused
   by review-required terminal abort signaling and prior-plugin settlement coverage;
   splitting it would leave the ordering fix incomplete.
+- **Step 6/10 base and scope:** based directly on merged Step 5 at `5ba0d3a6`
+  on the owner-provided `plan-parallel-requests` branch. The change scopes
+  rename, archive/unarchive, cleanup, and complete deletion to stable root-family
+  operations. There is no wire, database, client, UI, analytics, or plugin-interface change.
+- **Step 6/10 implementation:** `SessionMutationDispatcher` owns family admission
+  for rename and callback-scoped cleanup/deletion, repository subtree deletion,
+  tombstones, and `deletedSessions`. `SessionDeletionService` composes lifecycle
+  cleanup with that owner without nested dispatch. Archive/unarchive holds one
+  family lane through stored-session lookup, cleanup/restore, persistence, and
+  best-effort backend archive notification.
+- **Step 6/10 cleanup:** removed the mutation dispatcher's bridge-wide mutation
+  and backend tails plus their drain helpers. Already-reserved cleanup is explicit,
+  settled family state is removed by `SessionOperationDispatcher`, and direct
+  handler coordination was replaced with the deletion service.
+- **Step 6/10 verification:** 2,408 full `bridge/app` tests pass. Focused family,
+  lifecycle, mutation, deletion, rename, and archive tests pass, along with strict
+  `dart analyze --fatal-infos` and `git diff --check`.
+- **Step 6/10 architecture review:** `aristotle-impl-review` rejected the initial
+  split deletion-admission ownership and detached backend archive notification.
+  Both valid findings were applied directly: mutation dispatch now owns deletion
+  admission with callback-scoped cleanup, and archive notification settles inside
+  the family lane. Per policy, the corrected implementation was not re-reviewed.
+- **Step 6/10 delivery:** ready to open at 1,052 changed lines.

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -8,7 +8,8 @@
 - **Series state:** Steps 1–5 merged; Step 5/10
   [#700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700) merged as
   `5ba0d3a6`
-- **Current step:** Step 6/10 implemented on `plan-parallel-requests`
+- **Current step:** Step 6/10 PR
+  [#703](https://github.com/sesori-ai/sesori_apps_monorepo/pull/703) open
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged
 - **Next action:** open, review, and merge Step 6; Step 7 remains blocked until then
 
@@ -92,7 +93,7 @@
 | [x] | 3/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]` | 600–1,000 | [PR #696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) merged as `95178462` |
 | [x] | 4/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | [PR #699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) merged as `9ac855a3` with 1,326 changed lines |
 | [x] | 5/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | [PR #700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700) merged as `5ba0d3a6` with 1,534 changed lines |
-| [ ] | 6/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope session family mutations [step 6/10]` | 750–1,250 | Implemented from `5ba0d3a6`; ready to open |
+| [ ] | 6/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope session family mutations [step 6/10]` | 750–1,250 | [PR #703](https://github.com/sesori-ai/sesori_apps_monorepo/pull/703) open from `5ba0d3a6` |
 | [ ] | 7/10 | `relay-request-concurrency-session-visibility` | `🚧 [relay-request-concurrency] refactor(bridge): gate new session visibility [step 7/10]` | 600–1,100 | Blocked on Step 6 merge |
 | [ ] | 8/10 | `relay-request-concurrency-project-mutations` | `🚧 [relay-request-concurrency] refactor(bridge): order project path mutations [step 8/10]` | 650–1,100 | Blocked on Step 7 merge |
 | [ ] | 9/10 | `relay-request-concurrency-dispatch` | `🚧 [relay-request-concurrency] fix(bridge): route client requests concurrently [step 9/10]` | 950–1,450 | Blocked on Step 8 merge |
@@ -381,4 +382,5 @@
   Both valid findings were applied directly: mutation dispatch now owns deletion
   admission with callback-scoped cleanup, and archive notification settles inside
   the family lane. Per policy, the corrected implementation was not re-reviewed.
-- **Step 6/10 delivery:** ready to open at 1,052 changed lines.
+- **Step 6/10 delivery:** [PR #703](https://github.com/sesori-ai/sesori_apps_monorepo/pull/703)
+  is open at 1,054 changed lines.

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -129,6 +129,7 @@ import "services/project_activity_service.dart";
 import "services/project_initialization_service.dart";
 import "services/session_abort_service.dart";
 import "services/session_creation_service.dart";
+import "services/session_deletion_service.dart";
 import "services/session_diff_service.dart";
 import "services/session_event_dispatcher.dart";
 import "services/session_event_service.dart";
@@ -281,7 +282,10 @@ class Orchestrator {
     final sessionOperationDispatcher = SessionOperationDispatcher(
       sessionRepository: sessionRepository,
     );
-    final sessionMutationDispatcher = SessionMutationDispatcher(sessionRepository: sessionRepository);
+    final sessionMutationDispatcher = SessionMutationDispatcher(
+      sessionRepository: sessionRepository,
+      sessionOperationDispatcher: sessionOperationDispatcher,
+    );
     final pushTracker = PushSessionStateTracker(now: clock.now);
     final pushRateLimiter = PushRateLimiter(now: clock.now);
     final completionNotifier = CompletionNotifier(
@@ -432,6 +436,11 @@ class Orchestrator {
       worktreeService: worktreeService,
       sessionRepository: sessionRepository,
       filesystemRepository: filesystemRepository,
+      sessionOperationDispatcher: sessionOperationDispatcher,
+    );
+    final sessionDeletionService = SessionDeletionService(
+      sessionLifecycleService: sessionLifecycleService,
+      sessionMutationDispatcher: sessionMutationDispatcher,
     );
     final sessionAbortService = SessionAbortService(
       sessionRepository: sessionRepository,
@@ -525,10 +534,7 @@ class Orchestrator {
           sessionLifecycleService: sessionLifecycleService,
           sessionUnseenService: sessionUnseenService,
         ),
-        DeleteSessionHandler(
-          sessionLifecycleService: sessionLifecycleService,
-          sessionMutationDispatcher: sessionMutationDispatcher,
-        ),
+        DeleteSessionHandler(sessionDeletionService: sessionDeletionService),
         SendPromptHandler(sessionPromptService: sessionPromptService),
         AbortSessionHandler(sessionAbortService: sessionAbortService),
         GetProvidersHandler(providerRepository),

--- a/bridge/app/lib/src/bridge/routing/delete_session_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/delete_session_handler.dart
@@ -2,25 +2,21 @@ import "dart:convert";
 
 import "package:sesori_shared/sesori_shared.dart";
 
-import "../services/session_lifecycle_service.dart";
-import "../services/session_mutation_dispatcher.dart";
+import "../services/session_cleanup_result.dart";
+import "../services/session_deletion_service.dart";
 import "request_handler.dart";
 
 /// Handles `DELETE /session/delete` — deletes a session.
 class DeleteSessionHandler extends BodyRequestHandler<DeleteSessionRequest, SuccessEmptyResponse> {
-  final SessionLifecycleService _sessionLifecycleService;
-  final SessionMutationDispatcher _sessionMutationDispatcher;
+  final SessionDeletionService _sessionDeletionService;
 
-  DeleteSessionHandler({
-    required SessionLifecycleService sessionLifecycleService,
-    required SessionMutationDispatcher sessionMutationDispatcher,
-  }) : _sessionLifecycleService = sessionLifecycleService,
-       _sessionMutationDispatcher = sessionMutationDispatcher,
-       super(
-         HttpMethod.delete,
-         "/session/delete",
-         fromJson: DeleteSessionRequest.fromJson,
-       );
+  DeleteSessionHandler({required SessionDeletionService sessionDeletionService})
+    : _sessionDeletionService = sessionDeletionService,
+      super(
+        HttpMethod.delete,
+        "/session/delete",
+        fromJson: DeleteSessionRequest.fromJson,
+      );
 
   @override
   Future<SuccessEmptyResponse> handle(
@@ -35,7 +31,7 @@ class DeleteSessionHandler extends BodyRequestHandler<DeleteSessionRequest, Succ
       throw buildErrorResponse(request, 400, "empty session id");
     }
 
-    final cleanupResult = await _sessionLifecycleService.cleanup(
+    final cleanupResult = await _sessionDeletionService.deleteSession(
       sessionId: sessionId,
       deleteWorktree: body.deleteWorktree,
       deleteBranch: body.deleteBranch,
@@ -51,11 +47,6 @@ class DeleteSessionHandler extends BodyRequestHandler<DeleteSessionRequest, Succ
         body: jsonEncode(rejection.toJson()),
       );
     }
-
-    // Unconditional (not gated on a stored row): the repository delete also
-    // records the tombstone, and a rowless-but-enumerable backend session
-    // still needs one or it reappears from the next enumeration.
-    await _sessionMutationDispatcher.deleteSession(sessionId: sessionId);
 
     return const SuccessEmptyResponse();
   }

--- a/bridge/app/lib/src/bridge/services/session_cleanup_result.dart
+++ b/bridge/app/lib/src/bridge/services/session_cleanup_result.dart
@@ -1,0 +1,11 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+sealed class CleanupResult {}
+
+final class CleanupSuccess extends CleanupResult {}
+
+final class CleanupRejected extends CleanupResult {
+  final SessionCleanupRejection rejection;
+
+  CleanupRejected({required this.rejection});
+}

--- a/bridge/app/lib/src/bridge/services/session_deletion_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_deletion_service.dart
@@ -1,0 +1,32 @@
+import "session_cleanup_result.dart";
+import "session_lifecycle_service.dart";
+import "session_mutation_dispatcher.dart";
+
+/// Owns the complete cleanup-and-delete workflow for one session family.
+class SessionDeletionService {
+  final SessionLifecycleService _sessionLifecycleService;
+  final SessionMutationDispatcher _sessionMutationDispatcher;
+
+  SessionDeletionService({
+    required SessionLifecycleService sessionLifecycleService,
+    required SessionMutationDispatcher sessionMutationDispatcher,
+  }) : _sessionLifecycleService = sessionLifecycleService,
+       _sessionMutationDispatcher = sessionMutationDispatcher;
+
+  Future<CleanupResult> deleteSession({
+    required String sessionId,
+    required bool deleteWorktree,
+    required bool deleteBranch,
+    required bool force,
+  }) {
+    return _sessionMutationDispatcher.deleteSession(
+      sessionId: sessionId,
+      cleanup: () => _sessionLifecycleService.cleanupAlreadyReserved(
+        sessionId: sessionId,
+        deleteWorktree: deleteWorktree,
+        deleteBranch: deleteBranch,
+        force: force,
+      ),
+    );
+  }
+}

--- a/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
@@ -1,5 +1,3 @@
-import "dart:async";
-
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart";
 
@@ -7,17 +5,9 @@ import "../repositories/filesystem_repository.dart";
 import "../repositories/models/session_operation.dart";
 import "../repositories/models/stored_session.dart";
 import "../repositories/session_repository.dart";
+import "session_cleanup_result.dart";
+import "session_operation_dispatcher.dart";
 import "worktree_service.dart";
-
-sealed class CleanupResult {}
-
-class CleanupSuccess extends CleanupResult {}
-
-class CleanupRejected extends CleanupResult {
-  final SessionCleanupRejection rejection;
-
-  CleanupRejected({required this.rejection});
-}
 
 enum SessionCleanupOperation { removeWorktree, deleteBranch }
 
@@ -59,16 +49,21 @@ class SessionLifecycleService {
   final WorktreeService _worktreeService;
   final SessionRepository _sessionRepository;
   final FilesystemRepository _filesystemRepository;
+  final SessionOperationDispatcher _sessionOperationDispatcher;
 
   SessionLifecycleService({
     required WorktreeService worktreeService,
     required SessionRepository sessionRepository,
     required FilesystemRepository filesystemRepository,
+    required SessionOperationDispatcher sessionOperationDispatcher,
   }) : _worktreeService = worktreeService,
        _sessionRepository = sessionRepository,
-       _filesystemRepository = filesystemRepository;
+       _filesystemRepository = filesystemRepository,
+       _sessionOperationDispatcher = sessionOperationDispatcher;
 
-  Future<CleanupResult> cleanup({
+  /// Runs cleanup inside a session-family operation already reserved by the
+  /// archive or deletion workflow.
+  Future<CleanupResult> cleanupAlreadyReserved({
     required String sessionId,
     required bool deleteWorktree,
     required bool deleteBranch,
@@ -78,13 +73,13 @@ class SessionLifecycleService {
       sessionId: sessionId,
       operation: SessionOperation.cleanupSession,
     );
-    if (!(deleteWorktree || deleteBranch) || storedSession.worktreePath == null || storedSession.branchName == null) {
+    final worktreePath = storedSession.worktreePath;
+    final branchName = storedSession.branchName;
+    if (!(deleteWorktree || deleteBranch) || worktreePath == null || branchName == null) {
       return CleanupSuccess();
     }
 
     final projectId = storedSession.projectId;
-    final worktreePath = storedSession.worktreePath!;
-    final branchName = storedSession.branchName!;
 
     // Shared-worktree cleanup is forceable so the user can resolve a stalemate
     // when multiple sessions point at the same worktree or branch.
@@ -160,6 +155,27 @@ class SessionLifecycleService {
     required bool deleteWorktree,
     required bool deleteBranch,
     required bool force,
+  }) {
+    return _sessionOperationDispatcher.dispatch(
+      sessionId: sessionId,
+      operation: SessionOperation.updateSessionArchiveStatus,
+      interaction: null,
+      body: () => _updateArchiveStatusAlreadyReserved(
+        sessionId: sessionId,
+        archived: archived,
+        deleteWorktree: deleteWorktree,
+        deleteBranch: deleteBranch,
+        force: force,
+      ),
+    );
+  }
+
+  Future<ArchiveStatusUpdate> _updateArchiveStatusAlreadyReserved({
+    required String sessionId,
+    required bool archived,
+    required bool deleteWorktree,
+    required bool deleteBranch,
+    required bool force,
   }) async {
     final storedSession = await _getStoredSession(sessionId: sessionId);
     final wasArchived = storedSession.archivedAt != null;
@@ -202,14 +218,11 @@ class SessionLifecycleService {
       sessionId: storedSession.id,
       archivedAt: archivedAt,
     );
-    unawaited(
-      _sessionRepository.notifySessionArchived(sessionId: storedSession.id).catchError((
-        Object error,
-        StackTrace stackTrace,
-      ) {
-        Log.w("[archive] failed to notify plugin for session ${storedSession.id}", error, stackTrace);
-      }),
-    );
+    try {
+      await _sessionRepository.notifySessionArchived(sessionId: storedSession.id);
+    } on Object catch (error, stackTrace) {
+      Log.w("[archive] failed to notify plugin for session ${storedSession.id}", error, stackTrace);
+    }
     final session = await _sessionRepository.getCatalogSession(sessionId: storedSession.id);
     if (session == null) {
       throw SessionNotFoundException();
@@ -226,7 +239,7 @@ class SessionLifecycleService {
     if (!(deleteWorktree || deleteBranch)) {
       return;
     }
-    final cleanupResult = await cleanup(
+    final cleanupResult = await cleanupAlreadyReserved(
       sessionId: storedSession.id,
       deleteWorktree: deleteWorktree,
       deleteBranch: deleteBranch,

--- a/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
@@ -5,56 +5,70 @@ import "package:sesori_shared/sesori_shared.dart";
 
 import "../repositories/models/session_operation.dart";
 import "../repositories/session_repository.dart";
+import "session_cleanup_result.dart";
+import "session_operation_dispatcher.dart";
 
-/// Serializes bridge-owned session mutations and backend propagation.
+/// Owns bridge-persisted session mutations and their backend propagation.
 class SessionMutationDispatcher {
   final SessionRepository _sessionRepository;
+  final SessionOperationDispatcher _sessionOperationDispatcher;
   final StreamController<Session> _deletedSessionsController = StreamController<Session>.broadcast(sync: true);
-  Future<void> _tail = Future<void>.value();
-  Future<void> _backendTail = Future<void>.value();
   bool _disposed = false;
+  Future<void>? _disposeFuture;
 
-  SessionMutationDispatcher({required SessionRepository sessionRepository}) : _sessionRepository = sessionRepository;
+  SessionMutationDispatcher({
+    required SessionRepository sessionRepository,
+    required SessionOperationDispatcher sessionOperationDispatcher,
+  }) : _sessionRepository = sessionRepository,
+       _sessionOperationDispatcher = sessionOperationDispatcher;
 
   Stream<Session> get deletedSessions => _deletedSessionsController.stream;
 
-  /// Completes after the authoritative DB title is stored. Backend propagation
-  /// continues on its own serialized tail so later DB writes stay immediate
-  /// while delete and dispose still cannot overtake backend synchronization.
   Future<Session> renameSession({required String sessionId, required String title}) {
-    return _serialized(() async {
-      final stored = await _sessionRepository.setSessionTitleIfStored(sessionId: sessionId, title: title);
-      final renamed = stored ? await _sessionRepository.getCatalogSession(sessionId: sessionId) : null;
-      if (renamed == null) {
-        throw PluginOperationException.notFound(
-          SessionOperation.renameSession.name,
-          message: "session $sessionId was not found",
-        );
-      }
-      unawaited(
-        _serializedBackend(() => _propagateTitle(sessionId: sessionId, title: title)),
-      );
-      return renamed;
-    });
-  }
-
-  Future<void> deleteSession({required String sessionId}) {
     if (_disposed) return Future.error(StateError("SessionMutationDispatcher is disposed"));
-    return _serialized(() async {
-      final deleted = await _serializedBackend(() => _sessionRepository.deleteSession(sessionId: sessionId));
-      _deletedSessionsController.add(deleted);
-    });
+    return _sessionOperationDispatcher.dispatch(
+      sessionId: sessionId,
+      operation: SessionOperation.renameSession,
+      interaction: null,
+      body: () => _renameSessionAlreadyReserved(sessionId: sessionId, title: title),
+    );
   }
 
-  Future<void> drain() => _serialized(() => _serializedBackend(() async {}));
+  Future<CleanupResult> deleteSession({
+    required String sessionId,
+    required Future<CleanupResult> Function() cleanup,
+  }) {
+    if (_disposed) throw StateError("SessionMutationDispatcher is disposed");
+    return _sessionOperationDispatcher.dispatch(
+      sessionId: sessionId,
+      operation: SessionOperation.deleteSession,
+      interaction: null,
+      body: () async {
+        final cleanupResult = await cleanup();
+        if (cleanupResult is CleanupRejected) return cleanupResult;
+        final deleted = await _sessionRepository.deleteSession(sessionId: sessionId);
+        _deletedSessionsController.add(deleted);
+        return cleanupResult;
+      },
+    );
+  }
 
   Future<void> dispose() {
-    if (_disposed) return Future.value();
     _disposed = true;
-    return _serialized(() async {
-      await _serializedBackend(() async {});
-      await _deletedSessionsController.close();
-    });
+    return _disposeFuture ??= _deletedSessionsController.close();
+  }
+
+  Future<Session> _renameSessionAlreadyReserved({required String sessionId, required String title}) async {
+    final stored = await _sessionRepository.setSessionTitleIfStored(sessionId: sessionId, title: title);
+    final renamed = stored ? await _sessionRepository.getCatalogSession(sessionId: sessionId) : null;
+    if (renamed == null) {
+      throw PluginOperationException.notFound(
+        SessionOperation.renameSession.name,
+        message: "session $sessionId was not found",
+      );
+    }
+    await _propagateTitle(sessionId: sessionId, title: title);
+    return renamed;
   }
 
   Future<void> _propagateTitle({
@@ -66,33 +80,5 @@ class SessionMutationDispatcher {
     } catch (error, stackTrace) {
       Log.w("Could not propagate title for session $sessionId to its plugin", error, stackTrace);
     }
-  }
-
-  Future<T> _serialized<T>(Future<T> Function() operation) {
-    final previous = _tail;
-    final release = Completer<void>();
-    _tail = release.future;
-    return () async {
-      await previous;
-      try {
-        return await operation();
-      } finally {
-        release.complete();
-      }
-    }();
-  }
-
-  Future<T> _serializedBackend<T>(Future<T> Function() operation) {
-    final previous = _backendTail;
-    final release = Completer<void>();
-    _backendTail = release.future;
-    return () async {
-      await previous;
-      try {
-        return await operation();
-      } finally {
-        release.complete();
-      }
-    }();
   }
 }

--- a/bridge/app/test/bridge/routing/create_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_session_handler_test.dart
@@ -12,6 +12,7 @@ import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.
 import "package:sesori_bridge/src/bridge/routing/create_session_handler.dart";
 import "package:sesori_bridge/src/bridge/services/session_creation_service.dart";
 import "package:sesori_bridge/src/bridge/services/session_mutation_dispatcher.dart";
+import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
 import "package:sesori_bridge/src/bridge/services/worktree_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -62,6 +63,7 @@ void main() {
     late FakeMetadataService metadataService;
     late _FakeWorktreeService worktreeService;
     late SessionRepository sessionRepository;
+    late SessionOperationDispatcher sessionOperationDispatcher;
     late SessionMutationDispatcher sessionMutationDispatcher;
     late CreateSessionHandler handler;
     late AppDatabase db;
@@ -79,7 +81,11 @@ void main() {
         pullRequestDao: db.pullRequestDao,
         unseenCalculator: const SessionUnseenCalculator(),
       );
-      sessionMutationDispatcher = SessionMutationDispatcher(sessionRepository: sessionRepository);
+      sessionOperationDispatcher = SessionOperationDispatcher(sessionRepository: sessionRepository);
+      sessionMutationDispatcher = SessionMutationDispatcher(
+        sessionRepository: sessionRepository,
+        sessionOperationDispatcher: sessionOperationDispatcher,
+      );
       handler = CreateSessionHandler(
         sessionCreationService: SessionCreationService(
           metadataService: metadataService,
@@ -91,6 +97,7 @@ void main() {
     });
 
     tearDown(() async {
+      await sessionOperationDispatcher.dispose();
       await sessionMutationDispatcher.dispose();
       await plugin.close();
       await db.close();
@@ -472,7 +479,10 @@ void main() {
           metadataService: metadataService,
           worktreeService: worktreeService,
           sessionRepository: localRepository,
-          sessionMutationDispatcher: SessionMutationDispatcher(sessionRepository: localRepository),
+          sessionMutationDispatcher: SessionMutationDispatcher(
+            sessionRepository: localRepository,
+            sessionOperationDispatcher: SessionOperationDispatcher(sessionRepository: localRepository),
+          ),
         ),
       );
       worktreeService.prepareResult = WorktreeSuccess(
@@ -724,7 +734,6 @@ void main() {
       expect(worktreeService.lastPreparePreferredBranchName, equals("fix-login-bug"));
       expect(result.title, equals("Fix Login Bug"));
       expect((await db.sessionDao.getSession(sessionId: result.id))?.title, equals("Fix Login Bug"));
-      await sessionMutationDispatcher.drain();
       expect(plugin.lastRenameSessionTitle, equals("Fix Login Bug"));
     });
 
@@ -937,7 +946,10 @@ void main() {
           metadataService: metadataService,
           worktreeService: worktreeService,
           sessionRepository: orderedRepository,
-          sessionMutationDispatcher: SessionMutationDispatcher(sessionRepository: orderedRepository),
+          sessionMutationDispatcher: SessionMutationDispatcher(
+            sessionRepository: orderedRepository,
+            sessionOperationDispatcher: SessionOperationDispatcher(sessionRepository: orderedRepository),
+          ),
         ),
       );
 
@@ -1126,7 +1138,11 @@ void main() {
         pullRequestDao: db.pullRequestDao,
         unseenCalculator: const SessionUnseenCalculator(),
       );
-      final throwingDispatcher = SessionMutationDispatcher(sessionRepository: throwingRepository);
+      final throwingOperationDispatcher = SessionOperationDispatcher(sessionRepository: throwingRepository);
+      final throwingDispatcher = SessionMutationDispatcher(
+        sessionRepository: throwingRepository,
+        sessionOperationDispatcher: throwingOperationDispatcher,
+      );
       final localHandler = CreateSessionHandler(
         sessionCreationService: SessionCreationService(
           metadataService: metadataService,
@@ -1156,6 +1172,7 @@ void main() {
       _expectRandomSesoriId(sessionId: result.id, backendSessionId: "s1");
       expect(result.title, "Fix Login Bug");
       expect((await db.sessionDao.getSession(sessionId: result.id))?.title, "Fix Login Bug");
+      await throwingOperationDispatcher.dispose();
       await throwingDispatcher.dispose();
       await throwingPlugin.close();
     });

--- a/bridge/app/test/bridge/routing/delete_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/delete_session_handler_test.dart
@@ -9,8 +9,10 @@ import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
 import "package:sesori_bridge/src/bridge/repositories/filesystem_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/routing/delete_session_handler.dart";
+import "package:sesori_bridge/src/bridge/services/session_deletion_service.dart";
 import "package:sesori_bridge/src/bridge/services/session_lifecycle_service.dart";
 import "package:sesori_bridge/src/bridge/services/session_mutation_dispatcher.dart";
+import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
 import "package:sesori_bridge/src/bridge/services/worktree_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -24,6 +26,8 @@ void main() {
     late AppDatabase db;
     late _TrackingFakeBridgePlugin plugin;
     late _FakeWorktreeService worktreeService;
+    late SessionOperationDispatcher sessionOperationDispatcher;
+    late SessionMutationDispatcher sessionMutationDispatcher;
     late DeleteSessionHandler handler;
     late List<String> operationLog;
 
@@ -39,20 +43,31 @@ void main() {
         pullRequestDao: db.pullRequestDao,
         unseenCalculator: const SessionUnseenCalculator(),
       );
-      handler = DeleteSessionHandler(
-        sessionLifecycleService: SessionLifecycleService(
-          worktreeService: worktreeService,
-          sessionRepository: sessionRepository,
-          filesystemRepository: FilesystemRepository(
-            filesystemApi: const FilesystemApi(),
-            permissionValidator: const FilesystemPermissionValidator(),
-          ),
+      sessionOperationDispatcher = SessionOperationDispatcher(sessionRepository: sessionRepository);
+      sessionMutationDispatcher = SessionMutationDispatcher(
+        sessionRepository: sessionRepository,
+        sessionOperationDispatcher: sessionOperationDispatcher,
+      );
+      final sessionLifecycleService = SessionLifecycleService(
+        worktreeService: worktreeService,
+        sessionRepository: sessionRepository,
+        filesystemRepository: FilesystemRepository(
+          filesystemApi: const FilesystemApi(),
+          permissionValidator: const FilesystemPermissionValidator(),
         ),
-        sessionMutationDispatcher: SessionMutationDispatcher(sessionRepository: sessionRepository),
+        sessionOperationDispatcher: sessionOperationDispatcher,
+      );
+      handler = DeleteSessionHandler(
+        sessionDeletionService: SessionDeletionService(
+          sessionLifecycleService: sessionLifecycleService,
+          sessionMutationDispatcher: sessionMutationDispatcher,
+        ),
       );
     });
 
     tearDown(() async {
+      await sessionOperationDispatcher.dispose();
+      await sessionMutationDispatcher.dispose();
       await plugin.close();
       await db.close();
     });

--- a/bridge/app/test/bridge/routing/rename_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/rename_session_handler_test.dart
@@ -6,6 +6,7 @@ import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/routing/rename_session_handler.dart";
 import "package:sesori_bridge/src/bridge/services/session_mutation_dispatcher.dart";
+import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -18,6 +19,7 @@ void main() {
     late FakeBridgePlugin plugin;
     late AppDatabase db;
     late SessionRepository sessionRepository;
+    late SessionOperationDispatcher sessionOperationDispatcher;
     late SessionMutationDispatcher sessionMutationDispatcher;
     late RenameSessionHandler handler;
 
@@ -31,7 +33,11 @@ void main() {
         pullRequestDao: db.pullRequestDao,
         unseenCalculator: const SessionUnseenCalculator(),
       );
-      sessionMutationDispatcher = SessionMutationDispatcher(sessionRepository: sessionRepository);
+      sessionOperationDispatcher = SessionOperationDispatcher(sessionRepository: sessionRepository);
+      sessionMutationDispatcher = SessionMutationDispatcher(
+        sessionRepository: sessionRepository,
+        sessionOperationDispatcher: sessionOperationDispatcher,
+      );
       handler = RenameSessionHandler(sessionMutationDispatcher: sessionMutationDispatcher);
       await sessionRepository.insertStoredSession(
         sessionId: "s1",
@@ -50,6 +56,7 @@ void main() {
     });
 
     tearDown(() async {
+      await sessionOperationDispatcher.dispose();
       await sessionMutationDispatcher.dispose();
       await plugin.close();
       await db.close();

--- a/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
+++ b/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
@@ -12,6 +12,7 @@ import "package:sesori_bridge/src/bridge/repositories/filesystem_repository.dart
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/routing/update_session_archive_status_handler.dart";
 import "package:sesori_bridge/src/bridge/services/session_lifecycle_service.dart";
+import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
 import "package:sesori_bridge/src/bridge/services/session_unseen_service.dart";
 import "package:sesori_bridge/src/bridge/services/worktree_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
@@ -26,6 +27,7 @@ void main() {
     late AppDatabase db;
     late FakeBridgePlugin plugin;
     late _FakeWorktreeService worktreeService;
+    late SessionOperationDispatcher operationDispatcher;
     late SessionUnseenService unseenService;
     late UpdateSessionArchiveStatusHandler handler;
 
@@ -44,17 +46,20 @@ void main() {
         filesystemApi: const FilesystemApi(),
         permissionValidator: const FilesystemPermissionValidator(),
       );
+      operationDispatcher = SessionOperationDispatcher(sessionRepository: sessionRepository);
       handler = UpdateSessionArchiveStatusHandler(
         sessionLifecycleService: SessionLifecycleService(
           worktreeService: worktreeService,
           sessionRepository: sessionRepository,
           filesystemRepository: filesystemRepository,
+          sessionOperationDispatcher: operationDispatcher,
         ),
         sessionUnseenService: unseenService = buildTestSessionUnseenService(db, plugin),
       );
     });
 
     tearDown(() async {
+      await operationDispatcher.dispose();
       await plugin.close();
       await db.close();
     });
@@ -732,7 +737,7 @@ void main() {
       expect(result.time?.archived, equals(persisted?.archivedAt));
     });
 
-    test("archive does not await plugin archiveSession", () async {
+    test("archive holds its family operation through plugin notification", () async {
       await _insertSession(
         db: db,
         sessionId: "s1",
@@ -754,10 +759,10 @@ void main() {
           time: PluginSessionTime(created: 10, updated: 20, archived: null),
         ),
       ];
-      // Plugin never completes — if handler awaited, this test would hang.
-      plugin.archiveSessionCompleter = Completer<void>();
+      final archiveGate = Completer<void>();
+      plugin.archiveSessionCompleter = archiveGate;
 
-      final result = await handler.handle(
+      final resultFuture = handler.handle(
         makeRequest("PATCH", "/session/update/archive"),
         body: _archiveRequest(
           sessionId: "s1",
@@ -770,6 +775,15 @@ void main() {
         queryParams: {},
         fragment: null,
       );
+      var completed = false;
+      unawaited(resultFuture.then<void>((_) => completed = true));
+      while (plugin.lastArchiveSessionId == null) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(completed, isFalse);
+
+      archiveGate.complete();
+      final result = await resultFuture;
 
       expect(result.id, equals("s1"));
       expect(result.time?.archived, isNotNull);

--- a/bridge/app/test/bridge/services/session_creation_service_test.dart
+++ b/bridge/app/test/bridge/services/session_creation_service_test.dart
@@ -10,6 +10,7 @@ import "package:sesori_bridge/src/bridge/models/session_metadata.dart" as bridge
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/services/session_creation_service.dart";
 import "package:sesori_bridge/src/bridge/services/session_mutation_dispatcher.dart";
+import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
 import "package:sesori_bridge/src/bridge/services/worktree_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -23,6 +24,7 @@ void main() {
     late _FakePlugin plugin;
     late _FakeMetadataService metadataService;
     late _FakeWorktreeService worktreeService;
+    late SessionOperationDispatcher operationDispatcher;
     late SessionMutationDispatcher mutationDispatcher;
     late SessionCreationService service;
 
@@ -49,7 +51,11 @@ void main() {
         pullRequestDao: db.pullRequestDao,
         unseenCalculator: const SessionUnseenCalculator(),
       );
-      mutationDispatcher = SessionMutationDispatcher(sessionRepository: repository);
+      operationDispatcher = SessionOperationDispatcher(sessionRepository: repository);
+      mutationDispatcher = SessionMutationDispatcher(
+        sessionRepository: repository,
+        sessionOperationDispatcher: operationDispatcher,
+      );
       service = SessionCreationService(
         metadataService: metadataService,
         worktreeService: worktreeService,
@@ -59,6 +65,7 @@ void main() {
     });
 
     tearDown(() async {
+      await operationDispatcher.dispose();
       await mutationDispatcher.dispose();
       await db.close();
     });

--- a/bridge/app/test/bridge/services/session_family_mutation_test.dart
+++ b/bridge/app/test/bridge/services/session_family_mutation_test.dart
@@ -1,0 +1,515 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/bridge/repositories/filesystem_repository.dart";
+import "package:sesori_bridge/src/bridge/repositories/models/session_operation.dart";
+import "package:sesori_bridge/src/bridge/repositories/models/stored_session.dart";
+import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
+import "package:sesori_bridge/src/bridge/services/session_cleanup_result.dart";
+import "package:sesori_bridge/src/bridge/services/session_deletion_service.dart";
+import "package:sesori_bridge/src/bridge/services/session_lifecycle_service.dart";
+import "package:sesori_bridge/src/bridge/services/session_mutation_dispatcher.dart";
+import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
+import "package:sesori_bridge/src/bridge/services/worktree_service.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("session family mutations", () {
+    late _Fixture fixture;
+
+    setUp(() {
+      fixture = _Fixture();
+    });
+
+    tearDown(() => fixture.dispose());
+
+    test("earlier child rename finishes before root deletion", () async {
+      final renameStarted = Completer<void>();
+      final releaseRename = Completer<void>();
+      fixture.repository
+        ..renameStarted["child"] = renameStarted
+        ..renameGates["child"] = releaseRename.future;
+
+      final rename = fixture.mutations.renameSession(sessionId: "child", title: "renamed");
+      await renameStarted.future;
+      final deletion = fixture.deleteRoot();
+      await _flushEvents();
+
+      expect(fixture.repository.deleteStarted.isCompleted, isFalse);
+      releaseRename.complete();
+      await Future.wait([rename, deletion]);
+      expect(fixture.repository.contains(sessionId: "child"), isFalse);
+    });
+
+    test("earlier root deletion prevents a later child rename", () async {
+      final releaseDelete = Completer<void>();
+      fixture.repository.deleteGate = releaseDelete.future;
+
+      final deletion = fixture.deleteRoot();
+      await fixture.repository.deleteStarted.future;
+      final rename = fixture.mutations.renameSession(sessionId: "child", title: "too late");
+      await _flushEvents();
+
+      expect(fixture.repository.renameCalls, isZero);
+      releaseDelete.complete();
+      await deletion;
+      await expectLater(rename, throwsA(_isNotFound));
+      expect(fixture.repository.renameCalls, isZero);
+    });
+
+    test("earlier child action finishes before root deletion", () async {
+      final actionStarted = Completer<void>();
+      final releaseAction = Completer<void>();
+      fixture.repository
+        ..actionStarted = actionStarted
+        ..actionGate = releaseAction.future;
+
+      final action = fixture.dispatchAction(sessionId: "child");
+      await actionStarted.future;
+      final deletion = fixture.deleteRoot();
+      await _flushEvents();
+
+      expect(fixture.repository.deleteStarted.isCompleted, isFalse);
+      releaseAction.complete();
+      await Future.wait([action, deletion]);
+    });
+
+    test("earlier root deletion prevents a later child action", () async {
+      final releaseDelete = Completer<void>();
+      fixture.repository.deleteGate = releaseDelete.future;
+
+      final deletion = fixture.deleteRoot();
+      await fixture.repository.deleteStarted.future;
+      final action = fixture.dispatchAction(sessionId: "child");
+      releaseDelete.complete();
+
+      await deletion;
+      await expectLater(action, throwsA(_isNotFound));
+      expect(fixture.repository.actionCalls, isZero);
+    });
+
+    for (final archived in [true, false]) {
+      final operationName = archived ? "archive" : "unarchive";
+
+      test("earlier $operationName finishes before deletion", () async {
+        fixture.repository.setArchived(sessionId: "root", archived: !archived);
+        final lifecycleStarted = Completer<void>();
+        final releaseLifecycle = Completer<void>();
+        if (archived) {
+          fixture.repository
+            ..archiveStarted = lifecycleStarted
+            ..archiveGate = releaseLifecycle.future;
+        } else {
+          fixture.worktree
+            ..restoreStarted = lifecycleStarted
+            ..restoreGate = releaseLifecycle.future;
+        }
+
+        final lifecycle = fixture.updateArchiveStatus(archived: archived);
+        await lifecycleStarted.future;
+        final deletion = fixture.deleteRoot();
+        await _flushEvents();
+
+        expect(fixture.repository.deleteStarted.isCompleted, isFalse);
+        releaseLifecycle.complete();
+        await Future.wait([lifecycle, deletion]);
+      });
+
+      test("earlier deletion prevents later $operationName", () async {
+        fixture.repository.setArchived(sessionId: "root", archived: !archived);
+        final releaseDelete = Completer<void>();
+        fixture.repository.deleteGate = releaseDelete.future;
+
+        final deletion = fixture.deleteRoot();
+        await fixture.repository.deleteStarted.future;
+        final lifecycle = fixture.updateArchiveStatus(archived: archived);
+        releaseDelete.complete();
+
+        await deletion;
+        await expectLater(lifecycle, throwsA(_isNotFound));
+        expect(fixture.worktree.restoreCalls, isZero);
+      });
+    }
+
+    test("cleanup rejection releases the family without deleting", () async {
+      fixture.worktree.safetyResult = WorktreeUnsafe(issues: [UnstagedChanges()]);
+
+      final result = await fixture.deletions.deleteSession(
+        sessionId: "root",
+        deleteWorktree: true,
+        deleteBranch: false,
+        force: false,
+      );
+
+      expect(result, isA<CleanupRejected>());
+      expect(fixture.repository.deleteCalls, isZero);
+      expect(fixture.repository.contains(sessionId: "root"), isTrue);
+      expect(fixture.operations.activeLaneCount, isZero);
+    });
+
+    test("unrelated roots and plugins execute while one family is blocked", () async {
+      final childStarted = Completer<void>();
+      final releaseChild = Completer<void>();
+      final otherStarted = Completer<void>();
+      final pluginTwoStarted = Completer<void>();
+      fixture.repository
+        ..renameStarted["child"] = childStarted
+        ..renameGates["child"] = releaseChild.future
+        ..renameStarted["other"] = otherStarted
+        ..renameStarted["plugin-two"] = pluginTwoStarted;
+
+      final child = fixture.mutations.renameSession(sessionId: "child", title: "child");
+      await childStarted.future;
+      final other = fixture.mutations.renameSession(sessionId: "other", title: "other");
+      final pluginTwo = fixture.mutations.renameSession(sessionId: "plugin-two", title: "plugin two");
+
+      await Future.wait([otherStarted.future, pluginTwoStarted.future, other, pluginTwo]);
+      releaseChild.complete();
+      await child;
+      expect(fixture.operations.activeLaneCount, isZero);
+    });
+
+    test("failure releases the lane for later family work", () async {
+      fixture.repository.titleWriteError = StateError("title write failed");
+
+      await expectLater(
+        fixture.mutations.renameSession(sessionId: "child", title: "fails"),
+        throwsStateError,
+      );
+      await fixture.dispatchAction(sessionId: "root");
+
+      expect(fixture.repository.actionCalls, 1);
+      expect(fixture.operations.activeLaneCount, isZero);
+    });
+
+    test("drain waits for accepted work, rejects new work, and disposes once", () async {
+      final actionStarted = Completer<void>();
+      final releaseAction = Completer<void>();
+      fixture.repository
+        ..actionStarted = actionStarted
+        ..actionGate = releaseAction.future;
+      final action = fixture.dispatchAction(sessionId: "child");
+      await actionStarted.future;
+
+      final drain = fixture.operations.drain();
+      var drained = false;
+      unawaited(drain.then<void>((_) => drained = true));
+      await _flushEvents();
+      expect(drained, isFalse);
+      expect(
+        () => fixture.mutations.renameSession(sessionId: "root", title: "closed"),
+        throwsStateError,
+      );
+
+      releaseAction.complete();
+      await Future.wait([action, drain]);
+      expect(identical(drain, fixture.operations.dispose()), isTrue);
+      expect(fixture.operations.activeLaneCount, isZero);
+    });
+  });
+}
+
+final _isNotFound = isA<PluginOperationException>().having((error) => error.isNotFound, "isNotFound", isTrue);
+
+Future<void> _flushEvents() => Future<void>.delayed(Duration.zero);
+
+class _Fixture {
+  late final _FamilyRepository repository;
+  late final SessionOperationDispatcher operations;
+  late final SessionMutationDispatcher mutations;
+  late final _FamilyWorktreeService worktree;
+  late final SessionLifecycleService lifecycle;
+  late final SessionDeletionService deletions;
+
+  _Fixture() {
+    repository = _FamilyRepository();
+    operations = SessionOperationDispatcher(sessionRepository: repository);
+    mutations = SessionMutationDispatcher(
+      sessionRepository: repository,
+      sessionOperationDispatcher: operations,
+    );
+    worktree = _FamilyWorktreeService();
+    lifecycle = SessionLifecycleService(
+      worktreeService: worktree,
+      sessionRepository: repository,
+      filesystemRepository: _MissingFilesystemRepository(),
+      sessionOperationDispatcher: operations,
+    );
+    deletions = SessionDeletionService(
+      sessionLifecycleService: lifecycle,
+      sessionMutationDispatcher: mutations,
+    );
+  }
+
+  Future<void> deleteRoot() async {
+    final result = await deletions.deleteSession(
+      sessionId: "root",
+      deleteWorktree: false,
+      deleteBranch: false,
+      force: false,
+    );
+    if (result is CleanupRejected) throw StateError("unexpected cleanup rejection");
+  }
+
+  Future<ArchiveStatusUpdate> updateArchiveStatus({required bool archived}) {
+    return lifecycle.updateArchiveStatus(
+      sessionId: "root",
+      archived: archived,
+      deleteWorktree: false,
+      deleteBranch: false,
+      force: false,
+    );
+  }
+
+  Future<void> dispatchAction({required String sessionId}) {
+    return operations.dispatch(
+      sessionId: sessionId,
+      operation: SessionOperation.sendPrompt,
+      interaction: null,
+      body: () => repository.executeAction(sessionId: sessionId),
+    );
+  }
+
+  Future<void> dispose() async {
+    await operations.dispose();
+    await mutations.dispose();
+  }
+}
+
+class _FamilyRepository implements SessionRepository {
+  final Map<String, _SessionRecord> _sessions = {
+    "root": _SessionRecord(id: "root", rootId: "root", parentId: null, pluginId: "one"),
+    "child": _SessionRecord(id: "child", rootId: "root", parentId: "root", pluginId: "one"),
+    "other": _SessionRecord(id: "other", rootId: "other", parentId: null, pluginId: "one"),
+    "plugin-two": _SessionRecord(id: "plugin-two", rootId: "plugin-two", parentId: null, pluginId: "two"),
+  };
+  final Map<String, Completer<void>> renameStarted = {};
+  final Map<String, Future<void>> renameGates = {};
+  final Completer<void> deleteStarted = Completer<void>();
+  Completer<void>? archiveStarted;
+  Completer<void>? actionStarted;
+  Future<void>? archiveGate;
+  Future<void>? deleteGate;
+  Future<void>? actionGate;
+  Object? titleWriteError;
+  int renameCalls = 0;
+  int deleteCalls = 0;
+  int actionCalls = 0;
+
+  bool contains({required String sessionId}) => _sessions.containsKey(sessionId);
+
+  void setArchived({required String sessionId, required bool archived}) {
+    final record = _sessions[sessionId];
+    if (record == null) throw StateError("missing test session $sessionId");
+    record.archivedAt = archived ? 1 : null;
+  }
+
+  @override
+  Future<SessionFamilyScope> resolveSessionFamily({
+    required String sessionId,
+    required SessionOperation operation,
+  }) async {
+    final record = _sessions[sessionId];
+    if (record == null) throw _notFound(sessionId: sessionId, operation: operation);
+    return (rootSessionId: record.rootId, pluginId: record.pluginId);
+  }
+
+  @override
+  Future<bool> setSessionTitleIfStored({required String sessionId, required String? title}) async {
+    final error = titleWriteError;
+    titleWriteError = null;
+    if (error != null) throw error;
+    final record = _sessions[sessionId];
+    if (record == null) return false;
+    record.title = title;
+    return true;
+  }
+
+  @override
+  Future<Session?> getCatalogSession({required String sessionId}) async => _sessions[sessionId]?.session;
+
+  @override
+  Future<Session> renameSession({required String sessionId, required String title}) async {
+    renameCalls++;
+    renameStarted[sessionId]?.complete();
+    final gate = renameGates[sessionId];
+    if (gate != null) await gate;
+    final record = _sessions[sessionId];
+    if (record == null) throw _notFound(sessionId: sessionId, operation: SessionOperation.renameSession);
+    return record.session;
+  }
+
+  @override
+  Future<Session> deleteSession({required String sessionId}) async {
+    deleteCalls++;
+    if (!deleteStarted.isCompleted) deleteStarted.complete();
+    final snapshot = _sessions[sessionId];
+    if (snapshot == null) throw _notFound(sessionId: sessionId, operation: SessionOperation.deleteSession);
+    final gate = deleteGate;
+    if (gate != null) await gate;
+    if (!_sessions.containsKey(sessionId)) {
+      throw _notFound(sessionId: sessionId, operation: SessionOperation.deleteSession);
+    }
+    _sessions.removeWhere((_, record) => record.rootId == sessionId || record.id == sessionId);
+    return snapshot.session;
+  }
+
+  @override
+  Future<StoredSession> requireRoutableStoredSession({
+    required String sessionId,
+    required SessionOperation operation,
+  }) async {
+    final record = _sessions[sessionId];
+    if (record == null) throw _notFound(sessionId: sessionId, operation: operation);
+    return record.stored;
+  }
+
+  @override
+  Future<bool> hasOtherActiveSessionsSharing({
+    required String sessionId,
+    required String projectId,
+    required String? worktreePath,
+    required String? branchName,
+  }) async => false;
+
+  @override
+  Future<void> archiveStoredSession({required String sessionId, required int archivedAt}) async {
+    final started = archiveStarted;
+    if (started != null && !started.isCompleted) started.complete();
+    final gate = archiveGate;
+    if (gate != null) await gate;
+    final record = _sessions[sessionId];
+    if (record == null) throw _notFound(sessionId: sessionId, operation: SessionOperation.archiveSession);
+    record.archivedAt = archivedAt;
+  }
+
+  @override
+  Future<void> unarchiveStoredSession({required String sessionId}) async {
+    final record = _sessions[sessionId];
+    if (record == null) throw _notFound(sessionId: sessionId, operation: SessionOperation.updateSessionArchiveStatus);
+    record.archivedAt = null;
+  }
+
+  @override
+  Future<void> notifySessionArchived({required String sessionId}) async {}
+
+  Future<void> executeAction({required String sessionId}) async {
+    final started = actionStarted;
+    if (started != null && !started.isCompleted) started.complete();
+    final gate = actionGate;
+    if (gate != null) await gate;
+    if (!_sessions.containsKey(sessionId)) {
+      throw _notFound(sessionId: sessionId, operation: SessionOperation.sendPrompt);
+    }
+    actionCalls++;
+  }
+
+  PluginOperationException _notFound({required String sessionId, required SessionOperation operation}) {
+    return PluginOperationException.notFound(operation.name, message: "session $sessionId was not found");
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _SessionRecord {
+  final String id;
+  final String rootId;
+  final String? parentId;
+  final String pluginId;
+  String? title;
+  int? archivedAt;
+
+  _SessionRecord({
+    required this.id,
+    required this.rootId,
+    required this.parentId,
+    required this.pluginId,
+  }) : title = id;
+
+  StoredSession get stored => StoredSession(
+    id: id,
+    backendSessionId: "backend-$id",
+    pluginId: pluginId,
+    projectId: "project-$rootId",
+    parentSessionId: parentId,
+    directory: "/repo/$id",
+    worktreePath: "/repo/.worktrees/$id",
+    branchName: "branch-$id",
+    isDedicated: true,
+    archivedAt: archivedAt,
+    baseBranch: "main",
+    baseCommit: "abc123",
+  );
+
+  Session get session => Session(
+    id: id,
+    pluginId: pluginId,
+    projectID: "project-$rootId",
+    directory: "/repo/$id",
+    parentID: parentId,
+    title: title,
+    time: SessionTime(created: 1, updated: 1, archived: archivedAt),
+    pullRequest: null,
+    promptDefaults: null,
+    branchName: "branch-$id",
+  );
+}
+
+class _FamilyWorktreeService implements WorktreeService {
+  WorktreeSafetyResult safetyResult = WorktreeSafe();
+  Completer<void>? restoreStarted;
+  Future<void>? restoreGate;
+  int restoreCalls = 0;
+
+  @override
+  Future<WorktreeSafetyResult> checkWorktreeSafety({
+    required String worktreePath,
+    required String expectedBranch,
+  }) async => safetyResult;
+
+  @override
+  Future<bool> removeWorktree({
+    required String pluginId,
+    required String projectId,
+    required String worktreePath,
+    required bool force,
+  }) async => true;
+
+  @override
+  Future<bool> deleteBranch({required String projectId, required String branchName, required bool force}) async => true;
+
+  @override
+  Future<bool> branchExists({required String projectId, required String branchName}) async => false;
+
+  @override
+  Future<bool> restoreWorktree({
+    required String projectId,
+    required String worktreePath,
+    required String branchName,
+    required String baseBranch,
+    required String? baseCommit,
+  }) async {
+    restoreCalls++;
+    final started = restoreStarted;
+    if (started != null && !started.isCompleted) started.complete();
+    final gate = restoreGate;
+    if (gate != null) await gate;
+    return true;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _MissingFilesystemRepository implements FilesystemRepository {
+  @override
+  bool directoryExists({required String path}) => false;
+
+  @override
+  FilesystemEntityKind classifyPath({required String path}) => FilesystemEntityKind.notFound;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
+++ b/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
@@ -11,7 +11,9 @@ import "package:sesori_bridge/src/bridge/repositories/models/stored_session.dart
 import "package:sesori_bridge/src/bridge/repositories/models/verified_github_login.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
+import "package:sesori_bridge/src/bridge/services/session_cleanup_result.dart";
 import "package:sesori_bridge/src/bridge/services/session_lifecycle_service.dart";
+import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
 import "package:sesori_bridge/src/bridge/services/worktree_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -24,12 +26,14 @@ void main() {
     late AppDatabase db;
     late _FakeWorktreeService worktreeService;
     late _FakeSessionRepository sessionRepository;
+    late SessionOperationDispatcher operationDispatcher;
     late SessionLifecycleService service;
 
     setUp(() {
       db = createTestDatabase();
       worktreeService = _FakeWorktreeService(database: db);
       sessionRepository = _FakeSessionRepository();
+      operationDispatcher = SessionOperationDispatcher(sessionRepository: sessionRepository);
       service = SessionLifecycleService(
         worktreeService: worktreeService,
         sessionRepository: sessionRepository,
@@ -37,10 +41,12 @@ void main() {
           filesystemApi: const FilesystemApi(),
           permissionValidator: const FilesystemPermissionValidator(),
         ),
+        sessionOperationDispatcher: operationDispatcher,
       );
     });
 
     tearDown(() async {
+      await operationDispatcher.dispose();
       await db.close();
     });
 
@@ -64,7 +70,7 @@ void main() {
 
     test("missing root binding is an explicit not-found failure", () async {
       await expectLater(
-        service.cleanup(
+        service.cleanupAlreadyReserved(
           sessionId: "missing",
           deleteWorktree: true,
           deleteBranch: true,
@@ -424,6 +430,7 @@ void main() {
   group("SessionLifecycleService archive binding", () {
     late AppDatabase db;
     late _FakeBridgePlugin plugin;
+    late SessionOperationDispatcher operationDispatcher;
     late SessionLifecycleService service;
 
     setUp(() async {
@@ -437,6 +444,7 @@ void main() {
         pullRequestDao: db.pullRequestDao,
         unseenCalculator: const SessionUnseenCalculator(),
       );
+      operationDispatcher = SessionOperationDispatcher(sessionRepository: repository);
       service = SessionLifecycleService(
         worktreeService: _FakeWorktreeService(database: db),
         sessionRepository: repository,
@@ -444,6 +452,7 @@ void main() {
           filesystemApi: const FilesystemApi(),
           permissionValidator: const FilesystemPermissionValidator(),
         ),
+        sessionOperationDispatcher: operationDispatcher,
       );
       await db.sessionDao.insertSession(
         sessionId: "root-session",
@@ -461,7 +470,10 @@ void main() {
       );
     });
 
-    tearDown(() => db.close());
+    tearDown(() async {
+      await operationDispatcher.dispose();
+      await db.close();
+    });
 
     test("archive routes plugin I/O through the stored backend id", () async {
       final update = await service.updateArchiveStatus(
@@ -527,7 +539,7 @@ Future<CleanupResult> _cleanup({
     baseBranch: null,
     baseCommit: null,
   );
-  return service.cleanup(
+  return service.cleanupAlreadyReserved(
     sessionId: sessionId,
     deleteWorktree: deleteWorktree,
     deleteBranch: deleteBranch,
@@ -580,6 +592,21 @@ class _FakeSessionRepository implements SessionRepository {
     }
     await ensurePluginRoutable(pluginId: session.pluginId, operation: operation);
     return session;
+  }
+
+  @override
+  Future<SessionFamilyScope> resolveSessionFamily({
+    required String sessionId,
+    required SessionOperation operation,
+  }) async {
+    final session = storedSession;
+    if (session == null) {
+      throw PluginOperationException.notFound(
+        operation.name,
+        message: "session $sessionId was not found",
+      );
+    }
+    return (rootSessionId: session.id, pluginId: session.pluginId);
   }
 
   @override

--- a/bridge/app/test/bridge/services/session_mutation_dispatcher_test.dart
+++ b/bridge/app/test/bridge/services/session_mutation_dispatcher_test.dart
@@ -3,7 +3,9 @@ import "dart:async";
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
+import "package:sesori_bridge/src/bridge/services/session_cleanup_result.dart";
 import "package:sesori_bridge/src/bridge/services/session_mutation_dispatcher.dart";
+import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -14,6 +16,7 @@ void main() {
   group("SessionMutationDispatcher", () {
     late AppDatabase db;
     late SessionRepository repository;
+    late SessionOperationDispatcher operationDispatcher;
     late SessionMutationDispatcher dispatcher;
     late _FakeDerivedPlugin plugin;
 
@@ -27,10 +30,15 @@ void main() {
         pullRequestDao: db.pullRequestDao,
         unseenCalculator: const SessionUnseenCalculator(),
       );
-      dispatcher = SessionMutationDispatcher(sessionRepository: repository);
+      operationDispatcher = SessionOperationDispatcher(sessionRepository: repository);
+      dispatcher = SessionMutationDispatcher(
+        sessionRepository: repository,
+        sessionOperationDispatcher: operationDispatcher,
+      );
     });
 
     tearDown(() async {
+      await operationDispatcher.dispose();
       await dispatcher.dispose();
       await db.close();
     });
@@ -60,36 +68,27 @@ void main() {
       expect(plugin.renameCalls, isZero);
     });
 
-    test("returns the stored title while plugin propagation remains serialized", () async {
+    test("holds the family operation through backend title propagation", () async {
       final renameStarted = Completer<void>();
       final releaseRename = Completer<void>();
-      final deleteStarted = Completer<void>();
       plugin
         ..renameStarted = renameStarted
-        ..releaseRename = releaseRename.future
-        ..deleteStarted = deleteStarted;
+        ..releaseRename = releaseRename.future;
       await insertSession();
 
       final rename = dispatcher.renameSession(sessionId: "s1", title: "Stored title");
       await renameStarted.future;
-      Future<void>? deletion;
+      var completed = false;
+      unawaited(rename.then<void>((_) => completed = true));
       try {
-        final renamed = await rename.timeout(const Duration(milliseconds: 100));
-        final newerRename = await dispatcher
-            .renameSession(sessionId: "s1", title: "Newer title")
-            .timeout(const Duration(milliseconds: 100));
-        deletion = dispatcher.deleteSession(sessionId: "s1");
         await Future<void>.delayed(Duration.zero);
-
-        expect(renamed.title, "Stored title");
-        expect(newerRename.title, "Newer title");
-        expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "Newer title");
-        expect(deleteStarted.isCompleted, isFalse);
+        expect(completed, isFalse);
+        expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "Stored title");
       } finally {
         releaseRename.complete();
       }
-      await deletion;
-      expect(deleteStarted.isCompleted, isTrue);
+      expect((await rename).title, "Stored title");
+      expect(operationDispatcher.activeLaneCount, isZero);
     });
 
     test("keeps the stored title when plugin propagation fails", () async {
@@ -97,42 +96,13 @@ void main() {
       await insertSession();
 
       final renamed = await dispatcher.renameSession(sessionId: "s1", title: "Stored title");
-      await dispatcher.drain();
 
       expect(renamed.title, "Stored title");
       expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "Stored title");
       expect(plugin.renameCalls, 1);
     });
 
-    test("a rename waits for deletion and cannot reach the plugin afterward", () async {
-      final deleteStarted = Completer<void>();
-      final releaseDelete = Completer<void>();
-      plugin
-        ..deleteStarted = deleteStarted
-        ..releaseDelete = releaseDelete.future;
-      await insertSession();
-
-      final deletion = dispatcher.deleteSession(sessionId: "s1");
-      await deleteStarted.future;
-      final rename = dispatcher.renameSession(sessionId: "s1", title: "Resurrected");
-      await Future<void>.delayed(Duration.zero);
-      expect(plugin.renameCalls, isZero);
-
-      releaseDelete.complete();
-      await deletion;
-      await expectLater(
-        rename,
-        throwsA(isA<PluginOperationException>().having((error) => error.isNotFound, "isNotFound", isTrue)),
-      );
-      expect(plugin.renameCalls, isZero);
-    });
-
-    test("dispose waits for an in-flight deletion to emit", () async {
-      final deleteStarted = Completer<void>();
-      final releaseDelete = Completer<void>();
-      plugin
-        ..deleteStarted = deleteStarted
-        ..releaseDelete = releaseDelete.future;
+    test("owns repository deletion and deleted session events", () async {
       await insertSession();
       final events = expectLater(
         dispatcher.deletedSessions,
@@ -142,17 +112,18 @@ void main() {
         ]),
       );
 
-      final deletion = dispatcher.deleteSession(sessionId: "s1");
-      await deleteStarted.future;
-      final disposal = dispatcher.dispose();
-      releaseDelete.complete();
-
-      await deletion;
-      await disposal;
+      await dispatcher.deleteSession(
+        sessionId: "s1",
+        cleanup: () async => CleanupSuccess(),
+      );
+      await dispatcher.dispose();
       await events;
-      await expectLater(
-        dispatcher.deleteSession(sessionId: "after-dispose"),
-        throwsA(isA<StateError>()),
+      expect(
+        () => dispatcher.deleteSession(
+          sessionId: "after-dispose",
+          cleanup: () async => CleanupSuccess(),
+        ),
+        throwsStateError,
       );
     });
   });


### PR DESCRIPTION
## Complexity

🚧 Complex — stable root-family ordering crosses rename propagation, archive cleanup/restore, subtree deletion/tombstones/events, and multiple service lifecycles.

## What

- enroll rename and archive/unarchive workflows in the existing stable root-family dispatcher lanes
- add `SessionDeletionService` to compose lifecycle cleanup with mutation-owned callback-scoped deletion
- keep `SessionMutationDispatcher` responsible for deletion admission, repository subtree deletion, tombstones, and `deletedSessions`
- hold archive operations through cleanup, persistence, and best-effort backend archive notification
- remove obsolete bridge-wide mutation/backend tails and their drain helpers

## Why

A root deletion owns its descendants and worktree state. Without explicit family scope, a child rename or action can race root deletion, and unarchive can restore a worktree after cleanup. This step preserves arrival order only within the affected root family while unrelated roots and plugins remain concurrent.

## Risk and test focus

Risk: high within session lifecycle ordering, with no wire, database-schema, client, analytics, or plugin-interface change. Highest-value checks cover root-delete/child-action ordering in both directions, archive/delete and unarchive/delete inversion, cleanup rejection, backend archive settlement, unrelated-root/plugin concurrency, failure release, lane cleanup, drain, and deletion-event ownership.

## Expected result

- **User-visible:** root and descendant lifecycle actions retain arrival order; unrelated session families remain responsive
- **Persisted/database:** no schema or meaning change; existing titles, archive state, deletion tombstones, and bindings remain authoritative
- **Internal:** mutation scope is the stable root family instead of an individual session or the whole bridge

## Verification

- `dart test` from `bridge/app`: 2,408 tests passed
- focused family/lifecycle/mutation/deletion/rename/archive tests: 80 passed
- `dart analyze --fatal-infos` from `bridge/app`: passed
- `git diff --check`: passed
- `aristotle-impl-review`: two valid findings applied directly; corrected implementation not re-reviewed per policy
- changed-line count: 1,054


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes all session mutations to a stable root-family lane to preserve order between deletes, renames, and archive/unarchive while keeping unrelated roots concurrent. Adds a dedicated deletion service and routes archive notifications inside the family lane to prevent races.

- **Refactors**
  - Route rename and archive/unarchive through `SessionOperationDispatcher` family lanes; `SessionMutationDispatcher` now dispatches via it.
  - Introduce `SessionDeletionService` to own cleanup+delete; `DeleteSessionHandler` now uses it.
  - Move cleanup into `cleanupAlreadyReserved` and call it from deletion/archive workflows.
  - Keep `SessionMutationDispatcher` responsible for deletion admission, repository subtree deletion, tombstones, and `deletedSessions`; remove bridge-wide mutation/backend tails and drain helpers.
  - Hold archive operations through persistence and plugin notify to avoid cleanup/restore inversion.
  - Add focused tests for family ordering, cleanup rejection, unrelated-root concurrency; update existing tests.
  - No wire, database schema, client, or plugin-interface changes.

<sup>Written for commit 2809742d9980da90d1d782782820abd4a3b97c9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


