### PR TITLE
🚧 [relay-request-concurrency] fix(bridge): route client requests concurrently [step 9/10]

### DIFF
--- a/.plan/active/relay-request-concurrency/TRACKER.md
+++ b/.plan/active/relay-request-concurrency/TRACKER.md
@@ -3,14 +3,13 @@
 ## Current State
 
 - **Plan slug:** `relay-request-concurrency`
-- **Implementation base:** merged corrected Step 7 at
-  `6233da3e17f00517663b64e4eb5b789a47206514`
-- **Series state:** Steps 1–7 merged; over-defensive implementation
+- **Implementation base:** merged Step 8 at
+  `1d5816d14559b5970fad317921c12d29f66b4a23`
+- **Series state:** Steps 1–8 merged; over-defensive implementation
   [#716](https://github.com/sesori-ai/sesori_apps_monorepo/pull/716) remains closed without merge
-- **Current step:** Step 8/10 PR
-  [#721](https://github.com/sesori-ai/sesori_apps_monorepo/pull/721) open
+- **Current step:** Step 9/10 implementation ready for delivery
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged
-- **Next action:** review and merge Step 8; Step 9 remains blocked
+- **Next action:** open, review, and merge Step 9
 
 ## Incident Evidence
 
@@ -102,8 +101,8 @@
 | [x] | 5/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): preserve session action order [step 5/10]` | 900–1,400 | [PR #700](https://github.com/sesori-ai/sesori_apps_monorepo/pull/700) merged as `5ba0d3a6` with 1,534 changed lines |
 | [x] | 6/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope session family mutations [step 6/10]` | 750–1,250 | [PR #703](https://github.com/sesori-ai/sesori_apps_monorepo/pull/703) merged as `e4605eb1` with 1,054 changed lines |
 | [x] | 7/10 | `plan-parallel-requests` | `🌱 [relay-request-concurrency] docs: simplify remaining concurrency plan [step 7/10]` | 350–550 | [PR #720](https://github.com/sesori-ai/sesori_apps_monorepo/pull/720) merged as `6233da3e` with 543 changed lines; PR #716 closed without merge |
-| [ ] | 8/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): simplify domain mutation ordering [step 8/10]` | 500–900 | [PR #721](https://github.com/sesori-ai/sesori_apps_monorepo/pull/721) open from `6233da3e` |
-| [ ] | 9/10 | `relay-request-concurrency-dispatch` | `🚧 [relay-request-concurrency] fix(bridge): route client requests concurrently [step 9/10]` | 950–1,450 | Blocked on Step 8 merge |
+| [x] | 8/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): simplify domain mutation ordering [step 8/10]` | 500–900 | [PR #721](https://github.com/sesori-ai/sesori_apps_monorepo/pull/721) merged as `1d5816d1` with 709 changed lines |
+| [ ] | 9/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] fix(bridge): route client requests concurrently [step 9/10]` | 950–1,450 | Implementation ready from `1d5816d1`; verification and architecture review pass |
 | [ ] | 10/10 | `relay-request-concurrency-retire-plan` | `🌱 [relay-request-concurrency] docs: retire concurrent routing plan [step 10/10]` | 50–150 | Blocked on Step 9 merge |
 
 ## Exact PR Titles
@@ -427,4 +426,25 @@
   typed outcomes, dependency direction, lifecycle ownership, and proportionality
   passed.
 - **Step 8/10 delivery:** [PR #721](https://github.com/sesori-ai/sesori_apps_monorepo/pull/721)
-  is open from `6233da3e` at 709 changed lines.
+  merged as `1d5816d14559b5970fad317921c12d29f66b4a23` at 709 changed lines.
+- **Step 9/10 implementation:** relay frame ingestion now synchronously dispatches
+  and tracks routed transport completions without awaiting business work. Opaque
+  phone-incarnation tokens plus exact relay handles fence final encrypted sends;
+  accepted restarts still dispatch exactly once after sent, stale, or current
+  send-failure disposition. Initial SSE summaries reserve the existing summary
+  tail before detached construction, and teardown drains all session-owned relay
+  completions alongside the shared routed-request barrier.
+- **Step 9/10 cleanup:** removed the single in-flight route identity and the
+  shutdown-mislabeled completion-only slow-route diagnostic. Multi-operation
+  counts retain privacy-safe shutdown context. No timers, pools, new production
+  classes, wire/data, client, shared, plugin-interface, generated, or analytics
+  changes were added.
+- **Step 9/10 verification:** 2,428 full `bridge/app` tests pass. Focused request
+  concurrency, response fencing, restart disposition, registration/reconnect,
+  token re-auth, SSE summary ordering, error recovery, and shutdown suites pass;
+  strict `dart analyze --fatal-infos` reports no issues and `git diff --check`
+  passes.
+- **Step 9/10 architecture review:** `aristotle-impl-review` approved the complete
+  tracked and untracked diff with no findings. Lifecycle ownership, synchronous
+  tracking, incarnation/epoch fencing, restart sequencing, summary ordering,
+  teardown draining, and proportional scope passed.

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -2079,6 +2079,36 @@ class OrchestratorSession {
     }
     Log.v("response: status=${response.status}");
 
+    await _deliverRoutedResponse(
+      connection: connection,
+      connID: connID,
+      response: response,
+      routeIdentity: routeIdentity,
+      phoneIncarnation: phoneIncarnation,
+      activePhoneIncarnations: activePhoneIncarnations,
+    );
+
+    if (_cancelled) return;
+    switch (outcome) {
+      case ResponseOnly():
+        break;
+      case final RestartAccepted accepted:
+        try {
+          await _restartDispatcher.dispatch(restart: accepted);
+        } on Object catch (error, stackTrace) {
+          Log.e("route ${routeIdentity.diagnosticLabel} failed for connId $connID", error, stackTrace);
+        }
+    }
+  }
+
+  Future<void> _deliverRoutedResponse({
+    required RelayConnection connection,
+    required int connID,
+    required RelayResponse response,
+    required RouteIdentity routeIdentity,
+    required Object phoneIncarnation,
+    required Map<int, Object> activePhoneIncarnations,
+  }) async {
     final ({List<int> payload, int cleartextLength}) encrypted;
     try {
       encrypted = await _encryptRelayMessage(message: response, connID: connID);
@@ -2114,18 +2144,6 @@ class OrchestratorSession {
       }
     } on Object catch (error, stackTrace) {
       Log.w("failed to send response for ${routeIdentity.diagnosticLabel} to connId $connID", error, stackTrace);
-    }
-
-    if (_cancelled) return;
-    switch (outcome) {
-      case ResponseOnly():
-        break;
-      case final RestartAccepted accepted:
-        try {
-          await _restartDispatcher.dispatch(restart: accepted);
-        } on Object catch (error, stackTrace) {
-          Log.e("route ${routeIdentity.diagnosticLabel} failed for connId $connID", error, stackTrace);
-        }
     }
   }
 

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -693,6 +693,8 @@ class OrchestratorSession {
   // ignore: cancel_subscriptions - cancelled by the failure-isolated session drain.
   final CompositeSubscription _subscriptions = CompositeSubscription();
   final Map<String, Future<void>> _pluginEventProcessingTails = <String, Future<void>>{};
+  final Set<Future<void>> _inFlightRelayCompletions = <Future<void>>{};
+  final Map<String, int> _inFlightRouteCounts = <String, int>{};
   Future<void> _projectsSummaryTail = Future<void>.value();
   final Random _backoffJitter = Random();
   Future<void>? _lifecycleFuture;
@@ -705,12 +707,7 @@ class OrchestratorSession {
   /// diagnostics (the logger emits no timestamps, so durations are explicit).
   DateTime? _cancelRequestedAt;
 
-  /// Privacy-safe identity of the relay request currently being routed.
-  RouteIdentity? _inFlightRouteIdentity;
-
-  /// Completes when [cancel] is first called. Allows in-flight request routing
-  /// to abandon a response instead of awaiting an OpenCode HTTP call that has
-  /// outlived the relay session.
+  /// Completes when [cancel] is first called so reconnect waits wake promptly.
   final Completer<void> _shutdownCompleter = Completer<void>();
   final Completer<void> _firstPhoneConnectedCompleter = Completer<void>();
 
@@ -906,7 +903,7 @@ class OrchestratorSession {
     required Completer<OrchestratorSessionStartResult> readiness,
   }) async {
     final kxManager = KeyExchangeManager(_roomKey);
-    final activePhones = <int, bool>{};
+    final activePhoneIncarnations = <int, Object>{};
 
     Log.d("registering bridge with auth server...");
     await _bridgeRegistrationService.ensureRegistered();
@@ -1025,7 +1022,7 @@ class OrchestratorSession {
       readiness: readiness,
       initialConnection: relayConnection,
       kxManager: kxManager,
-      activePhones: activePhones,
+      activePhoneIncarnations: activePhoneIncarnations,
     );
   }
 
@@ -1051,7 +1048,7 @@ class OrchestratorSession {
     Log.d(
       "[shutdown] session teardown begin "
       "(${sinceCancelMs == null ? "no cancel timestamp" : "${sinceCancelMs}ms since cancel()"}"
-      "${_inFlightRouteIdentity == null ? "" : ", in-flight request: ${_inFlightRouteIdentity!.diagnosticLabel}"})",
+      "${_inFlightRelayWorkDiagnostic(separator: ", ")})",
     );
     await Future.wait([
       attempt(_subscriptions.cancel),
@@ -1067,8 +1064,12 @@ class OrchestratorSession {
         await Future.wait(_pluginEventProcessingTails.values);
       }),
       attempt(_routedRequestDispatcher.drain),
+      attempt(_drainRelayCompletions),
     ]);
-    Log.v("[shutdown] plugin events and routed requests drained (+${teardownSw.elapsedMilliseconds}ms)");
+    Log.v(
+      "[shutdown] plugin events, routed requests, and relay completions drained "
+      "(+${teardownSw.elapsedMilliseconds}ms)",
+    );
     _sessionOperationDispatcher.beginShutdown();
     await attempt(_sessionOperationDispatcher.dispose);
     Log.v("[shutdown] session operations drained (+${teardownSw.elapsedMilliseconds}ms)");
@@ -1121,7 +1122,7 @@ class OrchestratorSession {
     required Completer<OrchestratorSessionStartResult> readiness,
     required RelayConnection initialConnection,
     required KeyExchangeManager kxManager,
-    required Map<int, bool> activePhones,
+    required Map<int, Object> activePhoneIncarnations,
   }) async {
     var connection = initialConnection;
     while (!_cancelled) {
@@ -1141,7 +1142,7 @@ class OrchestratorSession {
             connection: connection,
             roomKey: _roomKey,
             kxManager: kxManager,
-            activePhones: activePhones,
+            activePhoneIncarnations: activePhoneIncarnations,
           );
         } on Object catch (error, stackTrace) {
           if (_cancelled) break;
@@ -1161,7 +1162,7 @@ class OrchestratorSession {
 
       Log.w("Relay connection lost. Reconnecting...");
       _sseManager.orphanAll();
-      activePhones.clear();
+      activePhoneIncarnations.clear();
       // Every phone connection died with the relay link; drop their view
       // declarations so no session stays "watched" by a ghost connection.
       // Phones re-assert their current view on reconnect.
@@ -1247,7 +1248,7 @@ class OrchestratorSession {
       _cancelRequestedAt = DateTime.now();
       Log.d(
         "[shutdown] cancel() requested"
-        "${_inFlightRouteIdentity == null ? "" : " — in-flight request: ${_inFlightRouteIdentity!.diagnosticLabel}"}",
+        "${_inFlightRelayWorkDiagnostic(separator: " — ")}",
       );
     } else {
       Log.v("[shutdown] cancel() again (already shutting down)");
@@ -1282,6 +1283,49 @@ class OrchestratorSession {
       _relayConnection = null;
     }
     await closeFuture;
+  }
+
+  void _trackRelayCompletion({
+    required Future<void> completion,
+    required RouteIdentity? routeIdentity,
+  }) {
+    final routeLabel = routeIdentity?.diagnosticLabel;
+    if (routeLabel != null) {
+      _inFlightRouteCounts.update(routeLabel, (count) => count + 1, ifAbsent: () => 1);
+    }
+
+    late final Future<void> trackedCompletion;
+    trackedCompletion = () async {
+      try {
+        await completion;
+      } finally {
+        _inFlightRelayCompletions.remove(trackedCompletion);
+        if (routeLabel != null) {
+          final remaining = _inFlightRouteCounts[routeLabel]! - 1;
+          if (remaining == 0) {
+            _inFlightRouteCounts.remove(routeLabel);
+          } else {
+            _inFlightRouteCounts[routeLabel] = remaining;
+          }
+        }
+      }
+    }();
+    _inFlightRelayCompletions.add(trackedCompletion);
+    trackedCompletion.ignore();
+  }
+
+  Future<void> _drainRelayCompletions() async {
+    await Future.wait(_inFlightRelayCompletions.toList(growable: false));
+  }
+
+  String _inFlightRelayWorkDiagnostic({required String separator}) {
+    if (_inFlightRelayCompletions.isEmpty) return "";
+    final routes = [
+      for (final MapEntry(key: label, value: count) in _inFlightRouteCounts.entries)
+        count == 1 ? label : "$label x$count",
+    ];
+    return "$separator${_inFlightRelayCompletions.length} in-flight relay completion(s)"
+        "${routes.isEmpty ? "" : ": ${routes.join(", ")}"}";
   }
 
   Future<void> _processPluginEventInOrder(NormalizedSourcedBridgeEvent source) {
@@ -1453,12 +1497,8 @@ class OrchestratorSession {
     required int? generation,
     required bool allowDuringStop,
   }) {
-    final previous = _projectsSummaryTail;
-    final release = Completer<void>();
-    _projectsSummaryTail = release.future;
-    return () async {
-      await previous;
-      try {
+    return _enqueueProjectsSummaryInOrder(
+      operation: () async {
         if (!_isCurrentSource(pluginId: pluginId, generation: generation, allowDuringStop: allowDuringStop)) return;
         final summary = await _buildProjectsSummary();
         if (summary != null) {
@@ -1469,6 +1509,18 @@ class OrchestratorSession {
             allowDuringStop: allowDuringStop,
           );
         }
+      },
+    );
+  }
+
+  Future<void> _enqueueProjectsSummaryInOrder({required Future<void> Function() operation}) {
+    final previous = _projectsSummaryTail;
+    final release = Completer<void>();
+    _projectsSummaryTail = release.future;
+    return () async {
+      await previous;
+      try {
+        await operation();
       } finally {
         release.complete();
       }
@@ -1702,7 +1754,7 @@ class OrchestratorSession {
     required RelayConnection connection,
     required List<int> roomKey,
     required KeyExchangeManager kxManager,
-    required Map<int, bool> activePhones,
+    required Map<int, Object> activePhoneIncarnations,
   }) async {
     var hasMessage = await firstRead;
     while (hasMessage) {
@@ -1737,7 +1789,7 @@ class OrchestratorSession {
               Log.v("phone_connected connID=$connID");
             case "phone_disconnected":
               Log.v("phone_disconnected connID=$connID");
-              activePhones.remove(connID);
+              activePhoneIncarnations.remove(connID);
               _sseManager.removeSubscriber(connID);
               _sessionViewTracker.releaseConnection(connID: connID);
               _projectViewTracker.releaseConnection(connID: connID);
@@ -1804,7 +1856,7 @@ class OrchestratorSession {
             throw Exception("send ready for connId $connID: $e");
           }
 
-          _markPhoneConnected(connID: connID, activePhones: activePhones);
+          _markPhoneConnected(connID: connID, activePhoneIncarnations: activePhoneIncarnations);
           break processMessage;
         }
 
@@ -1824,7 +1876,8 @@ class OrchestratorSession {
             decryptError = e;
           }
 
-          if (activePhones[connID] == true) {
+          final phoneIncarnation = activePhoneIncarnations[connID];
+          if (phoneIncarnation != null) {
             if (decryptError != null || decrypted == null) {
               Log.v(
                 "failed to decrypt from connId $connID: $decryptError",
@@ -1832,10 +1885,12 @@ class OrchestratorSession {
               break processMessage;
             }
             Log.v("decrypted OK from connID=$connID, handling...");
-            await _handleDecryptedMessage(
+            _handleDecryptedMessage(
               connection: connection,
               connID: connID,
               decrypted: decrypted,
+              phoneIncarnation: phoneIncarnation,
+              activePhoneIncarnations: activePhoneIncarnations,
             );
             Log.v("handled message from connID=$connID");
             break processMessage;
@@ -1899,26 +1954,31 @@ class OrchestratorSession {
             throw Exception("send resume ack for connId $connID: $e");
           }
 
-          _markPhoneConnected(connID: connID, activePhones: activePhones);
+          _markPhoneConnected(connID: connID, activePhoneIncarnations: activePhoneIncarnations);
         }
       }
       hasMessage = await iterator.moveNext();
     }
   }
 
-  void _markPhoneConnected({required int connID, required Map<int, bool> activePhones}) {
-    activePhones[connID] = true;
+  void _markPhoneConnected({
+    required int connID,
+    required Map<int, Object> activePhoneIncarnations,
+  }) {
+    activePhoneIncarnations[connID] = Object();
     if (!_firstPhoneConnectedCompleter.isCompleted) {
       _firstPhoneConnectedCompleter.complete();
     }
     Log.d("phone $connID is now active");
   }
 
-  Future<void> _handleDecryptedMessage({
+  void _handleDecryptedMessage({
     required RelayConnection connection,
     required int connID,
     required List<int> decrypted,
-  }) async {
+    required Object phoneIncarnation,
+    required Map<int, Object> activePhoneIncarnations,
+  }) {
     RelayMessage msg;
     try {
       msg = RelayMessage.fromJson(
@@ -1933,91 +1993,32 @@ class OrchestratorSession {
 
     switch (msg) {
       case final RelayRequest req:
+        Log.v("RelayRequest: ${req.method} ${req.path}");
         final dispatch = _routedRequestDispatcher.dispatch(request: req);
-        if (dispatch case final RoutedRequestShutdownRejected rejected) {
-          if (!_cancelled) {
-            try {
-              await _encryptAndSend(
+        switch (dispatch) {
+          case final RoutedRequestShutdownRejected rejected:
+            _trackRelayCompletion(
+              completion: _completeShutdownRejection(
                 connection: connection,
                 connID: connID,
-                message: rejected.response,
-              );
-            } on Object catch (error, stackTrace) {
-              Log.w("failed to send shutdown rejection to connId $connID", error, stackTrace);
-            }
-          }
-          return;
-        }
-        final pendingRoute = (dispatch as RoutedRequestAccepted).pendingRequest;
-        final routeIdentity = pendingRoute.routeIdentity;
-        Log.v("RelayRequest: ${req.method} ${req.path}");
-        _inFlightRouteIdentity = routeIdentity;
-        final routeSw = Stopwatch()..start();
-        // If shutdown wins the race below, this future keeps running in the
-        // background. ignore() marks any later failure as handled so it can
-        // never surface as an unhandled async exception after abandonment.
-        final routeFuture = pendingRoute.completion..ignore();
-        try {
-          final outcome = await Future.any<RoutedRequestOutcome>([
-            routeFuture,
-            _shutdownCompleter.future.then((_) => throw const _ShutdownInProgressException()),
-          ]);
-          final response = outcome.response;
-          if (_cancelled) {
-            Log.v(
-              "[shutdown] route ${routeIdentity.diagnosticLabel} completed after cancel — "
-              "dropping response (status=${response.status})",
+                response: rejected.response,
+                phoneIncarnation: phoneIncarnation,
+                activePhoneIncarnations: activePhoneIncarnations,
+              ),
+              routeIdentity: null,
             );
-            return;
-          }
-          if (routeSw.elapsedMilliseconds > 1000) {
-            Log.d(
-              "[shutdown] slow route ${routeIdentity.diagnosticLabel} for connId $connID "
-              "took ${routeSw.elapsedMilliseconds}ms (cancelled=$_cancelled)",
+          case final RoutedRequestAccepted accepted:
+            final pendingRoute = accepted.pendingRequest;
+            _trackRelayCompletion(
+              completion: _completeRoutedRequest(
+                connection: connection,
+                connID: connID,
+                pendingRoute: pendingRoute,
+                phoneIncarnation: phoneIncarnation,
+                activePhoneIncarnations: activePhoneIncarnations,
+              ),
+              routeIdentity: pendingRoute.routeIdentity,
             );
-          }
-          Log.v("response: status=${response.status}");
-          try {
-            final sendOutcome = await _encryptAndSend(
-              connection: connection,
-              connID: connID,
-              message: response,
-            );
-            if (sendOutcome == RelaySendOutcome.sent) {
-              Log.v("response sent to connID=$connID");
-            } else {
-              Log.v("response dropped because its relay connection is stale");
-            }
-          } finally {
-            if (!_cancelled) {
-              switch (outcome) {
-                case ResponseOnly():
-                  break;
-                case final RestartAccepted accepted:
-                  await _restartDispatcher.dispatch(restart: accepted);
-              }
-            }
-          }
-        } on _ShutdownInProgressException {
-          Log.v(
-            "[shutdown] route ${routeIdentity.diagnosticLabel} will finish without sending a response",
-          );
-          // Keep route-owned services and plugin APIs alive until the operation
-          // settles. The shutdown coordinator's process backstop bounds this
-          // drain if an upstream operation never returns.
-          try {
-            await routeFuture;
-          } on Object catch (error, stackTrace) {
-            Log.w("[shutdown] route ${routeIdentity.diagnosticLabel} failed while draining", error, stackTrace);
-          }
-        } on Object catch (error, stackTrace) {
-          if (_cancelled) {
-            Log.w("[shutdown] route ${routeIdentity.diagnosticLabel} failed during shutdown", error, stackTrace);
-          } else {
-            Log.e("route ${routeIdentity.diagnosticLabel} failed for connId $connID", error, stackTrace);
-          }
-        } finally {
-          _inFlightRouteIdentity = null;
         }
       case final RelaySseSubscribe subscribe:
         Log.v("SseSubscribe: path=${subscribe.path}");
@@ -2028,12 +2029,10 @@ class OrchestratorSession {
             client: _client,
             connection: connection,
           );
-          final projSummary = await _buildProjectsSummary();
-          if (projSummary != null) {
-            _enqueueWireEvent(projSummary);
-            _completionListener.handleSseEvent(projSummary);
-          }
-          Log.v("initial projectsSummary enqueued");
+          _trackRelayCompletion(
+            completion: _completeInitialProjectsSummary(connID: connID),
+            routeIdentity: null,
+          );
         } on Object catch (error, stackTrace) {
           Log.e("sse subscribe failed for connId $connID", error, stackTrace);
         }
@@ -2048,6 +2047,128 @@ class OrchestratorSession {
       default:
         Log.v("unhandled msg type: ${msg.runtimeType}");
     }
+  }
+
+  Future<void> _completeRoutedRequest({
+    required RelayConnection connection,
+    required int connID,
+    required PendingRoutedRequest pendingRoute,
+    required Object phoneIncarnation,
+    required Map<int, Object> activePhoneIncarnations,
+  }) async {
+    final routeIdentity = pendingRoute.routeIdentity;
+    final routeSw = Stopwatch()..start();
+    final RoutedRequestOutcome outcome;
+    try {
+      outcome = await pendingRoute.completion;
+    } on Object catch (error, stackTrace) {
+      if (_cancelled) {
+        Log.w("[shutdown] route ${routeIdentity.diagnosticLabel} failed while draining", error, stackTrace);
+      } else {
+        Log.e("route ${routeIdentity.diagnosticLabel} failed for connId $connID", error, stackTrace);
+      }
+      return;
+    }
+
+    final response = outcome.response;
+    if (routeSw.elapsedMilliseconds > 1000) {
+      Log.d(
+        "slow route ${routeIdentity.diagnosticLabel} for connId $connID "
+        "took ${routeSw.elapsedMilliseconds}ms (cancelled=$_cancelled)",
+      );
+    }
+    Log.v("response: status=${response.status}");
+
+    final ({List<int> payload, int cleartextLength}) encrypted;
+    try {
+      encrypted = await _encryptRelayMessage(message: response, connID: connID);
+    } on Object catch (error, stackTrace) {
+      Log.e("failed to encrypt response for ${routeIdentity.diagnosticLabel} and connId $connID", error, stackTrace);
+      return;
+    }
+
+    if (_cancelled) {
+      Log.v(
+        "[shutdown] route ${routeIdentity.diagnosticLabel} completed after cancel — "
+        "dropping response (status=${response.status})",
+      );
+      return;
+    }
+
+    try {
+      final sendOutcome = _sendEncryptedResponseIfCurrent(
+        connection: connection,
+        connID: connID,
+        payload: encrypted.payload,
+        cleartextLength: encrypted.cleartextLength,
+        phoneIncarnation: phoneIncarnation,
+        activePhoneIncarnations: activePhoneIncarnations,
+      );
+      if (sendOutcome == RelaySendOutcome.sent) {
+        Log.v("response sent to connID=$connID");
+      } else if (_cancelled) {
+        Log.v("[shutdown] response dropped after cancellation");
+        return;
+      } else {
+        Log.v("response dropped because its client incarnation or relay connection is stale");
+      }
+    } on Object catch (error, stackTrace) {
+      Log.w("failed to send response for ${routeIdentity.diagnosticLabel} to connId $connID", error, stackTrace);
+    }
+
+    if (_cancelled) return;
+    switch (outcome) {
+      case ResponseOnly():
+        break;
+      case final RestartAccepted accepted:
+        try {
+          await _restartDispatcher.dispatch(restart: accepted);
+        } on Object catch (error, stackTrace) {
+          Log.e("route ${routeIdentity.diagnosticLabel} failed for connId $connID", error, stackTrace);
+        }
+    }
+  }
+
+  Future<void> _completeShutdownRejection({
+    required RelayConnection connection,
+    required int connID,
+    required RelayResponse response,
+    required Object phoneIncarnation,
+    required Map<int, Object> activePhoneIncarnations,
+  }) async {
+    try {
+      final encrypted = await _encryptRelayMessage(message: response, connID: connID);
+      if (_cancelled) return;
+      _sendEncryptedResponseIfCurrent(
+        connection: connection,
+        connID: connID,
+        payload: encrypted.payload,
+        cleartextLength: encrypted.cleartextLength,
+        phoneIncarnation: phoneIncarnation,
+        activePhoneIncarnations: activePhoneIncarnations,
+      );
+    } on Object catch (error, stackTrace) {
+      Log.w("failed to send shutdown rejection to connId $connID", error, stackTrace);
+    }
+  }
+
+  Future<void> _completeInitialProjectsSummary({required int connID}) {
+    return _enqueueProjectsSummaryInOrder(
+      operation: () async {
+        try {
+          if (_cancelled) return;
+          final projectsSummary = await _buildProjectsSummary();
+          if (_cancelled) return;
+          if (projectsSummary != null) {
+            _enqueueWireEvent(projectsSummary);
+            _completionListener.handleSseEvent(projectsSummary);
+          }
+          Log.v("initial projectsSummary enqueued");
+        } on Object catch (error, stackTrace) {
+          Log.e("initial projectsSummary failed for connId $connID", error, stackTrace);
+        }
+      },
+    );
   }
 
   // Ordinary drop (network blip, relay restart) reconnects promptly; a
@@ -2096,25 +2217,38 @@ class OrchestratorSession {
     return base + Duration(milliseconds: extra);
   }
 
-  Future<RelaySendOutcome> _encryptAndSend({
-    required RelayConnection connection,
+  Future<({List<int> payload, int cleartextLength})> _encryptRelayMessage({
     required int connID,
     required RelayMessage message,
   }) async {
     final respJson = jsonEncode(message.toJson());
     final jsonBytes = utf8.encode(respJson);
-    Log.v("[response] sending ${jsonBytes.length} bytes to connID=$connID");
+    Log.v("[response] encrypting ${jsonBytes.length} bytes for connID=$connID");
     final cryptoService = RelayCryptoService();
     final encryptionKey = SecretKey(List<int>.from(_roomKey));
     final encryptor = cryptoService.createSessionEncryptor(encryptionKey);
     final framed = await frame(jsonBytes, encryptor: encryptor);
+    return (payload: framed, cleartextLength: jsonBytes.length);
+  }
+
+  RelaySendOutcome _sendEncryptedResponseIfCurrent({
+    required RelayConnection connection,
+    required int connID,
+    required List<int> payload,
+    required int cleartextLength,
+    required Object phoneIncarnation,
+    required Map<int, Object> activePhoneIncarnations,
+  }) {
+    if (_cancelled) return RelaySendOutcome.stale;
+    if (!identical(activePhoneIncarnations[connID], phoneIncarnation)) return RelaySendOutcome.stale;
+    if (!identical(_relayConnection, connection)) return RelaySendOutcome.stale;
     final outcome = _sendIfCurrent(
       connection: connection,
       connID: connID,
-      payload: framed,
+      payload: payload,
     );
     if (outcome == RelaySendOutcome.sent) {
-      _bytesSentController.add(jsonBytes.length);
+      _bytesSentController.add(cleartextLength);
     }
     return outcome;
   }
@@ -2146,9 +2280,4 @@ class OrchestratorSession {
       rethrow;
     }
   }
-}
-
-/// Thrown when a request is racing against shutdown and shutdown wins.
-class _ShutdownInProgressException implements Exception {
-  const _ShutdownInProgressException();
 }

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -451,6 +451,183 @@ void main() {
     await runFuture.timeout(const Duration(seconds: 5));
   });
 
+  test("initial SSE summary is detached and reserves summary delivery order", () async {
+    final relayServer = await TestRelayServer.start();
+    final harness = await _OrchestratorHarness.create(
+      pluginIds: const ["one"],
+      relayUrl: "ws://127.0.0.1:${relayServer.port}",
+    );
+    addTearDown(() async {
+      await harness.close();
+      await relayServer.close();
+    });
+
+    final running = await startTestOrchestratorSession(session: harness.composition.session);
+    final runFuture = running.stopped;
+    final socket = await relayServer.nextClient();
+    final messages = StreamIterator<dynamic>(socket);
+    final roomKey = await _exchangeRoomKey(
+      socket: socket,
+      messages: messages,
+      connID: 404,
+    );
+    await harness.activatePlugins();
+
+    const directory = "/projects/subscription-order";
+    const oldSession = PluginSession(
+      id: "initial-session",
+      projectID: directory,
+      directory: directory,
+      parentID: null,
+      title: "Initial session",
+      time: PluginSessionTime(created: 1, updated: 1, archived: null),
+    );
+    const newSession = PluginSession(
+      id: "later-session",
+      projectID: directory,
+      directory: directory,
+      parentID: null,
+      title: "Later session",
+      time: PluginSessionTime(created: 2, updated: 2, archived: null),
+    );
+    final plugin = harness.plugins.single;
+    final initialReadStarted = Completer<void>();
+    final releaseInitialRead = Completer<void>();
+    plugin
+      ..activitySummaries = const [
+        PluginProjectActivitySummary(
+          id: directory,
+          activeSessions: [PluginActiveSession(id: "initial-session", awaitingInput: false)],
+        ),
+      ]
+      ..currentProjectResult = const PluginProject(id: directory, directory: directory)
+      ..sessionsResult = const [oldSession, newSession]
+      ..getProjectStarted = initialReadStarted
+      ..getProjectGate = releaseInitialRead;
+    final summaries = <SesoriProjectsSummary>[];
+    final summarySubscription = harness.composition.session.localWireEvents
+        .where((event) => event is SesoriProjectsSummary)
+        .cast<SesoriProjectsSummary>()
+        .listen(summaries.add);
+
+    try {
+      await _sendEncryptedRelayMessage(
+        socket: socket,
+        connID: 404,
+        roomKey: roomKey,
+        message: const RelayMessage.sseSubscribe(path: "/events"),
+      );
+      await initialReadStarted.future.timeout(const Duration(seconds: 2));
+
+      final laterReadStarted = Completer<void>();
+      plugin
+        ..activitySummaries = const [
+          PluginProjectActivitySummary(
+            id: directory,
+            activeSessions: [PluginActiveSession(id: "later-session", awaitingInput: true)],
+          ),
+        ]
+        ..activeSummaryReadStarted = laterReadStarted;
+      plugin.emitEvent(const BridgeSseProjectUpdated());
+      await _sendEncryptedRelayMessage(
+        socket: socket,
+        connID: 404,
+        roomKey: roomKey,
+        message: const RelayMessage.projectView(projectId: "relay-remains-responsive"),
+      );
+
+      try {
+        await _waitFor(
+          () => harness.composition.projectViewTracker.activeProjectIds.contains("relay-remains-responsive"),
+          reason: "relay control while initial summary is blocked",
+          timeout: const Duration(milliseconds: 500),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        expect(
+          laterReadStarted.isCompleted,
+          isFalse,
+          reason: "the later summary must wait behind the already-enqueued initial build",
+        );
+      } finally {
+        if (!releaseInitialRead.isCompleted) releaseInitialRead.complete();
+      }
+
+      await laterReadStarted.future.timeout(const Duration(seconds: 2));
+      await _waitFor(() => summaries.length == 2, reason: "initial and later summaries");
+      expect(
+        summaries.map((summary) => summary.projects.single.activeSessions.single.awaitingInput),
+        [false, true],
+      );
+    } finally {
+      if (!releaseInitialRead.isCompleted) releaseInitialRead.complete();
+      await summarySubscription.cancel();
+      await harness.composition.session.cancel();
+      await runFuture.timeout(const Duration(seconds: 5));
+      await messages.cancel();
+    }
+  });
+
+  test("shutdown drains a detached initial summary without broadcasting it late", () async {
+    final relayServer = await TestRelayServer.start();
+    final harness = await _OrchestratorHarness.create(
+      pluginIds: const ["one"],
+      relayUrl: "ws://127.0.0.1:${relayServer.port}",
+    );
+    addTearDown(() async {
+      await harness.close();
+      await relayServer.close();
+    });
+
+    final running = await startTestOrchestratorSession(session: harness.composition.session);
+    final runFuture = running.stopped;
+    final socket = await relayServer.nextClient();
+    final messages = StreamIterator<dynamic>(socket);
+    final roomKey = await _exchangeRoomKey(
+      socket: socket,
+      messages: messages,
+      connID: 405,
+    );
+    await harness.activatePlugins();
+    final summaryStarted = Completer<void>();
+    final summaryGate = Completer<void>();
+    _configureBlockingProjectSummary(
+      plugin: harness.plugins.single,
+      started: summaryStarted,
+      gate: summaryGate,
+    );
+    final summaries = <SesoriProjectsSummary>[];
+    final summarySubscription = harness.composition.session.localWireEvents
+        .where((event) => event is SesoriProjectsSummary)
+        .cast<SesoriProjectsSummary>()
+        .listen(summaries.add);
+    var stopped = false;
+    runFuture.then((_) => stopped = true).ignore();
+
+    try {
+      await _sendEncryptedRelayMessage(
+        socket: socket,
+        connID: 405,
+        roomKey: roomKey,
+        message: const RelayMessage.sseSubscribe(path: "/events"),
+      );
+      await summaryStarted.future.timeout(const Duration(seconds: 2));
+
+      await harness.composition.session.cancel();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(stopped, isFalse);
+
+      summaryGate.complete();
+      await runFuture.timeout(const Duration(seconds: 5));
+      expect(summaries, isEmpty);
+    } finally {
+      if (!summaryGate.isCompleted) summaryGate.complete();
+      await summarySubscription.cancel();
+      await harness.composition.session.cancel();
+      await runFuture.timeout(const Duration(seconds: 5));
+      await messages.cancel();
+    }
+  });
+
   test("shutdown drains in-flight post-normalization work", () async {
     final relayServer = await TestRelayServer.start();
     final harness = await _OrchestratorHarness.create(

--- a/bridge/app/test/bridge/orchestrator_request_concurrency_test.dart
+++ b/bridge/app/test/bridge/orchestrator_request_concurrency_test.dart
@@ -1,0 +1,571 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+
+import "package:cryptography/cryptography.dart";
+import "package:http/http.dart" as http;
+import "package:sesori_bridge/src/api/database/database.dart";
+import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
+import "package:sesori_bridge/src/bridge/models/bridge_config.dart";
+import "package:sesori_bridge/src/bridge/orchestrator.dart";
+import "package:sesori_bridge/src/bridge/relay_client.dart";
+import "package:sesori_bridge/src/bridge/runtime/bridge_runtime.dart";
+import "package:sesori_bridge/src/server/services/bridge_restart_service.dart";
+import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" hide PermissionReply;
+import "package:test/test.dart";
+
+import "../helpers/plugin_lifecycle_test_support.dart";
+import "../helpers/test_database.dart";
+import "../helpers/test_helpers.dart";
+import "routing/routing_test_helpers.dart";
+
+void main() {
+  group("OrchestratorSession concurrent relay requests", () {
+    test("a stalled request does not block same-client health or another client's control flow", () async {
+      final harness = await _ConcurrencyHarness.start();
+      addTearDown(harness.close);
+      await harness.insertSession(sessionId: "stalled-session");
+      final firstPhone = await harness.activatePhone(connId: 11);
+      final routeStarted = Completer<void>();
+      final routeGate = Completer<void>();
+      harness.plugin
+        ..messagesStarted = routeStarted
+        ..messagesDelay = routeGate.future;
+
+      await harness.sendEncrypted(
+        connId: 11,
+        encryptor: firstPhone,
+        message: RelayMessage.request(
+          id: "stalled-request",
+          method: "POST",
+          path: "/session/messages",
+          headers: const {},
+          body: jsonEncode(const SessionIdRequest(sessionId: "stalled-session").toJson()),
+        ),
+      );
+      await routeStarted.future.timeout(const Duration(seconds: 2));
+
+      try {
+        final secondPhone = await harness.activatePhone(connId: 22);
+        harness.disconnectPhone(connId: 22);
+        await harness.resumePhone(connId: 22, encryptor: secondPhone);
+
+        await harness.sendEncrypted(
+          connId: 11,
+          encryptor: firstPhone,
+          message: const RelayMessage.request(
+            id: "health-request",
+            method: "GET",
+            path: "/global/health",
+            headers: {},
+            body: null,
+          ),
+        );
+        final health = await harness.nextResponse(
+          connId: 11,
+          encryptor: firstPhone,
+          requestId: "health-request",
+        );
+
+        expect(health.status, 200);
+        expect(routeGate.isCompleted, isFalse);
+
+        routeGate.complete();
+        final stalled = await harness.nextResponse(
+          connId: 11,
+          encryptor: firstPhone,
+          requestId: "stalled-request",
+        );
+        expect(stalled.status, 200);
+      } finally {
+        if (!routeGate.isCompleted) routeGate.complete();
+      }
+    });
+
+    test("phone disconnect and rekey fence a reused connId without suppressing restart", () async {
+      final harness = await _ConcurrencyHarness.start();
+      addTearDown(harness.close);
+      final originalPhone = await harness.activatePhone(connId: 31);
+      final preflightStarted = Completer<void>();
+      final preflightGate = Completer<void>();
+      harness.restartService
+        ..restartable = true
+        ..canRestartStarted = preflightStarted
+        ..canRestartDelay = preflightGate.future;
+
+      await harness.sendEncrypted(
+        connId: 31,
+        encryptor: originalPhone,
+        message: const RelayMessage.request(
+          id: "stale-restart",
+          method: "POST",
+          path: "/global/restart",
+          headers: {},
+          body: null,
+        ),
+      );
+      await preflightStarted.future.timeout(const Duration(seconds: 2));
+
+      try {
+        harness.disconnectPhone(connId: 31);
+        await harness.activatePhone(connId: 31);
+        final sendsBeforeCompletion = harness.relayClient.sendCount;
+        final attemptsBeforeCompletion = harness.relayClient.sendAttempts.length;
+
+        preflightGate.complete();
+        await harness.restartService.handoffPerformed.future.timeout(const Duration(seconds: 2));
+
+        expect(harness.restartService.handoffCalls, 1);
+        expect(harness.restartService.sendCountAtHandoff, sendsBeforeCompletion);
+        expect(harness.restartService.sendAttemptCountAtHandoff, attemptsBeforeCompletion);
+        await harness.runFuture.timeout(const Duration(seconds: 5));
+      } finally {
+        if (!preflightGate.isCompleted) preflightGate.complete();
+      }
+    });
+
+    test("relay reconnect fences an old response from a successor reusing the connId", () async {
+      final harness = await _ConcurrencyHarness.start();
+      addTearDown(harness.close);
+      final originalPhone = await harness.activatePhone(connId: 41);
+      final preflightStarted = Completer<void>();
+      final preflightGate = Completer<void>();
+      harness.restartService
+        ..restartable = true
+        ..canRestartStarted = preflightStarted
+        ..canRestartDelay = preflightGate.future;
+
+      await harness.sendEncrypted(
+        connId: 41,
+        encryptor: originalPhone,
+        message: const RelayMessage.request(
+          id: "old-epoch-restart",
+          method: "POST",
+          path: "/global/restart",
+          headers: {},
+          body: null,
+        ),
+      );
+      await preflightStarted.future.timeout(const Duration(seconds: 2));
+
+      try {
+        await harness.reconnectRelay();
+        await harness.activatePhone(connId: 41);
+        final sendsBeforeCompletion = harness.relayClient.sendCount;
+        final attemptsBeforeCompletion = harness.relayClient.sendAttempts.length;
+
+        preflightGate.complete();
+        await harness.restartService.handoffPerformed.future.timeout(const Duration(seconds: 2));
+
+        expect(harness.restartService.handoffCalls, 1);
+        expect(harness.restartService.sendCountAtHandoff, sendsBeforeCompletion);
+        expect(harness.restartService.sendAttemptCountAtHandoff, attemptsBeforeCompletion);
+        await harness.runFuture.timeout(const Duration(seconds: 5));
+      } finally {
+        if (!preflightGate.isCompleted) preflightGate.complete();
+      }
+    });
+
+    test("restart dispatch follows a synchronously claimed current send failure", () async {
+      final harness = await _ConcurrencyHarness.start();
+      addTearDown(harness.close);
+      final phone = await harness.activatePhone(connId: 51);
+      final closeGate = Completer<void>();
+      harness.restartService.restartable = true;
+      harness.relayClient
+        ..closeDelay = closeGate.future
+        ..failNextSend = true;
+      final sendsBeforeRestart = harness.relayClient.sendCount;
+      final attemptsBeforeRestart = harness.relayClient.sendAttempts.length;
+
+      await harness.sendEncrypted(
+        connId: 51,
+        encryptor: phone,
+        message: const RelayMessage.request(
+          id: "send-failure-restart",
+          method: "POST",
+          path: "/global/restart",
+          headers: {},
+          body: null,
+        ),
+      );
+
+      try {
+        await harness.restartService.handoffPerformed.future.timeout(const Duration(seconds: 2));
+
+        expect(harness.restartService.handoffCalls, 1);
+        expect(harness.restartService.sendCountAtHandoff, sendsBeforeRestart);
+        expect(harness.restartService.sendAttemptCountAtHandoff, attemptsBeforeRestart + 1);
+        expect(harness.restartService.closeAttemptCountAtHandoff, 1);
+        expect(harness.relayClient.closeStarted.isCompleted, isTrue);
+        expect(closeGate.isCompleted, isFalse, reason: "restart must not await the close handshake");
+      } finally {
+        if (!closeGate.isCompleted) closeGate.complete();
+      }
+      await harness.runFuture.timeout(const Duration(seconds: 5));
+    });
+
+    test("shutdown drains accepted work and prevents its late response send", () async {
+      final harness = await _ConcurrencyHarness.start();
+      addTearDown(harness.close);
+      await harness.insertSession(sessionId: "shutdown-session");
+      final phone = await harness.activatePhone(connId: 61);
+      final routeStarted = Completer<void>();
+      final routeGate = Completer<void>();
+      harness.plugin
+        ..messagesStarted = routeStarted
+        ..messagesDelay = routeGate.future;
+
+      await harness.sendEncrypted(
+        connId: 61,
+        encryptor: phone,
+        message: RelayMessage.request(
+          id: "shutdown-request",
+          method: "POST",
+          path: "/session/messages",
+          headers: const {},
+          body: jsonEncode(const SessionIdRequest(sessionId: "shutdown-session").toJson()),
+        ),
+      );
+      await routeStarted.future.timeout(const Duration(seconds: 2));
+      final sendsAtShutdown = harness.relayClient.sendCount;
+      final attemptsAtShutdown = harness.relayClient.sendAttempts.length;
+      var stopped = false;
+      harness.runFuture.then((_) => stopped = true).ignore();
+
+      try {
+        await harness.composition.session.cancel();
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(stopped, isFalse);
+
+        routeGate.complete();
+        await harness.runFuture.timeout(const Duration(seconds: 5));
+        expect(harness.relayClient.sendCount, sendsAtShutdown);
+        expect(harness.relayClient.sendAttempts.length, attemptsAtShutdown);
+      } finally {
+        if (!routeGate.isCompleted) routeGate.complete();
+      }
+    });
+  });
+}
+
+class _ConcurrencyHarness {
+  final _BlockingMessagesPlugin plugin;
+  final OrchestratorComposition composition;
+  final Future<void> runFuture;
+  final TestRelayServer relayServer;
+  final AppDatabase database;
+  final PluginLifecycleService lifecycleService;
+  final http.Client httpClient;
+  final BridgeRuntime runtime;
+  final _RecordingRelayClient relayClient;
+  final _RecordingRestartService restartService;
+
+  WebSocket _socket;
+  StreamIterator<dynamic> _messages;
+
+  _ConcurrencyHarness._({
+    required this.plugin,
+    required this.composition,
+    required this.runFuture,
+    required this.relayServer,
+    required this.database,
+    required this.lifecycleService,
+    required this.httpClient,
+    required this.runtime,
+    required this.relayClient,
+    required this.restartService,
+    required WebSocket socket,
+    required StreamIterator<dynamic> messages,
+  }) : _socket = socket,
+       _messages = messages;
+
+  static Future<_ConcurrencyHarness> start() async {
+    final relayServer = await TestRelayServer.start();
+    final database = createTestDatabase();
+    final plugin = _BlockingMessagesPlugin();
+    final lifecycleService = await createSinglePluginLifecycleService(plugin: plugin);
+    final httpClient = http.Client();
+    final registrationService = createFakeBridgeRegistrationService();
+    final relayClient = _RecordingRelayClient(
+      relayURL: "ws://127.0.0.1:${relayServer.port}",
+      accessTokenProvider: FakeAccessTokenProvider(),
+      bridgeIdProvider: registrationService,
+    );
+    final restartService = _RecordingRestartService(relayClient: relayClient);
+    final failureReporter = FakeFailureReporter();
+    final composition = Orchestrator(
+      config: BridgeConfig(
+        relayURL: "ws://127.0.0.1:${relayServer.port}",
+        authBackendURL: "http://127.0.0.1:8080",
+        sseReplayWindow: const Duration(minutes: 1),
+        yolo: false,
+      ),
+      client: relayClient,
+      legacyMissingPluginId: plugin.id,
+      pluginLifecycleService: lifecycleService,
+      pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
+      bridgeSettingsRepository: settingsRepositoryForLifecycleService(service: lifecycleService),
+      clock: const ServerClock(),
+      database: database,
+      httpClient: httpClient,
+      processRunner: ProcessRunner(),
+      accessTokenProvider: FakeAccessTokenProvider(),
+      tokenRefresher: FakeTokenRefresher(),
+      bridgeRegistrationService: registrationService,
+      failureReporter: failureReporter,
+      restartService: restartService,
+      filesystemAccessOk: true,
+      statusNotifier: null,
+    ).create();
+    final runtime = BridgeRuntime(
+      database: database,
+      failureReporter: failureReporter,
+      composition: composition,
+    );
+    final running = await startTestOrchestratorSession(session: composition.session);
+    final socket = await relayServer.nextClient();
+    final messages = StreamIterator<dynamic>(socket);
+    expect(await messages.moveNext(), isTrue);
+    expect(jsonDecodeMap(messages.current as String)["type"], "auth");
+
+    return _ConcurrencyHarness._(
+      plugin: plugin,
+      composition: composition,
+      runFuture: running.stopped,
+      relayServer: relayServer,
+      database: database,
+      lifecycleService: lifecycleService,
+      httpClient: httpClient,
+      runtime: runtime,
+      relayClient: relayClient,
+      restartService: restartService,
+      socket: socket,
+      messages: messages,
+    );
+  }
+
+  Future<void> insertSession({required String sessionId}) {
+    return composition.sessionRepository.insertStoredSession(
+      sessionId: sessionId,
+      backendSessionId: "backend-$sessionId",
+      pluginId: plugin.id,
+      projectId: "/repo",
+      isDedicated: false,
+      createdAt: 1,
+      worktreePath: null,
+      branchName: null,
+      baseBranch: null,
+      baseCommit: null,
+      agent: null,
+      agentModel: null,
+    );
+  }
+
+  Future<SessionEncryptor> activatePhone({required int connId}) async {
+    final crypto = RelayCryptoService();
+    final phoneKeyPair = await crypto.generateKeyPair();
+    final phonePublicKey = await phoneKeyPair.extractPublicKey();
+    _sendPayload(
+      connId: connId,
+      payload: utf8.encode(
+        jsonEncode(
+          RelayMessage.keyExchange(
+            publicKey: base64Url.encode(phonePublicKey.bytes).replaceAll("=", ""),
+          ).toJson(),
+        ),
+      ),
+    );
+
+    final response = await _nextPayload(connId: connId);
+    final bridgePublicKey = SimplePublicKey(response.sublist(0, 32), type: KeyPairType.x25519);
+    final secret = await crypto.deriveSharedSecret(phoneKeyPair, peerPublicKey: bridgePublicKey);
+    final keyExchangeEncryptor = crypto.createSessionEncryptor(await crypto.deriveEncryptionKey(secret));
+    final readyBytes = await unframe(response.sublist(32), encryptor: keyExchangeEncryptor);
+    final ready = RelayMessage.fromJson(jsonDecodeMap(utf8.decode(readyBytes))) as RelayReady;
+    final roomKey = SecretKey(base64Url.decode(base64Url.normalize(ready.roomKey)));
+    return crypto.createSessionEncryptor(roomKey);
+  }
+
+  void disconnectPhone({required int connId}) {
+    _socket.add(jsonEncode({"type": "phone_disconnected", "connId": connId}));
+  }
+
+  Future<void> resumePhone({required int connId, required SessionEncryptor encryptor}) async {
+    await sendEncrypted(
+      connId: connId,
+      encryptor: encryptor,
+      message: const RelayMessage.resume(),
+    );
+    final response = await _nextPayload(connId: connId);
+    final decrypted = await unframe(response, encryptor: encryptor);
+    expect(
+      RelayMessage.fromJson(jsonDecodeMap(utf8.decode(decrypted))),
+      isA<RelayResumeAck>(),
+    );
+  }
+
+  Future<void> sendEncrypted({
+    required int connId,
+    required SessionEncryptor encryptor,
+    required RelayMessage message,
+  }) async {
+    final payload = await frame(
+      utf8.encode(jsonEncode(message.toJson())),
+      encryptor: encryptor,
+    );
+    _sendPayload(connId: connId, payload: payload);
+  }
+
+  Future<RelayResponse> nextResponse({
+    required int connId,
+    required SessionEncryptor encryptor,
+    required String requestId,
+  }) async {
+    while (true) {
+      final payload = await _nextPayload(connId: connId);
+      final decrypted = await unframe(payload, encryptor: encryptor);
+      final message = RelayMessage.fromJson(jsonDecodeMap(utf8.decode(decrypted)));
+      if (message case final RelayResponse response when response.id == requestId) {
+        return response;
+      }
+    }
+  }
+
+  Future<void> reconnectRelay() async {
+    await _socket.close();
+    await _messages.cancel();
+    _socket = await relayServer.nextClient().timeout(const Duration(seconds: 5));
+    _messages = StreamIterator<dynamic>(_socket);
+    expect(await _messages.moveNext(), isTrue);
+    expect(jsonDecodeMap(_messages.current as String)["type"], "auth");
+  }
+
+  void _sendPayload({required int connId, required List<int> payload}) {
+    _socket.add(<int>[connId >> 8, connId & 0xFF, ...payload]);
+  }
+
+  Future<List<int>> _nextPayload({required int connId}) async {
+    while (await _messages.moveNext().timeout(const Duration(seconds: 5))) {
+      final message = _messages.current;
+      if (message is! List<int> || message.length < 2) continue;
+      final messageConnId = message[0] << 8 | message[1];
+      if (messageConnId == connId) return message.sublist(2);
+    }
+    throw StateError("relay closed before a payload for connId $connId");
+  }
+
+  Future<void> close() async {
+    await composition.session.cancel();
+    await runFuture.timeout(const Duration(seconds: 10));
+    await _messages.cancel();
+    await runtime.close();
+    await lifecycleService.dispose();
+    httpClient.close();
+    await plugin.closeEvents();
+    await relayServer.close();
+  }
+}
+
+class _BlockingMessagesPlugin extends FakeBridgePlugin {
+  Completer<void>? messagesStarted;
+  Future<void>? messagesDelay;
+
+  @override
+  Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId) async {
+    final started = messagesStarted;
+    if (started != null && !started.isCompleted) started.complete();
+    final delay = messagesDelay;
+    if (delay != null) await delay;
+    return super.getSessionMessages(sessionId);
+  }
+}
+
+class _RecordingRelayClient extends RelayClient {
+  _RecordingRelayClient({
+    required super.relayURL,
+    required super.accessTokenProvider,
+    required super.bridgeIdProvider,
+  });
+
+  final List<({RelayConnection connection, int connId})> sendAttempts = [];
+  final List<RelayConnection> closeAttempts = [];
+  final Completer<void> closeStarted = Completer<void>();
+  int sendCount = 0;
+  bool failNextSend = false;
+  Future<void>? closeDelay;
+
+  @override
+  RelaySendOutcome sendIfCurrent({
+    required RelayConnection connection,
+    required int connID,
+    required List<int> payload,
+  }) {
+    sendAttempts.add((connection: connection, connId: connID));
+    if (failNextSend) {
+      failNextSend = false;
+      throw StateError("send failed intentionally");
+    }
+    final outcome = super.sendIfCurrent(
+      connection: connection,
+      connID: connID,
+      payload: payload,
+    );
+    if (outcome == RelaySendOutcome.sent) sendCount++;
+    return outcome;
+  }
+
+  @override
+  Future<RelayCloseOutcome> closeIfCurrent({required RelayConnection connection}) async {
+    closeAttempts.add(connection);
+    final closeFuture = super.closeIfCurrent(connection: connection);
+    if (!closeStarted.isCompleted) closeStarted.complete();
+    final delay = closeDelay;
+    if (delay != null) await delay;
+    return closeFuture;
+  }
+}
+
+class _RecordingRestartService implements BridgeRestartService {
+  _RecordingRestartService({required this.relayClient});
+
+  final _RecordingRelayClient relayClient;
+  final Completer<void> handoffPerformed = Completer<void>();
+  bool restartable = false;
+  Completer<void>? canRestartStarted;
+  Future<void>? canRestartDelay;
+  int handoffCalls = 0;
+  int? sendCountAtHandoff;
+  int? sendAttemptCountAtHandoff;
+  int? closeAttemptCountAtHandoff;
+
+  @override
+  bool get supervisedRestartRequested => false;
+
+  @override
+  Future<bool> canRestart() async {
+    final started = canRestartStarted;
+    if (started != null && !started.isCompleted) started.complete();
+    final delay = canRestartDelay;
+    if (delay != null) await delay;
+    return restartable;
+  }
+
+  @override
+  Future<bool> canSpawnSuccessor() async => restartable;
+
+  @override
+  Future<bool> performRestartHandoff() async {
+    handoffCalls++;
+    sendCountAtHandoff = relayClient.sendCount;
+    sendAttemptCountAtHandoff = relayClient.sendAttempts.length;
+    closeAttemptCountAtHandoff = relayClient.closeAttempts.length;
+    if (!handoffPerformed.isCompleted) handoffPerformed.complete();
+    return true;
+  }
+
+  @override
+  Future<bool> spawnSuccessor() async => true;
+}


### PR DESCRIPTION
## Complexity

🚧 Complex — this separates relay frame ingestion from asynchronous route and SSE-summary completion while preserving client-incarnation, relay-epoch, restart, ordering, and teardown invariants.

## What

- Dispatches and tracks routed relay requests without awaiting business work in the frame loop.
- Fences encrypted responses with opaque phone-incarnation tokens and the exact relay connection handle immediately before synchronous send.
- Preserves accepted restart handoff after sent, stale, or current-send-failure disposition.
- Detaches initial SSE summary construction behind the existing summary-ordering tail.
- Drains session-owned relay completions during teardown and retains multi-operation diagnostics.
- Adds focused concurrency, reconnect/rekey fencing, restart, summary-ordering, and shutdown regressions.

## Why

A slow route previously blocked all subsequent relay frames, making otherwise healthy clients and plugins appear offline. The bridge must continue processing independent requests and control traffic while accepted domain work settles under its existing ordering owners.

## Risk and test focus

Risk is high around stale response delivery, reused connection IDs, reconnects, restart suppression, summary inversion, and incomplete shutdown drain. Tests gate requests and summaries to verify later same-client work and another client's control flow remain responsive, stale incarnations and relay handles cannot receive old responses, restart handoff follows every terminal delivery disposition, and shutdown prevents late sends while draining accepted work.

## Expected result

- **User-visible:** Healthy clients and plugins remain responsive while one request is slow; only the dependent request remains pending.
- **Persisted/database:** No schema or persistence-contract change. Accepted mutations retain their existing commit and ordering semantics.
- **Internal:** Relay ingestion and asynchronous transport completion have separate tracked lifecycles with exact connection/client fencing. No wire, client, shared, plugin-interface, generated, or analytics change.

## Verification

- `dart test test/bridge/orchestrator_request_concurrency_test.dart` — 5 passed
- `dart test test/bridge/orchestrator_emit_bridge_event_test.dart` — 12 passed
- `dart test test/bridge/orchestrator_registration_test.dart` — 16 passed
- `dart test test/bridge/orchestrator_error_recovery_test.dart test/bridge/orchestrator_token_reauth_test.dart` — 13 passed
- `dart analyze --fatal-infos` — no issues
- `dart test` — all 2,428 tests passed
- `git diff --check` — passed
- `aristotle-impl-review` — approved with no findings
- 1,167 changed lines, within the 1,500-line soft cap

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route client requests concurrently so one slow route no longer blocks other relay frames. Also ensures restart handoff is preserved even if encryption or send fails.

- **New Features**
  - Dispatch routed requests without awaiting business work; track and drain relay completions on shutdown.
  - Fence responses with per-connection incarnation tokens and the exact relay handle before send.
  - Preserve restart handoff after sent, stale, send-failure, or encryption-failure outcomes.
  - Build the initial SSE projects summary behind the existing summary tail to keep order; drain detached summaries during teardown.
  - Replace single in-flight route identity with per-route counts in diagnostics.
  - No wire/client/plugin-interface or persistence changes.

- **Verification**
  - Added tests for concurrency, fencing on reconnect/rekey, restart sequencing with encryption/send failures, SSE summary ordering, and shutdown drain of relay completions.
  - All tests pass; analyzer clean.

<sup>Written for commit 7d6f5023f8e7ac2e42fd032d8eeb018141d51403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

