### PR TITLE
⚙️ Paste image attachments into chat

### DIFF
--- a/client/app/lib/capabilities/media/composer_image_picker.dart
+++ b/client/app/lib/capabilities/media/composer_image_picker.dart
@@ -49,7 +49,18 @@ class ComposerImagePicker {
     );
     if (file == null) return null;
 
-    final bytes = await file.readAsBytes();
+    return attachmentFromBytes(
+      bytes: await file.readAsBytes(),
+      filename: file.name,
+    );
+  }
+
+  /// Validates image bytes from any composer source and creates the attachment
+  /// shape used by the existing send pipeline.
+  ComposerAttachment attachmentFromBytes({
+    required Uint8List bytes,
+    required String? filename,
+  }) {
     // Judge size by the conservative decoded estimate of the base64 form the
     // wire carries, so anything accepted here also passes receivers using the
     // shared [isInlineMessageAttachmentWithinSizeLimit] check.
@@ -61,11 +72,11 @@ class ComposerImagePicker {
     final mime = _sniffImageMime(bytes: bytes);
     if (mime == null) throw const UnsupportedAttachmentImageError();
 
-    final name = file.name.trim();
+    final name = filename?.trim();
     return ComposerAttachment(
       mime: mime,
       bytes: bytes,
-      filename: name.isEmpty ? null : name,
+      filename: name == null || name.isEmpty ? null : name,
     );
   }
 

--- a/client/app/lib/capabilities/media/composer_image_picker.dart
+++ b/client/app/lib/capabilities/media/composer_image_picker.dart
@@ -3,10 +3,9 @@ import "dart:typed_data";
 import "package:image_picker/image_picker.dart";
 import "package:injectable/injectable.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
-import "package:sesori_shared/sesori_shared.dart";
 
 /// The picked image cannot be sent inline: even after the picker's downscale
-/// pass it decodes past [maxInlineMessageAttachmentBytes].
+/// pass it exceeds [maxComposerPromptAttachmentBytes].
 final class AttachmentTooLargeError implements Exception {
   const AttachmentTooLargeError();
 }
@@ -61,11 +60,7 @@ class ComposerImagePicker {
     required Uint8List bytes,
     required String? filename,
   }) {
-    // Judge size by the conservative decoded estimate of the base64 form the
-    // wire carries, so anything accepted here also passes receivers using the
-    // shared [isInlineMessageAttachmentWithinSizeLimit] check.
-    final base64Length = 4 * ((bytes.length + 2) ~/ 3);
-    if (!isInlineMessageAttachmentWithinSizeLimit(base64Length: base64Length)) {
+    if (bytes.length > maxComposerPromptAttachmentBytes) {
       throw const AttachmentTooLargeError();
     }
 

--- a/client/app/lib/core/platform/flutter_image_clipboard.dart
+++ b/client/app/lib/core/platform/flutter_image_clipboard.dart
@@ -12,5 +12,8 @@ class FlutterImageClipboard implements ImageClipboard {
   FlutterImageClipboard({required PasteboardClient pasteboardClient}) : _pasteboardClient = pasteboardClient;
 
   @override
+  Future<Uint8List?> readImage() => _pasteboardClient.readImage();
+
+  @override
   Future<void> writeImage({required Uint8List bytes}) => _pasteboardClient.writeImage(bytes: bytes);
 }

--- a/client/app/lib/core/platform/pasteboard_client.dart
+++ b/client/app/lib/core/platform/pasteboard_client.dart
@@ -6,5 +6,7 @@ import "package:pasteboard/pasteboard.dart";
 /// Injectable seam around Pasteboard's static plugin API.
 @lazySingleton
 class PasteboardClient {
+  Future<Uint8List?> readImage() => Pasteboard.image;
+
   Future<void> writeImage({required Uint8List bytes}) => Pasteboard.writeImage(bytes);
 }

--- a/client/app/lib/features/session_detail/widgets/prompt_editor_sheet.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_editor_sheet.dart
@@ -1,5 +1,6 @@
 import "dart:math" as math;
 
+import "package:flutter/foundation.dart" show kIsWeb;
 import "package:flutter/material.dart";
 import "package:theme_prego/module_prego.dart";
 
@@ -14,17 +15,23 @@ import "../../../core/extensions/build_context_x.dart";
 class PromptEditorSheet extends StatelessWidget {
   final TextEditingController controller;
   final String placeholder;
+  final Action<PasteTextIntent> pasteAction;
+  final EditableTextContextMenuBuilder contextMenuBuilder;
 
   const PromptEditorSheet({
     super.key,
     required this.controller,
     required this.placeholder,
+    required this.pasteAction,
+    required this.contextMenuBuilder,
   });
 
   static Future<void> show(
     BuildContext context, {
     required TextEditingController controller,
     required String placeholder,
+    required Action<PasteTextIntent> pasteAction,
+    required EditableTextContextMenuBuilder contextMenuBuilder,
   }) {
     // Status-bar inset, captured before presenting: the modal route strips
     // the top inset from both `padding` and `viewPadding`, so inside the
@@ -43,7 +50,12 @@ class PromptEditorSheet extends StatelessWidget {
         final height = screenHeight - topInset - PregoBottomSheet.contentTopInset - keyboard;
         return SizedBox(
           height: math.max(height, screenHeight * 0.3),
-          child: PromptEditorSheet(controller: controller, placeholder: placeholder),
+          child: PromptEditorSheet(
+            controller: controller,
+            placeholder: placeholder,
+            pasteAction: pasteAction,
+            contextMenuBuilder: contextMenuBuilder,
+          ),
         );
       },
     );
@@ -52,20 +64,24 @@ class PromptEditorSheet extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
-    return TextField(
-      controller: controller,
-      autofocus: true,
-      expands: true,
-      maxLines: null,
-      textAlignVertical: TextAlignVertical.top,
-      keyboardType: TextInputType.multiline,
-      textInputAction: TextInputAction.newline,
-      style: prego.textTheme.textMd.regular.copyWith(color: prego.colors.textPrimary),
-      decoration: InputDecoration(
-        isCollapsed: true,
-        border: InputBorder.none,
-        hintText: placeholder,
-        hintStyle: prego.textTheme.textMd.regular.copyWith(color: prego.colors.textSecondary),
+    return Actions(
+      actions: kIsWeb ? const {} : {PasteTextIntent: pasteAction},
+      child: TextField(
+        controller: controller,
+        autofocus: true,
+        expands: true,
+        maxLines: null,
+        textAlignVertical: TextAlignVertical.top,
+        keyboardType: TextInputType.multiline,
+        textInputAction: TextInputAction.newline,
+        contextMenuBuilder: contextMenuBuilder,
+        style: prego.textTheme.textMd.regular.copyWith(color: prego.colors.textPrimary),
+        decoration: InputDecoration(
+          isCollapsed: true,
+          border: InputBorder.none,
+          hintText: placeholder,
+          hintStyle: prego.textTheme.textMd.regular.copyWith(color: prego.colors.textSecondary),
+        ),
       ),
     );
   }

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -446,6 +446,9 @@ class _PromptInputState extends State<PromptInput> {
     super.didUpdateWidget(oldWidget);
     final draftChanged = oldWidget.draftIdentity != widget.draftIdentity;
     final stagedCommandChanged = oldWidget.stagedCommand?.name != widget.stagedCommand?.name;
+    if (oldWidget.attachmentsSupported != widget.attachmentsSupported) {
+      _pasteGeneration++;
+    }
     if (draftChanged) {
       // The state was reused for another session without initState/dispose.
       // The owning Cubit already persisted each edit, so only restore the new

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -1296,14 +1296,21 @@ class _PromptInputState extends State<PromptInput> {
       final pasteItem = ContextMenuButtonItem(
         type: ContextMenuButtonType.paste,
         label: existingPaste?.label,
-        onPressed: () => unawaited(
-          _pasteImageOrText(
-            onTextPaste: existingPasteCallback == null
-                ? () => editableTextState.pasteText(SelectionChangedCause.toolbar)
-                : () async => existingPasteCallback(),
-            onImagePasted: editableTextState.hideToolbar,
-          ),
-        ),
+        onPressed: () {
+          // Preserve the selection from the paste intent; the image probe may
+          // outlive the menu, so a later caret move must not redirect the text
+          // fallback.
+          final initialValue = editableTextState.textEditingValue;
+          unawaited(
+            _pasteImageOrText(
+              initialValue: initialValue,
+              onTextPaste: existingPasteCallback == null
+                  ? () => editableTextState.pasteText(SelectionChangedCause.toolbar)
+                  : () async => existingPasteCallback(),
+              onImagePasted: editableTextState.hideToolbar,
+            ),
+          );
+        },
       );
       if (pasteIndex >= 0) {
         buttonItems[pasteIndex] = pasteItem;
@@ -1543,12 +1550,18 @@ class _PromptInputState extends State<PromptInput> {
   }
 
   Future<void> _pasteImageOrText({
+    required TextEditingValue initialValue,
     required Future<void> Function() onTextPaste,
     required VoidCallback onImagePasted,
   }) async {
     try {
       switch (await _handlePasteImage()) {
         case _PasteImageResult.noImage:
+          // Restore the caret captured when paste was pressed so the fallback
+          // replaces the same selection, unless the user typed meanwhile.
+          if (_controller.text == initialValue.text && initialValue.selection.isValid) {
+            _controller.selection = initialValue.selection;
+          }
           await onTextPaste();
           return;
         case _PasteImageResult.handled:

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:flutter/foundation.dart" show kIsWeb;
 import "package:flutter/gestures.dart" show kPrimaryButton;
 import "package:flutter/material.dart";
 import "package:flutter/services.dart";
@@ -24,6 +25,34 @@ import "prompt_editor_sheet.dart";
 import "voice_cancel_button.dart";
 
 enum _VoiceState { idle, recording, transcribing }
+
+final class _ComposerPasteAction extends Action<PasteTextIntent> {
+  final Future<bool> Function() _pasteImage;
+
+  _ComposerPasteAction({required Future<bool> Function() pasteImage}) : _pasteImage = pasteImage;
+
+  @override
+  Object? invoke(PasteTextIntent intent) {
+    // callingAction is available only during this synchronous override call,
+    // so retain Flutter's normal text-paste action before reading the image.
+    final textPasteAction = callingAction;
+    unawaited(_pasteImageOrText(intent: intent, textPasteAction: textPasteAction));
+    return null;
+  }
+
+  Future<void> _pasteImageOrText({
+    required PasteTextIntent intent,
+    required Action<PasteTextIntent>? textPasteAction,
+  }) async {
+    if (!await _pasteImage()) textPasteAction?.invoke(intent);
+  }
+
+  @override
+  bool get isActionEnabled => callingAction?.isActionEnabled ?? false;
+
+  @override
+  bool consumesKey(PasteTextIntent intent) => callingAction?.consumesKey(intent) ?? false;
+}
 
 typedef PromptSubmitCallback =
     void Function({
@@ -96,6 +125,7 @@ class _PromptInputState extends State<PromptInput> {
   final _controller = TextEditingController();
   final _textScrollController = ScrollController();
   final _focusNode = FocusNode();
+  late final Action<PasteTextIntent> _pasteAction;
   late ComposerDraft _draft;
   late TextEditingValue _previousEditingValue;
   bool _isApplyingDraft = false;
@@ -172,9 +202,12 @@ class _PromptInputState extends State<PromptInput> {
 
   ComposerImagePicker get _imagePicker => getIt<ComposerImagePicker>();
 
+  ImageClipboard get _imageClipboard => getIt<ImageClipboard>();
+
   @override
   void initState() {
     super.initState();
+    _pasteAction = _ComposerPasteAction(pasteImage: _handlePasteImage);
     final chatInputModeCubit = context.read<ChatInputModeCubit>();
     _chatInputMode = chatInputModeCubit.state;
     _chatInputModeSub = chatInputModeCubit.stream.listen((inputMode) {
@@ -1154,36 +1187,44 @@ class _PromptInputState extends State<PromptInput> {
                 // Clear the expand button on the trailing edge so text never
                 // runs underneath it.
                 padding: const EdgeInsetsDirectional.fromSTEB(PregoSpacing.xs, 0, 36, 0),
-                child: CallbackShortcuts(
-                  // Cmd/Ctrl+Enter sends (handy with a hardware keyboard);
-                  // plain Enter stays a newline via textInputAction below.
-                  bindings: <ShortcutActivator, VoidCallback>{
-                    const SingleActivator(LogicalKeyboardKey.enter, meta: true): _handleSend,
-                    const SingleActivator(LogicalKeyboardKey.enter, control: true): _handleSend,
-                  },
-                  child: TextField(
-                    controller: _controller,
-                    scrollController: _textScrollController,
-                    focusNode: _focusNode,
-                    minLines: 1,
-                    maxLines: 6,
-                    keyboardType: TextInputType.multiline,
-                    textInputAction: TextInputAction.newline,
-                    // Material's default keeps focus on mobile touch taps;
-                    // this composer wants outside taps (e.g. the picker
-                    // pills above the region) to dismiss the keyboard — the
-                    // behaviour the TextFieldTapRegion grouping was built
-                    // around.
-                    onTapOutside: (_) => _focusNode.unfocus(),
-                    style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textPrimary),
-                    decoration: InputDecoration(
-                      isCollapsed: true,
-                      border: InputBorder.none,
-                      contentPadding: const EdgeInsets.symmetric(vertical: PregoSpacing.md),
-                      // Command-aware placeholder: the staged command's hint,
-                      // else the follow-up/default prompt hint.
-                      hintText: _hintText(context),
-                      hintStyle: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textSecondary),
+                child: Actions(
+                  // Browser paste must remain synchronous with its DOM event;
+                  // deferring Flutter's text action behind an async Clipboard
+                  // API read can lose browser user activation.
+                  actions: kIsWeb ? const {} : {PasteTextIntent: _pasteAction},
+                  child: CallbackShortcuts(
+                    // Cmd/Ctrl+Enter sends (handy with a hardware keyboard);
+                    // plain Enter stays a newline via textInputAction below.
+                    bindings: <ShortcutActivator, VoidCallback>{
+                      const SingleActivator(LogicalKeyboardKey.enter, meta: true): _handleSend,
+                      const SingleActivator(LogicalKeyboardKey.enter, control: true): _handleSend,
+                    },
+                    child: TextField(
+                      controller: _controller,
+                      scrollController: _textScrollController,
+                      focusNode: _focusNode,
+                      minLines: 1,
+                      maxLines: 6,
+                      keyboardType: TextInputType.multiline,
+                      textInputAction: TextInputAction.newline,
+                      contextMenuBuilder: (_, editableTextState) =>
+                          _buildComposerContextMenu(editableTextState: editableTextState),
+                      // Material's default keeps focus on mobile touch taps;
+                      // this composer wants outside taps (e.g. the picker
+                      // pills above the region) to dismiss the keyboard — the
+                      // behaviour the TextFieldTapRegion grouping was built
+                      // around.
+                      onTapOutside: (_) => _focusNode.unfocus(),
+                      style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textPrimary),
+                      decoration: InputDecoration(
+                        isCollapsed: true,
+                        border: InputBorder.none,
+                        contentPadding: const EdgeInsets.symmetric(vertical: PregoSpacing.md),
+                        // Command-aware placeholder: the staged command's hint,
+                        // else the follow-up/default prompt hint.
+                        hintText: _hintText(context),
+                        hintStyle: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textSecondary),
+                      ),
                     ),
                   ),
                 ),
@@ -1206,6 +1247,36 @@ class _PromptInputState extends State<PromptInput> {
           if (voiceFirst) _buildTypingVoicePill(context) else _buildTypingActionRow(context),
         ],
       ),
+    );
+  }
+
+  Widget _buildComposerContextMenu({required EditableTextState editableTextState}) {
+    final buttonItems = [...editableTextState.contextMenuButtonItems];
+    if (!kIsWeb && widget.attachmentsSupported) {
+      final pasteIndex = buttonItems.indexWhere((item) => item.type == ContextMenuButtonType.paste);
+      final existingPaste = pasteIndex < 0 ? null : buttonItems[pasteIndex];
+      final pasteItem = ContextMenuButtonItem(
+        type: ContextMenuButtonType.paste,
+        label: existingPaste?.label,
+        onPressed: () => unawaited(
+          _pasteImageOrText(
+            onTextPaste:
+                existingPaste?.onPressed ?? () => unawaited(editableTextState.pasteText(SelectionChangedCause.toolbar)),
+            onImagePasted: editableTextState.hideToolbar,
+          ),
+        ),
+      );
+      if (pasteIndex >= 0) {
+        buttonItems[pasteIndex] = pasteItem;
+      } else {
+        final selectAllIndex = buttonItems.indexWhere((item) => item.type == ContextMenuButtonType.selectAll);
+        buttonItems.insert(selectAllIndex < 0 ? buttonItems.length : selectAllIndex, pasteItem);
+      }
+    }
+
+    return AdaptiveTextSelectionToolbar.buttonItems(
+      anchors: editableTextState.contextMenuAnchors,
+      buttonItems: buttonItems,
     );
   }
 
@@ -1376,11 +1447,7 @@ class _PromptInputState extends State<PromptInput> {
       if (!mounted || draftIdentity != widget.draftIdentity || !widget.attachmentsSupported || attachment == null) {
         return;
       }
-      if (_attachmentsDecodedSizeWith(attachment: attachment) > maxInlineMessageAttachmentBytes) {
-        _showComposerNotice(context.loc.sessionDetailAttachmentBudgetExceeded);
-        return;
-      }
-      setState(() => _attachments.add(attachment));
+      _stageAttachment(attachment: attachment);
     } on AttachmentTooLargeError {
       if (!mounted || draftIdentity != widget.draftIdentity) return;
       _showComposerNotice(context.loc.sessionDetailAttachmentTooLarge);
@@ -1392,6 +1459,57 @@ class _PromptInputState extends State<PromptInput> {
       if (!mounted || draftIdentity != widget.draftIdentity) return;
       _showComposerNotice(context.loc.sessionDetailAttachmentPickFailed);
     }
+  }
+
+  /// Reads an image before allowing Flutter's normal text paste to run. An
+  /// image wins when the clipboard exposes both binary and text formats.
+  Future<bool> _handlePasteImage() async {
+    if (!widget.attachmentsSupported) return false;
+    final draftIdentity = widget.draftIdentity;
+    final Uint8List? bytes;
+    try {
+      bytes = await _imageClipboard.readImage();
+    } catch (error, stackTrace) {
+      loge("Failed to read a pasted image", error, stackTrace);
+      return false;
+    }
+
+    // Never let an asynchronous paste land in a composer that replaced the
+    // one where the action started.
+    if (!mounted || draftIdentity != widget.draftIdentity || !widget.attachmentsSupported) return true;
+    if (bytes == null) return false;
+
+    try {
+      final attachment = _imagePicker.attachmentFromBytes(bytes: bytes, filename: null);
+      _stageAttachment(attachment: attachment);
+    } on AttachmentTooLargeError {
+      _showComposerNotice(context.loc.sessionDetailAttachmentTooLarge);
+    } on UnsupportedAttachmentImageError {
+      _showComposerNotice(context.loc.sessionDetailAttachmentUnsupported);
+    } catch (error, stackTrace) {
+      loge("Failed to attach a pasted image", error, stackTrace);
+      _showComposerNotice(context.loc.sessionDetailAttachmentPickFailed);
+    }
+    return true;
+  }
+
+  Future<void> _pasteImageOrText({
+    required VoidCallback onTextPaste,
+    required VoidCallback onImagePasted,
+  }) async {
+    if (await _handlePasteImage()) {
+      onImagePasted();
+    } else {
+      onTextPaste();
+    }
+  }
+
+  void _stageAttachment({required ComposerAttachment attachment}) {
+    if (_attachmentsDecodedSizeWith(attachment: attachment) > maxInlineMessageAttachmentBytes) {
+      _showComposerNotice(context.loc.sessionDetailAttachmentBudgetExceeded);
+      return;
+    }
+    setState(() => _attachments.add(attachment));
   }
 
   /// Total decoded bytes the staged strip would carry with [attachment]

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -26,25 +26,51 @@ import "voice_cancel_button.dart";
 
 enum _VoiceState { idle, recording, transcribing }
 
-final class _ComposerPasteAction extends Action<PasteTextIntent> {
-  final Future<bool> Function() _pasteImage;
+enum _PasteImageResult { noImage, handled, stale }
 
-  _ComposerPasteAction({required Future<bool> Function() pasteImage}) : _pasteImage = pasteImage;
+final class _ComposerPasteAction extends Action<PasteTextIntent> {
+  final Future<_PasteImageResult> Function() _pasteImage;
+  final TextEditingController _controller;
+
+  _ComposerPasteAction({
+    required Future<_PasteImageResult> Function() pasteImage,
+    required TextEditingController controller,
+  }) : _pasteImage = pasteImage,
+       _controller = controller;
 
   @override
   Object? invoke(PasteTextIntent intent) {
     // callingAction is available only during this synchronous override call,
     // so retain Flutter's normal text-paste action before reading the image.
     final textPasteAction = callingAction;
-    unawaited(_pasteImageOrText(intent: intent, textPasteAction: textPasteAction));
+    final initialValue = _controller.value;
+    unawaited(
+      _pasteImageOrText(
+        intent: intent,
+        textPasteAction: textPasteAction,
+        initialValue: initialValue,
+      ),
+    );
     return null;
   }
 
   Future<void> _pasteImageOrText({
     required PasteTextIntent intent,
     required Action<PasteTextIntent>? textPasteAction,
+    required TextEditingValue initialValue,
   }) async {
-    if (!await _pasteImage()) textPasteAction?.invoke(intent);
+    try {
+      if (await _pasteImage() != _PasteImageResult.noImage) return;
+      // Preserve the selection from the paste intent when only the caret moved
+      // while the clipboard image probe was pending. Never overwrite text that
+      // genuinely changed during that interval.
+      if (_controller.text == initialValue.text && initialValue.selection.isValid) {
+        _controller.selection = initialValue.selection;
+      }
+      textPasteAction?.invoke(intent);
+    } catch (error, stackTrace) {
+      loge("Failed to handle composer paste", error, stackTrace);
+    }
   }
 
   @override
@@ -126,6 +152,7 @@ class _PromptInputState extends State<PromptInput> {
   final _textScrollController = ScrollController();
   final _focusNode = FocusNode();
   late final Action<PasteTextIntent> _pasteAction;
+  int _pasteGeneration = 0;
   late ComposerDraft _draft;
   late TextEditingValue _previousEditingValue;
   bool _isApplyingDraft = false;
@@ -207,7 +234,10 @@ class _PromptInputState extends State<PromptInput> {
   @override
   void initState() {
     super.initState();
-    _pasteAction = _ComposerPasteAction(pasteImage: _handlePasteImage);
+    _pasteAction = _ComposerPasteAction(
+      pasteImage: _handlePasteImage,
+      controller: _controller,
+    );
     final chatInputModeCubit = context.read<ChatInputModeCubit>();
     _chatInputMode = chatInputModeCubit.state;
     _chatInputModeSub = chatInputModeCubit.stream.listen((inputMode) {
@@ -396,6 +426,7 @@ class _PromptInputState extends State<PromptInput> {
       );
     }
 
+    _pasteGeneration++;
     if (_attachments.isNotEmpty) {
       setState(_attachments.clear);
     }
@@ -420,6 +451,7 @@ class _PromptInputState extends State<PromptInput> {
       // The owning Cubit already persisted each edit, so only restore the new
       // immutable snapshot here. Staged attachments belong to the previous
       // session and never carry across.
+      _pasteGeneration++;
       _attachments.clear();
       _restoreDraft(draft: widget.initialDraft);
     }
@@ -781,6 +813,8 @@ class _PromptInputState extends State<PromptInput> {
       context,
       controller: _controller,
       placeholder: _hintText(context),
+      pasteAction: _pasteAction,
+      contextMenuBuilder: (_, editableTextState) => _buildComposerContextMenu(editableTextState: editableTextState),
     );
     if (!mounted) return;
     // Return the keyboard to the inline field. Via [_enterTypingMode] because
@@ -1255,13 +1289,15 @@ class _PromptInputState extends State<PromptInput> {
     if (!kIsWeb && widget.attachmentsSupported) {
       final pasteIndex = buttonItems.indexWhere((item) => item.type == ContextMenuButtonType.paste);
       final existingPaste = pasteIndex < 0 ? null : buttonItems[pasteIndex];
+      final existingPasteCallback = existingPaste?.onPressed;
       final pasteItem = ContextMenuButtonItem(
         type: ContextMenuButtonType.paste,
         label: existingPaste?.label,
         onPressed: () => unawaited(
           _pasteImageOrText(
-            onTextPaste:
-                existingPaste?.onPressed ?? () => unawaited(editableTextState.pasteText(SelectionChangedCause.toolbar)),
+            onTextPaste: existingPasteCallback == null
+                ? () => editableTextState.pasteText(SelectionChangedCause.toolbar)
+                : () async => existingPasteCallback(),
             onImagePasted: editableTextState.hideToolbar,
           ),
         ),
@@ -1463,21 +1499,27 @@ class _PromptInputState extends State<PromptInput> {
 
   /// Reads an image before allowing Flutter's normal text paste to run. An
   /// image wins when the clipboard exposes both binary and text formats.
-  Future<bool> _handlePasteImage() async {
-    if (!widget.attachmentsSupported) return false;
+  Future<_PasteImageResult> _handlePasteImage() async {
+    if (!widget.attachmentsSupported) return _PasteImageResult.noImage;
     final draftIdentity = widget.draftIdentity;
+    final pasteGeneration = _pasteGeneration;
     final Uint8List? bytes;
     try {
       bytes = await _imageClipboard.readImage();
     } catch (error, stackTrace) {
       loge("Failed to read a pasted image", error, stackTrace);
-      return false;
+      return _isPasteStale(draftIdentity: draftIdentity, pasteGeneration: pasteGeneration)
+          ? _PasteImageResult.stale
+          : _PasteImageResult.noImage;
     }
 
     // Never let an asynchronous paste land in a composer that replaced the
     // one where the action started.
-    if (!mounted || draftIdentity != widget.draftIdentity || !widget.attachmentsSupported) return true;
-    if (bytes == null) return false;
+    if (_isPasteStale(draftIdentity: draftIdentity, pasteGeneration: pasteGeneration)) {
+      return _PasteImageResult.stale;
+    }
+    if (!mounted) return _PasteImageResult.stale;
+    if (bytes == null) return _PasteImageResult.noImage;
 
     try {
       final attachment = _imagePicker.attachmentFromBytes(bytes: bytes, filename: null);
@@ -1490,22 +1532,38 @@ class _PromptInputState extends State<PromptInput> {
       loge("Failed to attach a pasted image", error, stackTrace);
       _showComposerNotice(context.loc.sessionDetailAttachmentPickFailed);
     }
-    return true;
+    return _PasteImageResult.handled;
   }
 
   Future<void> _pasteImageOrText({
-    required VoidCallback onTextPaste,
+    required Future<void> Function() onTextPaste,
     required VoidCallback onImagePasted,
   }) async {
-    if (await _handlePasteImage()) {
-      onImagePasted();
-    } else {
-      onTextPaste();
+    try {
+      switch (await _handlePasteImage()) {
+        case _PasteImageResult.noImage:
+          await onTextPaste();
+          return;
+        case _PasteImageResult.handled:
+          if (mounted) onImagePasted();
+          return;
+        case _PasteImageResult.stale:
+          return;
+      }
+    } catch (error, stackTrace) {
+      loge("Failed to handle composer paste", error, stackTrace);
     }
   }
 
+  bool _isPasteStale({required String draftIdentity, required int pasteGeneration}) {
+    return !mounted ||
+        draftIdentity != widget.draftIdentity ||
+        pasteGeneration != _pasteGeneration ||
+        !widget.attachmentsSupported;
+  }
+
   void _stageAttachment({required ComposerAttachment attachment}) {
-    if (_attachmentsDecodedSizeWith(attachment: attachment) > maxInlineMessageAttachmentBytes) {
+    if (_attachmentsDecodedSizeWith(attachment: attachment) > maxComposerPromptAttachmentBytes) {
       _showComposerNotice(context.loc.sessionDetailAttachmentBudgetExceeded);
       return;
     }
@@ -1513,9 +1571,8 @@ class _PromptInputState extends State<PromptInput> {
   }
 
   /// Total decoded bytes the staged strip would carry with [attachment]
-  /// added. The per-message inline budget reuses the per-image transport
-  /// limit, so a many-image prompt cannot multiply relay frames past what a
-  /// single maximal image is allowed to cost.
+  /// added. The outbound budget is aggregate, so multiple images cannot each
+  /// consume the full transport allowance.
   int _attachmentsDecodedSizeWith({required ComposerAttachment attachment}) {
     var total = attachment.bytes.length;
     for (final staged in _attachments) {

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -1330,8 +1330,7 @@ class _PromptInputState extends State<PromptInput> {
         child: Row(
           spacing: PregoSpacing.sm,
           children: [
-            for (var index = 0; index < _attachments.length; index++)
-              _buildAttachmentThumbnail(context, index: index),
+            for (var index = 0; index < _attachments.length; index++) _buildAttachmentThumbnail(context, index: index),
           ],
         ),
       ),
@@ -1526,16 +1525,21 @@ class _PromptInputState extends State<PromptInput> {
 
     try {
       final attachment = _imagePicker.attachmentFromBytes(bytes: bytes, filename: null);
-      _stageAttachment(attachment: attachment);
+      if (_stageAttachment(attachment: attachment)) return _PasteImageResult.handled;
+      // The staged strip is already at its aggregate budget, so no image was
+      // added; fall back so the clipboard's text is not swallowed.
+      return _PasteImageResult.noImage;
     } on AttachmentTooLargeError {
       _showComposerNotice(context.loc.sessionDetailAttachmentTooLarge);
+      return _PasteImageResult.noImage;
     } on UnsupportedAttachmentImageError {
       _showComposerNotice(context.loc.sessionDetailAttachmentUnsupported);
+      return _PasteImageResult.noImage;
     } catch (error, stackTrace) {
       loge("Failed to attach a pasted image", error, stackTrace);
       _showComposerNotice(context.loc.sessionDetailAttachmentPickFailed);
+      return _PasteImageResult.noImage;
     }
-    return _PasteImageResult.handled;
   }
 
   Future<void> _pasteImageOrText({
@@ -1565,12 +1569,14 @@ class _PromptInputState extends State<PromptInput> {
         !widget.attachmentsSupported;
   }
 
-  void _stageAttachment({required ComposerAttachment attachment}) {
+  /// Stages an attachment and reports whether it fit the aggregate budget.
+  bool _stageAttachment({required ComposerAttachment attachment}) {
     if (_attachmentsDecodedSizeWith(attachment: attachment) > maxComposerPromptAttachmentBytes) {
       _showComposerNotice(context.loc.sessionDetailAttachmentBudgetExceeded);
-      return;
+      return false;
     }
     setState(() => _attachments.add(attachment));
+    return true;
   }
 
   /// Total decoded bytes the staged strip would carry with [attachment]

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -434,9 +434,9 @@
   "@sessionDetailAttachmentUnsupported": {
     "description": "Snackbar shown when the picked file is not a recognized image format and cannot be attached."
   },
-  "sessionDetailAttachmentBudgetExceeded": "Attached images are limited to 5 MB per message.",
+  "sessionDetailAttachmentBudgetExceeded": "Attached images are limited to 50 MB per message.",
   "@sessionDetailAttachmentBudgetExceeded": {
-    "description": "Snackbar shown when adding another image would push the message's combined attachment size past the inline limit."
+    "description": "Snackbar shown when adding another image would push the message's combined attachment size past the outbound composer limit."
   },
   "sessionDetailAttachmentsNotWithCommands": "Images can't be sent with slash commands.",
   "@sessionDetailAttachmentsNotWithCommands": {

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -1363,10 +1363,10 @@ abstract class AppLocalizations {
   /// **'That image format isn\'t supported.'**
   String get sessionDetailAttachmentUnsupported;
 
-  /// Snackbar shown when adding another image would push the message's combined attachment size past the inline limit.
+  /// Snackbar shown when adding another image would push the message's combined attachment size past the outbound composer limit.
   ///
   /// In en, this message translates to:
-  /// **'Attached images are limited to 5 MB per message.'**
+  /// **'Attached images are limited to 50 MB per message.'**
   String get sessionDetailAttachmentBudgetExceeded;
 
   /// Snackbar shown when sending while both a slash command and image attachments are staged; the backend command paths carry only text, so the send is refused instead of silently dropping the images.

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -687,7 +687,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionDetailAttachmentUnsupported => 'That image format isn\'t supported.';
 
   @override
-  String get sessionDetailAttachmentBudgetExceeded => 'Attached images are limited to 5 MB per message.';
+  String get sessionDetailAttachmentBudgetExceeded => 'Attached images are limited to 50 MB per message.';
 
   @override
   String get sessionDetailAttachmentsNotWithCommands => 'Images can\'t be sent with slash commands.';

--- a/client/app/test/capabilities/media/composer_image_picker_test.dart
+++ b/client/app/test/capabilities/media/composer_image_picker_test.dart
@@ -41,6 +41,16 @@ void main() {
     expect(await picker.pickImage(), isNull);
   });
 
+  test("clipboard bytes use the same validation and have no filename", () {
+    final bytes = jpegBytes();
+
+    final attachment = picker.attachmentFromBytes(bytes: bytes, filename: null);
+
+    expect(attachment.mime, "image/jpeg");
+    expect(attachment.bytes, same(bytes));
+    expect(attachment.filename, isNull);
+  });
+
   test("sniffs the mime from content and keeps the picker filename", () async {
     // A path-backed XFile, like the real picker returns — XFile.fromData does
     // not surface a name.

--- a/client/app/test/capabilities/media/composer_image_picker_test.dart
+++ b/client/app/test/capabilities/media/composer_image_picker_test.dart
@@ -4,8 +4,8 @@ import "dart:typed_data";
 import "package:flutter_test/flutter_test.dart";
 import "package:image_picker/image_picker.dart";
 import "package:mocktail/mocktail.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/capabilities/media/composer_image_picker.dart";
-import "package:sesori_shared/sesori_shared.dart";
 
 class MockImagePicker extends Mock implements ImagePicker {}
 
@@ -97,17 +97,14 @@ void main() {
     expect(picker.pickImage, throwsA(isA<UnsupportedAttachmentImageError>()));
   });
 
-  test("an image over the inline transport limit is rejected", () async {
-    stubPick(XFile.fromData(jpegBytes(maxInlineMessageAttachmentBytes + 1), name: "huge.jpg"));
+  test("an image over the outbound composer limit is rejected", () async {
+    stubPick(XFile.fromData(jpegBytes(maxComposerPromptAttachmentBytes + 1), name: "huge.jpg"));
 
     expect(picker.pickImage, throwsA(isA<AttachmentTooLargeError>()));
   });
 
-  test("an exactly-boundary image passes the shared conservative check", () async {
-    // The conservative decoded estimate of the base64 form can overshoot the
-    // raw byte count by up to two bytes, so the accepted maximum sits just
-    // under the raw limit — anything accepted here is accepted by receivers.
-    final bytes = jpegBytes(maxInlineMessageAttachmentBytes - 2);
+  test("an exactly-boundary image passes the outbound composer check", () async {
+    final bytes = jpegBytes(maxComposerPromptAttachmentBytes);
     stubPick(XFile.fromData(bytes, name: "big.jpg"));
 
     final attachment = await picker.pickImage();

--- a/client/app/test/core/platform/flutter_image_clipboard_test.dart
+++ b/client/app/test/core/platform/flutter_image_clipboard_test.dart
@@ -6,6 +6,10 @@ import "package:sesori_mobile/core/platform/pasteboard_client.dart";
 
 class _FakePasteboardClient implements PasteboardClient {
   Uint8List? bytes;
+  Uint8List? imageToRead;
+
+  @override
+  Future<Uint8List?> readImage() async => imageToRead;
 
   @override
   Future<void> writeImage({required Uint8List bytes}) async {
@@ -14,6 +18,16 @@ class _FakePasteboardClient implements PasteboardClient {
 }
 
 void main() {
+  test("reads the original bytes through the injected Pasteboard client", () async {
+    final bytes = Uint8List.fromList(const [1, 2, 3]);
+    final client = _FakePasteboardClient()..imageToRead = bytes;
+    final clipboard = FlutterImageClipboard(pasteboardClient: client);
+
+    final result = await clipboard.readImage();
+
+    expect(identical(result, bytes), isTrue);
+  });
+
   test("writes the original bytes through the injected Pasteboard client", () async {
     final bytes = Uint8List.fromList(const [1, 2, 3]);
     final client = _FakePasteboardClient();

--- a/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
+++ b/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
@@ -40,6 +40,9 @@ class _FakeImageClipboard implements ImageClipboard {
   Uint8List? copiedBytes;
 
   @override
+  Future<Uint8List?> readImage() async => null;
+
+  @override
   Future<void> writeImage({required Uint8List bytes}) async {
     copiedBytes = bytes;
   }

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -33,6 +33,8 @@ class MockVoiceTranscriptionService extends Mock implements VoiceTranscriptionSe
 
 class MockComposerImagePicker extends Mock implements ComposerImagePicker {}
 
+class MockImageClipboard extends Mock implements ImageClipboard {}
+
 /// A valid 1x1 transparent PNG so `Image.memory` thumbnails decode in tests.
 final Uint8List _tinyPng = Uint8List.fromList(const [
   0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, //
@@ -187,6 +189,7 @@ void main() {
   late MockSessionDetailCubit cubit;
   late MockVoiceTranscriptionService voiceTranscriptionService;
   late MockComposerImagePicker imagePicker;
+  late MockImageClipboard imageClipboard;
 
   setUpAll(() {
     registerFallbackValue(ComposerDraft.typed(text: ""));
@@ -226,6 +229,10 @@ void main() {
 
     imagePicker = MockComposerImagePicker();
     GetIt.instance.registerSingleton<ComposerImagePicker>(imagePicker);
+
+    imageClipboard = MockImageClipboard();
+    when(imageClipboard.readImage).thenAnswer((_) async => null);
+    GetIt.instance.registerSingleton<ImageClipboard>(imageClipboard);
   });
 
   tearDown(() async {
@@ -1780,6 +1787,83 @@ void main() {
     expect(semanticsWithLabel("screenshot.png"), findsNothing);
     // Nothing left to show: the composer collapses back to its resting pill.
     expect(find.byType(EditableText), findsNothing);
+  });
+
+  testWidgets("image-only context-menu paste stages an attachment", (tester) async {
+    final attachment = ComposerAttachment(mime: "image/png", bytes: _tinyPng, filename: null);
+    when(imageClipboard.readImage).thenAnswer((_) async => _tinyPng);
+    when(
+      () => imagePicker.attachmentFromBytes(bytes: _tinyPng, filename: null),
+    ).thenReturn(attachment);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+    await enterTypingMode(tester);
+
+    final textField = tester.widget<TextField>(find.byType(TextField));
+    final editableTextState = tester.state<EditableTextState>(find.byType(EditableText));
+    final toolbar =
+        textField.contextMenuBuilder!(
+              tester.element(find.byType(TextField)),
+              editableTextState,
+            )
+            as AdaptiveTextSelectionToolbar;
+    final pasteItem = toolbar.buttonItems!.singleWhere((item) => item.type == ContextMenuButtonType.paste);
+
+    pasteItem.onPressed!();
+    await tester.pumpAndSettle();
+
+    expect(semanticsWithLabel("Attached image"), findsOneWidget);
+    verify(imageClipboard.readImage).called(1);
+    verify(() => imagePicker.attachmentFromBytes(bytes: _tinyPng, filename: null)).called(1);
+  });
+
+  testWidgets("keyboard image paste stages an attachment without inserting text", (tester) async {
+    final attachment = ComposerAttachment(mime: "image/png", bytes: _tinyPng, filename: null);
+    when(imageClipboard.readImage).thenAnswer((_) async => _tinyPng);
+    when(
+      () => imagePicker.attachmentFromBytes(bytes: _tinyPng, filename: null),
+    ).thenReturn(attachment);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+    await enterTypingMode(tester);
+
+    final actionContext = tester.element(
+      find.descendant(of: find.byType(EditableText), matching: find.byType(RawGestureDetector)).first,
+    );
+    Actions.invoke(actionContext, const PasteTextIntent(SelectionChangedCause.keyboard));
+    await tester.pumpAndSettle();
+
+    expect(semanticsWithLabel("Attached image"), findsOneWidget);
+    expect(tester.widget<EditableText>(find.byType(EditableText)).controller.text, isEmpty);
+    verify(imageClipboard.readImage).called(1);
+  });
+
+  testWidgets("plain text paste still delegates to Flutter's text action", (tester) async {
+    final messenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == "Clipboard.getData") return <String, Object>{"text": "pasted"};
+      return null;
+    });
+    addTearDown(() => messenger.setMockMethodCallHandler(SystemChannels.platform, null));
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+    await enterTypingMode(tester);
+    await tester.enterText(find.byType(EditableText), "before after");
+    final editableText = tester.widget<EditableText>(find.byType(EditableText));
+    editableText.controller.selection = const TextSelection(baseOffset: 0, extentOffset: 6);
+
+    final actionContext = tester.element(
+      find.descendant(of: find.byType(EditableText), matching: find.byType(RawGestureDetector)).first,
+    );
+    Actions.invoke(actionContext, const PasteTextIntent(SelectionChangedCause.keyboard));
+    await tester.pumpAndSettle();
+
+    expect(editableText.controller.text, "pasted after");
+    verify(imageClipboard.readImage).called(1);
+    verifyNever(() => imagePicker.attachmentFromBytes(bytes: _tinyPng, filename: null));
   });
 
   testWidgets("accordion offers no attach action on a harness that drops image parts", (tester) async {

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -23,6 +23,7 @@ import "package:sesori_mobile/features/session_detail/widgets/voice_cancel_butto
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
+import "package:theme_prego/interactions/prego_tappable.dart";
 import "package:theme_prego/module_prego.dart";
 
 import "../../../helpers/test_helpers.dart";
@@ -1427,6 +1428,33 @@ void main() {
     );
   });
 
+  testWidgets("expanded editor keyboard paste stages an image attachment", (tester) async {
+    final attachment = ComposerAttachment(mime: "image/png", bytes: _tinyPng, filename: null);
+    when(imageClipboard.readImage).thenAnswer((_) async => _tinyPng);
+    when(
+      () => imagePicker.attachmentFromBytes(bytes: _tinyPng, filename: null),
+    ).thenReturn(attachment);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+    await enterTypingMode(tester);
+    await tester.tap(find.byIcon(TablerRegular.maximize));
+    await tester.pumpAndSettle();
+
+    final sheetEditor = find.descendant(of: find.byType(PromptEditorSheet), matching: find.byType(EditableText));
+    final actionContext = tester.element(
+      find.descendant(of: sheetEditor, matching: find.byType(RawGestureDetector)).first,
+    );
+    Actions.invoke(actionContext, const PasteTextIntent(SelectionChangedCause.keyboard));
+    await tester.pumpAndSettle();
+
+    verify(imageClipboard.readImage).called(1);
+    verify(() => imagePicker.attachmentFromBytes(bytes: _tinyPng, filename: null)).called(1);
+    Navigator.of(tester.element(find.byType(PromptEditorSheet))).pop();
+    await tester.pumpAndSettle();
+    expect(semanticsWithLabel("Attached image"), findsOneWidget);
+  });
+
   testWidgets("recording swaps the pill chrome for the cancel target and waveform", (tester) async {
     final stopCompleter = Completer<String>();
     when(() => voiceTranscriptionService.startRecording()).thenAnswer((_) async {});
@@ -1782,7 +1810,11 @@ void main() {
     expect(find.byIcon(TablerRegular.arrow_up), findsOneWidget);
     expect(composerFocus(tester).hasFocus, isFalse);
 
-    await tester.tap(find.byTooltip("Remove attachment"));
+    final removeButton = find.descendant(
+      of: find.byTooltip("Remove attachment"),
+      matching: find.byType(PregoTappable),
+    );
+    tester.widget<PregoTappable>(removeButton).onTap!.call();
     await tester.pumpAndSettle();
     expect(semanticsWithLabel("screenshot.png"), findsNothing);
     // Nothing left to show: the composer collapses back to its resting pill.
@@ -1863,6 +1895,68 @@ void main() {
 
     expect(editableText.controller.text, "pasted after");
     verify(imageClipboard.readImage).called(1);
+    verifyNever(() => imagePicker.attachmentFromBytes(bytes: _tinyPng, filename: null));
+  });
+
+  testWidgets("delayed text paste uses the selection from the original intent", (tester) async {
+    final imageRead = Completer<Uint8List?>();
+    when(imageClipboard.readImage).thenAnswer((_) => imageRead.future);
+    final messenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == "Clipboard.getData") return <String, Object>{"text": "pasted"};
+      return null;
+    });
+    addTearDown(() => messenger.setMockMethodCallHandler(SystemChannels.platform, null));
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+    await enterTypingMode(tester);
+    await tester.enterText(find.byType(EditableText), "before after");
+    final editableText = tester.widget<EditableText>(find.byType(EditableText));
+    editableText.controller.selection = const TextSelection(baseOffset: 0, extentOffset: 6);
+
+    final actionContext = tester.element(
+      find.descendant(of: find.byType(EditableText), matching: find.byType(RawGestureDetector)).first,
+    );
+    Actions.invoke(actionContext, const PasteTextIntent(SelectionChangedCause.keyboard));
+    editableText.controller.selection = TextSelection.collapsed(offset: editableText.controller.text.length);
+    imageRead.complete(null);
+    await tester.pumpAndSettle();
+
+    expect(editableText.controller.text, "pasted after");
+  });
+
+  testWidgets("a clipboard image settling after send is discarded", (tester) async {
+    final imageRead = Completer<Uint8List?>();
+    when(imageClipboard.readImage).thenAnswer((_) => imageRead.future);
+    when(
+      () => imagePicker.attachmentFromBytes(bytes: _tinyPng, filename: null),
+    ).thenReturn(ComposerAttachment(mime: "image/png", bytes: _tinyPng, filename: null));
+    when(
+      () => cubit.sendMessage(
+        text: any(named: "text"),
+        command: any(named: "command"),
+        inputMode: any(named: "inputMode"),
+        attachments: any(named: "attachments"),
+      ),
+    ).thenAnswer((_) async {});
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+    await enterTypingMode(tester);
+    await tester.enterText(find.byType(EditableText), "send now");
+    await tester.pump();
+
+    final actionContext = tester.element(
+      find.descendant(of: find.byType(EditableText), matching: find.byType(RawGestureDetector)).first,
+    );
+    Actions.invoke(actionContext, const PasteTextIntent(SelectionChangedCause.keyboard));
+    await tester.tap(find.byIcon(TablerRegular.arrow_up));
+    await tester.pump();
+    imageRead.complete(_tinyPng);
+    await tester.pumpAndSettle();
+
+    expect(semanticsWithLabel("Attached image"), findsNothing);
     verifyNever(() => imagePicker.attachmentFromBytes(bytes: _tinyPng, filename: null));
   });
 
@@ -1961,9 +2055,9 @@ void main() {
 
   testWidgets("an image pushing the strip past the per-message budget is rejected", (tester) async {
     // Two picks: a tiny renderable image, then one whose size alone nearly
-    // fills the shared inline budget — staging it would push the combined
+    // fills the outbound composer budget — staging it would push the combined
     // strip past the limit, so it is refused with a notice instead.
-    final huge = Uint8List(maxInlineMessageAttachmentBytes - 32);
+    final huge = Uint8List(maxComposerPromptAttachmentBytes - 32);
     huge.setAll(0, const [0xFF, 0xD8, 0xFF]);
     final answers = <ComposerAttachment>[
       ComposerAttachment(mime: "image/png", bytes: _tinyPng, filename: "small.png"),
@@ -1985,7 +2079,7 @@ void main() {
     await tester.tap(find.byIcon(TablerRegular.photo));
     await tester.pumpAndSettle();
 
-    expect(find.text("Attached images are limited to 5 MB per message."), findsOneWidget);
+    expect(find.text("Attached images are limited to 50 MB per message."), findsOneWidget);
     // The refused image was never staged; the first one is untouched.
     expect(semanticsWithLabel("small.png"), findsOneWidget);
     expect(semanticsWithLabel("huge.jpg"), findsNothing);

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -1960,6 +1960,37 @@ void main() {
     verifyNever(() => imagePicker.attachmentFromBytes(bytes: _tinyPng, filename: null));
   });
 
+  testWidgets("a clipboard image is discarded after attachment support toggles", (tester) async {
+    final stateController = StreamController<SessionDetailState>();
+    addTearDown(stateController.close);
+    final opencodeState = _loadedState(pendingQuestions: const [], pendingPermissions: const []);
+    when(() => cubit.state).thenReturn(opencodeState);
+    whenListen(cubit, stateController.stream, initialState: opencodeState);
+    final imageRead = Completer<Uint8List?>();
+    when(imageClipboard.readImage).thenAnswer((_) => imageRead.future);
+    when(
+      () => imagePicker.attachmentFromBytes(bytes: _tinyPng, filename: null),
+    ).thenReturn(ComposerAttachment(mime: "image/png", bytes: _tinyPng, filename: null));
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+    await enterTypingMode(tester);
+
+    final actionContext = tester.element(
+      find.descendant(of: find.byType(EditableText), matching: find.byType(RawGestureDetector)).first,
+    );
+    Actions.invoke(actionContext, const PasteTextIntent(SelectionChangedCause.keyboard));
+    stateController.add(opencodeState.copyWith(pluginId: "codex"));
+    await tester.pumpAndSettle();
+    stateController.add(opencodeState);
+    await tester.pumpAndSettle();
+    imageRead.complete(_tinyPng);
+    await tester.pumpAndSettle();
+
+    expect(semanticsWithLabel("Attached image"), findsNothing);
+    verifyNever(() => imagePicker.attachmentFromBytes(bytes: _tinyPng, filename: null));
+  });
+
   testWidgets("accordion offers no attach action on a harness that drops image parts", (tester) async {
     // TEMPORARY 2026-08-03: remove with the harness gate once every harness
     // carries image parts — see harnessSupportsPromptAttachments.

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -197,7 +197,6 @@ void main() {
     registerFallbackValue(ComposerInputMode.typed);
   });
 
-
   Finder semanticsWithLabel(String label) =>
       find.byWidgetPredicate((widget) => widget is Semantics && widget.properties.label == label);
 
@@ -557,9 +556,8 @@ void main() {
   });
 
   testWidgets("send stays disabled until the composer holds text", (tester) async {
-    VoidCallback? sendAction() => tester
-        .widget<PregoButtonsSolid>(find.widgetWithIcon(PregoButtonsSolid, TablerRegular.arrow_up))
-        .onPressed;
+    VoidCallback? sendAction() =>
+        tester.widget<PregoButtonsSolid>(find.widgetWithIcon(PregoButtonsSolid, TablerRegular.arrow_up)).onPressed;
 
     await tester.pumpWidget(_buildApp(cubit: cubit));
     await tester.pumpAndSettle();
@@ -1219,7 +1217,8 @@ void main() {
       ),
     );
     when(
-      () => cubit.sendMessage(attachments: const [],
+      () => cubit.sendMessage(
+        attachments: const [],
         text: "typed transcript",
         command: null,
         inputMode: ComposerInputMode.voiceAssisted,
@@ -1234,7 +1233,8 @@ void main() {
     await tester.pump();
 
     verify(
-      () => cubit.sendMessage(attachments: const [],
+      () => cubit.sendMessage(
+        attachments: const [],
         text: "typed transcript",
         command: null,
         inputMode: ComposerInputMode.voiceAssisted,
@@ -1250,7 +1250,8 @@ void main() {
       ),
     );
     when(
-      () => cubit.sendMessage(attachments: const [],
+      () => cubit.sendMessage(
+        attachments: const [],
         text: "typed replacement",
         command: null,
         inputMode: ComposerInputMode.typed,
@@ -1270,7 +1271,8 @@ void main() {
     await tester.pump();
 
     verify(
-      () => cubit.sendMessage(attachments: const [],
+      () => cubit.sendMessage(
+        attachments: const [],
         text: "typed replacement",
         command: null,
         inputMode: ComposerInputMode.typed,
@@ -1286,7 +1288,8 @@ void main() {
       ),
     );
     when(
-      () => cubit.sendMessage(attachments: const [],
+      () => cubit.sendMessage(
+        attachments: const [],
         text: "typed",
         command: null,
         inputMode: ComposerInputMode.typed,
@@ -1299,7 +1302,8 @@ void main() {
     await tester.pump();
 
     verify(
-      () => cubit.sendMessage(attachments: const [],
+      () => cubit.sendMessage(
+        attachments: const [],
         text: "typed",
         command: null,
         inputMode: ComposerInputMode.typed,
@@ -1896,6 +1900,36 @@ void main() {
     expect(editableText.controller.text, "pasted after");
     verify(imageClipboard.readImage).called(1);
     verifyNever(() => imagePicker.attachmentFromBytes(bytes: _tinyPng, filename: null));
+  });
+
+  testWidgets("an unsupported pasted image falls back to text paste", (tester) async {
+    final bytes = Uint8List.fromList(const [0, 1, 2, 3, 4, 5, 6, 7]);
+    when(imageClipboard.readImage).thenAnswer((_) async => bytes);
+    when(
+      () => imagePicker.attachmentFromBytes(bytes: bytes, filename: null),
+    ).thenThrow(const UnsupportedAttachmentImageError());
+    final messenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == "Clipboard.getData") return <String, Object>{"text": "pasted"};
+      return null;
+    });
+    addTearDown(() => messenger.setMockMethodCallHandler(SystemChannels.platform, null));
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+    await enterTypingMode(tester);
+    await tester.enterText(find.byType(EditableText), "before after");
+    final editableText = tester.widget<EditableText>(find.byType(EditableText));
+    editableText.controller.selection = const TextSelection(baseOffset: 0, extentOffset: 6);
+
+    final actionContext = tester.element(
+      find.descendant(of: find.byType(EditableText), matching: find.byType(RawGestureDetector)).first,
+    );
+    Actions.invoke(actionContext, const PasteTextIntent(SelectionChangedCause.keyboard));
+    await tester.pumpAndSettle();
+
+    expect(find.text("That image format isn't supported."), findsOneWidget);
+    expect(editableText.controller.text, "pasted after");
   });
 
   testWidgets("delayed text paste uses the selection from the original intent", (tester) async {

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -1932,6 +1932,41 @@ void main() {
     expect(editableText.controller.text, "pasted after");
   });
 
+  testWidgets("delayed context-menu text fallback uses the original selection", (tester) async {
+    final imageRead = Completer<Uint8List?>();
+    when(imageClipboard.readImage).thenAnswer((_) => imageRead.future);
+    final messenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == "Clipboard.getData") return <String, Object>{"text": "pasted"};
+      return null;
+    });
+    addTearDown(() => messenger.setMockMethodCallHandler(SystemChannels.platform, null));
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+    await enterTypingMode(tester);
+    await tester.enterText(find.byType(EditableText), "before after");
+    final editableText = tester.widget<EditableText>(find.byType(EditableText));
+    editableText.controller.selection = const TextSelection(baseOffset: 0, extentOffset: 6);
+
+    final textField = tester.widget<TextField>(find.byType(TextField));
+    final editableTextState = tester.state<EditableTextState>(find.byType(EditableText));
+    final toolbar =
+        textField.contextMenuBuilder!(
+              tester.element(find.byType(TextField)),
+              editableTextState,
+            )
+            as AdaptiveTextSelectionToolbar;
+    final pasteItem = toolbar.buttonItems!.singleWhere((item) => item.type == ContextMenuButtonType.paste);
+
+    pasteItem.onPressed!();
+    editableText.controller.selection = TextSelection.collapsed(offset: editableText.controller.text.length);
+    imageRead.complete(null);
+    await tester.pumpAndSettle();
+
+    expect(editableText.controller.text, "pasted after");
+  });
+
   testWidgets("delayed text paste uses the selection from the original intent", (tester) async {
     final imageRead = Completer<Uint8List?>();
     when(imageClipboard.readImage).thenAnswer((_) => imageRead.future);

--- a/client/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/client/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -587,7 +587,12 @@ class RelayClient {
       );
     }
     final encryptedBytes = await encryptor.encrypt(jsonBytes);
-    final payload = Uint8List.fromList([_messageVersion, ...encryptedBytes]);
+    // Preallocate instead of spreading the ciphertext into a boxed List<int>:
+    // a max-size attachment would otherwise materialize tens of millions of
+    // boxed integers and exhaust mobile memory before the frame is sent.
+    final payload = Uint8List(encryptedBytes.length + 1);
+    payload[0] = _messageVersion;
+    payload.setRange(1, payload.length, encryptedBytes);
     channel.sink.add(payload);
   }
 
@@ -617,7 +622,9 @@ class RelayClient {
 
     final jsonBytes = utf8.encode(jsonEncode(message.toJson()));
     final encryptedBytes = await encryptor.encrypt(jsonBytes);
-    final payload = Uint8List.fromList([_messageVersion, ...encryptedBytes]);
+    final payload = Uint8List(encryptedBytes.length + 1);
+    payload[0] = _messageVersion;
+    payload.setRange(1, payload.length, encryptedBytes);
     _pendingHandshakeFrame = payload;
     channel.sink.add(payload);
   }

--- a/client/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/client/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -18,6 +18,19 @@ enum RelayClientConnectionState { disconnected, connecting, connected, disconnec
 /// Represents whether the bridge (desktop process) is reachable via the relay.
 enum BridgeStatus { online, offline }
 
+final class RelayMessageTooLargeException implements Exception {
+  final int plaintextBytes;
+  final int maxPlaintextBytes;
+
+  const RelayMessageTooLargeException({
+    required this.plaintextBytes,
+    required this.maxPlaintextBytes,
+  });
+
+  @override
+  String toString() => "Relay message is too large ($plaintextBytes bytes; maximum $maxPlaintextBytes bytes)";
+}
+
 class RelayClient {
   final String relayHost;
   final String? authToken;
@@ -567,6 +580,12 @@ class RelayClient {
     }
 
     final jsonBytes = utf8.encode(jsonEncode(message.toJson()));
+    if (!RelayProtocol.canEncryptMessage(plaintextBytes: jsonBytes.length)) {
+      throw RelayMessageTooLargeException(
+        plaintextBytes: jsonBytes.length,
+        maxPlaintextBytes: RelayProtocol.maxPlaintextMessageBytes,
+      );
+    }
     final encryptedBytes = await encryptor.encrypt(jsonBytes);
     final payload = Uint8List.fromList([_messageVersion, ...encryptedBytes]);
     channel.sink.add(payload);

--- a/client/module_core/lib/src/foundation/models/composer/composer_attachment.dart
+++ b/client/module_core/lib/src/foundation/models/composer/composer_attachment.dart
@@ -2,6 +2,12 @@ import "dart:typed_data";
 
 import "package:meta/meta.dart";
 
+/// Maximum decoded attachment bytes staged for one outbound prompt.
+///
+/// This is decimal 50 MB rather than 50 MiB: base64 expansion plus the relay
+/// request envelope must remain below the relay's 64 MiB message limit.
+const maxComposerPromptAttachmentBytes = 50 * 1000 * 1000;
+
 /// An image staged in the composer, transmitted inline (base64 `file_data`
 /// prompt part) with the submission it accompanies.
 ///

--- a/client/module_core/lib/src/foundation/models/composer/composer_attachment.dart
+++ b/client/module_core/lib/src/foundation/models/composer/composer_attachment.dart
@@ -4,8 +4,9 @@ import "package:meta/meta.dart";
 
 /// Maximum decoded attachment bytes staged for one outbound prompt.
 ///
-/// This is decimal 50 MB rather than 50 MiB: base64 expansion plus the relay
-/// request envelope must remain below the relay's 64 MiB message limit.
+/// This is decimal 50 MB rather than 50 MiB so ordinary request envelopes fit
+/// below the relay's 64 MiB message limit. RelayClient also preflights the
+/// actual serialized request for prompts with unusually large text or metadata.
 const maxComposerPromptAttachmentBytes = 50 * 1000 * 1000;
 
 /// An image staged in the composer, transmitted inline (base64 `file_data`

--- a/client/module_core/lib/src/foundation/platform/image_clipboard.dart
+++ b/client/module_core/lib/src/foundation/platform/image_clipboard.dart
@@ -1,6 +1,8 @@
 import "dart:typed_data";
 
-/// Writes image bytes to the platform clipboard.
+/// Reads and writes image bytes on the platform clipboard.
 abstract interface class ImageClipboard {
+  Future<Uint8List?> readImage();
+
   Future<void> writeImage({required Uint8List bytes});
 }

--- a/client/module_core/test/cubits/image_attachment_actions/image_attachment_actions_cubit_test.dart
+++ b/client/module_core/test/cubits/image_attachment_actions/image_attachment_actions_cubit_test.dart
@@ -27,6 +27,9 @@ final class _FakeImageClipboard implements ImageClipboard {
   Object? error;
 
   @override
+  Future<Uint8List?> readImage() async => null;
+
+  @override
   Future<void> writeImage({required Uint8List bytes}) async {
     final error = this.error;
     if (error != null) throw error;

--- a/shared/sesori_shared/lib/src/protocol/constants.dart
+++ b/shared/sesori_shared/lib/src/protocol/constants.dart
@@ -11,4 +11,15 @@ abstract final class RelayProtocol {
   // Payload type detection
   static const int versionByte = 0x01;
   static const int jsonStartByte = 0x7B;
+
+  /// Relay WebSocket messages are capped at 64 MiB by the relay server.
+  static const int maxMessageBytes = 64 * 1024 * 1024;
+
+  /// One protocol-version byte, a 24-byte XChaCha20 nonce, and a 16-byte tag.
+  static const int encryptedMessageOverheadBytes = 1 + 24 + 16;
+  static const int maxPlaintextMessageBytes = maxMessageBytes - encryptedMessageOverheadBytes;
+
+  static bool canEncryptMessage({required int plaintextBytes}) {
+    return plaintextBytes >= 0 && plaintextBytes <= maxPlaintextMessageBytes;
+  }
 }

--- a/shared/sesori_shared/test/protocol/constants_test.dart
+++ b/shared/sesori_shared/test/protocol/constants_test.dart
@@ -1,0 +1,19 @@
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("relay plaintext limit reserves encryption and version overhead", () {
+    expect(
+      RelayProtocol.canEncryptMessage(
+        plaintextBytes: RelayProtocol.maxPlaintextMessageBytes,
+      ),
+      isTrue,
+    );
+    expect(
+      RelayProtocol.canEncryptMessage(
+        plaintextBytes: RelayProtocol.maxPlaintextMessageBytes + 1,
+      ),
+      isFalse,
+    );
+  });
+}


### PR DESCRIPTION
## Complexity

Moderate. The change intercepts Flutter's overridable paste action, preserves the built-in text path, and extends the existing image clipboard platform boundary.

## What

- Paste clipboard images into attachment-capable chat composers with Cmd/Ctrl+V.
- Add an image-aware Paste item to native mobile and desktop text context menus, including image-only clipboards.
- Reuse the existing attachment MIME sniffing, 50 MB per-image and aggregate outbound composer budget.
- Keep ordinary text paste behavior unchanged when no supported image is present.
- Preserve normal browser text paste; browser image paste remains unchanged because it requires a synchronous DOM paste-event implementation.

## Why

Image attachments can currently be selected from the gallery, but screenshots and copied images cannot be staged directly from the clipboard. Pasting removes that extra save-and-pick step while reusing the existing attachment send contract.

## Risk and test focus

- Paste action delegation and text selection replacement.
- Image-only native context menus.
- Clipboard reads that settle after the composer changes.
- Unsupported and oversized image validation through the existing attachment path.
- No database impact. No bridge or wire-contract impact.

## Expected result

On native supported platforms, pasting a PNG, JPEG, GIF, WebP, or BMP into an attachment-capable composer stages the image preview and sends it through the existing attachment flow. Plain text still pastes normally, and unsupported harnesses keep their existing behavior.

## Verification

- `dart analyze` in `client/app`
- `dart analyze` in `client/module_core` and `shared/sesori_shared`
- 93 focused Flutter tests across clipboard, media, composer, and image rendering
- 7 focused Dart image-action tests
- 1 focused shared relay-size boundary test
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow pasting images from the clipboard into attachment‑capable chat composers on native platforms. Raises the per‑message attachment budget to 50 MB and preflights relay sends to stay under the 64 MiB limit.

- **New Features**
  - Cmd/Ctrl+V and context‑menu Paste stage a clipboard image when available; otherwise paste text. Preserves the original selection for delayed fallback and discards stale results.
  - Adds image‑aware Paste to native context menus and the expanded editor; web paste remains synchronous and unchanged.
  - Supports PNG, JPEG, GIF, WebP, BMP with a 50 MB total‑per‑message budget; validates via `ComposerImagePicker.attachmentFromBytes` and reads via `ImageClipboard.readImage`.

- **Bug Fixes**
  - Restores text paste when image read/validation fails or when the aggregate strip budget is exceeded.
  - Prevents pastes landing after send, on session switch, or when attachment support toggles; context‑menu fallback restores the original selection.
  - Preflights relay plaintext size with `RelayProtocol.maxPlaintextMessageBytes` and preallocates frames in `RelayClient` to avoid oversized boxed payloads.

<sup>Written for commit 15ff10d5157a036e72f99a7f29009388de24f431. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

