### PR TITLE
🌿 Hide newly discovered projects by default

### DIFF
--- a/bridge/app/lib/src/api/database/daos/projects_dao.dart
+++ b/bridge/app/lib/src/api/database/daos/projects_dao.dart
@@ -241,14 +241,19 @@ class ProjectsDao extends DatabaseAccessor<AppDatabase> with _$ProjectsDaoMixin 
     });
   }
 
-  /// Inserts one project with its explicit [path] when it does not exist.
-  /// Existing rows are untouched.
-  Future<void> insertProjectIfMissing({required String projectId, required String path}) async {
+  /// Inserts one project with its explicit [path] and [hidden] state when it
+  /// does not exist. Existing rows are untouched.
+  Future<void> insertProjectIfMissing({
+    required String projectId,
+    required String path,
+    required bool hidden,
+  }) async {
     final insertedAt = DateTime.now().millisecondsSinceEpoch;
     await into(projectsTable).insert(
       ProjectsTableCompanion.insert(
         projectId: projectId,
         path: path,
+        hidden: Value(hidden),
         createdAt: Value(insertedAt),
         updatedAt: Value(insertedAt),
         projectionUpdatedAt: insertedAt,
@@ -259,6 +264,7 @@ class ProjectsDao extends DatabaseAccessor<AppDatabase> with _$ProjectsDaoMixin 
 
   Future<void> insertProjectsWithPathsIfMissing({
     required Map<String, ({String path, int? createdAt, int? updatedAt})> projects,
+    required bool hidden,
   }) async {
     if (projects.isEmpty) return;
     final insertedAt = DateTime.now().millisecondsSinceEpoch;
@@ -272,6 +278,7 @@ class ProjectsDao extends DatabaseAccessor<AppDatabase> with _$ProjectsDaoMixin 
             return ProjectsTableCompanion.insert(
               projectId: entry.key,
               path: entry.value.path,
+              hidden: Value(hidden),
               createdAt: Value(createdAt),
               updatedAt: Value(updatedAt),
               projectionUpdatedAt: updatedAt,

--- a/bridge/app/lib/src/bridge/repositories/project_activity_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/project_activity_repository.dart
@@ -175,6 +175,7 @@ class ProjectActivityRepository {
             final inserted = ProjectDto(
               projectId: projectId,
               path: project.directory,
+              hidden: true,
               prCacheGithubLogin: null,
               createdAt: project.activity?.createdAt ?? 0,
               updatedAt: project.activity?.updatedAt ?? 0,
@@ -195,6 +196,7 @@ class ProjectActivityRepository {
         _requireCurrentProjectActivitySource(source);
         await _projectsDao.insertProjectsWithPathsIfMissing(
           projects: missingProjects,
+          hidden: true,
         );
         _requireCurrentProjectActivitySource(source);
         return evidence;

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -735,6 +735,7 @@ class SessionRepository {
             ProjectDto(
               projectId: project.id,
               path: project.directory,
+              hidden: true,
               prCacheGithubLogin: null,
               createdAt: 0,
               updatedAt: 0,
@@ -819,6 +820,7 @@ class SessionRepository {
           ProjectDto(
             projectId: preferredProjectId,
             path: projectDirectory,
+            hidden: true,
             prCacheGithubLogin: null,
             createdAt: 0,
             updatedAt: 0,
@@ -827,6 +829,7 @@ class SessionRepository {
       await _projectsDao.insertProjectIfMissing(
         projectId: hydratedProject.projectId,
         path: projectDirectory,
+        hidden: true,
       );
       final existingByBackendId = await _sessionDao.getSessionsByBackendIds(
         pluginId: pluginId,

--- a/bridge/app/lib/src/repositories/catalog_import_repository.dart
+++ b/bridge/app/lib/src/repositories/catalog_import_repository.dart
@@ -479,7 +479,7 @@ class CatalogImportRepository {
     return ProjectDto(
       projectId: existing?.projectId ?? observation.preferredId,
       path: observation.path,
-      hidden: existing?.hidden ?? false,
+      hidden: existing?.hidden ?? true,
       baseBranch: existing?.baseBranch,
       prCacheGithubLogin: existing?.prCacheGithubLogin,
       displayName: existing?.displayName ?? observation.displayName,

--- a/bridge/app/test/bridge/repositories/project_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_repository_test.dart
@@ -172,10 +172,12 @@ void main() {
 
       final newProject = await db.projectsDao.getProject(projectId: "new-project");
       expect(newProject?.path, "/projects/new");
+      expect(newProject?.hidden, isTrue);
       expect(newProject?.createdAt, 10);
       expect(newProject?.updatedAt, 20);
       final movedProject = await db.projectsDao.getProject(projectId: "moved-project");
       expect(movedProject?.path, "/projects/moved");
+      expect(movedProject?.hidden, isFalse);
       expect(movedProject?.updatedAt, 60, reason: "stable native identity must retain activity after a move");
     });
 

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -1544,6 +1544,8 @@ void main() {
       expect(commit.backendSessionIds, ["backend-root"]);
       expect(commit.kind, SessionBindingCommitKind.catalogSync);
       expect(commit.generation, 1);
+      expect((await db.projectsDao.getProject(projectId: directory))?.hidden, isTrue);
+      expect(await db.projectsDao.getCatalogProjects(), isEmpty);
       expect(
         (await db.sessionDao.getSessionByBinding(
           pluginId: plugin.id,

--- a/bridge/app/test/repositories/catalog_import_repository_test.dart
+++ b/bridge/app/test/repositories/catalog_import_repository_test.dart
@@ -171,6 +171,48 @@ void main() {
       );
     });
 
+    test("native import hides new projects while preserving existing visibility", () async {
+      final visiblePath = "${directory.path}/visible";
+      final importedPath = "${directory.path}/imported";
+      await database.projectsDao.upsertProjectRows(
+        rows: [_projectRow(id: "visible-project", path: visiblePath)],
+      );
+      final plugin = _NativeImportPlugin(
+        projects: [
+          PluginProject(id: "visible-project", directory: visiblePath),
+          PluginProject(id: "imported-project", directory: importedPath),
+        ],
+        rootsByProject: {
+          importedPath: [_pluginSession(id: "imported-root", directory: importedPath)],
+        },
+        childrenByParent: const {},
+      );
+
+      await _repository(database: database, plugin: plugin)
+          .importCatalog(
+            pluginId: plugin.id,
+            control: CatalogImportControl(
+              explicitImportRequested: true,
+              hydrationMarkerRequested: false,
+            ),
+          )
+          .drain<void>();
+
+      expect((await database.projectsDao.getProject(projectId: "visible-project"))?.hidden, isFalse);
+      expect((await database.projectsDao.getProject(projectId: "imported-project"))?.hidden, isTrue);
+      expect(
+        (await database.projectsDao.getCatalogProjects()).map((project) => project.projectId),
+        ["visible-project"],
+      );
+      expect(
+        (await database.sessionDao.getSessionByBinding(
+          pluginId: plugin.id,
+          backendSessionId: "imported-root",
+        ))?.projectId,
+        "imported-project",
+      );
+    });
+
     test("native import gives an exact project id precedence during a move", () async {
       final oldPath = "${directory.path}/old";
       final movedPath = "${directory.path}/moved";


### PR DESCRIPTION
## Complexity

🌿 Straightforward. This changes the missing-row visibility policy at the existing persistence seams without adding a schema migration or client contract.

## What

- Persist newly discovered projects as hidden during full catalog imports.
- Apply the same hidden default to native project activity reconciliation and active-root session hydration.
- Preserve the visibility of every existing project.
- Keep imported sessions persisted beneath hidden projects.

## Why

Backend discovery can surface projects the user has not explicitly opened in Sesori. Those projects should not automatically clutter the projects list, including when OpenCode activity hydrates an otherwise unknown project.

## Risk and test focus

The user-visible impact is limited to newly backend-discovered projects, which remain absent from the projects list until explicitly opened. Existing projects keep their current hidden or visible state, and explicit project open/create remains visible. There is no schema migration or wire-contract impact. No analytics event is added because this is persistence policy rather than a meaningful user action or product outcome.

## Expected result

Catalog import and opportunistic OpenCode hydration continue importing sessions, while any newly created project row starts hidden. Explicitly opening the project makes it visible through the existing behavior.

## Verification

- `dart test test/repositories/catalog_import_repository_test.dart test/bridge/repositories/project_repository_test.dart test/bridge/repositories/session_repository_test.dart`
- `dart analyze --fatal-infos`
- Aristotle architecture implementation review: approved with no findings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide newly discovered projects by default so they don’t clutter the projects list; sessions still import under those projects. Existing projects keep their current visibility.

- **New Features**
  - Default `hidden: true` for missing projects created during catalog import, native activity reconciliation, and session hydration.
  - `ProjectsDao.insertProjectIfMissing` and `insertProjectsWithPathsIfMissing` now accept a `hidden` flag.
  - Preserve existing project visibility; newly discovered projects stay hidden until explicitly opened.

<sup>Written for commit a07abca62ebcdbe28e07530656ccd2c9caed4523. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

