### PR TITLE
🌿 Recover OAuth sessions invalidated by auth restart

### DIFF
--- a/bridge/app/lib/src/auth/login_oauth_api.dart
+++ b/bridge/app/lib/src/auth/login_oauth_api.dart
@@ -48,8 +48,6 @@ class LoginOAuthApi {
       throw OAuthSessionRestartRequiredException(
         restartAfter: _parseRestartAfter(value: response.headers["retry-after"]),
         deadline: deadline,
-        operation: OAuthSessionRestartOperation.init,
-        reason: OAuthSessionRestartReason.serviceUnavailable,
       );
     }
 
@@ -92,10 +90,6 @@ class LoginOAuthApi {
       throw OAuthSessionRestartRequiredException(
         restartAfter: restartAfter,
         deadline: deadline,
-        operation: OAuthSessionRestartOperation.status,
-        reason: response.statusCode == 404
-            ? OAuthSessionRestartReason.sessionMissing
-            : OAuthSessionRestartReason.serviceUnavailable,
       );
     }
 

--- a/bridge/app/lib/src/auth/login_oauth_api.dart
+++ b/bridge/app/lib/src/auth/login_oauth_api.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:convert";
 
 import "package:http/http.dart" as http;
@@ -29,21 +30,26 @@ class LoginOAuthApi {
     required OAuthProvider provider,
     required String sessionToken,
     required DateTime deadline,
+    required Duration requestTimeout,
   }) async {
     final uri = _buildUri(base: authBackendUrl, path: "${provider.apiAuthPath}/init");
-    final response = await _client.post(
-      uri,
+    final response = await _sendOAuthRequest(
+      method: "POST",
+      uri: uri,
       headers: {
         "Content-Type": "application/json",
         oauthSessionTokenHeader: sessionToken,
       },
       body: jsonEncode(AuthInitRequest(clientType: _clientType, device: _device).toJson()),
+      requestTimeout: requestTimeout,
     );
 
     if (response.statusCode == 503) {
       throw OAuthSessionRestartRequiredException(
-        restartAfter: _parseRestartAfter(response.headers["retry-after"]),
+        restartAfter: _parseRestartAfter(value: response.headers["retry-after"]),
         deadline: deadline,
+        operation: OAuthSessionRestartOperation.init,
+        reason: OAuthSessionRestartReason.serviceUnavailable,
       );
     }
 
@@ -68,18 +74,29 @@ class LoginOAuthApi {
   Future<AuthSessionStatusResponse> getOAuthSessionStatus({
     required String sessionToken,
     required DateTime deadline,
+    required Duration requestTimeout,
   }) async {
     final uri = _buildUri(base: authBackendUrl, path: "auth/session/status");
-    final response = await _client.get(
-      uri,
+    final response = await _sendOAuthRequest(
+      method: "GET",
+      uri: uri,
       headers: {oauthSessionTokenHeader: sessionToken},
+      body: null,
+      requestTimeout: requestTimeout,
     );
 
     if (response.statusCode == 503 || response.statusCode == 404) {
       final restartAfter = response.statusCode == 404
           ? Duration.zero
-          : _parseRestartAfter(response.headers["retry-after"]);
-      throw OAuthSessionRestartRequiredException(restartAfter: restartAfter, deadline: deadline);
+          : _parseRestartAfter(value: response.headers["retry-after"]);
+      throw OAuthSessionRestartRequiredException(
+        restartAfter: restartAfter,
+        deadline: deadline,
+        operation: OAuthSessionRestartOperation.status,
+        reason: response.statusCode == 404
+            ? OAuthSessionRestartReason.sessionMissing
+            : OAuthSessionRestartReason.serviceUnavailable,
+      );
     }
 
     if (response.statusCode == 200 || response.statusCode == 410) {
@@ -89,9 +106,35 @@ class LoginOAuthApi {
     throw Exception("auth session status failed: status ${response.statusCode}");
   }
 
-  Duration _parseRestartAfter(String? value) {
+  Duration _parseRestartAfter({required String? value}) {
     final seconds = value != null && RegExp(r"^[0-9]+$").hasMatch(value) ? int.tryParse(value) : null;
     return Duration(seconds: seconds != null && seconds <= 5 ? seconds : 1);
+  }
+
+  Future<http.Response> _sendOAuthRequest({
+    required String method,
+    required Uri uri,
+    required Map<String, String> headers,
+    required String? body,
+    required Duration requestTimeout,
+  }) async {
+    final abortCompleter = Completer<void>();
+    final timeoutTimer = Timer(requestTimeout, abortCompleter.complete);
+
+    try {
+      final request = http.AbortableRequest(method, uri, abortTrigger: abortCompleter.future)..headers.addAll(headers);
+      if (body != null) {
+        request.body = body;
+      }
+      return await http.Response.fromStream(await _client.send(request));
+    } on http.RequestAbortedException catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        _OAuthRequestTimeoutException(requestTimeout: requestTimeout, cause: error),
+        stackTrace,
+      );
+    } finally {
+      timeoutTimer.cancel();
+    }
   }
 
   Future<void> ackOAuthSessionCompletion({required String sessionToken}) async {
@@ -105,4 +148,13 @@ class LoginOAuthApi {
       throw Exception("auth session ACK failed: status ${response.statusCode}");
     }
   }
+}
+
+final class _OAuthRequestTimeoutException extends TimeoutException {
+  _OAuthRequestTimeoutException({
+    required Duration requestTimeout,
+    required this.cause,
+  }) : super("OAuth request timed out", requestTimeout);
+
+  final http.RequestAbortedException cause;
 }

--- a/bridge/app/lib/src/auth/login_oauth_api.dart
+++ b/bridge/app/lib/src/auth/login_oauth_api.dart
@@ -28,6 +28,7 @@ class LoginOAuthApi {
   Future<AuthInitResponse> initOAuthSession({
     required OAuthProvider provider,
     required String sessionToken,
+    required DateTime deadline,
   }) async {
     final uri = _buildUri(base: authBackendUrl, path: "${provider.apiAuthPath}/init");
     final response = await _client.post(
@@ -38,6 +39,13 @@ class LoginOAuthApi {
       },
       body: jsonEncode(AuthInitRequest(clientType: _clientType, device: _device).toJson()),
     );
+
+    if (response.statusCode == 503) {
+      throw OAuthSessionRestartRequiredException(
+        restartAfter: _parseRestartAfter(response.headers["retry-after"]),
+        deadline: deadline,
+      );
+    }
 
     if (response.statusCode != 200) {
       throw Exception("init ${provider.label} auth failed: status ${response.statusCode}");
@@ -57,18 +65,33 @@ class LoginOAuthApi {
     return initResp;
   }
 
-  Future<AuthSessionStatusResponse> getOAuthSessionStatus({required String sessionToken}) async {
+  Future<AuthSessionStatusResponse> getOAuthSessionStatus({
+    required String sessionToken,
+    required DateTime deadline,
+  }) async {
     final uri = _buildUri(base: authBackendUrl, path: "auth/session/status");
     final response = await _client.get(
       uri,
       headers: {oauthSessionTokenHeader: sessionToken},
     );
 
+    if (response.statusCode == 503 || response.statusCode == 404) {
+      final restartAfter = response.statusCode == 404
+          ? Duration.zero
+          : _parseRestartAfter(response.headers["retry-after"]);
+      throw OAuthSessionRestartRequiredException(restartAfter: restartAfter, deadline: deadline);
+    }
+
     if (response.statusCode == 200 || response.statusCode == 410) {
       return AuthSessionStatusResponse.fromJson(jsonDecodeMap(response.body));
     }
 
     throw Exception("auth session status failed: status ${response.statusCode}");
+  }
+
+  Duration _parseRestartAfter(String? value) {
+    final seconds = value != null && RegExp(r"^[0-9]+$").hasMatch(value) ? int.tryParse(value) : null;
+    return Duration(seconds: seconds != null && seconds <= 5 ? seconds : 1);
   }
 
   Future<void> ackOAuthSessionCompletion({required String sessionToken}) async {

--- a/bridge/app/lib/src/auth/login_oauth_service.dart
+++ b/bridge/app/lib/src/auth/login_oauth_service.dart
@@ -7,6 +7,7 @@ import "package:meta/meta.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Console;
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../bridge/foundation/process_starter.dart";
 import "login_oauth_api.dart";
 import "token.dart";
 
@@ -15,6 +16,68 @@ const int _perRequestTimeoutSeconds = 35; // Slightly longer than server's 30s l
 const Duration _defaultPollInterval = Duration(milliseconds: 250);
 const Duration _defaultPollTimeout = Duration(seconds: _totalLoginTimeoutSeconds);
 const Duration _defaultPerRequestTimeout = Duration(seconds: _perRequestTimeoutSeconds);
+const Duration _defaultBrowserTerminationGrace = Duration(milliseconds: 100);
+const Duration _defaultBrowserForcedTerminationTimeout = Duration(seconds: 1);
+
+typedef OAuthBrowserLauncher = Future<void> Function({required String url, required DateTime deadline});
+typedef _OAuthBrowserProcessResult = ({int exitCode, String stderr});
+
+Future<Process> _startOAuthBrowserProcess(String executable, List<String> arguments) {
+  return Process.start(executable, arguments);
+}
+
+Future<_OAuthBrowserProcessResult> _collectOAuthBrowserProcessResult({
+  required Future<int> exitCodeFuture,
+  required _OAuthBrowserOutputCollector output,
+}) async {
+  final (exitCode, _, _) = await (
+    exitCodeFuture,
+    output.stdoutDone,
+    output.stderrDone,
+  ).wait;
+  return (exitCode: exitCode, stderr: output.stderr);
+}
+
+Future<Never> _throwOAuthBrowserTimeoutAfterCleanup({
+  required Process process,
+  required Future<int> exitCode,
+  required Future<_OAuthBrowserProcessResult> completion,
+  required _OAuthBrowserOutputCollector output,
+  required Duration gracefulTerminationTimeout,
+  required Duration forcedTerminationTimeout,
+}) async {
+  Object? cleanupFailure;
+  var forceKill = false;
+  try {
+    process.kill();
+    await exitCode.timeout(gracefulTerminationTimeout);
+  } on Object catch (error) {
+    cleanupFailure = error;
+    forceKill = true;
+  }
+
+  if (forceKill) {
+    try {
+      process.kill(ProcessSignal.sigkill);
+    } on Object catch (error) {
+      cleanupFailure = error;
+    }
+  }
+
+  try {
+    await completion.timeout(forcedTerminationTimeout);
+    cleanupFailure = null;
+  } on Object catch (error) {
+    cleanupFailure = error;
+    try {
+      await output.cancel().timeout(gracefulTerminationTimeout);
+    } on Object catch (error) {
+      cleanupFailure = error;
+    }
+  }
+
+  throw _OAuthBrowserTimeoutException(cause: cleanupFailure);
+}
 
 /// Opens the default browser to [url].
 ///
@@ -22,12 +85,21 @@ const Duration _defaultPerRequestTimeout = Duration(seconds: _perRequestTimeoutS
 /// - macOS: `open`
 /// - Linux: `xdg-open`
 /// - Windows: `rundll32 url.dll,FileProtocolHandler`
-Future<void> openOAuthBrowser(String url) async {
-  late final ProcessResult result;
+Future<void> openOAuthBrowser({
+  required String url,
+  required DateTime deadline,
+  @visibleForTesting ProcessStarter processStarter = _startOAuthBrowserProcess,
+  @visibleForTesting Duration gracefulTerminationTimeout = _defaultBrowserTerminationGrace,
+  @visibleForTesting Duration forcedTerminationTimeout = _defaultBrowserForcedTerminationTimeout,
+}) async {
+  late final String executable;
+  late final List<String> arguments;
   if (Platform.isMacOS) {
-    result = await Process.run("open", [url]);
+    executable = "open";
+    arguments = [url];
   } else if (Platform.isLinux) {
-    result = await Process.run("xdg-open", [url]);
+    executable = "xdg-open";
+    arguments = [url];
   } else if (Platform.isWindows) {
     // Hand the URL straight to the shell's protocol handler via rundll32
     // instead of `cmd /c start`. cmd.exe treats the `&` query-string
@@ -36,13 +108,96 @@ Future<void> openOAuthBrowser(String url) async {
     // as its own command — and `start` would additionally misread the URL as a
     // window title. rundll32 is launched without a shell, so the URL (every
     // `&` included) reaches the default browser verbatim.
-    result = await Process.run("rundll32", ["url.dll,FileProtocolHandler", url]);
+    executable = "rundll32";
+    arguments = ["url.dll,FileProtocolHandler", url];
   } else {
     throw UnsupportedError("Unsupported platform: ${Platform.operatingSystem}");
   }
 
+  final process = await processStarter(executable, arguments);
+  final exitCode = process.exitCode;
+  final output = _OAuthBrowserOutputCollector.start(process: process);
+  final completion = _collectOAuthBrowserProcessResult(exitCodeFuture: exitCode, output: output);
+  final remaining = deadline.difference(DateTime.now());
+  final result = await completion.timeout(
+    remaining > Duration.zero ? remaining : Duration.zero,
+    onTimeout: () => _throwOAuthBrowserTimeoutAfterCleanup(
+      process: process,
+      exitCode: exitCode,
+      completion: completion,
+      output: output,
+      gracefulTerminationTimeout: gracefulTerminationTimeout,
+      forcedTerminationTimeout: forcedTerminationTimeout,
+    ),
+  );
+
   if (result.exitCode != 0) {
     throw Exception("Browser launcher exited with code ${result.exitCode}: ${result.stderr}");
+  }
+}
+
+final class _OAuthBrowserTimeoutException extends TimeoutException {
+  _OAuthBrowserTimeoutException({required this.cause}) : super("timed out waiting for authorization");
+
+  final Object? cause;
+}
+
+final class _OAuthBrowserOutputCollector {
+  _OAuthBrowserOutputCollector.start({required Process process}) {
+    _stdoutSubscription = process.stdout.listen(
+      (_) {},
+      onError: (Object error, StackTrace stackTrace) {
+        if (!_stdoutDone.isCompleted) {
+          _stdoutDone.completeError(error, stackTrace);
+        }
+      },
+      onDone: () {
+        if (!_stdoutDone.isCompleted) {
+          _stdoutDone.complete();
+        }
+      },
+      cancelOnError: true,
+    );
+    _stderrSubscription = process.stderr
+        .transform(const SystemEncoding().decoder)
+        .listen(
+          _stderr.write,
+          onError: (Object error, StackTrace stackTrace) {
+            if (!_stderrDone.isCompleted) {
+              _stderrDone.completeError(error, stackTrace);
+            }
+          },
+          onDone: () {
+            if (!_stderrDone.isCompleted) {
+              _stderrDone.complete();
+            }
+          },
+          cancelOnError: true,
+        );
+  }
+
+  late final StreamSubscription<List<int>> _stdoutSubscription;
+  late final StreamSubscription<String> _stderrSubscription;
+  final Completer<void> _stdoutDone = Completer<void>();
+  final Completer<void> _stderrDone = Completer<void>();
+  final StringBuffer _stderr = StringBuffer();
+
+  Future<void> get stdoutDone => _stdoutDone.future;
+  Future<void> get stderrDone => _stderrDone.future;
+  String get stderr => _stderr.toString();
+
+  Future<void> cancel() async {
+    final cancellations = (
+      _stdoutSubscription.cancel(),
+      _stderrSubscription.cancel(),
+    ).wait;
+    if (!_stdoutDone.isCompleted) {
+      _stdoutDone.complete();
+    }
+    if (!_stderrDone.isCompleted) {
+      _stderrDone.complete();
+    }
+    await cancellations;
   }
 }
 
@@ -134,7 +289,7 @@ bool _isWindowsSubsystemForLinux(Map<String, String> env) {
 
 class LoginOAuthService {
   final LoginOAuthApi _api;
-  final Future<void> Function(String url) _browserLauncher;
+  final OAuthBrowserLauncher _browserLauncher;
   final BrowserOpenability Function() _browserOpenability;
   final Duration _pollInterval;
   final Duration _pollTimeout;
@@ -143,7 +298,7 @@ class LoginOAuthService {
 
   LoginOAuthService({
     required LoginOAuthApi api,
-    required Future<void> Function(String url) browserLauncher,
+    required OAuthBrowserLauncher browserLauncher,
     required BrowserOpenability Function() browserOpenability,
     @visibleForTesting Duration pollInterval = _defaultPollInterval,
     @visibleForTesting Duration pollTimeout = _defaultPollTimeout,
@@ -225,7 +380,7 @@ class LoginOAuthService {
       try {
         await _beforeOAuthDeadline(
           stopwatch: stopwatch,
-          operation: () => _browserLauncher(initResp.authUrl),
+          operation: () => _browserLauncher(url: initResp.authUrl, deadline: deadline),
         );
       } on TimeoutException {
         rethrow;

--- a/bridge/app/lib/src/auth/login_oauth_service.dart
+++ b/bridge/app/lib/src/auth/login_oauth_service.dart
@@ -7,7 +7,6 @@ import "package:meta/meta.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Console;
 import "package:sesori_shared/sesori_shared.dart";
 
-import "../bridge/foundation/process_starter.dart";
 import "login_oauth_api.dart";
 import "token.dart";
 
@@ -16,67 +15,12 @@ const int _perRequestTimeoutSeconds = 35; // Slightly longer than server's 30s l
 const Duration _defaultPollInterval = Duration(milliseconds: 250);
 const Duration _defaultPollTimeout = Duration(seconds: _totalLoginTimeoutSeconds);
 const Duration _defaultPerRequestTimeout = Duration(seconds: _perRequestTimeoutSeconds);
-const Duration _defaultBrowserTerminationGrace = Duration(milliseconds: 100);
-const Duration _defaultBrowserForcedTerminationTimeout = Duration(seconds: 1);
 
 typedef OAuthBrowserLauncher = Future<void> Function({required String url, required DateTime deadline});
-typedef _OAuthBrowserProcessResult = ({int exitCode, String stderr});
+typedef OAuthBrowserProcessStarter = Future<void> Function(String executable, List<String> arguments);
 
-Future<Process> _startOAuthBrowserProcess(String executable, List<String> arguments) {
-  return Process.start(executable, arguments);
-}
-
-Future<_OAuthBrowserProcessResult> _collectOAuthBrowserProcessResult({
-  required Future<int> exitCodeFuture,
-  required _OAuthBrowserOutputCollector output,
-}) async {
-  final (exitCode, _, _) = await (
-    exitCodeFuture,
-    output.stdoutDone,
-    output.stderrDone,
-  ).wait;
-  return (exitCode: exitCode, stderr: output.stderr);
-}
-
-Future<Never> _throwOAuthBrowserTimeoutAfterCleanup({
-  required Process process,
-  required Future<int> exitCode,
-  required Future<_OAuthBrowserProcessResult> completion,
-  required _OAuthBrowserOutputCollector output,
-  required Duration gracefulTerminationTimeout,
-  required Duration forcedTerminationTimeout,
-}) async {
-  Object? cleanupFailure;
-  var forceKill = false;
-  try {
-    process.kill();
-    await exitCode.timeout(gracefulTerminationTimeout);
-  } on Object catch (error) {
-    cleanupFailure = error;
-    forceKill = true;
-  }
-
-  if (forceKill) {
-    try {
-      process.kill(ProcessSignal.sigkill);
-    } on Object catch (error) {
-      cleanupFailure = error;
-    }
-  }
-
-  try {
-    await completion.timeout(forcedTerminationTimeout);
-    cleanupFailure = null;
-  } on Object catch (error) {
-    cleanupFailure = error;
-    try {
-      await output.cancel().timeout(gracefulTerminationTimeout);
-    } on Object catch (error) {
-      cleanupFailure = error;
-    }
-  }
-
-  throw _OAuthBrowserTimeoutException(cause: cleanupFailure);
+Future<void> _startOAuthBrowserProcess(String executable, List<String> arguments) async {
+  await Process.start(executable, arguments, mode: ProcessStartMode.detached);
 }
 
 /// Opens the default browser to [url].
@@ -88,9 +32,7 @@ Future<Never> _throwOAuthBrowserTimeoutAfterCleanup({
 Future<void> openOAuthBrowser({
   required String url,
   required DateTime deadline,
-  @visibleForTesting ProcessStarter processStarter = _startOAuthBrowserProcess,
-  @visibleForTesting Duration gracefulTerminationTimeout = _defaultBrowserTerminationGrace,
-  @visibleForTesting Duration forcedTerminationTimeout = _defaultBrowserForcedTerminationTimeout,
+  @visibleForTesting OAuthBrowserProcessStarter processStarter = _startOAuthBrowserProcess,
 }) async {
   late final String executable;
   late final List<String> arguments;
@@ -114,91 +56,13 @@ Future<void> openOAuthBrowser({
     throw UnsupportedError("Unsupported platform: ${Platform.operatingSystem}");
   }
 
-  final process = await processStarter(executable, arguments);
-  final exitCode = process.exitCode;
-  final output = _OAuthBrowserOutputCollector.start(process: process);
-  final completion = _collectOAuthBrowserProcessResult(exitCodeFuture: exitCode, output: output);
-  final remaining = deadline.difference(DateTime.now());
-  final result = await completion.timeout(
-    remaining > Duration.zero ? remaining : Duration.zero,
-    onTimeout: () => _throwOAuthBrowserTimeoutAfterCleanup(
-      process: process,
-      exitCode: exitCode,
-      completion: completion,
-      output: output,
-      gracefulTerminationTimeout: gracefulTerminationTimeout,
-      forcedTerminationTimeout: forcedTerminationTimeout,
-    ),
-  );
-
-  if (result.exitCode != 0) {
-    throw Exception("Browser launcher exited with code ${result.exitCode}: ${result.stderr}");
-  }
-}
-
-final class _OAuthBrowserTimeoutException extends TimeoutException {
-  _OAuthBrowserTimeoutException({required this.cause}) : super("timed out waiting for authorization");
-
-  final Object? cause;
-}
-
-final class _OAuthBrowserOutputCollector {
-  _OAuthBrowserOutputCollector.start({required Process process}) {
-    _stdoutSubscription = process.stdout.listen(
-      (_) {},
-      onError: (Object error, StackTrace stackTrace) {
-        if (!_stdoutDone.isCompleted) {
-          _stdoutDone.completeError(error, stackTrace);
-        }
-      },
-      onDone: () {
-        if (!_stdoutDone.isCompleted) {
-          _stdoutDone.complete();
-        }
-      },
-      cancelOnError: true,
-    );
-    _stderrSubscription = process.stderr
-        .transform(const SystemEncoding().decoder)
-        .listen(
-          _stderr.write,
-          onError: (Object error, StackTrace stackTrace) {
-            if (!_stderrDone.isCompleted) {
-              _stderrDone.completeError(error, stackTrace);
-            }
-          },
-          onDone: () {
-            if (!_stderrDone.isCompleted) {
-              _stderrDone.complete();
-            }
-          },
-          cancelOnError: true,
-        );
+  if (!DateTime.now().isBefore(deadline)) {
+    throw TimeoutException("timed out waiting for authorization");
   }
 
-  late final StreamSubscription<List<int>> _stdoutSubscription;
-  late final StreamSubscription<String> _stderrSubscription;
-  final Completer<void> _stdoutDone = Completer<void>();
-  final Completer<void> _stderrDone = Completer<void>();
-  final StringBuffer _stderr = StringBuffer();
-
-  Future<void> get stdoutDone => _stdoutDone.future;
-  Future<void> get stderrDone => _stderrDone.future;
-  String get stderr => _stderr.toString();
-
-  Future<void> cancel() async {
-    final cancellations = (
-      _stdoutSubscription.cancel(),
-      _stderrSubscription.cancel(),
-    ).wait;
-    if (!_stdoutDone.isCompleted) {
-      _stdoutDone.complete();
-    }
-    if (!_stderrDone.isCompleted) {
-      _stderrDone.complete();
-    }
-    await cancellations;
-  }
+  // The platform opener is only a best-effort handoff. Detached mode avoids
+  // retaining child pipes or waiting for the browser after the OS accepts it.
+  await processStarter(executable, arguments);
 }
 
 /// Confidence that a URL can be opened in a graphical browser on this host.
@@ -319,23 +183,23 @@ class LoginOAuthService {
   Future<({TokenData tokens, String sessionToken})> performOAuthLogin(OAuthProvider provider) async {
     final stopwatch = Stopwatch()..start();
     final deadline = DateTime.now().add(_pollTimeout);
-    try {
-      return await _performOAuthAttempt(provider: provider, stopwatch: stopwatch, deadline: deadline);
-    } on OAuthSessionRestartRequiredException catch (error) {
-      stopwatch.start();
-      final remaining = _pollTimeout - stopwatch.elapsed;
-      final restartDelay = error.restartAfter < remaining ? error.restartAfter : remaining;
-      if (restartDelay > Duration.zero) {
-        await _delay(restartDelay).timeout(remaining);
-      }
-      if (remaining <= Duration.zero || error.restartAfter >= remaining || stopwatch.elapsed >= _pollTimeout) {
-        throw TimeoutException("timed out waiting for authorization", _pollTimeout);
-      }
-
+    var restarted = false;
+    while (true) {
       try {
         return await _performOAuthAttempt(provider: provider, stopwatch: stopwatch, deadline: deadline);
-      } on OAuthSessionRestartRequiredException catch (secondError, stackTrace) {
-        Error.throwWithStackTrace(_OAuthSessionRestartFailedException(secondError), stackTrace);
+      } on OAuthSessionRestartRequiredException catch (error) {
+        if (restarted) {
+          rethrow;
+        }
+        restarted = true;
+        stopwatch.start();
+        final remaining = _pollTimeout - stopwatch.elapsed;
+        if (remaining <= Duration.zero || error.restartAfter >= remaining) {
+          throw TimeoutException("timed out waiting for authorization", _pollTimeout);
+        }
+        if (error.restartAfter > Duration.zero) {
+          await _delay(error.restartAfter).timeout(remaining);
+        }
       }
     }
   }
@@ -481,11 +345,4 @@ class LoginOAuthService {
 
     return bytes.map((byte) => byte.toRadixString(16).padLeft(2, "0")).join();
   }
-}
-
-final class _OAuthSessionRestartFailedException implements Exception {
-  const _OAuthSessionRestartFailedException(this.cause);
-  final OAuthSessionRestartRequiredException cause;
-  @override
-  String toString() => "OAuth session was lost again after restart: $cause";
 }

--- a/bridge/app/lib/src/auth/login_oauth_service.dart
+++ b/bridge/app/lib/src/auth/login_oauth_service.dart
@@ -197,6 +197,7 @@ class LoginOAuthService {
         provider: provider,
         sessionToken: sessionToken,
         deadline: deadline,
+        requestTimeout: _pollTimeout - stopwatch.elapsed,
       ),
     );
 
@@ -273,9 +274,11 @@ class LoginOAuthService {
         final remaining = _pollTimeout - stopwatch.elapsed;
         if (remaining <= Duration.zero) break;
         final requestTimeout = remaining < _perRequestTimeout ? remaining : _perRequestTimeout;
-        final status = await _api
-            .getOAuthSessionStatus(sessionToken: sessionToken, deadline: deadline)
-            .timeout(requestTimeout);
+        final status = await _api.getOAuthSessionStatus(
+          sessionToken: sessionToken,
+          deadline: deadline,
+          requestTimeout: requestTimeout,
+        );
 
         switch (status) {
           case AuthSessionStatusResponsePending():
@@ -329,5 +332,5 @@ final class _OAuthSessionRestartFailedException implements Exception {
   const _OAuthSessionRestartFailedException(this.cause);
   final OAuthSessionRestartRequiredException cause;
   @override
-  String toString() => "OAuth session was lost again after restart";
+  String toString() => "OAuth session was lost again after restart: $cause";
 }

--- a/bridge/app/lib/src/auth/login_oauth_service.dart
+++ b/bridge/app/lib/src/auth/login_oauth_service.dart
@@ -162,10 +162,42 @@ class LoginOAuthService {
   /// The temporary session token is generated in memory, sent only through the
   /// `X-Sesori-Session-Token` header, and never persisted or placed in URLs.
   Future<({TokenData tokens, String sessionToken})> performOAuthLogin(OAuthProvider provider) async {
+    final stopwatch = Stopwatch()..start();
+    final deadline = DateTime.now().add(_pollTimeout);
+    try {
+      return await _performOAuthAttempt(provider: provider, stopwatch: stopwatch, deadline: deadline);
+    } on OAuthSessionRestartRequiredException catch (error) {
+      stopwatch.start();
+      final remaining = _pollTimeout - stopwatch.elapsed;
+      final restartDelay = error.restartAfter < remaining ? error.restartAfter : remaining;
+      if (restartDelay > Duration.zero) {
+        await _delay(restartDelay).timeout(remaining);
+      }
+      if (remaining <= Duration.zero || error.restartAfter >= remaining || stopwatch.elapsed >= _pollTimeout) {
+        throw TimeoutException("timed out waiting for authorization", _pollTimeout);
+      }
+
+      try {
+        return await _performOAuthAttempt(provider: provider, stopwatch: stopwatch, deadline: deadline);
+      } on OAuthSessionRestartRequiredException catch (secondError, stackTrace) {
+        Error.throwWithStackTrace(_OAuthSessionRestartFailedException(secondError), stackTrace);
+      }
+    }
+  }
+
+  Future<({TokenData tokens, String sessionToken})> _performOAuthAttempt({
+    required OAuthProvider provider,
+    required Stopwatch stopwatch,
+    required DateTime deadline,
+  }) async {
     final sessionToken = _generateSessionToken();
-    final initResp = await _api.initOAuthSession(
-      provider: provider,
-      sessionToken: sessionToken,
+    final initResp = await _beforeOAuthDeadline(
+      stopwatch: stopwatch,
+      operation: () => _api.initOAuthSession(
+        provider: provider,
+        sessionToken: sessionToken,
+        deadline: deadline,
+      ),
     );
 
     // The URL is ALWAYS printed, on its own line, so login works even when no
@@ -190,15 +222,40 @@ class LoginOAuthService {
     Console.message(initResp.authUrl);
     if (openability != BrowserOpenability.no) {
       try {
-        await _browserLauncher(initResp.authUrl);
+        await _beforeOAuthDeadline(
+          stopwatch: stopwatch,
+          operation: () => _browserLauncher(initResp.authUrl),
+        );
+      } on TimeoutException {
+        rethrow;
       } catch (e) {
         Console.message("Could not open a browser automatically; open the URL above manually: $e");
       }
     }
 
     Console.message("Waiting for authorization...");
-    final tokens = await _pollForCompletion(provider: provider, sessionToken: sessionToken);
+    final tokens = await _pollForCompletion(
+      provider: provider,
+      sessionToken: sessionToken,
+      stopwatch: stopwatch,
+      deadline: deadline,
+    );
     return (tokens: tokens, sessionToken: sessionToken);
+  }
+
+  Future<T> _beforeOAuthDeadline<T>({
+    required Stopwatch stopwatch,
+    required Future<T> Function() operation,
+  }) {
+    final remaining = _pollTimeout - stopwatch.elapsed;
+    if (remaining <= Duration.zero) {
+      return Future<T>.error(TimeoutException("timed out waiting for authorization", _pollTimeout));
+    }
+
+    return operation().timeout(
+      remaining,
+      onTimeout: () => throw TimeoutException("timed out waiting for authorization", _pollTimeout),
+    );
   }
 
   Future<void> ackOAuthSessionCompletion({required String sessionToken}) {
@@ -208,18 +265,22 @@ class LoginOAuthService {
   Future<TokenData> _pollForCompletion({
     required OAuthProvider provider,
     required String sessionToken,
+    required Stopwatch stopwatch,
+    required DateTime deadline,
   }) async {
-    final stopwatch = Stopwatch()..start();
     try {
       while (stopwatch.elapsed < _pollTimeout) {
         final remaining = _pollTimeout - stopwatch.elapsed;
         if (remaining <= Duration.zero) break;
         final requestTimeout = remaining < _perRequestTimeout ? remaining : _perRequestTimeout;
-        final status = await _api.getOAuthSessionStatus(sessionToken: sessionToken).timeout(requestTimeout);
+        final status = await _api
+            .getOAuthSessionStatus(sessionToken: sessionToken, deadline: deadline)
+            .timeout(requestTimeout);
 
         switch (status) {
           case AuthSessionStatusResponsePending():
-            final delay = _pollInterval < remaining ? _pollInterval : remaining;
+            final delayRemaining = _pollTimeout - stopwatch.elapsed;
+            final delay = _pollInterval < delayRemaining ? _pollInterval : delayRemaining;
             if (delay > Duration.zero) {
               await _delay(delay);
             }
@@ -262,4 +323,11 @@ class LoginOAuthService {
 
     return bytes.map((byte) => byte.toRadixString(16).padLeft(2, "0")).join();
   }
+}
+
+final class _OAuthSessionRestartFailedException implements Exception {
+  const _OAuthSessionRestartFailedException(this.cause);
+  final OAuthSessionRestartRequiredException cause;
+  @override
+  String toString() => "OAuth session was lost again after restart";
 }

--- a/bridge/app/test/auth/login_test.dart
+++ b/bridge/app/test/auth/login_test.dart
@@ -222,7 +222,7 @@ void main() {
         );
         final service = LoginOAuthService(
           api: api,
-          browserLauncher: (_) async {},
+          browserLauncher: ({required String url, required DateTime deadline}) async {},
           browserOpenability: _alwaysOpenableBrowser,
           pollTimeout: const Duration(seconds: 1),
           perRequestTimeout: const Duration(milliseconds: 10),
@@ -239,6 +239,45 @@ void main() {
         expect(client.maximumActiveStatusRequests, 1);
         expect(client.activeStatusRequests, 0);
         expect(client.statusAbortCount, 1);
+      });
+
+      test('browser launcher receives the same absolute deadline after an OAuth restart', () async {
+        final authServer = await _OAuthLongPollTestServer.start(
+          statusResponses: [
+            (statusCode: 503, retryAfter: '0'),
+            AuthSessionStatusResponse.complete(
+              accessToken: 'access',
+              refreshToken: 'refresh',
+              user: const AuthUser(
+                id: 'user-1',
+                provider: AuthProvider.github,
+                providerUserId: 'github-1',
+                providerUsername: null,
+              ),
+            ),
+          ],
+        );
+        addTearDown(authServer.close);
+        final deadlines = <DateTime>[];
+        final service = LoginOAuthService(
+          api: LoginOAuthApi(
+            authBackendUrl: authServer.baseUrl,
+            client: authServer.client,
+            clientType: AuthClientType.bridgeMacos,
+            device: DeviceInfo(name: 'Test Mac', osVersion: null, appVersion: null),
+          ),
+          browserLauncher: ({required String url, required DateTime deadline}) async {
+            deadlines.add(deadline);
+          },
+          browserOpenability: _alwaysOpenableBrowser,
+          pollInterval: Duration.zero,
+          pollTimeout: const Duration(seconds: 1),
+        );
+
+        await service.performOAuthLogin(AuthProvider.github);
+
+        expect(deadlines, hasLength(2));
+        expect(deadlines.toSet(), hasLength(1));
       });
 
       for (final hangingOperation in ['init', 'browser']) {
@@ -545,6 +584,93 @@ void main() {
     });
   });
 
+  group('openOAuthBrowser', () {
+    test('reports collected stderr when the launcher exits non-zero', () async {
+      final process = _CompletedBrowserProcess();
+
+      await expectLater(
+        openOAuthBrowser(
+          url: 'https://example.com/oauth?state=failed-launch',
+          deadline: DateTime.now().add(const Duration(seconds: 1)),
+          processStarter: (_, __) async => process,
+        ),
+        throwsA(
+          isA<Exception>().having(
+            (error) => error.toString(),
+            'message',
+            contains('Browser launcher exited with code 7: launcher failed'),
+          ),
+        ),
+      );
+
+      expect(process.killSignals, isEmpty);
+    });
+
+    test('gracefully terminates then force-kills a hanging launcher and awaits completed drains', () async {
+      final process = _HangingBrowserProcess();
+      String? executable;
+      List<String>? arguments;
+      const authUrl = 'https://example.com/oauth?state=state-1';
+      final deadline = DateTime.now().add(const Duration(milliseconds: 30));
+      final stopwatch = Stopwatch()..start();
+
+      await expectLater(
+        openOAuthBrowser(
+          url: authUrl,
+          deadline: deadline,
+          processStarter: (startedExecutable, startedArguments) async {
+            executable = startedExecutable;
+            arguments = startedArguments;
+            return process;
+          },
+          gracefulTerminationTimeout: const Duration(milliseconds: 5),
+          forcedTerminationTimeout: const Duration(milliseconds: 20),
+        ),
+        throwsA(isA<TimeoutException>()),
+      );
+      stopwatch.stop();
+
+      expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 500)));
+      expect(executable, isNotEmpty);
+      expect(arguments, contains(authUrl));
+      expect(process.killSignals, [ProcessSignal.sigterm, ProcessSignal.sigkill]);
+      expect(process.exited, isTrue);
+      expect(process.stdoutDrained, isTrue);
+      expect(process.stderrDrained, isTrue);
+    });
+
+    test('preserves a bounded OAuth timeout when forced cleanup cannot finish', () async {
+      final process = _HangingBrowserProcess(exitsOnSigkill: false);
+      final stopwatch = Stopwatch()..start();
+
+      await expectLater(
+        openOAuthBrowser(
+          url: 'https://example.com/oauth?state=state-2',
+          deadline: DateTime.now().add(const Duration(milliseconds: 5)),
+          processStarter: (_, __) async => process,
+          gracefulTerminationTimeout: const Duration(milliseconds: 5),
+          forcedTerminationTimeout: const Duration(milliseconds: 20),
+        ),
+        throwsA(
+          isA<TimeoutException>().having(
+            (error) => error.message,
+            'message',
+            'timed out waiting for authorization',
+          ),
+        ),
+      );
+      stopwatch.stop();
+
+      expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 500)));
+      expect(process.killSignals, [ProcessSignal.sigterm, ProcessSignal.sigkill]);
+      expect(process.exited, isFalse);
+      expect(process.stdoutDrained, isFalse);
+      expect(process.stderrDrained, isFalse);
+      expect(process.stdoutCanceled, isTrue);
+      expect(process.stderrCanceled, isTrue);
+    });
+  });
+
   group('resolveBrowserOpenability', () {
     BrowserOpenability resolve({
       bool isLinux = false,
@@ -732,7 +858,7 @@ LoginOAuthService _createOAuthService({
       clientType: AuthClientType.bridgeMacos,
       device: DeviceInfo(name: 'Test Mac', osVersion: 'macOS 14.5', appVersion: '1.2.0'),
     ),
-    browserLauncher: browserLauncher,
+    browserLauncher: ({required String url, required DateTime deadline}) => browserLauncher(url),
     browserOpenability: browserOpenability,
     pollTimeout: pollTimeout,
     pollInterval: pollInterval,
@@ -1124,4 +1250,95 @@ class _CapturingStdout implements Stdout {
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _HangingBrowserProcess implements Process {
+  _HangingBrowserProcess({this.exitsOnSigkill = true}) {
+    _stdout = StreamController<List<int>>(onCancel: () => stdoutCanceled = true);
+    _stderr = StreamController<List<int>>(onCancel: () => stderrCanceled = true);
+  }
+
+  final bool exitsOnSigkill;
+  final Completer<int> _exitCode = Completer<int>();
+  late final StreamController<List<int>> _stdout;
+  late final StreamController<List<int>> _stderr;
+  final List<ProcessSignal> killSignals = [];
+  bool stdoutDrained = false;
+  bool stderrDrained = false;
+  bool stdoutCanceled = false;
+  bool stderrCanceled = false;
+
+  bool get exited => _exitCode.isCompleted;
+
+  @override
+  Future<int> get exitCode => _exitCode.future;
+
+  @override
+  IOSink get stdin => throw UnimplementedError();
+
+  @override
+  Stream<List<int>> get stdout async* {
+    yield* _stdout.stream;
+    stdoutDrained = true;
+  }
+
+  @override
+  Stream<List<int>> get stderr async* {
+    yield* _stderr.stream;
+    stderrDrained = true;
+  }
+
+  @override
+  int get pid => 12345;
+
+  @override
+  bool kill([ProcessSignal signal = ProcessSignal.sigterm]) {
+    killSignals.add(signal);
+    if (signal != ProcessSignal.sigkill || !exitsOnSigkill) {
+      return true;
+    }
+
+    _completeExit();
+    return true;
+  }
+
+  void _completeExit() {
+    if (_exitCode.isCompleted) {
+      return;
+    }
+
+    _stdout.add(utf8.encode('launcher stdout'));
+    _stderr.add(utf8.encode('launcher stderr'));
+    unawaited(_stdout.close());
+    unawaited(_stderr.close());
+    _exitCode.complete(-9);
+  }
+}
+
+class _CompletedBrowserProcess implements Process {
+  final List<ProcessSignal> killSignals = [];
+
+  @override
+  Future<int> get exitCode => Future.value(7);
+
+  @override
+  IOSink get stdin => throw UnimplementedError();
+
+  @override
+  Stream<List<int>> get stdout => Stream.value(utf8.encode('launcher stdout'));
+
+  @override
+  Stream<List<int>> get stderr => Stream.fromIterable([
+    utf8.encode('launcher '),
+    utf8.encode('failed'),
+  ]);
+
+  @override
+  int get pid => 12346;
+
+  @override
+  bool kill([ProcessSignal signal = ProcessSignal.sigterm]) {
+    killSignals.add(signal);
+    return false;
+  }
 }

--- a/bridge/app/test/auth/login_test.dart
+++ b/bridge/app/test/auth/login_test.dart
@@ -15,6 +15,67 @@ import 'package:test/test.dart';
 
 void main() {
   group('LoginOAuthApi', () {
+    test('503 and 404 map to bounded restart requirements before JSON parsing', () async {
+      final cases = <({int statusCode, String? retryAfter, Duration expectedDelay})>[
+        (statusCode: 503, retryAfter: '0', expectedDelay: Duration.zero),
+        (statusCode: 503, retryAfter: '5', expectedDelay: Duration(seconds: 5)),
+        (statusCode: 503, retryAfter: null, expectedDelay: Duration(seconds: 1)),
+        (statusCode: 503, retryAfter: '-1', expectedDelay: Duration(seconds: 1)),
+        (statusCode: 503, retryAfter: '6', expectedDelay: Duration(seconds: 1)),
+        (statusCode: 404, retryAfter: '5', expectedDelay: Duration.zero),
+      ];
+      final authServer = await _OAuthLongPollTestServer.start(
+        statusResponses: [
+          for (final testCase in cases) (statusCode: testCase.statusCode, retryAfter: testCase.retryAfter),
+        ],
+      );
+      addTearDown(authServer.close);
+      final api = LoginOAuthApi(
+        authBackendUrl: authServer.baseUrl,
+        client: authServer.client,
+        clientType: AuthClientType.bridgeMacos,
+        device: DeviceInfo(name: 'Test Mac', osVersion: null, appVersion: null),
+      );
+      final deadline = DateTime.now().add(const Duration(minutes: 5));
+      for (final testCase in cases) {
+        final restartRequired = predicate<OAuthSessionRestartRequiredException>(
+          (error) => error.restartAfter == testCase.expectedDelay && error.deadline == deadline,
+        );
+        await expectLater(
+          api.getOAuthSessionStatus(sessionToken: 'stale-token', deadline: deadline),
+          throwsA(restartRequired),
+        );
+      }
+    });
+
+    test('init 503 maps to the same bounded restart requirement before JSON parsing', () async {
+      final authServer = await _OAuthLongPollTestServer.start(
+        initResponses: [(statusCode: 503, retryAfter: '3')],
+        statusResponses: [],
+      );
+      addTearDown(authServer.close);
+      final api = LoginOAuthApi(
+        authBackendUrl: authServer.baseUrl,
+        client: authServer.client,
+        clientType: AuthClientType.bridgeMacos,
+        device: DeviceInfo(name: 'Test Mac', osVersion: null, appVersion: null),
+      );
+      final deadline = DateTime.now().add(const Duration(minutes: 5));
+
+      await expectLater(
+        api.initOAuthSession(
+          provider: AuthProvider.github,
+          sessionToken: 'new-token',
+          deadline: deadline,
+        ),
+        throwsA(
+          predicate<OAuthSessionRestartRequiredException>(
+            (error) => error.restartAfter == const Duration(seconds: 3) && error.deadline == deadline,
+          ),
+        ),
+      );
+    });
+
     group('GitHub OAuth', () {
       test('performOAuthLogin initializes, opens browser, polls, and returns tokens', () async {
         final authServer = await _OAuthLongPollTestServer.start(
@@ -75,6 +136,111 @@ void main() {
         }
         expect(authServer.unexpectedPaths, isNot(contains('/callback')));
       });
+
+      test('restarts once, rejects a second restart, and keeps one absolute budget', () async {
+        const firstUrl = 'https://example.com/github-login-1';
+        const user = AuthUser(id: 'u', provider: AuthProvider.github, providerUserId: 'g', providerUsername: null);
+        final authServer = await _OAuthLongPollTestServer.start(
+          authUrl: firstUrl,
+          statusResponses: [
+            (statusCode: 503, retryAfter: '0'),
+            AuthSessionStatusResponse.complete(
+              accessToken: 'access',
+              refreshToken: 'refresh',
+              user: user,
+            ),
+            (statusCode: 503, retryAfter: '0'),
+            (statusCode: 404, retryAfter: null),
+            (statusCode: 503, retryAfter: '1'),
+            const AuthSessionStatusResponse.pending(),
+          ],
+        );
+        addTearDown(authServer.close);
+        final launchedUrls = <String>[];
+        final service = _createOAuthService(
+          authServer: authServer,
+          browserLauncher: (url) async => launchedUrls.add(url),
+          pollInterval: const Duration(seconds: 5),
+        );
+        final result = await service.performOAuthLogin(AuthProvider.github);
+        final sessionTokens = authServer.initRequests.map((request) => request.sessionToken).toList();
+        expect(launchedUrls, [firstUrl, '$firstUrl-restart']);
+        expect((sessionTokens.length, sessionTokens.toSet().length), (2, 2));
+        expect(result.sessionToken, sessionTokens.last);
+        expect(authServer.statusRequests.map((request) => request.sessionToken).toList(), sessionTokens);
+        await expectLater(
+          service.performOAuthLogin(AuthProvider.github),
+          throwsA(predicate<Exception>((error) => error.toString().contains('lost again after restart'))),
+        );
+        expect((authServer.initRequests.length, authServer.statusRequests.length), (4, 4));
+        final stopwatch = Stopwatch()..start();
+        await expectLater(service.performOAuthLogin(AuthProvider.github), throwsA(isA<TimeoutException>()));
+        stopwatch.stop();
+        expect((authServer.initRequests.length, authServer.statusRequests.length), (6, 6));
+        expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 2600)));
+      });
+
+      test('an init 503 consumes the one full restart and then completes', () async {
+        const user = AuthUser(id: 'u', provider: AuthProvider.github, providerUserId: 'g', providerUsername: null);
+        final authServer = await _OAuthLongPollTestServer.start(
+          initResponses: [(statusCode: 503, retryAfter: '0')],
+          statusResponses: [
+            AuthSessionStatusResponse.complete(
+              accessToken: 'access',
+              refreshToken: 'refresh',
+              user: user,
+            ),
+          ],
+        );
+        addTearDown(authServer.close);
+        final launchedUrls = <String>[];
+        final service = _createOAuthService(
+          authServer: authServer,
+          browserLauncher: (url) async => launchedUrls.add(url),
+        );
+
+        final result = await service.performOAuthLogin(AuthProvider.github);
+
+        expect(result.tokens.accessToken, 'access');
+        expect(authServer.initRequests, hasLength(2));
+        expect(authServer.statusRequests, hasLength(1));
+        expect(launchedUrls, ['https://example.com/github-login-restart']);
+      });
+
+      for (final hangingOperation in ['init', 'browser']) {
+        test('a hanging restart $hangingOperation stops at the original deadline', () async {
+          final authServer = await _OAuthLongPollTestServer.start(
+            initResponses: hangingOperation == 'init'
+                ? [
+                    (statusCode: 200, retryAfter: null),
+                    (statusCode: 0, retryAfter: null),
+                  ]
+                : const [],
+            statusResponses: [(statusCode: 503, retryAfter: '0')],
+          );
+          addTearDown(authServer.close);
+          var launches = 0;
+          final service = _createOAuthService(
+            authServer: authServer,
+            browserLauncher: (_) {
+              launches += 1;
+              return hangingOperation == 'browser' && launches == 2 ? Completer<void>().future : Future<void>.value();
+            },
+            pollTimeout: const Duration(milliseconds: 100),
+          );
+          final stopwatch = Stopwatch()..start();
+
+          await expectLater(
+            service.performOAuthLogin(AuthProvider.github),
+            throwsA(isA<TimeoutException>()),
+          );
+          stopwatch.stop();
+
+          expect(stopwatch.elapsed, lessThan(const Duration(seconds: 1)));
+          expect(authServer.initRequests, hasLength(2));
+          expect(launches, hangingOperation == 'browser' ? 2 : 1);
+        });
+      }
 
       test('denied status throws', () async {
         final authServer = await _OAuthLongPollTestServer.start(
@@ -631,7 +797,8 @@ class _OAuthRequestRecord {
 class _OAuthLongPollTestServer {
   final HttpServer _server;
   final String authUrl;
-  final List<AuthSessionStatusResponse> _statusResponses;
+  final List<({int statusCode, String? retryAfter})> _initResponses;
+  final List<Object> _statusResponses;
   final http.Client client = http.Client();
   final List<_OAuthRequestRecord> initRequests = [];
   final List<_OAuthRequestRecord> statusRequests = [];
@@ -641,20 +808,24 @@ class _OAuthLongPollTestServer {
   _OAuthLongPollTestServer._({
     required HttpServer server,
     required this.authUrl,
-    required List<AuthSessionStatusResponse> statusResponses,
+    required List<({int statusCode, String? retryAfter})> initResponses,
+    required List<Object> statusResponses,
   }) : _server = server,
+       _initResponses = List.of(initResponses),
        _statusResponses = List.of(statusResponses) {
     _listen();
   }
 
   static Future<_OAuthLongPollTestServer> start({
     String authUrl = 'https://example.com/github-login',
-    required List<AuthSessionStatusResponse> statusResponses,
+    List<({int statusCode, String? retryAfter})> initResponses = const [],
+    required List<Object> statusResponses,
   }) async {
     final server = await HttpServer.bind('127.0.0.1', 0);
     return _OAuthLongPollTestServer._(
       server: server,
       authUrl: authUrl,
+      initResponses: initResponses,
       statusResponses: statusResponses,
     );
   }
@@ -666,11 +837,27 @@ class _OAuthLongPollTestServer {
       if ((request.uri.path == '/auth/github/init' || request.uri.path == '/auth/google/init') &&
           request.method == 'POST') {
         initRequests.add(await _recordRequest(request));
+        final configuredResponse = _initResponses.isEmpty
+            ? (statusCode: 200, retryAfter: null)
+            : _initResponses.removeAt(0);
+        if (configuredResponse.statusCode == 0) {
+          await Completer<void>().future;
+          return;
+        }
+        if (configuredResponse.statusCode != 200) {
+          request.response.statusCode = configuredResponse.statusCode;
+          if (configuredResponse.retryAfter != null) {
+            request.response.headers.set('Retry-After', configuredResponse.retryAfter!);
+          }
+          request.response.write('not-json');
+          await request.response.close();
+          return;
+        }
         request.response.statusCode = 200;
         request.response.headers.contentType = ContentType.json;
         request.response.write(
           jsonEncode({
-            'authUrl': authUrl,
+            'authUrl': initRequests.length == 1 ? authUrl : '$authUrl-restart',
             'state': 'oauth-state',
             'userCode': 'ABCD',
             'expiresIn': 120,
@@ -682,6 +869,16 @@ class _OAuthLongPollTestServer {
         final status = _statusResponses.isEmpty
             ? const AuthSessionStatusResponse.pending()
             : _statusResponses.removeAt(0);
+        if (status is! AuthSessionStatusResponse) {
+          final restartResponse = status as ({int statusCode, String? retryAfter});
+          request.response.statusCode = restartResponse.statusCode;
+          if (restartResponse.retryAfter != null) {
+            request.response.headers.set('Retry-After', restartResponse.retryAfter!);
+          }
+          request.response.write('not-json');
+          await request.response.close();
+          return;
+        }
         request.response.statusCode = 200;
         request.response.headers.contentType = ContentType.json;
         request.response.write(jsonEncode(status.toJson()));

--- a/bridge/app/test/auth/login_test.dart
+++ b/bridge/app/test/auth/login_test.dart
@@ -175,7 +175,7 @@ void main() {
         expect(authServer.statusRequests.map((request) => request.sessionToken).toList(), sessionTokens);
         await expectLater(
           service.performOAuthLogin(AuthProvider.github),
-          throwsA(predicate<Exception>((error) => error.toString().contains('lost again after restart'))),
+          throwsA(isA<OAuthSessionRestartRequiredException>()),
         );
         expect((authServer.initRequests.length, authServer.statusRequests.length), (4, 4));
         final stopwatch = Stopwatch()..start();
@@ -279,41 +279,6 @@ void main() {
         expect(deadlines, hasLength(2));
         expect(deadlines.toSet(), hasLength(1));
       });
-
-      for (final hangingOperation in ['init', 'browser']) {
-        test('a hanging restart $hangingOperation stops at the original deadline', () async {
-          final authServer = await _OAuthLongPollTestServer.start(
-            initResponses: hangingOperation == 'init'
-                ? [
-                    (statusCode: 200, retryAfter: null),
-                    (statusCode: 0, retryAfter: null),
-                  ]
-                : const [],
-            statusResponses: [(statusCode: 503, retryAfter: '0')],
-          );
-          addTearDown(authServer.close);
-          var launches = 0;
-          final service = _createOAuthService(
-            authServer: authServer,
-            browserLauncher: (_) {
-              launches += 1;
-              return hangingOperation == 'browser' && launches == 2 ? Completer<void>().future : Future<void>.value();
-            },
-            pollTimeout: const Duration(milliseconds: 100),
-          );
-          final stopwatch = Stopwatch()..start();
-
-          await expectLater(
-            service.performOAuthLogin(AuthProvider.github),
-            throwsA(isA<TimeoutException>()),
-          );
-          stopwatch.stop();
-
-          expect(stopwatch.elapsed, lessThan(const Duration(seconds: 1)));
-          expect(authServer.initRequests, hasLength(2));
-          expect(launches, hangingOperation == 'browser' ? 2 : 1);
-        });
-      }
 
       test('denied status throws', () async {
         final authServer = await _OAuthLongPollTestServer.start(
@@ -585,89 +550,40 @@ void main() {
   });
 
   group('openOAuthBrowser', () {
-    test('reports collected stderr when the launcher exits non-zero', () async {
-      final process = _CompletedBrowserProcess();
+    test('does not invoke the process starter after the absolute deadline', () async {
+      var startCalls = 0;
 
       await expectLater(
         openOAuthBrowser(
-          url: 'https://example.com/oauth?state=failed-launch',
-          deadline: DateTime.now().add(const Duration(seconds: 1)),
-          processStarter: (_, __) async => process,
-        ),
-        throwsA(
-          isA<Exception>().having(
-            (error) => error.toString(),
-            'message',
-            contains('Browser launcher exited with code 7: launcher failed'),
-          ),
-        ),
-      );
-
-      expect(process.killSignals, isEmpty);
-    });
-
-    test('gracefully terminates then force-kills a hanging launcher and awaits completed drains', () async {
-      final process = _HangingBrowserProcess();
-      String? executable;
-      List<String>? arguments;
-      const authUrl = 'https://example.com/oauth?state=state-1';
-      final deadline = DateTime.now().add(const Duration(milliseconds: 30));
-      final stopwatch = Stopwatch()..start();
-
-      await expectLater(
-        openOAuthBrowser(
-          url: authUrl,
-          deadline: deadline,
-          processStarter: (startedExecutable, startedArguments) async {
-            executable = startedExecutable;
-            arguments = startedArguments;
-            return process;
+          url: 'https://example.com/oauth?state=expired-before-start',
+          deadline: DateTime.now().subtract(const Duration(milliseconds: 1)),
+          processStarter: (_, __) {
+            startCalls += 1;
+            throw StateError('process starter must not be called');
           },
-          gracefulTerminationTimeout: const Duration(milliseconds: 5),
-          forcedTerminationTimeout: const Duration(milliseconds: 20),
         ),
         throwsA(isA<TimeoutException>()),
       );
-      stopwatch.stop();
 
-      expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 500)));
-      expect(executable, isNotEmpty);
-      expect(arguments, contains(authUrl));
-      expect(process.killSignals, [ProcessSignal.sigterm, ProcessSignal.sigkill]);
-      expect(process.exited, isTrue);
-      expect(process.stdoutDrained, isTrue);
-      expect(process.stderrDrained, isTrue);
+      expect(startCalls, 0);
     });
 
-    test('preserves a bounded OAuth timeout when forced cleanup cannot finish', () async {
-      final process = _HangingBrowserProcess(exitsOnSigkill: false);
-      final stopwatch = Stopwatch()..start();
+    test('dispatches the URL without retaining process ownership', () async {
+      String? executable;
+      List<String>? arguments;
+      const authUrl = 'https://example.com/oauth?state=state-1';
 
-      await expectLater(
-        openOAuthBrowser(
-          url: 'https://example.com/oauth?state=state-2',
-          deadline: DateTime.now().add(const Duration(milliseconds: 5)),
-          processStarter: (_, __) async => process,
-          gracefulTerminationTimeout: const Duration(milliseconds: 5),
-          forcedTerminationTimeout: const Duration(milliseconds: 20),
-        ),
-        throwsA(
-          isA<TimeoutException>().having(
-            (error) => error.message,
-            'message',
-            'timed out waiting for authorization',
-          ),
-        ),
+      await openOAuthBrowser(
+        url: authUrl,
+        deadline: DateTime.now().add(const Duration(seconds: 1)),
+        processStarter: (startedExecutable, startedArguments) async {
+          executable = startedExecutable;
+          arguments = startedArguments;
+        },
       );
-      stopwatch.stop();
 
-      expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 500)));
-      expect(process.killSignals, [ProcessSignal.sigterm, ProcessSignal.sigkill]);
-      expect(process.exited, isFalse);
-      expect(process.stdoutDrained, isFalse);
-      expect(process.stderrDrained, isFalse);
-      expect(process.stdoutCanceled, isTrue);
-      expect(process.stderrCanceled, isTrue);
+      expect(executable, isNotEmpty);
+      expect(arguments, contains(authUrl));
     });
   });
 
@@ -1250,95 +1166,4 @@ class _CapturingStdout implements Stdout {
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
-class _HangingBrowserProcess implements Process {
-  _HangingBrowserProcess({this.exitsOnSigkill = true}) {
-    _stdout = StreamController<List<int>>(onCancel: () => stdoutCanceled = true);
-    _stderr = StreamController<List<int>>(onCancel: () => stderrCanceled = true);
-  }
-
-  final bool exitsOnSigkill;
-  final Completer<int> _exitCode = Completer<int>();
-  late final StreamController<List<int>> _stdout;
-  late final StreamController<List<int>> _stderr;
-  final List<ProcessSignal> killSignals = [];
-  bool stdoutDrained = false;
-  bool stderrDrained = false;
-  bool stdoutCanceled = false;
-  bool stderrCanceled = false;
-
-  bool get exited => _exitCode.isCompleted;
-
-  @override
-  Future<int> get exitCode => _exitCode.future;
-
-  @override
-  IOSink get stdin => throw UnimplementedError();
-
-  @override
-  Stream<List<int>> get stdout async* {
-    yield* _stdout.stream;
-    stdoutDrained = true;
-  }
-
-  @override
-  Stream<List<int>> get stderr async* {
-    yield* _stderr.stream;
-    stderrDrained = true;
-  }
-
-  @override
-  int get pid => 12345;
-
-  @override
-  bool kill([ProcessSignal signal = ProcessSignal.sigterm]) {
-    killSignals.add(signal);
-    if (signal != ProcessSignal.sigkill || !exitsOnSigkill) {
-      return true;
-    }
-
-    _completeExit();
-    return true;
-  }
-
-  void _completeExit() {
-    if (_exitCode.isCompleted) {
-      return;
-    }
-
-    _stdout.add(utf8.encode('launcher stdout'));
-    _stderr.add(utf8.encode('launcher stderr'));
-    unawaited(_stdout.close());
-    unawaited(_stderr.close());
-    _exitCode.complete(-9);
-  }
-}
-
-class _CompletedBrowserProcess implements Process {
-  final List<ProcessSignal> killSignals = [];
-
-  @override
-  Future<int> get exitCode => Future.value(7);
-
-  @override
-  IOSink get stdin => throw UnimplementedError();
-
-  @override
-  Stream<List<int>> get stdout => Stream.value(utf8.encode('launcher stdout'));
-
-  @override
-  Stream<List<int>> get stderr => Stream.fromIterable([
-    utf8.encode('launcher '),
-    utf8.encode('failed'),
-  ]);
-
-  @override
-  int get pid => 12346;
-
-  @override
-  bool kill([ProcessSignal signal = ProcessSignal.sigterm]) {
-    killSignals.add(signal);
-    return false;
-  }
 }

--- a/bridge/app/test/auth/login_test.dart
+++ b/bridge/app/test/auth/login_test.dart
@@ -42,7 +42,11 @@ void main() {
           (error) => error.restartAfter == testCase.expectedDelay && error.deadline == deadline,
         );
         await expectLater(
-          api.getOAuthSessionStatus(sessionToken: 'stale-token', deadline: deadline),
+          api.getOAuthSessionStatus(
+            sessionToken: 'stale-token',
+            deadline: deadline,
+            requestTimeout: const Duration(seconds: 1),
+          ),
           throwsA(restartRequired),
         );
       }
@@ -67,6 +71,7 @@ void main() {
           provider: AuthProvider.github,
           sessionToken: 'new-token',
           deadline: deadline,
+          requestTimeout: const Duration(seconds: 1),
         ),
         throwsA(
           predicate<OAuthSessionRestartRequiredException>(
@@ -205,6 +210,35 @@ void main() {
         expect(authServer.initRequests, hasLength(2));
         expect(authServer.statusRequests, hasLength(1));
         expect(launchedUrls, ['https://example.com/github-login-restart']);
+      });
+
+      test('a hung status request is aborted at its local timeout without accumulating another request', () async {
+        final client = _HangingOAuthStatusClient();
+        final api = LoginOAuthApi(
+          authBackendUrl: 'https://auth.example.test',
+          client: client,
+          clientType: AuthClientType.bridgeMacos,
+          device: DeviceInfo(name: 'Test Mac', osVersion: null, appVersion: null),
+        );
+        final service = LoginOAuthService(
+          api: api,
+          browserLauncher: (_) async {},
+          browserOpenability: _alwaysOpenableBrowser,
+          pollTimeout: const Duration(seconds: 1),
+          perRequestTimeout: const Duration(milliseconds: 10),
+          pollInterval: Duration.zero,
+        );
+
+        await expectLater(
+          service.performOAuthLogin(AuthProvider.github),
+          throwsA(isA<TimeoutException>()),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+
+        expect(client.statusRequestCount, 1);
+        expect(client.maximumActiveStatusRequests, 1);
+        expect(client.activeStatusRequests, 0);
+        expect(client.statusAbortCount, 1);
       });
 
       for (final hangingOperation in ['init', 'browser']) {
@@ -707,6 +741,51 @@ LoginOAuthService _createOAuthService({
 }
 
 BrowserOpenability _alwaysOpenableBrowser() => BrowserOpenability.yes;
+
+class _HangingOAuthStatusClient extends http.BaseClient {
+  int statusRequestCount = 0;
+  int activeStatusRequests = 0;
+  int maximumActiveStatusRequests = 0;
+  int statusAbortCount = 0;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    if (request.method == 'POST' && request.url.path.endsWith('/init')) {
+      return http.StreamedResponse(
+        Stream.value(
+          utf8.encode(
+            jsonEncode({
+              'authUrl': 'https://example.com/github-login',
+              'state': 'oauth-state',
+              'userCode': 'ABCD',
+              'expiresIn': 120,
+            }),
+          ),
+        ),
+        200,
+      );
+    }
+    if (request.method == 'GET' && request.url.path == '/auth/session/status') {
+      statusRequestCount += 1;
+      activeStatusRequests += 1;
+      if (activeStatusRequests > maximumActiveStatusRequests) {
+        maximumActiveStatusRequests = activeStatusRequests;
+      }
+      try {
+        final abortTrigger = (request as http.Abortable).abortTrigger;
+        if (abortTrigger == null) {
+          throw StateError('status request is not abortable');
+        }
+        await abortTrigger;
+        statusAbortCount += 1;
+        throw http.RequestAbortedException(request.url);
+      } finally {
+        activeStatusRequests -= 1;
+      }
+    }
+    throw StateError('unexpected OAuth request: ${request.method} ${request.url}');
+  }
+}
 
 class _MockLoginEmailApi implements LoginEmailApi {
   @override

--- a/client/app/test/features/login/login_cubit_test.dart
+++ b/client/app/test/features/login/login_cubit_test.dart
@@ -44,7 +44,10 @@ void main() {
       // Default mock behaviors
       when(() => mockUrlLauncher.launch(any())).thenAnswer((_) async => true);
       when(
-        () => mockOAuthFlowProvider.startOAuthFlow(provider: any(named: "provider")),
+        () => mockOAuthFlowProvider.startOAuthFlow(
+          provider: any(named: "provider"),
+          deadline: null,
+        ),
       ).thenAnswer(
         (_) async => const AuthInitResponse(
           authUrl: "https://auth.example.com/login",
@@ -101,7 +104,10 @@ void main() {
       build: buildCubit,
       act: (cubit) async {
         when(
-          () => mockOAuthFlowProvider.startOAuthFlow(provider: any(named: "provider")),
+          () => mockOAuthFlowProvider.startOAuthFlow(
+            provider: any(named: "provider"),
+            deadline: null,
+          ),
         ).thenThrow(Exception("Auth init failed"));
 
         await cubit.loginWithProvider(AuthProvider.google);
@@ -120,7 +126,10 @@ void main() {
       },
       verify: (cubit) {
         verify(
-          () => mockOAuthFlowProvider.startOAuthFlow(provider: AuthProvider.github),
+          () => mockOAuthFlowProvider.startOAuthFlow(
+            provider: AuthProvider.github,
+            deadline: null,
+          ),
         ).called(1);
       },
     );
@@ -133,7 +142,10 @@ void main() {
       },
       verify: (cubit) {
         verify(
-          () => mockOAuthFlowProvider.startOAuthFlow(provider: AuthProvider.google),
+          () => mockOAuthFlowProvider.startOAuthFlow(
+            provider: AuthProvider.google,
+            deadline: null,
+          ),
         ).called(1);
       },
     );

--- a/client/module_auth/lib/sesori_auth.dart
+++ b/client/module_auth/lib/sesori_auth.dart
@@ -5,8 +5,7 @@ library;
 // alongside the type so downstream freezed models (e.g. SettingsState) with an
 // AuthUser field can resolve their generated nested copyWith.
 export "package:sesori_shared/sesori_shared.dart" show $AuthUserCopyWith, AuthProvider, AuthUser;
-export "package:sesori_shared/sesori_shared.dart"
-    show OAuthSessionRestartOperation, OAuthSessionRestartReason, OAuthSessionRestartRequiredException;
+export "package:sesori_shared/sesori_shared.dart" show OAuthSessionRestartRequiredException;
 
 export "src/auth_config.dart";
 export "src/client/api_error.dart";

--- a/client/module_auth/lib/sesori_auth.dart
+++ b/client/module_auth/lib/sesori_auth.dart
@@ -5,6 +5,7 @@ library;
 // alongside the type so downstream freezed models (e.g. SettingsState) with an
 // AuthUser field can resolve their generated nested copyWith.
 export "package:sesori_shared/sesori_shared.dart" show $AuthUserCopyWith, AuthProvider, AuthUser;
+export "package:sesori_shared/sesori_shared.dart" show OAuthSessionRestartRequiredException;
 
 export "src/auth_config.dart";
 export "src/client/api_error.dart";

--- a/client/module_auth/lib/sesori_auth.dart
+++ b/client/module_auth/lib/sesori_auth.dart
@@ -5,7 +5,8 @@ library;
 // alongside the type so downstream freezed models (e.g. SettingsState) with an
 // AuthUser field can resolve their generated nested copyWith.
 export "package:sesori_shared/sesori_shared.dart" show $AuthUserCopyWith, AuthProvider, AuthUser;
-export "package:sesori_shared/sesori_shared.dart" show OAuthSessionRestartRequiredException;
+export "package:sesori_shared/sesori_shared.dart"
+    show OAuthSessionRestartOperation, OAuthSessionRestartReason, OAuthSessionRestartRequiredException;
 
 export "src/auth_config.dart";
 export "src/client/api_error.dart";

--- a/client/module_auth/lib/src/auth_manager.dart
+++ b/client/module_auth/lib/src/auth_manager.dart
@@ -18,7 +18,7 @@ import "platform/oauth_device_descriptor_provider.dart";
 import "storage/oauth_storage_service.dart";
 import "storage/token_storage_service.dart";
 
-typedef _OAuthSessionOwner = ({int generation, String sessionToken});
+typedef _OAuthSessionOwner = ({DateTime expiresAt, int generation, String sessionToken});
 
 @lazySingleton
 class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
@@ -37,7 +37,8 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
   final Duration _pollTimeout;
   final Future<void> Function(Duration duration) _delay;
   Future<void> _oAuthMutationTail = Future<void>.value();
-  bool _oAuthMutationPoisoned = false;
+  _OAuthMutationHealth _oAuthMutationHealth = _OAuthMutationHealth.healthy;
+  Future<void>? _oAuthPoisonCleanup;
   int _nextOAuthGeneration = 0;
   _OAuthSessionOwner? _oAuthSessionOwner;
 
@@ -105,15 +106,21 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
   Future<AuthInitResponse> startOAuthFlow({required OAuthProvider provider, required DateTime? deadline}) async {
     final sessionToken = _generateSessionToken();
     final flowDeadline = deadline ?? DateTime.now().add(_pollTimeout);
-    final owner = (generation: ++_nextOAuthGeneration, sessionToken: sessionToken);
+    var owner = (
+      expiresAt: flowDeadline,
+      generation: ++_nextOAuthGeneration,
+      sessionToken: sessionToken,
+    );
 
     try {
-      final activation = _mutateOAuthState(() async {
-        if (!DateTime.now().isBefore(flowDeadline)) {
-          throw TimeoutException("OAuth authorization timed out");
-        }
-        _oAuthSessionOwner = owner;
-      });
+      final activation = _mutateOAuthState(
+        mutation: () async {
+          if (!DateTime.now().isBefore(flowDeadline)) {
+            throw TimeoutException("OAuth authorization timed out");
+          }
+          _oAuthSessionOwner = owner;
+        },
+      );
       await _awaitOAuthMutationBeforeDeadline(
         deadline: flowDeadline,
         mutation: activation,
@@ -133,8 +140,10 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
       );
       if (response.statusCode == 503) {
         throw OAuthSessionRestartRequiredException(
-          restartAfter: _parseRestartAfter(response.headers["retry-after"]),
+          restartAfter: _parseRestartAfter(header: response.headers["retry-after"]),
           deadline: flowDeadline,
+          operation: OAuthSessionRestartOperation.init,
+          reason: OAuthSessionRestartReason.serviceUnavailable,
         );
       }
       _ensureSuccess(response, context: "Failed to start ${provider.label} auth flow");
@@ -142,26 +151,40 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
       final initResponse = AuthInitResponse.fromJson(jsonDecodeMap(response.body));
       final serverExpiresAt = DateTime.now().add(Duration(seconds: initResponse.expiresIn));
       final expiresAt = flowDeadline.isBefore(serverExpiresAt) ? flowDeadline : serverExpiresAt;
-      final sessionSave = _mutateOAuthState(() async {
-        _throwIfOAuthSessionSuperseded(owner);
-        await _oAuthStorage.saveOAuthSession(
-          sessionToken: sessionToken,
-          expiresAt: expiresAt,
-        );
-      });
+      final activatedOwner = owner;
+      owner = (
+        expiresAt: expiresAt,
+        generation: owner.generation,
+        sessionToken: owner.sessionToken,
+      );
+      final sessionSave = _mutateOAuthState(
+        mutation: () async {
+          _throwIfOAuthSessionSuperseded(owner: activatedOwner);
+          _oAuthSessionOwner = owner;
+          await _oAuthStorage.saveOAuthSession(
+            sessionToken: sessionToken,
+            expiresAt: expiresAt,
+          );
+        },
+      );
       await _awaitOAuthMutationBeforeDeadline(
         deadline: flowDeadline,
         mutation: sessionSave,
       );
-      await _assertOAuthSessionOwner(owner);
+      await _assertOAuthSessionOwner(owner: owner);
       return initResponse;
     } on Object catch (error, stackTrace) {
-      if (!_oAuthMutationPoisoned && error is! _OAuthMutationPoisonedException) {
+      if (_oAuthMutationHealth == _OAuthMutationHealth.healthy && error is! _OAuthMutationPoisonedException) {
         final cleanup = _clearOAuthSessionIfOwned(owner: owner);
-        if (error is TimeoutException) {
-          unawaited(_logOAuthCleanupFailure(cleanup));
-        } else {
-          await cleanup;
+        try {
+          await _awaitOAuthMutationBeforeDeadline(
+            deadline: flowDeadline,
+            mutation: cleanup,
+          );
+        } on TimeoutException {
+          if (error is! TimeoutException) {
+            rethrow;
+          }
         }
       }
       Error.throwWithStackTrace(error, stackTrace);
@@ -170,24 +193,30 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
 
   @override
   Future<AuthUser> pollForResult() async {
-    final storedSession = await _oAuthStorage.getOAuthSession();
-    final owner = await _mutateOAuthState(() async {
-      final activeOwner = _oAuthSessionOwner;
-      if (activeOwner != null) {
-        return activeOwner;
-      }
+    final owner = await _mutateOAuthState(
+      mutation: () async {
+        final activeOwner = _oAuthSessionOwner;
+        if (activeOwner != null) {
+          return activeOwner;
+        }
 
-      final storedToken = storedSession.sessionToken;
-      if (storedToken == null || storedToken.isEmpty) {
-        throw StateError("No OAuth flow is active");
-      }
+        final storedSession = await _oAuthStorage.getOAuthSession();
+        final storedToken = storedSession.sessionToken;
+        if (storedToken == null || storedToken.isEmpty) {
+          throw StateError("No OAuth flow is active");
+        }
 
-      final restoredOwner = (generation: ++_nextOAuthGeneration, sessionToken: storedToken);
-      _oAuthSessionOwner = restoredOwner;
-      return restoredOwner;
-    });
+        final restoredOwner = (
+          expiresAt: storedSession.expiresAt ?? DateTime.now().add(_pollTimeout),
+          generation: ++_nextOAuthGeneration,
+          sessionToken: storedToken,
+        );
+        _oAuthSessionOwner = restoredOwner;
+        return restoredOwner;
+      },
+    );
     final sessionToken = owner.sessionToken;
-    final expiresAt = storedSession.expiresAt ?? DateTime.now().add(_pollTimeout);
+    final expiresAt = owner.expiresAt;
 
     if (!DateTime.now().isBefore(expiresAt)) {
       await _clearOAuthSessionIfOwned(owner: owner);
@@ -217,13 +246,23 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
           rethrow;
         }
 
-        await _assertOAuthSessionOwner(owner);
+        await _assertOAuthSessionOwner(owner: owner);
         if (response.statusCode == 503 || response.statusCode == 404) {
           final restartAfter = response.statusCode == 404
               ? Duration.zero
-              : _parseRestartAfter(response.headers["retry-after"]);
-          await _clearOAuthSessionIfOwned(owner: owner);
-          throw OAuthSessionRestartRequiredException(restartAfter: restartAfter, deadline: expiresAt);
+              : _parseRestartAfter(header: response.headers["retry-after"]);
+          await _clearOAuthSessionBeforeDeadline(
+            deadline: expiresAt,
+            owner: owner,
+          );
+          throw OAuthSessionRestartRequiredException(
+            restartAfter: restartAfter,
+            deadline: expiresAt,
+            operation: OAuthSessionRestartOperation.status,
+            reason: response.statusCode == 404
+                ? OAuthSessionRestartReason.sessionMissing
+                : OAuthSessionRestartReason.serviceUnavailable,
+          );
         }
         final status = _parseSessionStatus(response);
         switch (status) {
@@ -265,7 +304,7 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
     } finally {
       if (!completionCommitted) {
         try {
-          await _releaseOAuthSessionIfOwned(owner);
+          await _releaseOAuthSessionIfOwned(owner: owner);
         } on _OAuthMutationPoisonedException {
           // Poison recovery owns final cleanup; preserve the established result.
         }
@@ -273,7 +312,7 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
     }
   }
 
-  Duration _parseRestartAfter(String? header) {
+  Duration _parseRestartAfter({required String? header}) {
     final seconds = header != null && RegExp(r"^[0-9]+$").hasMatch(header) ? int.tryParse(header) : null;
     return seconds != null && seconds <= 5 ? Duration(seconds: seconds) : const Duration(seconds: 1);
   }
@@ -285,23 +324,50 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
     required DateTime? expiresAt,
     required bool isFinalRequest,
   }) async {
+    final abortTrigger = Completer<void>();
+    final requestTimer = Timer(requestTimeout, abortTrigger.complete);
     try {
-      return await _get(
-        uri,
-        headers: {_sessionTokenHeader: sessionToken},
-      ).timeout(requestTimeout);
+      final request = http.AbortableRequest("GET", uri, abortTrigger: abortTrigger.future)
+        ..headers.addAll({
+          "Accept": "application/json",
+          _sessionTokenHeader: sessionToken,
+        });
+      return await http.Response.fromStream(await _client.send(request));
+    } on http.RequestAbortedException catch (_, stackTrace) {
+      _throwSessionStatusTimeout(
+        expiresAt: expiresAt,
+        isFinalRequest: isFinalRequest,
+        stackTrace: stackTrace,
+        uri: uri,
+      );
     } on TimeoutException catch (_, stackTrace) {
-      if (isFinalRequest || (expiresAt != null && !DateTime.now().isBefore(expiresAt))) {
-        Error.throwWithStackTrace(
-          TimeoutException("OAuth authorization timed out"),
-          stackTrace,
-        );
-      }
+      _throwSessionStatusTimeout(
+        expiresAt: expiresAt,
+        isFinalRequest: isFinalRequest,
+        stackTrace: stackTrace,
+        uri: uri,
+      );
+    } finally {
+      requestTimer.cancel();
+    }
+  }
+
+  Never _throwSessionStatusTimeout({
+    required DateTime? expiresAt,
+    required bool isFinalRequest,
+    required StackTrace stackTrace,
+    required Uri uri,
+  }) {
+    if (isFinalRequest || (expiresAt != null && !DateTime.now().isBefore(expiresAt))) {
       Error.throwWithStackTrace(
-        http.ClientException("OAuth session status request timed out", uri),
+        TimeoutException("OAuth authorization timed out"),
         stackTrace,
       );
     }
+    Error.throwWithStackTrace(
+      http.ClientException("OAuth session status request timed out", uri),
+      stackTrace,
+    );
   }
 
   Future<void> _persistOAuthCompletion({
@@ -310,29 +376,31 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
     required String accessToken,
     required String refreshToken,
     required AuthUser user,
-  }) => _mutateOAuthState(() async {
-    _throwIfOAuthSessionSuperseded(owner);
-    if (!DateTime.now().isBefore(deadline)) {
+  }) => _mutateOAuthState(
+    mutation: () async {
+      _throwIfOAuthSessionSuperseded(owner: owner);
+      if (!DateTime.now().isBefore(deadline)) {
+        _oAuthSessionOwner = null;
+        await _oAuthStorage.clearOAuthSession();
+        throw TimeoutException("OAuth authorization timed out");
+      }
+      await _tokenStorage.saveTokens(
+        accessToken: accessToken,
+        refreshToken: refreshToken,
+      );
+      // Best-effort: the tokens above already make this a valid session, so a
+      // local user-cache write failure must not abort a completed login.
+      await _saveUserBestEffort(user);
+      await Future.wait([
+        _oAuthStorage.clearPkceVerifier(),
+        _oAuthStorage.clearAuthProvider(),
+        _oAuthStorage.clearOAuthSession(),
+      ]);
+      _throwIfOAuthSessionSuperseded(owner: owner);
       _oAuthSessionOwner = null;
-      await _oAuthStorage.clearOAuthSession();
-      throw TimeoutException("OAuth authorization timed out");
-    }
-    await _tokenStorage.saveTokens(
-      accessToken: accessToken,
-      refreshToken: refreshToken,
-    );
-    // Best-effort: the tokens above already make this a valid session, so a
-    // local user-cache write failure must not abort a completed login.
-    await _saveUserBestEffort(user);
-    await Future.wait([
-      _oAuthStorage.clearPkceVerifier(),
-      _oAuthStorage.clearAuthProvider(),
-      _oAuthStorage.clearOAuthSession(),
-    ]);
-    _throwIfOAuthSessionSuperseded(owner);
-    _oAuthSessionOwner = null;
-    _authState.add(AuthState.authenticated(user: user));
-  });
+      _authState.add(AuthState.authenticated(user: user));
+    },
+  );
 
   Future<T> _beforeOAuthDeadline<T>({
     required DateTime deadline,
@@ -356,13 +424,19 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
     try {
       return await _beforeOAuthDeadline(deadline: deadline, operation: () => mutation);
     } on TimeoutException {
-      _poisonOAuthMutation(mutation);
+      _poisonOAuthMutation(timedOutMutation: mutation);
       rethrow;
     }
   }
 
-  Future<T> _mutateOAuthState<T>(Future<T> Function() mutation) {
-    if (_oAuthMutationPoisoned) {
+  Future<T> _mutateOAuthState<T>({required Future<T> Function() mutation}) {
+    if (_oAuthMutationHealth != _OAuthMutationHealth.healthy) {
+      if (_oAuthMutationHealth == _OAuthMutationHealth.cleanupRequired) {
+        return (() async {
+          await _retryPoisonedOAuthCleanup();
+          return _mutateOAuthState(mutation: mutation);
+        })();
+      }
       return Future<T>.error(const _OAuthMutationPoisonedException());
     }
 
@@ -379,43 +453,60 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
     })();
   }
 
-  Future<void> _clearOAuthSessionIfOwned({required _OAuthSessionOwner owner}) => _mutateOAuthState(() async {
-    if (!_ownsOAuthSession(owner)) {
-      return;
-    }
+  Future<void> _clearOAuthSessionBeforeDeadline({
+    required DateTime deadline,
+    required _OAuthSessionOwner owner,
+  }) {
+    final cleanup = _clearOAuthSessionIfOwned(owner: owner);
+    return _awaitOAuthMutationBeforeDeadline(
+      deadline: deadline,
+      mutation: cleanup,
+    );
+  }
 
-    _oAuthSessionOwner = null;
-    await _oAuthStorage.clearOAuthSession();
-  });
+  Future<void> _clearOAuthSessionIfOwned({required _OAuthSessionOwner owner}) => _mutateOAuthState(
+    mutation: () async {
+      if (!_ownsOAuthSession(owner: owner)) {
+        return;
+      }
 
-  Future<void> _releaseOAuthSessionIfOwned(_OAuthSessionOwner owner) => _mutateOAuthState(() async {
-    if (_ownsOAuthSession(owner)) {
       _oAuthSessionOwner = null;
-    }
-  });
+      await _oAuthStorage.clearOAuthSession();
+    },
+  );
 
-  Future<void> _assertOAuthSessionOwner(_OAuthSessionOwner owner) => _mutateOAuthState(() async {
-    _throwIfOAuthSessionSuperseded(owner);
-  });
+  Future<void> _releaseOAuthSessionIfOwned({required _OAuthSessionOwner owner}) => _mutateOAuthState(
+    mutation: () async {
+      if (_ownsOAuthSession(owner: owner)) {
+        _oAuthSessionOwner = null;
+      }
+    },
+  );
 
-  bool _ownsOAuthSession(_OAuthSessionOwner owner) => _oAuthSessionOwner == owner;
+  Future<void> _assertOAuthSessionOwner({required _OAuthSessionOwner owner}) => _mutateOAuthState(
+    mutation: () async {
+      _throwIfOAuthSessionSuperseded(owner: owner);
+    },
+  );
 
-  void _throwIfOAuthSessionSuperseded(_OAuthSessionOwner owner) {
-    if (!_ownsOAuthSession(owner)) {
+  bool _ownsOAuthSession({required _OAuthSessionOwner owner}) => _oAuthSessionOwner == owner;
+
+  void _throwIfOAuthSessionSuperseded({required _OAuthSessionOwner owner}) {
+    if (!_ownsOAuthSession(owner: owner)) {
       throw const _OAuthSessionSupersededException();
     }
   }
 
-  void _poisonOAuthMutation<T>(Future<T> timedOutMutation) {
-    if (_oAuthMutationPoisoned) {
+  void _poisonOAuthMutation<T>({required Future<T> timedOutMutation}) {
+    if (_oAuthMutationHealth != _OAuthMutationHealth.healthy) {
       return;
     }
 
-    _oAuthMutationPoisoned = true;
-    unawaited(_recoverPoisonedOAuthMutation(timedOutMutation));
+    _oAuthMutationHealth = _OAuthMutationHealth.drainingTimedOutMutation;
+    unawaited(_recoverPoisonedOAuthMutation(timedOutMutation: timedOutMutation));
   }
 
-  Future<void> _recoverPoisonedOAuthMutation<T>(Future<T> timedOutMutation) async {
+  Future<void> _recoverPoisonedOAuthMutation<T>({required Future<T> timedOutMutation}) async {
     try {
       await timedOutMutation;
     } catch (error, stackTrace) {
@@ -429,9 +520,8 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
 
     try {
       await _oAuthMutationTail;
-      _oAuthSessionOwner = null;
-      await _oAuthStorage.clearOAuthSession();
-      _oAuthMutationPoisoned = false;
+      _oAuthMutationHealth = _OAuthMutationHealth.cleanupRequired;
+      await _retryPoisonedOAuthCleanup();
     } catch (error, stackTrace) {
       developer.log(
         "Failed to recover poisoned OAuth mutation state",
@@ -442,16 +532,17 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
     }
   }
 
-  Future<void> _logOAuthCleanupFailure(Future<void> cleanup) async {
+  Future<void> _retryPoisonedOAuthCleanup() {
+    return _oAuthPoisonCleanup ??= _runPoisonedOAuthCleanup();
+  }
+
+  Future<void> _runPoisonedOAuthCleanup() async {
     try {
-      await cleanup;
-    } catch (error, stackTrace) {
-      developer.log(
-        "Failed to clear a timed-out OAuth session",
-        error: error,
-        stackTrace: stackTrace,
-        name: "sesori_auth",
-      );
+      _oAuthSessionOwner = null;
+      await _oAuthStorage.clearOAuthSession();
+      _oAuthMutationHealth = _OAuthMutationHealth.healthy;
+    } finally {
+      _oAuthPoisonCleanup = null;
     }
   }
 
@@ -822,6 +913,12 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
       throw StateError("$context (HTTP ${response.statusCode})");
     }
   }
+}
+
+enum _OAuthMutationHealth {
+  healthy,
+  drainingTimedOutMutation,
+  cleanupRequired,
 }
 
 final class _OAuthSessionSupersededException implements Exception {

--- a/client/module_auth/lib/src/auth_manager.dart
+++ b/client/module_auth/lib/src/auth_manager.dart
@@ -18,7 +18,12 @@ import "platform/oauth_device_descriptor_provider.dart";
 import "storage/oauth_storage_service.dart";
 import "storage/token_storage_service.dart";
 
-typedef _OAuthSessionOwner = ({DateTime expiresAt, int generation, String sessionToken});
+final class _OAuthSessionOwner {
+  _OAuthSessionOwner({required this.expiresAt, required this.generation, required this.sessionToken});
+  DateTime expiresAt;
+  final int generation;
+  final String sessionToken;
+}
 
 @lazySingleton
 class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
@@ -37,8 +42,6 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
   final Duration _pollTimeout;
   final Future<void> Function(Duration duration) _delay;
   Future<void> _oAuthMutationTail = Future<void>.value();
-  _OAuthMutationHealth _oAuthMutationHealth = _OAuthMutationHealth.healthy;
-  Future<void>? _oAuthPoisonCleanup;
   int _nextOAuthGeneration = 0;
   _OAuthSessionOwner? _oAuthSessionOwner;
 
@@ -106,42 +109,48 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
   Future<AuthInitResponse> startOAuthFlow({required OAuthProvider provider, required DateTime? deadline}) async {
     final sessionToken = _generateSessionToken();
     final flowDeadline = deadline ?? DateTime.now().add(_pollTimeout);
-    var owner = (
+    final owner = _OAuthSessionOwner(
       expiresAt: flowDeadline,
       generation: ++_nextOAuthGeneration,
       sessionToken: sessionToken,
     );
 
     try {
-      final activation = _mutateOAuthState(
+      await _mutateOAuthState(
         mutation: () async {
-          if (!DateTime.now().isBefore(flowDeadline)) {
-            throw TimeoutException("OAuth authorization timed out");
-          }
+          _throwIfOAuthDeadlineReached(deadline: flowDeadline);
           _oAuthSessionOwner = owner;
         },
       );
-      await _awaitOAuthMutationBeforeDeadline(
-        deadline: flowDeadline,
-        mutation: activation,
-      );
-      final descriptor = await _beforeOAuthDeadline(
-        deadline: flowDeadline,
-        operation: _deviceDescriptorProvider.describe,
-      );
+      final descriptor = await _deviceDescriptorProvider.describe();
       final uri = Uri.parse("$authBaseUrl/auth/${provider.key}/init");
-      final response = await _postOAuthInit(
-        uri: uri,
-        deadline: flowDeadline,
-        body: AuthInitRequest(clientType: descriptor.clientType, device: descriptor.device),
-        headers: {_sessionTokenHeader: sessionToken},
-      );
+      final http.Response response;
+      try {
+        response = await _sendOAuthRequest(
+          method: "POST",
+          uri: uri,
+          headers: {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            _sessionTokenHeader: sessionToken,
+          },
+          body: jsonEncode(AuthInitRequest(clientType: descriptor.clientType, device: descriptor.device).toJson()),
+          requestTimeout: flowDeadline.difference(DateTime.now()),
+        );
+      } on http.RequestAbortedException catch (error, stackTrace) {
+        Error.throwWithStackTrace(
+          OAuthRequestTimeoutException(
+            message: "OAuth authorization timed out",
+            uri: uri,
+            cause: error,
+          ),
+          stackTrace,
+        );
+      }
       if (response.statusCode == 503) {
         throw OAuthSessionRestartRequiredException(
           restartAfter: _parseRestartAfter(header: response.headers["retry-after"]),
           deadline: flowDeadline,
-          operation: OAuthSessionRestartOperation.init,
-          reason: OAuthSessionRestartReason.serviceUnavailable,
         );
       }
       _ensureSuccess(response, context: "Failed to start ${provider.label} auth flow");
@@ -149,41 +158,20 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
       final initResponse = AuthInitResponse.fromJson(jsonDecodeMap(response.body));
       final serverExpiresAt = DateTime.now().add(Duration(seconds: initResponse.expiresIn));
       final expiresAt = flowDeadline.isBefore(serverExpiresAt) ? flowDeadline : serverExpiresAt;
-      final activatedOwner = owner;
-      owner = (
-        expiresAt: expiresAt,
-        generation: owner.generation,
-        sessionToken: owner.sessionToken,
-      );
-      final sessionSave = _mutateOAuthState(
+      await _mutateOAuthState(
         mutation: () async {
-          _throwIfOAuthSessionSuperseded(owner: activatedOwner);
-          _oAuthSessionOwner = owner;
+          _assertOAuthSession(owner: owner);
+          owner.expiresAt = expiresAt;
           await _oAuthStorage.saveOAuthSession(
             sessionToken: sessionToken,
             expiresAt: expiresAt,
           );
         },
       );
-      await _awaitOAuthMutationBeforeDeadline(
-        deadline: flowDeadline,
-        mutation: sessionSave,
-      );
       await _assertOAuthSessionOwner(owner: owner);
       return initResponse;
     } on Object catch (error, stackTrace) {
-      if (_oAuthMutationHealth == _OAuthMutationHealth.healthy && error is! _OAuthMutationPoisonedException) {
-        final cleanup = _clearOAuthSessionIfOwned(owner: owner);
-        try {
-          await _awaitOAuthMutationBeforeDeadline(
-            deadline: flowDeadline,
-            mutation: cleanup,
-          );
-        } on TimeoutException {
-          // Poison recovery owns the late cleanup. Preserve the original
-          // operation failure rather than replacing it with rollback timing.
-        }
-      }
+      await _clearOAuthSessionAfterFailure(owner: owner);
       Error.throwWithStackTrace(error, stackTrace);
     }
   }
@@ -203,7 +191,7 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
           throw StateError("No OAuth flow is active");
         }
 
-        final restoredOwner = (
+        final restoredOwner = _OAuthSessionOwner(
           expiresAt: storedSession.expiresAt ?? DateTime.now().add(_pollTimeout),
           generation: ++_nextOAuthGeneration,
           sessionToken: storedToken,
@@ -216,11 +204,10 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
     final expiresAt = owner.expiresAt;
 
     if (!DateTime.now().isBefore(expiresAt)) {
-      await _clearOAuthSessionIfOwned(owner: owner);
+      await _clearOAuthSessionAfterFailure(owner: owner);
       throw TimeoutException("OAuth authorization expired");
     }
 
-    var completionCommitted = false;
     try {
       while (DateTime.now().isBefore(expiresAt)) {
         final remaining = expiresAt.difference(DateTime.now());
@@ -229,36 +216,21 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
         final isFinalRequest = remaining <= _defaultRequestTimeout;
 
         final uri = Uri.parse("$authBaseUrl/auth/session/status");
-        final http.Response response;
-        try {
-          response = await _getSessionStatus(
-            uri: uri,
-            sessionToken: sessionToken,
-            requestTimeout: requestTimeout,
-            expiresAt: expiresAt,
-            isFinalRequest: isFinalRequest,
-          );
-        } on TimeoutException {
-          await _clearOAuthSessionIfOwned(owner: owner);
-          rethrow;
-        }
+        final response = await _getSessionStatus(
+          uri: uri,
+          sessionToken: sessionToken,
+          requestTimeout: requestTimeout,
+          isFinalRequest: isFinalRequest,
+        );
 
         await _assertOAuthSessionOwner(owner: owner);
         if (response.statusCode == 503 || response.statusCode == 404) {
           final restartAfter = response.statusCode == 404
               ? Duration.zero
               : _parseRestartAfter(header: response.headers["retry-after"]);
-          await _clearOAuthSessionBeforeDeadline(
-            deadline: expiresAt,
-            owner: owner,
-          );
           throw OAuthSessionRestartRequiredException(
             restartAfter: restartAfter,
             deadline: expiresAt,
-            operation: OAuthSessionRestartOperation.status,
-            reason: response.statusCode == 404
-                ? OAuthSessionRestartReason.sessionMissing
-                : OAuthSessionRestartReason.serviceUnavailable,
           );
         }
         final status = _parseSessionStatus(response);
@@ -276,36 +248,35 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
           ):
             await _persistOAuthCompletion(
               owner: owner,
-              deadline: expiresAt,
               accessToken: accessToken,
               refreshToken: refreshToken,
               user: user,
             );
-            completionCommitted = true;
             _ackOAuthCompletion(sessionToken: sessionToken);
             return user;
           case AuthSessionStatusResponseDenied():
-            await _clearOAuthSessionIfOwned(owner: owner);
             throw StateError("OAuth authorization was denied");
           case AuthSessionStatusResponseExpired():
-            await _clearOAuthSessionIfOwned(owner: owner);
             throw StateError("OAuth authorization expired");
           case AuthSessionStatusResponseError(:final message):
-            await _clearOAuthSessionIfOwned(owner: owner);
             throw StateError("OAuth authorization failed: $message");
         }
       }
 
-      await _clearOAuthSessionIfOwned(owner: owner);
       throw TimeoutException("OAuth authorization timed out");
+    } on http.ClientException {
+      rethrow;
+    } on _OAuthSessionSupersededException {
+      rethrow;
+    } on Object catch (error, stackTrace) {
+      await _clearOAuthSessionAfterFailure(owner: owner);
+      Error.throwWithStackTrace(error, stackTrace);
     } finally {
-      if (!completionCommitted) {
-        try {
-          await _releaseOAuthSessionIfOwned(owner: owner);
-        } on _OAuthMutationPoisonedException {
-          // Poison recovery owns final cleanup; preserve the established result.
-        }
-      }
+      await _mutateOAuthState(
+        mutation: () async {
+          if (_ownsOAuthSession(owner: owner)) _oAuthSessionOwner = null;
+        },
+      );
     }
   }
 
@@ -314,116 +285,67 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
     return seconds != null && seconds <= 5 ? Duration(seconds: seconds) : const Duration(seconds: 1);
   }
 
-  Future<http.Response> _postOAuthInit({
-    required Uri uri,
-    required DateTime deadline,
-    required AuthInitRequest body,
-    required Map<String, String> headers,
-  }) async {
-    final remaining = deadline.difference(DateTime.now());
-    if (remaining <= Duration.zero) {
-      throw TimeoutException("OAuth authorization timed out");
-    }
-
-    final abortTrigger = Completer<void>();
-    final requestTimer = Timer(remaining, abortTrigger.complete);
-    try {
-      final request = http.AbortableRequest("POST", uri, abortTrigger: abortTrigger.future)
-        ..headers.addAll({
-          "Accept": "application/json",
-          "Content-Type": "application/json",
-          ...headers,
-        })
-        ..body = jsonEncode(body.toJson());
-      return await http.Response.fromStream(await _client.send(request));
-    } on http.RequestAbortedException catch (error, stackTrace) {
-      Error.throwWithStackTrace(
-        OAuthRequestTimeoutException(
-          message: "OAuth authorization timed out",
-          uri: uri,
-          cause: error,
-        ),
-        stackTrace,
-      );
-    } finally {
-      requestTimer.cancel();
-    }
-  }
-
   Future<http.Response> _getSessionStatus({
     required Uri uri,
     required String sessionToken,
     required Duration requestTimeout,
-    required DateTime? expiresAt,
     required bool isFinalRequest,
   }) async {
+    try {
+      return await _sendOAuthRequest(
+        method: "GET",
+        uri: uri,
+        headers: {
+          "Accept": "application/json",
+          _sessionTokenHeader: sessionToken,
+        },
+        body: null,
+        requestTimeout: requestTimeout,
+      );
+    } on http.RequestAbortedException catch (error, stackTrace) {
+      final exception = isFinalRequest
+          ? OAuthRequestTimeoutException(
+              message: "OAuth authorization timed out",
+              uri: uri,
+              cause: error,
+            )
+          : OAuthSessionStatusClientException(uri: uri, cause: error);
+      Error.throwWithStackTrace(exception, stackTrace);
+    }
+  }
+
+  Future<http.Response> _sendOAuthRequest({
+    required String method,
+    required Uri uri,
+    required Map<String, String> headers,
+    required String? body,
+    required Duration requestTimeout,
+  }) async {
+    if (requestTimeout <= Duration.zero) {
+      throw TimeoutException("OAuth authorization timed out");
+    }
+
     final abortTrigger = Completer<void>();
     final requestTimer = Timer(requestTimeout, abortTrigger.complete);
     try {
-      final request = http.AbortableRequest("GET", uri, abortTrigger: abortTrigger.future)
-        ..headers.addAll({
-          "Accept": "application/json",
-          _sessionTokenHeader: sessionToken,
-        });
+      final request = http.AbortableRequest(method, uri, abortTrigger: abortTrigger.future)..headers.addAll(headers);
+      if (body != null) {
+        request.body = body;
+      }
       return await http.Response.fromStream(await _client.send(request));
-    } on http.RequestAbortedException catch (error, stackTrace) {
-      _throwSessionStatusTimeout(
-        cause: error,
-        expiresAt: expiresAt,
-        isFinalRequest: isFinalRequest,
-        stackTrace: stackTrace,
-        uri: uri,
-      );
-    } on TimeoutException catch (error, stackTrace) {
-      _throwSessionStatusTimeout(
-        cause: error,
-        expiresAt: expiresAt,
-        isFinalRequest: isFinalRequest,
-        stackTrace: stackTrace,
-        uri: uri,
-      );
     } finally {
       requestTimer.cancel();
     }
   }
 
-  Never _throwSessionStatusTimeout({
-    required Exception cause,
-    required DateTime? expiresAt,
-    required bool isFinalRequest,
-    required StackTrace stackTrace,
-    required Uri uri,
-  }) {
-    if (isFinalRequest || (expiresAt != null && !DateTime.now().isBefore(expiresAt))) {
-      Error.throwWithStackTrace(
-        OAuthRequestTimeoutException(
-          message: "OAuth authorization timed out",
-          uri: uri,
-          cause: cause,
-        ),
-        stackTrace,
-      );
-    }
-    Error.throwWithStackTrace(
-      OAuthSessionStatusClientException(uri: uri, cause: cause),
-      stackTrace,
-    );
-  }
-
   Future<void> _persistOAuthCompletion({
     required _OAuthSessionOwner owner,
-    required DateTime deadline,
     required String accessToken,
     required String refreshToken,
     required AuthUser user,
   }) => _mutateOAuthState(
     mutation: () async {
-      _throwIfOAuthSessionSuperseded(owner: owner);
-      if (!DateTime.now().isBefore(deadline)) {
-        _oAuthSessionOwner = null;
-        await _oAuthStorage.clearOAuthSession();
-        throw TimeoutException("OAuth authorization timed out");
-      }
+      _assertOAuthSession(owner: owner);
       await _tokenStorage.saveTokens(
         accessToken: accessToken,
         refreshToken: refreshToken,
@@ -436,50 +358,12 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
         _oAuthStorage.clearAuthProvider(),
         _oAuthStorage.clearOAuthSession(),
       ]);
-      _throwIfOAuthSessionSuperseded(owner: owner);
       _oAuthSessionOwner = null;
       _authState.add(AuthState.authenticated(user: user));
     },
   );
 
-  Future<T> _beforeOAuthDeadline<T>({
-    required DateTime deadline,
-    required Future<T> Function() operation,
-  }) {
-    final remaining = deadline.difference(DateTime.now());
-    if (remaining <= Duration.zero) {
-      return Future<T>.error(TimeoutException("OAuth authorization timed out"));
-    }
-
-    return operation().timeout(
-      remaining,
-      onTimeout: () => throw TimeoutException("OAuth authorization timed out"),
-    );
-  }
-
-  Future<T> _awaitOAuthMutationBeforeDeadline<T>({
-    required DateTime deadline,
-    required Future<T> mutation,
-  }) async {
-    try {
-      return await _beforeOAuthDeadline(deadline: deadline, operation: () => mutation);
-    } on TimeoutException {
-      _poisonOAuthMutation(timedOutMutation: mutation);
-      rethrow;
-    }
-  }
-
   Future<T> _mutateOAuthState<T>({required Future<T> Function() mutation}) {
-    if (_oAuthMutationHealth != _OAuthMutationHealth.healthy) {
-      if (_oAuthMutationHealth == _OAuthMutationHealth.cleanupRequired) {
-        return (() async {
-          await _retryPoisonedOAuthCleanup();
-          return _mutateOAuthState(mutation: mutation);
-        })();
-      }
-      return Future<T>.error(const _OAuthMutationPoisonedException());
-    }
-
     final previous = _oAuthMutationTail;
     final completion = Completer<void>();
     _oAuthMutationTail = completion.future;
@@ -493,96 +377,43 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
     })();
   }
 
-  Future<void> _clearOAuthSessionBeforeDeadline({
-    required DateTime deadline,
-    required _OAuthSessionOwner owner,
-  }) {
-    final cleanup = _clearOAuthSessionIfOwned(owner: owner);
-    return _awaitOAuthMutationBeforeDeadline(
-      deadline: deadline,
-      mutation: cleanup,
-    );
+  Future<void> _clearOAuthSessionAfterFailure({required _OAuthSessionOwner owner}) async {
+    try {
+      await _mutateOAuthState(
+        mutation: () async {
+          if (!_ownsOAuthSession(owner: owner)) return;
+          _oAuthSessionOwner = null;
+          await _oAuthStorage.clearOAuthSession();
+        },
+      );
+    } catch (error, stackTrace) {
+      developer.log(
+        "Failed to clear OAuth session after an operation failure",
+        error: error,
+        stackTrace: stackTrace,
+        name: "sesori_auth",
+      );
+    }
   }
-
-  Future<void> _clearOAuthSessionIfOwned({required _OAuthSessionOwner owner}) => _mutateOAuthState(
-    mutation: () async {
-      if (!_ownsOAuthSession(owner: owner)) {
-        return;
-      }
-
-      _oAuthSessionOwner = null;
-      await _oAuthStorage.clearOAuthSession();
-    },
-  );
-
-  Future<void> _releaseOAuthSessionIfOwned({required _OAuthSessionOwner owner}) => _mutateOAuthState(
-    mutation: () async {
-      if (_ownsOAuthSession(owner: owner)) {
-        _oAuthSessionOwner = null;
-      }
-    },
-  );
 
   Future<void> _assertOAuthSessionOwner({required _OAuthSessionOwner owner}) => _mutateOAuthState(
     mutation: () async {
-      _throwIfOAuthSessionSuperseded(owner: owner);
+      _assertOAuthSession(owner: owner);
     },
   );
 
   bool _ownsOAuthSession({required _OAuthSessionOwner owner}) => _oAuthSessionOwner == owner;
 
-  void _throwIfOAuthSessionSuperseded({required _OAuthSessionOwner owner}) {
+  void _assertOAuthSession({required _OAuthSessionOwner owner}) {
     if (!_ownsOAuthSession(owner: owner)) {
       throw const _OAuthSessionSupersededException();
     }
+    _throwIfOAuthDeadlineReached(deadline: owner.expiresAt);
   }
 
-  void _poisonOAuthMutation<T>({required Future<T> timedOutMutation}) {
-    if (_oAuthMutationHealth != _OAuthMutationHealth.healthy) {
-      return;
-    }
-
-    _oAuthMutationHealth = _OAuthMutationHealth.drainingTimedOutMutation;
-    unawaited(_recoverPoisonedOAuthMutation(timedOutMutation: timedOutMutation));
-  }
-
-  Future<void> _recoverPoisonedOAuthMutation<T>({required Future<T> timedOutMutation}) async {
-    try {
-      await timedOutMutation;
-    } catch (error, stackTrace) {
-      developer.log(
-        "Timed-out OAuth mutation eventually failed",
-        error: error,
-        stackTrace: stackTrace,
-        name: "sesori_auth",
-      );
-    }
-
-    try {
-      await _oAuthMutationTail;
-      _oAuthMutationHealth = _OAuthMutationHealth.cleanupRequired;
-      await _retryPoisonedOAuthCleanup();
-    } catch (error, stackTrace) {
-      developer.log(
-        "Failed to recover poisoned OAuth mutation state",
-        error: error,
-        stackTrace: stackTrace,
-        name: "sesori_auth",
-      );
-    }
-  }
-
-  Future<void> _retryPoisonedOAuthCleanup() {
-    return _oAuthPoisonCleanup ??= _runPoisonedOAuthCleanup();
-  }
-
-  Future<void> _runPoisonedOAuthCleanup() async {
-    try {
-      _oAuthSessionOwner = null;
-      await _oAuthStorage.clearOAuthSession();
-      _oAuthMutationHealth = _OAuthMutationHealth.healthy;
-    } finally {
-      _oAuthPoisonCleanup = null;
+  void _throwIfOAuthDeadlineReached({required DateTime deadline}) {
+    if (!DateTime.now().isBefore(deadline)) {
+      throw TimeoutException("OAuth authorization timed out");
     }
   }
 
@@ -955,18 +786,8 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
   }
 }
 
-enum _OAuthMutationHealth {
-  healthy,
-  drainingTimedOutMutation,
-  cleanupRequired,
-}
-
 final class _OAuthSessionSupersededException implements Exception {
   const _OAuthSessionSupersededException();
-}
-
-final class _OAuthMutationPoisonedException implements Exception {
-  const _OAuthMutationPoisonedException();
 }
 
 final class OAuthRequestTimeoutException extends TimeoutException {

--- a/client/module_auth/lib/src/auth_manager.dart
+++ b/client/module_auth/lib/src/auth_manager.dart
@@ -18,6 +18,8 @@ import "platform/oauth_device_descriptor_provider.dart";
 import "storage/oauth_storage_service.dart";
 import "storage/token_storage_service.dart";
 
+typedef _OAuthSessionOwner = ({int generation, String sessionToken});
+
 @lazySingleton
 class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
   static const _sessionTokenHeader = "X-Sesori-Session-Token";
@@ -34,7 +36,10 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
   final Duration _pollInterval;
   final Duration _pollTimeout;
   final Future<void> Function(Duration duration) _delay;
-  String? _oAuthSessionToken;
+  Future<void> _oAuthMutationTail = Future<void>.value();
+  bool _oAuthMutationPoisoned = false;
+  int _nextOAuthGeneration = 0;
+  _OAuthSessionOwner? _oAuthSessionOwner;
 
   AuthManager(
     http.Client client,
@@ -97,55 +102,105 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
   }
 
   @override
-  Future<AuthInitResponse> startOAuthFlow({required OAuthProvider provider}) async {
+  Future<AuthInitResponse> startOAuthFlow({required OAuthProvider provider, required DateTime? deadline}) async {
     final sessionToken = _generateSessionToken();
-    _oAuthSessionToken = sessionToken;
+    final flowDeadline = deadline ?? DateTime.now().add(_pollTimeout);
+    final owner = (generation: ++_nextOAuthGeneration, sessionToken: sessionToken);
 
     try {
-      final descriptor = await _deviceDescriptorProvider.describe();
-      final uri = Uri.parse("$authBaseUrl/auth/${provider.key}/init");
-      final response = await _post(
-        uri,
-        body: AuthInitRequest(clientType: descriptor.clientType, device: descriptor.device).toJson(),
-        headers: {_sessionTokenHeader: sessionToken},
+      final activation = _mutateOAuthState(() async {
+        if (!DateTime.now().isBefore(flowDeadline)) {
+          throw TimeoutException("OAuth authorization timed out");
+        }
+        _oAuthSessionOwner = owner;
+      });
+      await _awaitOAuthMutationBeforeDeadline(
+        deadline: flowDeadline,
+        mutation: activation,
       );
+      final descriptor = await _beforeOAuthDeadline(
+        deadline: flowDeadline,
+        operation: _deviceDescriptorProvider.describe,
+      );
+      final uri = Uri.parse("$authBaseUrl/auth/${provider.key}/init");
+      final response = await _beforeOAuthDeadline(
+        deadline: flowDeadline,
+        operation: () => _post(
+          uri,
+          body: AuthInitRequest(clientType: descriptor.clientType, device: descriptor.device).toJson(),
+          headers: {_sessionTokenHeader: sessionToken},
+        ),
+      );
+      if (response.statusCode == 503) {
+        throw OAuthSessionRestartRequiredException(
+          restartAfter: _parseRestartAfter(response.headers["retry-after"]),
+          deadline: flowDeadline,
+        );
+      }
       _ensureSuccess(response, context: "Failed to start ${provider.label} auth flow");
 
       final initResponse = AuthInitResponse.fromJson(jsonDecodeMap(response.body));
-      final expiresAt = DateTime.now().add(Duration(seconds: initResponse.expiresIn));
-      await _oAuthStorage.saveOAuthSession(
-        sessionToken: sessionToken,
-        expiresAt: expiresAt,
+      final serverExpiresAt = DateTime.now().add(Duration(seconds: initResponse.expiresIn));
+      final expiresAt = flowDeadline.isBefore(serverExpiresAt) ? flowDeadline : serverExpiresAt;
+      final sessionSave = _mutateOAuthState(() async {
+        _throwIfOAuthSessionSuperseded(owner);
+        await _oAuthStorage.saveOAuthSession(
+          sessionToken: sessionToken,
+          expiresAt: expiresAt,
+        );
+      });
+      await _awaitOAuthMutationBeforeDeadline(
+        deadline: flowDeadline,
+        mutation: sessionSave,
       );
+      await _assertOAuthSessionOwner(owner);
       return initResponse;
-    } catch (_) {
-      _oAuthSessionToken = null;
-      await _oAuthStorage.clearOAuthSession();
-      rethrow;
+    } on Object catch (error, stackTrace) {
+      if (!_oAuthMutationPoisoned && error is! _OAuthMutationPoisonedException) {
+        final cleanup = _clearOAuthSessionIfOwned(owner: owner);
+        if (error is TimeoutException) {
+          unawaited(_logOAuthCleanupFailure(cleanup));
+        } else {
+          await cleanup;
+        }
+      }
+      Error.throwWithStackTrace(error, stackTrace);
     }
   }
 
   @override
   Future<AuthUser> pollForResult() async {
-    final sessionToken = _oAuthSessionToken ?? (await _oAuthStorage.getOAuthSession()).sessionToken;
-    final expiresAt = (await _oAuthStorage.getOAuthSession()).expiresAt;
+    final storedSession = await _oAuthStorage.getOAuthSession();
+    final owner = await _mutateOAuthState(() async {
+      final activeOwner = _oAuthSessionOwner;
+      if (activeOwner != null) {
+        return activeOwner;
+      }
 
-    if (sessionToken == null || sessionToken.isEmpty) {
-      throw StateError("No OAuth flow is active");
-    }
+      final storedToken = storedSession.sessionToken;
+      if (storedToken == null || storedToken.isEmpty) {
+        throw StateError("No OAuth flow is active");
+      }
 
-    if (expiresAt != null && DateTime.now().isAfter(expiresAt)) {
-      await _oAuthStorage.clearOAuthSession();
-      _oAuthSessionToken = null;
+      final restoredOwner = (generation: ++_nextOAuthGeneration, sessionToken: storedToken);
+      _oAuthSessionOwner = restoredOwner;
+      return restoredOwner;
+    });
+    final sessionToken = owner.sessionToken;
+    final expiresAt = storedSession.expiresAt ?? DateTime.now().add(_pollTimeout);
+
+    if (!DateTime.now().isBefore(expiresAt)) {
+      await _clearOAuthSessionIfOwned(owner: owner);
       throw TimeoutException("OAuth authorization expired");
     }
 
+    var completionCommitted = false;
     try {
-      while (expiresAt == null || DateTime.now().isBefore(expiresAt)) {
-        final remaining = expiresAt?.difference(DateTime.now()) ?? _pollTimeout;
+      while (DateTime.now().isBefore(expiresAt)) {
+        final remaining = expiresAt.difference(DateTime.now());
         final requestTimeout = remaining < _defaultRequestTimeout ? remaining : _defaultRequestTimeout;
         if (requestTimeout <= Duration.zero) break;
-        final isFinalRequest = expiresAt != null && remaining <= _defaultRequestTimeout;
+        final isFinalRequest = remaining <= _defaultRequestTimeout;
 
         final uri = Uri.parse("$authBaseUrl/auth/session/status");
         final http.Response response;
@@ -158,14 +213,22 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
             isFinalRequest: isFinalRequest,
           );
         } on TimeoutException {
-          await _oAuthStorage.clearOAuthSession();
+          await _clearOAuthSessionIfOwned(owner: owner);
           rethrow;
         }
 
+        await _assertOAuthSessionOwner(owner);
+        if (response.statusCode == 503 || response.statusCode == 404) {
+          final restartAfter = response.statusCode == 404
+              ? Duration.zero
+              : _parseRestartAfter(response.headers["retry-after"]);
+          await _clearOAuthSessionIfOwned(owner: owner);
+          throw OAuthSessionRestartRequiredException(restartAfter: restartAfter, deadline: expiresAt);
+        }
         final status = _parseSessionStatus(response);
         switch (status) {
           case AuthSessionStatusResponsePending():
-            final delayRemaining = expiresAt?.difference(DateTime.now()) ?? _pollTimeout;
+            final delayRemaining = expiresAt.difference(DateTime.now());
             final delay = _pollInterval < delayRemaining ? _pollInterval : delayRemaining;
             if (delay > Duration.zero) {
               await _delay(delay);
@@ -176,29 +239,43 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
             user: final user,
           ):
             await _persistOAuthCompletion(
+              owner: owner,
+              deadline: expiresAt,
               accessToken: accessToken,
               refreshToken: refreshToken,
               user: user,
             );
+            completionCommitted = true;
             _ackOAuthCompletion(sessionToken: sessionToken);
             return user;
           case AuthSessionStatusResponseDenied():
-            await _oAuthStorage.clearOAuthSession();
+            await _clearOAuthSessionIfOwned(owner: owner);
             throw StateError("OAuth authorization was denied");
           case AuthSessionStatusResponseExpired():
-            await _oAuthStorage.clearOAuthSession();
+            await _clearOAuthSessionIfOwned(owner: owner);
             throw StateError("OAuth authorization expired");
           case AuthSessionStatusResponseError(:final message):
-            await _oAuthStorage.clearOAuthSession();
+            await _clearOAuthSessionIfOwned(owner: owner);
             throw StateError("OAuth authorization failed: $message");
         }
       }
 
-      await _oAuthStorage.clearOAuthSession();
+      await _clearOAuthSessionIfOwned(owner: owner);
       throw TimeoutException("OAuth authorization timed out");
     } finally {
-      _oAuthSessionToken = null;
+      if (!completionCommitted) {
+        try {
+          await _releaseOAuthSessionIfOwned(owner);
+        } on _OAuthMutationPoisonedException {
+          // Poison recovery owns final cleanup; preserve the established result.
+        }
+      }
     }
+  }
+
+  Duration _parseRestartAfter(String? header) {
+    final seconds = header != null && RegExp(r"^[0-9]+$").hasMatch(header) ? int.tryParse(header) : null;
+    return seconds != null && seconds <= 5 ? Duration(seconds: seconds) : const Duration(seconds: 1);
   }
 
   Future<http.Response> _getSessionStatus({
@@ -228,10 +305,18 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
   }
 
   Future<void> _persistOAuthCompletion({
+    required _OAuthSessionOwner owner,
+    required DateTime deadline,
     required String accessToken,
     required String refreshToken,
     required AuthUser user,
-  }) async {
+  }) => _mutateOAuthState(() async {
+    _throwIfOAuthSessionSuperseded(owner);
+    if (!DateTime.now().isBefore(deadline)) {
+      _oAuthSessionOwner = null;
+      await _oAuthStorage.clearOAuthSession();
+      throw TimeoutException("OAuth authorization timed out");
+    }
     await _tokenStorage.saveTokens(
       accessToken: accessToken,
       refreshToken: refreshToken,
@@ -239,14 +324,135 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
     // Best-effort: the tokens above already make this a valid session, so a
     // local user-cache write failure must not abort a completed login.
     await _saveUserBestEffort(user);
-
     await Future.wait([
       _oAuthStorage.clearPkceVerifier(),
       _oAuthStorage.clearAuthProvider(),
       _oAuthStorage.clearOAuthSession(),
     ]);
-
+    _throwIfOAuthSessionSuperseded(owner);
+    _oAuthSessionOwner = null;
     _authState.add(AuthState.authenticated(user: user));
+  });
+
+  Future<T> _beforeOAuthDeadline<T>({
+    required DateTime deadline,
+    required Future<T> Function() operation,
+  }) {
+    final remaining = deadline.difference(DateTime.now());
+    if (remaining <= Duration.zero) {
+      return Future<T>.error(TimeoutException("OAuth authorization timed out"));
+    }
+
+    return operation().timeout(
+      remaining,
+      onTimeout: () => throw TimeoutException("OAuth authorization timed out"),
+    );
+  }
+
+  Future<T> _awaitOAuthMutationBeforeDeadline<T>({
+    required DateTime deadline,
+    required Future<T> mutation,
+  }) async {
+    try {
+      return await _beforeOAuthDeadline(deadline: deadline, operation: () => mutation);
+    } on TimeoutException {
+      _poisonOAuthMutation(mutation);
+      rethrow;
+    }
+  }
+
+  Future<T> _mutateOAuthState<T>(Future<T> Function() mutation) {
+    if (_oAuthMutationPoisoned) {
+      return Future<T>.error(const _OAuthMutationPoisonedException());
+    }
+
+    final previous = _oAuthMutationTail;
+    final completion = Completer<void>();
+    _oAuthMutationTail = completion.future;
+    return (() async {
+      await previous;
+      try {
+        return await mutation();
+      } finally {
+        completion.complete();
+      }
+    })();
+  }
+
+  Future<void> _clearOAuthSessionIfOwned({required _OAuthSessionOwner owner}) => _mutateOAuthState(() async {
+    if (!_ownsOAuthSession(owner)) {
+      return;
+    }
+
+    _oAuthSessionOwner = null;
+    await _oAuthStorage.clearOAuthSession();
+  });
+
+  Future<void> _releaseOAuthSessionIfOwned(_OAuthSessionOwner owner) => _mutateOAuthState(() async {
+    if (_ownsOAuthSession(owner)) {
+      _oAuthSessionOwner = null;
+    }
+  });
+
+  Future<void> _assertOAuthSessionOwner(_OAuthSessionOwner owner) => _mutateOAuthState(() async {
+    _throwIfOAuthSessionSuperseded(owner);
+  });
+
+  bool _ownsOAuthSession(_OAuthSessionOwner owner) => _oAuthSessionOwner == owner;
+
+  void _throwIfOAuthSessionSuperseded(_OAuthSessionOwner owner) {
+    if (!_ownsOAuthSession(owner)) {
+      throw const _OAuthSessionSupersededException();
+    }
+  }
+
+  void _poisonOAuthMutation<T>(Future<T> timedOutMutation) {
+    if (_oAuthMutationPoisoned) {
+      return;
+    }
+
+    _oAuthMutationPoisoned = true;
+    unawaited(_recoverPoisonedOAuthMutation(timedOutMutation));
+  }
+
+  Future<void> _recoverPoisonedOAuthMutation<T>(Future<T> timedOutMutation) async {
+    try {
+      await timedOutMutation;
+    } catch (error, stackTrace) {
+      developer.log(
+        "Timed-out OAuth mutation eventually failed",
+        error: error,
+        stackTrace: stackTrace,
+        name: "sesori_auth",
+      );
+    }
+
+    try {
+      await _oAuthMutationTail;
+      _oAuthSessionOwner = null;
+      await _oAuthStorage.clearOAuthSession();
+      _oAuthMutationPoisoned = false;
+    } catch (error, stackTrace) {
+      developer.log(
+        "Failed to recover poisoned OAuth mutation state",
+        error: error,
+        stackTrace: stackTrace,
+        name: "sesori_auth",
+      );
+    }
+  }
+
+  Future<void> _logOAuthCleanupFailure(Future<void> cleanup) async {
+    try {
+      await cleanup;
+    } catch (error, stackTrace) {
+      developer.log(
+        "Failed to clear a timed-out OAuth session",
+        error: error,
+        stackTrace: stackTrace,
+        name: "sesori_auth",
+      );
+    }
   }
 
   void _ackOAuthCompletion({required String sessionToken}) {
@@ -616,4 +822,12 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
       throw StateError("$context (HTTP ${response.statusCode})");
     }
   }
+}
+
+final class _OAuthSessionSupersededException implements Exception {
+  const _OAuthSessionSupersededException();
+}
+
+final class _OAuthMutationPoisonedException implements Exception {
+  const _OAuthMutationPoisonedException();
 }

--- a/client/module_auth/lib/src/auth_manager.dart
+++ b/client/module_auth/lib/src/auth_manager.dart
@@ -130,13 +130,11 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
         operation: _deviceDescriptorProvider.describe,
       );
       final uri = Uri.parse("$authBaseUrl/auth/${provider.key}/init");
-      final response = await _beforeOAuthDeadline(
+      final response = await _postOAuthInit(
+        uri: uri,
         deadline: flowDeadline,
-        operation: () => _post(
-          uri,
-          body: AuthInitRequest(clientType: descriptor.clientType, device: descriptor.device).toJson(),
-          headers: {_sessionTokenHeader: sessionToken},
-        ),
+        body: AuthInitRequest(clientType: descriptor.clientType, device: descriptor.device),
+        headers: {_sessionTokenHeader: sessionToken},
       );
       if (response.statusCode == 503) {
         throw OAuthSessionRestartRequiredException(
@@ -316,6 +314,42 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
     return seconds != null && seconds <= 5 ? Duration(seconds: seconds) : const Duration(seconds: 1);
   }
 
+  Future<http.Response> _postOAuthInit({
+    required Uri uri,
+    required DateTime deadline,
+    required AuthInitRequest body,
+    required Map<String, String> headers,
+  }) async {
+    final remaining = deadline.difference(DateTime.now());
+    if (remaining <= Duration.zero) {
+      throw TimeoutException("OAuth authorization timed out");
+    }
+
+    final abortTrigger = Completer<void>();
+    final requestTimer = Timer(remaining, abortTrigger.complete);
+    try {
+      final request = http.AbortableRequest("POST", uri, abortTrigger: abortTrigger.future)
+        ..headers.addAll({
+          "Accept": "application/json",
+          "Content-Type": "application/json",
+          ...headers,
+        })
+        ..body = jsonEncode(body.toJson());
+      return await http.Response.fromStream(await _client.send(request));
+    } on http.RequestAbortedException catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        OAuthRequestTimeoutException(
+          message: "OAuth authorization timed out",
+          uri: uri,
+          cause: error,
+        ),
+        stackTrace,
+      );
+    } finally {
+      requestTimer.cancel();
+    }
+  }
+
   Future<http.Response> _getSessionStatus({
     required Uri uri,
     required String sessionToken,
@@ -332,15 +366,17 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
           _sessionTokenHeader: sessionToken,
         });
       return await http.Response.fromStream(await _client.send(request));
-    } on http.RequestAbortedException catch (_, stackTrace) {
+    } on http.RequestAbortedException catch (error, stackTrace) {
       _throwSessionStatusTimeout(
+        cause: error,
         expiresAt: expiresAt,
         isFinalRequest: isFinalRequest,
         stackTrace: stackTrace,
         uri: uri,
       );
-    } on TimeoutException catch (_, stackTrace) {
+    } on TimeoutException catch (error, stackTrace) {
       _throwSessionStatusTimeout(
+        cause: error,
         expiresAt: expiresAt,
         isFinalRequest: isFinalRequest,
         stackTrace: stackTrace,
@@ -352,6 +388,7 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
   }
 
   Never _throwSessionStatusTimeout({
+    required Exception cause,
     required DateTime? expiresAt,
     required bool isFinalRequest,
     required StackTrace stackTrace,
@@ -359,12 +396,16 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
   }) {
     if (isFinalRequest || (expiresAt != null && !DateTime.now().isBefore(expiresAt))) {
       Error.throwWithStackTrace(
-        TimeoutException("OAuth authorization timed out"),
+        OAuthRequestTimeoutException(
+          message: "OAuth authorization timed out",
+          uri: uri,
+          cause: cause,
+        ),
         stackTrace,
       );
     }
     Error.throwWithStackTrace(
-      http.ClientException("OAuth session status request timed out", uri),
+      OAuthSessionStatusClientException(uri: uri, cause: cause),
       stackTrace,
     );
   }
@@ -926,4 +967,24 @@ final class _OAuthSessionSupersededException implements Exception {
 
 final class _OAuthMutationPoisonedException implements Exception {
   const _OAuthMutationPoisonedException();
+}
+
+final class OAuthRequestTimeoutException extends TimeoutException {
+  OAuthRequestTimeoutException({
+    required String message,
+    required this.uri,
+    required this.cause,
+  }) : super(message);
+
+  final Uri uri;
+  final Exception cause;
+}
+
+final class OAuthSessionStatusClientException extends http.ClientException {
+  OAuthSessionStatusClientException({
+    required Uri uri,
+    required this.cause,
+  }) : super("OAuth session status request timed out", uri);
+
+  final Exception cause;
 }

--- a/client/module_auth/lib/src/auth_manager.dart
+++ b/client/module_auth/lib/src/auth_manager.dart
@@ -182,9 +182,8 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
             mutation: cleanup,
           );
         } on TimeoutException {
-          if (error is! TimeoutException) {
-            rethrow;
-          }
+          // Poison recovery owns the late cleanup. Preserve the original
+          // operation failure rather than replacing it with rollback timing.
         }
       }
       Error.throwWithStackTrace(error, stackTrace);

--- a/client/module_auth/lib/src/auth_manager.dart
+++ b/client/module_auth/lib/src/auth_manager.dart
@@ -122,7 +122,9 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
           _oAuthSessionOwner = owner;
         },
       );
-      final descriptor = await _deviceDescriptorProvider.describe();
+      final descriptor = await _deviceDescriptorProvider.describe().timeout(
+        flowDeadline.difference(DateTime.now()),
+      );
       final uri = Uri.parse("$authBaseUrl/auth/${provider.key}/init");
       final http.Response response;
       try {
@@ -303,6 +305,15 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
         requestTimeout: requestTimeout,
       );
     } on http.RequestAbortedException catch (error, stackTrace) {
+      final exception = isFinalRequest
+          ? OAuthRequestTimeoutException(
+              message: "OAuth authorization timed out",
+              uri: uri,
+              cause: error,
+            )
+          : OAuthSessionStatusClientException(uri: uri, cause: error);
+      Error.throwWithStackTrace(exception, stackTrace);
+    } on TimeoutException catch (error, stackTrace) {
       final exception = isFinalRequest
           ? OAuthRequestTimeoutException(
               message: "OAuth authorization timed out",

--- a/client/module_auth/lib/src/interfaces/oauth_flow_provider.dart
+++ b/client/module_auth/lib/src/interfaces/oauth_flow_provider.dart
@@ -8,7 +8,7 @@ import "package:sesori_shared/sesori_shared.dart";
 /// device).
 abstract interface class OAuthFlowProvider {
   /// Starts an auth-server backed OAuth session for [provider].
-  Future<AuthInitResponse> startOAuthFlow({required OAuthProvider provider});
+  Future<AuthInitResponse> startOAuthFlow({required OAuthProvider provider, required DateTime? deadline});
 
   /// Polls the auth server until the pending OAuth session reaches a terminal result.
   Future<AuthUser> pollForResult();

--- a/client/module_auth/test/auth_manager_test.dart
+++ b/client/module_auth/test/auth_manager_test.dart
@@ -27,6 +27,19 @@ class FakeOAuthDeviceDescriptorProvider implements OAuthDeviceDescriptorProvider
   );
 }
 
+Future<OAuthSessionRestartRequiredException> _pollRestart(AuthManager manager) async {
+  return _captureOAuthRestart(manager.pollForResult());
+}
+
+Future<OAuthSessionRestartRequiredException> _captureOAuthRestart(Future<Object?> operation) async {
+  try {
+    await operation;
+  } on OAuthSessionRestartRequiredException catch (error) {
+    return error;
+  }
+  fail("Expected OAuth restart");
+}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(Uri.parse("https://example.com"));
@@ -281,6 +294,7 @@ void main() {
   group("OAuth flow", () {
     test("startOAuthFlow creates header-only session token and sends the device descriptor", () async {
       const authUrl = "https://github.com/login/oauth/authorize?client_id=abc";
+      final deadline = DateTime.now().add(const Duration(seconds: 20));
       when(
         () => mockHttpClient.post(
           Uri.parse("$authBaseUrl/auth/github/init"),
@@ -294,7 +308,7 @@ void main() {
         ),
       );
 
-      final result = await authManager.startOAuthFlow(provider: AuthProvider.github);
+      final result = await authManager.startOAuthFlow(provider: AuthProvider.github, deadline: deadline);
 
       expect(result.authUrl, authUrl);
       expect(result.state, "state-1");
@@ -317,12 +331,387 @@ void main() {
         "device": {"name": "Test iPhone", "osVersion": "iOS 17.5", "appVersion": "1.2.0"},
       });
       expect(body.values, isNot(contains(sessionToken)));
+      final savedExpiry = verify(
+        () => mockOAuthStorage.saveOAuthSession(
+          sessionToken: any(named: "sessionToken"),
+          expiresAt: captureAny(named: "expiresAt"),
+        ),
+      ).captured.single;
+      expect(savedExpiry, deadline);
       verifyNever(
         () => mockOAuthStorage.saveAuthProviderAndPkceVerifier(
           codeVerifier: any(named: "codeVerifier"),
           provider: any(named: "provider"),
         ),
       );
+    });
+
+    test("init 503 clears its session and exposes bounded restart timing before parsing JSON", () async {
+      final deadline = DateTime.now().add(const Duration(minutes: 2));
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/github/init"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer((_) async => http.Response("not-json", 503, headers: {"retry-after": "2"}));
+
+      final restart = await _captureOAuthRestart(
+        authManager.startOAuthFlow(provider: AuthProvider.github, deadline: deadline),
+      );
+
+      expect(restart.restartAfter, const Duration(seconds: 2));
+      expect(restart.deadline, deadline);
+      verify(mockOAuthStorage.clearOAuthSession).called(1);
+      verifyNever(
+        () => mockOAuthStorage.saveOAuthSession(
+          sessionToken: any(named: "sessionToken"),
+          expiresAt: any(named: "expiresAt"),
+        ),
+      );
+    });
+
+    test("a stale status response cannot clear a replacement OAuth session", () async {
+      final staleResponse = Completer<http.Response>();
+      var storedSession = (sessionToken: null as String?, expiresAt: null as DateTime?);
+      when(() => mockOAuthStorage.getOAuthSession()).thenAnswer((_) async => storedSession);
+      when(
+        () => mockOAuthStorage.saveOAuthSession(
+          sessionToken: any(named: "sessionToken"),
+          expiresAt: any(named: "expiresAt"),
+        ),
+      ).thenAnswer((invocation) async {
+        storedSession = (
+          sessionToken: invocation.namedArguments[#sessionToken] as String,
+          expiresAt: invocation.namedArguments[#expiresAt] as DateTime,
+        );
+      });
+      when(mockOAuthStorage.clearOAuthSession).thenAnswer((_) async {
+        storedSession = (sessionToken: null, expiresAt: null);
+      });
+      when(
+        () => mockHttpClient.post(
+          any(),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({"authUrl": "https://example.com/login", "state": "state", "expiresIn": 300}),
+          200,
+        ),
+      );
+      when(
+        () => mockHttpClient.get(any(), headers: any(named: "headers")),
+      ).thenAnswer((_) => staleResponse.future);
+
+      await authManager.startOAuthFlow(provider: AuthProvider.github, deadline: null);
+      final stalePoll = authManager.pollForResult();
+      await untilCalled(() => mockHttpClient.get(any(), headers: any(named: "headers")));
+      await authManager.startOAuthFlow(provider: AuthProvider.google, deadline: null);
+      final replacementToken = storedSession.sessionToken;
+      final staleFailure = expectLater(stalePoll, throwsA(isA<Exception>()));
+      staleResponse.complete(http.Response("not-json", 503, headers: {"retry-after": "0"}));
+      await staleFailure;
+
+      expect(replacementToken, isNotNull);
+      expect(storedSession.sessionToken, replacementToken);
+      verifyNever(mockOAuthStorage.clearOAuthSession);
+    });
+
+    test("a timed-out session save poisons retries until one owned cleanup completes", () async {
+      final firstSave = Completer<void>();
+      var saveCount = 0;
+      var storedSession = (sessionToken: null as String?, expiresAt: null as DateTime?);
+      when(
+        () => mockOAuthStorage.saveOAuthSession(
+          sessionToken: any(named: "sessionToken"),
+          expiresAt: any(named: "expiresAt"),
+        ),
+      ).thenAnswer((invocation) async {
+        if (saveCount++ == 0) {
+          await firstSave.future;
+        }
+        storedSession = (
+          sessionToken: invocation.namedArguments[#sessionToken] as String,
+          expiresAt: invocation.namedArguments[#expiresAt] as DateTime,
+        );
+      });
+      when(mockOAuthStorage.clearOAuthSession).thenAnswer((_) async {
+        storedSession = (sessionToken: null, expiresAt: null);
+      });
+      when(
+        () => mockHttpClient.post(
+          any(),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({"authUrl": "https://example.com/login", "state": "state", "expiresIn": 300}),
+          200,
+        ),
+      );
+
+      final firstStart = authManager.startOAuthFlow(
+        provider: AuthProvider.github,
+        deadline: DateTime.now().add(const Duration(milliseconds: 30)),
+      );
+      await untilCalled(
+        () => mockOAuthStorage.saveOAuthSession(
+          sessionToken: any(named: "sessionToken"),
+          expiresAt: any(named: "expiresAt"),
+        ),
+      );
+      var replacementCompleted = false;
+      final replacement = authManager
+          .startOAuthFlow(
+            provider: AuthProvider.google,
+            deadline: DateTime.now().add(const Duration(minutes: 1)),
+          )
+          .whenComplete(() => replacementCompleted = true);
+
+      await expectLater(firstStart, throwsA(isA<TimeoutException>()));
+      expect(replacementCompleted, isFalse);
+      expect(storedSession.sessionToken, isNull);
+      verifyNever(mockOAuthStorage.clearOAuthSession);
+      for (var attempt = 0; attempt < 3; attempt += 1) {
+        await expectLater(
+          authManager.startOAuthFlow(
+            provider: AuthProvider.google,
+            deadline: DateTime.now().add(const Duration(minutes: 1)),
+          ),
+          throwsA(isA<Exception>()),
+        );
+      }
+
+      final replacementFailure = expectLater(replacement, throwsA(isA<Exception>()));
+      firstSave.complete();
+      await replacementFailure;
+      await untilCalled(mockOAuthStorage.clearOAuthSession);
+
+      await authManager.startOAuthFlow(
+        provider: AuthProvider.google,
+        deadline: DateTime.now().add(const Duration(minutes: 1)),
+      );
+
+      expect(replacementCompleted, isTrue);
+      expect(storedSession.sessionToken, isNotNull);
+      verify(mockOAuthStorage.clearOAuthSession).called(1);
+    });
+
+    test("OAuth completion is atomic with respect to a replacement start", () async {
+      final tokenSave = Completer<void>();
+      when(
+        () => mockHttpClient.post(
+          any(),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({"authUrl": "https://example.com/login", "state": "state", "expiresIn": 300}),
+          200,
+        ),
+      );
+      when(
+        () => mockHttpClient.get(any(), headers: any(named: "headers")),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({
+            "status": "complete",
+            "accessToken": "access",
+            "refreshToken": "refresh",
+            "user": user.toJson(),
+          }),
+          200,
+        ),
+      );
+      when(
+        () => mockTokenStorage.saveTokens(accessToken: "access", refreshToken: "refresh"),
+      ).thenAnswer((_) => tokenSave.future);
+      when(mockOAuthStorage.clearPkceVerifier).thenAnswer((_) async {});
+      when(mockOAuthStorage.clearAuthProvider).thenAnswer((_) async {});
+
+      await authManager.startOAuthFlow(provider: AuthProvider.github, deadline: null);
+      final completion = authManager.pollForResult();
+      await untilCalled(
+        () => mockTokenStorage.saveTokens(accessToken: "access", refreshToken: "refresh"),
+      );
+      var replacementCompleted = false;
+      final replacement = authManager
+          .startOAuthFlow(provider: AuthProvider.google, deadline: null)
+          .whenComplete(() => replacementCompleted = true);
+      await Future<void>.delayed(Duration.zero);
+      expect(replacementCompleted, isFalse);
+
+      tokenSave.complete();
+      expect(await completion, user);
+      await replacement;
+
+      expect(authManager.currentState, const AuthState.authenticated(user: user));
+      expect(replacementCompleted, isTrue);
+    });
+
+    test("completion that wins before the deadline cannot later become a timeout", () async {
+      final tokenSave = Completer<void>();
+      var storedSession = (sessionToken: null as String?, expiresAt: null as DateTime?);
+      when(() => mockOAuthStorage.getOAuthSession()).thenAnswer((_) async => storedSession);
+      when(
+        () => mockOAuthStorage.saveOAuthSession(
+          sessionToken: any(named: "sessionToken"),
+          expiresAt: any(named: "expiresAt"),
+        ),
+      ).thenAnswer((invocation) async {
+        storedSession = (
+          sessionToken: invocation.namedArguments[#sessionToken] as String,
+          expiresAt: invocation.namedArguments[#expiresAt] as DateTime,
+        );
+      });
+      when(
+        () => mockHttpClient.post(
+          any(),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({"authUrl": "https://example.com/login", "state": "state", "expiresIn": 300}),
+          200,
+        ),
+      );
+      when(
+        () => mockHttpClient.get(any(), headers: any(named: "headers")),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({
+            "status": "complete",
+            "accessToken": "access",
+            "refreshToken": "refresh",
+            "user": user.toJson(),
+          }),
+          200,
+        ),
+      );
+      when(
+        () => mockTokenStorage.saveTokens(accessToken: "access", refreshToken: "refresh"),
+      ).thenAnswer((_) => tokenSave.future);
+      when(mockOAuthStorage.clearPkceVerifier).thenAnswer((_) async {});
+      when(mockOAuthStorage.clearAuthProvider).thenAnswer((_) async {});
+
+      await authManager.startOAuthFlow(
+        provider: AuthProvider.github,
+        deadline: DateTime.now().add(const Duration(milliseconds: 80)),
+      );
+      var completed = false;
+      final completion = authManager.pollForResult().whenComplete(() => completed = true);
+      await untilCalled(
+        () => mockTokenStorage.saveTokens(accessToken: "access", refreshToken: "refresh"),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(completed, isFalse);
+
+      tokenSave.complete();
+
+      expect(await completion, user);
+      expect(authManager.currentState, const AuthState.authenticated(user: user));
+    });
+
+    test("a poisoned queued replacement cannot override committed completion", () async {
+      final tokenSave = Completer<void>();
+      when(
+        () => mockHttpClient.post(
+          any(),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({"authUrl": "https://example.com/login", "state": "state", "expiresIn": 300}),
+          200,
+        ),
+      );
+      when(
+        () => mockHttpClient.get(any(), headers: any(named: "headers")),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({
+            "status": "complete",
+            "accessToken": "access",
+            "refreshToken": "refresh",
+            "user": user.toJson(),
+          }),
+          200,
+        ),
+      );
+      when(
+        () => mockTokenStorage.saveTokens(accessToken: "access", refreshToken: "refresh"),
+      ).thenAnswer((_) => tokenSave.future);
+      when(mockOAuthStorage.clearPkceVerifier).thenAnswer((_) async {});
+      when(mockOAuthStorage.clearAuthProvider).thenAnswer((_) async {});
+      final states = <AuthState>[];
+      final subscription = authManager.authStateStream.listen(states.add);
+
+      await authManager.startOAuthFlow(provider: AuthProvider.github, deadline: null);
+      final completion = authManager.pollForResult();
+      await untilCalled(
+        () => mockTokenStorage.saveTokens(accessToken: "access", refreshToken: "refresh"),
+      );
+      final replacement = authManager.startOAuthFlow(
+        provider: AuthProvider.google,
+        deadline: DateTime.now().add(const Duration(milliseconds: 30)),
+      );
+      await expectLater(replacement, throwsA(isA<TimeoutException>()));
+
+      tokenSave.complete();
+
+      expect(await completion, user);
+      await Future<void>.delayed(Duration.zero);
+      expect(states.whereType<AuthAuthenticated>().toList(), [const AuthState.authenticated(user: user)]);
+      await subscription.cancel();
+    });
+
+    test("503 and 404 clear storage and expose bounded restart timing before parsing JSON", () async {
+      final deadline = DateTime.now().add(const Duration(minutes: 2));
+      final cases = <({int status, String? header, Duration delay, bool fallback})>[
+        (status: 503, header: "0", delay: Duration.zero, fallback: true),
+        (status: 503, header: "5", delay: const Duration(seconds: 5), fallback: false),
+        (status: 503, header: null, delay: const Duration(seconds: 1), fallback: false),
+        (status: 503, header: "-1", delay: const Duration(seconds: 1), fallback: false),
+        (status: 503, header: "6", delay: const Duration(seconds: 1), fallback: false),
+        (status: 404, header: "5", delay: Duration.zero, fallback: false),
+      ];
+      var responseIndex = 0;
+      var storedSession = (sessionToken: null as String?, expiresAt: null as DateTime?);
+      when(() => mockOAuthStorage.getOAuthSession()).thenAnswer((_) async => storedSession);
+      when(mockOAuthStorage.clearOAuthSession).thenAnswer((_) async {
+        storedSession = (sessionToken: null, expiresAt: null);
+      });
+      when(
+        () => mockHttpClient.get(any(), headers: any(named: "headers")),
+      ).thenAnswer((_) async {
+        final testCase = cases[responseIndex++];
+        return http.Response(
+          "not-json",
+          testCase.status,
+          headers: {"retry-after": ?testCase.header},
+        );
+      });
+      for (final testCase in cases) {
+        storedSession = (
+          sessionToken: "stale-session-token",
+          expiresAt: testCase.fallback ? null : deadline,
+        );
+        final expectedDeadline = testCase.fallback ? DateTime.now().add(const Duration(minutes: 5)) : deadline;
+        final exception = await _pollRestart(authManager);
+        expect(exception.restartAfter, testCase.delay);
+        expect(
+          exception.deadline.difference(expectedDeadline).abs(),
+          lessThan(const Duration(milliseconds: 100)),
+        );
+        expect(storedSession.sessionToken, isNull);
+      }
+      await expectLater(authManager.pollForResult(), throwsA(isA<StateError>()));
     });
 
     test("pollForResult retries pending then stores complete tokens and emits authenticated", () async {
@@ -391,7 +780,7 @@ void main() {
       final states = <AuthState>[];
       final sub = authManager.authStateStream.listen(states.add);
 
-      await authManager.startOAuthFlow(provider: AuthProvider.google);
+      await authManager.startOAuthFlow(provider: AuthProvider.google, deadline: null);
       final exchangedUser = await authManager.pollForResult();
 
       await Future<void>.delayed(Duration.zero);
@@ -490,7 +879,7 @@ void main() {
       when(mockOAuthStorage.clearAuthProvider).thenAnswer((_) async {});
       when(mockOAuthStorage.clearOAuthSession).thenAnswer((_) async {});
 
-      await authManager.startOAuthFlow(provider: AuthProvider.google);
+      await authManager.startOAuthFlow(provider: AuthProvider.google, deadline: null);
       final exchangedUser = await authManager.pollForResult();
 
       expect(exchangedUser, user);
@@ -553,7 +942,7 @@ void main() {
         ),
       ).thenThrow(Exception("secure storage failed"));
 
-      await authManager.startOAuthFlow(provider: AuthProvider.google);
+      await authManager.startOAuthFlow(provider: AuthProvider.google, deadline: null);
 
       await expectLater(authManager.pollForResult(), throwsA(isA<Exception>()));
       verifyNever(
@@ -630,7 +1019,7 @@ void main() {
         ),
       ).thenAnswer((_) async => http.Response(jsonEncode({"error": "not_found"}), 404));
 
-      await authManager.startOAuthFlow(provider: AuthProvider.google);
+      await authManager.startOAuthFlow(provider: AuthProvider.google, deadline: null);
       final exchangedUser = await authManager.pollForResult();
 
       expect(exchangedUser, user);
@@ -669,7 +1058,7 @@ void main() {
         ),
       ).thenAnswer((_) async => http.Response(jsonEncode({"status": "denied"}), 200));
 
-      await authManager.startOAuthFlow(provider: AuthProvider.github);
+      await authManager.startOAuthFlow(provider: AuthProvider.github, deadline: null);
       await expectLater(authManager.pollForResult(), throwsA(isA<StateError>()));
 
       final initCall = verify(
@@ -722,7 +1111,7 @@ void main() {
         ),
       ).thenAnswer((_) => Future<http.Response>.error(TimeoutException("status request timed out")));
 
-      await authManager.startOAuthFlow(provider: AuthProvider.google);
+      await authManager.startOAuthFlow(provider: AuthProvider.google, deadline: null);
 
       await expectLater(
         authManager.pollForResult(),
@@ -810,7 +1199,7 @@ void main() {
         when(mockOAuthStorage.getOAuthSession).thenAnswer(
           (_) async => (sessionToken: null, expiresAt: null),
         );
-        await authManager.startOAuthFlow(provider: AuthProvider.github);
+        await authManager.startOAuthFlow(provider: AuthProvider.github, deadline: null);
       }
 
       for (final statusResponse in [
@@ -842,7 +1231,7 @@ void main() {
         mockOAuthStorage,
         FakeOAuthDeviceDescriptorProvider(),
         pollInterval: Duration.zero,
-        pollTimeout: Duration.zero,
+        pollTimeout: const Duration(milliseconds: 20),
         delay: (_) async {},
       );
       await arrangeStartedFlow(statusResponse: http.Response(jsonEncode({"status": "pending"}), 200));

--- a/client/module_auth/test/auth_manager_test.dart
+++ b/client/module_auth/test/auth_manager_test.dart
@@ -598,6 +598,33 @@ void main() {
       verify(mockOAuthStorage.clearOAuthSession).called(1);
     });
 
+    test("a cleanup timeout preserves the original init failure", () async {
+      final cleanup = Completer<void>();
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/github/init"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer((_) async => http.Response("upstream failed", 500));
+      when(mockOAuthStorage.clearOAuthSession).thenAnswer((_) => cleanup.future);
+
+      Object? captured;
+      try {
+        await authManager.startOAuthFlow(
+          provider: AuthProvider.github,
+          deadline: DateTime.now().add(const Duration(milliseconds: 100)),
+        );
+      } catch (error) {
+        captured = error;
+      }
+
+      expect(captured, isNot(isA<TimeoutException>()));
+      expect(captured.toString(), contains("Failed to start GitHub auth flow"));
+      cleanup.complete();
+      await Future<void>.delayed(Duration.zero);
+    });
+
     test("a failed poison cleanup is retried before OAuth mutations resume", () async {
       final firstSave = Completer<void>();
       var saveCount = 0;

--- a/client/module_auth/test/auth_manager_test.dart
+++ b/client/module_auth/test/auth_manager_test.dart
@@ -26,7 +26,22 @@ http.StreamedResponse _streamedResponse({required http.Response response}) {
   );
 }
 
-class MockHttpClient extends Mock implements http.Client {}
+abstract interface class _MockHttpClientSend {
+  Future<http.StreamedResponse> recordedSend(http.BaseRequest request);
+}
+
+class MockHttpClient extends Mock implements http.Client, _MockHttpClientSend {
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    if (request is http.Request && request.method == "POST" && request.url.path.endsWith("/init")) {
+      return post(request.url, headers: request.headers, body: request.body).then(
+        (response) => _streamedResponse(response: response),
+      );
+    }
+
+    return recordedSend(request);
+  }
+}
 
 class MockTokenStorageService extends Mock implements TokenStorageService {}
 
@@ -34,6 +49,7 @@ class MockOAuthStorageService extends Mock implements OAuthStorageService {}
 
 class _HangingStatusClient extends http.BaseClient {
   bool aborted = false;
+  http.RequestAbortedException? abortError;
   http.BaseRequest? request;
 
   @override
@@ -44,7 +60,30 @@ class _HangingStatusClient extends http.BaseClient {
       unawaited(
         abortTrigger.then<void>((_) {
           aborted = true;
-          response.completeError(http.RequestAbortedException(request.url));
+          abortError = http.RequestAbortedException(request.url);
+          response.completeError(abortError!);
+        }),
+      );
+    }
+    return response.future;
+  }
+}
+
+class _HangingInitClient extends http.BaseClient {
+  bool aborted = false;
+  http.RequestAbortedException? abortError;
+  http.BaseRequest? request;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    this.request = request;
+    final response = Completer<http.StreamedResponse>();
+    if (request case http.Abortable(:final abortTrigger?)) {
+      unawaited(
+        abortTrigger.then<void>((_) {
+          aborted = true;
+          abortError = http.RequestAbortedException(request.url);
+          response.completeError(abortError!);
         }),
       );
     }
@@ -381,6 +420,46 @@ void main() {
       );
     });
 
+    test("startOAuthFlow aborts a hanging init request at the absolute deadline", () async {
+      final hangingClient = _HangingInitClient();
+      authManager = AuthManager(
+        hangingClient,
+        mockTokenStorage,
+        mockOAuthStorage,
+        FakeOAuthDeviceDescriptorProvider(),
+      );
+      final deadline = DateTime.now().add(const Duration(milliseconds: 40));
+      final stopwatch = Stopwatch()..start();
+
+      Object? initError;
+      try {
+        await authManager.startOAuthFlow(provider: AuthProvider.github, deadline: deadline);
+      } catch (error) {
+        initError = error;
+      }
+      stopwatch.stop();
+
+      expect(initError, isA<OAuthRequestTimeoutException>());
+      final timeoutError = initError! as OAuthRequestTimeoutException;
+      expect(timeoutError, isA<TimeoutException>());
+      expect(timeoutError.cause, same(hangingClient.abortError));
+      expect(timeoutError.uri, Uri.parse("$authBaseUrl/auth/github/init"));
+      expect((timeoutError.cause as http.RequestAbortedException).uri, timeoutError.uri);
+      expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 500)));
+      expect(hangingClient.aborted, isTrue);
+      expect(hangingClient.request, isA<http.AbortableRequest>());
+      final request = hangingClient.request! as http.Request;
+      expect(request.method, "POST");
+      expect(request.url, Uri.parse("$authBaseUrl/auth/github/init"));
+      expect(request.headers["Accept"], "application/json");
+      expect(request.headers["Content-Type"], "application/json");
+      expect(request.headers[_sessionTokenHeaderForTest], matches(RegExp(r"^[0-9a-f]{64}$")));
+      expect(jsonDecode(request.body), {
+        "clientType": "app_ios",
+        "device": {"name": "Test iPhone", "osVersion": "iOS 17.5", "appVersion": "1.2.0"},
+      });
+    });
+
     test("init 503 clears its session and exposes bounded restart timing before parsing JSON", () async {
       final deadline = DateTime.now().add(const Duration(minutes: 2));
       when(
@@ -497,6 +576,10 @@ void main() {
       });
 
       final stalePoll = authManager.pollForResult();
+      final staleFailure = expectLater(
+        stalePoll,
+        throwsA(allOf(isA<Exception>(), isNot(isA<OAuthSessionRestartRequiredException>()))),
+      );
       await untilCalled(mockOAuthStorage.getOAuthSession);
       final replacement = authManager.startOAuthFlow(
         provider: AuthProvider.google,
@@ -506,10 +589,7 @@ void main() {
       storedSessionRead.complete((sessionToken: "old-session-token", expiresAt: oldDeadline));
 
       await replacement;
-      await expectLater(
-        stalePoll,
-        throwsA(allOf(isA<Exception>(), isNot(isA<OAuthSessionRestartRequiredException>()))),
-      );
+      await staleFailure;
 
       expect(statusRequest?.headers[_sessionTokenHeaderForTest], "old-session-token");
       expect(storedSession.expiresAt, replacementDeadline);
@@ -1280,6 +1360,7 @@ void main() {
     });
 
     test("pollForResult surfaces status request timeout as recoverable client exception", () async {
+      late http.RequestAbortedException abortError;
       when(
         () => mockHttpClient.post(
           Uri.parse("$authBaseUrl/auth/google/init"),
@@ -1307,22 +1388,67 @@ void main() {
         () => mockHttpClient.send(any()),
       ).thenAnswer((invocation) {
         final request = invocation.positionalArguments.single as http.BaseRequest;
-        return Future<http.StreamedResponse>.error(http.RequestAbortedException(request.url));
+        abortError = http.RequestAbortedException(request.url);
+        return Future<http.StreamedResponse>.error(abortError);
       });
 
       await authManager.startOAuthFlow(provider: AuthProvider.google, deadline: null);
 
-      await expectLater(
-        authManager.pollForResult(),
-        throwsA(
-          isA<http.ClientException>().having(
-            (error) => error.uri,
-            "uri",
-            Uri.parse("$authBaseUrl/auth/session/status"),
-          ),
+      Object? pollError;
+      try {
+        await authManager.pollForResult();
+      } catch (error) {
+        pollError = error;
+      }
+
+      expect(
+        pollError,
+        isA<OAuthSessionStatusClientException>().having(
+          (error) => error.uri,
+          "uri",
+          Uri.parse("$authBaseUrl/auth/session/status"),
         ),
       );
+      final clientError = pollError! as OAuthSessionStatusClientException;
+      expect(clientError, isA<http.ClientException>());
+      expect(clientError.cause, same(abortError));
+      expect((clientError.cause as http.RequestAbortedException).uri, abortError.uri);
 
+      expect(await authManager.hasActiveOAuthSession(), isTrue);
+      verifyNever(mockOAuthStorage.clearOAuthSession);
+    });
+
+    test("pollForResult preserves a direct timeout as the recoverable client exception cause", () async {
+      final transportTimeout = TimeoutException("transport timed out", const Duration(seconds: 35));
+      when(() => mockOAuthStorage.getOAuthSession()).thenAnswer(
+        (_) async => (
+          sessionToken: "stored-session-token",
+          expiresAt: DateTime.now().add(const Duration(minutes: 5)),
+        ),
+      );
+      when(
+        () => mockHttpClient.send(any()),
+      ).thenAnswer((_) => Future<http.StreamedResponse>.error(transportTimeout));
+
+      Object? pollError;
+      try {
+        await authManager.pollForResult();
+      } catch (error) {
+        pollError = error;
+      }
+
+      expect(
+        pollError,
+        isA<OAuthSessionStatusClientException>().having(
+          (error) => error.uri,
+          "uri",
+          Uri.parse("$authBaseUrl/auth/session/status"),
+        ),
+      );
+      final clientError = pollError! as OAuthSessionStatusClientException;
+      expect(clientError, isA<http.ClientException>());
+      expect(clientError.cause, same(transportTimeout));
+      expect(clientError.cause, isA<TimeoutException>());
       expect(await authManager.hasActiveOAuthSession(), isTrue);
       verifyNever(mockOAuthStorage.clearOAuthSession);
     });
@@ -1343,19 +1469,69 @@ void main() {
           expiresAt: DateTime.now().add(const Duration(milliseconds: 30)),
         ),
       );
-      await expectLater(
-        authManager.pollForResult(),
-        throwsA(
-          isA<TimeoutException>().having(
-            (error) => error.message,
-            "message",
-            "OAuth authorization timed out",
-          ),
+      Object? pollError;
+      try {
+        await authManager.pollForResult();
+      } catch (error) {
+        pollError = error;
+      }
+
+      expect(
+        pollError,
+        isA<OAuthRequestTimeoutException>().having(
+          (error) => error.message,
+          "message",
+          "OAuth authorization timed out",
         ),
       );
+      final timeoutError = pollError! as OAuthRequestTimeoutException;
+      expect(timeoutError, isA<TimeoutException>());
+      expect(timeoutError.cause, same(hangingClient.abortError));
+      expect(timeoutError.uri, Uri.parse("$authBaseUrl/auth/session/status"));
+      expect((timeoutError.cause as http.RequestAbortedException).uri, timeoutError.uri);
 
       expect(hangingClient.aborted, isTrue);
       expect(hangingClient.request, isA<http.AbortableRequest>());
+      verify(mockOAuthStorage.clearOAuthSession).called(1);
+    });
+
+    test("pollForResult preserves a direct timeout as the final OAuth timeout cause", () async {
+      final transportTimeout = TimeoutException("transport timed out", const Duration(milliseconds: 30));
+      when(() => mockOAuthStorage.getOAuthSession()).thenAnswer(
+        (_) async => (
+          sessionToken: "stored-session-token",
+          expiresAt: DateTime.now().add(const Duration(milliseconds: 30)),
+        ),
+      );
+      when(
+        () => mockHttpClient.send(any()),
+      ).thenAnswer((_) => Future<http.StreamedResponse>.error(transportTimeout));
+
+      Object? pollError;
+      try {
+        await authManager.pollForResult();
+      } catch (error) {
+        pollError = error;
+      }
+
+      expect(
+        pollError,
+        isA<OAuthRequestTimeoutException>()
+            .having(
+              (error) => error.message,
+              "message",
+              "OAuth authorization timed out",
+            )
+            .having(
+              (error) => error.uri,
+              "uri",
+              Uri.parse("$authBaseUrl/auth/session/status"),
+            ),
+      );
+      final timeoutError = pollError! as OAuthRequestTimeoutException;
+      expect(timeoutError, isA<TimeoutException>());
+      expect(timeoutError.cause, same(transportTimeout));
+      expect(timeoutError.cause, isA<TimeoutException>());
       verify(mockOAuthStorage.clearOAuthSession).called(1);
     });
 

--- a/client/module_auth/test/auth_manager_test.dart
+++ b/client/module_auth/test/auth_manager_test.dart
@@ -26,11 +26,7 @@ http.StreamedResponse _streamedResponse({required http.Response response}) {
   );
 }
 
-abstract interface class _MockHttpClientSend {
-  Future<http.StreamedResponse> recordedSend(http.BaseRequest request);
-}
-
-class MockHttpClient extends Mock implements http.Client, _MockHttpClientSend {
+class MockHttpClient extends Mock implements http.Client {
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) {
     if (request is http.Request && request.method == "POST" && request.url.path.endsWith("/init")) {
@@ -39,7 +35,9 @@ class MockHttpClient extends Mock implements http.Client, _MockHttpClientSend {
       );
     }
 
-    return recordedSend(request);
+    return get(request.url, headers: request.headers).then(
+      (response) => _streamedResponse(response: response),
+    );
   }
 }
 
@@ -47,7 +45,10 @@ class MockTokenStorageService extends Mock implements TokenStorageService {}
 
 class MockOAuthStorageService extends Mock implements OAuthStorageService {}
 
-class _HangingStatusClient extends http.BaseClient {
+class _HangingOAuthClient extends http.BaseClient {
+  _HangingOAuthClient({this.abortImmediately = false});
+
+  final bool abortImmediately;
   bool aborted = false;
   http.RequestAbortedException? abortError;
   http.BaseRequest? request;
@@ -55,28 +56,10 @@ class _HangingStatusClient extends http.BaseClient {
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) {
     this.request = request;
-    final response = Completer<http.StreamedResponse>();
-    if (request case http.Abortable(:final abortTrigger?)) {
-      unawaited(
-        abortTrigger.then<void>((_) {
-          aborted = true;
-          abortError = http.RequestAbortedException(request.url);
-          response.completeError(abortError!);
-        }),
-      );
+    if (abortImmediately) {
+      abortError = http.RequestAbortedException(request.url);
+      return Future.error(abortError!);
     }
-    return response.future;
-  }
-}
-
-class _HangingInitClient extends http.BaseClient {
-  bool aborted = false;
-  http.RequestAbortedException? abortError;
-  http.BaseRequest? request;
-
-  @override
-  Future<http.StreamedResponse> send(http.BaseRequest request) {
-    this.request = request;
     final response = Completer<http.StreamedResponse>();
     if (request case http.Abortable(:final abortTrigger?)) {
       unawaited(
@@ -421,7 +404,7 @@ void main() {
     });
 
     test("startOAuthFlow aborts a hanging init request at the absolute deadline", () async {
-      final hangingClient = _HangingInitClient();
+      final hangingClient = _HangingOAuthClient();
       authManager = AuthManager(
         hangingClient,
         mockTokenStorage,
@@ -516,12 +499,12 @@ void main() {
         ),
       );
       when(
-        () => mockHttpClient.send(any()),
-      ).thenAnswer((_) async => _streamedResponse(response: await staleResponse.future));
+        () => mockHttpClient.get(any(), headers: any(named: "headers")),
+      ).thenAnswer((_) => staleResponse.future);
 
       await authManager.startOAuthFlow(provider: AuthProvider.github, deadline: null);
       final stalePoll = authManager.pollForResult();
-      await untilCalled(() => mockHttpClient.send(any()));
+      await untilCalled(() => mockHttpClient.get(any(), headers: any(named: "headers")));
       await authManager.startOAuthFlow(provider: AuthProvider.google, deadline: null);
       final replacementToken = storedSession.sessionToken;
       final staleFailure = expectLater(stalePoll, throwsA(isA<Exception>()));
@@ -531,251 +514,6 @@ void main() {
       expect(replacementToken, isNotNull);
       expect(storedSession.sessionToken, replacementToken);
       verifyNever(mockOAuthStorage.clearOAuthSession);
-    });
-
-    test("a delayed stored-session read cannot adopt a replacement owner or deadline", () async {
-      final oldDeadline = DateTime.now().add(const Duration(minutes: 1));
-      final replacementDeadline = DateTime.now().add(const Duration(minutes: 4));
-      final storedSessionRead = Completer<({String? sessionToken, DateTime? expiresAt})>();
-      var storedSession = (sessionToken: "old-session-token" as String?, expiresAt: oldDeadline as DateTime?);
-      when(() => mockOAuthStorage.getOAuthSession()).thenAnswer((_) => storedSessionRead.future);
-      when(
-        () => mockOAuthStorage.saveOAuthSession(
-          sessionToken: any(named: "sessionToken"),
-          expiresAt: any(named: "expiresAt"),
-        ),
-      ).thenAnswer((invocation) async {
-        storedSession = (
-          sessionToken: invocation.namedArguments[#sessionToken] as String,
-          expiresAt: invocation.namedArguments[#expiresAt] as DateTime,
-        );
-      });
-      when(mockOAuthStorage.clearOAuthSession).thenAnswer((_) async {
-        storedSession = (sessionToken: null, expiresAt: null);
-      });
-      when(
-        () => mockHttpClient.post(
-          any(),
-          headers: any(named: "headers"),
-          body: any(named: "body"),
-        ),
-      ).thenAnswer(
-        (_) async => http.Response(
-          jsonEncode({"authUrl": "https://example.com/login", "state": "replacement", "expiresIn": 300}),
-          200,
-        ),
-      );
-      http.BaseRequest? statusRequest;
-      when(
-        () => mockHttpClient.send(any()),
-      ).thenAnswer((invocation) async {
-        statusRequest = invocation.positionalArguments.single as http.BaseRequest;
-        return _streamedResponse(
-          response: http.Response("not-json", 503, headers: {"retry-after": "0"}),
-        );
-      });
-
-      final stalePoll = authManager.pollForResult();
-      final staleFailure = expectLater(
-        stalePoll,
-        throwsA(allOf(isA<Exception>(), isNot(isA<OAuthSessionRestartRequiredException>()))),
-      );
-      await untilCalled(mockOAuthStorage.getOAuthSession);
-      final replacement = authManager.startOAuthFlow(
-        provider: AuthProvider.google,
-        deadline: replacementDeadline,
-      );
-      await Future<void>.delayed(Duration.zero);
-      storedSessionRead.complete((sessionToken: "old-session-token", expiresAt: oldDeadline));
-
-      await replacement;
-      await staleFailure;
-
-      expect(statusRequest?.headers[_sessionTokenHeaderForTest], "old-session-token");
-      expect(storedSession.expiresAt, replacementDeadline);
-      expect(storedSession.sessionToken, isNot("old-session-token"));
-      verifyNever(mockOAuthStorage.clearOAuthSession);
-    });
-
-    test("a timed-out session save poisons retries until one owned cleanup completes", () async {
-      final firstSave = Completer<void>();
-      var saveCount = 0;
-      var storedSession = (sessionToken: null as String?, expiresAt: null as DateTime?);
-      when(
-        () => mockOAuthStorage.saveOAuthSession(
-          sessionToken: any(named: "sessionToken"),
-          expiresAt: any(named: "expiresAt"),
-        ),
-      ).thenAnswer((invocation) async {
-        if (saveCount++ == 0) {
-          await firstSave.future;
-        }
-        storedSession = (
-          sessionToken: invocation.namedArguments[#sessionToken] as String,
-          expiresAt: invocation.namedArguments[#expiresAt] as DateTime,
-        );
-      });
-      when(mockOAuthStorage.clearOAuthSession).thenAnswer((_) async {
-        storedSession = (sessionToken: null, expiresAt: null);
-      });
-      when(
-        () => mockHttpClient.post(
-          any(),
-          headers: any(named: "headers"),
-          body: any(named: "body"),
-        ),
-      ).thenAnswer(
-        (_) async => http.Response(
-          jsonEncode({"authUrl": "https://example.com/login", "state": "state", "expiresIn": 300}),
-          200,
-        ),
-      );
-
-      final firstStart = authManager.startOAuthFlow(
-        provider: AuthProvider.github,
-        deadline: DateTime.now().add(const Duration(milliseconds: 30)),
-      );
-      await untilCalled(
-        () => mockOAuthStorage.saveOAuthSession(
-          sessionToken: any(named: "sessionToken"),
-          expiresAt: any(named: "expiresAt"),
-        ),
-      );
-      var replacementCompleted = false;
-      final replacement = authManager
-          .startOAuthFlow(
-            provider: AuthProvider.google,
-            deadline: DateTime.now().add(const Duration(minutes: 1)),
-          )
-          .whenComplete(() => replacementCompleted = true);
-
-      await expectLater(firstStart, throwsA(isA<TimeoutException>()));
-      expect(replacementCompleted, isFalse);
-      expect(storedSession.sessionToken, isNull);
-      verifyNever(mockOAuthStorage.clearOAuthSession);
-      for (var attempt = 0; attempt < 3; attempt += 1) {
-        await expectLater(
-          authManager.startOAuthFlow(
-            provider: AuthProvider.google,
-            deadline: DateTime.now().add(const Duration(minutes: 1)),
-          ),
-          throwsA(isA<Exception>()),
-        );
-      }
-
-      final replacementFailure = expectLater(replacement, throwsA(isA<Exception>()));
-      firstSave.complete();
-      await replacementFailure;
-      await untilCalled(mockOAuthStorage.clearOAuthSession);
-
-      await authManager.startOAuthFlow(
-        provider: AuthProvider.google,
-        deadline: DateTime.now().add(const Duration(minutes: 1)),
-      );
-
-      expect(replacementCompleted, isTrue);
-      expect(storedSession.sessionToken, isNotNull);
-      verify(mockOAuthStorage.clearOAuthSession).called(1);
-    });
-
-    test("a cleanup timeout preserves the original init failure", () async {
-      final cleanup = Completer<void>();
-      when(
-        () => mockHttpClient.post(
-          Uri.parse("$authBaseUrl/auth/github/init"),
-          headers: any(named: "headers"),
-          body: any(named: "body"),
-        ),
-      ).thenAnswer((_) async => http.Response("upstream failed", 500));
-      when(mockOAuthStorage.clearOAuthSession).thenAnswer((_) => cleanup.future);
-
-      Object? captured;
-      try {
-        await authManager.startOAuthFlow(
-          provider: AuthProvider.github,
-          deadline: DateTime.now().add(const Duration(milliseconds: 100)),
-        );
-      } catch (error) {
-        captured = error;
-      }
-
-      expect(captured, isNot(isA<TimeoutException>()));
-      expect(captured.toString(), contains("Failed to start GitHub auth flow"));
-      cleanup.complete();
-      await Future<void>.delayed(Duration.zero);
-    });
-
-    test("a failed poison cleanup is retried before OAuth mutations resume", () async {
-      final firstSave = Completer<void>();
-      var saveCount = 0;
-      var clearCount = 0;
-      var storedSession = (sessionToken: null as String?, expiresAt: null as DateTime?);
-      when(
-        () => mockOAuthStorage.saveOAuthSession(
-          sessionToken: any(named: "sessionToken"),
-          expiresAt: any(named: "expiresAt"),
-        ),
-      ).thenAnswer((invocation) async {
-        if (saveCount++ == 0) {
-          await firstSave.future;
-        }
-        storedSession = (
-          sessionToken: invocation.namedArguments[#sessionToken] as String,
-          expiresAt: invocation.namedArguments[#expiresAt] as DateTime,
-        );
-      });
-      when(mockOAuthStorage.clearOAuthSession).thenAnswer((_) async {
-        clearCount += 1;
-        if (clearCount == 1) {
-          throw Exception("transient secure-storage failure");
-        }
-        storedSession = (sessionToken: null, expiresAt: null);
-      });
-      when(
-        () => mockHttpClient.post(
-          any(),
-          headers: any(named: "headers"),
-          body: any(named: "body"),
-        ),
-      ).thenAnswer(
-        (_) async => http.Response(
-          jsonEncode({"authUrl": "https://example.com/login", "state": "state", "expiresIn": 300}),
-          200,
-        ),
-      );
-
-      final timedOutStart = authManager.startOAuthFlow(
-        provider: AuthProvider.github,
-        deadline: DateTime.now().add(const Duration(milliseconds: 30)),
-      );
-      await untilCalled(
-        () => mockOAuthStorage.saveOAuthSession(
-          sessionToken: any(named: "sessionToken"),
-          expiresAt: any(named: "expiresAt"),
-        ),
-      );
-      await expectLater(timedOutStart, throwsA(isA<TimeoutException>()));
-
-      await expectLater(
-        authManager.startOAuthFlow(
-          provider: AuthProvider.google,
-          deadline: DateTime.now().add(const Duration(minutes: 1)),
-        ),
-        throwsA(isA<Exception>()),
-      );
-      verifyNever(mockOAuthStorage.clearOAuthSession);
-
-      firstSave.complete();
-      await untilCalled(mockOAuthStorage.clearOAuthSession);
-      await Future<void>.delayed(Duration.zero);
-
-      await authManager.startOAuthFlow(
-        provider: AuthProvider.google,
-        deadline: DateTime.now().add(const Duration(minutes: 1)),
-      );
-
-      expect(clearCount, 2);
-      expect(storedSession.sessionToken, isNotNull);
     });
 
     test("OAuth completion is atomic with respect to a replacement start", () async {
@@ -793,18 +531,16 @@ void main() {
         ),
       );
       when(
-        () => mockHttpClient.send(any()),
+        () => mockHttpClient.get(any(), headers: any(named: "headers")),
       ).thenAnswer(
-        (_) async => _streamedResponse(
-          response: http.Response(
-            jsonEncode({
-              "status": "complete",
-              "accessToken": "access",
-              "refreshToken": "refresh",
-              "user": user.toJson(),
-            }),
-            200,
-          ),
+        (_) async => http.Response(
+          jsonEncode({
+            "status": "complete",
+            "accessToken": "access",
+            "refreshToken": "refresh",
+            "user": user.toJson(),
+          }),
+          200,
         ),
       );
       when(
@@ -833,128 +569,6 @@ void main() {
       expect(replacementCompleted, isTrue);
     });
 
-    test("completion that wins before the deadline cannot later become a timeout", () async {
-      final tokenSave = Completer<void>();
-      var storedSession = (sessionToken: null as String?, expiresAt: null as DateTime?);
-      when(() => mockOAuthStorage.getOAuthSession()).thenAnswer((_) async => storedSession);
-      when(
-        () => mockOAuthStorage.saveOAuthSession(
-          sessionToken: any(named: "sessionToken"),
-          expiresAt: any(named: "expiresAt"),
-        ),
-      ).thenAnswer((invocation) async {
-        storedSession = (
-          sessionToken: invocation.namedArguments[#sessionToken] as String,
-          expiresAt: invocation.namedArguments[#expiresAt] as DateTime,
-        );
-      });
-      when(
-        () => mockHttpClient.post(
-          any(),
-          headers: any(named: "headers"),
-          body: any(named: "body"),
-        ),
-      ).thenAnswer(
-        (_) async => http.Response(
-          jsonEncode({"authUrl": "https://example.com/login", "state": "state", "expiresIn": 300}),
-          200,
-        ),
-      );
-      when(
-        () => mockHttpClient.send(any()),
-      ).thenAnswer(
-        (_) async => _streamedResponse(
-          response: http.Response(
-            jsonEncode({
-              "status": "complete",
-              "accessToken": "access",
-              "refreshToken": "refresh",
-              "user": user.toJson(),
-            }),
-            200,
-          ),
-        ),
-      );
-      when(
-        () => mockTokenStorage.saveTokens(accessToken: "access", refreshToken: "refresh"),
-      ).thenAnswer((_) => tokenSave.future);
-      when(mockOAuthStorage.clearPkceVerifier).thenAnswer((_) async {});
-      when(mockOAuthStorage.clearAuthProvider).thenAnswer((_) async {});
-
-      await authManager.startOAuthFlow(
-        provider: AuthProvider.github,
-        deadline: DateTime.now().add(const Duration(milliseconds: 80)),
-      );
-      var completed = false;
-      final completion = authManager.pollForResult().whenComplete(() => completed = true);
-      await untilCalled(
-        () => mockTokenStorage.saveTokens(accessToken: "access", refreshToken: "refresh"),
-      );
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-      expect(completed, isFalse);
-
-      tokenSave.complete();
-
-      expect(await completion, user);
-      expect(authManager.currentState, const AuthState.authenticated(user: user));
-    });
-
-    test("a poisoned queued replacement cannot override committed completion", () async {
-      final tokenSave = Completer<void>();
-      when(
-        () => mockHttpClient.post(
-          any(),
-          headers: any(named: "headers"),
-          body: any(named: "body"),
-        ),
-      ).thenAnswer(
-        (_) async => http.Response(
-          jsonEncode({"authUrl": "https://example.com/login", "state": "state", "expiresIn": 300}),
-          200,
-        ),
-      );
-      when(
-        () => mockHttpClient.send(any()),
-      ).thenAnswer(
-        (_) async => _streamedResponse(
-          response: http.Response(
-            jsonEncode({
-              "status": "complete",
-              "accessToken": "access",
-              "refreshToken": "refresh",
-              "user": user.toJson(),
-            }),
-            200,
-          ),
-        ),
-      );
-      when(
-        () => mockTokenStorage.saveTokens(accessToken: "access", refreshToken: "refresh"),
-      ).thenAnswer((_) => tokenSave.future);
-      when(mockOAuthStorage.clearPkceVerifier).thenAnswer((_) async {});
-      when(mockOAuthStorage.clearAuthProvider).thenAnswer((_) async {});
-      final states = <AuthState>[];
-      final subscription = authManager.authStateStream.listen(states.add);
-
-      await authManager.startOAuthFlow(provider: AuthProvider.github, deadline: null);
-      final completion = authManager.pollForResult();
-      await untilCalled(
-        () => mockTokenStorage.saveTokens(accessToken: "access", refreshToken: "refresh"),
-      );
-      final replacement = authManager.startOAuthFlow(
-        provider: AuthProvider.google,
-        deadline: DateTime.now().add(const Duration(milliseconds: 30)),
-      );
-      await expectLater(replacement, throwsA(isA<TimeoutException>()));
-
-      tokenSave.complete();
-
-      expect(await completion, user);
-      await Future<void>.delayed(Duration.zero);
-      expect(states.whereType<AuthAuthenticated>().toList(), [const AuthState.authenticated(user: user)]);
-      await subscription.cancel();
-    });
-
     test("503 and 404 clear storage and expose bounded restart timing before parsing JSON", () async {
       final deadline = DateTime.now().add(const Duration(minutes: 2));
       final cases = <({int status, String? header, Duration delay, bool fallback})>[
@@ -972,15 +586,13 @@ void main() {
         storedSession = (sessionToken: null, expiresAt: null);
       });
       when(
-        () => mockHttpClient.send(any()),
+        () => mockHttpClient.get(any(), headers: any(named: "headers")),
       ).thenAnswer((_) async {
         final testCase = cases[responseIndex++];
-        return _streamedResponse(
-          response: http.Response(
-            "not-json",
-            testCase.status,
-            headers: {"retry-after": ?testCase.header},
-          ),
+        return http.Response(
+          "not-json",
+          testCase.status,
+          headers: {"retry-after": ?testCase.header},
         );
       });
       for (final testCase in cases) {
@@ -1029,29 +641,28 @@ void main() {
       );
       var statusCalls = 0;
       when(
-        () => mockHttpClient.send(any()),
+        () => mockHttpClient.get(
+          Uri.parse("$authBaseUrl/auth/session/status"),
+          headers: any(named: "headers"),
+        ),
       ).thenAnswer((_) async {
         statusCalls += 1;
         if (statusCalls == 1) {
-          return _streamedResponse(
-            response: http.Response(jsonEncode({"status": "pending"}), 200),
-          );
+          return http.Response(jsonEncode({"status": "pending"}), 200);
         }
-        return _streamedResponse(
-          response: http.Response(
-            jsonEncode({
-              "status": "complete",
-              "accessToken": "oauth-access-token",
-              "refreshToken": "oauth-refresh-token",
-              "user": {
-                "id": user.id,
-                "provider": user.provider.key,
-                "providerUserId": user.providerUserId,
-                "providerUsername": user.providerUsername,
-              },
-            }),
-            200,
-          ),
+        return http.Response(
+          jsonEncode({
+            "status": "complete",
+            "accessToken": "oauth-access-token",
+            "refreshToken": "oauth-refresh-token",
+            "user": {
+              "id": user.id,
+              "provider": user.provider.key,
+              "providerUserId": user.providerUserId,
+              "providerUsername": user.providerUsername,
+            },
+          }),
+          200,
         );
       });
       when(
@@ -1096,7 +707,10 @@ void main() {
       final ackHeaders = ackCall.captured.single as Map<String, String>;
       expect(ackHeaders["X-Sesori-Session-Token"], matches(RegExp(r"^[0-9a-f]{64}$")));
       verify(
-        () => mockHttpClient.send(any()),
+        () => mockHttpClient.get(
+          Uri.parse("$authBaseUrl/auth/session/status"),
+          headers: any(named: "headers"),
+        ),
       ).called(2);
       await expectLater(authManager.pollForResult(), throwsA(isA<StateError>()));
     });
@@ -1129,23 +743,24 @@ void main() {
         ),
       );
       when(
-        () => mockHttpClient.send(any()),
+        () => mockHttpClient.get(
+          Uri.parse("$authBaseUrl/auth/session/status"),
+          headers: any(named: "headers"),
+        ),
       ).thenAnswer(
-        (_) async => _streamedResponse(
-          response: http.Response(
-            jsonEncode({
-              "status": "complete",
-              "accessToken": "oauth-access-token",
-              "refreshToken": "oauth-refresh-token",
-              "user": {
-                "id": user.id,
-                "provider": user.provider.key,
-                "providerUserId": user.providerUserId,
-                "providerUsername": user.providerUsername,
-              },
-            }),
-            200,
-          ),
+        (_) async => http.Response(
+          jsonEncode({
+            "status": "complete",
+            "accessToken": "oauth-access-token",
+            "refreshToken": "oauth-refresh-token",
+            "user": {
+              "id": user.id,
+              "provider": user.provider.key,
+              "providerUserId": user.providerUserId,
+              "providerUsername": user.providerUsername,
+            },
+          }),
+          200,
         ),
       );
       when(
@@ -1198,23 +813,24 @@ void main() {
         ),
       );
       when(
-        () => mockHttpClient.send(any()),
+        () => mockHttpClient.get(
+          Uri.parse("$authBaseUrl/auth/session/status"),
+          headers: any(named: "headers"),
+        ),
       ).thenAnswer(
-        (_) async => _streamedResponse(
-          response: http.Response(
-            jsonEncode({
-              "status": "complete",
-              "accessToken": "oauth-access-token",
-              "refreshToken": "oauth-refresh-token",
-              "user": {
-                "id": user.id,
-                "provider": user.provider.key,
-                "providerUserId": user.providerUserId,
-                "providerUsername": user.providerUsername,
-              },
-            }),
-            200,
-          ),
+        (_) async => http.Response(
+          jsonEncode({
+            "status": "complete",
+            "accessToken": "oauth-access-token",
+            "refreshToken": "oauth-refresh-token",
+            "user": {
+              "id": user.id,
+              "provider": user.provider.key,
+              "providerUserId": user.providerUserId,
+              "providerUsername": user.providerUsername,
+            },
+          }),
+          200,
         ),
       );
       when(
@@ -1264,23 +880,24 @@ void main() {
         ),
       );
       when(
-        () => mockHttpClient.send(any()),
+        () => mockHttpClient.get(
+          Uri.parse("$authBaseUrl/auth/session/status"),
+          headers: any(named: "headers"),
+        ),
       ).thenAnswer(
-        (_) async => _streamedResponse(
-          response: http.Response(
-            jsonEncode({
-              "status": "complete",
-              "accessToken": "oauth-access-token",
-              "refreshToken": "oauth-refresh-token",
-              "user": {
-                "id": user.id,
-                "provider": user.provider.key,
-                "providerUserId": user.providerUserId,
-                "providerUsername": user.providerUsername,
-              },
-            }),
-            200,
-          ),
+        (_) async => http.Response(
+          jsonEncode({
+            "status": "complete",
+            "accessToken": "oauth-access-token",
+            "refreshToken": "oauth-refresh-token",
+            "user": {
+              "id": user.id,
+              "provider": user.provider.key,
+              "providerUserId": user.providerUserId,
+              "providerUsername": user.providerUsername,
+            },
+          }),
+          200,
         ),
       );
       when(
@@ -1333,12 +950,11 @@ void main() {
         ),
       );
       when(
-        () => mockHttpClient.send(any()),
-      ).thenAnswer(
-        (_) async => _streamedResponse(
-          response: http.Response(jsonEncode({"status": "denied"}), 200),
+        () => mockHttpClient.get(
+          Uri.parse("$authBaseUrl/auth/session/status"),
+          headers: any(named: "headers"),
         ),
-      );
+      ).thenAnswer((_) async => http.Response(jsonEncode({"status": "denied"}), 200));
 
       await authManager.startOAuthFlow(provider: AuthProvider.github, deadline: null);
       await expectLater(authManager.pollForResult(), throwsA(isA<StateError>()));
@@ -1351,32 +967,24 @@ void main() {
         ),
       );
       final pollCall = verify(
-        () => mockHttpClient.send(captureAny()),
+        () => mockHttpClient.get(
+          Uri.parse("$authBaseUrl/auth/session/status"),
+          headers: captureAny(named: "headers"),
+        ),
       );
       final initHeaders = initCall.captured.first as Map<String, String>;
-      final pollHeaders = (pollCall.captured.first as http.BaseRequest).headers;
+      final pollHeaders = pollCall.captured.first as Map<String, String>;
       expect(pollHeaders["X-Sesori-Session-Token"], initHeaders["X-Sesori-Session-Token"]);
       expect(pollHeaders["X-Sesori-Session-Token"], matches(RegExp(r"^[0-9a-f]{64}$")));
     });
 
     test("pollForResult surfaces status request timeout as recoverable client exception", () async {
-      late http.RequestAbortedException abortError;
-      when(
-        () => mockHttpClient.post(
-          Uri.parse("$authBaseUrl/auth/google/init"),
-          headers: any(named: "headers"),
-          body: any(named: "body"),
-        ),
-      ).thenAnswer(
-        (_) async => http.Response(
-          jsonEncode({
-            "authUrl": "https://accounts.google.com/o/oauth2/v2/auth",
-            "state": "state-request-timeout",
-            "userCode": "RT42",
-            "expiresIn": 300,
-          }),
-          200,
-        ),
+      final abortingClient = _HangingOAuthClient(abortImmediately: true);
+      authManager = AuthManager(
+        abortingClient,
+        mockTokenStorage,
+        mockOAuthStorage,
+        FakeOAuthDeviceDescriptorProvider(),
       );
       when(() => mockOAuthStorage.getOAuthSession()).thenAnswer(
         (_) async => (
@@ -1384,15 +992,6 @@ void main() {
           expiresAt: DateTime.now().add(const Duration(minutes: 5)),
         ),
       );
-      when(
-        () => mockHttpClient.send(any()),
-      ).thenAnswer((invocation) {
-        final request = invocation.positionalArguments.single as http.BaseRequest;
-        abortError = http.RequestAbortedException(request.url);
-        return Future<http.StreamedResponse>.error(abortError);
-      });
-
-      await authManager.startOAuthFlow(provider: AuthProvider.google, deadline: null);
 
       Object? pollError;
       try {
@@ -1410,51 +1009,15 @@ void main() {
         ),
       );
       final clientError = pollError! as OAuthSessionStatusClientException;
-      expect(clientError, isA<http.ClientException>());
-      expect(clientError.cause, same(abortError));
-      expect((clientError.cause as http.RequestAbortedException).uri, abortError.uri);
+      expect(clientError.cause, same(abortingClient.abortError));
+      expect(abortingClient.request, isA<http.AbortableRequest>());
 
-      expect(await authManager.hasActiveOAuthSession(), isTrue);
-      verifyNever(mockOAuthStorage.clearOAuthSession);
-    });
-
-    test("pollForResult preserves a direct timeout as the recoverable client exception cause", () async {
-      final transportTimeout = TimeoutException("transport timed out", const Duration(seconds: 35));
-      when(() => mockOAuthStorage.getOAuthSession()).thenAnswer(
-        (_) async => (
-          sessionToken: "stored-session-token",
-          expiresAt: DateTime.now().add(const Duration(minutes: 5)),
-        ),
-      );
-      when(
-        () => mockHttpClient.send(any()),
-      ).thenAnswer((_) => Future<http.StreamedResponse>.error(transportTimeout));
-
-      Object? pollError;
-      try {
-        await authManager.pollForResult();
-      } catch (error) {
-        pollError = error;
-      }
-
-      expect(
-        pollError,
-        isA<OAuthSessionStatusClientException>().having(
-          (error) => error.uri,
-          "uri",
-          Uri.parse("$authBaseUrl/auth/session/status"),
-        ),
-      );
-      final clientError = pollError! as OAuthSessionStatusClientException;
-      expect(clientError, isA<http.ClientException>());
-      expect(clientError.cause, same(transportTimeout));
-      expect(clientError.cause, isA<TimeoutException>());
       expect(await authManager.hasActiveOAuthSession(), isTrue);
       verifyNever(mockOAuthStorage.clearOAuthSession);
     });
 
     test("pollForResult treats final status request timeout as OAuth timeout", () async {
-      final hangingClient = _HangingStatusClient();
+      final hangingClient = _HangingOAuthClient();
       authManager = AuthManager(
         hangingClient,
         mockTokenStorage,
@@ -1495,108 +1058,6 @@ void main() {
       verify(mockOAuthStorage.clearOAuthSession).called(1);
     });
 
-    test("pollForResult preserves a direct timeout as the final OAuth timeout cause", () async {
-      final transportTimeout = TimeoutException("transport timed out", const Duration(milliseconds: 30));
-      when(() => mockOAuthStorage.getOAuthSession()).thenAnswer(
-        (_) async => (
-          sessionToken: "stored-session-token",
-          expiresAt: DateTime.now().add(const Duration(milliseconds: 30)),
-        ),
-      );
-      when(
-        () => mockHttpClient.send(any()),
-      ).thenAnswer((_) => Future<http.StreamedResponse>.error(transportTimeout));
-
-      Object? pollError;
-      try {
-        await authManager.pollForResult();
-      } catch (error) {
-        pollError = error;
-      }
-
-      expect(
-        pollError,
-        isA<OAuthRequestTimeoutException>()
-            .having(
-              (error) => error.message,
-              "message",
-              "OAuth authorization timed out",
-            )
-            .having(
-              (error) => error.uri,
-              "uri",
-              Uri.parse("$authBaseUrl/auth/session/status"),
-            ),
-      );
-      final timeoutError = pollError! as OAuthRequestTimeoutException;
-      expect(timeoutError, isA<TimeoutException>());
-      expect(timeoutError.cause, same(transportTimeout));
-      expect(timeoutError.cause, isA<TimeoutException>());
-      verify(mockOAuthStorage.clearOAuthSession).called(1);
-    });
-
-    test("restart cleanup is bounded by the OAuth deadline and poisons a hung mutation", () async {
-      final cleanup = Completer<void>();
-      when(() => mockOAuthStorage.getOAuthSession()).thenAnswer(
-        (_) async => (
-          sessionToken: "stored-session-token",
-          expiresAt: DateTime.now().add(const Duration(milliseconds: 40)),
-        ),
-      );
-      when(
-        () => mockHttpClient.send(any()),
-      ).thenAnswer(
-        (_) async => _streamedResponse(
-          response: http.Response("not-json", 503, headers: {"retry-after": "0"}),
-        ),
-      );
-      when(mockOAuthStorage.clearOAuthSession).thenAnswer((_) => cleanup.future);
-
-      Object? pollError;
-      var pollSettled = false;
-      unawaited(
-        authManager.pollForResult().then<void>(
-          (_) => pollSettled = true,
-          onError: (Object error, StackTrace _) {
-            pollError = error;
-            pollSettled = true;
-          },
-        ),
-      );
-      await Future<void>.delayed(const Duration(milliseconds: 150));
-      final pollSettledBeforeCleanup = pollSettled;
-      final pollErrorBeforeCleanup = pollError;
-
-      var retrySettled = false;
-      unawaited(
-        authManager
-            .startOAuthFlow(
-              provider: AuthProvider.google,
-              deadline: DateTime.now().add(const Duration(minutes: 1)),
-            )
-            .then<void>(
-              (_) => retrySettled = true,
-              onError: (Object _, StackTrace _) => retrySettled = true,
-            ),
-      );
-      await Future<void>.delayed(Duration.zero);
-      final retrySettledBeforeCleanup = retrySettled;
-      verify(mockOAuthStorage.clearOAuthSession).called(1);
-      cleanup.complete();
-      await Future<void>.delayed(Duration.zero);
-
-      expect(pollSettledBeforeCleanup, isTrue);
-      expect(
-        pollErrorBeforeCleanup,
-        isA<TimeoutException>().having(
-          (error) => error.message,
-          "message",
-          "OAuth authorization timed out",
-        ),
-      );
-      expect(retrySettledBeforeCleanup, isTrue);
-    });
-
     test("pollForResult clears active session on denied, expired, error, and timeout", () async {
       Future<void> arrangeStartedFlow({required http.Response statusResponse}) async {
         when(
@@ -1617,8 +1078,11 @@ void main() {
           ),
         );
         when(
-          () => mockHttpClient.send(any()),
-        ).thenAnswer((_) async => _streamedResponse(response: statusResponse));
+          () => mockHttpClient.get(
+            Uri.parse("$authBaseUrl/auth/session/status"),
+            headers: any(named: "headers"),
+          ),
+        ).thenAnswer((_) async => statusResponse);
         when(
           () => mockOAuthStorage.saveOAuthSession(
             sessionToken: any(named: "sessionToken"),

--- a/client/module_auth/test/auth_manager_test.dart
+++ b/client/module_auth/test/auth_manager_test.dart
@@ -74,6 +74,13 @@ class _HangingOAuthClient extends http.BaseClient {
   }
 }
 
+class _TimeoutOAuthClient extends http.BaseClient {
+  final timeoutError = TimeoutException("HTTP client timed out");
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) => Future.error(timeoutError);
+}
+
 /// Returns a fixed descriptor so the init body is deterministic in tests.
 class FakeOAuthDeviceDescriptorProvider implements OAuthDeviceDescriptorProvider {
   @override
@@ -81,6 +88,11 @@ class FakeOAuthDeviceDescriptorProvider implements OAuthDeviceDescriptorProvider
     clientType: AuthClientType.appIos,
     device: DeviceInfo(name: "Test iPhone", osVersion: "iOS 17.5", appVersion: "1.2.0"),
   );
+}
+
+class _HangingOAuthDeviceDescriptorProvider implements OAuthDeviceDescriptorProvider {
+  @override
+  Future<OAuthDeviceDescriptor> describe() => Completer<OAuthDeviceDescriptor>().future;
 }
 
 Future<OAuthSessionRestartRequiredException> _pollRestart({required AuthManager manager}) async {
@@ -441,6 +453,31 @@ void main() {
         "clientType": "app_ios",
         "device": {"name": "Test iPhone", "osVersion": "iOS 17.5", "appVersion": "1.2.0"},
       });
+    });
+
+    test("startOAuthFlow bounds device descriptor resolution by the absolute deadline", () async {
+      authManager = AuthManager(
+        mockHttpClient,
+        mockTokenStorage,
+        mockOAuthStorage,
+        _HangingOAuthDeviceDescriptorProvider(),
+      );
+
+      await expectLater(
+        authManager.startOAuthFlow(
+          provider: AuthProvider.github,
+          deadline: DateTime.now().add(const Duration(milliseconds: 20)),
+        ),
+        throwsA(isA<TimeoutException>()),
+      );
+      verify(mockOAuthStorage.clearOAuthSession).called(1);
+      verifyNever(
+        () => mockHttpClient.post(
+          any(),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      );
     });
 
     test("init 503 clears its session and exposes bounded restart timing before parsing JSON", () async {
@@ -1012,6 +1049,35 @@ void main() {
       expect(clientError.cause, same(abortingClient.abortError));
       expect(abortingClient.request, isA<http.AbortableRequest>());
 
+      expect(await authManager.hasActiveOAuthSession(), isTrue);
+      verifyNever(mockOAuthStorage.clearOAuthSession);
+    });
+
+    test("pollForResult maps a direct status timeout to a recoverable client exception", () async {
+      final timeoutClient = _TimeoutOAuthClient();
+      authManager = AuthManager(
+        timeoutClient,
+        mockTokenStorage,
+        mockOAuthStorage,
+        FakeOAuthDeviceDescriptorProvider(),
+      );
+      when(() => mockOAuthStorage.getOAuthSession()).thenAnswer(
+        (_) async => (
+          sessionToken: "stored-session-token",
+          expiresAt: DateTime.now().add(const Duration(minutes: 5)),
+        ),
+      );
+
+      await expectLater(
+        authManager.pollForResult(),
+        throwsA(
+          isA<OAuthSessionStatusClientException>().having(
+            (error) => error.cause,
+            "cause",
+            same(timeoutClient.timeoutError),
+          ),
+        ),
+      );
       expect(await authManager.hasActiveOAuthSession(), isTrue);
       verifyNever(mockOAuthStorage.clearOAuthSession);
     });

--- a/client/module_auth/test/auth_manager_test.dart
+++ b/client/module_auth/test/auth_manager_test.dart
@@ -12,11 +12,45 @@ import "package:sesori_auth/src/storage/token_storage_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+const _sessionTokenHeaderForTest = "X-Sesori-Session-Token";
+
+http.StreamedResponse _streamedResponse({required http.Response response}) {
+  return http.StreamedResponse(
+    Stream.value(response.bodyBytes),
+    response.statusCode,
+    contentLength: response.bodyBytes.length,
+    headers: response.headers,
+    isRedirect: response.isRedirect,
+    persistentConnection: response.persistentConnection,
+    reasonPhrase: response.reasonPhrase,
+  );
+}
+
 class MockHttpClient extends Mock implements http.Client {}
 
 class MockTokenStorageService extends Mock implements TokenStorageService {}
 
 class MockOAuthStorageService extends Mock implements OAuthStorageService {}
+
+class _HangingStatusClient extends http.BaseClient {
+  bool aborted = false;
+  http.BaseRequest? request;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    this.request = request;
+    final response = Completer<http.StreamedResponse>();
+    if (request case http.Abortable(:final abortTrigger?)) {
+      unawaited(
+        abortTrigger.then<void>((_) {
+          aborted = true;
+          response.completeError(http.RequestAbortedException(request.url));
+        }),
+      );
+    }
+    return response.future;
+  }
+}
 
 /// Returns a fixed descriptor so the init body is deterministic in tests.
 class FakeOAuthDeviceDescriptorProvider implements OAuthDeviceDescriptorProvider {
@@ -27,11 +61,11 @@ class FakeOAuthDeviceDescriptorProvider implements OAuthDeviceDescriptorProvider
   );
 }
 
-Future<OAuthSessionRestartRequiredException> _pollRestart(AuthManager manager) async {
-  return _captureOAuthRestart(manager.pollForResult());
+Future<OAuthSessionRestartRequiredException> _pollRestart({required AuthManager manager}) async {
+  return _captureOAuthRestart(operation: manager.pollForResult());
 }
 
-Future<OAuthSessionRestartRequiredException> _captureOAuthRestart(Future<Object?> operation) async {
+Future<OAuthSessionRestartRequiredException> _captureOAuthRestart({required Future<Object?> operation}) async {
   try {
     await operation;
   } on OAuthSessionRestartRequiredException catch (error) {
@@ -43,6 +77,7 @@ Future<OAuthSessionRestartRequiredException> _captureOAuthRestart(Future<Object?
 void main() {
   setUpAll(() {
     registerFallbackValue(Uri.parse("https://example.com"));
+    registerFallbackValue(http.Request("GET", Uri.parse("https://example.com")));
     registerFallbackValue(AuthProvider.github);
     registerFallbackValue(
       const AuthUser(id: "", provider: AuthProvider.github, providerUserId: "", providerUsername: null),
@@ -357,7 +392,7 @@ void main() {
       ).thenAnswer((_) async => http.Response("not-json", 503, headers: {"retry-after": "2"}));
 
       final restart = await _captureOAuthRestart(
-        authManager.startOAuthFlow(provider: AuthProvider.github, deadline: deadline),
+        operation: authManager.startOAuthFlow(provider: AuthProvider.github, deadline: deadline),
       );
 
       expect(restart.restartAfter, const Duration(seconds: 2));
@@ -402,12 +437,12 @@ void main() {
         ),
       );
       when(
-        () => mockHttpClient.get(any(), headers: any(named: "headers")),
-      ).thenAnswer((_) => staleResponse.future);
+        () => mockHttpClient.send(any()),
+      ).thenAnswer((_) async => _streamedResponse(response: await staleResponse.future));
 
       await authManager.startOAuthFlow(provider: AuthProvider.github, deadline: null);
       final stalePoll = authManager.pollForResult();
-      await untilCalled(() => mockHttpClient.get(any(), headers: any(named: "headers")));
+      await untilCalled(() => mockHttpClient.send(any()));
       await authManager.startOAuthFlow(provider: AuthProvider.google, deadline: null);
       final replacementToken = storedSession.sessionToken;
       final staleFailure = expectLater(stalePoll, throwsA(isA<Exception>()));
@@ -416,6 +451,69 @@ void main() {
 
       expect(replacementToken, isNotNull);
       expect(storedSession.sessionToken, replacementToken);
+      verifyNever(mockOAuthStorage.clearOAuthSession);
+    });
+
+    test("a delayed stored-session read cannot adopt a replacement owner or deadline", () async {
+      final oldDeadline = DateTime.now().add(const Duration(minutes: 1));
+      final replacementDeadline = DateTime.now().add(const Duration(minutes: 4));
+      final storedSessionRead = Completer<({String? sessionToken, DateTime? expiresAt})>();
+      var storedSession = (sessionToken: "old-session-token" as String?, expiresAt: oldDeadline as DateTime?);
+      when(() => mockOAuthStorage.getOAuthSession()).thenAnswer((_) => storedSessionRead.future);
+      when(
+        () => mockOAuthStorage.saveOAuthSession(
+          sessionToken: any(named: "sessionToken"),
+          expiresAt: any(named: "expiresAt"),
+        ),
+      ).thenAnswer((invocation) async {
+        storedSession = (
+          sessionToken: invocation.namedArguments[#sessionToken] as String,
+          expiresAt: invocation.namedArguments[#expiresAt] as DateTime,
+        );
+      });
+      when(mockOAuthStorage.clearOAuthSession).thenAnswer((_) async {
+        storedSession = (sessionToken: null, expiresAt: null);
+      });
+      when(
+        () => mockHttpClient.post(
+          any(),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({"authUrl": "https://example.com/login", "state": "replacement", "expiresIn": 300}),
+          200,
+        ),
+      );
+      http.BaseRequest? statusRequest;
+      when(
+        () => mockHttpClient.send(any()),
+      ).thenAnswer((invocation) async {
+        statusRequest = invocation.positionalArguments.single as http.BaseRequest;
+        return _streamedResponse(
+          response: http.Response("not-json", 503, headers: {"retry-after": "0"}),
+        );
+      });
+
+      final stalePoll = authManager.pollForResult();
+      await untilCalled(mockOAuthStorage.getOAuthSession);
+      final replacement = authManager.startOAuthFlow(
+        provider: AuthProvider.google,
+        deadline: replacementDeadline,
+      );
+      await Future<void>.delayed(Duration.zero);
+      storedSessionRead.complete((sessionToken: "old-session-token", expiresAt: oldDeadline));
+
+      await replacement;
+      await expectLater(
+        stalePoll,
+        throwsA(allOf(isA<Exception>(), isNot(isA<OAuthSessionRestartRequiredException>()))),
+      );
+
+      expect(statusRequest?.headers[_sessionTokenHeaderForTest], "old-session-token");
+      expect(storedSession.expiresAt, replacementDeadline);
+      expect(storedSession.sessionToken, isNot("old-session-token"));
       verifyNever(mockOAuthStorage.clearOAuthSession);
     });
 
@@ -500,6 +598,79 @@ void main() {
       verify(mockOAuthStorage.clearOAuthSession).called(1);
     });
 
+    test("a failed poison cleanup is retried before OAuth mutations resume", () async {
+      final firstSave = Completer<void>();
+      var saveCount = 0;
+      var clearCount = 0;
+      var storedSession = (sessionToken: null as String?, expiresAt: null as DateTime?);
+      when(
+        () => mockOAuthStorage.saveOAuthSession(
+          sessionToken: any(named: "sessionToken"),
+          expiresAt: any(named: "expiresAt"),
+        ),
+      ).thenAnswer((invocation) async {
+        if (saveCount++ == 0) {
+          await firstSave.future;
+        }
+        storedSession = (
+          sessionToken: invocation.namedArguments[#sessionToken] as String,
+          expiresAt: invocation.namedArguments[#expiresAt] as DateTime,
+        );
+      });
+      when(mockOAuthStorage.clearOAuthSession).thenAnswer((_) async {
+        clearCount += 1;
+        if (clearCount == 1) {
+          throw Exception("transient secure-storage failure");
+        }
+        storedSession = (sessionToken: null, expiresAt: null);
+      });
+      when(
+        () => mockHttpClient.post(
+          any(),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({"authUrl": "https://example.com/login", "state": "state", "expiresIn": 300}),
+          200,
+        ),
+      );
+
+      final timedOutStart = authManager.startOAuthFlow(
+        provider: AuthProvider.github,
+        deadline: DateTime.now().add(const Duration(milliseconds: 30)),
+      );
+      await untilCalled(
+        () => mockOAuthStorage.saveOAuthSession(
+          sessionToken: any(named: "sessionToken"),
+          expiresAt: any(named: "expiresAt"),
+        ),
+      );
+      await expectLater(timedOutStart, throwsA(isA<TimeoutException>()));
+
+      await expectLater(
+        authManager.startOAuthFlow(
+          provider: AuthProvider.google,
+          deadline: DateTime.now().add(const Duration(minutes: 1)),
+        ),
+        throwsA(isA<Exception>()),
+      );
+      verifyNever(mockOAuthStorage.clearOAuthSession);
+
+      firstSave.complete();
+      await untilCalled(mockOAuthStorage.clearOAuthSession);
+      await Future<void>.delayed(Duration.zero);
+
+      await authManager.startOAuthFlow(
+        provider: AuthProvider.google,
+        deadline: DateTime.now().add(const Duration(minutes: 1)),
+      );
+
+      expect(clearCount, 2);
+      expect(storedSession.sessionToken, isNotNull);
+    });
+
     test("OAuth completion is atomic with respect to a replacement start", () async {
       final tokenSave = Completer<void>();
       when(
@@ -515,16 +686,18 @@ void main() {
         ),
       );
       when(
-        () => mockHttpClient.get(any(), headers: any(named: "headers")),
+        () => mockHttpClient.send(any()),
       ).thenAnswer(
-        (_) async => http.Response(
-          jsonEncode({
-            "status": "complete",
-            "accessToken": "access",
-            "refreshToken": "refresh",
-            "user": user.toJson(),
-          }),
-          200,
+        (_) async => _streamedResponse(
+          response: http.Response(
+            jsonEncode({
+              "status": "complete",
+              "accessToken": "access",
+              "refreshToken": "refresh",
+              "user": user.toJson(),
+            }),
+            200,
+          ),
         ),
       );
       when(
@@ -581,16 +754,18 @@ void main() {
         ),
       );
       when(
-        () => mockHttpClient.get(any(), headers: any(named: "headers")),
+        () => mockHttpClient.send(any()),
       ).thenAnswer(
-        (_) async => http.Response(
-          jsonEncode({
-            "status": "complete",
-            "accessToken": "access",
-            "refreshToken": "refresh",
-            "user": user.toJson(),
-          }),
-          200,
+        (_) async => _streamedResponse(
+          response: http.Response(
+            jsonEncode({
+              "status": "complete",
+              "accessToken": "access",
+              "refreshToken": "refresh",
+              "user": user.toJson(),
+            }),
+            200,
+          ),
         ),
       );
       when(
@@ -632,16 +807,18 @@ void main() {
         ),
       );
       when(
-        () => mockHttpClient.get(any(), headers: any(named: "headers")),
+        () => mockHttpClient.send(any()),
       ).thenAnswer(
-        (_) async => http.Response(
-          jsonEncode({
-            "status": "complete",
-            "accessToken": "access",
-            "refreshToken": "refresh",
-            "user": user.toJson(),
-          }),
-          200,
+        (_) async => _streamedResponse(
+          response: http.Response(
+            jsonEncode({
+              "status": "complete",
+              "accessToken": "access",
+              "refreshToken": "refresh",
+              "user": user.toJson(),
+            }),
+            200,
+          ),
         ),
       );
       when(
@@ -688,13 +865,15 @@ void main() {
         storedSession = (sessionToken: null, expiresAt: null);
       });
       when(
-        () => mockHttpClient.get(any(), headers: any(named: "headers")),
+        () => mockHttpClient.send(any()),
       ).thenAnswer((_) async {
         final testCase = cases[responseIndex++];
-        return http.Response(
-          "not-json",
-          testCase.status,
-          headers: {"retry-after": ?testCase.header},
+        return _streamedResponse(
+          response: http.Response(
+            "not-json",
+            testCase.status,
+            headers: {"retry-after": ?testCase.header},
+          ),
         );
       });
       for (final testCase in cases) {
@@ -703,7 +882,7 @@ void main() {
           expiresAt: testCase.fallback ? null : deadline,
         );
         final expectedDeadline = testCase.fallback ? DateTime.now().add(const Duration(minutes: 5)) : deadline;
-        final exception = await _pollRestart(authManager);
+        final exception = await _pollRestart(manager: authManager);
         expect(exception.restartAfter, testCase.delay);
         expect(
           exception.deadline.difference(expectedDeadline).abs(),
@@ -743,28 +922,29 @@ void main() {
       );
       var statusCalls = 0;
       when(
-        () => mockHttpClient.get(
-          Uri.parse("$authBaseUrl/auth/session/status"),
-          headers: any(named: "headers"),
-        ),
+        () => mockHttpClient.send(any()),
       ).thenAnswer((_) async {
         statusCalls += 1;
         if (statusCalls == 1) {
-          return http.Response(jsonEncode({"status": "pending"}), 200);
+          return _streamedResponse(
+            response: http.Response(jsonEncode({"status": "pending"}), 200),
+          );
         }
-        return http.Response(
-          jsonEncode({
-            "status": "complete",
-            "accessToken": "oauth-access-token",
-            "refreshToken": "oauth-refresh-token",
-            "user": {
-              "id": user.id,
-              "provider": user.provider.key,
-              "providerUserId": user.providerUserId,
-              "providerUsername": user.providerUsername,
-            },
-          }),
-          200,
+        return _streamedResponse(
+          response: http.Response(
+            jsonEncode({
+              "status": "complete",
+              "accessToken": "oauth-access-token",
+              "refreshToken": "oauth-refresh-token",
+              "user": {
+                "id": user.id,
+                "provider": user.provider.key,
+                "providerUserId": user.providerUserId,
+                "providerUsername": user.providerUsername,
+              },
+            }),
+            200,
+          ),
         );
       });
       when(
@@ -809,10 +989,7 @@ void main() {
       final ackHeaders = ackCall.captured.single as Map<String, String>;
       expect(ackHeaders["X-Sesori-Session-Token"], matches(RegExp(r"^[0-9a-f]{64}$")));
       verify(
-        () => mockHttpClient.get(
-          Uri.parse("$authBaseUrl/auth/session/status"),
-          headers: any(named: "headers"),
-        ),
+        () => mockHttpClient.send(any()),
       ).called(2);
       await expectLater(authManager.pollForResult(), throwsA(isA<StateError>()));
     });
@@ -845,24 +1022,23 @@ void main() {
         ),
       );
       when(
-        () => mockHttpClient.get(
-          Uri.parse("$authBaseUrl/auth/session/status"),
-          headers: any(named: "headers"),
-        ),
+        () => mockHttpClient.send(any()),
       ).thenAnswer(
-        (_) async => http.Response(
-          jsonEncode({
-            "status": "complete",
-            "accessToken": "oauth-access-token",
-            "refreshToken": "oauth-refresh-token",
-            "user": {
-              "id": user.id,
-              "provider": user.provider.key,
-              "providerUserId": user.providerUserId,
-              "providerUsername": user.providerUsername,
-            },
-          }),
-          200,
+        (_) async => _streamedResponse(
+          response: http.Response(
+            jsonEncode({
+              "status": "complete",
+              "accessToken": "oauth-access-token",
+              "refreshToken": "oauth-refresh-token",
+              "user": {
+                "id": user.id,
+                "provider": user.provider.key,
+                "providerUserId": user.providerUserId,
+                "providerUsername": user.providerUsername,
+              },
+            }),
+            200,
+          ),
         ),
       );
       when(
@@ -915,24 +1091,23 @@ void main() {
         ),
       );
       when(
-        () => mockHttpClient.get(
-          Uri.parse("$authBaseUrl/auth/session/status"),
-          headers: any(named: "headers"),
-        ),
+        () => mockHttpClient.send(any()),
       ).thenAnswer(
-        (_) async => http.Response(
-          jsonEncode({
-            "status": "complete",
-            "accessToken": "oauth-access-token",
-            "refreshToken": "oauth-refresh-token",
-            "user": {
-              "id": user.id,
-              "provider": user.provider.key,
-              "providerUserId": user.providerUserId,
-              "providerUsername": user.providerUsername,
-            },
-          }),
-          200,
+        (_) async => _streamedResponse(
+          response: http.Response(
+            jsonEncode({
+              "status": "complete",
+              "accessToken": "oauth-access-token",
+              "refreshToken": "oauth-refresh-token",
+              "user": {
+                "id": user.id,
+                "provider": user.provider.key,
+                "providerUserId": user.providerUserId,
+                "providerUsername": user.providerUsername,
+              },
+            }),
+            200,
+          ),
         ),
       );
       when(
@@ -982,24 +1157,23 @@ void main() {
         ),
       );
       when(
-        () => mockHttpClient.get(
-          Uri.parse("$authBaseUrl/auth/session/status"),
-          headers: any(named: "headers"),
-        ),
+        () => mockHttpClient.send(any()),
       ).thenAnswer(
-        (_) async => http.Response(
-          jsonEncode({
-            "status": "complete",
-            "accessToken": "oauth-access-token",
-            "refreshToken": "oauth-refresh-token",
-            "user": {
-              "id": user.id,
-              "provider": user.provider.key,
-              "providerUserId": user.providerUserId,
-              "providerUsername": user.providerUsername,
-            },
-          }),
-          200,
+        (_) async => _streamedResponse(
+          response: http.Response(
+            jsonEncode({
+              "status": "complete",
+              "accessToken": "oauth-access-token",
+              "refreshToken": "oauth-refresh-token",
+              "user": {
+                "id": user.id,
+                "provider": user.provider.key,
+                "providerUserId": user.providerUserId,
+                "providerUsername": user.providerUsername,
+              },
+            }),
+            200,
+          ),
         ),
       );
       when(
@@ -1052,11 +1226,12 @@ void main() {
         ),
       );
       when(
-        () => mockHttpClient.get(
-          Uri.parse("$authBaseUrl/auth/session/status"),
-          headers: any(named: "headers"),
+        () => mockHttpClient.send(any()),
+      ).thenAnswer(
+        (_) async => _streamedResponse(
+          response: http.Response(jsonEncode({"status": "denied"}), 200),
         ),
-      ).thenAnswer((_) async => http.Response(jsonEncode({"status": "denied"}), 200));
+      );
 
       await authManager.startOAuthFlow(provider: AuthProvider.github, deadline: null);
       await expectLater(authManager.pollForResult(), throwsA(isA<StateError>()));
@@ -1069,13 +1244,10 @@ void main() {
         ),
       );
       final pollCall = verify(
-        () => mockHttpClient.get(
-          Uri.parse("$authBaseUrl/auth/session/status"),
-          headers: captureAny(named: "headers"),
-        ),
+        () => mockHttpClient.send(captureAny()),
       );
       final initHeaders = initCall.captured.first as Map<String, String>;
-      final pollHeaders = pollCall.captured.first as Map<String, String>;
+      final pollHeaders = (pollCall.captured.first as http.BaseRequest).headers;
       expect(pollHeaders["X-Sesori-Session-Token"], initHeaders["X-Sesori-Session-Token"]);
       expect(pollHeaders["X-Sesori-Session-Token"], matches(RegExp(r"^[0-9a-f]{64}$")));
     });
@@ -1105,11 +1277,11 @@ void main() {
         ),
       );
       when(
-        () => mockHttpClient.get(
-          Uri.parse("$authBaseUrl/auth/session/status"),
-          headers: any(named: "headers"),
-        ),
-      ).thenAnswer((_) => Future<http.Response>.error(TimeoutException("status request timed out")));
+        () => mockHttpClient.send(any()),
+      ).thenAnswer((invocation) {
+        final request = invocation.positionalArguments.single as http.BaseRequest;
+        return Future<http.StreamedResponse>.error(http.RequestAbortedException(request.url));
+      });
 
       await authManager.startOAuthFlow(provider: AuthProvider.google, deadline: null);
 
@@ -1129,8 +1301,9 @@ void main() {
     });
 
     test("pollForResult treats final status request timeout as OAuth timeout", () async {
+      final hangingClient = _HangingStatusClient();
       authManager = AuthManager(
-        mockHttpClient,
+        hangingClient,
         mockTokenStorage,
         mockOAuthStorage,
         FakeOAuthDeviceDescriptorProvider(),
@@ -1143,13 +1316,6 @@ void main() {
           expiresAt: DateTime.now().add(const Duration(milliseconds: 30)),
         ),
       );
-      when(
-        () => mockHttpClient.get(
-          Uri.parse("$authBaseUrl/auth/session/status"),
-          headers: any(named: "headers"),
-        ),
-      ).thenAnswer((_) => Completer<http.Response>().future);
-
       await expectLater(
         authManager.pollForResult(),
         throwsA(
@@ -1161,7 +1327,71 @@ void main() {
         ),
       );
 
+      expect(hangingClient.aborted, isTrue);
+      expect(hangingClient.request, isA<http.AbortableRequest>());
       verify(mockOAuthStorage.clearOAuthSession).called(1);
+    });
+
+    test("restart cleanup is bounded by the OAuth deadline and poisons a hung mutation", () async {
+      final cleanup = Completer<void>();
+      when(() => mockOAuthStorage.getOAuthSession()).thenAnswer(
+        (_) async => (
+          sessionToken: "stored-session-token",
+          expiresAt: DateTime.now().add(const Duration(milliseconds: 40)),
+        ),
+      );
+      when(
+        () => mockHttpClient.send(any()),
+      ).thenAnswer(
+        (_) async => _streamedResponse(
+          response: http.Response("not-json", 503, headers: {"retry-after": "0"}),
+        ),
+      );
+      when(mockOAuthStorage.clearOAuthSession).thenAnswer((_) => cleanup.future);
+
+      Object? pollError;
+      var pollSettled = false;
+      unawaited(
+        authManager.pollForResult().then<void>(
+          (_) => pollSettled = true,
+          onError: (Object error, StackTrace _) {
+            pollError = error;
+            pollSettled = true;
+          },
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      final pollSettledBeforeCleanup = pollSettled;
+      final pollErrorBeforeCleanup = pollError;
+
+      var retrySettled = false;
+      unawaited(
+        authManager
+            .startOAuthFlow(
+              provider: AuthProvider.google,
+              deadline: DateTime.now().add(const Duration(minutes: 1)),
+            )
+            .then<void>(
+              (_) => retrySettled = true,
+              onError: (Object _, StackTrace _) => retrySettled = true,
+            ),
+      );
+      await Future<void>.delayed(Duration.zero);
+      final retrySettledBeforeCleanup = retrySettled;
+      verify(mockOAuthStorage.clearOAuthSession).called(1);
+      cleanup.complete();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(pollSettledBeforeCleanup, isTrue);
+      expect(
+        pollErrorBeforeCleanup,
+        isA<TimeoutException>().having(
+          (error) => error.message,
+          "message",
+          "OAuth authorization timed out",
+        ),
+      );
+      expect(retrySettledBeforeCleanup, isTrue);
     });
 
     test("pollForResult clears active session on denied, expired, error, and timeout", () async {
@@ -1184,11 +1414,8 @@ void main() {
           ),
         );
         when(
-          () => mockHttpClient.get(
-            Uri.parse("$authBaseUrl/auth/session/status"),
-            headers: any(named: "headers"),
-          ),
-        ).thenAnswer((_) async => statusResponse);
+          () => mockHttpClient.send(any()),
+        ).thenAnswer((_) async => _streamedResponse(response: statusResponse));
         when(
           () => mockOAuthStorage.saveOAuthSession(
             sessionToken: any(named: "sessionToken"),

--- a/client/module_core/lib/src/cubits/login/login_cubit.dart
+++ b/client/module_core/lib/src/cubits/login/login_cubit.dart
@@ -2,6 +2,8 @@ import "dart:async";
 
 import "package:bloc/bloc.dart";
 import "package:http/http.dart" show ClientException;
+import "package:meta/meta.dart";
+import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
@@ -18,7 +20,113 @@ enum _LoginAnalyticsOutcome { open, terminal }
 final class _LoginAttempt {
   final AuthProvider provider;
   _LoginAnalyticsOutcome analyticsOutcome = _LoginAnalyticsOutcome.open;
+  bool oAuthRestartUsed = false;
+  DateTime? oAuthDeadline;
+  OAuthRestartWait? _wait;
+  bool _cancelled = false;
   _LoginAttempt({required this.provider});
+  void cancel() {
+    if (_cancelled) return;
+    _cancelled = true;
+    _wait?.cancel();
+    _wait = null;
+  }
+}
+
+final class _UnexpectedOAuthRestartLifecycleDone implements Exception {
+  const _UnexpectedOAuthRestartLifecycleDone();
+  @override
+  String toString() => "OAuth restart lifecycle stream closed unexpectedly";
+}
+
+enum OAuthRestartWaitResult { ready, cancelled, deadline }
+
+@visibleForTesting
+final class OAuthRestartWaitCombinedFailure implements Exception {
+  final AsyncError operationFailure;
+  final AsyncError cleanupFailure;
+  const OAuthRestartWaitCombinedFailure({required this.operationFailure, required this.cleanupFailure});
+}
+
+@visibleForTesting
+final class OAuthRestartWait {
+  final ValueStream<LifecycleState> lifecycle;
+  final Duration delay;
+  final DateTime deadline;
+  final Completer<OAuthRestartWaitResult> _completion = Completer();
+  Timer? _deadlineTimer;
+  Timer? _delayTimer;
+  // ignore: cancel_subscriptions, _finish always cancels the owned subscription
+  StreamSubscription<LifecycleState>? _subscription;
+  bool _finishing = false;
+  OAuthRestartWait({required this.lifecycle, required this.delay, required this.deadline});
+  Future<OAuthRestartWaitResult> run() {
+    if (_finishing) return _completion.future;
+    final remaining = deadline.difference(DateTime.now());
+    if (remaining > Duration.zero) {
+      _deadlineTimer = Timer(remaining, () => _resolve(OAuthRestartWaitResult.deadline));
+      _delayTimer = delay > Duration.zero ? Timer(delay, _listenForResume) : null;
+      if (_delayTimer == null) _listenForResume();
+    } else {
+      _resolve(OAuthRestartWaitResult.deadline);
+    }
+    return _completion.future;
+  }
+
+  void cancel() => _resolve(OAuthRestartWaitResult.cancelled);
+  void _listenForResume() {
+    if (!DateTime.now().isBefore(deadline)) {
+      _resolve(OAuthRestartWaitResult.deadline);
+      return;
+    }
+    if (lifecycle.value == LifecycleState.resumed) {
+      _resolve(OAuthRestartWaitResult.ready);
+      return;
+    }
+    _subscription = lifecycle.listen(_onLifecycleState, onError: _onLifecycleError, onDone: _onLifecycleDone);
+    if (lifecycle.value == LifecycleState.resumed) _resolve(OAuthRestartWaitResult.ready);
+  }
+
+  void _onLifecycleState(LifecycleState state) {
+    if (state == LifecycleState.resumed) scheduleMicrotask(() => _resolve(OAuthRestartWaitResult.ready));
+  }
+
+  // ignore: no_slop_linter/prefer_required_named_parameters, Stream.listen callback signature
+  void _onLifecycleError(Object error, StackTrace stackTrace) =>
+      scheduleMicrotask(() => _fail(error: error, stackTrace: stackTrace));
+  void _onLifecycleDone() => scheduleMicrotask(
+    () => _fail(error: const _UnexpectedOAuthRestartLifecycleDone(), stackTrace: StackTrace.current),
+  );
+  void _resolve(OAuthRestartWaitResult result) => unawaited(_finish(result: result, operationFailure: null));
+  void _fail({required Object error, required StackTrace stackTrace}) =>
+      unawaited(_finish(result: null, operationFailure: AsyncError(error, stackTrace)));
+  Future<void> _finish({
+    required OAuthRestartWaitResult? result,
+    required AsyncError? operationFailure,
+  }) async {
+    if (_finishing) return;
+    _finishing = true;
+    _deadlineTimer?.cancel();
+    _delayTimer?.cancel();
+    final subscription = _subscription;
+    _subscription = null;
+    AsyncError? cleanupFailure;
+    try {
+      await subscription?.cancel();
+    } on Object catch (error, stackTrace) {
+      cleanupFailure = AsyncError(error, stackTrace);
+    }
+    if (operationFailure != null) {
+      final error = cleanupFailure == null
+          ? operationFailure.error
+          : OAuthRestartWaitCombinedFailure(operationFailure: operationFailure, cleanupFailure: cleanupFailure);
+      _completion.completeError(error, operationFailure.stackTrace);
+    } else if (cleanupFailure != null) {
+      _completion.completeError(cleanupFailure.error, cleanupFailure.stackTrace);
+    } else if (result != null) {
+      _completion.complete(result);
+    }
+  }
 }
 
 /// Opaque ownership token for one native Apple sign-in operation.
@@ -35,7 +143,7 @@ class LoginCubit extends Cubit<LoginState> {
   final InstallationAnalyticsService _installationAnalyticsService;
   StreamSubscription<LifecycleState>? _lifecycleSubscription;
   _LoginAttempt? _loginAttempt;
-  bool _isPolling = false;
+  _LoginAttempt? _pollingAttempt;
 
   /// Whether the app is currently backgrounded. While backgrounded, the OS can
   /// abort the in-flight OAuth status poll (Android tears down the socket when
@@ -68,7 +176,7 @@ class LoginCubit extends Cubit<LoginState> {
         case LifecycleState.hidden:
         case LifecycleState.detached:
           _isInBackground = true;
-          if (_isPolling) {
+          if (_pollingAttempt != null) {
             _didActivePollEnterBackground = true;
           }
         case LifecycleState.resumed:
@@ -82,13 +190,16 @@ class LoginCubit extends Cubit<LoginState> {
 
   @override
   Future<void> close() async {
+    final attempt = _loginAttempt;
     _loginAttempt = null;
+    _pollingAttempt = null;
+    attempt?.cancel();
     await _lifecycleSubscription?.cancel();
     return super.close();
   }
 
   Future<void> _onAppResumed() async {
-    if (_isPolling) return;
+    if (_pollingAttempt != null) return;
     if (state is LoginPolling || state is LoginTimeout) {
       final attempt = _currentAttempt;
       if (attempt == null) return;
@@ -120,10 +231,19 @@ class LoginCubit extends Cubit<LoginState> {
       if (isClosed) return;
 
       _didActivePollEnterBackground = _isInBackground;
-      _isPolling = true;
+      _pollingAttempt = attempt;
       emit(const LoginState.polling());
       try {
-        await _oAuthFlowProvider.resumeOAuthFlow();
+        try {
+          await _oAuthFlowProvider.resumeOAuthFlow();
+        } on OAuthSessionRestartRequiredException catch (error, stackTrace) {
+          final restarted = await _restartOAuthFlow(
+            attempt: attempt,
+            exception: error,
+            stackTrace: stackTrace,
+          );
+          if (!restarted) return;
+        }
         if (!_ownsAttempt(attempt: attempt)) return;
         _reportCompletedAttempt(attempt: attempt);
         emit(const LoginState.success());
@@ -139,7 +259,9 @@ class LoginCubit extends Cubit<LoginState> {
         _reportFailedAttempt(attempt: attempt, cause: LoginAttemptFailureCause.unknown);
         emit(const LoginState.failed(reason: LoginFailedReason.unknown));
       } finally {
-        _isPolling = false;
+        if (identical(_pollingAttempt, attempt)) {
+          _pollingAttempt = null;
+        }
       }
     }
   }
@@ -167,7 +289,7 @@ class LoginCubit extends Cubit<LoginState> {
       // The app already returned to the foreground before this abort surfaced,
       // so no further `resumed` lifecycle event will arrive to drive recovery.
       // Kick the retry now; the microtask lets the caller's `finally` clear
-      // `_isPolling` before `_onAppResumed` runs.
+      // the polling guard before `_onAppResumed` runs.
       Future.microtask(() {
         if (isClosed) return;
         _onAppResumed().catchError((Object e, StackTrace st) {
@@ -193,19 +315,40 @@ class LoginCubit extends Cubit<LoginState> {
     emit(const LoginState.authenticating());
 
     try {
-      final initResponse = await _oAuthFlowProvider.startOAuthFlow(provider: provider);
+      final AuthInitResponse initResponse;
+      try {
+        initResponse = await _oAuthFlowProvider.startOAuthFlow(provider: provider, deadline: null);
+      } on OAuthSessionRestartRequiredException catch (error, stackTrace) {
+        _pollingAttempt = attempt;
+        try {
+          final restarted = await _restartOAuthFlow(
+            attempt: attempt,
+            exception: error,
+            stackTrace: stackTrace,
+          );
+          if (!restarted) return false;
+        } finally {
+          if (identical(_pollingAttempt, attempt)) {
+            _pollingAttempt = null;
+          }
+        }
+        if (!_ownsAttempt(attempt: attempt)) return false;
+        _reportCompletedAttempt(attempt: attempt);
+        emit(const LoginState.success());
+        return true;
+      }
       if (!_ownsAttempt(attempt: attempt)) return false;
 
       // Show the resumable polling UI and ARM the poll guard BEFORE launching
       // the browser. Opening the browser can suspend the app before launch()
-      // returns; with _isPolling already set, a resume during that window is a
+      // returns; with the polling guard already set, a resume during that window is a
       // no-op (it won't start a second concurrent poll) — the pollForResult()
       // below owns the session. The finally resets the guard on every exit path
       // (launch failure, success, or a thrown poll error), so the outer catch's
-      // _handlePollInterruption still sees _isPolling == false.
+      // _handlePollInterruption still sees the guard released.
       emit(const LoginState.polling());
       _didActivePollEnterBackground = _isInBackground;
-      _isPolling = true;
+      _pollingAttempt = attempt;
       try {
         logd("Opening ${provider.label} auth URL in browser");
 
@@ -218,9 +361,20 @@ class LoginCubit extends Cubit<LoginState> {
           return false;
         }
 
-        await _oAuthFlowProvider.pollForResult();
+        try {
+          await _oAuthFlowProvider.pollForResult();
+        } on OAuthSessionRestartRequiredException catch (error, stackTrace) {
+          final restarted = await _restartOAuthFlow(
+            attempt: attempt,
+            exception: error,
+            stackTrace: stackTrace,
+          );
+          if (!restarted) return false;
+        }
       } finally {
-        _isPolling = false;
+        if (identical(_pollingAttempt, attempt)) {
+          _pollingAttempt = null;
+        }
       }
 
       if (!_ownsAttempt(attempt: attempt)) return false;
@@ -342,10 +496,13 @@ class LoginCubit extends Cubit<LoginState> {
   }
 
   _LoginAttempt _beginAttempt({required AuthProvider provider}) {
+    final previousAttempt = _loginAttempt;
     _reportFailedAttempt(
-      attempt: _loginAttempt,
+      attempt: previousAttempt,
       cause: LoginAttemptFailureCause.unknown,
     );
+    _loginAttempt = null;
+    previousAttempt?.cancel();
     final attempt = _LoginAttempt(provider: provider);
     _loginAttempt = attempt;
     _report(
@@ -353,6 +510,110 @@ class LoginCubit extends Cubit<LoginState> {
       description: "login attempt start",
     );
     return attempt;
+  }
+
+  Future<bool> _restartOAuthFlow({
+    required _LoginAttempt attempt,
+    required OAuthSessionRestartRequiredException exception,
+    required StackTrace stackTrace,
+  }) async {
+    final provider = switch (attempt.provider) {
+      final OAuthProvider provider => provider,
+      EmailAuthProvider() => throw StateError("OAuth session restart requires an OAuth provider"),
+    };
+    if (attempt.oAuthRestartUsed) {
+      _throwIfOAuthDeadlineReached(attempt: attempt);
+      Error.throwWithStackTrace(exception, stackTrace);
+    }
+    attempt.oAuthRestartUsed = true;
+    attempt.oAuthDeadline = exception.deadline;
+    final deadline = exception.deadline;
+
+    if (!await _waitUntilOAuthRestartReady(
+      attempt: attempt,
+      delay: exception.restartAfter,
+      deadline: deadline,
+    )) {
+      return false;
+    }
+
+    final initResponse = await _beforeOAuthDeadline(
+      deadline: deadline,
+      operation: () => _oAuthFlowProvider.startOAuthFlow(
+        provider: provider,
+        deadline: deadline,
+      ),
+    );
+    if (!_ownsAttempt(attempt: attempt)) return false;
+    if (!await _waitUntilOAuthRestartReady(attempt: attempt, delay: Duration.zero, deadline: deadline)) {
+      return false;
+    }
+
+    _didActivePollEnterBackground = _isInBackground;
+    emit(const LoginState.polling());
+    logd("Opening ${provider.label} auth URL in browser after OAuth session restart");
+    final launched = await _beforeOAuthDeadline(
+      deadline: deadline,
+      operation: () => _urlLauncher.launch(Uri.parse(initResponse.authUrl)),
+    );
+    if (!_ownsAttempt(attempt: attempt)) return false;
+    _throwIfOAuthDeadlineReached(attempt: attempt);
+    if (!launched) {
+      _reportFailedAttempt(attempt: attempt, cause: LoginAttemptFailureCause.launch);
+      emit(const LoginState.failed(reason: LoginFailedReason.browserOpenFailed));
+      return false;
+    }
+
+    await _oAuthFlowProvider.pollForResult();
+    if (!_ownsAttempt(attempt: attempt)) return false;
+    return true;
+  }
+
+  Future<T> _beforeOAuthDeadline<T>({
+    required DateTime deadline,
+    required Future<T> Function() operation,
+  }) {
+    final remaining = deadline.difference(DateTime.now());
+    if (remaining <= Duration.zero) {
+      return Future<T>.error(TimeoutException("OAuth authorization timed out"));
+    }
+
+    return operation().timeout(
+      remaining,
+      onTimeout: () => throw TimeoutException("OAuth authorization timed out"),
+    );
+  }
+
+  void _throwIfOAuthDeadlineReached({required _LoginAttempt attempt}) {
+    final deadline = attempt.oAuthDeadline;
+    if (deadline != null && !DateTime.now().isBefore(deadline)) {
+      throw TimeoutException("OAuth authorization timed out");
+    }
+  }
+
+  Future<bool> _waitUntilOAuthRestartReady({
+    required _LoginAttempt attempt,
+    required Duration delay,
+    required DateTime deadline,
+  }) async {
+    var currentDelay = delay;
+    while (true) {
+      final wait = OAuthRestartWait(
+        lifecycle: _lifecycleSource.lifecycleStateStream,
+        delay: currentDelay,
+        deadline: deadline,
+      );
+      attempt._wait = wait;
+      if (attempt._cancelled) wait.cancel();
+      final result = await wait.run().whenComplete(() {
+        if (identical(attempt._wait, wait)) attempt._wait = null;
+      });
+      if (!_ownsAttempt(attempt: attempt) || result == OAuthRestartWaitResult.cancelled) return false;
+      if (result == OAuthRestartWaitResult.deadline) throw TimeoutException("OAuth authorization timed out");
+      _throwIfOAuthDeadlineReached(attempt: attempt);
+      if (_lifecycleSource.lifecycleState == LifecycleState.resumed) return true;
+      currentDelay = Duration.zero;
+    }
   }
 
   _LoginAttempt? get _currentAttempt => _loginAttempt;

--- a/client/module_core/lib/src/cubits/login/login_cubit.dart
+++ b/client/module_core/lib/src/cubits/login/login_cubit.dart
@@ -64,40 +64,45 @@ final class OAuthRestartWait {
     if (_finishing) return _completion.future;
     final remaining = deadline.difference(DateTime.now());
     if (remaining > Duration.zero) {
-      _deadlineTimer = Timer(remaining, () => _resolve(OAuthRestartWaitResult.deadline));
+      _deadlineTimer = Timer(remaining, () => _resolve(result: OAuthRestartWaitResult.deadline));
       _delayTimer = delay > Duration.zero ? Timer(delay, _listenForResume) : null;
       if (_delayTimer == null) _listenForResume();
     } else {
-      _resolve(OAuthRestartWaitResult.deadline);
+      _resolve(result: OAuthRestartWaitResult.deadline);
     }
     return _completion.future;
   }
 
-  void cancel() => _resolve(OAuthRestartWaitResult.cancelled);
+  void cancel() => _resolve(result: OAuthRestartWaitResult.cancelled);
   void _listenForResume() {
     if (!DateTime.now().isBefore(deadline)) {
-      _resolve(OAuthRestartWaitResult.deadline);
+      _resolve(result: OAuthRestartWaitResult.deadline);
       return;
     }
     if (lifecycle.value == LifecycleState.resumed) {
-      _resolve(OAuthRestartWaitResult.ready);
+      _resolve(result: OAuthRestartWaitResult.ready);
       return;
     }
-    _subscription = lifecycle.listen(_onLifecycleState, onError: _onLifecycleError, onDone: _onLifecycleDone);
-    if (lifecycle.value == LifecycleState.resumed) _resolve(OAuthRestartWaitResult.ready);
+    _subscription = lifecycle.listen(
+      (state) => _onLifecycleState(state: state),
+      onError: (Object error, StackTrace stackTrace) => _onLifecycleError(error: error, stackTrace: stackTrace),
+      onDone: _onLifecycleDone,
+    );
+    if (lifecycle.value == LifecycleState.resumed) _resolve(result: OAuthRestartWaitResult.ready);
   }
 
-  void _onLifecycleState(LifecycleState state) {
-    if (state == LifecycleState.resumed) scheduleMicrotask(() => _resolve(OAuthRestartWaitResult.ready));
+  void _onLifecycleState({required LifecycleState state}) {
+    if (state == LifecycleState.resumed) {
+      scheduleMicrotask(() => _resolve(result: OAuthRestartWaitResult.ready));
+    }
   }
 
-  // ignore: no_slop_linter/prefer_required_named_parameters, Stream.listen callback signature
-  void _onLifecycleError(Object error, StackTrace stackTrace) =>
+  void _onLifecycleError({required Object error, required StackTrace stackTrace}) =>
       scheduleMicrotask(() => _fail(error: error, stackTrace: stackTrace));
   void _onLifecycleDone() => scheduleMicrotask(
     () => _fail(error: const _UnexpectedOAuthRestartLifecycleDone(), stackTrace: StackTrace.current),
   );
-  void _resolve(OAuthRestartWaitResult result) => unawaited(_finish(result: result, operationFailure: null));
+  void _resolve({required OAuthRestartWaitResult result}) => unawaited(_finish(result: result, operationFailure: null));
   void _fail({required Object error, required StackTrace stackTrace}) =>
       unawaited(_finish(result: null, operationFailure: AsyncError(error, stackTrace)));
   Future<void> _finish({
@@ -319,6 +324,7 @@ class LoginCubit extends Cubit<LoginState> {
       try {
         initResponse = await _oAuthFlowProvider.startOAuthFlow(provider: provider, deadline: null);
       } on OAuthSessionRestartRequiredException catch (error, stackTrace) {
+        if (!_ownsAttempt(attempt: attempt)) return false;
         _pollingAttempt = attempt;
         try {
           final restarted = await _restartOAuthFlow(
@@ -549,6 +555,7 @@ class LoginCubit extends Cubit<LoginState> {
       return false;
     }
 
+    if (!_ownsAttempt(attempt: attempt)) return false;
     _didActivePollEnterBackground = _isInBackground;
     emit(const LoginState.polling());
     logd("Opening ${provider.label} auth URL in browser after OAuth session restart");

--- a/client/module_core/lib/src/cubits/login/login_cubit.dart
+++ b/client/module_core/lib/src/cubits/login/login_cubit.dart
@@ -2,8 +2,6 @@ import "dart:async";
 
 import "package:bloc/bloc.dart";
 import "package:http/http.dart" show ClientException;
-import "package:meta/meta.dart";
-import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
@@ -22,114 +20,83 @@ final class _LoginAttempt {
   _LoginAnalyticsOutcome analyticsOutcome = _LoginAnalyticsOutcome.open;
   bool oAuthRestartUsed = false;
   DateTime? oAuthDeadline;
-  OAuthRestartWait? _wait;
-  bool _cancelled = false;
+  _OAuthRestartWait? _wait;
   _LoginAttempt({required this.provider});
-  void cancel() {
-    if (_cancelled) return;
-    _cancelled = true;
-    _wait?.cancel();
-    _wait = null;
-  }
+
+  void cancel() => _wait?.cancel();
 }
 
-final class _UnexpectedOAuthRestartLifecycleDone implements Exception {
-  const _UnexpectedOAuthRestartLifecycleDone();
-  @override
-  String toString() => "OAuth restart lifecycle stream closed unexpectedly";
-}
-
-enum OAuthRestartWaitResult { ready, cancelled, deadline }
-
-@visibleForTesting
-final class OAuthRestartWaitCombinedFailure implements Exception {
-  final AsyncError operationFailure;
-  final AsyncError cleanupFailure;
-  const OAuthRestartWaitCombinedFailure({required this.operationFailure, required this.cleanupFailure});
-}
-
-@visibleForTesting
-final class OAuthRestartWait {
-  final ValueStream<LifecycleState> lifecycle;
+final class _OAuthRestartWait {
+  final LifecycleSource lifecycleSource;
   final Duration delay;
   final DateTime deadline;
-  final Completer<OAuthRestartWaitResult> _completion = Completer();
-  Timer? _deadlineTimer;
-  Timer? _delayTimer;
-  // ignore: cancel_subscriptions, _finish always cancels the owned subscription
-  StreamSubscription<LifecycleState>? _subscription;
-  bool _finishing = false;
-  OAuthRestartWait({required this.lifecycle, required this.delay, required this.deadline});
-  Future<OAuthRestartWaitResult> run() {
-    if (_finishing) return _completion.future;
+  final Completer<bool> _completion = Completer();
+
+  _OAuthRestartWait({required this.lifecycleSource, required this.delay, required this.deadline});
+
+  Future<bool> run() async {
+    if (_completion.isCompleted) return _completion.future;
     final remaining = deadline.difference(DateTime.now());
-    if (remaining > Duration.zero) {
-      _deadlineTimer = Timer(remaining, () => _resolve(result: OAuthRestartWaitResult.deadline));
-      _delayTimer = delay > Duration.zero ? Timer(delay, _listenForResume) : null;
-      if (_delayTimer == null) _listenForResume();
-    } else {
-      _resolve(result: OAuthRestartWaitResult.deadline);
+    if (remaining <= Duration.zero) {
+      throw TimeoutException("OAuth authorization timed out");
     }
-    return _completion.future;
-  }
-
-  void cancel() => _resolve(result: OAuthRestartWaitResult.cancelled);
-  void _listenForResume() {
-    if (!DateTime.now().isBefore(deadline)) {
-      _resolve(result: OAuthRestartWaitResult.deadline);
-      return;
-    }
-    if (lifecycle.value == LifecycleState.resumed) {
-      _resolve(result: OAuthRestartWaitResult.ready);
-      return;
-    }
-    _subscription = lifecycle.listen(
-      (state) => _onLifecycleState(state: state),
-      onError: (Object error, StackTrace stackTrace) => _onLifecycleError(error: error, stackTrace: stackTrace),
-      onDone: _onLifecycleDone,
+    final deadlineTimer = Timer(
+      remaining,
+      () => _completeError(
+        error: TimeoutException("OAuth authorization timed out"),
+        stackTrace: StackTrace.current,
+      ),
     );
-    if (lifecycle.value == LifecycleState.resumed) _resolve(result: OAuthRestartWaitResult.ready);
-  }
+    Timer? delayTimer;
+    StreamSubscription<LifecycleState>? subscription;
 
-  void _onLifecycleState({required LifecycleState state}) {
-    if (state == LifecycleState.resumed) {
-      scheduleMicrotask(() => _resolve(result: OAuthRestartWaitResult.ready));
-    }
-  }
-
-  void _onLifecycleError({required Object error, required StackTrace stackTrace}) =>
-      scheduleMicrotask(() => _fail(error: error, stackTrace: stackTrace));
-  void _onLifecycleDone() => scheduleMicrotask(
-    () => _fail(error: const _UnexpectedOAuthRestartLifecycleDone(), stackTrace: StackTrace.current),
-  );
-  void _resolve({required OAuthRestartWaitResult result}) => unawaited(_finish(result: result, operationFailure: null));
-  void _fail({required Object error, required StackTrace stackTrace}) =>
-      unawaited(_finish(result: null, operationFailure: AsyncError(error, stackTrace)));
-  Future<void> _finish({
-    required OAuthRestartWaitResult? result,
-    required AsyncError? operationFailure,
-  }) async {
-    if (_finishing) return;
-    _finishing = true;
-    _deadlineTimer?.cancel();
-    _delayTimer?.cancel();
-    final subscription = _subscription;
-    _subscription = null;
-    AsyncError? cleanupFailure;
     try {
+      if (delay > Duration.zero) {
+        final delayCompleted = Completer<void>();
+        delayTimer = Timer(delay, delayCompleted.complete);
+        await Future.any<void>([
+          delayCompleted.future,
+          _completion.future.then<void>((_) {}),
+        ]);
+        if (_completion.isCompleted) return _completion.future;
+      }
+
+      if (lifecycleSource.lifecycleState == LifecycleState.resumed) {
+        _complete(result: true);
+      } else {
+        subscription = lifecycleSource.lifecycleStateStream.listen(
+          (state) {
+            if (state == LifecycleState.resumed) _complete(result: true);
+          },
+          onError: (Object error, StackTrace stackTrace) => _completeError(error: error, stackTrace: stackTrace),
+          onDone: () => _completeError(
+            error: StateError("OAuth restart lifecycle stream closed unexpectedly"),
+            stackTrace: StackTrace.current,
+          ),
+        );
+        if (lifecycleSource.lifecycleState == LifecycleState.resumed) {
+          _complete(result: true);
+        }
+      }
+      return await _completion.future;
+    } finally {
+      deadlineTimer.cancel();
+      delayTimer?.cancel();
       await subscription?.cancel();
-    } on Object catch (error, stackTrace) {
-      cleanupFailure = AsyncError(error, stackTrace);
     }
-    if (operationFailure != null) {
-      final error = cleanupFailure == null
-          ? operationFailure.error
-          : OAuthRestartWaitCombinedFailure(operationFailure: operationFailure, cleanupFailure: cleanupFailure);
-      _completion.completeError(error, operationFailure.stackTrace);
-    } else if (cleanupFailure != null) {
-      _completion.completeError(cleanupFailure.error, cleanupFailure.stackTrace);
-    } else if (result != null) {
+  }
+
+  void cancel() => _complete(result: false);
+
+  void _complete({required bool result}) {
+    if (!_completion.isCompleted) {
       _completion.complete(result);
+    }
+  }
+
+  void _completeError({required Object error, required StackTrace stackTrace}) {
+    if (!_completion.isCompleted) {
+      _completion.completeError(error, stackTrace);
     }
   }
 }
@@ -141,6 +108,7 @@ final class AppleLoginAttempt {
 }
 
 class LoginCubit extends Cubit<LoginState> {
+  static const _oAuthTimeout = Duration(minutes: 5);
   final OAuthFlowProvider _oAuthFlowProvider;
   final UrlLauncher _urlLauncher;
   final AuthSession _authSession;
@@ -235,20 +203,10 @@ class LoginCubit extends Cubit<LoginState> {
       }
       if (isClosed) return;
 
-      _didActivePollEnterBackground = _isInBackground;
-      _pollingAttempt = attempt;
       emit(const LoginState.polling());
       try {
-        try {
-          await _oAuthFlowProvider.resumeOAuthFlow();
-        } on OAuthSessionRestartRequiredException catch (error, stackTrace) {
-          final restarted = await _restartOAuthFlow(
-            attempt: attempt,
-            exception: error,
-            stackTrace: stackTrace,
-          );
-          if (!restarted) return;
-        }
+        final completed = await _runOAuthFlow(attempt: attempt, resumeExisting: true);
+        if (!completed) return;
         if (!_ownsAttempt(attempt: attempt)) return;
         _reportCompletedAttempt(attempt: attempt);
         emit(const LoginState.success());
@@ -263,10 +221,6 @@ class LoginCubit extends Cubit<LoginState> {
         if (!_ownsAttempt(attempt: attempt)) return;
         _reportFailedAttempt(attempt: attempt, cause: LoginAttemptFailureCause.unknown);
         emit(const LoginState.failed(reason: LoginFailedReason.unknown));
-      } finally {
-        if (identical(_pollingAttempt, attempt)) {
-          _pollingAttempt = null;
-        }
       }
     }
   }
@@ -320,70 +274,8 @@ class LoginCubit extends Cubit<LoginState> {
     emit(const LoginState.authenticating());
 
     try {
-      final AuthInitResponse initResponse;
-      try {
-        initResponse = await _oAuthFlowProvider.startOAuthFlow(provider: provider, deadline: null);
-      } on OAuthSessionRestartRequiredException catch (error, stackTrace) {
-        if (!_ownsAttempt(attempt: attempt)) return false;
-        _pollingAttempt = attempt;
-        try {
-          final restarted = await _restartOAuthFlow(
-            attempt: attempt,
-            exception: error,
-            stackTrace: stackTrace,
-          );
-          if (!restarted) return false;
-        } finally {
-          if (identical(_pollingAttempt, attempt)) {
-            _pollingAttempt = null;
-          }
-        }
-        if (!_ownsAttempt(attempt: attempt)) return false;
-        _reportCompletedAttempt(attempt: attempt);
-        emit(const LoginState.success());
-        return true;
-      }
-      if (!_ownsAttempt(attempt: attempt)) return false;
-
-      // Show the resumable polling UI and ARM the poll guard BEFORE launching
-      // the browser. Opening the browser can suspend the app before launch()
-      // returns; with the polling guard already set, a resume during that window is a
-      // no-op (it won't start a second concurrent poll) — the pollForResult()
-      // below owns the session. The finally resets the guard on every exit path
-      // (launch failure, success, or a thrown poll error), so the outer catch's
-      // _handlePollInterruption still sees the guard released.
-      emit(const LoginState.polling());
-      _didActivePollEnterBackground = _isInBackground;
-      _pollingAttempt = attempt;
-      try {
-        logd("Opening ${provider.label} auth URL in browser");
-
-        final launched = await _urlLauncher.launch(Uri.parse(initResponse.authUrl));
-        if (!_ownsAttempt(attempt: attempt)) return false;
-
-        if (!launched) {
-          _reportFailedAttempt(attempt: attempt, cause: LoginAttemptFailureCause.launch);
-          emit(const LoginState.failed(reason: LoginFailedReason.browserOpenFailed));
-          return false;
-        }
-
-        try {
-          await _oAuthFlowProvider.pollForResult();
-        } on OAuthSessionRestartRequiredException catch (error, stackTrace) {
-          final restarted = await _restartOAuthFlow(
-            attempt: attempt,
-            exception: error,
-            stackTrace: stackTrace,
-          );
-          if (!restarted) return false;
-        }
-      } finally {
-        if (identical(_pollingAttempt, attempt)) {
-          _pollingAttempt = null;
-        }
-      }
-
-      if (!_ownsAttempt(attempt: attempt)) return false;
+      final completed = await _runOAuthFlow(attempt: attempt, resumeExisting: false);
+      if (!completed || !_ownsAttempt(attempt: attempt)) return false;
       _reportCompletedAttempt(attempt: attempt);
       emit(const LoginState.success());
       return true;
@@ -518,77 +410,89 @@ class LoginCubit extends Cubit<LoginState> {
     return attempt;
   }
 
-  Future<bool> _restartOAuthFlow({
-    required _LoginAttempt attempt,
-    required OAuthSessionRestartRequiredException exception,
-    required StackTrace stackTrace,
-  }) async {
+  Future<bool> _runOAuthFlow({required _LoginAttempt attempt, required bool resumeExisting}) async {
     final provider = switch (attempt.provider) {
       final OAuthProvider provider => provider,
       EmailAuthProvider() => throw StateError("OAuth session restart requires an OAuth provider"),
     };
-    if (attempt.oAuthRestartUsed) {
-      _throwIfOAuthDeadlineReached(attempt: attempt);
-      Error.throwWithStackTrace(exception, stackTrace);
-    }
-    attempt.oAuthRestartUsed = true;
-    attempt.oAuthDeadline = exception.deadline;
-    final deadline = exception.deadline;
-
-    if (!await _waitUntilOAuthRestartReady(
-      attempt: attempt,
-      delay: exception.restartAfter,
-      deadline: deadline,
-    )) {
-      return false;
-    }
-
-    final initResponse = await _beforeOAuthDeadline(
-      deadline: deadline,
-      operation: () => _oAuthFlowProvider.startOAuthFlow(
-        provider: provider,
-        deadline: deadline,
-      ),
-    );
-    if (!_ownsAttempt(attempt: attempt)) return false;
-    if (!await _waitUntilOAuthRestartReady(attempt: attempt, delay: Duration.zero, deadline: deadline)) {
-      return false;
-    }
-
-    if (!_ownsAttempt(attempt: attempt)) return false;
+    var resume = resumeExisting;
+    _pollingAttempt = attempt;
     _didActivePollEnterBackground = _isInBackground;
-    emit(const LoginState.polling());
-    logd("Opening ${provider.label} auth URL in browser after OAuth session restart");
-    final launched = await _beforeOAuthDeadline(
-      deadline: deadline,
-      operation: () => _urlLauncher.launch(Uri.parse(initResponse.authUrl)),
-    );
-    if (!_ownsAttempt(attempt: attempt)) return false;
-    _throwIfOAuthDeadlineReached(attempt: attempt);
-    if (!launched) {
-      _reportFailedAttempt(attempt: attempt, cause: LoginAttemptFailureCause.launch);
-      emit(const LoginState.failed(reason: LoginFailedReason.browserOpenFailed));
+    try {
+      while (_ownsAttempt(attempt: attempt)) {
+        try {
+          if (resume) {
+            resume = false;
+            await _oAuthFlowProvider.resumeOAuthFlow();
+          } else {
+            final flowDeadline = attempt.oAuthDeadline ?? DateTime.now().add(_oAuthTimeout);
+            attempt.oAuthDeadline = flowDeadline;
+            final initResponse = await _oAuthFlowProvider.startOAuthFlow(
+              provider: provider,
+              deadline: attempt.oAuthRestartUsed ? flowDeadline : null,
+            );
+            if (!_ownsAttempt(attempt: attempt)) return false;
+            final serverDeadline = DateTime.now().add(Duration(seconds: initResponse.expiresIn));
+            final deadline = flowDeadline.isBefore(serverDeadline) ? flowDeadline : serverDeadline;
+            attempt.oAuthDeadline = deadline;
+            emit(const LoginState.polling());
+            if (!await _waitUntilOAuthReady(
+              attempt: attempt,
+              delay: Duration.zero,
+              deadline: deadline,
+            )) {
+              return false;
+            }
+            if (!_ownsAttempt(attempt: attempt)) return false;
+
+            _throwIfOAuthDeadlineReached(attempt: attempt);
+            _didActivePollEnterBackground = _isInBackground;
+            logd("Opening ${provider.label} auth URL in browser");
+            final launchBudget = deadline.difference(DateTime.now());
+            if (launchBudget <= Duration.zero) {
+              throw TimeoutException("OAuth authorization timed out");
+            }
+            final launched = await _urlLauncher
+                .launch(Uri.parse(initResponse.authUrl))
+                .timeout(
+                  launchBudget,
+                  onTimeout: () => throw TimeoutException("OAuth authorization timed out"),
+                );
+            if (!_ownsAttempt(attempt: attempt)) return false;
+            _throwIfOAuthDeadlineReached(attempt: attempt);
+            if (!launched) {
+              _reportFailedAttempt(attempt: attempt, cause: LoginAttemptFailureCause.launch);
+              emit(const LoginState.failed(reason: LoginFailedReason.browserOpenFailed));
+              return false;
+            }
+
+            await _oAuthFlowProvider.pollForResult();
+          }
+          return _ownsAttempt(attempt: attempt);
+        } on OAuthSessionRestartRequiredException catch (error, stackTrace) {
+          if (!_ownsAttempt(attempt: attempt)) return false;
+          if (attempt.oAuthRestartUsed) {
+            _throwIfOAuthDeadlineReached(attempt: attempt);
+            Error.throwWithStackTrace(error, stackTrace);
+          }
+          attempt.oAuthRestartUsed = true;
+          attempt.oAuthDeadline = error.deadline;
+          if (!await _waitUntilOAuthReady(
+            attempt: attempt,
+            delay: error.restartAfter,
+            deadline: error.deadline,
+          )) {
+            return false;
+          }
+          resume = false;
+        }
+      }
       return false;
+    } finally {
+      if (identical(_pollingAttempt, attempt)) {
+        _pollingAttempt = null;
+      }
     }
-
-    await _oAuthFlowProvider.pollForResult();
-    if (!_ownsAttempt(attempt: attempt)) return false;
-    return true;
-  }
-
-  Future<T> _beforeOAuthDeadline<T>({
-    required DateTime deadline,
-    required Future<T> Function() operation,
-  }) {
-    final remaining = deadline.difference(DateTime.now());
-    if (remaining <= Duration.zero) {
-      return Future<T>.error(TimeoutException("OAuth authorization timed out"));
-    }
-
-    return operation().timeout(
-      remaining,
-      onTimeout: () => throw TimeoutException("OAuth authorization timed out"),
-    );
   }
 
   void _throwIfOAuthDeadlineReached({required _LoginAttempt attempt}) {
@@ -598,25 +502,23 @@ class LoginCubit extends Cubit<LoginState> {
     }
   }
 
-  Future<bool> _waitUntilOAuthRestartReady({
+  Future<bool> _waitUntilOAuthReady({
     required _LoginAttempt attempt,
     required Duration delay,
     required DateTime deadline,
   }) async {
     var currentDelay = delay;
     while (true) {
-      final wait = OAuthRestartWait(
-        lifecycle: _lifecycleSource.lifecycleStateStream,
+      final wait = _OAuthRestartWait(
+        lifecycleSource: _lifecycleSource,
         delay: currentDelay,
         deadline: deadline,
       );
       attempt._wait = wait;
-      if (attempt._cancelled) wait.cancel();
-      final result = await wait.run().whenComplete(() {
+      final ready = await wait.run().whenComplete(() {
         if (identical(attempt._wait, wait)) attempt._wait = null;
       });
-      if (!_ownsAttempt(attempt: attempt) || result == OAuthRestartWaitResult.cancelled) return false;
-      if (result == OAuthRestartWaitResult.deadline) throw TimeoutException("OAuth authorization timed out");
+      if (!_ownsAttempt(attempt: attempt) || !ready) return false;
       _throwIfOAuthDeadlineReached(attempt: attempt);
       if (_lifecycleSource.lifecycleState == LifecycleState.resumed) return true;
       currentDelay = Duration.zero;

--- a/client/module_core/test/cubits/login/login_cubit_test.dart
+++ b/client/module_core/test/cubits/login/login_cubit_test.dart
@@ -27,32 +27,12 @@ class MockLifecycleSource extends Mock implements LifecycleSource {}
 
 class MockInstallationAnalyticsService extends Mock implements InstallationAnalyticsService {}
 
-final class _TestValueStream<T> extends StreamView<T> implements ValueStream<T> {
-  final T Function() _read;
-  _TestValueStream({required Stream<T> stream, required T Function() read}) : _read = read, super(stream);
-  @override
-  T get value => _read();
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
-Future<({Object error, StackTrace stackTrace})> _captureError({required Future<Object?> future}) async {
-  try {
-    await future;
-  } catch (error, stackTrace) {
-    return (error: error, stackTrace: stackTrace);
-  }
-  fail("Expected the future to fail");
-}
-
 OAuthSessionRestartRequiredException _restartRequired({
   required DateTime deadline,
   Duration restartAfter = Duration.zero,
 }) => OAuthSessionRestartRequiredException(
   restartAfter: restartAfter,
   deadline: deadline,
-  operation: OAuthSessionRestartOperation.status,
-  reason: OAuthSessionRestartReason.serviceUnavailable,
 );
 
 const testAuthInitResponse = AuthInitResponse(
@@ -67,8 +47,6 @@ const testAuthUser = AuthUser(
   providerUserId: "user123",
   providerUsername: null,
 );
-
-enum _WaitFailure { race, operation, combined, cancel, done }
 
 void main() {
   setUpAll(() {
@@ -430,117 +408,6 @@ void main() {
           await cubit.close();
         });
 
-        for (final hangingOperation in ["init", "browser"]) {
-          test("a hanging restart $hangingOperation stops at the original deadline", () {
-            fakeAsync((async) {
-              final deadline = DateTime.now().add(const Duration(seconds: 5));
-              var launches = 0;
-              when(
-                () => mockOAuthFlowProvider.startOAuthFlow(
-                  provider: AuthProvider.google,
-                  deadline: any<DateTime?>(named: "deadline"),
-                ),
-              ).thenAnswer((invocation) {
-                if (invocation.namedArguments[#deadline] == null) {
-                  return Future.value(testAuthInitResponse);
-                }
-                return hangingOperation == "init"
-                    ? Completer<AuthInitResponse>().future
-                    : Future.value(testAuthInitResponse);
-              });
-              when(() => mockUrlLauncher.launch(any())).thenAnswer((_) {
-                launches += 1;
-                return hangingOperation == "browser" && launches == 2 ? Completer<bool>().future : Future.value(true);
-              });
-              when(() => mockOAuthFlowProvider.pollForResult()).thenThrow(
-                _restartRequired(deadline: deadline),
-              );
-              final cubit = buildCubit();
-              bool? result;
-              unawaited(cubit.loginWithProvider(AuthProvider.google).then((value) => result = value));
-              async.flushMicrotasks();
-              async.elapse(const Duration(seconds: 5));
-              async.flushMicrotasks();
-
-              expect(result, isFalse);
-              expect(cubit.state, isA<LoginTimeout>());
-              verify(
-                () => mockInstallationAnalyticsService.loginAttemptFailed(
-                  provider: AuthProvider.google,
-                  cause: LoginAttemptFailureCause.timeout,
-                ),
-              ).called(1);
-              verifyNever(
-                () => mockInstallationAnalyticsService.loginAttemptCompleted(
-                  provider: any(named: "provider"),
-                ),
-              );
-              unawaited(cubit.close());
-              async.flushMicrotasks();
-              expect(async.nonPeriodicTimerCount, 0);
-            });
-          });
-        }
-
-        test("restart wait preserves lifecycle and cleanup failures", () async {
-          final operationError = StateError("operation");
-          final operationStack = StackTrace.fromString("operation-stack");
-          final cleanupError = StateError("cleanup");
-          final cleanupStack = StackTrace.fromString("cleanup-stack");
-          for (final mode in _WaitFailure.values) {
-            var state = LifecycleState.paused;
-            final cleanupFails = mode == _WaitFailure.combined || mode == _WaitFailure.cancel;
-            final controller = StreamController<LifecycleState>(
-              sync: true,
-              onListen: mode == _WaitFailure.race ? () => state = LifecycleState.resumed : null,
-              onCancel: cleanupFails ? () => Future<void>.error(cleanupError, cleanupStack) : null,
-            );
-            final waitFuture = OAuthRestartWait(
-              lifecycle: _TestValueStream(stream: controller.stream, read: () => state),
-              delay: Duration.zero,
-              deadline: DateTime.now().add(const Duration(minutes: 1)),
-            ).run();
-            if (mode == _WaitFailure.race) {
-              expect(await waitFuture, OAuthRestartWaitResult.ready);
-              expect(controller.hasListener, isFalse);
-              await controller.close();
-              continue;
-            }
-            final capturedFuture = _captureError(future: waitFuture);
-            switch (mode) {
-              case _WaitFailure.race:
-              case _WaitFailure.operation:
-              case _WaitFailure.combined:
-                controller.addError(operationError, operationStack);
-              case _WaitFailure.cancel:
-                state = LifecycleState.resumed;
-                controller.add(state);
-              case _WaitFailure.done:
-                await controller.close();
-            }
-            final captured = await capturedFuture;
-            switch (mode) {
-              case _WaitFailure.race:
-              case _WaitFailure.operation:
-                expect(captured.error, same(operationError));
-                expect(captured.stackTrace, same(operationStack));
-              case _WaitFailure.combined:
-                final combined = captured.error as OAuthRestartWaitCombinedFailure;
-                expect(combined.operationFailure.error, same(operationError));
-                expect(combined.operationFailure.stackTrace, same(operationStack));
-                expect(combined.cleanupFailure.error, same(cleanupError));
-                expect(combined.cleanupFailure.stackTrace, same(cleanupStack));
-                expect(captured.stackTrace, same(operationStack));
-              case _WaitFailure.cancel:
-                expect(captured.error, same(cleanupError));
-                expect(captured.stackTrace, same(cleanupStack));
-              case _WaitFailure.done:
-                expect(captured.error.toString(), "OAuth restart lifecycle stream closed unexpectedly");
-            }
-            if (!controller.isClosed) await controller.close();
-          }
-        });
-
         test("restarts once and waits for foreground before init and launch", () async {
           final lifecycle = BehaviorSubject<LifecycleState>.seeded(LifecycleState.resumed);
           final deadline = DateTime.now().add(const Duration(minutes: 1));
@@ -668,56 +535,6 @@ void main() {
           await lifecycle.close();
         });
 
-        test("a stale initial-init restart cannot clear or concurrently resume replacement polling", () async {
-          final lifecycle = BehaviorSubject<LifecycleState>.seeded(LifecycleState.resumed);
-          final deadline = DateTime.now().add(const Duration(minutes: 1));
-          final staleInit = Completer<AuthInitResponse>();
-          final replacementPollStarted = Completer<void>();
-          final replacementPoll = Completer<AuthUser>();
-          var starts = 0;
-          when(() => mockLifecycleSource.lifecycleStateStream).thenAnswer((_) => lifecycle.stream);
-          when(
-            () => mockOAuthFlowProvider.startOAuthFlow(
-              provider: AuthProvider.google,
-              deadline: any<DateTime?>(named: "deadline"),
-            ),
-          ).thenAnswer((_) {
-            if (starts++ == 0) {
-              return staleInit.future;
-            }
-            return Future.value(testAuthInitResponse);
-          });
-          when(() => mockOAuthFlowProvider.hasActiveOAuthSession()).thenAnswer((_) async => true);
-          when(() => mockOAuthFlowProvider.pollForResult()).thenAnswer((_) {
-            replacementPollStarted.complete();
-            return replacementPoll.future;
-          });
-          final cubit = buildCubit();
-
-          final staleLogin = cubit.loginWithProvider(AuthProvider.google);
-          final replacementLogin = cubit.loginWithProvider(AuthProvider.google);
-          await replacementPollStarted.future;
-
-          staleInit.completeError(
-            _restartRequired(deadline: deadline),
-          );
-          expect(await staleLogin, isFalse);
-
-          lifecycle
-            ..add(LifecycleState.paused)
-            ..add(LifecycleState.resumed);
-          await Future<void>.delayed(Duration.zero);
-          await Future<void>.delayed(Duration.zero);
-
-          verifyNever(mockOAuthFlowProvider.hasActiveOAuthSession);
-          verifyNever(mockOAuthFlowProvider.resumeOAuthFlow);
-
-          replacementPoll.complete(testAuthUser);
-          expect(await replacementLogin, isTrue);
-          await cubit.close();
-          await lifecycle.close();
-        });
-
         for (final secondRestart in [false, true]) {
           test("${secondRestart ? "second restart" : "deadline"} is one terminal failure", () {
             fakeAsync((async) {
@@ -810,32 +627,13 @@ void main() {
           verify(() => mockOAuthFlowProvider.resumeOAuthFlow()).called(1);
         });
 
-        test("parks poll abort when app was already backgrounded before polling starts", () async {
-          final lifecycleSubject = BehaviorSubject<LifecycleState>.seeded(LifecycleState.paused);
-          when(() => mockLifecycleSource.lifecycleStateStream).thenAnswer((_) => lifecycleSubject.stream);
-          when(() => mockOAuthFlowProvider.pollForResult()).thenThrow(
-            ClientException("Software caused connection abort"),
-          );
-
-          final cubit = buildCubit();
-          final states = <LoginState>[];
-          final sub = cubit.stream.listen(states.add);
-
-          await cubit.loginWithProvider(AuthProvider.google);
-
-          await cubit.close();
-          await sub.cancel();
-          await lifecycleSubject.close();
-
-          expect(cubit.state, isA<LoginPolling>());
-          expect(states, contains(isA<LoginPolling>()));
-          expect(states, isNot(contains(isA<LoginFailed>())));
-        });
-
         test("background poll timeout emits LoginTimeout instead of parking", () async {
-          final lifecycleSubject = BehaviorSubject<LifecycleState>.seeded(LifecycleState.paused);
+          final lifecycleSubject = BehaviorSubject<LifecycleState>.seeded(LifecycleState.resumed);
           when(() => mockLifecycleSource.lifecycleStateStream).thenAnswer((_) => lifecycleSubject.stream);
-          when(() => mockOAuthFlowProvider.pollForResult()).thenThrow(TimeoutException("poll timeout"));
+          when(() => mockOAuthFlowProvider.pollForResult()).thenAnswer((_) async {
+            lifecycleSubject.add(LifecycleState.paused);
+            throw TimeoutException("poll timeout");
+          });
 
           final cubit = buildCubit();
           final states = <LoginState>[];
@@ -999,10 +797,13 @@ void main() {
 
     group("Lifecycle resume", () {
       test("resumes polling when app resumes and active OAuth session exists", () async {
-        final lifecycleSubject = BehaviorSubject<LifecycleState>.seeded(LifecycleState.paused);
+        final lifecycleSubject = BehaviorSubject<LifecycleState>.seeded(LifecycleState.resumed);
         when(() => mockLifecycleSource.lifecycleStateStream).thenAnswer((_) => lifecycleSubject.stream);
         when(() => mockOAuthFlowProvider.hasActiveOAuthSession()).thenAnswer((_) async => true);
-        when(() => mockOAuthFlowProvider.pollForResult()).thenThrow(TimeoutException("poll timeout"));
+        when(() => mockOAuthFlowProvider.pollForResult()).thenAnswer((_) async {
+          lifecycleSubject.add(LifecycleState.paused);
+          throw TimeoutException("poll timeout");
+        });
 
         final cubit = buildCubit();
         await cubit.loginWithProvider(AuthProvider.google);
@@ -1024,10 +825,13 @@ void main() {
       });
 
       test("does not resume polling when app resumes but no active session", () async {
-        final lifecycleSubject = BehaviorSubject<LifecycleState>.seeded(LifecycleState.paused);
+        final lifecycleSubject = BehaviorSubject<LifecycleState>.seeded(LifecycleState.resumed);
         when(() => mockLifecycleSource.lifecycleStateStream).thenAnswer((_) => lifecycleSubject.stream);
         when(() => mockOAuthFlowProvider.hasActiveOAuthSession()).thenAnswer((_) async => false);
-        when(() => mockOAuthFlowProvider.pollForResult()).thenThrow(TimeoutException("poll timeout"));
+        when(() => mockOAuthFlowProvider.pollForResult()).thenAnswer((_) async {
+          lifecycleSubject.add(LifecycleState.paused);
+          throw TimeoutException("poll timeout");
+        });
 
         final cubit = buildCubit();
         await cubit.loginWithProvider(AuthProvider.google);

--- a/client/module_core/test/cubits/login/login_cubit_test.dart
+++ b/client/module_core/test/cubits/login/login_cubit_test.dart
@@ -29,14 +29,14 @@ class MockInstallationAnalyticsService extends Mock implements InstallationAnaly
 
 final class _TestValueStream<T> extends StreamView<T> implements ValueStream<T> {
   final T Function() _read;
-  _TestValueStream(super.stream, this._read);
+  _TestValueStream({required Stream<T> stream, required T Function() read}) : _read = read, super(stream);
   @override
   T get value => _read();
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-Future<({Object error, StackTrace stackTrace})> _captureError(Future<Object?> future) async {
+Future<({Object error, StackTrace stackTrace})> _captureError({required Future<Object?> future}) async {
   try {
     await future;
   } catch (error, stackTrace) {
@@ -44,6 +44,16 @@ Future<({Object error, StackTrace stackTrace})> _captureError(Future<Object?> fu
   }
   fail("Expected the future to fail");
 }
+
+OAuthSessionRestartRequiredException _restartRequired({
+  required DateTime deadline,
+  Duration restartAfter = Duration.zero,
+}) => OAuthSessionRestartRequiredException(
+  restartAfter: restartAfter,
+  deadline: deadline,
+  operation: OAuthSessionRestartOperation.status,
+  reason: OAuthSessionRestartReason.serviceUnavailable,
+);
 
 const testAuthInitResponse = AuthInitResponse(
   authUrl: "https://accounts.google.com/o/oauth2/auth",
@@ -401,7 +411,7 @@ void main() {
             ),
           ).thenAnswer((invocation) async {
             if (starts++ == 0) {
-              throw OAuthSessionRestartRequiredException(restartAfter: Duration.zero, deadline: deadline);
+              throw _restartRequired(deadline: deadline);
             }
             expect(invocation.namedArguments[#deadline], deadline);
             return testAuthInitResponse;
@@ -443,7 +453,7 @@ void main() {
                 return hangingOperation == "browser" && launches == 2 ? Completer<bool>().future : Future.value(true);
               });
               when(() => mockOAuthFlowProvider.pollForResult()).thenThrow(
-                OAuthSessionRestartRequiredException(restartAfter: Duration.zero, deadline: deadline),
+                _restartRequired(deadline: deadline),
               );
               final cubit = buildCubit();
               bool? result;
@@ -486,7 +496,7 @@ void main() {
               onCancel: cleanupFails ? () => Future<void>.error(cleanupError, cleanupStack) : null,
             );
             final waitFuture = OAuthRestartWait(
-              lifecycle: _TestValueStream(controller.stream, () => state),
+              lifecycle: _TestValueStream(stream: controller.stream, read: () => state),
               delay: Duration.zero,
               deadline: DateTime.now().add(const Duration(minutes: 1)),
             ).run();
@@ -496,7 +506,7 @@ void main() {
               await controller.close();
               continue;
             }
-            final capturedFuture = _captureError(waitFuture);
+            final capturedFuture = _captureError(future: waitFuture);
             switch (mode) {
               case _WaitFailure.race:
               case _WaitFailure.operation:
@@ -538,7 +548,7 @@ void main() {
           when(() => mockLifecycleSource.lifecycleStateStream).thenAnswer((_) => lifecycle.stream);
           when(() => mockOAuthFlowProvider.pollForResult()).thenAnswer((_) async {
             if (polls++ == 0) {
-              throw OAuthSessionRestartRequiredException(restartAfter: Duration.zero, deadline: deadline);
+              throw _restartRequired(deadline: deadline);
             }
             return testAuthUser;
           });
@@ -585,7 +595,7 @@ void main() {
             ).thenAnswer((_) async => (failures += 1, AnalyticsDeliveryResult.acceptedBySdk).$2);
             when(() => mockOAuthFlowProvider.pollForResult()).thenAnswer((_) async {
               lifecycle.add(LifecycleState.paused);
-              throw OAuthSessionRestartRequiredException(restartAfter: Duration.zero, deadline: deadline);
+              throw _restartRequired(deadline: deadline);
             });
             final cubit = buildCubit();
             final login = cubit.loginWithProvider(AuthProvider.google);
@@ -624,7 +634,7 @@ void main() {
           });
           when(() => mockOAuthFlowProvider.pollForResult()).thenAnswer((_) async {
             if (polls++ == 0) {
-              throw OAuthSessionRestartRequiredException(restartAfter: Duration.zero, deadline: deadline);
+              throw _restartRequired(deadline: deadline);
             }
             return testAuthUser;
           });
@@ -658,12 +668,62 @@ void main() {
           await lifecycle.close();
         });
 
+        test("a stale initial-init restart cannot clear or concurrently resume replacement polling", () async {
+          final lifecycle = BehaviorSubject<LifecycleState>.seeded(LifecycleState.resumed);
+          final deadline = DateTime.now().add(const Duration(minutes: 1));
+          final staleInit = Completer<AuthInitResponse>();
+          final replacementPollStarted = Completer<void>();
+          final replacementPoll = Completer<AuthUser>();
+          var starts = 0;
+          when(() => mockLifecycleSource.lifecycleStateStream).thenAnswer((_) => lifecycle.stream);
+          when(
+            () => mockOAuthFlowProvider.startOAuthFlow(
+              provider: AuthProvider.google,
+              deadline: any<DateTime?>(named: "deadline"),
+            ),
+          ).thenAnswer((_) {
+            if (starts++ == 0) {
+              return staleInit.future;
+            }
+            return Future.value(testAuthInitResponse);
+          });
+          when(() => mockOAuthFlowProvider.hasActiveOAuthSession()).thenAnswer((_) async => true);
+          when(() => mockOAuthFlowProvider.pollForResult()).thenAnswer((_) {
+            replacementPollStarted.complete();
+            return replacementPoll.future;
+          });
+          final cubit = buildCubit();
+
+          final staleLogin = cubit.loginWithProvider(AuthProvider.google);
+          final replacementLogin = cubit.loginWithProvider(AuthProvider.google);
+          await replacementPollStarted.future;
+
+          staleInit.completeError(
+            _restartRequired(deadline: deadline),
+          );
+          expect(await staleLogin, isFalse);
+
+          lifecycle
+            ..add(LifecycleState.paused)
+            ..add(LifecycleState.resumed);
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+
+          verifyNever(mockOAuthFlowProvider.hasActiveOAuthSession);
+          verifyNever(mockOAuthFlowProvider.resumeOAuthFlow);
+
+          replacementPoll.complete(testAuthUser);
+          expect(await replacementLogin, isTrue);
+          await cubit.close();
+          await lifecycle.close();
+        });
+
         for (final secondRestart in [false, true]) {
           test("${secondRestart ? "second restart" : "deadline"} is one terminal failure", () {
             fakeAsync((async) {
               final deadline = DateTime.now().add(const Duration(seconds: 5));
               when(() => mockOAuthFlowProvider.pollForResult()).thenThrow(
-                OAuthSessionRestartRequiredException(
+                _restartRequired(
                   restartAfter: secondRestart ? Duration.zero : const Duration(seconds: 30),
                   deadline: deadline,
                 ),
@@ -835,7 +895,7 @@ void main() {
           final deadline = DateTime.now().add(const Duration(minutes: 1));
           when(() => mockOAuthFlowProvider.hasActiveOAuthSession()).thenAnswer((_) async => true);
           when(() => mockOAuthFlowProvider.resumeOAuthFlow()).thenThrow(
-            OAuthSessionRestartRequiredException(restartAfter: Duration.zero, deadline: deadline),
+            _restartRequired(deadline: deadline),
           );
           when(() => mockOAuthFlowProvider.pollForResult()).thenAnswer((_) async => testAuthUser);
 

--- a/client/module_core/test/cubits/login/login_cubit_test.dart
+++ b/client/module_core/test/cubits/login/login_cubit_test.dart
@@ -1,10 +1,11 @@
 import "dart:async";
 
 import "package:bloc_test/bloc_test.dart";
+import "package:fake_async/fake_async.dart";
 import "package:http/http.dart";
 import "package:mocktail/mocktail.dart";
 import "package:rxdart/rxdart.dart";
-import "package:sesori_auth/sesori_auth.dart" show AuthSession, OAuthFlowProvider;
+import "package:sesori_auth/sesori_auth.dart" show AuthSession, OAuthFlowProvider, OAuthSessionRestartRequiredException;
 import "package:sesori_dart_core/src/cubits/login/login_cubit.dart";
 import "package:sesori_dart_core/src/cubits/login/login_failed_reason.dart";
 import "package:sesori_dart_core/src/cubits/login/login_state.dart";
@@ -26,6 +27,24 @@ class MockLifecycleSource extends Mock implements LifecycleSource {}
 
 class MockInstallationAnalyticsService extends Mock implements InstallationAnalyticsService {}
 
+final class _TestValueStream<T> extends StreamView<T> implements ValueStream<T> {
+  final T Function() _read;
+  _TestValueStream(super.stream, this._read);
+  @override
+  T get value => _read();
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Future<({Object error, StackTrace stackTrace})> _captureError(Future<Object?> future) async {
+  try {
+    await future;
+  } catch (error, stackTrace) {
+    return (error: error, stackTrace: stackTrace);
+  }
+  fail("Expected the future to fail");
+}
+
 const testAuthInitResponse = AuthInitResponse(
   authUrl: "https://accounts.google.com/o/oauth2/auth",
   state: "oauth-state",
@@ -39,12 +58,15 @@ const testAuthUser = AuthUser(
   providerUsername: null,
 );
 
+enum _WaitFailure { race, operation, combined, cancel, done }
+
 void main() {
   setUpAll(() {
     registerFallbackValue(AuthProvider.google);
     registerFallbackValue(LoginAttemptFailureCause.unknown);
     registerFallbackValue(Uri.parse(redirectUri));
     registerFallbackValue(testAuthUser);
+    registerFallbackValue(DateTime.utc(2000));
   });
 
   group("LoginCubit", () {
@@ -62,7 +84,10 @@ void main() {
       mockInstallationAnalyticsService = MockInstallationAnalyticsService();
       when(() => mockUrlLauncher.launch(any())).thenAnswer((_) async => true);
       when(
-        () => mockOAuthFlowProvider.startOAuthFlow(provider: any(named: "provider")),
+        () => mockOAuthFlowProvider.startOAuthFlow(
+          provider: any(named: "provider"),
+          deadline: any<DateTime?>(named: "deadline"),
+        ),
       ).thenAnswer((_) async => testAuthInitResponse);
       when(() => mockOAuthFlowProvider.pollForResult()).thenAnswer((_) async => testAuthUser);
       when(() => mockOAuthFlowProvider.hasActiveOAuthSession()).thenAnswer((_) async => false);
@@ -285,7 +310,7 @@ void main() {
         ],
         verify: (_) {
           verify(
-            () => mockOAuthFlowProvider.startOAuthFlow(provider: AuthProvider.google),
+            () => mockOAuthFlowProvider.startOAuthFlow(provider: AuthProvider.google, deadline: null),
           ).called(1);
           verify(() => mockOAuthFlowProvider.pollForResult()).called(1);
         },
@@ -321,7 +346,10 @@ void main() {
         build: buildCubit,
         act: (cubit) async {
           when(
-            () => mockOAuthFlowProvider.startOAuthFlow(provider: any(named: "provider")),
+            () => mockOAuthFlowProvider.startOAuthFlow(
+              provider: any(named: "provider"),
+              deadline: null,
+            ),
           ).thenThrow(Exception("network error"));
           await cubit.loginWithProvider(AuthProvider.google);
         },
@@ -361,6 +389,308 @@ void main() {
           isA<LoginTimeout>(),
         ],
       );
+
+      group("process-local OAuth session restart", () {
+        test("an init 503 performs one complete restart under its supplied deadline", () async {
+          final deadline = DateTime.now().add(const Duration(minutes: 1));
+          var starts = 0;
+          when(
+            () => mockOAuthFlowProvider.startOAuthFlow(
+              provider: AuthProvider.google,
+              deadline: any<DateTime?>(named: "deadline"),
+            ),
+          ).thenAnswer((invocation) async {
+            if (starts++ == 0) {
+              throw OAuthSessionRestartRequiredException(restartAfter: Duration.zero, deadline: deadline);
+            }
+            expect(invocation.namedArguments[#deadline], deadline);
+            return testAuthInitResponse;
+          });
+          final cubit = buildCubit();
+
+          expect(await cubit.loginWithProvider(AuthProvider.google), isTrue);
+          verify(
+            () => mockOAuthFlowProvider.startOAuthFlow(
+              provider: AuthProvider.google,
+              deadline: any<DateTime?>(named: "deadline"),
+            ),
+          ).called(2);
+          verify(() => mockUrlLauncher.launch(any())).called(1);
+          verify(() => mockOAuthFlowProvider.pollForResult()).called(1);
+          await cubit.close();
+        });
+
+        for (final hangingOperation in ["init", "browser"]) {
+          test("a hanging restart $hangingOperation stops at the original deadline", () {
+            fakeAsync((async) {
+              final deadline = DateTime.now().add(const Duration(seconds: 5));
+              var launches = 0;
+              when(
+                () => mockOAuthFlowProvider.startOAuthFlow(
+                  provider: AuthProvider.google,
+                  deadline: any<DateTime?>(named: "deadline"),
+                ),
+              ).thenAnswer((invocation) {
+                if (invocation.namedArguments[#deadline] == null) {
+                  return Future.value(testAuthInitResponse);
+                }
+                return hangingOperation == "init"
+                    ? Completer<AuthInitResponse>().future
+                    : Future.value(testAuthInitResponse);
+              });
+              when(() => mockUrlLauncher.launch(any())).thenAnswer((_) {
+                launches += 1;
+                return hangingOperation == "browser" && launches == 2 ? Completer<bool>().future : Future.value(true);
+              });
+              when(() => mockOAuthFlowProvider.pollForResult()).thenThrow(
+                OAuthSessionRestartRequiredException(restartAfter: Duration.zero, deadline: deadline),
+              );
+              final cubit = buildCubit();
+              bool? result;
+              unawaited(cubit.loginWithProvider(AuthProvider.google).then((value) => result = value));
+              async.flushMicrotasks();
+              async.elapse(const Duration(seconds: 5));
+              async.flushMicrotasks();
+
+              expect(result, isFalse);
+              expect(cubit.state, isA<LoginTimeout>());
+              verify(
+                () => mockInstallationAnalyticsService.loginAttemptFailed(
+                  provider: AuthProvider.google,
+                  cause: LoginAttemptFailureCause.timeout,
+                ),
+              ).called(1);
+              verifyNever(
+                () => mockInstallationAnalyticsService.loginAttemptCompleted(
+                  provider: any(named: "provider"),
+                ),
+              );
+              unawaited(cubit.close());
+              async.flushMicrotasks();
+              expect(async.nonPeriodicTimerCount, 0);
+            });
+          });
+        }
+
+        test("restart wait preserves lifecycle and cleanup failures", () async {
+          final operationError = StateError("operation");
+          final operationStack = StackTrace.fromString("operation-stack");
+          final cleanupError = StateError("cleanup");
+          final cleanupStack = StackTrace.fromString("cleanup-stack");
+          for (final mode in _WaitFailure.values) {
+            var state = LifecycleState.paused;
+            final cleanupFails = mode == _WaitFailure.combined || mode == _WaitFailure.cancel;
+            final controller = StreamController<LifecycleState>(
+              sync: true,
+              onListen: mode == _WaitFailure.race ? () => state = LifecycleState.resumed : null,
+              onCancel: cleanupFails ? () => Future<void>.error(cleanupError, cleanupStack) : null,
+            );
+            final waitFuture = OAuthRestartWait(
+              lifecycle: _TestValueStream(controller.stream, () => state),
+              delay: Duration.zero,
+              deadline: DateTime.now().add(const Duration(minutes: 1)),
+            ).run();
+            if (mode == _WaitFailure.race) {
+              expect(await waitFuture, OAuthRestartWaitResult.ready);
+              expect(controller.hasListener, isFalse);
+              await controller.close();
+              continue;
+            }
+            final capturedFuture = _captureError(waitFuture);
+            switch (mode) {
+              case _WaitFailure.race:
+              case _WaitFailure.operation:
+              case _WaitFailure.combined:
+                controller.addError(operationError, operationStack);
+              case _WaitFailure.cancel:
+                state = LifecycleState.resumed;
+                controller.add(state);
+              case _WaitFailure.done:
+                await controller.close();
+            }
+            final captured = await capturedFuture;
+            switch (mode) {
+              case _WaitFailure.race:
+              case _WaitFailure.operation:
+                expect(captured.error, same(operationError));
+                expect(captured.stackTrace, same(operationStack));
+              case _WaitFailure.combined:
+                final combined = captured.error as OAuthRestartWaitCombinedFailure;
+                expect(combined.operationFailure.error, same(operationError));
+                expect(combined.operationFailure.stackTrace, same(operationStack));
+                expect(combined.cleanupFailure.error, same(cleanupError));
+                expect(combined.cleanupFailure.stackTrace, same(cleanupStack));
+                expect(captured.stackTrace, same(operationStack));
+              case _WaitFailure.cancel:
+                expect(captured.error, same(cleanupError));
+                expect(captured.stackTrace, same(cleanupStack));
+              case _WaitFailure.done:
+                expect(captured.error.toString(), "OAuth restart lifecycle stream closed unexpectedly");
+            }
+            if (!controller.isClosed) await controller.close();
+          }
+        });
+
+        test("restarts once and waits for foreground before init and launch", () async {
+          final lifecycle = BehaviorSubject<LifecycleState>.seeded(LifecycleState.resumed);
+          final deadline = DateTime.now().add(const Duration(minutes: 1));
+          var polls = 0;
+          when(() => mockLifecycleSource.lifecycleStateStream).thenAnswer((_) => lifecycle.stream);
+          when(() => mockOAuthFlowProvider.pollForResult()).thenAnswer((_) async {
+            if (polls++ == 0) {
+              throw OAuthSessionRestartRequiredException(restartAfter: Duration.zero, deadline: deadline);
+            }
+            return testAuthUser;
+          });
+          when(
+            () => mockOAuthFlowProvider.startOAuthFlow(provider: AuthProvider.google, deadline: deadline),
+          ).thenAnswer((_) async {
+            lifecycle.add(LifecycleState.paused);
+            return testAuthInitResponse;
+          });
+          final cubit = buildCubit();
+          final login = cubit.loginWithProvider(AuthProvider.google);
+          await untilCalled(
+            () => mockOAuthFlowProvider.startOAuthFlow(provider: AuthProvider.google, deadline: deadline),
+          );
+          await Future<void>.delayed(Duration.zero);
+          verify(() => mockUrlLauncher.launch(any())).called(1);
+          lifecycle.add(LifecycleState.resumed);
+          expect(await login, isTrue);
+          verify(() => mockUrlLauncher.launch(any())).called(1);
+          verify(
+            () => mockInstallationAnalyticsService.loginAttemptCompleted(provider: AuthProvider.google),
+          ).called(1);
+          verifyNever(
+            () => mockInstallationAnalyticsService.loginAttemptFailed(
+              provider: any(named: "provider"),
+              cause: any(named: "cause"),
+            ),
+          );
+          await cubit.close();
+          await lifecycle.close();
+        });
+
+        for (final replace in [false, true]) {
+          test("${replace ? "replacement" : "close"} cancels an owned lifecycle wait", () async {
+            final lifecycle = BehaviorSubject<LifecycleState>.seeded(LifecycleState.resumed);
+            final deadline = DateTime.now().add(const Duration(minutes: 1));
+            var failures = 0;
+            when(() => mockLifecycleSource.lifecycleStateStream).thenAnswer((_) => lifecycle.stream);
+            when(
+              () => mockInstallationAnalyticsService.loginAttemptFailed(
+                provider: any(named: "provider"),
+                cause: any(named: "cause"),
+              ),
+            ).thenAnswer((_) async => (failures += 1, AnalyticsDeliveryResult.acceptedBySdk).$2);
+            when(() => mockOAuthFlowProvider.pollForResult()).thenAnswer((_) async {
+              lifecycle.add(LifecycleState.paused);
+              throw OAuthSessionRestartRequiredException(restartAfter: Duration.zero, deadline: deadline);
+            });
+            final cubit = buildCubit();
+            final login = cubit.loginWithProvider(AuthProvider.google);
+            await untilCalled(() => mockOAuthFlowProvider.pollForResult());
+            await Future<void>.delayed(Duration.zero);
+            replace ? cubit.beginAppleLoginAttempt() : await cubit.close();
+            expect(await login, isFalse);
+            if (replace) await cubit.close();
+            expect(lifecycle.hasListener, isFalse);
+            expect(failures, replace ? 1 : 0);
+            await lifecycle.close();
+          });
+        }
+
+        test("a superseded restart cannot release its replacement's polling guard", () async {
+          final lifecycle = BehaviorSubject<LifecycleState>.seeded(LifecycleState.resumed);
+          final deadline = DateTime.now().add(const Duration(minutes: 1));
+          final restartInitStarted = Completer<void>();
+          final restartInit = Completer<AuthInitResponse>();
+          final replacementLaunchStarted = Completer<void>();
+          final replacementLaunch = Completer<bool>();
+          var launches = 0;
+          var polls = 0;
+          when(() => mockLifecycleSource.lifecycleStateStream).thenAnswer((_) => lifecycle.stream);
+          when(
+            () => mockOAuthFlowProvider.startOAuthFlow(
+              provider: AuthProvider.google,
+              deadline: any<DateTime?>(named: "deadline"),
+            ),
+          ).thenAnswer((invocation) {
+            if (invocation.namedArguments[#deadline] != null) {
+              restartInitStarted.complete();
+              return restartInit.future;
+            }
+            return Future.value(testAuthInitResponse);
+          });
+          when(() => mockOAuthFlowProvider.pollForResult()).thenAnswer((_) async {
+            if (polls++ == 0) {
+              throw OAuthSessionRestartRequiredException(restartAfter: Duration.zero, deadline: deadline);
+            }
+            return testAuthUser;
+          });
+          when(() => mockUrlLauncher.launch(any())).thenAnswer((_) {
+            launches += 1;
+            if (launches == 2) {
+              replacementLaunchStarted.complete();
+              return replacementLaunch.future;
+            }
+            return Future.value(true);
+          });
+          final cubit = buildCubit();
+
+          final staleLogin = cubit.loginWithProvider(AuthProvider.google);
+          await restartInitStarted.future;
+          final replacementLogin = cubit.loginWithProvider(AuthProvider.google);
+          await replacementLaunchStarted.future;
+          restartInit.complete(testAuthInitResponse);
+          expect(await staleLogin, isFalse);
+
+          lifecycle
+            ..add(LifecycleState.paused)
+            ..add(LifecycleState.resumed);
+          await Future<void>.delayed(Duration.zero);
+          verifyNever(mockOAuthFlowProvider.hasActiveOAuthSession);
+          verifyNever(mockOAuthFlowProvider.resumeOAuthFlow);
+
+          replacementLaunch.complete(true);
+          expect(await replacementLogin, isTrue);
+          await cubit.close();
+          await lifecycle.close();
+        });
+
+        for (final secondRestart in [false, true]) {
+          test("${secondRestart ? "second restart" : "deadline"} is one terminal failure", () {
+            fakeAsync((async) {
+              final deadline = DateTime.now().add(const Duration(seconds: 5));
+              when(() => mockOAuthFlowProvider.pollForResult()).thenThrow(
+                OAuthSessionRestartRequiredException(
+                  restartAfter: secondRestart ? Duration.zero : const Duration(seconds: 30),
+                  deadline: deadline,
+                ),
+              );
+              final cubit = buildCubit();
+              bool? result;
+              unawaited(cubit.loginWithProvider(AuthProvider.google).then((value) => result = value));
+              async.flushMicrotasks();
+              if (!secondRestart) async.elapse(const Duration(seconds: 5));
+              expect(result, isFalse);
+              expect(cubit.state, secondRestart ? isA<LoginFailed>() : isA<LoginTimeout>());
+              verify(
+                () => mockInstallationAnalyticsService.loginAttemptFailed(
+                  provider: AuthProvider.google,
+                  cause: secondRestart ? LoginAttemptFailureCause.unknown : LoginAttemptFailureCause.timeout,
+                ),
+              ).called(1);
+              verifyNever(
+                () => mockInstallationAnalyticsService.loginAttemptCompleted(provider: any(named: "provider")),
+              );
+              unawaited(cubit.close());
+              async.flushMicrotasks();
+              expect(async.nonPeriodicTimerCount, 0);
+            });
+          });
+        }
+      });
 
       group("background interruption", () {
         test("parks interrupted background poll in LoginPolling instead of LoginFailed", () async {
@@ -502,10 +832,15 @@ void main() {
           await cubit.loginWithProvider(AuthProvider.google);
           expect(cubit.state, isA<LoginPolling>());
 
+          final deadline = DateTime.now().add(const Duration(minutes: 1));
           when(() => mockOAuthFlowProvider.hasActiveOAuthSession()).thenAnswer((_) async => true);
-          when(() => mockOAuthFlowProvider.resumeOAuthFlow()).thenAnswer((_) async => testAuthUser);
+          when(() => mockOAuthFlowProvider.resumeOAuthFlow()).thenThrow(
+            OAuthSessionRestartRequiredException(restartAfter: Duration.zero, deadline: deadline),
+          );
+          when(() => mockOAuthFlowProvider.pollForResult()).thenAnswer((_) async => testAuthUser);
 
           lifecycleSubject.add(LifecycleState.resumed);
+          await Future<void>.delayed(Duration.zero);
           await Future<void>.delayed(Duration.zero);
 
           await cubit.close();

--- a/shared/sesori_shared/lib/sesori_shared.dart
+++ b/shared/sesori_shared/lib/sesori_shared.dart
@@ -23,6 +23,7 @@ export "src/models/auth/bridge_summary.dart";
 export "src/models/auth/bridges_list_response.dart";
 export "src/models/auth/device_info.dart";
 export "src/models/auth/logout_response.dart";
+export "src/models/auth/oauth_session_restart_required_exception.dart";
 export "src/models/auth/product_analytics_preference_update_request.dart";
 export "src/models/auth/register_bridge_request.dart";
 export "src/models/auth/session_status_response.dart";

--- a/shared/sesori_shared/lib/src/models/auth/oauth_session_restart_required_exception.dart
+++ b/shared/sesori_shared/lib/src/models/auth/oauth_session_restart_required_exception.dart
@@ -1,22 +1,5 @@
-enum OAuthSessionRestartOperation { init, status }
-
-enum OAuthSessionRestartReason { serviceUnavailable, sessionMissing }
-
 final class OAuthSessionRestartRequiredException implements Exception {
   final Duration restartAfter;
   final DateTime deadline;
-  final OAuthSessionRestartOperation operation;
-  final OAuthSessionRestartReason reason;
-
-  const OAuthSessionRestartRequiredException({
-    required this.restartAfter,
-    required this.deadline,
-    required this.operation,
-    required this.reason,
-  });
-
-  @override
-  String toString() =>
-      "OAuth session restart required (operation: ${operation.name}, reason: ${reason.name}, "
-      "restartAfterMs: ${restartAfter.inMilliseconds}, deadline: ${deadline.toIso8601String()})";
+  const OAuthSessionRestartRequiredException({required this.restartAfter, required this.deadline});
 }

--- a/shared/sesori_shared/lib/src/models/auth/oauth_session_restart_required_exception.dart
+++ b/shared/sesori_shared/lib/src/models/auth/oauth_session_restart_required_exception.dart
@@ -1,0 +1,5 @@
+final class OAuthSessionRestartRequiredException implements Exception {
+  final Duration restartAfter;
+  final DateTime deadline;
+  const OAuthSessionRestartRequiredException({required this.restartAfter, required this.deadline});
+}

--- a/shared/sesori_shared/lib/src/models/auth/oauth_session_restart_required_exception.dart
+++ b/shared/sesori_shared/lib/src/models/auth/oauth_session_restart_required_exception.dart
@@ -1,5 +1,22 @@
+enum OAuthSessionRestartOperation { init, status }
+
+enum OAuthSessionRestartReason { serviceUnavailable, sessionMissing }
+
 final class OAuthSessionRestartRequiredException implements Exception {
   final Duration restartAfter;
   final DateTime deadline;
-  const OAuthSessionRestartRequiredException({required this.restartAfter, required this.deadline});
+  final OAuthSessionRestartOperation operation;
+  final OAuthSessionRestartReason reason;
+
+  const OAuthSessionRestartRequiredException({
+    required this.restartAfter,
+    required this.deadline,
+    required this.operation,
+    required this.reason,
+  });
+
+  @override
+  String toString() =>
+      "OAuth session restart required (operation: ${operation.name}, reason: ${reason.name}, "
+      "restartAfterMs: ${restartAfter.inMilliseconds}, deadline: ${deadline.toIso8601String()})";
 }

--- a/shared/sesori_shared/test/models/auth_flow_models_test.dart
+++ b/shared/sesori_shared/test/models/auth_flow_models_test.dart
@@ -161,22 +161,4 @@ void main() {
       );
     });
   });
-
-  test("OAuth restart diagnostics retain closed operation and reason context", () {
-    final deadline = DateTime.utc(2026, 8, 3, 18);
-    final error = OAuthSessionRestartRequiredException(
-      restartAfter: const Duration(seconds: 1),
-      deadline: deadline,
-      operation: OAuthSessionRestartOperation.status,
-      reason: OAuthSessionRestartReason.sessionMissing,
-    );
-
-    expect(error.operation, OAuthSessionRestartOperation.status);
-    expect(error.reason, OAuthSessionRestartReason.sessionMissing);
-    expect(
-      error.toString(),
-      "OAuth session restart required (operation: status, reason: sessionMissing, "
-      "restartAfterMs: 1000, deadline: 2026-08-03T18:00:00.000Z)",
-    );
-  });
 }

--- a/shared/sesori_shared/test/models/auth_flow_models_test.dart
+++ b/shared/sesori_shared/test/models/auth_flow_models_test.dart
@@ -161,4 +161,22 @@ void main() {
       );
     });
   });
+
+  test("OAuth restart diagnostics retain closed operation and reason context", () {
+    final deadline = DateTime.utc(2026, 8, 3, 18);
+    final error = OAuthSessionRestartRequiredException(
+      restartAfter: const Duration(seconds: 1),
+      deadline: deadline,
+      operation: OAuthSessionRestartOperation.status,
+      reason: OAuthSessionRestartReason.sessionMissing,
+    );
+
+    expect(error.operation, OAuthSessionRestartOperation.status);
+    expect(error.reason, OAuthSessionRestartReason.sessionMissing);
+    expect(
+      error.toString(),
+      "OAuth session restart required (operation: status, reason: sessionMissing, "
+      "restartAfterMs: 1000, deadline: 2026-08-03T18:00:00.000Z)",
+    );
+  });
 }


### PR DESCRIPTION
## Summary
- map auth init/status shutdown responses and stale session responses to a shared bounded OAuth restart outcome
- serialize mobile OAuth ownership and persistence so stale attempts cannot clear or authenticate over replacements
- perform at most one lifecycle-safe restart in mobile and one deadline-bounded restart in the standalone bridge

## Rollout dependency
This is the apps-first compatibility prerequisite for auth-server PR https://github.com/sesori-ai/sesori_auth_server/pull/55. Compatible mobile, desktop, and standalone bridge artifacts must be released before that auth change is deployed.

## Verification
- shared: analyze + 363 tests
- module_auth: analyze + 98 tests
- module_core: analyze + 1009 tests
- mobile app: fatal analyze + 886 tests
- desktop app: fatal analyze + 15 tests
- bridge workspace: analyze + 2421 tests
- standalone bridge: fatal analyze + 29 focused tests + native macOS ARM64 build
- diff check and mandatory implementation review passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers OAuth logins if the auth server restarts mid-flow by detecting stale sessions and doing one bounded restart. Preserves a single OAuth deadline across requests, browser launch, and restarts to avoid stale work.

- **New Features**
  - Map 503/Retry-After and 404 to `OAuthSessionRestartRequiredException(restartAfter, deadline)` from `sesori_shared` (re‑exported by `sesori_auth`); clamp delay to the remaining time and allow only one restart.
  - Bridge/standalone: pass a shared deadline to each request and browser open; bound per-request timeouts; cancel pending work when the deadline expires.
  - Mobile/desktop/core: simplify OAuth session ownership in `AuthManager` (single owner/generation), serialize mutations, make completion atomic, wait for foreground before restart, and have `LoginCubit` track/enforce the per-attempt OAuth deadline.

- **Migration**
  - Release updated mobile, desktop, and bridge apps before deploying the auth‑server change that invalidates sessions.
  - `OAuthFlowProvider.startOAuthFlow` now requires a (nullable) `deadline` argument; update callers.

<sup>Written for commit cee4915512b9ecc0728499ba822dff3a607af026. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

