### PR TITLE
⚙️ Keep cached PR status when a waited refresh fails

### DIFF
--- a/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
@@ -11,8 +11,6 @@ import "request_handler.dart";
 ///
 /// Reads the durable catalog and applies bridge-owned enrichment.
 class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionListResponse> {
-  static const _maximumFallbackReserve = Duration(milliseconds: 100);
-
   final SessionRepository _sessionRepository;
   final PrSyncService _prSyncService;
   final Duration _prRefreshTimeout;
@@ -57,117 +55,96 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
       verifiedGithubLogin: null,
     );
     final timeoutStopwatch = Stopwatch()..start();
-    final halfRefreshTimeout = Duration(microseconds: _prRefreshTimeout.inMicroseconds ~/ 2);
-    final fallbackReserve = halfRefreshTimeout.compareTo(_maximumFallbackReserve) < 0
-        ? halfRefreshTimeout
-        : _maximumFallbackReserve;
-    final mainDeadline = _prRefreshTimeout - fallbackReserve;
+    final prRefreshFuture = _triggerPrRefresh(
+      projectId: projectId,
+      refreshPolicy: body.waitForPrData ? PrRefreshPolicy.explicit : PrRefreshPolicy.background,
+    );
 
+    final List<Session> identityGatedSessions;
     try {
-      return await _readIdentityGatedPullRequestData(
-        projectId: projectId,
+      identityGatedSessions = await _readIdentityGatedPullRequestData(
         sessionsWithoutPullRequestData: sessionsWithoutPullRequestData,
-        waitForPrData: body.waitForPrData,
-      ).timeout(mainDeadline);
-    } on _PrRefreshFailedException {
-      return _buildPrFreeFallbackResponse(
-        sessionsWithoutPullRequestData: sessionsWithoutPullRequestData,
-        timeoutStopwatch: timeoutStopwatch,
-      );
+      ).timeout(_prRefreshTimeout);
     } on Object catch (error, stackTrace) {
+      unawaited(prRefreshFuture);
       Log.w(
-        "PR identity-gated read or refresh work failed after waiting up to "
-        "${_prRefreshTimeout.inSeconds}s — returning sessions without cached PR data",
+        "PR identity-gated read did not finish within ${_prRefreshTimeout.inSeconds}s — "
+        "returning sessions without cached PR data",
         error,
         stackTrace,
       );
-      return _buildPrFreeFallbackResponse(
-        sessionsWithoutPullRequestData: sessionsWithoutPullRequestData,
-        timeoutStopwatch: timeoutStopwatch,
-      );
-    }
-  }
-
-  Future<SessionListResponse> _readIdentityGatedPullRequestData({
-    required String projectId,
-    required List<Session> sessionsWithoutPullRequestData,
-    required bool waitForPrData,
-  }) async {
-    final prRefreshFuture = _triggerPrRefresh(
-      projectId: projectId,
-      refreshPolicy: waitForPrData ? PrRefreshPolicy.explicit : PrRefreshPolicy.background,
-    );
-    var sessions = sessionsWithoutPullRequestData;
-    final verifiedGithubLogin = await _prSyncService.verifyGithubIdentity();
-    try {
-      sessions = await _sessionRepository.enrichSessions(
-        sessions: sessions,
-        verifiedGithubLogin: verifiedGithubLogin,
-      );
-    } on Object catch (error, stackTrace) {
-      Log.w("GetSessionsHandler: post-publication enrichment failed", error, stackTrace);
+      return SessionListResponse(items: sessionsWithoutPullRequestData);
     }
 
-    if (!waitForPrData) {
+    if (!body.waitForPrData) {
       // COMPATIBILITY 2026-08-01 (v1.6.1): Released clients rely on the
       // non-waiting request to trigger background PR refresh. Remove this path
       // only after those client versions are no longer supported.
       unawaited(prRefreshFuture);
-      return SessionListResponse(items: sessions);
+      return SessionListResponse(items: identityGatedSessions);
     }
 
-    final refreshOutcome = await prRefreshFuture;
-    if (refreshOutcome != PrRefreshOutcome.completed) {
-      throw const _PrRefreshFailedException();
-    }
-
-    // Refresh succeeded within the shared request deadline. Verify identity
-    // again before mapping updated PR/CI metadata from the database.
-    final refreshedGithubLogin = await _prSyncService.verifyGithubIdentity();
-    final enrichedSessions = await _sessionRepository.enrichSessions(
-      sessions: sessions,
-      verifiedGithubLogin: refreshedGithubLogin,
-    );
-    return SessionListResponse(items: enrichedSessions);
-  }
-
-  Future<SessionListResponse> _buildPrFreeFallbackResponse({
-    required List<Session> sessionsWithoutPullRequestData,
-    required Stopwatch timeoutStopwatch,
-  }) async {
-    final fallbackBudget = _remainingBudget(
-      timeoutStopwatch: timeoutStopwatch,
-      deadline: _prRefreshTimeout,
-    );
-    if (fallbackBudget == Duration.zero) {
-      return SessionListResponse(items: sessionsWithoutPullRequestData);
-    }
     return SessionListResponse(
-      items: await _reEnrichWithoutPullRequestData(
-        sessionsWithoutPullRequestData: sessionsWithoutPullRequestData,
-        timeout: fallbackBudget,
+      items: await _awaitRefreshedPullRequestData(
+        prRefreshFuture: prRefreshFuture,
+        identityGatedSessions: identityGatedSessions,
+        deadline: _remainingBudget(timeoutStopwatch: timeoutStopwatch, deadline: _prRefreshTimeout),
       ),
     );
   }
 
-  Future<List<Session>> _reEnrichWithoutPullRequestData({
+  Future<List<Session>> _readIdentityGatedPullRequestData({
     required List<Session> sessionsWithoutPullRequestData,
-    required Duration timeout,
   }) async {
+    final verifiedGithubLogin = await _prSyncService.verifyGithubIdentity();
     try {
+      return await _sessionRepository.enrichSessions(
+        sessions: sessionsWithoutPullRequestData,
+        verifiedGithubLogin: verifiedGithubLogin,
+      );
+    } on Object catch (error, stackTrace) {
+      Log.w("GetSessionsHandler: post-publication enrichment failed", error, stackTrace);
+      return sessionsWithoutPullRequestData;
+    }
+  }
+
+  /// Waits for the explicit refresh and re-reads PR metadata within [deadline].
+  ///
+  /// A failed, slow, or unreadable refresh keeps [identityGatedSessions] — the
+  /// snapshot this request already read behind a fresh identity check — instead
+  /// of downgrading the response to PR-free data. Discarding it would clear the
+  /// rendered PR status of every session on an explicit pull-to-refresh.
+  Future<List<Session>> _awaitRefreshedPullRequestData({
+    required Future<PrRefreshOutcome> prRefreshFuture,
+    required List<Session> identityGatedSessions,
+    required Duration deadline,
+  }) async {
+    if (deadline == Duration.zero) {
+      unawaited(prRefreshFuture);
+      return identityGatedSessions;
+    }
+    final refreshStopwatch = Stopwatch()..start();
+    try {
+      if (await prRefreshFuture.timeout(deadline) != PrRefreshOutcome.completed) {
+        return identityGatedSessions;
+      }
+      // Refresh succeeded within the shared request deadline. Verify identity
+      // again before mapping updated PR/CI metadata from the database.
+      final refreshedGithubLogin = await _prSyncService.verifyGithubIdentity();
       return await _sessionRepository
           .enrichSessions(
-            sessions: sessionsWithoutPullRequestData,
-            verifiedGithubLogin: null,
+            sessions: identityGatedSessions,
+            verifiedGithubLogin: refreshedGithubLogin,
           )
-          .timeout(timeout);
+          .timeout(_remainingBudget(timeoutStopwatch: refreshStopwatch, deadline: deadline));
     } on Object catch (error, stackTrace) {
       Log.w(
-        "GetSessionsHandler: PR-free fallback enrichment failed; returning the original snapshot",
+        "PR refresh did not produce a readable snapshot within "
+        "${_prRefreshTimeout.inSeconds}s — keeping the identity-gated PR data already read",
         error,
         stackTrace,
       );
-      return sessionsWithoutPullRequestData;
+      return identityGatedSessions;
     }
   }
 
@@ -194,8 +171,4 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
       return PrRefreshOutcome.failed;
     }
   }
-}
-
-final class _PrRefreshFailedException implements Exception {
-  const _PrRefreshFailedException();
 }

--- a/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
@@ -130,7 +130,9 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
       }
       // Refresh succeeded within the shared request deadline. Verify identity
       // again before mapping updated PR/CI metadata from the database.
-      final refreshedGithubLogin = await _prSyncService.verifyGithubIdentity();
+      final refreshedGithubLogin = await _prSyncService.verifyGithubIdentity().timeout(
+        _remainingBudget(timeoutStopwatch: refreshStopwatch, deadline: deadline),
+      );
       return await _sessionRepository
           .enrichSessions(
             sessions: identityGatedSessions,

--- a/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
@@ -1088,7 +1088,7 @@ void main() {
       expect(plugin.lastGetCurrentProjectProjectId, isNull);
     });
 
-    test("returns the latest PR-free branch when a waited refresh times out", () async {
+    test("keeps identity-gated PR data on the latest branch when a waited refresh times out", () async {
       plugin.sessionsResult = const [
         PluginSession(
           id: "s1",
@@ -1148,8 +1148,7 @@ void main() {
         final result = await response;
         expect(result.items, hasLength(1));
         expect(result.items.single.branchName, "feature/b");
-        expect(result.items.single.pullRequest, isNull);
-        expect(result.items.single.pullRequestHistory, isEmpty);
+        expect(result.items.single.pullRequest?.number, 98);
         expect(sessionRepository.getSessionsCallCount, equals(1));
       } finally {
         refreshBlocker.complete();
@@ -1158,7 +1157,7 @@ void main() {
       }
     });
 
-    test("returns the original snapshot when timeout fallback enrichment stalls", () async {
+    test("returns PR-free sessions when the identity-gated read itself stalls", () async {
       plugin.sessionsResult = const [
         PluginSession(
           id: "s1",
@@ -1170,24 +1169,33 @@ void main() {
         ),
       ];
       sessionDao.setSession(_storedSession(currentBranchName: "feature/a"));
-      final fallbackBlockingRepository = _FallbackBlockingSessionRepository(
+      pullRequestRepository.setPr(
+        sessionId: "s1",
+        pullRequest: const PullRequestDto(
+          projectId: "p1",
+          githubRepositoryIdentity: "org/repo",
+          githubLogin: "octocat",
+          prNumber: 96,
+          branchName: "feature/a",
+          url: "https://github.com/org/repo/pull/96",
+          title: "Unreadable PR",
+          state: PrState.open,
+          mergeableStatus: PrMergeableStatus.mergeable,
+          reviewDecision: PrReviewDecision.approved,
+          checkStatus: PrCheckStatus.success,
+          lastCheckedAt: 1,
+          createdAt: 1,
+        ),
+      );
+      final stalledEnrichmentRepository = _StalledEnrichmentSessionRepository(
         plugin: plugin,
         sessionDao: sessionDao,
         pullRequestRepository: pullRequestRepository,
         persistenceDatabase: db,
-        initialBranchName: "feature/a",
       );
-      final branchPersisted = Completer<void>();
-      final stalledRefresh = Completer<void>();
       final timeoutHandler = GetSessionsHandler(
-        sessionRepository: fallbackBlockingRepository,
-        prSyncService: FakePrSyncService(
-          refreshAction: () async {
-            sessionDao.setSession(_storedSession(currentBranchName: "feature/b"));
-            branchPersisted.complete();
-            await stalledRefresh.future;
-          },
-        ),
+        sessionRepository: stalledEnrichmentRepository,
+        prSyncService: FakePrSyncService(),
         prRefreshTimeout: const Duration(milliseconds: 40),
       );
 
@@ -1201,14 +1209,12 @@ void main() {
           )
           .timeout(const Duration(milliseconds: 500));
 
-      expect(branchPersisted.isCompleted, isTrue);
-      expect(fallbackBlockingRepository.fallbackEnrichmentStarted.isCompleted, isTrue);
-      expect(result.items.single.branchName, "feature/a");
+      expect(stalledEnrichmentRepository.enrichmentStarted.isCompleted, isTrue);
       expect(result.items.single.pullRequest, isNull);
       expect(result.items.single.pullRequestHistory, isEmpty);
     });
 
-    test("returns the original PR-free snapshot when timeout fallback enrichment fails", () async {
+    test("keeps identity-gated PR data when the post-refresh re-read fails", () async {
       plugin.sessionsResult = const [
         PluginSession(
           id: "s1",
@@ -1219,50 +1225,49 @@ void main() {
           time: null,
         ),
       ];
-      final fallbackFailingRepository = _FallbackFailingSessionRepository(
+      pullRequestRepository.setPr(
+        sessionId: "s1",
+        pullRequest: const PullRequestDto(
+          projectId: "p1",
+          githubRepositoryIdentity: "org/repo",
+          githubLogin: "octocat",
+          prNumber: 95,
+          branchName: "feature/reread-failure",
+          url: "https://github.com/org/repo/pull/95",
+          title: "Preserved PR",
+          state: PrState.open,
+          mergeableStatus: PrMergeableStatus.mergeable,
+          reviewDecision: PrReviewDecision.approved,
+          checkStatus: PrCheckStatus.success,
+          lastCheckedAt: 1,
+          createdAt: 1,
+        ),
+      );
+      final rereadFailingRepository = _RereadFailingSessionRepository(
         plugin: plugin,
         sessionDao: sessionDao,
         pullRequestRepository: pullRequestRepository,
         persistenceDatabase: db,
       );
-      final refreshStarted = Completer<void>();
-      final refreshBlocker = Completer<void>();
-      final refreshReleased = Completer<void>();
       final timeoutHandler = GetSessionsHandler(
-        sessionRepository: fallbackFailingRepository,
-        prSyncService: FakePrSyncService(
-          refreshAction: () async {
-            refreshStarted.complete();
-            await refreshBlocker.future;
-            refreshReleased.complete();
-          },
-        ),
-        prRefreshTimeout: const Duration(milliseconds: 20),
+        sessionRepository: rereadFailingRepository,
+        prSyncService: FakePrSyncService(),
       );
 
-      final response = timeoutHandler.handle(
+      final result = await timeoutHandler.handle(
         makeRequest("POST", "/sessions"),
         body: const SessionListRequest(projectId: "p1", start: null, limit: null, waitForPrData: true),
         pathParams: {},
         queryParams: {},
         fragment: null,
       );
-      await refreshStarted.future;
 
-      try {
-        final result = await response;
-        expect(result.items.single.title, "session one");
-        expect(result.items.single.pullRequest, isNull);
-        expect(result.items.single.pullRequestHistory, isEmpty);
-        expect(fallbackFailingRepository.enrichmentAttempts, 2);
-      } finally {
-        refreshBlocker.complete();
-        await refreshReleased.future;
-        await Future<void>.delayed(Duration.zero);
-      }
+      expect(result.items.single.title, "session one");
+      expect(result.items.single.pullRequest?.number, 95);
+      expect(rereadFailingRepository.enrichmentAttempts, 2);
     });
 
-    test("returns the latest PR-free branch when a refresh fails near the main deadline", () async {
+    test("keeps identity-gated PR data on the latest branch when a refresh fails", () async {
       plugin.sessionsResult = const [
         PluginSession(
           id: "s1",
@@ -1283,7 +1288,7 @@ void main() {
           prNumber: 100,
           branchName: "feature/failed-refresh",
           url: "https://github.com/org/repo/pull/100",
-          title: "Stale PR",
+          title: "Retained PR",
           state: PrState.open,
           mergeableStatus: PrMergeableStatus.mergeable,
           reviewDecision: PrReviewDecision.approved,
@@ -1296,19 +1301,11 @@ void main() {
         refreshOutcome: PrRefreshOutcome.failed,
         refreshAction: () async {
           sessionDao.setSession(_storedSession(currentBranchName: "feature/new"));
-          await Future<void>.delayed(const Duration(milliseconds: 150));
         },
-      );
-      final delayedFallbackRepository = _DelayedPrFreeEnrichmentSessionRepository(
-        plugin: plugin,
-        sessionDao: sessionDao,
-        pullRequestRepository: pullRequestRepository,
-        persistenceDatabase: db,
-        delay: const Duration(milliseconds: 75),
       );
       const prRefreshTimeout = Duration(milliseconds: 300);
       final failingHandler = GetSessionsHandler(
-        sessionRepository: delayedFallbackRepository,
+        sessionRepository: sessionRepository,
         prSyncService: failedRefresh,
         prRefreshTimeout: prRefreshTimeout,
       );
@@ -1324,13 +1321,12 @@ void main() {
           .timeout(prRefreshTimeout);
 
       expect(result.items.single.branchName, "feature/new");
-      expect(result.items.single.pullRequest, isNull);
-      expect(result.items.single.pullRequestHistory, isEmpty);
-      expect(delayedFallbackRepository.getSessionsCallCount, 1);
-      expect(delayedFallbackRepository.enrichSessionsCallCount, 2);
+      expect(result.items.single.pullRequest?.number, 100);
+      expect(sessionRepository.getSessionsCallCount, 1);
+      expect(sessionRepository.enrichSessionsCallCount, 1);
       expect(failedRefresh.calls.single.refreshPolicy, PrRefreshPolicy.explicit);
     });
-    test("keeps final identity verification inside the waited deadline", () async {
+    test("keeps identity-gated PR data when final identity verification exceeds the deadline", () async {
       plugin.sessionsResult = const [
         PluginSession(
           id: "s1",
@@ -1379,12 +1375,11 @@ void main() {
         fragment: null,
       );
 
-      expect(result.items.single.pullRequest, isNull);
-      expect(result.items.single.pullRequestHistory, isEmpty);
+      expect(result.items.single.pullRequest?.number, 102);
       await Future<void>.delayed(const Duration(milliseconds: 110));
     });
 
-    test("converts asynchronous refresh errors to a PR-free response", () async {
+    test("keeps identity-gated PR data when the refresh throws asynchronously", () async {
       plugin.sessionsResult = const [
         PluginSession(
           id: "s1",
@@ -1395,6 +1390,24 @@ void main() {
           time: null,
         ),
       ];
+      pullRequestRepository.setPr(
+        sessionId: "s1",
+        pullRequest: const PullRequestDto(
+          projectId: "p1",
+          githubRepositoryIdentity: "org/repo",
+          githubLogin: "octocat",
+          prNumber: 103,
+          branchName: "feature/refresh-error",
+          url: "https://github.com/org/repo/pull/103",
+          title: "Retained across refresh error",
+          state: PrState.open,
+          mergeableStatus: PrMergeableStatus.mergeable,
+          reviewDecision: PrReviewDecision.approved,
+          checkStatus: PrCheckStatus.success,
+          lastCheckedAt: 1,
+          createdAt: 1,
+        ),
+      );
       final failingHandler = GetSessionsHandler(
         sessionRepository: sessionRepository,
         prSyncService: FakePrSyncService(refreshError: StateError("refresh failed")),
@@ -1408,8 +1421,7 @@ void main() {
         fragment: null,
       );
 
-      expect(result.items.single.pullRequest, isNull);
-      expect(result.items.single.pullRequestHistory, isEmpty);
+      expect(result.items.single.pullRequest?.number, 103);
     });
 
     test("enriches sessions when PR refresh succeeds within timeout", () async {
@@ -1506,10 +1518,11 @@ final class _IdentityBlockingPrSyncService extends FakePrSyncService {
   }
 }
 
-final class _FallbackFailingSessionRepository extends FakeSessionRepository {
+/// Fails only the post-refresh re-read, keeping the first identity-gated read.
+final class _RereadFailingSessionRepository extends FakeSessionRepository {
   int enrichmentAttempts = 0;
 
-  _FallbackFailingSessionRepository({
+  _RereadFailingSessionRepository({
     required super.plugin,
     required super.sessionDao,
     required super.pullRequestRepository,
@@ -1523,7 +1536,7 @@ final class _FallbackFailingSessionRepository extends FakeSessionRepository {
   }) {
     enrichmentAttempts++;
     if (enrichmentAttempts == 2) {
-      throw StateError("fallback enrichment failed");
+      throw StateError("post-refresh re-read failed");
     }
     return super.enrichSessions(
       sessions: sessions,
@@ -1532,75 +1545,25 @@ final class _FallbackFailingSessionRepository extends FakeSessionRepository {
   }
 }
 
-final class _DelayedPrFreeEnrichmentSessionRepository extends FakeSessionRepository {
-  final Duration delay;
+final class _StalledEnrichmentSessionRepository extends FakeSessionRepository {
+  final Completer<void> enrichmentStarted = Completer<void>();
+  final Completer<List<Session>> _stalled = Completer<List<Session>>();
 
-  _DelayedPrFreeEnrichmentSessionRepository({
+  _StalledEnrichmentSessionRepository({
     required super.plugin,
     required super.sessionDao,
     required super.pullRequestRepository,
     required super.persistenceDatabase,
-    required this.delay,
   });
-
-  @override
-  Future<List<Session>> enrichSessions({
-    required List<Session> sessions,
-    required VerifiedGithubLogin? verifiedGithubLogin,
-  }) async {
-    if (verifiedGithubLogin == null) {
-      await Future<void>.delayed(delay);
-    }
-    return super.enrichSessions(
-      sessions: sessions,
-      verifiedGithubLogin: verifiedGithubLogin,
-    );
-  }
-}
-
-final class _FallbackBlockingSessionRepository extends FakeSessionRepository {
-  final String initialBranchName;
-  final Completer<void> fallbackEnrichmentStarted = Completer<void>();
-  final Completer<List<Session>> _stalledFallback = Completer<List<Session>>();
-
-  _FallbackBlockingSessionRepository({
-    required super.plugin,
-    required super.sessionDao,
-    required super.pullRequestRepository,
-    required super.persistenceDatabase,
-    required this.initialBranchName,
-  });
-
-  @override
-  Future<List<Session>> getSessionsForProject({
-    required String projectId,
-    required int? start,
-    required int? limit,
-    required VerifiedGithubLogin? verifiedGithubLogin,
-  }) async {
-    final sessions = await super.getSessionsForProject(
-      projectId: projectId,
-      start: start,
-      limit: limit,
-      verifiedGithubLogin: verifiedGithubLogin,
-    );
-    return [
-      for (final session in sessions) session.copyWith(branchName: initialBranchName),
-    ];
-  }
 
   @override
   Future<List<Session>> enrichSessions({
     required List<Session> sessions,
     required VerifiedGithubLogin? verifiedGithubLogin,
   }) {
-    if (verifiedGithubLogin == null) {
-      fallbackEnrichmentStarted.complete();
-      return _stalledFallback.future;
+    if (!enrichmentStarted.isCompleted) {
+      enrichmentStarted.complete();
     }
-    return super.enrichSessions(
-      sessions: sessions,
-      verifiedGithubLogin: verifiedGithubLogin,
-    );
+    return _stalled.future;
   }
 }

--- a/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
@@ -1367,6 +1367,7 @@ void main() {
         prRefreshTimeout: const Duration(milliseconds: 10),
       );
 
+      final elapsed = Stopwatch()..start();
       final result = await boundedHandler.handle(
         makeRequest("POST", "/sessions"),
         body: const SessionListRequest(projectId: "p1", start: null, limit: null, waitForPrData: true),
@@ -1374,8 +1375,10 @@ void main() {
         queryParams: {},
         fragment: null,
       );
+      elapsed.stop();
 
       expect(result.items.single.pullRequest?.number, 102);
+      expect(elapsed.elapsed, lessThan(const Duration(milliseconds: 100)));
       await Future<void>.delayed(const Duration(milliseconds: 110));
     });
 


### PR DESCRIPTION
## Complexity

Moderate. The change is small but sits in the shared request deadline logic of
`GetSessionsHandler`, and several existing tests had encoded the buggy behavior
as their expectation.

## What

On the explicit pull-to-refresh path (`waitForPrData: true`), `GetSessionsHandler`
no longer discards PR metadata it has already read.

Previously the handler read an identity-gated snapshot (fresh `gh` identity check
plus cached PR/CI join), then awaited the GitHub refresh. If that refresh failed,
timed out, or its post-refresh re-read stalled, the handler threw away the
snapshot it already had and deliberately re-enriched with `verifiedGithubLogin:
null` — a response with `pullRequest: null` and an empty `pullRequestHistory` for
every session.

Now the identity-gated snapshot is the retained baseline. A failed or slow refresh
means "no newer data", not "no data". The dedicated PR-free fallback re-enrichment
and its reserve budget are gone; only a stalled or failed identity-gated read
itself still returns PR-free sessions, which is correct because in that case no PR
data was successfully read.

## Why

Users saw PR status vanish for every session in a project after a pull to refresh.

The client-side merge in `SessionListService.applySessionUpdatedEvent` treats
omitted PR fields as "retain previous", but only for SSE `session.updated` events.
A REST `POST /sessions` response is authoritative and replaces `_allSessions`
wholesale, so a PR-free bridge response clears the entire list's PR status. The
bridge was producing exactly that response on any explicit-refresh failure —
`gh` hiccup, GitHub timeout, transient network failure — which matches the
intermittent, all-sessions-at-once symptom.

Deliberately blanking PR data is only correct when identity is unknown or changed
(fail-closed privacy). A refresh failure is not an identity failure: the snapshot
was already read behind a fresh identity check and remains safe to return.

## Risk and test focus

- **Privacy**: unchanged. PR data is still gated on a fresh `verifyGithubIdentity()`
  before it is read. An unknown or switched login still yields no PR data, and the
  final identity recheck still gates the post-refresh re-read. The only difference
  is that a *refresh* failure no longer discards a snapshot that already passed the
  identity gate.
- **Staleness**: on a failed refresh the client now sees the last known PR status
  instead of none. This is the same data any non-waiting session load returns, and
  a later successful refresh corrects it.
- **Deadline**: the total request budget is still `prRefreshTimeout` (5 s default).
  The reserve carve-out is removed because there is no longer a second enrichment
  pass to fund; the refresh wait and the re-read now share the remaining budget.

Focus review on `_awaitRefreshedPullRequestData` in
`bridge/app/lib/src/bridge/routing/get_sessions_handler.dart`.

## Expected result

- Pull to refresh with a healthy `gh` and GitHub: unchanged, PR status updates.
- Pull to refresh while GitHub or `gh` is failing or slow: sessions keep their
  previously known PR status instead of all going blank.
- Switched or unverifiable GitHub identity: PR data still hidden, unchanged.

No database impact. No wire-contract change — `SessionListRequest` and
`SessionListResponse` are untouched, so older and newer clients are unaffected.
No client-side change.

## Verification

- `dart analyze --fatal-infos lib test` in `bridge/app` — clean.
- `dart test test/bridge/` in `bridge/app` — 1360 tests pass.
- Five existing tests had asserted the wipe (`expect(pullRequest, isNull)` after a
  failed or timed-out refresh); they now assert retention. Two fakes that only
  existed to exercise the removed PR-free fallback were replaced with fakes that
  stall the identity-gated read and fail the post-refresh re-read.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the cached, identity-verified PR data when an explicit pull-to-refresh fails or times out, so sessions retain their last known PR status instead of going blank. Also bounds the post-refresh identity check to the request deadline to prevent overruns.

- **Bug Fixes**
  - Treat failed/slow refresh as “no newer data,” not “no data.”
  - Retain the identity-gated snapshot; only a failed identity-gated read returns PR-free sessions.
  - Bound the post-refresh `verifyGithubIdentity()` to the remaining request budget; keep cached PR data if it times out.
  - Non-waiting requests still trigger background refresh.
  - Privacy unchanged; PR data remains behind fresh identity verification.

- **Refactors**
  - Removed the PR-free fallback path and its reserve budget.
  - Consolidated refresh wait and post-refresh re-read under the shared request deadline.
  - Updated tests to assert PR status retention on refresh failures.

<sup>Written for commit 9242ce852333b5699886e5ae8ac48e59cc544883. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

