### PR TITLE
🌱 [codex-plugin-stability] Encode debug SSE as UTF-8 [step 1/8]

### DIFF
--- a/bridge/app/lib/src/bridge/debug_server.dart
+++ b/bridge/app/lib/src/bridge/debug_server.dart
@@ -223,7 +223,7 @@ class DebugServer {
     request.response.bufferOutput = false;
 
     try {
-      response.write(": ok\n\n");
+      response.add(utf8.encode(": ok\n\n"));
       await response.flush();
 
       _sseClients.add(response);
@@ -273,7 +273,7 @@ class DebugServer {
     final clients = List<HttpResponse>.from(_sseClients);
     for (final client in clients) {
       try {
-        client.write("data: $eventData\n\n");
+        client.add(utf8.encode("data: $eventData\n\n"));
         await client.flush();
       } catch (e) {
         Log.d("fan-out: client write/flush failed, removing: $e");

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -141,6 +141,22 @@ void main() {
       expect(secondEvent, contains("vcs.branch.updated"));
     });
 
+    test("UTF-8 event data remains readable and the connection stays open", () async {
+      final client = await _SseTestClient.connect(debugServer.boundPort!);
+      addTearDown(client.close);
+
+      plugin.add(const BridgeSseWorkspaceReady(name: "developer’s workspace"));
+
+      final unicodeEvent = jsonDecode(await client.nextEvent()) as Map<String, dynamic>;
+      expect(unicodeEvent["type"], "workspace.ready");
+      expect(unicodeEvent["name"], "developer’s workspace");
+
+      plugin.add(const BridgeSseVcsBranchUpdated());
+
+      final followingEvent = jsonDecode(await client.nextEvent()) as Map<String, dynamic>;
+      expect(followingEvent["type"], "vcs.branch.updated");
+    });
+
     test(
       "first client still receives events after second disconnects",
       () async {
@@ -1499,9 +1515,9 @@ class _SseTestClient {
     var headersParsed = false;
     var lineBuffer = "";
 
-    socket.listen(
+    utf8.decoder.bind(socket).listen(
       (chunk) {
-        buffer += utf8.decode(chunk);
+        buffer += chunk;
 
         if (!headersParsed) {
           final headerEnd = buffer.indexOf("\r\n\r\n");

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -147,13 +147,13 @@ void main() {
 
       plugin.add(const BridgeSseWorkspaceReady(name: "developer’s workspace"));
 
-      final unicodeEvent = jsonDecode(await client.nextEvent()) as Map<String, dynamic>;
+      final unicodeEvent = jsonDecodeMap(await client.nextEvent());
       expect(unicodeEvent["type"], "workspace.ready");
       expect(unicodeEvent["name"], "developer’s workspace");
 
       plugin.add(const BridgeSseVcsBranchUpdated());
 
-      final followingEvent = jsonDecode(await client.nextEvent()) as Map<String, dynamic>;
+      final followingEvent = jsonDecodeMap(await client.nextEvent());
       expect(followingEvent["type"], "vcs.branch.updated");
     });
 


### PR DESCRIPTION
## Complexity

🌱 Trivial. The change only makes the existing debug SSE byte encoding explicit.

## What

- Encode the debug SSE ready marker and event frames as UTF-8 bytes.
- Decode arbitrary socket chunk boundaries through a streaming UTF-8 decoder in the test client.
- Add a regression proving a non-Latin-1 event does not disconnect the SSE stream.

## Why

`HttpResponse.write` used the response's default Latin-1 encoding. Assistant text containing characters such as curly apostrophes raised an encoding exception and disconnected debug SSE consumers.

## Risk and test focus

- Risk is limited to the local debug SSE endpoint; production relay transport is unchanged.
- The regression checks both Unicode decoding and receipt of a subsequent event on the same connection.
- No database impact.

## Expected result

Debug SSE clients continue receiving events when payloads contain valid Unicode text.

## Verification

- `dart test test/bridge/debug_server_test.dart`
- `dart analyze --fatal-infos`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encode debug SSE messages as UTF-8 to prevent disconnects when payloads contain Unicode. This affects only the local debug SSE endpoint; production transport is unchanged.

- **Bug Fixes**
  - Send the ready marker and event frames as UTF-8 bytes via `response.add` instead of the default Latin-1.
  - Update tests to stream-decode UTF-8, use typed JSON map decoding, and add a regression ensuring a Unicode event is readable and the connection stays open.

<sup>Written for commit da0fde927c6a725cf8e90e15b85b4f8cf70bd9f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

