### PR TITLE
🌱 chore(release): v1.7.1

### DIFF
--- a/bridge/app/lib/src/version.dart
+++ b/bridge/app/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String appVersion = '1.7.0';
+const String appVersion = '1.7.1';

--- a/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-arm64",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS ARM64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.7.0",
+    "releaseTag": "v1.7.1",
     "releaseArtifact": "sesori-bridge-macos-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-darwin-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-x64",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS x64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.7.0",
+    "releaseTag": "v1.7.1",
     "releaseArtifact": "sesori-bridge-macos-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-arm64",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux ARM64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.7.0",
+    "releaseTag": "v1.7.1",
     "releaseArtifact": "sesori-bridge-linux-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-x64",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux x64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.7.0",
+    "releaseTag": "v1.7.1",
     "releaseArtifact": "sesori-bridge-linux-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-arm64",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows ARM64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.7.0",
+    "releaseTag": "v1.7.1",
     "releaseArtifact": "sesori-bridge-windows-arm64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-x64",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows x64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.7.0",
+    "releaseTag": "v1.7.1",
     "releaseArtifact": "sesori-bridge-windows-x64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge/package.json
+++ b/bridge/app/npm/sesori-bridge/package.json
@@ -1,22 +1,22 @@
 {
   "name": "@sesori/bridge",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Bootstrap launcher for the managed Sesori Bridge runtime",
   "bin": {
     "sesori-bridge": "bin/bridge.js"
   },
   "optionalDependencies": {
-    "@sesori/bridge-darwin-arm64": "1.7.0",
-    "@sesori/bridge-darwin-x64": "1.7.0",
-    "@sesori/bridge-linux-x64": "1.7.0",
-    "@sesori/bridge-linux-arm64": "1.7.0",
-    "@sesori/bridge-win32-x64": "1.7.0",
-    "@sesori/bridge-win32-arm64": "1.7.0"
+    "@sesori/bridge-darwin-arm64": "1.7.1",
+    "@sesori/bridge-darwin-x64": "1.7.1",
+    "@sesori/bridge-linux-x64": "1.7.1",
+    "@sesori/bridge-linux-arm64": "1.7.1",
+    "@sesori/bridge-win32-x64": "1.7.1",
+    "@sesori/bridge-win32-arm64": "1.7.1"
   },
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.7.0",
+    "releaseTag": "v1.7.1",
     "runtimeBundleSource": "github-release-assets"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sesori_bridge
 description: Dart implementation of the Sesori Bridge CLI for WebSocket communication.
-version: 1.7.0
+version: 1.7.1
 publish_to: none
 resolution: workspace
 

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -17,7 +17,7 @@ resolution: workspace
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.7.0+1
+version: 1.7.1+1
 environment:
   sdk: ^3.12.2
 


### PR DESCRIPTION
## Complexity
🌱 Trivial — automated version bump only (`make bump-version TYPE=patch`).

## What
- Bump shared version from v1.7.0 to v1.7.1 across bridge and client (`bridge/app/lib/src/version.dart`, bridge npm package manifests, `bridge/app/pubspec.yaml`, `client/app/pubspec.yaml`).
- Mobile build number preserved.

Changes since v1.7.0:
- ⚙️ [read-only-archiving] Reject unarchive and delete restore machinery [step 2/4] (#767)
- 🌱 [internal-chat-history] Raise plan [step 1/8] (#763)
- 🌱 [read-only-archiving] Raise plan [step 1/4] (#765)
- docs(readme): put the assistants in the hero heading (#761)
- ⚙️ Keep cached PR status when a waited refresh fails (#762)
- 🌱 Treat desktop window occlusion as inactive, not backgrounded (#760)

## Why
Patch release to ship the fixes merged since v1.7.0.

## Risk and test focus
- No user-visible behavior change from this PR itself; version metadata only.
- CI test/analyzer matrix covers the release.

## Expected result
- Bridge and client both report version 1.7.1; no database or wire-contract impact.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch release: bump shared version from 1.7.0 to 1.7.1 across Bridge and Client. Updates `version.dart`, bridge/client `pubspec.yaml`, and all `@sesori/bridge*` npm packages and release tags; mobile build number unchanged; no behavior change.

<sup>Written for commit 41c408dbaf24ea48b3369261bda6910198ba6df0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

