### PR TITLE
🌱 List more than 50 folders in the Add Project browser

### DIFF
--- a/bridge/app/test/bridge/repositories/filesystem_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/filesystem_repository_test.dart
@@ -148,6 +148,22 @@ void main() {
       expect(result.data.map((s) => s.name).toList(), ["a", "b"]);
     });
 
+    test("listSuggestions returns every child when maxResults exceeds the directory size", () {
+      // Guards the reported bug: a directory of 152 folders listed only its
+      // first 50 because the client asked for 50. maxResults must be the only
+      // bound in this path — no other cap may re-truncate a listing that fits.
+      const childCount = 152;
+      for (var index = 0; index < childCount; index++) {
+        Directory("${tempDir.path}/project-${index.toString().padLeft(3, "0")}").createSync();
+      }
+
+      final result = repository.listSuggestions(prefix: tempDir.path, maxResults: 1000);
+
+      expect(result.data, hasLength(childCount));
+      expect(result.data.first.name, "project-000");
+      expect(result.data.last.name, "project-151");
+    });
+
     test("translates a permission denial into FilesystemPermissionDeniedException", () {
       final repo = FilesystemRepository(
         filesystemApi: _PermissionDeniedFilesystemApi(),

--- a/client/module_core/lib/src/api/filesystem_api.dart
+++ b/client/module_core/lib/src/api/filesystem_api.dart
@@ -6,6 +6,16 @@ import "client/relay_http_client.dart";
 
 @lazySingleton
 class FilesystemApi {
+  /// How many child directories one browse request asks the bridge for.
+  ///
+  /// The bridge sorts by name and truncates to this many, so the value is a
+  /// ceiling on what the browser can reach in a folder — not a page size, since
+  /// there is no cursor to request the rest. It is set high enough that ordinary
+  /// folders list completely, and kept bounded only to cap the response payload
+  /// for pathological directories (`node_modules` and the like), at roughly
+  /// 150 bytes per entry.
+  static const _browseResultLimit = 1000;
+
   final RelayHttpApiClient _client;
 
   FilesystemApi({required RelayHttpApiClient client}) : _client = client;
@@ -15,7 +25,7 @@ class FilesystemApi {
   }) {
     return _client.post(
       "/filesystem/suggestions",
-      body: FilesystemSuggestionsRequest(prefix: prefix, maxResults: 50),
+      body: FilesystemSuggestionsRequest(prefix: prefix, maxResults: _browseResultLimit),
       fromJson: FilesystemSuggestions.fromJson,
     );
   }

--- a/client/module_core/test/api/filesystem_api_test.dart
+++ b/client/module_core/test/api/filesystem_api_test.dart
@@ -38,7 +38,7 @@ void main() {
       () => client.post<FilesystemSuggestions>(
         "/filesystem/suggestions",
         fromJson: any(named: "fromJson"),
-        body: const FilesystemSuggestionsRequest(prefix: "/projects", maxResults: 50),
+        body: const FilesystemSuggestionsRequest(prefix: "/projects", maxResults: 1000),
       ),
     ).called(1);
   });


### PR DESCRIPTION
## Complexity

Trivial. One production constant, plus the two tests that pinned the old value
and the new behaviour.

## What

The Add Project directory browser asked the bridge for at most 50 child
directories. `FilesystemApi.getSuggestions` sent a bare `maxResults: 50`
literal, and `FilesystemRepository.listSuggestions` filters dotfolders, sorts
by name, then `.take(maxResults)`.

A folder with more than 50 child directories therefore listed only its
alphabetically-first 50. `FilesystemSuggestions` carries no `hasMore` or total,
the handler does no clamping, and there is no cursor — so the remainder was not
merely unpaged, it was unreachable and unannounced.

This raises the limit to 1000 and gives it a name and a rationale, so the
number no longer sits in the call as an unexplained literal.

## Why

Reported from real use: a directory with 152 folders showed 50, with no
"load more" affordance and no hint that anything was missing.

The bound is kept rather than removed because `listSuggestions` probes `.git`
per returned entry and the response crosses the relay; 1000 entries is roughly
150 KB, which keeps a pathological directory (`node_modules` and friends) from
producing an unbounded payload while covering every realistic project folder.

Pagination was considered and deliberately not added. `listDirectories` already
enumerates the whole directory before truncating, so a cursor would only reduce
the per-entry `.git` probes and the JSON size — not the directory walk — while
adding a wire contract with compatibility obligations and page races on top of
the browser's existing stale-listing guard.

## Risk and test focus

No database impact. No wire shape change: `maxResults` is an existing required
request field, so the client is the only side that had to change and both
older and newer bridges honour the new value unchanged.

User-visible impact is limited to the Add Project sheet, which now lists
folders it previously omitted.

Worth a reviewer's attention:

- `.git` is now probed for up to 1000 entries instead of 50. That probe is
  `FileSystemEntity.typeSync`, which returns `notFound` rather than throwing on
  an `EACCES` denial (verified empirically), so an unreadable child yields
  `isGitRepo: false` and cannot escalate through `_guard` into a 403 for the
  whole listing.
- Truncation above 1000 is still silent. That is unchanged behaviour, not a
  regression, and making it visible would require a new response field.

## Expected result

Browsing a folder with more than 50 subdirectories lists them all, up to 1000.
Dot-prefixed folders and non-directories remain excluded, as before.

## Verification

- `dart test` in `client/module_core` — 1006 passed
- `dart test test/bridge/repositories/filesystem_repository_test.dart` in
  `bridge/app` — 17 passed, including a new case asserting a 152-child
  directory returns all 152 when `maxResults` exceeds it
- `flutter test test/features/project_list/add_project_dialog_test.dart` in
  `client/app` — 18 passed
- `dart analyze --fatal-infos` in `client/module_core` — no issues
- Manually on a physical Android device against a running bridge: the browser
  listed folders well past the previous alphabetical cutoff


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Add Project browser truncation by raising the child-directory limit from 50 to 1000, so folders with many subfolders are fully listed. Keeps responses bounded without adding pagination.

- **Bug Fixes**
  - Use `_browseResultLimit = 1000` in `FilesystemApi.getSuggestions` (was 50).
  - No API shape change; only increases the `maxResults` sent by the client, compatible with existing bridges.
  - Updated tests and added a case verifying all 152 subfolders are returned when under the limit.

<sup>Written for commit 45c846811f92250e6baac4baf84c7952faefb6d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

