### PR TITLE
🌿 Skip active-work interruption for non-owned OpenCode servers during shutdown

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_bridge_plugin.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_bridge_plugin.dart
@@ -157,6 +157,14 @@ class OpenCodeBridgePlugin implements BridgePlugin {
 
   @override
   Future<Set<String>> interruptActiveWork({required Duration budget}) {
+    // A server this bridge does not own (attach mode, or a degraded start that
+    // never spawned one) outlives the bridge: cancelling its in-flight work
+    // would destroy runs the user expects to continue, and when the server is
+    // unreachable the interruption can only hang until the budget expires.
+    if ((_monitor.currentHandle?.record ?? _ownedRecord) == null) {
+      Log.d("[opencode] server is not bridge-owned; skipping active-work interruption");
+      return Future.value(const <String>{});
+    }
     return api.interruptActiveWork(budget: budget);
   }
 

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_bridge_plugin_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_bridge_plugin_test.dart
@@ -45,6 +45,32 @@ void main() {
       expect(status.current, isA<PluginStopped>());
     });
 
+    test("interruptActiveWork delegates to the api when the runtime is bridge-owned", () async {
+      final owned = plugin();
+
+      await owned.interruptActiveWork(budget: const Duration(seconds: 1));
+
+      expect(api.interruptCount, equals(1));
+    });
+
+    test("interruptActiveWork skips the api when the server is not bridge-owned", () async {
+      status = PluginStatusController(initial: const PluginReady());
+      final attached = OpenCodeBridgePlugin(
+        api: api,
+        reporter: OpenCodeRuntimeStatusReporter(status: status, clock: const _ImmediateClock()),
+        monitor: monitor,
+        service: service,
+        ownedRecord: null,
+        port: 51000,
+        serverUrl: "http://127.0.0.1:51000",
+      );
+
+      final interrupted = await attached.interruptActiveWork(budget: const Duration(seconds: 1));
+
+      expect(interrupted, isEmpty);
+      expect(api.interruptCount, equals(0));
+    });
+
     test("a disarm failure is the primary teardown error when later steps also fail", () async {
       monitor.disarmError = StateError("disarm failed");
       api.disposeError = StateError("dispose failed");
@@ -88,7 +114,14 @@ class _ImmediateClock implements ServerClock {
 
 class _FakeApi implements OpenCodeManagedApi {
   int disposeCount = 0;
+  int interruptCount = 0;
   Object? disposeError;
+
+  @override
+  Future<Set<String>> interruptActiveWork({required Duration budget}) async {
+    interruptCount += 1;
+    return const <String>{};
+  }
 
   @override
   PluginWorkState get currentWorkState => PluginWorkState.idle;


### PR DESCRIPTION
## Complexity
🌿 Straightforward — a single ownership guard in the OpenCode plugin plus two unit tests.

## What
`OpenCodeBridgePlugin.interruptActiveWork` now returns immediately (empty set) when the bridge does not own the OpenCode server — attach mode (`--opencode-no-auto-start`) or a degraded start that never spawned a child. Ownership is derived from the monitor's current handle falling back to the start-time record, the same source `shutdown()` already uses.

## Why
Pressing Ctrl-C on a bridge attached to an externally managed OpenCode server tried to cancel that server's in-flight work. That is wrong twice over: the server outlives the bridge, so cancelling runs the user expects to continue is destructive; and when the server is unreachable (degraded attach), the interruption just hangs for the full 10s shutdown budget and logs a TimeoutException, as seen in the reported shutdown trace.

## Risk and test focus
Low risk, plugin-local. No wire, database, or contract impact. Focus: managed-mode shutdown still interrupts active work (delegation test), attach/degraded shutdown skips it (skip test). Backend-specific attach semantics stay inside the OpenCode plugin.

## Expected result
Ctrl-C on a `--opencode-no-auto-start` bridge shuts down promptly without touching the external server's active sessions and without the 10-second interrupt timeout. Managed-mode shutdown behavior is unchanged. No user-visible impact beyond faster, quieter shutdown in attach mode.

## Verification
`dart test test/runtime/open_code_bridge_plugin_test.dart` and `dart analyze --fatal-infos` pass in `bridge/sesori_plugin_opencode/`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip active-work interruption for OpenCode servers not owned by the bridge during shutdown. Prevents canceling external runs and removes the 10s hang in attach/degraded mode.

- **Bug Fixes**
  - Guard `interruptActiveWork` to skip when ownership is absent (checks `monitor.currentHandle?.record` fallback to the startup-owned record).
  - Managed mode still calls `api.interruptActiveWork`; added tests for delegate vs skip.

<sup>Written for commit da16f4b3a396a233074392c9edb22df4f81a6075. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

