### PR TITLE
⚙️ [read-only-archiving] Reject unarchive and delete restore machinery [step 2/4]

### DIFF
--- a/.plan/active/read-only-archiving/TRACKER.md
+++ b/.plan/active/read-only-archiving/TRACKER.md
@@ -3,20 +3,20 @@
 ## Current State
 
 - **Plan slug:** `read-only-archiving`
-- **Implementation base:** `origin/main` at `232974e1`
-- **Series state:** Step 1/4 plan PR open
-- **Current step:** 1/4
-- **Plan PR:** [#765](https://github.com/sesori-ai/sesori_apps_monorepo/pull/765)
+- **Implementation base:** `origin/main` at `483e9401`
+- **Series state:** Step 2/4 in PR
+- **Current step:** 2/4
+- **Plan PR:** [#765](https://github.com/sesori-ai/sesori_apps_monorepo/pull/765) merged
 - **Relationship:** prerequisite of `internal-chat-history`; that series does
   not start until this one has fully merged.
-- **Next action:** merge PR #765, then start step 2/4.
+- **Next action:** merge step 2/4, then start step 3/4.
 
 ## Delivery Steps
 
 | Done | Step | Exact PR title | State |
 |---|---|---|---|
-| [ ] | 1/4 | `🌱 [read-only-archiving] Raise plan [step 1/4]` | [PR #765](https://github.com/sesori-ai/sesori_apps_monorepo/pull/765) open |
-| [ ] | 2/4 | `⚙️ [read-only-archiving] Reject unarchive and delete restore machinery [step 2/4]` | pending |
+| [x] | 1/4 | `🌱 [read-only-archiving] Raise plan [step 1/4]` | [PR #765](https://github.com/sesori-ai/sesori_apps_monorepo/pull/765) merged |
+| [ ] | 2/4 | `⚙️ [read-only-archiving] Reject unarchive and delete restore machinery [step 2/4]` | in PR |
 | [ ] | 3/4 | `🌿 [read-only-archiving] Enforce read-only archived sessions [step 3/4]` | pending |
 | [ ] | 4/4 | `🌱 [read-only-archiving] Retire plan [step 4/4]` | pending |
 
@@ -33,8 +33,16 @@
 
 ## Verification Log
 
-- (empty)
+- 2026-08-07 (step 2/4) — `bridge/app`: `dart analyze --fatal-infos .` clean,
+  `dart test` 2430 passing. `shared/sesori_shared`: `dart analyze
+  --fatal-infos .` clean, `dart test` 364 passing.
 
 ## Findings And Plan Deltas
 
-- (empty)
+- 2026-08-07 (step 2/4) — `ArchivedSessionValidator.requireNotArchived` takes
+  only `sessionId`. It reads `SessionRepository.getStoredSession`, which is a
+  durable catalog read and needs no `SessionOperation` for plugin routing;
+  passing one would have been unused ceremony.
+- 2026-08-07 (step 2/4) — an unknown session passes the validator so the
+  caller keeps owning the 404 decision (the lifecycle service already resolves
+  the stored session before consulting it).

--- a/bridge/app/lib/src/api/database/daos/session_dao.dart
+++ b/bridge/app/lib/src/api/database/daos/session_dao.dart
@@ -426,20 +426,6 @@ class SessionDao extends DatabaseAccessor<AppDatabase> with _$SessionDaoMixin {
     );
   }
 
-  Future<void> clearArchived({
-    required String sessionId,
-    required int updatedAt,
-    required int projectionUpdatedAt,
-  }) async {
-    await (update(sessionTable)..where((t) => t.sessionId.equals(sessionId))).write(
-      SessionTableCompanion(
-        archivedAt: const Value(null),
-        updatedAt: Value(updatedAt),
-        projectionUpdatedAt: Value(projectionUpdatedAt),
-      ),
-    );
-  }
-
   Future<List<SessionDto>> getSessionsByProject({required String projectId}) async {
     return (select(sessionTable)..where((t) => t.projectId.equals(projectId))).get();
   }

--- a/bridge/app/lib/src/bridge/api/git_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/git_cli_api.dart
@@ -552,28 +552,6 @@ class GitCliApi {
     return result.exitCode == 0;
   }
 
-  Future<bool> restoreWorktree({
-    required String projectPath,
-    required String worktreePath,
-    required String branchName,
-    required String baseBranch,
-    required String? baseCommit,
-  }) async {
-    final startPoint = baseCommit ?? baseBranch;
-    final verifyResult = await runGit(
-      projectPath: projectPath,
-      arguments: ["rev-parse", "--verify", "--", "refs/heads/$branchName"],
-    );
-
-    final addResult = await runGit(
-      projectPath: projectPath,
-      arguments: verifyResult.exitCode == 0
-          ? ["worktree", "add", "--", worktreePath, branchName]
-          : ["worktree", "add", "-b", branchName, "--", worktreePath, startPoint],
-    );
-    return addResult.exitCode == 0;
-  }
-
   Future<ProcessResult> runGit({required String projectPath, required List<String> arguments}) {
     return _processRunner.run("git", arguments, workingDirectory: projectPath);
   }

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -121,6 +121,7 @@ import "routing/send_prompt_handler.dart";
 import "routing/set_base_branch_handler.dart";
 import "routing/update_session_archive_status_handler.dart";
 import "runtime/plugin_runtime.dart";
+import "services/archived_session_validator.dart";
 import "services/deleted_session_storage_cleanup_service.dart";
 import "services/pending_interaction_service.dart";
 import "services/permission_auto_approval_service.dart";
@@ -447,6 +448,7 @@ class Orchestrator {
       sessionRepository: sessionRepository,
       filesystemRepository: filesystemRepository,
       sessionOperationDispatcher: sessionOperationDispatcher,
+      archivedSessionValidator: ArchivedSessionValidator(sessionRepository: sessionRepository),
     );
     final sessionDeletionService = SessionDeletionService(
       sessionLifecycleService: sessionLifecycleService,

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -1323,14 +1323,6 @@ class SessionRepository {
     );
   }
 
-  Future<void> unarchiveStoredSession({required String sessionId}) {
-    return _sessionDao.clearArchived(
-      sessionId: sessionId,
-      updatedAt: DateTime.now().millisecondsSinceEpoch,
-      projectionUpdatedAt: captureProjectionTimestamp(),
-    );
-  }
-
   Future<void> insertStoredSession({
     required String sessionId,
     required String backendSessionId,

--- a/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
@@ -269,22 +269,6 @@ class WorktreeRepository {
     );
   }
 
-  Future<bool> restoreWorktree({
-    required String projectPath,
-    required String worktreePath,
-    required String branchName,
-    required String baseBranch,
-    required String? baseCommit,
-  }) async {
-    return _gitApi.restoreWorktree(
-      projectPath: projectPath,
-      worktreePath: worktreePath,
-      branchName: branchName,
-      baseBranch: baseBranch,
-      baseCommit: baseCommit,
-    );
-  }
-
   bool isValidWorktreePath({required String projectPath, required String worktreePath}) {
     final expectedPrefix = "$projectPath/$_worktreeDir/";
     return worktreePath.startsWith(expectedPrefix);

--- a/bridge/app/lib/src/bridge/routing/update_session_archive_status_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/update_session_archive_status_handler.dart
@@ -3,6 +3,7 @@ import "dart:convert";
 
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../services/archived_session_validator.dart";
 import "../services/session_lifecycle_service.dart";
 import "../services/session_unseen_service.dart";
 import "request_handler.dart";
@@ -66,10 +67,15 @@ class UpdateSessionArchiveStatusHandler extends BodyRequestHandler<UpdateSession
         headers: {"content-type": "application/json"},
         body: jsonEncode(e.rejection.toJson()),
       );
+    } on SessionArchivedReadOnlyException catch (e) {
+      throw RelayResponse(
+        id: request.id,
+        status: 409,
+        headers: {"content-type": "application/json"},
+        body: jsonEncode(e.rejection.toJson()),
+      );
     } on SessionNotFoundException {
       throw buildErrorResponse(request, 404, "session not found");
-    } on SessionInitializationException {
-      throw buildErrorResponse(request, 500, "failed to initialize session");
     }
   }
 }

--- a/bridge/app/lib/src/bridge/services/archived_session_validator.dart
+++ b/bridge/app/lib/src/bridge/services/archived_session_validator.dart
@@ -1,5 +1,6 @@
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../repositories/models/stored_session.dart";
 import "../repositories/session_repository.dart";
 
 class SessionArchivedReadOnlyException implements Exception {
@@ -19,9 +20,13 @@ class ArchivedSessionValidator {
   ArchivedSessionValidator({required SessionRepository sessionRepository}) : _sessionRepository = sessionRepository;
 
   /// Throws [SessionArchivedReadOnlyException] when [sessionId] is archived.
-  Future<void> requireNotArchived({required String sessionId}) async {
+  ///
+  /// This is a store-only read, so it answers even when the session's plugin is
+  /// stopped. An unknown session is not archived; the caller owns that 404, and
+  /// receives `null` so it does not have to read the row again.
+  Future<StoredSession?> requireNotArchived({required String sessionId}) async {
     final storedSession = await _sessionRepository.getStoredSession(sessionId: sessionId);
-    if (storedSession?.archivedAt == null) return;
+    if (storedSession?.archivedAt == null) return storedSession;
     throw SessionArchivedReadOnlyException(
       rejection: SessionArchivedRejection(
         sessionId: sessionId,

--- a/bridge/app/lib/src/bridge/services/archived_session_validator.dart
+++ b/bridge/app/lib/src/bridge/services/archived_session_validator.dart
@@ -1,0 +1,32 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../repositories/session_repository.dart";
+
+class SessionArchivedReadOnlyException implements Exception {
+  final SessionArchivedRejection rejection;
+
+  SessionArchivedReadOnlyException({required this.rejection});
+
+  @override
+  String toString() => "session ${rejection.sessionId} is archived and read-only";
+}
+
+/// The single archive-permanence rule in the bridge. Archiving is final, so an
+/// archived session can never be unarchived, prompted, or otherwise mutated.
+class ArchivedSessionValidator {
+  final SessionRepository _sessionRepository;
+
+  ArchivedSessionValidator({required SessionRepository sessionRepository}) : _sessionRepository = sessionRepository;
+
+  /// Throws [SessionArchivedReadOnlyException] when [sessionId] is archived.
+  Future<void> requireNotArchived({required String sessionId}) async {
+    final storedSession = await _sessionRepository.getStoredSession(sessionId: sessionId);
+    if (storedSession?.archivedAt == null) return;
+    throw SessionArchivedReadOnlyException(
+      rejection: SessionArchivedRejection(
+        sessionId: sessionId,
+        reason: SessionArchivedReason.archivedReadOnly,
+      ),
+    );
+  }
+}

--- a/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
@@ -178,36 +178,43 @@ class SessionLifecycleService {
     required bool deleteBranch,
     required bool force,
   }) async {
-    final storedSession = await _getStoredSession(sessionId: sessionId);
-    final wasArchived = storedSession.archivedAt != null;
     // COMPATIBILITY 2026-08-07 (v1.7.0): published apps render Unarchive from
     // time.archived alone, so the request shape still accepts `archived: false`
     // and answers with an explicit rejection; remove tolerance when out of
     // support.
-    final session = archived
-        ? await _doArchive(
-            storedSession: storedSession,
-            deleteWorktree: deleteWorktree,
-            deleteBranch: deleteBranch,
-            force: force,
-          )
-        : await _refuseUnarchive(storedSession: storedSession);
+    if (!archived) {
+      return _refuseUnarchive(sessionId: sessionId);
+    }
+    final storedSession = await _getStoredSession(sessionId: sessionId);
     return ArchiveStatusUpdate(
-      session: session,
-      changed: wasArchived != archived,
+      session: await _doArchive(
+        storedSession: storedSession,
+        deleteWorktree: deleteWorktree,
+        deleteBranch: deleteBranch,
+        force: force,
+      ),
+      changed: storedSession.archivedAt == null,
       projectId: storedSession.projectId,
     );
   }
 
-  /// Archiving is permanent. `archived: false` stays a no-op for a session that
-  /// is not archived and is refused for one that is.
-  Future<Session> _refuseUnarchive({required StoredSession storedSession}) async {
-    await _archivedSessionValidator.requireNotArchived(sessionId: storedSession.id);
-    final session = await _sessionRepository.getCatalogSession(sessionId: storedSession.id);
-    if (session == null) {
+  /// Archiving is permanent. `archived: false` is refused for an archived
+  /// session and stays an unchanged no-op for one that is not.
+  ///
+  /// Neither answer needs the backend, so this path deliberately skips the
+  /// routability requirement: an archived session must still be refused with
+  /// the archived rejection when its plugin is stopped.
+  Future<ArchiveStatusUpdate> _refuseUnarchive({required String sessionId}) async {
+    final storedSession = await _archivedSessionValidator.requireNotArchived(sessionId: sessionId);
+    final session = await _sessionRepository.getCatalogSession(sessionId: sessionId);
+    if (storedSession == null || session == null) {
       throw SessionNotFoundException();
     }
-    return session;
+    return ArchiveStatusUpdate(
+      session: session,
+      changed: false,
+      projectId: storedSession.projectId,
+    );
   }
 
   Future<StoredSession> _getStoredSession({required String sessionId}) async {

--- a/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
@@ -5,6 +5,7 @@ import "../repositories/filesystem_repository.dart";
 import "../repositories/models/session_operation.dart";
 import "../repositories/models/stored_session.dart";
 import "../repositories/session_repository.dart";
+import "archived_session_validator.dart";
 import "session_cleanup_result.dart";
 import "session_operation_dispatcher.dart";
 import "worktree_service.dart";
@@ -43,23 +44,24 @@ class ArchiveStatusUpdate {
 
 class SessionNotFoundException implements Exception {}
 
-class SessionInitializationException implements Exception {}
-
 class SessionLifecycleService {
   final WorktreeService _worktreeService;
   final SessionRepository _sessionRepository;
   final FilesystemRepository _filesystemRepository;
   final SessionOperationDispatcher _sessionOperationDispatcher;
+  final ArchivedSessionValidator _archivedSessionValidator;
 
   SessionLifecycleService({
     required WorktreeService worktreeService,
     required SessionRepository sessionRepository,
     required FilesystemRepository filesystemRepository,
     required SessionOperationDispatcher sessionOperationDispatcher,
+    required ArchivedSessionValidator archivedSessionValidator,
   }) : _worktreeService = worktreeService,
        _sessionRepository = sessionRepository,
        _filesystemRepository = filesystemRepository,
-       _sessionOperationDispatcher = sessionOperationDispatcher;
+       _sessionOperationDispatcher = sessionOperationDispatcher,
+       _archivedSessionValidator = archivedSessionValidator;
 
   /// Runs cleanup inside a session-family operation already reserved by the
   /// archive or deletion workflow.
@@ -178,6 +180,10 @@ class SessionLifecycleService {
   }) async {
     final storedSession = await _getStoredSession(sessionId: sessionId);
     final wasArchived = storedSession.archivedAt != null;
+    // COMPATIBILITY 2026-08-07 (v1.7.0): published apps render Unarchive from
+    // time.archived alone, so the request shape still accepts `archived: false`
+    // and answers with an explicit rejection; remove tolerance when out of
+    // support.
     final session = archived
         ? await _doArchive(
             storedSession: storedSession,
@@ -185,12 +191,23 @@ class SessionLifecycleService {
             deleteBranch: deleteBranch,
             force: force,
           )
-        : await _doUnarchive(storedSession: storedSession);
+        : await _refuseUnarchive(storedSession: storedSession);
     return ArchiveStatusUpdate(
       session: session,
       changed: wasArchived != archived,
       projectId: storedSession.projectId,
     );
+  }
+
+  /// Archiving is permanent. `archived: false` stays a no-op for a session that
+  /// is not archived and is refused for one that is.
+  Future<Session> _refuseUnarchive({required StoredSession storedSession}) async {
+    await _archivedSessionValidator.requireNotArchived(sessionId: storedSession.id);
+    final session = await _sessionRepository.getCatalogSession(sessionId: storedSession.id);
+    if (session == null) {
+      throw SessionNotFoundException();
+    }
+    return session;
   }
 
   Future<StoredSession> _getStoredSession({required String sessionId}) async {
@@ -247,50 +264,6 @@ class SessionLifecycleService {
     if (cleanupResult case CleanupRejected(:final rejection)) {
       throw SessionArchiveConflictException(rejection: rejection);
     }
-  }
-
-  Future<Session> _doUnarchive({required StoredSession storedSession}) async {
-    await _sessionRepository.unarchiveStoredSession(sessionId: storedSession.id);
-    if (storedSession case StoredSession(
-      isDedicated: true,
-      :final projectId,
-      worktreePath: final worktreePath?,
-      branchName: final branchName?,
-    )) {
-      final hasWorktreeOnDisk = _filesystemRepository.directoryExists(path: worktreePath);
-      if (!hasWorktreeOnDisk) {
-        final restoreBaseBranch = await _resolveRestoreBaseBranch(
-          projectId: projectId,
-          storedBaseBranch: storedSession.baseBranch,
-        );
-        await _worktreeService.restoreWorktree(
-          projectId: projectId,
-          worktreePath: worktreePath,
-          branchName: branchName,
-          baseBranch: restoreBaseBranch,
-          baseCommit: storedSession.baseCommit?.normalize(),
-        );
-      }
-    }
-    final session = await _sessionRepository.getCatalogSession(sessionId: storedSession.id);
-    if (session == null) {
-      throw SessionNotFoundException();
-    }
-    return session;
-  }
-
-  Future<String> _resolveRestoreBaseBranch({
-    required String projectId,
-    required String? storedBaseBranch,
-  }) async {
-    if (storedBaseBranch case final baseBranch?) {
-      return baseBranch;
-    }
-    final resolved = await _worktreeService.resolveBaseBranchAndCommit(projectId: projectId);
-    if (resolved == null) {
-      throw SessionInitializationException();
-    }
-    return resolved.baseBranch;
   }
 
   List<CleanupIssue> _mapSafetyIssues({required List<SafetyIssue> issues}) {

--- a/bridge/app/lib/src/bridge/services/worktree_service.dart
+++ b/bridge/app/lib/src/bridge/services/worktree_service.dart
@@ -161,16 +161,6 @@ class WorktreeService {
     );
   }
 
-  Future<({String baseBranch, String baseCommit, String startPoint})?> resolveBaseBranchAndCommit({
-    required String projectId,
-  }) async {
-    return _worktreeRepository.resolveBaseBranchAndCommit(
-      projectId: projectId,
-      projectPath: await _worktreeRepository.resolveProjectPath(projectId: projectId),
-      refreshOrigin: false,
-    );
-  }
-
   Future<String?> resolveHeadCommit({
     required String projectId,
   }) async {
@@ -229,29 +219,6 @@ class WorktreeService {
     return _worktreeRepository.branchExists(
       projectPath: await _worktreeRepository.resolveProjectPath(projectId: projectId),
       branchName: branchName,
-    );
-  }
-
-  Future<bool> restoreWorktree({
-    required String projectId,
-    required String worktreePath,
-    required String branchName,
-    required String baseBranch,
-    required String? baseCommit,
-  }) async {
-    final projectPath = await _worktreeRepository.resolveProjectPath(projectId: projectId);
-    if (!_worktreeRepository.isValidWorktreePath(
-      projectPath: projectPath,
-      worktreePath: worktreePath,
-    )) {
-      return false;
-    }
-    return _worktreeRepository.restoreWorktree(
-      projectPath: projectPath,
-      worktreePath: worktreePath,
-      branchName: branchName,
-      baseBranch: baseBranch,
-      baseCommit: baseCommit,
     );
   }
 }

--- a/bridge/app/test/bridge/routing/delete_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/delete_session_handler_test.dart
@@ -9,6 +9,7 @@ import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
 import "package:sesori_bridge/src/bridge/repositories/filesystem_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/routing/delete_session_handler.dart";
+import "package:sesori_bridge/src/bridge/services/archived_session_validator.dart";
 import "package:sesori_bridge/src/bridge/services/session_deletion_service.dart";
 import "package:sesori_bridge/src/bridge/services/session_lifecycle_service.dart";
 import "package:sesori_bridge/src/bridge/services/session_mutation_dispatcher.dart";
@@ -56,6 +57,7 @@ void main() {
           permissionValidator: const FilesystemPermissionValidator(),
         ),
         sessionOperationDispatcher: sessionOperationDispatcher,
+        archivedSessionValidator: ArchivedSessionValidator(sessionRepository: sessionRepository),
       );
       handler = DeleteSessionHandler(
         sessionDeletionService: SessionDeletionService(

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -550,17 +550,6 @@ class FakeSessionDao {
     }
   }
 
-  Future<void> clearArchived({
-    required String sessionId,
-    required int updatedAt,
-    required int projectionUpdatedAt,
-  }) async {
-    if (_sessions.containsKey(sessionId)) {
-      final session = _sessions[sessionId]!;
-      _sessions[sessionId] = session.copyWith(archivedAt: null);
-    }
-  }
-
   Future<List<SessionDto>> getSessionsByProject({required String projectId}) async {
     return _sessions.values.where((s) => s.projectId == projectId).toList();
   }
@@ -990,9 +979,6 @@ class _NoopSessionRepository implements SessionRepository {
     required String sessionId,
     required int archivedAt,
   }) async {}
-
-  @override
-  Future<void> unarchiveStoredSession({required String sessionId}) async {}
 
   @override
   Future<void> insertStoredSession({
@@ -1441,9 +1427,6 @@ class FakeSessionRepository implements SessionRepository {
     required String sessionId,
     required int archivedAt,
   }) async {}
-
-  @override
-  Future<void> unarchiveStoredSession({required String sessionId}) async {}
 
   @override
   Future<void> insertStoredSession({

--- a/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
+++ b/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
@@ -369,6 +369,49 @@ void main() {
       expect((await db.sessionDao.getSession(sessionId: "s1"))?.archivedAt, 123);
     });
 
+    test("archived: false still returns 409 when the session's plugin is stopped", () async {
+      await _insertSession(
+        db: db,
+        sessionId: "stale-plugin-session",
+        projectId: "/repo",
+        isDedicated: false,
+        worktreePath: null,
+        branchName: null,
+        baseBranch: null,
+        archivedAt: 123,
+        baseCommit: null,
+        pluginId: "stopped-plugin",
+      );
+
+      final response = await handler.handleInternal(
+        makeRequest(
+          "PATCH",
+          "/session/update/archive",
+          body: jsonEncode(
+            _archiveRequest(
+              sessionId: "stale-plugin-session",
+              archived: false,
+              deleteWorktree: false,
+              deleteBranch: false,
+              force: false,
+            ).toJson(),
+          ),
+        ),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(response.status, 409);
+      expect(
+        SessionArchivedRejection.fromJson(jsonDecodeMap(response.body ?? "")),
+        const SessionArchivedRejection(
+          sessionId: "stale-plugin-session",
+          reason: SessionArchivedReason.archivedReadOnly,
+        ),
+      );
+    });
+
     test("archive with force skips safety check", () async {
       await _insertSession(
         db: db,

--- a/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
+++ b/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
@@ -11,6 +11,7 @@ import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
 import "package:sesori_bridge/src/bridge/repositories/filesystem_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/routing/update_session_archive_status_handler.dart";
+import "package:sesori_bridge/src/bridge/services/archived_session_validator.dart";
 import "package:sesori_bridge/src/bridge/services/session_lifecycle_service.dart";
 import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
 import "package:sesori_bridge/src/bridge/services/session_unseen_service.dart";
@@ -53,6 +54,7 @@ void main() {
           sessionRepository: sessionRepository,
           filesystemRepository: filesystemRepository,
           sessionOperationDispatcher: operationDispatcher,
+          archivedSessionValidator: ArchivedSessionValidator(sessionRepository: sessionRepository),
         ),
         sessionUnseenService: unseenService = buildTestSessionUnseenService(db, plugin),
       );
@@ -323,6 +325,50 @@ void main() {
       expect(persisted?.archivedAt, isNull);
     });
 
+    test("archived: false on an archived session throws 409 with the archived rejection body", () async {
+      await _insertSession(
+        db: db,
+        sessionId: "s1",
+        projectId: "/repo",
+        isDedicated: false,
+        worktreePath: null,
+        branchName: null,
+        baseBranch: null,
+        archivedAt: 123,
+        baseCommit: null,
+      );
+
+      await expectLater(
+        () => handler.handle(
+          makeRequest("PATCH", "/session/update/archive"),
+          body: _archiveRequest(
+            sessionId: "s1",
+            archived: false,
+            deleteWorktree: false,
+            deleteBranch: false,
+            force: false,
+          ),
+          pathParams: {},
+          queryParams: {},
+          fragment: null,
+        ),
+        throwsA(
+          isA<RelayResponse>()
+              .having((r) => r.status, "status", equals(409))
+              .having(
+                (r) => SessionArchivedRejection.fromJson(jsonDecodeMap(r.body ?? "")),
+                "body",
+                const SessionArchivedRejection(
+                  sessionId: "s1",
+                  reason: SessionArchivedReason.archivedReadOnly,
+                ),
+              ),
+        ),
+      );
+
+      expect((await db.sessionDao.getSession(sessionId: "s1"))?.archivedAt, 123);
+    });
+
     test("archive with force skips safety check", () async {
       await _insertSession(
         db: db,
@@ -363,133 +409,6 @@ void main() {
       expect(worktreeService.checkCallCount, equals(0));
       expect(worktreeService.removeCallCount, equals(1));
       expect(worktreeService.lastRemoveForce, isTrue);
-    });
-
-    test("unarchive with existing worktree clears archivedAt", () async {
-      final existingDir = Directory.systemTemp.createTempSync("archive-handler-");
-      addTearDown(() {
-        if (existingDir.existsSync()) {
-          existingDir.deleteSync(recursive: true);
-        }
-      });
-
-      await _insertSession(
-        db: db,
-        sessionId: "s1",
-        projectId: "/repo",
-        isDedicated: true,
-        worktreePath: existingDir.path,
-        branchName: "session-001",
-        baseBranch: null,
-        archivedAt: 123,
-        baseCommit: null,
-      );
-      plugin.sessionsResult = [
-        PluginSession(
-          id: "s1",
-          projectID: "/repo",
-          directory: existingDir.path,
-          parentID: null,
-          title: "Session 1",
-          time: const PluginSessionTime(created: 10, updated: 20, archived: 123),
-        ),
-      ];
-      await _setPullRequestScope(db: db, sessionId: "s1");
-      await db.pullRequestDao.upsertPr(
-        pullRequest: const PullRequestDto(
-          projectId: "/repo",
-          githubRepositoryIdentity: "org/repo",
-          githubLogin: "octocat",
-          branchName: "session-001",
-          prNumber: 22,
-          url: "https://github.com/org/repo/pull/22",
-          title: "Unarchive PR",
-          state: PrState.open,
-          mergeableStatus: PrMergeableStatus.unknown,
-          reviewDecision: PrReviewDecision.unknown,
-          checkStatus: PrCheckStatus.unknown,
-          lastCheckedAt: 1,
-          createdAt: 1,
-        ),
-      );
-
-      final result = await handler.handle(
-        makeRequest("PATCH", "/session/update/archive"),
-        body: _archiveRequest(
-          sessionId: "s1",
-          archived: false,
-          deleteWorktree: false,
-          deleteBranch: false,
-          force: false,
-        ),
-        pathParams: {},
-        queryParams: {},
-        fragment: null,
-      );
-
-      expect(worktreeService.restoreCallCount, equals(0));
-      final persisted = await db.sessionDao.getSession(sessionId: "s1");
-      expect(persisted?.archivedAt, isNull);
-      expect(result.time?.archived, isNull);
-      expect(result.pullRequest, isNull);
-    });
-
-    test("unarchive with deleted worktree restores worktree", () async {
-      final deletedWorktreePath = "${Directory.systemTemp.path}/missing-worktree-s1";
-      final deletedWorktree = Directory(deletedWorktreePath);
-      if (deletedWorktree.existsSync()) {
-        deletedWorktree.deleteSync(recursive: true);
-      }
-
-      await _insertSession(
-        db: db,
-        sessionId: "s1",
-        projectId: "/repo",
-        isDedicated: true,
-        worktreePath: deletedWorktreePath,
-        branchName: "session-001",
-        baseBranch: null,
-        archivedAt: 123,
-        baseCommit: null,
-      );
-      plugin.sessionsResult = [
-        PluginSession(
-          id: "s1",
-          projectID: "/repo",
-          directory: deletedWorktreePath,
-          parentID: null,
-          title: "Session 1",
-          time: const PluginSessionTime(created: 10, updated: 20, archived: 123),
-        ),
-      ];
-      worktreeService.resolveBaseBranchAndCommitResult = (
-        baseBranch: "develop",
-        baseCommit: "abc123",
-        startPoint: "develop",
-      );
-
-      await handler.handle(
-        makeRequest("PATCH", "/session/update/archive"),
-        body: _archiveRequest(
-          sessionId: "s1",
-          archived: false,
-          deleteWorktree: false,
-          deleteBranch: false,
-          force: false,
-        ),
-        pathParams: {},
-        queryParams: {},
-        fragment: null,
-      );
-
-      expect(worktreeService.restoreCallCount, equals(1));
-      expect(worktreeService.lastRestoreProjectId, equals("/repo"));
-      expect(worktreeService.lastRestoreWorktreePath, equals(deletedWorktreePath));
-      expect(worktreeService.lastRestoreBranchName, equals("session-001"));
-      expect(worktreeService.lastRestoreBaseBranch, equals("develop"));
-      expect(worktreeService.lastRestoreBaseCommit, isNull);
-      final persisted = await db.sessionDao.getSession(sessionId: "s1");
-      expect(persisted?.archivedAt, isNull);
     });
 
     test("missing binding returns 404 before plugin or cleanup calls", () async {
@@ -560,50 +479,6 @@ void main() {
       expect((await db.sessionDao.getSession(sessionId: "stale-plugin-session"))?.archivedAt, isNull);
     });
 
-    test("unarchive simple session clears archivedAt without worktree ops", () async {
-      await _insertSession(
-        db: db,
-        sessionId: "s1",
-        projectId: "/repo",
-        isDedicated: false,
-        worktreePath: null,
-        branchName: null,
-        baseBranch: null,
-        archivedAt: 123,
-        baseCommit: null,
-      );
-      plugin.sessionsResult = const [
-        PluginSession(
-          id: "s1",
-          projectID: "/repo",
-          directory: "/repo",
-          parentID: null,
-          title: "Simple Session",
-          time: PluginSessionTime(created: 10, updated: 20, archived: 123),
-        ),
-      ];
-
-      await handler.handle(
-        makeRequest("PATCH", "/session/update/archive"),
-        body: _archiveRequest(
-          sessionId: "s1",
-          archived: false,
-          deleteWorktree: false,
-          deleteBranch: false,
-          force: false,
-        ),
-        pathParams: {},
-        queryParams: {},
-        fragment: null,
-      );
-
-      expect(worktreeService.restoreCallCount, equals(0));
-      expect(worktreeService.removeCallCount, equals(0));
-      expect(worktreeService.deleteBranchCallCount, equals(0));
-      final persisted = await db.sessionDao.getSession(sessionId: "s1");
-      expect(persisted?.archivedAt, isNull);
-    });
-
     test("archive fires plugin archiveSession", () async {
       await _insertSession(
         db: db,
@@ -644,54 +519,6 @@ void main() {
       // Fire-and-forget — give the microtask a chance to run.
       await Future<void>.delayed(Duration.zero);
       expect(plugin.lastArchiveSessionId, equals("s1"));
-    });
-
-    test("unarchive does not fire plugin archiveSession", () async {
-      final existingDir = Directory.systemTemp.createTempSync("archive-handler-");
-      addTearDown(() {
-        if (existingDir.existsSync()) {
-          existingDir.deleteSync(recursive: true);
-        }
-      });
-
-      await _insertSession(
-        db: db,
-        sessionId: "s1",
-        projectId: "/repo",
-        isDedicated: true,
-        worktreePath: existingDir.path,
-        branchName: "session-001",
-        baseBranch: null,
-        archivedAt: 123,
-        baseCommit: null,
-      );
-      plugin.sessionsResult = [
-        PluginSession(
-          id: "s1",
-          projectID: "/repo",
-          directory: existingDir.path,
-          parentID: null,
-          title: "Session 1",
-          time: const PluginSessionTime(created: 10, updated: 20, archived: 123),
-        ),
-      ];
-
-      await handler.handle(
-        makeRequest("PATCH", "/session/update/archive"),
-        body: _archiveRequest(
-          sessionId: "s1",
-          archived: false,
-          deleteWorktree: false,
-          deleteBranch: false,
-          force: false,
-        ),
-        pathParams: {},
-        queryParams: {},
-        fragment: null,
-      );
-
-      await Future<void>.delayed(Duration.zero);
-      expect(plugin.lastArchiveSessionId, isNull);
     });
 
     test("archive succeeds even when plugin archiveSession throws", () async {
@@ -913,133 +740,6 @@ void main() {
       expect(result.hasWorktree, isFalse);
     });
 
-    test("unarchive response has hasWorktree true when session has worktreePath", () async {
-      final existingDir = Directory.systemTemp.createTempSync("archive-handler-worktree-");
-      addTearDown(() {
-        if (existingDir.existsSync()) {
-          existingDir.deleteSync(recursive: true);
-        }
-      });
-
-      await _insertSession(
-        db: db,
-        sessionId: "s1",
-        projectId: "/repo",
-        isDedicated: true,
-        worktreePath: existingDir.path,
-        branchName: "session-001",
-        baseBranch: null,
-        archivedAt: 123,
-        baseCommit: null,
-      );
-      plugin.sessionsResult = [
-        PluginSession(
-          id: "s1",
-          projectID: "/repo",
-          directory: existingDir.path,
-          parentID: null,
-          title: "Session 1",
-          time: const PluginSessionTime(created: 10, updated: 20, archived: 123),
-        ),
-      ];
-
-      final result = await handler.handle(
-        makeRequest("PATCH", "/session/update/archive"),
-        body: _archiveRequest(
-          sessionId: "s1",
-          archived: false,
-          deleteWorktree: false,
-          deleteBranch: false,
-          force: false,
-        ),
-        pathParams: {},
-        queryParams: {},
-        fragment: null,
-      );
-
-      expect(result.hasWorktree, isTrue);
-    });
-
-    test("unarchive response has hasWorktree false when session has no worktreePath", () async {
-      await _insertSession(
-        db: db,
-        sessionId: "s1",
-        projectId: "/repo",
-        isDedicated: false,
-        worktreePath: null,
-        branchName: null,
-        baseBranch: null,
-        archivedAt: 123,
-        baseCommit: null,
-      );
-      plugin.sessionsResult = const [
-        PluginSession(
-          id: "s1",
-          projectID: "/repo",
-          directory: "/repo",
-          parentID: null,
-          title: "Session 1",
-          time: PluginSessionTime(created: 10, updated: 20, archived: 123),
-        ),
-      ];
-
-      final result = await handler.handle(
-        makeRequest("PATCH", "/session/update/archive"),
-        body: _archiveRequest(
-          sessionId: "s1",
-          archived: false,
-          deleteWorktree: false,
-          deleteBranch: false,
-          force: false,
-        ),
-        pathParams: {},
-        queryParams: {},
-        fragment: null,
-      );
-
-      expect(result.hasWorktree, isFalse);
-    });
-
-    test("session id is preserved on unarchive response", () async {
-      await _insertSession(
-        db: db,
-        sessionId: "s-preserve",
-        projectId: "/repo",
-        isDedicated: false,
-        worktreePath: null,
-        branchName: null,
-        baseBranch: null,
-        archivedAt: 123,
-        baseCommit: null,
-      );
-      plugin.sessionsResult = const [
-        PluginSession(
-          id: "s-preserve",
-          projectID: "/repo",
-          directory: "/repo",
-          parentID: null,
-          title: "Preserved",
-          time: PluginSessionTime(created: 10, updated: 20, archived: 123),
-        ),
-      ];
-
-      final result = await handler.handle(
-        makeRequest("PATCH", "/session/update/archive"),
-        body: _archiveRequest(
-          sessionId: "s-preserve",
-          archived: false,
-          deleteWorktree: false,
-          deleteBranch: false,
-          force: false,
-        ),
-        pathParams: {},
-        queryParams: {},
-        fragment: null,
-      );
-
-      expect(result.id, equals("s-preserve"));
-      expect(result.time?.archived, isNull);
-    });
   });
 }
 
@@ -1118,13 +818,10 @@ class _FakeWorktreeService extends WorktreeService {
   bool removeResult = true;
   bool deleteBranchResult = true;
   bool branchExistsResult = true;
-  bool restoreResult = true;
-  ({String baseBranch, String baseCommit, String startPoint})? resolveBaseBranchAndCommitResult;
 
   int checkCallCount = 0;
   int removeCallCount = 0;
   int deleteBranchCallCount = 0;
-  int restoreCallCount = 0;
 
   String? lastCheckWorktreePath;
   String? lastCheckExpectedBranch;
@@ -1134,11 +831,6 @@ class _FakeWorktreeService extends WorktreeService {
   String? lastDeleteBranchProjectId;
   String? lastDeleteBranchName;
   bool? lastDeleteBranchForce;
-  String? lastRestoreProjectId;
-  String? lastRestoreWorktreePath;
-  String? lastRestoreBranchName;
-  String? lastRestoreBaseBranch;
-  String? lastRestoreBaseCommit;
 
   _FakeWorktreeService({required AppDatabase database})
     : super(
@@ -1197,30 +889,6 @@ class _FakeWorktreeService extends WorktreeService {
     required String branchName,
   }) async {
     return branchExistsResult;
-  }
-
-  @override
-  Future<bool> restoreWorktree({
-    required String projectId,
-    required String worktreePath,
-    required String branchName,
-    required String baseBranch,
-    required String? baseCommit,
-  }) async {
-    restoreCallCount++;
-    lastRestoreProjectId = projectId;
-    lastRestoreWorktreePath = worktreePath;
-    lastRestoreBranchName = branchName;
-    lastRestoreBaseBranch = baseBranch;
-    lastRestoreBaseCommit = baseCommit;
-    return restoreResult;
-  }
-
-  @override
-  Future<({String baseBranch, String baseCommit, String startPoint})?> resolveBaseBranchAndCommit({
-    required String projectId,
-  }) async {
-    return resolveBaseBranchAndCommitResult;
   }
 }
 

--- a/bridge/app/test/bridge/services/archived_session_validator_test.dart
+++ b/bridge/app/test/bridge/services/archived_session_validator_test.dart
@@ -1,0 +1,76 @@
+import "package:sesori_bridge/src/api/database/database.dart";
+import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
+import "package:sesori_bridge/src/bridge/services/archived_session_validator.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "../../helpers/test_database.dart";
+import "../routing/routing_test_helpers.dart";
+
+void main() {
+  group("ArchivedSessionValidator", () {
+    late AppDatabase db;
+    late FakeBridgePlugin plugin;
+    late ArchivedSessionValidator validator;
+
+    setUp(() async {
+      db = createTestDatabase();
+      plugin = FakeBridgePlugin();
+      await db.projectsDao.insertProjectsIfMissing(projectIds: ["/repo"]);
+      validator = ArchivedSessionValidator(
+        sessionRepository: singlePluginSessionRepository(
+          plugin: plugin,
+          sessionDao: db.sessionDao,
+          projectsDao: db.projectsDao,
+          pullRequestDao: db.pullRequestDao,
+          unseenCalculator: const SessionUnseenCalculator(),
+        ),
+      );
+      await db.sessionDao.insertSession(
+        sessionId: "s1",
+        backendSessionId: "s1",
+        projectId: "/repo",
+        isDedicated: false,
+        createdAt: 1,
+        worktreePath: null,
+        branchName: null,
+        baseBranch: null,
+        baseCommit: null,
+        lastAgent: null,
+        lastAgentModel: null,
+        pluginId: "fake",
+      );
+    });
+
+    tearDown(() async {
+      await plugin.close();
+      await db.close();
+    });
+
+    test("allows a session that is not archived", () async {
+      await expectLater(validator.requireNotArchived(sessionId: "s1"), completes);
+    });
+
+    test("allows an unknown session so the caller decides on 404", () async {
+      await expectLater(validator.requireNotArchived(sessionId: "missing"), completes);
+    });
+
+    test("rejects an archived session with the archived read-only rejection", () async {
+      await db.sessionDao.setArchived(sessionId: "s1", archivedAt: 5, updatedAt: 5, projectionUpdatedAt: 5);
+
+      await expectLater(
+        validator.requireNotArchived(sessionId: "s1"),
+        throwsA(
+          isA<SessionArchivedReadOnlyException>().having(
+            (e) => e.rejection,
+            "rejection",
+            const SessionArchivedRejection(
+              sessionId: "s1",
+              reason: SessionArchivedReason.archivedReadOnly,
+            ),
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/bridge/app/test/bridge/services/session_family_mutation_test.dart
+++ b/bridge/app/test/bridge/services/session_family_mutation_test.dart
@@ -4,6 +4,7 @@ import "package:sesori_bridge/src/bridge/repositories/filesystem_repository.dart
 import "package:sesori_bridge/src/bridge/repositories/models/session_operation.dart";
 import "package:sesori_bridge/src/bridge/repositories/models/stored_session.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
+import "package:sesori_bridge/src/bridge/services/archived_session_validator.dart";
 import "package:sesori_bridge/src/bridge/services/session_cleanup_result.dart";
 import "package:sesori_bridge/src/bridge/services/session_deletion_service.dart";
 import "package:sesori_bridge/src/bridge/services/session_lifecycle_service.dart";
@@ -89,48 +90,37 @@ void main() {
       expect(fixture.repository.actionCalls, isZero);
     });
 
-    for (final archived in [true, false]) {
-      final operationName = archived ? "archive" : "unarchive";
+    test("earlier archive finishes before deletion", () async {
+      fixture.repository.setArchived(sessionId: "root", archived: false);
+      final lifecycleStarted = Completer<void>();
+      final releaseLifecycle = Completer<void>();
+      fixture.repository
+        ..archiveStarted = lifecycleStarted
+        ..archiveGate = releaseLifecycle.future;
 
-      test("earlier $operationName finishes before deletion", () async {
-        fixture.repository.setArchived(sessionId: "root", archived: !archived);
-        final lifecycleStarted = Completer<void>();
-        final releaseLifecycle = Completer<void>();
-        if (archived) {
-          fixture.repository
-            ..archiveStarted = lifecycleStarted
-            ..archiveGate = releaseLifecycle.future;
-        } else {
-          fixture.worktree
-            ..restoreStarted = lifecycleStarted
-            ..restoreGate = releaseLifecycle.future;
-        }
+      final lifecycle = fixture.updateArchiveStatus(archived: true);
+      await lifecycleStarted.future;
+      final deletion = fixture.deleteRoot();
+      await _flushEvents();
 
-        final lifecycle = fixture.updateArchiveStatus(archived: archived);
-        await lifecycleStarted.future;
-        final deletion = fixture.deleteRoot();
-        await _flushEvents();
+      expect(fixture.repository.deleteStarted.isCompleted, isFalse);
+      releaseLifecycle.complete();
+      await Future.wait([lifecycle, deletion]);
+    });
 
-        expect(fixture.repository.deleteStarted.isCompleted, isFalse);
-        releaseLifecycle.complete();
-        await Future.wait([lifecycle, deletion]);
-      });
+    test("earlier deletion prevents later archive", () async {
+      fixture.repository.setArchived(sessionId: "root", archived: false);
+      final releaseDelete = Completer<void>();
+      fixture.repository.deleteGate = releaseDelete.future;
 
-      test("earlier deletion prevents later $operationName", () async {
-        fixture.repository.setArchived(sessionId: "root", archived: !archived);
-        final releaseDelete = Completer<void>();
-        fixture.repository.deleteGate = releaseDelete.future;
+      final deletion = fixture.deleteRoot();
+      await fixture.repository.deleteStarted.future;
+      final lifecycle = fixture.updateArchiveStatus(archived: true);
+      releaseDelete.complete();
 
-        final deletion = fixture.deleteRoot();
-        await fixture.repository.deleteStarted.future;
-        final lifecycle = fixture.updateArchiveStatus(archived: archived);
-        releaseDelete.complete();
-
-        await deletion;
-        await expectLater(lifecycle, throwsA(_isNotFound));
-        expect(fixture.worktree.restoreCalls, isZero);
-      });
-    }
+      await deletion;
+      await expectLater(lifecycle, throwsA(_isNotFound));
+    });
 
     test("cleanup rejection releases the family without deleting", () async {
       fixture.worktree.safetyResult = WorktreeUnsafe(issues: [UnstagedChanges()]);
@@ -235,6 +225,7 @@ class _Fixture {
       sessionRepository: repository,
       filesystemRepository: _MissingFilesystemRepository(),
       sessionOperationDispatcher: operations,
+      archivedSessionValidator: ArchivedSessionValidator(sessionRepository: repository),
     );
     deletions = SessionDeletionService(
       sessionLifecycleService: lifecycle,
@@ -384,13 +375,6 @@ class _FamilyRepository implements SessionRepository {
   }
 
   @override
-  Future<void> unarchiveStoredSession({required String sessionId}) async {
-    final record = _sessions[sessionId];
-    if (record == null) throw _notFound(sessionId: sessionId, operation: SessionOperation.updateSessionArchiveStatus);
-    record.archivedAt = null;
-  }
-
-  @override
   Future<void> notifySessionArchived({required String sessionId}) async {}
 
   Future<void> executeAction({required String sessionId}) async {
@@ -458,9 +442,6 @@ class _SessionRecord {
 
 class _FamilyWorktreeService implements WorktreeService {
   WorktreeSafetyResult safetyResult = WorktreeSafe();
-  Completer<void>? restoreStarted;
-  Future<void>? restoreGate;
-  int restoreCalls = 0;
 
   @override
   Future<WorktreeSafetyResult> checkWorktreeSafety({
@@ -482,21 +463,6 @@ class _FamilyWorktreeService implements WorktreeService {
   @override
   Future<bool> branchExists({required String projectId, required String branchName}) async => false;
 
-  @override
-  Future<bool> restoreWorktree({
-    required String projectId,
-    required String worktreePath,
-    required String branchName,
-    required String baseBranch,
-    required String? baseCommit,
-  }) async {
-    restoreCalls++;
-    final started = restoreStarted;
-    if (started != null && !started.isCompleted) started.complete();
-    final gate = restoreGate;
-    if (gate != null) await gate;
-    return true;
-  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
+++ b/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
@@ -11,6 +11,7 @@ import "package:sesori_bridge/src/bridge/repositories/models/stored_session.dart
 import "package:sesori_bridge/src/bridge/repositories/models/verified_github_login.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
+import "package:sesori_bridge/src/bridge/services/archived_session_validator.dart";
 import "package:sesori_bridge/src/bridge/services/session_cleanup_result.dart";
 import "package:sesori_bridge/src/bridge/services/session_lifecycle_service.dart";
 import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
@@ -42,6 +43,7 @@ void main() {
           permissionValidator: const FilesystemPermissionValidator(),
         ),
         sessionOperationDispatcher: operationDispatcher,
+        archivedSessionValidator: ArchivedSessionValidator(sessionRepository: sessionRepository),
       );
     });
 
@@ -453,6 +455,7 @@ void main() {
           permissionValidator: const FilesystemPermissionValidator(),
         ),
         sessionOperationDispatcher: operationDispatcher,
+        archivedSessionValidator: ArchivedSessionValidator(sessionRepository: repository),
       );
       await db.sessionDao.insertSession(
         sessionId: "root-session",
@@ -491,7 +494,7 @@ void main() {
       expect((await db.sessionDao.getSession(sessionId: "root-session"))?.archivedAt, isNotNull);
     });
 
-    test("unarchive uses the existing root binding and returns its stable id", () async {
+    test("archived: false on an archived session is refused and keeps it archived", () async {
       await db.sessionDao.setArchived(
         sessionId: "root-session",
         archivedAt: 2,
@@ -499,6 +502,29 @@ void main() {
         projectionUpdatedAt: 2,
       );
 
+      await expectLater(
+        service.updateArchiveStatus(
+          sessionId: "root-session",
+          archived: false,
+          deleteWorktree: false,
+          deleteBranch: false,
+          force: false,
+        ),
+        throwsA(
+          isA<SessionArchivedReadOnlyException>().having(
+            (e) => e.rejection,
+            "rejection",
+            const SessionArchivedRejection(
+              sessionId: "root-session",
+              reason: SessionArchivedReason.archivedReadOnly,
+            ),
+          ),
+        ),
+      );
+      expect((await db.sessionDao.getSession(sessionId: "root-session"))?.archivedAt, 2);
+    });
+
+    test("archived: false on a non-archived session stays an unchanged no-op", () async {
       final update = await service.updateArchiveStatus(
         sessionId: "root-session",
         archived: false,
@@ -508,8 +534,7 @@ void main() {
       );
 
       expect(update.session.id, "root-session");
-      expect(update.changed, isTrue);
-      expect(plugin.lastArchivedSessionId, isNull);
+      expect(update.changed, isFalse);
       expect((await db.sessionDao.getSession(sessionId: "root-session"))?.archivedAt, isNull);
     });
   });

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -881,7 +881,7 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  // pruneWorktrees / removeWorktree / deleteBranch / restoreWorktree
+  // pruneWorktrees / removeWorktree / deleteBranch
   // -------------------------------------------------------------------------
 
   group("WorktreeService lifecycle methods", () {
@@ -1047,59 +1047,6 @@ void main() {
       expect(inv.arguments, equals(["branch", "-D", "--", "session-001"]));
     });
 
-    // restoreWorktree — branch exists
-
-    test("restoreWorktree: branch exists → calls rev-parse then worktree add without -b", () async {
-      // git rev-parse --verify refs/heads/session-001 → exit 0 (branch exists)
-      processRunner.enqueue(result: _ok(stdout: "abc123\n"));
-      // git worktree add <path> <branch>
-      processRunner.enqueue(result: _ok());
-
-      final result = await service.restoreWorktree(
-        projectId: _projectId,
-        worktreePath: "$_projectId/.worktrees/session-001",
-        branchName: "session-001",
-        baseBranch: "main",
-        baseCommit: null,
-      );
-
-      expect(result, isTrue);
-      expect(processRunner.invocations, hasLength(2));
-
-      final verifyInv = processRunner.invocations[0];
-      expect(verifyInv.arguments, equals(["rev-parse", "--verify", "--", "refs/heads/session-001"]));
-
-      final addInv = processRunner.invocations[1];
-      expect(addInv.arguments, equals(["worktree", "add", "--", "$_projectId/.worktrees/session-001", "session-001"]));
-      expect(addInv.arguments, isNot(contains("-b")));
-      expect(addInv.workingDirectory, equals(_projectId));
-    });
-
-    // restoreWorktree — branch does not exist
-
-    test("restoreWorktree: branch missing → calls rev-parse then worktree add with -b and baseBranch", () async {
-      // git rev-parse --verify refs/heads/session-001 → exit 128 (branch missing)
-      processRunner.enqueue(result: _fail(exitCode: 128, stderr: "fatal: Needed a single revision"));
-      // git worktree add <path> -b <branch> <baseBranch>
-      processRunner.enqueue(result: _ok());
-
-      final result = await service.restoreWorktree(
-        projectId: _projectId,
-        worktreePath: "$_projectId/.worktrees/session-001",
-        branchName: "session-001",
-        baseBranch: "main",
-        baseCommit: "abc123def",
-      );
-
-      expect(result, isTrue);
-      expect(processRunner.invocations, hasLength(2));
-
-      final addInv = processRunner.invocations[1];
-      expect(
-        addInv.arguments,
-        equals(["worktree", "add", "-b", "session-001", "--", "$_projectId/.worktrees/session-001", "abc123def"]),
-      );
-    });
   });
 }
 

--- a/bridge/app/test/persistence/session_dao_test.dart
+++ b/bridge/app/test/persistence/session_dao_test.dart
@@ -276,7 +276,7 @@ void main() {
       expect(await dao.getTombstonedSessionIds(pluginId: "codex"), isEmpty);
     });
 
-    test("setArchived and clearArchived update archivedAt", () async {
+    test("setArchived updates archivedAt", () async {
       await dao.insertSession(
         pluginId: "opencode",
         sessionId: "ses-4",
@@ -299,16 +299,8 @@ void main() {
         updatedAt: 1234567890,
         projectionUpdatedAt: 1234567890,
       );
-      var result = await dao.getSession(sessionId: "ses-4");
+      final result = await dao.getSession(sessionId: "ses-4");
       expect(result!.archivedAt, equals(1234567890));
-
-      await dao.clearArchived(
-        sessionId: "ses-4",
-        updatedAt: 1234567891,
-        projectionUpdatedAt: 1234567891,
-      );
-      result = await dao.getSession(sessionId: "ses-4");
-      expect(result!.archivedAt, isNull);
     });
 
     test("getSessionsByProject and getSessionsByIds return expected sessions", () async {

--- a/shared/sesori_shared/lib/sesori_shared.dart
+++ b/shared/sesori_shared/lib/sesori_shared.dart
@@ -71,6 +71,7 @@ export "src/models/sesori/send_notification_payload.dart";
 export "src/models/sesori/send_prompt_request.dart";
 export "src/models/sesori/sesori_sse_event.dart";
 export "src/models/sesori/session.dart";
+export "src/models/sesori/session_archived_rejection.dart";
 export "src/models/sesori/session_cleanup_rejection.dart";
 export "src/models/sesori/session_diffs_response.dart";
 export "src/models/sesori/session_options_error_response.dart";

--- a/shared/sesori_shared/lib/src/models/sesori/session_archived_rejection.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session_archived_rejection.dart
@@ -1,0 +1,23 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "session_archived_rejection.freezed.dart";
+
+part "session_archived_rejection.g.dart";
+
+/// Why a mutation against an archived session was refused.
+enum SessionArchivedReason {
+  @JsonValue("archived_read_only")
+  archivedReadOnly,
+}
+
+/// The 409 body returned for every mutation refused because the target session
+/// is archived. Archiving is permanent: archived sessions are audit-only.
+@Freezed(fromJson: true, toJson: true)
+sealed class SessionArchivedRejection with _$SessionArchivedRejection {
+  const factory SessionArchivedRejection({
+    required String sessionId,
+    required SessionArchivedReason reason,
+  }) = _SessionArchivedRejection;
+
+  factory SessionArchivedRejection.fromJson(Map<String, dynamic> json) => _$SessionArchivedRejectionFromJson(json);
+}

--- a/shared/sesori_shared/lib/src/models/sesori/session_archived_rejection.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session_archived_rejection.freezed.dart
@@ -1,0 +1,151 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'session_archived_rejection.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$SessionArchivedRejection {
+
+ String get sessionId; SessionArchivedReason get reason;
+/// Create a copy of SessionArchivedRejection
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SessionArchivedRejectionCopyWith<SessionArchivedRejection> get copyWith => _$SessionArchivedRejectionCopyWithImpl<SessionArchivedRejection>(this as SessionArchivedRejection, _$identity);
+
+  /// Serializes this SessionArchivedRejection to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionArchivedRejection&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.reason, reason) || other.reason == reason));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,sessionId,reason);
+
+@override
+String toString() {
+  return 'SessionArchivedRejection(sessionId: $sessionId, reason: $reason)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SessionArchivedRejectionCopyWith<$Res>  {
+  factory $SessionArchivedRejectionCopyWith(SessionArchivedRejection value, $Res Function(SessionArchivedRejection) _then) = _$SessionArchivedRejectionCopyWithImpl;
+@useResult
+$Res call({
+ String sessionId, SessionArchivedReason reason
+});
+
+
+
+
+}
+/// @nodoc
+class _$SessionArchivedRejectionCopyWithImpl<$Res>
+    implements $SessionArchivedRejectionCopyWith<$Res> {
+  _$SessionArchivedRejectionCopyWithImpl(this._self, this._then);
+
+  final SessionArchivedRejection _self;
+  final $Res Function(SessionArchivedRejection) _then;
+
+/// Create a copy of SessionArchivedRejection
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? sessionId = null,Object? reason = null,}) {
+  return _then(_self.copyWith(
+sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
+as String,reason: null == reason ? _self.reason : reason // ignore: cast_nullable_to_non_nullable
+as SessionArchivedReason,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _SessionArchivedRejection implements SessionArchivedRejection {
+  const _SessionArchivedRejection({required this.sessionId, required this.reason});
+  factory _SessionArchivedRejection.fromJson(Map<String, dynamic> json) => _$SessionArchivedRejectionFromJson(json);
+
+@override final  String sessionId;
+@override final  SessionArchivedReason reason;
+
+/// Create a copy of SessionArchivedRejection
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SessionArchivedRejectionCopyWith<_SessionArchivedRejection> get copyWith => __$SessionArchivedRejectionCopyWithImpl<_SessionArchivedRejection>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SessionArchivedRejectionToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionArchivedRejection&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.reason, reason) || other.reason == reason));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,sessionId,reason);
+
+@override
+String toString() {
+  return 'SessionArchivedRejection(sessionId: $sessionId, reason: $reason)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SessionArchivedRejectionCopyWith<$Res> implements $SessionArchivedRejectionCopyWith<$Res> {
+  factory _$SessionArchivedRejectionCopyWith(_SessionArchivedRejection value, $Res Function(_SessionArchivedRejection) _then) = __$SessionArchivedRejectionCopyWithImpl;
+@override @useResult
+$Res call({
+ String sessionId, SessionArchivedReason reason
+});
+
+
+
+
+}
+/// @nodoc
+class __$SessionArchivedRejectionCopyWithImpl<$Res>
+    implements _$SessionArchivedRejectionCopyWith<$Res> {
+  __$SessionArchivedRejectionCopyWithImpl(this._self, this._then);
+
+  final _SessionArchivedRejection _self;
+  final $Res Function(_SessionArchivedRejection) _then;
+
+/// Create a copy of SessionArchivedRejection
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? sessionId = null,Object? reason = null,}) {
+  return _then(_SessionArchivedRejection(
+sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
+as String,reason: null == reason ? _self.reason : reason // ignore: cast_nullable_to_non_nullable
+as SessionArchivedReason,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/shared/sesori_shared/lib/src/models/sesori/session_archived_rejection.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session_archived_rejection.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'session_archived_rejection.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_SessionArchivedRejection _$SessionArchivedRejectionFromJson(Map json) =>
+    _SessionArchivedRejection(
+      sessionId: json['sessionId'] as String,
+      reason: $enumDecode(_$SessionArchivedReasonEnumMap, json['reason']),
+    );
+
+Map<String, dynamic> _$SessionArchivedRejectionToJson(
+  _SessionArchivedRejection instance,
+) => <String, dynamic>{
+  'sessionId': instance.sessionId,
+  'reason': _$SessionArchivedReasonEnumMap[instance.reason]!,
+};
+
+const _$SessionArchivedReasonEnumMap = {
+  SessionArchivedReason.archivedReadOnly: 'archived_read_only',
+};

--- a/shared/sesori_shared/test/models/session_archived_rejection_test.dart
+++ b/shared/sesori_shared/test/models/session_archived_rejection_test.dart
@@ -1,0 +1,31 @@
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("SessionArchivedRejection", () {
+    test("round-trips through JSON", () {
+      const rejection = SessionArchivedRejection(
+        sessionId: "ses-1",
+        reason: SessionArchivedReason.archivedReadOnly,
+      );
+
+      expect(rejection.toJson(), {"sessionId": "ses-1", "reason": "archived_read_only"});
+      expect(SessionArchivedRejection.fromJson(rejection.toJson()), rejection);
+    });
+
+    test("does not decode as SessionCleanupRejection", () {
+      // Published clients parse 409 bodies from archive/delete as a cleanup
+      // rejection. The archived body must fail that parse so no bogus
+      // cleanup/force dialog is shown; they fall back to a generic error.
+      const rejection = SessionArchivedRejection(
+        sessionId: "ses-1",
+        reason: SessionArchivedReason.archivedReadOnly,
+      );
+
+      expect(
+        () => SessionCleanupRejection.fromJson(rejection.toJson()),
+        throwsA(anything),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Complexity

⚙️ Moderate — a new Layer-3 validator, a new shared wire model, and a full
vertical deletion across service, repository, DAO, and git-API layers, with the
compatibility behavior of a published wire field to preserve.

## What

- Add `SessionArchivedRejection` (shared, closed `SessionArchivedReason` enum) as
  the 409 body for every archived-mutation rejection.
- Add `ArchivedSessionValidator` — the single archive-permanence rule in the
  bridge. It throws the typed `SessionArchivedReadOnlyException`.
- `PATCH /session/update/archive` with `archived: false` now consults the
  validator: refused with 409 when the session is archived, unchanged no-op
  otherwise. The request shape still accepts `archived: false` because published
  apps send it (dated compatibility comment in the service).
- Delete the whole unarchive vertical: `SessionLifecycleService._doUnarchive` and
  `_resolveRestoreBaseBranch`, `SessionRepository.unarchiveStoredSession`,
  `SessionDao.clearArchived`, `WorktreeService.restoreWorktree` and
  `resolveBaseBranchAndCommit`, `WorktreeRepository.restoreWorktree`,
  `GitCliApi.restoreWorktree`, `SessionInitializationException` and its handler
  branch — plus their tests.

## Why

Archiving becomes a final, permanent action: an archived session is audit-only
and can never be unarchived, prompted, or mutated again. This step removes the
bridge's ability to unarchive at all and establishes the single rejection type
and wire body that step 3/4 reuses for prompt, question, and permission sends.

Step 2/4 of `.plan/active/read-only-archiving/PLAN.md`. Prompt/question/permission
enforcement and every client-side change land in step 3/4.

## Risk and test focus

Moderate risk, confined to the archive route and worktree restore code.

- Impacted flows: archive (unchanged), unarchive from a published app (now an
  explicit 409), and worktree restore-on-unarchive (gone).
- Published apps still render Unarchive until they update. `SessionApi.unarchiveSession`
  does not parse 409 bodies, so the call fails and its optimistic UI rolls back
  with the generic failure surface. Intended, not silent breakage.
- The new 409 body shares no required keys with `SessionCleanupRejection`, so the
  published client's `_throwIfCleanupRejected` parse fails and no bogus
  cleanup/force dialog appears. Pinned by a test.
- Most valuable checks: the archive path is untouched; `archived: false` on a
  non-archived session is still an unchanged no-op; the 409 body decodes as
  `SessionArchivedRejection` and not as `SessionCleanupRejection`.

## Expected result

- **User-visible:** unarchiving from a current or published app fails explicitly
  instead of restoring the session. The client's Unarchive affordances are
  removed in step 3/4.
- **Database:** no schema change. `archived_at` and `idx_sessions_archive` stay;
  nothing clears `archived_at` anymore, so an archived row stays archived.
- **Internal:** `ArchivedSessionValidator` is now the only archive-permanence
  rule; step 3/4 routes prompt/question/permission through the same check.

## Verification

- `bridge/app`: `dart analyze --fatal-infos .` clean; `dart test` 2430 passing.
- `shared/sesori_shared`: `dart analyze --fatal-infos .` clean; `dart test` 364 passing.
- `architecture-implementation-review` (sub-agent): approved, no findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make archiving permanent by rejecting all unarchive attempts and removing the restore path. PATCH /session/update/archive with archived: false now returns 409 with a SessionArchivedRejection when the session is archived (even if the plugin is stopped); it’s a no‑op on non‑archived sessions.

- **New Features**
  - Added ArchivedSessionValidator that enforces archive permanence via a store-only check and throws SessionArchivedReadOnlyException with a SessionArchivedRejection body.
  - Introduced shared wire model SessionArchivedRejection with a closed SessionArchivedReason enum for consistent 409 responses.
  - Updated archive route to return 409 JSON for archived targets even when their plugin is stopped; request still accepts archived: false for backward compatibility.

- **Refactors**
  - Removed the entire unarchive/restore path across service, repository, DAO, and git layers.
  - Deleted: SessionLifecycleService._doUnarchive, SessionRepository.unarchiveStoredSession, SessionDao.clearArchived, WorktreeService.restoreWorktree/resolveBaseBranchAndCommit, WorktreeRepository.restoreWorktree, GitCliApi.restoreWorktree, and SessionInitializationException.
  - Simplified tests and helpers to align with the new read-only archived behavior.

<sup>Written for commit b88e6bc6857f86f99f1c1af29c66ca1adef9e859. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

