### PR TITLE
🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
     "figma": {
       "type": "http",
       "url": "http://127.0.0.1:3845/mcp"
+    },
+    "mobile-mcp": {
+      "command": "npx",
+      "args": ["@mobilenext/mobile-mcp@latest"]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,7 @@
     },
     "mobile-mcp": {
       "command": "npx",
-      "args": ["@mobilenext/mobile-mcp@latest"]
+      "args": ["-y", "@mobilenext/mobile-mcp@1.0.0"]
     }
   }
 }

--- a/.plan/active/claude-code-plugin/PLAN.md
+++ b/.plan/active/claude-code-plugin/PLAN.md
@@ -1,0 +1,675 @@
+# Claude Code Harness Plugin
+
+## Status
+
+- **Plan slug:** `claude-code-plugin`
+- **Status:** Step 1/17 plan PR open
+- **Plan date:** 2026-08-04
+- **Plan delivery:** this document, `TRACKER.md`, and the `PROTOCOL.md` skeleton
+  are Step 1/17
+- **Implementation base:** `origin/main` at
+  `ca7470fd6ead8f7e1ff0d58e3591e7ce25a5314d`
+- **Repository:** `sesori-ai/sesori_apps_monorepo`
+- **Delivery:** one planning PR, thirteen sequential bridge PRs, one activation
+  PR, one client PR, one live-verification PR, and one plan-retirement PR
+
+## Goal
+
+Add Claude Code as a first-class Sesori harness by driving the `claude` CLI's
+headless **stream-json** protocol directly from a new bespoke bridge plugin, at
+full parity with the existing harnesses: sessions, live streaming, tools,
+permissions and questions, plan mode, model selection, interrupt, resume with
+history replay, slash commands, and image attachments.
+
+The plugin speaks the same ndjson stdio protocol the official Agent SDK speaks
+internally, so it needs no Node runtime — the `claude` CLI is a self-contained
+binary the user already has installed and logged in.
+
+## Success Criteria
+
+1. `GET /plugin` advertises a `claude` plugin with displayName `Claude Code`,
+   correct setup state, and a working brand mark in the mobile picker.
+2. A new Claude session created from the phone streams assistant text
+   token-by-token, renders thinking, and renders tool cards through their
+   pending → running → completed lifecycle.
+3. Tool permission requests reach the phone as permission cards; once, always,
+   and reject all round-trip correctly, and `always` never escalates beyond the
+   permissions the backend itself suggested.
+4. `AskUserQuestion` and `ExitPlanMode` render as question cards and their
+   answers reach the backend in the exact shapes the CLI expects.
+5. Model catalog and mid-session model switching work, and the client nav-bar
+   subtitle reflects the switch because every assistant message envelope carries
+   both `providerID` and `modelID`.
+6. Interrupt stops a running turn promptly and clears any pending permission or
+   question card; no stale prompt survives an abort, a session stop, or a
+   process exit.
+7. History survives a bridge restart: sessions enumerate from the on-disk
+   transcript index, open with a full replay whose shapes match live rendering,
+   and accept a follow-up turn through `--resume`.
+8. Sessions started in an external terminal appear in Sesori after a refresh,
+   under the project matching their working directory.
+9. No Claude-specific concept — tool name, model id, permission mode, transcript
+   path — escapes the plugin package into shared, bridge, or client code.
+10. No new `MessagePartType` value and no breaking wire change; the client
+    remains data-driven from `GET /plugin` apart from the brand asset and the
+    attachment gate.
+11. Every implementation PR is independently buildable and targets no more than
+    1,500 changed lines as a soft cap, counting additions plus deletions,
+    generated output, and tests against that PR's base.
+
+## Current Behavior And Evidence
+
+### There is no prior Claude work in this repository
+
+- Branch `claude-code-support` is 0 commits ahead of `main`; `.plan/` contains
+  nothing for Claude.
+- The single mention is `README.md:147`, the harness table row
+  `| [Claude Code](https://claude.com) | Coming soon | ... |`.
+- `shared/sesori_shared/lib/src/models/sesori/plugin_identity.dart` declares
+  `enum Harness { opencode, codex, cursor }`.
+- `bridge/app/lib/src/bridge/runtime/plugin_registry.dart` registers exactly
+  three descriptors.
+
+### The plugin seam is already sufficient
+
+Three shipped plugins cover the two shapes this work needs:
+
+- **Cursor** (`bridge/sesori_plugin_cursor/`) is the closest lifecycle model: a
+  CLI subprocess with no port and no ownership file, wrapped in
+  `SteadyPluginLifecycle` rather than `ManagedProcessService`, with
+  `projectOwnership = bridgeDerived` and `sessionOptionsScope = plugin`.
+  `cursor_plugin_descriptor.dart` is the template for probe-then-start.
+- **ACP** (`bridge/sesori_plugin_acp/`) owns the mechanics this plugin needs
+  verbatim: `AcpStdioClient` line framing and teardown, `AcpApprovalRegistry`
+  permission/question bifurcation, `AcpPlugin`'s per-session turn queue with
+  generation fencing, and `FakeAcpProcess` as the test seam pattern.
+- **Codex** (`bridge/sesori_plugin_codex/`) owns the enumeration model: a global
+  on-disk transcript index read through an injected-environment API, scanned in
+  `Isolate.run`, with `primeSessionDirectory` a documented no-op.
+
+### The client already renders an unknown harness gracefully
+
+Sessions, messages, tools, permissions, questions, models, and agents are all
+data-driven from `GET /plugin`. The only client work is the brand asset, its two
+lookup cases, and widening the temporary composer attachment gate.
+
+### Local runtime evidence
+
+The development machine has `claude` 2.1.221 on PATH. Step 2 pins the verified
+floor version and records the exact wire shapes observed at that version.
+
+## Protocol Reference
+
+The stream-json control protocol is SDK-internal and not formally versioned.
+`PROTOCOL.md` in this directory is the durable ground truth: Step 2 fills it from
+direct observation of the pinned CLI plus the SDK's own type declarations, and
+every later step cites it rather than re-deriving wire shapes.
+
+Condensed research carried into Step 2 (all marked verify-at-implementation in
+`PROTOCOL.md`):
+
+- Invocation: `claude --input-format stream-json --output-format stream-json
+  --verbose --include-partial-messages [--model <id>] [--permission-mode <mode>]
+  [--session-id <uuid> | --resume <uuid>]`, cwd = the session directory, one
+  process per session kept alive by streaming stdin.
+- Stdout types: `system` (`init`, `api_retry`, `permission_denied`),
+  `assistant`, `user`, `stream_event` (raw Anthropic SSE deltas), `result`,
+  `control_request`, `control_response`.
+- Permissions arrive as `can_use_tool` control requests answered with
+  `{"behavior":"allow"|"deny", ...}`; `AskUserQuestion` and `ExitPlanMode` are
+  ordinary tools whose approval is a user question rather than a permission.
+- Transcripts live at `$CLAUDE_CONFIG_DIR ?? ~/.claude` +
+  `/projects/<munged-cwd>/<session-id>.jsonl`; the filename is the session id
+  and each record carries its own `cwd` and timestamps, so the munged directory
+  name is never un-munged.
+- Auth is the user's existing `claude` login. The plugin never runs a login
+  flow and never overrides `HOME`, which would break macOS keychain lookup.
+
+## Locked Scope And Product Decisions
+
+### Included
+
+- A bespoke `bridge/sesori_plugin_claude/` package (pub name `claude_plugin`)
+  driving stream-json over stdio, one child process per live session.
+- Full `BridgePluginApi` surface plus `PersistedSessionCleanupApi`.
+- Global transcript enumeration, history replay, and `--resume` continuation.
+- Permission modes surfaced as two agents, **Default** and **Plan**.
+- Model catalog with mid-session `set_model` switching.
+- Text and image prompt parts; slash commands.
+- Brand assets and the two client lookups.
+
+### Excluded
+
+- The `claude-agent-acp` Node adapter route (decided against: adds a Node
+  dependency and hides half the protocol behind an adapter).
+- `--fork-session`, subagent sessions as first-class children (subagent work
+  renders inside its Task tool card), and MCP server management.
+- Any managed runtime, download, or version provisioning. The plugin resolves an
+  existing binary and reports setup state; it never installs one.
+- Any login flow, credential storage, or auth mutation.
+- Reasoning-effort variants unless Step 11 finds first-party support; the
+  decision is recorded there with evidence rather than assumed now.
+- New shared wire types, new `MessagePartType` values, relay changes, database
+  migrations, and product analytics. This harness adds no new authoritative user
+  action beyond the ones the existing harnesses already instrument.
+
+### Naming
+
+`Harness.claude` with id `claude`; displayName `Claude Code`; package directory
+`bridge/sesori_plugin_claude/`; pub name `claude_plugin`; plan slug
+`claude-code-plugin`.
+
+## Final Architecture
+
+### Lifecycle shape
+
+Cursor-style lifecycle, codex-style enumeration, per-session processes:
+
+- `SteadyPluginLifecycle`, not `ManagedProcessService` — there is no port to
+  reclaim and no ownership file to arbitrate.
+- `ensureRuntime` stays the inherited no-op. There is no `RuntimeManifest`
+  because there is no first-party download this plugin may legitimately perform.
+- The binary is `--claude-bin` (declared as the bare option name `bin`) else
+  `claude` on PATH, gated in `inspectSetup` by a typed `SemanticVersion` floor.
+- `start()` is cheap: construct, `markReady()`. Authentication failures surface
+  at use time as `PluginAuthenticationRequiredException`, which
+  `PluginRuntime.use()` already converts into a setup-state flip.
+- Per-session child processes spawn lazily on the first turn, are reaped after
+  an idle window, and respawn transparently through `--resume`.
+
+### Type
+
+`ClaudePlugin extends BridgeDerivedProjectsPluginApi implements
+PersistedSessionCleanupApi`. Claude has no project concept, so projects are
+bridge-derived from session working directories. `listAllSessions` ignores
+`knownDirectories` because the transcript index is global, and
+`primeSessionDirectory` is a documented no-op, both matching Codex.
+
+### Package layout
+
+```
+bridge/sesori_plugin_claude/
+  pubspec.yaml            claude_plugin; publish_to: none; resolution: workspace
+  analysis_options.yaml   include: ../app/analysis_options.yaml
+  build.yaml              freezed {format:false,map:false,when:false};
+                          json_serializable {any_map:true,explicit_to_json:true}
+  lib/claude_plugin.dart          barrel; exports ClaudePluginDescriptor
+  lib/claude_testing.dart         barrel; exports FakeClaudeProcess
+  lib/src/api/
+    claude_stream_client.dart     ndjson stdio client for ONE process
+    claude_process_factory.dart   launch spec + host-routed factory
+    claude_transcript_api.dart    ~/.claude/projects reader
+    models/                       freezed stream, control, and transcript DTOs
+  lib/src/repositories/
+    claude_catalog_repository.dart      transcript scan -> session records
+    mappers/claude_event_mapper.dart    stream messages -> BridgeSseEvent
+    mappers/claude_history_mapper.dart  transcript -> PluginMessageWithParts
+    mappers/claude_content_mapper.dart  content blocks -> parts/attachments
+    trackers/claude_tool_tracker.dart   tool_use lifecycle + delta buffering
+  lib/src/services/
+    claude_session_service.dart   residency, turn queue, idle reaping, interrupt
+    claude_catalog_service.dart   model/agent/command catalog + applied cache
+  lib/src/claude_approval_registry.dart  can_use_tool -> permissions/questions
+  lib/src/claude_plugin_impl.dart        ClaudePlugin
+  lib/src/runtime/
+    claude_plugin_descriptor.dart  const descriptor
+    claude_bridge_plugin.dart      SteadyPluginLifecycle wrapper
+  lib/src/testing/fake_claude_process.dart
+  test/                            flat *_test.dart + test/runtime/ + test/support/
+```
+
+Layering follows the house style: `api/` is the wire boundary, `repositories/`
+normalizes, `services/` coordinates, `runtime/` is descriptor and lifecycle glue.
+
+### Component contracts
+
+**`ClaudeStreamClient`** — one per resident session process. Ports
+`AcpStdioClient`'s load-bearing mechanics: `utf8.decoder` plus `LineSplitter` on
+stdout; stderr line-logged at debug through `Utf8Decoder(allowMalformed: true)`
+(the lenient decoder comes from `managed_runtime_monitor.dart`, because crashing
+children emit non-UTF-8 bytes); `unawaited(process.stdin.done.catchError(...))`
+to absorb broken pipes; connection-generation fencing across teardown; fail-fast
+requests once exited; `_failPending` on teardown; POSIX SIGTERM then SIGKILL,
+straight kill on Windows. It also carries Codex's `_redactForLog` secret
+redaction for frame and error logging. Surface: a `ClaudeStreamMessage` stream, a
+resolved init future, `sendUserMessage`, `sendControlRequest` with request-id
+correlation, `sendControlResponse`, a process-exit future, and `dispose`.
+Unknown message types are debug-logged and dropped, never warned per line.
+
+**`ClaudeSessionService`** — owns per-session residency (client, applied model,
+applied agent, idle timer) plus the turn queue ported from
+`AcpPlugin._SessionTurnState`: a `tail` future chain, a `pending` count, and a
+`generation` re-checked after every await. The first pending turn emits busy
+status plus a project-updated event; turn completion emits idle or error.
+Residency reuses a live process, otherwise spawns with `--resume` for an
+existing session or `--session-id` for a new one. Idle reaping runs off
+`host.clock` and gracefully disposes only that session's client. An unexpected
+exit mid-turn finishes the turn as interrupted rather than errored when the
+bridge sent the signal, cancels that session's approvals, and drops residency.
+
+**`ClaudeApprovalRegistry`** — architecturally identical to
+`AcpApprovalRegistry`: injected emit and respond callbacks, bridge-minted `br-N`
+ids, permission/question bifurcation, and a `cancelForSession`/`dispose` contract
+that resolves every pending request *and* emits its replied or rejected event.
+Claude specifics: requests arrive on a known session's own process, so there is
+no session-resolution ambiguity; `AskUserQuestion` and `ExitPlanMode` become
+questions and everything else a permission; `once` maps to a plain allow,
+`always` echoes only the backend's own `permission_suggestions`, and `reject`
+maps to deny with a short message.
+
+**`ClaudeEventMapper`** — the hard contract shared with the Codex and ACP
+mappers: every `info` map on a session or message event is sesori-schema JSON
+built from `sesori_shared` typed models via `.toJson()`. It maps stream deltas to
+message and part updates, `tool_result` blocks to tool completion or error,
+edit-shaped tool completions to a session diff signal, `TodoWrite` to the
+content-free todo-staleness signal, `api_retry` to a retry status, and error
+`result` subtypes to an error message envelope. Every assistant message envelope
+is stamped with both `providerID` and `modelID`, because the client nav-bar
+subtitle derives from the latest assistant message and renders only when both are
+non-null. Per-turn state is pruned at turn boundaries and per-session maps are
+nested rather than keyed by composite strings.
+
+**`ClaudeTranscriptApi` + `ClaudeCatalogRepository`** — resolve the transcript
+root as `environment["CLAUDE_CONFIG_DIR"]` else `resolveUserHomeDirectory(...)`
+plus `/.claude`, mirroring `CodexRolloutApi`'s injected-environment pattern; that
+injected map is also the tests' pinning seam. Directory scans run in
+`Isolate.run`. JSONL decoding is per-record tolerant because the last line may be
+half-written, and that specific case is not warned. Malformed-line diagnostics
+report a redacted schema shape and never raw content, because transcript content
+is user data. Sidechain and subagent records are excluded from enumeration. No
+live tailer is needed: the live stream carries everything, and externally started
+sessions appear on the next enumeration.
+
+**`ClaudeHistoryMapper`** — transcript records to `PluginMessageWithParts`,
+reusing the content mapper so replayed history matches live rendering. A failed
+load throws `PluginOperationException`; it never returns an empty list, because
+an empty list means a genuinely empty thread and the phone renders
+error-with-retry only for throws.
+
+**`ClaudePluginDescriptor`** — templated on `cursor_plugin_descriptor.dart`. It
+declares id, displayName, `bridgeDerived` ownership, `plugin` options scope, and
+the single `bin` value option as a bare name that the bridge's option mapper
+namespaces to `--claude-bin`. `inspectSetup` runs a bounded `--version` probe
+through `HostProcessCommandExecutor`, applies the typed `SemanticVersion` floor,
+then probes auth, returning one of the five inspectable statuses — never
+`PluginSetupNotInspected`, which is the bridge's own disabled marker — with a
+non-empty `actionHint` on each non-ready variant. `start()` checks
+`host.startAborted` at entry and after construction, rolls back through
+`shutdown(budget: null)` on abort, builds the process factory through
+`host.processes` with `runInShell: Platform.isWindows`, and returns a
+`ClaudeBridgePlugin`.
+
+**`ClaudeBridgePlugin`** — `with SteadyPluginLifecycle implements BridgePlugin`.
+`describe()` reports `{"transport": "claude-stream-json"}`;
+`interruptActiveWork` delegates to the session service bounded by the budget;
+`onShutdown` disposes the plugin, which reaps every child and resolves every
+approval. Per-session process exits are session-level events, not plugin-level
+degradation: `markDegraded(recoverable)` fires only when a spawn fails at the
+binary level, and `markReady` on the next success.
+
+### BridgePluginApi method mapping
+
+| Method | Implementation |
+|---|---|
+| `getSessions(projectId)` | catalog scan filtered by normalized directory |
+| `getCommands` | slash commands from `system/init`; `PluginCommandSource.command` |
+| `getSessionOptions` | aggregate agents, providers, and commands; `refresh` re-probes |
+| `createSession` | pre-generate the session UUID, spawn with `--session-id`, dispatch the first prompt through the turn queue |
+| `renameSession` | optimistic only; the mobile database is authoritative (Cursor precedent) |
+| `deleteSession` | kill the resident process, cancel approvals, delete the transcript, forget caches |
+| `archiveSession` / `deleteWorkspace` | no-ops under the best-effort contract |
+| `getChildSessions` | `const []`; subagents render inside their Task tool card |
+| `getSessionStatuses` | derived from turn bookkeeping |
+| `getSessionMessages` | history mapper; throws on failed load |
+| `sendPrompt` | ensure residency, apply model/agent selection, queue the turn, write the user message |
+| `sendCommand` | dispatch `/command args` as the turn text; completes on write acceptance, not turn completion |
+| `abortSession` | interrupt control request, generation bump, `cancelForSession` |
+| `getAgents` | Default and Plan permission-mode agents |
+| pending / reply / reject permission and question | approval registry |
+| `healthCheck` | cheap and instantaneous; `status` is the debounced signal |
+| `getProviders` | one Anthropic provider, models from the catalog service |
+| `getActiveSessionsSummary` | synchronous; grouped by directory |
+| `listAllSessions` | full catalog scan, ignoring `knownDirectories` |
+| `launchDirectory` | the same source Cursor's descriptor uses |
+| `primeSessionDirectory` | documented no-op (global index) |
+| `deletePersistedSession` | idempotent transcript delete |
+| `dispose` | reap processes, cancel approvals, close the event channel; idempotent |
+
+### Prompt parts to content blocks
+
+`PluginPromptPartText` becomes a text block. `fileData` with an image MIME
+becomes a base64 image block; non-image `fileData` is dropped with a warning,
+mirroring the ACP inline-content null case. `filePath` becomes a text block
+carrying the path, because Claude reads files itself. `fileUrl` becomes a text
+block carrying the URL.
+
+## Registration Waves
+
+Registration lands in two waves. The workspace, Makefile, and CI lists are all
+explicit, so a package absent from them is both locally unbuildable and invisible
+to CI; the plumbing must therefore land with the scaffold while the app stays
+unaware until the flip.
+
+**Wave 1 — with the scaffold in Step 2, app-invisible:**
+
+1. `bridge/pubspec.yaml` — add `sesori_plugin_claude` to `workspace:`. A
+   `resolution: workspace` package that is not a member fails `dart pub get`.
+2. `bridge/Makefile` — add to `MODULES`.
+3. `.github/workflows/bridge-ci.yml` — add the analyze and test step pair.
+
+**Wave 2 — the activation flip in Step 14:**
+
+4. `bridge/app/pubspec.yaml` — path dependency on the new package.
+5. `bridge/app/lib/src/bridge/runtime/plugin_registry.dart` — import and register
+   `ClaudePluginDescriptor()`. `preferredDefaultPluginId` is untouched. This is
+   the only place app code may import the plugin.
+6. `shared/sesori_shared/.../plugin_identity.dart` — extend `Harness` with
+   `claude`. Additive and wire-safe: identity travels as strings and an absent
+   value still decodes to OpenCode.
+7. `bridge/app/test/bridge/runtime/plugin_registry_test.dart` — the id-set
+   assertion.
+
+## Client Changes
+
+Three files, two assets, and the affected tests:
+
+- `client/module_prego/assets/svgs/brands/claude_light.svg` and `claude_dark.svg`
+  (the directory is declared wholesale, so no pubspec edit).
+- `client/module_prego/lib/components/icons/prego_brand_logo.dart` — one case in
+  `_assetFor` and one in `displayNameFor`.
+- `client/module_core/lib/src/foundation/models/composer/composer_attachment_support.dart`
+  — widen the dated temporary gate to include Claude, only in the step where
+  image forwarding is implemented and verified, keeping the dated comment.
+- Tests: `prego_brand_logo_test.dart`, `session_tile_states_test.dart`, and the
+  attachment-gate consumers, reusing `findBrandLogo(String pluginId)` from
+  `client/app/test/helpers/test_helpers.dart`.
+
+Forward-compatibility guardrail: introduce no new `MessagePartType` value. That
+enum has no unknown fallback, so a new value crashes released clients. Every
+Claude part kind maps onto an existing type inside the plugin.
+
+## Cleanup Assessment
+
+This is additive work against an untouched harness slot, so it makes nothing
+obsolete. Two items are in scope as directly caused updates rather than cleanup:
+the README harness row moves from "Coming soon" to Beta in Step 16, and the
+temporary composer attachment gate — already carrying a dated comment — gains one
+more harness in Step 15 rather than being removed, because Codex and Cursor still
+do not accept prompt attachments. No obsolete calculation, model field, column,
+transport field, cache, flag, job, or test was found.
+
+## Delivery Rules
+
+- The series has exactly seventeen steps. Every PR title uses the fixed
+  `<emoji> [claude-code-plugin] <description> [step <x>/17]` form below.
+- Step 1 raises this plan, the tracker, and the protocol skeleton, and registers
+  mobile-mcp in `.mcp.json` for the Step 16 simulator run. It runs documentation
+  validation, not Dart or Flutter suites.
+- Step 17 retires the plan by moving `.plan/active/claude-code-plugin/` to
+  `.plan/completed/claude-code-plugin/`, with no production change.
+- Steps form one ordered dependency chain. A successor may target its immediate
+  predecessor while both are open, but merges occur in numeric order and every PR
+  must be independently valid at its own base.
+- Count additions plus deletions from `git diff --numstat`, including generated
+  code and tests. Target no more than 1,500 changed lines per PR as a soft cap,
+  reassessing at roughly 1,300. In this repository tests run about 1.2–1.9× the
+  production source and Freezed emits committed `.freezed.dart`/`.g.dart`; the
+  estimates below budget for that.
+- Do not merge neighboring steps because one lands under estimate. If a step is
+  projected to exceed the cap after codegen, find a smaller independently valid
+  split and update this plan; if no coherent split is practical, record the
+  reason before opening the PR.
+- Generated files change only through code generation.
+- Internal package contracts update every in-repository caller in lockstep. No
+  compatibility shims for internal Dart APIs.
+- Every production class introduced by a step has a production consumer or an
+  explicitly stated next-step consumer recorded in that step's PR body.
+- Run `aristotle-impl-review` on Steps 2–14, each scoped to that PR's branch
+  against its base, at most twice per step before asking the user. Steps 1 and
+  15–17 are documentation, assets, localized client copy, and mechanical moves,
+  and are not reviewed.
+- Monitor every PR with `pr-monitor:watch` after opening it.
+
+## Delivery Sequence
+
+| Step | Branch | Exact PR title | Estimate |
+|---|---|---|---:|
+| 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 900-1,100 |
+| 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 1,100-1,500 |
+| 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,000-1,400 |
+| 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,100-1,500 |
+| 5/17 | `claude-code-plugin-content-mapper` | `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]` | 900-1,300 |
+| 6/17 | `claude-code-plugin-history-mapper` | `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]` | 1,000-1,400 |
+| 7/17 | `claude-code-plugin-tool-tracker` | `⚙️ [claude-code-plugin] feat(claude): track tool lifecycle [step 7/17]` | 1,000-1,400 |
+| 8/17 | `claude-code-plugin-event-mapper` | `🚧 [claude-code-plugin] feat(claude): map stream events to SSE [step 8/17]` | 1,200-1,500 |
+| 9/17 | `claude-code-plugin-approvals` | `🚧 [claude-code-plugin] feat(claude): add permission and question registry [step 9/17]` | 1,100-1,500 |
+| 10/17 | `claude-code-plugin-session-service` | `🚧 [claude-code-plugin] feat(claude): add session residency and turn queue [step 10/17]` | 1,200-1,500 |
+| 11/17 | `claude-code-plugin-catalog-service` | `⚙️ [claude-code-plugin] feat(claude): add model and agent catalog [step 11/17]` | 900-1,300 |
+| 12/17 | `claude-code-plugin-plugin-impl` | `🚧 [claude-code-plugin] feat(claude): implement the plugin API surface [step 12/17]` | 1,200-1,500 |
+| 13/17 | `claude-code-plugin-descriptor` | `⚙️ [claude-code-plugin] feat(claude): add descriptor and lifecycle [step 13/17]` | 1,100-1,500 |
+| 14/17 | `claude-code-plugin-activation` | `⚙️ [claude-code-plugin] feat(claude): register the Claude Code harness [step 14/17]` | 250-500 |
+| 15/17 | `claude-code-plugin-client-polish` | `🌿 [claude-code-plugin] feat(client): add Claude Code branding [step 15/17]` | 400-800 |
+| 16/17 | `claude-code-plugin-e2e` | `🌿 [claude-code-plugin] docs: record Claude Code live verification [step 16/17]` | 200-500 |
+| 17/17 | `claude-code-plugin-retire` | `🌱 [claude-code-plugin] docs: retire Claude Code plugin plan [step 17/17]` | 50-200 |
+
+## Step Details And Verification
+
+### Step 1/17 — Raise The Plan
+
+- Add `PLAN.md`, `TRACKER.md`, and the `PROTOCOL.md` skeleton under
+  `.plan/active/claude-code-plugin/`.
+- Register mobile-mcp in `.mcp.json` for the Step 16 simulator run, translating
+  `opencode.json`'s entry to the `.mcp.json` schema.
+- Validate the fixed slug, titles, totals, estimates, and dependencies, and run
+  `git diff --check`. No Dart or Flutter suites, no implementation review.
+
+### Step 2/17 — Ground The Protocol And Scaffold The Package
+
+- Pin the CLI version; capture real stream-json transcripts and `--help` output;
+  cross-check flags, control subtypes, the stdin user-message envelope, and the
+  transcript record schema against the Agent SDK's own declarations.
+- Fill `PROTOCOL.md` with observed ground truth, replacing every verify marker
+  with either a confirmed shape or a recorded absence.
+- Create the package with its pubspec, analysis options, build config, and
+  barrels, plus Wave-1 workspace, Makefile, and CI plumbing.
+- Add the Freezed and JSON DTOs for stream messages, control payloads, and
+  transcript records, with tolerant unknown variants, and run codegen.
+- Verify: `dart pub get` at `bridge/`, `dart analyze --fatal-infos` and
+  `dart test` in the new package, `make codegen`, implementation review.
+
+### Step 3/17 — Add The Stream-JSON Transport
+
+- Add `ClaudeStreamClient` with line framing, request-id correlation, lenient
+  stderr decoding, redacted frame logging, generation fencing, pending-request
+  failure on teardown, and platform-correct termination.
+- Add `FakeClaudeProcess` and the `claude_testing.dart` barrel.
+- Cover framing, exit mid-request, generation fencing, redaction, and
+  unknown-type absorption.
+- Verify: focused and full package tests, fatal analysis, implementation review.
+
+### Step 4/17 — Enumerate Transcript Sessions
+
+- Add `ClaudeTranscriptApi` with injected-environment root resolution and
+  `ClaudeCatalogRepository` with isolate-backed scanning.
+- Add captured, trimmed, anonymized transcript fixtures as inline Dart literals.
+- Cover the scan, malformed lines, the half-written last line, sidechain
+  exclusion, and privacy-safe diagnostics.
+- Verify: focused and full package tests, fatal analysis, implementation review.
+
+### Step 5/17 — Map Content Blocks To Parts
+
+- Add `ClaudeContentMapper` converting content blocks to plugin parts and
+  attachments under the existing tool-output and inline-attachment limits.
+- Cover text, thinking, tool use, tool results, images, oversize degradation, and
+  unsupported kinds.
+- Verify: focused and full package tests, fatal analysis, implementation review.
+
+### Step 6/17 — Replay Transcript History
+
+- Add `ClaudeHistoryMapper` producing `PluginMessageWithParts` from transcript
+  records through the Step 5 mapper.
+- Prove throw-on-failure rather than empty-list, and record the shape parity that
+  Step 8 must match.
+- Verify: focused and full package tests, fatal analysis, implementation review.
+
+### Step 7/17 — Track Tool Lifecycle
+
+- Add `ClaudeToolTracker` owning `tool_use` lifecycle, streamed `input_json_delta`
+  buffering, `tool_result` matching by id, and edit-shaped diff detection.
+- Cover out-of-order updates, partial input JSON, unmatched results, and errors.
+- Verify: focused and full package tests, fatal analysis, implementation review.
+
+### Step 8/17 — Map Stream Events To SSE
+
+- Add `ClaudeEventMapper` over the Step 5 and Step 7 components: message and part
+  envelopes, text and thinking deltas, tool parts, retry status, the todo
+  staleness signal, error result envelopes, and provider/model stamping.
+- Prove live shapes match the Step 6 history shapes.
+- The Codex analog ran larger than this budget; if codegen or coverage pushes
+  this past the cap, record the overage rationale here before opening the PR.
+- Verify: focused and full package tests, fatal analysis, implementation review.
+
+### Step 9/17 — Add The Permission And Question Registry
+
+- Add `ClaudeApprovalRegistry` with permission/question bifurcation, the three
+  reply behaviors, `AskUserQuestion` answer-key handling, `ExitPlanMode` approval,
+  and teardown that resolves every pending request and emits its outcome.
+- Cover cancel-on-abort, cancel-on-dispose, and cancel-on-process-exit.
+- Verify: focused and full package tests, fatal analysis, implementation review.
+
+### Step 10/17 — Add Session Residency And The Turn Queue
+
+- Add `ClaudeSessionService` with residency, the serialized turn queue with
+  generation fencing re-checked after every await, interrupt, idle reaping, and
+  interrupted-not-errored classification for signalled exits.
+- Cover turn serialization, fencing, resume-versus-new spawn arguments, idle reap
+  followed by transparent resume, and approval cancellation on exit.
+- Verify: focused and full package tests, fatal analysis, implementation review.
+
+### Step 11/17 — Add The Model And Agent Catalog
+
+- Add `ClaudeCatalogService` owning models, agents, providers, and commands, plus
+  `set_model` and `set_permission_mode` application with an applied-selection
+  cache cleared on respawn.
+- Record the reasoning-effort variant decision with the evidence gathered in
+  Step 2; ship without variants if the pinned CLI has no first-party support.
+- Verify: focused and full package tests, fatal analysis, implementation review.
+
+### Step 12/17 — Implement The Plugin API Surface
+
+- Add `ClaudePlugin` implementing the full `BridgePluginApi` plus
+  `PersistedSessionCleanupApi` over the Step 3–11 components, as the composition
+  root that injects every collaborator explicitly.
+- Cover contract-level behavior: not-found handling, the buffered event channel,
+  session creation identity, delete semantics, and the activity summary.
+- Verify: focused and full package tests, fatal analysis, implementation review.
+
+### Step 13/17 — Add The Descriptor And Lifecycle
+
+- Add `ClaudePluginDescriptor` with the option declaration, the bounded version
+  probe, the auth probe, and the five inspectable setup states with action hints;
+  add `ClaudeBridgePlugin` over `SteadyPluginLifecycle`.
+- Cover probe sequencing through a stubbed process service, abort rollback, and
+  the degraded/ready transitions.
+- Verify: focused and full package tests, fatal analysis, implementation review.
+
+### Step 14/17 — Register The Harness
+
+- Extend `Harness` with `claude`, add the app path dependency, register the
+  descriptor in `knownPlugins`, and update the registry and identity tests.
+- Verify: `cd bridge && make analyze && make test`, plus a
+  `dart run bin/bridge.dart --version` smoke run, and implementation review.
+
+### Step 15/17 — Add Claude Code Branding
+
+- Add the light and dark brand SVGs matching the existing brand assets'
+  conventions, add the logo and display-name cases, widen the composer attachment
+  gate, and update the affected client tests.
+- Verify: `flutter test` in `client/module_prego`, `client/module_core`, and
+  `client/app` for the touched tests. Asset-rendering tests may be flaky locally
+  in a worktree; trust CI for those.
+
+### Step 16/17 — Record Live Verification
+
+- Run the E2E matrix below on the simulator against a source-run bridge and a
+  real logged-in `claude` CLI; record `E2E.md` in this directory.
+- Move the README harness row from "Coming soon" to Beta.
+- Failures become ordinary single-PR fixes with normal titles between Steps 15
+  and 16, or explicitly labelled non-blocking follow-ups.
+
+### Step 17/17 — Retire The Plan
+
+- Record the final merged PR and verification evidence in the tracker, then move
+  the plan tree from `.plan/active/` to `.plan/completed/` in the same commit.
+- Confirm all seventeen PRs merged in order and run `git diff --check`. No suites
+  and no implementation review.
+
+## Live Verification Matrix
+
+Recorded in `E2E.md` at Step 16, following
+`.plan/completed/setup-aware-harness-settings/E2E.md`.
+
+**Environment.** iPhone 17 simulator with `com.sesori.app` installed and signed
+into the same account as the bridge; the bridge run from source with
+`dart run bin/bridge.dart --debug-port 9977 --data-dir
+/Users/daniil/.local/share/sesori-dev --log-level debug`; a real logged-in
+`claude` on PATH. Assertions are hybrid: `curl http://127.0.0.1:9977` against the
+same router the relay uses, alongside mobile-mcp UI observation using element-list
+point coordinates rather than screenshot pixels. Turns consume the user's own
+quota, so prompts stay minimal.
+
+| ID | Check |
+|---|---|
+| E2E-01 | `GET /plugin` shows claude ready with the correct display name |
+| E2E-02 | `--claude-bin /nonexistent` yields RuntimeMissing with an action hint |
+| E2E-03 | The new-session picker lists Claude Code with its brand mark |
+| E2E-04 | A tiny first prompt streams token-by-token and the session row appears |
+| E2E-05 | An extended-thinking prompt renders a reasoning part |
+| E2E-06 | A file-listing prompt renders a tool card through to Done with output |
+| E2E-07 | A file-creating prompt raises a permission card; approve once succeeds, reject continues the turn with a denial |
+| E2E-08 | Approving always lets the next same-tool call proceed without a prompt |
+| E2E-09 | A question-provoking prompt renders a question card and the answer reaches the turn |
+| E2E-10 | Plan agent plus a change request yields an ExitPlanMode card; approval resumes execution in default mode |
+| E2E-11 | The catalog lists real models and a mid-session switch updates the nav-bar subtitle after the next reply |
+| E2E-12 | Stopping a long task goes idle promptly with sane process state |
+| E2E-13 | Aborting with a pending permission clears the card |
+| E2E-14 | After a bridge restart the session list is intact, history replays fully, and a follow-up resumes |
+| E2E-15 | A session started in an external terminal appears under its project after refresh |
+| E2E-16 | An attached photo is described correctly |
+| E2E-17 | The command catalog lists slash commands and one executes |
+| E2E-18 | A follow-up after the idle-reap window resumes transparently |
+| E2E-19 | The harness settings card disables and re-enables Claude Code |
+| E2E-20 | The debug-level bridge log has no unhandled errors and no `claude` process leaks after shutdown |
+
+## Compatibility
+
+- The client/bridge wire contract is unchanged. Plugin identity already travels
+  as a string with a documented OpenCode fallback for absence, so adding
+  `Harness.claude` is additive in both directions.
+- An older app against a new bridge sees Claude sessions rendered through the
+  existing unknown-harness fallback: a generic mark instead of the brand asset,
+  everything else identical.
+- A newer app against an older bridge simply never sees the harness, because the
+  picker is populated from `GET /plugin`.
+- Internal Dart package APIs update all monorepo consumers in lockstep, with no
+  deprecated aliases or optional compatibility parameters.
+
+## Material Risks And Mitigations
+
+| Risk | Evidence level | Mitigation |
+|---|---|---|
+| The stream-json control protocol is SDK-internal and drifts between CLI releases. | Known upstream property | Pin a floor in `inspectSetup`, feature-detect from `init.capabilities`, parse tolerantly, and keep `PROTOCOL.md` as dated ground truth for the pinned version. |
+| Verify-at-implementation items (stdin envelope, control subtypes, permission-prompt flag, model listing, effort support, slash dispatch, auth probe, transcript schema) turn out different from the research. | Unresolved by design | Step 2 resolves each against the pinned CLI and the SDK declarations before any consumer is written; each resolution is recorded in `PROTOCOL.md`. |
+| The auth probe costs seconds inside `inspectSetup`. | Ordinary flow | Run the version probe first, bound the auth probe, and accept `PluginSetupUnknown` as honest degradation. |
+| Overriding `HOME` for test isolation breaks keychain auth and reports a logged-in user as logged out. | Observed in prior integrations | Never override `HOME`; isolate tests through `CLAUDE_CONFIG_DIR` only, and assert that in the transcript tests. |
+| A stale permission or question card survives a stop, an abort, or a process exit. | Observed in prior integrations | The registry teardown contract resolves every pending request and emits its outcome; Steps 9 and 10 cover all three paths. |
+| Idle resident processes accumulate memory. | Known upstream property | Reap after an idle window and rely on `--resume` to make respawn invisible. |
+| Coordination machinery grows beyond the evidence. | Repository rule | The ported turn queue with generation fencing is the ceiling of allowed coordination; anything beyond it requires an observed failure first. |
+| Live verification consumes the user's own token quota. | Certain | Keep every E2E prompt minimal and note consumption in the E2E cleanup section. |
+
+## Plan Review Record
+
+`aristotle-plan-review` is an architecture reviewer for architecture-bearing
+production plans, which this is. The review verdict, date, reviewed scope, and
+any applied corrections are recorded in `TRACKER.md` when the review runs, before
+Step 2 begins.

--- a/.plan/active/claude-code-plugin/PLAN.md
+++ b/.plan/active/claude-code-plugin/PLAN.md
@@ -557,7 +557,7 @@ transport field, cache, flag, job, or test was found.
 
 | Step | Branch | Exact PR title | Estimate |
 |---|---|---|---:|
-| 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 900-1,100 |
+| 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 1,700-1,900 |
 | 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 1,100-1,500 |
 | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,000-1,400 |
 | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,100-1,500 |

--- a/.plan/active/claude-code-plugin/PLAN.md
+++ b/.plan/active/claude-code-plugin/PLAN.md
@@ -147,11 +147,18 @@ Condensed research carried into Step 2 (all marked verify-at-implementation in
 - Any managed runtime, download, or version provisioning. The plugin resolves an
   existing binary and reports setup state; it never installs one.
 - Any login flow, credential storage, or auth mutation.
-- Reasoning-effort variants unless Step 11 finds first-party support; the
-  decision is recorded there with evidence rather than assumed now.
-- New shared wire types, new `MessagePartType` values, relay changes, database
-  migrations, and product analytics. This harness adds no new authoritative user
-  action beyond the ones the existing harnesses already instrument.
+- New `MessagePartType` values, relay changes, database migrations, and product
+  analytics. This harness adds no new authoritative user action beyond the ones
+  the existing harnesses already instrument.
+- New shared wire types. **Under review:** plan review found that widening the
+  client's `harnessSupportsPromptAttachments` branch violates the plugin-boundary
+  invariant, and the compliant fix adds an additive capability flag to
+  `PluginMetadata`. That decision is pending; this exclusion stands until it is
+  made. See Plan Review Record.
+
+Reasoning-effort variants were previously excluded pending evidence. Step 2
+found `supportsEffort` and `supportedEffortLevels` declared per model in the
+`initialize` response, so **variants are in scope** and Step 11 maps them.
 
 ### Naming
 
@@ -195,22 +202,36 @@ bridge/sesori_plugin_claude/
                           json_serializable {any_map:true,explicit_to_json:true}
   lib/claude_plugin.dart          barrel; exports ClaudePluginDescriptor
   lib/claude_testing.dart         barrel; exports FakeClaudeProcess
-  lib/src/api/
+  lib/src/api/                    LAYER 1 — wire boundary
     claude_stream_client.dart     ndjson stdio client for ONE process
-    claude_process_factory.dart   launch spec + host-routed factory
+    claude_process_factory.dart   host-routed process seam
+    claude_launch_spec.dart       the verified argument vector
     claude_transcript_api.dart    ~/.claude/projects reader
-    models/                       freezed stream, control, and transcript DTOs
-  lib/src/repositories/
-    claude_catalog_repository.dart      transcript scan -> session records
-    mappers/claude_event_mapper.dart    stream messages -> BridgeSseEvent
-    mappers/claude_history_mapper.dart  transcript -> PluginMessageWithParts
+    models/                       wire DTOs ONLY (stream, control, transcript)
+  lib/src/models/                 package-local domain models, no wire coupling
+    claude_permission_mode.dart   dual-spelled mode enum (CLI vs control)
+    claude_effort_level.dart      reasoning effort levels
+  lib/src/repositories/           LAYER 2 — normalization; no peer dependencies
+    claude_session_process_repository.dart  per-session client map; spawn vs
+                                            resume; per-session teardown; the
+                                            applied model/agent/mode of each
+                                            resident process; control-request
+                                            dispatch by session id
+    claude_transcript_catalog_repository.dart  transcript scan -> session records
+    claude_backend_catalog_repository.dart     initialize payload -> PluginModel,
+                                               PluginProvider, PluginCommand,
+                                               PluginAgent
     mappers/claude_content_mapper.dart  content blocks -> parts/attachments
     trackers/claude_tool_tracker.dart   tool_use lifecycle + delta buffering
-  lib/src/services/
-    claude_session_service.dart   residency, turn queue, idle reaping, interrupt
-    claude_catalog_service.dart   model/agent/command catalog + applied cache
-  lib/src/claude_approval_registry.dart  can_use_tool -> permissions/questions
-  lib/src/claude_plugin_impl.dart        ClaudePlugin
+  lib/src/services/               LAYER 3 — coordination; imports repositories only
+    claude_session_service.dart   turn queue, generation fencing, idle-reap
+                                  policy, interrupt, exit classification
+    claude_catalog_service.dart   catalog exposure + switch requests
+  lib/src/                        above Layer 2 — consumers of Layer-2 components
+    claude_event_mapper.dart      stream messages -> BridgeSseEvent
+    claude_history_mapper.dart    transcript -> PluginMessageWithParts
+    claude_approval_registry.dart can_use_tool -> permissions/questions
+    claude_plugin_impl.dart       ClaudePlugin — LAYER 4 composition root
   lib/src/runtime/
     claude_plugin_descriptor.dart  const descriptor
     claude_bridge_plugin.dart      SteadyPluginLifecycle wrapper
@@ -220,6 +241,20 @@ bridge/sesori_plugin_claude/
 
 Layering follows the house style: `api/` is the wire boundary, `repositories/`
 normalizes, `services/` coordinates, `runtime/` is descriptor and lifecycle glue.
+
+Two placement rules this layout exists to satisfy, both taken from the shipped
+plugins rather than invented here:
+
+- **No file under `services/` imports `api/`.** `CodexSessionService` takes only
+  repositories, and `AcpStdioClient` is owned by `AcpPlugin`, never by a service.
+  With N processes rather than one, the client map is per-session state that
+  belongs to a repository, so `ClaudeSessionProcessRepository` is the Layer-2
+  boundary every service and mapper goes through to reach a process.
+- **No Layer-2 component depends on another Layer-2 component.**
+  `ClaudeEventMapper` consumes the content mapper and the tool tracker, and
+  `ClaudeHistoryMapper` consumes the content mapper, so both consumers live at
+  `lib/src/` — exactly where ACP puts `acp_event_mapper.dart` and
+  `acp_session_loader.dart` relative to its own `repositories/` components.
 
 ### Component contracts
 
@@ -236,28 +271,66 @@ resolved init future, `sendUserMessage`, `sendControlRequest` with request-id
 correlation, `sendControlResponse`, a process-exit future, and `dispose`.
 Unknown message types are debug-logged and dropped, never warned per line.
 
-**`ClaudeSessionService`** — owns per-session residency (client, applied model,
-applied agent, idle timer) plus the turn queue ported from
-`AcpPlugin._SessionTurnState`: a `tail` future chain, a `pending` count, and a
-`generation` re-checked after every await. The first pending turn emits busy
-status plus a project-updated event; turn completion emits idle or error.
-Residency reuses a live process, otherwise spawns with `--resume` for an
-existing session or `--session-id` for a new one. Idle reaping runs off
-`host.clock` and gracefully disposes only that session's client. An unexpected
-exit mid-turn finishes the turn as interrupted rather than errored when the
-bridge sent the signal, cancels that session's approvals, and drops residency.
+**`ClaudeSessionProcessRepository`** — the Layer-2 boundary over the transport,
+and the only component that touches `api/`.
+`ClaudeSessionProcessRepository({required ClaudeProcessFactory processFactory,
+required String binaryPath, required Map<String, String> environment})`.
+
+It owns the `sessionId -> resident process` map and everything that is
+per-process state: the `ClaudeStreamClient`, the applied model, applied agent,
+and applied permission mode, and the spawn-versus-resume argument choice
+(`--session-id` for a new session, `--resume` for an existing one). It exposes
+session-keyed operations — ensure resident, send a turn, send a control request,
+answer a control request, tear one session down, tear all down — plus a merged
+stream of `(sessionId, ClaudeStreamMessage)` and per-session exit futures. Every
+other component reaches a process through this repository, never directly.
+
+Applied selection lives here and nowhere else: it is per-resident-process state
+whose single invalidation trigger is that process being respawned, so it has one
+owner by construction.
+
+**`ClaudeSessionService`** —
+`ClaudeSessionService({required ClaudeSessionProcessRepository processes,
+required ClaudeApprovalRegistry approvals, required Clock clock})`. It holds no
+client and imports nothing from `api/`.
+
+It owns the turn queue ported from `AcpPlugin._SessionTurnState`: a `tail` future
+chain, a `pending` count, and a `generation` re-checked after every await. The
+first pending turn emits busy status plus a project-updated event; turn
+completion emits idle or error. It owns the idle-reap policy and asks the
+repository to tear a session down when the window elapses; the repository owns
+how. An unexpected exit mid-turn finishes the turn as interrupted rather than
+errored when the bridge sent the signal, and cancels that session's approvals.
 
 **`ClaudeApprovalRegistry`** — architecturally identical to
-`AcpApprovalRegistry`: injected emit and respond callbacks, bridge-minted `br-N`
-ids, permission/question bifurcation, and a `cancelForSession`/`dispose` contract
-that resolves every pending request *and* emits its replied or rejected event.
-Claude specifics: requests arrive on a known session's own process, so there is
-no session-resolution ambiguity; `AskUserQuestion` and `ExitPlanMode` become
-questions and everything else a permission; `once` maps to a plain allow,
-`always` echoes only the backend's own `permission_suggestions`, and `reject`
-maps to deny with a short message.
+`AcpApprovalRegistry`, with one deliberate difference in how it responds.
+`ClaudeApprovalRegistry({required void Function(BridgeSseEvent) emit,
+required void Function({required String sessionId, required String requestId,
+required Map<String, Object?> payload}) respond})`.
 
-**`ClaudeEventMapper`** — the hard contract shared with the Codex and ACP
+`AcpApprovalRegistry.forClient` binds to a single `AcpStdioClient` because ACP
+runs one process for every session. One process per session makes that binding
+impossible, so the injected `respond` is **session-keyed** rather than
+client-bound, and the composition root wires it to
+`ClaudeSessionProcessRepository`, which resolves the session to its client and
+writes the `control_response`. The registry itself never holds a client.
+
+It keeps the rest verbatim: bridge-minted `br-N` ids, permission/question
+bifurcation, and a `cancelForSession`/`dispose` contract that resolves every
+pending request *and* emits its replied or rejected event. Claude specifics: asks
+flagged `requires_user_interaction` become questions and everything else a
+permission; `once` maps to a plain allow, `always` echoes only the backend's own
+`permission_suggestions` and is withheld entirely when
+`suppress_always_allow_rule` is set, and `reject` maps to deny with a short
+message. `decision_reason` may carry ANSI escapes and is sanitized before it
+reaches the phone.
+
+**`ClaudeEventMapper`** — lives at `lib/src/`, not in `repositories/`, because it
+consumes two Layer-2 components.
+`ClaudeEventMapper({required ClaudeContentMapper content,
+required ClaudeToolTracker tools})`.
+
+It carries the hard contract shared with the Codex and ACP
 mappers: every `info` map on a session or message event is sesori-schema JSON
 built from `sesori_shared` typed models via `.toJson()`. It maps stream deltas to
 message and part updates, `tool_result` blocks to tool completion or error,
@@ -269,7 +342,37 @@ subtitle derives from the latest assistant message and renders only when both ar
 non-null. Per-turn state is pruned at turn boundaries and per-session maps are
 nested rather than keyed by composite strings.
 
-**`ClaudeTranscriptApi` + `ClaudeCatalogRepository`** — resolve the transcript
+**`ClaudeContentMapper`** — `ClaudeContentMapper()`, no collaborators. Content
+blocks to plugin parts and attachments under the existing tool-output and
+inline-attachment limits. Layer 2.
+
+**`ClaudeToolTracker`** — `ClaudeToolTracker()`, no collaborators. Owns the
+`tool_use` lifecycle, streamed `input_json_delta` buffering, `tool_result`
+matching by id, and edit-shaped diff detection. Layer 2.
+
+**`ClaudeBackendCatalogRepository`** —
+`ClaudeBackendCatalogRepository({required ClaudeSessionProcessRepository
+processes})`. The DTO-to-internal-model boundary for the backend catalog, kept
+out of `services/` where such mapping does not belong. It reads the retained
+`initialize` payload through the process repository and returns
+`PluginModel` — `variants` populated from `supportedEffortLevels` default-first,
+and omitted entirely for a model that declares no effort support —
+`PluginProvider` for Anthropic, `PluginCommand` from `commands`, and the
+Default/Plan `PluginAgent` pair. `list_models` is its refresh path.
+
+Named distinctly from the transcript catalog on purpose: the two are different
+catalogs over different sources and must not share a name.
+
+**`ClaudeCatalogService`** —
+`ClaudeCatalogService({required ClaudeBackendCatalogRepository catalog,
+required ClaudeSessionProcessRepository processes})`. It exposes the catalog to
+the plugin and turns a model or agent selection into a `set_model` or
+`set_permission_mode` request through the process repository. It holds **no**
+applied-selection cache — that state belongs to the resident process and lives in
+the process repository.
+
+**`ClaudeTranscriptApi` + `ClaudeTranscriptCatalogRepository`** — resolve the
+transcript
 root as `environment["CLAUDE_CONFIG_DIR"]` else `resolveUserHomeDirectory(...)`
 plus `/.claude`, mirroring `CodexRolloutApi`'s injected-environment pattern; that
 injected map is also the tests' pinning seam. Directory scans run in
@@ -280,11 +383,28 @@ is user data. Sidechain and subagent records are excluded from enumeration. No
 live tailer is needed: the live stream carries everything, and externally started
 sessions appear on the next enumeration.
 
-**`ClaudeHistoryMapper`** — transcript records to `PluginMessageWithParts`,
-reusing the content mapper so replayed history matches live rendering. A failed
-load throws `PluginOperationException`; it never returns an empty list, because
-an empty list means a genuinely empty thread and the phone renders
-error-with-retry only for throws.
+**`ClaudeHistoryMapper`** — lives at `lib/src/` for the same reason as the event
+mapper: it consumes a Layer-2 component.
+`ClaudeHistoryMapper({required ClaudeContentMapper content,
+required ClaudeTranscriptCatalogRepository transcripts})`.
+
+Transcript records to `PluginMessageWithParts`, reusing the content mapper so
+replayed history matches live rendering. A failed load throws
+`PluginOperationException`; it never returns an empty list, because an empty list
+means a genuinely empty thread and the phone renders error-with-retry only for
+throws.
+
+**`ClaudePlugin`** — the Layer-4 composition root. It constructs one instance of
+each component and injects every collaborator explicitly:
+`ClaudePlugin({required ClaudeSessionProcessRepository processes,
+required ClaudeTranscriptCatalogRepository transcripts,
+required ClaudeBackendCatalogRepository catalog,
+required ClaudeSessionService sessions,
+required ClaudeCatalogService catalogService,
+required ClaudeApprovalRegistry approvals,
+required ClaudeEventMapper events,
+required ClaudeHistoryMapper history})`. No constructor default creates a hidden
+production dependency.
 
 **`ClaudePluginDescriptor`** — templated on `cursor_plugin_descriptor.dart`. It
 declares id, displayName, `bridgeDerived` ownership, `plugin` options scope, and
@@ -475,10 +595,18 @@ transport field, cache, flag, job, or test was found.
   with either a confirmed shape or a recorded absence.
 - Create the package with its pubspec, analysis options, build config, and
   barrels, plus Wave-1 workspace, Makefile, and CI plumbing.
-- Add the Freezed and JSON DTOs for stream messages, control payloads, and
-  transcript records, with tolerant unknown variants, and run codegen.
+- Add the verified launch contract in named files at declared layers:
+  `lib/src/api/claude_launch_spec.dart` holds the argument vector and the sealed
+  new-versus-resumed launch variant (Layer 1, because it describes the process
+  invocation); `lib/src/models/claude_permission_mode.dart` and
+  `lib/src/models/claude_effort_level.dart` hold the two closed scalar sets.
+  Those enums are **domain** models, not wire DTOs: the permission mode is
+  spelled `manual` on the launch flag and `default` in the control protocol, so
+  both the launch path and the control path depend on it. They therefore live in
+  a package-local `models/` directory rather than `api/models/`, which is
+  reserved for wire DTOs, so neither path imports the other.
 - Verify: `dart pub get` at `bridge/`, `dart analyze --fatal-infos` and
-  `dart test` in the new package, `make codegen`, implementation review.
+  `dart test` in the new package, implementation review.
 
 ### Step 3/17 — Add The Stream-JSON Transport
 
@@ -509,8 +637,9 @@ transport field, cache, flag, job, or test was found.
 
 ### Step 6/17 — Replay Transcript History
 
-- Add `ClaudeHistoryMapper` producing `PluginMessageWithParts` from transcript
-  records through the Step 5 mapper.
+- Add `ClaudeHistoryMapper` at `lib/src/` — not in `repositories/mappers/`,
+  because it consumes the Layer-2 content mapper — producing
+  `PluginMessageWithParts` from transcript records through the Step 5 mapper.
 - Prove throw-on-failure rather than empty-list, and record the shape parity that
   Step 8 must match.
 - Verify: focused and full package tests, fatal analysis, implementation review.
@@ -524,9 +653,11 @@ transport field, cache, flag, job, or test was found.
 
 ### Step 8/17 — Map Stream Events To SSE
 
-- Add `ClaudeEventMapper` over the Step 5 and Step 7 components: message and part
-  envelopes, text and thinking deltas, tool parts, retry status, the todo
-  staleness signal, error result envelopes, and provider/model stamping.
+- Add `ClaudeEventMapper` at `lib/src/` — not in `repositories/mappers/`, because
+  it consumes the Layer-2 content mapper and tool tracker — over the Step 5 and
+  Step 7 components: message and part envelopes, text and thinking deltas, tool
+  parts, retry status, the todo staleness signal, error result envelopes, and
+  provider/model stamping.
 - Prove live shapes match the Step 6 history shapes.
 - The Codex analog ran larger than this budget; if codegen or coverage pushes
   this past the cap, record the overage rationale here before opening the PR.
@@ -542,20 +673,32 @@ transport field, cache, flag, job, or test was found.
 
 ### Step 10/17 — Add Session Residency And The Turn Queue
 
-- Add `ClaudeSessionService` with residency, the serialized turn queue with
-  generation fencing re-checked after every await, interrupt, idle reaping, and
-  interrupted-not-errored classification for signalled exits.
+- Add `ClaudeSessionProcessRepository` (Layer 2) owning the per-session client
+  map, spawn-versus-resume argument choice, per-session teardown, applied
+  selection state, and session-keyed control dispatch.
+- Add `ClaudeSessionService` (Layer 3) over that repository: the serialized turn
+  queue with generation fencing re-checked after every await, interrupt, the
+  idle-reap policy, and interrupted-not-errored classification for signalled
+  exits. It imports nothing from `api/`.
 - Cover turn serialization, fencing, resume-versus-new spawn arguments, idle reap
   followed by transparent resume, and approval cancellation on exit.
 - Verify: focused and full package tests, fatal analysis, implementation review.
 
 ### Step 11/17 — Add The Model And Agent Catalog
 
-- Add `ClaudeCatalogService` owning models, agents, providers, and commands, plus
-  `set_model` and `set_permission_mode` application with an applied-selection
-  cache cleared on respawn.
-- Record the reasoning-effort variant decision with the evidence gathered in
-  Step 2; ship without variants if the pinned CLI has no first-party support.
+- Add `ClaudeBackendCatalogRepository` (Layer 2), which performs all
+  `initialize`-payload DTO mapping to `PluginModel`, `PluginProvider`,
+  `PluginCommand`, and `PluginAgent`. That mapping belongs in a repository, not a
+  service.
+- Add `ClaudeCatalogService` (Layer 3) over that repository plus the process
+  repository. It exposes the catalog and turns a selection into a `set_model` or
+  `set_permission_mode` request. It holds no applied-selection cache — that state
+  belongs to the resident process and lives in the process repository.
+- Source the catalog from the retained `initialize` response rather than separate
+  probes; `list_models` is the refresh path only.
+- Ship effort variants. Step 2 confirmed `supportsEffort` and
+  `supportedEffortLevels` are declared per model, so variants are first-party
+  data — default-first, and omitted entirely for models that declare no support.
 - Verify: focused and full package tests, fatal analysis, implementation review.
 
 ### Step 12/17 — Implement The Plugin API Surface
@@ -672,7 +815,36 @@ quota, so prompts stay minimal.
 
 ## Plan Review Record
 
-`aristotle-plan-review` is an architecture reviewer for architecture-bearing
-production plans, which this is. The review verdict, date, reviewed scope, and
-any applied corrections are recorded in `TRACKER.md` when the review runs, before
-Step 2 begins.
+`aristotle-plan-review` rejected this plan on 2026-08-04 with nine violations.
+Eight are applied above; the ninth is a scope decision awaiting the user.
+
+**Applied — layering (violations 1–5).** The plan had `services/` importing
+`api/` directly: `ClaudeSessionService` owned and spawned `ClaudeStreamClient`,
+and `ClaudeCatalogService` read the retained `initialize` response straight off
+it. The repository's own precedent contradicted that —`CodexSessionService` takes
+only repositories and `AcpStdioClient` is owned by `AcpPlugin`. A Layer-2
+`ClaudeSessionProcessRepository` now owns the per-session client map and is the
+only component that touches `api/`. `initialize`-payload DTO mapping moved out of
+the service into `ClaudeBackendCatalogRepository`, and the two catalogs were given
+distinct names. `ClaudeEventMapper` and `ClaudeHistoryMapper` moved from
+`repositories/mappers/` up to `lib/src/`, because a Layer-2 component may not
+depend on another Layer-2 component — the placement ACP already uses.
+
+**Applied — ownership and declarations (violations 6–8).** Applied model, agent,
+and permission mode were owned by two classes with one invalidation trigger; they
+now belong solely to the resident process in the process repository. Every
+non-trivial class now declares its constructor collaborators. The approval
+registry's `respond` callback is explicitly session-keyed rather than
+client-bound, because `AcpApprovalRegistry.forClient`'s single-client binding is
+impossible with one process per session.
+
+**Pending — violation 9, prompt-attachment capability.** The reviewer found that
+widening `harnessSupportsPromptAttachments` in `client/module_core` to a second
+harness id violates the plugin-boundary invariant, and that the compliant fix is
+an additive `PluginMetadata` capability flag following the existing
+`supportsSessionOptions` precedent. That is correct architecturally but expands
+scope into shared wire types, all four descriptors, and client code beyond this
+plan's three files. It is a user decision and is recorded in `TRACKER.md`.
+
+The corrected plan was not re-reviewed merely to obtain an approval verdict, per
+the repository's plan-review process.

--- a/.plan/active/claude-code-plugin/PLAN.md
+++ b/.plan/active/claude-code-plugin/PLAN.md
@@ -10,8 +10,9 @@
 - **Implementation base:** `origin/main` at
   `ca7470fd6ead8f7e1ff0d58e3591e7ce25a5314d`
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
-- **Delivery:** one planning PR, thirteen sequential bridge PRs, one activation
-  PR, one client PR, one live-verification PR, and one plan-retirement PR
+- **Delivery:** one planning PR, twelve sequential bridge PRs, one activation PR,
+  one client PR, one live-verification PR, and one plan-retirement PR — seventeen
+  in total
 
 ## Goal
 
@@ -48,8 +49,12 @@ binary the user already has installed and logged in.
    and accept a follow-up turn through `--resume`.
 8. Sessions started in an external terminal appear in Sesori after a refresh,
    under the project matching their working directory.
-9. No Claude-specific concept — tool name, model id, permission mode, transcript
-   path — escapes the plugin package into shared, bridge, or client code.
+9. No Claude *backend payload* concept — tool name, model id, permission mode,
+   transcript path, wire shape — escapes the plugin package into shared, bridge,
+   or client code. Three identity and presentation items are deliberate,
+   enumerated exceptions: `Harness.claude` in `sesori_shared`, the brand asset
+   and display name in `module_prego`, and the harness id in the dated composer
+   attachment gate. Every existing harness carries the same three.
 10. No new `MessagePartType` value and no breaking wire change; the client
     remains data-driven from `GET /plugin` apart from the brand asset and the
     attachment gate.
@@ -348,26 +353,36 @@ inline-attachment limits. Layer 2.
 `tool_use` lifecycle, streamed `input_json_delta` buffering, `tool_result`
 matching by id, and edit-shaped diff detection. Layer 2.
 
-**`ClaudeBackendCatalogRepository`** —
-`ClaudeBackendCatalogRepository({required ClaudeSessionProcessRepository
-processes})`. The DTO-to-internal-model boundary for the backend catalog, kept
-out of `services/` where such mapping does not belong. It reads the retained
-`initialize` payload through the process repository and returns
-`PluginModel` — `variants` populated from `supportedEffortLevels` default-first,
-and omitted entirely for a model that declares no effort support —
-`PluginProvider` for Anthropic, `PluginCommand` from `commands`, and the
-Default/Plan `PluginAgent` pair. `list_models` is its refresh path.
+**`ClaudeBackendCatalogRepository`** — `ClaudeBackendCatalogRepository()`, **no
+collaborators**. The DTO-to-internal-model boundary for the backend catalog, kept
+out of `services/` where such mapping does not belong.
+
+It is a pure mapping over an `initialize` payload handed to it: the caller
+supplies the map, the repository returns `PluginModel` — `variants` populated
+from `supportedEffortLevels` default-first, and omitted entirely for a model that
+declares no effort support — `PluginProvider` for Anthropic, `PluginCommand` from
+`commands`, and the Default/Plan `PluginAgent` pair.
+
+It deliberately does **not** hold `ClaudeSessionProcessRepository`. An earlier
+revision had it fetch the payload itself, which made one Layer-2 component depend
+on a Layer-2 peer — the exact rule this layout states. `ClaudeCatalogService`
+holds both and passes the payload across, so the mapping stays in Layer 2 while
+the peer dependency disappears.
 
 Named distinctly from the transcript catalog on purpose: the two are different
 catalogs over different sources and must not share a name.
 
 **`ClaudeCatalogService`** —
 `ClaudeCatalogService({required ClaudeBackendCatalogRepository catalog,
-required ClaudeSessionProcessRepository processes})`. It exposes the catalog to
-the plugin and turns a model or agent selection into a `set_model` or
-`set_permission_mode` request through the process repository. It holds **no**
-applied-selection cache — that state belongs to the resident process and lives in
-the process repository.
+required ClaudeSessionProcessRepository processes})`. It reads the retained
+`initialize` payload from the process repository, hands it to the catalog
+repository to map, and exposes the result to the plugin. It turns a model or
+agent selection into a `set_model` or `set_permission_mode` request through the
+process repository. It holds **no** applied-selection cache — that state belongs
+to the resident process and lives in the process repository.
+
+Holding both repositories is what keeps them from holding each other; the service
+is the allowed place for that composition.
 
 **`ClaudeTranscriptApi` + `ClaudeTranscriptCatalogRepository`** — resolve the
 transcript
@@ -432,7 +447,7 @@ binary level, and `markReady` on the next success.
 | `getSessions(projectId)` | catalog scan filtered by normalized directory |
 | `getCommands` | slash commands from `system/init`; `PluginCommandSource.command` |
 | `getSessionOptions` | aggregate agents, providers, and commands; `refresh` re-probes |
-| `createSession` | pre-generate the session UUID, spawn with `--session-id`, dispatch the first prompt through the turn queue |
+| `createSession` | pre-generate the session UUID, spawn with `--session-id`, dispatch the first prompt through the turn queue; **the id reported on `system/init` is authoritative** and is cross-checked against the pre-generated UUID (see Session Identity below) |
 | `renameSession` | optimistic only; the mobile database is authoritative (Cursor precedent) |
 | `deleteSession` | kill the resident process, cancel approvals, delete the transcript, forget caches |
 | `archiveSession` / `deleteWorkspace` | no-ops under the best-effort contract |
@@ -452,6 +467,44 @@ binary level, and `markReady` on the next success.
 | `primeSessionDirectory` | documented no-op (global index) |
 | `deletePersistedSession` | idempotent transcript delete |
 | `dispose` | reap processes, cancel approvals, close the event channel; idempotent |
+
+### Session identity
+
+Enumeration, replay, `--resume`, and delete all key on the session id, so a
+mismatch between the id the bridge minted and the id the CLI actually used would
+silently split one session into two views.
+
+`--session-id` pre-binding is **verified**, not assumed: a probe run with a
+pre-generated UUID produced a transcript at `<that uuid>.jsonl`, and every record
+inside reported the same `sessionId`. Multi-turn residency on one process is
+verified the same way — two turns ran on a single process that stayed alive
+between them and exited cleanly only when stdin closed.
+
+The contract is nonetheless defensive rather than trusting: the `session_id`
+reported on `system/init` is the source of truth, cross-checked against the
+pre-generated UUID. A mismatch is logged and the reported id wins, because it is
+the one the transcript is named after. Note that `init` is emitted when a turn
+starts, not when the process spawns, so the check happens on the first turn —
+which is exactly when `createSession` dispatches its first prompt.
+
+### Respawn state durability
+
+Idle reaping plus `--resume` means a session's process is replaced underneath the
+user, so anything the plugin believes about a process must survive that or be
+re-derived. Two properties are unresolved and are settled with evidence before
+Step 10 relies on them, then covered live in Step 16:
+
+1. **Does `--resume` restore the session's last-used model?** If the resumed
+   process honors a persisted model while the plugin believes "default", the
+   applied-model bookkeeping drifts from reality. The nav-bar subtitle is
+   server-stamped from the latest assistant message, so the UI would show one
+   model while the next `set_model` decision is made against another. If resume
+   does restore it, the process repository seeds applied-model from the first
+   post-resume assistant message rather than assuming a default.
+2. **Does an `always` permission grant survive a respawn?** If grants are
+   in-memory session state, users re-see permission cards after every idle
+   window — a visible regression that a transparent-resume check would not catch,
+   because that only asserts the turn completes.
 
 ### Prompt parts to content blocks
 
@@ -555,7 +608,7 @@ transport field, cache, flag, job, or test was found.
 
 | Step | Branch | Exact PR title | Estimate |
 |---|---|---|---:|
-| 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 1,700-1,900 |
+| 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 1,200-1,400 |
 | 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 1,100-1,500 |
 | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,000-1,400 |
 | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,100-1,500 |
@@ -745,6 +798,10 @@ transport field, cache, flag, job, or test was found.
 
 - Record the final merged PR and verification evidence in the tracker, then move
   the plan tree from `.plan/active/` to `.plan/completed/` in the same commit.
+- Remove the `mobile-mcp` entry from `.mcp.json`. It exists only for the Step 16
+  simulator run, and every ordinary Claude Code session in this repository starts
+  the servers listed there; leaving it registered would impose that cost
+  permanently for a one-off verification.
 - Confirm all seventeen PRs merged in order and run `git diff --check`. No suites
   and no implementation review.
 
@@ -782,6 +839,8 @@ quota, so prompts stay minimal.
 | E2E-16 | An attached photo is described correctly |
 | E2E-17 | The command catalog lists slash commands and one executes |
 | E2E-18 | A follow-up after the idle-reap window resumes transparently |
+| E2E-18a | After an idle reap, the model shown in the nav-bar subtitle still matches the model the plugin believes is applied |
+| E2E-18b | After an idle reap, a tool previously granted "always" runs without prompting again |
 | E2E-19 | The harness settings card disables and re-enables Claude Code |
 | E2E-20 | The debug-level bridge log has no unhandled errors and no `claude` process leaks after shutdown |
 

--- a/.plan/active/claude-code-plugin/PLAN.md
+++ b/.plan/active/claude-code-plugin/PLAN.md
@@ -407,9 +407,12 @@ transport field, cache, flag, job, or test was found.
   validation, not Dart or Flutter suites.
 - Step 17 retires the plan by moving `.plan/active/claude-code-plugin/` to
   `.plan/completed/claude-code-plugin/`, with no production change.
-- Steps form one ordered dependency chain. A successor may target its immediate
-  predecessor while both are open, but merges occur in numeric order and every PR
-  must be independently valid at its own base.
+- Steps form one ordered dependency chain and **only one PR is open at a time**.
+  Do not stack a successor on an open predecessor. The next step is developed
+  locally on its own branch and its PR is opened only after the current PR
+  merges, so every PR targets `main` and reviewers never face a queue of
+  interdependent branches. Merges therefore occur in numeric order by
+  construction, and every PR is independently valid at its own base.
 - Count additions plus deletions from `git diff --numstat`, including generated
   code and tests. Target no more than 1,500 changed lines per PR as a soft cap,
   reassessing at roughly 1,300. In this repository tests run about 1.2–1.9× the

--- a/.plan/active/claude-code-plugin/PLAN.md
+++ b/.plan/active/claude-code-plugin/PLAN.md
@@ -150,11 +150,9 @@ Condensed research carried into Step 2 (all marked verify-at-implementation in
 - New `MessagePartType` values, relay changes, database migrations, and product
   analytics. This harness adds no new authoritative user action beyond the ones
   the existing harnesses already instrument.
-- New shared wire types. **Under review:** plan review found that widening the
-  client's `harnessSupportsPromptAttachments` branch violates the plugin-boundary
-  invariant, and the compliant fix adds an additive capability flag to
-  `PluginMetadata`. That decision is pending; this exclusion stands until it is
-  made. See Plan Review Record.
+- New shared wire types, including a prompt-attachment capability flag on
+  `PluginMetadata`. Plan review argued for one; the user decided on 2026-08-04 to
+  widen the existing dated gate instead. See Plan Review Record.
 
 Reasoning-effort variants were previously excluded pending evidence. Step 2
 found `supportsEffort` and `supportedEffortLevels` declared per model in the
@@ -838,13 +836,25 @@ registry's `respond` callback is explicitly session-keyed rather than
 client-bound, because `AcpApprovalRegistry.forClient`'s single-client binding is
 impossible with one process per session.
 
-**Pending — violation 9, prompt-attachment capability.** The reviewer found that
-widening `harnessSupportsPromptAttachments` in `client/module_core` to a second
-harness id violates the plugin-boundary invariant, and that the compliant fix is
-an additive `PluginMetadata` capability flag following the existing
-`supportsSessionOptions` precedent. That is correct architecturally but expands
-scope into shared wire types, all four descriptors, and client code beyond this
-plan's three files. It is a user decision and is recorded in `TRACKER.md`.
+**Declined by the user — violation 9, prompt-attachment capability.** The
+reviewer found that widening `harnessSupportsPromptAttachments` in
+`client/module_core` to a second harness id violates the plugin-boundary
+invariant, and that the compliant fix is an additive `PluginMetadata` capability
+flag following the existing `supportsSessionOptions` precedent.
+
+The finding is architecturally correct. The user decided on 2026-08-04 to widen
+the existing gate as planned, and that decision supersedes the review. The
+reasoning: the fix expands scope into shared wire types, all four descriptors,
+and client code well beyond this plan's three client files, and the gate it
+targets is already marked temporary with a dated comment. It also is not the
+one-line change it appears to be — a plain `@Default(false)` would silently
+disable OpenCode attachments for a new app against an older bridge, so the field
+would have to be nullable with a dated legacy fallback, since absence genuinely
+means "old bridge, apply the legacy rule" rather than "not supported".
+
+Step 15 therefore widens the gate and keeps its dated comment. Do not reopen this
+without new evidence; the capability migration remains available as its own
+future PR.
 
 The corrected plan was not re-reviewed merely to obtain an approval verdict, per
 the repository's plan-review process.

--- a/.plan/active/claude-code-plugin/PROTOCOL.md
+++ b/.plan/active/claude-code-plugin/PROTOCOL.md
@@ -1,0 +1,219 @@
+# Claude Code stream-json Protocol: Ground Truth
+
+## Status
+
+- **State:** skeleton — every section below is unverified research until Step 2
+  replaces it with observed ground truth.
+- **Pinned CLI version:** _to be pinned in Step 2_ (development machine currently
+  has `2.1.221 (Claude Code)`).
+- **Supported floor (`ClaudePluginDescriptor.minVersion`):** _to be decided in
+  Step 2 from the observed capability set._
+- **Observed on:** _date + platform, recorded in Step 2._
+- **Cross-checked against:** _Agent SDK declaration files for the matching
+  release, recorded in Step 2 with the exact package version._
+
+This document is the single source of wire truth for the plugin. Later steps cite
+it instead of re-deriving shapes. When a verification finds something different
+from the research below, replace the research rather than annotating around it,
+and note the correction in `TRACKER.md` under Findings And Plan Deltas.
+
+Every heading marked **UNVERIFIED** carries a hypothesis from external research
+(the headless and Agent SDK documentation, the SDK's own declaration files, and
+two working open-source integrations). Step 2 must turn each into either a
+confirmed shape or a recorded absence — never leave a marker in place.
+
+## 1. Invocation
+
+**UNVERIFIED.** Hypothesis:
+
+```
+claude --input-format stream-json --output-format stream-json --verbose \
+       --include-partial-messages [--model <id>] [--permission-mode <mode>] \
+       [--session-id <uuid> | --resume <uuid>]
+```
+
+To record in Step 2:
+
+- The exact accepted flag set, from `claude --help` at the pinned version.
+- Whether `--verbose` is genuinely required for full stream-json output.
+- Whether `--include-partial-messages` is required for token-level deltas.
+- Whether `--permission-prompt-tool` (or an equivalent) is required for
+  `can_use_tool` control requests to arrive on stdout, or whether registering
+  callbacks in the `initialize` control request is sufficient.
+- Whether an `initialize` control request must be sent before the first turn,
+  and its exact payload.
+- The auto-update and telemetry environment variables the pinned version honors
+  for supervised children.
+- Confirmation that the process stays alive between turns while stdin is open.
+
+Fixed decisions that verification cannot change:
+
+- cwd is the session's directory; one process serves exactly one session.
+- The bridge's environment is inherited. `HOME` is **never** overridden —
+  doing so breaks macOS keychain lookup and reports a logged-in user as logged
+  out. `CLAUDE_CONFIG_DIR` is for test isolation only.
+
+## 2. Stdout Message Types
+
+**UNVERIFIED.** One JSON object per line. Hypothesised envelope set:
+
+| `type` | Key fields | Maps to |
+|---|---|---|
+| `system` / `init` | `session_id`, `model`, `tools`, `slash_commands`, `mcp_servers`, `capabilities` | init handshake, command catalog, capability detection |
+| `system` / `api_retry` | `attempt`, `max_retries`, `retry_delay_ms`, `error` | retry session status |
+| `system` / `permission_denied` | `tool_name`, `decision_reason_type` | local log only |
+| `assistant` | `message.content[]`, `parent_tool_use_id` | complete message envelope plus parts |
+| `user` | echoed message; carries `tool_result` blocks | tool completion, matched by `tool_use_id` |
+| `stream_event` | `event` (raw Anthropic SSE), `parent_tool_use_id`, `session_id` | live part deltas |
+| `result` | `result`, `total_cost_usd`, token counts, `session_id`, error subtypes | turn end → idle or error |
+| `control_request` | `request_id`, `request.subtype` | permissions and questions |
+| `control_response` | reply to requests we sent | model switch, interrupt acknowledgement |
+
+To record in Step 2: a captured real line for each type, trimmed and anonymized,
+plus the full `stream_event` inner event set actually observed
+(`message_start`, `content_block_start`, `content_block_delta` with its delta
+variants, `content_block_stop`, `message_delta`, `message_stop`), the exhaustive
+`result` subtype list, and every `system` subtype encountered.
+
+`parent_tool_use_id != null` marks subagent traffic. Confirm which subagent
+blocks are forwarded on the root process at the pinned version.
+
+## 3. Stdin Message Types
+
+**UNVERIFIED.** Hypothesised shapes:
+
+- User turn:
+  `{"type":"user","message":{"role":"user","content":[{"type":"text","text":…}]},
+  "session_id":…}`, with images as
+  `{"type":"image","source":{"type":"base64","media_type":…,"data":…}}`.
+- Control response:
+  `{"type":"control_response","response":{"subtype":"success","request_id":…,
+  "response":{…}}}`.
+- Control request:
+  `{"type":"control_request","request_id":…,"request":{"subtype":"interrupt"}}`,
+  plus `set_permission_mode` and `set_model` subtypes.
+
+To record in Step 2: the exact envelope the pinned CLI accepts for each, the
+exhaustive control-request subtype list it supports, whether `session_id` is
+required on the user turn, and the error shape when a malformed frame is sent.
+
+## 4. Permission Protocol
+
+**UNVERIFIED.** Hypothesis: `can_use_tool` control requests carry `tool_name`,
+`input`, and optionally `permission_suggestions`, `blocked_path`, and
+`decision_reason`. The response payload is
+`{"behavior":"allow"|"deny", "updatedInput":{…}, "updatedPermissions":[…],
+"message":"…"}`.
+
+Fixed mapping decisions, independent of verification:
+
+| Sesori reply | Claude response |
+|---|---|
+| `once` | plain `allow`; **never** send `updatedPermissions` |
+| `always` | `allow` plus an echo of the request's own `permission_suggestions` when present, else a plain allow — never a broader rule than the backend itself suggested |
+| `reject` | `deny` with a short message |
+
+Two tools are questions rather than permissions:
+
+- **`AskUserQuestion`** — `input.questions[]` carries question, header, options,
+  and multi-select, which maps onto `PluginQuestionInfo` directly. The reply is
+  `allow` with `updatedInput`. **UNVERIFIED:** whether answer keys are the full
+  question text at the pinned version. Research says yes for SDK ≥ 2.1.121;
+  confirm against a real request before Step 9 consumes it.
+- **`ExitPlanMode`** — becomes an approve-or-keep-planning question whose body is
+  `input.plan`. Approve replies `allow` and then returns the permission mode to
+  default; keep-planning replies `deny` with a continue-planning message.
+
+To record in Step 2: a captured `can_use_tool` request for an ordinary tool, one
+for `AskUserQuestion`, and one for `ExitPlanMode`, plus the observed effect of
+each response variant.
+
+## 5. Session Storage
+
+**UNVERIFIED.** Hypothesis: transcripts live at
+`$CLAUDE_CONFIG_DIR ?? ~/.claude` + `/projects/<munged-cwd>/<session-id>.jsonl`.
+
+Fixed decisions:
+
+- The munged directory name is **never** un-munged. Each transcript's own records
+  supply `cwd`, timestamps, and title.
+- The filename minus `.jsonl` is the session id, cross-checked against record
+  content.
+- Subagent sidechains are excluded from enumeration.
+
+To record in Step 2: the exact record schema (one anonymized example per record
+kind), how sidechains are marked or separated, which record supplies a usable
+session title, whether a half-written trailing line is common in practice, and
+whether `--session-id` reliably pre-binds a new session's id.
+
+## 6. Models, Agents, And Modes
+
+**UNVERIFIED.** Hypotheses:
+
+- A model catalog is reachable from the CLI through a control request; the SDK
+  exposes it as a supported-models call. If it is unusable from the CLI, derive
+  from `system/init` plus a version-gated fallback list.
+- `set_model` switches models mid-session and `set_permission_mode` switches
+  modes.
+- Permission modes are `default`, `acceptEdits`, `plan`, `bypassPermissions`, and
+  possibly `dontAsk`.
+- Reasoning effort may be settable per session.
+
+Fixed decisions: only **Default** and **Plan** are exposed as agents in this
+series. Applied model and agent selections are cached per resident process and
+the cache is cleared on respawn.
+
+To record in Step 2: the working model-listing mechanism (or its confirmed
+absence), the exact `set_model` and `set_permission_mode` request and response
+shapes, the exhaustive permission-mode list, and whether per-session reasoning
+effort exists — which decides whether Step 11 ships model variants.
+
+## 7. Slash Commands
+
+**UNVERIFIED.** Hypothesis: `system/init.slash_commands` lists available commands
+and sending `/command args` as ordinary turn text executes them.
+
+To record in Step 2: whether slash text is actually parsed in stream-json mode.
+If it is not, `sendCommand` degrades to a `PluginOperationException` and the
+catalog reports no commands.
+
+## 8. Authentication
+
+Fixed decision: the plugin relies entirely on the user's existing `claude` login
+and never runs a login flow.
+
+**UNVERIFIED.** Probe options, in order of preference:
+
+1. A status-style subcommand, if the pinned CLI has one.
+2. A zero-token init probe: spawn stream-json with no prompt, read the init
+   response for account and auth information, then kill. Bounded by a timeout.
+3. Otherwise report `PluginSetupUnknown` with an action hint.
+
+To record in Step 2: which probe works, its observed latency, and the exact
+signal that distinguishes logged-in from logged-out.
+
+## 9. Known Traps
+
+Carried from prior integrations; each is a fixed constraint, not a hypothesis.
+
+1. Never override `HOME` for isolation — it breaks keychain lookup. Use
+   `CLAUDE_CONFIG_DIR` in tests only.
+2. On Windows, an npm-shim `claude.cmd` needs `runInShell`. The repository
+   already does this everywhere through the host process seam.
+3. `AskUserQuestion` answers are keyed by full question text (verify at the
+   pinned version, section 4).
+4. Unknown stream message types are absorbed with a debug log, never a warning
+   per line — the protocol adds message types frequently.
+5. A signal-killed child mid-turn surfaces as interrupted, not as an error.
+6. Pending permission and question requests must be resolved when a session stops
+   or its process exits, or the phone shows a stale card forever.
+7. Feature-detect from `system/init.capabilities` rather than sniffing versions
+   wherever possible.
+8. Idle resident processes cost real memory; reap them and rely on `--resume`.
+
+## 10. Captured Fixtures
+
+**Empty until Step 2.** Real captured lines, trimmed and anonymized, that the
+package's tests reuse as inline Dart literals. No golden files — that is the
+house style. Nothing here may contain prompt text, transcript content, file
+paths, account identifiers, or tokens.

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -28,10 +28,13 @@
   and put the two domain enums in `lib/src/models/` rather than `api/models/`;
   and made the approval registry's `respond` session-keyed rather than
   client-bound.
-- **Deferred to the user:** violation 9 — replacing the client's
+- **Declined by the user:** violation 9 — replacing the client's
   `harnessSupportsPromptAttachments` branch with a `PluginMetadata` capability
   flag. Architecturally correct, but it expands scope into shared wire types, all
-  four descriptors, and client code beyond this plan's three files.
+  four descriptors, and client code beyond this plan's three files, and the gate
+  is already dated and temporary. The user decided on 2026-08-04 to widen the
+  gate as planned; that decision supersedes the review and must not be reopened
+  without new evidence.
 - **Note:** the reviewer confirmed the protocol-verification changes are
   architecturally sound and flagged none of them, and treated the three
   user-locked decisions as binding.
@@ -122,6 +125,18 @@
   documentation-only step.
 
 ## Findings And Plan Deltas
+
+- **2026-08-04 — Prompt-attachment gate stays a client branch (user decision):**
+  plan review wanted a `PluginMetadata` capability flag replacing
+  `harnessSupportsPromptAttachments`. The user chose to widen the existing dated
+  gate instead, keeping this series scoped. Noted for whoever does the capability
+  migration later: a plain `@Default(false)` is wrong, because a new app against
+  an older bridge would silently lose OpenCode attachments — the field needs to
+  be nullable so absence can mean "old bridge, apply the legacy rule".
+- **2026-08-04 — One PR open at a time (user decision):** successors are built
+  locally and their PRs open only after the current PR merges. PR #739 (step 2)
+  was closed for this reason and reopens against `main` after #737 merges; its
+  branch and commits are intact.
 
 - **2026-08-04 — Route decision:** Bespoke stream-json over stdio rather than the
   `claude-agent-acp` Node adapter. The adapter would add a Node runtime

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -43,7 +43,7 @@
 
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
-| [x] | 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 1,700-1,900 | [PR #737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737) open; 1,784 changed lines after applying the plan review |
+| [x] | 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 1,200-1,400 | [PR #737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737) open; see the verification log for the measured diff |
 | [ ] | 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 1,100-1,500 | Not started |
 | [ ] | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,000-1,400 | Not started |
 | [ ] | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,100-1,500 | Not started |
@@ -119,13 +119,39 @@
   `maxInlineMessageAttachmentBytes`, `BufferedUntilFirstListener`,
   `PluginAuthenticationRequiredException`, `PluginStartAbortedException`,
   `HostProcessCommandExecutor`, `PluginValueOption`, and `PluginQuestionInfo`.
-  `.mcp.json` parses and `git diff --cached --check` passes. The staged diff is
-  997 changed lines; the original 500-800 estimate was corrected to 900-1,100
-  rather than published stale. No Dart or Flutter suites were run for this
-  documentation-only step.
+  `.mcp.json` parses and `git diff --cached --check` passes. No Dart or Flutter
+  suites were run for this documentation-only step.
+
+  **Changed-line measurement, corrected twice.** The figure first recorded here
+  was 997, taken from `git diff --cached --numstat` against a partially staged
+  tree — it undercounted. The correction to 1,784 was also wrong, measured
+  against a stale local `main` that was two commits behind the remote, which
+  added unrelated diff. The authoritative command is
+
+      git diff $(git merge-base origin/main HEAD) --numstat
+
+  which reports **1,300 changed lines** for this step including the review-fix
+  commits. Both earlier numbers are superseded; the method is recorded so the
+  figure can be re-derived rather than trusted.
 
 ## Findings And Plan Deltas
 
+- **2026-08-04 — Multi-turn residency PROVEN:** PR review challenged the
+  assumption that one process serves several turns, noting the CLI docs describe
+  stream-json as producing a final result and exiting. Verified directly: two
+  turns ran on one process, `poll()` confirmed it alive between them, both
+  returned `result` frames, and it exited 0 only when stdin was closed. The
+  architecture's residency model holds. A second `system/init` arrived with the
+  second turn, independently confirming that frame is turn-triggered.
+- **2026-08-04 — `--session-id` pre-binding PROVEN:** a run with a pre-generated
+  UUID produced `<that uuid>.jsonl`, and every record inside reported the same
+  `sessionId`. The plan still treats init's reported id as authoritative and
+  cross-checks it, because the identity chain is load-bearing for enumeration,
+  replay, resume, and delete.
+- **2026-08-04 — Respawn-state durability is an open question:** PR review asked
+  whether `--resume` restores the last-used model and whether an `always` grant
+  survives a respawn. Neither is answered yet; both are now recorded in PLAN.md
+  as pre-Step-10 evidence items with E2E rows 18a and 18b.
 - **2026-08-04 — Prompt-attachment gate stays a client branch (user decision):**
   plan review wanted a `PluginMetadata` capability flag replacing
   `harnessSupportsPromptAttachments`. The user chose to widen the existing dated

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -5,10 +5,10 @@
 - **Plan slug:** `claude-code-plugin`
 - **Implementation base:** `origin/main` at
   `ca7470fd6ead8f7e1ff0d58e3591e7ce25a5314d`
-- **Series state:** Step 1/17 in progress
+- **Series state:** Step 1/17 open for review
 - **Current step:** 1/17 — raise the plan
-- **Plan PR:** pending
-- **Next action:** open the Step 1 PR, then begin Step 2 protocol ground truth
+- **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737)
+- **Next action:** Step 2 protocol ground truth and package scaffold
 
 ## Plan Review
 
@@ -22,7 +22,7 @@
 
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
-| [x] | 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 900-1,100 | PR open |
+| [x] | 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 900-1,100 | [PR #737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737) open; 997 changed lines |
 | [ ] | 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 1,100-1,500 | Not started |
 | [ ] | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,000-1,400 | Not started |
 | [ ] | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,100-1,500 | Not started |

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -12,11 +12,29 @@
 
 ## Plan Review
 
-- **Verdict:** pending
+- **Verdict:** REJECTED, nine violations
 - **Reviewer:** `aristotle-plan-review`
-- **Date:** pending
-- **Reviewed scope:** `.plan/active/claude-code-plugin/PLAN.md`
-- **Applied corrections:** pending
+- **Date:** 2026-08-04
+- **Reviewed scope:** `.plan/active/claude-code-plugin/PLAN.md`, with
+  `TRACKER.md` and `PROTOCOL.md` as supporting context
+- **Applied corrections:** violations 1-8 applied directly and not re-reviewed,
+  per the repository plan-review process — added the Layer-2
+  `ClaudeSessionProcessRepository` so no `services/` file imports `api/`; moved
+  `initialize` DTO mapping into a new `ClaudeBackendCatalogRepository` and gave
+  the two catalogs distinct names; moved `ClaudeEventMapper` and
+  `ClaudeHistoryMapper` up to `lib/src/` to remove Layer-2 peer dependencies;
+  gave applied model/agent/mode a single owner; declared constructor
+  collaborators for every non-trivial class; declared the launch contract's files
+  and put the two domain enums in `lib/src/models/` rather than `api/models/`;
+  and made the approval registry's `respond` session-keyed rather than
+  client-bound.
+- **Deferred to the user:** violation 9 — replacing the client's
+  `harnessSupportsPromptAttachments` branch with a `PluginMetadata` capability
+  flag. Architecturally correct, but it expands scope into shared wire types, all
+  four descriptors, and client code beyond this plan's three files.
+- **Note:** the reviewer confirmed the protocol-verification changes are
+  architecturally sound and flagged none of them, and treated the three
+  user-locked decisions as binding.
 
 ## Delivery Steps
 

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -62,10 +62,13 @@
 
 ## Execution Rules
 
-- Merge in numeric order. A successor may target its immediate predecessor while
-  both are open, but each step must remain independently buildable and valid.
+- **Only one PR is open at a time.** Never stack a successor on an open
+  predecessor. Build the next step locally on its own branch and open its PR only
+  after the current one merges, so every PR targets `main`.
 - After a PR merges, continue automatically with the next numbered step without
   waiting for another user prompt. Stop only for a material decision or blocker.
+- Merge in numeric order; each step must remain independently buildable and
+  valid at its own base.
 - Count additions plus deletions, including generated files and tests, against
   each PR base. Target no more than 1,500 changed lines per PR as a soft cap;
   split coherently first or record why an expected overage is unavoidable.

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -1,0 +1,113 @@
+# Claude Code Harness Plugin: Tracker
+
+## Current State
+
+- **Plan slug:** `claude-code-plugin`
+- **Implementation base:** `origin/main` at
+  `ca7470fd6ead8f7e1ff0d58e3591e7ce25a5314d`
+- **Series state:** Step 1/17 in progress
+- **Current step:** 1/17 — raise the plan
+- **Plan PR:** pending
+- **Next action:** open the Step 1 PR, then begin Step 2 protocol ground truth
+
+## Plan Review
+
+- **Verdict:** pending
+- **Reviewer:** `aristotle-plan-review`
+- **Date:** pending
+- **Reviewed scope:** `.plan/active/claude-code-plugin/PLAN.md`
+- **Applied corrections:** pending
+
+## Delivery Steps
+
+| Done | Step | Branch | Exact PR title | Changed-line target | State |
+|---|---|---|---|---:|---|
+| [x] | 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 900-1,100 | PR open |
+| [ ] | 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 1,100-1,500 | Not started |
+| [ ] | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,000-1,400 | Not started |
+| [ ] | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,100-1,500 | Not started |
+| [ ] | 5/17 | `claude-code-plugin-content-mapper` | `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]` | 900-1,300 | Not started |
+| [ ] | 6/17 | `claude-code-plugin-history-mapper` | `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]` | 1,000-1,400 | Not started |
+| [ ] | 7/17 | `claude-code-plugin-tool-tracker` | `⚙️ [claude-code-plugin] feat(claude): track tool lifecycle [step 7/17]` | 1,000-1,400 | Not started |
+| [ ] | 8/17 | `claude-code-plugin-event-mapper` | `🚧 [claude-code-plugin] feat(claude): map stream events to SSE [step 8/17]` | 1,200-1,500 | Not started |
+| [ ] | 9/17 | `claude-code-plugin-approvals` | `🚧 [claude-code-plugin] feat(claude): add permission and question registry [step 9/17]` | 1,100-1,500 | Not started |
+| [ ] | 10/17 | `claude-code-plugin-session-service` | `🚧 [claude-code-plugin] feat(claude): add session residency and turn queue [step 10/17]` | 1,200-1,500 | Not started |
+| [ ] | 11/17 | `claude-code-plugin-catalog-service` | `⚙️ [claude-code-plugin] feat(claude): add model and agent catalog [step 11/17]` | 900-1,300 | Not started |
+| [ ] | 12/17 | `claude-code-plugin-plugin-impl` | `🚧 [claude-code-plugin] feat(claude): implement the plugin API surface [step 12/17]` | 1,200-1,500 | Not started |
+| [ ] | 13/17 | `claude-code-plugin-descriptor` | `⚙️ [claude-code-plugin] feat(claude): add descriptor and lifecycle [step 13/17]` | 1,100-1,500 | Not started |
+| [ ] | 14/17 | `claude-code-plugin-activation` | `⚙️ [claude-code-plugin] feat(claude): register the Claude Code harness [step 14/17]` | 250-500 | Not started |
+| [ ] | 15/17 | `claude-code-plugin-client-polish` | `🌿 [claude-code-plugin] feat(client): add Claude Code branding [step 15/17]` | 400-800 | Not started |
+| [ ] | 16/17 | `claude-code-plugin-e2e` | `🌿 [claude-code-plugin] docs: record Claude Code live verification [step 16/17]` | 200-500 | Not started |
+| [ ] | 17/17 | `claude-code-plugin-retire` | `🌱 [claude-code-plugin] docs: retire Claude Code plugin plan [step 17/17]` | 50-200 | Not started |
+
+## Exact PR Titles
+
+1. `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]`
+2. `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]`
+3. `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]`
+4. `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]`
+5. `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]`
+6. `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]`
+7. `⚙️ [claude-code-plugin] feat(claude): track tool lifecycle [step 7/17]`
+8. `🚧 [claude-code-plugin] feat(claude): map stream events to SSE [step 8/17]`
+9. `🚧 [claude-code-plugin] feat(claude): add permission and question registry [step 9/17]`
+10. `🚧 [claude-code-plugin] feat(claude): add session residency and turn queue [step 10/17]`
+11. `⚙️ [claude-code-plugin] feat(claude): add model and agent catalog [step 11/17]`
+12. `🚧 [claude-code-plugin] feat(claude): implement the plugin API surface [step 12/17]`
+13. `⚙️ [claude-code-plugin] feat(claude): add descriptor and lifecycle [step 13/17]`
+14. `⚙️ [claude-code-plugin] feat(claude): register the Claude Code harness [step 14/17]`
+15. `🌿 [claude-code-plugin] feat(client): add Claude Code branding [step 15/17]`
+16. `🌿 [claude-code-plugin] docs: record Claude Code live verification [step 16/17]`
+17. `🌱 [claude-code-plugin] docs: retire Claude Code plugin plan [step 17/17]`
+
+## Execution Rules
+
+- Merge in numeric order. A successor may target its immediate predecessor while
+  both are open, but each step must remain independently buildable and valid.
+- After a PR merges, continue automatically with the next numbered step without
+  waiting for another user prompt. Stop only for a material decision or blocker.
+- Count additions plus deletions, including generated files and tests, against
+  each PR base. Target no more than 1,500 changed lines per PR as a soft cap;
+  split coherently first or record why an expected overage is unavoidable.
+- Do not merge adjacent steps merely because one is small.
+- The app stays unaware of the plugin until Step 14, so no intermediate state
+  violates the full-`BridgePluginApi` rule. Wave-1 workspace, Makefile, and CI
+  plumbing still lands with the scaffold in Step 2, otherwise Steps 2–13 are
+  locally unbuildable and invisible to CI.
+- Generated files are regenerated, never hand-edited.
+- Every production class introduced by a step has a production consumer in that
+  step, or an explicitly named next-step consumer recorded in the PR body.
+- Run focused tests, owning-package full tests, `dart analyze --fatal-infos`,
+  `git diff --check`, and `aristotle-impl-review` for Steps 2–14. Steps 1 and
+  15–17 need only their own relevant validation.
+- Open every PR with `--body-file` and start monitoring with `pr-monitor:watch`.
+
+## Verification Log
+
+- Step 1/17 (2026-08-04): authored the plan, tracker, and protocol skeleton, and
+  registered mobile-mcp in `.mcp.json` for the Step 16 simulator run. The fixed
+  slug, seventeen exact titles, lifecycle boundaries, delivery order, and
+  changed-line estimates were cross-checked. Referenced repository symbols were
+  verified to exist before being cited: `SteadyPluginLifecycle`,
+  `BridgeDerivedProjectsPluginApi`, `PersistedSessionCleanupApi`,
+  `PluginSetupAuthenticationRequired`, `SemanticVersion`,
+  `resolveUserHomeDirectory`, `maxToolOutputLength`,
+  `maxInlineMessageAttachmentBytes`, `BufferedUntilFirstListener`,
+  `PluginAuthenticationRequiredException`, `PluginStartAbortedException`,
+  `HostProcessCommandExecutor`, `PluginValueOption`, and `PluginQuestionInfo`.
+  `.mcp.json` parses and `git diff --cached --check` passes. The staged diff is
+  997 changed lines; the original 500-800 estimate was corrected to 900-1,100
+  rather than published stale. No Dart or Flutter suites were run for this
+  documentation-only step.
+
+## Findings And Plan Deltas
+
+- **2026-08-04 — Route decision:** Bespoke stream-json over stdio rather than the
+  `claude-agent-acp` Node adapter. The adapter would add a Node runtime
+  dependency and hide protocol surface the parity scope needs.
+- **2026-08-04 — Scope decision:** Full core parity in this series — sessions,
+  streaming, tools, permissions and questions, plan mode, models, interrupt,
+  resume with history, slash commands, and images.
+- **2026-08-04 — Effort variants deferred to evidence:** Reasoning-effort
+  variants ship only if Step 2 finds first-party per-session support in the
+  pinned CLI. Step 11 records the decision either way.

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -40,7 +40,7 @@
 
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
-| [x] | 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 900-1,100 | [PR #737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737) open; 997 changed lines |
+| [x] | 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 1,700-1,900 | [PR #737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737) open; 1,784 changed lines after applying the plan review |
 | [ ] | 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 1,100-1,500 | Not started |
 | [ ] | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,000-1,400 | Not started |
 | [ ] | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,100-1,500 | Not started |


### PR DESCRIPTION
## Complexity

🌱 Trivial — documentation only. Three new plan files and one MCP config entry; no production code, no generated code, no tests.

## What

Raises the durable plan for adding **Claude Code** as a first-class Sesori harness, driven by the `claude` CLI's headless **stream-json** protocol over stdio.

- `.plan/active/claude-code-plugin/PLAN.md` — goal, success criteria, current-behavior evidence, locked scope, final architecture (package layout, component contracts, complete `BridgePluginApi` method mapping), two-wave registration, client touchpoints, cleanup assessment, delivery rules, the fixed 17-step sequence with per-step verification, the 20-check live matrix, compatibility, and risks with evidence levels.
- `.plan/active/claude-code-plugin/TRACKER.md` — fixed exact PR titles, execution rules, verification log, and the findings/deltas record.
- `.plan/active/claude-code-plugin/PROTOCOL.md` — skeleton ground-truth document. Every wire section is explicitly marked **UNVERIFIED** with its research hypothesis; Step 2 replaces each with an observed shape or a recorded absence.
- `.mcp.json` — registers `mobile-mcp` (the same server `opencode.json` already declares, translated to this file's schema) so the Step 16 simulator verification can run.

## Why

The README harness table still lists Claude Code as "Coming soon" — it is the flagship missing backend. The bridge already runs three plugins across the two shapes this needs (Cursor's port-less `SteadyPluginLifecycle`, Codex's global on-disk enumeration, ACP's stdio transport / approval registry / turn queue), and the client renders an unknown harness gracefully, so the groundwork exists.

The work is large enough to need a durable plan and a fixed PR series before implementation starts. The protocol skeleton exists separately because the stream-json control protocol is SDK-internal and unversioned: pinning its ground truth once, from direct observation, keeps thirteen later steps from each re-deriving wire shapes.

## Risk and test focus

**Risk: none.** No production code, no shared contracts, no generated output, no database or wire change.

- **User-visible behavior:** none.
- **Database:** no change.
- **Analytics:** none. Passive planning work with no authoritative user action.

Review focus is the plan itself: whether the step boundaries are independently valid and merge-ordered, whether the changed-line estimates are realistic against this repo's test-to-source ratio and committed Freezed output, and whether the architecture honors the layering, plugin-encapsulation, and no-speculative-machinery rules.

Two deliberate constraints worth checking:

- The plugin is registered only in **Step 14**, so no intermediate state ships a partial `BridgePluginApi`. But the workspace / Makefile / CI plumbing lands with the scaffold in **Step 2**, because all three lists are explicit — a package missing from them is locally unbuildable *and* invisible to CI.
- No new `MessagePartType` value is introduced anywhere in the series. That enum has no unknown fallback, so a new value would crash released clients.

## Expected result

`.plan/active/claude-code-plugin/` exists with three documents; `.mcp.json` declares `mobile-mcp` alongside `figma`. Nothing else changes and nothing builds differently.

## Verification

- `.mcp.json` parses (`python3 -m json.tool`).
- `git diff --check` passes.
- Every repository symbol cited in `PLAN.md` was verified to exist before being referenced: `SteadyPluginLifecycle`, `BridgeDerivedProjectsPluginApi`, `PersistedSessionCleanupApi`, `PluginSetupAuthenticationRequired`, `SemanticVersion`, `resolveUserHomeDirectory`, `maxToolOutputLength`, `maxInlineMessageAttachmentBytes`, `BufferedUntilFirstListener`, `PluginAuthenticationRequiredException`, `PluginStartAbortedException`, `HostProcessCommandExecutor`, `PluginValueOption`, `PluginQuestionInfo`.
- Diff is 997 changed lines. The initial 500-800 estimate was corrected to 900-1,100 in both `PLAN.md` and `TRACKER.md` rather than published stale.
- No Dart or Flutter suites were run: this is a documentation-only step.

https://claude.ai/code/session_01HuG5CqV5bHvpfS9aRcKMSN

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a durable plan for the Claude Code harness plugin using the `claude` CLI stream‑json protocol, with the protocol skeleton and a Step 1 tracker, and enforces a one‑open‑PR rule. Applies review feedback (fix delivery count, narrow scope guardrail, verify and make init `session_id` authoritative, add respawn‑durability checks), keeps the existing attachment‑gate decision, and updates Step 1 diff to ~1,300 lines; no production code.

- **Dependencies**
  - `.mcp.json`: add `mobile-mcp` via `npx -y @mobilenext/mobile-mcp@1.0.0` for the Step 16 simulator run.

<sup>Written for commit 529f7f2382005b73e3e6fbca5132687908185336. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

