### PR TITLE
🌱 Avoid false GitHub authentication warnings

### DIFF
--- a/bridge/app/lib/src/bridge/api/gh_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/gh_cli_api.dart
@@ -13,7 +13,7 @@ class GhCliApi {
 
   final ProcessRunner _processRunner;
   bool _availabilityFailureReported = false;
-  bool _authenticationVerificationFailureReported = false;
+  _GhAuthenticationFailure? _reportedAuthenticationFailure;
 
   GhCliApi({required ProcessRunner processRunner}) : _processRunner = processRunner;
 
@@ -47,10 +47,15 @@ class GhCliApi {
         const ["auth", "status", "--hostname", "github.com"],
       );
       if (result.exitCode == 0) {
-        _authenticationVerificationFailureReported = false;
+        _reportedAuthenticationFailure = null;
         return true;
       }
-      _reportAuthenticationVerificationFailure();
+      final stderr = result.stderr.toString();
+      _reportAuthenticationFailure(
+        failure: _reportsNoConfiguredGithubAccount(stderr: stderr)
+            ? _GhAuthenticationFailure.unauthenticated
+            : _GhAuthenticationFailure.verificationFailed,
+      );
       return false;
     } on ProcessException {
       _reportAvailabilityFailure(
@@ -77,7 +82,7 @@ class GhCliApi {
       );
     }
 
-    _authenticationVerificationFailureReported = false;
+    _reportedAuthenticationFailure = null;
     return GhAuthenticatedIdentity(rawLogin: result.stdout.toString());
   }
 
@@ -87,14 +92,25 @@ class GhCliApi {
     Console.warning(message);
   }
 
-  void _reportAuthenticationVerificationFailure() {
-    if (_authenticationVerificationFailureReported) return;
-    _authenticationVerificationFailureReported = true;
-    Console.warning(
-      "GitHub CLI (gh) could not verify authentication for github.com. "
-      "GitHub pull request and CI status sync is temporarily unavailable. "
-      "Run 'gh auth status --hostname github.com' to check authentication and connectivity.",
-    );
+  bool _reportsNoConfiguredGithubAccount({required String stderr}) {
+    // gh also calls tokens invalid for connectivity failures, so only its local no-account diagnostics are definitive.
+    return stderr.contains("You are not logged into any GitHub hosts") ||
+        stderr.contains("You are not logged into any accounts on github.com");
+  }
+
+  void _reportAuthenticationFailure({required _GhAuthenticationFailure failure}) {
+    if (_reportedAuthenticationFailure == failure) return;
+    _reportedAuthenticationFailure = failure;
+    final message = switch (failure) {
+      _GhAuthenticationFailure.unauthenticated =>
+        "GitHub CLI (gh) is not authenticated for github.com. Run 'gh auth login' or set GH_TOKEN/GITHUB_TOKEN "
+            "to enable GitHub pull request and CI status sync.",
+      _GhAuthenticationFailure.verificationFailed =>
+        "GitHub CLI (gh) could not verify authentication for github.com. "
+            "GitHub pull request and CI status sync is temporarily unavailable. "
+            "Run 'gh auth status --hostname github.com' to check authentication and connectivity.",
+    };
+    Console.warning(message);
   }
 
   Future<GhPullRequestBatchResponse> queryInitialPullRequestPages({
@@ -353,3 +369,5 @@ class GhCliApi {
     }
   }
 }
+
+enum _GhAuthenticationFailure { unauthenticated, verificationFailed }

--- a/bridge/app/lib/src/bridge/api/gh_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/gh_cli_api.dart
@@ -13,7 +13,7 @@ class GhCliApi {
 
   final ProcessRunner _processRunner;
   bool _availabilityFailureReported = false;
-  bool _authenticationFailureReported = false;
+  bool _authenticationVerificationFailureReported = false;
 
   GhCliApi({required ProcessRunner processRunner}) : _processRunner = processRunner;
 
@@ -47,10 +47,10 @@ class GhCliApi {
         const ["auth", "status", "--hostname", "github.com"],
       );
       if (result.exitCode == 0) {
-        _authenticationFailureReported = false;
+        _authenticationVerificationFailureReported = false;
         return true;
       }
-      _reportAuthenticationFailure();
+      _reportAuthenticationVerificationFailure();
       return false;
     } on ProcessException {
       _reportAvailabilityFailure(
@@ -77,7 +77,7 @@ class GhCliApi {
       );
     }
 
-    _authenticationFailureReported = false;
+    _authenticationVerificationFailureReported = false;
     return GhAuthenticatedIdentity(rawLogin: result.stdout.toString());
   }
 
@@ -87,12 +87,13 @@ class GhCliApi {
     Console.warning(message);
   }
 
-  void _reportAuthenticationFailure() {
-    if (_authenticationFailureReported) return;
-    _authenticationFailureReported = true;
+  void _reportAuthenticationVerificationFailure() {
+    if (_authenticationVerificationFailureReported) return;
+    _authenticationVerificationFailureReported = true;
     Console.warning(
-      "GitHub CLI (gh) is not authenticated for github.com. Run 'gh auth login' or set GH_TOKEN/GITHUB_TOKEN "
-      "to enable GitHub pull request and CI status sync.",
+      "GitHub CLI (gh) could not verify authentication for github.com. "
+      "GitHub pull request and CI status sync is temporarily unavailable. "
+      "Run 'gh auth status --hostname github.com' to check authentication and connectivity.",
     );
   }
 

--- a/bridge/app/test/bridge/api/gh_cli_api_test.dart
+++ b/bridge/app/test/bridge/api/gh_cli_api_test.dart
@@ -151,6 +151,37 @@ void main() {
         ),
       );
     });
+
+    for (final diagnostic in const [
+      (name: "no configured GitHub hosts", stderr: "You are not logged into any GitHub hosts"),
+      (name: "no configured github.com account", stderr: "You are not logged into any accounts on github.com"),
+    ]) {
+      test("reports known unauthentication for ${diagnostic.name}", () async {
+        final stderrLines = <String>[];
+        processRunner
+          ..enqueueResult(result: _fail(exitCode: 1, stderr: diagnostic.stderr))
+          ..enqueueResult(result: _fail(exitCode: 1, stderr: diagnostic.stderr));
+
+        await IOOverrides.runZoned(
+          () async {
+            expect(await service.isAuthenticated(), isFalse);
+            expect(await service.isAuthenticated(), isFalse);
+          },
+          stderr: () => _CapturingStdout(stderrLines),
+        );
+
+        expect(stderrLines, hasLength(1));
+        expect(
+          stderrLines.single,
+          allOf(
+            contains("GitHub CLI (gh) is not authenticated for github.com"),
+            contains("gh auth login"),
+            contains("GH_TOKEN/GITHUB_TOKEN"),
+            isNot(contains("could not verify authentication")),
+          ),
+        );
+      });
+    }
   });
 
   group("GhCliApi.getAuthenticatedIdentity", () {

--- a/bridge/app/test/bridge/api/gh_cli_api_test.dart
+++ b/bridge/app/test/bridge/api/gh_cli_api_test.dart
@@ -124,11 +124,11 @@ void main() {
       await expectLater(service.isAuthenticated(), throwsA(isA<TimeoutException>()));
     });
 
-    test("reports unauthenticated gh with actionable options only once", () async {
+    test("reports an ambiguous auth failure without claiming the user is unauthenticated", () async {
       final stderrLines = <String>[];
       processRunner
-        ..enqueueResult(result: _fail(exitCode: 1))
-        ..enqueueResult(result: _fail(exitCode: 1));
+        ..enqueueResult(result: _fail(exitCode: 1, stderr: "network is unreachable"))
+        ..enqueueResult(result: _fail(exitCode: 1, stderr: "network is unreachable"));
 
       await IOOverrides.runZoned(
         () async {
@@ -142,9 +142,11 @@ void main() {
       expect(
         stderrLines.single,
         allOf(
-          contains("GitHub CLI (gh) is not authenticated for github.com"),
-          contains("gh auth login"),
-          contains("GH_TOKEN/GITHUB_TOKEN"),
+          contains("GitHub CLI (gh) could not verify authentication for github.com"),
+          contains("gh auth status --hostname github.com"),
+          contains("authentication and connectivity"),
+          isNot(contains("is not authenticated")),
+          isNot(contains("gh auth login")),
           isNot(contains("worktree")),
         ),
       );


### PR DESCRIPTION
## Complexity

🌱 Trivial. This is a localized warning-classification correction with focused regression coverage.

## What

- Treat `gh auth status`'s explicit local “no hosts” and “no github.com account” diagnostics as definitive unauthentication.
- Treat every other nonzero result as an ambiguous authentication verification failure.
- Keep warning deduplication typed so a change between failure categories remains visible.
- Cover network-originated failures and both definitive missing-account diagnostics.

## Why

`gh auth status` exits with code 1 for both invalid credentials and transient connectivity failures, and can even call a token invalid when the network is unavailable. The bridge should recommend login only when `gh` confirms locally that no GitHub account is configured; otherwise it should direct users to check authentication and connectivity.

## Risk and test focus

Risk is low and limited to console warning classification. If GitHub CLI changes either local diagnostic, the safe fallback is the neutral verification warning rather than a false unauthentication claim. PR sync remains fail-closed while authentication cannot be verified. User-visible impact is limited to corrected warnings; there is no database, wire-contract, or analytics impact.

## Expected result

- A transient network or otherwise ambiguous failure reports that GitHub authentication could not be verified.
- A definitively missing GitHub account reports that `gh` is not authenticated and provides login/token guidance.

## Verification

- `dart test test/bridge/api/gh_cli_api_test.dart`
- `dart analyze --fatal-infos`
- `git diff --check`
