### PR TITLE
🌿 Update coding backend runtime targets

### DIFF
--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart
@@ -21,7 +21,7 @@ import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 /// the downloaded archive), confirm the [_assets] filenames still match the
 /// release, raise [minPathVersion] only if the bridge starts to require a newer
 /// codex API, and re-run the integration tests. The hashes below are the
-/// published asset digests for codex `rust-v0.145.0`.
+/// published asset digests for codex `rust-v0.146.0`.
 class CodexRuntimeManifest extends RuntimeManifest {
   const CodexRuntimeManifest();
 
@@ -29,7 +29,7 @@ class CodexRuntimeManifest extends RuntimeManifest {
   static final SemanticVersion _minPathVersion = SemanticVersion.parse(value: "0.139.0");
 
   /// The exact codex version the managed runtime installs.
-  static final SemanticVersion _bundledVersion = SemanticVersion.parse(value: "0.145.0");
+  static final SemanticVersion _bundledVersion = SemanticVersion.parse(value: "0.146.0");
 
   static const String _releaseBaseUrl = "https://github.com/openai/codex/releases/download";
 
@@ -43,13 +43,13 @@ class CodexRuntimeManifest extends RuntimeManifest {
       PlatformArch.arm64: RuntimeAsset(
         assetName: "codex-aarch64-apple-darwin.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "072a30a65f05666735889ef0f60b56db186adbdde9d5c5cc1a64be0b598530fe",
+        sha256: "2750132d300e64f1dbffb95e3d913fd9c9dc7812bc8e1bce5c61357248b7929e",
         archiveBinaryName: "codex-aarch64-apple-darwin",
       ),
       PlatformArch.x64: RuntimeAsset(
         assetName: "codex-x86_64-apple-darwin.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "4216d7a40aa49d74b65fab93d2a86d2e25a902482b827dbdb3f357777b09fadf",
+        sha256: "710d727b0fa2b4ab2189eb1bdc5ab40177c168296af264913eb7ab3ce848d04b",
         archiveBinaryName: "codex-x86_64-apple-darwin",
       ),
     },
@@ -57,13 +57,13 @@ class CodexRuntimeManifest extends RuntimeManifest {
       PlatformArch.arm64: RuntimeAsset(
         assetName: "codex-aarch64-unknown-linux-musl.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "d384f90bc842450b42bd675feef06a12a46a3b1ca97efcb22566b270e4a11227",
+        sha256: "975bac91562abeedeb8f79636d51a86649b31f34a9de6a3bcb059565b6cf1f87",
         archiveBinaryName: "codex-aarch64-unknown-linux-musl",
       ),
       PlatformArch.x64: RuntimeAsset(
         assetName: "codex-x86_64-unknown-linux-musl.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "bfaf13c9ba34f2ad764e4a916c49cf7177aeba329cf0f719e2227566fc8d662a",
+        sha256: "5ba3b9405543953081f661d0854d266f76e2abbe51d41349355a36de7673776a",
         archiveBinaryName: "codex-x86_64-unknown-linux-musl",
       ),
     },
@@ -71,13 +71,13 @@ class CodexRuntimeManifest extends RuntimeManifest {
       PlatformArch.arm64: RuntimeAsset(
         assetName: "codex-aarch64-pc-windows-msvc.exe.zip",
         format: ArchiveFormat.zip,
-        sha256: "e38667194ddf24dfeb877ab9f6346b55bd979ff52bee9dbf4123e2a48f3627e2",
+        sha256: "5219938c0138580611735d8c2a79b100be0929083f779a8f375aadf192175b33",
         archiveBinaryName: "codex-aarch64-pc-windows-msvc.exe",
       ),
       PlatformArch.x64: RuntimeAsset(
         assetName: "codex-x86_64-pc-windows-msvc.exe.zip",
         format: ArchiveFormat.zip,
-        sha256: "bc6ae808bf5a9cdf113364ac281594d6da76dc103c19129e9d32caed54ec3cda",
+        sha256: "4781b618fa3a16d91c892f8a1e2c82625f9286f9bb944a5690ba727c84fc5729",
         archiveBinaryName: "codex-x86_64-pc-windows-msvc.exe",
       ),
     },

--- a/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
@@ -19,7 +19,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 1,
-            stdoutBytes: utf8.encode("codex 0.145.0\n"),
+            stdoutBytes: utf8.encode("codex 0.146.0\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(
@@ -110,7 +110,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 3,
-            stdoutBytes: utf8.encode("codex 0.145.0\n"),
+            stdoutBytes: utf8.encode("codex 0.146.0\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(
@@ -141,7 +141,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 5,
-            stdoutBytes: utf8.encode("codex 0.145.0\n"),
+            stdoutBytes: utf8.encode("codex 0.146.0\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(
@@ -169,7 +169,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 7,
-            stdoutBytes: utf8.encode("codex 0.145.0\n"),
+            stdoutBytes: utf8.encode("codex 0.146.0\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(

--- a/bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart
@@ -14,7 +14,7 @@ void main() {
     });
 
     test("pinned versions", () {
-      expect(manifest.bundledVersion.toString(), "0.145.0");
+      expect(manifest.bundledVersion.toString(), "0.146.0");
       expect(manifest.minPathVersion.toString(), "0.139.0");
       expect(manifest.runtimeId, const CodexPluginDescriptor().id);
       expect(manifest.pathExecutableName, "codex");
@@ -83,7 +83,7 @@ void main() {
       )!;
       expect(
         manifest.downloadUrlFor(asset: asset),
-        equals("https://github.com/openai/codex/releases/download/rust-v0.145.0/codex-aarch64-apple-darwin.tar.gz"),
+        equals("https://github.com/openai/codex/releases/download/rust-v0.146.0/codex-aarch64-apple-darwin.tar.gz"),
       );
     });
 

--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
@@ -75,7 +75,7 @@ class CursorPluginDescriptor extends BridgePluginDescriptor {
 
   /// Latest official-installer build targeted for the future bundled Cursor
   /// runtime. This records the preferred build without changing availability.
-  static const String targetVersion = "2026.07.20-8cc9c0b";
+  static const String targetVersion = "2026.07.23-e383d2b";
 
   /// CLI option naming the Cursor CLI binary (path or PATH name). Declared
   /// as the bare local name — the bridge's [PluginCliOptionsMapper] namespaces

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
@@ -20,7 +20,7 @@ void main() {
 
     test("tracks the installer target separately from the compatibility floor", () {
       expect(CursorPluginDescriptor.minVersion, "2026.07.16");
-      expect(CursorPluginDescriptor.targetVersion, "2026.07.20-8cc9c0b");
+      expect(CursorPluginDescriptor.targetVersion, "2026.07.23-e383d2b");
     });
 
     test("declares plugin-scoped session options", () {

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_manifest.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_manifest.dart
@@ -30,7 +30,7 @@ class OpenCodeRuntimeManifest extends RuntimeManifest {
   static final SemanticVersion _minPathVersion = SemanticVersion.parse(value: "1.14.0");
 
   /// The exact OpenCode version the managed runtime installs.
-  static final SemanticVersion _bundledVersion = SemanticVersion.parse(value: "1.18.3");
+  static final SemanticVersion _bundledVersion = SemanticVersion.parse(value: "1.18.11");
 
   static const String _releaseBaseUrl = "https://github.com/anomalyco/opencode/releases/download";
 
@@ -43,13 +43,13 @@ class OpenCodeRuntimeManifest extends RuntimeManifest {
       PlatformArch.arm64: RuntimeAsset(
         assetName: "opencode-darwin-arm64.zip",
         format: ArchiveFormat.zip,
-        sha256: "946f62b155638b911144b7bef520ee4a6442f696297907873463bca3524e40ef",
+        sha256: "188ff6a716bcd40e33ac62f17f4aec9bd760164fa6a2cde66f779a5db4abc7ce",
         archiveBinaryName: "opencode",
       ),
       PlatformArch.x64: RuntimeAsset(
         assetName: "opencode-darwin-x64.zip",
         format: ArchiveFormat.zip,
-        sha256: "4ea147867ba19e4ec03559df557811f1674f40788aea4d10326dc563b7667c6d",
+        sha256: "95953ab2aca4322b90690bf34697cc9b47b6a7c72f78e7c469056fb589124d31",
         archiveBinaryName: "opencode",
       ),
     },
@@ -57,13 +57,13 @@ class OpenCodeRuntimeManifest extends RuntimeManifest {
       PlatformArch.arm64: RuntimeAsset(
         assetName: "opencode-linux-arm64.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "da0a631174eba380b2a1d51f9d364fa3812da433e72743c72471d4b5da59c69d",
+        sha256: "03e07aa461ac241dfa8c7ab54ed58c7a0e911c62fc3cb490b83e4fb3424eb73b",
         archiveBinaryName: "opencode",
       ),
       PlatformArch.x64: RuntimeAsset(
         assetName: "opencode-linux-x64.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "60f27b2679f00a511b6539f97e02448afaf58d9c66e2448285ea0c517ca84583",
+        sha256: "a4dffcc00a5a93256c6bd06aa0c984320528f564db52a1f4becd5c7de9fb59a1",
         archiveBinaryName: "opencode",
       ),
     },
@@ -71,13 +71,13 @@ class OpenCodeRuntimeManifest extends RuntimeManifest {
       PlatformArch.arm64: RuntimeAsset(
         assetName: "opencode-windows-arm64.zip",
         format: ArchiveFormat.zip,
-        sha256: "a549fb2e9041db9438bcd9b77bfa0a4b2476caf2d550f37479aabfec1b079bfb",
+        sha256: "4510ccf446284f5492438c4b40b23895dc7ae78cb5eb4e7f51cbe998c1148d58",
         archiveBinaryName: "opencode.exe",
       ),
       PlatformArch.x64: RuntimeAsset(
         assetName: "opencode-windows-x64.zip",
         format: ArchiveFormat.zip,
-        sha256: "68bc62930f6cb5755e0409aa9de0bb270a66ed2b8c9cf0c029e9f2287ed5486e",
+        sha256: "f3a5ea814aecc692a4e04259d9005283f364225b38456c90f9a47b7a9d83c0e9",
         archiveBinaryName: "opencode.exe",
       ),
     },

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_availability_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_availability_test.dart
@@ -24,7 +24,7 @@ void main() {
       final processes = _ProbeProcessService(
         process: _ProbeProcess(
           pid: 1,
-          stdoutBytes: utf8.encode("opencode 1.18.3\n"),
+          stdoutBytes: utf8.encode("opencode 1.18.11\n"),
           exitCode: Future<int>.value(0),
         ),
       );

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_manifest_test.dart
@@ -44,7 +44,7 @@ void main() {
       )!;
       expect(
         manifest.downloadUrlFor(asset: asset),
-        equals("https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-darwin-arm64.zip"),
+        equals("https://github.com/anomalyco/opencode/releases/download/v1.18.11/opencode-darwin-arm64.zip"),
       );
     });
 


### PR DESCRIPTION
## Complexity

🌿 Straightforward implementation: eight manifest, descriptor, and test files. The upstream compatibility assessment spans all intervening releases and runtime-facing protocol surfaces.

## What

- Update the managed OpenCode runtime from `1.18.3` to `1.18.11` and refresh all six platform SHA-256 digests.
- Update the managed Codex runtime from `0.145.0` to `0.146.0` and refresh all six platform SHA-256 digests.
- Update the Cursor installer target from `2026.07.20-8cc9c0b` to `2026.07.23-e383d2b`.
- Update current-version test fixtures and download URL assertions.
- Preserve the OpenCode `1.14.0`, Codex `0.139.0`, and Cursor `2026.07.16` compatibility floors because the bridge does not require newer capabilities.

## Why

These are the latest stable targets advertised by the official channels as of 2026-08-03. GitHub `latest` and npm agree for OpenCode and Codex, while Cursor's official installer exposes one unambiguous build identifier. All twelve expected GitHub release assets retain their filenames and publish non-null SHA-256 digests.

## Risk and test focus

- OpenCode `v1.18.3...v1.18.11`: bridge-facing REST routes, global SSE, authentication, session/message/input behavior, and storage schemas are unchanged. Relevant net changes are provider/model fixes, MCP recovery/reconnect fixes, a model-catalog host move to `models.opencode.ai`, and an additive widening of provider `interleaved` reasoning metadata.
- Codex `rust-v0.145.0...rust-v0.146.0`: the app-server v2 surface used by Sesori remains compatible. Changes are additive, including defaulted thread/tool metadata and a new plan enum value; no used methods or notifications were removed. Upstream strengthened rollout writer/fork handling, so Sesori's existing direct rollout-file cleanup remains the main focused persistence risk, especially for externally-created paginated-history threads.
- Cursor `2026.07.20...2026.07.23`: static comparison of all six official platform archives found stable launchers, package layout, ACP v1 dispatch, custom model discovery, session operations, auth variables, status/version handling, and persistence paths. The Cursor ACP implementation changed only its embedded build version; the main CLI bundle also changed feature defaults, including enabling `cli_meta_mcp_tool` by default.
- No Sesori UI or database schema changes. Managed OpenCode and Codex users receive the newer upstream runtime behavior on the next provisioned install.

Pre-existing findings deliberately left out of this runtime-pin PR:

- OpenCode's API-surface allowlist metadata does not fully match current production calls (`session.prompt` and `session.summarize`). The reviewed routes themselves are unchanged across this update.
- Cursor question/plan extension responses appear to use older shapes than current official docs and both compared artifacts expect. This mismatch predates both Cursor targets and warrants a separate compatibility fix.

## Expected result

Fresh managed runtime provisioning installs OpenCode `1.18.11` or Codex `0.146.0` with verified per-platform artifacts, while compatible user-installed runtimes continue to be preferred. Cursor records the latest official installer build without rejecting already-compatible installations.

## Verification

- `bridge/sesori_plugin_opencode`: `dart test` (409 passed), `dart analyze --fatal-infos`
- `bridge/sesori_plugin_codex`: `dart test` (238 passed), `dart analyze --fatal-infos`
- `bridge/sesori_plugin_cursor`: `dart test` (109 passed), `dart analyze --fatal-infos`
- `git diff --check`

Upstream comparisons:

- https://github.com/anomalyco/opencode/compare/v1.18.3...v1.18.11
- https://github.com/openai/codex/compare/rust-v0.145.0...rust-v0.146.0
- https://cursor.com/install


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump managed runtimes to OpenCode 1.18.11 and Codex 0.146.0, and update the Cursor installer target to 2026.07.23-e383d2b. Refreshed per-platform SHA-256 digests and test fixtures (version probes and download URL assertions).

- **Dependencies**
  - OpenCode: 1.18.3 → 1.18.11; six asset hashes updated.
  - Codex: 0.145.0 → 0.146.0; six asset hashes updated.
  - Cursor installer target: 2026.07.20-8cc9c0b → 2026.07.23-e383d2b.
  - Compatibility floors unchanged: OpenCode 1.14.0, Codex 0.139.0, Cursor 2026.07.16.

<sup>Written for commit 7d2f4ac8bdb6a77b436bf2b85d2c330157b224b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

