### PR TITLE
🚧 fix(bridge): bound graceful shutdown when agent work blocks teardown

### DIFF
--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -845,9 +845,9 @@ class OrchestratorSession {
   Future<void> get firstPhoneConnected => _firstPhoneConnectedCompleter.future;
   RoutedRequestDispatcher get routedRequestDispatcher => _routedRequestDispatcher;
 
-  /// Completes when [beginShutdown] starts the graceful shutdown, so
-  /// composition-root machinery (e.g. the shutdown coordinator's backstop)
-  /// can start bounding the session teardown at the same moment.
+  /// Completes when [beginShutdown] starts the graceful shutdown, so the
+  /// composition root can start the ordered shutdown coordinator (agent-work
+  /// interrupt, backstop deadline) the moment the session begins tearing down.
   Future<void> get shutdownRequested => _shutdownCompleter.future;
 
   Future<OrchestratorSessionStartResult> start() {
@@ -1265,11 +1265,6 @@ class OrchestratorSession {
         "[shutdown] cancel() requested"
         "${_inFlightRelayWorkDiagnostic(separator: " — ")}",
       );
-      // Interrupt in-flight agent work now (budgeted, best-effort) so the
-      // teardown drains below are not held open by agent-coupled requests
-      // (an in-flight turn, a resume-load, a lazy agent respawn) while the
-      // agent process is still alive and can answer a cancellation.
-      unawaited(_pluginRuntime.interruptActiveWorkForShutdown());
     } else {
       Log.v("[shutdown] cancel() again (already shutting down)");
     }

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -845,6 +845,11 @@ class OrchestratorSession {
   Future<void> get firstPhoneConnected => _firstPhoneConnectedCompleter.future;
   RoutedRequestDispatcher get routedRequestDispatcher => _routedRequestDispatcher;
 
+  /// Completes when [beginShutdown] starts the graceful shutdown, so
+  /// composition-root machinery (e.g. the shutdown coordinator's backstop)
+  /// can start bounding the session teardown at the same moment.
+  Future<void> get shutdownRequested => _shutdownCompleter.future;
+
   Future<OrchestratorSessionStartResult> start() {
     if (_lifecycleFuture != null) {
       return Future.error(StateError("OrchestratorSession has already started"), StackTrace.current);
@@ -1260,6 +1265,11 @@ class OrchestratorSession {
         "[shutdown] cancel() requested"
         "${_inFlightRelayWorkDiagnostic(separator: " — ")}",
       );
+      // Interrupt in-flight agent work now (budgeted, best-effort) so the
+      // teardown drains below are not held open by agent-coupled requests
+      // (an in-flight turn, a resume-load, a lazy agent respawn) while the
+      // agent process is still alive and can answer a cancellation.
+      unawaited(_pluginRuntime.interruptActiveWorkForShutdown());
     } else {
       Log.v("[shutdown] cancel() again (already shutting down)");
     }

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
@@ -85,12 +85,12 @@ class BridgeRuntime {
   }
 }
 
-Future<DebugServer?> startDebugServerIfRequested({
+Future<void> startDebugServerIfRequested({
   required int? debugPort,
   required BridgeRuntime runtime,
   required BridgeShutdownCoordinator shutdownCoordinator,
 }) async {
-  if (debugPort == null) return null;
+  if (debugPort == null) return;
 
   final bandwidthTracker = runtime.createBandwidthTracker();
   shutdownCoordinator.add(disposable: bandwidthTracker.dispose);
@@ -98,10 +98,19 @@ Future<DebugServer?> startDebugServerIfRequested({
   try {
     final debugServer = runtime.createDebugServer(port: debugPort);
     await debugServer.start();
-    return debugServer;
+    // Registered only once the server is listening, so the coordinator's
+    // phase closures never capture a half-started server.
+    shutdownCoordinator
+      ..addPhase(
+        phase: BridgeShutdownPhase.signal,
+        action: debugServer.beginShutdown,
+      )
+      ..addPhase(
+        phase: BridgeShutdownPhase.drain,
+        action: debugServer.drain,
+      );
   } on Object catch (error, stackTrace) {
     Log.w("failed to start debug server", error, stackTrace);
-    return null;
   }
 }
 

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -858,21 +858,6 @@ class BridgeRuntimeRunner {
         );
       }
 
-      // Start the ordered shutdown the moment the session begins shutting
-      // down (any trigger: signal, supervised logout/restart, control-channel
-      // loss), so the coordinator's backstop bounds the session teardown
-      // itself — a teardown blocked on in-flight agent work must not hang the
-      // process with no deadline. The runner's finally joins the same
-      // (memoized) shutdown future, so a failure here is still surfaced there
-      // with the exit-code policy applied.
-      unawaited(
-        // The runner's finally awaits the same (memoized) shutdown future and
-        // applies the exit-code policy there, so the failure is already
-        // surfaced; this early-start copy must not raise an unhandled error.
-        activeRuntime.session.shutdownRequested
-            .then((_) => shutdownCoordinator.shutdown())
-            .catchError((Object _, StackTrace __) {}),
-      );
       registerSignalHandlers(session: activeRuntime.session, subscriptions: subscriptions);
       // start() synchronously subscribes local route-trigger listeners before
       // the debug server can expose mutation routes.
@@ -883,6 +868,24 @@ class BridgeRuntimeRunner {
         debugPort: options.debugPort,
         runtime: activeRuntime,
         shutdownCoordinator: shutdownCoordinator,
+      );
+      // Start the ordered shutdown the moment the session begins shutting down
+      // (any trigger: signal, supervised logout/restart, control-channel loss),
+      // so the coordinator's backstop bounds the session teardown itself — a
+      // teardown blocked on in-flight agent work must not hang the process
+      // with no deadline. Registered only after the debug server is assigned:
+      // the coordinator's signal phase reads `debugServer` (beginShutdown), so
+      // a shutdown racing the async server start would otherwise miss it, and
+      // no agent-coupled work can exist before startup completes anyway. The
+      // runner's finally joins the same (memoized) shutdown future, so a
+      // failure here is still surfaced there with the exit-code policy applied.
+      unawaited(
+        // The runner's finally awaits the same (memoized) shutdown future and
+        // applies the exit-code policy there, so the failure is already
+        // surfaced; this early-start copy must not raise an unhandled error.
+        activeRuntime.session.shutdownRequested
+            .then((_) => shutdownCoordinator.shutdown())
+            .catchError((Object _, StackTrace __) {}),
       );
       // Background: check + download + stage + apply-in-place on a 4h cadence.
       // The swap takes effect on the next launch (or a phone-triggered restart).

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -204,9 +204,24 @@ class BridgeRuntimeRunner {
     // loss listener assigns with `??=` so a loss never overwrites an already
     // decided intentional exit.
     SupervisedExitCode? requestedSupervisedExit;
+    BridgeRestartService? restartService;
     final shutdownCoordinator = BridgeShutdownCoordinator(
       startAbortSignal: startAbortController.signal,
-      backstopExitCode: () => requestedSupervisedExit?.code ?? 0,
+      backstopExitCode: () {
+        final exit = requestedSupervisedExit;
+        if (exit != null) return exit.code;
+        // The supervised-restart respawn sentinel is folded into the slot in
+        // the try's finally, which has not run when the backstop fires
+        // mid-teardown; consult the handoff flag directly so a hung teardown
+        // still reports the sentinel and the GUI respawns.
+        if (restartService?.supervisedRestartRequested ?? false) {
+          return SupervisedExitCode.restart.code;
+        }
+        return 0;
+      },
+      // Last resort before a forced exit: stop plugin backends so their agent
+      // processes are not orphaned when the teardown (or a phase) hangs.
+      emergencyDisposal: () => pluginRuntime?.disposeStartedApis() ?? Future<void>.value(),
     );
     shutdownCoordinator
       ..addPhase(
@@ -762,7 +777,7 @@ class BridgeRuntimeRunner {
         shutdownCoordinator.add(disposable: controlStatusNotifier.dispose);
       }
 
-      final restartService = BridgeRestartService(
+      restartService = BridgeRestartService(
         processRepository: processRepository,
         commandBuilder: const BridgeRestartCommandBuilder(),
         binaryPath: managedRuntimePaths.binaryPath,
@@ -843,6 +858,21 @@ class BridgeRuntimeRunner {
         );
       }
 
+      // Start the ordered shutdown the moment the session begins shutting
+      // down (any trigger: signal, supervised logout/restart, control-channel
+      // loss), so the coordinator's backstop bounds the session teardown
+      // itself — a teardown blocked on in-flight agent work must not hang the
+      // process with no deadline. The runner's finally joins the same
+      // (memoized) shutdown future, so a failure here is still surfaced there
+      // with the exit-code policy applied.
+      unawaited(
+        // The runner's finally awaits the same (memoized) shutdown future and
+        // applies the exit-code policy there, so the failure is already
+        // surfaced; this early-start copy must not raise an unhandled error.
+        activeRuntime.session.shutdownRequested
+            .then((_) => shutdownCoordinator.shutdown())
+            .catchError((Object _, StackTrace __) {}),
+      );
       registerSignalHandlers(session: activeRuntime.session, subscriptions: subscriptions);
       // start() synchronously subscribes local route-trigger listeners before
       // the debug server can expose mutation routes.

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -100,7 +100,6 @@ import "../../updater/services/update_lifecycle_service.dart";
 import "../../updater/services/update_reconciliation_service.dart";
 import "../../updater/services/update_service.dart";
 import "../../version.dart";
-import "../debug_server.dart";
 import "../foundation/process_runner.dart";
 import "../foundation/process_runner_command_executor.dart";
 import "../log_failure_reporter.dart";
@@ -188,7 +187,6 @@ class BridgeRuntimeRunner {
     PluginRuntime? pluginRuntime;
     PluginLifecycleService? pluginLifecycleService;
     BridgeRuntime? runtime;
-    DebugServer? debugServer;
     CatalogImportConsoleListener? catalogImportConsoleListener;
     Future<void>? sessionRun;
     // The single typed slot for a deliberate supervised exit (restart /
@@ -204,24 +202,15 @@ class BridgeRuntimeRunner {
     // loss listener assigns with `??=` so a loss never overwrites an already
     // decided intentional exit.
     SupervisedExitCode? requestedSupervisedExit;
-    BridgeRestartService? restartService;
+    // Shared by the ordered pluginDispose phase and the backstop's emergency
+    // disposal so the two cannot drift.
+    Future<void> disposePluginApis() => pluginRuntime?.disposeStartedApis() ?? Future<void>.value();
     final shutdownCoordinator = BridgeShutdownCoordinator(
       startAbortSignal: startAbortController.signal,
-      backstopExitCode: () {
-        final exit = requestedSupervisedExit;
-        if (exit != null) return exit.code;
-        // The supervised-restart respawn sentinel is folded into the slot in
-        // the try's finally, which has not run when the backstop fires
-        // mid-teardown; consult the handoff flag directly so a hung teardown
-        // still reports the sentinel and the GUI respawns.
-        if (restartService?.supervisedRestartRequested ?? false) {
-          return SupervisedExitCode.restart.code;
-        }
-        return 0;
-      },
+      backstopExitCode: () => requestedSupervisedExit?.code ?? 0,
       // Last resort before a forced exit: stop plugin backends so their agent
       // processes are not orphaned when the teardown (or a phase) hangs.
-      emergencyDisposal: () => pluginRuntime?.disposeStartedApis() ?? Future<void>.value(),
+      emergencyDisposal: disposePluginApis,
     );
     shutdownCoordinator
       ..addPhase(
@@ -234,15 +223,22 @@ class BridgeRuntimeRunner {
       )
       ..addPhase(
         phase: BridgeShutdownPhase.signal,
+        // Cancel in-flight agent work (budgeted, best-effort) so the drain
+        // phase is not held open by agent-coupled requests — an in-flight
+        // turn, a resume-load, a lazy agent respawn — while the agent process
+        // is still alive and can answer a cancellation. Signal actions fire in
+        // registration order, so `beginShutdown` above has already fenced new
+        // lease acquisitions, and the phase is awaited before drain begins.
+        action: () => pluginRuntime?.interruptActiveWorkForShutdown() ?? Future<void>.value(),
+        budget: _pluginShutdownBudget,
+      )
+      ..addPhase(
+        phase: BridgeShutdownPhase.signal,
         action: () => runtime?.catalogImportService.beginShutdown(),
       )
       ..addPhase(
         phase: BridgeShutdownPhase.signal,
         action: () => runtime?.session.beginShutdown(),
-      )
-      ..addPhase(
-        phase: BridgeShutdownPhase.signal,
-        action: () => debugServer?.beginShutdown(),
       )
       ..addPhase(
         phase: BridgeShutdownPhase.signal,
@@ -257,12 +253,8 @@ class BridgeRuntimeRunner {
         action: () => sessionRun ?? Future<void>.value(),
       )
       ..addPhase(
-        phase: BridgeShutdownPhase.drain,
-        action: () => debugServer?.drain() ?? Future<void>.value(),
-      )
-      ..addPhase(
         phase: BridgeShutdownPhase.pluginDispose,
-        action: () => pluginRuntime?.disposeStartedApis() ?? Future<void>.value(),
+        action: disposePluginApis,
         budget: _pluginShutdownBudget,
       )
       ..addPhase(
@@ -777,7 +769,7 @@ class BridgeRuntimeRunner {
         shutdownCoordinator.add(disposable: controlStatusNotifier.dispose);
       }
 
-      restartService = BridgeRestartService(
+      final restartService = BridgeRestartService(
         processRepository: processRepository,
         commandBuilder: const BridgeRestartCommandBuilder(),
         binaryPath: managedRuntimePaths.binaryPath,
@@ -787,6 +779,12 @@ class BridgeRuntimeRunner {
         // exits with the sentinel code instead of spawning a successor (which
         // would replay --control-url with no off-argv secret and fail closed).
         isSupervised: options.isSupervised,
+        // Record the GUI-respawn sentinel the moment the handoff is decided —
+        // before the shutdown it triggers — so the normal return, the error
+        // paths, and a hung-teardown backstop all report the same code.
+        onSupervisedRestartRequested: () {
+          requestedSupervisedExit = SupervisedExitCode.restart;
+        },
       );
 
       // Run startup diagnostics before composing the runtime so the
@@ -864,28 +862,10 @@ class BridgeRuntimeRunner {
       final sessionStart = activeRuntime.session.start();
       sessionStart.ignore();
       sessionRun = activeRuntime.session.waitUntilStopped();
-      debugServer = await startDebugServerIfRequested(
+      await startDebugServerIfRequested(
         debugPort: options.debugPort,
         runtime: activeRuntime,
         shutdownCoordinator: shutdownCoordinator,
-      );
-      // Start the ordered shutdown the moment the session begins shutting down
-      // (any trigger: signal, supervised logout/restart, control-channel loss),
-      // so the coordinator's backstop bounds the session teardown itself — a
-      // teardown blocked on in-flight agent work must not hang the process
-      // with no deadline. Registered only after the debug server is assigned:
-      // the coordinator's signal phase reads `debugServer` (beginShutdown), so
-      // a shutdown racing the async server start would otherwise miss it, and
-      // no agent-coupled work can exist before startup completes anyway. The
-      // runner's finally joins the same (memoized) shutdown future, so a
-      // failure here is still surfaced there with the exit-code policy applied.
-      unawaited(
-        // The runner's finally awaits the same (memoized) shutdown future and
-        // applies the exit-code policy there, so the failure is already
-        // surfaced; this early-start copy must not raise an unhandled error.
-        activeRuntime.session.shutdownRequested
-            .then((_) => shutdownCoordinator.shutdown())
-            .catchError((Object _, StackTrace __) {}),
       );
       // Background: check + download + stage + apply-in-place on a 4h cadence.
       // The swap takes effect on the next launch (or a phone-triggered restart).
@@ -917,37 +897,35 @@ class BridgeRuntimeRunner {
         onboardingPreparation = null;
       }
 
-      try {
-        final startResult = await sessionStart;
-        if (startResult == OrchestratorSessionStartResult.ready) {
-          if (onboardingPreparation case final preparation?) {
-            final decision = await Future.any<AppClientOnboardingDecision>([
-              sessionRun.then((_) => AppClientOnboardingDecision.skip),
-              preparation,
-            ]);
-            if (decision == AppClientOnboardingDecision.prompt) {
-              _presentAppOnboardingPrompt(environment: environment);
-              await _waitForFirstPhoneConnection(
-                firstPhoneConnected: activeRuntime.session.firstPhoneConnected,
-                sessionRun: sessionRun,
-                environment: environment,
-              );
-            }
+      // Start the ordered shutdown the moment the session begins shutting down
+      // (any trigger: signal, supervised logout/restart, control-channel loss),
+      // so the coordinator's signal phase interrupts in-flight agent work and
+      // its backstop bounds the session teardown itself — a teardown blocked
+      // on agent-coupled requests must not hang the process with no deadline.
+      // Registered after startup wiring so every phase action and disposable
+      // above is in place (no agent-coupled work can exist before startup
+      // completes anyway). The runner's finally joins the same (memoized)
+      // shutdown future and applies the exit-code policy there, so this
+      // early-start copy only marks its error as handled.
+      activeRuntime.session.shutdownRequested.then((_) => shutdownCoordinator.shutdown()).ignore();
+
+      final startResult = await sessionStart;
+      if (startResult == OrchestratorSessionStartResult.ready) {
+        if (onboardingPreparation case final preparation?) {
+          final decision = await Future.any<AppClientOnboardingDecision>([
+            sessionRun.then((_) => AppClientOnboardingDecision.skip),
+            preparation,
+          ]);
+          if (decision == AppClientOnboardingDecision.prompt) {
+            _presentAppOnboardingPrompt(environment: environment);
+            await _waitForFirstPhoneConnection(
+              firstPhoneConnected: activeRuntime.session.firstPhoneConnected,
+              sessionRun: sessionRun,
+              environment: environment,
+            );
           }
-          await sessionRun;
         }
-      } finally {
-        // A supervised phone-triggered restart handed the session off by exiting
-        // rather than spawning a successor; resolve the GUI-respawn sentinel here
-        // (in a finally) so it survives even if session teardown throws —
-        // otherwise the error path below would return a crash code and
-        // the GUI would back off instead of respawning. `restartService` is only
-        // in scope inside this try, hence resolving into the outer-scoped local.
-        // Assigned before the outer `finally`'s shutdown runs, so a hung-shutdown
-        // backstop reports the same code too.
-        if (restartService.supervisedRestartRequested) {
-          requestedSupervisedExit = SupervisedExitCode.restart;
-        }
+        await sessionRun;
       }
       return requestedSupervisedExit?.code ?? 0;
     } on PluginStartAbortedException {

--- a/bridge/app/lib/src/bridge/runtime/bridge_shutdown_coordinator.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_shutdown_coordinator.dart
@@ -17,16 +17,22 @@ class BridgeShutdownCoordinator {
     required StartAbortSignal startAbortSignal,
     int Function()? backstopExitCode,
     void Function(int code)? exitProcess,
+    Future<void> Function()? emergencyDisposal,
   }) : _backstopExitCode = backstopExitCode ?? _alwaysZero,
        _exitProcess = exitProcess ?? io.exit,
-       _startAbortSignal = startAbortSignal;
+       _startAbortSignal = startAbortSignal,
+       _emergencyDisposal = emergencyDisposal;
 
   static int _alwaysZero() => 0;
   static const Duration _backstopSlack = Duration(seconds: 10);
 
+  /// How long the backstop waits for [emergencyDisposal] before exiting.
+  static const Duration _emergencyDisposalCap = Duration(seconds: 3);
+
   final int Function() _backstopExitCode;
   final void Function(int code) _exitProcess;
   final StartAbortSignal _startAbortSignal;
+  final Future<void> Function()? _emergencyDisposal;
   final Map<BridgeShutdownPhase, List<_ShutdownAction>> _actions = {
     for (final phase in BridgeShutdownPhase.values) phase: <_ShutdownAction>[],
   };
@@ -61,7 +67,7 @@ class BridgeShutdownCoordinator {
     final totalSw = Stopwatch()..start();
     final backstop = Timer(shutdownBudget + _backstopSlack, () {
       Log.e("Failed to finish gracefully after ${totalSw.elapsedMilliseconds}ms - forcing exit");
-      _exitProcess(_backstopExitCode());
+      unawaited(_emergencyDisposalThenExit());
     });
     Object? firstError;
     StackTrace? firstStackTrace;
@@ -103,6 +109,20 @@ class BridgeShutdownCoordinator {
 
   bool _isExpected(Object error) {
     return error is PluginStartAbortedException && _startAbortSignal.isAborted;
+  }
+
+  /// Last-resort disposal before the backstop exits the process: kicks the
+  /// registered emergency disposal (e.g. stopping plugin backend processes so
+  /// they are not orphaned by a forced exit) and bounds it with
+  /// [_emergencyDisposalCap]. Never throws — the exit happens regardless.
+  Future<void> _emergencyDisposalThenExit() async {
+    try {
+      await _emergencyDisposal?.call().timeout(_emergencyDisposalCap);
+    } on Object catch (error, stackTrace) {
+      Log.w("[shutdown] emergency disposal failed; exiting anyway", error, stackTrace);
+    } finally {
+      _exitProcess(_backstopExitCode());
+    }
   }
 }
 

--- a/bridge/app/lib/src/bridge/runtime/bridge_shutdown_coordinator.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_shutdown_coordinator.dart
@@ -27,7 +27,12 @@ class BridgeShutdownCoordinator {
   static const Duration _backstopSlack = Duration(seconds: 10);
 
   /// How long the backstop waits for [emergencyDisposal] before exiting.
-  static const Duration _emergencyDisposalCap = Duration(seconds: 3);
+  /// Sized above the plugins' agent-process kill escalation so it can run to
+  /// completion — ACP's teardown SIGTERMs the agent, waits up to 5s, then
+  /// SIGKILLs; a smaller cap would exit the bridge before the SIGKILL and
+  /// orphan an agent that ignores SIGTERM, the exact outcome this hook
+  /// exists to prevent.
+  static const Duration _emergencyDisposalCap = Duration(seconds: 6);
 
   final int Function() _backstopExitCode;
   final void Function(int code) _exitProcess;

--- a/bridge/app/lib/src/bridge/runtime/plugin_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_runtime.dart
@@ -587,6 +587,37 @@ class PluginRuntime {
     }
   }
 
+  /// Best-effort, budgeted cancellation of in-flight agent work across every
+  /// started plugin. Invoked when bridge shutdown begins so session-teardown
+  /// drains (relay completions, session operations, plugin-event tails) are
+  /// not held open by agent-coupled requests — an ACP `session/prompt`
+  /// awaiting a busy agent, a `session/load`/`session/resume` replay, or a
+  /// lazy agent respawn — while the agent process is still alive and can
+  /// answer a cancellation.
+  ///
+  /// Uses the same per-plugin `interruptActiveWork` contract as the forced-
+  /// stop path ([_interruptActiveWork]) but emits no terminal handoff: the
+  /// ongoing session teardown drains whatever events the cancellation
+  /// produces. Never throws; isolates and logs per-plugin failures.
+  Future<void> interruptActiveWorkForShutdown() {
+    return Future.wait([
+      for (final slot in _slots.values)
+        if (slot.plugin case final plugin?) _interruptPluginForShutdown(slot, plugin),
+    ]);
+  }
+
+  Future<void> _interruptPluginForShutdown(_PluginRuntimeSlot slot, BridgePlugin plugin) async {
+    try {
+      await plugin.interruptActiveWork(budget: _shutdownBudget).timeout(_shutdownBudget);
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        'Plugin "${slot.registration.descriptor.id}" could not interrupt active work during shutdown',
+        error,
+        stackTrace,
+      );
+    }
+  }
+
   Future<void> disposeStartedApis() => _disposeStartedApisFuture ??= _disposeStartedApis();
 
   Future<void> _disposeStartedApis() async {

--- a/bridge/app/lib/src/bridge/runtime/plugin_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_runtime.dart
@@ -588,25 +588,31 @@ class PluginRuntime {
   }
 
   /// Best-effort, budgeted cancellation of in-flight agent work across every
-  /// started plugin. Invoked when bridge shutdown begins so session-teardown
+  /// started plugin. Invoked by the composition root's shutdown coordinator
+  /// as a signal-phase action — after [beginShutdown] has fenced new lease
+  /// acquisitions, and awaited before the drain phase — so session-teardown
   /// drains (relay completions, session operations, plugin-event tails) are
   /// not held open by agent-coupled requests — an ACP `session/prompt`
   /// awaiting a busy agent, a `session/load`/`session/resume` replay, or a
   /// lazy agent respawn — while the agent process is still alive and can
   /// answer a cancellation.
   ///
-  /// Uses the same per-plugin `interruptActiveWork` contract as the forced-
-  /// stop path ([_interruptActiveWork]) but emits no terminal handoff: the
-  /// ongoing session teardown drains whatever events the cancellation
-  /// produces. Never throws; isolates and logs per-plugin failures.
+  /// Unlike the forced-stop path ([_interruptActiveWork]) there is no barrier
+  /// drain of pre-fence operations first (interrupting them is the point) and
+  /// no terminal handoff afterwards; cancellation events the plugins emit
+  /// reach the concurrently tearing-down session only on a best-effort basis.
+  /// Never throws; isolates and logs per-plugin failures.
   Future<void> interruptActiveWorkForShutdown() {
     return Future.wait([
       for (final slot in _slots.values)
-        if (slot.plugin case final plugin?) _interruptPluginForShutdown(slot, plugin),
+        if (slot.plugin case final plugin?) _interruptPluginForShutdown(slot: slot, plugin: plugin),
     ]);
   }
 
-  Future<void> _interruptPluginForShutdown(_PluginRuntimeSlot slot, BridgePlugin plugin) async {
+  Future<void> _interruptPluginForShutdown({
+    required _PluginRuntimeSlot slot,
+    required BridgePlugin plugin,
+  }) async {
     try {
       await plugin.interruptActiveWork(budget: _shutdownBudget).timeout(_shutdownBudget);
     } on Object catch (error, stackTrace) {

--- a/bridge/app/lib/src/server/services/bridge_restart_service.dart
+++ b/bridge/app/lib/src/server/services/bridge_restart_service.dart
@@ -17,10 +17,10 @@ import '../repositories/process_repository.dart';
 ///   ([spawnSuccessor]); the successor waits this pid out before enforcing
 ///   single-live-bridge.
 /// - **supervised** — the desktop GUI owns this process's lifecycle and respawns
-///   it, so no successor is spawned. Instead [performRestartHandoff] records that
-///   a supervised restart was requested ([supervisedRestartRequested]); the
-///   composition root reads that flag once the session ends and exits with the
-///   GUI-respawn sentinel code. Spawning a supervised successor would replay
+///   it, so no successor is spawned. Instead [performRestartHandoff] notifies
+///   the composition root (`onSupervisedRestartRequested`) at the moment the
+///   handoff is decided, so the GUI-respawn sentinel exit code is recorded
+///   before any shutdown runs. Spawning a supervised successor would replay
 ///   `--control-url` into a detached child with no off-argv secret and fail
 ///   closed, so supervised mode must never call [spawnSuccessor].
 ///
@@ -36,12 +36,14 @@ class BridgeRestartService {
     required List<String> cliArgs,
     required int currentPid,
     required bool isSupervised,
+    required void Function() onSupervisedRestartRequested,
   }) : _processRepository = processRepository,
        _commandBuilder = commandBuilder,
        _binaryPath = binaryPath,
        _cliArgs = cliArgs,
        _currentPid = currentPid,
-       _isSupervised = isSupervised;
+       _isSupervised = isSupervised,
+       _onSupervisedRestartRequested = onSupervisedRestartRequested;
 
   final ProcessRepository _processRepository;
   final BridgeRestartCommandBuilder _commandBuilder;
@@ -50,13 +52,12 @@ class BridgeRestartService {
   final int _currentPid;
   final bool _isSupervised;
 
-  bool _supervisedRestartRequested = false;
-
-  /// Whether a supervised restart handoff has been performed, so the composition
-  /// root can exit with the GUI-respawn sentinel code instead of a clean 0. Only
-  /// ever set in supervised mode; standalone spawns a successor and leaves this
-  /// false.
-  bool get supervisedRestartRequested => _supervisedRestartRequested;
+  /// Invoked the moment a supervised restart handoff is decided, before the
+  /// shutdown it triggers, so the composition root can record the GUI-respawn
+  /// sentinel exit code ahead of any teardown (including a hung one whose
+  /// backstop force-exits). Only ever invoked in supervised mode; standalone
+  /// spawns a successor instead.
+  final void Function() _onSupervisedRestartRequested;
 
   /// Whether an explicit restart can be delivered right now, so the handler only
   /// promises a restart it can actually carry out.
@@ -97,7 +98,7 @@ class BridgeRestartService {
   /// Performs the restart handoff for the active run mode and reports whether the
   /// caller should now request graceful shutdown.
   ///
-  /// - **supervised:** records [supervisedRestartRequested] and returns `true`
+  /// - **supervised:** notifies `onSupervisedRestartRequested` and returns `true`
   ///   without spawning a successor — the desktop GUI respawns this process after
   ///   it exits with the sentinel code.
   /// - **standalone:** spawns a successor and returns whether it started; `false`
@@ -105,7 +106,7 @@ class BridgeRestartService {
   Future<bool> performRestartHandoff() async {
     if (_isSupervised) {
       Log.i('Supervised restart: exiting for GUI respawn (no successor spawn)');
-      _supervisedRestartRequested = true;
+      _onSupervisedRestartRequested();
       return true;
     }
     Log.i('Standalone restart: spawning successor bridge');

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -958,9 +958,6 @@ class _BlockingRestartDispatcher implements BridgeRestartDispatcher {
 
 class _AlwaysRestartableService implements BridgeRestartService {
   @override
-  bool get supervisedRestartRequested => false;
-
-  @override
   Future<bool> canRestart() async => true;
 
   @override
@@ -992,6 +989,7 @@ BridgeRestartService _spawnableRestartService({
     cliArgs: const <String>[],
     currentPid: 4321,
     isSupervised: false,
+    onSupervisedRestartRequested: () {},
   );
 }
 

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -692,9 +692,6 @@ class _RecordingRestartService implements BridgeRestartService {
   int? connIdAtHandoff;
 
   @override
-  bool get supervisedRestartRequested => false;
-
-  @override
   Future<bool> canRestart() async => restartable;
 
   @override

--- a/bridge/app/test/bridge/orchestrator_request_concurrency_test.dart
+++ b/bridge/app/test/bridge/orchestrator_request_concurrency_test.dart
@@ -543,9 +543,6 @@ class _RecordingRestartService implements BridgeRestartService {
   int? closeAttemptCountAtHandoff;
 
   @override
-  bool get supervisedRestartRequested => false;
-
-  @override
   Future<bool> canRestart() async {
     final started = canRestartStarted;
     if (started != null && !started.isCompleted) started.complete();

--- a/bridge/app/test/bridge/routing/bridge_restart_dispatcher_test.dart
+++ b/bridge/app/test/bridge/routing/bridge_restart_dispatcher_test.dart
@@ -91,9 +91,6 @@ class _FakeRestartService implements BridgeRestartService {
   int handoffCalls = 0;
 
   @override
-  bool get supervisedRestartRequested => false;
-
-  @override
   Future<bool> canRestart() async => true;
 
   @override

--- a/bridge/app/test/bridge/routing/restart_bridge_handler_test.dart
+++ b/bridge/app/test/bridge/routing/restart_bridge_handler_test.dart
@@ -64,6 +64,7 @@ void main() {
       cliArgs: const ['run'],
       currentPid: 1234,
       isSupervised: isSupervised,
+      onSupervisedRestartRequested: () {},
     );
   }
 

--- a/bridge/app/test/bridge/runtime/bridge_shutdown_coordinator_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_shutdown_coordinator_test.dart
@@ -248,6 +248,47 @@ void main() {
       });
     });
 
+    test("backstop runs the emergency disposal (capped) before forcing exit", () {
+      fakeAsync((async) {
+        final exitCalls = <int>[];
+        var emergencyRuns = 0;
+        final coordinator = BridgeShutdownCoordinator(
+          startAbortSignal: StartAbortSignal.never,
+          emergencyDisposal: () async {
+            emergencyRuns++;
+            await Completer<void>().future;
+          },
+          exitProcess: exitCalls.add,
+        );
+        coordinator.add(disposable: () => Completer<void>().future);
+
+        unawaited(coordinator.shutdown());
+        async.elapse(const Duration(seconds: 11));
+        expect(emergencyRuns, 1);
+        expect(exitCalls, isEmpty, reason: "exit waits for the bounded emergency disposal");
+
+        async.elapse(const Duration(seconds: 3));
+        expect(exitCalls, [0]);
+      });
+    });
+
+    test("backstop exits promptly when the emergency disposal completes early", () {
+      fakeAsync((async) {
+        final exitCalls = <int>[];
+        final coordinator = BridgeShutdownCoordinator(
+          startAbortSignal: StartAbortSignal.never,
+          emergencyDisposal: () async {},
+          exitProcess: exitCalls.add,
+        );
+        coordinator.add(disposable: () => Completer<void>().future);
+
+        unawaited(coordinator.shutdown());
+        async.elapse(const Duration(seconds: 11));
+
+        expect(exitCalls, [0]);
+      });
+    });
+
     test("backstop never fires when shutdown completes in time", () {
       fakeAsync((async) {
         final exitCalls = <int>[];

--- a/bridge/app/test/bridge/runtime/bridge_shutdown_coordinator_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_shutdown_coordinator_test.dart
@@ -104,6 +104,40 @@ void main() {
       expect(operations, ["parallel.b"]);
     });
 
+    test("an async signal action is awaited before the drain phase starts", () async {
+      final coordinator = BridgeShutdownCoordinator(
+        startAbortSignal: StartAbortSignal.never,
+        exitProcess: (_) {},
+      );
+      final interrupt = Completer<void>();
+      final operations = <String>[];
+
+      coordinator
+        ..addPhase(
+          phase: BridgeShutdownPhase.signal,
+          action: () {
+            operations.add("signal.interrupt");
+            return interrupt.future;
+          },
+        )
+        ..addPhase(
+          phase: BridgeShutdownPhase.drain,
+          action: () => operations.add("drain"),
+        );
+
+      final shutdown = coordinator.shutdown();
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        operations,
+        ["signal.interrupt"],
+        reason: "drain must not race a still-running signal action (e.g. the agent-work interrupt)",
+      );
+
+      interrupt.complete();
+      await shutdown;
+      expect(operations, ["signal.interrupt", "drain"]);
+    });
+
     test("starts every action in a phase before awaiting a blocked peer", () async {
       final coordinator = BridgeShutdownCoordinator(
         startAbortSignal: StartAbortSignal.never,
@@ -263,11 +297,18 @@ void main() {
         coordinator.add(disposable: () => Completer<void>().future);
 
         unawaited(coordinator.shutdown());
+        // Backstop fires at 10s (no phase budgets + slack); the emergency
+        // disposal starts then.
         async.elapse(const Duration(seconds: 11));
         expect(emergencyRuns, 1);
         expect(exitCalls, isEmpty, reason: "exit waits for the bounded emergency disposal");
 
-        async.elapse(const Duration(seconds: 3));
+        // The cap exceeds the plugins' 5s SIGTERM→SIGKILL escalation so a
+        // hung disposal is still granted the full kill window before exit.
+        async.elapse(const Duration(seconds: 4));
+        expect(exitCalls, isEmpty, reason: "the kill escalation window must fit inside the cap");
+
+        async.elapse(const Duration(seconds: 1));
         expect(exitCalls, [0]);
       });
     });

--- a/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
@@ -545,7 +545,10 @@ void main() {
       startGate: Future<void>.value(),
       pluginFactory: (_) => plugin = _FakePlugin(api: api),
     );
-    final runtime = _runtime(factory: factory);
+    final runtime = _runtime(
+      factory: factory,
+      shutdownBudget: const Duration(milliseconds: 20),
+    );
     addTearDown(runtime.dispose);
     await runtime.start(pluginId: "one");
     plugin.interruptActiveWorkHandler = (_) => Completer<Set<String>>().future;
@@ -1574,6 +1577,7 @@ enum _TestOperation {
 PluginRuntime _runtime({
   required _FakeGenerationFactory factory,
   BridgePluginDescriptor descriptor = const _FakeDescriptor(),
+  Duration shutdownBudget = const Duration(seconds: 1),
 }) {
   final runtime = PluginRuntime(
     registrations: [
@@ -1587,7 +1591,7 @@ PluginRuntime _runtime({
     setupProcesses: const _UnusedHostProcessService(),
     environment: const {},
     clock: const ServerClock(),
-    shutdownBudget: const Duration(seconds: 1),
+    shutdownBudget: shutdownBudget,
   );
   runtime.applyAccess(
     entries: const [

--- a/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
@@ -499,6 +499,62 @@ void main() {
     expect(runtime.snapshot.single.state, PluginRuntimeState.active);
   });
 
+  test("shutdown interrupt asks every started plugin to quiesce active work within the budget", () async {
+    final api = _FakeApi();
+    late _FakePlugin plugin;
+    final factory = _FakeGenerationFactory(
+      startGate: Future<void>.value(),
+      pluginFactory: (_) => plugin = _FakePlugin(api: api),
+    );
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.start(pluginId: "one");
+    Duration? seenBudget;
+    plugin.interruptActiveWorkHandler = (budget) async {
+      seenBudget = budget;
+      return const {};
+    };
+
+    await runtime.interruptActiveWorkForShutdown();
+
+    expect(plugin.interruptActiveWorkCount, 1);
+    expect(seenBudget, const Duration(seconds: 1));
+  });
+
+  test("shutdown interrupt isolates a failing plugin and never throws", () async {
+    final api = _FakeApi();
+    late _FakePlugin plugin;
+    final factory = _FakeGenerationFactory(
+      startGate: Future<void>.value(),
+      pluginFactory: (_) => plugin = _FakePlugin(api: api),
+    );
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.start(pluginId: "one");
+    plugin.interruptActiveWorkHandler = (_) => Future.error(StateError("cannot quiesce"));
+
+    await runtime.interruptActiveWorkForShutdown();
+
+    expect(plugin.interruptActiveWorkCount, 1);
+  });
+
+  test("shutdown interrupt bounds a hung plugin", () async {
+    final api = _FakeApi();
+    late _FakePlugin plugin;
+    final factory = _FakeGenerationFactory(
+      startGate: Future<void>.value(),
+      pluginFactory: (_) => plugin = _FakePlugin(api: api),
+    );
+    final runtime = _runtime(factory: factory);
+    addTearDown(runtime.dispose);
+    await runtime.start(pluginId: "one");
+    plugin.interruptActiveWorkHandler = (_) => Completer<Set<String>>().future;
+
+    await runtime.interruptActiveWorkForShutdown();
+
+    expect(plugin.interruptActiveWorkCount, 1);
+  });
+
   test("a force stop interrupts active sessions before retiring the generation", () async {
     final api = _FakeApi(
       activeSessionsSummary: const [

--- a/bridge/app/test/helpers/restart_test_support.dart
+++ b/bridge/app/test/helpers/restart_test_support.dart
@@ -49,5 +49,6 @@ BridgeRestartService buildTestRestartService() {
     cliArgs: const <String>[],
     currentPid: 0,
     isSupervised: false,
+    onSupervisedRestartRequested: () {},
   );
 }

--- a/bridge/app/test/server/services/bridge_restart_service_test.dart
+++ b/bridge/app/test/server/services/bridge_restart_service_test.dart
@@ -43,10 +43,12 @@ class _RecordingProcessRunner implements ProcessRunner {
 void main() {
   late Directory tempDir;
   late _RecordingProcessRunner runner;
+  late int supervisedRestartNotifications;
 
   setUp(() async {
     tempDir = await Directory.systemTemp.createTemp('bridge-restart-service');
     runner = _RecordingProcessRunner();
+    supervisedRestartNotifications = 0;
   });
 
   tearDown(() async {
@@ -75,6 +77,7 @@ void main() {
       cliArgs: cliArgs,
       currentPid: 7777,
       isSupervised: isSupervised,
+      onSupervisedRestartRequested: () => supervisedRestartNotifications++,
     );
   }
 
@@ -129,7 +132,7 @@ void main() {
 
     expect(proceed, isTrue);
     expect(runner.detachedCalls, hasLength(1));
-    expect(service.supervisedRestartRequested, isFalse);
+    expect(supervisedRestartNotifications, 0);
   });
 
   test('performRestartHandoff keeps running when the standalone successor cannot spawn', () async {
@@ -137,16 +140,16 @@ void main() {
     final service = buildService(binaryPath: '/opt/sesori/sesori-bridge');
 
     expect(await service.performRestartHandoff(), isFalse);
-    expect(service.supervisedRestartRequested, isFalse);
+    expect(supervisedRestartNotifications, 0);
   });
 
-  test('performRestartHandoff records the supervised intent and never spawns a successor', () async {
+  test('performRestartHandoff notifies the supervised intent and never spawns a successor', () async {
     final service = buildService(binaryPath: '/opt/sesori/sesori-bridge', isSupervised: true);
 
     final proceed = await service.performRestartHandoff();
 
     expect(proceed, isTrue);
-    expect(service.supervisedRestartRequested, isTrue);
+    expect(supervisedRestartNotifications, 1);
     // The desktop GUI respawns a supervised bridge; spawning our own successor
     // would replay --control-url with no off-argv secret and fail closed.
     expect(runner.detachedCalls, isEmpty);

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin.dart
@@ -46,12 +46,23 @@ abstract class BridgePlugin {
   /// Cheap, synchronous, side-effect-free diagnostics (endpoint, version).
   PluginDiagnostics describe();
 
-  /// Interrupts every active backend session before a forced generation stop.
+  /// Interrupts every active backend session and waits for it to quiesce.
   ///
-  /// The runtime has already fenced new acquisitions and drained pre-fence
-  /// operations when this is called.
-  /// Implementations must wait until interrupted history is reloadable and
-  /// return only backend session IDs that are no longer busy or retrying.
+  /// Called on two paths:
+  ///
+  /// - **Forced generation stop.** The runtime has already fenced new
+  ///   acquisitions and drained pre-fence operations; the returned session
+  ///   IDs feed the terminal handoff.
+  /// - **Bridge shutdown.** Best-effort cancellation while the session
+  ///   teardown keeps running concurrently: new acquisitions are fenced, but
+  ///   pre-fence operations are deliberately not drained first (interrupting
+  ///   them is the point), so in-flight requests may still be executing when
+  ///   this is called. No terminal handoff follows; the return value is
+  ///   ignored.
+  ///
+  /// Implementations must tolerate concurrently in-flight operations, wait
+  /// until interrupted history is reloadable, and return only backend session
+  /// IDs that are no longer busy or retrying.
   /// [budget] bounds the complete interruption and quiescence operation.
   Future<Set<String>> interruptActiveWork({required Duration budget});
 


### PR DESCRIPTION
## Complexity

🚧 Complex — shutdown-lifecycle coordination across four production files with strict ordering invariants (drain → plugin dispose → lifecycle → shared) and supervised exit-code discipline.

## What

Fixes a graceful-shutdown hang where Ctrl+C during/after an active Cursor (ACP) agent turn left the bridge stuck for 30-60s+ until a second SIGINT force-exited it, with the agent process killed only by the terminal's own SIGINT (exit 130), never by the bridge.

Three coordinated changes:

1. **Interrupt agent work at shutdown start** — `OrchestratorSession.beginShutdown()` now kicks off `PluginRuntime.interruptActiveWorkForShutdown()` (budgeted, best-effort per-plugin `interruptActiveWork`, same contract as the forced-stop path, no terminal handoff). In-flight turns get `session/cancel` and pending approvals resolve while the agent is still alive, so session-teardown drains (relay completions, session operations, plugin-event tails) are not held open by agent-coupled requests.
2. **Coordinator backstop covers the teardown** — the runner starts `shutdownCoordinator.shutdown()` the moment the session's new `shutdownRequested` future completes (any trigger: signal, supervised logout/restart, control-channel loss). The backstop now bounds the whole graceful path; before, it only started after the teardown finished.
3. **Emergency disposal before forced exit** — the coordinator's backstop runs an optional bounded (3s) `emergencyDisposal` before exiting; the runner wires it to `pluginRuntime.disposeStartedApis()` so backend agent processes get SIGTERM rather than being orphaned when the backstop fires. The backstop exit code also consults `restartService.supervisedRestartRequested` so a supervised-restart respawn sentinel (86) survives a backstop that fires mid-teardown.

## Why

The only mechanism that stopped the ACP agent (`AcpPlugin.dispose` → `AcpStdioClient.dispose`, SIGTERM → 5s → SIGKILL) ran in the coordinator's `pluginDispose` phase, which the runner invoked only after the full session teardown completed. A teardown blocked on agent-coupled work (in-flight `session/prompt` with a 30-min timeout, `session/load`/`session/resume` with 2-min timeouts, a lazy agent respawn) therefore hung indefinitely with no deadline and the agent never stopped gracefully.

## Risk and test focus

- Shutdown ordering invariants: drain events → relay close → plugin dispose → lifecycle → shared. The early coordinator start changes only the backstop timer start (cancel time), not phase order — the drain phase still awaits the full teardown before `pluginDispose`.
- Reentrancy: coordinator `shutdown()` is memoized; the early start and the runner's final join share one run, and failures still surface with the existing exit-code policy.
- Supervised exit codes: the sentinel slot stays authoritative; the restart flag is consulted only when the slot is empty (the mid-teardown backstop window).
- Verified: `dart analyze --fatal-infos` clean; full app suite passes (2435 tests); new tests cover the coordinator emergency-disposal cap/prompt-exit and the runtime interrupt (budget, isolation, hang bounding). Architecture implementation review: approved, no findings.

## Expected result

- Ctrl+C during an active agent turn stops the bridge cleanly in seconds: agent turn cancelled, teardown drains complete, plugin dispose reaps the agent.
- Any residual teardown blockage is bounded by the backstop (~40s) with agent processes SIGTERM'd instead of orphaned, and the second-Ctrl+C force-exit no longer needs to exist for the common case.
- No user-visible or database impact otherwise; no wire-contract changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes shutdown hangs when stopping the bridge during an active agent turn. Starts the shutdown coordinator as soon as teardown begins, cancels agent work up front, and bounds teardown with a backstop so we don’t orphan agent processes.

- **Bug Fixes**
  - Move the agent-work cancel to the shutdown coordinator’s signal phase (after the plugin-runtime fence) and await it before drain.
  - Start the coordinator on `session.shutdownRequested` after startup wiring; register the debug server’s shutdown phases only once it’s listening inside `startDebugServerIfRequested`.
  - Run a capped emergency disposal (6s) before forced exit, via `pluginRuntime.disposeStartedApis()`, so backend agents get SIGTERM/SIGKILL instead of being orphaned.
  - Record the supervised-restart sentinel at decision time via a `BridgeRestartService` callback, ensuring a single, consistent exit code across normal, error, and backstop paths.

<sup>Written for commit 19a4901584e88e78f3e33ce7874c44e6a9a977f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

