### PR TITLE
🌿 Prevent harness tooltip follower assertion

### DIFF
--- a/client/app/lib/features/new_session/new_session_plugin_chooser.dart
+++ b/client/app/lib/features/new_session/new_session_plugin_chooser.dart
@@ -189,6 +189,9 @@ class _HarnessesMenuHeader extends StatelessWidget {
                 style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textSecondary),
               ),
             ),
+            // Flutter's tooltip OverlayPortal cannot be laid out below this
+            // anchored menu's follower layer (flutter/flutter#178522). Keep the
+            // accessible label without creating that nested overlay.
             IconButton(
               key: const Key("new_session_harness_settings"),
               onPressed: onSettingsPressed,
@@ -196,8 +199,8 @@ class _HarnessesMenuHeader extends StatelessWidget {
                 TablerRegular.adjustments_horizontal,
                 size: 20,
                 color: prego.colors.textTertiary,
+                semanticLabel: loc.newSessionHarnessSettings,
               ),
-              tooltip: loc.newSessionHarnessSettings,
               visualDensity: VisualDensity.compact,
             ),
           ],

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -1,6 +1,7 @@
 import "dart:async";
 
 import "package:bloc_test/bloc_test.dart";
+import "package:flutter/gestures.dart";
 import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart";
@@ -717,6 +718,35 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text("harnesses-settings"), findsOneWidget);
+  });
+
+  testWidgets("keeps the harness settings icon layout-safe on hover", (tester) async {
+    final semantics = tester.ensureSemantics();
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+    await openHarnessMenu(tester);
+
+    final settings = find.byKey(const Key("new_session_harness_settings"));
+    final loc = AppLocalizations.of(tester.element(settings))!;
+    expect(
+      tester.getSemantics(settings),
+      matchesSemantics(
+        label: loc.newSessionHarnessSettings,
+        isButton: true,
+        isFocusable: true,
+        hasEnabledState: true,
+        isEnabled: true,
+        hasTapAction: true,
+        hasFocusAction: true,
+      ),
+    );
+    semantics.dispose();
+
+    final pointer = TestPointer(1, PointerDeviceKind.mouse);
+    await tester.sendEventToBinding(pointer.hover(tester.getCenter(settings)));
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets("keeps model and variant controls available when no agents load", (tester) async {


### PR DESCRIPTION
## Complexity

🌿 Straightforward: a localized widget workaround plus focused regression coverage.

## What

- Remove the Material tooltip overlay from the harness-settings icon inside the anchored menu.
- Preserve the same localized accessibility label on the icon.
- Add a widget test that hovers the real menu control and verifies both semantics and layout safety.

## Why

Flutter 3.44 implements tooltips with `OverlayPortal.overlayChildLayoutBuilder`, which cannot compute its transform while nested below the `CompositedTransformFollower` used by the menu transition. Hovering the icon therefore triggers the framework assertion tracked in [flutter/flutter#178522](https://github.com/flutter/flutter/issues/178522), followed by cascading layout assertions.

## Risk and test focus

Risk is low and isolated to the harness menu header. The user-visible impact is that this icon no longer displays a visual hover/long-press tooltip; its localized screen-reader label and tap action remain intact. There is no database impact.

Test focus is opening the actual anchored menu, checking the settings button semantics, hovering it past the tooltip delay, and confirming no rendering exception occurs.

## Expected result

Hovering or relaying out the harness-settings icon, including around a debug hot restart, no longer emits `RenderFollowerLayer` or `debugNeedsLayout` assertions.

## Verification

- `flutter test test/features/new_session/new_session_screen_test.dart`
- `dart analyze` in `client/app`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents layout assertions when hovering the harness settings icon by removing its tooltip overlay inside the anchored menu. Keeps the localized a11y label and tap action, and adds a test to verify semantics and hover safety.

- **Bug Fixes**
  - Removed tooltip from the menu icon to avoid `OverlayPortal` + `CompositedTransformFollower` transform assertion (Flutter 3.44; flutter/flutter#178522); set `semanticLabel` on the `Icon` instead.
  - Added a widget test that opens the anchored menu, verifies the settings button semantics, hovers past the tooltip delay, and asserts no exceptions.

<sup>Written for commit 8c6beec66e4840b43c40cc2bf6338d5e2c278982. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

