### PR TITLE
⚙️ Isolate session command catalog refreshes

### DIFF
--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -2036,6 +2036,7 @@ class OrchestratorSession {
           _sseManager.subscribePath(
             connID: connID,
             path: subscribe.path,
+            supportsSessionCommandsUpdated: subscribe.supportsSessionCommandsUpdated,
             client: _client,
             connection: connection,
           );

--- a/bridge/app/lib/src/bridge/repositories/health_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/health_repository.dart
@@ -20,6 +20,7 @@ class HealthRepository {
       healthy: true,
       version: _bridgeVersion,
       filesystemAccessDegraded: !_filesystemAccessOk,
+      supportsSessionCommandsUpdated: true,
     );
   }
 }

--- a/bridge/app/lib/src/bridge/repositories/mappers/session_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/repositories/mappers/session_event_mapper.dart
@@ -21,7 +21,7 @@ class SessionEventMapper {
     }
     return switch (event) {
       BridgeSseTerminalHandoff(:final event) => backendSessionIds(event: event),
-      BridgeSseSessionsUpdated(:final sessionID) ||
+      BridgeSseSessionCommandsUpdated(:final sessionID) ||
       BridgeSseSessionDiff(:final sessionID) ||
       BridgeSseSessionCompacted(:final sessionID) ||
       BridgeSseSessionStatus(:final sessionID) ||
@@ -113,8 +113,8 @@ class SessionEventMapper {
         final session? => BridgeSseSessionDeleted(info: session.toJson()),
         null => null,
       },
-      BridgeSseSessionsUpdated(:final sessionID, :final projectID) => switch (mapped(sessionID)) {
-        final sessionId? => BridgeSseSessionsUpdated(sessionID: sessionId, projectID: projectID),
+      BridgeSseSessionCommandsUpdated(:final sessionID, :final projectID) => switch (mapped(sessionID)) {
+        final sessionId? => BridgeSseSessionCommandsUpdated(sessionID: sessionId, projectID: projectID),
         null => null,
       },
       BridgeSseSessionDiff(:final sessionID) => switch (mapped(sessionID)) {

--- a/bridge/app/lib/src/bridge/services/session_event_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_event_service.dart
@@ -456,10 +456,10 @@ class SessionEventService {
         ),
         null => null,
       },
-      BridgeSseSessionsUpdated(:final sessionID) => switch (await _sessionRepository.findProjectIdForSession(
+      BridgeSseSessionCommandsUpdated(:final sessionID) => switch (await _sessionRepository.findProjectIdForSession(
         sessionId: sessionID,
       )) {
-        final projectId? => BridgeSseSessionsUpdated(sessionID: sessionID, projectID: projectId),
+        final projectId? => BridgeSseSessionCommandsUpdated(sessionID: sessionID, projectID: projectId),
         null => null,
       },
       _ => translated,

--- a/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
@@ -27,7 +27,10 @@ class BridgeEventMapper {
         BridgeSseGlobalDisposed() => null,
         BridgeSseSessionCreated(:final info) => _tryParseSseEvent({"type": "session.created", "info": info}),
         BridgeSseSessionUpdated(:final info) => _tryParseSseEvent({"type": "session.updated", "info": info}),
-        BridgeSseSessionsUpdated(:final projectID) => SesoriSseEvent.sessionsUpdated(projectID: projectID),
+        BridgeSseSessionCommandsUpdated(:final sessionID, :final projectID) => SesoriSseEvent.sessionCommandsUpdated(
+          sessionID: sessionID,
+          projectID: projectID,
+        ),
         BridgeSseSessionOptionsChanged() => null,
         BridgeSseSessionDeleted(:final info) => _tryParseSseEvent({"type": "session.deleted", "info": info}),
         BridgeSseSessionDiff(:final sessionID) => SesoriSseEvent.sessionDiff(sessionID: sessionID),

--- a/bridge/app/lib/src/bridge/sse/sse_manager.dart
+++ b/bridge/app/lib/src/bridge/sse/sse_manager.dart
@@ -46,10 +46,12 @@ class SSEManager {
   /// Registers [connID] as an SSE subscriber.
   ///
   /// [path] is accepted for API compatibility with call sites but is not used
-  /// by this manager.
+  /// by this manager. [supportsSessionCommandsUpdated] controls only the wire
+  /// representation selected when each queued command-catalog event is sent.
   void subscribePath({
     required int connID,
     required String path,
+    required bool supportsSessionCommandsUpdated,
     required RelayClient client,
     required RelayConnection connection,
   }) {
@@ -65,6 +67,7 @@ class SSEManager {
             client: client,
             connection: connection,
             subscriptionOwner: subscriptionOwner,
+            supportsSessionCommandsUpdated: supportsSessionCommandsUpdated,
           ),
           onError: _createErrorHandler(connID),
         );
@@ -79,6 +82,7 @@ class SSEManager {
           client: client,
           connection: connection,
           subscriptionOwner: subscriptionOwner,
+          supportsSessionCommandsUpdated: supportsSessionCommandsUpdated,
         ),
         onError: _createErrorHandler(connID),
       );
@@ -203,6 +207,7 @@ class SSEManager {
     required RelayClient client,
     required RelayConnection connection,
     required Object subscriptionOwner,
+    required bool supportsSessionCommandsUpdated,
   }) {
     SessionEncryptor? encryptor;
 
@@ -220,7 +225,15 @@ class SSEManager {
         return cryptoService.createSessionEncryptor(secretKey);
       }();
 
-      final eventData = jsonEncode(_toOpenCodeFormat(event));
+      // COMPATIBILITY 2026-08-04 (v1.6.0): The public v1.6.0 app only
+      // understands sessions.updated. Remove this mapping once v1.6.0 apps are
+      // unsupported.
+      final deliveryEvent = switch (event) {
+        SesoriSessionCommandsUpdated(:final projectID) when !supportsSessionCommandsUpdated =>
+          SesoriSseEvent.sessionsUpdated(projectID: projectID),
+        _ => event,
+      };
+      final eventData = jsonEncode(_toOpenCodeFormat(deliveryEvent));
       final relayMessage = RelayMessage.sseEvent(data: eventData);
       final payloadBytes = utf8.encode(jsonEncode(relayMessage.toJson()));
       Log.v("[sse] sending ${payloadBytes.length} bytes to connID=$connID");

--- a/bridge/app/test/bridge/repositories/mappers/session_event_mapper_test.dart
+++ b/bridge/app/test/bridge/repositories/mappers/session_event_mapper_test.dart
@@ -55,8 +55,8 @@ void main() {
           expectedBackendIds: ids.keys.toSet(),
         ),
         (
-          name: "sessions updated",
-          event: const BridgeSseSessionsUpdated(sessionID: "backend-session", projectID: "project"),
+          name: "session commands updated",
+          event: const BridgeSseSessionCommandsUpdated(sessionID: "backend-session", projectID: "project"),
           expectedBackendIds: {"backend-session"},
         ),
         (
@@ -199,6 +199,23 @@ void main() {
           reason: testCase.name,
         );
       }
+    });
+
+    test("normalizes command update identity while retaining plugin project context", () {
+      final mapped = mapper.map(
+        event: const BridgeSseSessionCommandsUpdated(
+          sessionID: "backend-session",
+          projectID: "backend-project",
+        ),
+        sessionIdsByBackendId: ids,
+      );
+
+      expect(
+        mapped,
+        isA<BridgeSseSessionCommandsUpdated>()
+            .having((event) => event.sessionID, "sessionID", "ses-session")
+            .having((event) => event.projectID, "projectID", "backend-project"),
+      );
     });
 
     test("drops an event when any required session reference is unknown", () {

--- a/bridge/app/test/bridge/routing/health_check_handler_test.dart
+++ b/bridge/app/test/bridge/routing/health_check_handler_test.dart
@@ -45,6 +45,7 @@ void main() {
       expect(response.healthy, isTrue);
       expect(response.version, equals("9.9.9"));
       expect(response.filesystemAccessDegraded, isFalse);
+      expect(response.supportsSessionCommandsUpdated, isTrue);
     });
 
     test("reports filesystemAccessDegraded when access is not ok", () async {

--- a/bridge/app/test/bridge/services/session_event_service_test.dart
+++ b/bridge/app/test/bridge/services/session_event_service_test.dart
@@ -230,6 +230,35 @@ void main() {
       expect(failureReporter.recordedIdentifiers, ["bridge.sse.session_event"]);
     });
 
+    test("resolves command updates to the stable session and authoritative project", () async {
+      await _insertRoot(
+        database: database,
+        pluginId: plugin.id,
+        sessionId: "stable-root",
+        backendSessionId: "backend-root",
+      );
+
+      final output = await service.normalize(
+        allowDuringStop: false,
+        source: (
+          pluginId: plugin.id,
+          generation: 1,
+          projectionUpdatedAt: 2,
+          event: const BridgeSseSessionCommandsUpdated(
+            sessionID: "backend-root",
+            projectID: "untrusted-backend-project",
+          ),
+        ),
+      );
+
+      expect(
+        output.single,
+        isA<BridgeSseSessionCommandsUpdated>()
+            .having((event) => event.sessionID, "sessionID", "stable-root")
+            .having((event) => event.projectID, "projectID", "project-stable-root"),
+      );
+    });
+
     test("recursively drains out-of-order descendants under a durable same-plugin parent", () async {
       await _insertRoot(
         database: database,

--- a/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
+++ b/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
@@ -105,13 +105,17 @@ void main() {
       expect((result! as SesoriSessionDiff).sessionID, equals("s1"));
     });
 
-    test("maps stale project sessions to sessions.updated", () {
+    test("maps command-catalog invalidation to the dedicated session event", () {
       final result = mapper.map(
-        const BridgeSseSessionsUpdated(sessionID: "s1", projectID: "p1"),
+        const BridgeSseSessionCommandsUpdated(sessionID: "s1", projectID: "p1"),
       );
 
-      expect(result, isA<SesoriSessionsUpdated>());
-      expect((result! as SesoriSessionsUpdated).projectID, "p1");
+      expect(
+        result,
+        isA<SesoriSessionCommandsUpdated>()
+            .having((event) => event.sessionID, "sessionID", "s1")
+            .having((event) => event.projectID, "projectID", "p1"),
+      );
     });
 
     test("maps command.executed events", () {

--- a/bridge/app/test/bridge/sse_manager_test.dart
+++ b/bridge/app/test/bridge/sse_manager_test.dart
@@ -108,6 +108,125 @@ void main() {
       expect((secondMsg as RelaySseEvent).data, equals(expectedData));
     });
 
+    test("delivers command updates according to subscriber capability", () async {
+      final roomKey = makeRoomKey();
+      final client = _RecordingRelayClient();
+      final manager = SSEManager(
+        replayWindow: SSEManager.defaultReplayWindow,
+        onBytesSent: (_) {},
+        failureReporter: FakeFailureReporter(),
+      );
+      manager.setRoomKey(roomKey);
+      addTearDown(manager.stop);
+
+      manager.subscribeForTest(
+        1,
+        client,
+        supportsSessionCommandsUpdated: true,
+      );
+      manager.subscribeForTest(
+        2,
+        client,
+        supportsSessionCommandsUpdated: false,
+      );
+      manager.enqueueEvent(
+        const SesoriSseEvent.sessionCommandsUpdated(
+          sessionID: "session-1",
+          projectID: "project-1",
+        ),
+      );
+
+      await _waitForSendCount(client, 2);
+
+      final capableEvent = await _decryptSentEvent(
+        client: client,
+        sendIndex: client.sentConnIDs.indexOf(1),
+        roomKey: roomKey,
+      );
+      final legacyEvent = await _decryptSentEvent(
+        client: client,
+        sendIndex: client.sentConnIDs.indexOf(2),
+        roomKey: roomKey,
+      );
+      expect(
+        capableEvent,
+        isA<SesoriSessionCommandsUpdated>()
+            .having((event) => event.sessionID, "sessionID", "session-1")
+            .having((event) => event.projectID, "projectID", "project-1"),
+      );
+      expect(
+        legacyEvent,
+        isA<SesoriSessionsUpdated>().having((event) => event.projectID, "projectID", "project-1"),
+      );
+    });
+
+    test("orphan replay uses the reconnecting subscriber capability", () async {
+      final roomKey = makeRoomKey();
+      final client = _RecordingRelayClient();
+      final manager = SSEManager(
+        replayWindow: SSEManager.defaultReplayWindow,
+        onBytesSent: (_) {},
+        failureReporter: FakeFailureReporter(),
+      );
+      manager.setRoomKey(roomKey);
+      addTearDown(manager.stop);
+
+      manager.subscribeForTest(
+        1,
+        client,
+        supportsSessionCommandsUpdated: false,
+      );
+      manager.unsubscribe(1);
+      manager.enqueueEvent(
+        const SesoriSseEvent.sessionCommandsUpdated(
+          sessionID: "session-capable",
+          projectID: "project-capable",
+        ),
+      );
+      manager.subscribeForTest(
+        2,
+        client,
+        supportsSessionCommandsUpdated: true,
+      );
+      await _waitForSendCount(client, 1);
+      await _pumpEventLoop();
+
+      manager.unsubscribe(2);
+      manager.enqueueEvent(
+        const SesoriSseEvent.sessionCommandsUpdated(
+          sessionID: "session-legacy",
+          projectID: "project-legacy",
+        ),
+      );
+      manager.subscribeForTest(
+        3,
+        client,
+        supportsSessionCommandsUpdated: false,
+      );
+      await _waitForSendCount(client, 2);
+
+      final capableEvent = await _decryptSentEvent(
+        client: client,
+        sendIndex: 0,
+        roomKey: roomKey,
+      );
+      final legacyEvent = await _decryptSentEvent(
+        client: client,
+        sendIndex: 1,
+        roomKey: roomKey,
+      );
+      expect(
+        capableEvent,
+        isA<SesoriSessionCommandsUpdated>()
+            .having((event) => event.sessionID, "sessionID", "session-capable")
+            .having((event) => event.projectID, "projectID", "project-capable"),
+      );
+      expect(
+        legacyEvent,
+        isA<SesoriSessionsUpdated>().having((event) => event.projectID, "projectID", "project-legacy"),
+      );
+    });
+
     test("without room key events are not sent", () async {
       final client = _RecordingRelayClient();
       final manager = SSEManager(
@@ -425,6 +544,32 @@ Future<Map<String, dynamic>> _decryptEnvelope(
   return jsonDecode(utf8.decode(decrypted)) as Map<String, dynamic>;
 }
 
+Future<SesoriSseEvent> _decryptSentEvent({
+  required _RecordingRelayClient client,
+  required int sendIndex,
+  required List<int> roomKey,
+}) async {
+  final relayMessage = RelayMessage.fromJson(
+    await _decryptEnvelope(client.sentPayloads[sendIndex], roomKey),
+  );
+  if (relayMessage is! RelaySseEvent) {
+    throw StateError("Expected an SSE relay message, got ${relayMessage.runtimeType}");
+  }
+  final wireEnvelope = jsonDecodeMap(relayMessage.data);
+  final payload = switch (wireEnvelope["payload"]) {
+    final Map<String, dynamic> value => value,
+    _ => throw StateError("Expected an SSE payload object"),
+  };
+  final properties = switch (payload["properties"]) {
+    final Map<String, dynamic> value => value,
+    _ => throw StateError("Expected SSE properties"),
+  };
+  return SesoriSseEvent.fromJson({
+    ...properties,
+    "type": payload["type"],
+  });
+}
+
 Future<void> _waitForSendCount(_RecordingRelayClient client, int count) async {
   if (client.sentConnIDs.length >= count) return;
   // The recording client emits per recorded send, so the wait is event-driven
@@ -533,10 +678,15 @@ class _CompletingFailureReporter extends CapturingFailureReporter {
 }
 
 extension on SSEManager {
-  void subscribeForTest(int connID, RelayClient client) {
+  void subscribeForTest(
+    int connID,
+    RelayClient client, {
+    bool supportsSessionCommandsUpdated = false,
+  }) {
     subscribePath(
       connID: connID,
       path: "/global/event",
+      supportsSessionCommandsUpdated: supportsSessionCommandsUpdated,
       client: client,
       connection: _testRelayConnection,
     );

--- a/bridge/app/tool/benchmarks/catalog_import_event_soak.dart
+++ b/bridge/app/tool/benchmarks/catalog_import_event_soak.dart
@@ -182,6 +182,7 @@ class _CatalogImportEventSoak {
         sseManager.subscribePath(
           connID: 1,
           path: "/global/event",
+          supportsSessionCommandsUpdated: true,
           client: relay.client,
           connection: relay.connection,
         );

--- a/bridge/app/tool/benchmarks/event_projection_benchmark.dart
+++ b/bridge/app/tool/benchmarks/event_projection_benchmark.dart
@@ -180,6 +180,7 @@ class _EventProjectionBenchmark {
       sseManager.subscribePath(
         connID: 1,
         path: "/global/event",
+        supportsSessionCommandsUpdated: true,
         client: relay.client,
         connection: relay.connection,
       );

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -341,9 +341,9 @@ class AcpEventMapper {
       case "available_commands_update":
         // The advertised commands themselves are tracked by AcpCommandTracker
         // (served via getCommands); this makes the matching client session
-        // re-fetch its snapshot so the new command list becomes visible.
+        // re-fetch only its command catalog.
         return [
-          BridgeSseSessionsUpdated(
+          BridgeSseSessionCommandsUpdated(
             sessionID: sessionId,
             projectID: projectForSession(sessionId: sessionId),
           ),

--- a/bridge/sesori_plugin_acp/test/acp_commands_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_commands_test.dart
@@ -183,6 +183,12 @@ void main() {
       expect(options.completeness, PluginSessionOptionsCompleteness.complete);
       expect(options.commands.single.name, "create_plan");
       expect(
+        emitted.whereType<BridgeSseSessionCommandsUpdated>().single,
+        isA<BridgeSseSessionCommandsUpdated>()
+            .having((event) => event.sessionID, "sessionID", "s1")
+            .having((event) => event.projectID, "projectID", cwd),
+      );
+      expect(
         emitted.whereType<BridgeSseSessionOptionsChanged>().single.sessionID,
         "s1",
       );
@@ -224,7 +230,7 @@ void main() {
     });
   });
 
-  test("history replay advertises commands and emits a session refresh", () async {
+  test("history replay advertises commands and emits a command-catalog refresh", () async {
     final live = FakeAcpProcess();
     final replay = FakeAcpProcess();
     final processes = [live, replay];
@@ -338,8 +344,10 @@ void main() {
 
       expect((await plugin.getCommands(projectId: "/repo")).single.name, "from_replay");
       expect(
-        emitted.whereType<BridgeSseSessionsUpdated>().single.sessionID,
-        "s1",
+        emitted.whereType<BridgeSseSessionCommandsUpdated>().single,
+        isA<BridgeSseSessionCommandsUpdated>()
+            .having((event) => event.sessionID, "sessionID", "s1")
+            .having((event) => event.projectID, "projectID", "/repo/worktree"),
       );
       expect(
         emitted.whereType<BridgeSseSessionOptionsChanged>().single.sessionID,

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -579,7 +579,7 @@ void main() {
       expect(late.whereType<BridgeSseMessagePartDelta>().single.messageID, firstId);
     });
 
-    test("plan maps to a todo update, commands mark their project sessions stale", () {
+    test("plan maps to a todo update, commands invalidate only their session catalog", () {
       expect(
         mapper.map(update({"sessionUpdate": "plan", "entries": const <Object?>[]})).single,
         isA<BridgeSseTodoUpdated>(),
@@ -587,8 +587,8 @@ void main() {
       mapper.setSessionProject("s1", "/repo/other");
       final events = mapper.map(update({"sessionUpdate": "available_commands_update"}));
       expect(
-        events.whereType<BridgeSseSessionsUpdated>().single,
-        isA<BridgeSseSessionsUpdated>()
+        events.whereType<BridgeSseSessionCommandsUpdated>().single,
+        isA<BridgeSseSessionCommandsUpdated>()
             .having((event) => event.sessionID, "sessionID", "s1")
             .having((event) => event.projectID, "projectID", "/repo/other"),
       );

--- a/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
@@ -250,7 +250,10 @@ void main() {
       await loading;
       await pump();
 
-      expect(emitted.whereType<BridgeSseSessionsUpdated>(), isNotEmpty);
+      expect(
+        emitted.whereType<BridgeSseSessionCommandsUpdated>(),
+        isNotEmpty,
+      );
     });
 
     test("a genuine RPC error (not -32601/-32602) still surfaces as a typed failure", () async {

--- a/bridge/sesori_plugin_acp/test/acp_resume_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_test.dart
@@ -132,8 +132,11 @@ void main() {
       // The suppressed replay produced no message events on the live stream.
       expect(emitted.whereType<BridgeSseMessagePartDelta>(), isEmpty);
       // Command metadata is current even during a history replay, so the
-      // client receives the stale-session signal and re-fetches it.
-      expect(emitted.whereType<BridgeSseSessionsUpdated>(), hasLength(1));
+      // client receives the dedicated command-catalog invalidation.
+      expect(
+        emitted.whereType<BridgeSseSessionCommandsUpdated>(),
+        hasLength(1),
+      );
       expect(
         emitted.whereType<BridgeSseSessionOptionsChanged>().single.sessionID,
         "old-session",

--- a/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
@@ -43,11 +43,15 @@ class BridgeSseSessionUpdated extends BridgeSseEvent {
   const BridgeSseSessionUpdated({required this.info, required this.titleChanged});
 }
 
-/// Signals that every session under [projectID] should be re-fetched.
-class BridgeSseSessionsUpdated extends BridgeSseEvent {
+/// Signals that the command catalog changed for [sessionID].
+///
+/// Plugin emitters provide the backend session identity and project context.
+/// Bridge core replaces both with the stable Sesori session identity and its
+/// authoritative persisted project before relay delivery.
+class BridgeSseSessionCommandsUpdated extends BridgeSseEvent {
   final String sessionID;
   final String projectID;
-  const BridgeSseSessionsUpdated({
+  const BridgeSseSessionCommandsUpdated({
     required this.sessionID,
     required this.projectID,
   });

--- a/client/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/client/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -1277,7 +1277,14 @@ void main() {
           (_) async => ApiResponse.success(SessionListResponse(items: [oldChild, newChild])),
         );
 
-        globalEvents.add(SseEvent(data: const SesoriSessionsUpdated(projectID: "project-1")));
+        connectionStatus.add(
+          ConnectionStatus.connected(
+            config: const ServerConnectionConfig(relayHost: "fake.example.com"),
+            health: testHealthResponse(),
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+        mockConnectionService.emitDataMayBeStale();
         await Future<void>.delayed(const Duration(milliseconds: 10));
       },
       expect: () => [
@@ -1341,7 +1348,14 @@ void main() {
       addTearDown(cubit.close);
       await _awaitLoaded(cubit);
 
-      globalEvents.add(SseEvent(data: const SesoriSessionsUpdated(projectID: "project-1")));
+      connectionStatus.add(
+        ConnectionStatus.connected(
+          config: const ServerConnectionConfig(relayHost: "fake.example.com"),
+          health: testHealthResponse(),
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+      mockConnectionService.emitDataMayBeStale();
       await slowRefreshStarted.future;
 
       cubit.selectModel(providerID: "openai", modelID: "gpt-4.1");
@@ -1917,9 +1931,7 @@ void main() {
       );
 
       when(() => mockConnectionService.currentStatus).thenReturn(connected);
-      globalEvents.add(
-        SseEvent(data: const SesoriSessionsUpdated(projectID: "project-1")),
-      );
+      mockConnectionService.emitDataMayBeStale();
       await slowRefreshStarted.future;
 
       connectionStatus.add(connected);

--- a/client/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/client/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -412,7 +412,14 @@ class RelayClient {
 
     final controller = StreamController<RelaySseEvent>.broadcast();
     _sseController = controller;
-    unawaited(_sendEncryptedMessage(RelayMessage.sseSubscribe(path: path)));
+    unawaited(
+      _sendEncryptedMessage(
+        RelayMessage.sseSubscribe(
+          path: path,
+          supportsSessionCommandsUpdated: true,
+        ),
+      ),
+    );
     return controller.stream;
   }
 

--- a/client/module_core/lib/src/capabilities/server_connection/models/sse_event.dart
+++ b/client/module_core/lib/src/capabilities/server_connection/models/sse_event.dart
@@ -13,6 +13,7 @@ class SseEvent {
   static String? _extractSessionId(SesoriSseEvent event) => switch (event) {
     SesoriSessionCreated(:final info) => info.id,
     SesoriSessionUpdated(:final info) => info.id,
+    SesoriSessionCommandsUpdated(:final sessionID) => sessionID,
     SesoriSessionDeleted(:final info) => info.id,
     SesoriSessionDiff(:final sessionID) => sessionID,
     SesoriSessionError(:final sessionID) => sessionID,

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -31,7 +31,6 @@ import "session_detail_state.dart";
 import "streaming_text_buffer.dart";
 
 enum _SessionRefreshTrigger {
-  projectSessionsUpdated("project_sessions_updated"),
   commandExecuted("command_executed"),
   connectionReconnected("connection_reconnected"),
   lifecycleResumed("lifecycle_resumed"),
@@ -85,6 +84,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
   bool _waitingForConnection = false;
   bool _wasPaused = false;
   bool _wasConnected = false;
+  int _commandRefreshGeneration = 0;
 
   /// Set when a resume/reconnect requires the next successful silent refresh
   /// to re-declare "the user is viewing this session". The viewing service
@@ -291,17 +291,16 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     );
   }
 
-  /// Coalesces event-driven staleness signals (sessions.updated,
-  /// command.executed, dataMayBeStale) into at most one silent refresh per
+  /// Coalesces event-driven staleness signals (command.executed and
+  /// dataMayBeStale) into at most one silent refresh per
   /// [eventRefreshMinInterval]. While the agent works, the bridge can emit
-  /// these in sustained bursts (e.g. sessions.updated on every PR-sync tick),
-  /// and each silent refresh refetches the whole session snapshot — ~10
-  /// encrypted relay round-trips — so refreshing per event keeps the radio
-  /// and main isolate busy for the entire turn. The first signal after a
-  /// quiet period still refreshes immediately; follow-ups within the cooldown
-  /// collapse into a single trailing refresh. Reconnect and app-resume
-  /// refreshes bypass this on purpose: they must run promptly and re-assert
-  /// the bridge-side view declaration.
+  /// these in sustained bursts, and each silent refresh refetches the whole
+  /// session snapshot — ~10 encrypted relay round-trips — so refreshing per
+  /// event keeps the radio and main isolate busy for the entire turn. The first
+  /// signal after a quiet period still refreshes immediately; follow-ups within
+  /// the cooldown collapse into a single trailing refresh. Reconnect and
+  /// app-resume refreshes bypass this on purpose: they must run promptly and
+  /// re-assert the bridge-side view declaration.
   void _requestEventDrivenRefresh({required _SessionRefreshTrigger trigger}) {
     _logRefresh(action: _SessionRefreshAction.observed, trigger: trigger);
     if (state is! SessionDetailLoaded) {
@@ -383,6 +382,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     final current = state;
     if (current is! SessionDetailLoaded) return _SessionRefreshResult.closed;
 
+    final commandRefreshGeneration = _commandRefreshGeneration;
     emit(current.copyWith(isRefreshing: true, queuedMessages: _promptQueue.items));
 
     try {
@@ -428,6 +428,9 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
           final preservedSelectedAgent = latest.selectedAgent;
           final preservedSelectedAgentModel = latest.selectedAgentModel;
           final preservedStagedCommand = latest.stagedCommand;
+          final availableCommands = commandRefreshGeneration == _commandRefreshGeneration
+              ? snapshot.commands
+              : latest.availableCommands;
           final availableVariants = _deriveAvailableVariants(
             providers: availableProviders,
             model: preservedSelectedAgentModel,
@@ -455,12 +458,12 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
               isArchived: snapshot.isArchived,
               availableAgents: availableAgents,
               availableProviders: availableProviders,
-              availableCommands: snapshot.commands,
+              availableCommands: availableCommands,
               sessionTitle: snapshot.canonicalSessionTitle ?? latest.sessionTitle,
               selectedAgent: preservedSelectedAgent,
               selectedAgentModel: preservedSelectedAgentModel,
               stagedCommand: _resolveStagedCommand(
-                availableCommands: snapshot.commands,
+                availableCommands: availableCommands,
                 stagedCommand: preservedStagedCommand,
               ),
               queuedMessages: _promptQueue.items,
@@ -531,6 +534,44 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     logd("[session-refresh] action=${action.name} trigger=${trigger.logValue}");
   }
 
+  void _refreshCommands({required String projectId}) {
+    final current = state;
+    if (current is! SessionDetailLoaded) return;
+    final pluginId = current.pluginId;
+    if (pluginId == null) return;
+
+    final generation = ++_commandRefreshGeneration;
+    unawaited(_loadCommands(projectId: projectId, pluginId: pluginId, generation: generation));
+  }
+
+  Future<void> _loadCommands({
+    required String projectId,
+    required String pluginId,
+    required int generation,
+  }) async {
+    final result = await _loadService.loadCommands(projectId: projectId, pluginId: pluginId);
+    if (isClosed || generation != _commandRefreshGeneration) return;
+
+    switch (result) {
+      case SessionCommandsLoadResultLoaded(:final commands):
+        final latest = state;
+        if (latest is! SessionDetailLoaded) return;
+        emit(
+          latest.copyWith(
+            availableCommands: commands,
+            stagedCommand: _resolveStagedCommand(
+              availableCommands: commands,
+              stagedCommand: latest.stagedCommand,
+            ),
+          ),
+        );
+      case SessionCommandsLoadResultWaitingForConnection():
+        return;
+      case SessionCommandsLoadResultFailed(:final error, :final stackTrace):
+        logw("Session command refresh failed", error, stackTrace);
+    }
+  }
+
   CommandInfo? _resolveStagedCommand({
     required List<CommandInfo> availableCommands,
     required CommandInfo? stagedCommand,
@@ -587,6 +628,8 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
           _onPermissionResolved(requestID);
         case SesoriSessionUpdated(:final info):
           _onSessionUpdated(info);
+        case SesoriSessionCommandsUpdated(:final projectID):
+          _refreshCommands(projectId: projectID);
         case SesoriCommandExecuted():
           _onDataMayBeStale(trigger: _SessionRefreshTrigger.commandExecuted);
         case SesoriSessionPromptDefaultsChanged(:final promptDefaults):
@@ -677,6 +720,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
       SesoriCatalogImportProgress() ||
       SesoriPluginManagementChanged() ||
       SesoriSessionDeleted() ||
+      SesoriSessionCommandsUpdated() ||
       SesoriSessionDiff() ||
       SesoriSessionError() ||
       SesoriSessionCompacted() ||
@@ -712,12 +756,15 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
       // Unseen-state changes are list-level concerns handled by the tracker;
       // the detail screen does not react to them.
       SesoriSessionUnseenChanged() => false,
-      // Command catalogs can change while the initial snapshot is in flight
-      // (Cursor advertises them during the concurrent history load), so retain
-      // a matching project invalidation and refresh once loading completes.
-      SesoriSessionsUpdated(:final projectID) => projectID.isNotEmpty && projectID == _projectId,
+      SesoriSessionsUpdated(:final projectID) =>
+        _usesPublicV160CommandFallback && projectID.isNotEmpty && projectID == _projectId,
     };
   }
+
+  bool get _usesPublicV160CommandFallback => switch (_connectionService.currentStatus) {
+    ConnectionConnected(:final health) => !health.supportsSessionCommandsUpdated,
+    ConnectionDisconnected() || ConnectionReconnecting() || ConnectionLost() || ConnectionBridgeOffline() => false,
+  };
 
   void _processGlobalEvent(SseEvent event) {
     final data = event.data;
@@ -759,6 +806,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
             SesoriGlobalDisposed() ||
             SesoriCatalogImportProgress() ||
             SesoriPluginManagementChanged() ||
+            SesoriSessionCommandsUpdated() ||
             SesoriMessageUpdated() ||
             SesoriMessageRemoved() ||
             SesoriMessagePartUpdated() ||
@@ -796,17 +844,11 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
             SesoriSessionPromptDefaultsChanged():
           break;
         case SesoriSessionsUpdated(:final projectID):
-          if (projectID.isNotEmpty && projectID == _projectId) {
-            _requestEventDrivenRefresh(trigger: _SessionRefreshTrigger.projectSessionsUpdated);
-          } else {
-            _logRefresh(
-              action: _SessionRefreshAction.observed,
-              trigger: _SessionRefreshTrigger.projectSessionsUpdated,
-            );
-            _logRefresh(
-              action: _SessionRefreshAction.ignored,
-              trigger: _SessionRefreshTrigger.projectSessionsUpdated,
-            );
+          // COMPATIBILITY 2026-08-04 (v1.6.0): The public v1.6.0 bridge uses
+          // `sessions.updated` for command invalidation. Remove this fallback
+          // once v1.6.0 bridges are unsupported.
+          if (_usesPublicV160CommandFallback && projectID.isNotEmpty && projectID == _projectId) {
+            _refreshCommands(projectId: projectID);
           }
       }
     } catch (e, st) {

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -125,6 +125,7 @@ class SessionListCubit extends Cubit<SessionListState> {
             SesoriGlobalDisposed() ||
             SesoriCatalogImportProgress() ||
             SesoriPluginManagementChanged() ||
+            SesoriSessionCommandsUpdated() ||
             SesoriSessionDiff() ||
             SesoriSessionError() ||
             SesoriSessionCompacted() ||

--- a/client/module_core/lib/src/services/session_detail_load_service.dart
+++ b/client/module_core/lib/src/services/session_detail_load_service.dart
@@ -30,6 +30,28 @@ class SessionDetailLoadService {
     return _loadSnapshot(sessionId: sessionId, projectId: projectId);
   }
 
+  Future<SessionCommandsLoadResult> loadCommands({
+    required String projectId,
+    required String pluginId,
+  }) async {
+    if (_connectionService.currentStatus is! ConnectionConnected) {
+      return const SessionCommandsLoadResult.waitingForConnection();
+    }
+
+    try {
+      final response = await _repository.listCommands(projectId: projectId, pluginId: pluginId);
+      return switch (response) {
+        SuccessResponse(:final data) => SessionCommandsLoadResult.loaded(commands: data.items),
+        ErrorResponse(:final error) => SessionCommandsLoadResult.failed(
+          error: error,
+          stackTrace: error.stackTrace,
+        ),
+      };
+    } on Object catch (error, stackTrace) {
+      return SessionCommandsLoadResult.failed(error: error, stackTrace: stackTrace);
+    }
+  }
+
   Future<SessionDetailLoadResult> _loadSnapshot({
     required String sessionId,
     required String projectId,
@@ -269,4 +291,38 @@ final class SessionDetailLoadResultFailed extends SessionDetailLoadResult {
   final StackTrace? stackTrace;
 
   const SessionDetailLoadResultFailed({required this.error, required this.stackTrace});
+}
+
+sealed class SessionCommandsLoadResult {
+  const SessionCommandsLoadResult();
+
+  const factory SessionCommandsLoadResult.loaded({
+    required List<CommandInfo> commands,
+  }) = SessionCommandsLoadResultLoaded;
+
+  const factory SessionCommandsLoadResult.waitingForConnection() = SessionCommandsLoadResultWaitingForConnection;
+
+  const factory SessionCommandsLoadResult.failed({
+    // ignore: no_slop_linter/prefer_specific_type
+    required Object error,
+    required StackTrace? stackTrace,
+  }) = SessionCommandsLoadResultFailed;
+}
+
+final class SessionCommandsLoadResultLoaded extends SessionCommandsLoadResult {
+  final List<CommandInfo> commands;
+
+  const SessionCommandsLoadResultLoaded({required this.commands});
+}
+
+final class SessionCommandsLoadResultWaitingForConnection extends SessionCommandsLoadResult {
+  const SessionCommandsLoadResultWaitingForConnection();
+}
+
+final class SessionCommandsLoadResultFailed extends SessionCommandsLoadResult {
+  // ignore: no_slop_linter/prefer_specific_type
+  final Object error;
+  final StackTrace? stackTrace;
+
+  const SessionCommandsLoadResultFailed({required this.error, required this.stackTrace});
 }

--- a/client/module_core/lib/src/services/sse_event_tracker.dart
+++ b/client/module_core/lib/src/services/sse_event_tracker.dart
@@ -98,6 +98,7 @@ class SseEventTracker with Disposable {
           }
         case SesoriSessionCreated() ||
             SesoriSessionUpdated() ||
+            SesoriSessionCommandsUpdated() ||
             SesoriSessionDeleted() ||
             SesoriServerConnected() ||
             SesoriServerHeartbeat() ||

--- a/client/module_core/test/capabilities/relay/relay_client_handshake_replay_test.dart
+++ b/client/module_core/test/capabilities/relay/relay_client_handshake_replay_test.dart
@@ -56,6 +56,22 @@ void main() {
     expect(client.isConnected, isTrue);
     expect(client.didResume, isTrue);
     verifyNever(roomKeyStorage.clearRoomKey);
+
+    final subscriptionFrameReady = outgoing.moveNext();
+    client.subscribeSse("/global/event");
+    expect(await subscriptionFrameReady.timeout(const Duration(seconds: 1)), isTrue);
+    final subscriptionFrame = Uint8List.fromList(outgoing.current! as List<int>);
+    final subscriptionJson = jsonDecodeMap(
+      utf8.decode(await unframe(subscriptionFrame, encryptor: encryptor)),
+    );
+
+    expect(
+      RelayMessage.fromJson(subscriptionJson),
+      const RelaySseSubscribe(
+        path: "/global/event",
+        supportsSessionCommandsUpdated: true,
+      ),
+    );
   });
 }
 

--- a/client/module_core/test/capabilities/server_connection/connection_service_sse_test.dart
+++ b/client/module_core/test/capabilities/server_connection/connection_service_sse_test.dart
@@ -177,6 +177,35 @@ void main() {
       expect(logs, contains(contains("Ignoring unknown SSE event type: plugin.future.changed")));
     });
 
+    test("routes session.commands.updated through the matching stable session stream", () async {
+      final result = await service.connect(config);
+      expect(result, isA<SuccessResponse<HealthResponse>>());
+      final matchingEvent = service.sessionEvents("session-1").first;
+
+      sseController.add(
+        RelaySseEvent(
+          data: jsonEncode({
+            "payload": {
+              "type": "session.commands.updated",
+              "properties": {
+                "sessionID": "session-1",
+                "projectID": "project-1",
+              },
+            },
+          }),
+        ),
+      );
+
+      final event = await matchingEvent.timeout(const Duration(seconds: 1));
+      expect(
+        event,
+        const SesoriSessionCommandsUpdated(
+          sessionID: "session-1",
+          projectID: "project-1",
+        ),
+      );
+    });
+
     test("still reports a malformed payload for a known event type", () async {
       final previousLogLevel = logLevel;
       setLogLevel(LogLevel.none);

--- a/client/module_core/test/capabilities/server_connection/models/sse_event_test.dart
+++ b/client/module_core/test/capabilities/server_connection/models/sse_event_test.dart
@@ -14,6 +14,18 @@ void main() {
     expect(event.sessionId, equals("session-123"));
   });
 
+  test("sessionCommandsUpdated exposes its stable sessionId", () {
+    final event = SseEvent(
+      data: const SesoriSseEvent.sessionCommandsUpdated(
+        sessionID: "session-123",
+        projectID: "project-456",
+      ),
+    );
+
+    expect(event.sessionId, equals("session-123"));
+    expect(event.data, isA<SesoriSessionEvent>());
+  });
+
   test("catalogImportProgress is a global non-session event", () {
     final event = SseEvent(
       data: const SesoriSseEvent.catalogImportProgress(

--- a/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
@@ -8,6 +8,7 @@ import "package:sesori_dart_core/src/capabilities/server_connection/models/sse_e
 import "package:sesori_dart_core/src/capabilities/server_connection/server_connection_config.dart";
 import "package:sesori_dart_core/src/cubits/session_detail/session_detail_cubit.dart";
 import "package:sesori_dart_core/src/cubits/session_detail/session_detail_state.dart";
+import "package:sesori_dart_core/src/logging/logging.dart";
 import "package:sesori_dart_core/src/platform/notification_canceller.dart";
 import "package:sesori_dart_core/src/repositories/permission_repository.dart";
 import "package:sesori_dart_core/src/services/session_detail_load_service.dart";
@@ -226,10 +227,9 @@ void main() {
       expect(state.children.first.id, "child-1");
     });
 
-    test("refreshes commands when sessions.updated arrives during loading", () async {
+    test("refreshes commands when session.commands.updated arrives during loading", () async {
       final mockLoadService = MockSessionDetailLoadService();
       final loadCompleter = Completer<SessionDetailLoadResult>();
-      var reloadCount = 0;
 
       when(
         () => mockLoadService.load(
@@ -238,36 +238,22 @@ void main() {
         ),
       ).thenAnswer((_) => loadCompleter.future);
       when(
-        () => mockLoadService.reload(
-          sessionId: _sessionId,
-          projectId: any(named: "projectId"),
+        () => mockLoadService.loadCommands(
+          projectId: "project-1",
+          pluginId: "opencode",
         ),
-      ).thenAnswer((_) async {
-        reloadCount++;
-        return SessionDetailLoadResult.loaded(
-          snapshot: SessionDetailSnapshot(
-            projectId: "project-1",
-            pluginId: "opencode",
-            messages: const <MessageWithParts>[],
-            pendingQuestions: const <PendingQuestion>[],
-            pendingPermissions: const <PendingPermission>[],
-            childSessions: const <Session>[],
-            statuses: const <String, SessionStatus>{},
-            agents: const <AgentInfo?>[],
-            providerData: null,
-            commands: [testCommandInfo(name: "compact", template: "/compact")],
-            canonicalSessionTitle: null,
-            promptDefaults: null,
-            isRootSession: true,
-            isArchived: false,
-          ),
-          isBridgeConnected: true,
-        );
-      });
+      ).thenAnswer(
+        (_) async => SessionCommandsLoadResult.loaded(
+          commands: [testCommandInfo(name: "compact", template: "/compact")],
+        ),
+      );
 
       final cubit = createCubit(loadService: mockLoadService);
-      globalEvents.add(
-        SseEvent(data: const SesoriSessionsUpdated(projectID: "project-1")),
+      sessionEvents.add(
+        const SesoriSessionCommandsUpdated(
+          sessionID: _sessionId,
+          projectID: "project-1",
+        ),
       );
       await Future<void>.delayed(Duration.zero);
 
@@ -293,11 +279,318 @@ void main() {
         ),
       );
 
-      for (var i = 0; i < 100 && reloadCount == 0; i++) {
-        await Future<void>.delayed(const Duration(milliseconds: 5));
-      }
-      expect(reloadCount, 1);
       await _awaitLoadedWithCommand(cubit, command: "compact");
+      verify(() => mockLoadService.loadCommands(projectId: "project-1", pluginId: "opencode")).called(1);
+      verifyNever(
+        () => mockLoadService.reload(
+          sessionId: any(named: "sessionId"),
+          projectId: any(named: "projectId"),
+        ),
+      );
+    });
+
+    test("command refresh changes only the catalog and retained staged command", () async {
+      final mockLoadService = MockSessionDetailLoadService();
+      final initialCommand = testCommandInfo(name: "review", template: "/review old");
+      final refreshedCommand = testCommandInfo(name: "review", template: "/review new");
+      final replacementCommand = testCommandInfo(name: "compact", template: "/compact");
+      final commandResponses = <List<CommandInfo>>[
+        [refreshedCommand],
+        [replacementCommand],
+      ];
+      when(
+        () => mockLoadService.load(
+          sessionId: _sessionId,
+          projectId: any(named: "projectId"),
+        ),
+      ).thenAnswer((_) async => _loadedResult(commands: [initialCommand]));
+      when(
+        () => mockLoadService.loadCommands(
+          projectId: "project-1",
+          pluginId: "opencode",
+        ),
+      ).thenAnswer(
+        (_) async => SessionCommandsLoadResult.loaded(commands: commandResponses.removeAt(0)),
+      );
+
+      final cubit = createCubit(loadService: mockLoadService);
+      await _awaitLoaded(cubit);
+      cubit.stageCommand(initialCommand);
+      final beforeRefresh = cubit.state as SessionDetailLoaded;
+      final retainedUpdate = cubit.stream.firstWhere(
+        (state) =>
+            state is SessionDetailLoaded &&
+            state.availableCommands.length == 1 &&
+            state.availableCommands.single.template == refreshedCommand.template,
+      );
+
+      sessionEvents.add(
+        const SesoriSessionCommandsUpdated(
+          sessionID: _sessionId,
+          projectID: "project-1",
+        ),
+      );
+      final retained = await retainedUpdate.timeout(const Duration(seconds: 1)) as SessionDetailLoaded;
+
+      expect(
+        retained,
+        beforeRefresh.copyWith(
+          availableCommands: [refreshedCommand],
+          stagedCommand: refreshedCommand,
+        ),
+      );
+      expect(retained.isRefreshing, isFalse);
+
+      final removedUpdate = cubit.stream.firstWhere(
+        (state) =>
+            state is SessionDetailLoaded &&
+            state.availableCommands.length == 1 &&
+            state.availableCommands.single.name == "compact",
+      );
+      sessionEvents.add(
+        const SesoriSessionCommandsUpdated(
+          sessionID: _sessionId,
+          projectID: "project-1",
+        ),
+      );
+      final removed = await removedUpdate.timeout(const Duration(seconds: 1)) as SessionDetailLoaded;
+
+      expect(
+        removed,
+        retained.copyWith(
+          availableCommands: [replacementCommand],
+          stagedCommand: null,
+        ),
+      );
+      verify(() => mockLoadService.loadCommands(projectId: "project-1", pluginId: "opencode")).called(2);
+      verifyNever(
+        () => mockLoadService.reload(
+          sessionId: any(named: "sessionId"),
+          projectId: any(named: "projectId"),
+        ),
+      );
+    });
+
+    test("newer command refresh wins when responses complete out of order", () async {
+      final mockLoadService = MockSessionDetailLoadService();
+      final initialCommand = testCommandInfo(name: "review", template: "/review initial");
+      final olderCommand = testCommandInfo(name: "review", template: "/review older");
+      final newerCommand = testCommandInfo(name: "review", template: "/review newer");
+      final firstRefresh = Completer<SessionCommandsLoadResult>();
+      final secondRefresh = Completer<SessionCommandsLoadResult>();
+      final commandRefreshes = [firstRefresh, secondRefresh];
+      when(
+        () => mockLoadService.load(
+          sessionId: _sessionId,
+          projectId: any(named: "projectId"),
+        ),
+      ).thenAnswer((_) async => _loadedResult(commands: [initialCommand]));
+      when(
+        () => mockLoadService.loadCommands(
+          projectId: "project-1",
+          pluginId: "opencode",
+        ),
+      ).thenAnswer((_) => commandRefreshes.removeAt(0).future);
+
+      final cubit = createCubit(loadService: mockLoadService);
+      await _awaitLoaded(cubit);
+
+      const event = SesoriSessionCommandsUpdated(
+        sessionID: _sessionId,
+        projectID: "project-1",
+      );
+      sessionEvents.add(event);
+      await untilCalled(
+        () => mockLoadService.loadCommands(projectId: "project-1", pluginId: "opencode"),
+      );
+      sessionEvents.add(event);
+      await pumpEventQueue();
+
+      secondRefresh.complete(SessionCommandsLoadResult.loaded(commands: [newerCommand]));
+      await _awaitLoadedWithCommandTemplate(cubit, template: "/review newer");
+      firstRefresh.complete(SessionCommandsLoadResult.loaded(commands: [olderCommand]));
+      await pumpEventQueue();
+
+      expect((cubit.state as SessionDetailLoaded).availableCommands, [newerCommand]);
+      verify(() => mockLoadService.loadCommands(projectId: "project-1", pluginId: "opencode")).called(2);
+    });
+
+    test("command refresh is not overwritten by an older silent snapshot", () async {
+      final mockLoadService = MockSessionDetailLoadService();
+      final initialCommand = testCommandInfo(name: "review", template: "/review initial");
+      final staleCommand = testCommandInfo(name: "review", template: "/review stale");
+      final refreshedCommand = testCommandInfo(name: "review", template: "/review refreshed");
+      final snapshotRefresh = Completer<SessionDetailLoadResult>();
+      when(
+        () => mockLoadService.load(
+          sessionId: _sessionId,
+          projectId: any(named: "projectId"),
+        ),
+      ).thenAnswer((_) async => _loadedResult(commands: [initialCommand]));
+      when(
+        () => mockLoadService.reload(
+          sessionId: _sessionId,
+          projectId: "project-1",
+        ),
+      ).thenAnswer((_) => snapshotRefresh.future);
+      when(
+        () => mockLoadService.loadCommands(
+          projectId: "project-1",
+          pluginId: "opencode",
+        ),
+      ).thenAnswer(
+        (_) async => SessionCommandsLoadResult.loaded(commands: [refreshedCommand]),
+      );
+
+      final cubit = createCubit(loadService: mockLoadService);
+      await _awaitLoaded(cubit);
+      mockConnectionService.emitDataMayBeStale();
+      await untilCalled(
+        () => mockLoadService.reload(sessionId: _sessionId, projectId: "project-1"),
+      );
+
+      sessionEvents.add(
+        const SesoriSessionCommandsUpdated(
+          sessionID: _sessionId,
+          projectID: "project-1",
+        ),
+      );
+      await _awaitLoadedWithCommandTemplate(cubit, template: "/review refreshed");
+      snapshotRefresh.complete(_loadedResult(commands: [staleCommand]));
+      await pumpEventQueue();
+
+      final state = cubit.state as SessionDetailLoaded;
+      expect(state.availableCommands, [refreshedCommand]);
+      expect(state.isRefreshing, isFalse);
+    });
+
+    test("waiting command refresh preserves the loaded state", () async {
+      final mockLoadService = MockSessionDetailLoadService();
+      final command = testCommandInfo(name: "review", template: "/review");
+      when(
+        () => mockLoadService.load(
+          sessionId: _sessionId,
+          projectId: any(named: "projectId"),
+        ),
+      ).thenAnswer((_) async => _loadedResult(commands: [command]));
+      when(
+        () => mockLoadService.loadCommands(
+          projectId: "project-1",
+          pluginId: "opencode",
+        ),
+      ).thenAnswer((_) async => const SessionCommandsLoadResult.waitingForConnection());
+
+      final cubit = createCubit(loadService: mockLoadService);
+      await _awaitLoaded(cubit);
+      cubit.stageCommand(command);
+      final beforeRefresh = cubit.state;
+
+      sessionEvents.add(
+        const SesoriSessionCommandsUpdated(
+          sessionID: _sessionId,
+          projectID: "project-1",
+        ),
+      );
+      await untilCalled(
+        () => mockLoadService.loadCommands(projectId: "project-1", pluginId: "opencode"),
+      );
+      await pumpEventQueue();
+
+      expect(cubit.state, same(beforeRefresh));
+    });
+
+    test("failed command refresh keeps state and logs the original error and stack", () async {
+      final mockLoadService = MockSessionDetailLoadService();
+      final command = testCommandInfo(name: "review", template: "/review");
+      final error = StateError("command catalog unavailable");
+      final stackTrace = StackTrace.fromString("command-catalog-stack");
+      final logs = <String>[];
+      final stackLogged = Completer<void>();
+      final previousLogLevel = logLevel;
+      setLogLevel(LogLevel.warning);
+      addTearDown(() => setLogLevel(previousLogLevel));
+      when(
+        () => mockLoadService.load(
+          sessionId: _sessionId,
+          projectId: any(named: "projectId"),
+        ),
+      ).thenAnswer((_) async => _loadedResult(commands: [command]));
+      when(
+        () => mockLoadService.loadCommands(
+          projectId: "project-1",
+          pluginId: "opencode",
+        ),
+      ).thenAnswer(
+        (_) async => SessionCommandsLoadResult.failed(error: error, stackTrace: stackTrace),
+      );
+
+      final cubit = runZoned(
+        () => createCubit(loadService: mockLoadService),
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, line) {
+            logs.add(line);
+            if (line == stackTrace.toString() && !stackLogged.isCompleted) {
+              stackLogged.complete();
+            }
+          },
+        ),
+      );
+      await _awaitLoaded(cubit);
+      cubit.stageCommand(command);
+      final beforeRefresh = cubit.state;
+
+      sessionEvents.add(
+        const SesoriSessionCommandsUpdated(
+          sessionID: _sessionId,
+          projectID: "project-1",
+        ),
+      );
+      await stackLogged.future.timeout(const Duration(seconds: 1));
+
+      expect(cubit.state, same(beforeRefresh));
+      expect(logs, contains("Session command refresh failed: ${error.toString()}"));
+      expect(logs, contains(stackTrace.toString()));
+    });
+
+    test("command refresh completion after close does not alter state", () async {
+      final mockLoadService = MockSessionDetailLoadService();
+      final command = testCommandInfo(name: "review", template: "/review");
+      final commandLoad = Completer<SessionCommandsLoadResult>();
+      when(
+        () => mockLoadService.load(
+          sessionId: _sessionId,
+          projectId: any(named: "projectId"),
+        ),
+      ).thenAnswer((_) async => _loadedResult(commands: [command]));
+      when(
+        () => mockLoadService.loadCommands(
+          projectId: "project-1",
+          pluginId: "opencode",
+        ),
+      ).thenAnswer((_) => commandLoad.future);
+
+      final cubit = createCubit(loadService: mockLoadService);
+      await _awaitLoaded(cubit);
+      final beforeRefresh = cubit.state;
+      sessionEvents.add(
+        const SesoriSessionCommandsUpdated(
+          sessionID: _sessionId,
+          projectID: "project-1",
+        ),
+      );
+      await untilCalled(
+        () => mockLoadService.loadCommands(projectId: "project-1", pluginId: "opencode"),
+      );
+
+      await cubit.close();
+      commandLoad.complete(
+        SessionCommandsLoadResult.loaded(
+          commands: [testCommandInfo(name: "compact", template: "/compact")],
+        ),
+      );
+      await pumpEventQueue();
+
+      expect(cubit.state, same(beforeRefresh));
     });
 
     test("clears pending events when load fails", () async {
@@ -592,4 +885,40 @@ Future<void> _awaitLoadedWithCommand(
     await Future<void>.delayed(const Duration(milliseconds: 5));
   }
   fail("Timed out waiting for '$command'; current state: ${cubit.state}");
+}
+
+Future<void> _awaitLoadedWithCommandTemplate(
+  SessionDetailCubit cubit, {
+  required String template,
+}) async {
+  for (var i = 0; i < 100; i++) {
+    final state = cubit.state;
+    if (state is SessionDetailLoaded && state.availableCommands.any((item) => item.template == template)) {
+      return;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+  fail("Timed out waiting for '$template'; current state: ${cubit.state}");
+}
+
+SessionDetailLoadResult _loadedResult({required List<CommandInfo> commands}) {
+  return SessionDetailLoadResult.loaded(
+    snapshot: SessionDetailSnapshot(
+      projectId: "project-1",
+      pluginId: "opencode",
+      messages: const <MessageWithParts>[],
+      pendingQuestions: const <PendingQuestion>[],
+      pendingPermissions: const <PendingPermission>[],
+      childSessions: const <Session>[],
+      statuses: const <String, SessionStatus>{},
+      agents: const <AgentInfo?>[],
+      providerData: null,
+      commands: commands,
+      canonicalSessionTitle: null,
+      promptDefaults: null,
+      isRootSession: true,
+      isArchived: false,
+    ),
+    isBridgeConnected: true,
+  );
 }

--- a/client/module_core/test/cubits/session_detail/session_detail_reconnect_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_reconnect_test.dart
@@ -8,7 +8,6 @@ import "package:sesori_dart_core/src/capabilities/server_connection/models/sse_e
 import "package:sesori_dart_core/src/capabilities/server_connection/server_connection_config.dart";
 import "package:sesori_dart_core/src/cubits/session_detail/session_detail_cubit.dart";
 import "package:sesori_dart_core/src/cubits/session_detail/session_detail_state.dart";
-import "package:sesori_dart_core/src/logging/logging.dart";
 import "package:sesori_dart_core/src/platform/notification_canceller.dart";
 import "package:sesori_dart_core/src/repositories/permission_repository.dart";
 import "package:sesori_dart_core/src/repositories/project_repository.dart";
@@ -205,7 +204,7 @@ void main() {
     expect(cubit.state, isA<SessionDetailLoaded>());
   });
 
-  test("ignores sessions.updated events from unrelated projects", () async {
+  test("uses sessions.updated only for the public v1.6.0 command fallback", () async {
     final mockLoadService = MockSessionDetailLoadService();
     final mockSessionRepository = MockSessionRepository();
     final mockConnectionService = MockConnectionService();
@@ -214,14 +213,9 @@ void main() {
     final sessionEvents = StreamController<SesoriSessionEvent>.broadcast();
     final globalEvents = StreamController<SseEvent>.broadcast();
     final connectionStatus = BehaviorSubject<ConnectionStatus>.seeded(connectedStatus);
-    final logs = <String>[];
-    final previousLogLevel = logLevel;
-    setLogLevel(LogLevel.debug);
-
     addTearDown(sessionEvents.close);
     addTearDown(globalEvents.close);
     addTearDown(connectionStatus.close);
-    addTearDown(() => setLogLevel(previousLogLevel));
 
     when(() => mockConnectionService.sessionEvents(_sessionId)).thenAnswer((_) => sessionEvents.stream);
     when(() => mockConnectionService.events).thenAnswer((_) => globalEvents.stream);
@@ -276,26 +270,30 @@ void main() {
     ).thenAnswer(
       (_) async => loadedResult,
     );
-
-    final cubit = runZoned(
-      () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: mockLoadService,
-        promptDispatcher: mockSessionRepository,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: FakeLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: _sessionId,
+    when(
+      () => mockLoadService.loadCommands(
         projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
+        pluginId: "opencode",
       ),
-      zoneSpecification: ZoneSpecification(
-        print: (self, parent, zone, line) => logs.add(line),
+    ).thenAnswer(
+      (_) async => SessionCommandsLoadResult.loaded(
+        commands: [testCommandInfo(name: "compact", template: "/compact")],
       ),
+    );
+    final cubit = SessionDetailCubit(
+      mockConnectionService,
+      loadService: mockLoadService,
+      promptDispatcher: mockSessionRepository,
+      permissionRepository: mockPermissionRepository,
+      sessionViewingService: stubbedSessionViewingService(),
+      projectViewingService: stubbedProjectViewingService(),
+      lifecycleSource: FakeLifecycleSource(),
+      composerDraftRepository: inMemoryComposerDraftRepository(),
+      productAnalyticsService: stubbedProductAnalyticsService(),
+      sessionId: _sessionId,
+      projectId: "project-1",
+      notificationCanceller: mockNotificationCanceller,
+      failureReporter: MockFailureReporter(),
     );
     addTearDown(cubit.close);
 
@@ -303,36 +301,49 @@ void main() {
     verify(() => mockLoadService.load(sessionId: _sessionId, projectId: "project-1")).called(1);
 
     globalEvents.add(SseEvent(data: const SesoriSseEvent.sessionsUpdated(projectID: "project-2")));
-    await Future<void>.delayed(Duration.zero);
+    await pumpEventQueue();
+
+    verifyNever(
+      () => mockLoadService.loadCommands(
+        projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
+      ),
+    );
+
+    final commandsUpdated = cubit.stream.firstWhere(
+      (state) => state is SessionDetailLoaded && state.availableCommands.any((command) => command.name == "compact"),
+    );
+    globalEvents.add(SseEvent(data: const SesoriSseEvent.sessionsUpdated(projectID: "project-1")));
+    await commandsUpdated.timeout(const Duration(seconds: 1));
+
+    verify(() => mockLoadService.loadCommands(projectId: "project-1", pluginId: "opencode")).called(1);
+
+    const capableStatus = ConnectionStatus.connected(
+      config: ServerConnectionConfig(relayHost: "relay.example.com", authToken: "token"),
+      health: HealthResponse(
+        healthy: true,
+        version: "1.7.0",
+        filesystemAccessDegraded: null,
+        supportsSessionCommandsUpdated: true,
+      ),
+    );
+    connectionStatus.add(capableStatus);
+    await pumpEventQueue();
+    globalEvents.add(SseEvent(data: const SesoriSseEvent.sessionsUpdated(projectID: "project-1")));
+    await pumpEventQueue();
+
+    verifyNever(
+      () => mockLoadService.loadCommands(
+        projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
+      ),
+    );
 
     verifyNever(
       () => mockLoadService.reload(
-        sessionId: _sessionId,
+        sessionId: any(named: "sessionId"),
         projectId: any(named: "projectId"),
       ),
-    );
-    expect(
-      logs,
-      containsAll([
-        contains("[session-refresh] action=observed trigger=project_sessions_updated"),
-        contains("[session-refresh] action=ignored trigger=project_sessions_updated"),
-      ]),
-    );
-
-    globalEvents.add(SseEvent(data: const SesoriSseEvent.sessionsUpdated(projectID: "project-1")));
-    await Future<void>.delayed(Duration.zero);
-
-    verify(() => mockLoadService.reload(sessionId: _sessionId, projectId: "project-1")).called(1);
-    expect(
-      logs,
-      containsAll([
-        contains("[session-refresh] action=started trigger=project_sessions_updated"),
-        allOf(
-          contains("[session-refresh] action=completed trigger=project_sessions_updated"),
-          contains("result=applied"),
-          contains("durationMs="),
-        ),
-      ]),
     );
   });
 }

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -1333,6 +1333,23 @@ void main() {
       expect(afterSessionUpdate.sessions.single.pullRequest, mergedPullRequest);
 
       eventController.add(
+        SseEvent(
+          data: const SesoriSessionCommandsUpdated(
+            sessionID: "s1",
+            projectID: projectId,
+          ),
+        ),
+      );
+      await pumpEventQueue();
+      expect((cubit.state as SessionListLoaded).sessions.single.pullRequest, mergedPullRequest);
+      verify(
+        () => mockProjectRepository.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
+      ).called(1);
+
+      eventController.add(
         SseEvent(data: const SesoriSessionsUpdated(projectID: projectId)),
       );
       final afterAuthoritativeRefresh =

--- a/client/module_core/test/services/session_detail_load_service_test.dart
+++ b/client/module_core/test/services/session_detail_load_service_test.dart
@@ -46,6 +46,63 @@ void main() {
       await connectionStatus.close();
     });
 
+    test("loadCommands returns commands from the command repository route", () async {
+      connectionStatus.add(connectedStatus);
+      final commands = [testCommandInfo(name: "review", template: "/review")];
+      when(
+        () => repository.listCommands(projectId: "project-1", pluginId: "plugin-1"),
+      ).thenAnswer((_) async => ApiResponse.success(CommandListResponse(items: commands)));
+
+      final result = await service.loadCommands(projectId: "project-1", pluginId: "plugin-1");
+
+      expect(result, isA<SessionCommandsLoadResultLoaded>());
+      expect((result as SessionCommandsLoadResultLoaded).commands, commands);
+      verify(() => repository.listCommands(projectId: "project-1", pluginId: "plugin-1")).called(1);
+    });
+
+    test("loadCommands waits without requesting when disconnected", () async {
+      final result = await service.loadCommands(projectId: "project-1", pluginId: "plugin-1");
+
+      expect(result, isA<SessionCommandsLoadResultWaitingForConnection>());
+      verifyNever(
+        () => repository.listCommands(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
+      );
+    });
+
+    test("loadCommands preserves an API failure instead of returning an empty catalog", () async {
+      connectionStatus.add(connectedStatus);
+      final error = ApiError.generic();
+      when(
+        () => repository.listCommands(projectId: "project-1", pluginId: "plugin-1"),
+      ).thenAnswer((_) async => ApiResponse.error(error));
+
+      final result = await service.loadCommands(projectId: "project-1", pluginId: "plugin-1");
+
+      expect(result, isA<SessionCommandsLoadResultFailed>());
+      final failed = result as SessionCommandsLoadResultFailed;
+      expect(failed.error, same(error));
+      expect(failed.stackTrace, same(error.stackTrace));
+    });
+
+    test("loadCommands preserves a thrown error and stack trace", () async {
+      connectionStatus.add(connectedStatus);
+      final error = StateError("command catalog unavailable");
+      final stackTrace = StackTrace.fromString("command-catalog-stack");
+      when(
+        () => repository.listCommands(projectId: "project-1", pluginId: "plugin-1"),
+      ).thenAnswer((_) => Future<ApiResponse<CommandListResponse>>.error(error, stackTrace));
+
+      final result = await service.loadCommands(projectId: "project-1", pluginId: "plugin-1");
+
+      expect(result, isA<SessionCommandsLoadResultFailed>());
+      final failed = result as SessionCommandsLoadResultFailed;
+      expect(failed.error, same(error));
+      expect(failed.stackTrace, same(stackTrace));
+    });
+
     test("load returns exactly one typed outcome without emitting ui state", () async {
       connectionStatus.add(connectedStatus);
       _stubRepositorySnapshot(repository: repository);

--- a/shared/sesori_shared/lib/src/models/sesori/health_response.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/health_response.dart
@@ -15,6 +15,8 @@ sealed class HealthResponse with _$HealthResponse {
     // never sends it decodes to null and is treated as "not degraded".
     // COMPATIBILITY 2026-06-27 (v1.2.0): Old bridges omit filesystem-access state. Make this non-null and remove client null fallbacks once those bridges are unsupported.
     required bool? filesystemAccessDegraded,
+    // COMPATIBILITY 2026-08-04 (v1.6.0): The public v1.6.0 bridge omits dedicated command-catalog event support. Make this required once v1.6.0 bridges are unsupported.
+    @Default(false) bool supportsSessionCommandsUpdated,
   }) = _HealthResponse;
 
   factory HealthResponse.fromJson(Map<String, dynamic> json) => _$HealthResponseFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/health_response.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/health_response.freezed.dart
@@ -20,7 +20,8 @@ mixin _$HealthResponse {
 // warn the user. Nullable for backward compatibility: an older bridge that
 // never sends it decodes to null and is treated as "not degraded".
 // COMPATIBILITY 2026-06-27 (v1.2.0): Old bridges omit filesystem-access state. Make this non-null and remove client null fallbacks once those bridges are unsupported.
- bool? get filesystemAccessDegraded;
+ bool? get filesystemAccessDegraded;// COMPATIBILITY 2026-08-04 (v1.6.0): The public v1.6.0 bridge omits dedicated command-catalog event support. Make this required once v1.6.0 bridges are unsupported.
+ bool get supportsSessionCommandsUpdated;
 /// Create a copy of HealthResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -33,16 +34,16 @@ $HealthResponseCopyWith<HealthResponse> get copyWith => _$HealthResponseCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is HealthResponse&&(identical(other.healthy, healthy) || other.healthy == healthy)&&(identical(other.version, version) || other.version == version)&&(identical(other.filesystemAccessDegraded, filesystemAccessDegraded) || other.filesystemAccessDegraded == filesystemAccessDegraded));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HealthResponse&&(identical(other.healthy, healthy) || other.healthy == healthy)&&(identical(other.version, version) || other.version == version)&&(identical(other.filesystemAccessDegraded, filesystemAccessDegraded) || other.filesystemAccessDegraded == filesystemAccessDegraded)&&(identical(other.supportsSessionCommandsUpdated, supportsSessionCommandsUpdated) || other.supportsSessionCommandsUpdated == supportsSessionCommandsUpdated));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,healthy,version,filesystemAccessDegraded);
+int get hashCode => Object.hash(runtimeType,healthy,version,filesystemAccessDegraded,supportsSessionCommandsUpdated);
 
 @override
 String toString() {
-  return 'HealthResponse(healthy: $healthy, version: $version, filesystemAccessDegraded: $filesystemAccessDegraded)';
+  return 'HealthResponse(healthy: $healthy, version: $version, filesystemAccessDegraded: $filesystemAccessDegraded, supportsSessionCommandsUpdated: $supportsSessionCommandsUpdated)';
 }
 
 
@@ -53,7 +54,7 @@ abstract mixin class $HealthResponseCopyWith<$Res>  {
   factory $HealthResponseCopyWith(HealthResponse value, $Res Function(HealthResponse) _then) = _$HealthResponseCopyWithImpl;
 @useResult
 $Res call({
- bool healthy, String version, bool? filesystemAccessDegraded
+ bool healthy, String version, bool? filesystemAccessDegraded, bool supportsSessionCommandsUpdated
 });
 
 
@@ -70,12 +71,13 @@ class _$HealthResponseCopyWithImpl<$Res>
 
 /// Create a copy of HealthResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? healthy = null,Object? version = null,Object? filesystemAccessDegraded = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? healthy = null,Object? version = null,Object? filesystemAccessDegraded = freezed,Object? supportsSessionCommandsUpdated = null,}) {
   return _then(_self.copyWith(
 healthy: null == healthy ? _self.healthy : healthy // ignore: cast_nullable_to_non_nullable
 as bool,version: null == version ? _self.version : version // ignore: cast_nullable_to_non_nullable
 as String,filesystemAccessDegraded: freezed == filesystemAccessDegraded ? _self.filesystemAccessDegraded : filesystemAccessDegraded // ignore: cast_nullable_to_non_nullable
-as bool?,
+as bool?,supportsSessionCommandsUpdated: null == supportsSessionCommandsUpdated ? _self.supportsSessionCommandsUpdated : supportsSessionCommandsUpdated // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 
@@ -87,7 +89,7 @@ as bool?,
 @JsonSerializable()
 
 class _HealthResponse implements HealthResponse {
-  const _HealthResponse({required this.healthy, required this.version, required this.filesystemAccessDegraded});
+  const _HealthResponse({required this.healthy, required this.version, required this.filesystemAccessDegraded, this.supportsSessionCommandsUpdated = false});
   factory _HealthResponse.fromJson(Map<String, dynamic> json) => _$HealthResponseFromJson(json);
 
 @override final  bool healthy;
@@ -98,6 +100,8 @@ class _HealthResponse implements HealthResponse {
 // never sends it decodes to null and is treated as "not degraded".
 // COMPATIBILITY 2026-06-27 (v1.2.0): Old bridges omit filesystem-access state. Make this non-null and remove client null fallbacks once those bridges are unsupported.
 @override final  bool? filesystemAccessDegraded;
+// COMPATIBILITY 2026-08-04 (v1.6.0): The public v1.6.0 bridge omits dedicated command-catalog event support. Make this required once v1.6.0 bridges are unsupported.
+@override@JsonKey() final  bool supportsSessionCommandsUpdated;
 
 /// Create a copy of HealthResponse
 /// with the given fields replaced by the non-null parameter values.
@@ -112,16 +116,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HealthResponse&&(identical(other.healthy, healthy) || other.healthy == healthy)&&(identical(other.version, version) || other.version == version)&&(identical(other.filesystemAccessDegraded, filesystemAccessDegraded) || other.filesystemAccessDegraded == filesystemAccessDegraded));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HealthResponse&&(identical(other.healthy, healthy) || other.healthy == healthy)&&(identical(other.version, version) || other.version == version)&&(identical(other.filesystemAccessDegraded, filesystemAccessDegraded) || other.filesystemAccessDegraded == filesystemAccessDegraded)&&(identical(other.supportsSessionCommandsUpdated, supportsSessionCommandsUpdated) || other.supportsSessionCommandsUpdated == supportsSessionCommandsUpdated));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,healthy,version,filesystemAccessDegraded);
+int get hashCode => Object.hash(runtimeType,healthy,version,filesystemAccessDegraded,supportsSessionCommandsUpdated);
 
 @override
 String toString() {
-  return 'HealthResponse(healthy: $healthy, version: $version, filesystemAccessDegraded: $filesystemAccessDegraded)';
+  return 'HealthResponse(healthy: $healthy, version: $version, filesystemAccessDegraded: $filesystemAccessDegraded, supportsSessionCommandsUpdated: $supportsSessionCommandsUpdated)';
 }
 
 
@@ -132,7 +136,7 @@ abstract mixin class _$HealthResponseCopyWith<$Res> implements $HealthResponseCo
   factory _$HealthResponseCopyWith(_HealthResponse value, $Res Function(_HealthResponse) _then) = __$HealthResponseCopyWithImpl;
 @override @useResult
 $Res call({
- bool healthy, String version, bool? filesystemAccessDegraded
+ bool healthy, String version, bool? filesystemAccessDegraded, bool supportsSessionCommandsUpdated
 });
 
 
@@ -149,12 +153,13 @@ class __$HealthResponseCopyWithImpl<$Res>
 
 /// Create a copy of HealthResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? healthy = null,Object? version = null,Object? filesystemAccessDegraded = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? healthy = null,Object? version = null,Object? filesystemAccessDegraded = freezed,Object? supportsSessionCommandsUpdated = null,}) {
   return _then(_HealthResponse(
 healthy: null == healthy ? _self.healthy : healthy // ignore: cast_nullable_to_non_nullable
 as bool,version: null == version ? _self.version : version // ignore: cast_nullable_to_non_nullable
 as String,filesystemAccessDegraded: freezed == filesystemAccessDegraded ? _self.filesystemAccessDegraded : filesystemAccessDegraded // ignore: cast_nullable_to_non_nullable
-as bool?,
+as bool?,supportsSessionCommandsUpdated: null == supportsSessionCommandsUpdated ? _self.supportsSessionCommandsUpdated : supportsSessionCommandsUpdated // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/health_response.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/health_response.g.dart
@@ -10,6 +10,8 @@ _HealthResponse _$HealthResponseFromJson(Map json) => _HealthResponse(
   healthy: json['healthy'] as bool,
   version: json['version'] as String,
   filesystemAccessDegraded: json['filesystemAccessDegraded'] as bool?,
+  supportsSessionCommandsUpdated:
+      json['supportsSessionCommandsUpdated'] as bool? ?? false,
 );
 
 Map<String, dynamic> _$HealthResponseToJson(_HealthResponse instance) =>
@@ -17,4 +19,5 @@ Map<String, dynamic> _$HealthResponseToJson(_HealthResponse instance) =>
       'healthy': instance.healthy,
       'version': instance.version,
       'filesystemAccessDegraded': ?instance.filesystemAccessDegraded,
+      'supportsSessionCommandsUpdated': instance.supportsSessionCommandsUpdated,
     };

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
@@ -71,6 +71,15 @@ sealed class SesoriSseEvent with _$SesoriSseEvent {
     required Session info,
   }) = SesoriSessionUpdated;
 
+  /// Invalidates the command catalog for one session without invalidating its
+  /// transcript or other session-detail state.
+  @FreezedUnionValue("session.commands.updated")
+  @Implements<SesoriSessionEvent>()
+  const factory SesoriSseEvent.sessionCommandsUpdated({
+    required String sessionID,
+    required String projectID,
+  }) = SesoriSessionCommandsUpdated;
+
   @FreezedUnionValue("session.deleted")
   @Implements<SesoriSessionEvent>()
   const factory SesoriSseEvent.sessionDeleted({
@@ -281,9 +290,8 @@ sealed class SesoriSseEvent with _$SesoriSseEvent {
   @FreezedUnionValue("vcs.branch.updated")
   const factory SesoriSseEvent.vcsBranchUpdated() = SesoriVcsBranchUpdated;
 
-  /// Notifies phones that PR data changed for sessions in this project.
-  /// Unlike [sessionUpdated] (single session content change), this triggers
-  /// a full session list re-fetch to pick up updated PR metadata.
+  /// Invalidates the project-level session list, including rendered PR data.
+  /// This never signals that a session transcript or command catalog changed.
   @FreezedUnionValue("sessions.updated")
   const factory SesoriSseEvent.sessionsUpdated({
     required String projectID,

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.freezed.dart
@@ -47,6 +47,10 @@ SesoriSseEvent _$SesoriSseEventFromJson(
           return SesoriSessionUpdated.fromJson(
             json
           );
+                case 'session.commands.updated':
+          return SesoriSessionCommandsUpdated.fromJson(
+            json
+          );
                 case 'session.deleted':
           return SesoriSessionDeleted.fromJson(
             json
@@ -754,6 +758,81 @@ $SessionCopyWith<$Res> get info {
     return _then(_self.copyWith(info: value));
   });
 }
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class SesoriSessionCommandsUpdated implements SesoriSseEvent, SesoriSessionEvent {
+  const SesoriSessionCommandsUpdated({required this.sessionID, required this.projectID, final  String? $type}): $type = $type ?? 'session.commands.updated';
+  factory SesoriSessionCommandsUpdated.fromJson(Map<String, dynamic> json) => _$SesoriSessionCommandsUpdatedFromJson(json);
+
+ final  String sessionID;
+ final  String projectID;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of SesoriSseEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SesoriSessionCommandsUpdatedCopyWith<SesoriSessionCommandsUpdated> get copyWith => _$SesoriSessionCommandsUpdatedCopyWithImpl<SesoriSessionCommandsUpdated>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SesoriSessionCommandsUpdatedToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SesoriSessionCommandsUpdated&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.projectID, projectID) || other.projectID == projectID));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,sessionID,projectID);
+
+@override
+String toString() {
+  return 'SesoriSseEvent.sessionCommandsUpdated(sessionID: $sessionID, projectID: $projectID)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SesoriSessionCommandsUpdatedCopyWith<$Res> implements $SesoriSseEventCopyWith<$Res> {
+  factory $SesoriSessionCommandsUpdatedCopyWith(SesoriSessionCommandsUpdated value, $Res Function(SesoriSessionCommandsUpdated) _then) = _$SesoriSessionCommandsUpdatedCopyWithImpl;
+@useResult
+$Res call({
+ String sessionID, String projectID
+});
+
+
+
+
+}
+/// @nodoc
+class _$SesoriSessionCommandsUpdatedCopyWithImpl<$Res>
+    implements $SesoriSessionCommandsUpdatedCopyWith<$Res> {
+  _$SesoriSessionCommandsUpdatedCopyWithImpl(this._self, this._then);
+
+  final SesoriSessionCommandsUpdated _self;
+  final $Res Function(SesoriSessionCommandsUpdated) _then;
+
+/// Create a copy of SesoriSseEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? sessionID = null,Object? projectID = null,}) {
+  return _then(SesoriSessionCommandsUpdated(
+sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
+as String,projectID: null == projectID ? _self.projectID : projectID // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
 }
 
 /// @nodoc

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.g.dart
@@ -89,6 +89,21 @@ Map<String, dynamic> _$SesoriSessionUpdatedToJson(
   SesoriSessionUpdated instance,
 ) => <String, dynamic>{'info': instance.info.toJson(), 'type': instance.$type};
 
+SesoriSessionCommandsUpdated _$SesoriSessionCommandsUpdatedFromJson(Map json) =>
+    SesoriSessionCommandsUpdated(
+      sessionID: json['sessionID'] as String,
+      projectID: json['projectID'] as String,
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$SesoriSessionCommandsUpdatedToJson(
+  SesoriSessionCommandsUpdated instance,
+) => <String, dynamic>{
+  'sessionID': instance.sessionID,
+  'projectID': instance.projectID,
+  'type': instance.$type,
+};
+
 SesoriSessionDeleted _$SesoriSessionDeletedFromJson(Map json) =>
     SesoriSessionDeleted(
       info: Session.fromJson(Map<String, dynamic>.from(json['info'] as Map)),

--- a/shared/sesori_shared/lib/src/protocol/messages.dart
+++ b/shared/sesori_shared/lib/src/protocol/messages.dart
@@ -26,7 +26,11 @@ sealed class RelayMessage with _$RelayMessage {
   const factory RelayMessage.sseEvent({required String data}) = RelaySseEvent;
 
   @FreezedUnionValue("sse_subscribe")
-  const factory RelayMessage.sseSubscribe({required String path}) = RelaySseSubscribe;
+  const factory RelayMessage.sseSubscribe({
+    required String path,
+    // COMPATIBILITY 2026-08-04 (v1.6.0): The public v1.6.0 app omits dedicated command-catalog event support. Make this required once v1.6.0 apps are unsupported.
+    @Default(false) bool supportsSessionCommandsUpdated,
+  }) = RelaySseSubscribe;
 
   @FreezedUnionValue("sse_unsubscribe")
   const factory RelayMessage.sseUnsubscribe() = RelaySseUnsubscribe;

--- a/shared/sesori_shared/lib/src/protocol/messages.freezed.dart
+++ b/shared/sesori_shared/lib/src/protocol/messages.freezed.dart
@@ -361,10 +361,12 @@ as String,
 @JsonSerializable()
 
 class RelaySseSubscribe implements RelayMessage {
-  const RelaySseSubscribe({required this.path, final  String? $type}): $type = $type ?? 'sse_subscribe';
+  const RelaySseSubscribe({required this.path, this.supportsSessionCommandsUpdated = false, final  String? $type}): $type = $type ?? 'sse_subscribe';
   factory RelaySseSubscribe.fromJson(Map<String, dynamic> json) => _$RelaySseSubscribeFromJson(json);
 
  final  String path;
+// COMPATIBILITY 2026-08-04 (v1.6.0): The public v1.6.0 app omits dedicated command-catalog event support. Make this required once v1.6.0 apps are unsupported.
+@JsonKey() final  bool supportsSessionCommandsUpdated;
 
 @JsonKey(name: 'type')
 final String $type;
@@ -383,16 +385,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RelaySseSubscribe&&(identical(other.path, path) || other.path == path));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RelaySseSubscribe&&(identical(other.path, path) || other.path == path)&&(identical(other.supportsSessionCommandsUpdated, supportsSessionCommandsUpdated) || other.supportsSessionCommandsUpdated == supportsSessionCommandsUpdated));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,path);
+int get hashCode => Object.hash(runtimeType,path,supportsSessionCommandsUpdated);
 
 @override
 String toString() {
-  return 'RelayMessage.sseSubscribe(path: $path)';
+  return 'RelayMessage.sseSubscribe(path: $path, supportsSessionCommandsUpdated: $supportsSessionCommandsUpdated)';
 }
 
 
@@ -403,7 +405,7 @@ abstract mixin class $RelaySseSubscribeCopyWith<$Res> implements $RelayMessageCo
   factory $RelaySseSubscribeCopyWith(RelaySseSubscribe value, $Res Function(RelaySseSubscribe) _then) = _$RelaySseSubscribeCopyWithImpl;
 @useResult
 $Res call({
- String path
+ String path, bool supportsSessionCommandsUpdated
 });
 
 
@@ -420,10 +422,11 @@ class _$RelaySseSubscribeCopyWithImpl<$Res>
 
 /// Create a copy of RelayMessage
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? path = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? path = null,Object? supportsSessionCommandsUpdated = null,}) {
   return _then(RelaySseSubscribe(
 path: null == path ? _self.path : path // ignore: cast_nullable_to_non_nullable
-as String,
+as String,supportsSessionCommandsUpdated: null == supportsSessionCommandsUpdated ? _self.supportsSessionCommandsUpdated : supportsSessionCommandsUpdated // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/protocol/messages.g.dart
+++ b/shared/sesori_shared/lib/src/protocol/messages.g.dart
@@ -50,11 +50,17 @@ Map<String, dynamic> _$RelaySseEventToJson(RelaySseEvent instance) =>
 
 RelaySseSubscribe _$RelaySseSubscribeFromJson(Map json) => RelaySseSubscribe(
   path: json['path'] as String,
+  supportsSessionCommandsUpdated:
+      json['supportsSessionCommandsUpdated'] as bool? ?? false,
   $type: json['type'] as String?,
 );
 
 Map<String, dynamic> _$RelaySseSubscribeToJson(RelaySseSubscribe instance) =>
-    <String, dynamic>{'path': instance.path, 'type': instance.$type};
+    <String, dynamic>{
+      'path': instance.path,
+      'supportsSessionCommandsUpdated': instance.supportsSessionCommandsUpdated,
+      'type': instance.$type,
+    };
 
 RelaySseUnsubscribe _$RelaySseUnsubscribeFromJson(Map json) =>
     RelaySseUnsubscribe($type: json['type'] as String?);

--- a/shared/sesori_shared/test/models/health_response_test.dart
+++ b/shared/sesori_shared/test/models/health_response_test.dart
@@ -1,0 +1,25 @@
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("defaults dedicated command event support for the public v1.6.0 bridge", () {
+    final response = HealthResponse.fromJson({
+      "healthy": true,
+      "version": "1.6.0",
+      "filesystemAccessDegraded": false,
+    });
+
+    expect(response.supportsSessionCommandsUpdated, isFalse);
+  });
+
+  test("round-trips dedicated command event support", () {
+    const response = HealthResponse(
+      healthy: true,
+      version: "1.7.0",
+      filesystemAccessDegraded: false,
+      supportsSessionCommandsUpdated: true,
+    );
+
+    expect(HealthResponse.fromJson(response.toJson()), response);
+  });
+}

--- a/shared/sesori_shared/test/models/sesori_sse_event_sessions_updated_test.dart
+++ b/shared/sesori_shared/test/models/sesori_sse_event_sessions_updated_test.dart
@@ -40,5 +40,11 @@ void main() {
 
       expect(event, isNot(isA<SesoriSessionEvent>()));
     });
+
+    test("contains only project-level list scope", () {
+      const event = SesoriSseEvent.sessionsUpdated(projectID: "proj-test");
+
+      expect(event.toJson().keys, unorderedEquals(["type", "projectID"]));
+    });
   });
 }

--- a/shared/sesori_shared/test/models/sesori_sse_event_test.dart
+++ b/shared/sesori_shared/test/models/sesori_sse_event_test.dart
@@ -142,6 +142,24 @@ void main() {
     });
   });
 
+  group('sessionCommandsUpdated round-trip', () {
+    test('preserves its explicit session and project scope', () {
+      const event = SesoriSseEvent.sessionCommandsUpdated(
+        sessionID: 'ses_commands',
+        projectID: 'project_commands',
+      );
+
+      final json = event.toJson();
+
+      expect(json, {
+        'type': 'session.commands.updated',
+        'sessionID': 'ses_commands',
+        'projectID': 'project_commands',
+      });
+      expect(SesoriSseEvent.fromJson(json), event);
+    });
+  });
+
   group('sessionDeleted round-trip', () {
     test('serializes and deserializes correctly', () {
       const session = Session(
@@ -490,6 +508,14 @@ void main() {
         status: SessionStatus.idle(),
       );
       expect(status, isA<SesoriSessionEvent>());
+    });
+
+    test('sessionCommandsUpdated implements SesoriSessionEvent', () {
+      const event = SesoriSseEvent.sessionCommandsUpdated(
+        sessionID: 'x',
+        projectID: 'p',
+      );
+      expect(event, isA<SesoriSessionEvent>());
     });
 
     test('messageUpdated implements SesoriSessionEvent', () {

--- a/shared/sesori_shared/test/protocol/relay_sse_subscribe_test.dart
+++ b/shared/sesori_shared/test/protocol/relay_sse_subscribe_test.dart
@@ -1,0 +1,23 @@
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("defaults dedicated command event support for the public v1.6.0 app", () {
+    final message = RelayMessage.fromJson({
+      "type": "sse_subscribe",
+      "path": "/global/event",
+    });
+
+    expect(message, isA<RelaySseSubscribe>());
+    expect((message as RelaySseSubscribe).supportsSessionCommandsUpdated, isFalse);
+  });
+
+  test("round-trips dedicated command event support", () {
+    const message = RelayMessage.sseSubscribe(
+      path: "/global/event",
+      supportsSessionCommandsUpdated: true,
+    );
+
+    expect(RelayMessage.fromJson(message.toJson()), message);
+  });
+}


### PR DESCRIPTION
## Complexity

Moderate. This changes a shared wire event and carries it through the ACP plugin, bridge normalization and SSE delivery, and client state handling, with narrow compatibility for the public v1.6.0 release.

## What

- Add `session.commands.updated` as the explicit session-scoped command-catalog invalidation.
- Keep `sessions.updated` project-list-only so PR synchronization no longer refreshes open session details.
- Refresh only commands and staged-command resolution on the client, preserving transcript and unrelated detail state.
- Advertise dedicated-event support in bridge health and SSE subscriptions.
- Translate command events to legacy `sessions.updated` per subscriber only for public v1.6.0 peers that omit capability support.
- Fence concurrent command loads and older silent snapshots so the newest command catalog wins.

## Why

PR synchronization emits `sessions.updated` for project-list metadata. Session detail was also treating that event as a full snapshot invalidation, causing repeated transcript refreshes during normal PR polling. Command discovery had overloaded the same event, so the two meanings needed separate protocol signals.

## Risk and test focus

The main risks are old/new app and bridge compatibility, stable session/project identity mapping, replay-time per-subscriber event selection, and command-refresh ordering. Tests cover wire defaults and round trips, ACP emission, bridge normalization and delivery, client routing, command-only state preservation, legacy fallback, reconnect behavior, out-of-order requests, and stale snapshot races.

User-visible impact: open session transcripts no longer refresh when only project-list PR data changes, while command catalogs still update. Database impact: none.

## Expected result

`sessions.updated` refreshes session lists only. `session.commands.updated` refreshes only the affected session's command catalog, with public v1.6.0 peers continuing to work through explicit capability-based degradation.

## Verification

- Strict `dart analyze --fatal-infos` passed in shared, bridge app, plugin interface, ACP plugin, client core, and mobile app packages.
- Focused shared protocol tests passed: 50 tests.
- Focused bridge app tests passed: 68 tests.
- Focused ACP tests passed: 69 tests.
- Focused client core tests passed: 92 tests.
- Mobile session-detail tests passed: 43 tests.
- Shared code generation produced no additional changes.
- Architecture implementation review: approved with no findings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolate command catalog refreshes from full session updates. Open session transcripts no longer reload during PR sync; only the command list updates.

- **New Features**
  - Added `session.commands.updated` for session-scoped command catalog invalidation.
  - Kept `sessions.updated` for project session lists only (PR/metadata), not session detail.
  - Bridge advertises support via health and SSE subscribe (`supportsSessionCommandsUpdated`), and maps to legacy `sessions.updated` per subscriber when needed (public v1.6.0).
  - Client reacts by reloading only the command catalog and resolving the staged command, preserving transcript and other state. Fences concurrent loads so the newest catalog wins.

- **Bug Fixes**
  - Eliminates repeated transcript refreshes during normal PR polling.

<sup>Written for commit 61d86a80f8e7a11dd63eb7aad38d9598869d7cc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

