### PR TITLE
⚙️ [relay-request-concurrency] refactor(bridge): simplify domain mutation ordering [step 8/10]

### DIFF
--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -3,15 +3,13 @@
 ## Current State
 
 - **Plan slug:** `relay-request-concurrency`
-- **Implementation base:** current `main` at
-  `132694ea379b18bd8f87d45ca5a7323945363039`, including merged Step 6 at
-  `e4605eb15b68f5433b5740981d03ff6e63f964cb`
-- **Series state:** Steps 1–6 merged; over-defensive Step 7 implementation
-  [#716](https://github.com/sesori-ai/sesori_apps_monorepo/pull/716) closed without merge
-- **Current step:** Step 7/10 PR
-  [#720](https://github.com/sesori-ai/sesori_apps_monorepo/pull/720) open
+- **Implementation base:** merged corrected Step 7 at
+  `6233da3e17f00517663b64e4eb5b789a47206514`
+- **Series state:** Steps 1–7 merged; over-defensive implementation
+  [#716](https://github.com/sesori-ai/sesori_apps_monorepo/pull/716) remains closed without merge
+- **Current step:** Step 8/10 implementation on `plan-parallel-requests`
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged
-- **Next action:** review and merge corrected Step 7; Step 8 remains blocked
+- **Next action:** commit, open, review, and merge Step 8
 
 ## Incident Evidence
 
@@ -102,8 +100,8 @@
 | [x] | 4/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): bind relay connection epochs [step 4/10]` | 550–950 | [PR #699](https://github.com/sesori-ai/sesori_apps_monorepo/pull/699) merged as `9ac855a3` with 1,326 changed lines |
 | [x] | 5/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | [PR #700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700) merged as `5ba0d3a6` with 1,534 changed lines |
 | [x] | 6/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope session family mutations [step 6/10]` | 750–1,250 | [PR #703](https://github.com/sesori-ai/sesori_apps_monorepo/pull/703) merged as `e4605eb1` with 1,054 changed lines |
-| [ ] | 7/10 | `plan-parallel-requests` | `🌱 [relay-request-concurrency] docs: simplify remaining concurrency plan [step 7/10]` | 350–550 | [PR #720](https://github.com/sesori-ai/sesori_apps_monorepo/pull/720) open; PR #716 closed without merge |
-| [ ] | 8/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): simplify domain mutation ordering [step 8/10]` | 500–900 | Blocked on corrected Step 7 merge |
+| [x] | 7/10 | `plan-parallel-requests` | `🌱 [relay-request-concurrency] docs: simplify remaining concurrency plan [step 7/10]` | 350–550 | [PR #720](https://github.com/sesori-ai/sesori_apps_monorepo/pull/720) merged as `6233da3e` with 543 changed lines; PR #716 closed without merge |
+| [ ] | 8/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): simplify domain mutation ordering [step 8/10]` | 500–900 | Implemented from `6233da3e`; PR pending |
 | [ ] | 9/10 | `relay-request-concurrency-dispatch` | `🚧 [relay-request-concurrency] fix(bridge): route client requests concurrently [step 9/10]` | 950–1,450 | Blocked on Step 8 merge |
 | [ ] | 10/10 | `relay-request-concurrency-retire-plan` | `🌱 [relay-request-concurrency] docs: retire concurrent routing plan [step 10/10]` | 50–150 | Blocked on Step 9 merge |
 
@@ -408,4 +406,23 @@
   detaching relay route/SSE-summary work, existing incarnation/epoch/restart
   fences, and shutdown drain required by the demonstrated head-of-line incident.
 - **Corrected Step 7 delivery:** [PR #720](https://github.com/sesori-ai/sesori_apps_monorepo/pull/720)
-  is open from current `main`; its diff is documentation/agent guidance only.
+  merged as `6233da3e17f00517663b64e4eb5b789a47206514` with 543
+  documentation/agent-only changed lines.
+- **Step 8/10 implementation:** removed dedicated permission/question interaction
+  types, keys, lanes, parameters, and cleanup; modern writers continue through
+  the existing family FIFO while legacy sessionless rejection retains plugin
+  settlement, owner resolution, plugin validation, and family admission.
+  `ProjectMutationService` now owns one synchronous failure-safe FIFO around the
+  complete create/open/hide workflows with sealed open outcomes and no lifecycle.
+- **Step 8/10 cleanup:** project handlers no longer own filesystem,
+  initialization, activity, or repository workflow dependencies. No canonical
+  path lanes, per-project parallelism, registry, drain/dispose owner, wire/data,
+  client, shared, plugin-interface, generated, or analytics changes were added.
+- **Step 8/10 verification:** 2,421 full `bridge/app` tests pass, focused project,
+  dispatcher, pending-interaction, auto-approval, and legacy suites pass, strict
+  `dart analyze --fatal-infos` reports no issues, and `git diff --check` passes.
+- **Step 8/10 architecture review:** `aristotle-impl-review` approved the complete
+  uncommitted diff with no findings; synchronous admission, failure-safe FIFO,
+  typed outcomes, dependency direction, lifecycle ownership, and proportionality
+  passed.
+- **Step 8/10 delivery:** PR pending at 707 changed lines.

--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -7,9 +7,10 @@
   `6233da3e17f00517663b64e4eb5b789a47206514`
 - **Series state:** Steps 1–7 merged; over-defensive implementation
   [#716](https://github.com/sesori-ai/sesori_apps_monorepo/pull/716) remains closed without merge
-- **Current step:** Step 8/10 implementation on `plan-parallel-requests`
+- **Current step:** Step 8/10 PR
+  [#721](https://github.com/sesori-ai/sesori_apps_monorepo/pull/721) open
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged
-- **Next action:** commit, open, review, and merge Step 8
+- **Next action:** review and merge Step 8; Step 9 remains blocked
 
 ## Incident Evidence
 
@@ -101,7 +102,7 @@
 | [x] | 5/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | [PR #700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700) merged as `5ba0d3a6` with 1,534 changed lines |
 | [x] | 6/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope session family mutations [step 6/10]` | 750–1,250 | [PR #703](https://github.com/sesori-ai/sesori_apps_monorepo/pull/703) merged as `e4605eb1` with 1,054 changed lines |
 | [x] | 7/10 | `plan-parallel-requests` | `🌱 [relay-request-concurrency] docs: simplify remaining concurrency plan [step 7/10]` | 350–550 | [PR #720](https://github.com/sesori-ai/sesori_apps_monorepo/pull/720) merged as `6233da3e` with 543 changed lines; PR #716 closed without merge |
-| [ ] | 8/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): simplify domain mutation ordering [step 8/10]` | 500–900 | Implemented from `6233da3e`; PR pending |
+| [ ] | 8/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): simplify domain mutation ordering [step 8/10]` | 500–900 | [PR #721](https://github.com/sesori-ai/sesori_apps_monorepo/pull/721) open from `6233da3e` |
 | [ ] | 9/10 | `relay-request-concurrency-dispatch` | `🚧 [relay-request-concurrency] fix(bridge): route client requests concurrently [step 9/10]` | 950–1,450 | Blocked on Step 8 merge |
 | [ ] | 10/10 | `relay-request-concurrency-retire-plan` | `🌱 [relay-request-concurrency] docs: retire concurrent routing plan [step 10/10]` | 50–150 | Blocked on Step 9 merge |
 
@@ -425,4 +426,5 @@
   uncommitted diff with no findings; synchronous admission, failure-safe FIFO,
   typed outcomes, dependency direction, lifecycle ownership, and proportionality
   passed.
-- **Step 8/10 delivery:** PR pending at 707 changed lines.
+- **Step 8/10 delivery:** [PR #721](https://github.com/sesori-ai/sesori_apps_monorepo/pull/721)
+  is open from `6233da3e` at 709 changed lines.

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -127,6 +127,7 @@ import "services/permission_auto_approval_service.dart";
 import "services/pr_sync_service.dart";
 import "services/project_activity_service.dart";
 import "services/project_initialization_service.dart";
+import "services/project_mutation_service.dart";
 import "services/session_abort_service.dart";
 import "services/session_creation_service.dart";
 import "services/session_deletion_service.dart";
@@ -396,6 +397,12 @@ class Orchestrator {
       worktreeRepository: worktreeRepository,
       filesystemRepository: filesystemRepository,
     );
+    final projectMutationService = ProjectMutationService(
+      filesystemRepository: filesystemRepository,
+      projectInitializationService: projectInitializationService,
+      projectActivityService: projectActivityService,
+      projectRepository: projectRepository,
+    );
     final roomKey = _generateRoomKey();
     final bytesSentController = StreamController<int>.broadcast();
     final localWireEventsController = StreamController<SesoriSseEvent>.broadcast();
@@ -549,16 +556,9 @@ class Orchestrator {
         RejectQuestionHandler(pendingInteractionService: pendingInteractionService),
         ReplyToPermissionHandler(pendingInteractionService: pendingInteractionService),
         RenameProjectHandler(projectRepository),
-        CreateProjectHandler(
-          projectInitializationService: projectInitializationService,
-          projectActivityService: projectActivityService,
-        ),
-        OpenProjectHandler(
-          filesystemRepository: filesystemRepository,
-          projectInitializationService: projectInitializationService,
-          projectActivityService: projectActivityService,
-        ),
-        HideProjectHandler(projectRepository: projectRepository),
+        CreateProjectHandler(projectMutationService: projectMutationService),
+        OpenProjectHandler(projectMutationService: projectMutationService),
+        HideProjectHandler(projectMutationService: projectMutationService),
         GetBaseBranchHandler(projectRepository: projectRepository),
         SetBaseBranchHandler(projectRepository: projectRepository),
         FilesystemSuggestionsHandler(filesystemRepository: filesystemRepository),

--- a/bridge/app/lib/src/bridge/routing/create_project_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/create_project_handler.dart
@@ -2,25 +2,21 @@ import "package:path/path.dart" as p;
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../repositories/filesystem_repository.dart";
-import "../services/project_activity_service.dart";
 import "../services/project_initialization_service.dart";
+import "../services/project_mutation_service.dart";
 import "request_handler.dart";
 
 /// Handles `POST /project/create` — creates a new project directory with git init.
 class CreateProjectHandler extends BodyRequestHandler<ProjectPathRequest, Project> {
-  final ProjectInitializationService _projectInitializationService;
-  final ProjectActivityService _projectActivityService;
+  final ProjectMutationService _projectMutationService;
 
-  CreateProjectHandler({
-    required ProjectInitializationService projectInitializationService,
-    required ProjectActivityService projectActivityService,
-  }) : _projectInitializationService = projectInitializationService,
-       _projectActivityService = projectActivityService,
-       super(
-         HttpMethod.post,
-         "/project/create",
-         fromJson: ProjectPathRequest.fromJson,
-       );
+  CreateProjectHandler({required ProjectMutationService projectMutationService})
+    : _projectMutationService = projectMutationService,
+      super(
+        HttpMethod.post,
+        "/project/create",
+        fromJson: ProjectPathRequest.fromJson,
+      );
 
   @override
   Future<Project> handle(
@@ -43,7 +39,7 @@ class CreateProjectHandler extends BodyRequestHandler<ProjectPathRequest, Projec
     }
 
     try {
-      await _projectInitializationService.initializeProject(path: path);
+      return await _projectMutationService.createProject(path: path);
     } on FilesystemPermissionDeniedException {
       throw buildErrorResponse(request, 403, "permission denied: $path");
     } on ProjectParentMissingException {
@@ -53,7 +49,5 @@ class CreateProjectHandler extends BodyRequestHandler<ProjectPathRequest, Projec
     } on ProjectGitSetupException {
       throw buildErrorResponse(request, 500, "Git setup failed");
     }
-
-    return _projectActivityService.openProject(path: path);
   }
 }

--- a/bridge/app/lib/src/bridge/routing/hide_project_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/hide_project_handler.dart
@@ -1,6 +1,6 @@
 import "package:sesori_shared/sesori_shared.dart";
 
-import "../repositories/project_repository.dart";
+import "../services/project_mutation_service.dart";
 import "request_handler.dart";
 
 /// Handles `POST /project/hide` — hides a project from listings.
@@ -9,10 +9,10 @@ import "request_handler.dart";
 /// slashes (it can be a filesystem path), so it is passed in the body rather
 /// than as a URL path parameter.
 class HideProjectHandler extends BodyRequestHandler<ProjectIdRequest, SuccessEmptyResponse> {
-  final ProjectRepository _projectRepository;
+  final ProjectMutationService _projectMutationService;
 
-  HideProjectHandler({required ProjectRepository projectRepository})
-    : _projectRepository = projectRepository,
+  HideProjectHandler({required ProjectMutationService projectMutationService})
+    : _projectMutationService = projectMutationService,
       super(
         HttpMethod.post,
         "/project/hide",
@@ -32,7 +32,7 @@ class HideProjectHandler extends BodyRequestHandler<ProjectIdRequest, SuccessEmp
       throw buildErrorResponse(request, 400, "empty project id");
     }
 
-    await _projectRepository.hideProject(projectId: projectId);
+    await _projectMutationService.hideProject(projectId: projectId);
 
     return const SuccessEmptyResponse();
   }

--- a/bridge/app/lib/src/bridge/routing/open_project_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/open_project_handler.dart
@@ -5,28 +5,20 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../repositories/filesystem_repository.dart";
-import "../services/project_activity_service.dart";
-import "../services/project_initialization_service.dart";
+import "../services/project_mutation_service.dart";
 import "request_handler.dart";
 
 /// Handles `POST /project/open` — opens an existing directory as a project.
 class OpenProjectHandler extends BodyRequestHandler<OpenProjectRequest, Project> {
-  final FilesystemRepository _filesystemRepository;
-  final ProjectInitializationService _projectInitializationService;
-  final ProjectActivityService _projectActivityService;
+  final ProjectMutationService _projectMutationService;
 
-  OpenProjectHandler({
-    required FilesystemRepository filesystemRepository,
-    required ProjectInitializationService projectInitializationService,
-    required ProjectActivityService projectActivityService,
-  }) : _filesystemRepository = filesystemRepository,
-       _projectInitializationService = projectInitializationService,
-       _projectActivityService = projectActivityService,
-       super(
-         HttpMethod.post,
-         "/project/open",
-         fromJson: OpenProjectRequest.fromJson,
-       );
+  OpenProjectHandler({required ProjectMutationService projectMutationService})
+    : _projectMutationService = projectMutationService,
+      super(
+        HttpMethod.post,
+        "/project/open",
+        fromJson: OpenProjectRequest.fromJson,
+      );
 
   @override
   Future<Project> handle(
@@ -48,9 +40,12 @@ class OpenProjectHandler extends BodyRequestHandler<OpenProjectRequest, Project>
       throw buildErrorResponse(request, 400, "path traversal not allowed");
     }
 
-    final FilesystemEntityKind kind;
+    final OpenProjectOutcome outcome;
     try {
-      kind = _filesystemRepository.classifyPath(path: path);
+      outcome = await _projectMutationService.openProject(
+        path: path,
+        gitAction: body.gitAction,
+      );
     } on FilesystemPermissionDeniedException {
       throw buildErrorResponse(request, 403, "permission denied: $path");
     } on FileSystemException catch (error, stackTrace) {
@@ -58,22 +53,15 @@ class OpenProjectHandler extends BodyRequestHandler<OpenProjectRequest, Project>
       throw buildErrorResponse(request, 500, "failed to open directory");
     }
 
-    switch (kind) {
-      case FilesystemEntityKind.notFound:
+    switch (outcome) {
+      case OpenProjectDirectoryNotFound():
         throw buildErrorResponse(request, 404, "directory not found");
-      case FilesystemEntityKind.notDirectory:
+      case OpenProjectPathNotDirectory():
         throw buildErrorResponse(request, 400, "path is not a directory");
-      case FilesystemEntityKind.directory:
-        final preparation = await _projectInitializationService.prepareExistingProject(
-          path: path,
-          gitAction: body.gitAction,
-        );
-        switch (preparation) {
-          case ExistingProjectPreparationOutcome.gitChoiceRequired:
-            throw buildErrorResponse(request, 428, "Git setup choice required");
-          case ExistingProjectPreparationOutcome.ready:
-            return _projectActivityService.openProject(path: path);
-        }
+      case OpenProjectGitChoiceRequired():
+        throw buildErrorResponse(request, 428, "Git setup choice required");
+      case OpenProjectSuccess(:final project):
+        return project;
     }
   }
 }

--- a/bridge/app/lib/src/bridge/routing/open_project_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/open_project_handler.dart
@@ -49,7 +49,7 @@ class OpenProjectHandler extends BodyRequestHandler<OpenProjectRequest, Project>
     } on FilesystemPermissionDeniedException {
       throw buildErrorResponse(request, 403, "permission denied: $path");
     } on FileSystemException catch (error, stackTrace) {
-      Log.w("OpenProjectHandler: failed to classify $path", error, stackTrace);
+      Log.w("OpenProjectHandler: failed to open project at $path", error, stackTrace);
       throw buildErrorResponse(request, 500, "failed to open directory");
     }
 

--- a/bridge/app/lib/src/bridge/services/pending_interaction_service.dart
+++ b/bridge/app/lib/src/bridge/services/pending_interaction_service.dart
@@ -32,7 +32,6 @@ class PendingInteractionService {
     return _dispatcher.dispatch(
       sessionId: sessionId,
       operation: SessionOperation.replyToPermission,
-      interaction: PendingPermissionInteraction(requestId: requestId),
       body: () => _permissionRepository.replyToPermission(
         requestId: requestId,
         sessionId: sessionId,
@@ -50,7 +49,6 @@ class PendingInteractionService {
     return _dispatcher.dispatch(
       sessionId: sessionId,
       operation: SessionOperation.replyToQuestion,
-      interaction: PendingQuestionInteraction(requestId: questionId),
       body: () => _questionRepository.replyToQuestion(
         questionId: questionId,
         sessionId: sessionId,
@@ -68,7 +66,6 @@ class PendingInteractionService {
       return _dispatcher.dispatch(
         sessionId: sessionId,
         operation: SessionOperation.rejectQuestion,
-        interaction: PendingQuestionInteraction(requestId: questionId),
         body: () => _questionRepository.rejectQuestion(
           questionId: questionId,
           sessionId: sessionId,

--- a/bridge/app/lib/src/bridge/services/project_mutation_service.dart
+++ b/bridge/app/lib/src/bridge/services/project_mutation_service.dart
@@ -1,0 +1,92 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../repositories/filesystem_repository.dart";
+import "../repositories/project_repository.dart";
+import "project_activity_service.dart";
+import "project_initialization_service.dart";
+
+sealed class OpenProjectOutcome {
+  const OpenProjectOutcome();
+}
+
+final class OpenProjectSuccess extends OpenProjectOutcome {
+  final Project project;
+
+  const OpenProjectSuccess({required this.project});
+}
+
+final class OpenProjectDirectoryNotFound extends OpenProjectOutcome {
+  const OpenProjectDirectoryNotFound();
+}
+
+final class OpenProjectPathNotDirectory extends OpenProjectOutcome {
+  const OpenProjectPathNotDirectory();
+}
+
+final class OpenProjectGitChoiceRequired extends OpenProjectOutcome {
+  const OpenProjectGitChoiceRequired();
+}
+
+/// Owns complete create, open, and hide workflows under one bridge-wide FIFO.
+class ProjectMutationService {
+  final FilesystemRepository _filesystemRepository;
+  final ProjectInitializationService _projectInitializationService;
+  final ProjectActivityService _projectActivityService;
+  final ProjectRepository _projectRepository;
+
+  Future<void> _tail = Future<void>.value();
+
+  ProjectMutationService({
+    required FilesystemRepository filesystemRepository,
+    required ProjectInitializationService projectInitializationService,
+    required ProjectActivityService projectActivityService,
+    required ProjectRepository projectRepository,
+  }) : _filesystemRepository = filesystemRepository,
+       _projectInitializationService = projectInitializationService,
+       _projectActivityService = projectActivityService,
+       _projectRepository = projectRepository;
+
+  Future<Project> createProject({required String path}) {
+    return _enqueue(() async {
+      await _projectInitializationService.initializeProject(path: path);
+      return _projectActivityService.openProject(path: path);
+    });
+  }
+
+  Future<OpenProjectOutcome> openProject({
+    required String path,
+    required OpenProjectGitAction gitAction,
+  }) {
+    return _enqueue(() async {
+      switch (_filesystemRepository.classifyPath(path: path)) {
+        case FilesystemEntityKind.notFound:
+          return const OpenProjectDirectoryNotFound();
+        case FilesystemEntityKind.notDirectory:
+          return const OpenProjectPathNotDirectory();
+        case FilesystemEntityKind.directory:
+          final preparation = await _projectInitializationService.prepareExistingProject(
+            path: path,
+            gitAction: gitAction,
+          );
+          switch (preparation) {
+            case ExistingProjectPreparationOutcome.gitChoiceRequired:
+              return const OpenProjectGitChoiceRequired();
+            case ExistingProjectPreparationOutcome.ready:
+              return OpenProjectSuccess(
+                project: await _projectActivityService.openProject(path: path),
+              );
+          }
+      }
+    });
+  }
+
+  Future<void> hideProject({required String projectId}) {
+    return _enqueue(() => _projectRepository.hideProject(projectId: projectId));
+  }
+
+  Future<T> _enqueue<T>(Future<T> Function() workflow) {
+    final result = _tail.then((_) => workflow());
+    _tail = result.then<void>((_) {}, onError: (Object _, StackTrace __) {});
+    return result;
+  }
+}

--- a/bridge/app/lib/src/bridge/services/session_abort_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_abort_service.dart
@@ -25,7 +25,6 @@ class SessionAbortService {
     final operation = _dispatcher.dispatch<void>(
       sessionId: sessionId,
       operation: SessionOperation.abortSession,
-      interaction: null,
       body: () async {
         await _sessionRepository.abortSession(sessionId: sessionId);
         _abortedSessionsController.add(sessionId);

--- a/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
@@ -159,7 +159,6 @@ class SessionLifecycleService {
     return _sessionOperationDispatcher.dispatch(
       sessionId: sessionId,
       operation: SessionOperation.updateSessionArchiveStatus,
-      interaction: null,
       body: () => _updateArchiveStatusAlreadyReserved(
         sessionId: sessionId,
         archived: archived,

--- a/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
@@ -29,7 +29,6 @@ class SessionMutationDispatcher {
     return _sessionOperationDispatcher.dispatch(
       sessionId: sessionId,
       operation: SessionOperation.renameSession,
-      interaction: null,
       body: () => _renameSessionAlreadyReserved(sessionId: sessionId, title: title),
     );
   }
@@ -42,7 +41,6 @@ class SessionMutationDispatcher {
     return _sessionOperationDispatcher.dispatch(
       sessionId: sessionId,
       operation: SessionOperation.deleteSession,
-      interaction: null,
       body: () async {
         final cleanupResult = await cleanup();
         if (cleanupResult is CleanupRejected) return cleanupResult;

--- a/bridge/app/lib/src/bridge/services/session_operation_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/services/session_operation_dispatcher.dart
@@ -6,35 +6,12 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Plugi
 import "../repositories/models/session_operation.dart";
 import "../repositories/session_repository.dart";
 
-sealed class PendingInteractionRequest {
-  final String requestId;
-
-  const PendingInteractionRequest({required this.requestId});
-}
-
-final class PendingPermissionInteraction extends PendingInteractionRequest {
-  const PendingPermissionInteraction({required super.requestId});
-}
-
-final class PendingQuestionInteraction extends PendingInteractionRequest {
-  const PendingQuestionInteraction({required super.requestId});
-}
-
-enum _PendingInteractionKind { permission, question }
-
 typedef _FamilyKey = ({String pluginId, String rootSessionId});
-typedef _InteractionKey = ({
-  String pluginId,
-  String ownerSessionId,
-  _PendingInteractionKind kind,
-  String requestId,
-});
 
 /// Admits session work in arrival order, then serializes only shared domains.
 class SessionOperationDispatcher {
   final SessionRepository _sessionRepository;
   final Map<_FamilyKey, _LaneToken> _familyLanes = {};
-  final Map<_InteractionKey, _LaneToken> _interactionLanes = {};
   final Map<String, _LaneToken> _pluginAdmissionLanes = {};
   final Map<String, Set<Future<void>>> _pluginSettlements = {};
   final Set<Future<void>> _inFlightSettlements = {};
@@ -50,7 +27,6 @@ class SessionOperationDispatcher {
   Future<T> dispatch<T>({
     required String sessionId,
     required SessionOperation operation,
-    required PendingInteractionRequest? interaction,
     required Future<T> Function() body,
   }) {
     if (!_accepting) throw _closedError();
@@ -72,8 +48,6 @@ class SessionOperationDispatcher {
             _registerOperation(
               ticket: ticket,
               family: family,
-              ownerSessionId: sessionId,
-              interaction: interaction,
               body: body,
               result: result,
             );
@@ -123,8 +97,6 @@ class SessionOperationDispatcher {
             _registerOperation(
               ticket: ticket,
               family: family,
-              ownerSessionId: ownerSessionId,
-              interaction: PendingQuestionInteraction(requestId: questionId),
               body: () => body(ownerSessionId: ownerSessionId),
               result: result,
             );
@@ -149,7 +121,7 @@ class SessionOperationDispatcher {
   }
 
   @visibleForTesting
-  int get activeLaneCount => _familyLanes.length + _interactionLanes.length + _pluginAdmissionLanes.length;
+  int get activeLaneCount => _familyLanes.length + _pluginAdmissionLanes.length;
 
   Future<void> _drain() async {
     beginShutdown();
@@ -209,39 +181,17 @@ class SessionOperationDispatcher {
   void _registerOperation<T>({
     required int ticket,
     required SessionFamilyScope family,
-    required String ownerSessionId,
-    required PendingInteractionRequest? interaction,
     required Future<T> Function() body,
     required Completer<T> result,
   }) {
     final familyKey = (pluginId: family.pluginId, rootSessionId: family.rootSessionId);
-    final predecessors = <Future<void>>[
-      _familyLanes[familyKey]?.completion.future ?? Future<void>.value(),
-    ];
+    final predecessor = _familyLanes[familyKey]?.completion.future ?? Future<void>.value();
     final token = _LaneToken(ticket: ticket);
     _familyLanes[familyKey] = token;
-
-    final interactionKey = interaction == null
-        ? null
-        : (
-            pluginId: family.pluginId,
-            ownerSessionId: ownerSessionId,
-            kind: switch (interaction) {
-              PendingPermissionInteraction() => _PendingInteractionKind.permission,
-              PendingQuestionInteraction() => _PendingInteractionKind.question,
-            },
-            requestId: interaction.requestId,
-          );
-    if (interactionKey != null) {
-      predecessors.add(
-        _interactionLanes[interactionKey]?.completion.future ?? Future<void>.value(),
-      );
-      _interactionLanes[interactionKey] = token;
-    }
     _trackPlugin(result: result, pluginId: family.pluginId);
 
     unawaited(() async {
-      await Future.wait(predecessors);
+      await predecessor;
       try {
         result.complete(await body());
       } on Object catch (error, stackTrace) {
@@ -249,9 +199,6 @@ class SessionOperationDispatcher {
       } finally {
         token.completion.complete();
         if (identical(_familyLanes[familyKey], token)) _familyLanes.remove(familyKey);
-        if (interactionKey != null && identical(_interactionLanes[interactionKey], token)) {
-          _interactionLanes.remove(interactionKey);
-        }
       }
     }());
   }

--- a/bridge/app/lib/src/bridge/services/session_prompt_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_prompt_service.dart
@@ -45,7 +45,6 @@ class SessionPromptService {
       operation: normalizedCommand == null || normalizedCommand.isEmpty
           ? SessionOperation.sendPrompt
           : SessionOperation.sendCommand,
-      interaction: null,
       body: () => _sendPrompt(
         sessionId: sessionId,
         parts: parts,

--- a/bridge/app/test/bridge/routing/create_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_project_handler_test.dart
@@ -11,6 +11,7 @@ import "package:sesori_bridge/src/bridge/repositories/worktree_repository.dart";
 import "package:sesori_bridge/src/bridge/routing/create_project_handler.dart";
 import "package:sesori_bridge/src/bridge/services/project_activity_service.dart";
 import "package:sesori_bridge/src/bridge/services/project_initialization_service.dart";
+import "package:sesori_bridge/src/bridge/services/project_mutation_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -35,14 +36,15 @@ void main() {
         filesystemApi: const FilesystemApi(),
         permissionValidator: const FilesystemPermissionValidator(),
       );
+      final projectRepository = singlePluginProjectRepository(
+        gitCliApi: FakeGitCliApi(),
+        projectsDao: db.projectsDao,
+        sessionDao: db.sessionDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(),
+      );
       projectActivityService = ProjectActivityService(
-        projectRepository: singlePluginProjectRepository(
-          gitCliApi: FakeGitCliApi(),
-          projectsDao: db.projectsDao,
-          sessionDao: db.sessionDao,
-          unseenCalculator: const SessionUnseenCalculator(),
-          filesystemApi: FakeFilesystemApi(),
-        ),
+        projectRepository: projectRepository,
         projectActivityRepository: singlePluginProjectActivityRepository(
           plugin: plugin,
           projectsDao: db.projectsDao,
@@ -50,21 +52,26 @@ void main() {
         ),
         now: () => 1234,
       );
-      handler = CreateProjectHandler(
-        projectInitializationService: ProjectInitializationService(
-          worktreeRepository: singlePluginWorktreeRepository(
-            projectsDao: db.projectsDao,
-            sessionDao: db.sessionDao,
-            plugin: plugin,
-            gitApi: GitCliApi(
-              processRunner: ProcessRunner(),
-              gitPathExists: ({required String gitPath}) =>
-                  FileSystemEntity.typeSync(gitPath) != FileSystemEntityType.notFound,
-            ),
+      final projectInitializationService = ProjectInitializationService(
+        worktreeRepository: singlePluginWorktreeRepository(
+          projectsDao: db.projectsDao,
+          sessionDao: db.sessionDao,
+          plugin: plugin,
+          gitApi: GitCliApi(
+            processRunner: ProcessRunner(),
+            gitPathExists: ({required String gitPath}) =>
+                FileSystemEntity.typeSync(gitPath) != FileSystemEntityType.notFound,
           ),
-          filesystemRepository: filesystemRepository,
         ),
-        projectActivityService: projectActivityService,
+        filesystemRepository: filesystemRepository,
+      );
+      handler = CreateProjectHandler(
+        projectMutationService: ProjectMutationService(
+          filesystemRepository: filesystemRepository,
+          projectInitializationService: projectInitializationService,
+          projectActivityService: projectActivityService,
+          projectRepository: projectRepository,
+        ),
       );
       tempDir = await Directory.systemTemp.createTemp("create-project-handler-test-");
     });

--- a/bridge/app/test/bridge/routing/hide_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/hide_project_handler_test.dart
@@ -2,6 +2,7 @@ import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/bridge/repositories/project_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/routing/hide_project_handler.dart";
+import "package:sesori_bridge/src/bridge/services/project_mutation_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -27,7 +28,9 @@ void main() {
         unseenCalculator: const SessionUnseenCalculator(),
         filesystemApi: FakeFilesystemApi(),
       );
-      handler = HideProjectHandler(projectRepository: projectRepository);
+      handler = HideProjectHandler(
+        projectMutationService: _ProjectMutationService(projectRepository: projectRepository),
+      );
     });
 
     tearDown(() async {
@@ -85,4 +88,18 @@ void main() {
       expect(hiddenIds, contains(projectId));
     });
   });
+}
+
+class _ProjectMutationService implements ProjectMutationService {
+  final ProjectRepository projectRepository;
+
+  _ProjectMutationService({required this.projectRepository});
+
+  @override
+  Future<void> hideProject({required String projectId}) {
+    return projectRepository.hideProject(projectId: projectId);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/bridge/app/test/bridge/routing/open_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/open_project_handler_test.dart
@@ -10,6 +10,7 @@ import "package:sesori_bridge/src/bridge/repositories/worktree_repository.dart";
 import "package:sesori_bridge/src/bridge/routing/open_project_handler.dart";
 import "package:sesori_bridge/src/bridge/services/project_activity_service.dart";
 import "package:sesori_bridge/src/bridge/services/project_initialization_service.dart";
+import "package:sesori_bridge/src/bridge/services/project_mutation_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -57,18 +58,22 @@ void main() {
         ),
         now: () => 1234,
       );
-      handler = OpenProjectHandler(
-        filesystemRepository: filesystemRepository,
-        projectInitializationService: ProjectInitializationService(
-          worktreeRepository: WorktreeRepository(
-            projectsDao: db.projectsDao,
-            sessionDao: db.sessionDao,
-            gitApi: gitCliApi,
-            runtime: createTestPluginRuntime(plugins: [plugin]),
-          ),
-          filesystemRepository: filesystemRepository,
+      final projectInitializationService = ProjectInitializationService(
+        worktreeRepository: WorktreeRepository(
+          projectsDao: db.projectsDao,
+          sessionDao: db.sessionDao,
+          gitApi: gitCliApi,
+          runtime: createTestPluginRuntime(plugins: [plugin]),
         ),
-        projectActivityService: projectActivityService,
+        filesystemRepository: filesystemRepository,
+      );
+      handler = OpenProjectHandler(
+        projectMutationService: ProjectMutationService(
+          filesystemRepository: filesystemRepository,
+          projectInitializationService: projectInitializationService,
+          projectActivityService: projectActivityService,
+          projectRepository: projectRepository,
+        ),
       );
     });
 

--- a/bridge/app/test/bridge/services/project_mutation_service_test.dart
+++ b/bridge/app/test/bridge/services/project_mutation_service_test.dart
@@ -1,0 +1,259 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/bridge/repositories/filesystem_repository.dart";
+import "package:sesori_bridge/src/bridge/repositories/project_repository.dart";
+import "package:sesori_bridge/src/bridge/services/project_activity_service.dart";
+import "package:sesori_bridge/src/bridge/services/project_initialization_service.dart";
+import "package:sesori_bridge/src/bridge/services/project_mutation_service.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ProjectMutationService", () {
+    test("runs complete create and open workflows in FIFO order without overlap", () async {
+      final fixture = _Fixture();
+      final createGate = Completer<void>();
+      fixture.initialization.initializeGate = createGate;
+
+      final create = fixture.service.createProject(path: "/created");
+      await fixture.initialization.initializeStarted.future;
+      final open = fixture.service.openProject(
+        path: "/opened",
+        gitAction: OpenProjectGitAction.initializeGit,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(fixture.events, ["initialize:/created"]);
+
+      createGate.complete();
+      expect((await create).id, "/created");
+      expect(
+        await open,
+        isA<OpenProjectSuccess>().having((outcome) => outcome.project.id, "project id", "/opened"),
+      );
+      expect(fixture.events, [
+        "initialize:/created",
+        "open:/created",
+        "classify:/opened",
+        "prepare:/opened:initializeGit",
+        "open:/opened",
+      ]);
+    });
+
+    test("returns distinct open outcomes before persistence", () async {
+      final fixture = _Fixture();
+      fixture.filesystem.kinds.addAll({
+        "/missing": FilesystemEntityKind.notFound,
+        "/file": FilesystemEntityKind.notDirectory,
+      });
+      fixture.initialization.preparations["/choice"] = ExistingProjectPreparationOutcome.gitChoiceRequired;
+
+      expect(
+        await fixture.service.openProject(
+          path: "/missing",
+          gitAction: OpenProjectGitAction.promptIfNeeded,
+        ),
+        isA<OpenProjectDirectoryNotFound>(),
+      );
+      expect(
+        await fixture.service.openProject(
+          path: "/file",
+          gitAction: OpenProjectGitAction.promptIfNeeded,
+        ),
+        isA<OpenProjectPathNotDirectory>(),
+      );
+      expect(
+        await fixture.service.openProject(
+          path: "/choice",
+          gitAction: OpenProjectGitAction.promptIfNeeded,
+        ),
+        isA<OpenProjectGitChoiceRequired>(),
+      );
+      expect(fixture.activity.openedPaths, isEmpty);
+    });
+
+    test("open followed by hide finishes hidden", () async {
+      final fixture = _Fixture();
+      final openGate = Completer<void>();
+      fixture.activity.openGate = openGate;
+
+      final open = fixture.service.openProject(
+        path: "/project",
+        gitAction: OpenProjectGitAction.openWithoutGit,
+      );
+      await fixture.activity.openStarted.future;
+      final hide = fixture.service.hideProject(projectId: "/project");
+      await Future<void>.delayed(Duration.zero);
+
+      expect(fixture.projects.hideCalls, isEmpty);
+      openGate.complete();
+      await Future.wait([open, hide]);
+      expect(fixture.projects.hidden, isTrue);
+      expect(fixture.events, [
+        "classify:/project",
+        "prepare:/project:openWithoutGit",
+        "open:/project",
+        "hide:/project",
+      ]);
+    });
+
+    test("hide followed by open finishes visible", () async {
+      final fixture = _Fixture();
+      final hideGate = Completer<void>();
+      fixture.projects.hideGate = hideGate;
+
+      final hide = fixture.service.hideProject(projectId: "/project");
+      await fixture.projects.hideStarted.future;
+      final open = fixture.service.openProject(
+        path: "/project",
+        gitAction: OpenProjectGitAction.openWithoutGit,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(fixture.filesystem.classifiedPaths, isEmpty);
+      hideGate.complete();
+      await Future.wait([hide, open]);
+      expect(fixture.projects.hidden, isFalse);
+      expect(fixture.events, [
+        "hide:/project",
+        "classify:/project",
+        "prepare:/project:openWithoutGit",
+        "open:/project",
+      ]);
+    });
+
+    test("a failed workflow releases the FIFO for later work", () async {
+      final fixture = _Fixture();
+      final failure = StateError("Git setup failed");
+      fixture.initialization.initializeError = failure;
+
+      final create = fixture.service.createProject(path: "/failed");
+      final hide = fixture.service.hideProject(projectId: "/later");
+
+      await expectLater(create, throwsA(same(failure)));
+      await hide;
+      expect(fixture.projects.hideCalls, ["/later"]);
+      expect(fixture.events, ["initialize:/failed", "hide:/later"]);
+    });
+  });
+}
+
+class _Fixture {
+  final List<String> events = [];
+  late final _FilesystemRepository filesystem = _FilesystemRepository(events: events);
+  late final _ProjectInitializationService initialization = _ProjectInitializationService(events: events);
+  late final _ProjectRepository projects = _ProjectRepository(events: events);
+  late final _ProjectActivityService activity = _ProjectActivityService(
+    events: events,
+    projects: projects,
+  );
+  late final ProjectMutationService service = ProjectMutationService(
+    filesystemRepository: filesystem,
+    projectInitializationService: initialization,
+    projectActivityService: activity,
+    projectRepository: projects,
+  );
+}
+
+class _FilesystemRepository implements FilesystemRepository {
+  final List<String> events;
+  final Map<String, FilesystemEntityKind> kinds = {};
+  final List<String> classifiedPaths = [];
+
+  _FilesystemRepository({required this.events});
+
+  @override
+  FilesystemEntityKind classifyPath({required String path}) {
+    events.add("classify:$path");
+    classifiedPaths.add(path);
+    return kinds[path] ?? FilesystemEntityKind.directory;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _ProjectInitializationService implements ProjectInitializationService {
+  final List<String> events;
+  final Completer<void> initializeStarted = Completer<void>();
+  final Map<String, ExistingProjectPreparationOutcome> preparations = {};
+  Completer<void>? initializeGate;
+  Object? initializeError;
+
+  _ProjectInitializationService({required this.events});
+
+  @override
+  Future<void> initializeProject({required String path}) async {
+    events.add("initialize:$path");
+    if (!initializeStarted.isCompleted) initializeStarted.complete();
+    final gate = initializeGate;
+    if (gate != null) await gate.future;
+    final error = initializeError;
+    if (error != null) throw error;
+  }
+
+  @override
+  Future<ExistingProjectPreparationOutcome> prepareExistingProject({
+    required String path,
+    required OpenProjectGitAction gitAction,
+  }) async {
+    events.add("prepare:$path:${gitAction.name}");
+    return preparations[path] ?? ExistingProjectPreparationOutcome.ready;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _ProjectActivityService implements ProjectActivityService {
+  final List<String> events;
+  final _ProjectRepository projects;
+  final Completer<void> openStarted = Completer<void>();
+  final List<String> openedPaths = [];
+  Completer<void>? openGate;
+
+  _ProjectActivityService({required this.events, required this.projects});
+
+  @override
+  Future<Project> openProject({required String path}) async {
+    events.add("open:$path");
+    openedPaths.add(path);
+    if (!openStarted.isCompleted) openStarted.complete();
+    final gate = openGate;
+    if (gate != null) await gate.future;
+    projects.hidden = false;
+    return Project(
+      id: path,
+      name: path,
+      path: path,
+      time: null,
+      supportsDedicatedWorktrees: false,
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _ProjectRepository implements ProjectRepository {
+  final List<String> events;
+  final Completer<void> hideStarted = Completer<void>();
+  final List<String> hideCalls = [];
+  Completer<void>? hideGate;
+  bool hidden = false;
+
+  _ProjectRepository({required this.events});
+
+  @override
+  Future<void> hideProject({required String projectId}) async {
+    events.add("hide:$projectId");
+    hideCalls.add(projectId);
+    if (!hideStarted.isCompleted) hideStarted.complete();
+    final gate = hideGate;
+    if (gate != null) await gate.future;
+    hidden = true;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/bridge/services/session_family_mutation_test.dart
+++ b/bridge/app/test/bridge/services/session_family_mutation_test.dart
@@ -266,7 +266,6 @@ class _Fixture {
     return operations.dispatch(
       sessionId: sessionId,
       operation: SessionOperation.sendPrompt,
-      interaction: null,
       body: () => repository.executeAction(sessionId: sessionId),
     );
   }

--- a/bridge/app/test/bridge/services/session_operation_dispatcher_test.dart
+++ b/bridge/app/test/bridge/services/session_operation_dispatcher_test.dart
@@ -3,6 +3,7 @@ import "dart:async";
 import "package:sesori_bridge/src/bridge/repositories/models/session_operation.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginOperationException;
 import "package:test/test.dart";
 
 void main() {
@@ -25,7 +26,6 @@ void main() {
       final root = dispatcher.dispatch<void>(
         sessionId: "root",
         operation: SessionOperation.sendPrompt,
-        interaction: null,
         body: () async {
           rootStarted.complete();
           await rootGate.future;
@@ -34,19 +34,16 @@ void main() {
       final child = dispatcher.dispatch<void>(
         sessionId: "child",
         operation: SessionOperation.abortSession,
-        interaction: null,
         body: () async => childStarted.complete(),
       );
       final other = dispatcher.dispatch<void>(
         sessionId: "other",
         operation: SessionOperation.sendPrompt,
-        interaction: null,
         body: () async => otherStarted.complete(),
       );
       final pluginTwo = dispatcher.dispatch<void>(
         sessionId: "plugin-two",
         operation: SessionOperation.sendPrompt,
-        interaction: null,
         body: () async => pluginTwoStarted.complete(),
       );
 
@@ -58,7 +55,7 @@ void main() {
       expect(dispatcher.activeLaneCount, isZero);
     });
 
-    test("isolates reused interaction IDs and releases a failed lane", () async {
+    test("releases a failed family lane while unrelated families run", () async {
       final repository = _FamilyRepository({
         "a": (rootSessionId: "a", pluginId: "one"),
         "b": (rootSessionId: "b", pluginId: "one"),
@@ -75,7 +72,6 @@ void main() {
       final first = dispatcher.dispatch<void>(
         sessionId: "a",
         operation: SessionOperation.replyToQuestion,
-        interaction: const PendingQuestionInteraction(requestId: "reused"),
         body: () async {
           firstStarted.complete();
           await gate.future;
@@ -85,19 +81,16 @@ void main() {
       final same = dispatcher.dispatch<void>(
         sessionId: "a",
         operation: SessionOperation.rejectQuestion,
-        interaction: const PendingQuestionInteraction(requestId: "reused"),
         body: () async => sameStarted.complete(),
       );
       final otherFamily = dispatcher.dispatch<void>(
         sessionId: "b",
         operation: SessionOperation.rejectQuestion,
-        interaction: const PendingQuestionInteraction(requestId: "reused"),
         body: () async => otherFamilyStarted.complete(),
       );
       final otherPlugin = dispatcher.dispatch<void>(
         sessionId: "c",
         operation: SessionOperation.rejectQuestion,
-        interaction: const PendingQuestionInteraction(requestId: "reused"),
         body: () async => otherPluginStarted.complete(),
       );
 
@@ -130,7 +123,6 @@ void main() {
       final earlier = dispatcher.dispatch<void>(
         sessionId: "earlier",
         operation: SessionOperation.replyToQuestion,
-        interaction: const PendingQuestionInteraction(requestId: "question"),
         body: () async {
           earlierStarted.complete();
           await earlierGate.future;
@@ -154,13 +146,11 @@ void main() {
       final later = dispatcher.dispatch<void>(
         sessionId: "legacy-owner",
         operation: SessionOperation.abortSession,
-        interaction: null,
         body: () async => laterStarted.complete(),
       );
       final otherPlugin = dispatcher.dispatch<void>(
         sessionId: "other-plugin",
         operation: SessionOperation.abortSession,
-        interaction: null,
         body: () async => otherPluginStarted.complete(),
       );
 
@@ -175,6 +165,41 @@ void main() {
       legacyBodyGate.complete();
       await Future.wait([earlier, legacy, later, otherPlugin]);
       expect(laterStarted.isCompleted, isTrue);
+      expect(dispatcher.activeLaneCount, isZero);
+    });
+
+    test("legacy owner plugin mismatch releases later plugin admission", () async {
+      final repository = _FamilyRepository({
+        "wrong-owner": (rootSessionId: "wrong-owner", pluginId: "other"),
+        "later": (rootSessionId: "later", pluginId: "legacy"),
+      });
+      final dispatcher = SessionOperationDispatcher(sessionRepository: repository);
+      addTearDown(dispatcher.dispose);
+      var legacyBodyCalled = false;
+
+      final legacy = dispatcher.dispatchLegacyQuestion<void>(
+        pluginId: "legacy",
+        questionId: "question",
+        operation: SessionOperation.rejectQuestion,
+        resolveOwnerSessionId: () async => "wrong-owner",
+        body: ({required String ownerSessionId}) async {
+          legacyBodyCalled = true;
+        },
+      );
+      final later = dispatcher.dispatch<void>(
+        sessionId: "later",
+        operation: SessionOperation.abortSession,
+        body: () async {},
+      );
+
+      await expectLater(
+        legacy,
+        throwsA(
+          isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 409),
+        ),
+      );
+      await later;
+      expect(legacyBodyCalled, isFalse);
       expect(dispatcher.activeLaneCount, isZero);
     });
 
@@ -196,13 +221,11 @@ void main() {
       final first = dispatcher.dispatch<void>(
         sessionId: "first",
         operation: SessionOperation.sendPrompt,
-        interaction: null,
         body: () async {},
       );
       final second = dispatcher.dispatch<void>(
         sessionId: "second",
         operation: SessionOperation.sendPrompt,
-        interaction: null,
         body: () async {},
       );
       await firstResolutionStarted.future;
@@ -215,7 +238,6 @@ void main() {
         () => dispatcher.dispatch<void>(
           sessionId: "second",
           operation: SessionOperation.abortSession,
-          interaction: null,
           body: () async {},
         ),
         throwsStateError,


### PR DESCRIPTION
## Complexity

⚙️ Moderate — the change removes redundant session lane state and moves three project workflows behind one service FIFO across handlers, filesystem/Git operations, activity persistence, and repository mutation.

## What

- Remove modern permission/question interaction types, keys, lanes, parameters, and cleanup from `SessionOperationDispatcher`.
- Keep root-family FIFO as the modern interaction ordering owner.
- Preserve the released-client sessionless question fallback, including prior same-plugin settlement, owner lookup, plugin validation, and family admission.
- Add `ProjectMutationService` with one synchronous failure-safe FIFO around complete create/open/hide workflows.
- Keep request validation, HTTP mapping, and diagnostics in thin handlers through sealed open outcomes.
- Reuse routed-request lifecycle draining; add no canonical-path lanes, per-project concurrency, registry, drain, or disposal owner.

## Why

Family FIFO already serialized every modern pending interaction, so the second lane duplicated ownership. Concurrent relay dispatch will also remove the accidental transport ordering around project mutations; one coarse FIFO preserves current create/open/hide and Git sequencing without the disproportionate canonical-path machinery rejected during the Step 7 proportionality review.

## Risk and test focus

Risk is weakening modern or legacy pending-response order, allowing auto approval to bypass family ownership, poisoning the project tail after failure, overlapping Git setup, or letting open/hide completion invert arrival order. Highest-value checks cover family FIFO, legacy unique/missing/ambiguous owner behavior, complete project workflow serialization, both open/hide orders, create/open non-overlap, typed open outcomes, and failure release.

## Expected result

- **User-visible:** Session choices retain family arrival order. Project create/open/hide retain their existing arrival semantics; unrelated project mutations are intentionally serialized because no throughput need is demonstrated.
- **Persisted/database:** No schema or ID change. Existing project hidden/activity and session mutation meanings remain unchanged.
- **Internal:** Fewer session lane types and one coarse project workflow owner. No client, shared, wire, plugin-interface, generated, or analytics change.

## Verification

- `dart test` from `bridge/app`: 2,421 tests passed
- focused project mutation/handler, session dispatcher, pending interaction, auto-approval, family lifecycle, and legacy routing suites: passed
- `dart analyze --fatal-infos` from `bridge/app`: no issues
- `git diff --check`: passed
- changed lines: 707
- `aristotle-impl-review`: approved with no findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies project-mutation ordering by removing redundant interaction lanes and introducing a single FIFO-backed `ProjectMutationService` that serializes create/open/hide. Preserves session-family order and returns typed `open` outcomes.

- **Refactors**
  - Removed permission/question interaction lanes and related types/params from the session dispatcher and callers; root-family FIFO remains the ordering owner with legacy sessionless question fallback intact.
  - Added `ProjectMutationService` to run complete create/open/hide workflows behind one failure-safe FIFO and return sealed `OpenProjectOutcome` values (including Git-choice required).
  - Wired the service in orchestrator; routed `CreateProjectHandler`, `OpenProjectHandler`, and `HideProjectHandler` through it. Handlers now only validate and map HTTP (403/404/400/428/500).
  - No canonical-path lanes or per-project parallelism; no schema, wire, plugin-interface, or client changes.

- **Bug Fixes**
  - Clarified `OpenProjectHandler` failure log to report “failed to open project at <path>”.

<sup>Written for commit 07d9ed20b419061a5fb6141c6f5a8b7fe3fab0a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

