### PR TITLE
🌿 Test: service the catalog warm-up handshake in cursor session-option tests

### DIFF
--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
@@ -229,7 +229,7 @@ void main() {
     test("captureSessionConfig populates providers, effort variants, and mode agents", () async {
       capture(catalogResult(), fromNewSession: true);
 
-      final providers = await plugin.getProviders(projectId: "/repo");
+      final providers = await providersAfterWarmup();
       expect(providers.providers, hasLength(1));
       final provider = providers.providers.single;
       expect(provider.id, "cursor");
@@ -252,10 +252,20 @@ void main() {
     test("getSessionOptions delegates one plugin-scoped tracker snapshot", () async {
       capture(catalogResult(), fromNewSession: true);
 
-      final result = await plugin.getSessionOptions(
+      final optionsFuture = plugin.getSessionOptions(
         projectId: "/another-project",
         discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
       );
+      // Service the catalog warm-up probe so it completes instantly instead of
+      // waiting out the 12s total probe timeout with no agent on hand.
+      await respond("initialize", const {
+        "protocolVersion": 1,
+        "agentCapabilities": <String, dynamic>{},
+        "authMethods": <Object?>[],
+      });
+      await respond("cursor/list_available_models", const {"models": <Object?>[]});
+
+      final result = await optionsFuture;
 
       final options = (result as PluginSessionOptionsDiscoveryObserved).options;
       expect(options.completeness, PluginSessionOptionsCompleteness.partial);
@@ -994,7 +1004,7 @@ void main() {
     test("a models-only capture surfaces effort variants once thought_level is captured", () async {
       capture(modelCatalog("gpt-5.4", includeMode: false), fromNewSession: true);
       capture(catalogResult(), fromNewSession: false);
-      final full = await plugin.getProviders(projectId: "/repo");
+      final full = await providersAfterWarmup();
       expect(full.providers.single.models.first.variants, ["medium", "low", "high"]);
     });
 


### PR DESCRIPTION
## Complexity

🌿 straightforward — test-only change, no production code touched.

## What

Three tests in `bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart`
(`captureSessionConfig populates providers…`, `getSessionOptions delegates…`,
`a models-only capture surfaces effort variants…`) called
`getProviders`/`getSessionOptions` without answering the ACP handshake, so
the catalog warm-up probe waited out its full 12s `totalTimeout` before
returning.

They now service the probe (respond to `initialize` +
`cursor/list_available_models`) using the same pattern as the existing
`providersAfterWarmup()` helper. `providersAfterWarmup` is safe here because
each test uses a fresh plugin and this is its first fetch per scope.

## Why

These three tests were 12s each — 36s of the ~37s `sesori_plugin_cursor`
test suite. The assertions are unchanged; the probe completes in
milliseconds instead of timing out.

## Risk and test focus

Low risk: `stageForDiscovery()` copies the captured catalog, so the
probe commits still start from the captured snapshot and every assertion
reads the same data. Verified by the full cursor package suite
(109 tests) and `dart analyze --fatal-infos`.

## Expected result

- `sesori_plugin_cursor` test time drops from ~37s to under 1s.
- No user-visible or database impact.
- All 109 cursor tests still pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up `sesori_plugin_cursor` tests by servicing the catalog warm-up handshake in three session-option tests, eliminating the 12s probe timeout. Runtime drops from ~37s to under 1s with unchanged assertions and no production code changes.

- **Bug Fixes**
  - In `cursor_plugin_test.dart`, answer the ACP handshake (`initialize`, `cursor/list_available_models`) before calling `getProviders`/`getSessionOptions` (via `providersAfterWarmup` or inline `respond`) so the warm-up completes immediately.

<sup>Written for commit 00be00501f2868fc8ddf2059408e3464e9f9f792. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

