### PR TITLE
🌱 [relay-request-concurrency] docs: retire concurrent routing plan [step 10/10]

### DIFF
--- a/.plan/completed/relay-request-concurrency/PLAN.md
+++ b/.plan/completed/relay-request-concurrency/PLAN.md
@@ -63,7 +63,10 @@ This is head-of-line blocking in the bridge transport. The stalled request was
 not introduced by PR #686; that PR exposed the pre-existing behavior during
 long-running testing.
 
-## Success Criteria
+## Success Criteria — Complete
+
+All criteria below were implemented and verified across Steps 2–9. The accepted
+bounded creation-visibility risk in criterion 10 remains intentional.
 
 1. A routed request never blocks the relay read loop from processing a later
    frame.

--- a/.plan/completed/relay-request-concurrency/TRACKER.md
+++ b/.plan/completed/relay-request-concurrency/TRACKER.md
@@ -3,13 +3,13 @@
 ## Current State
 
 - **Plan slug:** `relay-request-concurrency`
-- **Implementation base:** merged Step 8 at
-  `1d5816d14559b5970fad317921c12d29f66b4a23`
-- **Series state:** Steps 1–8 merged; over-defensive implementation
+- **Implementation base:** merged Step 9 at
+  `2fd3423ebb426a4889ca6d87a008e45240f7e42d`
+- **Series state:** Steps 1–9 merged; Step 10 retirement prepared. Over-defensive implementation
   [#716](https://github.com/sesori-ai/sesori_apps_monorepo/pull/716) remains closed without merge
-- **Current step:** Step 9/10 implementation ready for delivery
+- **Current step:** Step 10/10 retirement
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged
-- **Next action:** open, review, and merge Step 9
+- **Next action:** open and merge the documentation-only retirement PR
 
 ## Incident Evidence
 
@@ -102,8 +102,8 @@
 | [x] | 6/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] refactor(bridge): scope session family mutations [step 6/10]` | 750–1,250 | [PR #703](https://github.com/sesori-ai/sesori_apps_monorepo/pull/703) merged as `e4605eb1` with 1,054 changed lines |
 | [x] | 7/10 | `plan-parallel-requests` | `🌱 [relay-request-concurrency] docs: simplify remaining concurrency plan [step 7/10]` | 350–550 | [PR #720](https://github.com/sesori-ai/sesori_apps_monorepo/pull/720) merged as `6233da3e` with 543 changed lines; PR #716 closed without merge |
 | [x] | 8/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): simplify domain mutation ordering [step 8/10]` | 500–900 | [PR #721](https://github.com/sesori-ai/sesori_apps_monorepo/pull/721) merged as `1d5816d1` with 709 changed lines |
-| [ ] | 9/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] fix(bridge): route client requests concurrently [step 9/10]` | 950–1,450 | Implementation ready from `1d5816d1`; verification and architecture review pass |
-| [ ] | 10/10 | `relay-request-concurrency-retire-plan` | `🌱 [relay-request-concurrency] docs: retire concurrent routing plan [step 10/10]` | 50–150 | Blocked on Step 9 merge |
+| [x] | 9/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] fix(bridge): route client requests concurrently [step 9/10]` | 950–1,450 | [PR #722](https://github.com/sesori-ai/sesori_apps_monorepo/pull/722) merged as `2fd3423e` with 1,185 changed lines and 11/11 checks passing |
+| [x] | 10/10 | `plan-parallel-requests` | `🌱 [relay-request-concurrency] docs: retire concurrent routing plan [step 10/10]` | 50–150 | Documentation-only retirement prepared from current `main`; PR pending |
 
 ## Exact PR Titles
 
@@ -448,3 +448,25 @@
   tracked and untracked diff with no findings. Lifecycle ownership, synchronous
   tracking, incarnation/epoch fencing, restart sequencing, summary ordering,
   teardown draining, and proportional scope passed.
+- **Step 9/10 review feedback:** three duplicate bot findings correctly identified
+  that an encryption failure could suppress an already-accepted restart. Commit
+  `7d6f5023` separated response delivery from restart dispatch so encryption
+  failure remains observable without cancelling the accepted action. All three
+  bot threads were answered and resolved; Cubic approved the correction.
+- **Step 9/10 delivery:** [PR #722](https://github.com/sesori-ai/sesori_apps_monorepo/pull/722)
+  merged as `2fd3423ebb426a4889ca6d87a008e45240f7e42d` with 1,185
+  changed lines and 11/11 checks passing.
+- **Final outcome:** all thirteen success criteria are complete. The observed
+  relay head-of-line failure is removed while explicit family/project ordering,
+  exact response fencing, restart execution, and bounded shutdown draining remain.
+  No wire, database, persisted-data, client API, UI, analytics, or plugin-interface
+  change was introduced.
+- **Final cleanup assessment:** directly obsolete route/restart ownership,
+  mutable relay-handle operations, redundant interaction lanes, broad mutation
+  tails, handler-owned project workflows, and single-route diagnostics were
+  removed in their owning steps. No further causally obsolete artifacts were
+  found. The unmerged provisional-visibility implementation requires no cleanup;
+  its bounded transient remains an explicitly accepted risk.
+- **Step 10/10 validation:** GitHub merge state, titles, merge SHAs, changed-line
+  counts, and checks were cross-checked through Step 9. The active plan directory
+  is removed, the completed directory is present, and `git diff --check` passes.

--- a/.plan/completed/relay-request-concurrency/TRACKER.md
+++ b/.plan/completed/relay-request-concurrency/TRACKER.md
@@ -9,7 +9,8 @@
   [#716](https://github.com/sesori-ai/sesori_apps_monorepo/pull/716) remains closed without merge
 - **Current step:** Step 10/10 retirement
 - **Plan PR:** [#687](https://github.com/sesori-ai/sesori_apps_monorepo/pull/687) merged
-- **Next action:** open and merge the documentation-only retirement PR
+- **Next action:** merge documentation-only retirement
+  [PR #736](https://github.com/sesori-ai/sesori_apps_monorepo/pull/736)
 
 ## Incident Evidence
 
@@ -103,7 +104,7 @@
 | [x] | 7/10 | `plan-parallel-requests` | `🌱 [relay-request-concurrency] docs: simplify remaining concurrency plan [step 7/10]` | 350–550 | [PR #720](https://github.com/sesori-ai/sesori_apps_monorepo/pull/720) merged as `6233da3e` with 543 changed lines; PR #716 closed without merge |
 | [x] | 8/10 | `plan-parallel-requests` | `⚙️ [relay-request-concurrency] refactor(bridge): simplify domain mutation ordering [step 8/10]` | 500–900 | [PR #721](https://github.com/sesori-ai/sesori_apps_monorepo/pull/721) merged as `1d5816d1` with 709 changed lines |
 | [x] | 9/10 | `plan-parallel-requests` | `🚧 [relay-request-concurrency] fix(bridge): route client requests concurrently [step 9/10]` | 950–1,450 | [PR #722](https://github.com/sesori-ai/sesori_apps_monorepo/pull/722) merged as `2fd3423e` with 1,185 changed lines and 11/11 checks passing |
-| [x] | 10/10 | `plan-parallel-requests` | `🌱 [relay-request-concurrency] docs: retire concurrent routing plan [step 10/10]` | 50–150 | Documentation-only retirement prepared from current `main`; PR pending |
+| [x] | 10/10 | `plan-parallel-requests` | `🌱 [relay-request-concurrency] docs: retire concurrent routing plan [step 10/10]` | 50–150 | Documentation-only retirement [PR #736](https://github.com/sesori-ai/sesori_apps_monorepo/pull/736) opened from current `main` |
 
 ## Exact PR Titles
 
@@ -470,3 +471,6 @@
 - **Step 10/10 validation:** GitHub merge state, titles, merge SHAs, changed-line
   counts, and checks were cross-checked through Step 9. The active plan directory
   is removed, the completed directory is present, and `git diff --check` passes.
+- **Step 10/10 delivery:** documentation-only retirement
+  [PR #736](https://github.com/sesori-ai/sesori_apps_monorepo/pull/736) opened with
+  the exact fixed title; merge remains the only outstanding action.


### PR DESCRIPTION
## Complexity

🌱 Trivial — documentation-only completion evidence and a mechanical plan-directory move.

## What

- Records the Step 9 merge SHA, final changed-line count, CI result, review correction, and cleanup outcome.
- Marks all thirteen success criteria complete while preserving the explicitly accepted bounded visibility risk.
- Moves `.plan/active/relay-request-concurrency/` to `.plan/completed/relay-request-concurrency/`.

## Why

All production work in the ten-step concurrent relay routing plan has merged, so the durable plan should no longer remain active.

## Risk and test focus

Low risk, limited to stale completion evidence or an incorrect directory move. GitHub metadata was cross-checked and the source/destination paths and Markdown diff were validated.

## Expected result

- **User-visible:** None.
- **Persisted/database:** None.
- **Internal:** The completed implementation record is archived and no active relay-request-concurrency work remains.

## Verification

- PR #722 confirmed merged as `2fd3423ebb426a4889ca6d87a008e45240f7e42d`
- PR #722 confirmed at 1,185 changed lines with 11/11 checks passing
- Active plan directory absent; completed plan directory present
- `git diff --cached --check` passed before commit
- Git recognized both files as renames
- 41 documentation-only changed lines
- No Dart/Flutter suites run because this PR changes documentation only

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires the relay-request-concurrency plan by moving `.plan/active/relay-request-concurrency/` to `.plan/completed/relay-request-concurrency/`. Updates PLAN/TRACKER to mark all success criteria complete, confirm Step 9 merged, capture final review fixes, and record the retirement pull request; docs only, no runtime changes.

<sup>Written for commit ced85c71c4f4855920b2289d0dbf00d5b09f4463. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

