### PR TITLE
🌱 chore(release): v1.7.0

### DIFF
--- a/bridge/app/lib/src/version.dart
+++ b/bridge/app/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String appVersion = '1.6.1';
+const String appVersion = '1.7.0';

--- a/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-arm64",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS ARM64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.6.1",
+    "releaseTag": "v1.7.0",
     "releaseArtifact": "sesori-bridge-macos-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-darwin-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-x64",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS x64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.6.1",
+    "releaseTag": "v1.7.0",
     "releaseArtifact": "sesori-bridge-macos-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-arm64",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux ARM64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.6.1",
+    "releaseTag": "v1.7.0",
     "releaseArtifact": "sesori-bridge-linux-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-x64",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux x64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.6.1",
+    "releaseTag": "v1.7.0",
     "releaseArtifact": "sesori-bridge-linux-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-arm64",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows ARM64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.6.1",
+    "releaseTag": "v1.7.0",
     "releaseArtifact": "sesori-bridge-windows-arm64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-x64",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows x64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.6.1",
+    "releaseTag": "v1.7.0",
     "releaseArtifact": "sesori-bridge-windows-x64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge/package.json
+++ b/bridge/app/npm/sesori-bridge/package.json
@@ -1,22 +1,22 @@
 {
   "name": "@sesori/bridge",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Bootstrap launcher for the managed Sesori Bridge runtime",
   "bin": {
     "sesori-bridge": "bin/bridge.js"
   },
   "optionalDependencies": {
-    "@sesori/bridge-darwin-arm64": "1.6.1",
-    "@sesori/bridge-darwin-x64": "1.6.1",
-    "@sesori/bridge-linux-x64": "1.6.1",
-    "@sesori/bridge-linux-arm64": "1.6.1",
-    "@sesori/bridge-win32-x64": "1.6.1",
-    "@sesori/bridge-win32-arm64": "1.6.1"
+    "@sesori/bridge-darwin-arm64": "1.7.0",
+    "@sesori/bridge-darwin-x64": "1.7.0",
+    "@sesori/bridge-linux-x64": "1.7.0",
+    "@sesori/bridge-linux-arm64": "1.7.0",
+    "@sesori/bridge-win32-x64": "1.7.0",
+    "@sesori/bridge-win32-arm64": "1.7.0"
   },
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.6.1",
+    "releaseTag": "v1.7.0",
     "runtimeBundleSource": "github-release-assets"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sesori_bridge
 description: Dart implementation of the Sesori Bridge CLI for WebSocket communication.
-version: 1.6.1
+version: 1.7.0
 publish_to: none
 resolution: workspace
 

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -17,7 +17,7 @@ resolution: workspace
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.6.1+1
+version: 1.7.0+1
 environment:
   sdk: ^3.12.2
 


### PR DESCRIPTION
## Summary
- Bump the shared app and bridge version to v1.7.0
- Preserve the mobile build number at 1 (`1.7.0+1`)
- `@sesori/bridge` and all platform packages updated to `1.7.0` with `releaseTag` `v1.7.0`

## Complexity
🌱 Trivial — version bump only; no behavior or code changes.

## What
Updates the shared semantic version to `1.7.0` across the bridge Dart package, client app, and all `@sesori/bridge` npm packages.

## Why
Publishes the accumulated changes since v1.6.0.

## Risk and test focus
No user-visible or database impact from this change itself; the changes being released were already verified by their own PRs. The mobile build number is intentionally preserved.

## Expected result
- Bridge and app both report `1.7.0`; client reports `1.7.0+1`
- `@sesori/bridge@1.7.0` and platform packages publish with `releaseTag` `v1.7.0`
- CI passes on the release branch

## Verification
- `make bump-version VERSION=1.7.0` synced bridge `1.6.1 -> 1.7.0` and client `1.6.1+1 -> 1.7.0+1`
- Diff inspected across the 10 version files

## Changes Since v1.6.0
Summarized by theme from the merged commits on `main`.

### Added
- Secure message attachments and image attachments from the composer (#618, #654, #750)
- Full-screen image attachment viewer and Markdown image viewing (#637, #673, #684, #683)
- Output image support across ACP and Codex plugins: live output images, replay, tool and message images, mobile image prompts (#639–#751)
- Voice-first chat input with settings-selectable composer mode (#621)
- Current-session PR monitoring: configurable refresh cadence, scoped GitHub PR queries, viewed-project and branch refresh (#649–#707)
- Session option caching and dynamic loading for multi-plugin release readiness (#605–#647)
- Harness management controls, overview, and per-bridge memory (#579–#595, #742)
- Bounded outcome analytics contracts and engagement/activation/voice/login instrumentation (#611–#634)
- New session flow: harness picker, dedicated workspace toggle, sessions nav bar (#742)
- Diffs for in-place sessions (#604, #622)
- Reworked empty Projects, archived-sessions, and bridge-disconnected states (#599, #606, #607, #608)

### Fixed
- Relay recovery after bridge replacement and handshake recovery after reconnect (#723, #582)
- Codex plugin stability: interrupted tool settling, image wrapper handling, command identity, archived history preservation (#709–#751)
- Hold-to-talk recording latency, height jitter, haptics, and Android recorder worker (#655, #676, #682, #689, #695, #702)
- Image attachment filenames and iOS Photos metadata; desktop image saving (#645, #640)
- GitHub repository rename handling and base-branch refresh before worktree creation (#691, #603)
- Relay failures no longer surface as fatal client crashes (#564)
- OpenCode automatic compaction messages now shown (#566)
- Expand `~` in `--data-dir` (#651)
- Hide newly discovered projects and YOLO permission snapshots from users (#708, #738)

### Changed
- Bridge now routes client requests concurrently through the relay (#687–#722)
- Plugin lifecycle management: transactional disable, idle timeouts, transient residency, attach-only residency (#556–#572)
- Composer controls unified across platforms; composer surface borders kept in sync (#672, #675)
- Push notification preferences synced with the auth server (#706)
- Backend coding runtimes updated (#705)
- Weekly dependency update (2026-07-28) (#598)
- Architecture review and plan agents converted to skills (#741, #744)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump shared version to 1.7.0 across the bridge and apps to cut the v1.7.0 release; no code or behavior changes. Publishes `@sesori/bridge@1.7.0` and platform bundles with `releaseTag` `v1.7.0`; mobile stays `1.7.0+1`.

- **Dependencies**
  - Bridge Dart and client app: `1.7.0` (client `1.7.0+1`).
  - NPM: `@sesori/bridge` and `@sesori/bridge-*` optional deps to `1.7.0` with `releaseTag` `v1.7.0`.

<sup>Written for commit 206902d57740b733d18f9ae512819addedd809a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

