### PR TITLE
🌿 Present harness settings per entry point

### DIFF
--- a/client/app/lib/core/routing/app_router.dart
+++ b/client/app/lib/core/routing/app_router.dart
@@ -83,13 +83,21 @@ extension AppRouteToGoRoute on AppRouteDef {
   }
 
   Widget _buildScreen({required BuildContext context, required GoRouterState state}) {
-    final route = AppRoute.fromDef(
+    return AppRoute.fromDef(
       def: this,
       pathParams: state.pathParameters,
       queryParams: state.uri.queryParameters,
-    );
+    ).screen;
+  }
+}
 
-    return switch (route) {
+extension on AppRoute {
+  /// The screen this decoded route shows. Separate from [AppRouteToGoRoute._buildScreen]
+  /// so a page builder that already resolved its route — to choose a page type
+  /// from the route's own parameters — builds the screen from that same
+  /// instance instead of decoding the URL a second time.
+  Widget get screen {
+    return switch (this) {
       AppRouteSplash() => const SplashScreen(),
       AppRouteLogin() => const LoginScreen(),
       AppRouteProjects() => const ProjectListScreen(),
@@ -396,8 +404,8 @@ List<RouteBase> _buildAppRoutes({
           // Android too. The pushed page is the MaterialPage go_router would
           // have built itself, so it keeps the platform's push transition.
           pageBuilder: (context, state) {
-            final child = AppRouteDef.settingsHarnesses._buildScreen(context: context, state: state);
             final route = AppRouteSettingsHarnesses.fromParams(queryParams: state.uri.queryParameters);
+            final child = route.screen;
             return switch (route.presentation) {
               HarnessSettingsPresentation.modal => CupertinoPage<void>(
                 key: state.pageKey,

--- a/client/app/lib/core/routing/app_router.dart
+++ b/client/app/lib/core/routing/app_router.dart
@@ -95,7 +95,7 @@ extension AppRouteToGoRoute on AppRouteDef {
       AppRouteProjects() => const ProjectListScreen(),
       AppRouteSettings() => const SettingsScreen(),
       AppRouteSettingsNotifications() => const NotificationSettingsScreen(),
-      AppRouteSettingsHarnesses() => const HarnessesSettingsScreen(),
+      AppRouteSettingsHarnesses(:final presentation) => HarnessesSettingsScreen(presentation: presentation),
       AppRouteSettingsProfile() => const ProfileScreen(),
       AppRouteSessions(:final projectId, :final projectName) => SessionListScreen(
         projectId: projectId,
@@ -385,16 +385,28 @@ List<RouteBase> _buildAppRoutes({
         ),
         GoRoute(
           path: _settingsHarnessesRouteSegment,
-          // Harness settings are reached from two places — the settings list
-          // and the new-session harness menu — and are a detour from both, so
-          // they rise as a modal over whatever raised them and close back onto
-          // it. A CupertinoPage for the same reason settings itself uses one:
-          // only the Cupertino route honours `fullscreenDialog` on Android too.
-          pageBuilder: (context, state) => CupertinoPage<void>(
-            key: state.pageKey,
-            fullscreenDialog: true,
-            child: AppRouteDef.settingsHarnesses._buildScreen(context: context, state: state),
-          ),
+          // Harness settings are reached from two places, and the route says
+          // which one. From the settings list they are the next page of that
+          // stack, so they push in like every other settings page. From the
+          // new-session harness menu they are a detour from an unrelated
+          // screen, so they rise as a modal and close back onto it.
+          //
+          // The modal is a CupertinoPage for the same reason settings itself
+          // uses one: only the Cupertino route honours `fullscreenDialog` on
+          // Android too. The pushed page is the MaterialPage go_router would
+          // have built itself, so it keeps the platform's push transition.
+          pageBuilder: (context, state) {
+            final child = AppRouteDef.settingsHarnesses._buildScreen(context: context, state: state);
+            final route = AppRouteSettingsHarnesses.fromParams(queryParams: state.uri.queryParameters);
+            return switch (route.presentation) {
+              HarnessSettingsPresentation.modal => CupertinoPage<void>(
+                key: state.pageKey,
+                fullscreenDialog: true,
+                child: child,
+              ),
+              HarnessSettingsPresentation.pushed => MaterialPage<void>(key: state.pageKey, child: child),
+            };
+          },
         ),
         GoRoute(
           path: _settingsProfileRouteSegment,

--- a/client/app/lib/features/new_session/new_session_screen.dart
+++ b/client/app/lib/features/new_session/new_session_screen.dart
@@ -292,7 +292,9 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
           selectedPluginId: data.plugin?.id,
           isSelectionEnabled: data.backendScope.isVerified && !data.isPluginDiscoveryInFlight,
           onSelected: (pluginId) => context.read<NewSessionCubit>().selectPlugin(pluginId: pluginId),
-          onSettingsPressed: () => context.pushRoute(const AppRoute.settingsHarnesses()),
+          onSettingsPressed: () => context.pushRoute(
+            const AppRoute.settingsHarnesses(presentation: HarnessSettingsPresentation.modal),
+          ),
         ),
         if (status != null) _buildOptionsStatus(status: status),
         if (data.supportsDedicatedWorktrees) ...[

--- a/client/app/lib/features/settings/harnesses_settings_screen.dart
+++ b/client/app/lib/features/settings/harnesses_settings_screen.dart
@@ -17,23 +17,33 @@ import "widgets/settings_section.dart";
 const double _contentTopPadding = 10.0;
 
 class HarnessesSettingsScreen extends StatelessWidget {
-  const HarnessesSettingsScreen({super.key});
+  const HarnessesSettingsScreen({super.key, required this.presentation});
+
+  /// How the page was raised, which decides how the user leaves it: a pushed
+  /// page goes back, a modal one closes.
+  final HarnessSettingsPresentation presentation;
 
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
       create: (_) => PluginManagementCubit(service: getIt<PluginManagementService>()),
-      child: const _HarnessesSettingsBody(),
+      child: _HarnessesSettingsBody(presentation: presentation),
     );
   }
 }
 
 class _HarnessesSettingsBody extends StatelessWidget {
-  const _HarnessesSettingsBody();
+  const _HarnessesSettingsBody({required this.presentation});
+
+  final HarnessSettingsPresentation presentation;
 
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
+    final isModal = switch (presentation) {
+      HarnessSettingsPresentation.modal => true,
+      HarnessSettingsPresentation.pushed => false,
+    };
     final cubit = context.read<PluginManagementCubit>();
     final state = context.watch<PluginManagementCubit>().state;
 
@@ -48,21 +58,23 @@ class _HarnessesSettingsBody extends StatelessWidget {
         title: loc.settingsHarnessesTitle,
         titleMode: PregoTopNavigationTitleMode.inline,
         banner: ConnectionBanner.maybeFor(context),
-        // The page always rises as a modal, so closing is the only way out and
-        // the close button below owns it. An implied back chevron would be a
-        // second, redundant dismissal in the same bar.
-        automaticallyImplyLeading: false,
+        // A modal has no page below it to go back to, so the close button is
+        // its only way out and an implied back chevron would be a second,
+        // redundant dismissal in the same bar. A pushed page is the other way
+        // round: the settings list sits underneath and the back chevron is the
+        // way back to it.
+        automaticallyImplyLeading: !isModal,
         actions: [
-          PregoButtonsIconGlass(
-            icon: TablerRegular.x,
-            semanticLabel: loc.settingsClose,
-            // This page is raised as a modal from more than one place, so
-            // closing it means going back to whatever raised it. Only a
-            // deep link arrives with nothing underneath, and that falls back
-            // to the app's home.
-            onPressed: () =>
-                context.canPop() ? context.pop() : context.goRoute(const AppRoute.projects()),
-          ),
+          if (isModal)
+            PregoButtonsIconGlass(
+              icon: TablerRegular.x,
+              semanticLabel: loc.settingsClose,
+              // Closing the modal means going back to whatever raised it. Only
+              // a deep link arrives with nothing underneath, and that falls
+              // back to the app's home.
+              onPressed: () =>
+                  context.canPop() ? context.pop() : context.goRoute(const AppRoute.projects()),
+            ),
         ],
         onRefresh: cubit.refresh,
         slivers: [

--- a/client/app/lib/features/settings/harnesses_settings_screen.dart
+++ b/client/app/lib/features/settings/harnesses_settings_screen.dart
@@ -48,6 +48,10 @@ class _HarnessesSettingsBody extends StatelessWidget {
         title: loc.settingsHarnessesTitle,
         titleMode: PregoTopNavigationTitleMode.inline,
         banner: ConnectionBanner.maybeFor(context),
+        // The page always rises as a modal, so closing is the only way out and
+        // the close button below owns it. An implied back chevron would be a
+        // second, redundant dismissal in the same bar.
+        automaticallyImplyLeading: false,
         actions: [
           PregoButtonsIconGlass(
             icon: TablerRegular.x,

--- a/client/app/lib/features/settings/settings_screen.dart
+++ b/client/app/lib/features/settings/settings_screen.dart
@@ -121,7 +121,11 @@ class _SettingsBody extends StatelessWidget {
                       icon: TablerRegular.plug,
                       title: Text(loc.settingsHarnessesTitle),
                       trailing: const Icon(TablerRegular.chevron_right),
-                      onTap: () => context.pushRoute(const AppRoute.settingsHarnesses()),
+                      onTap: () => context.pushRoute(
+                        const AppRoute.settingsHarnesses(
+                          presentation: HarnessSettingsPresentation.pushed,
+                        ),
+                      ),
                       isLast: true,
                     ),
                   ],

--- a/client/app/test/core/routing/app_route_test.dart
+++ b/client/app/test/core/routing/app_route_test.dart
@@ -41,7 +41,17 @@ void main() {
       expect(const AppRoute.login().buildPath(), "/login");
       expect(const AppRoute.projects().buildPath(), "/projects");
       expect(const AppRoute.settings().buildPath(), "/settings");
-      expect(const AppRoute.settingsHarnesses().buildPath(), "/settings/harnesses");
+    });
+
+    test("carries the presentation for settingsHarnesses", () {
+      expect(
+        const AppRoute.settingsHarnesses(presentation: HarnessSettingsPresentation.modal).buildPath(),
+        "/settings/harnesses?presentation=modal",
+      );
+      expect(
+        const AppRoute.settingsHarnesses(presentation: HarnessSettingsPresentation.pushed).buildPath(),
+        "/settings/harnesses?presentation=pushed",
+      );
     });
 
     test("substitutes projectId for sessions", () {
@@ -173,13 +183,28 @@ void main() {
 
       expect(children.map((route) => route.path), equals(["notifications", "harnesses", "profile"]));
       expect(children[0].builder!(_FakeBuildContext(), _FakeGoRouterState()), isA<NotificationSettingsScreen>());
-      // Harnesses rise as a modal from the settings list and from the
-      // new-session harness menu alike, so the route carries its own
-      // fullscreen-dialog page rather than the default push.
-      final harnessesPage =
-          children[1].pageBuilder!(_FakeBuildContext(), _FakeGoRouterState()) as CupertinoPage<void>;
-      expect(harnessesPage.fullscreenDialog, isTrue);
-      expect(harnessesPage.child, isA<HarnessesSettingsScreen>());
+      // Harnesses rise as a modal from the new-session harness menu and push
+      // in from the settings list, so the route builds its own page per
+      // presentation instead of taking the default push for both.
+      final harnessesModalPage =
+          children[1].pageBuilder!(
+                _FakeBuildContext(),
+                _FakeGoRouterState(queryParameters: {harnessSettingsPresentationQueryParam: "modal"}),
+              )
+              as CupertinoPage<void>;
+      expect(harnessesModalPage.fullscreenDialog, isTrue);
+      expect(harnessesModalPage.child, isA<HarnessesSettingsScreen>());
+      final harnessesPushedPage =
+          children[1].pageBuilder!(
+                _FakeBuildContext(),
+                _FakeGoRouterState(queryParameters: {harnessSettingsPresentationQueryParam: "pushed"}),
+              )
+              as MaterialPage<void>;
+      expect(harnessesPushedPage.child, isA<HarnessesSettingsScreen>());
+      expect(
+        (harnessesPushedPage.child as HarnessesSettingsScreen).presentation,
+        HarnessSettingsPresentation.pushed,
+      );
       expect(children[1].routes, isEmpty);
       expect(children[2].builder!(_FakeBuildContext(), _FakeGoRouterState()), isA<ProfileScreen>());
       expect(

--- a/client/app/test/features/settings/harnesses_settings_screen_test.dart
+++ b/client/app/test/features/settings/harnesses_settings_screen_test.dart
@@ -75,7 +75,7 @@ Widget _app() {
         path: "/",
         builder: (context, state) => BlocProvider<ConnectionOverlayCubit>.value(
           value: StubConnectionOverlayCubit(),
-          child: const HarnessesSettingsScreen(),
+          child: const HarnessesSettingsScreen(presentation: HarnessSettingsPresentation.modal),
         ),
       ),
       GoRoute(
@@ -96,7 +96,9 @@ Widget _app() {
 /// The app's real route table with a stand-in for whatever screen raises
 /// harness settings — the new-session harness menu in production. Exercises the
 /// close button's pop branch, which `_app` (mounted at the router root) cannot.
-Widget _appPushedFromOpener() {
+Widget _appPushedFromOpener({
+  HarnessSettingsPresentation presentation = HarnessSettingsPresentation.modal,
+}) {
   final rootNavigatorKey = GlobalKey<NavigatorState>();
   final router = GoRouter(
     navigatorKey: rootNavigatorKey,
@@ -106,7 +108,7 @@ Widget _appPushedFromOpener() {
         path: "/opener",
         builder: (context, state) => Scaffold(
           body: TextButton(
-            onPressed: () => context.pushRoute(const AppRoute.settingsHarnesses()),
+            onPressed: () => context.pushRoute(AppRoute.settingsHarnesses(presentation: presentation)),
             child: const Text("open-harnesses"),
           ),
         ),
@@ -894,5 +896,35 @@ void main() {
     expect(find.byType(HarnessesSettingsScreen), findsNothing);
     expect(find.text("open-harnesses"), findsOneWidget);
     expect(find.text("projects-route"), findsNothing);
+  });
+
+  testWidgets("raised as a modal, the bar closes with the X and shows no back button", (tester) async {
+    snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+    await tester.pumpWidget(_appPushedFromOpener());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text("open-harnesses"));
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel("Close settings"), findsOneWidget);
+    expect(find.bySemanticsLabel("Back"), findsNothing);
+  });
+
+  testWidgets("pushed onto the settings stack, the bar goes back and shows no close button", (tester) async {
+    snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+    await tester.pumpWidget(_appPushedFromOpener(presentation: HarnessSettingsPresentation.pushed));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text("open-harnesses"));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(HarnessesSettingsScreen), findsOneWidget);
+    expect(find.bySemanticsLabel("Close settings"), findsNothing);
+
+    await tester.tap(find.bySemanticsLabel("Back"));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(HarnessesSettingsScreen), findsNothing);
+    expect(find.text("open-harnesses"), findsOneWidget);
   });
 }

--- a/client/module_core/lib/src/routing/app_routes.dart
+++ b/client/module_core/lib/src/routing/app_routes.dart
@@ -4,6 +4,28 @@ const projectNameQueryParam = "name";
 const supportsDedicatedWorktreesQueryParam = "supportsDedicatedWorktrees";
 const projectIdPathParam = "projectId";
 const sessionIdPathParam = "sessionId";
+const harnessSettingsPresentationQueryParam = "presentation";
+
+/// How the harness settings page was raised, which decides both its page
+/// transition and the way out of it.
+enum HarnessSettingsPresentation {
+  /// Raised over a screen it does not belong to — the new-session harness
+  /// menu. It slides up as a modal and closes back onto its opener.
+  modal,
+
+  /// Pushed as the next page of the settings stack. It slides in like any
+  /// other settings page and returns with the back button.
+  pushed;
+
+  /// Reads a presentation from its URL spelling, or null when the value is
+  /// absent or unknown.
+  static HarnessSettingsPresentation? tryParse(String? value) {
+    for (final presentation in values) {
+      if (presentation.name == value) return presentation;
+    }
+    return null;
+  }
+}
 
 String _appendQuery({required String path, required Map<String, String> queryParameters}) {
   if (queryParameters.isEmpty) return path;
@@ -64,7 +86,9 @@ sealed class AppRoute {
   const factory AppRoute.projects() = AppRouteProjects;
   const factory AppRoute.settings() = AppRouteSettings;
   const factory AppRoute.settingsNotifications() = AppRouteSettingsNotifications;
-  const factory AppRoute.settingsHarnesses() = AppRouteSettingsHarnesses;
+  const factory AppRoute.settingsHarnesses({
+    required HarnessSettingsPresentation presentation,
+  }) = AppRouteSettingsHarnesses;
   const factory AppRoute.settingsProfile() = AppRouteSettingsProfile;
   const factory AppRoute.sessions({
     required String projectId,
@@ -103,7 +127,7 @@ sealed class AppRoute {
       AppRouteDef.projects => const AppRoute.projects(),
       AppRouteDef.settings => const AppRoute.settings(),
       AppRouteDef.settingsNotifications => const AppRoute.settingsNotifications(),
-      AppRouteDef.settingsHarnesses => const AppRoute.settingsHarnesses(),
+      AppRouteDef.settingsHarnesses => AppRouteSettingsHarnesses.fromParams(queryParams: queryParams),
       AppRouteDef.settingsProfile => const AppRoute.settingsProfile(),
       AppRouteDef.sessions => AppRouteSessions.fromParams(pathParams: pathParams, queryParams: queryParams),
       AppRouteDef.newSession => AppRouteNewSession.fromParams(pathParams: pathParams, queryParams: queryParams),
@@ -170,13 +194,34 @@ class AppRouteSettingsNotifications extends AppRoute {
 }
 
 class AppRouteSettingsHarnesses extends AppRoute {
-  const AppRouteSettingsHarnesses();
+  static const _presentationQueryParam = harnessSettingsPresentationQueryParam;
+
+  final HarnessSettingsPresentation presentation;
+
+  const AppRouteSettingsHarnesses({required this.presentation});
+
+  /// Decodes from query parameter maps (inverse of [buildPath]).
+  factory AppRouteSettingsHarnesses.fromParams({required Map<String, String> queryParams}) {
+    return AppRouteSettingsHarnesses(
+      // A deep link or a hand-typed URL names no presentation. It arrives over
+      // whatever was on screen rather than over the settings list, so it is
+      // raised the same way that detour is: as a modal with a way out.
+      presentation:
+          HarnessSettingsPresentation.tryParse(queryParams[_presentationQueryParam]) ??
+          HarnessSettingsPresentation.modal,
+    );
+  }
 
   @override
   AppRouteDef get def => AppRouteDef.settingsHarnesses;
 
   @override
-  String buildPath() => def.path;
+  String buildPath() {
+    return _appendQuery(
+      path: def.path,
+      queryParameters: {_presentationQueryParam: presentation.name},
+    );
+  }
 }
 
 class AppRouteSettingsProfile extends AppRoute {

--- a/client/module_core/test/routing/app_routes_test.dart
+++ b/client/module_core/test/routing/app_routes_test.dart
@@ -3,18 +3,41 @@ import "package:test/test.dart";
 
 void main() {
   group("AppRoute", () {
-    test("settings Harnesses route round-trips without extra state", () {
-      const route = AppRoute.settingsHarnesses();
+    test("settings Harnesses route round-trips its presentation", () {
+      for (final presentation in HarnessSettingsPresentation.values) {
+        final route = AppRoute.settingsHarnesses(presentation: presentation);
 
-      expect(route.buildPath(), "/settings/harnesses");
-      expect(
-        AppRoute.fromDef(
-          def: AppRouteDef.settingsHarnesses,
-          pathParams: const {},
-          queryParams: const {},
-        ),
-        isA<AppRouteSettingsHarnesses>(),
-      );
+        expect(route.buildPath(), "/settings/harnesses?presentation=${presentation.name}");
+        expect(
+          AppRoute.fromDef(
+            def: AppRouteDef.settingsHarnesses,
+            pathParams: const {},
+            queryParams: {harnessSettingsPresentationQueryParam: presentation.name},
+          ),
+          isA<AppRouteSettingsHarnesses>().having(
+            (route) => route.presentation,
+            "presentation",
+            presentation,
+          ),
+        );
+      }
+    });
+
+    test("settings Harnesses route without a known presentation decodes as a modal", () {
+      for (final queryParams in [const <String, String>{}, const {harnessSettingsPresentationQueryParam: "sheet"}]) {
+        expect(
+          AppRoute.fromDef(
+            def: AppRouteDef.settingsHarnesses,
+            pathParams: const {},
+            queryParams: queryParams,
+          ),
+          isA<AppRouteSettingsHarnesses>().having(
+            (route) => route.presentation,
+            "presentation",
+            HarnessSettingsPresentation.modal,
+          ),
+        );
+      }
     });
 
     test("settings Harness management route is removed", () {


### PR DESCRIPTION
## Complexity

Straightforward: one new route parameter threaded through the router and the
screen's top bar.

## What

Harness settings now present differently depending on where they are opened
from, instead of always being a modal:

- **Settings list** — pushes onto the settings stack as a plain `MaterialPage`
  and returns with the back chevron. No close button.
- **New-session harness menu** — rises as a modal
  (`CupertinoPage(fullscreenDialog: true)`) and closes with the X. No back
  chevron.

`AppRoute.settingsHarnesses` carries a `HarnessSettingsPresentation`
(`pushed` | `modal`), encoded as a `presentation` query parameter, so the
router picks the page type and the screen picks its dismissal affordance from
the same decoded route.

## Why

Previously both entry points shared one fullscreen-dialog page that showed a
back chevron and an X side by side — two dismissals in one bar, and the wrong
motion when the page is simply the next step in the settings stack. From the
settings list it belongs in that stack; from the new-session screen it is a
detour from an unrelated screen and a modal is right.

## Risk and test focus

Low. Presentation-only; no database, wire, or backend impact. The close
action itself is unchanged, including the fallback to Projects when nothing
sits underneath.

A URL that names no presentation — a deep link or a hand-typed address —
decodes as `modal`, so it always keeps a working way out rather than a back
chevron with nothing behind it.

Test focus: opening harness settings from both entry points, and dismissing
from each.

## Expected result

From Settings → Harnesses: slides in sideways, back chevron only. From the
new-session harness picker: slides up, X only, closing returns to the new
session screen.

## Verification

- New widget tests: each entry point shows exactly one dismissal affordance,
  and the pushed page's back button returns to the opener.
- Updated route round-trip tests for the `presentation` query parameter,
  including the unknown/absent-value fallback to `modal`.
- `flutter test` green for the harness settings, settings, new-session, and
  routing suites; `flutter analyze` clean for `app` and `module_core`.
