### PR TITLE
🚧 [relay-request-concurrency] refactor(bridge): gate new session visibility [step 7/10]

### DIFF
--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -396,9 +396,17 @@
   hydration/import publication, stale paginated exclusion snapshots, and direct
   question/permission/unseen visibility bypasses. All findings were applied
   directly; per policy, the corrected implementation was not re-reviewed.
-- **Step 7/10 verification:** 2,416 full `bridge/app` tests pass, affected suites
+- **Step 7/10 PR review:** valid bot findings now retain the catalog reservation
+  through descendant initialization, reveal/publish committed state after a
+  post-commit generation failure, make durable creation publication independent
+  of plugin generation, bypass no-op hydration admission, filter project-activity
+  reconciliation, reject import cancellation after gate admission, and replace
+  the new post-insert bang assertion with an explicit invariant failure. Positional
+  exception-API and bounded pagination-retry suggestions were declined as broad
+  unrelated API churn and a correctness-breaking speculative fallback.
+- **Step 7/10 verification:** 2,423 full `bridge/app` tests pass, affected suites
   pass, strict `dart analyze --fatal-infos` reports no issues, and
-  `git diff --check` passes. The 1,539 changed lines exceed the soft cap by 39;
+  `git diff --check` passes. The 2,068 changed lines exceed the soft cap by 568;
   one atomic invariant spans creation, catalog writers/reads, interactions, unseen
   state, and events, and splitting would expose a bypass between mergeable PRs.
 - **Step 7/10 delivery:** [PR #716](https://github.com/sesori-ai/sesori_apps_monorepo/pull/716)

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -401,12 +401,12 @@
   post-commit generation failure, make durable creation publication independent
   of plugin generation, bypass no-op hydration admission, filter project-activity
   reconciliation, reject import cancellation after gate admission, and replace
-  the new post-insert bang assertion with an explicit invariant failure. Positional
+  new post-insert/coordinator bang assertions with explicit invariant failures. Positional
   exception-API and bounded pagination-retry suggestions were declined as broad
   unrelated API churn and a correctness-breaking speculative fallback.
 - **Step 7/10 verification:** 2,423 full `bridge/app` tests pass, affected suites
   pass, strict `dart analyze --fatal-infos` reports no issues, and
-  `git diff --check` passes. The 2,068 changed lines exceed the soft cap by 568;
+  `git diff --check` passes. The 2,080 changed lines exceed the soft cap by 580;
   one atomic invariant spans creation, catalog writers/reads, interactions, unseen
   state, and events, and splitting would expose a bypass between mergeable PRs.
 - **Step 7/10 delivery:** [PR #716](https://github.com/sesori-ai/sesori_apps_monorepo/pull/716)

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -398,7 +398,7 @@
   directly; per policy, the corrected implementation was not re-reviewed.
 - **Step 7/10 verification:** 2,416 full `bridge/app` tests pass, affected suites
   pass, strict `dart analyze --fatal-infos` reports no issues, and
-  `git diff --check` passes. The 1,540 changed lines exceed the soft cap by 40;
+  `git diff --check` passes. The 1,539 changed lines exceed the soft cap by 39;
   one atomic invariant spans creation, catalog writers/reads, interactions, unseen
   state, and events, and splitting would expose a bypass between mergeable PRs.
 - **Step 7/10 delivery:** [PR #716](https://github.com/sesori-ai/sesori_apps_monorepo/pull/716)

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -3,15 +3,14 @@
 ## Current State
 
 - **Plan slug:** `relay-request-concurrency`
-- **Implementation base:** merged Step 5 at
-  `5ba0d3a6029cdb699120e6254bd248c806fa2f95`
-- **Series state:** Steps 1–5 merged; Step 5/10
-  [#700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700) merged as
-  `5ba0d3a6`
-- **Current step:** Step 6/10 PR
-  [#703](https://github.com/sesori-ai/sesori_apps_monorepo/pull/703) open
+- **Implementation base:** merged Step 6 at
+  `e4605eb15b68f5433b5740981d03ff6e63f964cb`
+- **Series state:** Steps 1–6 merged; Step 6/10
+  [#703](https://github.com/sesori-ai/sesori_apps_monorepo/pull/703) merged as
+  `e4605eb1`
+- **Current step:** Step 7/10 implementation on `plan-parallel-requests`
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged
-- **Next action:** open, review, and merge Step 6; Step 7 remains blocked until then
+- **Next action:** commit, open, review, and merge Step 7
 
 ## Incident Evidence
 
@@ -93,8 +92,8 @@
 | [x] | 3/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): coordinate routed request shutdown [step 3/10]` | 600–1,000 | [PR #696](https://github.com/sesori-ai/sesori_apps_monorepo/pull/696) merged as `95178462` |
 | [x] | 4/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | [PR #699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) merged as `9ac855a3` with 1,326 changed lines |
 | [x] | 5/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | [PR #700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700) merged as `5ba0d3a6` with 1,534 changed lines |
-| [ ] | 6/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope session family mutations [step 6/10]` | 750–1,250 | [PR #703](https://github.com/sesori-ai/sesori_apps_monorepo/pull/703) open from `5ba0d3a6` |
-| [ ] | 7/10 | `relay-request-concurrency-session-visibility` | `🚧 [relay-request-concurrency] refactor(bridge): gate new session visibility [step 7/10]` | 600–1,100 | Blocked on Step 6 merge |
+| [x] | 6/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope session family mutations [step 6/10]` | 750–1,250 | [PR #703](https://github.com/sesori-ai/sesori_apps_monorepo/pull/703) merged as `e4605eb1` with 1,054 changed lines |
+| [ ] | 7/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): gate new session visibility [step 7/10]` | 600–1,100 | Implemented from `e4605eb1`; PR pending |
 | [ ] | 8/10 | `relay-request-concurrency-project-mutations` | `🚧 [relay-request-concurrency] refactor(bridge): order project path mutations [step 8/10]` | 650–1,100 | Blocked on Step 7 merge |
 | [ ] | 9/10 | `relay-request-concurrency-dispatch` | `🚧 [relay-request-concurrency] fix(bridge): route client requests concurrently [step 9/10]` | 950–1,450 | Blocked on Step 8 merge |
 | [ ] | 10/10 | `relay-request-concurrency-retire-plan` | `🌱 [relay-request-concurrency] docs: retire concurrent routing plan [step 10/10]` | 50–150 | Blocked on Step 9 merge |
@@ -383,4 +382,21 @@
   admission with callback-scoped cleanup, and archive notification settles inside
   the family lane. Per policy, the corrected implementation was not re-reviewed.
 - **Step 6/10 delivery:** [PR #703](https://github.com/sesori-ai/sesori_apps_monorepo/pull/703)
-  is open at 1,054 changed lines.
+  merged as `e4605eb15b68f5433b5740981d03ff6e63f964cb` at 1,054 changed lines.
+- **Step 7/10 implementation:** `SessionRepository` creates an opaque unpublished
+  binding, token-scopes initial command/title work, and reveals through one
+  exactly-once binding publication in `finally`. A process-local visibility state
+  gates same-plugin catalog writers and filters catalog, interaction, unseen,
+  activity, and event projections until reveal; restart keeps durable rows visible.
+- **Step 7/10 cleanup:** removed eager creation publication and ordinary-lookup
+  initialization paths. No persisted visibility field, migration, callback, wire,
+  client, plugin-interface, analytics event, or obsolete compatibility path was added.
+- **Step 7/10 architecture review:** `aristotle-impl-review` found pre-token
+  hydration/import publication, stale paginated exclusion snapshots, and direct
+  question/permission/unseen visibility bypasses. All findings were applied
+  directly; per policy, the corrected implementation was not re-reviewed.
+- **Step 7/10 verification:** 2,416 full `bridge/app` tests pass, affected suites
+  pass, strict `dart analyze --fatal-infos` reports no issues, and
+  `git diff --check` passes. The 1,537 changed lines exceed the soft cap by 37;
+  one atomic invariant spans creation, catalog writers/reads, interactions, unseen
+  state, and events, and splitting would expose a bypass between mergeable PRs.

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -8,9 +8,10 @@
 - **Series state:** Steps 1–6 merged; Step 6/10
   [#703](https://github.com/sesori-ai/sesori_apps_monorepo/pull/703) merged as
   `e4605eb1`
-- **Current step:** Step 7/10 implementation on `plan-parallel-requests`
+- **Current step:** Step 7/10 PR
+  [#716](https://github.com/sesori-ai/sesori_apps_monorepo/pull/716) open
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged
-- **Next action:** commit, open, review, and merge Step 7
+- **Next action:** review and merge Step 7; Step 8 remains blocked until then
 
 ## Incident Evidence
 
@@ -93,7 +94,7 @@
 | [x] | 4/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | [PR #699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) merged as `9ac855a3` with 1,326 changed lines |
 | [x] | 5/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | [PR #700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700) merged as `5ba0d3a6` with 1,534 changed lines |
 | [x] | 6/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope session family mutations [step 6/10]` | 750–1,250 | [PR #703](https://github.com/sesori-ai/sesori_apps_monorepo/pull/703) merged as `e4605eb1` with 1,054 changed lines |
-| [ ] | 7/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): gate new session visibility [step 7/10]` | 600–1,100 | Implemented from `e4605eb1`; PR pending |
+| [ ] | 7/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): gate new session visibility [step 7/10]` | 600–1,100 | [PR #716](https://github.com/sesori-ai/sesori_apps_monorepo/pull/716) open from `e4605eb1` |
 | [ ] | 8/10 | `relay-request-concurrency-project-mutations` | `🚧 [relay-request-concurrency] refactor(bridge): order project path mutations [step 8/10]` | 650–1,100 | Blocked on Step 7 merge |
 | [ ] | 9/10 | `relay-request-concurrency-dispatch` | `🚧 [relay-request-concurrency] fix(bridge): route client requests concurrently [step 9/10]` | 950–1,450 | Blocked on Step 8 merge |
 | [ ] | 10/10 | `relay-request-concurrency-retire-plan` | `🌱 [relay-request-concurrency] docs: retire concurrent routing plan [step 10/10]` | 50–150 | Blocked on Step 9 merge |
@@ -397,6 +398,8 @@
   directly; per policy, the corrected implementation was not re-reviewed.
 - **Step 7/10 verification:** 2,416 full `bridge/app` tests pass, affected suites
   pass, strict `dart analyze --fatal-infos` reports no issues, and
-  `git diff --check` passes. The 1,537 changed lines exceed the soft cap by 37;
+  `git diff --check` passes. The 1,540 changed lines exceed the soft cap by 40;
   one atomic invariant spans creation, catalog writers/reads, interactions, unseen
   state, and events, and splitting would expose a bypass between mergeable PRs.
+- **Step 7/10 delivery:** [PR #716](https://github.com/sesori-ai/sesori_apps_monorepo/pull/716)
+  is open from `e4605eb1`.

--- a/bridge/app/lib/src/api/database/daos/session_dao.dart
+++ b/bridge/app/lib/src/api/database/daos/session_dao.dart
@@ -370,10 +370,14 @@ class SessionDao extends DatabaseAccessor<AppDatabase> with _$SessionDaoMixin {
     required String projectId,
     required int offset,
     required int? limit,
+    required List<String> excludedSessionIds,
   }) {
     return (select(sessionTable)
           ..where(
-            (table) => table.projectId.equals(projectId) & table.parentSessionId.isNull(),
+            (table) {
+              final roots = table.projectId.equals(projectId) & table.parentSessionId.isNull();
+              return excludedSessionIds.isEmpty ? roots : roots & table.sessionId.isNotIn(excludedSessionIds);
+            },
           )
           ..orderBy([
             (table) => OrderingTerm.desc(table.updatedAt),
@@ -385,10 +389,14 @@ class SessionDao extends DatabaseAccessor<AppDatabase> with _$SessionDaoMixin {
 
   Future<List<SessionDto>> getChildCatalogSessions({
     required String parentSessionId,
+    required List<String> excludedSessionIds,
   }) {
     return (select(sessionTable)
           ..where(
-            (table) => table.parentSessionId.equals(parentSessionId),
+            (table) {
+              final children = table.parentSessionId.equals(parentSessionId);
+              return excludedSessionIds.isEmpty ? children : children & table.sessionId.isNotIn(excludedSessionIds);
+            },
           )
           ..orderBy([
             (table) => OrderingTerm.desc(table.updatedAt),

--- a/bridge/app/lib/src/bridge/foundation/session_visibility_state.dart
+++ b/bridge/app/lib/src/bridge/foundation/session_visibility_state.dart
@@ -35,7 +35,10 @@ class SessionVisibilityState {
     final pluginState = _pluginStates.putIfAbsent(pluginId, _PluginVisibilityState.new);
     final catalogWritesFinished = pluginState.activeCatalogWrites == 0
         ? Future<void>.value()
-        : pluginState.catalogWritesFinished!.future;
+        : switch (pluginState.catalogWritesFinished) {
+            final Completer<void> completion => completion.future,
+            null => throw StateError("Active catalog writes have no completion signal"),
+          };
     pluginState.creationReservations++;
     pluginState.creationReservationsFinished ??= Completer<void>();
     return SessionCreationReservation._(pluginState: pluginState, catalogWritesFinished: catalogWritesFinished);
@@ -47,7 +50,12 @@ class SessionVisibilityState {
     final pluginState = reservation._pluginState;
     pluginState.creationReservations--;
     if (pluginState.creationReservations != 0) return;
-    pluginState.creationReservationsFinished!.complete();
+    switch (pluginState.creationReservationsFinished) {
+      case final Completer<void> completion:
+        completion.complete();
+      case null:
+        throw StateError("Session creation reservations have no completion signal");
+    }
     pluginState.creationReservationsFinished = null;
   }
 
@@ -71,16 +79,20 @@ class SessionVisibilityState {
   Future<T> withCatalogWrite<T>({required String pluginId, required Future<T> Function() body}) async {
     final pluginState = _pluginStates.putIfAbsent(pluginId, _PluginVisibilityState.new);
     while (pluginState.creationReservations > 0) {
-      await pluginState.creationReservationsFinished!.future;
+      final completion = pluginState.creationReservationsFinished;
+      if (completion == null) {
+        throw StateError("Session creation reservations have no completion signal");
+      }
+      await completion.future;
     }
     pluginState.activeCatalogWrites++;
-    pluginState.catalogWritesFinished ??= Completer<void>();
+    final catalogWritesFinished = pluginState.catalogWritesFinished ??= Completer<void>();
     try {
       return await body();
     } finally {
       pluginState.activeCatalogWrites--;
       if (pluginState.activeCatalogWrites == 0) {
-        pluginState.catalogWritesFinished!.complete();
+        catalogWritesFinished.complete();
         pluginState.catalogWritesFinished = null;
       }
     }

--- a/bridge/app/lib/src/bridge/foundation/session_visibility_state.dart
+++ b/bridge/app/lib/src/bridge/foundation/session_visibility_state.dart
@@ -10,6 +10,7 @@ final class SessionCreationReservation {
        _catalogWritesFinished = catalogWritesFinished;
   final _PluginVisibilityState _pluginState;
   final Future<void> _catalogWritesFinished;
+  bool _released = false;
 }
 
 final class UnpublishedSessionReservation {
@@ -39,7 +40,10 @@ class SessionVisibilityState {
     pluginState.creationReservationsFinished ??= Completer<void>();
     return SessionCreationReservation._(pluginState: pluginState, catalogWritesFinished: catalogWritesFinished);
   }
+
   void releaseSessionCreation({required SessionCreationReservation reservation}) {
+    if (reservation._released) return;
+    reservation._released = true;
     final pluginState = reservation._pluginState;
     pluginState.creationReservations--;
     if (pluginState.creationReservations != 0) return;

--- a/bridge/app/lib/src/bridge/foundation/session_visibility_state.dart
+++ b/bridge/app/lib/src/bridge/foundation/session_visibility_state.dart
@@ -1,0 +1,108 @@
+import "dart:async";
+
+typedef SessionVisibilitySnapshot = ({int version, List<String> unpublishedSessionIds});
+
+final class SessionCreationReservation {
+  SessionCreationReservation._({
+    required _PluginVisibilityState pluginState,
+    required Future<void> catalogWritesFinished,
+  }) : _pluginState = pluginState,
+       _catalogWritesFinished = catalogWritesFinished;
+  final _PluginVisibilityState _pluginState;
+  final Future<void> _catalogWritesFinished;
+}
+
+final class UnpublishedSessionReservation {
+  UnpublishedSessionReservation._({required this.sessionId});
+  final String sessionId;
+  bool _active = true;
+  bool get isActive => _active;
+}
+
+/// Orders catalog writes against process-local unpublished bindings, which are visible after restart.
+class SessionVisibilityState {
+  final Set<String> _unpublishedSessionIds = <String>{};
+  final Map<String, _PluginVisibilityState> _pluginStates = <String, _PluginVisibilityState>{};
+  int _version = 0;
+  SessionVisibilitySnapshot get snapshot => (
+    version: _version,
+    unpublishedSessionIds: List<String>.unmodifiable(_unpublishedSessionIds),
+  );
+  bool isSnapshotCurrent({required SessionVisibilitySnapshot snapshot}) => snapshot.version == _version;
+  bool isPublished({required String sessionId}) => !_unpublishedSessionIds.contains(sessionId);
+  SessionCreationReservation reserveSessionCreation({required String pluginId}) {
+    final pluginState = _pluginStates.putIfAbsent(pluginId, _PluginVisibilityState.new);
+    final catalogWritesFinished = pluginState.activeCatalogWrites == 0
+        ? Future<void>.value()
+        : pluginState.catalogWritesFinished!.future;
+    pluginState.creationReservations++;
+    pluginState.creationReservationsFinished ??= Completer<void>();
+    return SessionCreationReservation._(pluginState: pluginState, catalogWritesFinished: catalogWritesFinished);
+  }
+  void releaseSessionCreation({required SessionCreationReservation reservation}) {
+    final pluginState = reservation._pluginState;
+    pluginState.creationReservations--;
+    if (pluginState.creationReservations != 0) return;
+    pluginState.creationReservationsFinished!.complete();
+    pluginState.creationReservationsFinished = null;
+  }
+
+  Future<T> withSessionCreationCommit<T>({
+    required SessionCreationReservation reservation,
+    required Future<T> Function() body,
+  }) async {
+    await reservation._catalogWritesFinished;
+    final pluginState = reservation._pluginState;
+    final predecessor = pluginState.creationCommitTail;
+    final released = Completer<void>();
+    pluginState.creationCommitTail = released.future;
+    await predecessor;
+    try {
+      return await body();
+    } finally {
+      released.complete();
+    }
+  }
+
+  Future<T> withCatalogWrite<T>({required String pluginId, required Future<T> Function() body}) async {
+    final pluginState = _pluginStates.putIfAbsent(pluginId, _PluginVisibilityState.new);
+    while (pluginState.creationReservations > 0) {
+      await pluginState.creationReservationsFinished!.future;
+    }
+    pluginState.activeCatalogWrites++;
+    pluginState.catalogWritesFinished ??= Completer<void>();
+    try {
+      return await body();
+    } finally {
+      pluginState.activeCatalogWrites--;
+      if (pluginState.activeCatalogWrites == 0) {
+        pluginState.catalogWritesFinished!.complete();
+        pluginState.catalogWritesFinished = null;
+      }
+    }
+  }
+
+  UnpublishedSessionReservation? beginUnpublishedSession({required String sessionId}) {
+    if (!_unpublishedSessionIds.add(sessionId)) return null;
+    _version++;
+    return UnpublishedSessionReservation._(sessionId: sessionId);
+  }
+
+  bool completeUnpublishedSession({required UnpublishedSessionReservation reservation}) {
+    if (!reservation._active) return false;
+    reservation._active = false;
+    if (!_unpublishedSessionIds.remove(reservation.sessionId)) {
+      throw StateError("Unpublished session reservation lost its visibility marker");
+    }
+    _version++;
+    return true;
+  }
+}
+
+class _PluginVisibilityState {
+  int creationReservations = 0;
+  Completer<void>? creationReservationsFinished;
+  int activeCatalogWrites = 0;
+  Completer<void>? catalogWritesFinished;
+  Future<void> creationCommitTail = Future<void>.value();
+}

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -355,6 +355,7 @@ class Orchestrator {
         sessionDao: _database.sessionDao,
         projectCatalogIdentityCalculator: projectCatalogIdentityCalculator,
         aggregateSourceDeadline: aggregateSourceDeadline,
+        visibilityState: sessionVisibilityState,
       ),
       now: () => DateTime.now().millisecondsSinceEpoch,
     );

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -57,6 +57,7 @@ import "api/gh_cli_api.dart";
 import "api/git_cli_api.dart";
 import "foundation/filesystem_permission_validator.dart";
 import "foundation/process_runner.dart";
+import "foundation/session_visibility_state.dart";
 import "key_exchange.dart";
 import "metadata_service.dart";
 import "models/bridge_config.dart";
@@ -221,6 +222,7 @@ class Orchestrator {
     const aggregateSourceDeadline = Duration(seconds: 5);
     const unseenCalculator = SessionUnseenCalculator();
     const projectCatalogIdentityCalculator = ProjectCatalogIdentityCalculator();
+    final sessionVisibilityState = SessionVisibilityState();
     final gitCliApi = GitCliApi(processRunner: _processRunner, gitPathExists: _gitPathExists);
     final sessionRepository = SessionRepository(
       runtime: _pluginRuntime,
@@ -234,6 +236,7 @@ class Orchestrator {
       unseenCalculator: unseenCalculator,
       projectCatalogIdentityCalculator: projectCatalogIdentityCalculator,
       aggregateSourceDeadline: aggregateSourceDeadline,
+      visibilityState: sessionVisibilityState,
     );
     final sessionOptionsRepository = SessionOptionsRepository(
       runtime: _pluginRuntime,
@@ -257,6 +260,7 @@ class Orchestrator {
       filesystemApi: const FilesystemApi(),
       gitCliApi: gitCliApi,
       projectCatalogIdentityCalculator: projectCatalogIdentityCalculator,
+      visibilityState: sessionVisibilityState,
     );
     final sessionViewTracker = SessionViewTracker();
     final projectViewTracker = ProjectViewTracker();
@@ -264,6 +268,7 @@ class Orchestrator {
       unseenRepository: SessionUnseenRepository(
         sessionDao: _database.sessionDao,
         calculator: unseenCalculator,
+        visibilityState: sessionVisibilityState,
       ),
       projectRepository: projectRepository,
       viewTracker: sessionViewTracker,
@@ -356,6 +361,7 @@ class Orchestrator {
     final permissionRepository = PermissionRepository(
       runtime: _pluginRuntime,
       sessionDao: _database.sessionDao,
+      visibilityState: sessionVisibilityState,
     );
     final healthRepository = HealthRepository(
       bridgeVersion: appVersion,
@@ -375,6 +381,7 @@ class Orchestrator {
       sessionDao: _database.sessionDao,
       projectsDao: _database.projectsDao,
       aggregateSourceDeadline: aggregateSourceDeadline,
+      visibilityState: sessionVisibilityState,
     );
     final pendingInteractionService = PendingInteractionService(
       permissionRepository: permissionRepository,
@@ -390,6 +397,7 @@ class Orchestrator {
       ),
       worktreeService: worktreeService,
       sessionRepository: sessionRepository,
+      sessionOperationDispatcher: sessionOperationDispatcher,
       sessionMutationDispatcher: sessionMutationDispatcher,
     );
     final projectInitializationService = ProjectInitializationService(
@@ -412,6 +420,7 @@ class Orchestrator {
       sessionDao: _database.sessionDao,
       catalogHydrationsDao: _database.catalogHydrationsDao,
       projectCatalogIdentityCalculator: projectCatalogIdentityCalculator,
+      visibilityState: sessionVisibilityState,
     );
     final catalogImportService = CatalogImportService(
       orderedPluginIds: pluginComposition.orderedPluginIds,

--- a/bridge/app/lib/src/bridge/repositories/permission_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/permission_repository.dart
@@ -3,6 +3,7 @@ import "package:sesori_shared/sesori_shared.dart";
 
 import "../../api/database/daos/session_dao.dart";
 import "../../api/database/tables/session_table.dart";
+import "../foundation/session_visibility_state.dart";
 import "../runtime/plugin_runtime.dart";
 import "mappers/plugin_permission_mapper.dart";
 import "models/session_operation.dart";
@@ -19,10 +20,15 @@ import "models/session_operation.dart";
 class PermissionRepository {
   final PluginRuntime _runtime;
   final SessionDao _sessionDao;
+  final SessionVisibilityState _visibilityState;
 
-  PermissionRepository({required PluginRuntime runtime, required SessionDao sessionDao})
-    : _runtime = runtime,
-      _sessionDao = sessionDao;
+  PermissionRepository({
+    required PluginRuntime runtime,
+    required SessionDao sessionDao,
+    required SessionVisibilityState visibilityState,
+  }) : _runtime = runtime,
+       _sessionDao = sessionDao,
+       _visibilityState = visibilityState;
 
   /// Pending permissions to surface on [sessionId]'s screen (its own plus any
   /// descendant session whose root resolves to it).
@@ -70,6 +76,12 @@ class PermissionRepository {
       pluginId: binding.pluginId,
       operation: SessionOperation.replyToPermission,
       body: (plugin) async {
+        if (!_visibilityState.isPublished(sessionId: binding.sessionId)) {
+          throw PluginOperationException.notFound(
+            SessionOperation.replyToPermission.name,
+            message: "session ${binding.sessionId} was not found",
+          );
+        }
         if (plugin is BridgeDerivedProjectsPluginApi) {
           final tombstoned = await _sessionDao.getTombstonedSessionIds(pluginId: plugin.id);
           if (tombstoned.contains(binding.backendSessionId)) {
@@ -116,7 +128,7 @@ class PermissionRepository {
     required SessionOperation operation,
   }) async {
     final binding = await _sessionDao.getSession(sessionId: sessionId);
-    if (binding == null) {
+    if (binding == null || !_visibilityState.isPublished(sessionId: sessionId)) {
       throw PluginOperationException.notFound(
         operation.name,
         message: "session $sessionId was not found",
@@ -135,10 +147,13 @@ class PermissionRepository {
         ?permission.displaySessionId,
       },
     };
-    final bindings = await _sessionDao.getSessionsByBackendIds(
-      pluginId: pluginId,
-      backendSessionIds: backendSessionIds.toList(growable: false),
+    final bindings = Map.of(
+      await _sessionDao.getSessionsByBackendIds(
+        pluginId: pluginId,
+        backendSessionIds: backendSessionIds.toList(growable: false),
+      ),
     );
+    bindings.removeWhere((_, binding) => !_visibilityState.isPublished(sessionId: binding.sessionId));
     return [
       for (final permission in permissions)
         if (bindings[permission.sessionID] case final session?)

--- a/bridge/app/lib/src/bridge/repositories/project_activity_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/project_activity_repository.dart
@@ -6,6 +6,7 @@ import "../../api/database/daos/projects_dao.dart";
 import "../../api/database/daos/session_dao.dart" show SessionDao;
 import "../../api/database/tables/projects_table.dart" show ProjectDto;
 import "../../repositories/project_catalog_identity_calculator.dart";
+import "../foundation/session_visibility_state.dart";
 import "../runtime/plugin_runtime.dart";
 import "models/project_activity_evidence.dart";
 
@@ -23,17 +24,20 @@ class ProjectActivityRepository {
     required SessionDao sessionDao,
     required ProjectCatalogIdentityCalculator projectCatalogIdentityCalculator,
     required Duration aggregateSourceDeadline,
+    required SessionVisibilityState visibilityState,
   }) : _runtime = runtime,
        _projectsDao = projectsDao,
        _sessionDao = sessionDao,
        _projectCatalogIdentityCalculator = projectCatalogIdentityCalculator,
-       _aggregateSourceDeadline = aggregateSourceDeadline;
+       _aggregateSourceDeadline = aggregateSourceDeadline,
+       _visibilityState = visibilityState;
 
   final PluginRuntime _runtime;
   final ProjectsDao _projectsDao;
   final SessionDao _sessionDao;
   final ProjectCatalogIdentityCalculator _projectCatalogIdentityCalculator;
   final Duration _aggregateSourceDeadline;
+  final SessionVisibilityState _visibilityState;
 
   Set<String> get operationalPluginIds => _runtime.activePluginIds;
 
@@ -91,18 +95,26 @@ class ProjectActivityRepository {
           _sessionDao.getSessionProjectPaths(pluginId: plugin.id),
           _sessionDao.getTombstonedSessionIds(pluginId: plugin.id),
         ).wait;
+        final publishedSessionProjectPaths = [
+          for (final row in sessionProjectPaths)
+            if (_visibilityState.isPublished(sessionId: row.sessionId)) row,
+        ];
+        final unpublishedBackendSessionIds = {
+          for (final row in sessionProjectPaths)
+            if (!_visibilityState.isPublished(sessionId: row.sessionId)) row.backendSessionId,
+        };
         final sessions = await plugin.listAllSessions(
           knownDirectories: {
             for (final stored in storedProjects) stored.path,
-            for (final row in sessionProjectPaths) ?row.worktreePath,
+            for (final row in publishedSessionProjectPaths) ?row.worktreePath,
           },
         );
         final pathBySessionId = {
-          for (final row in sessionProjectPaths) row.backendSessionId: row.projectPath,
+          for (final row in publishedSessionProjectPaths) row.backendSessionId: row.projectPath,
         };
         final grouped = <String, List<PluginSessionTime>>{};
         for (final session in sessions) {
-          if (tombstoned.contains(session.id)) continue;
+          if (tombstoned.contains(session.id) || unpublishedBackendSessionIds.contains(session.id)) continue;
           final time = session.time;
           if (time == null) continue;
           final projectPath = pathBySessionId[session.id] ?? session.directory;

--- a/bridge/app/lib/src/bridge/repositories/project_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/project_repository.dart
@@ -12,6 +12,7 @@ import "../../api/database/tables/projects_table.dart" show ProjectDto;
 import "../../repositories/project_catalog_identity_calculator.dart";
 import "../api/filesystem_api.dart";
 import "../api/git_cli_api.dart";
+import "../foundation/session_visibility_state.dart";
 import "mappers/git_remote_identity_parser.dart";
 import "mappers/project_catalog_mapper.dart";
 import "models/project_activity.dart";
@@ -29,6 +30,7 @@ class ProjectRepository {
   final FilesystemApi _filesystemApi;
   final GitCliApi _gitCliApi;
   final ProjectCatalogIdentityCalculator _projectCatalogIdentityCalculator;
+  final SessionVisibilityState _visibilityState;
 
   ProjectRepository({
     required ProjectsDao projectsDao,
@@ -37,12 +39,14 @@ class ProjectRepository {
     required FilesystemApi filesystemApi,
     required GitCliApi gitCliApi,
     required ProjectCatalogIdentityCalculator projectCatalogIdentityCalculator,
+    required SessionVisibilityState visibilityState,
   }) : _projectsDao = projectsDao,
        _sessionDao = sessionDao,
        _unseenCalculator = unseenCalculator,
        _filesystemApi = filesystemApi,
        _gitCliApi = gitCliApi,
-       _projectCatalogIdentityCalculator = projectCatalogIdentityCalculator;
+       _projectCatalogIdentityCalculator = projectCatalogIdentityCalculator,
+       _visibilityState = visibilityState;
 
   Future<List<Project>> getProjects() async {
     final rows = await _projectsDao.getCatalogProjects();
@@ -82,6 +86,7 @@ class ProjectRepository {
 
   bool _anyUnseen(List<SessionUnseenRow> rows) {
     for (final row in rows) {
+      if (!_visibilityState.isPublished(sessionId: row.sessionId)) continue;
       if (row.parentSessionId != null) continue;
       if (row.archivedAt != null) continue;
       if (_unseenCalculator.isUnseen(

--- a/bridge/app/lib/src/bridge/repositories/question_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/question_repository.dart
@@ -4,6 +4,7 @@ import "package:sesori_shared/sesori_shared.dart";
 import "../../api/database/daos/projects_dao.dart";
 import "../../api/database/daos/session_dao.dart";
 import "../../api/database/tables/session_table.dart";
+import "../foundation/session_visibility_state.dart";
 import "../runtime/plugin_runtime.dart";
 import "derived_session_builder.dart";
 import "mappers/plugin_question_mapper.dart";
@@ -20,6 +21,7 @@ class QuestionRepository {
   final PluginRuntime _runtime;
   final SessionDao _sessionDao;
   final ProjectsDao _projectsDao;
+  final SessionVisibilityState _visibilityState;
   final Duration _aggregateSourceDeadline;
 
   QuestionRepository({
@@ -27,10 +29,12 @@ class QuestionRepository {
     required SessionDao sessionDao,
     required ProjectsDao projectsDao,
     required Duration aggregateSourceDeadline,
+    required SessionVisibilityState visibilityState,
   }) : _runtime = runtime,
        _sessionDao = sessionDao,
        _projectsDao = projectsDao,
-       _aggregateSourceDeadline = aggregateSourceDeadline;
+       _aggregateSourceDeadline = aggregateSourceDeadline,
+       _visibilityState = visibilityState;
 
   /// Pending questions to surface on [sessionId]'s screen (its own plus any
   /// descendant session whose root resolves to it).
@@ -193,6 +197,12 @@ class QuestionRepository {
       pluginId: binding.pluginId,
       operation: SessionOperation.replyToQuestion,
       body: (plugin) async {
+        if (!_visibilityState.isPublished(sessionId: binding.sessionId)) {
+          throw PluginOperationException.notFound(
+            SessionOperation.replyToQuestion.name,
+            message: "session ${binding.sessionId} was not found",
+          );
+        }
         await _throwIfMutationTargetTombstoned(
           questionId: questionId,
           backendSessionId: binding.backendSessionId,
@@ -220,6 +230,12 @@ class QuestionRepository {
       pluginId: binding.pluginId,
       operation: SessionOperation.rejectQuestion,
       body: (plugin) async {
+        if (!_visibilityState.isPublished(sessionId: binding.sessionId)) {
+          throw PluginOperationException.notFound(
+            SessionOperation.rejectQuestion.name,
+            message: "session ${binding.sessionId} was not found",
+          );
+        }
         await _throwIfMutationTargetTombstoned(
           questionId: questionId,
           backendSessionId: binding.backendSessionId,
@@ -254,7 +270,9 @@ class QuestionRepository {
           for (final question in questions) {
             if (question.id != questionId || !_isVisible(question, tombstoned)) continue;
             final owner = bindings[question.sessionID];
-            if (owner != null) owners.add(owner.sessionId);
+            if (owner != null && _visibilityState.isPublished(sessionId: owner.sessionId)) {
+              owners.add(owner.sessionId);
+            }
           }
         }
         return owners.toList(growable: false)..sort();
@@ -301,7 +319,7 @@ class QuestionRepository {
     required SessionOperation operation,
   }) async {
     final binding = await _sessionDao.getSession(sessionId: sessionId);
-    if (binding == null) {
+    if (binding == null || !_visibilityState.isPublished(sessionId: sessionId)) {
       throw PluginOperationException.notFound(
         operation.name,
         message: "session $sessionId was not found",
@@ -320,10 +338,13 @@ class QuestionRepository {
         ?question.displaySessionId,
       },
     };
-    final bindings = await _sessionDao.getSessionsByBackendIds(
-      pluginId: pluginId,
-      backendSessionIds: backendSessionIds.toList(growable: false),
+    final bindings = Map.of(
+      await _sessionDao.getSessionsByBackendIds(
+        pluginId: pluginId,
+        backendSessionIds: backendSessionIds.toList(growable: false),
+      ),
     );
+    bindings.removeWhere((_, binding) => !_visibilityState.isPublished(sessionId: binding.sessionId));
     return [
       for (final question in questions)
         if (bindings[question.sessionID] case final session?)

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -35,6 +35,7 @@ import "../../api/database/tables/projects_table.dart" show ProjectDto;
 import "../../api/database/tables/pull_requests_table.dart";
 import "../../api/database/tables/session_table.dart" show SessionDto;
 import "../../repositories/project_catalog_identity_calculator.dart";
+import "../foundation/session_visibility_state.dart";
 import "../runtime/plugin_runtime.dart";
 import "mappers/plugin_activity_summary_mapper.dart";
 import "mappers/plugin_command_mapper.dart";
@@ -63,6 +64,27 @@ typedef SessionBindingsCommitted = ({
 
 typedef SessionFamilyScope = ({String rootSessionId, String pluginId});
 
+final class UnpublishedSessionBinding {
+  UnpublishedSessionBinding._({
+    required SessionRepository repository,
+    required SessionDto binding,
+    required this.session,
+    required int generation,
+    required UnpublishedSessionReservation visibilityReservation,
+  }) : _repository = repository,
+       _binding = binding,
+       _generation = generation,
+       _visibilityReservation = visibilityReservation;
+
+  final SessionRepository _repository;
+  final SessionDto _binding;
+  final int _generation;
+  final UnpublishedSessionReservation _visibilityReservation;
+  final Session session;
+
+  SessionFamilyScope get familyScope => (rootSessionId: _binding.sessionId, pluginId: _binding.pluginId);
+}
+
 class SessionRepository {
   static const SessionCatalogMapper _sessionCatalogMapper = SessionCatalogMapper();
 
@@ -73,6 +95,7 @@ class SessionRepository {
   final PullRequestDao _pullRequestDao;
   final SessionUnseenCalculator _unseenCalculator;
   final ProjectCatalogIdentityCalculator _projectCatalogIdentityCalculator;
+  final SessionVisibilityState _visibilityState;
   final Duration _aggregateSourceDeadline;
   final Map<String, Set<String>> _tombstonedBackendSessionIds = <String, Set<String>>{};
   final Set<String> _deletedSessionIds = <String>{};
@@ -91,6 +114,7 @@ class SessionRepository {
     required SessionUnseenCalculator unseenCalculator,
     required ProjectCatalogIdentityCalculator projectCatalogIdentityCalculator,
     required Duration aggregateSourceDeadline,
+    required SessionVisibilityState visibilityState,
   }) : _runtime = runtime,
        _bridgeDerivedProjectPluginIds = Set<String>.unmodifiable(bridgeDerivedProjectPluginIds),
        _sessionDao = sessionDao,
@@ -98,7 +122,8 @@ class SessionRepository {
        _pullRequestDao = pullRequestDao,
        _unseenCalculator = unseenCalculator,
        _projectCatalogIdentityCalculator = projectCatalogIdentityCalculator,
-       _aggregateSourceDeadline = aggregateSourceDeadline;
+       _aggregateSourceDeadline = aggregateSourceDeadline,
+       _visibilityState = visibilityState;
 
   Stream<SessionBindingsCommitted> get bindingCommits => _bindingCommitsController.stream;
 
@@ -118,7 +143,7 @@ class SessionRepository {
           message: "session $sessionId has cyclic ancestry at $currentSessionId",
         );
       }
-      final binding = await _sessionDao.getSession(sessionId: currentSessionId);
+      final binding = await _getPublishedBinding(sessionId: currentSessionId);
       if (binding == null) {
         throw PluginOperationException.notFound(
           operation.name,
@@ -156,14 +181,19 @@ class SessionRepository {
       throw ProjectNotFoundException(projectId: projectId);
     }
     final effectiveLimit = limit == null || limit <= 0 ? null : limit;
-    return _mapCatalogSessions(
-      rows: await _sessionDao.getRootCatalogSessions(
-        projectId: projectId,
-        offset: start ?? 0,
-        limit: effectiveLimit,
-      ),
-      verifiedGithubLogin: verifiedGithubLogin,
-    );
+    while (true) {
+      final visibility = _visibilityState.snapshot;
+      final sessions = await _mapCatalogSessions(
+        rows: await _sessionDao.getRootCatalogSessions(
+          projectId: projectId,
+          offset: start ?? 0,
+          limit: effectiveLimit,
+          excludedSessionIds: visibility.unpublishedSessionIds,
+        ),
+        verifiedGithubLogin: verifiedGithubLogin,
+      );
+      if (_visibilityState.isSnapshotCurrent(snapshot: visibility)) return sessions;
+    }
   }
 
   Future<Session> enrichSession({
@@ -184,11 +214,10 @@ class SessionRepository {
     );
   }
 
-  Future<Session> createSession({
+  Future<UnpublishedSessionBinding> createSession({
     required String pluginId,
     required String projectId,
     required String directory,
-    required String? parentSessionId,
     required List<PromptPart> parts,
     required String? userVisibleText,
     required SessionVariant? variant,
@@ -202,76 +231,132 @@ class SessionRepository {
     required String? lastAgent,
     required AgentModel? lastAgentModel,
   }) async {
-    final result = await _runtime.useAndCommit(
+    final creationReservation = _visibilityState.reserveSessionCreation(
       pluginId: pluginId,
-      operation: SessionOperation.createSession,
-      prepare: (plugin) {
-        return plugin.createSession(
-          directory: directory,
-          parentSessionId: parentSessionId,
-          parts: parts.map((part) => part.toPlugin()).toList(growable: false),
-          userVisibleText: userVisibleText,
-          variant: _toPluginVariant(variant),
-          agent: agent,
-          model: switch (model) {
-            PromptModel(:final providerID, :final modelID) => (providerID: providerID, modelID: modelID),
-            null => null,
-          },
-        );
-      },
-      commit: (created, generation) async {
-        final projectionUpdatedAt = captureProjectionTimestamp();
-        final createdAt = created.time?.created ?? projectionUpdatedAt;
-        final updatedAt = created.time?.updated ?? createdAt;
-        late String sessionId;
-        await _sessionDao.attachedDatabase.transaction(() async {
-          final existingBinding = await _sessionDao.getSessionByBinding(
-            pluginId: pluginId,
-            backendSessionId: created.id,
-          );
-          if (existingBinding?.parentSessionId != null) {
-            throw PluginOperationException(
-              SessionOperation.createSession.name,
-              statusCode: 409,
-              message: "backend session ${created.id} is already bound as a child session",
-            );
-          }
-          sessionId = existingBinding?.sessionId ?? await _allocateSessionId();
-          await _projectsDao.insertProjectsIfMissing(projectIds: [projectId]);
-          await _sessionDao.insertSession(
-            sessionId: sessionId,
-            backendSessionId: created.id,
-            projectId: projectId,
-            isDedicated: isDedicated,
-            createdAt: createdAt,
-            worktreePath: worktreePath,
-            branchName: branchName,
-            baseBranch: baseBranch,
-            baseCommit: baseCommit,
-            lastAgent: lastAgent,
-            lastAgentModel: lastAgentModel,
-            pluginId: pluginId,
-          );
-          await _sessionDao.updateObservedSessionProjection(
-            sessionId: sessionId,
+    );
+    UnpublishedSessionReservation? visibilityReservation;
+    try {
+      final result = await _runtime.useAndCommit(
+        pluginId: pluginId,
+        operation: SessionOperation.createSession,
+        prepare: (plugin) {
+          return plugin.createSession(
             directory: directory,
-            catalogTitle: created.title,
-            updateCatalogTitle: true,
-            updatedAt: updatedAt,
-            projectionUpdatedAt: projectionUpdatedAt,
+            parentSessionId: null,
+            parts: parts.map((part) => part.toPlugin()).toList(growable: false),
+            userVisibleText: userVisibleText,
+            variant: _toPluginVariant(variant),
+            agent: agent,
+            model: switch (model) {
+              PromptModel(:final providerID, :final modelID) => (providerID: providerID, modelID: modelID),
+              null => null,
+            },
           );
-        });
-        return (created: created, sessionId: sessionId, generation: generation);
-      },
-    );
+        },
+        commit: (created, generation) => _visibilityState.withSessionCreationCommit(
+          reservation: creationReservation,
+          body: () async {
+            final projectionUpdatedAt = captureProjectionTimestamp();
+            final createdAt = created.time?.created ?? projectionUpdatedAt;
+            final updatedAt = created.time?.updated ?? createdAt;
+            final existingBinding = await _sessionDao.getSessionByBinding(
+              pluginId: pluginId,
+              backendSessionId: created.id,
+            );
+            if (existingBinding?.parentSessionId != null) {
+              throw PluginOperationException(
+                SessionOperation.createSession.name,
+                statusCode: 409,
+                message: "backend session ${created.id} is already bound as a child session",
+              );
+            }
+            final sessionId = existingBinding?.sessionId ?? await _allocateSessionId();
+            final unpublished = _visibilityState.beginUnpublishedSession(
+              sessionId: sessionId,
+            );
+            if (unpublished == null) {
+              throw PluginOperationException(
+                SessionOperation.createSession.name,
+                statusCode: 409,
+                message: "session $sessionId is already being initialized",
+              );
+            }
+            visibilityReservation = unpublished;
+            late SessionDto committedBinding;
+            await _sessionDao.attachedDatabase.transaction(() async {
+              await _projectsDao.insertProjectsIfMissing(projectIds: [projectId]);
+              await _sessionDao.insertSession(
+                sessionId: sessionId,
+                backendSessionId: created.id,
+                projectId: projectId,
+                isDedicated: isDedicated,
+                createdAt: createdAt,
+                worktreePath: worktreePath,
+                branchName: branchName,
+                baseBranch: baseBranch,
+                baseCommit: baseCommit,
+                lastAgent: lastAgent,
+                lastAgentModel: lastAgentModel,
+                pluginId: pluginId,
+              );
+              await _sessionDao.updateObservedSessionProjection(
+                sessionId: sessionId,
+                directory: directory,
+                catalogTitle: created.title,
+                updateCatalogTitle: true,
+                updatedAt: updatedAt,
+                projectionUpdatedAt: projectionUpdatedAt,
+              );
+              committedBinding = (await _sessionDao.getSession(sessionId: sessionId))!;
+            });
+            return (
+              created: created,
+              binding: committedBinding,
+              generation: generation,
+              visibilityReservation: unpublished,
+            );
+          },
+        ),
+      );
+      return UnpublishedSessionBinding._(
+        repository: this,
+        binding: result.binding,
+        session: result.created.toSharedSessionWithId(
+          sessionId: result.binding.sessionId,
+          pluginId: pluginId,
+        ),
+        generation: result.generation,
+        visibilityReservation: result.visibilityReservation,
+      );
+    } on Object {
+      final unpublished = visibilityReservation;
+      if (unpublished != null) {
+        _visibilityState.completeUnpublishedSession(
+          reservation: unpublished,
+        );
+      }
+      rethrow;
+    } finally {
+      _visibilityState.releaseSessionCreation(
+        reservation: creationReservation,
+      );
+    }
+  }
+
+  void revealSession({required UnpublishedSessionBinding binding}) {
+    _verifyInitialBindingOwner(binding: binding);
+    if (!_visibilityState.completeUnpublishedSession(
+      reservation: binding._visibilityReservation,
+    )) {
+      return;
+    }
     _publishBindingsCommitted(
-      pluginId: pluginId,
-      projectId: projectId,
-      generation: result.generation,
+      pluginId: binding._binding.pluginId,
+      projectId: binding._binding.projectId,
+      generation: binding._generation,
       kind: SessionBindingCommitKind.sessionCreation,
-      backendSessionIds: [result.created.id],
+      backendSessionIds: [binding._binding.backendSessionId],
     );
-    return result.created.toSharedSessionWithId(sessionId: result.sessionId, pluginId: pluginId);
   }
 
   Future<Session> renameSession({required String sessionId, required String title}) async {
@@ -279,6 +364,18 @@ class SessionRepository {
       sessionId: sessionId,
       operation: SessionOperation.renameSession,
     );
+    return _renameSession(binding: binding, title: title);
+  }
+
+  Future<Session> renameInitialSession({
+    required UnpublishedSessionBinding binding,
+    required String title,
+  }) => _renameSession(
+    binding: _requireInitialBinding(binding: binding),
+    title: title,
+  );
+
+  Future<Session> _renameSession({required SessionDto binding, required String title}) async {
     final updated = await _runtime.use(
       pluginId: binding.pluginId,
       operation: SessionOperation.renameSession,
@@ -321,6 +418,44 @@ class SessionRepository {
       sessionId: sessionId,
       operation: SessionOperation.sendCommand,
     );
+    return _sendCommand(
+      binding: binding,
+      command: command,
+      arguments: arguments,
+      userVisibleArguments: userVisibleArguments,
+      variant: variant,
+      agent: agent,
+      model: model,
+    );
+  }
+
+  Future<void> sendInitialCommand({
+    required UnpublishedSessionBinding binding,
+    required String command,
+    required String arguments,
+    required String? userVisibleArguments,
+    required SessionVariant? variant,
+    required String? agent,
+    required PromptModel? model,
+  }) => _sendCommand(
+    binding: _requireInitialBinding(binding: binding),
+    command: command,
+    arguments: arguments,
+    userVisibleArguments: userVisibleArguments,
+    variant: variant,
+    agent: agent,
+    model: model,
+  );
+
+  Future<void> _sendCommand({
+    required SessionDto binding,
+    required String command,
+    required String arguments,
+    required String? userVisibleArguments,
+    required SessionVariant? variant,
+    required String? agent,
+    required PromptModel? model,
+  }) {
     return _runtime.use(
       pluginId: binding.pluginId,
       operation: SessionOperation.sendCommand,
@@ -395,7 +530,7 @@ class SessionRepository {
   /// Persists the bridge-owned title override. Null removes the override so
   /// later reads fall back to the latest observed catalog title.
   Future<bool> setSessionTitleIfStored({required String sessionId, required String? title}) async {
-    if (await _sessionDao.getSession(sessionId: sessionId) == null) return false;
+    if (await _getPublishedBinding(sessionId: sessionId) == null) return false;
     await _sessionDao.setTitle(
       sessionId: sessionId,
       title: title,
@@ -403,6 +538,20 @@ class SessionRepository {
       projectionUpdatedAt: captureProjectionTimestamp(),
     );
     return true;
+  }
+
+  Future<Session> setInitialSessionTitle({
+    required UnpublishedSessionBinding binding,
+    required String title,
+  }) async {
+    final stored = _requireInitialBinding(binding: binding);
+    await _sessionDao.setTitle(
+      sessionId: stored.sessionId,
+      title: title,
+      updatedAt: DateTime.now().millisecondsSinceEpoch,
+      projectionUpdatedAt: captureProjectionTimestamp(),
+    );
+    return binding.session.copyWith(title: title);
   }
 
   Future<bool> isSessionTombstoned({required String sessionId}) async {
@@ -592,13 +741,16 @@ class SessionRepository {
             generation: generation,
             operation: SessionOperation.getProjectActivitySummaries,
           );
-          await _runtime.commitCurrentGeneration(
+          await _visibilityState.withCatalogWrite(
             pluginId: pluginId,
-            generation: generation,
-            operation: SessionOperation.getProjectActivitySummaries,
-            commit: () => _persistActiveRootHydrations(
-              observation: observation,
+            body: () => _runtime.commitCurrentGeneration(
+              pluginId: pluginId,
               generation: generation,
+              operation: SessionOperation.getProjectActivitySummaries,
+              commit: () => _persistActiveRootHydrations(
+                observation: observation,
+                generation: generation,
+              ),
             ),
           );
           return _mapPluginProjectActivitySummaries(observation: observation);
@@ -642,14 +794,22 @@ class SessionRepository {
           ...active.childSessionIds,
         },
     };
-    final bindings = await _sessionDao.getSessionsByBackendIds(
+    final storedBindings = await _sessionDao.getSessionsByBackendIds(
       pluginId: pluginId,
       backendSessionIds: backendSessionIds.toList(growable: false),
     );
+    final unpublishedBackendSessionIds = {
+      for (final entry in storedBindings.entries)
+        if (!_visibilityState.isPublished(sessionId: entry.value.sessionId)) entry.key,
+    };
+    final bindings = {
+      for (final entry in storedBindings.entries)
+        if (_visibilityState.isPublished(sessionId: entry.value.sessionId)) entry.key: entry.value,
+    };
     final missingRootIds = {
       for (final summary in summaries)
         for (final active in summary.activeSessions)
-          if (!bindings.containsKey(active.id)) active.id,
+          if (!bindings.containsKey(active.id) && !unpublishedBackendSessionIds.contains(active.id)) active.id,
     };
     final hydrations = missingRootIds.isNotEmpty && plugin is NativeProjectsPluginApi
         ? await _collectActiveRootHydrations(
@@ -670,10 +830,14 @@ class SessionRepository {
   Future<List<ProjectActivitySummary>> _mapPluginProjectActivitySummaries({
     required _PluginActivityObservation observation,
   }) async {
-    final bindings = await _sessionDao.getSessionsByBackendIds(
+    final storedBindings = await _sessionDao.getSessionsByBackendIds(
       pluginId: observation.pluginId,
       backendSessionIds: observation.backendSessionIds.toList(growable: false),
     );
+    final bindings = {
+      for (final entry in storedBindings.entries)
+        if (_visibilityState.isPublished(sessionId: entry.value.sessionId)) entry.key: entry.value,
+    };
 
     ActiveSession? mapActiveSession(PluginActiveSession active) {
       final binding = bindings[active.id];
@@ -866,7 +1030,10 @@ class SessionRepository {
       projectId: result.project.projectId,
       generation: generation,
       kind: SessionBindingCommitKind.catalogSync,
-      backendSessionIds: result.committedByBackendId.keys.toList(growable: false),
+      backendSessionIds: [
+        for (final entry in result.committedByBackendId.entries)
+          if (_visibilityState.isPublished(sessionId: entry.value.sessionId)) entry.key,
+      ],
     );
     return result.project;
   }
@@ -883,7 +1050,7 @@ class SessionRepository {
     required String sessionId,
     required VerifiedGithubLogin? verifiedGithubLogin,
   }) async {
-    final row = await _sessionDao.getSession(sessionId: sessionId);
+    final row = await _getPublishedBinding(sessionId: sessionId);
     if (row == null || row.projectId != projectId) return null;
     return (await _mapCatalogSessions(
       rows: [row],
@@ -892,7 +1059,7 @@ class SessionRepository {
   }
 
   Future<String?> findProjectIdForSession({required String sessionId}) async {
-    return (await _sessionDao.getSession(sessionId: sessionId))?.projectId;
+    return (await _getPublishedBinding(sessionId: sessionId))?.projectId;
   }
 
   Future<void> notifySessionArchived({required String sessionId}) async {
@@ -943,7 +1110,9 @@ class SessionRepository {
             pluginId: pluginId,
             statuses: {
               for (final entry in pluginStatuses.entries)
-                if (bindings[entry.key] case final binding?) binding.sessionId: entry.value.toSharedSessionStatus(),
+                if (bindings[entry.key] case final binding?
+                    when _visibilityState.isPublished(sessionId: binding.sessionId))
+                  binding.sessionId: entry.value.toSharedSessionStatus(),
             },
           );
         } on Object {
@@ -1071,21 +1240,34 @@ class SessionRepository {
   }
 
   Future<List<Session>> getChildSessions({required String sessionId}) async {
-    if (await _sessionDao.getSession(sessionId: sessionId) == null) {
-      throw PluginOperationException.notFound(
-        SessionOperation.getChildSessions.name,
-        message: "session $sessionId was not found",
+    while (true) {
+      final visibility = _visibilityState.snapshot;
+      final binding = visibility.unpublishedSessionIds.contains(sessionId)
+          ? null
+          : await _sessionDao.getSession(sessionId: sessionId);
+      if (binding == null) {
+        throw PluginOperationException.notFound(
+          SessionOperation.getChildSessions.name,
+          message: "session $sessionId was not found",
+        );
+      }
+      final sessions = await _mapCatalogSessions(
+        rows: await _sessionDao.getChildCatalogSessions(
+          parentSessionId: sessionId,
+          excludedSessionIds: visibility.unpublishedSessionIds,
+        ),
+        verifiedGithubLogin: null,
       );
+      if (_visibilityState.isSnapshotCurrent(snapshot: visibility)) return sessions;
     }
-    return _mapCatalogSessions(
-      rows: await _sessionDao.getChildCatalogSessions(parentSessionId: sessionId),
-      verifiedGithubLogin: null,
-    );
   }
 
   Future<List<StoredSession>> getStoredSessionsByProjectId({required String projectId}) async {
     final sessions = await _sessionDao.getSessionsByProject(projectId: projectId);
-    return sessions.map((session) => session.toStoredSession()).toList(growable: false);
+    return [
+      for (final session in sessions)
+        if (_visibilityState.isPublished(sessionId: session.sessionId)) session.toStoredSession(),
+    ];
   }
 
   Future<bool> hasOtherActiveSessionsSharing({
@@ -1118,17 +1300,19 @@ class SessionRepository {
   }
 
   Future<StoredSession?> getStoredSession({required String sessionId}) async {
-    return (await _sessionDao.getSession(sessionId: sessionId))?.toStoredSession();
+    return (await _getPublishedBinding(sessionId: sessionId))?.toStoredSession();
   }
 
   Future<StoredSession?> getStoredSessionByBackendId({
     required String pluginId,
     required String backendSessionId,
   }) async {
-    return (await _sessionDao.getSessionByBinding(
+    final binding = await _sessionDao.getSessionByBinding(
       pluginId: pluginId,
       backendSessionId: backendSessionId,
-    ))?.toStoredSession();
+    );
+    if (binding == null || !_visibilityState.isPublished(sessionId: binding.sessionId)) return null;
+    return binding.toStoredSession();
   }
 
   Future<Map<String, StoredSession>> getStoredSessionsByBackendIds({
@@ -1140,7 +1324,8 @@ class SessionRepository {
       backendSessionIds: backendSessionIds,
     );
     return {
-      for (final entry in rows.entries) entry.key: entry.value.toStoredSession(),
+      for (final entry in rows.entries)
+        if (_visibilityState.isPublished(sessionId: entry.value.sessionId)) entry.key: entry.value.toStoredSession(),
     };
   }
 
@@ -1166,7 +1351,7 @@ class SessionRepository {
           pluginId: pluginId,
           backendSessionId: observed.id,
         );
-        if (binding == null) return null;
+        if (binding == null || !_visibilityState.isPublished(sessionId: binding.sessionId)) return null;
         _runtime.requireCurrentGeneration(
           pluginId: pluginId,
           generation: generation,
@@ -1187,6 +1372,7 @@ class SessionRepository {
         );
         if (!updated) return null;
         final stored = (await _sessionDao.getSession(sessionId: binding.sessionId))?.toStoredSession();
+        if (!_visibilityState.isPublished(sessionId: binding.sessionId)) return null;
         _runtime.requireCurrentGeneration(
           pluginId: pluginId,
           generation: generation,
@@ -1209,7 +1395,8 @@ class SessionRepository {
       generation: generation,
       operation: SessionOperation.insertObservedChild,
       commit: () => _sessionDao.attachedDatabase.transaction(() async {
-        if (parent.pluginId != pluginId ||
+        if (!_visibilityState.isPublished(sessionId: parent.id) ||
+            parent.pluginId != pluginId ||
             await _sessionDao.isSessionTombstoned(
               backendSessionId: observed.id,
               pluginId: pluginId,
@@ -1217,7 +1404,11 @@ class SessionRepository {
           return null;
         }
         final durableParent = await _sessionDao.getSession(sessionId: parent.id);
-        if (durableParent == null || durableParent.pluginId != pluginId) return null;
+        if (durableParent == null ||
+            !_visibilityState.isPublished(sessionId: durableParent.sessionId) ||
+            durableParent.pluginId != pluginId) {
+          return null;
+        }
         final existing = await _sessionDao.getSessionByBinding(
           pluginId: pluginId,
           backendSessionId: observed.id,
@@ -1300,7 +1491,7 @@ class SessionRepository {
   }
 
   Future<Session?> getCatalogSession({required String sessionId}) async {
-    final row = await _sessionDao.getSession(sessionId: sessionId);
+    final row = await _getPublishedBinding(sessionId: sessionId);
     if (row == null) return null;
     return (await _mapCatalogSessions(
       rows: [row],
@@ -1415,7 +1606,7 @@ class SessionRepository {
     required String sessionId,
     required SessionOperation operation,
   }) async {
-    final binding = await _sessionDao.getSession(sessionId: sessionId);
+    final binding = await _getPublishedBinding(sessionId: sessionId);
     if (binding == null) {
       throw PluginOperationException.notFound(
         operation.name,
@@ -1423,6 +1614,27 @@ class SessionRepository {
       );
     }
     return binding;
+  }
+
+  Future<SessionDto?> _getPublishedBinding({required String sessionId}) async {
+    if (!_visibilityState.isPublished(sessionId: sessionId)) return null;
+    final binding = await _sessionDao.getSession(sessionId: sessionId);
+    if (binding == null || !_visibilityState.isPublished(sessionId: sessionId)) return null;
+    return binding;
+  }
+
+  SessionDto _requireInitialBinding({required UnpublishedSessionBinding binding}) {
+    _verifyInitialBindingOwner(binding: binding);
+    if (!binding._visibilityReservation.isActive) {
+      throw StateError("Initial session binding is no longer unpublished");
+    }
+    return binding._binding;
+  }
+
+  void _verifyInitialBindingOwner({required UnpublishedSessionBinding binding}) {
+    if (!identical(binding._repository, this)) {
+      throw StateError("Initial session binding belongs to another repository");
+    }
   }
 
   static final Random _secureRandom = Random.secure();

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -57,7 +57,7 @@ enum SessionBindingCommitKind { sessionCreation, catalogSync }
 typedef SessionBindingsCommitted = ({
   String pluginId,
   String projectId,
-  int generation,
+  int? generation,
   SessionBindingCommitKind kind,
   List<String> backendSessionIds,
 });
@@ -69,17 +69,17 @@ final class UnpublishedSessionBinding {
     required SessionRepository repository,
     required SessionDto binding,
     required this.session,
-    required int generation,
     required UnpublishedSessionReservation visibilityReservation,
+    required SessionCreationReservation creationReservation,
   }) : _repository = repository,
        _binding = binding,
-       _generation = generation,
-       _visibilityReservation = visibilityReservation;
+       _visibilityReservation = visibilityReservation,
+       _creationReservation = creationReservation;
 
   final SessionRepository _repository;
   final SessionDto _binding;
-  final int _generation;
   final UnpublishedSessionReservation _visibilityReservation;
+  final SessionCreationReservation _creationReservation;
   final Session session;
 
   SessionFamilyScope get familyScope => (rootSessionId: _binding.sessionId, pluginId: _binding.pluginId);
@@ -235,6 +235,7 @@ class SessionRepository {
       pluginId: pluginId,
     );
     UnpublishedSessionReservation? visibilityReservation;
+    UnpublishedSessionBinding? durableBinding;
     try {
       final result = await _runtime.useAndCommit(
         pluginId: pluginId,
@@ -253,7 +254,7 @@ class SessionRepository {
             },
           );
         },
-        commit: (created, generation) => _visibilityState.withSessionCreationCommit(
+        commit: (created, _) => _visibilityState.withSessionCreationCommit(
           reservation: creationReservation,
           body: () async {
             final projectionUpdatedAt = captureProjectionTimestamp();
@@ -282,6 +283,10 @@ class SessionRepository {
               );
             }
             visibilityReservation = unpublished;
+            final session = created.toSharedSessionWithId(
+              sessionId: sessionId,
+              pluginId: pluginId,
+            );
             late SessionDto committedBinding;
             await _sessionDao.attachedDatabase.transaction(() async {
               await _projectsDao.insertProjectsIfMissing(projectIds: [projectId]);
@@ -307,56 +312,67 @@ class SessionRepository {
                 updatedAt: updatedAt,
                 projectionUpdatedAt: projectionUpdatedAt,
               );
-              committedBinding = (await _sessionDao.getSession(sessionId: sessionId))!;
+              final inserted = await _sessionDao.getSession(sessionId: sessionId);
+              if (inserted == null) {
+                throw StateError("Created session $sessionId was not found after insertion");
+              }
+              committedBinding = inserted;
             });
-            return (
-              created: created,
+            final binding = UnpublishedSessionBinding._(
+              repository: this,
               binding: committedBinding,
-              generation: generation,
+              session: session,
               visibilityReservation: unpublished,
+              creationReservation: creationReservation,
             );
+            durableBinding = binding;
+            return binding;
           },
         ),
       );
-      return UnpublishedSessionBinding._(
-        repository: this,
-        binding: result.binding,
-        session: result.created.toSharedSessionWithId(
-          sessionId: result.binding.sessionId,
-          pluginId: pluginId,
-        ),
-        generation: result.generation,
-        visibilityReservation: result.visibilityReservation,
-      );
+      return result;
     } on Object {
-      final unpublished = visibilityReservation;
-      if (unpublished != null) {
-        _visibilityState.completeUnpublishedSession(
-          reservation: unpublished,
-        );
+      final committed = durableBinding;
+      if (committed != null) {
+        revealSession(binding: committed);
+      } else {
+        final unpublished = visibilityReservation;
+        try {
+          if (unpublished != null) {
+            _visibilityState.completeUnpublishedSession(
+              reservation: unpublished,
+            );
+          }
+        } finally {
+          _visibilityState.releaseSessionCreation(
+            reservation: creationReservation,
+          );
+        }
       }
       rethrow;
-    } finally {
-      _visibilityState.releaseSessionCreation(
-        reservation: creationReservation,
-      );
     }
   }
 
   void revealSession({required UnpublishedSessionBinding binding}) {
     _verifyInitialBindingOwner(binding: binding);
-    if (!_visibilityState.completeUnpublishedSession(
-      reservation: binding._visibilityReservation,
-    )) {
-      return;
+    try {
+      if (!_visibilityState.completeUnpublishedSession(
+        reservation: binding._visibilityReservation,
+      )) {
+        return;
+      }
+      _publishBindingsCommitted(
+        pluginId: binding._binding.pluginId,
+        projectId: binding._binding.projectId,
+        generation: null,
+        kind: SessionBindingCommitKind.sessionCreation,
+        backendSessionIds: [binding._binding.backendSessionId],
+      );
+    } finally {
+      _visibilityState.releaseSessionCreation(
+        reservation: binding._creationReservation,
+      );
     }
-    _publishBindingsCommitted(
-      pluginId: binding._binding.pluginId,
-      projectId: binding._binding.projectId,
-      generation: binding._generation,
-      kind: SessionBindingCommitKind.sessionCreation,
-      backendSessionIds: [binding._binding.backendSessionId],
-    );
   }
 
   Future<Session> renameSession({required String sessionId, required String title}) async {
@@ -741,18 +757,20 @@ class SessionRepository {
             generation: generation,
             operation: SessionOperation.getProjectActivitySummaries,
           );
-          await _visibilityState.withCatalogWrite(
-            pluginId: pluginId,
-            body: () => _runtime.commitCurrentGeneration(
+          if (observation.hydrations.isNotEmpty) {
+            await _visibilityState.withCatalogWrite(
               pluginId: pluginId,
-              generation: generation,
-              operation: SessionOperation.getProjectActivitySummaries,
-              commit: () => _persistActiveRootHydrations(
-                observation: observation,
+              body: () => _runtime.commitCurrentGeneration(
+                pluginId: pluginId,
                 generation: generation,
+                operation: SessionOperation.getProjectActivitySummaries,
+                commit: () => _persistActiveRootHydrations(
+                  observation: observation,
+                  generation: generation,
+                ),
               ),
-            ),
-          );
+            );
+          }
           return _mapPluginProjectActivitySummaries(observation: observation);
         } on Object catch (error, stackTrace) {
           Log.w("Could not read activity summaries from plugin $pluginId", error, stackTrace);
@@ -1651,7 +1669,7 @@ class SessionRepository {
   void _publishBindingsCommitted({
     required String pluginId,
     required String projectId,
-    required int generation,
+    required int? generation,
     required SessionBindingCommitKind kind,
     required List<String> backendSessionIds,
   }) {

--- a/bridge/app/lib/src/bridge/repositories/session_unseen_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_unseen_repository.dart
@@ -1,4 +1,5 @@
 import "../../api/database/daos/session_dao.dart";
+import "../foundation/session_visibility_state.dart";
 import "session_unseen_calculator.dart";
 
 /// The unseen-relevant timestamps for a single session, plus its project id.
@@ -19,18 +20,22 @@ typedef UnseenRow = ({
 class SessionUnseenRepository {
   final SessionDao _sessionDao;
   final SessionUnseenCalculator _calculator;
+  final SessionVisibilityState _visibilityState;
 
   SessionUnseenRepository({
     required SessionDao sessionDao,
     required SessionUnseenCalculator calculator,
+    required SessionVisibilityState visibilityState,
   }) : _sessionDao = sessionDao,
-       _calculator = calculator;
+       _calculator = calculator,
+       _visibilityState = visibilityState;
 
   /// Returns the unseen timestamps + project id for [sessionId], or null when
   /// the session has no persisted row.
   Future<UnseenRow?> getUnseenRow({required String sessionId}) async {
+    if (!isPublished(sessionId: sessionId)) return null;
     final dto = await _sessionDao.getSession(sessionId: sessionId);
-    if (dto == null) return null;
+    if (dto == null || !isPublished(sessionId: sessionId)) return null;
     return (
       projectId: dto.projectId,
       userMessageAt: dto.lastUserMessageAt,
@@ -48,8 +53,9 @@ class SessionUnseenRepository {
     required int at,
     required bool isUserMessage,
     required bool advanceSeen,
-  }) async {
-    await _sessionDao.setActivityTimestamps(
+  }) {
+    if (!isPublished(sessionId: sessionId)) return Future<void>.value();
+    return _sessionDao.setActivityTimestamps(
       sessionId: sessionId,
       activityAt: at,
       userMessageAt: isUserMessage ? at : null,
@@ -62,11 +68,13 @@ class SessionUnseenRepository {
   /// recorded without touching the activity/seen timeline, so a re-emitted
   /// (old) user message can never clear unseen activity.
   Future<void> recordUserMessage({required String sessionId, required int at}) {
+    if (!isPublished(sessionId: sessionId)) return Future<void>.value();
     return _sessionDao.setUserMessageAt(sessionId: sessionId, userMessageAt: at);
   }
 
   /// Marks [sessionId] seen as of [at] ("Mark as Read" / viewing).
   Future<void> markSessionSeen({required String sessionId, required int at}) {
+    if (!isPublished(sessionId: sessionId)) return Future<void>.value();
     return _sessionDao.setSeenAt(sessionId: sessionId, seenAt: at);
   }
 
@@ -74,6 +82,7 @@ class SessionUnseenRepository {
   /// clearing `last_seen_at` alone, this reliably bolds even baseline sessions
   /// and sessions whose latest activity was the user's own message.
   Future<void> markSessionUnseen({required String sessionId, required int at}) {
+    if (!isPublished(sessionId: sessionId)) return Future<void>.value();
     return _sessionDao.forceUnseen(sessionId: sessionId, activityAt: at);
   }
 
@@ -81,7 +90,12 @@ class SessionUnseenRepository {
   /// a stale unseen row can't keep its project's aggregate bold). No-op if the
   /// row doesn't exist.
   Future<void> deleteSession({required String sessionId}) {
+    if (!isPublished(sessionId: sessionId)) return Future<void>.value();
     return _sessionDao.deleteSession(sessionId: sessionId);
+  }
+
+  bool isPublished({required String sessionId}) {
+    return _visibilityState.isPublished(sessionId: sessionId);
   }
 
   /// Whether [sessionId] currently has unseen changes.

--- a/bridge/app/lib/src/bridge/services/session_creation_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_creation_service.dart
@@ -6,22 +6,26 @@ import "../models/session_metadata.dart" as bridge_metadata;
 import "../repositories/models/session_operation.dart";
 import "../repositories/session_repository.dart";
 import "session_mutation_dispatcher.dart";
+import "session_operation_dispatcher.dart";
 import "worktree_service.dart";
 
 class SessionCreationService {
   final MetadataService _metadataService;
   final WorktreeService _worktreeService;
   final SessionRepository _sessionRepository;
+  final SessionOperationDispatcher _sessionOperationDispatcher;
   final SessionMutationDispatcher _sessionMutationDispatcher;
 
   SessionCreationService({
     required MetadataService metadataService,
     required WorktreeService worktreeService,
     required SessionRepository sessionRepository,
+    required SessionOperationDispatcher sessionOperationDispatcher,
     required SessionMutationDispatcher sessionMutationDispatcher,
   }) : _metadataService = metadataService,
        _worktreeService = worktreeService,
        _sessionRepository = sessionRepository,
+       _sessionOperationDispatcher = sessionOperationDispatcher,
        _sessionMutationDispatcher = sessionMutationDispatcher;
 
   Future<Session> createSession({required CreateSessionRequest request}) async {
@@ -45,11 +49,10 @@ class SessionCreationService {
       dedicatedWorktree: request.dedicatedWorktree,
       worktreeResult: worktreeResult,
     );
-    final created = await _sessionRepository.createSession(
+    final binding = await _sessionRepository.createSession(
       pluginId: request.pluginId,
       projectId: request.projectId,
       directory: _resolveDirectory(projectDirectory: projectDirectory, worktreeResult: worktreeResult),
-      parentSessionId: null,
       parts: _buildPromptParts(
         parts: request.parts,
         worktreeResult: worktreeResult,
@@ -73,19 +76,24 @@ class SessionCreationService {
             )
           : null,
     );
-    await _maybeSendCommand(
-      session: created,
-      command: normalizedCommand,
-      arguments: _buildCommandArguments(
-        userArguments: firstText ?? '',
-        worktreeResult: worktreeResult,
-      ),
-      userVisibleArguments: firstText,
-      variant: request.variant,
-      agent: request.agent,
-      model: request.model,
-    );
-    final finalSession = await _maybeRenameSession(session: created, metadata: metadata);
+    var finalSession = binding.session;
+    try {
+      await _maybeSendCommand(
+        binding: binding,
+        command: normalizedCommand,
+        arguments: _buildCommandArguments(
+          userArguments: firstText ?? '',
+          worktreeResult: worktreeResult,
+        ),
+        userVisibleArguments: firstText,
+        variant: request.variant,
+        agent: request.agent,
+        model: request.model,
+      );
+      finalSession = await _maybeRenameSession(binding: binding, metadata: metadata);
+    } finally {
+      _sessionRepository.revealSession(binding: binding);
+    }
     // The plugin only knows the directory the session was created in, so for
     // a moved project it echoes the live path (or its own internal id) as the
     // session's projectID. Re-key the response to the stable identifier the
@@ -177,21 +185,28 @@ class SessionCreationService {
   }
 
   Future<Session> _maybeRenameSession({
-    required Session session,
+    required UnpublishedSessionBinding binding,
     required bridge_metadata.SessionMetadata? metadata,
   }) async {
     if (metadata?.title case final title?) {
       try {
-        return await _sessionMutationDispatcher.renameSession(sessionId: session.id, title: title);
-      } catch (e) {
-        Log.w("Failed to rename session ${session.id}: $e");
+        return await _sessionMutationDispatcher.renameInitialSession(
+          binding: binding,
+          title: title,
+        );
+      } on Object catch (error, stackTrace) {
+        Log.w(
+          "Failed to apply initial metadata title for session ${binding.session.id}",
+          error,
+          stackTrace,
+        );
       }
     }
-    return session;
+    return binding.session;
   }
 
   Future<void> _maybeSendCommand({
-    required Session session,
+    required UnpublishedSessionBinding binding,
     required String? command,
     required String arguments,
     required String? userVisibleArguments,
@@ -202,14 +217,17 @@ class SessionCreationService {
     if (command == null) {
       return;
     }
-    await _sessionRepository.sendCommand(
-      sessionId: session.id,
-      command: command,
-      arguments: arguments,
-      userVisibleArguments: userVisibleArguments,
-      variant: variant,
-      agent: agent,
-      model: model,
+    await _sessionOperationDispatcher.dispatchInitial(
+      binding: binding,
+      body: () => _sessionRepository.sendInitialCommand(
+        binding: binding,
+        command: command,
+        arguments: arguments,
+        userVisibleArguments: userVisibleArguments,
+        variant: variant,
+        agent: agent,
+        model: model,
+      ),
     );
   }
 

--- a/bridge/app/lib/src/bridge/services/session_event_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_event_service.dart
@@ -15,7 +15,7 @@ typedef SourcedBridgeEvent = ({
   int projectionUpdatedAt,
   BridgeSseEvent event,
 });
-typedef NormalizedRuntimeEvent = ({int generation, BridgeSseEvent event});
+typedef NormalizedRuntimeEvent = ({int? generation, BridgeSseEvent event});
 typedef _ProjectedSession = ({StoredSession binding, bool inserted});
 
 class SessionEventService {
@@ -195,12 +195,8 @@ class SessionEventService {
         ),
       );
     }
-    if (commit.kind == SessionBindingCommitKind.sessionCreation &&
-        isCurrentGeneration(
-          pluginId: commit.pluginId,
-          generation: commit.generation,
-        )) {
-      output.add((generation: commit.generation, event: const BridgeSseProjectUpdated()));
+    if (commit.kind == SessionBindingCommitKind.sessionCreation) {
+      output.add((generation: null, event: const BridgeSseProjectUpdated()));
     }
     return output;
   }

--- a/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
@@ -34,6 +34,27 @@ class SessionMutationDispatcher {
     );
   }
 
+  Future<Session> renameInitialSession({
+    required UnpublishedSessionBinding binding,
+    required String title,
+  }) {
+    if (_disposed) return Future.error(StateError("SessionMutationDispatcher is disposed"));
+    return _sessionOperationDispatcher.dispatchInitial(
+      binding: binding,
+      body: () async {
+        final renamed = await _sessionRepository.setInitialSessionTitle(
+          binding: binding,
+          title: title,
+        );
+        await _propagateTitle(
+          sessionId: binding.session.id,
+          propagate: () => _sessionRepository.renameInitialSession(binding: binding, title: title),
+        );
+        return renamed;
+      },
+    );
+  }
+
   Future<CleanupResult> deleteSession({
     required String sessionId,
     required Future<CleanupResult> Function() cleanup,
@@ -67,16 +88,19 @@ class SessionMutationDispatcher {
         message: "session $sessionId was not found",
       );
     }
-    await _propagateTitle(sessionId: sessionId, title: title);
+    await _propagateTitle(
+      sessionId: sessionId,
+      propagate: () => _sessionRepository.renameSession(sessionId: sessionId, title: title),
+    );
     return renamed;
   }
 
   Future<void> _propagateTitle({
     required String sessionId,
-    required String title,
+    required Future<Object?> Function() propagate,
   }) async {
     try {
-      await _sessionRepository.renameSession(sessionId: sessionId, title: title);
+      await propagate();
     } catch (error, stackTrace) {
       Log.w("Could not propagate title for session $sessionId to its plugin", error, stackTrace);
     }

--- a/bridge/app/lib/src/bridge/services/session_operation_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/services/session_operation_dispatcher.dart
@@ -86,6 +86,40 @@ class SessionOperationDispatcher {
     return result.future;
   }
 
+  Future<T> dispatchInitial<T>({
+    required UnpublishedSessionBinding binding,
+    required Future<T> Function() body,
+  }) {
+    if (!_accepting) throw _closedError();
+
+    final ticket = _nextTicket++;
+    final result = Completer<T>();
+    _track(result: result);
+    _enqueueResolution(
+      ticket: ticket,
+      action: () {
+        final family = binding.familyScope;
+        _enqueuePluginAdmission(
+          pluginId: family.pluginId,
+          ticket: ticket,
+          action: () {
+            _registerOperation(
+              ticket: ticket,
+              family: family,
+              ownerSessionId: family.rootSessionId,
+              interaction: null,
+              body: body,
+              result: result,
+            );
+          },
+          onError: result.completeError,
+        );
+      },
+      onError: result.completeError,
+    );
+    return result.future;
+  }
+
   /// Queues a sessionless question ticket synchronously. Its plugin admission
   /// waits for prior plugin work, then blocks later admissions while resolving.
   Future<T> dispatchLegacyQuestion<T>({

--- a/bridge/app/lib/src/bridge/services/session_options_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_options_service.dart
@@ -175,17 +175,40 @@ class SessionOptionsService {
     if (!_repository.isCurrentGeneration(pluginId: pluginId, generation: generation)) {
       return const SessionOptionsAutomaticNoOp();
     }
+    return _refreshActiveProject(
+      pluginId: pluginId,
+      projectId: projectId,
+      expectedGeneration: generation,
+    );
+  }
+
+  Future<SessionOptionsOutcome> refreshCurrentActiveOnly({
+    required String pluginId,
+    required String projectId,
+  }) {
+    return _refreshActiveProject(
+      pluginId: pluginId,
+      projectId: projectId,
+      expectedGeneration: null,
+    );
+  }
+
+  Future<SessionOptionsOutcome> _refreshActiveProject({
+    required String pluginId,
+    required String projectId,
+    required int? expectedGeneration,
+  }) async {
     final resolved = await _resolve(pluginId: pluginId, projectId: projectId);
     if (resolved == null) return const SessionOptionsProjectNotFound();
     return _coalesce(
       key: resolved.key,
       intent: _RefreshIntent.reuse,
-      generation: generation,
+      generation: expectedGeneration,
       operation: () => _refresh(
         resolved: resolved,
         activation: SessionOptionsCaptureActivation.activeOnly,
         discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
-        expectedGeneration: generation,
+        expectedGeneration: expectedGeneration,
         automatic: true,
       ),
     );

--- a/bridge/app/lib/src/bridge/services/session_unseen_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_unseen_service.dart
@@ -300,6 +300,7 @@ class SessionUnseenService {
   /// cleared per-session state plus the recomputed project aggregate.
   Future<void> _deleteRowAndEmit({required String sessionId, required String projectId}) async {
     await _unseenRepository.deleteSession(sessionId: sessionId);
+    if (!_unseenRepository.isPublished(sessionId: sessionId)) return;
     await _emitDeleted(sessionId: sessionId, projectId: projectId);
   }
 
@@ -307,6 +308,7 @@ class SessionUnseenService {
   /// `unseen: false` plus the recomputed project aggregate. Best-effort.
   Future<void> _emitDeleted({required String sessionId, required String projectId}) async {
     try {
+      if (!_unseenRepository.isPublished(sessionId: sessionId)) return;
       final projectHasUnseen = await _projectRepository.projectHasUnseenChanges(projectId: projectId);
       _add(projectId: projectId, sessionId: sessionId, unseen: false, projectHasUnseenChanges: projectHasUnseen);
     } catch (error, stackTrace) {
@@ -319,6 +321,7 @@ class SessionUnseenService {
   /// committed (or that is fire-and-forget from the SSE path).
   Future<void> _emit({required String sessionId, required String projectId}) async {
     try {
+      if (!_unseenRepository.isPublished(sessionId: sessionId)) return;
       final unseen = await _unseenRepository.isUnseen(sessionId: sessionId);
       final projectHasUnseen = await _projectRepository.projectHasUnseenChanges(projectId: projectId);
       _add(projectId: projectId, sessionId: sessionId, unseen: unseen, projectHasUnseenChanges: projectHasUnseen);
@@ -333,7 +336,7 @@ class SessionUnseenService {
     required bool unseen,
     required bool projectHasUnseenChanges,
   }) {
-    if (_changes.isClosed) return;
+    if (_changes.isClosed || !_unseenRepository.isPublished(sessionId: sessionId)) return;
     _changes.add(
       (
         projectId: projectId,

--- a/bridge/app/lib/src/listeners/session_options_creation_refresh_listener.dart
+++ b/bridge/app/lib/src/listeners/session_options_creation_refresh_listener.dart
@@ -47,10 +47,9 @@ class SessionOptionsCreationRefreshListener {
 
   Future<void> _refresh({required SessionBindingsCommitted commit}) async {
     try {
-      final outcome = await _service.refreshActiveOnly(
+      final outcome = await _service.refreshCurrentActiveOnly(
         pluginId: commit.pluginId,
         projectId: commit.projectId,
-        generation: commit.generation,
       );
       switch (outcome) {
         case SessionOptionsAvailable() ||

--- a/bridge/app/lib/src/repositories/catalog_import_repository.dart
+++ b/bridge/app/lib/src/repositories/catalog_import_repository.dart
@@ -91,7 +91,12 @@ class CatalogImportRepository {
                   generation: ready.generation,
                   operation: _CatalogOperation.importCatalog,
                 );
-                result = await _publishCatalog(observation: ready, control: control);
+                final publication = await _publishCatalog(observation: ready, control: control);
+                if (publication == null) {
+                  yield CatalogImportProgress.cancelled(pluginId: pluginId);
+                } else {
+                  result = publication;
+                }
               }
             } finally {
               if (!publicationFinished.isCompleted) publicationFinished.complete();
@@ -321,7 +326,7 @@ class CatalogImportRepository {
     await publicationFinished;
   }
 
-  Future<_CatalogPublication> _publishCatalog({
+  Future<_CatalogPublication?> _publishCatalog({
     required _CatalogImportObservation observation,
     required CatalogImportControl control,
   }) async {
@@ -476,7 +481,10 @@ class CatalogImportRepository {
     );
     return _visibilityState.withCatalogWrite(
       pluginId: pluginId,
-      body: commit,
+      body: () async {
+        if (control.cancellationRequested) return null;
+        return commit();
+      },
     );
   }
 

--- a/bridge/app/lib/src/repositories/catalog_import_repository.dart
+++ b/bridge/app/lib/src/repositories/catalog_import_repository.dart
@@ -12,9 +12,12 @@ import "../api/database/daos/session_dao.dart";
 import "../api/database/tables/catalog_hydrations_table.dart";
 import "../api/database/tables/projects_table.dart";
 import "../api/database/tables/session_table.dart";
+import "../bridge/foundation/session_visibility_state.dart";
 import "../bridge/runtime/plugin_runtime.dart";
 import "models/catalog_import_control.dart";
 import "project_catalog_identity_calculator.dart";
+
+typedef _CatalogPublication = ({int projectsImported, int sessionsImported, int completedAt});
 
 class CatalogImportRepository {
   CatalogImportRepository({
@@ -23,11 +26,13 @@ class CatalogImportRepository {
     required SessionDao sessionDao,
     required CatalogHydrationsDao catalogHydrationsDao,
     required ProjectCatalogIdentityCalculator projectCatalogIdentityCalculator,
+    required SessionVisibilityState visibilityState,
   }) : _runtime = runtime,
        _projectsDao = projectsDao,
        _sessionDao = sessionDao,
        _catalogHydrationsDao = catalogHydrationsDao,
-       _projectCatalogIdentityCalculator = projectCatalogIdentityCalculator;
+       _projectCatalogIdentityCalculator = projectCatalogIdentityCalculator,
+       _visibilityState = visibilityState;
 
   static const int projectionVersion = 1;
   static const int _responsivenessBatchSize = 512;
@@ -38,6 +43,7 @@ class CatalogImportRepository {
   final SessionDao _sessionDao;
   final CatalogHydrationsDao _catalogHydrationsDao;
   final ProjectCatalogIdentityCalculator _projectCatalogIdentityCalculator;
+  final SessionVisibilityState _visibilityState;
 
   Set<String> get eligiblePluginIds => _runtime.eligiblePluginIds;
   Set<String> get importEligiblePluginIds => _runtime.startAllowedPluginIds;
@@ -315,10 +321,10 @@ class CatalogImportRepository {
     await publicationFinished;
   }
 
-  Future<({int projectsImported, int sessionsImported, int completedAt})> _publishCatalog({
+  Future<_CatalogPublication> _publishCatalog({
     required _CatalogImportObservation observation,
     required CatalogImportControl control,
-  }) {
+  }) async {
     final pluginId = observation.pluginId;
     final observedProjects = observation.observedProjects;
     final observedSessions = observation.observedSessions;
@@ -332,7 +338,8 @@ class CatalogImportRepository {
       );
     }
 
-    return _runtime.commitCurrentGeneration(
+    // ignore: prefer_function_declarations_over_variables
+    final Future<_CatalogPublication> Function() commit = () => _runtime.commitCurrentGeneration(
       pluginId: pluginId,
       generation: observation.generation,
       operation: _CatalogOperation.importCatalog,
@@ -467,6 +474,10 @@ class CatalogImportRepository {
           completedAt: completedAt,
         );
       }),
+    );
+    return _visibilityState.withCatalogWrite(
+      pluginId: pluginId,
+      body: commit,
     );
   }
 

--- a/bridge/app/lib/src/repositories/catalog_import_repository.dart
+++ b/bridge/app/lib/src/repositories/catalog_import_repository.dart
@@ -338,8 +338,7 @@ class CatalogImportRepository {
       );
     }
 
-    // ignore: prefer_function_declarations_over_variables
-    final Future<_CatalogPublication> Function() commit = () => _runtime.commitCurrentGeneration(
+    Future<_CatalogPublication> commit() => _runtime.commitCurrentGeneration(
       pluginId: pluginId,
       generation: observation.generation,
       operation: _CatalogOperation.importCatalog,

--- a/bridge/app/test/bridge/foundation/session_visibility_state_test.dart
+++ b/bridge/app/test/bridge/foundation/session_visibility_state_test.dart
@@ -1,0 +1,34 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/bridge/foundation/session_visibility_state.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("creation blocks only later same-plugin catalog writers", () async {
+    final state = SessionVisibilityState();
+    final creation = state.reserveSessionCreation(pluginId: "reserved");
+    final entered = Completer<void>();
+    final reservedWrite = state.withCatalogWrite(pluginId: "reserved", body: () async => entered.complete());
+    await state.withCatalogWrite(pluginId: "unrelated", body: () async {});
+    expect(entered.isCompleted, isFalse);
+    state.releaseSessionCreation(reservation: creation);
+    await reservedWrite;
+  });
+
+  test("creation commit drains a catalog writer that acquired first", () async {
+    final state = SessionVisibilityState();
+    final releaseWrite = Completer<void>();
+    final catalogWrite = state.withCatalogWrite(pluginId: "plugin", body: () => releaseWrite.future);
+    await Future<void>.delayed(Duration.zero);
+    final creation = state.reserveSessionCreation(pluginId: "plugin");
+    var committed = false;
+    final commitFuture = state.withSessionCreationCommit(reservation: creation, body: () async => committed = true);
+    await Future<void>.delayed(Duration.zero);
+    expect(committed, isFalse);
+    releaseWrite.complete();
+    await catalogWrite;
+    await commitFuture;
+    expect(committed, isTrue);
+    state.releaseSessionCreation(reservation: creation);
+  });
+}

--- a/bridge/app/test/bridge/foundation/session_visibility_state_test.dart
+++ b/bridge/app/test/bridge/foundation/session_visibility_state_test.dart
@@ -31,4 +31,20 @@ void main() {
     expect(committed, isTrue);
     state.releaseSessionCreation(reservation: creation);
   });
+
+  test("creation release is idempotent", () async {
+    final state = SessionVisibilityState();
+    final released = state.reserveSessionCreation(pluginId: "plugin");
+    state.releaseSessionCreation(reservation: released);
+    state.releaseSessionCreation(reservation: released);
+    final active = state.reserveSessionCreation(pluginId: "plugin");
+    var writeEntered = false;
+    final write = state.withCatalogWrite(pluginId: "plugin", body: () async => writeEntered = true);
+
+    await Future<void>.delayed(Duration.zero);
+    expect(writeEntered, isFalse);
+    state.releaseSessionCreation(reservation: active);
+    await write;
+    expect(writeEntered, isTrue);
+  });
 }

--- a/bridge/app/test/bridge/persistence/catalog_queries_test.dart
+++ b/bridge/app/test/bridge/persistence/catalog_queries_test.dart
@@ -105,6 +105,7 @@ void main() {
       projectId: "project-1",
       offset: 0,
       limit: 10,
+      excludedSessionIds: const [],
     );
     expect(roots.map((row) => row.sessionId), ["root-new", "root-old"]);
     expect(
@@ -112,12 +113,14 @@ void main() {
         projectId: "project-1",
         offset: 1,
         limit: null,
+        excludedSessionIds: const [],
       )).map((row) => row.sessionId),
       ["root-old"],
     );
     expect(
       (await db.sessionDao.getChildCatalogSessions(
         parentSessionId: "root-new",
+        excludedSessionIds: const [],
       )).single.sessionId,
       "child",
     );

--- a/bridge/app/test/bridge/repositories/project_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_repository_test.dart
@@ -3,6 +3,7 @@ import "dart:async";
 import "package:sesori_bridge/src/api/database/daos/projects_dao.dart";
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/api/database/tables/projects_table.dart";
+import "package:sesori_bridge/src/bridge/foundation/session_visibility_state.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/project_activity.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/project_not_found_exception.dart";
 import "package:sesori_bridge/src/bridge/repositories/project_activity_repository.dart";
@@ -124,6 +125,7 @@ void main() {
         filesystemApi: FakeFilesystemApi(),
         gitCliApi: FakeGitCliApi(),
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
+        visibilityState: SessionVisibilityState(),
       );
 
       final projects = await zeroPluginRepository.getProjects();

--- a/bridge/app/test/bridge/repositories/project_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_repository_test.dart
@@ -273,6 +273,7 @@ void main() {
         sessionDao: db.sessionDao,
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
         aggregateSourceDeadline: const Duration(seconds: 5),
+        visibilityState: SessionVisibilityState(),
       );
 
       final reconciliation = generationAwareActivityRepo.listProjectActivityEvidence(pluginId: plugin.id);
@@ -306,6 +307,7 @@ void main() {
         sessionDao: db.sessionDao,
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
         aggregateSourceDeadline: const Duration(seconds: 5),
+        visibilityState: SessionVisibilityState(),
       );
       runtime.generationCurrent = false;
 
@@ -831,21 +833,25 @@ void main() {
     late _FakeDerivedPlugin plugin;
     late ProjectRepository repo;
     late ProjectActivityRepository activityRepo;
+    late SessionVisibilityState visibilityState;
 
     setUp(() {
       db = createTestDatabase();
       plugin = _FakeDerivedPlugin([]);
+      visibilityState = SessionVisibilityState();
       repo = singlePluginProjectRepository(
         gitCliApi: FakeGitCliApi(),
         projectsDao: db.projectsDao,
         sessionDao: db.sessionDao,
         unseenCalculator: const SessionUnseenCalculator(),
         filesystemApi: FakeFilesystemApi(),
+        visibilityState: visibilityState,
       );
       activityRepo = singlePluginProjectActivityRepository(
         plugin: plugin,
         projectsDao: db.projectsDao,
         sessionDao: db.sessionDao,
+        visibilityState: visibilityState,
       );
     });
 
@@ -940,6 +946,40 @@ void main() {
       final observation = await activityRepo.listProjectActivityEvidence(pluginId: plugin.id);
 
       expect(observation!.evidence.map((e) => e.projectId), isNot(contains("/tmp/proj/deleted-only")));
+    });
+
+    test("derived activity excludes unpublished stored bindings from hints and evidence", () async {
+      const project = "/tmp/proj/alpha";
+      const worktree = "/tmp/proj/alpha/.worktrees/hidden";
+      await db.projectsDao.recordOpenedProject(
+        projectId: project,
+        path: project,
+        displayName: null,
+        createdAt: 1,
+        updatedAt: 2,
+      );
+      await db.sessionDao.insertSession(
+        sessionId: "stable-hidden",
+        backendSessionId: "backend-hidden",
+        pluginId: plugin.id,
+        projectId: project,
+        isDedicated: true,
+        createdAt: 1,
+        worktreePath: worktree,
+        branchName: "hidden",
+        baseBranch: "main",
+        baseCommit: null,
+        lastAgent: null,
+        lastAgentModel: null,
+      );
+      visibilityState.beginUnpublishedSession(sessionId: "stable-hidden");
+      plugin.sessions = [_session(worktree, id: "backend-hidden", created: 10, updated: 20)];
+
+      final observation = await activityRepo.listProjectActivityEvidence(pluginId: plugin.id);
+
+      expect(plugin.receivedKnownDirectories, contains(project));
+      expect(plugin.receivedKnownDirectories, isNot(contains(worktree)));
+      expect(observation!.evidence, isEmpty);
     });
 
     test("derived activity uses the stored native project identity for the same directory", () async {

--- a/bridge/app/test/bridge/repositories/question_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/question_repository_test.dart
@@ -2,6 +2,7 @@ import "dart:async";
 import "dart:io";
 
 import "package:sesori_bridge/src/api/database/database.dart";
+import "package:sesori_bridge/src/bridge/foundation/session_visibility_state.dart";
 import "package:sesori_bridge/src/bridge/repositories/question_repository.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
@@ -164,6 +165,7 @@ void main() {
         sessionDao: db.sessionDao,
         projectsDao: db.projectsDao,
         aggregateSourceDeadline: const Duration(milliseconds: 20),
+        visibilityState: SessionVisibilityState(),
       );
       final previousLogLevel = Log.level;
       final logs = <String>[];
@@ -206,6 +208,7 @@ void main() {
         sessionDao: db.sessionDao,
         projectsDao: db.projectsDao,
         aggregateSourceDeadline: const Duration(milliseconds: 20),
+        visibilityState: SessionVisibilityState(),
       );
 
       expect(await repository.getProjectQuestions(projectId: projectId), isEmpty);
@@ -227,6 +230,7 @@ void main() {
         sessionDao: db.sessionDao,
         projectsDao: db.projectsDao,
         aggregateSourceDeadline: const Duration(milliseconds: 20),
+        visibilityState: SessionVisibilityState(),
       );
 
       await expectLater(
@@ -516,6 +520,14 @@ void main() {
         projectId: "/repo",
         parentStableId: "stable-root",
       );
+      await recordSession(
+        stableId: "stable-hidden",
+        backendId: "hidden-child",
+        projectId: "/repo",
+        parentStableId: "stable-root",
+      );
+      final visibilityState = SessionVisibilityState();
+      visibilityState.beginUnpublishedSession(sessionId: "stable-hidden");
       for (final sessionId in ["gone-child", "gone-root"]) {
         await db.sessionDao.insertSessionTombstone(
           backendSessionId: sessionId,
@@ -546,6 +558,12 @@ void main() {
               displaySessionId: "root",
               questions: [],
             ),
+            PluginPendingQuestion(
+              id: "hidden",
+              sessionID: "hidden-child",
+              displaySessionId: "root",
+              questions: [],
+            ),
           ],
         },
       );
@@ -553,6 +571,7 @@ void main() {
         plugin: plugin,
         sessionDao: db.sessionDao,
         projectsDao: db.projectsDao,
+        visibilityState: visibilityState,
       );
 
       final questions = await repository.getPendingQuestions(sessionId: "stable-root");
@@ -560,6 +579,23 @@ void main() {
       expect(questions.map((question) => question.id), ["visible"]);
       expect(questions.single.sessionID, "stable-child");
       expect(questions.single.displaySessionId, "stable-root");
+      expect(
+        await repository.findPendingQuestionOwnerSessionIds(
+          pluginId: plugin.id,
+          questionId: "hidden",
+        ),
+        isEmpty,
+      );
+      visibilityState.beginUnpublishedSession(sessionId: "stable-root");
+      await expectLater(
+        repository.replyToQuestion(
+          questionId: "visible",
+          sessionId: "stable-root",
+          answers: const [],
+        ),
+        throwsA(isA<PluginOperationException>().having((error) => error.isNotFound, "isNotFound", isTrue)),
+      );
+      expect(plugin.questionMutationCalls, isZero);
     });
 
     test("question mutations reject a tombstoned displayed root", () async {

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -1113,7 +1113,7 @@ void main() {
       final commits = await commitsFuture;
       expect(commits.map((commit) => commit.kind), everyElement(SessionBindingCommitKind.sessionCreation));
       expect(commits.map((commit) => commit.projectId), everyElement("/repo"));
-      expect(commits.map((commit) => commit.generation), everyElement(1));
+      expect(commits.map((commit) => commit.generation), everyElement(isNull));
     });
 
     test("createSession rejects a plugin mismatch before plugin I/O", () async {
@@ -1247,6 +1247,44 @@ void main() {
       expect((await repository.getCatalogSession(sessionId: sessionId))?.id, sessionId);
     });
 
+    test("reveals and publishes a durable creation before rethrowing a post-commit generation failure", () async {
+      final db = createTestDatabase();
+      addTearDown(db.close);
+      final visibilityState = SessionVisibilityState();
+      final runtime = _PostCommitGenerationReplacingRuntime(plugin: plugin);
+      final repository = SessionRepository(
+        runtime: runtime,
+        bridgeDerivedProjectPluginIds: const {},
+        sessionDao: db.sessionDao,
+        projectsDao: db.projectsDao,
+        pullRequestDao: db.pullRequestDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+        projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
+        aggregateSourceDeadline: const Duration(seconds: 5),
+        visibilityState: visibilityState,
+      );
+      addTearDown(repository.dispose);
+      final commits = <SessionBindingsCommitted>[];
+      final subscription = repository.bindingCommits.listen(commits.add);
+      addTearDown(subscription.cancel);
+
+      await expectLater(
+        _createUnpublished(repository: repository, pluginId: plugin.id),
+        throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 503)),
+      );
+
+      final stored = await db.sessionDao.getSessionByBinding(
+        pluginId: plugin.id,
+        backendSessionId: plugin.createSessionResult.id,
+      );
+      expect(stored, isNotNull);
+      expect(visibilityState.isPublished(sessionId: stored!.sessionId), isTrue);
+      expect((await repository.getCatalogSession(sessionId: stored.sessionId))?.id, stored.sessionId);
+      expect(commits, hasLength(1));
+      expect(commits.single.kind, SessionBindingCommitKind.sessionCreation);
+      expect(commits.single.generation, isNull);
+    });
+
     test("reserves a plugin before active-root hydration can bind the created backend session", () async {
       final db = createTestDatabase();
       addTearDown(db.close);
@@ -1304,8 +1342,10 @@ void main() {
 
       createResult.complete(createdBackendSession);
       final binding = await creation;
+      repository.revealSession(binding: binding);
 
-      expect(await hydration, isEmpty);
+      final summaries = await hydration;
+      expect(summaries.single.activeSessions.single.id, binding.session.id);
       expect(
         (await db.sessionDao.getSessionByBinding(
           pluginId: plugin.id,
@@ -1313,8 +1353,6 @@ void main() {
         ))?.sessionId,
         binding.session.id,
       );
-
-      repository.revealSession(binding: binding);
     });
 
     test("removes the unpublished marker when the creation transaction rolls back", () async {
@@ -1341,6 +1379,37 @@ void main() {
       );
 
       expect(visibilityState.isPublished(sessionId: sessionDao.failedSessionId!), isTrue);
+    });
+
+    test("reports the stable id when the inserted creation binding cannot be reloaded", () async {
+      final db = createTestDatabase();
+      addTearDown(db.close);
+      final sessionDao = _MissingPostInsertSessionDao(db);
+      final repository = singlePluginSessionRepository(
+        plugin: plugin,
+        sessionDao: sessionDao,
+        projectsDao: db.projectsDao,
+        pullRequestDao: db.pullRequestDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+      );
+      addTearDown(repository.dispose);
+      Object? failure;
+
+      try {
+        await _createUnpublished(repository: repository, pluginId: plugin.id);
+      } on Object catch (error) {
+        failure = error;
+      }
+
+      expect(failure, isA<StateError>());
+      expect(failure.toString(), contains(sessionDao.missingSessionId));
+      expect(
+        await db.sessionDao.getSessionByBinding(
+          pluginId: plugin.id,
+          backendSessionId: plugin.createSessionResult.id,
+        ),
+        isNull,
+      );
     });
 
     group("moved project (stable id, new live path)", () {
@@ -1734,6 +1803,47 @@ void main() {
         ))?.sessionId,
         active.id,
       );
+    });
+
+    test("activity without hydrations bypasses catalog-write admission", () async {
+      final db = createTestDatabase();
+      addTearDown(db.close);
+      const directory = "/projects/active";
+      await db.projectsDao.insertProjectsIfMissing(projectIds: [directory]);
+      await db.sessionDao.insertSession(
+        sessionId: "stable-root",
+        backendSessionId: "backend-root",
+        pluginId: plugin.id,
+        projectId: directory,
+        isDedicated: false,
+        createdAt: 1,
+        worktreePath: null,
+        branchName: null,
+        baseBranch: null,
+        baseCommit: null,
+        lastAgent: null,
+        lastAgentModel: null,
+      );
+      plugin.activitySummaries = const [
+        PluginProjectActivitySummary(
+          id: directory,
+          activeSessions: [PluginActiveSession(id: "backend-root", awaitingInput: true)],
+        ),
+      ];
+      final visibilityState = _CountingCatalogWriteVisibilityState();
+      final repository = singlePluginSessionRepository(
+        plugin: plugin,
+        sessionDao: db.sessionDao,
+        projectsDao: db.projectsDao,
+        pullRequestDao: db.pullRequestDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+        visibilityState: visibilityState,
+      );
+      addTearDown(repository.dispose);
+      final summaries = await repository.getProjectActivitySummaries();
+
+      expect(summaries.single.activeSessions.single.id, "stable-root");
+      expect(visibilityState.catalogWriteCalls, isZero);
     });
 
     test("active-root hydration is not persisted after generation replacement", () async {
@@ -2684,6 +2794,39 @@ class _GenerationReplacingRuntime extends TestPluginRuntime {
   }
 }
 
+class _CountingCatalogWriteVisibilityState extends SessionVisibilityState {
+  int catalogWriteCalls = 0;
+
+  @override
+  Future<T> withCatalogWrite<T>({required String pluginId, required Future<T> Function() body}) {
+    catalogWriteCalls++;
+    return super.withCatalogWrite(pluginId: pluginId, body: body);
+  }
+}
+
+class _PostCommitGenerationReplacingRuntime extends TestPluginRuntime {
+  _PostCommitGenerationReplacingRuntime({required BridgePluginApi plugin})
+    : _plugin = plugin,
+      super(plugins: {plugin.id: plugin}, eligiblePluginIds: null);
+
+  final BridgePluginApi _plugin;
+
+  @override
+  Future<R> useAndCommit<P, R>({
+    required String pluginId,
+    required Enum operation,
+    required Future<P> Function(BridgePluginApi api) prepare,
+    required Future<R> Function(P prepared, int generation) commit,
+  }) async {
+    final generation = currentGeneration;
+    final prepared = await prepare(_plugin);
+    final result = await commit(prepared, generation);
+    generationCurrent = false;
+    requireCurrentGeneration(pluginId: pluginId, generation: generation, operation: operation);
+    return result;
+  }
+}
+
 class _CapabilityProbeFailingRuntime extends TestPluginRuntime {
   _CapabilityProbeFailingRuntime({
     required Iterable<BridgePluginApi> plugins,
@@ -2959,6 +3102,19 @@ class _FailingCreationSessionDao extends SessionDao {
   }) {
     failedSessionId = sessionId;
     throw StateError("creation projection failed");
+  }
+}
+
+class _MissingPostInsertSessionDao extends SessionDao {
+  _MissingPostInsertSessionDao(super.attachedDatabase);
+
+  String? missingSessionId;
+
+  @override
+  Future<SessionDto?> getSession({required String sessionId}) async {
+    final stored = await super.getSession(sessionId: sessionId);
+    if (stored != null) missingSessionId = sessionId;
+    return null;
   }
 }
 

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -6,6 +6,7 @@ import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/api/database/tables/projects_table.dart";
 import "package:sesori_bridge/src/api/database/tables/pull_requests_table.dart";
 import "package:sesori_bridge/src/api/database/tables/session_table.dart";
+import "package:sesori_bridge/src/bridge/foundation/session_visibility_state.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/project_not_found_exception.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/session_operation.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/verified_github_login.dart";
@@ -238,6 +239,7 @@ void main() {
         unseenCalculator: const SessionUnseenCalculator(),
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
         aggregateSourceDeadline: const Duration(seconds: 5),
+        visibilityState: SessionVisibilityState(),
       );
 
       expect(await repository.persistedSessionCleanupPluginIds, [cleanupPlugin.id]);
@@ -644,6 +646,7 @@ void main() {
         unseenCalculator: const SessionUnseenCalculator(),
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
         aggregateSourceDeadline: const Duration(seconds: 1),
+        visibilityState: SessionVisibilityState(),
       );
       await db.projectsDao.insertProjectsIfMissing(projectIds: ["stored-native", "stored-derived"]);
       await db.sessionDao.insertSession(
@@ -1098,24 +1101,12 @@ void main() {
       final commitsFuture = repository.bindingCommits.take(cases.length).toList();
 
       for (final variant in cases) {
-        await repository.createSession(
+        final binding = await _createUnpublished(
+          repository: repository,
           pluginId: plugin.id,
-          projectId: "/repo",
-          directory: "/repo",
-          parentSessionId: null,
-          parts: const [PromptPart.text(text: "Ship it")],
-          userVisibleText: "Ship it",
           variant: variant,
-          agent: null,
-          model: null,
-          isDedicated: false,
-          worktreePath: null,
-          branchName: null,
-          baseBranch: null,
-          baseCommit: null,
-          lastAgent: null,
-          lastAgentModel: null,
         );
+        repository.revealSession(binding: binding);
 
         expect(plugin.lastCreateSessionVariant, equals(variant?.id));
       }
@@ -1141,7 +1132,6 @@ void main() {
           pluginId: "other-plugin",
           projectId: "/repo",
           directory: "/repo",
-          parentSessionId: null,
           parts: const [],
           userVisibleText: null,
           variant: null,
@@ -1158,6 +1148,199 @@ void main() {
         throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 503)),
       );
       expect(plugin.createSessionCalls, isZero);
+    });
+
+    test("keeps a committed creation private across a concurrent paginated read", () async {
+      final db = createTestDatabase();
+      addTearDown(db.close);
+      final sessionDao = _BlockingRootCatalogSessionDao(database: db);
+      final repository = singlePluginSessionRepository(
+        plugin: plugin,
+        sessionDao: sessionDao,
+        projectsDao: db.projectsDao,
+        pullRequestDao: db.pullRequestDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+      );
+      addTearDown(repository.dispose);
+      plugin.createSessionResult = const PluginSession(
+        id: "visible-root",
+        projectID: "/repo",
+        directory: "/repo",
+        parentID: null,
+        title: "Visible",
+        time: PluginSessionTime(created: 10, updated: 10, archived: null),
+      );
+      final visible = await _createUnpublished(repository: repository, pluginId: plugin.id);
+      repository.revealSession(binding: visible);
+      plugin.createSessionResult = const PluginSession(
+        id: "backend-hidden",
+        projectID: "/repo",
+        directory: "/repo",
+        parentID: null,
+        title: "Hidden",
+        time: PluginSessionTime(created: 30, updated: 30, archived: null),
+      );
+      final commits = <SessionBindingsCommitted>[];
+      final commitSubscription = repository.bindingCommits.listen(commits.add);
+      addTearDown(commitSubscription.cancel);
+
+      final page = repository.getSessionsForProject(
+        projectId: "/repo",
+        start: 0,
+        limit: 1,
+        verifiedGithubLogin: null,
+      );
+      await sessionDao.snapshotTaken.future;
+      final binding = await _createUnpublished(
+        repository: repository,
+        pluginId: plugin.id,
+      );
+      final sessionId = binding.session.id;
+
+      expect(await db.sessionDao.getSession(sessionId: sessionId), isNotNull);
+      expect(commits, isEmpty);
+      expect(await repository.getCatalogSession(sessionId: sessionId), isNull);
+      await expectLater(
+        repository.sendCommand(
+          sessionId: sessionId,
+          command: "ordinary",
+          arguments: "",
+          userVisibleArguments: null,
+          variant: null,
+          agent: null,
+          model: null,
+        ),
+        throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 404)),
+      );
+
+      await repository.sendInitialCommand(
+        binding: binding,
+        command: "initialize",
+        arguments: "",
+        userVisibleArguments: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      expect(plugin.lastSendCommandSessionId, "backend-hidden");
+
+      final recoveredRepository = singlePluginSessionRepository(
+        plugin: plugin,
+        sessionDao: db.sessionDao,
+        projectsDao: db.projectsDao,
+        pullRequestDao: db.pullRequestDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+      );
+      addTearDown(recoveredRepository.dispose);
+      expect((await recoveredRepository.getCatalogSession(sessionId: sessionId))?.id, sessionId);
+
+      sessionDao.releaseSnapshot.complete();
+      expect((await page).map((session) => session.id), [visible.session.id]);
+      expect(sessionDao.readCount, 2);
+
+      repository.revealSession(binding: binding);
+      repository.revealSession(binding: binding);
+
+      expect(commits, hasLength(1));
+      expect(commits.single.kind, SessionBindingCommitKind.sessionCreation);
+      expect(commits.single.backendSessionIds, ["backend-hidden"]);
+      expect((await repository.getCatalogSession(sessionId: sessionId))?.id, sessionId);
+    });
+
+    test("reserves a plugin before active-root hydration can bind the created backend session", () async {
+      final db = createTestDatabase();
+      addTearDown(db.close);
+      const directory = "/projects/creating";
+      final createResult = Completer<PluginSession>();
+      const createdBackendSession = PluginSession(
+        id: "backend-creating",
+        projectID: directory,
+        directory: directory,
+        parentID: null,
+        title: "Creating",
+        time: PluginSessionTime(created: 1, updated: 2, archived: null),
+      );
+      plugin
+        ..createSessionStarted = Completer<void>()
+        ..createSessionFuture = createResult.future
+        ..getSessionsStarted = Completer<void>()
+        ..activitySummaries = const [
+          PluginProjectActivitySummary(
+            id: directory,
+            activeSessions: [PluginActiveSession(id: "backend-creating", awaitingInput: true)],
+          ),
+        ]
+        ..sessionsByWorktree = const {
+          directory: [
+            createdBackendSession,
+          ],
+        };
+      final repository = singlePluginSessionRepository(
+        plugin: plugin,
+        sessionDao: db.sessionDao,
+        projectsDao: db.projectsDao,
+        pullRequestDao: db.pullRequestDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+      );
+      addTearDown(repository.dispose);
+
+      final creation = _createUnpublished(
+        repository: repository,
+        pluginId: plugin.id,
+        projectId: directory,
+      );
+      await plugin.createSessionStarted!.future;
+      final hydration = repository.getProjectActivitySummaries();
+      await plugin.getSessionsStarted!.future;
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        await db.sessionDao.getSessionByBinding(
+          pluginId: plugin.id,
+          backendSessionId: "backend-creating",
+        ),
+        isNull,
+      );
+
+      createResult.complete(createdBackendSession);
+      final binding = await creation;
+
+      expect(await hydration, isEmpty);
+      expect(
+        (await db.sessionDao.getSessionByBinding(
+          pluginId: plugin.id,
+          backendSessionId: "backend-creating",
+        ))?.sessionId,
+        binding.session.id,
+      );
+
+      repository.revealSession(binding: binding);
+    });
+
+    test("removes the unpublished marker when the creation transaction rolls back", () async {
+      final db = createTestDatabase();
+      addTearDown(db.close);
+      final visibilityState = SessionVisibilityState();
+      final sessionDao = _FailingCreationSessionDao(db);
+      final repository = singlePluginSessionRepository(
+        plugin: plugin,
+        sessionDao: sessionDao,
+        projectsDao: db.projectsDao,
+        pullRequestDao: db.pullRequestDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+        visibilityState: visibilityState,
+      );
+      addTearDown(repository.dispose);
+
+      await expectLater(
+        _createUnpublished(
+          repository: repository,
+          pluginId: plugin.id,
+        ),
+        throwsStateError,
+      );
+
+      expect(visibilityState.isPublished(sessionId: sessionDao.failedSessionId!), isTrue);
     });
 
     group("moved project (stable id, new live path)", () {
@@ -1586,6 +1769,7 @@ void main() {
         unseenCalculator: const SessionUnseenCalculator(),
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
         aggregateSourceDeadline: const Duration(seconds: 5),
+        visibilityState: SessionVisibilityState(),
       );
 
       final summaries = repository.getProjectActivitySummaries();
@@ -2450,6 +2634,31 @@ void main() {
   });
 }
 
+Future<UnpublishedSessionBinding> _createUnpublished({
+  required SessionRepository repository,
+  required String pluginId,
+  String projectId = "/repo",
+  SessionVariant? variant,
+}) {
+  return repository.createSession(
+    pluginId: pluginId,
+    projectId: projectId,
+    directory: projectId,
+    parts: const [],
+    userVisibleText: null,
+    variant: variant,
+    agent: null,
+    model: null,
+    isDedicated: false,
+    worktreePath: null,
+    branchName: null,
+    baseBranch: null,
+    baseCommit: null,
+    lastAgent: null,
+    lastAgentModel: null,
+  );
+}
+
 class _GenerationReplacingRuntime extends TestPluginRuntime {
   _GenerationReplacingRuntime({required BridgePluginApi plugin})
     : super(plugins: {plugin.id: plugin}, eligiblePluginIds: null);
@@ -2519,6 +2728,9 @@ class _FakeBridgePlugin implements NativeProjectsPluginApi {
     time: null,
   );
   PluginSession? renameSessionResult;
+  Future<PluginSession>? createSessionFuture;
+  Completer<void>? createSessionStarted;
+  Completer<void>? getSessionsStarted;
   String? lastRenameSessionId;
   String? lastRenameSessionTitle;
   String? lastCreateSessionVariant;
@@ -2559,6 +2771,8 @@ class _FakeBridgePlugin implements NativeProjectsPluginApi {
   Future<List<PluginSession>> getSessions(String worktree, {int? start, int? limit}) async {
     getSessionsCalls++;
     lastGetSessionsWorktree = worktree;
+    final started = getSessionsStarted;
+    if (started != null && !started.isCompleted) started.complete();
     if (getSessionsFailuresRemaining > 0) {
       getSessionsFailuresRemaining--;
       throw StateError("session collection unavailable");
@@ -2598,6 +2812,10 @@ class _FakeBridgePlugin implements NativeProjectsPluginApi {
   }) async {
     createSessionCalls++;
     lastCreateSessionVariant = variant?.id;
+    final started = createSessionStarted;
+    if (started != null && !started.isCompleted) started.complete();
+    final pending = createSessionFuture;
+    if (pending != null) return pending;
     return createSessionResult;
   }
 
@@ -2723,6 +2941,53 @@ class _CountingSessionDao implements SessionDao {
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FailingCreationSessionDao extends SessionDao {
+  _FailingCreationSessionDao(super.attachedDatabase);
+
+  String? failedSessionId;
+
+  @override
+  Future<bool> updateObservedSessionProjection({
+    required String sessionId,
+    required String directory,
+    required String? catalogTitle,
+    required bool updateCatalogTitle,
+    required int updatedAt,
+    required int projectionUpdatedAt,
+  }) {
+    failedSessionId = sessionId;
+    throw StateError("creation projection failed");
+  }
+}
+
+class _BlockingRootCatalogSessionDao extends SessionDao {
+  _BlockingRootCatalogSessionDao({required AppDatabase database}) : super(database);
+
+  final Completer<void> snapshotTaken = Completer<void>();
+  final Completer<void> releaseSnapshot = Completer<void>();
+  int readCount = 0;
+
+  @override
+  Future<List<SessionDto>> getRootCatalogSessions({
+    required String projectId,
+    required int offset,
+    required int? limit,
+    required List<String> excludedSessionIds,
+  }) async {
+    readCount++;
+    if (readCount == 1) {
+      snapshotTaken.complete();
+      await releaseSnapshot.future;
+    }
+    return super.getRootCatalogSessions(
+      projectId: projectId,
+      offset: offset,
+      limit: limit,
+      excludedSessionIds: excludedSessionIds,
+    );
+  }
 }
 
 class _BlockingSnapshotProjectsDao extends ProjectsDao {

--- a/bridge/app/test/bridge/routing/create_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_session_handler_test.dart
@@ -91,6 +91,7 @@ void main() {
           metadataService: metadataService,
           worktreeService: worktreeService,
           sessionRepository: sessionRepository,
+          sessionOperationDispatcher: sessionOperationDispatcher,
           sessionMutationDispatcher: sessionMutationDispatcher,
         ),
       );
@@ -474,15 +475,20 @@ void main() {
         pullRequestDao: db.pullRequestDao,
         unseenCalculator: const SessionUnseenCalculator(),
       );
+      final localOperationDispatcher = SessionOperationDispatcher(sessionRepository: localRepository);
+      final localMutationDispatcher = SessionMutationDispatcher(
+        sessionRepository: localRepository,
+        sessionOperationDispatcher: localOperationDispatcher,
+      );
+      addTearDown(localOperationDispatcher.dispose);
+      addTearDown(localMutationDispatcher.dispose);
       final localHandler = CreateSessionHandler(
         sessionCreationService: SessionCreationService(
           metadataService: metadataService,
           worktreeService: worktreeService,
           sessionRepository: localRepository,
-          sessionMutationDispatcher: SessionMutationDispatcher(
-            sessionRepository: localRepository,
-            sessionOperationDispatcher: SessionOperationDispatcher(sessionRepository: localRepository),
-          ),
+          sessionOperationDispatcher: localOperationDispatcher,
+          sessionMutationDispatcher: localMutationDispatcher,
         ),
       );
       worktreeService.prepareResult = WorktreeSuccess(
@@ -941,15 +947,20 @@ void main() {
         pullRequestDao: db.pullRequestDao,
         unseenCalculator: const SessionUnseenCalculator(),
       );
+      final orderedOperationDispatcher = SessionOperationDispatcher(sessionRepository: orderedRepository);
+      final orderedMutationDispatcher = SessionMutationDispatcher(
+        sessionRepository: orderedRepository,
+        sessionOperationDispatcher: orderedOperationDispatcher,
+      );
+      addTearDown(orderedOperationDispatcher.dispose);
+      addTearDown(orderedMutationDispatcher.dispose);
       final localHandler = CreateSessionHandler(
         sessionCreationService: SessionCreationService(
           metadataService: metadataService,
           worktreeService: worktreeService,
           sessionRepository: orderedRepository,
-          sessionMutationDispatcher: SessionMutationDispatcher(
-            sessionRepository: orderedRepository,
-            sessionOperationDispatcher: SessionOperationDispatcher(sessionRepository: orderedRepository),
-          ),
+          sessionOperationDispatcher: orderedOperationDispatcher,
+          sessionMutationDispatcher: orderedMutationDispatcher,
         ),
       );
 
@@ -1148,6 +1159,7 @@ void main() {
           metadataService: metadataService,
           worktreeService: worktreeService,
           sessionRepository: throwingRepository,
+          sessionOperationDispatcher: throwingOperationDispatcher,
           sessionMutationDispatcher: throwingDispatcher,
         ),
       );

--- a/bridge/app/test/bridge/routing/get_session_permissions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_session_permissions_handler_test.dart
@@ -1,4 +1,5 @@
 import "package:sesori_bridge/src/api/database/database.dart";
+import "package:sesori_bridge/src/bridge/foundation/session_visibility_state.dart";
 import "package:sesori_bridge/src/bridge/routing/get_session_permissions_handler.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -152,6 +153,13 @@ void main() {
             tool: "shell",
             description: "visible",
           ),
+          PluginPendingPermission(
+            id: "hidden",
+            sessionID: "hidden-child",
+            displaySessionId: "root",
+            tool: "shell",
+            description: "hidden",
+          ),
         ];
       await recordSessionBinding(
         database: db,
@@ -169,6 +177,14 @@ void main() {
         projectId: "/repo",
         parentSessionId: "stable-root",
       );
+      await recordSessionBinding(
+        database: db,
+        sessionId: "stable-hidden",
+        backendSessionId: "hidden-child",
+        pluginId: derivedPlugin.id,
+        projectId: "/repo",
+        parentSessionId: "stable-root",
+      );
       for (final sessionId in ["gone-child", "gone-root"]) {
         await db.sessionDao.insertSessionTombstone(
           backendSessionId: sessionId,
@@ -176,12 +192,14 @@ void main() {
           deletedAt: 1,
         );
       }
-      final derivedHandler = GetSessionPermissionsHandler(
-        permissionRepository: singlePluginPermissionRepository(
-          plugin: derivedPlugin,
-          sessionDao: db.sessionDao,
-        ),
+      final visibilityState = SessionVisibilityState();
+      visibilityState.beginUnpublishedSession(sessionId: "stable-hidden");
+      final repository = singlePluginPermissionRepository(
+        plugin: derivedPlugin,
+        sessionDao: db.sessionDao,
+        visibilityState: visibilityState,
       );
+      final derivedHandler = GetSessionPermissionsHandler(permissionRepository: repository);
 
       final response = await derivedHandler.handle(
         makeRequest("POST", "/session/permissions"),
@@ -194,6 +212,16 @@ void main() {
       expect(response.data.map((permission) => permission.id), ["visible"]);
       expect(response.data.single.sessionID, "stable-child");
       expect(response.data.single.displaySessionId, "stable-root");
+      visibilityState.beginUnpublishedSession(sessionId: "stable-root");
+      await expectLater(
+        repository.replyToPermission(
+          requestId: "visible",
+          sessionId: "stable-root",
+          reply: PermissionReply.once,
+        ),
+        throwsA(isA<PluginOperationException>().having((error) => error.isNotFound, "isNotFound", isTrue)),
+      );
+      expect(derivedPlugin.permissionReplyCalls, isZero);
     });
 
     test("permission replies reject a tombstoned displayed root", () async {

--- a/bridge/app/test/bridge/routing/post_session_options_handler_test.dart
+++ b/bridge/app/test/bridge/routing/post_session_options_handler_test.dart
@@ -270,6 +270,12 @@ class _FakeSessionOptionsService implements SessionOptionsService {
   }) async => const SessionOptionsAutomaticNoOp();
 
   @override
+  Future<SessionOptionsOutcome> refreshCurrentActiveOnly({
+    required String pluginId,
+    required String projectId,
+  }) async => const SessionOptionsAutomaticNoOp();
+
+  @override
   Future<SessionOptionsOutcome> refreshActiveOnlyForBackendSession({
     required String pluginId,
     required String backendSessionId,

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -5,6 +5,7 @@ import "package:sesori_bridge/src/api/database/daos/session_dao.dart";
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/api/database/tables/pull_requests_table.dart";
 import "package:sesori_bridge/src/api/database/tables/session_table.dart";
+import "package:sesori_bridge/src/bridge/foundation/session_visibility_state.dart";
 import "package:sesori_bridge/src/bridge/metadata_service.dart";
 import "package:sesori_bridge/src/bridge/models/session_metadata.dart" as bridge_metadata;
 import "package:sesori_bridge/src/bridge/repositories/mappers/plugin_command_mapper.dart";
@@ -40,10 +41,12 @@ import "../../helpers/single_plugin_repository_test_support.dart";
 /// Builds a real [SessionUnseenService] backed by [db] for handler/router tests.
 SessionUnseenService buildTestSessionUnseenService(AppDatabase db, BridgePluginApi plugin) {
   const calculator = SessionUnseenCalculator();
+  final visibilityState = SessionVisibilityState();
   return SessionUnseenService(
     unseenRepository: SessionUnseenRepository(
       sessionDao: db.sessionDao,
       calculator: calculator,
+      visibilityState: visibilityState,
     ),
     projectRepository: singlePluginProjectRepository(
       gitCliApi: FakeGitCliApi(),
@@ -51,6 +54,7 @@ SessionUnseenService buildTestSessionUnseenService(AppDatabase db, BridgePluginA
       sessionDao: db.sessionDao,
       unseenCalculator: calculator,
       filesystemApi: FakeFilesystemApi(),
+      visibilityState: visibilityState,
     ),
     viewTracker: SessionViewTracker(),
   );
@@ -60,6 +64,7 @@ SessionUnseenService buildTestSessionUnseenService(AppDatabase db, BridgePluginA
   required AppDatabase database,
   required BridgePluginApi plugin,
 }) {
+  final visibilityState = SessionVisibilityState();
   final dispatcher = SessionOperationDispatcher(
     sessionRepository: singlePluginSessionRepository(
       plugin: plugin,
@@ -67,6 +72,7 @@ SessionUnseenService buildTestSessionUnseenService(AppDatabase db, BridgePluginA
       projectsDao: database.projectsDao,
       pullRequestDao: database.pullRequestDao,
       unseenCalculator: const SessionUnseenCalculator(),
+      visibilityState: visibilityState,
     ),
   );
   return (
@@ -75,11 +81,13 @@ SessionUnseenService buildTestSessionUnseenService(AppDatabase db, BridgePluginA
       permissionRepository: singlePluginPermissionRepository(
         plugin: plugin,
         sessionDao: database.sessionDao,
+        visibilityState: visibilityState,
       ),
       questionRepository: singlePluginQuestionRepository(
         plugin: plugin,
         sessionDao: database.sessionDao,
         projectsDao: database.projectsDao,
+        visibilityState: visibilityState,
       ),
       dispatcher: dispatcher,
       legacyMissingPluginId: plugin.id,
@@ -869,11 +877,10 @@ class _NoopSessionRepository implements SessionRepository {
   Future<List<ProjectActivitySummary>> getProjectActivitySummaries() async => const <ProjectActivitySummary>[];
 
   @override
-  Future<Session> createSession({
+  Future<UnpublishedSessionBinding> createSession({
     required String pluginId,
     required String projectId,
     required String directory,
-    required String? parentSessionId,
     required List<PromptPart> parts,
     required String? userVisibleText,
     required SessionVariant? variant,
@@ -886,18 +893,10 @@ class _NoopSessionRepository implements SessionRepository {
     required String? baseCommit,
     required String? lastAgent,
     required AgentModel? lastAgentModel,
-  }) async => const Session(
-    branchName: null,
-    id: "",
-    pluginId: "fake",
-    projectID: "",
-    directory: "",
-    parentID: null,
-    title: null,
-    time: null,
-    pullRequest: null,
-    promptDefaults: null,
-  );
+  }) {
+    throw UnimplementedError();
+  }
+
   @override
   Future<List<Session>> getSessionsForProject({
     required String projectId,
@@ -1073,6 +1072,9 @@ class _NoopSessionRepository implements SessionRepository {
 
   @override
   Future<String> resolveProjectDirectory({required String projectId}) async => projectId;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 /// Test-friendly [SessionRepository] that delegates to a [FakeBridgePlugin]
@@ -1164,11 +1166,10 @@ class FakeSessionRepository implements SessionRepository {
   ];
 
   @override
-  Future<Session> createSession({
+  Future<UnpublishedSessionBinding> createSession({
     required String pluginId,
     required String projectId,
     required String directory,
-    required String? parentSessionId,
     required List<PromptPart> parts,
     required String? userVisibleText,
     required SessionVariant? variant,
@@ -1181,18 +1182,9 @@ class FakeSessionRepository implements SessionRepository {
     required String? baseCommit,
     required String? lastAgent,
     required AgentModel? lastAgentModel,
-  }) async => const Session(
-    branchName: null,
-    id: "",
-    pluginId: "fake",
-    projectID: "",
-    directory: "",
-    parentID: null,
-    title: null,
-    time: null,
-    pullRequest: null,
-    promptDefaults: null,
-  );
+  }) {
+    throw UnimplementedError();
+  }
 
   @override
   Future<List<Session>> getSessionsForProject({
@@ -1592,4 +1584,7 @@ class FakeSessionRepository implements SessionRepository {
 
   @override
   Future<String> resolveProjectDirectory({required String projectId}) async => projectId;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/bridge/app/test/bridge/routing/send_prompt_handler_test.dart
+++ b/bridge/app/test/bridge/routing/send_prompt_handler_test.dart
@@ -1,6 +1,7 @@
 import "dart:convert";
 
 import "package:sesori_bridge/src/api/database/database.dart";
+import "package:sesori_bridge/src/bridge/foundation/session_visibility_state.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/routing/send_prompt_handler.dart";
@@ -692,6 +693,7 @@ class _ThrowingUpdateSessionRepository extends SessionRepository {
          pullRequestDao: database.pullRequestDao,
          projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
          aggregateSourceDeadline: const Duration(seconds: 5),
+         visibilityState: SessionVisibilityState(),
        );
 
   @override

--- a/bridge/app/test/bridge/services/session_creation_service_test.dart
+++ b/bridge/app/test/bridge/services/session_creation_service_test.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:io";
 
 import "package:http/http.dart" as http;
@@ -7,6 +8,7 @@ import "package:sesori_bridge/src/bridge/api/git_cli_api.dart";
 import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
 import "package:sesori_bridge/src/bridge/metadata_service.dart";
 import "package:sesori_bridge/src/bridge/models/session_metadata.dart" as bridge_metadata;
+import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/services/session_creation_service.dart";
 import "package:sesori_bridge/src/bridge/services/session_mutation_dispatcher.dart";
@@ -24,6 +26,7 @@ void main() {
     late _FakePlugin plugin;
     late _FakeMetadataService metadataService;
     late _FakeWorktreeService worktreeService;
+    late SessionRepository repository;
     late SessionOperationDispatcher operationDispatcher;
     late SessionMutationDispatcher mutationDispatcher;
     late SessionCreationService service;
@@ -44,7 +47,7 @@ void main() {
           plugin: plugin,
         ),
       );
-      final repository = singlePluginSessionRepository(
+      repository = singlePluginSessionRepository(
         plugin: plugin,
         sessionDao: db.sessionDao,
         projectsDao: db.projectsDao,
@@ -60,6 +63,7 @@ void main() {
         metadataService: metadataService,
         worktreeService: worktreeService,
         sessionRepository: repository,
+        sessionOperationDispatcher: operationDispatcher,
         sessionMutationDispatcher: mutationDispatcher,
       );
     });
@@ -237,7 +241,54 @@ void main() {
       expect(createdBinding?.backendSessionId, "backend-session");
       expect(createdBinding?.projectId, "/repo");
     });
+
+    test("reveals exactly once after a delayed initial command fails", () async {
+      final commandStarted = Completer<void>();
+      final releaseCommand = Completer<void>();
+      final failure = StateError("initial command failed");
+      plugin
+        ..commandStarted = commandStarted
+        ..releaseCommand = releaseCommand.future
+        ..commandError = failure;
+      final commits = <SessionBindingsCommitted>[];
+      final subscription = repository.bindingCommits.listen(commits.add);
+      addTearDown(subscription.cancel);
+
+      final creation = service.createSession(
+        request: _request(
+          text: "private prompt",
+          command: "review",
+        ),
+      );
+      await commandStarted.future;
+      final stored = await db.sessionDao.getSessionByBinding(
+        pluginId: plugin.id,
+        backendSessionId: "backend-session",
+      );
+      expect(stored, isNotNull);
+      expect(commits, isEmpty);
+      expect(await repository.getCatalogSession(sessionId: stored!.sessionId), isNull);
+
+      releaseCommand.complete();
+      await expectLater(creation, throwsA(same(failure)));
+
+      expect((await repository.getCatalogSession(sessionId: stored.sessionId))?.id, stored.sessionId);
+      expect(commits, hasLength(1));
+    });
   });
+}
+
+CreateSessionRequest _request({required String text, required String? command}) {
+  return CreateSessionRequest(
+    projectId: "/repo",
+    pluginId: "fake",
+    dedicatedWorktree: false,
+    parts: [PromptPart.text(text: text)],
+    variant: null,
+    agent: null,
+    model: null,
+    command: command,
+  );
 }
 
 class _FakeMetadataService extends MetadataService {
@@ -294,6 +345,9 @@ class _FakePlugin implements NativeProjectsPluginApi {
   String? lastCreateDirectory;
   String? lastCreateUserVisibleText;
   List<PluginPromptPart>? lastCreateParts;
+  Completer<void>? commandStarted;
+  Future<void>? releaseCommand;
+  Object? commandError;
 
   @override
   String get id => "fake";
@@ -323,6 +377,21 @@ class _FakePlugin implements NativeProjectsPluginApi {
       title: null,
       time: null,
     );
+  }
+
+  @override
+  Future<void> sendCommand({
+    required String sessionId,
+    required String command,
+    required String arguments,
+    required String? userVisibleArguments,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async {
+    if (commandStarted case final started? when !started.isCompleted) started.complete();
+    if (releaseCommand case final release?) await release;
+    if (commandError case final error?) throw error;
   }
 
   @override

--- a/bridge/app/test/bridge/services/session_creation_service_test.dart
+++ b/bridge/app/test/bridge/services/session_creation_service_test.dart
@@ -6,6 +6,7 @@ import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/auth/token_refresher.dart";
 import "package:sesori_bridge/src/bridge/api/git_cli_api.dart";
 import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
+import "package:sesori_bridge/src/bridge/foundation/session_visibility_state.dart";
 import "package:sesori_bridge/src/bridge/metadata_service.dart";
 import "package:sesori_bridge/src/bridge/models/session_metadata.dart" as bridge_metadata;
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
@@ -27,6 +28,7 @@ void main() {
     late _FakeMetadataService metadataService;
     late _FakeWorktreeService worktreeService;
     late SessionRepository repository;
+    late SessionVisibilityState visibilityState;
     late SessionOperationDispatcher operationDispatcher;
     late SessionMutationDispatcher mutationDispatcher;
     late SessionCreationService service;
@@ -47,12 +49,14 @@ void main() {
           plugin: plugin,
         ),
       );
+      visibilityState = SessionVisibilityState();
       repository = singlePluginSessionRepository(
         plugin: plugin,
         sessionDao: db.sessionDao,
         projectsDao: db.projectsDao,
         pullRequestDao: db.pullRequestDao,
         unseenCalculator: const SessionUnseenCalculator(),
+        visibilityState: visibilityState,
       );
       operationDispatcher = SessionOperationDispatcher(sessionRepository: repository);
       mutationDispatcher = SessionMutationDispatcher(
@@ -275,6 +279,62 @@ void main() {
       expect((await repository.getCatalogSession(sessionId: stored.sessionId))?.id, stored.sessionId);
       expect(commits, hasLength(1));
     });
+
+    test("holds same-plugin catalog writes through initial command and metadata title", () async {
+      metadataService.result = const bridge_metadata.SessionMetadata(
+        title: "Generated title",
+        branchName: "generated-title",
+        worktreeName: "generated-title",
+      );
+      final commandStarted = Completer<void>();
+      final releaseCommand = Completer<void>();
+      final renameStarted = Completer<void>();
+      final releaseRename = Completer<void>();
+      plugin
+        ..commandStarted = commandStarted
+        ..releaseCommand = releaseCommand.future
+        ..renameStarted = renameStarted
+        ..releaseRename = releaseRename.future;
+
+      final creation = service.createSession(
+        request: _request(text: "private prompt", command: "review"),
+      );
+      await commandStarted.future;
+      final root = await db.sessionDao.getSessionByBinding(
+        pluginId: plugin.id,
+        backendSessionId: "backend-session",
+      );
+      final descendantWrite = visibilityState.withCatalogWrite(
+        pluginId: plugin.id,
+        body: () => db.sessionDao.insertObservedChild(
+          sessionId: "stable-child",
+          backendSessionId: "backend-child",
+          projectId: "/repo",
+          parentSessionId: root!.sessionId,
+          directory: "/repo",
+          catalogTitle: "Child",
+          archivedAt: null,
+          createdAt: 1,
+          updatedAt: 1,
+          projectionUpdatedAt: 1,
+          pluginId: plugin.id,
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+      final wroteDuringCommand = await db.sessionDao.getSession(sessionId: "stable-child") != null;
+
+      releaseCommand.complete();
+      await renameStarted.future;
+      await Future<void>.delayed(Duration.zero);
+      final wroteBeforeRenameFinished = await db.sessionDao.getSession(sessionId: "stable-child") != null;
+      releaseRename.complete();
+      final created = await creation;
+      await descendantWrite;
+
+      expect(wroteDuringCommand, isFalse);
+      expect(wroteBeforeRenameFinished, isFalse);
+      expect((await db.sessionDao.getSession(sessionId: "stable-child"))?.parentSessionId, created.id);
+    });
   });
 }
 
@@ -293,6 +353,7 @@ CreateSessionRequest _request({required String text, required String? command}) 
 
 class _FakeMetadataService extends MetadataService {
   int generateCalls = 0;
+  bridge_metadata.SessionMetadata? result;
 
   _FakeMetadataService()
     : super(
@@ -304,7 +365,7 @@ class _FakeMetadataService extends MetadataService {
   @override
   Future<bridge_metadata.SessionMetadata?> generate({required String firstMessage}) async {
     generateCalls++;
-    return null;
+    return result;
   }
 }
 
@@ -348,6 +409,8 @@ class _FakePlugin implements NativeProjectsPluginApi {
   Completer<void>? commandStarted;
   Future<void>? releaseCommand;
   Object? commandError;
+  Completer<void>? renameStarted;
+  Future<void>? releaseRename;
 
   @override
   String get id => "fake";
@@ -392,6 +455,20 @@ class _FakePlugin implements NativeProjectsPluginApi {
     if (commandStarted case final started? when !started.isCompleted) started.complete();
     if (releaseCommand case final release?) await release;
     if (commandError case final error?) throw error;
+  }
+
+  @override
+  Future<PluginSession> renameSession({required String sessionId, required String title}) async {
+    if (renameStarted case final started? when !started.isCompleted) started.complete();
+    if (releaseRename case final release?) await release;
+    return PluginSession(
+      id: sessionId,
+      projectID: "/repo",
+      directory: "/repo",
+      parentID: null,
+      title: title,
+      time: null,
+    );
   }
 
   @override

--- a/bridge/app/test/bridge/services/session_event_service_test.dart
+++ b/bridge/app/test/bridge/services/session_event_service_test.dart
@@ -2,6 +2,7 @@ import "dart:async";
 
 import "package:sesori_bridge/src/api/database/daos/session_dao.dart";
 import "package:sesori_bridge/src/api/database/database.dart";
+import "package:sesori_bridge/src/bridge/foundation/session_visibility_state.dart";
 import "package:sesori_bridge/src/bridge/repositories/mappers/session_event_mapper.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
@@ -41,6 +42,7 @@ void main() {
         unseenCalculator: const SessionUnseenCalculator(),
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
         aggregateSourceDeadline: const Duration(seconds: 5),
+        visibilityState: SessionVisibilityState(),
       );
       eventTracker = SessionEventTracker(maxPendingEntriesPerPlugin: 1024);
       failureReporter = CapturingFailureReporter();

--- a/bridge/app/test/bridge/services/session_event_service_test.dart
+++ b/bridge/app/test/bridge/services/session_event_service_test.dart
@@ -647,14 +647,15 @@ void main() {
         commit: (
           pluginId: plugin.id,
           projectId: "project",
-          generation: 1,
+          generation: null,
           kind: SessionBindingCommitKind.sessionCreation,
           backendSessionIds: const ["backend-root"],
         ),
       );
 
       expect(output, hasLength(5));
-      expect(output.map((item) => item.generation), everyElement(1));
+      expect(output.take(4).map((item) => item.generation), everyElement(1));
+      expect(output.last.generation, isNull);
       expect(Session.fromJson((output[0].event as BridgeSseSessionCreated).info).id, "stable-root");
       expect(Message.fromJson((output[1].event as BridgeSseMessageUpdated).info).sessionID, "stable-root");
       expect((output[2].event as BridgeSseMessagePartUpdated).part.sessionID, "stable-root");
@@ -663,20 +664,48 @@ void main() {
       expect(eventTracker.length, 0);
     });
 
-    test("does not refresh project activity for a stale creation commit", () async {
+    test("publishes durable project activity after replacement without replaying stale plugin events", () async {
+      expect(
+        await service.normalize(
+          allowDuringStop: false,
+          source: (
+            pluginId: plugin.id,
+            generation: 1,
+            projectionUpdatedAt: 1,
+            event: BridgeSseSessionCreated(
+              info: _sessionInfo(
+                sessionId: "backend-root",
+                parentId: null,
+                projectId: "project",
+                directory: "/repo",
+              ),
+            ),
+          ),
+        ),
+        isEmpty,
+      );
+      await _insertRoot(
+        database: database,
+        pluginId: plugin.id,
+        sessionId: "stable-root",
+        backendSessionId: "backend-root",
+      );
       pluginRuntime.currentGeneration = 2;
 
       final output = await service.handleBindingsCommitted(
         commit: (
           pluginId: plugin.id,
           projectId: "project",
-          generation: 1,
+          generation: null,
           kind: SessionBindingCommitKind.sessionCreation,
           backendSessionIds: const ["backend-root"],
         ),
       );
 
-      expect(output, isEmpty);
+      expect(output, hasLength(1));
+      expect(output.single.generation, isNull);
+      expect(output.single.event, isA<BridgeSseProjectUpdated>());
+      expect(eventTracker.length, 0);
     });
 
     test("replays an update that follows a pending root creation", () async {

--- a/bridge/app/test/bridge/services/session_options_service_test.dart
+++ b/bridge/app/test/bridge/services/session_options_service_test.dart
@@ -716,9 +716,10 @@ void main() {
       expect(repository.captureCalls.single.discoveryMode, PluginSessionOptionsDiscoveryMode.refresh);
 
       repository.captureCalls.clear();
-      await service.refreshActiveOnly(pluginId: "plugin-1", projectId: "project-1", generation: 7);
+      await service.refreshCurrentActiveOnly(pluginId: "plugin-1", projectId: "project-1");
       expect(repository.captureCalls.single.activation, SessionOptionsCaptureActivation.activeOnly);
       expect(repository.captureCalls.single.discoveryMode, PluginSessionOptionsDiscoveryMode.reuse);
+      expect(repository.captureCalls.single.expectedGeneration, isNull);
     });
 
     test("backend-session refresh resolves the stable binding before capturing", () async {

--- a/bridge/app/test/bridge/services/session_unseen_service_test.dart
+++ b/bridge/app/test/bridge/services/session_unseen_service_test.dart
@@ -1,4 +1,5 @@
 import "package:sesori_bridge/src/api/database/database.dart";
+import "package:sesori_bridge/src/bridge/foundation/session_visibility_state.dart";
 import "package:sesori_bridge/src/bridge/repositories/project_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_repository.dart";
@@ -15,11 +16,13 @@ void main() {
     late AppDatabase db;
     late SessionViewTracker viewTracker;
     late SessionUnseenService service;
+    late SessionVisibilityState visibilityState;
     var clock = 1000;
 
     SessionUnseenRepository unseenRepository() => SessionUnseenRepository(
       sessionDao: db.sessionDao,
       calculator: const SessionUnseenCalculator(),
+      visibilityState: visibilityState,
     );
 
     ProjectRepository projectRepository() => singlePluginProjectRepository(
@@ -28,6 +31,7 @@ void main() {
       sessionDao: db.sessionDao,
       unseenCalculator: const SessionUnseenCalculator(),
       filesystemApi: FakeFilesystemApi(),
+      visibilityState: visibilityState,
     );
 
     Future<bool> unseen(String sessionId) {
@@ -54,6 +58,7 @@ void main() {
     setUp(() {
       db = createTestDatabase();
       clock = 1000;
+      visibilityState = SessionVisibilityState();
       viewTracker = SessionViewTracker();
       service = SessionUnseenService(
         unseenRepository: unseenRepository(),
@@ -170,6 +175,31 @@ void main() {
       expect(await unseen("never-learned"), isFalse);
       expect(events, isEmpty);
       await sub.cancel();
+    });
+
+    test("unpublished sessions reject unseen mutations and never emit", () async {
+      await persistRoot(sessionId: "hidden");
+      await db.sessionDao.setActivityTimestamps(
+        sessionId: "hidden",
+        activityAt: 900,
+        userMessageAt: null,
+        seenAt: null,
+      );
+      visibilityState.beginUnpublishedSession(sessionId: "hidden");
+      final events = <UnseenChange>[];
+      final subscription = service.unseenChanges.listen(events.add);
+
+      await service.recordActivity(sessionId: "hidden", isUserMessage: false);
+      await service.notifyExternalChange(sessionId: "hidden", projectId: "p1");
+      await service.recordSessionDeleted(sessionId: "hidden", projectId: "p1");
+      await Future<void>.delayed(Duration.zero);
+
+      final stored = await db.sessionDao.getSession(sessionId: "hidden");
+      expect(stored, isNotNull);
+      expect(stored?.lastActivityAt, 900);
+      expect(await projectRepository().projectHasUnseenChanges(projectId: "p1"), isFalse);
+      expect(events, isEmpty);
+      await subscription.cancel();
     });
 
     test("activity while viewing does not bold (seen advances)", () async {

--- a/bridge/app/test/helpers/single_plugin_repository_test_support.dart
+++ b/bridge/app/test/helpers/single_plugin_repository_test_support.dart
@@ -4,6 +4,7 @@ import "package:sesori_bridge/src/api/database/daos/pull_request_dao.dart";
 import "package:sesori_bridge/src/api/database/daos/session_dao.dart";
 import "package:sesori_bridge/src/bridge/api/filesystem_api.dart";
 import "package:sesori_bridge/src/bridge/api/git_cli_api.dart";
+import "package:sesori_bridge/src/bridge/foundation/session_visibility_state.dart";
 import "package:sesori_bridge/src/bridge/repositories/agent_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/permission_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/project_activity_repository.dart";
@@ -33,10 +34,12 @@ AgentRepository singlePluginAgentRepository({
 PermissionRepository singlePluginPermissionRepository({
   required BridgePluginApi plugin,
   required SessionDao sessionDao,
+  SessionVisibilityState? visibilityState,
 }) {
   return PermissionRepository(
     runtime: createTestPluginRuntime(plugins: [plugin]),
     sessionDao: sessionDao,
+    visibilityState: visibilityState ?? SessionVisibilityState(),
   );
 }
 
@@ -46,6 +49,7 @@ ProjectRepository singlePluginProjectRepository({
   required SessionUnseenCalculator unseenCalculator,
   required FilesystemApi filesystemApi,
   required GitCliApi gitCliApi,
+  SessionVisibilityState? visibilityState,
 }) {
   return ProjectRepository(
     projectsDao: projectsDao,
@@ -54,6 +58,7 @@ ProjectRepository singlePluginProjectRepository({
     filesystemApi: filesystemApi,
     gitCliApi: gitCliApi,
     projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
+    visibilityState: visibilityState ?? SessionVisibilityState(),
   );
 }
 
@@ -85,12 +90,14 @@ QuestionRepository singlePluginQuestionRepository({
   required BridgePluginApi plugin,
   required SessionDao sessionDao,
   required ProjectsDao projectsDao,
+  SessionVisibilityState? visibilityState,
 }) {
   return QuestionRepository(
     runtime: createTestPluginRuntime(plugins: [plugin]),
     sessionDao: sessionDao,
     projectsDao: projectsDao,
     aggregateSourceDeadline: const Duration(seconds: 5),
+    visibilityState: visibilityState ?? SessionVisibilityState(),
   );
 }
 
@@ -101,6 +108,7 @@ SessionRepository singlePluginSessionRepository({
   required PullRequestDao pullRequestDao,
   required SessionUnseenCalculator unseenCalculator,
   Set<String>? eligiblePluginIds,
+  SessionVisibilityState? visibilityState,
 }) {
   return SessionRepository(
     runtime: createTestPluginRuntime(
@@ -116,6 +124,7 @@ SessionRepository singlePluginSessionRepository({
     unseenCalculator: unseenCalculator,
     projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
     aggregateSourceDeadline: const Duration(seconds: 5),
+    visibilityState: visibilityState ?? SessionVisibilityState(),
   );
 }
 
@@ -138,6 +147,7 @@ CatalogImportRepository singlePluginCatalogImportRepository({
   required ProjectsDao projectsDao,
   required SessionDao sessionDao,
   required CatalogHydrationsDao catalogHydrationsDao,
+  SessionVisibilityState? visibilityState,
 }) {
   return CatalogImportRepository(
     runtime: createTestPluginRuntime(plugins: [plugin]),
@@ -145,5 +155,6 @@ CatalogImportRepository singlePluginCatalogImportRepository({
     sessionDao: sessionDao,
     catalogHydrationsDao: catalogHydrationsDao,
     projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
+    visibilityState: visibilityState ?? SessionVisibilityState(),
   );
 }

--- a/bridge/app/test/helpers/single_plugin_repository_test_support.dart
+++ b/bridge/app/test/helpers/single_plugin_repository_test_support.dart
@@ -66,6 +66,7 @@ ProjectActivityRepository singlePluginProjectActivityRepository({
   required BridgePluginApi plugin,
   required ProjectsDao projectsDao,
   required SessionDao sessionDao,
+  SessionVisibilityState? visibilityState,
 }) {
   return ProjectActivityRepository(
     runtime: createTestPluginRuntime(plugins: [plugin]),
@@ -73,6 +74,7 @@ ProjectActivityRepository singlePluginProjectActivityRepository({
     sessionDao: sessionDao,
     projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
     aggregateSourceDeadline: const Duration(seconds: 5),
+    visibilityState: visibilityState ?? SessionVisibilityState(),
   );
 }
 

--- a/bridge/app/test/listeners/session_event_trigger_listeners_test.dart
+++ b/bridge/app/test/listeners/session_event_trigger_listeners_test.dart
@@ -27,7 +27,7 @@ void main() {
     source.add((
       pluginId: "selected",
       projectId: "selected-project",
-      generation: 2,
+      generation: null,
       kind: SessionBindingCommitKind.sessionCreation,
       backendSessionIds: const ["root"],
     ));
@@ -44,7 +44,7 @@ void main() {
       (
         pluginId: "selected",
         projectId: "selected-project",
-        generation: 2,
+        generation: null,
         kind: SessionBindingCommitKind.sessionCreation,
         backendSessionIds: const ["root"],
       ),

--- a/bridge/app/test/listeners/session_options_refresh_listeners_test.dart
+++ b/bridge/app/test/listeners/session_options_refresh_listeners_test.dart
@@ -32,19 +32,19 @@ void main() {
       await _flushEvents();
 
       expect(service.creationCalls, [
-        (pluginId: "plugin", projectId: "stable-project", generation: 7),
+        (pluginId: "plugin", projectId: "stable-project"),
       ]);
       expect(service.successfulCreationProjects, ["stable-project"]);
     });
 
-    test("passes stale generations to the service fence without refreshing", () async {
+    test("refreshes against the active generation after a durable creation", () async {
       service.currentGeneration = 8;
 
       source.add(_commit(kind: SessionBindingCommitKind.sessionCreation, projectId: "stale-project"));
       await _flushEvents();
 
-      expect(service.creationCalls.single.generation, 7);
-      expect(service.successfulCreationProjects, isEmpty);
+      expect(service.creationCalls.single.projectId, "stale-project");
+      expect(service.successfulCreationProjects, ["stale-project"]);
     });
 
     test("contains an async refresh error and continues listening", () async {
@@ -140,7 +140,7 @@ SessionBindingsCommitted _commit({
   return (
     pluginId: "plugin",
     projectId: projectId,
-    generation: 7,
+    generation: kind == SessionBindingCommitKind.catalogSync ? 7 : null,
     kind: kind,
     backendSessionIds: const ["backend-session"],
   );
@@ -162,7 +162,7 @@ class _FakeSessionOptionsService implements SessionOptionsService {
   final Set<String> boundBackendSessionIds = {};
   final Set<String> failingCreationProjects = {};
   final Set<String> failingBackendSessionIds = {};
-  final List<({String pluginId, String projectId, int generation})> creationCalls = [];
+  final List<({String pluginId, String projectId})> creationCalls = [];
   final List<({String pluginId, String backendSessionId, int generation})> backendCalls = [];
   final List<String> successfulCreationProjects = [];
   final List<String> successfulBackendSessions = [];
@@ -177,10 +177,17 @@ class _FakeSessionOptionsService implements SessionOptionsService {
     required String pluginId,
     required String projectId,
     required int generation,
+  }) async => generation == currentGeneration
+      ? const SessionOptionsAvailable(response: _optionsResponse)
+      : const SessionOptionsAutomaticNoOp();
+
+  @override
+  Future<SessionOptionsOutcome> refreshCurrentActiveOnly({
+    required String pluginId,
+    required String projectId,
   }) async {
-    creationCalls.add((pluginId: pluginId, projectId: projectId, generation: generation));
+    creationCalls.add((pluginId: pluginId, projectId: projectId));
     if (failingCreationProjects.contains(projectId)) throw StateError("creation refresh failed");
-    if (generation != currentGeneration) return const SessionOptionsAutomaticNoOp();
     successfulCreationProjects.add(projectId);
     return const SessionOptionsAvailable(response: _optionsResponse);
   }

--- a/bridge/app/test/repositories/catalog_import_repository_test.dart
+++ b/bridge/app/test/repositories/catalog_import_repository_test.dart
@@ -720,6 +720,40 @@ void main() {
       await completed;
     });
 
+    test("cancellation while waiting for creation publishes no catalog", () async {
+      final projectPath = "${directory.path}/cancelled-behind-creation";
+      final plugin = _NativeImportPlugin(
+        projects: [PluginProject(id: "cancelled", directory: projectPath)],
+        rootsByProject: {
+          projectPath: [_pluginSession(id: "cancelled-root", directory: projectPath)],
+        },
+        childrenByParent: const {},
+      );
+      final visibilityState = _SignalingCatalogWriteVisibilityState();
+      final creationReservation = visibilityState.reserveSessionCreation(pluginId: plugin.id);
+      final control = CatalogImportControl(
+        explicitImportRequested: true,
+        hydrationMarkerRequested: true,
+      );
+      final repository = _repository(
+        database: database,
+        plugin: plugin,
+        visibilityState: visibilityState,
+      );
+      final statuses = repository.importCatalog(pluginId: plugin.id, control: control).toList();
+      await visibilityState.catalogWriteRequested.future;
+
+      control.cancellationRequested = true;
+      visibilityState.releaseSessionCreation(reservation: creationReservation);
+      final result = await statuses;
+
+      expect(result.last, isA<CatalogImportCancelled>());
+      expect(result, isNot(contains(isA<CatalogImportCompleted>())));
+      expect(await database.projectsDao.getAllProjects(), isEmpty);
+      expect(await database.sessionDao.getSessionsForPlugin(pluginId: plugin.id), isEmpty);
+      expect(await repository.getHydrationCompletion(pluginId: plugin.id), isNull);
+    });
+
     test("generation replacement inside the transaction rolls back catalog publication", () async {
       final projectPath = "${directory.path}/stale-transaction-generation";
       final plugin = _NativeImportPlugin(
@@ -853,6 +887,16 @@ class _RecordingSessionDao extends SessionDao {
       throw StateError("injected session batch failure");
     }
     await super.upsertSessionRows(rows: rows);
+  }
+}
+
+class _SignalingCatalogWriteVisibilityState extends SessionVisibilityState {
+  final Completer<void> catalogWriteRequested = Completer<void>();
+
+  @override
+  Future<T> withCatalogWrite<T>({required String pluginId, required Future<T> Function() body}) {
+    if (!catalogWriteRequested.isCompleted) catalogWriteRequested.complete();
+    return super.withCatalogWrite(pluginId: pluginId, body: body);
   }
 }
 

--- a/bridge/app/test/repositories/catalog_import_repository_test.dart
+++ b/bridge/app/test/repositories/catalog_import_repository_test.dart
@@ -6,6 +6,7 @@ import "package:sesori_bridge/src/api/database/daos/session_dao.dart";
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/api/database/tables/projects_table.dart";
 import "package:sesori_bridge/src/api/database/tables/session_table.dart";
+import "package:sesori_bridge/src/bridge/foundation/session_visibility_state.dart";
 import "package:sesori_bridge/src/repositories/catalog_import_repository.dart";
 import "package:sesori_bridge/src/repositories/models/catalog_import_control.dart";
 import "package:sesori_bridge/src/repositories/project_catalog_identity_calculator.dart";
@@ -271,6 +272,7 @@ void main() {
         sessionDao: database.sessionDao,
         catalogHydrationsDao: database.catalogHydrationsDao,
         projectCatalogIdentityCalculator: calculator,
+        visibilityState: SessionVisibilityState(),
       );
 
       await repository
@@ -321,6 +323,7 @@ void main() {
         sessionDao: sessionDao,
         catalogHydrationsDao: database.catalogHydrationsDao,
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
+        visibilityState: SessionVisibilityState(),
       );
 
       await repository
@@ -634,6 +637,7 @@ void main() {
         sessionDao: database.sessionDao,
         catalogHydrationsDao: database.catalogHydrationsDao,
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
+        visibilityState: SessionVisibilityState(),
       );
       final finished = Completer<void>();
       Object? streamError;
@@ -665,6 +669,57 @@ void main() {
       await runtime.dispose();
     });
 
+    test("a pending creation reservation blocks catalog binding publication", () async {
+      final projectPath = "${directory.path}/pending-creation";
+      final plugin = _NativeImportPlugin(
+        projects: [PluginProject(id: "pending-creation", directory: projectPath)],
+        rootsByProject: {
+          projectPath: [
+            _pluginSession(
+              id: "backend-creating",
+              directory: projectPath,
+            ),
+          ],
+        },
+        childrenByParent: const {},
+      );
+      final visibilityState = SessionVisibilityState();
+      final creationReservation = visibilityState.reserveSessionCreation(
+        pluginId: plugin.id,
+      );
+      final repository = _repository(
+        database: database,
+        plugin: plugin,
+        visibilityState: visibilityState,
+      );
+      final committing = Completer<void>();
+      final completed = repository
+          .importCatalog(
+            pluginId: plugin.id,
+            control: CatalogImportControl(
+              explicitImportRequested: true,
+              hydrationMarkerRequested: false,
+            ),
+          )
+          .forEach((status) {
+            if (status is CatalogImportCommitting) committing.complete();
+          });
+      await committing.future;
+
+      expect(
+        await database.sessionDao.getSessionByBinding(
+          pluginId: plugin.id,
+          backendSessionId: "backend-creating",
+        ),
+        isNull,
+      );
+
+      visibilityState.releaseSessionCreation(
+        reservation: creationReservation,
+      );
+      await completed;
+    });
+
     test("generation replacement inside the transaction rolls back catalog publication", () async {
       final projectPath = "${directory.path}/stale-transaction-generation";
       final plugin = _NativeImportPlugin(
@@ -682,6 +737,7 @@ void main() {
         sessionDao: database.sessionDao,
         catalogHydrationsDao: database.catalogHydrationsDao,
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
+        visibilityState: SessionVisibilityState(),
       );
       final publication = repository
           .importCatalog(
@@ -729,6 +785,7 @@ void main() {
         sessionDao: sessionDao,
         catalogHydrationsDao: database.catalogHydrationsDao,
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
+        visibilityState: SessionVisibilityState(),
       );
 
       await expectLater(
@@ -838,12 +895,17 @@ class _TrackingProjectCatalogIdentityCalculator extends ProjectCatalogIdentityCa
   }
 }
 
-CatalogImportRepository _repository({required AppDatabase database, required BridgePluginApi plugin}) {
+CatalogImportRepository _repository({
+  required AppDatabase database,
+  required BridgePluginApi plugin,
+  SessionVisibilityState? visibilityState,
+}) {
   return singlePluginCatalogImportRepository(
     plugin: plugin,
     projectsDao: database.projectsDao,
     sessionDao: database.sessionDao,
     catalogHydrationsDao: database.catalogHydrationsDao,
+    visibilityState: visibilityState,
   );
 }
 

--- a/bridge/app/tool/benchmarks/catalog_import_event_soak.dart
+++ b/bridge/app/tool/benchmarks/catalog_import_event_soak.dart
@@ -11,6 +11,7 @@ import "package:sesori_bridge/src/api/database/tables/session_table.dart";
 import "package:sesori_bridge/src/bridge/api/filesystem_api.dart";
 import "package:sesori_bridge/src/bridge/api/git_cli_api.dart";
 import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
+import "package:sesori_bridge/src/bridge/foundation/session_visibility_state.dart";
 import "package:sesori_bridge/src/bridge/repositories/mappers/session_event_mapper.dart";
 import "package:sesori_bridge/src/bridge/repositories/project_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
@@ -136,12 +137,14 @@ class _CatalogImportEventSoak {
       );
       final plugins = <String, BridgePluginApi>{plugin.id: plugin};
       final runtime = createBenchmarkPluginRuntime(plugins: plugins.values);
+      final visibilityState = SessionVisibilityState();
       final importRepository = CatalogImportRepository(
         runtime: runtime,
         projectsDao: database.projectsDao,
         sessionDao: database.sessionDao,
         catalogHydrationsDao: database.catalogHydrationsDao,
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
+        visibilityState: visibilityState,
       );
       sessionRepository = SessionRepository(
         runtime: runtime,
@@ -152,6 +155,7 @@ class _CatalogImportEventSoak {
         unseenCalculator: const SessionUnseenCalculator(),
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
         aggregateSourceDeadline: const Duration(seconds: 5),
+        visibilityState: visibilityState,
       );
       final projectRepository = ProjectRepository(
         projectsDao: database.projectsDao,
@@ -163,6 +167,7 @@ class _CatalogImportEventSoak {
           gitPathExists: ({required String gitPath}) => false,
         ),
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
+        visibilityState: visibilityState,
       );
       final eventTracker = SessionEventTracker(
         maxPendingEntriesPerPlugin: SessionEventTracker.defaultMaxPendingEntries,

--- a/bridge/app/tool/benchmarks/event_projection_benchmark.dart
+++ b/bridge/app/tool/benchmarks/event_projection_benchmark.dart
@@ -5,6 +5,7 @@ import "dart:io";
 import "package:args/args.dart";
 import "package:path/path.dart" as p;
 import "package:sesori_bridge/src/api/database/database.dart";
+import "package:sesori_bridge/src/bridge/foundation/session_visibility_state.dart";
 import "package:sesori_bridge/src/bridge/repositories/mappers/session_event_mapper.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
@@ -91,6 +92,7 @@ class _EventProjectionBenchmark {
         unseenCalculator: const SessionUnseenCalculator(),
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
         aggregateSourceDeadline: const Duration(seconds: 5),
+        visibilityState: SessionVisibilityState(),
       );
       final failureReporter = _BenchmarkFailureReporter();
       final service = SessionEventService(

--- a/bridge/app/tool/benchmarks/import_concurrency_benchmark.dart
+++ b/bridge/app/tool/benchmarks/import_concurrency_benchmark.dart
@@ -8,6 +8,7 @@ import "package:path/path.dart" as p;
 import "package:sesori_bridge/src/api/database/daos/projects_dao.dart";
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/api/database/tables/projects_table.dart";
+import "package:sesori_bridge/src/bridge/foundation/session_visibility_state.dart";
 import "package:sesori_bridge/src/repositories/catalog_import_repository.dart";
 import "package:sesori_bridge/src/repositories/models/catalog_import_control.dart";
 import "package:sesori_bridge/src/repositories/project_catalog_identity_calculator.dart";
@@ -115,6 +116,7 @@ class _ImportConcurrencyBenchmark {
         sessionDao: database.sessionDao,
         catalogHydrationsDao: database.catalogHydrationsDao,
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
+        visibilityState: SessionVisibilityState(),
       );
       final importDone = Completer<void>();
       final publicationStopwatch = Stopwatch();

--- a/bridge/app/tool/benchmarks/live_list_baseline.dart
+++ b/bridge/app/tool/benchmarks/live_list_baseline.dart
@@ -11,6 +11,7 @@ import "package:sesori_bridge/src/api/database/tables/session_table.dart";
 import "package:sesori_bridge/src/bridge/api/filesystem_api.dart";
 import "package:sesori_bridge/src/bridge/api/git_cli_api.dart";
 import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
+import "package:sesori_bridge/src/bridge/foundation/session_visibility_state.dart";
 import "package:sesori_bridge/src/bridge/repositories/project_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
@@ -191,6 +192,7 @@ class _LiveListBenchmark {
     await _seedProjects(database: database, projectCount: _configuration.projectCount);
     final filesystemApi = _ExistingFilesystemApi();
     const unseenCalculator = SessionUnseenCalculator();
+    final visibilityState = SessionVisibilityState();
     // Never invoked by the benchmarked listing paths; wired only to satisfy
     // the repository constructor.
     final gitCliApi = GitCliApi(processRunner: ProcessRunner(), gitPathExists: ({required String gitPath}) => false);
@@ -202,6 +204,7 @@ class _LiveListBenchmark {
       unseenCalculator: unseenCalculator,
       filesystemApi: filesystemApi,
       projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
+      visibilityState: visibilityState,
     );
     final results = <Map<String, Object?>>[];
     results.add(
@@ -234,7 +237,11 @@ class _LiveListBenchmark {
       unpaginatedSessionCount: _configuration.unpaginatedSessionCount,
     );
 
-    final sessionRepository = _sessionRepository(database: database, plugins: operationalPlugins);
+    final sessionRepository = _sessionRepository(
+      database: database,
+      plugins: operationalPlugins,
+      visibilityState: visibilityState,
+    );
     final pageSize = min(100, _configuration.sessionCount);
 
     try {
@@ -437,6 +444,7 @@ class _LiveListBenchmark {
   SessionRepository _sessionRepository({
     required AppDatabase database,
     required Map<String, BridgePluginApi> plugins,
+    required SessionVisibilityState visibilityState,
   }) {
     return SessionRepository(
       runtime: createBenchmarkPluginRuntime(plugins: plugins.values),
@@ -450,6 +458,7 @@ class _LiveListBenchmark {
       unseenCalculator: const SessionUnseenCalculator(),
       projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
       aggregateSourceDeadline: const Duration(seconds: 5),
+      visibilityState: visibilityState,
     );
   }
 


### PR DESCRIPTION
## Complexity

🚧 Complex — repository-owned provisional visibility crosses session creation, catalog writers and reads, interaction projections, unseen state, plugin events, family ordering, failure recovery, and restart semantics.

## What

- Add an opaque unpublished-session binding and process-local visibility coordinator.
- Reserve same-plugin catalog binding writes before backend creation and keep unrelated plugins concurrent.
- Carry the unpublished token through dedicated initial command and metadata-title paths.
- Hide provisional sessions from catalog/detail/child reads, questions, permissions, unseen state, project activity, and event projection.
- Reveal through the existing binding-commit stream exactly once after initialization, including command or rename failure paths.
- Remove eager creation publication and ordinary-lookup initialization paths.

The PR is 1,537 changed lines, 37 above the soft cap. The visibility invariant must land atomically across every identity-producing path; splitting it would leave an independently mergeable bypass.

## Why

Persisting a stable binding before the initial command/title workflow settles lets another phone, desktop surface, catalog writer, or plugin event discover and mutate a partially initialized session. Delaying only SSE publication is insufficient because catalog and interaction reads can expose the committed stable ID.

## Risk and test focus

Risk is high around concurrent creation/catalog binding, stale paginated visibility snapshots, duplicate or missing publication, event loss, failure paths that leave sessions hidden, and accidental suppression after restart. The highest-value checks cover same-plugin creation versus active hydration/import, unrelated-plugin concurrency, token-authorized initialization versus ordinary lookup rejection, concurrent catalog reads, question/permission/unseen filtering, pending-event replay, success and failure reveal, rollback cleanup, exactly-once publication, and fresh-repository recovery.

## Expected result

- **User-visible:** A newly discoverable session has finished its initial command/title workflow. If accepted initialization work fails, the authoritative committed session still becomes visible before the route returns the existing failure outcome.
- **Persisted/database:** No schema, migration, backfill, or persisted visibility field. Committed bindings remain the restart recovery authority.
- **Internal:** One repository-authorized transition controls provisional visibility across catalog writers, reads, interactions, unseen state, and events. No wire, client, plugin-interface, analytics, or compatibility-path change.

## Verification

- `dart test` from `bridge/app`: 2,423 tests passed
- `dart analyze --fatal-infos` from `bridge/app`: no issues
- affected visibility, creation, repository, import, interaction, unseen, event, and routing suites: passed
- `git diff --check`: passed
- `aristotle-impl-review`: initial review rejected pre-token catalog publication, stale paginated exclusion snapshots, and question/permission/unseen bypasses; all valid findings were applied directly and the corrected implementation was not re-reviewed per policy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate new session visibility so partially initialized sessions stay hidden until the initial command/title finishes. This prevents catalog, questions, permissions, unseen, activity, import, and events from exposing or mutating sessions before they’re ready and reveals them exactly once.

- **New Features**
  - Added a process-local visibility coordinator to track unpublished sessions and gate same‑plugin catalog writes while unrelated plugins stay concurrent.
  - Introduced an unpublished-session binding that flows through initial command and initial title; catalog queries now accept excludedSessionIds to hide provisional roots/children.
  - Permissions, questions, unseen, project activity, event projection, and catalog import now respect unpublished sessions; session creation commits emit ProjectUpdated without a generation to refresh the active project only.

- **Refactors**
  - Removed eager publication and ordinary-lookup init; all initial ops go through a new dispatcher with plugin-scoped gating and an initial rename path.
  - Repositories/services accept a shared `SessionVisibilityState`; orchestrator wires it in; reads and unseen emissions are publish-only; tests and benchmarks updated.
  - Made binding-commit/event generations nullable and added a refreshCurrentActiveOnly path; listeners now call it to refresh the active project after durable creation.

<sup>Written for commit 81ceaf4f77af5021e0cde3f5de5531ae17bf36a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

