### PR TITLE
🌱 [read-only-archiving] Retire plan [step 4/4]

### DIFF
--- a/.plan/active/internal-chat-history/PLAN.md
+++ b/.plan/active/internal-chat-history/PLAN.md
@@ -9,7 +9,7 @@
   were merged into this plan and that draft is superseded)
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Base:** `main` at `232974e1`
-- **Prerequisite:** the `read-only-archiving` plan lands and merges fully
+- **Prerequisite (satisfied 2026-08-07):** the `read-only-archiving` plan lands and merges fully
   first. It removes unarchive end to end and makes archived sessions
   read-only; this plan builds its archive export/purge on that permanence
   guarantee and contains no unarchive-removal work itself.

--- a/.plan/active/internal-chat-history/PLAN.md
+++ b/.plan/active/internal-chat-history/PLAN.md
@@ -9,10 +9,10 @@
   were merged into this plan and that draft is superseded)
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Base:** `main` at `232974e1`
-- **Prerequisite (satisfied 2026-08-07):** the `read-only-archiving` plan lands and merges fully
-  first. It removes unarchive end to end and makes archived sessions
-  read-only; this plan builds its archive export/purge on that permanence
-  guarantee and contains no unarchive-removal work itself.
+- **Prerequisite (satisfied 2026-08-07):** the `read-only-archiving` plan has
+  landed and merged fully. It removed unarchive end to end and made archived
+  sessions read-only; this plan builds its archive export/purge on that
+  permanence guarantee and contains no unarchive-removal work itself.
 
 ## Goal
 

--- a/.plan/active/internal-chat-history/TRACKER.md
+++ b/.plan/active/internal-chat-history/TRACKER.md
@@ -3,19 +3,19 @@
 ## Current State
 
 - **Plan slug:** `internal-chat-history`
-- **Implementation base:** `origin/main` at `232974e1`
-- **Series state:** Step 1/8 plan PR open
-- **Current step:** 1/8
-- **Plan PR:** [#763](https://github.com/sesori-ai/sesori_apps_monorepo/pull/763)
+- **Implementation base:** `origin/main` at `b710f0df`
+- **Series state:** Step 1/8 merged; implementation not started
+- **Current step:** 2/8
+- **Plan PR:** [#763](https://github.com/sesori-ai/sesori_apps_monorepo/pull/763) merged
 - **Prerequisite:** satisfied — the `read-only-archiving` series merged fully on
   2026-08-07 (through [PR #770](https://github.com/sesori-ai/sesori_apps_monorepo/pull/770)).
-- **Next action:** merge PR #763, then start step 2/8.
+- **Next action:** start step 2/8.
 
 ## Delivery Steps
 
 | Done | Step | Exact PR title | Estimate | State |
 |---|---|---|---:|---|
-| [ ] | 1/8 | `🌱 [internal-chat-history] Raise plan [step 1/8]` | 400–700 | [PR #763](https://github.com/sesori-ai/sesori_apps_monorepo/pull/763) open |
+| [x] | 1/8 | `🌱 [internal-chat-history] Raise plan [step 1/8]` | 400–700 | [PR #763](https://github.com/sesori-ai/sesori_apps_monorepo/pull/763) merged |
 | [ ] | 2/8 | `🚧 [internal-chat-history] Introduce the chat history database [step 2/8]` | 1,500–2,600 | pending |
 | [ ] | 3/8 | `🚧 [internal-chat-history] Capture live message events and backfill lazily [step 3/8]` | 900–1,400 | pending |
 | [ ] | 4/8 | `⚙️ [internal-chat-history] Serve session messages from the store [step 4/8]` | 700–1,100 | pending |

--- a/.plan/active/internal-chat-history/TRACKER.md
+++ b/.plan/active/internal-chat-history/TRACKER.md
@@ -7,10 +7,9 @@
 - **Series state:** Step 1/8 plan PR open
 - **Current step:** 1/8
 - **Plan PR:** [#763](https://github.com/sesori-ai/sesori_apps_monorepo/pull/763)
-- **Prerequisite:** the `read-only-archiving` series must merge fully before
-  step 2/8 starts.
-- **Next action:** merge PR #763; implement the `read-only-archiving` series;
-  then start step 2/8.
+- **Prerequisite:** satisfied — the `read-only-archiving` series merged fully on
+  2026-08-07 (through [PR #770](https://github.com/sesori-ai/sesori_apps_monorepo/pull/770)).
+- **Next action:** merge PR #763, then start step 2/8.
 
 ## Delivery Steps
 
@@ -29,8 +28,7 @@
 
 - Merge in numeric order; each PR must remain independently valid at its own
   base. A successor may target its open predecessor.
-- Do not start step 2/8 until the `read-only-archiving` series has fully
-  merged.
+- The `read-only-archiving` prerequisite has merged, so step 2/8 is unblocked.
 - Count additions plus deletions (including generated code and tests) against
   the 1,500-line soft cap; the step 2 overage from new-database codegen is
   pre-recorded in `PLAN.md`.

--- a/.plan/completed/read-only-archiving/PLAN.md
+++ b/.plan/completed/read-only-archiving/PLAN.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **Plan slug:** `read-only-archiving`
-- **Status:** Completed — all delivery steps merged; retired 2026-08-07
+- **Status:** Completed — all implementation steps merged; retired 2026-08-07
 - **Plan date:** 2026-08-06
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Base:** `main` at `232974e1`

--- a/.plan/completed/read-only-archiving/PLAN.md
+++ b/.plan/completed/read-only-archiving/PLAN.md
@@ -3,13 +3,16 @@
 ## Status
 
 - **Plan slug:** `read-only-archiving`
-- **Status:** Active — plan raised, implementation not started
+- **Status:** Completed — all delivery steps merged; retired 2026-08-07
 - **Plan date:** 2026-08-06
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Base:** `main` at `232974e1`
-- **Relationship:** prerequisite of `internal-chat-history`. This series lands
-  and merges fully before the chat-history series starts; the chat-history
-  archive export/purge builds on the permanence guarantee established here.
+- **Relationship:** prerequisite of `internal-chat-history`, now satisfied. The
+  chat-history archive export/purge builds on the permanence guarantee
+  established here.
+- **As-built deltas:** see `TRACKER.md`. Notably, `ArchivedSessionValidator`
+  checks only the session the caller named — the family/ancestor checks two
+  review rounds asked for were tried and deliberately reverted.
 
 ## Goal
 

--- a/.plan/completed/read-only-archiving/TRACKER.md
+++ b/.plan/completed/read-only-archiving/TRACKER.md
@@ -3,13 +3,13 @@
 ## Current State
 
 - **Plan slug:** `read-only-archiving`
-- **Implementation base:** `origin/main` at `354c61c1`
-- **Series state:** Step 3/4 in PR
-- **Current step:** 3/4
+- **Status:** Completed — all delivery steps merged
+- **Implementation base:** `origin/main` at `b710f0df`
+- **Series state:** Steps 1–3 merged; step 4 is this retirement
 - **Plan PR:** [#765](https://github.com/sesori-ai/sesori_apps_monorepo/pull/765) merged
-- **Relationship:** prerequisite of `internal-chat-history`; that series does
-  not start until this one has fully merged.
-- **Next action:** merge step 3/4, then start step 4/4.
+- **Relationship:** prerequisite of `internal-chat-history`, which is now
+  unblocked — unarchive is gone end to end and archived sessions are read-only.
+- **Next action:** none; the plan is retired.
 
 ## Delivery Steps
 
@@ -17,19 +17,20 @@
 |---|---|---|---|
 | [x] | 1/4 | `🌱 [read-only-archiving] Raise plan [step 1/4]` | [PR #765](https://github.com/sesori-ai/sesori_apps_monorepo/pull/765) merged |
 | [x] | 2/4 | `⚙️ [read-only-archiving] Reject unarchive and delete restore machinery [step 2/4]` | [PR #767](https://github.com/sesori-ai/sesori_apps_monorepo/pull/767) merged |
-| [ ] | 3/4 | `⚙️ [read-only-archiving] Enforce read-only archived sessions [step 3/4]` | in PR |
-| [ ] | 4/4 | `🌱 [read-only-archiving] Retire plan [step 4/4]` | pending |
+| [x] | 3/4 | `⚙️ [read-only-archiving] Enforce read-only archived sessions [step 3/4]` | [PR #770](https://github.com/sesori-ai/sesori_apps_monorepo/pull/770) merged |
+| [x] | 4/4 | `🌱 [read-only-archiving] Retire plan [step 4/4]` | this PR |
 
-## Execution Rules
+## Outcome
 
-- Merge in numeric order; each PR must remain independently valid at its own
-  base.
-- If step 3 trends past the 1,500-line soft cap it splits at the
-  bridge/client boundary and the series total is restated before the first
-  affected PR opens.
-- Run focused tests, the owning package's tests, and the analyzer for each
-  implementation step; run `architecture-implementation-review` (sub-agent)
-  for steps 2 and 3.
+Archiving is a final, permanent action. The unarchive vertical is gone from the
+bridge (service, repository, DAO, worktree restore, git API) and from the client
+(API, repository, service, list cubit, UI, undo). `ArchivedSessionValidator` is
+the single archive-permanence rule; prompts, permission replies, and question
+replies/rejections consult it inside their dispatched operation, and
+`RequestHandlerBase` maps its exception to the shared 409
+`SessionArchivedRejection` body once for every route. Archived session detail is
+read-only in the app, with the refusal in `SessionDetailCubit` and presentation
+only in the shell. Archiving and deleting both always confirm.
 
 ## Verification Log
 

--- a/.plan/completed/read-only-archiving/TRACKER.md
+++ b/.plan/completed/read-only-archiving/TRACKER.md
@@ -3,9 +3,10 @@
 ## Current State
 
 - **Plan slug:** `read-only-archiving`
-- **Status:** Completed — all delivery steps merged
-- **Implementation base:** `origin/main` at `b710f0df`
-- **Series state:** Steps 1–3 merged; step 4 is this retirement
+- **Completion base:** `origin/main` at `b710f0df`, the merge commit for the
+  final implementation PR #770
+- **Series state:** Steps 1–3 merged; step 4 records completion and retires the
+  plan
 - **Plan PR:** [#765](https://github.com/sesori-ai/sesori_apps_monorepo/pull/765) merged
 - **Relationship:** prerequisite of `internal-chat-history`, which is now
   unblocked — unarchive is gone end to end and archived sessions are read-only.
@@ -18,7 +19,7 @@
 | [x] | 1/4 | `🌱 [read-only-archiving] Raise plan [step 1/4]` | [PR #765](https://github.com/sesori-ai/sesori_apps_monorepo/pull/765) merged |
 | [x] | 2/4 | `⚙️ [read-only-archiving] Reject unarchive and delete restore machinery [step 2/4]` | [PR #767](https://github.com/sesori-ai/sesori_apps_monorepo/pull/767) merged |
 | [x] | 3/4 | `⚙️ [read-only-archiving] Enforce read-only archived sessions [step 3/4]` | [PR #770](https://github.com/sesori-ai/sesori_apps_monorepo/pull/770) merged |
-| [x] | 4/4 | `🌱 [read-only-archiving] Retire plan [step 4/4]` | this PR |
+| [x] | 4/4 | `🌱 [read-only-archiving] Retire plan [step 4/4]` | [PR #771](https://github.com/sesori-ai/sesori_apps_monorepo/pull/771) |
 
 ## Outcome
 


### PR DESCRIPTION
## Complexity

🌱 Trivial — documentation only: a plan directory move plus status bookkeeping.

## What

- Move `.plan/active/read-only-archiving/` to `.plan/completed/`.
- Mark the plan and tracker completed, record the delivered outcome, and note
  the as-built deltas (most notably that `ArchivedSessionValidator` checks only
  the session the caller named — the family/ancestor checks two review rounds
  asked for were tried and deliberately reverted).
- Clear the prerequisite gate in the `internal-chat-history` plan and tracker,
  which was waiting on this series.

## Why

All four delivery steps have merged, so the plan is no longer active work.
`internal-chat-history` was explicitly blocked on it and is now unblocked.

## Risk and test focus

None. No production code, tests, configuration, or generated files are touched.
The only consumer of these files is a human or agent reading the plan.

## Expected result

- **User-visible:** none.
- **Database:** none.
- **Internal:** the read-only-archiving plan lives under `.plan/completed/`, and
  `internal-chat-history` step 2/8 is no longer gated.

## Verification

Documentation-only change, so no Dart/Flutter suites were run per the repository
instructions. The three preceding steps were verified in their own PRs (#765,
#767, #770).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retire the `read-only-archiving` plan: move it to `.plan/completed/`, record the delivered outcome and as-built deltas, and unblock `internal-chat-history` so step 2/8 can start. Also refresh stale status details in the plan and tracker to reflect merged implementation steps and retirement on 2026-08-07.

<sup>Written for commit b69b7cfda238526c769336b499edaba4eed36c63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

