### PR TITLE
🌿 Recover relay after bridge replacement

### DIFF
--- a/bridge/app/yaak/opencode/yaak.rq_vCuXW4iXW3.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_vCuXW4iXW3.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_vCuXW4iXW3
 createdAt: 2026-03-13T12:40:22.635390
-updatedAt: 2026-04-27T08:20:01.795664
+updatedAt: 2026-08-03T08:09:40.655760
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_McTnzzzzcF
 authentication: {}
@@ -35,11 +35,11 @@ url: ${[ base_url ]}/session
 urlParameters:
 - enabled: false
   name: directory
-  value: ''
+  value: ${[ directory ]}
   id: tg69Aa6EmW
 - enabled: true
   name: roots
-  value: 'true'
+  value: 'false'
   id: NKnwfKRbGd
 - enabled: false
   name: start
@@ -56,4 +56,19 @@ urlParameters:
 - enabled: true
   name: ''
   value: ''
-  id: ttf8wj4vRB
+  id: Qdypid4k6j
+settingSendCookies:
+  enabled: false
+  value: true
+settingStoreCookies:
+  enabled: false
+  value: true
+settingValidateCertificates:
+  enabled: false
+  value: true
+settingFollowRedirects:
+  enabled: false
+  value: true
+settingRequestTimeout:
+  enabled: false
+  value: 0

--- a/client/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/client/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -509,8 +509,18 @@ class ConnectionService {
       (status) {
         switch (status) {
           case BridgeStatus.online:
-            if (_status.value is ConnectionBridgeOffline) {
-              logd("Bridge came back online — reconnecting to re-establish encryption");
+            final currentStatus = _status.value;
+            if (currentStatus is ConnectionBridgeOffline || currentStatus is ConnectionConnected) {
+              if (currentStatus is ConnectionConnected) {
+                // A replacement bridge can connect without an intervening
+                // offline event. Stop requests from using the prior bridge's
+                // room key while token refresh prepares the replacement socket.
+                logd("Bridge connection was replaced — reconnecting to re-establish encryption");
+                unawaited(_disconnectRelayClient());
+                _status.add(ConnectionStatus.reconnecting(config: config));
+              } else {
+                logd("Bridge came back online — reconnecting to re-establish encryption");
+              }
               // immediate: the bridge is provably present and the parked (or
               // stale) socket needs replacing now, so skip the reconnect backoff
               // delay. Backoff still applies to genuinely failed retries, so a

--- a/client/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
+++ b/client/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
@@ -1027,6 +1027,7 @@ void main() {
       expect(service.currentStatus, isA<ConnectionReconnecting>());
       expect(service.relayClient, isNull);
       expect(factory.callCount, 1);
+      await untilCalled(initialClient.disconnect);
       verify(initialClient.disconnect).called(1);
 
       refreshedToken.complete("fresh-token");

--- a/client/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
+++ b/client/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
@@ -961,6 +961,82 @@ void main() {
       expect(service.currentStatus, isA<ConnectionConnected>());
     });
 
+    test("replacement bridge detaches the connected client before refreshing auth", () async {
+      final bridgeStatusController = StreamController<BridgeStatus>.broadcast();
+      addTearDown(bridgeStatusController.close);
+      final initialSseController = StreamController<RelaySseEvent>.broadcast();
+      addTearDown(initialSseController.close);
+
+      final initialClient = MockRelayClient();
+      when(initialClient.connect).thenAnswer((_) async {});
+      when(() => initialClient.isConnected).thenReturn(true);
+      when(() => initialClient.connectionState).thenReturn(RelayClientConnectionState.connected);
+      when(() => initialClient.didResume).thenReturn(false);
+      when(() => initialClient.sendRequest(any())).thenAnswer(
+        (_) async => RelayResponse(id: "h", status: 200, body: jsonEncode(health.toJson()), headers: const {}),
+      );
+      when(() => initialClient.subscribeSse(any())).thenAnswer((_) => initialSseController.stream);
+      when(() => initialClient.bridgeStatus).thenAnswer((_) => bridgeStatusController.stream);
+      when(initialClient.disconnect).thenAnswer((_) async {});
+
+      final replacementSseController = StreamController<RelaySseEvent>.broadcast();
+      addTearDown(replacementSseController.close);
+      final replacementClient = MockRelayClient();
+      when(replacementClient.connect).thenAnswer((_) async {});
+      when(() => replacementClient.isConnected).thenReturn(true);
+      when(() => replacementClient.connectionState).thenReturn(RelayClientConnectionState.connected);
+      when(() => replacementClient.didResume).thenReturn(true);
+      when(() => replacementClient.subscribeSse(any())).thenAnswer((_) => replacementSseController.stream);
+      when(() => replacementClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
+      when(replacementClient.disconnect).thenAnswer((_) async {});
+
+      final clients = <MockRelayClient>[initialClient, replacementClient];
+      var nextClient = 0;
+      final factory = _TestRelayClientFactory(
+        ({
+          required String relayHost,
+          required RelayCryptoService cryptoService,
+          required RoomKeyStorage roomKeyStorage,
+          required String? authToken,
+        }) => clients[nextClient++],
+      );
+      final service = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        failureReporter,
+        relayClientFactory: factory,
+      );
+      addTearDown(service.dispose);
+
+      await service.connect(config);
+      expect(service.currentStatus, isA<ConnectionConnected>());
+
+      final refreshedToken = Completer<String?>();
+      when(
+        () => authTokenProvider.getFreshAccessToken(minTtl: any(named: "minTtl")),
+      ).thenAnswer((_) => refreshedToken.future);
+
+      // The relay emits bridge_connected, but intentionally no disconnected
+      // event, when one live bridge connection replaces another.
+      bridgeStatusController.add(BridgeStatus.online);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(service.currentStatus, isA<ConnectionReconnecting>());
+      expect(service.relayClient, isNull);
+      expect(factory.callCount, 1);
+      verify(initialClient.disconnect).called(1);
+
+      refreshedToken.complete("fresh-token");
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(factory.callCount, 2);
+      expect(service.relayClient, same(replacementClient));
+      expect(service.currentStatus, isA<ConnectionConnected>());
+    });
+
     test("socket closing while parked is recovered like an SSE drop", () async {
       final socketClosedController = StreamController<void>.broadcast();
       addTearDown(socketClosedController.close);


### PR DESCRIPTION
## Complexity

🌿 Straightforward. This is a localized connection-lifecycle correction with focused regression coverage and a small Yaak request refresh.

## What

- Treat `bridge_connected` received while already connected as a direct bridge replacement.
- Detach the stale relay client and publish `ConnectionReconnecting` before auth refresh can delay replacement.
- Reuse the existing immediate reconnect flow to resume or negotiate a fresh room key.
- Cover replacement without an intervening `bridge_disconnected` event using deterministic teardown synchronization.
- Refresh the List Sessions Yaak request to use the directory environment value and request all sessions by default.

## Why

The relay intentionally replaces a live bridge connection without first reporting the bridge offline. The client previously ignored `bridge_connected` while its status remained connected, retained the old bridge room key, and sent the next prompt with that stale key. The replacement bridge then returned plaintext `rekey_required`; the client attempted to decode its leading `{` byte as an encrypted protocol version and logged `Unsupported relay message version: 123`.

This occurs before OpenCode request handling and is not caused by an OpenCode response format.

## Risk and test focus

No database impact and no wire-contract changes. The user-visible impact is limited to entering the existing reconnect state when a bridge connection is replaced, instead of letting the next request fail with a stale encryption key. The Yaak change affects only a development request fixture.

Test focus is immediate stale-client detachment, reconnect state publication, and successful replacement-client connection after token refresh.

## Expected result

A phone connected during bridge replacement immediately re-establishes its encrypted relay session. Sending a prompt no longer produces `Unsupported relay message version: 123` from a plaintext `rekey_required` response. The List Sessions Yaak request defaults to all sessions and can use the configured project directory.

## Verification

- `dart test test/capabilities/server_connection/connection_service_reconnect_test.dart`
- `dart test` in `client/module_core`
- `dart analyze` in `client/module_core`
- `flutter test` in `client/app`
- `git diff --check origin/main...HEAD`
- Aristotle architecture review: approved with no findings
