### PR TITLE
⚙️ Bridge: injectable reconnect backoff policy for deterministic tests

### DIFF
--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -2310,10 +2310,10 @@ class OrchestratorSession {
 /// [ReconnectBackoffPolicy.standard].
 class ReconnectBackoffPolicy {
   const ReconnectBackoffPolicy({
-    this.ordinaryInitial = const Duration(seconds: 1),
-    this.ordinaryMax = const Duration(seconds: 30),
-    this.takeoverInitial = const Duration(minutes: 2),
-    this.takeoverMax = const Duration(minutes: 5),
+    required this.ordinaryInitial,
+    required this.ordinaryMax,
+    required this.takeoverInitial,
+    required this.takeoverMax,
   });
 
   /// Backoff for a plain network drop (network blip, relay restart).
@@ -2325,5 +2325,10 @@ class ReconnectBackoffPolicy {
   final Duration takeoverInitial;
   final Duration takeoverMax;
 
-  static const ReconnectBackoffPolicy standard = ReconnectBackoffPolicy();
+  static const ReconnectBackoffPolicy standard = ReconnectBackoffPolicy(
+    ordinaryInitial: Duration(seconds: 1),
+    ordinaryMax: Duration(seconds: 30),
+    takeoverInitial: Duration(minutes: 2),
+    takeoverMax: Duration(minutes: 5),
+  );
 }

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -178,6 +178,7 @@ class Orchestrator {
   final BridgeRestartService _restartService;
   final bool _filesystemAccessOk;
   final ControlStatusNotifier? _statusNotifier;
+  final ReconnectBackoffPolicy _reconnectBackoff;
 
   Orchestrator({
     required this.config,
@@ -199,6 +200,7 @@ class Orchestrator {
     // Supervised mode only: owns the status-class pushes to the desktop GUI.
     // Standalone has no control channel, so this is null there.
     required ControlStatusNotifier? statusNotifier,
+    required ReconnectBackoffPolicy reconnectBackoff,
   }) : _client = client,
        _legacyMissingPluginId = legacyMissingPluginId,
        _pluginLifecycleService = pluginLifecycleService,
@@ -214,7 +216,8 @@ class Orchestrator {
        _failureReporter = failureReporter,
        _restartService = restartService,
        _filesystemAccessOk = filesystemAccessOk,
-       _statusNotifier = statusNotifier;
+       _statusNotifier = statusNotifier,
+       _reconnectBackoff = reconnectBackoff;
 
   /// Creates a new session with a fresh room key and SSE manager.
   OrchestratorComposition create() {
@@ -614,6 +617,7 @@ class Orchestrator {
       sessionMutationDispatcher: sessionMutationDispatcher,
       restartDispatcher: restartDispatcher,
       statusNotifier: _statusNotifier,
+      reconnectBackoff: _reconnectBackoff,
     );
     return (
       session: session,
@@ -690,6 +694,7 @@ class OrchestratorSession {
   final ProjectActivityService _projectActivityService;
   final BridgeRestartDispatcher _restartDispatcher;
   final ControlStatusNotifier? _statusNotifier;
+  final ReconnectBackoffPolicy _reconnectBackoff;
   // ignore: cancel_subscriptions - cancelled by the failure-isolated session drain.
   final CompositeSubscription _subscriptions = CompositeSubscription();
   final Map<String, Future<void>> _pluginEventProcessingTails = <String, Future<void>>{};
@@ -752,6 +757,7 @@ class OrchestratorSession {
     required SessionMutationDispatcher sessionMutationDispatcher,
     required BridgeRestartDispatcher restartDispatcher,
     required ControlStatusNotifier? statusNotifier,
+    required ReconnectBackoffPolicy reconnectBackoff,
   }) : _client = client,
        _pluginEvents = pluginEvents,
        _pluginEventListeners = pluginEventListeners,
@@ -788,7 +794,8 @@ class OrchestratorSession {
        _sessionAbortService = sessionAbortService,
        _projectActivityService = projectActivityService,
        _restartDispatcher = restartDispatcher,
-       _statusNotifier = statusNotifier {
+       _statusNotifier = statusNotifier,
+       _reconnectBackoff = reconnectBackoff {
     _restartDispatcher.shutdownRequests
         .listen((request) {
           switch (request) {
@@ -2192,10 +2199,6 @@ class OrchestratorSession {
   // Ordinary drop (network blip, relay restart) reconnects promptly; a
   // takeover drop reconnects on a minutes-order backoff so two always-on
   // bridges don't tight-loop kicking each other (ADR A22).
-  static const _ordinaryInitialBackoff = Duration(seconds: 1);
-  static const _ordinaryMaxBackoff = Duration(seconds: 30);
-  static const _takeoverInitialBackoff = Duration(minutes: 2);
-  static const _takeoverMaxBackoff = Duration(minutes: 5);
 
   /// Waits out a reconnect backoff, but wakes immediately on shutdown so a
   /// pending long wait (a minutes-order takeover backoff, ADR A22) never blocks
@@ -2210,14 +2213,14 @@ class OrchestratorSession {
   }
 
   Duration _initialBackoff({required bool takenOver}) {
-    if (!takenOver) return _ordinaryInitialBackoff;
+    if (!takenOver) return _reconnectBackoff.ordinaryInitial;
     // Jitter the takeover backoff so two mutually-displacing bridges don't
     // resynchronize onto the same retry cadence.
-    return _jitter(_takeoverInitialBackoff);
+    return _jitter(_reconnectBackoff.takeoverInitial);
   }
 
   Duration _nextBackoff(Duration backoff, {required bool takenOver}) {
-    final max = takenOver ? _takeoverMaxBackoff : _ordinaryMaxBackoff;
+    final max = takenOver ? _reconnectBackoff.takeoverMax : _reconnectBackoff.ordinaryMax;
     final next = Duration(microseconds: backoff.inMicroseconds * 2);
     // Re-jitter every takeover step (not just the cap) so two mutually
     // displacing bridges don't resynchronize onto the same retry cadence as
@@ -2298,4 +2301,29 @@ class OrchestratorSession {
       rethrow;
     }
   }
+}
+
+/// Reconnect backoff durations used by the relay loop.
+///
+/// Injectable so tests can exercise backoff and takeover scenarios with
+/// milliseconds-order waits instead of real minutes; production uses
+/// [ReconnectBackoffPolicy.standard].
+class ReconnectBackoffPolicy {
+  const ReconnectBackoffPolicy({
+    this.ordinaryInitial = const Duration(seconds: 1),
+    this.ordinaryMax = const Duration(seconds: 30),
+    this.takeoverInitial = const Duration(minutes: 2),
+    this.takeoverMax = const Duration(minutes: 5),
+  });
+
+  /// Backoff for a plain network drop (network blip, relay restart).
+  final Duration ordinaryInitial;
+  final Duration ordinaryMax;
+
+  /// Backoff for a takeover drop, so two always-on bridges don't tight-loop
+  /// kicking each other (ADR A22).
+  final Duration takeoverInitial;
+  final Duration takeoverMax;
+
+  static const ReconnectBackoffPolicy standard = ReconnectBackoffPolicy();
 }

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -814,6 +814,7 @@ class BridgeRuntimeRunner {
         restartService: restartService,
         filesystemAccessOk: filesystemAccessOk,
         statusNotifier: controlStatusNotifier,
+        reconnectBackoff: ReconnectBackoffPolicy.standard,
       ).create();
       runtime = BridgeRuntime(
         database: database,

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -75,6 +75,7 @@ Future<_DebugServerHarness> _createDebugServerHarness({
     restartService: effectiveRestartService,
     filesystemAccessOk: true,
     statusNotifier: null,
+        reconnectBackoff: ReconnectBackoffPolicy.standard,
   ).create();
   final runtime = BridgeRuntime(
     database: db,

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -877,6 +877,7 @@ class _OrchestratorHarness {
       restartService: restartService,
       filesystemAccessOk: true,
       statusNotifier: null,
+        reconnectBackoff: ReconnectBackoffPolicy.standard,
     ).create();
     final runtime = BridgeRuntime(
       database: database,

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -81,6 +81,7 @@ void main() {
       restartService: buildTestRestartService(),
       filesystemAccessOk: true,
       statusNotifier: null,
+        reconnectBackoff: ReconnectBackoffPolicy.standard,
     ).create();
     final running = await startTestOrchestratorSession(session: composition.session);
     final runFuture = running.stopped;
@@ -155,6 +156,7 @@ void main() {
       restartService: buildTestRestartService(),
       filesystemAccessOk: true,
       statusNotifier: null,
+        reconnectBackoff: ReconnectBackoffPolicy.standard,
     ).create().session;
 
     final startFuture = session.start();
@@ -207,6 +209,7 @@ void main() {
         restartService: buildTestRestartService(),
         filesystemAccessOk: true,
         statusNotifier: null,
+        reconnectBackoff: ReconnectBackoffPolicy.standard,
       );
 
       final session = orchestrator.create().session;
@@ -324,6 +327,7 @@ class _TestHarness {
       restartService: buildTestRestartService(),
       filesystemAccessOk: true,
       statusNotifier: null,
+        reconnectBackoff: ReconnectBackoffPolicy.standard,
     );
 
     final session = orchestrator.create().session;

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -365,7 +365,10 @@ void main() {
   group("OrchestratorSession relay takeover (ADR A22)", () {
     test("a 4007 replaced-close does not reconnect within the war window", () async {
       final repository = FakeBridgeRegistrationRepository()..nextBridgeId = "br_first001";
-      final harness = await _RegistrationHarness.start(repository: repository);
+      final harness = await _RegistrationHarness.start(
+        repository: repository,
+        backoffPolicy: _takeoverHoldoffBackoff,
+      );
       addTearDown(harness.close);
 
       final firstSocket = await harness.relayServer.nextClient();
@@ -376,8 +379,11 @@ void main() {
       // long backoff, so no reconnect happens within the war window.
       await firstSocket.close(RelayCloseCodes.bridgeReplaced, "replaced");
 
+      // The injected takeover backoff is minutes-order while the ordinary
+      // backoff is 50ms, so any wrongful reconnect would appear almost
+      // immediately — long before this 400ms wait elapses.
       await expectLater(
-        harness.relayServer.nextClient(timeout: const Duration(seconds: 3)),
+        harness.relayServer.nextClient(timeout: const Duration(milliseconds: 400)),
         throwsA(isA<TimeoutException>()),
         reason: "displaced bridge must not reconnect on a tight loop",
       );
@@ -386,7 +392,10 @@ void main() {
 
     test("the 1000/replaced rollout fallback also holds off reconnect", () async {
       final repository = FakeBridgeRegistrationRepository()..nextBridgeId = "br_first001";
-      final harness = await _RegistrationHarness.start(repository: repository);
+      final harness = await _RegistrationHarness.start(
+        repository: repository,
+        backoffPolicy: _takeoverHoldoffBackoff,
+      );
       addTearDown(harness.close);
 
       final firstSocket = await harness.relayServer.nextClient();
@@ -395,7 +404,7 @@ void main() {
       await firstSocket.close(1000, "replaced");
 
       await expectLater(
-        harness.relayServer.nextClient(timeout: const Duration(seconds: 3)),
+        harness.relayServer.nextClient(timeout: const Duration(milliseconds: 400)),
         throwsA(isA<TimeoutException>()),
         reason: "the rollout fallback (1000/replaced) must be treated as a takeover",
       );
@@ -453,6 +462,25 @@ Future<Map<String, dynamic>> _firstTextMessage(WebSocket socket) async {
   return jsonDecodeMap(message as String);
 }
 
+/// Takeover closes must hold off reconnect: the injected takeover backoff is
+/// minutes-order, while the ordinary backoff stays fast so a regression to
+/// the ordinary reconnect path surfaces within a few hundred milliseconds.
+const ReconnectBackoffPolicy _takeoverHoldoffBackoff = ReconnectBackoffPolicy(
+  ordinaryInitial: Duration(milliseconds: 50),
+  ordinaryMax: Duration(seconds: 1),
+  takeoverInitial: Duration(minutes: 5),
+  takeoverMax: Duration(minutes: 5),
+);
+
+/// Fast ordinary reconnect backoff for registration/reconnect scenarios: none
+/// of these tests assert the production 1s cadence, only the reconnect
+/// behavior. The takeover durations stay at production defaults so the
+/// cancel-wakes-long-backoff test remains meaningful.
+const ReconnectBackoffPolicy _registrationTestBackoff = ReconnectBackoffPolicy(
+  ordinaryInitial: Duration(milliseconds: 50),
+  ordinaryMax: Duration(seconds: 1),
+);
+
 Future<void> _waitFor(bool Function() condition, {required String reason}) async {
   final timeoutAt = DateTime.now().add(const Duration(seconds: 10));
   while (!condition()) {
@@ -495,6 +523,7 @@ class _RegistrationHarness {
   static Future<_RegistrationHarness> start({
     required FakeBridgeRegistrationRepository repository,
     Future<void>? connectReturnDelay,
+    ReconnectBackoffPolicy backoffPolicy = _registrationTestBackoff,
   }) async {
     final relayServer = await _CountingRelayServer.start();
     final database = createTestDatabase();
@@ -540,6 +569,7 @@ class _RegistrationHarness {
       restartService: restartService,
       filesystemAccessOk: true,
       statusNotifier: null,
+      reconnectBackoff: backoffPolicy,
     );
 
     final composition = orchestrator.create();

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -479,6 +479,8 @@ const ReconnectBackoffPolicy _takeoverHoldoffBackoff = ReconnectBackoffPolicy(
 const ReconnectBackoffPolicy _registrationTestBackoff = ReconnectBackoffPolicy(
   ordinaryInitial: Duration(milliseconds: 50),
   ordinaryMax: Duration(seconds: 1),
+  takeoverInitial: Duration(minutes: 2),
+  takeoverMax: Duration(minutes: 5),
 );
 
 Future<void> _waitFor(bool Function() condition, {required String reason}) async {

--- a/bridge/app/test/bridge/orchestrator_request_concurrency_test.dart
+++ b/bridge/app/test/bridge/orchestrator_request_concurrency_test.dart
@@ -319,6 +319,7 @@ class _ConcurrencyHarness {
       restartService: restartService,
       filesystemAccessOk: true,
       statusNotifier: null,
+        reconnectBackoff: ReconnectBackoffPolicy.standard,
     ).create();
     final runtime = BridgeRuntime(
       database: database,

--- a/bridge/app/test/bridge/orchestrator_token_reauth_test.dart
+++ b/bridge/app/test/bridge/orchestrator_token_reauth_test.dart
@@ -59,7 +59,10 @@ void main() {
       // never re-checks it, so the live socket must stay up.
       authority.emit(_jwt(userId: "user-1", seq: 2));
 
-      await Future<void>.delayed(const Duration(seconds: 1));
+      // With the fast injected backoff the loop would have reconnected within
+      // ~50ms if a rotation wrongly dropped the socket; 250ms is several
+      // iterations of headroom.
+      await Future<void>.delayed(const Duration(milliseconds: 250));
       expect(
         harness.relayServer.acceptedClientCount,
         equals(1),
@@ -97,7 +100,7 @@ void main() {
       // the socket already authenticated with. This must NOT re-auth/flap the
       // live connection.
       authority.emit("token-1");
-      await Future<void>.delayed(const Duration(seconds: 1));
+      await Future<void>.delayed(const Duration(milliseconds: 250));
       expect(harness.relayServer.acceptedClientCount, equals(1), reason: "unchanged token must not re-auth");
     });
 
@@ -115,8 +118,9 @@ void main() {
       authority.failRefresh = true;
       await firstSocket.close();
 
-      // Give the reconnect loop several backoff iterations; none should connect.
-      await Future<void>.delayed(const Duration(seconds: 2));
+      // Give the reconnect loop several fast backoff iterations; none should
+      // connect. A broken implementation would attempt within ~50ms.
+      await Future<void>.delayed(const Duration(milliseconds: 300));
       expect(harness.relayServer.acceptedClientCount, equals(1), reason: "no reconnect while signed out");
 
       // Signing back in lets the deferred reconnect proceed.
@@ -196,7 +200,7 @@ void main() {
         ..cachedTokenAvailable = false;
       await firstSocket.close();
 
-      await Future<void>.delayed(const Duration(seconds: 2));
+      await Future<void>.delayed(const Duration(milliseconds: 300));
       expect(harness.relayServer.acceptedClientCount, equals(1), reason: "no reconnect without a safe token");
 
       // Once a token is available again the deferred reconnect proceeds.
@@ -281,6 +285,13 @@ class _TransientRefreshException implements Exception {
   const _TransientRefreshException();
 }
 
+/// A fast ordinary reconnect backoff so re-auth scenarios run in tens of
+/// milliseconds instead of waiting out the production 1s initial backoff.
+const ReconnectBackoffPolicy _fastOrdinaryBackoff = ReconnectBackoffPolicy(
+  ordinaryInitial: Duration(milliseconds: 50),
+  ordinaryMax: Duration(seconds: 1),
+);
+
 class _ReauthHarness {
   final OrchestratorSession session;
   final Future<void> runFuture;
@@ -304,6 +315,7 @@ class _ReauthHarness {
 
   static Future<_ReauthHarness> start({
     required _ScriptedTokenAuthority authority,
+    ReconnectBackoffPolicy backoffPolicy = _fastOrdinaryBackoff,
   }) async {
     final relayServer = await _CountingRelayServer.start();
     final database = createTestDatabase();
@@ -343,6 +355,7 @@ class _ReauthHarness {
       restartService: buildTestRestartService(),
       filesystemAccessOk: true,
       statusNotifier: null,
+      reconnectBackoff: backoffPolicy,
     );
 
     final session = orchestrator.create().session;

--- a/bridge/app/test/bridge/orchestrator_token_reauth_test.dart
+++ b/bridge/app/test/bridge/orchestrator_token_reauth_test.dart
@@ -290,6 +290,8 @@ class _TransientRefreshException implements Exception {
 const ReconnectBackoffPolicy _fastOrdinaryBackoff = ReconnectBackoffPolicy(
   ordinaryInitial: Duration(milliseconds: 50),
   ordinaryMax: Duration(seconds: 1),
+  takeoverInitial: Duration(minutes: 2),
+  takeoverMax: Duration(minutes: 5),
 );
 
 class _ReauthHarness {

--- a/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
@@ -79,6 +79,7 @@ void main() {
       restartService: restartService,
       filesystemAccessOk: true,
       statusNotifier: null,
+        reconnectBackoff: ReconnectBackoffPolicy.standard,
     ).create();
     final runtime = BridgeRuntime(
       database: database,

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
@@ -229,7 +229,7 @@ void main() {
     test("captureSessionConfig populates providers, effort variants, and mode agents", () async {
       capture(catalogResult(), fromNewSession: true);
 
-      final providers = await plugin.getProviders(projectId: "/repo");
+      final providers = await providersAfterWarmup();
       expect(providers.providers, hasLength(1));
       final provider = providers.providers.single;
       expect(provider.id, "cursor");
@@ -252,10 +252,20 @@ void main() {
     test("getSessionOptions delegates one plugin-scoped tracker snapshot", () async {
       capture(catalogResult(), fromNewSession: true);
 
-      final result = await plugin.getSessionOptions(
+      final optionsFuture = plugin.getSessionOptions(
         projectId: "/another-project",
         discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
       );
+      // Service the catalog warm-up probe so it completes instantly instead of
+      // waiting out the 12s total probe timeout with no agent on hand.
+      await respond("initialize", const {
+        "protocolVersion": 1,
+        "agentCapabilities": <String, dynamic>{},
+        "authMethods": <Object?>[],
+      });
+      await respond("cursor/list_available_models", const {"models": <Object?>[]});
+
+      final result = await optionsFuture;
 
       final options = (result as PluginSessionOptionsDiscoveryObserved).options;
       expect(options.completeness, PluginSessionOptionsCompleteness.partial);
@@ -994,7 +1004,7 @@ void main() {
     test("a models-only capture surfaces effort variants once thought_level is captured", () async {
       capture(modelCatalog("gpt-5.4", includeMode: false), fromNewSession: true);
       capture(catalogResult(), fromNewSession: false);
-      final full = await plugin.getProviders(projectId: "/repo");
+      final full = await providersAfterWarmup();
       expect(full.providers.single.models.first.variants, ["medium", "low", "high"]);
     });
 


### PR DESCRIPTION
## Complexity

⚙️ moderate — small production change (one value class + constructor threading) with focused test updates.

## What

- New `ReconnectBackoffPolicy` value class in `bridge/app/lib/src/bridge/orchestrator.dart` carrying the ordinary (1s/30s) and takeover (2min/5min) reconnect backoff durations. All four durations are required; the production defaults live only in `ReconnectBackoffPolicy.standard`.
- `Orchestrator` and `OrchestratorSession` take `required ReconnectBackoffPolicy reconnectBackoff`; `bridge_runtime_runner.dart` passes `standard`.
- `orchestrator_registration_test.dart` and `orchestrator_token_reauth_test.dart` harnesses accept a policy: registration tests default to a fast ordinary backoff (50ms → 1s), the two takeover-holdoff tests inject a minutes-order takeover backoff and assert no reconnect within 400ms, and the re-auth observation windows drop from 1-2s to 250-300ms.
- The takeover holdoff tests also inject a fast *ordinary* backoff, so a regression to the ordinary reconnect path would still reconnect within the window and fail the assertion — coverage is not weakened.

## Why

The reconnect loop's real-time backoff forced every "observe reconnect behavior" test to wait real seconds: the registration suite cost ~16s, token re-auth ~12s of bridge/app CI per PR. With injectable durations these run in a few hundred milliseconds each while keeping every assertion.

## Risk and test focus

- All 2428 bridge/app tests pass; `dart analyze --fatal-infos` clean.
- Test focus: registration/reconnect/takeover/re-auth flows (the files above), plus the orchestrator groups that construct `Orchestrator` directly (emit_bridge_event, error_recovery, request_concurrency, debug_server, runtime_builder).
- No wire, persistence, or user-visible behavior change: production passes `standard`, identical durations to before.

## Expected result

- `orchestrator_registration_test.dart` ~16s → ~2.5s; `orchestrator_token_reauth_test.dart` ~12s → ~2s (measured locally).
- No user-visible or database impact.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the reconnect backoff in the orchestrator injectable so tests run fast and deterministically without changing production behavior. Adds a `ReconnectBackoffPolicy` and threads it through `Orchestrator` and `OrchestratorSession`; production uses the same timings via `ReconnectBackoffPolicy.standard`.

- **New Features**
  - Introduced `ReconnectBackoffPolicy` with four required durations (ordinary initial/max, takeover initial/max). Defaults live in `ReconnectBackoffPolicy.standard`.
  - `Orchestrator` and `OrchestratorSession` now take a required `reconnectBackoff`; runtime passes `standard`.
  - Tests inject fast ordinary backoff and minutes-order takeover backoff. Registration and token re-auth checks now assert within 250–400ms and run ~5–8x faster.

- **Migration**
  - If you construct an `Orchestrator`, pass `ReconnectBackoffPolicy.standard` in production or a custom policy in tests.
  - No API, wire, or data changes; behavior in production is unchanged.

<sup>Written for commit fa2c9bf7f65f9de201235b7bf098b58c3621d75e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

