### PR TITLE
🌿 Support the codex CLI bundled by the Codex desktop app

### DIFF
--- a/bridge/sesori_plugin_codex/lib/codex_plugin.dart
+++ b/bridge/sesori_plugin_codex/lib/codex_plugin.dart
@@ -15,6 +15,7 @@ export "src/repositories/mappers/codex_rollout_tool_mapper.dart";
 // Runtime lifecycle: the descriptor is the public entry point the bridge
 // registers in bin/bridge.dart.
 export "src/runtime/codex_bridge_plugin.dart";
+export "src/runtime/codex_desktop_app_locator.dart";
 export "src/runtime/codex_managed_api.dart";
 export "src/runtime/codex_plugin_descriptor.dart";
 export "src/runtime/codex_runtime_manifest.dart";

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_desktop_app_locator.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_desktop_app_locator.dart
@@ -50,16 +50,22 @@ List<String> codexDesktopAppCliCandidates({
 
 /// Subdirectory paths of [directoryPath], newest-modified first so the app's
 /// most recently relocated CLI copy is probed before stale hash directories.
-/// A listing failure degrades to no subdirectory candidates.
+/// Each entry is stat-ed once; an entry removed mid-enumeration (`notFound`)
+/// is skipped, and a listing failure degrades to no subdirectory candidates.
 List<String> _subdirectoriesNewestFirst({required String directoryPath}) {
   try {
     final directory = io.Directory(directoryPath);
     if (!directory.existsSync()) return const [];
-    final subdirectories = directory.listSync().whereType<io.Directory>().toList()
-      ..sort((a, b) => b.statSync().modified.compareTo(a.statSync().modified));
-    return [for (final subdirectory in subdirectories) subdirectory.path];
-  } on Object catch (error) {
-    Log.d("[codex] could not list desktop-app CLI directory '$directoryPath': $error");
+    final entries = [
+      for (final subdirectory in directory.listSync().whereType<io.Directory>())
+        (path: subdirectory.path, stat: subdirectory.statSync()),
+    ]..sort((a, b) => b.stat.modified.compareTo(a.stat.modified));
+    return [
+      for (final entry in entries)
+        if (entry.stat.type != io.FileSystemEntityType.notFound) entry.path,
+    ];
+  } on Object catch (error, stackTrace) {
+    Log.w("[codex] could not list desktop-app CLI directory '$directoryPath'", error, stackTrace);
     return const [];
   }
 }

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_desktop_app_locator.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_desktop_app_locator.dart
@@ -1,0 +1,65 @@
+import "dart:io" as io;
+
+import "package:path/path.dart" as p;
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
+/// Candidate paths of the `codex` CLI bundled by the Codex desktop app, for
+/// users who installed the app without a standalone CLI on `PATH`.
+///
+/// - macOS: the app ships the CLI inside its bundle at
+///   `<bundle>/Contents/Resources/codex`. The bundle is `ChatGPT.app` on newer
+///   builds and `Codex.app` on older ones (both bundle id `com.openai.codex`),
+///   under `/Applications` or `~/Applications` — the same locations the codex
+///   CLI itself searches (`codex-rs/cli/src/desktop_app/mac.rs`).
+/// - Windows: the MSIX app relocates its bundled CLI out of the launch-protected
+///   `WindowsApps` directory to `%LOCALAPPDATA%\OpenAI\Codex\bin\codex.exe`,
+///   with content-hash-named sibling subdirectories under that `bin` directory.
+/// - Linux: no desktop app exists, so there are no candidates.
+///
+/// Returns launch candidates in preference order without probing them: callers
+/// version-gate each candidate, and a missing path fails that probe harmlessly.
+List<String> codexDesktopAppCliCandidates({
+  required Map<String, String> environment,
+  required PlatformOs os,
+}) {
+  switch (os) {
+    case PlatformOs.macos:
+      final home = resolveUserHomeDirectory(environment: environment);
+      return [
+        for (final root in [
+          "/Applications",
+          if (home != null) p.join(home, "Applications"),
+        ])
+          for (final bundle in const ["ChatGPT.app", "Codex.app"])
+            p.join(root, bundle, "Contents", "Resources", "codex"),
+      ];
+    case PlatformOs.windows:
+      final localAppData = environment["LOCALAPPDATA"];
+      if (localAppData == null || localAppData.trim().isEmpty) return const [];
+      final binDir = p.join(localAppData, "OpenAI", "Codex", "bin");
+      return [
+        p.join(binDir, "codex.exe"),
+        for (final subdirectory in _subdirectoriesNewestFirst(directoryPath: binDir))
+          p.join(subdirectory, "codex.exe"),
+      ];
+    case PlatformOs.linux:
+      return const [];
+  }
+}
+
+/// Subdirectory paths of [directoryPath], newest-modified first so the app's
+/// most recently relocated CLI copy is probed before stale hash directories.
+/// A listing failure degrades to no subdirectory candidates.
+List<String> _subdirectoriesNewestFirst({required String directoryPath}) {
+  try {
+    final directory = io.Directory(directoryPath);
+    if (!directory.existsSync()) return const [];
+    final subdirectories = directory.listSync().whereType<io.Directory>().toList()
+      ..sort((a, b) => b.statSync().modified.compareTo(a.statSync().modified));
+    return [for (final subdirectory in subdirectories) subdirectory.path];
+  } on Object catch (error) {
+    Log.d("[codex] could not list desktop-app CLI directory '$directoryPath': $error");
+    return const [];
+  }
+}

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
@@ -25,6 +25,7 @@ import "../repositories/mappers/codex_rollout_tool_mapper.dart";
 import "../services/codex_rollout_tailer.dart";
 import "../services/codex_session_service.dart";
 import "codex_bridge_plugin.dart";
+import "codex_desktop_app_locator.dart";
 import "codex_managed_api.dart";
 import "codex_ownership_record.dart";
 import "codex_record_mapper.dart";
@@ -132,13 +133,15 @@ class CodexPluginDescriptor extends BridgePluginDescriptor {
     Duration coldStartBudget = codexColdStartBudget,
     Duration versionProbeTimeout = codexVersionProbeTimeout,
     ManagedRuntimeProvisionService? provisionService,
+    List<String>? desktopAppCliCandidates,
   }) : _buildApi = buildApi,
        _candidatePorts = candidatePorts,
        _random = random,
        _degradedDebounce = degradedDebounce,
        _coldStartBudget = coldStartBudget,
        _versionProbeTimeout = versionProbeTimeout,
-       _provisionService = provisionService;
+       _provisionService = provisionService,
+       _desktopAppCliCandidates = desktopAppCliCandidates;
 
   final CodexManagedApiFactory? _buildApi;
   final Iterable<int>? _candidatePorts;
@@ -150,6 +153,10 @@ class CodexPluginDescriptor extends BridgePluginDescriptor {
   /// Test seam for existing-runtime resolution. Production builds a default in
   /// [ensureRuntime] from the host's process service.
   final ManagedRuntimeProvisionService? _provisionService;
+
+  /// Test seam for desktop-app CLI candidates. Production enumerates them with
+  /// [codexDesktopAppCliCandidates] for the current platform.
+  final List<String>? _desktopAppCliCandidates;
 
   @override
   bool get supportsPromptAttachments => true;
@@ -220,8 +227,21 @@ class CodexPluginDescriptor extends BridgePluginDescriptor {
       probeTimeout: _versionProbeTimeout,
     );
 
+    // Fallback resolution mirroring ensureRuntime's precedence when the primary
+    // probe fails: a recent-enough desktop-app-bundled CLI, then the pinned
+    // managed runtime.
     Future<bool> resolveManagedRuntime() async {
       if (hasExplicitBin) return false;
+      for (final candidate in _resolveDesktopAppCliCandidates(environment: environment)) {
+        final candidateVersion = await versionValidator.detectVersion(
+          executable: candidate,
+          environment: environment,
+        );
+        if (candidateVersion != null && candidateVersion.compareTo(manifest.minPathVersion) >= 0) {
+          executable = candidate;
+          return true;
+        }
+      }
       final managedExecutable = manifest.managedBinaryPath(stateDirectory: stateDirectory);
       final managedVersion = await versionValidator.detectVersion(
         executable: managedExecutable,
@@ -336,8 +356,9 @@ class CodexPluginDescriptor extends BridgePluginDescriptor {
     return value;
   }
 
-  /// Resolves an existing codex runtime (a recent-enough PATH install or the
-  /// pinned managed runtime when already installed). Skipped when an explicit
+  /// Resolves an existing codex runtime (a recent-enough PATH install, a
+  /// recent-enough CLI bundled by the Codex desktop app, or the pinned managed
+  /// runtime when already installed). Skipped when an explicit
   /// `--codex-bin` path is set (it already names the binary). The resolved
   /// launch path is surfaced via [ProvisionReady]; a failure is non-fatal here
   /// and `start()` fails with guidance.
@@ -361,6 +382,15 @@ class CodexPluginDescriptor extends BridgePluginDescriptor {
     return combined.replaceAll(RegExp(r"\x1B\[[0-?]*[ -/]*[@-~]"), "").trim().toLowerCase();
   }
 
+  /// The injected desktop-app CLI candidates, or the platform's real ones.
+  List<String> _resolveDesktopAppCliCandidates({required Map<String, String> environment}) {
+    return _desktopAppCliCandidates ??
+        codexDesktopAppCliCandidates(
+          environment: environment,
+          os: PlatformOs.fromOperatingSystem(operatingSystem: io.Platform.operatingSystem),
+        );
+  }
+
   /// Assembles the production resolver from the host's process service so
   /// helper commands go through the host, never a raw spawn.
   ManagedRuntimeProvisionService _buildDefaultProvisionService({
@@ -379,6 +409,7 @@ class CodexPluginDescriptor extends BridgePluginDescriptor {
         runtimeId: manifest.runtimeId,
         probeTimeout: _versionProbeTimeout,
       ),
+      fallbackExecutableCandidates: _resolveDesktopAppCliCandidates(environment: host.environment),
     );
   }
 

--- a/bridge/sesori_plugin_codex/test/runtime/codex_desktop_app_locator_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_desktop_app_locator_test.dart
@@ -1,0 +1,74 @@
+import "dart:io";
+
+import "package:codex_plugin/codex_plugin.dart";
+import "package:path/path.dart" as p;
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("codexDesktopAppCliCandidates", () {
+    test("macOS probes both bundle names under system and user Applications", () {
+      final candidates = codexDesktopAppCliCandidates(
+        environment: const {"HOME": "/Users/dev"},
+        os: PlatformOs.macos,
+      );
+
+      expect(candidates, [
+        p.join("/Applications", "ChatGPT.app", "Contents", "Resources", "codex"),
+        p.join("/Applications", "Codex.app", "Contents", "Resources", "codex"),
+        p.join("/Users/dev", "Applications", "ChatGPT.app", "Contents", "Resources", "codex"),
+        p.join("/Users/dev", "Applications", "Codex.app", "Contents", "Resources", "codex"),
+      ]);
+    });
+
+    test("macOS omits user Applications without a home directory", () {
+      final candidates = codexDesktopAppCliCandidates(
+        environment: const {},
+        os: PlatformOs.macos,
+      );
+
+      expect(candidates, hasLength(2));
+      expect(candidates, everyElement(startsWith("/Applications")));
+    });
+
+    test("windows probes the stable path and hash subdirectories newest first", () async {
+      final localAppData = Directory.systemTemp.createTempSync("codex-locator-test");
+      addTearDown(() => localAppData.deleteSync(recursive: true));
+      final binDir = Directory(p.join(localAppData.path, "OpenAI", "Codex", "bin"))
+        ..createSync(recursive: true);
+      final older = Directory(p.join(binDir.path, "aaaa1111"))..createSync();
+      // Directory mtimes cannot be set directly from dart:io; a real delay
+      // between creations keeps newest-first ordering observable.
+      await Future<void>.delayed(const Duration(milliseconds: 1100));
+      final newer = Directory(p.join(binDir.path, "bbbb2222"))..createSync();
+
+      final candidates = codexDesktopAppCliCandidates(
+        environment: {"LOCALAPPDATA": localAppData.path},
+        os: PlatformOs.windows,
+      );
+
+      expect(candidates, [
+        p.join(binDir.path, "codex.exe"),
+        p.join(newer.path, "codex.exe"),
+        p.join(older.path, "codex.exe"),
+      ]);
+    });
+
+    test("windows yields no candidates without LOCALAPPDATA", () {
+      expect(
+        codexDesktopAppCliCandidates(environment: const {}, os: PlatformOs.windows),
+        isEmpty,
+      );
+    });
+
+    test("linux has no desktop app", () {
+      expect(
+        codexDesktopAppCliCandidates(
+          environment: const {"HOME": "/home/dev"},
+          os: PlatformOs.linux,
+        ),
+        isEmpty,
+      );
+    });
+  });
+}

--- a/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
@@ -9,6 +9,9 @@ void main() {
   group("CodexPluginDescriptor.inspectSetup", () {
     const stateDirectory = "/state";
     const config = PluginConfig(values: {"port": null, "bin": "codex"});
+    // Probes must stay deterministic regardless of what the host machine has
+    // installed, so the desktop-app candidate list is injected everywhere.
+    const descriptor = CodexPluginDescriptor(desktopAppCliCandidates: []);
 
     test("declares project-scoped session options", () {
       expect(const CodexPluginDescriptor().sessionOptionsScope, PluginSessionOptionsScope.project);
@@ -31,7 +34,7 @@ void main() {
         ],
       );
 
-      final result = await const CodexPluginDescriptor().inspectSetup(
+      final result = await descriptor.inspectSetup(
         config: config,
         processes: processes,
         environment: const <String, String>{},
@@ -51,7 +54,7 @@ void main() {
         spawnError: const ProcessException("codex", ["--version"], "missing", 2),
       );
 
-      final result = await const CodexPluginDescriptor().inspectSetup(
+      final result = await descriptor.inspectSetup(
         config: config,
         processes: processes,
         environment: const <String, String>{},
@@ -80,7 +83,7 @@ void main() {
         ],
       );
 
-      final result = await const CodexPluginDescriptor().inspectSetup(
+      final result = await descriptor.inspectSetup(
         config: config,
         processes: processes,
         environment: const <String, String>{},
@@ -91,12 +94,81 @@ void main() {
       expect(processes.spawnedExecutables, ["codex", managedBinaryPath, managedBinaryPath]);
     });
 
+    test("falls back to a desktop-app-bundled CLI when PATH is missing", () async {
+      const appCli = "/Applications/ChatGPT.app/Contents/Resources/codex";
+      final processes = _ProbeProcessService(
+        spawnOutcomes: [
+          const ProcessException("codex", ["--version"], "missing", 2),
+          _ProbeProcess(
+            pid: 3,
+            stdoutBytes: utf8.encode("codex-cli 0.146.0\n"),
+            exitCode: Future<int>.value(0),
+          ),
+          _ProbeProcess(
+            pid: 4,
+            stdoutBytes: utf8.encode("Logged in using ChatGPT\n"),
+            exitCode: Future<int>.value(0),
+          ),
+        ],
+      );
+
+      final result = await const CodexPluginDescriptor(
+        desktopAppCliCandidates: [appCli],
+      ).inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, const PluginSetupReady());
+      expect(processes.spawnedExecutables, ["codex", appCli, appCli]);
+    });
+
+    test("skips an outdated desktop-app CLI in favor of the managed runtime", () async {
+      const manifest = CodexRuntimeManifest();
+      final managedBinaryPath = manifest.managedBinaryPath(stateDirectory: stateDirectory);
+      const appCli = "/Applications/ChatGPT.app/Contents/Resources/codex";
+      final processes = _ProbeProcessService(
+        spawnOutcomes: [
+          const ProcessException("codex", ["--version"], "missing", 2),
+          _ProbeProcess(
+            pid: 3,
+            stdoutBytes: utf8.encode("codex-cli 0.100.0\n"),
+            exitCode: Future<int>.value(0),
+          ),
+          _ProbeProcess(
+            pid: 4,
+            stdoutBytes: utf8.encode("codex ${manifest.bundledVersion}\n"),
+            exitCode: Future<int>.value(0),
+          ),
+          _ProbeProcess(
+            pid: 5,
+            stdoutBytes: utf8.encode("Logged in using ChatGPT\n"),
+            exitCode: Future<int>.value(0),
+          ),
+        ],
+      );
+
+      final result = await const CodexPluginDescriptor(
+        desktopAppCliCandidates: [appCli],
+      ).inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, const PluginSetupReady());
+      expect(processes.spawnedExecutables, ["codex", appCli, managedBinaryPath, managedBinaryPath]);
+    });
+
     test("reports a missing explicitly configured runtime", () async {
       final processes = _ProbeProcessService(
         spawnError: const ProcessException("/custom/codex", ["--version"], "missing", 2),
       );
 
-      final result = await const CodexPluginDescriptor().inspectSetup(
+      final result = await descriptor.inspectSetup(
         config: const PluginConfig(values: {"port": null, "bin": "/custom/codex"}),
         processes: processes,
         environment: const <String, String>{},
@@ -122,7 +194,7 @@ void main() {
         ],
       );
 
-      final result = await const CodexPluginDescriptor().inspectSetup(
+      final result = await descriptor.inspectSetup(
         config: config,
         processes: processes,
         environment: const <String, String>{},
@@ -153,7 +225,7 @@ void main() {
         ],
       );
 
-      final result = await const CodexPluginDescriptor().inspectSetup(
+      final result = await descriptor.inspectSetup(
         config: config,
         processes: processes,
         environment: const <String, String>{},
@@ -181,7 +253,7 @@ void main() {
         ],
       );
 
-      final result = await const CodexPluginDescriptor().inspectSetup(
+      final result = await descriptor.inspectSetup(
         config: config,
         processes: processes,
         environment: const <String, String>{},

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
@@ -428,6 +428,8 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
         runtimeId: manifest.runtimeId,
         probeTimeout: _versionProbeTimeout,
       ),
+      // OpenCode has no desktop app bundling a CLI.
+      fallbackExecutableCandidates: const [],
     );
   }
 

--- a/bridge/sesori_plugin_runtime/lib/src/provisioning/managed_runtime_provision_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/provisioning/managed_runtime_provision_service.dart
@@ -14,17 +14,26 @@ import "runtime_version_validator.dart";
 
 /// Resolves an already-installed runtime without downloading or mutating it.
 ///
-/// Precedence is a sufficiently recent PATH runtime, then the pinned managed
-/// runtime when that exact version is already present and runnable.
+/// Precedence is a sufficiently recent PATH runtime, then the first
+/// sufficiently recent fallback executable candidate (e.g. a CLI bundled by a
+/// backend's desktop app, enumerated by the owning plugin), then the pinned
+/// managed runtime when that exact version is already present and runnable.
 class ManagedRuntimeProvisionService {
   final RuntimeManifest _manifest;
   final RuntimeVersionValidator _versionValidator;
 
+  /// Absolute executable paths probed after PATH, in preference order. Each is
+  /// version-gated like a PATH install; a missing path fails its probe
+  /// harmlessly.
+  final List<String> _fallbackExecutableCandidates;
+
   ManagedRuntimeProvisionService({
     required RuntimeManifest manifest,
     required RuntimeVersionValidator versionValidator,
+    required List<String> fallbackExecutableCandidates,
   }) : _manifest = manifest,
-       _versionValidator = versionValidator;
+       _versionValidator = versionValidator,
+       _fallbackExecutableCandidates = fallbackExecutableCandidates;
 
   Stream<RuntimeProvisionProgress> provision({required PluginHost host}) async* {
     _throwIfAborted(host);
@@ -44,6 +53,19 @@ class ManagedRuntimeProvisionService {
       Log.i("[$id] using PATH $name $pathVersion (>= minimum $minimum)");
       yield ProvisionReady(binaryPath: _manifest.pathExecutableName);
       return;
+    }
+
+    for (final candidate in _fallbackExecutableCandidates) {
+      final candidateVersion = await _versionValidator.detectVersion(
+        executable: candidate,
+        environment: host.environment,
+      );
+      _throwIfAborted(host);
+      if (candidateVersion != null && candidateVersion.compareTo(minimum) >= 0) {
+        Log.i("[$id] using $name $candidateVersion at $candidate (>= minimum $minimum)");
+        yield ProvisionReady(binaryPath: candidate);
+        return;
+      }
     }
 
     final managedBinaryPath = _manifest.managedBinaryPath(stateDirectory: host.stateDirectory);

--- a/bridge/sesori_plugin_runtime/test/provisioning/managed_runtime_provision_service_test.dart
+++ b/bridge/sesori_plugin_runtime/test/provisioning/managed_runtime_provision_service_test.dart
@@ -51,11 +51,13 @@ class _FakeValidator implements RuntimeVersionValidator {
   _FakeValidator({
     required this.pathVersion,
     required this.managedVersion,
+    this.candidateVersions = const {},
     this.onDetect,
   });
 
   final SemanticVersion? pathVersion;
   final SemanticVersion? managedVersion;
+  final Map<String, SemanticVersion?> candidateVersions;
   final void Function(String executable)? onDetect;
   final List<String> detectedExecutables = [];
 
@@ -66,7 +68,9 @@ class _FakeValidator implements RuntimeVersionValidator {
   }) async {
     detectedExecutables.add(executable);
     onDetect?.call(executable);
-    return executable == "opencode" ? pathVersion : managedVersion;
+    if (executable == "opencode") return pathVersion;
+    if (candidateVersions.containsKey(executable)) return candidateVersions[executable];
+    return managedVersion;
   }
 
   @override
@@ -103,10 +107,17 @@ void main() {
   Future<List<RuntimeProvisionProgress>> resolve({
     required SemanticVersion? pathVersion,
     required SemanticVersion? managedVersion,
+    List<String> fallbackCandidates = const [],
+    Map<String, SemanticVersion?> candidateVersions = const {},
   }) {
     return ManagedRuntimeProvisionService(
           manifest: const _StubManifest(),
-          versionValidator: _FakeValidator(pathVersion: pathVersion, managedVersion: managedVersion),
+          versionValidator: _FakeValidator(
+            pathVersion: pathVersion,
+            managedVersion: managedVersion,
+            candidateVersions: candidateVersions,
+          ),
+          fallbackExecutableCandidates: fallbackCandidates,
         )
         .provision(
           host: _FakeHost(
@@ -148,6 +159,34 @@ void main() {
     expect((events.last as ProvisionReady).binaryPath, managedBinaryPath);
   });
 
+  test("uses a sufficiently recent fallback candidate when PATH is absent", () async {
+    final events = await resolve(
+      pathVersion: null,
+      managedVersion: SemanticVersion.parse(value: "1.17.9"),
+      fallbackCandidates: const ["/apps/bundle/opencode", "/apps/old/opencode"],
+      candidateVersions: {
+        "/apps/bundle/opencode": SemanticVersion.parse(value: "1.5.0"),
+        "/apps/old/opencode": SemanticVersion.parse(value: "1.6.0"),
+      },
+    );
+
+    expect((events.last as ProvisionReady).binaryPath, "/apps/bundle/opencode");
+  });
+
+  test("skips outdated and missing fallback candidates before the managed runtime", () async {
+    final events = await resolve(
+      pathVersion: null,
+      managedVersion: SemanticVersion.parse(value: "1.17.9"),
+      fallbackCandidates: const ["/apps/missing/opencode", "/apps/old/opencode"],
+      candidateVersions: {
+        "/apps/missing/opencode": null,
+        "/apps/old/opencode": SemanticVersion.parse(value: "0.9.0"),
+      },
+    );
+
+    expect((events.last as ProvisionReady).binaryPath, managedBinaryPath);
+  });
+
   test("does not accept a managed runtime with a different version", () async {
     final events = await resolve(
       pathVersion: null,
@@ -173,6 +212,7 @@ void main() {
         ManagedRuntimeProvisionService(
           manifest: const _StubManifest(),
           versionValidator: validator,
+          fallbackExecutableCandidates: const [],
         ).provision(
           host: _FakeHost(stateDirectory: stateDirectory, abortSignal: abort.signal),
         );
@@ -194,6 +234,7 @@ void main() {
         ManagedRuntimeProvisionService(
           manifest: const _StubManifest(),
           versionValidator: validator,
+          fallbackExecutableCandidates: const [],
         ).provision(
           host: _FakeHost(stateDirectory: stateDirectory, abortSignal: abort.signal),
         );


### PR DESCRIPTION
## Complexity
🌿 Straightforward: one new pure locator function, a neutral candidate-list parameter on the shared provision service, and wiring in the codex descriptor.

## What
Adds discovery of the `codex` CLI bundled inside the Codex desktop app, for users who installed only the app and have no standalone CLI on `PATH`:

- `ManagedRuntimeProvisionService` gains a required, backend-neutral `fallbackExecutableCandidates` list, probed after `PATH` and before the pinned managed runtime; each candidate is version-gated by `minPathVersion` like a `PATH` install.
- New `codexDesktopAppCliCandidates` in `sesori_plugin_codex` enumerates the app's CLI locations:
  - macOS: `<bundle>/Contents/Resources/codex` for `ChatGPT.app` (new builds) and `Codex.app` (old builds) under `/Applications` and `~/Applications` — the same locations the codex CLI itself searches (`codex-rs/cli/src/desktop_app/mac.rs`).
  - Windows: `%LOCALAPPDATA%\OpenAI\Codex\bin\codex.exe` plus its content-hash subdirectories (newest first) — where the MSIX app relocates its bundled CLI out of the launch-protected `WindowsApps` directory.
  - Linux: no desktop app exists, so no candidates.
- `CodexPluginDescriptor.inspectSetup` mirrors the same fallback order (PATH → desktop-app CLI → managed runtime) so setup status agrees with what `start()` will launch.
- OpenCode passes an empty candidate list (no desktop app bundles a CLI).

## Why
Some users only have the Codex desktop app installed. The bridge previously probed only the bare `codex` PATH name and the managed download, so those users were reported as runtime-missing even though a fully working CLI was on disk.

## Risk and test focus
- Low risk: candidates are only consulted when the PATH probe fails or is outdated, so existing installs resolve exactly as before. No user-visible or database impact for users with a PATH codex.
- Discovery is read-only (`ensureRuntime` never mutates files); a missing candidate path just fails its version probe harmlessly.
- Windows relocation-dir layout is derived from the app's own bundled resolution logic but not verified on real Windows hardware — worth a smoke test if a Windows machine with the Codex app is available.
- Wire/persisted contracts unchanged.

## Expected result
A machine with only the Codex desktop app installed now reaches `PluginSetupReady` and starts the codex plugin using the app-bundled CLI on macOS and Windows. Linux behavior is unchanged.

## Verification
- `dart analyze --fatal-infos sesori_plugin_runtime sesori_plugin_codex sesori_plugin_opencode` — clean.
- `dart test` in `sesori_plugin_runtime` (102 pass) and runtime tests in `sesori_plugin_codex` / `sesori_plugin_opencode` (all pass), including new locator, precedence, and inspectSetup fallback tests.
- Architecture implementation review: approved (codex specifics stay in the plugin; the shared service only gained a neutral parameter, updated at both call sites in lockstep).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add discovery of the `codex` CLI bundled with the Codex desktop app on macOS and Windows. Users with only the app installed (no CLI on PATH) can now start the plugin without a managed download when the bundled CLI meets the minimum version.

- **New Features**
  - `ManagedRuntimeProvisionService` now accepts `fallbackExecutableCandidates`, checked after PATH and before the managed runtime.
  - New `codexDesktopAppCliCandidates` in `sesori_plugin_codex` lists app-bundled CLI paths:
    - macOS: `/Applications` and `~/Applications` bundles `ChatGPT.app`/`Codex.app` → `Contents/Resources/codex`.
    - Windows: `%LOCALAPPDATA%\OpenAI\Codex\bin\codex.exe` plus newest hash-subdir copies.
  - `CodexPluginDescriptor.inspectSetup` mirrors this order; `sesori_plugin_opencode` passes an empty list (no desktop app).

<sup>Written for commit 1ba2ab586144700af8a04c0abc6c1ea08f469611. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

