### PR TITLE
⚙️ Scope ACP command catalog updates

### DIFF
--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -1413,7 +1413,7 @@ class OrchestratorSession {
       }
 
       final refreshProjectsSummary = event is BridgeSseProjectUpdated || event is BridgeSseSessionDeleted;
-      final sesoriEvent = event is BridgeSseProjectUpdated ? null : _mapper.map(event);
+      final sesoriEvent = event is BridgeSseProjectUpdated ? null : _mapper.map(event: event, pluginId: pluginId);
       if (generation != null &&
           !_pluginRuntime.isCurrentEvent(
             pluginId: pluginId,

--- a/bridge/app/lib/src/bridge/repositories/mappers/session_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/repositories/mappers/session_event_mapper.dart
@@ -46,6 +46,7 @@ class SessionEventMapper {
       BridgeSseServerHeartbeat() ||
       BridgeSseServerInstanceDisposed() ||
       BridgeSseGlobalDisposed() ||
+      BridgeSseCommandCatalogUpdated() ||
       BridgeSseSessionOptionsChanged() ||
       BridgeSsePtyCreated() ||
       BridgeSsePtyUpdated() ||
@@ -260,6 +261,7 @@ class SessionEventMapper {
       BridgeSseServerHeartbeat() ||
       BridgeSseServerInstanceDisposed() ||
       BridgeSseGlobalDisposed() ||
+      BridgeSseCommandCatalogUpdated() ||
       BridgeSseSessionOptionsChanged() ||
       BridgeSsePtyCreated() ||
       BridgeSsePtyUpdated() ||

--- a/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
@@ -17,7 +17,7 @@ class BridgeEventMapper {
   }) : _failureReporter = failureReporter;
 
   /// Maps a [BridgeSseEvent] to a [SesoriSseEvent], or null if unmappable.
-  SesoriSseEvent? map(BridgeSseEvent event) {
+  SesoriSseEvent? map({required BridgeSseEvent event, required String pluginId}) {
     try {
       return switch (event) {
         BridgeSseTerminalHandoff() => throw StateError("terminal handoff must be unwrapped by Orchestrator"),
@@ -25,6 +25,7 @@ class BridgeEventMapper {
         BridgeSseServerHeartbeat() => null,
         BridgeSseServerInstanceDisposed() => null,
         BridgeSseGlobalDisposed() => null,
+        BridgeSseCommandCatalogUpdated() => SesoriSseEvent.commandCatalogUpdated(pluginId: pluginId),
         BridgeSseSessionCreated(:final info) => _tryParseSseEvent({"type": "session.created", "info": info}),
         BridgeSseSessionUpdated(:final info) => _tryParseSseEvent({"type": "session.updated", "info": info}),
         BridgeSseSessionsUpdated(:final projectID) => SesoriSseEvent.sessionsUpdated(projectID: projectID),

--- a/bridge/app/test/bridge/repositories/mappers/session_event_mapper_test.dart
+++ b/bridge/app/test/bridge/repositories/mappers/session_event_mapper_test.dart
@@ -232,6 +232,7 @@ void main() {
     test("preserves nullable session references and non-session events", () {
       const error = BridgeSseSessionError(sessionID: null);
       const connected = BridgeSseServerConnected();
+      const commandCatalogUpdated = BridgeSseCommandCatalogUpdated();
       const optionsChanged = BridgeSseSessionOptionsChanged(sessionID: "backend-session");
 
       expect(mapper.backendSessionIds(event: error), isEmpty);
@@ -239,6 +240,11 @@ void main() {
       expect(mappedError, isA<BridgeSseSessionError>());
       expect((mappedError! as BridgeSseSessionError).sessionID, isNull);
       expect(mapper.map(event: connected, sessionIdsByBackendId: const {}), same(connected));
+      expect(mapper.backendSessionIds(event: commandCatalogUpdated), isEmpty);
+      expect(
+        mapper.map(event: commandCatalogUpdated, sessionIdsByBackendId: const {}),
+        same(commandCatalogUpdated),
+      );
       expect(mapper.backendSessionIds(event: optionsChanged), isEmpty);
       expect(
         mapper.map(event: optionsChanged, sessionIdsByBackendId: const {}),

--- a/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
+++ b/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
@@ -15,6 +15,8 @@ void main() {
       );
     });
 
+    SesoriSseEvent? mapEvent(BridgeSseEvent event) => mapper.map(event: event, pluginId: "test-plugin");
+
     test("filters plugin lifecycle events from bridge-global wire semantics", () {
       const lifecycleEvents = <BridgeSseEvent>[
         BridgeSseServerConnected(),
@@ -24,19 +26,28 @@ void main() {
       ];
 
       for (final event in lifecycleEvents) {
-        expect(mapper.map(event), isNull, reason: event.runtimeType.toString());
+        expect(mapEvent(event), isNull, reason: event.runtimeType.toString());
       }
     });
 
     test("does not expose the internal session-options change event to clients", () {
       expect(
-        mapper.map(const BridgeSseSessionOptionsChanged(sessionID: "backend-session")),
+        mapEvent(const BridgeSseSessionOptionsChanged(sessionID: "backend-session")),
         isNull,
       );
     });
 
-    test("maps session.created with provided enriched payload", () {
+    test("attributes command catalog updates to their source plugin", () {
       final result = mapper.map(
+        event: const BridgeSseCommandCatalogUpdated(),
+        pluginId: "cursor",
+      );
+
+      expect(result, const SesoriCommandCatalogUpdated(pluginId: "cursor"));
+    });
+
+    test("maps session.created with provided enriched payload", () {
+      final result = mapEvent(
         const BridgeSseSessionCreated(
           info: {
             "id": "s1",
@@ -67,7 +78,7 @@ void main() {
     });
 
     test("maps session.updated with provided enriched payload", () {
-      final result = mapper.map(
+      final result = mapEvent(
         const BridgeSseSessionUpdated(
           info: {
             "id": "s1",
@@ -99,14 +110,14 @@ void main() {
     });
 
     test("maps session.diff without diff payload", () async {
-      final result = mapper.map(const BridgeSseSessionDiff(sessionID: "s1"));
+      final result = mapEvent(const BridgeSseSessionDiff(sessionID: "s1"));
 
       expect(result, isA<SesoriSessionDiff>());
       expect((result! as SesoriSessionDiff).sessionID, equals("s1"));
     });
 
     test("maps stale project sessions to sessions.updated", () {
-      final result = mapper.map(
+      final result = mapEvent(
         const BridgeSseSessionsUpdated(sessionID: "s1", projectID: "p1"),
       );
 
@@ -115,7 +126,7 @@ void main() {
     });
 
     test("maps command.executed events", () {
-      final result = mapper.map(
+      final result = mapEvent(
         const BridgeSseCommandExecuted(
           name: "review",
           sessionID: "s1",
@@ -133,7 +144,7 @@ void main() {
     });
 
     test("passes file message part updates with normalized attachment data", () async {
-      final result = mapper.map(
+      final result = mapEvent(
         const BridgeSseMessagePartUpdated(
           part: PluginMessagePart(
             id: "p1",
@@ -163,7 +174,7 @@ void main() {
     });
 
     test("filters snapshot message part updates", () async {
-      final result = mapper.map(
+      final result = mapEvent(
         const BridgeSseMessagePartUpdated(
           part: PluginMessagePart(
             id: "p1",
@@ -188,7 +199,7 @@ void main() {
     });
 
     test("filters patch message part updates", () async {
-      final result = mapper.map(
+      final result = mapEvent(
         const BridgeSseMessagePartUpdated(
           part: PluginMessagePart(
             id: "p1",
@@ -213,7 +224,7 @@ void main() {
     });
 
     test("filters compaction message part updates", () async {
-      final result = mapper.map(
+      final result = mapEvent(
         const BridgeSseMessagePartUpdated(
           part: PluginMessagePart(
             id: "p1",
@@ -238,7 +249,7 @@ void main() {
     });
 
     test("passes agent message part updates", () async {
-      final result = mapper.map(
+      final result = mapEvent(
         const BridgeSseMessagePartUpdated(
           part: PluginMessagePart(
             id: "p1",
@@ -264,7 +275,7 @@ void main() {
     });
 
     test("passes retry message part updates", () async {
-      final result = mapper.map(
+      final result = mapEvent(
         const BridgeSseMessagePartUpdated(
           part: PluginMessagePart(
             id: "p1",
@@ -291,7 +302,7 @@ void main() {
 
     test("truncates tool output to 500 characters", () async {
       final longOutput = List.filled(1000, "x").join();
-      final result = mapper.map(
+      final result = mapEvent(
         BridgeSseMessagePartUpdated(
           part: PluginMessagePart(
             id: "p1",
@@ -325,7 +336,7 @@ void main() {
     });
 
     test("passes through text message parts", () async {
-      final result = mapper.map(
+      final result = mapEvent(
         const BridgeSseMessagePartUpdated(
           part: PluginMessagePart(
             id: "p1",
@@ -353,7 +364,7 @@ void main() {
     });
 
     test("keeps short tool output unchanged", () async {
-      final result = mapper.map(
+      final result = mapEvent(
         const BridgeSseMessagePartUpdated(
           part: PluginMessagePart(
             id: "p1",
@@ -386,7 +397,7 @@ void main() {
     });
 
     test("map() drops BridgeSseProjectUpdated (the orchestrator builds the summary)", () {
-      final result = mapper.map(const BridgeSseProjectUpdated());
+      final result = mapEvent(const BridgeSseProjectUpdated());
 
       expect(result, isNull);
     });

--- a/bridge/app/tool/benchmarks/catalog_import_event_soak.dart
+++ b/bridge/app/tool/benchmarks/catalog_import_event_soak.dart
@@ -577,7 +577,7 @@ class _CatalogImportEventSoak {
     if (normalized.length != 1) {
       throw StateError("known-session input produced ${normalized.length} translated events; expected one");
     }
-    final shared = bridgeEventMapper.map(normalized.single);
+    final shared = bridgeEventMapper.map(event: normalized.single, pluginId: source.pluginId);
     if (shared == null) throw StateError("known-session event did not map to a shared event");
     final encoded = jsonEncode(shared.toJson());
     if (encoded.contains(fixture.sessions.first.id)) {

--- a/bridge/app/tool/benchmarks/event_projection_benchmark.dart
+++ b/bridge/app/tool/benchmarks/event_projection_benchmark.dart
@@ -292,7 +292,7 @@ class _EventProjectionBenchmark {
     if (output.length != 1) {
       throw StateError("event projection emitted ${output.length} events; expected 1");
     }
-    final mapped = bridgeEventMapper.map(output.single);
+    final mapped = bridgeEventMapper.map(event: output.single, pluginId: _pluginId);
     if (mapped == null) throw StateError("projected session update did not map to a shared event");
     sseManager.enqueueEvent(mapped);
   }

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -340,13 +340,10 @@ class AcpEventMapper {
         return [BridgeSseTodoUpdated(sessionID: sessionId)];
       case "available_commands_update":
         // The advertised commands themselves are tracked by AcpCommandTracker
-        // (served via getCommands); this makes the matching client session
-        // re-fetch its snapshot so the new command list becomes visible.
+        // and served via getCommands. The catalog is process-wide, while the
+        // options-change event retains the originating session for persistence.
         return [
-          BridgeSseSessionsUpdated(
-            sessionID: sessionId,
-            projectID: projectForSession(sessionId: sessionId),
-          ),
+          const BridgeSseCommandCatalogUpdated(),
           BridgeSseSessionOptionsChanged(sessionID: sessionId),
         ];
       case "session_info_update":

--- a/bridge/sesori_plugin_acp/test/acp_commands_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_commands_test.dart
@@ -182,6 +182,7 @@ void main() {
       final options = (discovery as PluginSessionOptionsDiscoveryObserved).options;
       expect(options.completeness, PluginSessionOptionsCompleteness.complete);
       expect(options.commands.single.name, "create_plan");
+      expect(emitted.whereType<BridgeSseCommandCatalogUpdated>(), hasLength(1));
       expect(
         emitted.whereType<BridgeSseSessionOptionsChanged>().single.sessionID,
         "s1",
@@ -224,7 +225,7 @@ void main() {
     });
   });
 
-  test("history replay advertises commands and emits a session refresh", () async {
+  test("history replay advertises commands and invalidates the command catalog", () async {
     final live = FakeAcpProcess();
     final replay = FakeAcpProcess();
     final processes = [live, replay];
@@ -337,10 +338,7 @@ void main() {
       await messages;
 
       expect((await plugin.getCommands(projectId: "/repo")).single.name, "from_replay");
-      expect(
-        emitted.whereType<BridgeSseSessionsUpdated>().single.sessionID,
-        "s1",
-      );
+      expect(emitted.whereType<BridgeSseCommandCatalogUpdated>(), hasLength(1));
       expect(
         emitted.whereType<BridgeSseSessionOptionsChanged>().single.sessionID,
         "s1",

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -579,19 +579,13 @@ void main() {
       expect(late.whereType<BridgeSseMessagePartDelta>().single.messageID, firstId);
     });
 
-    test("plan maps to a todo update, commands mark their project sessions stale", () {
+    test("plan maps to a todo update, commands invalidate the plugin catalog", () {
       expect(
         mapper.map(update({"sessionUpdate": "plan", "entries": const <Object?>[]})).single,
         isA<BridgeSseTodoUpdated>(),
       );
-      mapper.setSessionProject("s1", "/repo/other");
       final events = mapper.map(update({"sessionUpdate": "available_commands_update"}));
-      expect(
-        events.whereType<BridgeSseSessionsUpdated>().single,
-        isA<BridgeSseSessionsUpdated>()
-            .having((event) => event.sessionID, "sessionID", "s1")
-            .having((event) => event.projectID, "projectID", "/repo/other"),
-      );
+      expect(events.whereType<BridgeSseCommandCatalogUpdated>(), hasLength(1));
       expect(
         events.whereType<BridgeSseSessionOptionsChanged>().single.sessionID,
         "s1",

--- a/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
@@ -250,7 +250,7 @@ void main() {
       await loading;
       await pump();
 
-      expect(emitted.whereType<BridgeSseSessionsUpdated>(), isNotEmpty);
+      expect(emitted.whereType<BridgeSseCommandCatalogUpdated>(), isNotEmpty);
     });
 
     test("a genuine RPC error (not -32601/-32602) still surfaces as a typed failure", () async {

--- a/bridge/sesori_plugin_acp/test/acp_resume_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_test.dart
@@ -131,9 +131,9 @@ void main() {
 
       // The suppressed replay produced no message events on the live stream.
       expect(emitted.whereType<BridgeSseMessagePartDelta>(), isEmpty);
-      // Command metadata is current even during a history replay, so the
-      // client receives the stale-session signal and re-fetches it.
-      expect(emitted.whereType<BridgeSseSessionsUpdated>(), hasLength(1));
+      // Command metadata is current even during a history replay, so clients
+      // receive a plugin-wide catalog invalidation and re-fetch it.
+      expect(emitted.whereType<BridgeSseCommandCatalogUpdated>(), hasLength(1));
       expect(
         emitted.whereType<BridgeSseSessionOptionsChanged>().single.sessionID,
         "old-session",

--- a/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
@@ -32,6 +32,11 @@ class BridgeSseGlobalDisposed extends BridgeSseEvent {
   const BridgeSseGlobalDisposed();
 }
 
+/// Signals that the emitting plugin's process-wide command catalog changed.
+class BridgeSseCommandCatalogUpdated extends BridgeSseEvent {
+  const BridgeSseCommandCatalogUpdated();
+}
+
 class BridgeSseSessionCreated extends BridgeSseEvent {
   final Map<String, dynamic> info;
   const BridgeSseSessionCreated({required this.info});

--- a/client/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/client/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -1277,7 +1277,20 @@ void main() {
           (_) async => ApiResponse.success(SessionListResponse(items: [oldChild, newChild])),
         );
 
-        globalEvents.add(SseEvent(data: const SesoriSessionsUpdated(projectID: "project-1")));
+        connectionStatus.add(
+          ConnectionStatus.connected(
+            config: const ServerConnectionConfig(relayHost: "fake.example.com"),
+            health: testHealthResponse(),
+          ),
+        );
+        sessionEvents.add(
+          const SesoriCommandExecuted(
+            name: "refresh",
+            sessionID: sessionId,
+            arguments: "",
+            messageID: "refresh-message",
+          ),
+        );
         await Future<void>.delayed(const Duration(milliseconds: 10));
       },
       expect: () => [
@@ -1341,7 +1354,20 @@ void main() {
       addTearDown(cubit.close);
       await _awaitLoaded(cubit);
 
-      globalEvents.add(SseEvent(data: const SesoriSessionsUpdated(projectID: "project-1")));
+      connectionStatus.add(
+        ConnectionStatus.connected(
+          config: const ServerConnectionConfig(relayHost: "fake.example.com"),
+          health: testHealthResponse(),
+        ),
+      );
+      sessionEvents.add(
+        const SesoriCommandExecuted(
+          name: "refresh",
+          sessionID: sessionId,
+          arguments: "",
+          messageID: "refresh-message",
+        ),
+      );
       await slowRefreshStarted.future;
 
       cubit.selectModel(providerID: "openai", modelID: "gpt-4.1");
@@ -1917,8 +1943,13 @@ void main() {
       );
 
       when(() => mockConnectionService.currentStatus).thenReturn(connected);
-      globalEvents.add(
-        SseEvent(data: const SesoriSessionsUpdated(projectID: "project-1")),
+      sessionEvents.add(
+        const SesoriCommandExecuted(
+          name: "refresh",
+          sessionID: sessionId,
+          arguments: "",
+          messageID: "refresh-message",
+        ),
       );
       await slowRefreshStarted.future;
 

--- a/client/module_core/lib/src/capabilities/server_connection/models/sse_event.dart
+++ b/client/module_core/lib/src/capabilities/server_connection/models/sse_event.dart
@@ -37,6 +37,7 @@ class SseEvent {
     SesoriGlobalDisposed() ||
     SesoriCatalogImportProgress() ||
     SesoriPluginManagementChanged() ||
+    SesoriCommandCatalogUpdated() ||
     SesoriPtyCreated() ||
     SesoriPtyUpdated() ||
     SesoriPtyExited() ||

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -31,7 +31,6 @@ import "session_detail_state.dart";
 import "streaming_text_buffer.dart";
 
 enum _SessionRefreshTrigger {
-  projectSessionsUpdated("project_sessions_updated"),
   commandExecuted("command_executed"),
   connectionReconnected("connection_reconnected"),
   lifecycleResumed("lifecycle_resumed"),
@@ -79,6 +78,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
   late final StreamSubscription<LifecycleState> _lifecycleSubscription;
   late final StreamingTextBuffer _streamingBuffer;
   Future<void>? _activeRefresh;
+  int _commandCatalogGeneration = 0;
   Timer? _eventRefreshCooldown;
   bool _eventRefreshQueued = false;
   bool _needsStaleRefresh = false;
@@ -291,17 +291,14 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     );
   }
 
-  /// Coalesces event-driven staleness signals (sessions.updated,
-  /// command.executed, dataMayBeStale) into at most one silent refresh per
-  /// [eventRefreshMinInterval]. While the agent works, the bridge can emit
-  /// these in sustained bursts (e.g. sessions.updated on every PR-sync tick),
-  /// and each silent refresh refetches the whole session snapshot — ~10
-  /// encrypted relay round-trips — so refreshing per event keeps the radio
-  /// and main isolate busy for the entire turn. The first signal after a
-  /// quiet period still refreshes immediately; follow-ups within the cooldown
-  /// collapse into a single trailing refresh. Reconnect and app-resume
-  /// refreshes bypass this on purpose: they must run promptly and re-assert
-  /// the bridge-side view declaration.
+  /// Coalesces event-driven staleness signals (command.executed,
+  /// dataMayBeStale) into at most one silent refresh per
+  /// [eventRefreshMinInterval]. Repeated signals would otherwise each refetch
+  /// the whole session snapshot — ~10 encrypted relay round-trips. The first
+  /// signal after a quiet period still refreshes immediately; follow-ups within
+  /// the cooldown collapse into a single trailing refresh. Reconnect and
+  /// app-resume refreshes bypass this on purpose: they must run promptly and
+  /// re-assert the bridge-side view declaration.
   void _requestEventDrivenRefresh({required _SessionRefreshTrigger trigger}) {
     _logRefresh(action: _SessionRefreshAction.observed, trigger: trigger);
     if (state is! SessionDetailLoaded) {
@@ -382,6 +379,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
   Future<_SessionRefreshResult> _doSilentRefresh() async {
     final current = state;
     if (current is! SessionDetailLoaded) return _SessionRefreshResult.closed;
+    final commandCatalogGeneration = _commandCatalogGeneration;
 
     emit(current.copyWith(isRefreshing: true, queuedMessages: _promptQueue.items));
 
@@ -428,6 +426,9 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
           final preservedSelectedAgent = latest.selectedAgent;
           final preservedSelectedAgentModel = latest.selectedAgentModel;
           final preservedStagedCommand = latest.stagedCommand;
+          final availableCommands = commandCatalogGeneration == _commandCatalogGeneration
+              ? snapshot.commands
+              : latest.availableCommands;
           final availableVariants = _deriveAvailableVariants(
             providers: availableProviders,
             model: preservedSelectedAgentModel,
@@ -455,12 +456,12 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
               isArchived: snapshot.isArchived,
               availableAgents: availableAgents,
               availableProviders: availableProviders,
-              availableCommands: snapshot.commands,
+              availableCommands: availableCommands,
               sessionTitle: snapshot.canonicalSessionTitle ?? latest.sessionTitle,
               selectedAgent: preservedSelectedAgent,
               selectedAgentModel: preservedSelectedAgentModel,
               stagedCommand: _resolveStagedCommand(
-                availableCommands: snapshot.commands,
+                availableCommands: availableCommands,
                 stagedCommand: preservedStagedCommand,
               ),
               queuedMessages: _promptQueue.items,
@@ -529,6 +530,38 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     required _SessionRefreshTrigger trigger,
   }) {
     logd("[session-refresh] action=${action.name} trigger=${trigger.logValue}");
+  }
+
+  void _onCommandCatalogUpdated({required String pluginId}) {
+    final current = state;
+    if (current is! SessionDetailLoaded || current.pluginId != pluginId) return;
+    final generation = ++_commandCatalogGeneration;
+    unawaited(_refreshCommandCatalog(pluginId: pluginId, generation: generation));
+  }
+
+  Future<void> _refreshCommandCatalog({required String pluginId, required int generation}) async {
+    try {
+      final response = await _sessionRepository.listCommands(projectId: _projectId, pluginId: pluginId);
+      if (isClosed || generation != _commandCatalogGeneration) return;
+      switch (response) {
+        case SuccessResponse(:final data):
+          final latest = state;
+          if (latest is! SessionDetailLoaded || latest.pluginId != pluginId) return;
+          emit(
+            latest.copyWith(
+              availableCommands: data.items,
+              stagedCommand: _resolveStagedCommand(
+                availableCommands: data.items,
+                stagedCommand: latest.stagedCommand,
+              ),
+            ),
+          );
+        case ErrorResponse(:final error):
+          logw("Failed to refresh command catalog", error);
+      }
+    } on Object catch (error, stackTrace) {
+      logw("Failed to refresh command catalog", error, stackTrace);
+    }
   }
 
   CommandInfo? _resolveStagedCommand({
@@ -669,6 +702,9 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
         sessionID: sessionID,
         displaySessionId: displaySessionId,
       ),
+      // The loaded session identifies its plugin after the initial snapshot,
+      // so retain catalog invalidations until that scope can be matched.
+      SesoriCommandCatalogUpdated() => true,
       // Definitively irrelevant high-volume events.
       SesoriServerConnected() ||
       SesoriServerHeartbeat() ||
@@ -676,6 +712,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
       SesoriGlobalDisposed() ||
       SesoriCatalogImportProgress() ||
       SesoriPluginManagementChanged() ||
+      SesoriSessionsUpdated() ||
       SesoriSessionDeleted() ||
       SesoriSessionDiff() ||
       SesoriSessionError() ||
@@ -712,10 +749,6 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
       // Unseen-state changes are list-level concerns handled by the tracker;
       // the detail screen does not react to them.
       SesoriSessionUnseenChanged() => false,
-      // Command catalogs can change while the initial snapshot is in flight
-      // (Cursor advertises them during the concurrent history load), so retain
-      // a matching project invalidation and refresh once loading completes.
-      SesoriSessionsUpdated(:final projectID) => projectID.isNotEmpty && projectID == _projectId,
     };
   }
 
@@ -748,6 +781,8 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
         case final SesoriQuestionRejected event
             when _surfacesChildRequestHere(sessionID: event.sessionID, displaySessionId: event.displaySessionId):
           _onQuestionResolved(event.requestID);
+        case SesoriCommandCatalogUpdated(:final pluginId):
+          _onCommandCatalogUpdated(pluginId: pluginId);
         case SesoriSessionCreated() ||
             SesoriSessionDeleted() ||
             SesoriSessionDiff() ||
@@ -759,6 +794,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
             SesoriGlobalDisposed() ||
             SesoriCatalogImportProgress() ||
             SesoriPluginManagementChanged() ||
+            SesoriSessionsUpdated() ||
             SesoriMessageUpdated() ||
             SesoriMessageRemoved() ||
             SesoriMessagePartUpdated() ||
@@ -795,19 +831,6 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
             SesoriSessionUnseenChanged() ||
             SesoriSessionPromptDefaultsChanged():
           break;
-        case SesoriSessionsUpdated(:final projectID):
-          if (projectID.isNotEmpty && projectID == _projectId) {
-            _requestEventDrivenRefresh(trigger: _SessionRefreshTrigger.projectSessionsUpdated);
-          } else {
-            _logRefresh(
-              action: _SessionRefreshAction.observed,
-              trigger: _SessionRefreshTrigger.projectSessionsUpdated,
-            );
-            _logRefresh(
-              action: _SessionRefreshAction.ignored,
-              trigger: _SessionRefreshTrigger.projectSessionsUpdated,
-            );
-          }
       }
     } catch (e, st) {
       loge("SSE global event handler error", e, st);

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -125,6 +125,7 @@ class SessionListCubit extends Cubit<SessionListState> {
             SesoriGlobalDisposed() ||
             SesoriCatalogImportProgress() ||
             SesoriPluginManagementChanged() ||
+            SesoriCommandCatalogUpdated() ||
             SesoriSessionDiff() ||
             SesoriSessionError() ||
             SesoriSessionCompacted() ||

--- a/client/module_core/lib/src/services/sse_event_tracker.dart
+++ b/client/module_core/lib/src/services/sse_event_tracker.dart
@@ -105,6 +105,7 @@ class SseEventTracker with Disposable {
             SesoriGlobalDisposed() ||
             SesoriCatalogImportProgress() ||
             SesoriPluginManagementChanged() ||
+            SesoriCommandCatalogUpdated() ||
             SesoriSessionDiff() ||
             SesoriSessionError() ||
             SesoriSessionCompacted() ||

--- a/client/module_core/test/capabilities/server_connection/models/sse_event_test.dart
+++ b/client/module_core/test/capabilities/server_connection/models/sse_event_test.dart
@@ -28,4 +28,13 @@ void main() {
     expect(event.sessionId, isNull);
     expect(event.data, isNot(isA<SesoriSessionEvent>()));
   });
+
+  test("commandCatalogUpdated is a global plugin event", () {
+    final event = SseEvent(
+      data: const SesoriSseEvent.commandCatalogUpdated(pluginId: "cursor"),
+    );
+
+    expect(event.sessionId, isNull);
+    expect(event.data, isNot(isA<SesoriSessionEvent>()));
+  });
 }

--- a/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
@@ -226,10 +226,9 @@ void main() {
       expect(state.children.first.id, "child-1");
     });
 
-    test("refreshes commands when sessions.updated arrives during loading", () async {
+    test("refreshes only commands when a catalog update arrives during loading", () async {
       final mockLoadService = MockSessionDetailLoadService();
       final loadCompleter = Completer<SessionDetailLoadResult>();
-      var reloadCount = 0;
 
       when(
         () => mockLoadService.load(
@@ -238,36 +237,24 @@ void main() {
         ),
       ).thenAnswer((_) => loadCompleter.future);
       when(
-        () => mockLoadService.reload(
-          sessionId: _sessionId,
-          projectId: any(named: "projectId"),
+        () => mockSessionRepository.listCommands(
+          projectId: "project-1",
+          pluginId: "opencode",
         ),
-      ).thenAnswer((_) async {
-        reloadCount++;
-        return SessionDetailLoadResult.loaded(
-          snapshot: SessionDetailSnapshot(
-            projectId: "project-1",
-            pluginId: "opencode",
-            messages: const <MessageWithParts>[],
-            pendingQuestions: const <PendingQuestion>[],
-            pendingPermissions: const <PendingPermission>[],
-            childSessions: const <Session>[],
-            statuses: const <String, SessionStatus>{},
-            agents: const <AgentInfo?>[],
-            providerData: null,
-            commands: [testCommandInfo(name: "compact", template: "/compact")],
-            canonicalSessionTitle: null,
-            promptDefaults: null,
-            isRootSession: true,
-            isArchived: false,
+      ).thenAnswer(
+        (_) async => ApiResponse.success(
+          CommandListResponse(
+            items: [testCommandInfo(name: "compact", template: "/compact")],
           ),
-          isBridgeConnected: true,
-        );
-      });
+        ),
+      );
 
       final cubit = createCubit(loadService: mockLoadService);
       globalEvents.add(
-        SseEvent(data: const SesoriSessionsUpdated(projectID: "project-1")),
+        SseEvent(data: const SesoriCommandCatalogUpdated(pluginId: "cursor")),
+      );
+      globalEvents.add(
+        SseEvent(data: const SesoriCommandCatalogUpdated(pluginId: "opencode")),
       );
       await Future<void>.delayed(Duration.zero);
 
@@ -293,11 +280,98 @@ void main() {
         ),
       );
 
-      for (var i = 0; i < 100 && reloadCount == 0; i++) {
-        await Future<void>.delayed(const Duration(milliseconds: 5));
-      }
-      expect(reloadCount, 1);
       await _awaitLoadedWithCommand(cubit, command: "compact");
+      verify(
+        () => mockSessionRepository.listCommands(
+          projectId: "project-1",
+          pluginId: "opencode",
+        ),
+      ).called(1);
+      verifyNever(
+        () => mockSessionRepository.listCommands(
+          projectId: "project-1",
+          pluginId: "cursor",
+        ),
+      );
+      verifyNever(
+        () => mockLoadService.reload(
+          sessionId: _sessionId,
+          projectId: any(named: "projectId"),
+        ),
+      );
+    });
+
+    test("keeps the newest command catalog when refreshes finish out of order", () async {
+      final mockLoadService = MockSessionDetailLoadService();
+      when(
+        () => mockLoadService.load(
+          sessionId: _sessionId,
+          projectId: any(named: "projectId"),
+        ),
+      ).thenAnswer(
+        (_) async => const SessionDetailLoadResult.loaded(
+          snapshot: SessionDetailSnapshot(
+            projectId: "project-1",
+            pluginId: "opencode",
+            messages: <MessageWithParts>[],
+            pendingQuestions: <PendingQuestion>[],
+            pendingPermissions: <PendingPermission>[],
+            childSessions: <Session>[],
+            statuses: <String, SessionStatus>{},
+            agents: <AgentInfo?>[],
+            providerData: null,
+            commands: <CommandInfo>[],
+            canonicalSessionTitle: null,
+            promptDefaults: null,
+            isRootSession: true,
+            isArchived: false,
+          ),
+          isBridgeConnected: true,
+        ),
+      );
+      final responses = <Completer<ApiResponse<CommandListResponse>>>[];
+      when(
+        () => mockSessionRepository.listCommands(
+          projectId: "project-1",
+          pluginId: "opencode",
+        ),
+      ).thenAnswer((_) {
+        final response = Completer<ApiResponse<CommandListResponse>>();
+        responses.add(response);
+        return response.future;
+      });
+
+      final cubit = createCubit(loadService: mockLoadService);
+      await _awaitLoaded(cubit);
+
+      globalEvents.add(
+        SseEvent(data: const SesoriCommandCatalogUpdated(pluginId: "opencode")),
+      );
+      await _awaitCondition(() => responses.length == 1);
+      globalEvents.add(
+        SseEvent(data: const SesoriCommandCatalogUpdated(pluginId: "opencode")),
+      );
+      await _awaitCondition(() => responses.length == 2);
+
+      responses[1].complete(
+        ApiResponse.success(
+          CommandListResponse(
+            items: [testCommandInfo(name: "newest", template: "/newest")],
+          ),
+        ),
+      );
+      await _awaitLoadedWithCommand(cubit, command: "newest");
+      responses[0].complete(
+        ApiResponse.success(
+          CommandListResponse(
+            items: [testCommandInfo(name: "stale", template: "/stale")],
+          ),
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final state = cubit.state as SessionDetailLoaded;
+      expect(state.availableCommands.map((command) => command.name), ["newest"]);
     });
 
     test("clears pending events when load fails", () async {
@@ -592,4 +666,12 @@ Future<void> _awaitLoadedWithCommand(
     await Future<void>.delayed(const Duration(milliseconds: 5));
   }
   fail("Timed out waiting for '$command'; current state: ${cubit.state}");
+}
+
+Future<void> _awaitCondition(bool Function() condition) async {
+  for (var i = 0; i < 100; i++) {
+    if (condition()) return;
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+  fail("Timed out waiting for condition");
 }

--- a/client/module_core/test/cubits/session_detail/session_detail_reconnect_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_reconnect_test.dart
@@ -8,7 +8,6 @@ import "package:sesori_dart_core/src/capabilities/server_connection/models/sse_e
 import "package:sesori_dart_core/src/capabilities/server_connection/server_connection_config.dart";
 import "package:sesori_dart_core/src/cubits/session_detail/session_detail_cubit.dart";
 import "package:sesori_dart_core/src/cubits/session_detail/session_detail_state.dart";
-import "package:sesori_dart_core/src/logging/logging.dart";
 import "package:sesori_dart_core/src/platform/notification_canceller.dart";
 import "package:sesori_dart_core/src/repositories/permission_repository.dart";
 import "package:sesori_dart_core/src/repositories/project_repository.dart";
@@ -205,7 +204,7 @@ void main() {
     expect(cubit.state, isA<SessionDetailLoaded>());
   });
 
-  test("ignores sessions.updated events from unrelated projects", () async {
+  test("does not treat sessions.updated as a session-detail invalidation", () async {
     final mockLoadService = MockSessionDetailLoadService();
     final mockSessionRepository = MockSessionRepository();
     final mockConnectionService = MockConnectionService();
@@ -214,14 +213,10 @@ void main() {
     final sessionEvents = StreamController<SesoriSessionEvent>.broadcast();
     final globalEvents = StreamController<SseEvent>.broadcast();
     final connectionStatus = BehaviorSubject<ConnectionStatus>.seeded(connectedStatus);
-    final logs = <String>[];
-    final previousLogLevel = logLevel;
-    setLogLevel(LogLevel.debug);
 
     addTearDown(sessionEvents.close);
     addTearDown(globalEvents.close);
     addTearDown(connectionStatus.close);
-    addTearDown(() => setLogLevel(previousLogLevel));
 
     when(() => mockConnectionService.sessionEvents(_sessionId)).thenAnswer((_) => sessionEvents.stream);
     when(() => mockConnectionService.events).thenAnswer((_) => globalEvents.stream);
@@ -277,25 +272,20 @@ void main() {
       (_) async => loadedResult,
     );
 
-    final cubit = runZoned(
-      () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: mockLoadService,
-        promptDispatcher: mockSessionRepository,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: FakeLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: _sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-      ),
-      zoneSpecification: ZoneSpecification(
-        print: (self, parent, zone, line) => logs.add(line),
-      ),
+    final cubit = SessionDetailCubit(
+      mockConnectionService,
+      loadService: mockLoadService,
+      promptDispatcher: mockSessionRepository,
+      permissionRepository: mockPermissionRepository,
+      sessionViewingService: stubbedSessionViewingService(),
+      projectViewingService: stubbedProjectViewingService(),
+      lifecycleSource: FakeLifecycleSource(),
+      composerDraftRepository: inMemoryComposerDraftRepository(),
+      productAnalyticsService: stubbedProductAnalyticsService(),
+      sessionId: _sessionId,
+      projectId: "project-1",
+      notificationCanceller: mockNotificationCanceller,
+      failureReporter: MockFailureReporter(),
     );
     addTearDown(cubit.close);
 
@@ -311,28 +301,14 @@ void main() {
         projectId: any(named: "projectId"),
       ),
     );
-    expect(
-      logs,
-      containsAll([
-        contains("[session-refresh] action=observed trigger=project_sessions_updated"),
-        contains("[session-refresh] action=ignored trigger=project_sessions_updated"),
-      ]),
-    );
-
     globalEvents.add(SseEvent(data: const SesoriSseEvent.sessionsUpdated(projectID: "project-1")));
     await Future<void>.delayed(Duration.zero);
 
-    verify(() => mockLoadService.reload(sessionId: _sessionId, projectId: "project-1")).called(1);
-    expect(
-      logs,
-      containsAll([
-        contains("[session-refresh] action=started trigger=project_sessions_updated"),
-        allOf(
-          contains("[session-refresh] action=completed trigger=project_sessions_updated"),
-          contains("result=applied"),
-          contains("durationMs="),
-        ),
-      ]),
+    verifyNever(
+      () => mockLoadService.reload(
+        sessionId: _sessionId,
+        projectId: any(named: "projectId"),
+      ),
     );
   });
 }

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
@@ -55,6 +55,12 @@ sealed class SesoriSseEvent with _$SesoriSseEvent {
     required String snapshotToken,
   }) = SesoriPluginManagementChanged;
 
+  /// Invalidates the process-wide slash-command catalog for one plugin.
+  @FreezedUnionValue("command.catalog.updated")
+  const factory SesoriSseEvent.commandCatalogUpdated({
+    required String pluginId,
+  }) = SesoriCommandCatalogUpdated;
+
   // ---------------------------------------------------------------------------
   // Session — all implement SesoriSessionEvent
   // ---------------------------------------------------------------------------

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.freezed.dart
@@ -39,6 +39,10 @@ SesoriSseEvent _$SesoriSseEventFromJson(
           return SesoriPluginManagementChanged.fromJson(
             json
           );
+                case 'command.catalog.updated':
+          return SesoriCommandCatalogUpdated.fromJson(
+            json
+          );
                 case 'session.created':
           return SesoriSessionCreated.fromJson(
             json
@@ -585,6 +589,79 @@ class _$SesoriPluginManagementChangedCopyWithImpl<$Res>
 @pragma('vm:prefer-inline') $Res call({Object? snapshotToken = null,}) {
   return _then(SesoriPluginManagementChanged(
 snapshotToken: null == snapshotToken ? _self.snapshotToken : snapshotToken // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class SesoriCommandCatalogUpdated implements SesoriSseEvent {
+  const SesoriCommandCatalogUpdated({required this.pluginId, final  String? $type}): $type = $type ?? 'command.catalog.updated';
+  factory SesoriCommandCatalogUpdated.fromJson(Map<String, dynamic> json) => _$SesoriCommandCatalogUpdatedFromJson(json);
+
+ final  String pluginId;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of SesoriSseEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SesoriCommandCatalogUpdatedCopyWith<SesoriCommandCatalogUpdated> get copyWith => _$SesoriCommandCatalogUpdatedCopyWithImpl<SesoriCommandCatalogUpdated>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SesoriCommandCatalogUpdatedToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SesoriCommandCatalogUpdated&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,pluginId);
+
+@override
+String toString() {
+  return 'SesoriSseEvent.commandCatalogUpdated(pluginId: $pluginId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SesoriCommandCatalogUpdatedCopyWith<$Res> implements $SesoriSseEventCopyWith<$Res> {
+  factory $SesoriCommandCatalogUpdatedCopyWith(SesoriCommandCatalogUpdated value, $Res Function(SesoriCommandCatalogUpdated) _then) = _$SesoriCommandCatalogUpdatedCopyWithImpl;
+@useResult
+$Res call({
+ String pluginId
+});
+
+
+
+
+}
+/// @nodoc
+class _$SesoriCommandCatalogUpdatedCopyWithImpl<$Res>
+    implements $SesoriCommandCatalogUpdatedCopyWith<$Res> {
+  _$SesoriCommandCatalogUpdatedCopyWithImpl(this._self, this._then);
+
+  final SesoriCommandCatalogUpdated _self;
+  final $Res Function(SesoriCommandCatalogUpdated) _then;
+
+/// Create a copy of SesoriSseEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? pluginId = null,}) {
+  return _then(SesoriCommandCatalogUpdated(
+pluginId: null == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
 as String,
   ));
 }

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.g.dart
@@ -69,6 +69,16 @@ Map<String, dynamic> _$SesoriPluginManagementChangedToJson(
   'type': instance.$type,
 };
 
+SesoriCommandCatalogUpdated _$SesoriCommandCatalogUpdatedFromJson(Map json) =>
+    SesoriCommandCatalogUpdated(
+      pluginId: json['pluginId'] as String,
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$SesoriCommandCatalogUpdatedToJson(
+  SesoriCommandCatalogUpdated instance,
+) => <String, dynamic>{'pluginId': instance.pluginId, 'type': instance.$type};
+
 SesoriSessionCreated _$SesoriSessionCreatedFromJson(Map json) =>
     SesoriSessionCreated(
       info: Session.fromJson(Map<String, dynamic>.from(json['info'] as Map)),

--- a/shared/sesori_shared/test/models/sesori_sse_event_test.dart
+++ b/shared/sesori_shared/test/models/sesori_sse_event_test.dart
@@ -12,6 +12,15 @@ void main() {
     expect(SesoriSseEvent.fromJson(json), event);
   });
 
+  test('command catalog update round-trips its plugin scope', () {
+    const event = SesoriSseEvent.commandCatalogUpdated(pluginId: 'cursor');
+
+    final json = event.toJson();
+
+    expect(json, {'type': 'command.catalog.updated', 'pluginId': 'cursor'});
+    expect(SesoriSseEvent.fromJson(json), event);
+  });
+
   // ---------------------------------------------------------------------------
   // Round-trip JSON compatibility
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Complexity

Moderate. This adds one backend-neutral SSE contract across the ACP plugin, bridge mapping, shared protocol, and client state flow.

## What

- Add a plugin-scoped `command.catalog.updated` event for process-wide command catalog invalidation.
- Map ACP `available_commands_update` to that event while retaining the existing internal session-options persistence trigger.
- Refresh only the matching session detail's commands and preserve newer command results across concurrent refreshes.
- Stop treating `sessions.updated` as a session-detail invalidation; it remains a session-list event.
- Add no health flags, subscriber capabilities, legacy translations, or fallback behavior.

## Why

ACP commands are stored as one process-global last-update-wins catalog. Reusing project-scoped `sessions.updated` gave the event the wrong meaning and forced an expensive full session-detail reload just to update slash commands.

ACP was not enabled in a public production release, so there is no ACP compatibility behavior to preserve.

## Risk and test focus

The wire event is new and intentionally has no compatibility shim. Tests focus on source plugin attribution, process-wide ACP emission, non-session classification, plugin filtering, loading-time buffering, out-of-order refreshes, and keeping `sessions.updated` list-only.

There is no database impact. The user-visible impact is limited to slash-command pickers updating without reloading unrelated session detail data.

## Expected result

An ACP command advertisement invalidates the emitting plugin's command catalog on connected clients. Open session details for that plugin fetch only `/command`; sessions using other plugins do nothing, and session-list invalidations no longer refresh detail snapshots.

## Verification

- `dart test` in `shared/sesori_shared`, `bridge/sesori_plugin_interface`, `bridge/sesori_plugin_acp`, `bridge/app`, and `client/module_core`
- `flutter test test/features/session_detail/session_detail_cubit_test.dart` in `client/app`
- `dart analyze` in shared, client core, and mobile app
- `dart analyze --fatal-infos` in bridge interface, ACP, OpenCode, Codex, Cursor, and bridge app
- Architecture implementation review: approved with no findings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new plugin-scoped SSE event to invalidate command catalogs (`command.catalog.updated`) and stops using `sessions.updated` for session-detail refreshes, so clients update slash commands without reloading session snapshots.

- **New Features**
  - Introduced `command.catalog.updated` (plugin-scoped) in shared SSE protocol; bridge maps it with `pluginId`.
  - ACP maps `available_commands_update` to this event and still emits `session.options.changed` for persistence.
  - Client refreshes only the matching session’s command list, preserves staged commands, buffers during load, and keeps newest results across concurrent refreshes.
  - Reclassified `sessions.updated` as session-list only; session detail no longer treats it as an invalidation.

<sup>Written for commit 45c786b843cb24966d12bb795b3143f73b7647c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

