### PR TITLE
⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]

### DIFF
--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -62,6 +62,10 @@ jobs:
         run: dart analyze --fatal-infos
         working-directory: bridge/sesori_plugin_cursor
 
+      - name: Analyze sesori_plugin_claude
+        run: dart analyze --fatal-infos
+        working-directory: bridge/sesori_plugin_claude
+
       - name: Run tests for bridge/app
         run: dart test
         working-directory: bridge/app
@@ -93,6 +97,10 @@ jobs:
       - name: Run tests for sesori_plugin_cursor
         run: dart test
         working-directory: bridge/sesori_plugin_cursor
+
+      - name: Run tests for sesori_plugin_claude
+        run: dart test
+        working-directory: bridge/sesori_plugin_claude
 
   build-smoke:
     runs-on: ubuntu-latest

--- a/.plan/active/claude-code-plugin/PLAN.md
+++ b/.plan/active/claude-code-plugin/PLAN.md
@@ -105,25 +105,35 @@ The stream-json control protocol is SDK-internal and not formally versioned.
 direct observation of the pinned CLI plus the SDK's own type declarations, and
 every later step cites it rather than re-deriving wire shapes.
 
-Condensed research carried into Step 2 (all marked verify-at-implementation in
-`PROTOCOL.md`):
+Step 2 verified it against CLI 2.1.221 and
+`@anthropic-ai/claude-agent-sdk@0.3.221`. The findings that shape this plan:
 
-- Invocation: `claude --input-format stream-json --output-format stream-json
-  --verbose --include-partial-messages [--model <id>] [--permission-mode <mode>]
-  [--session-id <uuid> | --resume <uuid>]`, cwd = the session directory, one
-  process per session kept alive by streaming stdin.
-- Stdout types: `system` (`init`, `api_retry`, `permission_denied`),
-  `assistant`, `user`, `stream_event` (raw Anthropic SSE deltas), `result`,
-  `control_request`, `control_response`.
-- Permissions arrive as `can_use_tool` control requests answered with
-  `{"behavior":"allow"|"deny", ...}`; `AskUserQuestion` and `ExitPlanMode` are
-  ordinary tools whose approval is a user question rather than a permission.
-- Transcripts live at `$CLAUDE_CONFIG_DIR ?? ~/.claude` +
-  `/projects/<munged-cwd>/<session-id>.jsonl`; the filename is the session id
-  and each record carries its own `cwd` and timestamps, so the munged directory
-  name is never un-munged.
-- Auth is the user's existing `claude` login. The plugin never runs a login
-  flow and never overrides `HOME`, which would break macOS keychain lookup.
+- **`--permission-prompt-tool stdio` is mandatory.** Without it the CLI silently
+  auto-denies every permission-gated tool — no control request, no error, the
+  turn still reports success, and the refusal appears only in the result's
+  `permission_denials`. The flag is absent from `claude --help`. `-p/--print` is
+  likewise mandatory for the stream-json formats.
+- **One `initialize` round trip returns the whole catalog** — commands, agents,
+  models, and account — so the catalog service needs no separate startup probes.
+- **Effort is first-party and per model** (`supportsEffort`,
+  `supportedEffortLevels`), which settles the variant question in favor of
+  shipping variants.
+- **`requires_user_interaction` on a permission request** marks the asks whose
+  own card is the interaction surface, replacing a hardcoded tool-name list;
+  `suppress_always_allow_rule` forbids offering "always" for that ask.
+- **`claude auth status --json` reports `loggedIn`**, so the auth probe is a
+  fast structured subcommand rather than the planned init probe. Its payload
+  also carries PII that must never be logged.
+- **Transcripts** live at `$CLAUDE_CONFIG_DIR ?? ~/.claude` +
+  `/projects/<munged-cwd>/<session-id>.jsonl`. `ai-title` records carry the
+  session title and `isSidechain` marks subagent records; each record carries
+  its own `cwd`, so the munged directory name is never un-munged.
+- **Two message types the research missed** — `rate_limit_event` and
+  `system/status` — appeared in the very first capture, confirming that tolerant
+  unknown-type absorption is a requirement rather than a precaution.
+
+The plugin never runs a login flow and never overrides `HOME`, which would break
+macOS keychain lookup.
 
 ## Locked Scope And Product Decisions
 
@@ -252,10 +262,12 @@ bridge sent the signal, cancels that session's approvals, and drops residency.
 ids, permission/question bifurcation, and a `cancelForSession`/`dispose` contract
 that resolves every pending request *and* emits its replied or rejected event.
 Claude specifics: requests arrive on a known session's own process, so there is
-no session-resolution ambiguity; `AskUserQuestion` and `ExitPlanMode` become
+no session-resolution ambiguity; asks flagged `requires_user_interaction` become
 questions and everything else a permission; `once` maps to a plain allow,
-`always` echoes only the backend's own `permission_suggestions`, and `reject`
-maps to deny with a short message.
+`always` echoes only the backend's own `permission_suggestions` and is withheld
+entirely when `suppress_always_allow_rule` is set, and `reject` maps to deny with
+a short message. `decision_reason` may carry ANSI escapes and is sanitized before
+it reaches the phone.
 
 **`ClaudeEventMapper`** — the hard contract shared with the Codex and ACP
 mappers: every `info` map on a session or message event is sesori-schema JSON
@@ -291,7 +303,9 @@ declares id, displayName, `bridgeDerived` ownership, `plugin` options scope, and
 the single `bin` value option as a bare name that the bridge's option mapper
 namespaces to `--claude-bin`. `inspectSetup` runs a bounded `--version` probe
 through `HostProcessCommandExecutor`, applies the typed `SemanticVersion` floor,
-then probes auth, returning one of the five inspectable statuses — never
+then runs `claude auth status` and reads only its `loggedIn` field — the rest of
+that payload is PII and is neither logged nor retained — returning one of the
+five inspectable statuses — never
 `PluginSetupNotInspected`, which is the bridge's own disabled marker — with a
 non-empty `actionHint` on each non-ready variant. `start()` checks
 `host.startAborted` at entry and after construction, rolls back through
@@ -435,10 +449,10 @@ transport field, cache, flag, job, or test was found.
 | Step | Branch | Exact PR title | Estimate |
 |---|---|---|---:|
 | 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 900-1,100 |
-| 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 1,100-1,500 |
-| 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,000-1,400 |
-| 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,100-1,500 |
-| 5/17 | `claude-code-plugin-content-mapper` | `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]` | 900-1,300 |
+| 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 900-1,100 |
+| 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,200-1,500 |
+| 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,200-1,500 |
+| 5/17 | `claude-code-plugin-content-mapper` | `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]` | 1,000-1,400 |
 | 6/17 | `claude-code-plugin-history-mapper` | `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]` | 1,000-1,400 |
 | 7/17 | `claude-code-plugin-tool-tracker` | `⚙️ [claude-code-plugin] feat(claude): track tool lifecycle [step 7/17]` | 1,000-1,400 |
 | 8/17 | `claude-code-plugin-event-mapper` | `🚧 [claude-code-plugin] feat(claude): map stream events to SSE [step 8/17]` | 1,200-1,500 |
@@ -465,23 +479,42 @@ transport field, cache, flag, job, or test was found.
 
 ### Step 2/17 — Ground The Protocol And Scaffold The Package
 
-- Pin the CLI version; capture real stream-json transcripts and `--help` output;
+- Pin the CLI version; capture real stream-json frames and `--help` output;
   cross-check flags, control subtypes, the stdin user-message envelope, and the
   transcript record schema against the Agent SDK's own declarations.
 - Fill `PROTOCOL.md` with observed ground truth, replacing every verify marker
   with either a confirmed shape or a recorded absence.
 - Create the package with its pubspec, analysis options, build config, and
-  barrels, plus Wave-1 workspace, Makefile, and CI plumbing.
-- Add the Freezed and JSON DTOs for stream messages, control payloads, and
-  transcript records, with tolerant unknown variants, and run codegen.
+  barrel, plus Wave-1 workspace, Makefile, and CI plumbing.
+- Add the verified launch contract — the argument vector, the dual-spelled
+  permission mode, and the per-model effort level — with tests. This is the one
+  piece of the protocol every later step depends on, and it gives the package a
+  real test suite from its first commit so CI is meaningful.
 - Verify: `dart pub get` at `bridge/`, `dart analyze --fatal-infos` and
-  `dart test` in the new package, `make codegen`, implementation review.
+  `dart test` in the new package, implementation review.
+
+**DTOs land with their consumers, not here.** The original plan bundled every
+stream, control, and transcript DTO into this step. Measured against the Codex
+analog, Freezed expands roughly tenfold — `codex_rollout_dto.dart` is 326 source
+lines and 3,286 generated ones — so a full sealed envelope set would exceed this
+step's cap several times over with no production consumer in the same PR. Each
+DTO group therefore moves into the step that first consumes it: stream and
+control envelopes with the transport (Step 3), transcript records with the
+catalog (Step 4), and content blocks with the content mapper (Step 5). This also
+satisfies the repository rule that a production type has a production consumer
+in the PR that introduces it. The step total is unchanged.
 
 ### Step 3/17 — Add The Stream-JSON Transport
 
+- Add the stream-message and control-envelope DTOs this step consumes, with
+  tolerant unknown variants covering the `rate_limit_event` and `system/status`
+  types the original research missed, and run codegen.
 - Add `ClaudeStreamClient` with line framing, request-id correlation, lenient
   stderr decoding, redacted frame logging, generation fencing, pending-request
   failure on teardown, and platform-correct termination.
+- Perform the `initialize` handshake on connect and retain its response: it
+  carries the command, agent, model, and account catalog in one round trip, so
+  Step 11 needs no separate startup probes.
 - Add `FakeClaudeProcess` and the `claude_testing.dart` barrel.
 - Cover framing, exit mid-request, generation fencing, redaction, and
   unknown-type absorption.
@@ -489,8 +522,13 @@ transport field, cache, flag, job, or test was found.
 
 ### Step 4/17 — Enumerate Transcript Sessions
 
+- Add the transcript record DTOs this step consumes — `user`, `assistant`,
+  `attachment`, `ai-title`, `last-prompt`, `queue-operation`, and unknown — and
+  run codegen.
 - Add `ClaudeTranscriptApi` with injected-environment root resolution and
   `ClaudeCatalogRepository` with isolate-backed scanning.
+- Take the session title from `ai-title.aiTitle` and exclude records flagged
+  `isSidechain`; both are first-party fields, so neither needs a heuristic.
 - Add captured, trimmed, anonymized transcript fixtures as inline Dart literals.
 - Cover the scan, malformed lines, the half-written last line, sidechain
   exclusion, and privacy-safe diagnostics.
@@ -498,6 +536,7 @@ transport field, cache, flag, job, or test was found.
 
 ### Step 5/17 — Map Content Blocks To Parts
 
+- Add the content-block DTOs this step consumes and run codegen.
 - Add `ClaudeContentMapper` converting content blocks to plugin parts and
   attachments under the existing tool-output and inline-attachment limits.
 - Cover text, thinking, tool use, tool results, images, oversize degradation, and
@@ -534,6 +573,16 @@ transport field, cache, flag, job, or test was found.
 - Add `ClaudeApprovalRegistry` with permission/question bifurcation, the three
   reply behaviors, `AskUserQuestion` answer-key handling, `ExitPlanMode` approval,
   and teardown that resolves every pending request and emits its outcome.
+- Bifurcate on the request's own `requires_user_interaction` flag rather than a
+  hardcoded tool-name list, so the split stays correct as new
+  interaction-shaped tools appear.
+- Honor `suppress_always_allow_rule` by withholding the always affordance, and
+  sanitize ANSI escapes out of `decision_reason` before it reaches the phone.
+- Decide and record whether `always` may echo a `setMode` suggestion. The
+  observed suggestion for a file write was
+  `{type: setMode, mode: acceptEdits, destination: session}`, which escalates
+  the whole session rather than allowing one tool; the recommendation is to echo
+  rule-shaped suggestions only.
 - Cover cancel-on-abort, cancel-on-dispose, and cancel-on-process-exit.
 - Verify: focused and full package tests, fatal analysis, implementation review.
 
@@ -551,8 +600,14 @@ transport field, cache, flag, job, or test was found.
 - Add `ClaudeCatalogService` owning models, agents, providers, and commands, plus
   `set_model` and `set_permission_mode` application with an applied-selection
   cache cleared on respawn.
-- Record the reasoning-effort variant decision with the evidence gathered in
-  Step 2; ship without variants if the pinned CLI has no first-party support.
+- Source the catalog from the retained `initialize` response rather than
+  separate probes; `list_models` becomes the refresh path only.
+- Ship effort variants. Step 2 confirmed `supportsEffort` and
+  `supportedEffortLevels` are declared per model, so variants are first-party
+  data — default-first, and omitted entirely for models that declare no support.
+- Expose Default and Plan as agents driving `set_permission_mode`. Claude's own
+  `agents` array is deliberately not mapped; surfacing it is a follow-up outside
+  this series.
 - Verify: focused and full package tests, fatal analysis, implementation review.
 
 ### Step 12/17 — Implement The Plugin API Surface
@@ -659,7 +714,7 @@ quota, so prompts stay minimal.
 | Risk | Evidence level | Mitigation |
 |---|---|---|
 | The stream-json control protocol is SDK-internal and drifts between CLI releases. | Known upstream property | Pin a floor in `inspectSetup`, feature-detect from `init.capabilities`, parse tolerantly, and keep `PROTOCOL.md` as dated ground truth for the pinned version. |
-| Verify-at-implementation items (stdin envelope, control subtypes, permission-prompt flag, model listing, effort support, slash dispatch, auth probe, transcript schema) turn out different from the research. | Unresolved by design | Step 2 resolves each against the pinned CLI and the SDK declarations before any consumer is written; each resolution is recorded in `PROTOCOL.md`. |
+| Verify-at-implementation items turn out different from the research. | Mostly resolved | Step 2 resolved the stdin envelope, control subtypes, permission-prompt flag, model listing, effort support, auth probe, and transcript schema against the pinned CLI and the SDK declarations, and found the research wrong about the invocation and the permission flag. The remainder — error `result` subtypes, `AskUserQuestion`/`ExitPlanMode` captures, image round-trip, slash dispatch, `attachment` payload, and the auto-update environment variables — are listed in `PROTOCOL.md` section 11 against the steps that consume them. |
 | The auth probe costs seconds inside `inspectSetup`. | Ordinary flow | Run the version probe first, bound the auth probe, and accept `PluginSetupUnknown` as honest degradation. |
 | Overriding `HOME` for test isolation breaks keychain auth and reports a logged-in user as logged out. | Observed in prior integrations | Never override `HOME`; isolate tests through `CLAUDE_CONFIG_DIR` only, and assert that in the transcript tests. |
 | A stale permission or question card survives a stop, an abort, or a process exit. | Observed in prior integrations | The registry teardown contract resolves every pending request and emits its outcome; Steps 9 and 10 cover all three paths. |

--- a/.plan/active/claude-code-plugin/PROTOCOL.md
+++ b/.plan/active/claude-code-plugin/PROTOCOL.md
@@ -2,218 +2,435 @@
 
 ## Status
 
-- **State:** skeleton — every section below is unverified research until Step 2
-  replaces it with observed ground truth.
-- **Pinned CLI version:** _to be pinned in Step 2_ (development machine currently
-  has `2.1.221 (Claude Code)`).
-- **Supported floor (`ClaudePluginDescriptor.minVersion`):** _to be decided in
-  Step 2 from the observed capability set._
-- **Observed on:** _date + platform, recorded in Step 2._
-- **Cross-checked against:** _Agent SDK declaration files for the matching
-  release, recorded in Step 2 with the exact package version._
+- **State:** verified against a live CLI. Sections below are observed fact unless
+  explicitly marked **OPEN**.
+- **Pinned CLI version:** `2.1.221 (Claude Code)`.
+- **Cross-checked against:** `@anthropic-ai/claude-agent-sdk@0.3.221`
+  (`package/sdk.d.ts` for declared shapes, `package/sdk.mjs` for the exact
+  argument vector the SDK builds). The SDK patch number tracks the CLI's.
+- **Observed on:** 2026-08-04, macOS (darwin 25.6.0), account on a `max`
+  subscription with first-party (`claude.ai` OAuth) auth.
+- **Method:** a Python driver held one long-lived process open over stdio,
+  recorded every frame verbatim, and answered control requests. Captures live in
+  the session scratchpad, not in the repository — transcript and prompt content
+  is user data.
 
-This document is the single source of wire truth for the plugin. Later steps cite
-it instead of re-deriving shapes. When a verification finds something different
-from the research below, replace the research rather than annotating around it,
-and note the correction in `TRACKER.md` under Findings And Plan Deltas.
-
-Every heading marked **UNVERIFIED** carries a hypothesis from external research
-(the headless and Agent SDK documentation, the SDK's own declaration files, and
-two working open-source integrations). Step 2 must turn each into either a
-confirmed shape or a recorded absence — never leave a marker in place.
+This document is the single source of wire truth for the plugin. Later steps
+cite it instead of re-deriving shapes. When a later observation contradicts it,
+replace the text here and record the correction in `TRACKER.md` under Findings
+And Plan Deltas.
 
 ## 1. Invocation
 
-**UNVERIFIED.** Hypothesis:
+**Verified.** The working invocation is:
 
 ```
-claude --input-format stream-json --output-format stream-json --verbose \
-       --include-partial-messages [--model <id>] [--permission-mode <mode>] \
+claude -p --input-format stream-json --output-format stream-json \
+       --verbose --include-partial-messages \
+       --permission-prompt-tool stdio \
+       [--permission-mode <mode>] [--model <id>] [--effort <level>] \
        [--session-id <uuid> | --resume <uuid>]
 ```
 
-To record in Step 2:
+Load-bearing details, each observed:
 
-- The exact accepted flag set, from `claude --help` at the pinned version.
-- Whether `--verbose` is genuinely required for full stream-json output.
-- Whether `--include-partial-messages` is required for token-level deltas.
-- Whether `--permission-prompt-tool` (or an equivalent) is required for
-  `can_use_tool` control requests to arrive on stdout, or whether registering
-  callbacks in the `initialize` control request is sufficient.
-- Whether an `initialize` control request must be sent before the first turn,
-  and its exact payload.
-- The auto-update and telemetry environment variables the pinned version honors
-  for supervised children.
-- Confirmation that the process stays alive between turns while stdin is open.
+- **`-p` / `--print` is mandatory.** `--input-format`, `--output-format`,
+  `--include-partial-messages`, and `--forward-subagent-text` are all documented
+  as "only works with `--print`". The plan's original research omitted it.
+- **`--permission-prompt-tool stdio` is REQUIRED to receive permission
+  requests.** This is the single most important finding. The flag does not
+  appear in `claude --help`; it was found in `sdk.mjs`, which builds
+  `if (canUseTool) push("--permission-prompt-tool", "stdio")`. Empirically:
+  - without it, a permission-gated tool is **silently auto-denied**. No
+    `control_request` is emitted, the turn completes `subtype: "success"`, and
+    the only trace is an entry in `result.permission_denials`;
+  - an `initialize` control request alone does **not** enable prompts;
+  - with it, `can_use_tool` arrives as documented in section 4.
 
-Fixed decisions that verification cannot change:
-
+  A plugin that omits this flag would appear to work while every write, edit,
+  and command was refused. Its presence is not optional and must have a test.
+- **The process exits when stdin closes.** Keeping stdin open is what makes the
+  process long-lived across turns. This is the residency mechanism.
 - cwd is the session's directory; one process serves exactly one session.
-- The bridge's environment is inherited. `HOME` is **never** overridden —
-  doing so breaks macOS keychain lookup and reports a logged-in user as logged
-  out. `CLAUDE_CONFIG_DIR` is for test isolation only.
+- The bridge's environment is inherited. `HOME` is **never** overridden — doing
+  so breaks macOS keychain lookup and reports a logged-in user as logged out.
+  `CLAUDE_CONFIG_DIR` is for test isolation only.
+- The SDK writes resume as `--resume=<id>` (single token). Both forms are
+  accepted; match the SDK.
+
+**OPEN:** the auto-update and telemetry environment variables to set for a
+supervised child. Not yet probed; resolve before the descriptor lands.
+
+### Flags relevant to this plugin
+
+| Flag | Status | Note |
+|---|---|---|
+| `--session-id <uuid>` | verified | Must be a valid UUID. Pre-binds a new session's id. |
+| `--resume [value]` | verified | Resumes by session id. |
+| `--fork-session` | verified present | Out of scope. |
+| `--effort <level>` | verified | `low`, `medium`, `high`, `xhigh`, `max`. |
+| `--agent <agent>` | verified present | Selects a first-party agent. See section 6. |
+| `--permission-mode <mode>` | verified | Choices differ from the control API — see section 6. |
+| `--forward-subagent-text` | verified present | Opt-in; forwards subagent text/thinking with `parent_tool_use_id` set. Not used in v1. |
+| `--replay-user-messages` | verified present | Re-emits stdin user messages on stdout for acknowledgment. Candidate for `sendPrompt` acceptance. |
+| `--include-hook-events` | verified present | Not used. |
+| `--no-session-persistence` | verified present | Must **not** be used — it disables the transcripts the catalog enumerates. |
 
 ## 2. Stdout Message Types
 
-**UNVERIFIED.** One JSON object per line. Hypothesised envelope set:
+**Verified.** One JSON object per line. Every frame carries `uuid` and
+`session_id`.
 
-| `type` | Key fields | Maps to |
+| `type` | Observed key fields | Maps to |
 |---|---|---|
-| `system` / `init` | `session_id`, `model`, `tools`, `slash_commands`, `mcp_servers`, `capabilities` | init handshake, command catalog, capability detection |
-| `system` / `api_retry` | `attempt`, `max_retries`, `retry_delay_ms`, `error` | retry session status |
-| `system` / `permission_denied` | `tool_name`, `decision_reason_type` | local log only |
-| `assistant` | `message.content[]`, `parent_tool_use_id` | complete message envelope plus parts |
+| `system` / `init` | `session_id`, `model`, `permissionMode`, `capabilities`, `tools`, `slash_commands`, `agents`, `skills`, `plugins`, `mcp_servers`, `output_style`, `apiKeySource`, `claude_code_version`, `cwd`, `memory_paths`, `uuid` | init handshake, capability detection |
+| `system` / `status` | `status` (e.g. `"requesting"`) | work-state signal |
+| `rate_limit_event` | `rate_limit_info` = `{status, resetsAt, rateLimitType, overageStatus, overageDisabledReason, isUsingOverage}` | rate-limit surface |
+| `assistant` | `message` (full Anthropic message), `parent_tool_use_id`, `timestamp`, `request_id` | complete message envelope plus parts |
 | `user` | echoed message; carries `tool_result` blocks | tool completion, matched by `tool_use_id` |
-| `stream_event` | `event` (raw Anthropic SSE), `parent_tool_use_id`, `session_id` | live part deltas |
-| `result` | `result`, `total_cost_usd`, token counts, `session_id`, error subtypes | turn end → idle or error |
+| `stream_event` | `event` (raw Anthropic SSE), `parent_tool_use_id`, `uuid`, `ttft_ms` on `message_start` | live part deltas |
+| `result` | see below | turn end |
 | `control_request` | `request_id`, `request.subtype` | permissions and questions |
-| `control_response` | reply to requests we sent | model switch, interrupt acknowledgement |
+| `control_response` | `response.subtype`, `response.request_id`, `response.response` | replies to our requests |
 
-To record in Step 2: a captured real line for each type, trimmed and anonymized,
-plus the full `stream_event` inner event set actually observed
-(`message_start`, `content_block_start`, `content_block_delta` with its delta
-variants, `content_block_stop`, `message_delta`, `message_stop`), the exhaustive
-`result` subtype list, and every `system` subtype encountered.
+`rate_limit_event` and `system/status` were **not** in the plan's research. They
+confirm why tolerant unknown-type absorption is mandatory rather than defensive.
 
-`parent_tool_use_id != null` marks subagent traffic. Confirm which subagent
-blocks are forwarded on the root process at the pinned version.
+### `stream_event` inner events
+
+Observed for a plain text turn, in order: `message_start`,
+`content_block_start`, `content_block_delta` (×N, `delta.type = "text_delta"`),
+`content_block_stop`, `message_delta` (carries `stop_reason` and final usage),
+`message_stop`.
+
+**Ordering trap, verified:** the complete `assistant` envelope arrives
+**before** `content_block_stop` / `message_delta` / `message_stop`, not after
+the stream events. The mapper must not assume "all deltas, then the complete
+message".
+
+**Model id trap, verified:** `init.model` was `claude-opus-5[1m]` while the same
+turn's `message_start.message.model` and `assistant.message.model` were
+`claude-opus-5`. The `[1m]` context-window suffix is a *selection* token, not
+the resolved model. Stamp message envelopes from `message.model`; use the
+catalog's `resolvedModel` when mapping a selection back to a display name.
+
+### `result`
+
+Observed keys: `subtype`, `is_error`, `result`, `stop_reason`,
+`terminal_reason`, `duration_ms`, `duration_api_ms`, `time_to_request_ms`,
+`ttft_ms`, `ttft_stream_ms`, `num_turns`, `total_cost_usd`, `usage`,
+`modelUsage`, `api_error_status`, `permission_denials`, `fast_mode_state`,
+`fast_mode_disabled_reason`, `session_id`, `uuid`.
+
+A successful turn is `subtype: "success"`, `is_error: false`,
+`stop_reason: "end_turn"`, `terminal_reason: "completed"`.
+
+`permission_denials` is an array of `{tool_name, tool_use_id, tool_input}`. It
+is populated when a tool was refused **without** the host being asked — the
+silent-denial signature described in section 1.
+
+**OPEN:** the exhaustive `subtype` and `terminal_reason` value sets for error
+turns (usage limit, auth expiry, max turns). Capture before the event mapper
+maps error envelopes.
 
 ## 3. Stdin Message Types
 
-**UNVERIFIED.** Hypothesised shapes:
+**Verified.** The following were accepted by the pinned CLI:
 
-- User turn:
-  `{"type":"user","message":{"role":"user","content":[{"type":"text","text":…}]},
-  "session_id":…}`, with images as
-  `{"type":"image","source":{"type":"base64","media_type":…,"data":…}}`.
-- Control response:
-  `{"type":"control_response","response":{"subtype":"success","request_id":…,
-  "response":{…}}}`.
+- User turn — `session_id` may be included and was accepted:
+  ```json
+  {"type":"user","message":{"role":"user","content":[{"type":"text","text":"…"}]},"session_id":"…"}
+  ```
 - Control request:
-  `{"type":"control_request","request_id":…,"request":{"subtype":"interrupt"}}`,
-  plus `set_permission_mode` and `set_model` subtypes.
+  ```json
+  {"type":"control_request","request_id":"init-1","request":{"subtype":"initialize"}}
+  ```
+- Control response (answering `can_use_tool`):
+  ```json
+  {"type":"control_response","response":{"subtype":"success","request_id":"…","response":{"behavior":"deny","message":"…"}}}
+  ```
 
-To record in Step 2: the exact envelope the pinned CLI accepts for each, the
-exhaustive control-request subtype list it supports, whether `session_id` is
-required on the user turn, and the error shape when a malformed frame is sent.
+`request_id` is caller-minted for requests we send (the CLI echoes it back) and
+CLI-minted (a UUID) for requests it sends us.
 
-## 4. Permission Protocol
+**OPEN:** the image content-block shape has not been exercised live. The SDK
+declares the standard Anthropic
+`{"type":"image","source":{"type":"base64","media_type":…,"data":…}}`; verify
+before the attachment gate is widened in Step 15.
 
-**UNVERIFIED.** Hypothesis: `can_use_tool` control requests carry `tool_name`,
-`input`, and optionally `permission_suggestions`, `blocked_path`, and
-`decision_reason`. The response payload is
-`{"behavior":"allow"|"deny", "updatedInput":{…}, "updatedPermissions":[…],
-"message":"…"}`.
+### Control request subtypes
 
-Fixed mapping decisions, independent of verification:
+Declared in `sdk.d.ts` (names verified; only the marked ones exercised live):
+
+`initialize` ✓, `can_use_tool` ✓ (inbound), `interrupt`, `set_model`,
+`set_permission_mode`, `set_max_thinking_tokens`, `list_models`,
+`rename_session`, `get_plan`, `get_workspace_diff`, `get_context_usage`,
+`get_session_cost`, `get_usage`, `get_settings`, `apply_flag_settings`,
+`get_binary_version`, `read_file`, `rewind_files`, `seed_read_state`,
+`register_repo_root`, `set_color`, `stop_task`, `background_tasks`,
+`cancel_async_message`, `cancel`, `elicitation`, `request_user_dialog`,
+`file_suggestions`, `reload_plugins`, `reload_skills`, `mcp_*`.
+
+Exact shapes for the ones this plugin uses:
+
+```ts
+{subtype: 'interrupt', cancel_queued?: boolean}
+{subtype: 'set_model', model?: string | null}   // null/'default' resets
+{subtype: 'set_permission_mode', mode: PermissionMode}
+{subtype: 'list_models'}
+{subtype: 'rename_session', title: string}
+```
+
+`interrupt.cancel_queued` also cancels queued commands and is gated by the
+`interrupt_cancel_queued_v1` capability, which the observed `init.capabilities`
+advertised. A Stop button sets it true so one round-trip halts the session.
+
+## 4. The `initialize` Handshake
+
+**Verified.** Every field of the request is optional; `{"subtype":"initialize"}`
+is valid. Useful fields: `hooks`, `agents`, `systemPrompt`,
+`appendSystemPrompt`, `planModeInstructions`, `toolAliases`, `title`, `skills`,
+`forwardSubagentText`, `supportedDialogKinds`.
+
+**The response is the whole catalog.** Observed top-level keys:
+
+```
+account, agents, available_output_styles, commands, fast_mode_disabled_reason,
+fast_mode_state, ide_rc_auto_enable_gate, models, output_style, pid,
+remote_control_auto_enable, remote_control_auto_on_by_default
+```
+
+- `commands` — 66 entries of `{name, description, argumentHint}`. This is the
+  slash-command catalog; no separate probe is needed.
+- `agents` — 5 entries of `{name, description}`. First-party agents. See the
+  design note in section 6.
+- `models` — the model catalog, shape below.
+- `account` — `{apiProvider, email, organization, subscriptionType}`.
+  **Contains PII.** Never log or forward it; the plugin may read only what it
+  needs and must not persist the rest.
+- `pid` — the CLI's process id.
+
+One handshake therefore yields commands, agents, models, and account state
+together. The catalog service needs no separate startup probes.
+
+### `models`
+
+```json
+{
+  "value": "opus[1m]",
+  "resolvedModel": "claude-opus-5[1m]",
+  "displayName": "Opus (1M context)",
+  "description": "Opus 5 with 1M context · Best for everyday, complex tasks",
+  "supportsEffort": true,
+  "supportedEffortLevels": ["low", "medium", "high", "xhigh", "max"],
+  "supportsAdaptiveThinking": true,
+  "supportsFastMode": true,
+  "supportsAutoMode": true
+}
+```
+
+Five models were returned; `value: "default"` is the session default entry.
+Effort support is declared **per model** — the Haiku entry carried no effort
+fields at all.
+
+**This resolves the Step 11 effort question: variants are first-party and
+declared.** `supportedEffortLevels` maps directly onto codex-style
+`PluginModel.variants`, default-first, with models lacking the field shipping
+without variants. No hardcoded catalog and no version gate is required.
+
+## 5. Permission Protocol
+
+**Verified live.** With `--permission-prompt-tool stdio`, a `Write` in `manual`
+mode produced:
+
+```json
+{"type":"control_request","request_id":"<uuid>","request":{
+  "subtype":"can_use_tool","tool_name":"Write","display_name":"Write",
+  "input":{"file_path":"…","content":"hello\n"},
+  "description":"probe.txt",
+  "permission_suggestions":[{"type":"setMode","mode":"acceptEdits","destination":"session"}],
+  "tool_use_id":"toolu_…"}}
+```
+
+Replying `{"behavior":"deny","message":"…"}` was accepted and the turn completed
+normally with the model explaining the block.
+
+Full declared request shape (`SDKControlPermissionRequest`), with the fields the
+plan's research did not have:
+
+| Field | Meaning for the registry |
+|---|---|
+| `tool_name`, `display_name`, `description`, `input` | card content |
+| `tool_use_id` | **links the permission to its tool part** |
+| `agent_id` | set for subagent-originated asks |
+| `permission_suggestions` | the only rules `always` may ever echo |
+| `blocked_path` | path that triggered the ask |
+| `decision_reason` | **may contain ANSI escapes — sanitize before rendering** |
+| `decision_reason_type` | typed: `rule`, `mode`, `subcommandResults`, `permissionPromptTool`, `hook`, `asyncAgent`, `sandboxOverride`, `workingDir`, `safetyCheck`, `classifier`, `other` |
+| `classifier_approvable` | false = a safety check requires manual approval |
+| `suppress_always_allow_rule` | **true = the host MUST NOT offer "always"** |
+| `matched_ask_rule` | a user ask-rule forced this prompt |
+| `requires_user_interaction` | **true = one-tap approve/deny must not be offered; the tool's own card is the interaction surface** |
+
+Two of these change the planned design:
+
+1. **`requires_user_interaction` replaces the hardcoded tool-name list.** The
+   plan proposed bifurcating permissions from questions by matching
+   `AskUserQuestion` and `ExitPlanMode` by name. The CLI declares this
+   first-party. Bifurcate on the flag, not on names — it stays correct as new
+   interaction-shaped tools appear.
+2. **`suppress_always_allow_rule` is a hard constraint.** When set, the phone
+   must not render an "always" affordance, because accepting it would write a
+   rule broader than the ask's own verb.
+
+Fixed reply mapping (unchanged by verification):
 
 | Sesori reply | Claude response |
 |---|---|
-| `once` | plain `allow`; **never** send `updatedPermissions` |
-| `always` | `allow` plus an echo of the request's own `permission_suggestions` when present, else a plain allow — never a broader rule than the backend itself suggested |
+| `once` | plain `allow`; never send `updatedPermissions` |
+| `always` | `allow` plus an echo of the request's own `permission_suggestions`; never a broader rule; not offered at all when `suppress_always_allow_rule` is set |
 | `reject` | `deny` with a short message |
 
-Two tools are questions rather than permissions:
+**Design note on `permission_suggestions`:** the observed suggestion was
+`{"type":"setMode","mode":"acceptEdits","destination":"session"}` — a *session
+mode change*, not a per-tool rule. Echoing it for `always` would switch the
+whole session to auto-accepting edits, which is materially broader than "always
+allow this tool". Step 9 must decide whether `always` echoes `setMode`
+suggestions or only rule-shaped ones. Recommendation: echo rule-shaped
+suggestions and decline to escalate on `setMode`.
 
-- **`AskUserQuestion`** — `input.questions[]` carries question, header, options,
-  and multi-select, which maps onto `PluginQuestionInfo` directly. The reply is
-  `allow` with `updatedInput`. **UNVERIFIED:** whether answer keys are the full
-  question text at the pinned version. Research says yes for SDK ≥ 2.1.121;
-  confirm against a real request before Step 9 consumes it.
-- **`ExitPlanMode`** — becomes an approve-or-keep-planning question whose body is
-  `input.plan`. Approve replies `allow` and then returns the permission mode to
-  default; keep-planning replies `deny` with a continue-planning message.
-
-To record in Step 2: a captured `can_use_tool` request for an ordinary tool, one
-for `AskUserQuestion`, and one for `ExitPlanMode`, plus the observed effect of
-each response variant.
-
-## 5. Session Storage
-
-**UNVERIFIED.** Hypothesis: transcripts live at
-`$CLAUDE_CONFIG_DIR ?? ~/.claude` + `/projects/<munged-cwd>/<session-id>.jsonl`.
-
-Fixed decisions:
-
-- The munged directory name is **never** un-munged. Each transcript's own records
-  supply `cwd`, timestamps, and title.
-- The filename minus `.jsonl` is the session id, cross-checked against record
-  content.
-- Subagent sidechains are excluded from enumeration.
-
-To record in Step 2: the exact record schema (one anonymized example per record
-kind), how sidechains are marked or separated, which record supplies a usable
-session title, whether a half-written trailing line is common in practice, and
-whether `--session-id` reliably pre-binds a new session's id.
+**OPEN:** live `can_use_tool` captures for `AskUserQuestion` and `ExitPlanMode`,
+including whether answer keys are the full question text. Capture before Step 9.
 
 ## 6. Models, Agents, And Modes
 
-**UNVERIFIED.** Hypotheses:
+**Verified — the CLI flag and the control API disagree on one name.**
 
-- A model catalog is reachable from the CLI through a control request; the SDK
-  exposes it as a supported-models call. If it is unusable from the CLI, derive
-  from `system/init` plus a version-gated fallback list.
-- `set_model` switches models mid-session and `set_permission_mode` switches
-  modes.
-- Permission modes are `default`, `acceptEdits`, `plan`, `bypassPermissions`, and
-  possibly `dontAsk`.
-- Reasoning effort may be settable per session.
+- `--permission-mode` accepts: `acceptEdits`, `auto`, `bypassPermissions`,
+  `manual`, `dontAsk`, `plan`.
+- `set_permission_mode` documents: `default`, `acceptEdits`, `bypassPermissions`,
+  `plan`, `dontAsk`, `auto`.
 
-Fixed decisions: only **Default** and **Plan** are exposed as agents in this
-series. Applied model and agent selections are cached per resident process and
-the cache is cleared on respawn.
+The CLI flag spells the prompt-for-dangerous-operations mode `manual`; the
+control API spells it `default`. Observed `init.permissionMode` was `auto` for a
+run with no flag, so **`auto` is the default**, and `auto` uses a model
+classifier to approve or deny prompts. Parse both spellings at the boundary and
+never hardcode one across both surfaces.
 
-To record in Step 2: the working model-listing mechanism (or its confirmed
-absence), the exact `set_model` and `set_permission_mode` request and response
-shapes, the exhaustive permission-mode list, and whether per-session reasoning
-effort exists — which decides whether Step 11 ships model variants.
+**Design collision to resolve (Step 11/13).** The plan proposed exposing
+permission modes as `PluginAgent`s named "Default" and "Plan", following the
+Codex collaboration-mode precedent. But Claude has a *first-party* `agents`
+concept — the initialize response returned 5 of them and `--agent` selects one.
+Exposing permission modes under the same word as a real, different Claude
+concept is ambiguous.
+
+Both readings are defensible; this is a product decision, not a technical one,
+and it is recorded here rather than silently chosen.
 
 ## 7. Slash Commands
 
-**UNVERIFIED.** Hypothesis: `system/init.slash_commands` lists available commands
-and sending `/command args` as ordinary turn text executes them.
+**Verified.** `initialize` returns 66 commands as
+`{name, description, argumentHint}`, and `system/init` carries a
+`slash_commands` list as well.
 
-To record in Step 2: whether slash text is actually parsed in stream-json mode.
-If it is not, `sendCommand` degrades to a `PluginOperationException` and the
-catalog reports no commands.
+**OPEN:** whether sending `/command args` as ordinary turn text actually
+dispatches the command in stream-json mode. Verify before Step 12 wires
+`sendCommand`; if it does not, `sendCommand` degrades to a
+`PluginOperationException`.
 
 ## 8. Authentication
 
-Fixed decision: the plugin relies entirely on the user's existing `claude` login
-and never runs a login flow.
+**Verified — the preferred probe exists.** `claude auth status` defaults to JSON:
 
-**UNVERIFIED.** Probe options, in order of preference:
+```json
+{"loggedIn": true, "authMethod": "claude.ai", "apiProvider": "firstParty",
+ "email": "…", "orgId": "…", "orgName": "…", "subscriptionType": "max"}
+```
 
-1. A status-style subcommand, if the pinned CLI has one.
-2. A zero-token init probe: spawn stream-json with no prompt, read the init
-   response for account and auth information, then kill. Bounded by a timeout.
-3. Otherwise report `PluginSetupUnknown` with an action hint.
+The plugin reads **only `loggedIn`**. Everything else is PII and must never be
+logged, persisted, or forwarded. Subcommands are `login`, `logout`, `status`;
+the plugin never invokes the first two.
 
-To record in Step 2: which probe works, its observed latency, and the exact
-signal that distinguishes logged-in from logged-out.
+This eliminates the planned zero-token init-probe fallback: the probe is a fast,
+bounded, structured subcommand. `inspectSetup` runs `--version` first, then
+`auth status`, and degrades to `PluginSetupUnknown` on timeout or unparseable
+output.
 
-## 9. Known Traps
+## 9. Session Storage
 
-Carried from prior integrations; each is a fixed constraint, not a hypothesis.
+**Verified.** Transcripts live at
+`$CLAUDE_CONFIG_DIR ?? ~/.claude` + `/projects/<munged-cwd>/<session-id>.jsonl`.
 
-1. Never override `HOME` for isolation — it breaks keychain lookup. Use
-   `CLAUDE_CONFIG_DIR` in tests only.
-2. On Windows, an npm-shim `claude.cmd` needs `runInShell`. The repository
-   already does this everywhere through the host process seam.
-3. `AskUserQuestion` answers are keyed by full question text (verify at the
-   pinned version, section 4).
-4. Unknown stream message types are absorbed with a debug log, never a warning
-   per line — the protocol adds message types frequently.
-5. A signal-killed child mid-turn surfaces as interrupted, not as an error.
-6. Pending permission and question requests must be resolved when a session stops
-   or its process exits, or the phone shows a stale card forever.
-7. Feature-detect from `system/init.capabilities` rather than sniffing versions
-   wherever possible.
-8. Idle resident processes cost real memory; reap them and rely on `--resume`.
+Munging replaces path separators with `-`, producing names like
+`-private-tmp-…-scratchpad-probe1`. It is lossy and ambiguous — **never
+un-munge**. The filename minus `.jsonl` is the session id.
 
-## 10. Captured Fixtures
+Observed record types in a single-turn transcript: `ai-title`,
+`queue-operation`, `user`, `attachment`, `assistant`, `last-prompt`.
 
-**Empty until Step 2.** Real captured lines, trimmed and anonymized, that the
-package's tests reuse as inline Dart literals. No golden files — that is the
-house style. Nothing here may contain prompt text, transcript content, file
-paths, account identifiers, or tokens.
+| Record | Observed keys |
+|---|---|
+| `user` | `cwd`, `entrypoint`, `gitBranch`, `isSidechain`, `message`, `parentUuid`, `permissionMode`, `promptId`, `promptSource`, `sessionId`, `timestamp`, `type`, `userType`, `uuid`, `version` |
+| `assistant` | as above plus `effort`, `requestId`; no `promptId`/`promptSource` |
+| `attachment` | `attachment`, `cwd`, `entrypoint`, `gitBranch`, `isSidechain`, `parentUuid`, `sessionId`, `timestamp`, `type`, `userType`, `uuid`, `version` |
+| `ai-title` | `aiTitle`, `sessionId`, `type` |
+| `last-prompt` | `lastPrompt`, `leafUuid`, `sessionId`, `type` |
+| `queue-operation` | `operation`, `sessionId`, `timestamp`, `type` |
+
+Consequences for the catalog and history mapper:
+
+- **`ai-title.aiTitle` is the session title source.** No heuristic needed.
+- **`isSidechain` is the sidechain marker** — a boolean on the record itself, not
+  a separate directory. Exclude sidechain records from enumeration.
+- Every content record carries its own `cwd`, so project attribution needs no
+  directory-name parsing.
+- `gitBranch` is present and free; `version` records the writing CLI version.
+- `attachment` records are context attachments (memory files and similar), not
+  user images.
+
+**OPEN:** the `attachment.attachment` payload shape, and whether user-supplied
+images appear as `user` message content blocks or as `attachment` records.
+Resolve before Step 6.
+
+## 10. Known Traps
+
+1. **`--permission-prompt-tool stdio` or permissions silently fail.** Section 1.
+2. Never override `HOME` — it breaks keychain lookup. `CLAUDE_CONFIG_DIR` in
+   tests only.
+3. On Windows an npm-shim `claude.cmd` needs `runInShell`; the repository's host
+   process seam already does this.
+4. Unknown stream types are absorbed with a debug log, never a warning per line.
+   `rate_limit_event` and `system/status` were both absent from the research and
+   present in the very first capture.
+5. The complete `assistant` envelope interleaves with stream events rather than
+   following them.
+6. `init.model` carries a selection suffix that the message model does not.
+7. A signal-killed child mid-turn surfaces as interrupted, not as an error.
+8. Pending permission requests must be resolved when a session stops or its
+   process exits.
+9. `decision_reason` may contain ANSI escapes.
+10. `account` and `auth status` output contain PII.
+11. Closing stdin ends the process — that is the reap mechanism, and also the
+    accidental-death mechanism if the writer is careless.
+
+## 11. Open Items
+
+Carried into their consuming steps rather than blocking the scaffold:
+
+| Item | Needed by |
+|---|---|
+| Error `result` subtypes and `terminal_reason` values | Step 8 |
+| `AskUserQuestion` / `ExitPlanMode` live captures and answer-key shape | Step 9 |
+| Image content-block round-trip | Step 15 |
+| Slash-command dispatch in stream-json | Step 12 |
+| `attachment` record payload shape | Step 6 |
+| Auto-update / telemetry environment variables | Step 13 |
+| Permission-mode versus agent product decision | Step 11 |
+
+## 12. Captured Fixtures
+
+Real captures live in the session scratchpad and are **not** committed —
+they contain the developer's own environment, MCP server names, account email,
+and organization id. Fixtures committed into `test/` are hand-trimmed to the
+fields under test, with all identifiers replaced by synthetic values, following
+the house style of inline Dart map literals rather than golden files.

--- a/.plan/active/claude-code-plugin/PROTOCOL.md
+++ b/.plan/active/claude-code-plugin/PROTOCOL.md
@@ -317,15 +317,21 @@ run with no flag, so **`auto` is the default**, and `auto` uses a model
 classifier to approve or deny prompts. Parse both spellings at the boundary and
 never hardcode one across both surfaces.
 
-**Design collision to resolve (Step 11/13).** The plan proposed exposing
-permission modes as `PluginAgent`s named "Default" and "Plan", following the
-Codex collaboration-mode precedent. But Claude has a *first-party* `agents`
-concept — the initialize response returned 5 of them and `--agent` selects one.
-Exposing permission modes under the same word as a real, different Claude
-concept is ambiguous.
+**Design collision — resolved 2026-08-04.** The plan exposes permission modes as
+`PluginAgent`s named "Default" and "Plan", following the Codex
+collaboration-mode precedent. Claude also has a *first-party* `agents` concept:
+the initialize response returned 5 of them and `--agent` selects one, so the
+word is overloaded.
 
-Both readings are defensible; this is a product decision, not a technical one,
-and it is recorded here rather than silently chosen.
+The user decided the phone's agent picker drives **permission modes**, as
+originally planned. Plan mode is the headline feature in scope and the thing
+users toggle mid-session; Claude's own agents stay internal, dispatched by the
+main agent. Surfacing the first-party agent list is a deliberate follow-up
+outside this series, not an oversight.
+
+Consequence for Step 11: the picker sends `set_permission_mode`, and the
+`agents` array from the initialize response is deliberately not mapped to
+`getAgents`.
 
 ## 7. Slash Commands
 

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -5,10 +5,10 @@
 - **Plan slug:** `claude-code-plugin`
 - **Implementation base:** `origin/main` at
   `ca7470fd6ead8f7e1ff0d58e3591e7ce25a5314d`
-- **Series state:** Step 1/17 open for review
-- **Current step:** 1/17 — raise the plan
+- **Series state:** Steps 1/17 and 2/17 open for review
+- **Current step:** 2/17 — protocol ground truth and package scaffold
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737)
-- **Next action:** Step 2 protocol ground truth and package scaffold
+- **Next action:** Step 3 stream-json transport
 
 ## Plan Review
 
@@ -23,10 +23,10 @@
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
 | [x] | 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 900-1,100 | [PR #737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737) open; 997 changed lines |
-| [ ] | 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 1,100-1,500 | Not started |
-| [ ] | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,000-1,400 | Not started |
-| [ ] | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,100-1,500 | Not started |
-| [ ] | 5/17 | `claude-code-plugin-content-mapper` | `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]` | 900-1,300 | Not started |
+| [x] | 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 900-1,100 | PR open; 987 changed lines |
+| [ ] | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,200-1,500 | Not started |
+| [ ] | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,200-1,500 | Not started |
+| [ ] | 5/17 | `claude-code-plugin-content-mapper` | `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]` | 1,000-1,400 | Not started |
 | [ ] | 6/17 | `claude-code-plugin-history-mapper` | `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]` | 1,000-1,400 | Not started |
 | [ ] | 7/17 | `claude-code-plugin-tool-tracker` | `⚙️ [claude-code-plugin] feat(claude): track tool lifecycle [step 7/17]` | 1,000-1,400 | Not started |
 | [ ] | 8/17 | `claude-code-plugin-event-mapper` | `🚧 [claude-code-plugin] feat(claude): map stream events to SSE [step 8/17]` | 1,200-1,500 | Not started |
@@ -100,6 +100,24 @@
   rather than published stale. No Dart or Flutter suites were run for this
   documentation-only step.
 
+- Step 2/17 (2026-08-04): verified the protocol against a live `claude` 2.1.221
+  and `@anthropic-ai/claude-agent-sdk@0.3.221`, rewrote `PROTOCOL.md` from
+  observation, created `bridge/sesori_plugin_claude` with its Wave-1 workspace,
+  Makefile, and CI plumbing, and added the verified launch contract
+  (`ClaudeLaunchSpec`, `ClaudePermissionMode`, `ClaudeEffortLevel`).
+  `dart pub get` at `bridge/`, `dart analyze --fatal-infos`, all 12 package
+  tests, and `git diff --cached --check` pass. The 987 changed-line diff against
+  its Step 1 base is within the corrected 900-1,100 estimate and below the
+  1,500-line soft cap.
+
+  DTOs were moved out of this step into the steps that consume them. Measured
+  against the Codex analog, Freezed expands roughly tenfold
+  (`codex_rollout_dto.dart`: 326 source lines, 3,286 generated), so the original
+  bundle of stream, control, and transcript DTOs would have exceeded the cap
+  several times over while having no production consumer in the same PR. Step
+  estimates for 3, 4, and 5 were raised to absorb them and the step total is
+  unchanged.
+
 ## Findings And Plan Deltas
 
 - **2026-08-04 — Route decision:** Bespoke stream-json over stdio rather than the
@@ -111,3 +129,29 @@
 - **2026-08-04 — Effort variants deferred to evidence:** Reasoning-effort
   variants ship only if Step 2 finds first-party per-session support in the
   pinned CLI. Step 11 records the decision either way.
+  **Resolved in Step 2: variants ship.** The initialize response declares
+  `supportsEffort` and `supportedEffortLevels` per model, so variants are
+  first-party data with no hardcoded catalog and no version gate.
+- **2026-08-04 — `--permission-prompt-tool stdio` is mandatory:** Step 2 proved
+  that without this flag the CLI silently auto-denies permission-gated tools —
+  no control request, no error, `result.subtype: "success"`, and the refusal
+  visible only in `result.permission_denials`. The flag is absent from
+  `claude --help` and was found in the SDK's argv builder. It is not optional
+  and Step 3 must cover it.
+- **2026-08-04 — Permission/question split is first-party:** the `can_use_tool`
+  request carries `requires_user_interaction`, which replaces the planned
+  hardcoded `AskUserQuestion`/`ExitPlanMode` name list. Two new safety
+  constraints also apply: `suppress_always_allow_rule` forbids offering
+  "always", and `decision_reason` may carry ANSI escapes.
+- **2026-08-04 — Agent picker drives permission modes:** the user confirmed the
+  planned mapping despite Claude having a first-party `agents` concept. The
+  initialize response's `agents` array is deliberately not mapped to
+  `getAgents`; surfacing it is a follow-up outside this series.
+- **2026-08-04 — Catalog comes from one handshake:** the `initialize` response
+  returns commands, agents, models, and account together, so the catalog service
+  needs no separate startup probes and `list_models` is a refresh path only.
+- **2026-08-04 — Auth probe simplified:** `claude auth status --json` reports
+  `loggedIn`, so the planned zero-token init-probe fallback is unnecessary. The
+  same payload carries PII (email, org) that must never be logged.
+- **2026-08-04 — `rename_session` exists:** the control API supports renaming, so
+  Step 12's optimistic-only rename should be revisited against it.

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -23,7 +23,7 @@
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
 | [x] | 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 900-1,100 | [PR #737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737) open; 997 changed lines |
-| [x] | 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 900-1,100 | PR open; 987 changed lines |
+| [x] | 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 900-1,100 | [PR #739](https://github.com/sesori-ai/sesori_apps_monorepo/pull/739) open; 1,089 changed lines |
 | [ ] | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,200-1,500 | Not started |
 | [ ] | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,200-1,500 | Not started |
 | [ ] | 5/17 | `claude-code-plugin-content-mapper` | `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]` | 1,000-1,400 | Not started |
@@ -106,7 +106,7 @@
   Makefile, and CI plumbing, and added the verified launch contract
   (`ClaudeLaunchSpec`, `ClaudePermissionMode`, `ClaudeEffortLevel`).
   `dart pub get` at `bridge/`, `dart analyze --fatal-infos`, all 12 package
-  tests, and `git diff --cached --check` pass. The 987 changed-line diff against
+  tests, and `git diff --cached --check` pass. The 1,089 changed-line diff against
   its Step 1 base is within the corrected 900-1,100 estimate and below the
   1,500-line soft cap.
 

--- a/bridge/Makefile
+++ b/bridge/Makefile
@@ -2,7 +2,7 @@ TOOL_VERSIONS := $(shell git rev-parse --show-toplevel)/.tool-versions
 FLUTTER_VERSION := $(shell grep '^flutter' $(TOOL_VERSIONS) | awk '{print $$2}')
 DART := $(HOME)/.asdf/installs/flutter/$(FLUTTER_VERSION)/bin/cache/dart-sdk/bin/dart
 
-MODULES := sesori_plugin_interface sesori_bridge_foundation sesori_plugin_runtime sesori_plugin_opencode sesori_plugin_codex sesori_plugin_acp sesori_plugin_cursor app
+MODULES := sesori_plugin_interface sesori_bridge_foundation sesori_plugin_runtime sesori_plugin_opencode sesori_plugin_codex sesori_plugin_acp sesori_plugin_cursor sesori_plugin_claude app
 
 .PHONY: codegen opencode-codegen pub-get test analyze
 

--- a/bridge/pubspec.yaml
+++ b/bridge/pubspec.yaml
@@ -13,3 +13,4 @@ workspace:
   - sesori_plugin_interface
   - sesori_plugin_acp
   - sesori_plugin_cursor
+  - sesori_plugin_claude

--- a/bridge/sesori_plugin_claude/analysis_options.yaml
+++ b/bridge/sesori_plugin_claude/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../app/analysis_options.yaml

--- a/bridge/sesori_plugin_claude/build.yaml
+++ b/bridge/sesori_plugin_claude/build.yaml
@@ -1,0 +1,12 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          any_map: true
+          explicit_to_json: true
+      freezed:
+        options:
+          format: false
+          map: false
+          when: false

--- a/bridge/sesori_plugin_claude/lib/claude_plugin.dart
+++ b/bridge/sesori_plugin_claude/lib/claude_plugin.dart
@@ -1,0 +1,14 @@
+/// The Sesori bridge plugin for the Claude Code harness.
+///
+/// Drives the `claude` CLI's headless stream-json protocol over stdio — the
+/// same ndjson protocol the official Agent SDK speaks internally — so the
+/// bridge needs no Node runtime.
+///
+/// The wire protocol this package implements is documented in
+/// `.plan/active/claude-code-plugin/PROTOCOL.md`, verified against Claude CLI
+/// 2.1.221 and `@anthropic-ai/claude-agent-sdk@0.3.221`.
+library;
+
+export "src/api/claude_launch_spec.dart";
+export "src/api/models/claude_effort_level.dart";
+export "src/api/models/claude_permission_mode.dart";

--- a/bridge/sesori_plugin_claude/lib/src/api/claude_launch_spec.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/claude_launch_spec.dart
@@ -1,0 +1,93 @@
+import "models/claude_effort_level.dart";
+import "models/claude_permission_mode.dart";
+
+/// Whether a launch starts a brand-new session or continues an existing one.
+///
+/// A launch is exactly one of these. Modelling them as separate variants keeps
+/// "new and resumed at once" and "neither" unrepresentable, and each carries
+/// only the session id it needs.
+sealed class ClaudeSessionLaunch {
+  const ClaudeSessionLaunch({required this.sessionId});
+
+  /// The Claude session id. For a new session the bridge pre-generates it so
+  /// the Sesori-to-backend binding is durable from the very first event.
+  final String sessionId;
+}
+
+/// Starts a new session under a bridge-generated id (`--session-id`).
+final class ClaudeNewSession extends ClaudeSessionLaunch {
+  const ClaudeNewSession({required super.sessionId});
+}
+
+/// Continues an existing session from its transcript (`--resume`).
+final class ClaudeResumedSession extends ClaudeSessionLaunch {
+  const ClaudeResumedSession({required super.sessionId});
+}
+
+/// The verified command line for one long-lived Claude stream-json process.
+///
+/// One process serves exactly one session, with the session's directory as its
+/// working directory. The process stays alive for as long as its stdin stays
+/// open; closing stdin is what ends it.
+///
+/// Verified against Claude CLI 2.1.221 — see
+/// `.plan/active/claude-code-plugin/PROTOCOL.md` section 1.
+class ClaudeLaunchSpec {
+  const ClaudeLaunchSpec({
+    required this.binaryPath,
+    required this.launch,
+    required this.model,
+    required this.effort,
+    required this.permissionMode,
+  });
+
+  /// The `claude` executable: a `--claude-bin` override or a PATH name.
+  final String binaryPath;
+
+  /// Whether this launch creates or resumes a session.
+  final ClaudeSessionLaunch launch;
+
+  /// Model selection token from the catalog (`ClaudeModel.value`), or null to
+  /// let the CLI pick the account default.
+  final String? model;
+
+  /// Reasoning effort, or null when the selected model does not support it.
+  final ClaudeEffortLevel? effort;
+
+  /// Starting permission mode, or null to accept the CLI's own default.
+  final ClaudePermissionMode? permissionMode;
+
+  /// Routes tool-permission asks to us over stdio as `can_use_tool` control
+  /// requests.
+  ///
+  /// This flag is REQUIRED and is deliberately not optional. It does not appear
+  /// in `claude --help`; it was found in the Agent SDK's argument builder and
+  /// confirmed live. Without it the CLI silently auto-denies every
+  /// permission-gated tool: no control request is sent, the turn still reports
+  /// `subtype: "success"`, and the refusal is visible only in the result's
+  /// `permission_denials` array. A plugin missing this flag looks healthy while
+  /// every write, edit, and command fails.
+  static const List<String> permissionPromptToolArguments = ["--permission-prompt-tool", "stdio"];
+
+  /// The full argument vector, excluding the executable itself.
+  List<String> get arguments => [
+    // `--print` is mandatory: the stream-json input/output formats and partial
+    // message streaming are all documented as print-mode only.
+    "-p",
+    "--input-format", "stream-json",
+    "--output-format", "stream-json",
+    // Required for full stream-json output.
+    "--verbose",
+    // Enables the token-level `stream_event` deltas the client renders.
+    "--include-partial-messages",
+    ...permissionPromptToolArguments,
+    if (permissionMode != null) ...["--permission-mode", permissionMode!.cliValue],
+    if (model != null) ...["--model", model!],
+    if (effort != null) ...["--effort", effort!.wireValue],
+    switch (launch) {
+      ClaudeNewSession() => "--session-id",
+      ClaudeResumedSession() => "--resume",
+    },
+    launch.sessionId,
+  ];
+}

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_effort_level.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_effort_level.dart
@@ -1,0 +1,33 @@
+/// Reasoning effort for a Claude session.
+///
+/// Effort support is declared per model: the `initialize` control response
+/// carries `supportsEffort` and `supportedEffortLevels` for each catalog entry,
+/// and models that do not support it omit both fields. Never assume the full
+/// set is available for a given model.
+///
+/// Verified against Claude CLI 2.1.221 — see
+/// `.plan/active/claude-code-plugin/PROTOCOL.md` section 4.
+enum ClaudeEffortLevel {
+  low,
+  medium,
+  high,
+  xhigh,
+  max;
+
+  /// Value accepted by the `--effort` command-line flag and reported back on
+  /// transcript `assistant` records.
+  String get wireValue => name;
+
+  /// Parses a level at the wire boundary.
+  ///
+  /// Returns null for an unrecognized value so a newer CLI's level does not
+  /// throw; callers fall back to the model's declared default.
+  static ClaudeEffortLevel? tryParse(String? raw) {
+    if (raw == null) return null;
+    final trimmed = raw.trim();
+    for (final level in ClaudeEffortLevel.values) {
+      if (level.wireValue == trimmed) return level;
+    }
+    return null;
+  }
+}

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_permission_mode.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_permission_mode.dart
@@ -1,0 +1,55 @@
+/// How the Claude CLI decides whether a tool may run.
+///
+/// The CLI flag and the control protocol disagree on one spelling: the
+/// prompt-for-dangerous-operations mode is `manual` on `--permission-mode` and
+/// `default` in a `set_permission_mode` control request. Both spellings name
+/// the same mode, so this enum owns the translation and no caller hardcodes
+/// either string.
+///
+/// Verified against Claude CLI 2.1.221 — see
+/// `.plan/active/claude-code-plugin/PROTOCOL.md` section 6.
+enum ClaudePermissionMode {
+  /// Prompts before dangerous operations. `manual` on the CLI, `default` in the
+  /// control protocol.
+  standard(cliValue: "manual", controlValue: "default"),
+
+  /// Auto-accepts file edits.
+  acceptEdits(cliValue: "acceptEdits", controlValue: "acceptEdits"),
+
+  /// Planning mode. Tools that change state do not execute; the model finishes
+  /// by proposing a plan through `ExitPlanMode`.
+  plan(cliValue: "plan", controlValue: "plan"),
+
+  /// Skips every permission check. Requires the CLI's dangerous-skip opt-in.
+  bypassPermissions(cliValue: "bypassPermissions", controlValue: "bypassPermissions"),
+
+  /// Never prompts; denies anything not already permitted.
+  dontAsk(cliValue: "dontAsk", controlValue: "dontAsk"),
+
+  /// Uses a model classifier to approve or deny prompts. This is the CLI's own
+  /// default when no mode is passed.
+  auto(cliValue: "auto", controlValue: "auto");
+
+  const ClaudePermissionMode({required this.cliValue, required this.controlValue});
+
+  /// Spelling accepted by the `--permission-mode` command-line flag.
+  final String cliValue;
+
+  /// Spelling accepted by a `set_permission_mode` control request, and reported
+  /// back on `system/init.permissionMode` and in transcript records.
+  final String controlValue;
+
+  /// Parses either spelling at the wire boundary.
+  ///
+  /// Returns null for an unrecognized value so callers fail soft rather than
+  /// throwing on a mode a newer CLI introduced.
+  static ClaudePermissionMode? tryParse(String? raw) {
+    if (raw == null) return null;
+    final trimmed = raw.trim();
+    if (trimmed.isEmpty) return null;
+    for (final mode in ClaudePermissionMode.values) {
+      if (mode.cliValue == trimmed || mode.controlValue == trimmed) return mode;
+    }
+    return null;
+  }
+}

--- a/bridge/sesori_plugin_claude/pubspec.yaml
+++ b/bridge/sesori_plugin_claude/pubspec.yaml
@@ -1,0 +1,25 @@
+name: claude_plugin
+version: 0.1.0
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.12.2
+
+dependencies:
+  sesori_plugin_interface:
+    path: ../sesori_plugin_interface
+  sesori_bridge_foundation:
+    path: ../sesori_bridge_foundation
+  sesori_shared:
+    path: ../../shared/sesori_shared
+  path: ^1.9.1
+  freezed_annotation: ^3.1.0
+  json_annotation: ^4.12.0
+
+dev_dependencies:
+  build_runner: any
+  freezed: ^3.2.5
+  json_serializable: ^6.14.0
+  test: ^1.31.1
+  lints: ^6.1.0

--- a/bridge/sesori_plugin_claude/test/claude_launch_spec_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_launch_spec_test.dart
@@ -1,0 +1,127 @@
+import "package:claude_plugin/claude_plugin.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ClaudeLaunchSpec", () {
+    ClaudeLaunchSpec specFor(
+      ClaudeSessionLaunch launch, {
+      String? model,
+      ClaudeEffortLevel? effort,
+      ClaudePermissionMode? permissionMode,
+    }) {
+      return ClaudeLaunchSpec(
+        binaryPath: "claude",
+        launch: launch,
+        model: model,
+        effort: effort,
+        permissionMode: permissionMode,
+      );
+    }
+
+    test("always requests stream-json in print mode with partial messages", () {
+      final arguments = specFor(const ClaudeNewSession(sessionId: "s-1")).arguments;
+
+      // `--print` is what makes the stream-json formats legal at all.
+      expect(arguments, containsAllInOrder(["-p", "--input-format", "stream-json"]));
+      expect(arguments, containsAllInOrder(["--output-format", "stream-json"]));
+      expect(arguments, contains("--verbose"));
+      expect(arguments, contains("--include-partial-messages"));
+    });
+
+    test("always routes permission asks over stdio", () {
+      // Regression guard for the protocol's sharpest edge: without this flag
+      // the CLI silently auto-denies every permission-gated tool instead of
+      // asking, and the turn still reports success.
+      for (final launch in [
+        const ClaudeNewSession(sessionId: "s-1"),
+        const ClaudeResumedSession(sessionId: "s-1"),
+      ]) {
+        expect(
+          specFor(launch).arguments,
+          containsAllInOrder(["--permission-prompt-tool", "stdio"]),
+          reason: "$launch must still route permission asks over stdio",
+        );
+      }
+    });
+
+    test("binds a pre-generated id for a new session", () {
+      final arguments = specFor(const ClaudeNewSession(sessionId: "new-session")).arguments;
+
+      expect(arguments, containsAllInOrder(["--session-id", "new-session"]));
+      expect(arguments, isNot(contains("--resume")));
+    });
+
+    test("resumes an existing session by id", () {
+      final arguments = specFor(const ClaudeResumedSession(sessionId: "old-session")).arguments;
+
+      expect(arguments, containsAllInOrder(["--resume", "old-session"]));
+      expect(arguments, isNot(contains("--session-id")));
+    });
+
+    test("omits optional selections that were not made", () {
+      final arguments = specFor(const ClaudeNewSession(sessionId: "s-1")).arguments;
+
+      expect(arguments, isNot(contains("--model")));
+      expect(arguments, isNot(contains("--effort")));
+      expect(arguments, isNot(contains("--permission-mode")));
+    });
+
+    test("passes model, effort, and permission mode when selected", () {
+      final arguments = specFor(
+        const ClaudeNewSession(sessionId: "s-1"),
+        model: "opus[1m]",
+        effort: ClaudeEffortLevel.xhigh,
+        permissionMode: ClaudePermissionMode.plan,
+      ).arguments;
+
+      expect(arguments, containsAllInOrder(["--model", "opus[1m]"]));
+      expect(arguments, containsAllInOrder(["--effort", "xhigh"]));
+      expect(arguments, containsAllInOrder(["--permission-mode", "plan"]));
+    });
+
+    test("spells the standard mode the way the command line expects", () {
+      final arguments = specFor(
+        const ClaudeNewSession(sessionId: "s-1"),
+        permissionMode: ClaudePermissionMode.standard,
+      ).arguments;
+
+      // The CLI flag calls it `manual`; only the control protocol says
+      // `default`. Passing the control spelling here is rejected.
+      expect(arguments, containsAllInOrder(["--permission-mode", "manual"]));
+      expect(arguments, isNot(contains("default")));
+    });
+  });
+
+  group("ClaudePermissionMode", () {
+    test("keeps the command line and control spellings apart", () {
+      expect(ClaudePermissionMode.standard.cliValue, "manual");
+      expect(ClaudePermissionMode.standard.controlValue, "default");
+    });
+
+    test("parses either spelling of the same mode", () {
+      expect(ClaudePermissionMode.tryParse("manual"), ClaudePermissionMode.standard);
+      expect(ClaudePermissionMode.tryParse("default"), ClaudePermissionMode.standard);
+      expect(ClaudePermissionMode.tryParse(" plan "), ClaudePermissionMode.plan);
+      expect(ClaudePermissionMode.tryParse("acceptEdits"), ClaudePermissionMode.acceptEdits);
+    });
+
+    test("fails soft on a mode this build does not know", () {
+      expect(ClaudePermissionMode.tryParse("someFutureMode"), isNull);
+      expect(ClaudePermissionMode.tryParse(""), isNull);
+      expect(ClaudePermissionMode.tryParse(null), isNull);
+    });
+  });
+
+  group("ClaudeEffortLevel", () {
+    test("round-trips every level the CLI accepts", () {
+      for (final level in ClaudeEffortLevel.values) {
+        expect(ClaudeEffortLevel.tryParse(level.wireValue), level);
+      }
+    });
+
+    test("fails soft on an unknown level", () {
+      expect(ClaudeEffortLevel.tryParse("extreme"), isNull);
+      expect(ClaudeEffortLevel.tryParse(null), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Complexity

⚙️ Moderate — a new workspace package plus three build-list edits, and a protocol contract derived from live verification rather than documentation. Small code surface, but the launch contract is load-bearing for every later step.

> Targets `claude-code-support` (step 1/17, #737) while both are open. Merges in numeric order.

## What

**Protocol ground truth.** `PROTOCOL.md` is rewritten from a skeleton of unverified hypotheses into observed fact, captured from a live `claude` 2.1.221 driven over stdio and cross-checked against `@anthropic-ai/claude-agent-sdk@0.3.221` (`sdk.d.ts` for declared shapes, `sdk.mjs` for the argv the SDK actually builds).

**Package scaffold + Wave-1 plumbing.** `bridge/sesori_plugin_claude` (`claude_plugin`), added to `bridge/pubspec.yaml` `workspace:`, `bridge/Makefile` `MODULES`, and both the analyze and test step lists in `bridge-ci.yml`. All three lists are explicit — without them the package is locally unbuildable *and* invisible to CI for steps 2–13. The app stays unaware until step 14.

**The launch contract**, which is what the verification produced:

- `ClaudeLaunchSpec` — the argument vector, including `--permission-prompt-tool stdio`.
- `ClaudeSessionLaunch` — sealed into `ClaudeNewSession` / `ClaudeResumedSession`, so a launch cannot be both or neither and each carries only the id it needs.
- `ClaudePermissionMode` — owns the CLI-versus-control spelling split.
- `ClaudeEffortLevel` — the five levels, parsed fail-soft.

## Why

The stream-json control protocol is SDK-internal and unversioned, so it has to be pinned by observation once rather than re-derived by thirteen later steps. Doing that first found two things the research had wrong, one of which would have shipped a broken plugin:

**`--permission-prompt-tool stdio` is required, and is absent from `claude --help`.** Without it the CLI does not ask for permission — it *silently auto-denies*. No control request, no error, the turn still reports `subtype: "success"`, and the only trace is an entry in `result.permission_denials`. Every write, edit, and command would have failed while the plugin looked healthy. Proven by three probes: no flag → silent denial; `initialize` alone → still silent denial; with the flag → `can_use_tool` arrives as documented. The flag was found in the SDK's argv builder, not in any documentation.

**`-p/--print` is mandatory** for the stream-json formats; the planned invocation omitted it.

Other questions the plan had left open are now closed: effort variants are first-party and declared per model; one `initialize` round trip returns commands, agents, models and account together; `claude auth status --json` exposes `loggedIn`; `ai-title` records carry the session title; `isSidechain` marks subagent records; and `requires_user_interaction` / `suppress_always_allow_rule` replace the planned hardcoded permission-versus-question tool-name list.

## Risk and test focus

**Risk: none at runtime.** The package has no consumers — it is not in `knownPlugins`, `bridge/app` does not depend on it, and no existing code imports it. The three build-list edits are additive.

- **User-visible behavior:** none.
- **Database:** no change.
- **Analytics:** none.

Review focus:

1. **The three build-list edits** — a missing one silently removes the package from CI for the next eleven PRs.
2. **`ClaudeLaunchSpec.arguments`** against `PROTOCOL.md` section 1. The `--permission-prompt-tool stdio` constant is deliberately not optional and has a regression test that asserts it for both launch variants.
3. **The permission-mode spelling split.** `--permission-mode` takes `manual`; `set_permission_mode` takes `default`. Same mode, two spellings, and passing the wrong one is rejected. The enum owns both so no call site hardcodes either.

## Expected result

`bridge/sesori_plugin_claude` analyzes clean and its 12 tests pass; `dart pub get` resolves the workspace; `make analyze` and `make test` include the new module; CI gains one analyze and one test step. Nothing else builds or behaves differently.

## Plan delta

DTOs moved out of this step into the steps that consume them. Measured against the Codex analog, Freezed expands roughly tenfold — `codex_rollout_dto.dart` is 326 source lines and 3,286 generated — so the original bundle of stream, control, and transcript DTOs would have exceeded this step's cap several times over *and* landed with no production consumer in the same PR, against the repository rule. Stream and control envelopes now land with the transport (step 3), transcript records with the catalog (step 4), content blocks with the content mapper (step 5). Estimates for steps 3–5 were raised to absorb them; **the 17-step total is unchanged.** Recorded in `PLAN.md` and `TRACKER.md`.

`build.yaml` and the Freezed dev dependencies land here rather than in step 3, as part of one coherent package scaffold. They generate nothing yet.

## Verification

- `dart pub get` at `bridge/` resolves the workspace with the new member.
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_claude` — no issues.
- `dart test` in `bridge/sesori_plugin_claude` — 12/12 pass.
- `git diff --check` passes.
- Diff is 1,089 changed lines against its step 1 base, within the corrected 900–1,100 estimate and below the 1,500-line soft cap.
- Protocol claims are from live capture, not documentation. Raw captures are deliberately **not** committed — they contain the developer's environment, MCP server names, account email, and organization id.

https://claude.ai/code/session_01HuG5CqV5bHvpfS9aRcKMSN


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the Claude stream‑json protocol to verified ground truth and scaffolds the `claude_plugin` package with a tested launch contract and CI wiring. Enforces the required `--permission-prompt-tool stdio` to avoid silent permission failures.

- **New Features**
  - Added `bridge/sesori_plugin_claude` (`claude_plugin`) with pubspec, analysis, build config, and 12 tests; exported API: `ClaudeLaunchSpec`, `ClaudePermissionMode`, `ClaudeEffortLevel`, `ClaudeSessionLaunch`.
  - `ClaudeLaunchSpec` builds the args for a long‑lived process: `-p`, stream‑json flags, `--include-partial-messages`, and mandatory `--permission-prompt-tool stdio`; supports model, effort, and permission mode.
  - Sealed session variants: `ClaudeNewSession` and `ClaudeResumedSession`.
  - `ClaudePermissionMode` owns the CLI/control spelling split (`manual` ↔ `default`); `ClaudeEffortLevel` parses the five levels fail‑soft.
  - Wired into workspace and CI: updated `bridge/pubspec.yaml`, `bridge/Makefile`, and `.github/workflows/bridge-ci.yml`. No runtime impact; the app does not depend on this package yet.

- **Protocol Findings**
  - Rewrote `PROTOCOL.md` from live `claude` 2.1.221 and `@anthropic-ai/claude-agent-sdk@0.3.221`.
  - `-p/--print` is required; without `--permission-prompt-tool stdio` the CLI silently auto‑denies tools (no control request; only in `result.permission_denials`).
  - One `initialize` round trip returns commands, agents, models, and account; effort is declared per model; `claude auth status --json` exposes `loggedIn`.
  - Transcripts: `~/.claude/projects/.../<session>.jsonl`; `ai-title` is the title; `isSidechain` marks sidechains; tolerate unknown `rate_limit_event` and `system/status`.
  - Moved DTOs to later steps; this PR only adds the launch contract to keep the surface minimal.

<sup>Written for commit d808e4b012d07af513bb0b966cf8df4cf7be55f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

