### PR TITLE
⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]

### DIFF
--- a/.plan/active/codex-plugin-stability-feedback/PLAN.md
+++ b/.plan/active/codex-plugin-stability-feedback/PLAN.md
@@ -397,7 +397,7 @@ already merged before this durable plan existed.
 
 | Step | Branch | Exact PR title | Existing/target size | Primary finding |
 |---|---|---|---:|---|
-| 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 932 total | F-07 |
+| 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 1,043 total | F-07 |
 | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 73 | F-02 |
 | 3/11 | `codex-stability-deep-test-3-image-wrapper-projection` | `⚙️ [codex-plugin-stability-feedback] fix(codex): hide generated image wrappers [step 3/11]` | 118 | F-07 |
 | 4/11 | `codex-stability-deep-test-4-late-abort-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): retain late command identity after abort [step 4/11]` | 86 | F-08 |

--- a/.plan/active/codex-plugin-stability-feedback/PLAN.md
+++ b/.plan/active/codex-plugin-stability-feedback/PLAN.md
@@ -397,7 +397,7 @@ already merged before this durable plan existed.
 
 | Step | Branch | Exact PR title | Existing/target size | Primary finding |
 |---|---|---|---:|---|
-| 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 1,061 total | F-07 |
+| 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 1,086 total | F-07 |
 | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 73 | F-02 |
 | 3/11 | `codex-stability-deep-test-3-image-wrapper-projection` | `⚙️ [codex-plugin-stability-feedback] fix(codex): hide generated image wrappers [step 3/11]` | 118 | F-07 |
 | 4/11 | `codex-stability-deep-test-4-late-abort-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): retain late command identity after abort [step 4/11]` | 86 | F-08 |

--- a/.plan/active/codex-plugin-stability-feedback/PLAN.md
+++ b/.plan/active/codex-plugin-stability-feedback/PLAN.md
@@ -397,7 +397,7 @@ already merged before this durable plan existed.
 
 | Step | Branch | Exact PR title | Existing/target size | Primary finding |
 |---|---|---|---:|---|
-| 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 844 total | F-07 |
+| 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 932 total | F-07 |
 | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 73 | F-02 |
 | 3/11 | `codex-stability-deep-test-3-image-wrapper-projection` | `⚙️ [codex-plugin-stability-feedback] fix(codex): hide generated image wrappers [step 3/11]` | 118 | F-07 |
 | 4/11 | `codex-stability-deep-test-4-late-abort-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): retain late command identity after abort [step 4/11]` | 86 | F-08 |
@@ -535,6 +535,10 @@ already merged before this durable plan existed.
 - **What:** Declare prompt-attachment capability, enable Codex data-image input,
   replace the hardcoded plugin gate, and fail closed when capability provenance
   is unresolved.
+- **Compatibility acceptance:** Keep the dated
+  `COMPATIBILITY 2026-08-04 (v1.8.0)` comment beside `@Default(false)`,
+  documenting older bridge omission and the exact cleanup when those bridge
+  versions become unsupported.
 - **Why:** Codex supports image input, but mobile previously exposed attachment
   selection only through an OpenCode-specific temporary gate.
 - **Risk and test focus:** Older bridges, different-bridge reconnect, queued

--- a/.plan/active/codex-plugin-stability-feedback/PLAN.md
+++ b/.plan/active/codex-plugin-stability-feedback/PLAN.md
@@ -397,7 +397,7 @@ already merged before this durable plan existed.
 
 | Step | Branch | Exact PR title | Existing/target size | Primary finding |
 |---|---|---|---:|---|
-| 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 1,043 total | F-07 |
+| 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 1,061 total | F-07 |
 | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 73 | F-02 |
 | 3/11 | `codex-stability-deep-test-3-image-wrapper-projection` | `⚙️ [codex-plugin-stability-feedback] fix(codex): hide generated image wrappers [step 3/11]` | 118 | F-07 |
 | 4/11 | `codex-stability-deep-test-4-late-abort-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): retain late command identity after abort [step 4/11]` | 86 | F-08 |

--- a/.plan/active/codex-plugin-stability-feedback/PLAN.md
+++ b/.plan/active/codex-plugin-stability-feedback/PLAN.md
@@ -3,8 +3,8 @@
 ## Status
 
 - **Plan slug:** `codex-plugin-stability-feedback`
-- **Status:** Active — preparing Step 2/11 after Step 1 PR
-  [#724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) merged
+- **Status:** Active — Step 2/11 PR
+  [#731](https://github.com/sesori-ai/sesori_apps_monorepo/pull/731) open
 - **Plan date:** 2026-08-04
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Implementation base:** `origin/main` at

--- a/.plan/active/codex-plugin-stability-feedback/PLAN.md
+++ b/.plan/active/codex-plugin-stability-feedback/PLAN.md
@@ -3,17 +3,18 @@
 ## Status
 
 - **Plan slug:** `codex-plugin-stability-feedback`
-- **Status:** Active — Step 1/11 PR
-  [#724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) open
+- **Status:** Active — preparing Step 2/11 after Step 1 PR
+  [#724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) merged
 - **Plan date:** 2026-08-04
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Implementation base:** `origin/main` at
-  `009bb44a72683d0a1bc6dacd13cbc19397e92d43`
+  `4f890087cbebe1fa23e410c18e53257f707102c0`
 - **Stack root:** merged Codex image-history fix `2408b574`
 - **Delivery:** nine existing deep-test branches in their exact ancestry order,
   one additional confirmed finding fix, and one plan-retirement PR
 - **Plan PR:** [#724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724),
-  combined with the first unmerged production fix at the user's direction
+  merged as `149e7914`; it combined the plan with the first unmerged production
+  fix at the user's direction
 
 This document and `TRACKER.md` are the implementation authority for the
 remaining Codex stability series. The evidence report at
@@ -381,6 +382,9 @@ already merged before this durable plan existed.
 - A successor may target its immediate predecessor while both are open, but
   merges occur in numeric order. Do not delete a predecessor branch while a
   dependent PR uses it as a base.
+- After a merge notification, immediately continue with the next numbered step
+  without waiting for another user prompt. Stop only for a material decision or
+  blocker.
 - Count additions plus deletions, generated code, tests, and plan updates against
   each PR base. Reassess near 1,300 lines; prefer a coherent split before 1,500.
 - Generated files change only through their generators.

--- a/.plan/active/codex-plugin-stability-feedback/PLAN.md
+++ b/.plan/active/codex-plugin-stability-feedback/PLAN.md
@@ -397,7 +397,7 @@ already merged before this durable plan existed.
 
 | Step | Branch | Exact PR title | Existing/target size | Primary finding |
 |---|---|---|---:|---|
-| 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 1,086 total | F-07 |
+| 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 1,100 total | F-07 |
 | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 73 | F-02 |
 | 3/11 | `codex-stability-deep-test-3-image-wrapper-projection` | `⚙️ [codex-plugin-stability-feedback] fix(codex): hide generated image wrappers [step 3/11]` | 118 | F-07 |
 | 4/11 | `codex-stability-deep-test-4-late-abort-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): retain late command identity after abort [step 4/11]` | 86 | F-08 |
@@ -609,6 +609,11 @@ already merged before this durable plan existed.
   successor; never rebase.
 - **False wrapper suppression:** Exact bounded structural checks remain local to
   known generated forms. Mixed-purpose code remains visible.
+- **Accepted wrapper-language boundary:** The scanner balances the observed
+  invocation through strings/comments and rejects visible nested `tools.*`
+  calls. It intentionally does not tokenize JavaScript regex literals, template
+  interpolation expressions, or complete brace/bracket grammar without an
+  observed Codex fixture. The owner accepted this bounded risk on 2026-08-04.
 - **Identity leaks or over-correlation:** Correlation remains per thread/turn and
   exact wrapper type, with authoritative completion cleanup.
 - **False replay terminalization:** Only service-owned authoritative activity

--- a/.plan/active/codex-plugin-stability-feedback/PLAN.md
+++ b/.plan/active/codex-plugin-stability-feedback/PLAN.md
@@ -3,7 +3,8 @@
 ## Status
 
 - **Plan slug:** `codex-plugin-stability-feedback`
-- **Status:** Active — Step 1/11 ready for delivery
+- **Status:** Active — Step 1/11 PR
+  [#724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) open
 - **Plan date:** 2026-08-04
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Implementation base:** `origin/main` at
@@ -11,8 +12,8 @@
 - **Stack root:** merged Codex image-history fix `2408b574`
 - **Delivery:** nine existing deep-test branches in their exact ancestry order,
   one additional confirmed finding fix, and one plan-retirement PR
-- **Plan PR:** Step 1/11, combined with the first unmerged production fix at the
-  user's direction
+- **Plan PR:** [#724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724),
+  combined with the first unmerged production fix at the user's direction
 
 This document and `TRACKER.md` are the implementation authority for the
 remaining Codex stability series. The evidence report at
@@ -396,7 +397,7 @@ already merged before this durable plan existed.
 
 | Step | Branch | Exact PR title | Existing/target size | Primary finding |
 |---|---|---|---:|---|
-| 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 841 total | F-07 |
+| 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 844 total | F-07 |
 | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 73 | F-02 |
 | 3/11 | `codex-stability-deep-test-3-image-wrapper-projection` | `⚙️ [codex-plugin-stability-feedback] fix(codex): hide generated image wrappers [step 3/11]` | 118 | F-07 |
 | 4/11 | `codex-stability-deep-test-4-late-abort-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): retain late command identity after abort [step 4/11]` | 86 | F-08 |

--- a/.plan/active/codex-plugin-stability-feedback/PLAN.md
+++ b/.plan/active/codex-plugin-stability-feedback/PLAN.md
@@ -1,0 +1,635 @@
+# Codex Plugin Stability Feedback
+
+## Status
+
+- **Plan slug:** `codex-plugin-stability-feedback`
+- **Status:** Active — Step 1/11 ready for delivery
+- **Plan date:** 2026-08-04
+- **Repository:** `sesori-ai/sesori_apps_monorepo`
+- **Implementation base:** `origin/main` at
+  `009bb44a72683d0a1bc6dacd13cbc19397e92d43`
+- **Stack root:** merged Codex image-history fix `2408b574`
+- **Delivery:** nine existing deep-test branches in their exact ancestry order,
+  one additional confirmed finding fix, and one plan-retirement PR
+- **Plan PR:** Step 1/11, combined with the first unmerged production fix at the
+  user's direction
+
+This document and `TRACKER.md` are the implementation authority for the
+remaining Codex stability series. The evidence report at
+`docs/codex-plugin-stability-report.md` remains the detailed validation record;
+it is not the delivery tracker.
+
+## Goal
+
+Deliver the already-tested Codex deep-stability stack without rewriting its Git
+history, close the confirmed repository-instruction history leak, and preserve
+one durable record that maps every observed finding to its owning branch,
+commit, PR, behavior, and verification.
+
+The completed series must keep Codex sessions consistent while live, after
+navigation, after reconnect, and after cold bridge restart. It must also let the
+mobile app submit images only when the selected bridge plugin explicitly
+declares support.
+
+## Success Criteria
+
+1. The existing `codex-stability-deep-test-1-*` through
+   `codex-stability-deep-test-9-*` branches merge in their current order without
+   rebase, reset, cherry-pick, or commit reordering.
+2. Every F-01 through F-12 finding has an individual acceptance entry below and
+   a matching state in `TRACKER.md`.
+3. Generated shell/image wrappers, command and file identities, interrupted
+   lifecycle state, archive behavior, and replay policy remain consistent live
+   and after reload.
+4. Mobile image prompts reach Codex through a backend-neutral declared
+   capability; unsupported, unresolved, and older bridges fail closed.
+5. Codex-generated `AGENTS.md` repository instructions do not render as authored
+   user messages, while real authored text and near matches remain visible.
+6. No prompt, transcript, source content, image data, repository instructions,
+   local path, raw capture, or entity identifier is added to logs, analytics, or
+   this plan.
+7. Each implementation PR stays below the 1,500 changed-line soft cap unless a
+   coherent split is impossible and the tracker records why.
+8. The final PR records every merge and verification result and moves this plan
+   from `.plan/active/` to `.plan/completed/`.
+
+## Evidence And Current Behavior
+
+The stability pass exercised a real bridge, Codex runtime, and iOS simulator.
+It compared live normalized events, bridge session snapshots, and rendered
+mobile state through navigation, reconnect, restart, lifecycle actions, and
+deletion. Privacy-sensitive raw captures remain outside the repository.
+
+Evidence levels are intentionally explicit:
+
+- **Observed ordinary user flows:** F-01 through F-12. Each changed or exposed
+  user-visible session history, tool state, identity, attachment, or lifecycle
+  behavior during normal creation, reload, reconnect, archive, abort, or image
+  submission.
+- **Accepted bounded observations:** one transient incomplete initial history
+  self-healed on the next refresh and did not recur after navigation; one bridge
+  shutdown stall did not reproduce; empty upstream reasoning summaries contain
+  no renderable reasoning. These are not promoted into coordination machinery or
+  extra production steps without new evidence.
+- **Separately owned defect:** the unsupported relay message-version `123` error
+  was found and is being fixed outside this plan at the user's direction.
+
+## Scope
+
+### Included
+
+- The exact existing D1 through D9 production commits and their tests.
+- The existing stability report commits on D7 through D9.
+- A localized post-D9 F-12 fix for generated repository-instruction history.
+- Plan/tracker maintenance and final retirement.
+- Merge-forward propagation between stacked branches as each predecessor is
+  updated or merged.
+
+### Excluded
+
+- The separately owned relay framing/version `123` fix.
+- New Codex runtime versions or runtime provisioning changes.
+- Database schema changes, migrations, or data backfills.
+- New relay protocol variants or attachment payload types.
+- New analytics events or parameters.
+- Broad parsing frameworks, generic wrapper interpreters, global identity
+  registries, cross-plugin coordination, or speculative lifecycle machinery.
+- Rendering invented reasoning when upstream supplies no summary.
+- Fixing bounded self-healing UI refresh behavior without a reproducible cause
+  and meaningful impact.
+
+## Ownership And Data Flow
+
+### Generated wrapper projection
+
+`CodexRolloutToolMapper` owns backend-specific recognition of generated rollout
+wrappers. Steps 1 and 3 extend only exact known Codex wrapper forms. Mixed-purpose
+code, malformed directives, additional tool calls, and variable mismatches remain
+visible rather than being guessed away.
+
+```text
+Codex rollout response item
+  -> CodexRolloutToolMapper
+  -> canonical PluginToolState / image-generation projection
+  -> shared bridge message mapping
+  -> client renderer
+```
+
+### Live tool identity and lifecycle
+
+`CodexToolLifecycleTracker` owns app-server-to-rollout identity correlation.
+`CodexPlugin` supplies typed events and authoritative item/turn lifecycle. Steps
+2, 4, and 5 keep command and file correlations narrow, per thread/turn, and
+retire aliases at the authoritative item completion boundary.
+
+No bridge-global identity registry is added. The observed duplicate cards are
+backend-specific and remain inside `sesori_plugin_codex`.
+
+### Replay terminalization and typed boundaries
+
+`CodexSessionService` owns the policy decision derived from authoritative
+session activity. `CodexMessageRepository` reconstructs messages, while
+`CodexToolLifecycleTracker` applies the explicit replay disposition. Step 6
+first delivers the proven behavior; Step 8 replaces raw status/map decisions
+with sealed typed values without changing that behavior.
+
+```text
+CodexPlugin reads bridge session status
+  -> CodexSessionService maps status to CodexReplayToolDisposition
+  -> CodexMessageRepository reads typed rollout records
+  -> CodexToolLifecycleTracker preserves or terminalizes unresolved tools
+```
+
+### Archive authority
+
+The bridge database remains the sole archive-state authority. Codex has no
+symmetric backend unarchive callback, so Step 7 removes the destructive backend
+archive call while retaining destructive delete behavior.
+
+### Mobile prompt-attachment capability
+
+Step 9 keeps backend knowledge in plugin descriptors and carries only a neutral
+boolean contract across shared and client layers:
+
+```text
+BridgePluginDescriptor.supportsPromptAttachments
+  -> RegisteredPluginMetadata
+  -> PluginLifecycleService
+  -> PluginMetadata wire response
+  -> PluginRepository
+  -> NewSessionCubit / SessionDetailLoadService
+  -> SessionDetailCubit state
+  -> composer visibility and send guard
+  -> CodexThreadRepository data-image input
+```
+
+OpenCode and Codex declare support. Cursor inherits false. Existing-session
+capability lookup is optional to transcript loading and fails closed. A
+disconnect clears capability provenance before queued attachments can drain
+through a different bridge; successful refresh explicitly restarts draining.
+
+### Generated repository-instruction history
+
+`CodexMessageRepository` already owns F-01 generated-context filtering and the
+submitted-user-message evidence that protects authored text. Step 10 extends
+that same local boundary for Codex 0.146.0's observed complete shape:
+
+```text
+# AGENTS.md instructions[ for <directory>]
+
+<INSTRUCTIONS>
+...
+</INSTRUCTIONS>
+```
+
+At Step 10 start, capture and sanitize one fresh structural fixture to confirm
+whether the envelope exists only in rollout history. If so, change only
+`CodexMessageRepository` and its rollout tests. Do not modify live app-server
+mapping unless a captured ordinary flow proves the same envelope is emitted
+there. If evidence expands the fix into cross-layer state or authored-message
+coordination, stop and ask before broadening the step.
+
+## Compatibility, Persistence, Privacy, And Analytics
+
+### Compatibility
+
+- Steps 1 through 8 and Step 10 alter internal plugin behavior/contracts only;
+  all in-repository consumers move together and need no compatibility shim.
+- Step 9 adds `PluginMetadata.supportsPromptAttachments` to the client/bridge
+  transport. Older bridges omit it, so `@Default(false)` keeps attachment UI and
+  sends disabled rather than risking silent image loss.
+- No unpublished alternate route, dual contract, or backend-specific identifier
+  escapes the plugin boundary.
+
+### Persistence
+
+- No database schema or migration changes.
+- Step 7 changes archive side effects, not persisted bridge archive shape.
+- Steps 6 and 8 change replay interpretation, not rollout persistence.
+- Step 10 changes projection only; stored Codex rollout content is untouched.
+
+### Privacy and security
+
+- The F-12 fix is privacy-relevant because generated instructions can contain
+  repository content and local paths.
+- Tests use marker-only, sanitized fixtures and never commit real instructions.
+- Local diagnostic policy remains unchanged: useful errors and stack traces stay
+  available, while prompts, transcripts, images, and instruction bodies remain
+  excluded.
+
+### Analytics
+
+No new analytics event is planned. The stability fixes are passive projection,
+identity, and lifecycle corrections. Step 9's authoritative session/message
+outcome already flows through existing product analytics; adding an image tap or
+plugin-specific event would not answer a distinct product decision and could
+expose sensitive content/provider context. Product behavior remains independent
+of analytics delivery.
+
+## Finding Acceptance Steps
+
+These are individual product acceptance items. Their numbering follows the
+evidence report; PR delivery numbering separately preserves the existing stacked
+branch order because some findings span more than one commit and several were
+already merged before this durable plan existed.
+
+### Finding step F-01 — Generated internal context rendered as user text
+
+- **State:** Fixed on `main`.
+- **Observed impact:** Cold history inserted generated context as a large user
+  message and displaced authored transcript content.
+- **Cause/fix:** `CodexMessageRepository` now excludes complete generated
+  envelopes while preserving mixed/authored text using submitted-user evidence.
+- **Delivery:** `codex-stability-2-user-context`, PR
+  [#710](https://github.com/sesori-ai/sesori_apps_monorepo/pull/710), commit
+  `0dc0c6ec`.
+- **Acceptance:** Existing F-01 regressions remain green throughout this series.
+
+### Finding step F-02 — One shell command had two live identities
+
+- **State:** Direct path fixed on `main`; code-mode continuation is Delivery
+  Step 2/11.
+- **Observed impact:** One command appeared as app-server `exec-*` and rollout
+  `call_*` cards before reload collapsed it.
+- **Delivery:** direct fix `e5cb9d86` on `codex-stability-3-tool-identity`, PR
+  [#712](https://github.com/sesori-ai/sesori_apps_monorepo/pull/712); code-mode
+  fix `58585e1f` on `codex-stability-deep-test-2-code-mode-tool-identity`.
+- **Acceptance:** Direct and exact single-command wrappers retain one canonical
+  ID from running through terminal replay.
+
+### Finding step F-03 — Interrupted historical tools stayed running
+
+- **State:** Fixed on `main`.
+- **Observed impact:** Aborted/interrupted commands without ordinary output
+  replayed forever as running.
+- **Delivery:** `codex-stability-4-tool-lifecycle`, PR
+  [#713](https://github.com/sesori-ai/sesori_apps_monorepo/pull/713), commit
+  `f70bdbcb`.
+- **Acceptance:** Durable turn evidence settles historical tools into one honest
+  terminal card.
+
+### Finding step F-04 — Prompt images disappeared from history
+
+- **State:** Fixed on `main`.
+- **Observed impact:** Codex received the image, but navigation/restart lost the
+  expandable prompt attachment.
+- **Delivery:** `codex-stability-5-prompt-images`, PR
+  [#715](https://github.com/sesori-ai/sesori_apps_monorepo/pull/715), commit
+  `6930b3a9`.
+- **Acceptance:** One bounded text part and PNG file part survive navigation and
+  restart with stable identities.
+
+### Finding step F-05 — Debug SSE disconnected on non-Latin-1 text
+
+- **State:** Fixed on `main`.
+- **Observed impact:** A curly apostrophe terminated the debug stream and removed
+  its client.
+- **Delivery:** `codex-stability-1-debug-sse`, PR
+  [#709](https://github.com/sesori-ai/sesori_apps_monorepo/pull/709), commit
+  `025ba43b`.
+- **Acceptance:** Explicit UTF-8 output preserves the same SSE connection for
+  non-Latin-1 and following events.
+
+### Finding step F-06 — Failed commands became completed after reload
+
+- **State:** Fixed on `main`.
+- **Observed impact:** A command that exited with code 7 replayed as successful.
+- **Delivery:** `codex-stability-6-failed-tool-status`, PR
+  [#717](https://github.com/sesori-ai/sesori_apps_monorepo/pull/717), commit
+  `20521cc2`.
+- **Acceptance:** Error state, useful output, marker, and exit code remain stable
+  live and cold.
+
+### Finding step F-07 — Generated output images did not converge
+
+- **State:** Durable image history fixed on `main`; wrapper continuations are
+  Delivery Steps 1/11 and 3/11.
+- **Observed impact:** Live and cold views differed in wrapper card count,
+  identity, title, filename, or attachment.
+- **Delivery:** merged `2408b574` on `codex-stability-7-image-generation-history`,
+  PR [#718](https://github.com/sesori-ai/sesori_apps_monorepo/pull/718);
+  directed wrapper `c3ab5fcb` on D1; complete forwarded wrapper `36ee48e9` on D3.
+- **Acceptance:** Every generation has one completed `image_generation` card and
+  one expandable attachment; mixed-purpose code remains visible.
+
+### Finding step F-08 — Late completion forked an aborted tool
+
+- **State:** Fixed on stack in Delivery Step 4/11.
+- **Observed impact:** A process outlived its aborted turn and later appeared as a
+  second completed native command.
+- **Delivery:** `a32b6c29` on
+  `codex-stability-deep-test-4-late-abort-tool-identity`.
+- **Acceptance:** Started unfinished aliases survive turn termination only until
+  item completion updates the original failed card.
+
+### Finding step F-09 — Code-mode file changes had two identities
+
+- **State:** Fixed on stack in Delivery Steps 5/11 and 8/11.
+- **Observed impact:** App-server file changes and rollout wrappers produced
+  different live/cold cards and lost edit projection.
+- **Delivery:** behavior fix `9da8f2e1` on D5; typed boundary follow-up
+  `d4e30b87` on D8.
+- **Acceptance:** Fresh create/update/delete operations produce exactly one edit
+  card each with stable IDs, titles, patches, and completion.
+
+### Finding step F-10 — Restart left an active tool running forever
+
+- **State:** Fixed on stack in Delivery Steps 6/11 and 8/11.
+- **Observed impact:** After bridge restart, session status was idle while an
+  unresolved command still displayed running.
+- **Delivery:** behavior fix `8f0f4ece` on D6; service-owned sealed replay policy
+  `d4e30b87` on D8.
+- **Acceptance:** Idle interrupted calls replay failed; genuinely active calls
+  remain running until normal completion.
+
+### Finding step F-11 — Archive removed readable Codex history
+
+- **State:** Fixed on stack in Delivery Step 7/11.
+- **Observed impact:** Backend archive moved the rollout out of the readable
+  catalog, so Sesori archive/unarchive lost transcript access.
+- **Delivery:** `cdd3a305` on
+  `codex-stability-deep-test-7-local-archive-history`.
+- **Acceptance:** Rename/archive/unarchive preserve transcript; delete still
+  removes the disposable session and rollout.
+
+### Finding step F-12 — Repository instructions appeared as a user message
+
+- **State:** Confirmed and documented in Delivery Step 9/11; fix required in
+  Delivery Step 10/11.
+- **Observed impact:** A fresh iOS-created session rendered generated repository
+  instructions and a local path as a large authored user message before the real
+  image prompt.
+- **Likely boundary:** Existing `CodexMessageRepository` generated-context
+  filtering does not recognize Codex's non-angle-bracket AGENTS header.
+- **Delivery:** discovery/report update in `ef2356c4` on D9; fix branch
+  `codex-plugin-stability-feedback-f12-generated-repository-instructions`.
+- **Acceptance:** Complete generated AGENTS envelopes disappear from cold
+  history; authored marker-like text, mixed content, and near matches remain.
+
+## Delivery Rules
+
+- The series has exactly eleven PRs. Every title uses the fixed
+  `[codex-plugin-stability-feedback] ... [step <x>/11]` form below.
+- At the user's direction, Step 1 combines this plan/tracker with the first
+  unmerged production fix rather than using a plan-only PR.
+- Steps 1 through 9 preserve the exact D1 through D9 branch order. Do not rebase,
+  reset, cherry-pick, reorder, or recreate existing production commits.
+- Merge current `main` and predecessor updates forward. Before each successor PR,
+  merge its updated predecessor into that successor so the plan/tracker and all
+  prior fixes remain ancestors.
+- A successor may target its immediate predecessor while both are open, but
+  merges occur in numeric order. Do not delete a predecessor branch while a
+  dependent PR uses it as a base.
+- Count additions plus deletions, generated code, tests, and plan updates against
+  each PR base. Reassess near 1,300 lines; prefer a coherent split before 1,500.
+- Generated files change only through their generators.
+- Update `TRACKER.md` in every step with actual base, line count, verification,
+  review, PR, merge, and cleanup evidence.
+- Run `aristotle-impl-review` only for architecture-bearing Steps 6, 8, and 9,
+  unless implementation evidence changes another step's architecture scope.
+- Step 10 starts with sanitized runtime-shape confirmation. It stays localized
+  unless ordinary-flow evidence proves another projection boundary is required.
+- Step 11 contains no production changes and moves the complete plan directory
+  to `.plan/completed/codex-plugin-stability-feedback/`.
+
+## Delivery Sequence
+
+| Step | Branch | Exact PR title | Existing/target size | Primary finding |
+|---|---|---|---:|---|
+| 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 841 total | F-07 |
+| 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 73 | F-02 |
+| 3/11 | `codex-stability-deep-test-3-image-wrapper-projection` | `⚙️ [codex-plugin-stability-feedback] fix(codex): hide generated image wrappers [step 3/11]` | 118 | F-07 |
+| 4/11 | `codex-stability-deep-test-4-late-abort-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): retain late command identity after abort [step 4/11]` | 86 | F-08 |
+| 5/11 | `codex-stability-deep-test-5-file-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify file change identity [step 5/11]` | 214 | F-09 |
+| 6/11 | `codex-stability-deep-test-6-restart-tool-terminalization` | `⚙️ [codex-plugin-stability-feedback] fix(codex): settle interrupted tools after restart [step 6/11]` | 70 | F-10 |
+| 7/11 | `codex-stability-deep-test-7-local-archive-history` | `🌿 [codex-plugin-stability-feedback] fix(codex): preserve locally archived history [step 7/11]` | 308 | F-11 |
+| 8/11 | `codex-stability-deep-test-8-typed-boundaries` | `🚧 [codex-plugin-stability-feedback] refactor(codex): type replay and item boundaries [step 8/11]` | 1,084 | F-09, F-10 |
+| 9/11 | `codex-stability-deep-test-9-mobile-images` | `🚧 [codex-plugin-stability-feedback] feat(codex): support mobile image prompts [step 9/11]` | 707 | F-12 discovery plus image support |
+| 10/11 | `codex-plugin-stability-feedback-f12-generated-repository-instructions` | `🌿 [codex-plugin-stability-feedback] fix(codex): hide generated repository instructions [step 10/11]` | target 70–140 | F-12 |
+| 11/11 | `codex-plugin-stability-feedback-retire-plan` | `🌱 [codex-plugin-stability-feedback] docs: retire Codex stability feedback plan [step 11/11]` | target 40–100 | Lifecycle |
+
+## Per-Step Review Briefs
+
+### Step 1/11 — Directed image wrappers plus plan
+
+- **Complexity:** Straightforward — two localized Codex mapper/test files plus
+  durable delivery documentation.
+- **What:** Recognize the exact generated `// @exec: {...}` directive preceding
+  directed image wrappers; add this plan and tracker.
+- **Why:** Generated wrapper shells otherwise appear beside the durable image
+  result, and the remaining stack needs one explicit delivery authority.
+- **Risk and test focus:** Exact directive matching, malformed directives,
+  mixed-purpose code, and plan/title/branch consistency.
+- **Expected result:** One image card for directed generated wrappers. No wire,
+  database, client, or analytics change.
+- **Verification:** Focused wrapper lifecycle tests, full Codex tests, fatal
+  analysis, `git diff --check`, and architecture plan review.
+
+### Step 2/11 — Code-mode command identity
+
+- **Complexity:** Moderate — per-turn correlation across app-server and rollout
+  identity domains.
+- **What:** Correlate only wrappers containing exactly one
+  `tools.exec_command(...)` invocation to the canonical rollout call.
+- **Why:** The merged direct-command fix does not cover generated code-mode
+  wrappers.
+- **Risk and test focus:** Multiple calls, turn isolation, FIFO order, cleanup,
+  and unchanged direct-command behavior.
+- **Expected result:** One command ID live and cold. No user-visible change
+  beyond duplicate removal; no wire/database change.
+- **Verification:** Focused tracker tests, full Codex tests, fatal analysis, and
+  `git diff --check`.
+
+### Step 3/11 — Complete generated image wrappers
+
+- **Complexity:** Moderate — exact syntax, tool-count, and variable-identity
+  constraints protect against hiding real code.
+- **What:** Recognize forwarded/content-forwarded generated image wrappers and
+  suppress only complete generated forms.
+- **Why:** Forwarded forms still create extra shell cards.
+- **Risk and test focus:** Mixed code, extra calls, mismatched variables,
+  malformed wrappers, and direct/forwarded/directed/preview variants.
+- **Expected result:** One durable image-generation card and attachment. No
+  wire/database/client change.
+- **Verification:** Focused wrapper matrix, full Codex tests, fatal analysis,
+  and `git diff --check`.
+
+### Step 4/11 — Late abort completion identity
+
+- **Complexity:** Moderate — alias lifetime crosses turn termination and item
+  completion.
+- **What:** Retain aliases only for started unfinished items, then retire them at
+  authoritative item completion.
+- **Why:** Late native completion otherwise forks the original failed card.
+- **Risk and test focus:** Alias leaks, abort-before-start, ordinary completion,
+  and restart replay.
+- **Expected result:** The original failed card receives the terminal update. No
+  wire/database/client change.
+- **Verification:** Focused abort/late-completion tests, full Codex tests, fatal
+  analysis, and `git diff --check`.
+
+### Step 5/11 — File-change identity
+
+- **Complexity:** Moderate — a second correlated item type carries edit-specific
+  patch output.
+- **What:** Recognize exact single-`apply_patch` wrappers, correlate app-server
+  file changes per turn, and project the patch as an edit.
+- **Why:** Live and cold identity diverge and edit presentation is lost.
+- **Risk and test focus:** Create/update/delete, multi-operation patches,
+  malformed strings, command/file queue separation, and failure state.
+- **Expected result:** One stable edit card per logical operation. No
+  wire/database/client change.
+- **Verification:** Focused file-correlation tests, full Codex tests, fatal
+  analysis, and `git diff --check`.
+
+### Step 6/11 — Interrupted replay terminalization
+
+- **Complexity:** Moderate — replay policy crosses plugin, service, repository,
+  and tracker seams.
+- **What:** Supply authoritative session activity to replay and terminalize
+  unresolved chronology only when the session is idle.
+- **Why:** Restart can leave a visible running tool with no active backend turn.
+- **Risk and test focus:** Busy/provisional/retry states, idle restart, active
+  snapshots, and false premature failure.
+- **Expected result:** Interrupted idle tools become failed; active tools remain
+  running. No wire/database/client change.
+- **Verification:** Active-versus-idle replay tests, full Codex tests, fatal
+  analysis, `git diff --check`, and implementation architecture review.
+
+### Step 7/11 — Local archive authority
+
+- **Complexity:** Straightforward — remove one destructive backend side effect
+  and retain evidence documentation.
+- **What:** Keep archive state bridge-local and add the completed stability
+  evidence report.
+- **Why:** Codex archive removes readable rollout history and has no symmetric
+  unarchive callback.
+- **Risk and test focus:** Archive/unarchive transcript, rename persistence,
+  delete remaining destructive, and no backend archive call.
+- **Expected result:** Archived sessions remain readable and reversible. No
+  schema/wire/client change.
+- **Verification:** Archive/delete write-path tests, full Codex tests, fatal
+  analysis, report consistency, and `git diff --check`.
+
+### Step 8/11 — Typed replay and item boundaries
+
+- **Complexity:** Complex — generated typed variants, parser ownership, tracker
+  migration, and service-owned replay policy across 25 files.
+- **What:** Introduce typed command/file events and sealed replay disposition;
+  remove raw map/status interpretation from downstream owners.
+- **Why:** F-09/F-10 behavior is correct but impossible states and misplaced
+  decisions remain representable.
+- **Risk and test focus:** Unknown/malformed input, status mapping, parser
+  privacy, code generation, composition, and behavior equivalence.
+- **Expected result:** Same visible behavior with typed owner-correct boundaries.
+  No wire/database/client change.
+- **Verification:** Codegen, parser/tracker/service/repository tests, all Codex
+  tests, fatal analysis, `git diff --check`, and implementation architecture
+  review.
+
+### Step 9/11 — Mobile image prompts
+
+- **Complexity:** Complex — backward-compatible shared wire capability plus
+  bridge, plugin, client service/state, reconnect, queue, and UI flow.
+- **What:** Declare prompt-attachment capability, enable Codex data-image input,
+  replace the hardcoded plugin gate, and fail closed when capability provenance
+  is unresolved.
+- **Why:** Codex supports image input, but mobile previously exposed attachment
+  selection only through an OpenCode-specific temporary gate.
+- **Risk and test focus:** Older bridges, different-bridge reconnect, queued
+  images, lookup failure, unsupported plugins, generated output, and history.
+- **Expected result:** Mobile Codex image prompts work without silent loss.
+  User-visible and compatible wire change; no database change.
+- **Verification:** Shared/client codegen; relevant tests and fatal analysis in
+  shared, plugin interface, OpenCode, Codex, bridge app, client core, and mobile;
+  widget tests, real iOS E2E, `git diff --check`, and implementation architecture
+  review.
+
+### Step 10/11 — Generated repository instructions
+
+- **Complexity:** Straightforward — localized but privacy-sensitive history
+  classification.
+- **What:** Confirm the sanitized Codex shape, then recognize only complete
+  AGENTS instruction envelopes at the existing history projection boundary.
+- **Why:** F-12 exposes generated repository instructions and paths as authored
+  user history.
+- **Risk and test focus:** False positives: optional directory header, no-path
+  form, mixed text, authored exact marker with submitted-user evidence, near
+  matches, incomplete markers, casing, and outer whitespace.
+- **Expected result:** Generated instructions disappear; authored content stays.
+  User-visible privacy fix; no wire/database/client/analytics change.
+- **Verification:** Failing regression first, focused rollout tests, all Codex
+  tests, fatal analysis, `git diff --check`, report/tracker update. No
+  architecture implementation review unless captured evidence broadens scope.
+
+### Step 11/11 — Retire the plan
+
+- **Complexity:** Trivial documentation lifecycle work.
+- **What:** Record final PR/merge/verification evidence and move the entire plan
+  directory from active to completed.
+- **Why:** Completed work must not remain actionable.
+- **Risk and test focus:** Missing links, wrong hashes/titles, incomplete finding
+  acceptance, or a stale active copy.
+- **Expected result:** One immutable completed record. No production,
+  user-visible, wire, database, or analytics change.
+- **Verification:** Cross-check all 12 finding items and 11 PRs; run
+  `git diff --check`. No Dart/Flutter suites.
+
+## Cleanup Assessment
+
+- **Step 4:** Replace unconditional alias clearing with settled-item cleanup and
+  retire aliases at item completion.
+- **Step 5:** Generalize command-only correlation naming only where file changes
+  use the same invariant; keep command and file queues distinct.
+- **Step 7:** Remove the obsolete backend `thread/archive` request and its
+  best-effort catch. Bridge archive persistence remains required.
+- **Step 8:** Remove raw item-map inspection, the command-only lifecycle enum,
+  and plugin-layer replay-policy decisions after typed owners replace them.
+- **Step 9:** Delete `composer_attachment_support.dart` and its hardcoded
+  plugin-name gate. Keep generated files because they are required outputs.
+- **Step 10:** Reuse the existing generated-context filter; add no parser
+  framework, path registry, raw payload logging, or persisted flag.
+- **Step 11:** Move, rather than copy, the plan tree. After all dependent PRs
+  merge, obsolete remote D1-D9 and Step 10 delivery branches/worktrees may be
+  removed separately.
+- **Retained intentionally:** `docs/codex-plugin-stability-report.md` remains the
+  privacy-safe test evidence artifact, while this plan/tracker owns delivery.
+  Existing wire fields, bridge archive data, rollout files, and tool identities
+  remain product data, not cleanup candidates.
+
+## Material Risks And Mitigations
+
+- **Stack drift:** Updating D1 without forwarding it would make successor PRs
+  appear to delete the plan. Merge each predecessor forward before opening its
+  successor; never rebase.
+- **False wrapper suppression:** Exact bounded structural checks remain local to
+  known generated forms. Mixed-purpose code remains visible.
+- **Identity leaks or over-correlation:** Correlation remains per thread/turn and
+  exact wrapper type, with authoritative completion cleanup.
+- **False replay terminalization:** Only service-owned authoritative activity
+  selects preserve-running; idle selects terminalization.
+- **Attachment compatibility:** Missing capability means false. Disconnect clears
+  provenance before queued attachment delivery.
+- **F-12 false positives:** Require the full generated envelope and preserve
+  exact authored text when submitted-user evidence exists. Do not expand to
+  other upstream contextual markers without observed fixtures.
+- **Scope expansion:** If F-12 requires live/cold cross-layer coordination or any
+  later finding grows beyond its current owner and estimate, stop and ask before
+  adding shared state or compatibility machinery.
+
+## Plan Review
+
+- **Reviewer:** `aristotle-plan-review`
+- **Verdict:** Approved with no findings.
+- **Date:** 2026-08-04
+- **Review scope:** `.plan/active/codex-plugin-stability-feedback/`
+- **Applied corrections:** None required. The reviewed version passed the
+  pre-review gate and the bridge, shared, and client architecture checks.
+
+## Completion Criteria
+
+The plan is complete only when all eleven delivery PRs merge in order, all
+twelve finding acceptance entries are checked, Step 10 proves F-12 fixed without
+hiding authored text, the stability report and tracker contain final evidence,
+the plan directory is moved to `.plan/completed/`, and no successor PR still
+depends on a branch scheduled for cleanup.

--- a/.plan/active/codex-plugin-stability-feedback/TRACKER.md
+++ b/.plan/active/codex-plugin-stability-feedback/TRACKER.md
@@ -46,7 +46,7 @@
 
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
-| [ ] | 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 1,043 actual | [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) open; verified; D1 merged current `origin/main` forward at `636546f6` |
+| [ ] | 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 1,061 actual | [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) open; verified; D1 merged current `origin/main` forward at `636546f6` |
 | [ ] | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 73 | Existing `58585e1f`; blocked on Step 1 merge-forward |
 | [ ] | 3/11 | `codex-stability-deep-test-3-image-wrapper-projection` | `⚙️ [codex-plugin-stability-feedback] fix(codex): hide generated image wrappers [step 3/11]` | 118 | Existing `36ee48e9`; blocked on Step 2 |
 | [ ] | 4/11 | `codex-stability-deep-test-4-late-abort-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): retain late command identity after abort [step 4/11]` | 86 | Existing `a32b6c29`; blocked on Step 3 |
@@ -158,15 +158,16 @@ origin/main
 - **Step 1 production verification:** All 29 focused lifecycle-tracker tests and
   all 297 Codex package tests pass. `dart analyze --fatal-infos` reports no
   issues. Both branch and staged `git diff --check` pass.
-- **Step 1 PR review:** Seven bot threads produced three valid correction
-  groups. Step 9 now explicitly requires its dated transport-compatibility
-  cleanup comment; malformed `@exec` JSON remains visible; and a local balanced
-  scanner requires the exact direct/forwarded wrapper remainder while ignoring
-  call-like prompt text. All five code regressions failed before the mapper
-  hardening. All 29 focused tests, fatal analysis, and `git diff --check` pass
-  afterward.
-- **Step 1 change size:** 1,043 lines against `origin/main`: 826 plan/tracker
-  additions plus 209 production/test additions and 8 deletions. This is below the
+- **Step 1 PR review:** Nine bot threads produced five valid correction groups.
+  Step 9 now explicitly requires its dated transport-compatibility cleanup
+  comment; malformed `@exec` JSON remains visible; a local balanced scanner
+  requires the exact direct/forwarded wrapper remainder while ignoring call-like
+  prompt text; directive marker spacing is horizontal-only; and forwarded
+  capture handling is null-safe. All six code regressions failed before the
+  mapper hardening. All 29 focused tests, fatal analysis, and `git diff --check`
+  pass afterward.
+- **Step 1 change size:** 1,061 lines against `origin/main`: 827 plan/tracker
+  additions plus 226 production/test additions and 8 deletions. This is below the
   1,500-line soft cap.
 - **Step 1 delivery:** Plan/tracker committed as `d3ec1923`, pushed, and opened
   as [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724).

--- a/.plan/active/codex-plugin-stability-feedback/TRACKER.md
+++ b/.plan/active/codex-plugin-stability-feedback/TRACKER.md
@@ -46,7 +46,7 @@
 
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
-| [ ] | 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 844 actual | [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) open; verified; D1 merged current `origin/main` forward at `636546f6` |
+| [ ] | 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 932 actual | [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) open; verified; D1 merged current `origin/main` forward at `636546f6` |
 | [ ] | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 73 | Existing `58585e1f`; blocked on Step 1 merge-forward |
 | [ ] | 3/11 | `codex-stability-deep-test-3-image-wrapper-projection` | `⚙️ [codex-plugin-stability-feedback] fix(codex): hide generated image wrappers [step 3/11]` | 118 | Existing `36ee48e9`; blocked on Step 2 |
 | [ ] | 4/11 | `codex-stability-deep-test-4-late-abort-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): retain late command identity after abort [step 4/11]` | 86 | Existing `a32b6c29`; blocked on Step 3 |
@@ -158,8 +158,14 @@ origin/main
 - **Step 1 production verification:** All 29 focused lifecycle-tracker tests and
   all 297 Codex package tests pass. `dart analyze --fatal-infos` reports no
   issues. Both branch and staged `git diff --check` pass.
-- **Step 1 change size:** 844 lines against `origin/main`: 815 plan/tracker
-  additions plus 27 production/test additions and 2 deletions. This is below the
+- **Step 1 PR review:** Five bot threads produced three valid corrections. Step
+  9 now explicitly requires its dated transport-compatibility cleanup comment;
+  malformed `@exec` JSON remains visible; and a directed wrapper containing any
+  additional call remains visible. All three code regressions failed before the
+  mapper hardening. All 29 focused tests, fatal analysis, and
+  `git diff --check` pass afterward.
+- **Step 1 change size:** 932 lines against `origin/main`: 825 plan/tracker
+  additions plus 105 production/test additions and 2 deletions. This is below the
   1,500-line soft cap.
 - **Step 1 delivery:** Plan/tracker committed as `d3ec1923`, pushed, and opened
   as [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724).

--- a/.plan/active/codex-plugin-stability-feedback/TRACKER.md
+++ b/.plan/active/codex-plugin-stability-feedback/TRACKER.md
@@ -8,13 +8,14 @@
 - **Stack root:** `2408b574`
 - **Series state:** Step 1 PR
   [#724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) merged;
-  D1 and current `main` are merged forward into D2; D2 through D9 remain in
-  stack order
+  Step 2 PR [#731](https://github.com/sesori-ai/sesori_apps_monorepo/pull/731)
+  open; D3 through D9 remain in stack order
 - **Current step:** Step 2/11
 - **Current branch:** `codex-stability-deep-test-2-code-mode-tool-identity`
 - **Plan PR:** [#724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724),
   merged as `149e7914` with the Step 1 production fix
-- **Next action:** Commit, push, and open Step 2 against `main`
+- **Next action:** Monitor Step 2 CI and review; merge it before forwarding D2
+  into D3
 
 ## Plan Review
 
@@ -47,7 +48,7 @@
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
 | [x] | 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 1,100 actual | [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) merged as `149e7914` |
-| [ ] | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 132 actual | Verified; D1 merged forward as `8ee54e0b`, current `main` as `24e07907` |
+| [ ] | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 135 actual | [PR #731](https://github.com/sesori-ai/sesori_apps_monorepo/pull/731) open; verified; D1 and current `main` merged forward |
 | [ ] | 3/11 | `codex-stability-deep-test-3-image-wrapper-projection` | `⚙️ [codex-plugin-stability-feedback] fix(codex): hide generated image wrappers [step 3/11]` | 118 | Existing `36ee48e9`; blocked on Step 2 |
 | [ ] | 4/11 | `codex-stability-deep-test-4-late-abort-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): retain late command identity after abort [step 4/11]` | 86 | Existing `a32b6c29`; blocked on Step 3 |
 | [ ] | 5/11 | `codex-stability-deep-test-5-file-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify file change identity [step 5/11]` | 214 | Existing `9da8f2e1`; blocked on Step 4 |
@@ -188,9 +189,11 @@ origin/main
   and all 298 Codex package tests pass. `dart analyze --fatal-infos` reports no
   issues. Both the branch comparison and current working-tree `git diff --check`
   pass.
-- **Step 2 change size:** 132 lines against the PR merge base,
+- **Step 2 change size:** 135 lines against the PR merge base,
   including production code, tests, and plan/tracker updates. This is below the
   1,500-line soft cap.
+- **Step 2 delivery:** Pushed and opened as
+  [PR #731](https://github.com/sesori-ai/sesori_apps_monorepo/pull/731).
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/codex-plugin-stability-feedback/TRACKER.md
+++ b/.plan/active/codex-plugin-stability-feedback/TRACKER.md
@@ -46,7 +46,7 @@
 
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
-| [ ] | 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 932 actual | [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) open; verified; D1 merged current `origin/main` forward at `636546f6` |
+| [ ] | 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 1,043 actual | [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) open; verified; D1 merged current `origin/main` forward at `636546f6` |
 | [ ] | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 73 | Existing `58585e1f`; blocked on Step 1 merge-forward |
 | [ ] | 3/11 | `codex-stability-deep-test-3-image-wrapper-projection` | `⚙️ [codex-plugin-stability-feedback] fix(codex): hide generated image wrappers [step 3/11]` | 118 | Existing `36ee48e9`; blocked on Step 2 |
 | [ ] | 4/11 | `codex-stability-deep-test-4-late-abort-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): retain late command identity after abort [step 4/11]` | 86 | Existing `a32b6c29`; blocked on Step 3 |
@@ -158,14 +158,15 @@ origin/main
 - **Step 1 production verification:** All 29 focused lifecycle-tracker tests and
   all 297 Codex package tests pass. `dart analyze --fatal-infos` reports no
   issues. Both branch and staged `git diff --check` pass.
-- **Step 1 PR review:** Five bot threads produced three valid corrections. Step
-  9 now explicitly requires its dated transport-compatibility cleanup comment;
-  malformed `@exec` JSON remains visible; and a directed wrapper containing any
-  additional call remains visible. All three code regressions failed before the
-  mapper hardening. All 29 focused tests, fatal analysis, and
-  `git diff --check` pass afterward.
-- **Step 1 change size:** 932 lines against `origin/main`: 825 plan/tracker
-  additions plus 105 production/test additions and 2 deletions. This is below the
+- **Step 1 PR review:** Seven bot threads produced three valid correction
+  groups. Step 9 now explicitly requires its dated transport-compatibility
+  cleanup comment; malformed `@exec` JSON remains visible; and a local balanced
+  scanner requires the exact direct/forwarded wrapper remainder while ignoring
+  call-like prompt text. All five code regressions failed before the mapper
+  hardening. All 29 focused tests, fatal analysis, and `git diff --check` pass
+  afterward.
+- **Step 1 change size:** 1,043 lines against `origin/main`: 826 plan/tracker
+  additions plus 209 production/test additions and 8 deletions. This is below the
   1,500-line soft cap.
 - **Step 1 delivery:** Plan/tracker committed as `d3ec1923`, pushed, and opened
   as [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724).

--- a/.plan/active/codex-plugin-stability-feedback/TRACKER.md
+++ b/.plan/active/codex-plugin-stability-feedback/TRACKER.md
@@ -1,0 +1,177 @@
+# Codex Plugin Stability Feedback: Tracker
+
+## Current State
+
+- **Plan slug:** `codex-plugin-stability-feedback`
+- **Implementation base:** `origin/main` at
+  `009bb44a72683d0a1bc6dacd13cbc19397e92d43`
+- **Stack root:** `2408b574`
+- **Series state:** Historical F-01 through F-07 baseline PRs merged; remaining
+  D1 through D9 branches exist and are pushed; Step 1 is verified and ready for
+  commit
+- **Current step:** Step 1/11
+- **Current branch:** `codex-stability-deep-test-1-image-wrapper-directive`
+- **Plan PR:** Pending; combined with Step 1 production fix by user direction
+- **Next action:** Commit/push the updated D1 branch and open the first PR
+  against `main`
+
+## Plan Review
+
+- **Reviewer:** `aristotle-plan-review`
+- **Verdict:** Approved with no findings
+- **Date:** 2026-08-04
+- **Reviewed scope:** `.plan/active/codex-plugin-stability-feedback/`
+- **Findings and corrections:** None. The reviewed plan passed the pre-review
+  gate and the bridge, shared, and client architecture checks.
+
+## Finding Ledger
+
+| Done | Finding | State | Existing fix branch / PR / commit | Current delivery acceptance |
+|---|---|---|---|---|
+| [x] | F-01 generated context | Fixed on `main` | `codex-stability-2-user-context`; [#710](https://github.com/sesori-ai/sesori_apps_monorepo/pull/710); `0dc0c6ec` | Preserve complete-envelope omission and authored-text regressions |
+| [ ] | F-02 shell identity | Direct path fixed; code-mode fix stacked | `codex-stability-3-tool-identity`; [#712](https://github.com/sesori-ai/sesori_apps_monorepo/pull/712); `e5cb9d86` | Step 2 adds `58585e1f` and proves one code-mode ID |
+| [x] | F-03 interrupted history | Fixed on `main` | `codex-stability-4-tool-lifecycle`; [#713](https://github.com/sesori-ai/sesori_apps_monorepo/pull/713); `f70bdbcb` | Preserve terminal replay regressions |
+| [x] | F-04 prompt image history | Fixed on `main` | `codex-stability-5-prompt-images`; [#715](https://github.com/sesori-ai/sesori_apps_monorepo/pull/715); `6930b3a9` | Preserve stable text/file replay regressions |
+| [x] | F-05 debug SSE UTF-8 | Fixed on `main` | `codex-stability-1-debug-sse`; [#709](https://github.com/sesori-ai/sesori_apps_monorepo/pull/709); `025ba43b` | Preserve same-connection UTF-8 regression |
+| [x] | F-06 failed tool replay | Fixed on `main` | `codex-stability-6-failed-tool-status`; [#717](https://github.com/sesori-ai/sesori_apps_monorepo/pull/717); `20521cc2` | Preserve error/output/exit-code replay |
+| [ ] | F-07 generated image convergence | Durable history fixed; wrappers stacked | `codex-stability-7-image-generation-history`; [#718](https://github.com/sesori-ai/sesori_apps_monorepo/pull/718); `2408b574` | Steps 1 and 3 deliver `c3ab5fcb` and `36ee48e9` |
+| [ ] | F-08 late abort identity | Fixed on stack | D4; `a32b6c29` | Step 4 proves late completion updates the failed card |
+| [ ] | F-09 file identity | Fixed on stack | D5 `9da8f2e1`; D8 `d4e30b87` | Steps 5 and 8 deliver behavior and typed boundary |
+| [ ] | F-10 restart terminalization | Fixed on stack | D6 `8f0f4ece`; D8 `d4e30b87` | Steps 6 and 8 deliver behavior and service-owned policy |
+| [ ] | F-11 archive history | Fixed on stack | D7; `cdd3a305` | Step 7 proves archive/unarchive readable and delete destructive |
+| [ ] | F-12 generated repository instructions | Confirmed; not fixed | Documented on D9 `ef2356c4` | Step 10 must hide complete generated AGENTS envelopes without hiding authored text |
+
+## Delivery Steps
+
+| Done | Step | Branch | Exact PR title | Changed-line target | State |
+|---|---|---|---|---:|---|
+| [ ] | 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 841 actual | Verified; D1 merged current `origin/main` forward at `636546f6` |
+| [ ] | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 73 | Existing `58585e1f`; blocked on Step 1 merge-forward |
+| [ ] | 3/11 | `codex-stability-deep-test-3-image-wrapper-projection` | `⚙️ [codex-plugin-stability-feedback] fix(codex): hide generated image wrappers [step 3/11]` | 118 | Existing `36ee48e9`; blocked on Step 2 |
+| [ ] | 4/11 | `codex-stability-deep-test-4-late-abort-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): retain late command identity after abort [step 4/11]` | 86 | Existing `a32b6c29`; blocked on Step 3 |
+| [ ] | 5/11 | `codex-stability-deep-test-5-file-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify file change identity [step 5/11]` | 214 | Existing `9da8f2e1`; blocked on Step 4 |
+| [ ] | 6/11 | `codex-stability-deep-test-6-restart-tool-terminalization` | `⚙️ [codex-plugin-stability-feedback] fix(codex): settle interrupted tools after restart [step 6/11]` | 70 | Existing `8f0f4ece`; blocked on Step 5 |
+| [ ] | 7/11 | `codex-stability-deep-test-7-local-archive-history` | `🌿 [codex-plugin-stability-feedback] fix(codex): preserve locally archived history [step 7/11]` | 308 | Existing `cdd3a305` + `c4767b04`; blocked on Step 6 |
+| [ ] | 8/11 | `codex-stability-deep-test-8-typed-boundaries` | `🚧 [codex-plugin-stability-feedback] refactor(codex): type replay and item boundaries [step 8/11]` | 1,084 | Existing `d4e30b87` + `e86bb66f`; blocked on Step 7 |
+| [ ] | 9/11 | `codex-stability-deep-test-9-mobile-images` | `🚧 [codex-plugin-stability-feedback] feat(codex): support mobile image prompts [step 9/11]` | 707 | Existing `ef2356c4`; blocked on Step 8 |
+| [ ] | 10/11 | `codex-plugin-stability-feedback-f12-generated-repository-instructions` | `🌿 [codex-plugin-stability-feedback] fix(codex): hide generated repository instructions [step 10/11]` | 70–140 | Planned after D9; confirmed F-12 fix |
+| [ ] | 11/11 | `codex-plugin-stability-feedback-retire-plan` | `🌱 [codex-plugin-stability-feedback] docs: retire Codex stability feedback plan [step 11/11]` | 40–100 | Blocked on Step 10 merge |
+
+## Exact PR Titles
+
+1. `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]`
+2. `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]`
+3. `⚙️ [codex-plugin-stability-feedback] fix(codex): hide generated image wrappers [step 3/11]`
+4. `⚙️ [codex-plugin-stability-feedback] fix(codex): retain late command identity after abort [step 4/11]`
+5. `⚙️ [codex-plugin-stability-feedback] fix(codex): unify file change identity [step 5/11]`
+6. `⚙️ [codex-plugin-stability-feedback] fix(codex): settle interrupted tools after restart [step 6/11]`
+7. `🌿 [codex-plugin-stability-feedback] fix(codex): preserve locally archived history [step 7/11]`
+8. `🚧 [codex-plugin-stability-feedback] refactor(codex): type replay and item boundaries [step 8/11]`
+9. `🚧 [codex-plugin-stability-feedback] feat(codex): support mobile image prompts [step 9/11]`
+10. `🌿 [codex-plugin-stability-feedback] fix(codex): hide generated repository instructions [step 10/11]`
+11. `🌱 [codex-plugin-stability-feedback] docs: retire Codex stability feedback plan [step 11/11]`
+
+## Branch Ancestry
+
+```text
+origin/main
+  -> D1 + PLAN.md + TRACKER.md
+  -> D2
+  -> D3
+  -> D4
+  -> D5
+  -> D6
+  -> D7
+  -> D8
+  -> D9
+  -> F-12 fix
+  -> plan retirement
+```
+
+- Preserve existing production commit order:
+  `c3ab5fcb` -> `58585e1f` -> `36ee48e9` -> `a32b6c29` ->
+  `9da8f2e1` -> `8f0f4ece` -> `cdd3a305` -> `d4e30b87` ->
+  `ef2356c4`.
+- Documentation commits `c4767b04` and `e86bb66f` remain on D7 and D8.
+- Merge forward only. Never rebase, reset, reorder, or cherry-pick the stack.
+- Before opening Step N, merge the updated Step N-1 branch into it and resolve
+  only evidenced conflicts.
+
+## Locked Decisions
+
+- Backend-specific wrapper, identity, replay, and generated-context behavior
+  stays in `sesori_plugin_codex`.
+- Shared/mobile code consumes only declared backend-neutral capabilities.
+- Missing or unresolved attachment support is false; disconnect clears prior
+  bridge capability provenance.
+- No database migration, new persisted field, generic correlation registry,
+  broad parser framework, global lock, or cross-plugin lifecycle owner.
+- Complete generated content may be hidden only at an owning projection boundary
+  with authored-content evidence and focused false-positive tests.
+- The relay-version `123` defect is explicitly outside this plan.
+- The transient self-healing initial-history observation is accepted unless new
+  ordinary-flow evidence demonstrates meaningful persistent impact.
+- Existing product analytics remain unchanged; no content/provider/image data is
+  reported.
+
+## Cleanup Outcomes Planned
+
+- Step 4 narrows alias retention and retires aliases at item completion.
+- Step 7 removes destructive backend archive notification.
+- Step 8 removes raw map/status interpretation after typed owners replace it.
+- Step 9 deletes the hardcoded composer attachment-support helper.
+- Step 10 reuses the existing generated-context boundary without new machinery.
+- Step 11 moves the active plan tree to completed and later permits obsolete
+  branch/worktree cleanup once no stacked PR depends on those refs.
+- The stability report remains as test evidence; plan/tracker own delivery state.
+
+## Execution Rules
+
+- Merge PRs in numeric order. A successor may target its immediate predecessor
+  while open, but every step must be independently valid at its base.
+- Update this tracker in every step with actual base SHA, changed-line count,
+  tests, analysis, review, PR URL, merge SHA, and finding-state changes.
+- Target at most 1,500 changed lines per PR, counting generated code and tests.
+- Run code generation instead of hand-editing generated files.
+- Run focused tests, owning-package full tests, fatal analysis, and
+  `git diff --check` for production steps. Run architecture implementation
+  review only for Steps 6, 8, and 9 unless scope materially changes.
+- Step 10 captures a sanitized structural fixture first and broadens beyond cold
+  history only if ordinary-flow evidence requires it.
+- Step 11 runs documentation validation only and leaves no active plan copy.
+
+## Verification Log
+
+- **Historical baseline:** PRs #709, #710, #712, #713, #715, #717, and #718
+  merged to `main`; their exact finding mapping appears above.
+- **Existing deep-test verification:** the stability report records focused and
+  full Codex tests, fatal analysis, simulator evidence, navigation/reconnect/
+  restart checks, and privacy-safe cleanup through D8.
+- **Step 1 base update:** merged `origin/main` at `009bb44a` forward into D1 as
+  merge commit `636546f6`; no rebase or history rewrite.
+- **Step 1 plan authoring:** `PLAN.md` and `TRACKER.md` added with fixed slug,
+  eleven titles, D1-D9 ancestry, F-12 follow-up, retirement lifecycle, and
+  individual F-01 through F-12 acceptance entries.
+- **Step 1 plan review:** `aristotle-plan-review` approved the complete plan and
+  tracker with no findings on 2026-08-04.
+- **Step 1 production verification:** All 29 focused lifecycle-tracker tests and
+  all 297 Codex package tests pass. `dart analyze --fatal-infos` reports no
+  issues. Both branch and staged `git diff --check` pass.
+- **Step 1 change size:** 841 lines against `origin/main`: 812 plan/tracker
+  additions plus 27 production/test additions and 2 deletions. This is below the
+  1,500-line soft cap.
+- **Step 1 delivery:** Pending commit, push, and PR.
+
+## Findings And Plan Deltas
+
+- **2026-08-04 — First PR scope:** User selected the first unmerged deep-test
+  fix rather than rebuilding already-merged F-01 history. Step 1 combines the
+  plan/tracker with D1 `c3ab5fcb`.
+- **2026-08-04 — Stack order:** User required plan delivery steps to match the
+  existing stacked branches exactly. D1 through D9 remain Steps 1 through 9.
+- **2026-08-04 — Remaining findings:** Confirmed F-12 is added after D9 and must
+  be fixed inside this plan. The separately owned relay-version defect is not
+  duplicated here.
+- **2026-08-04 — Finding traceability:** Because historical findings do not map
+  one-to-one to the remaining branches, the plan keeps an independent F-01
+  through F-12 acceptance ledger alongside the PR delivery sequence.

--- a/.plan/active/codex-plugin-stability-feedback/TRACKER.md
+++ b/.plan/active/codex-plugin-stability-feedback/TRACKER.md
@@ -7,13 +7,14 @@
   `009bb44a72683d0a1bc6dacd13cbc19397e92d43`
 - **Stack root:** `2408b574`
 - **Series state:** Historical F-01 through F-07 baseline PRs merged; remaining
-  D1 through D9 branches exist and are pushed; Step 1 is verified and ready for
-  commit
+  D1 through D9 branches exist and are pushed; Step 1 PR
+  [#724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) is open
 - **Current step:** Step 1/11
 - **Current branch:** `codex-stability-deep-test-1-image-wrapper-directive`
-- **Plan PR:** Pending; combined with Step 1 production fix by user direction
-- **Next action:** Commit/push the updated D1 branch and open the first PR
-  against `main`
+- **Plan PR:** [#724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724),
+  combined with Step 1 production fix by user direction
+- **Next action:** Monitor Step 1 CI and review; merge it before forwarding D1
+  into D2
 
 ## Plan Review
 
@@ -45,7 +46,7 @@
 
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
-| [ ] | 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 841 actual | Verified; D1 merged current `origin/main` forward at `636546f6` |
+| [ ] | 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 844 actual | [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) open; verified; D1 merged current `origin/main` forward at `636546f6` |
 | [ ] | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 73 | Existing `58585e1f`; blocked on Step 1 merge-forward |
 | [ ] | 3/11 | `codex-stability-deep-test-3-image-wrapper-projection` | `⚙️ [codex-plugin-stability-feedback] fix(codex): hide generated image wrappers [step 3/11]` | 118 | Existing `36ee48e9`; blocked on Step 2 |
 | [ ] | 4/11 | `codex-stability-deep-test-4-late-abort-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): retain late command identity after abort [step 4/11]` | 86 | Existing `a32b6c29`; blocked on Step 3 |
@@ -157,10 +158,11 @@ origin/main
 - **Step 1 production verification:** All 29 focused lifecycle-tracker tests and
   all 297 Codex package tests pass. `dart analyze --fatal-infos` reports no
   issues. Both branch and staged `git diff --check` pass.
-- **Step 1 change size:** 841 lines against `origin/main`: 812 plan/tracker
+- **Step 1 change size:** 844 lines against `origin/main`: 815 plan/tracker
   additions plus 27 production/test additions and 2 deletions. This is below the
   1,500-line soft cap.
-- **Step 1 delivery:** Pending commit, push, and PR.
+- **Step 1 delivery:** Plan/tracker committed as `d3ec1923`, pushed, and opened
+  as [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724).
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/codex-plugin-stability-feedback/TRACKER.md
+++ b/.plan/active/codex-plugin-stability-feedback/TRACKER.md
@@ -4,17 +4,17 @@
 
 - **Plan slug:** `codex-plugin-stability-feedback`
 - **Implementation base:** `origin/main` at
-  `009bb44a72683d0a1bc6dacd13cbc19397e92d43`
+  `4f890087cbebe1fa23e410c18e53257f707102c0`
 - **Stack root:** `2408b574`
-- **Series state:** Historical F-01 through F-07 baseline PRs merged; remaining
-  D1 through D9 branches exist and are pushed; Step 1 PR
-  [#724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) is open
-- **Current step:** Step 1/11
-- **Current branch:** `codex-stability-deep-test-1-image-wrapper-directive`
+- **Series state:** Step 1 PR
+  [#724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) merged;
+  D1 and current `main` are merged forward into D2; D2 through D9 remain in
+  stack order
+- **Current step:** Step 2/11
+- **Current branch:** `codex-stability-deep-test-2-code-mode-tool-identity`
 - **Plan PR:** [#724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724),
-  combined with Step 1 production fix by user direction
-- **Next action:** Monitor Step 1 CI and review; merge it before forwarding D1
-  into D2
+  merged as `149e7914` with the Step 1 production fix
+- **Next action:** Commit, push, and open Step 2 against `main`
 
 ## Plan Review
 
@@ -46,8 +46,8 @@
 
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
-| [ ] | 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 1,100 actual | [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) open; verified; D1 merged current `origin/main` forward at `636546f6` |
-| [ ] | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 73 | Existing `58585e1f`; blocked on Step 1 merge-forward |
+| [x] | 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 1,100 actual | [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) merged as `149e7914` |
+| [ ] | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 132 actual | Verified; D1 merged forward as `8ee54e0b`, current `main` as `24e07907` |
 | [ ] | 3/11 | `codex-stability-deep-test-3-image-wrapper-projection` | `⚙️ [codex-plugin-stability-feedback] fix(codex): hide generated image wrappers [step 3/11]` | 118 | Existing `36ee48e9`; blocked on Step 2 |
 | [ ] | 4/11 | `codex-stability-deep-test-4-late-abort-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): retain late command identity after abort [step 4/11]` | 86 | Existing `a32b6c29`; blocked on Step 3 |
 | [ ] | 5/11 | `codex-stability-deep-test-5-file-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify file change identity [step 5/11]` | 214 | Existing `9da8f2e1`; blocked on Step 4 |
@@ -130,6 +130,8 @@ origin/main
 
 - Merge PRs in numeric order. A successor may target its immediate predecessor
   while open, but every step must be independently valid at its base.
+- After each merge notification, continue automatically with the next numbered
+  step. Stop only for a material decision or blocker.
 - Update this tracker in every step with actual base SHA, changed-line count,
   tests, analysis, review, PR URL, merge SHA, and finding-state changes.
 - Target at most 1,500 changed lines per PR, counting generated code and tests.
@@ -170,13 +172,25 @@ origin/main
 - **Step 1 accepted review risk:** Four subsequent bot threads requested broader
   JavaScript regex/template/delimiter parsing for unobserved generated wrappers.
   The owner accepted the bounded risk on 2026-08-04 rather than growing this
-  localized classifier into a partial JavaScript tokenizer. Every thread has a
-  rationale reply and remains open for human closure.
+  localized classifier into a partial JavaScript tokenizer. Every thread
+  received a rationale reply and was closed before merge.
 - **Step 1 change size:** 1,100 lines against the PR merge base: 842 plan/tracker
   additions plus 250 production/test additions and 8 deletions. This is below the
   1,500-line soft cap.
-- **Step 1 delivery:** Plan/tracker committed as `d3ec1923`, pushed, and opened
-  as [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724).
+- **Step 1 delivery:** Plan/tracker committed as `d3ec1923`; PR
+  [#724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) merged as
+  `149e7914` on 2026-08-04 with zero unresolved threads.
+- **Step 2 base update:** Merged the complete local D1 branch forward as
+  `8ee54e0b`, then merged `origin/main` at `4f890087` as `24e07907`. Existing
+  production commit `58585e1f` remains in its original stack position; no
+  rebase, reset, reorder, or cherry-pick occurred.
+- **Step 2 production verification:** The focused lifecycle-tracker test suite
+  and all 298 Codex package tests pass. `dart analyze --fatal-infos` reports no
+  issues. Both the branch comparison and current working-tree `git diff --check`
+  pass.
+- **Step 2 change size:** 132 lines against the PR merge base,
+  including production code, tests, and plan/tracker updates. This is below the
+  1,500-line soft cap.
 
 ## Findings And Plan Deltas
 
@@ -195,3 +209,6 @@ origin/main
   for unobserved regex-literal, template-interpolation, and malformed-delimiter
   wrapper shapes; no broader JavaScript tokenizer is planned without new runtime
   evidence.
+- **2026-08-04 — Automatic continuation:** After every merge notification,
+  proceed immediately with the next numbered step without another user prompt;
+  stop only for a material decision or blocker.

--- a/.plan/active/codex-plugin-stability-feedback/TRACKER.md
+++ b/.plan/active/codex-plugin-stability-feedback/TRACKER.md
@@ -48,7 +48,7 @@
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
 | [x] | 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 1,100 actual | [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) merged as `149e7914` |
-| [ ] | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 135 actual | [PR #731](https://github.com/sesori-ai/sesori_apps_monorepo/pull/731) open; verified; D1 and current `main` merged forward |
+| [ ] | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 299 actual | [PR #731](https://github.com/sesori-ai/sesori_apps_monorepo/pull/731) open; verified; D1 and current `main` merged forward |
 | [ ] | 3/11 | `codex-stability-deep-test-3-image-wrapper-projection` | `⚙️ [codex-plugin-stability-feedback] fix(codex): hide generated image wrappers [step 3/11]` | 118 | Existing `36ee48e9`; blocked on Step 2 |
 | [ ] | 4/11 | `codex-stability-deep-test-4-late-abort-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): retain late command identity after abort [step 4/11]` | 86 | Existing `a32b6c29`; blocked on Step 3 |
 | [ ] | 5/11 | `codex-stability-deep-test-5-file-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify file change identity [step 5/11]` | 214 | Existing `9da8f2e1`; blocked on Step 4 |
@@ -185,11 +185,17 @@ origin/main
   `8ee54e0b`, then merged `origin/main` at `4f890087` as `24e07907`. Existing
   production commit `58585e1f` remains in its original stack position; no
   rebase, reset, reorder, or cherry-pick occurred.
-- **Step 2 production verification:** The focused lifecycle-tracker test suite
-  and all 298 Codex package tests pass. `dart analyze --fatal-infos` reports no
+- **Step 2 production verification:** All 33 focused lifecycle-tracker tests and
+  all 301 Codex package tests pass. `dart analyze --fatal-infos` reports no
   issues. Both the branch comparison and current working-tree `git diff --check`
   pass.
-- **Step 2 change size:** 135 lines against the PR merge base,
+- **Step 2 PR review:** Four bot threads produced one valid correction group.
+  The code-mode classifier now finds exactly one balanced command invocation
+  outside strings and comments while accepting invocation whitespace; three
+  regressions failed before the correction. The separate direct and code-mode
+  queues remain intentional because a direct rollout `exec_command` record is
+  authoritative and the custom code-mode call is only its fallback.
+- **Step 2 change size:** 299 lines against the PR merge base,
   including production code, tests, and plan/tracker updates. This is below the
   1,500-line soft cap.
 - **Step 2 delivery:** Pushed and opened as
@@ -215,3 +221,8 @@ origin/main
 - **2026-08-04 — Automatic continuation:** After every merge notification,
   proceed immediately with the next numbered step without another user prompt;
   stop only for a material decision or blocker.
+- **2026-08-04 — Code-mode fallback ordering:** Preserve direct rollout command
+  correlation ahead of the custom code-mode fallback. A shared FIFO would let
+  an outer custom wrapper claim the app-server item before its authoritative
+  direct rollout call; no ordinary-flow evidence justifies that regression to
+  protect a theoretical mixed-form ordering case.

--- a/.plan/active/codex-plugin-stability-feedback/TRACKER.md
+++ b/.plan/active/codex-plugin-stability-feedback/TRACKER.md
@@ -46,7 +46,7 @@
 
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
-| [ ] | 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 1,061 actual | [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) open; verified; D1 merged current `origin/main` forward at `636546f6` |
+| [ ] | 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 1,086 actual | [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) open; verified; D1 merged current `origin/main` forward at `636546f6` |
 | [ ] | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 73 | Existing `58585e1f`; blocked on Step 1 merge-forward |
 | [ ] | 3/11 | `codex-stability-deep-test-3-image-wrapper-projection` | `⚙️ [codex-plugin-stability-feedback] fix(codex): hide generated image wrappers [step 3/11]` | 118 | Existing `36ee48e9`; blocked on Step 2 |
 | [ ] | 4/11 | `codex-stability-deep-test-4-late-abort-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): retain late command identity after abort [step 4/11]` | 86 | Existing `a32b6c29`; blocked on Step 3 |
@@ -158,16 +158,17 @@ origin/main
 - **Step 1 production verification:** All 29 focused lifecycle-tracker tests and
   all 297 Codex package tests pass. `dart analyze --fatal-infos` reports no
   issues. Both branch and staged `git diff --check` pass.
-- **Step 1 PR review:** Nine bot threads produced five valid correction groups.
+- **Step 1 PR review:** Ten bot threads produced six valid correction groups.
   Step 9 now explicitly requires its dated transport-compatibility cleanup
   comment; malformed `@exec` JSON remains visible; a local balanced scanner
   requires the exact direct/forwarded wrapper remainder while ignoring call-like
   prompt text; directive marker spacing is horizontal-only; and forwarded
-  capture handling is null-safe. All six code regressions failed before the
-  mapper hardening. All 29 focused tests, fatal analysis, and `git diff --check`
-  pass afterward.
-- **Step 1 change size:** 1,061 lines against `origin/main`: 827 plan/tracker
-  additions plus 226 production/test additions and 8 deletions. This is below the
+  capture handling is null-safe. Nested executable tool calls also fail visible
+  without treating call-like prompt text as code. All seven code regressions
+  failed before the mapper hardening. All 29 focused tests, fatal analysis, and
+  `git diff --check` pass afterward.
+- **Step 1 change size:** 1,086 lines against `origin/main`: 828 plan/tracker
+  additions plus 250 production/test additions and 8 deletions. This is below the
   1,500-line soft cap.
 - **Step 1 delivery:** Plan/tracker committed as `d3ec1923`, pushed, and opened
   as [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724).

--- a/.plan/active/codex-plugin-stability-feedback/TRACKER.md
+++ b/.plan/active/codex-plugin-stability-feedback/TRACKER.md
@@ -46,7 +46,7 @@
 
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
-| [ ] | 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 1,086 actual | [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) open; verified; D1 merged current `origin/main` forward at `636546f6` |
+| [ ] | 1/11 | `codex-stability-deep-test-1-image-wrapper-directive` | `🌿 [codex-plugin-stability-feedback] fix(codex): recognize directed image wrappers [step 1/11]` | 1,100 actual | [PR #724](https://github.com/sesori-ai/sesori_apps_monorepo/pull/724) open; verified; D1 merged current `origin/main` forward at `636546f6` |
 | [ ] | 2/11 | `codex-stability-deep-test-2-code-mode-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): unify code-mode command identity [step 2/11]` | 73 | Existing `58585e1f`; blocked on Step 1 merge-forward |
 | [ ] | 3/11 | `codex-stability-deep-test-3-image-wrapper-projection` | `⚙️ [codex-plugin-stability-feedback] fix(codex): hide generated image wrappers [step 3/11]` | 118 | Existing `36ee48e9`; blocked on Step 2 |
 | [ ] | 4/11 | `codex-stability-deep-test-4-late-abort-tool-identity` | `⚙️ [codex-plugin-stability-feedback] fix(codex): retain late command identity after abort [step 4/11]` | 86 | Existing `a32b6c29`; blocked on Step 3 |
@@ -167,7 +167,12 @@ origin/main
   without treating call-like prompt text as code. All seven code regressions
   failed before the mapper hardening. All 29 focused tests, fatal analysis, and
   `git diff --check` pass afterward.
-- **Step 1 change size:** 1,086 lines against `origin/main`: 828 plan/tracker
+- **Step 1 accepted review risk:** Four subsequent bot threads requested broader
+  JavaScript regex/template/delimiter parsing for unobserved generated wrappers.
+  The owner accepted the bounded risk on 2026-08-04 rather than growing this
+  localized classifier into a partial JavaScript tokenizer. Every thread has a
+  rationale reply and remains open for human closure.
+- **Step 1 change size:** 1,100 lines against the PR merge base: 842 plan/tracker
   additions plus 250 production/test additions and 8 deletions. This is below the
   1,500-line soft cap.
 - **Step 1 delivery:** Plan/tracker committed as `d3ec1923`, pushed, and opened
@@ -186,3 +191,7 @@ origin/main
 - **2026-08-04 — Finding traceability:** Because historical findings do not map
   one-to-one to the remaining branches, the plan keeps an independent F-01
   through F-12 acceptance ledger alongside the PR delivery sequence.
+- **2026-08-04 — Wrapper parser boundary:** The owner accepted bounded behavior
+  for unobserved regex-literal, template-interpolation, and malformed-delimiter
+  wrapper shapes; no broader JavaScript tokenizer is planned without new runtime
+  evidence.

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_tool_lifecycle_tracker.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_tool_lifecycle_tracker.dart
@@ -120,6 +120,16 @@ class CodexToolLifecycleTracker {
         if (pending.isEmpty) thread.pendingShellCallsByTurn.remove(turnId);
       }
     }
+    if (canonicalId == null && turnId != null) {
+      final pending = thread.pendingCodeModeShellCallsByTurn[turnId];
+      if (pending != null && pending.isNotEmpty) {
+        canonicalId = pending.removeAt(0);
+        thread.appServerItemAliases[itemId] = canonicalId;
+        if (pending.isEmpty) {
+          thread.pendingCodeModeShellCallsByTurn.remove(turnId);
+        }
+      }
+    }
     if (canonicalId == null && thread.tools.containsKey(itemId)) {
       canonicalId = itemId;
       thread.appServerItemAliases[itemId] = canonicalId;
@@ -238,8 +248,16 @@ class CodexToolLifecycleTracker {
         ),
       );
       tool.title ??= call.title;
-      if (effectiveTurnId != null && _rolloutToolMapper.isCommandExecutionCall(payload: payload)) {
-        final pending = thread.pendingShellCallsByTurn.putIfAbsent(effectiveTurnId, () => []);
+      Map<String, List<String>>? pendingByTurn;
+      if (_rolloutToolMapper.isCommandExecutionCall(payload: payload)) {
+        pendingByTurn = thread.pendingShellCallsByTurn;
+      } else if (_rolloutToolMapper.isSingleCodeModeCommandExecutionCall(
+        payload: payload,
+      )) {
+        pendingByTurn = thread.pendingCodeModeShellCallsByTurn;
+      }
+      if (effectiveTurnId != null && pendingByTurn != null) {
+        final pending = pendingByTurn.putIfAbsent(effectiveTurnId, () => []);
         if (!pending.contains(call.id) && !thread.appServerItemAliases.containsValue(call.id)) {
           pending.add(call.id);
         }
@@ -419,6 +437,7 @@ class CodexToolLifecycleTracker {
   void _clearCorrelationState({required _ThreadToolLifecycle thread}) {
     thread
       ..pendingShellCallsByTurn.clear()
+      ..pendingCodeModeShellCallsByTurn.clear()
       ..visibleCallByCell.clear()
       ..visibleCallByThreadCell.clear()
       ..waitTargetByCall.clear()
@@ -497,6 +516,7 @@ class CodexToolLifecycleTracker {
 class _ThreadToolLifecycle {
   final Map<String, _TrackedTool> tools = {};
   final Map<String, List<String>> pendingShellCallsByTurn = {};
+  final Map<String, List<String>> pendingCodeModeShellCallsByTurn = {};
   final Map<String, String> visibleCallByCell = {};
   final Map<String, String> visibleCallByThreadCell = {};
   final Map<String, String> waitTargetByCall = {};

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
@@ -139,9 +139,7 @@ class CodexRolloutToolMapper {
       :final name,
       :final input,
     ) when name.toLowerCase() == "exec") {
-      const marker = "tools.exec_command(";
-      final first = input.indexOf(marker);
-      return first >= 0 && input.indexOf(marker, first + marker.length) < 0;
+      return _hasSingleCodeModeCommandInvocation(input);
     }
     return false;
   }
@@ -642,6 +640,71 @@ final RegExp _forwardedGeneratedImageInvocationPrefixPattern = RegExp(
 final RegExp _nestedToolInvocationPrefixPattern = RegExp(
   r"\btools\.[A-Za-z_$][A-Za-z0-9_$.]*\s*\(",
 );
+
+final RegExp _codeModeCommandInvocationPrefixPattern = RegExp(
+  r"\btools\.exec_command\s*\(",
+);
+
+bool _hasSingleCodeModeCommandInvocation(String source) {
+  var invocationCount = 0;
+  int? quote;
+  var escaped = false;
+  var inLineComment = false;
+  var inBlockComment = false;
+  for (var index = 0; index < source.length; index++) {
+    final current = source.codeUnitAt(index);
+    final next = index + 1 < source.length ? source.codeUnitAt(index + 1) : null;
+    if (inLineComment) {
+      if (current == 0x0A || current == 0x0D) inLineComment = false;
+      continue;
+    }
+    if (inBlockComment) {
+      if (current == 0x2A && next == 0x2F) {
+        inBlockComment = false;
+        index++;
+      }
+      continue;
+    }
+    if (quote != null) {
+      if (escaped) {
+        escaped = false;
+      } else if (current == 0x5C) {
+        escaped = true;
+      } else if (current == quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (current == 0x2F && next == 0x2F) {
+      inLineComment = true;
+      index++;
+      continue;
+    }
+    if (current == 0x2F && next == 0x2A) {
+      inBlockComment = true;
+      index++;
+      continue;
+    }
+    if (current == 0x22 || current == 0x27 || current == 0x60) {
+      quote = current;
+      continue;
+    }
+    final invocation = _codeModeCommandInvocationPrefixPattern.matchAsPrefix(
+      source,
+      index,
+    );
+    if (invocation == null) continue;
+    final invocationEnd = _matchingInvocationEnd(
+      source: source,
+      openParenthesisIndex: invocation.end - 1,
+    );
+    if (invocationEnd == null) return false;
+    invocationCount++;
+    if (invocationCount > 1) return false;
+    index = invocationEnd - 1;
+  }
+  return invocationCount == 1;
+}
 
 bool _isGeneratedImageInvocation(String input) {
   final directive = _generatedExecDirectivePattern.firstMatch(input);

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
@@ -114,8 +114,8 @@ class CodexRolloutToolMapper {
 
   final CodexImageAttachmentMapper _imageAttachmentMapper;
 
-  /// Whether this persisted call has a matching stable `commandExecution`
-  /// item. Code-mode custom `exec` calls are rollout-only tool items.
+  /// Whether this persisted function call has a matching stable
+  /// `commandExecution` item.
   bool isCommandExecutionCall({
     required CodexRolloutResponseItemDto payload,
   }) {
@@ -130,6 +130,20 @@ class CodexRolloutToolMapper {
       CodexRolloutImageGenerationDto() ||
       CodexRolloutUnknownResponseItemDto() => false,
     };
+  }
+
+  bool isSingleCodeModeCommandExecutionCall({
+    required CodexRolloutResponseItemDto payload,
+  }) {
+    if (payload case CodexRolloutCustomToolCallDto(
+      :final name,
+      :final input,
+    ) when name.toLowerCase() == "exec") {
+      const marker = "tools.exec_command(";
+      final first = input.indexOf(marker);
+      return first >= 0 && input.indexOf(marker, first + marker.length) < 0;
+    }
+    return false;
   }
 
   CodexRolloutImageGeneration mapImageGeneration({

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
@@ -617,7 +617,7 @@ final RegExp _generatedImageInvocationPrefixPattern = RegExp(
 );
 
 final RegExp _generatedExecDirectivePattern = RegExp(
-  r"^\s*//\s*@exec:\s*(\{[^\r\n]*\})[ \t]*(?:\r?\n|$)",
+  r"^[ \t]*//[ \t]*@exec:[ \t]*(\{[^\r\n]*\})[ \t]*(?:\r?\n|$)",
 );
 
 final RegExp _forwardedGeneratedImageInvocationPrefixPattern = RegExp(
@@ -648,7 +648,8 @@ bool _isGeneratedImageInvocation(String input) {
     openParenthesisIndex: forwarded.end - 1,
   );
   if (callEnd == null) return false;
-  final variable = forwarded.group(1)!;
+  final variable = forwarded.group(1);
+  if (variable == null) return false;
   return RegExp(
     "^\\s*;\\s*generatedImage\\(\\s*${RegExp.escape(variable)}\\s*\\)\\s*;?\\s*\$",
   ).hasMatch(invocation.substring(callEnd));

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
@@ -625,6 +625,10 @@ final RegExp _forwardedGeneratedImageInvocationPrefixPattern = RegExp(
   r"tools\.image_gen__[A-Za-z0-9_]+\s*\(",
 );
 
+final RegExp _nestedToolInvocationPrefixPattern = RegExp(
+  r"\btools\.[A-Za-z_$][A-Za-z0-9_$.]*\s*\(",
+);
+
 bool _isGeneratedImageInvocation(String input) {
   final directive = _generatedExecDirectivePattern.firstMatch(input);
   if (directive != null && !_isValidGeneratedExecDirective(directive: directive)) {
@@ -718,6 +722,9 @@ int? _matchingInvocationEnd({
     if (current == 0x22 || current == 0x27 || current == 0x60) {
       quote = current;
       continue;
+    }
+    if (index > openParenthesisIndex && _nestedToolInvocationPrefixPattern.matchAsPrefix(source, index) != null) {
+      return null;
     }
     if (current == 0x28) {
       depth++;

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
@@ -612,22 +612,17 @@ class CodexRolloutToolMapper {
   }
 }
 
-final RegExp _generatedImageInvocationPattern = RegExp(
-  r"^\s*(?:await\s+)?tools\.image_gen__[A-Za-z0-9_]+\s*\([\s\S]*\)\s*;?\s*$",
+final RegExp _generatedImageInvocationPrefixPattern = RegExp(
+  r"^\s*(?:await\s+)?tools\.image_gen__[A-Za-z0-9_]+\s*\(",
 );
 
 final RegExp _generatedExecDirectivePattern = RegExp(
   r"^\s*//\s*@exec:\s*(\{[^\r\n]*\})[ \t]*(?:\r?\n|$)",
 );
 
-final RegExp _forwardedGeneratedImageInvocationPattern = RegExp(
+final RegExp _forwardedGeneratedImageInvocationPrefixPattern = RegExp(
   r"^\s*(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*await\s+"
-  r"tools\.image_gen__[A-Za-z0-9_]+\s*\([\s\S]*\)\s*;\s*"
-  r"generatedImage\(\s*([A-Za-z_$][A-Za-z0-9_$]*)\s*\)\s*;?\s*$",
-);
-
-final RegExp _callInvocationPattern = RegExp(
-  r"\b([A-Za-z_$][A-Za-z0-9_$.]*)\s*\(",
+  r"tools\.image_gen__[A-Za-z0-9_]+\s*\(",
 );
 
 bool _isGeneratedImageInvocation(String input) {
@@ -636,20 +631,27 @@ bool _isGeneratedImageInvocation(String input) {
     return false;
   }
   final invocation = directive == null ? input : input.substring(directive.end);
-  final calls = _callInvocationPattern.allMatches(invocation).toList(growable: false);
-  if (calls.isEmpty || !calls.first.group(1)!.startsWith("tools.image_gen__")) {
-    return false;
+  final direct = _generatedImageInvocationPrefixPattern.firstMatch(invocation);
+  if (direct != null) {
+    final callEnd = _matchingInvocationEnd(
+      source: invocation,
+      openParenthesisIndex: direct.end - 1,
+    );
+    return callEnd != null && RegExp(r"^\s*;?\s*$").hasMatch(invocation.substring(callEnd));
   }
-  if (calls.length == 1) {
-    return _generatedImageInvocationPattern.hasMatch(invocation);
-  }
-  if (calls.length != 2 || calls[1].group(1) != "generatedImage") {
-    return false;
-  }
-  final forwarded = _forwardedGeneratedImageInvocationPattern.firstMatch(
+  final forwarded = _forwardedGeneratedImageInvocationPrefixPattern.firstMatch(
     invocation,
   );
-  return forwarded != null && forwarded.group(1) == forwarded.group(2);
+  if (forwarded == null) return false;
+  final callEnd = _matchingInvocationEnd(
+    source: invocation,
+    openParenthesisIndex: forwarded.end - 1,
+  );
+  if (callEnd == null) return false;
+  final variable = forwarded.group(1)!;
+  return RegExp(
+    "^\\s*;\\s*generatedImage\\(\\s*${RegExp.escape(variable)}\\s*\\)\\s*;?\\s*\$",
+  ).hasMatch(invocation.substring(callEnd));
 }
 
 bool _isValidGeneratedExecDirective({required RegExpMatch directive}) {
@@ -661,4 +663,67 @@ bool _isValidGeneratedExecDirective({required RegExpMatch directive}) {
   } on FormatException {
     return false;
   }
+}
+
+int? _matchingInvocationEnd({
+  required String source,
+  required int openParenthesisIndex,
+}) {
+  if (openParenthesisIndex < 0 ||
+      openParenthesisIndex >= source.length ||
+      source.codeUnitAt(openParenthesisIndex) != 0x28) {
+    return null;
+  }
+
+  var depth = 0;
+  int? quote;
+  var escaped = false;
+  var inLineComment = false;
+  var inBlockComment = false;
+  for (var index = openParenthesisIndex; index < source.length; index++) {
+    final current = source.codeUnitAt(index);
+    final next = index + 1 < source.length ? source.codeUnitAt(index + 1) : null;
+    if (inLineComment) {
+      if (current == 0x0A || current == 0x0D) inLineComment = false;
+      continue;
+    }
+    if (inBlockComment) {
+      if (current == 0x2A && next == 0x2F) {
+        inBlockComment = false;
+        index++;
+      }
+      continue;
+    }
+    if (quote != null) {
+      if (escaped) {
+        escaped = false;
+      } else if (current == 0x5C) {
+        escaped = true;
+      } else if (current == quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (current == 0x2F && next == 0x2F) {
+      inLineComment = true;
+      index++;
+      continue;
+    }
+    if (current == 0x2F && next == 0x2A) {
+      inBlockComment = true;
+      index++;
+      continue;
+    }
+    if (current == 0x22 || current == 0x27 || current == 0x60) {
+      quote = current;
+      continue;
+    }
+    if (current == 0x28) {
+      depth++;
+    } else if (current == 0x29) {
+      depth--;
+      if (depth == 0) return index + 1;
+    }
+  }
+  return null;
 }

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
@@ -617,7 +617,7 @@ final RegExp _generatedImageInvocationPattern = RegExp(
 );
 
 final RegExp _generatedExecDirectivePattern = RegExp(
-  r"^\s*//\s*@exec:\s*\{[^\r\n]*\}[ \t]*(?:\r?\n|$)",
+  r"^\s*//\s*@exec:\s*(\{[^\r\n]*\})[ \t]*(?:\r?\n|$)",
 );
 
 final RegExp _forwardedGeneratedImageInvocationPattern = RegExp(
@@ -626,12 +626,39 @@ final RegExp _forwardedGeneratedImageInvocationPattern = RegExp(
   r"generatedImage\(\s*([A-Za-z_$][A-Za-z0-9_$]*)\s*\)\s*;?\s*$",
 );
 
+final RegExp _callInvocationPattern = RegExp(
+  r"\b([A-Za-z_$][A-Za-z0-9_$.]*)\s*\(",
+);
+
 bool _isGeneratedImageInvocation(String input) {
   final directive = _generatedExecDirectivePattern.firstMatch(input);
+  if (directive != null && !_isValidGeneratedExecDirective(directive: directive)) {
+    return false;
+  }
   final invocation = directive == null ? input : input.substring(directive.end);
-  if (_generatedImageInvocationPattern.hasMatch(invocation)) return true;
+  final calls = _callInvocationPattern.allMatches(invocation).toList(growable: false);
+  if (calls.isEmpty || !calls.first.group(1)!.startsWith("tools.image_gen__")) {
+    return false;
+  }
+  if (calls.length == 1) {
+    return _generatedImageInvocationPattern.hasMatch(invocation);
+  }
+  if (calls.length != 2 || calls[1].group(1) != "generatedImage") {
+    return false;
+  }
   final forwarded = _forwardedGeneratedImageInvocationPattern.firstMatch(
     invocation,
   );
   return forwarded != null && forwarded.group(1) == forwarded.group(2);
+}
+
+bool _isValidGeneratedExecDirective({required RegExpMatch directive}) {
+  final payload = directive.group(1);
+  if (payload == null) return false;
+  try {
+    jsonDecodeMap(payload);
+    return true;
+  } on FormatException {
+    return false;
+  }
 }

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
@@ -616,6 +616,10 @@ final RegExp _generatedImageInvocationPattern = RegExp(
   r"^\s*(?:await\s+)?tools\.image_gen__[A-Za-z0-9_]+\s*\([\s\S]*\)\s*;?\s*$",
 );
 
+final RegExp _generatedExecDirectivePattern = RegExp(
+  r"^\s*//\s*@exec:\s*\{[^\r\n]*\}[ \t]*(?:\r?\n|$)",
+);
+
 final RegExp _forwardedGeneratedImageInvocationPattern = RegExp(
   r"^\s*(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*await\s+"
   r"tools\.image_gen__[A-Za-z0-9_]+\s*\([\s\S]*\)\s*;\s*"
@@ -623,7 +627,11 @@ final RegExp _forwardedGeneratedImageInvocationPattern = RegExp(
 );
 
 bool _isGeneratedImageInvocation(String input) {
-  if (_generatedImageInvocationPattern.hasMatch(input)) return true;
-  final forwarded = _forwardedGeneratedImageInvocationPattern.firstMatch(input);
+  final directive = _generatedExecDirectivePattern.firstMatch(input);
+  final invocation = directive == null ? input : input.substring(directive.end);
+  if (_generatedImageInvocationPattern.hasMatch(invocation)) return true;
+  final forwarded = _forwardedGeneratedImageInvocationPattern.firstMatch(
+    invocation,
+  );
   return forwarded != null && forwarded.group(1) == forwarded.group(2);
 }

--- a/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
@@ -208,6 +208,16 @@ void main() {
         "input": "const result = await tools.image_gen__generate({prompt: 'private'}); generatedImage(result);",
       },
     });
+    final directedForwardedWrapper = CodexRolloutLineDto.fromJson({
+      "type": "response_item",
+      "payload": {
+        "type": "custom_tool_call",
+        "call_id": "call-directed-image-wrapper",
+        "name": "exec",
+        "input":
+            "// @exec: {\"yield_time_ms\": 120000}\nconst r = await tools.image_gen__imagegen({prompt: 'private'}); generatedImage(r);",
+      },
+    });
     final unrelatedForwarding = CodexRolloutLineDto.fromJson({
       "type": "response_item",
       "payload": {
@@ -230,6 +240,13 @@ void main() {
       target.observeRolloutLine(
         threadId: "thread-1",
         line: forwardedWrapper,
+      ),
+      isEmpty,
+    );
+    expect(
+      target.observeRolloutLine(
+        threadId: "thread-1",
+        line: directedForwardedWrapper,
       ),
       isEmpty,
     );

--- a/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
@@ -248,6 +248,25 @@ void main() {
             "// @exec: {\"yield-time_ms\": 120000}\nawait tools.image_gen__imagegen({prompt: 'private'}); console.log('keep visible');",
       },
     });
+    final directedWrapperWithCallLikePrompt = CodexRolloutLineDto.fromJson({
+      "type": "response_item",
+      "payload": {
+        "type": "custom_tool_call",
+        "call_id": "call-directed-image-wrapper-with-call-like-prompt",
+        "name": "exec",
+        "input": "// @exec: {\"yield_time_ms\": 120000}\nawait tools.image_gen__imagegen({prompt: 'draw cat(s)'});",
+      },
+    });
+    final directedWrapperWithParenthesizedTrailingCode = CodexRolloutLineDto.fromJson({
+      "type": "response_item",
+      "payload": {
+        "type": "custom_tool_call",
+        "call_id": "call-directed-image-wrapper-with-parenthesized-trailing-code",
+        "name": "exec",
+        "input":
+            "// @exec: {\"yield_time_ms\": 120000}\nawait tools.image_gen__imagegen({prompt: 'private'}); process.exitCode = (1);",
+      },
+    });
     final unrelatedForwarding = CodexRolloutLineDto.fromJson({
       "type": "response_item",
       "payload": {
@@ -298,6 +317,20 @@ void main() {
       target.observeRolloutLine(
         threadId: "thread-1",
         line: directedWrapperWithTrailingCode,
+      ),
+      hasLength(1),
+    );
+    expect(
+      target.observeRolloutLine(
+        threadId: "thread-1",
+        line: directedWrapperWithCallLikePrompt,
+      ),
+      isEmpty,
+    );
+    expect(
+      target.observeRolloutLine(
+        threadId: "thread-1",
+        line: directedWrapperWithParenthesizedTrailingCode,
       ),
       hasLength(1),
     );

--- a/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
@@ -228,6 +228,15 @@ void main() {
             "// @exec: {invalid}\nconst r = await tools.image_gen__imagegen({prompt: 'private'}); generatedImage(r);",
       },
     });
+    final multilineDirectedMarker = CodexRolloutLineDto.fromJson({
+      "type": "response_item",
+      "payload": {
+        "type": "custom_tool_call",
+        "call_id": "call-multiline-directed-marker",
+        "name": "exec",
+        "input": "//\n@exec: {\"yield_time_ms\": 120000}\nawait tools.image_gen__imagegen({prompt: 'private'});",
+      },
+    });
     final mixedDirectedWrapper = CodexRolloutLineDto.fromJson({
       "type": "response_item",
       "payload": {
@@ -303,6 +312,13 @@ void main() {
       target.observeRolloutLine(
         threadId: "thread-1",
         line: malformedDirectedWrapper,
+      ),
+      hasLength(1),
+    );
+    expect(
+      target.observeRolloutLine(
+        threadId: "thread-1",
+        line: multilineDirectedMarker,
       ),
       hasLength(1),
     );

--- a/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
@@ -210,6 +210,82 @@ void main() {
     expect(completed?.status, PluginToolStatus.completed);
   });
 
+  test("correlates code-mode commands containing invocation-like text", () {
+    final target = tracker();
+    target.observeRolloutLine(
+      threadId: "thread-1",
+      line: _codeModeExecCall(
+        callId: "call-raw",
+        turnId: "turn-1",
+        input: "await tools.exec_command({cmd: \"echo 'tools.exec_command('\"});",
+      ),
+    );
+
+    expect(
+      target
+          .observeAppServerTool(
+            imageGeneration: null,
+            notification: _commandNotification(
+              method: "item/started",
+              itemId: "exec-1",
+              turnId: "turn-1",
+            ),
+          )
+          ?.canonicalId,
+      "call-raw",
+    );
+  });
+
+  test("correlates code-mode commands with invocation whitespace", () {
+    final target = tracker();
+    target.observeRolloutLine(
+      threadId: "thread-1",
+      line: _codeModeExecCall(
+        callId: "call-raw",
+        turnId: "turn-1",
+        input: "await tools.exec_command ({cmd: 'pwd'});",
+      ),
+    );
+
+    expect(
+      target
+          .observeAppServerTool(
+            imageGeneration: null,
+            notification: _commandNotification(
+              method: "item/started",
+              itemId: "exec-1",
+              turnId: "turn-1",
+            ),
+          )
+          ?.canonicalId,
+      "call-raw",
+    );
+  });
+
+  test("does not correlate invocation text inside a string", () {
+    final target = tracker();
+    target.observeRolloutLine(
+      threadId: "thread-1",
+      line: _codeModeExecCall(
+        callId: "call-raw",
+        turnId: "turn-1",
+        input: "console.log('tools.exec_command(');",
+      ),
+    );
+
+    expect(
+      target.observeAppServerTool(
+        imageGeneration: null,
+        notification: _commandNotification(
+          method: "item/started",
+          itemId: "exec-1",
+          turnId: "turn-1",
+        ),
+      ),
+      isNull,
+    );
+  });
+
   test("suppresses only complete generated image wrapper invocations", () {
     final target = tracker();
     final wrapper = CodexRolloutLineDto.fromJson({
@@ -1208,13 +1284,25 @@ CodexRolloutLineDto _rawExecCall({
   required String callId,
   required String? turnId,
 }) {
+  return _codeModeExecCall(
+    callId: callId,
+    turnId: turnId,
+    input: "await tools.exec_command({cmd: 'pwd'});",
+  );
+}
+
+CodexRolloutLineDto _codeModeExecCall({
+  required String callId,
+  required String? turnId,
+  required String input,
+}) {
   return CodexRolloutLineDto.fromJson({
     "type": "response_item",
     "payload": {
       "type": "custom_tool_call",
       "call_id": callId,
       "name": "exec",
-      "input": "await tools.exec_command({cmd: 'pwd'});",
+      "input": input,
       if (turnId != null)
         "internal_chat_message_metadata_passthrough": {
           "turn_id": turnId,

--- a/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
@@ -276,6 +276,16 @@ void main() {
             "// @exec: {\"yield_time_ms\": 120000}\nawait tools.image_gen__imagegen({prompt: 'private'}); process.exitCode = (1);",
       },
     });
+    final directedWrapperWithNestedToolCall = CodexRolloutLineDto.fromJson({
+      "type": "response_item",
+      "payload": {
+        "type": "custom_tool_call",
+        "call_id": "call-directed-image-wrapper-with-nested-tool",
+        "name": "exec",
+        "input":
+            "// @exec: {\"yield_time_ms\": 120000}\nawait tools.image_gen__imagegen({prompt: (await tools.exec_command({cmd: 'keep visible'}), 'cat')});",
+      },
+    });
     final unrelatedForwarding = CodexRolloutLineDto.fromJson({
       "type": "response_item",
       "payload": {
@@ -347,6 +357,13 @@ void main() {
       target.observeRolloutLine(
         threadId: "thread-1",
         line: directedWrapperWithParenthesizedTrailingCode,
+      ),
+      hasLength(1),
+    );
+    expect(
+      target.observeRolloutLine(
+        threadId: "thread-1",
+        line: directedWrapperWithNestedToolCall,
       ),
       hasLength(1),
     );

--- a/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
@@ -218,6 +218,36 @@ void main() {
             "// @exec: {\"yield_time_ms\": 120000}\nconst r = await tools.image_gen__imagegen({prompt: 'private'}); generatedImage(r);",
       },
     });
+    final malformedDirectedWrapper = CodexRolloutLineDto.fromJson({
+      "type": "response_item",
+      "payload": {
+        "type": "custom_tool_call",
+        "call_id": "call-malformed-directed-image-wrapper",
+        "name": "exec",
+        "input":
+            "// @exec: {invalid}\nconst r = await tools.image_gen__imagegen({prompt: 'private'}); generatedImage(r);",
+      },
+    });
+    final mixedDirectedWrapper = CodexRolloutLineDto.fromJson({
+      "type": "response_item",
+      "payload": {
+        "type": "custom_tool_call",
+        "call_id": "call-mixed-directed-image-wrapper",
+        "name": "exec",
+        "input":
+            "// @exec: {\"yield_time_ms\": 120000}\nawait tools.image_gen__imagegen({prompt: 'private'}); await tools.exec_command({cmd: 'keep visible'});",
+      },
+    });
+    final directedWrapperWithTrailingCode = CodexRolloutLineDto.fromJson({
+      "type": "response_item",
+      "payload": {
+        "type": "custom_tool_call",
+        "call_id": "call-directed-image-wrapper-with-trailing-code",
+        "name": "exec",
+        "input":
+            "// @exec: {\"yield-time_ms\": 120000}\nawait tools.image_gen__imagegen({prompt: 'private'}); console.log('keep visible');",
+      },
+    });
     final unrelatedForwarding = CodexRolloutLineDto.fromJson({
       "type": "response_item",
       "payload": {
@@ -249,6 +279,27 @@ void main() {
         line: directedForwardedWrapper,
       ),
       isEmpty,
+    );
+    expect(
+      target.observeRolloutLine(
+        threadId: "thread-1",
+        line: malformedDirectedWrapper,
+      ),
+      hasLength(1),
+    );
+    expect(
+      target.observeRolloutLine(
+        threadId: "thread-1",
+        line: mixedDirectedWrapper,
+      ),
+      hasLength(1),
+    );
+    expect(
+      target.observeRolloutLine(
+        threadId: "thread-1",
+        line: directedWrapperWithTrailingCode,
+      ),
+      hasLength(1),
     );
     expect(
       target.observeRolloutLine(

--- a/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
@@ -179,6 +179,37 @@ void main() {
     );
   });
 
+  test("correlates a lone code-mode command with its app-server item", () {
+    final target = tracker();
+    target.observeRolloutLine(
+      threadId: "thread-1",
+      line: _rawExecCall(callId: "call-raw", turnId: "turn-1"),
+    );
+
+    final started = target.observeAppServerTool(
+      imageGeneration: null,
+      notification: _commandNotification(
+        method: "item/started",
+        itemId: "exec-1",
+        turnId: "turn-1",
+      ),
+    );
+    final completed = target.observeAppServerTool(
+      imageGeneration: null,
+      notification: _commandNotification(
+        method: "item/completed",
+        itemId: "exec-1",
+        turnId: "turn-1",
+        status: "completed",
+        exitCode: 0,
+      ),
+    );
+
+    expect(started?.canonicalId, "call-raw");
+    expect(completed?.canonicalId, "call-raw");
+    expect(completed?.status, PluginToolStatus.completed);
+  });
+
   test("suppresses only complete generated image wrapper invocations", () {
     final target = tracker();
     final wrapper = CodexRolloutLineDto.fromJson({


### PR DESCRIPTION
## Complexity

Moderate (`⚙️`): this changes per-turn identity correlation across Codex rollout classification and lifecycle tracking, with focused state and replay edge cases contained inside the Codex plugin.

## What

- Recognize persisted code-mode `exec` calls that contain one `tools.exec_command(...)` invocation.
- Correlate that rollout call with its app-server command item through a dedicated per-turn queue, preserving one canonical tool ID through completion.
- Clear the additional correlation state with the existing lifecycle reset and add a focused regression.
- Advance the durable stability plan and tracker to Step 2/11.

## Why

An observed code-mode shell command could appear as two live tool cards because the rollout `call_*` ID and app-server `exec-*` ID were treated independently. Reload later collapsed the duplicate, but live session history was inconsistent.

## Risk and test focus

Medium risk, limited to Codex code-mode command identity. Review and CI should focus on single-command correlation, existing direct shell correlation, generated wrapper classification, completion state, and reset behavior. OpenCode, Cursor, wire contracts, and database persistence are unchanged.

## Expected result

A single code-mode shell command keeps one canonical tool card and ID from its rollout record through app-server start and completion. There is no database or transport change and no behavior change for other backend plugins.

## Verification

- `dart test test/codex_tool_lifecycle_tracker_test.dart`
- `dart test` — all 298 Codex package tests passed
- `dart analyze --fatal-infos` — no issues
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies code‑mode shell command identity so one tool card persists from rollout `exec` to app-server start and completion. Hardens detection to only correlate a single real `tools.exec_command(...)` call, ignoring strings and comments.

- **Bug Fixes**
  - Parse code-mode `exec` input to find exactly one `tools.exec_command(...)` call outside strings/comments; accept invocation whitespace.
  - Correlate that rollout call with app-server `exec-*` via a per-turn queue to keep one canonical tool ID through completion.
  - Ignore invocation-like text inside strings; add tests for single, whitespace, and embedded cases.
  - Clear correlation state on lifecycle reset and update Step 2/11 plan/tracker.

<sup>Written for commit 70ae07cb13da5d43e90f20bf9d004ae9851f390c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

