### PR TITLE
🌱 Treat desktop window occlusion as inactive, not backgrounded

### DIFF
--- a/client/app/lib/core/platform/app_lifecycle_observer.dart
+++ b/client/app/lib/core/platform/app_lifecycle_observer.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:flutter/foundation.dart" show TargetPlatform, defaultTargetPlatform, kIsWeb;
 import "package:flutter/widgets.dart";
 import "package:get_it/get_it.dart";
 import "package:injectable/injectable.dart";
@@ -33,10 +34,21 @@ class AppLifecycleObserver with WidgetsBindingObserver, Disposable implements Li
       switch (state) {
         .resumed => .resumed,
         .inactive => .inactive,
-        .hidden => .hidden,
+        // Desktop reports `hidden` for plain window occlusion (Cmd-Tab, another
+        // window on top, minimize) while the process, its relay socket and its
+        // timers keep running. That is not backgrounding, so it is reported as
+        // `inactive` and consumers keep their connection and viewed state.
+        .hidden => _isDesktop ? LifecycleState.inactive : LifecycleState.hidden,
         .paused => .paused,
         .detached => .detached,
       },
     );
   }
+
+  static bool get _isDesktop =>
+      !kIsWeb &&
+      switch (defaultTargetPlatform) {
+        TargetPlatform.macOS || TargetPlatform.windows || TargetPlatform.linux => true,
+        TargetPlatform.android || TargetPlatform.iOS || TargetPlatform.fuchsia => false,
+      };
 }

--- a/client/app/test/core/platform/app_lifecycle_observer_test.dart
+++ b/client/app/test/core/platform/app_lifecycle_observer_test.dart
@@ -11,14 +11,18 @@ void main() {
 
   test("window occlusion on desktop is inactive, not backgrounded", () {
     debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
-    final observer = AppLifecycleObserver()..didChangeAppLifecycleState(AppLifecycleState.hidden);
+    final observer = AppLifecycleObserver();
+    addTearDown(observer.onDispose);
+    observer.didChangeAppLifecycleState(AppLifecycleState.hidden);
 
     expect(observer.lifecycleState, LifecycleState.inactive);
   });
 
   test("hidden on mobile still reports backgrounding", () {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-    final observer = AppLifecycleObserver()..didChangeAppLifecycleState(AppLifecycleState.hidden);
+    final observer = AppLifecycleObserver();
+    addTearDown(observer.onDispose);
+    observer.didChangeAppLifecycleState(AppLifecycleState.hidden);
 
     expect(observer.lifecycleState, LifecycleState.hidden);
   });

--- a/client/app/test/core/platform/app_lifecycle_observer_test.dart
+++ b/client/app/test/core/platform/app_lifecycle_observer_test.dart
@@ -1,0 +1,25 @@
+import "package:flutter/foundation.dart";
+import "package:flutter/widgets.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_mobile/core/platform/app_lifecycle_observer.dart";
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  tearDown(() => debugDefaultTargetPlatformOverride = null);
+
+  test("window occlusion on desktop is inactive, not backgrounded", () {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    final observer = AppLifecycleObserver()..didChangeAppLifecycleState(AppLifecycleState.hidden);
+
+    expect(observer.lifecycleState, LifecycleState.inactive);
+  });
+
+  test("hidden on mobile still reports backgrounding", () {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    final observer = AppLifecycleObserver()..didChangeAppLifecycleState(AppLifecycleState.hidden);
+
+    expect(observer.lifecycleState, LifecycleState.hidden);
+  });
+}

--- a/client/desktop/lib/core/platform/desktop_lifecycle_observer.dart
+++ b/client/desktop/lib/core/platform/desktop_lifecycle_observer.dart
@@ -33,7 +33,11 @@ class DesktopLifecycleObserver with WidgetsBindingObserver, Disposable implement
       switch (state) {
         .resumed => .resumed,
         .inactive => .inactive,
-        .hidden => .hidden,
+        // `hidden` here only means the window is occluded (Cmd-Tab, another
+        // window on top, minimize); the process, its relay socket and its
+        // timers keep running, unlike a backgrounded phone. Report it as
+        // `inactive` so consumers keep their connection and viewed state.
+        .hidden => .inactive,
         .paused => .paused,
         .detached => .detached,
       },

--- a/client/module_core/lib/src/platform/lifecycle_source.dart
+++ b/client/module_core/lib/src/platform/lifecycle_source.dart
@@ -24,10 +24,12 @@ enum LifecycleState {
   // * -> Desktop -- app not in focus (user is interacting with other app)
   inactive,
 
-  // when app is no longer visible to the user
+  // when app is no longer visible to the user AND its work is suspended
   // * Mobile -> app is about to be paused
   // * Web -> running in a window or tab that is no longer visible
-  // * Desktop -> app was minimized or placed on a desktop that is no longer visible
+  // * Desktop -> NEVER ENTERS THIS STATE: the platform adapters report an
+  //   occluded or minimized desktop window as [inactive], because the process,
+  //   its socket, and its timers all keep running
   hidden,
 
   // when app is no longer visible to the user

--- a/client/module_core/lib/src/services/project_viewing_service.dart
+++ b/client/module_core/lib/src/services/project_viewing_service.dart
@@ -35,7 +35,8 @@ class ProjectViewPaneClaim {
 /// List and detail cubits contribute pending/ready claims. Route and adaptive
 /// pane visibility decide which ready claim is actually visible. The resulting
 /// declaration is serialized, cleared while the app is hidden, and reasserted
-/// after resume or relay reconnect. This is intentionally independent from
+/// after resume or relay reconnect. A desktop window that loses focus or is
+/// occluded reports [LifecycleState.inactive], so it keeps its declaration. This is intentionally independent from
 /// session-view declarations, whose mark-seen side effect has different rules.
 @lazySingleton
 class ProjectViewingService with Disposable {

--- a/client/module_core/lib/src/services/session_viewing_service.dart
+++ b/client/module_core/lib/src/services/session_viewing_service.dart
@@ -13,7 +13,9 @@ import "../repositories/session_view_repository.dart";
 /// session id and declares it to the bridge via [SessionViewRepository].
 ///
 /// On background it declares "viewing nothing" but retains the intended
-/// session. It deliberately does NOT auto-re-assert on resume or reconnect:
+/// session. Only a real background transition counts: a desktop window that
+/// loses focus or is occluded reports [LifecycleState.inactive] and keeps its
+/// declaration. It deliberately does NOT auto-re-assert on resume or reconnect:
 /// declaring "viewed" marks the session seen on the bridge (clearing its bold
 /// globally), so the owning `SessionDetailCubit` re-asserts only after its
 /// post-resume/reconnect refresh has rendered fresh content.


### PR DESCRIPTION
## Complexity

Two-line mapping change in the two lifecycle platform adapters, plus one test.
No consumer, service, cubit, or contract changes.

## What

On desktop, `AppLifecycleState.hidden` is now reported as `LifecycleState.inactive`
instead of `LifecycleState.hidden`.

- `AppLifecycleObserver` (mobile shell) applies this only on macOS/Windows/Linux;
  mobile and web keep the previous mapping.
- `DesktopLifecycleObserver` applies it unconditionally, since that shell only
  runs on desktop.

## Why

macOS emits `hidden` for plain window occlusion — Cmd-Tab, another window on top,
Mission Control, minimize. The process, its relay socket, its timers, and its SSE
stream all keep running, so this is nothing like a backgrounded phone. Every
consumer of `LifecycleState.hidden` treats it as backgrounding:

- `SessionViewingService` declares "viewing nothing" to the bridge.
- `ProjectViewingService` clears the declared project.
- `SessionDetailCubit` sets `_wasPaused`, cancels the refresh cooldown, and forces
  a full re-declare refresh on the next `resumed`.

The result was that clicking away from the Sesori window and back re-ran a whole
session-detail refresh cycle. `inactive` is the state macOS already uses for
"visible but not focused", and no consumer treats it as a background transition,
so the connection and viewed state now survive focus changes.

Mobile is untouched: iOS/Android backgrounding still emits `hidden` then `paused`,
and `paused` alone already drives every background code path.

## Risk and test focus

Low. `LifecycleState` itself, its consumers, and the wire contract are unchanged;
only what the desktop adapters emit changed.

- No database impact.
- No wire/transport contract impact.
- User-visible impact is desktop only: no refresh flash and no view-declaration
  churn when the window loses or regains focus.

Focus on desktop macOS: Cmd-Tab away from a session detail screen and back,
minimize and restore, and put another window fully over it. Genuine app quit and
mobile backgrounding are unaffected.

## Expected result

On macOS, taking focus away from the window and returning no longer triggers the
"needing full refresh" path on the session details screen, and the bridge keeps
seeing the session as viewed. Mobile background behavior is byte-for-byte the same.

## Verification

- `flutter test test/core/platform/app_lifecycle_observer_test.dart` (new) — asserts
  desktop `hidden` maps to `inactive` and mobile `hidden` still maps to `hidden`.
- `flutter test test/capabilities/server_connection/connection_service_test.dart` from `client/app`
- `dart test test/services/session_viewing_service_test.dart test/services/project_viewing_service_test.dart` from `client/module_core`
- `flutter test` from `client/desktop`
- `dart analyze --fatal-infos` in `client/app` and `client/desktop`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On desktop, window occlusion is now treated as inactive instead of backgrounded to avoid refresh churn when the app loses focus. Mobile and web behavior is unchanged.

- **Bug Fixes**
  - Map `AppLifecycleState.hidden` to `LifecycleState.inactive` on macOS/Windows/Linux; mobile/web keep `hidden`.
  - `AppLifecycleObserver` uses `defaultTargetPlatform` and `kIsWeb` to apply the mapping only on desktop.
  - `DesktopLifecycleObserver` unconditionally maps `hidden` to `inactive`.
  - Added tests covering desktop (inactive) and mobile (hidden).

- **Refactors**
  - Clarified `LifecycleState.hidden` docs: desktop never enters `hidden`; occluded/minimized windows are `inactive`.
  - Updated service docs to note desktop occlusion keeps viewed declarations.

<sup>Written for commit 03ff2ad4e69b8248d30adca0939faad628f46831. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

