### PR TITLE
🌿 fix(bridge): hide YOLO permission snapshots

### DIFF
--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -554,7 +554,10 @@ class Orchestrator {
         PostAgentsHandler(agentRepository),
         GetSessionQuestionsHandler(questionRepository: questionRepository),
         GetProjectQuestionsHandler(questionRepository: questionRepository),
-        GetSessionPermissionsHandler(permissionRepository: permissionRepository),
+        GetSessionPermissionsHandler(
+          permissionRepository: permissionRepository,
+          suppressPendingPermissions: config.yolo,
+        ),
         ReplyToQuestionHandler(pendingInteractionService: pendingInteractionService),
         RejectQuestionHandler(pendingInteractionService: pendingInteractionService),
         ReplyToPermissionHandler(pendingInteractionService: pendingInteractionService),

--- a/bridge/app/lib/src/bridge/routing/get_session_permissions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_session_permissions_handler.dart
@@ -8,14 +8,18 @@ import "request_handler.dart";
 /// (sub-agent) session whose top-most root resolves to this session.
 class GetSessionPermissionsHandler extends BodyRequestHandler<SessionIdRequest, PendingPermissionResponse> {
   final PermissionRepository _permissionRepository;
+  final bool _suppressPendingPermissions;
 
-  GetSessionPermissionsHandler({required PermissionRepository permissionRepository})
-    : _permissionRepository = permissionRepository,
-      super(
-        HttpMethod.post,
-        "/session/permissions",
-        fromJson: SessionIdRequest.fromJson,
-      );
+  GetSessionPermissionsHandler({
+    required PermissionRepository permissionRepository,
+    required bool suppressPendingPermissions,
+  }) : _permissionRepository = permissionRepository,
+       _suppressPendingPermissions = suppressPendingPermissions,
+       super(
+         HttpMethod.post,
+         "/session/permissions",
+         fromJson: SessionIdRequest.fromJson,
+       );
 
   @override
   Future<PendingPermissionResponse> handle(
@@ -28,6 +32,11 @@ class GetSessionPermissionsHandler extends BodyRequestHandler<SessionIdRequest, 
     final sessionId = body.sessionId;
     if (sessionId.isEmpty) {
       throw buildErrorResponse(request, 400, "empty session id");
+    }
+
+    // YOLO suppresses permission prompts from both live events and this snapshot path.
+    if (_suppressPendingPermissions) {
+      return const PendingPermissionResponse(data: []);
     }
 
     final permissions = await _permissionRepository.getPendingPermissions(sessionId: sessionId);

--- a/bridge/app/lib/src/bridge/routing/get_session_permissions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_session_permissions_handler.dart
@@ -34,12 +34,13 @@ class GetSessionPermissionsHandler extends BodyRequestHandler<SessionIdRequest, 
       throw buildErrorResponse(request, 400, "empty session id");
     }
 
-    // YOLO suppresses permission prompts from both live events and this snapshot path.
+    final permissions = await _permissionRepository.getPendingPermissions(sessionId: sessionId);
+
+    // Query first to preserve binding/plugin errors; YOLO suppresses only the snapshot response payload.
     if (_suppressPendingPermissions) {
       return const PendingPermissionResponse(data: []);
     }
 
-    final permissions = await _permissionRepository.getPendingPermissions(sessionId: sessionId);
     return PendingPermissionResponse(data: permissions);
   }
 }

--- a/bridge/app/test/bridge/routing/get_session_permissions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_session_permissions_handler_test.dart
@@ -82,6 +82,24 @@ void main() {
       );
     });
 
+    test("preserves not-found for an unknown session when pending permissions are suppressed", () async {
+      final suppressedHandler = GetSessionPermissionsHandler(
+        permissionRepository: singlePluginPermissionRepository(plugin: plugin, sessionDao: db.sessionDao),
+        suppressPendingPermissions: true,
+      );
+
+      await expectLater(
+        suppressedHandler.handle(
+          makeRequest("POST", "/session/permissions"),
+          body: const SessionIdRequest(sessionId: "unknown"),
+          pathParams: {},
+          queryParams: {},
+          fragment: null,
+        ),
+        throwsA(isA<PluginOperationException>().having((error) => error.isNotFound, "isNotFound", isTrue)),
+      );
+    });
+
     test("returns no pending permissions when snapshot suppression is enabled", () async {
       plugin.pendingPermissionsResult = [
         const PluginPendingPermission(

--- a/bridge/app/test/bridge/routing/get_session_permissions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_session_permissions_handler_test.dart
@@ -34,6 +34,7 @@ void main() {
       );
       handler = GetSessionPermissionsHandler(
         permissionRepository: singlePluginPermissionRepository(plugin: plugin, sessionDao: db.sessionDao),
+        suppressPendingPermissions: false,
       );
     });
 
@@ -61,6 +62,50 @@ void main() {
         ),
         throwsA(isA<RelayResponse>().having((r) => r.status, "status", equals(400))),
       );
+    });
+
+    test("returns 400 for an empty session id when pending permissions are suppressed", () async {
+      final suppressedHandler = GetSessionPermissionsHandler(
+        permissionRepository: singlePluginPermissionRepository(plugin: plugin, sessionDao: db.sessionDao),
+        suppressPendingPermissions: true,
+      );
+
+      await expectLater(
+        () => suppressedHandler.handle(
+          makeRequest("POST", "/session/permissions"),
+          body: const SessionIdRequest(sessionId: ""),
+          pathParams: {},
+          queryParams: {},
+          fragment: null,
+        ),
+        throwsA(isA<RelayResponse>().having((r) => r.status, "status", equals(400))),
+      );
+    });
+
+    test("returns no pending permissions when snapshot suppression is enabled", () async {
+      plugin.pendingPermissionsResult = [
+        const PluginPendingPermission(
+          id: "p-1",
+          sessionID: "backend-root",
+          displaySessionId: "backend-root",
+          tool: "bash",
+          description: "Run ls",
+        ),
+      ];
+      final suppressedHandler = GetSessionPermissionsHandler(
+        permissionRepository: singlePluginPermissionRepository(plugin: plugin, sessionDao: db.sessionDao),
+        suppressPendingPermissions: true,
+      );
+
+      final response = await suppressedHandler.handle(
+        makeRequest("POST", "/session/permissions"),
+        body: const SessionIdRequest(sessionId: "root"),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(response, const PendingPermissionResponse(data: []));
     });
 
     test("maps plugin permissions to shared, preserving displaySessionId", () async {
@@ -104,6 +149,7 @@ void main() {
       );
       final derivedHandler = GetSessionPermissionsHandler(
         permissionRepository: repository,
+        suppressPendingPermissions: false,
       );
 
       await expectLater(
@@ -181,6 +227,7 @@ void main() {
           plugin: derivedPlugin,
           sessionDao: db.sessionDao,
         ),
+        suppressPendingPermissions: false,
       );
 
       final response = await derivedHandler.handle(


### PR DESCRIPTION
## Complexity

🌿 Straightforward — this adds one localized configuration policy to the sole pending-permission snapshot handler and updates focused coverage.

## What

- Passes the bridge's YOLO setting into `GetSessionPermissionsHandler` as a required suppression policy.
- Returns an empty typed permission snapshot in YOLO mode after validating the request and before querying the backend.
- Adds regressions for snapshot suppression and preservation of empty-session validation.

## Why

YOLO already suppresses live permission events while auto-approving them, but a concurrent session-detail refresh could still read the backend permission before approval settled. Because the automatic reply event is also suppressed, the client could display a stale permission prompt that had already been approved.

## Risk and test focus

Low risk. The affected flow is limited to `POST /session/permissions` while YOLO is enabled. Tests verify normal mode still maps pending permissions, YOLO returns none even when the plugin reports one, and malformed requests still return 400. Auto-approval itself and session-family ordering remain unchanged.

## Expected result

- **User-visible:** Permission prompts no longer appear through session snapshots while YOLO mode is enabled.
- **Persisted/database:** No change.
- **Internal:** The live-event and snapshot exposure paths now enforce the same YOLO policy. No wire, client, analytics, or plugin-interface change.

## Verification

- TDD red: YOLO regression initially returned the plugin permission instead of an empty snapshot
- `dart test test/bridge/routing/get_session_permissions_handler_test.dart` — 10 passed
- Focused handler and auto-approval suites — 11 passed
- `dart analyze --fatal-infos` — no issues
- `dart test` — all 2,428 tests passed
- `git diff --check` — passed
- `aristotle-impl-review` — approved with no findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide pending permission snapshots when YOLO is enabled to prevent stale prompts during session refreshes and align with live-event suppression. Maintain backend error propagation while only suppressing the snapshot payload.

- **Bug Fixes**
  - Pass `config.yolo` into `GetSessionPermissionsHandler` as `suppressPendingPermissions`.
  - Query the repository first, then return an empty `PendingPermissionResponse` when suppression is on to preserve errors (e.g., not-found).
  - Keep validation: 400 on empty session ID; unknown sessions still raise plugin not-found.
  - Add tests for suppression, normal mapping, empty-session 400, and preserved not-found.

<sup>Written for commit be614780a0807c0675fa7fe5b6203a9dcabf25b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

