### PR TITLE
🌿 Credit new contributors in generated release notes

### DIFF
--- a/.opencode/skills/release-notes/SKILL.md
+++ b/.opencode/skills/release-notes/SKILL.md
@@ -74,7 +74,7 @@ Use this ONLY when the user explicitly says not to use the existing notes.
 - **PR enumeration** walks the full `compare` API (paged, no arbitrary cap) and refuses to emit truncated notes.
 - **Exclusions**: drops `dependabot` / `dependabot[bot]` authors and any PR labelled `ignore-for-release`.
 - **App/Bridge classification** pages `/pulls/<n>/files` fully and degrades conservatively (lists under both) when a PR is too large to enumerate.
-- **New-contributor detection** credits each author with no commit in the repository at or before the previous stable tag, matching GitHub's own `--generate-notes` behavior.
+- **New-contributor detection** credits each author with no commit reachable from the previous stable tag, matching GitHub's own `--generate-notes` behavior. A failed lookup omits that one author rather than failing the run, so the section can be incomplete on a degraded API; spot-check it when a release is expected to introduce someone.
 
 Reusing it means Mode B and CI can never drift, so just run it instead of re-deriving the same data.
 

--- a/.opencode/skills/release-notes/SKILL.md
+++ b/.opencode/skills/release-notes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-notes
-description: Generate a polished, user-facing release-notes markdown file for a requested release (e.g. "do this for v1.1.0"). By default it starts from the existing auto-generated GitHub release notes and post-processes them (re-orders by importance, merges multi-PR efforts, highlights the big items, drops noise) while preserving the "All PRs merged" section verbatim. Alternatively, when the user explicitly says NOT to use the existing notes, it analyzes all commits/PRs merged since the previous release tag and builds the notes from scratch. Writes a RELEASE_NOTES_<version>.md file only — never edits the live GitHub release.
+description: Generate a polished, user-facing release-notes markdown file for a requested release (e.g. "do this for v1.1.0"). By default it starts from the existing auto-generated GitHub release notes and post-processes them (re-orders by importance, merges multi-PR efforts, highlights the big items, drops noise) while preserving the "All PRs merged" and "New Contributors" sections verbatim. Alternatively, when the user explicitly says NOT to use the existing notes, it analyzes all commits/PRs merged since the previous release tag and builds the notes from scratch. Writes a RELEASE_NOTES_<version>.md file only — never edits the live GitHub release.
 compatibility: opencode
 metadata:
   audience: maintainers
@@ -9,7 +9,7 @@ metadata:
 
 # Release Notes Skill
 
-Generates a curated, user-facing release-notes markdown file for a given release version. The output mirrors the hand-edited style the maintainer prefers: a top **Highlights** block, then per-target **App** / **Bridge** sections (subdivided into New / Improved / Fixed / Other), then the original **All PRs merged** list kept verbatim.
+Generates a curated, user-facing release-notes markdown file for a given release version. The output mirrors the hand-edited style the maintainer prefers: a top **Highlights** block, then per-target **App** / **Bridge** sections (subdivided into New / Improved / Fixed / Other), then the original **All PRs merged** list kept verbatim, then the **New Contributors** section (also verbatim) when the source has one.
 
 This skill **only writes a file** (`RELEASE_NOTES_<version>.md` in the repo root). The maintainer manually pastes the result into the GitHub release once happy. **Never edit, publish, or otherwise mutate the live GitHub release.**
 
@@ -44,7 +44,7 @@ If the release is not found, list recent releases and ask the user which one the
 gh release list --repo sesori-ai/sesori_apps_monorepo --limit 15
 ```
 
-The `body` field contains the auto-generated notes with `### App`, `### Bridge`, and `### All PRs merged` sections.
+The `body` field contains the auto-generated notes with `### App`, `### Bridge`, `### All PRs merged`, and (when the release introduced first-time authors) `## New Contributors` sections.
 
 ### Step A2: Parse the existing notes
 
@@ -52,6 +52,7 @@ From the fetched body, extract:
 - Every App entry (Added / Fixed / Changed) with its PR number(s).
 - Every Bridge entry with its PR number(s).
 - The complete **All PRs merged** list (keep this text exactly as-is for the final output).
+- The **New Contributors** list, if present (also kept exactly as-is).
 
 ### Step A3: Apply the post-processing rules
 
@@ -59,7 +60,7 @@ Apply all rules in the **Post-Processing Rules** section below to the App and Br
 
 ### Step A4: Write the file
 
-Write `RELEASE_NOTES_<version>.md` using the **Output Format** below. The **All PRs merged** section is copied verbatim from the source.
+Write `RELEASE_NOTES_<version>.md` using the **Output Format** below. The **All PRs merged** and **New Contributors** sections are copied verbatim from the source.
 
 ---
 
@@ -73,6 +74,7 @@ Use this ONLY when the user explicitly says not to use the existing notes.
 - **PR enumeration** walks the full `compare` API (paged, no arbitrary cap) and refuses to emit truncated notes.
 - **Exclusions**: drops `dependabot` / `dependabot[bot]` authors and any PR labelled `ignore-for-release`.
 - **App/Bridge classification** pages `/pulls/<n>/files` fully and degrades conservatively (lists under both) when a PR is too large to enumerate.
+- **New-contributor detection** credits each author with no commit in the repository at or before the previous stable tag, matching GitHub's own `--generate-notes` behavior.
 
 Reusing it means Mode B and CI can never drift, so just run it instead of re-deriving the same data.
 
@@ -92,15 +94,15 @@ GITHUB_TOKEN="$(gh auth token)" dart tool/generate_release_notes.dart \
 - **User-supplied range:** if the user explicitly gives a previous tag/ref, pass it as `--from` to override auto-resolution.
 - The tool prints the resolved `from...to` range to stderr — always surface it to the user and confirm it looks right before proceeding.
 
-This produces the same structure Mode A consumes: `### App`, `### Bridge`, and `### All PRs merged` (plus a `**Full Changelog**` link).
+This produces the same structure Mode A consumes: `### App`, `### Bridge`, `### All PRs merged`, an optional `## New Contributors` section (plus a `**Full Changelog**` link).
 
 ### Step B2: Parse, post-process, and write the file
 
 From here the flow is identical to Mode A:
 
-1. Parse the generated `### App`, `### Bridge`, and `### All PRs merged` sections (same as Step A2).
+1. Parse the generated `### App`, `### Bridge`, `### All PRs merged`, and `## New Contributors` sections (same as Step A2).
 2. Apply the **Post-Processing Rules** to the App/Bridge entries (same as Step A3).
-3. Write `RELEASE_NOTES_<version>.md` using the **Output Format**, copying the **All PRs merged** section verbatim from the generated output.
+3. Write `RELEASE_NOTES_<version>.md` using the **Output Format**, copying the **All PRs merged** and **New Contributors** sections verbatim from the generated output.
 
 This guarantees Mode B's range, exclusions, and classification exactly match what GitHub would have shown — the only difference from Mode A is that the raw notes come from the generator instead of an already-published release.
 
@@ -108,7 +110,7 @@ This guarantees Mode B's range, exclusions, and classification exactly match wha
 
 ## Post-Processing Rules (both modes)
 
-Apply these to produce the App and Bridge narrative sections. The **All PRs merged** section is NEVER curated — it stays complete.
+Apply these to produce the App and Bridge narrative sections. The **All PRs merged** and **New Contributors** sections are NEVER curated — they stay complete. Never drop a new contributor because their PR was filtered out of the narrative as chore/CI noise.
 
 1. **Merge multi-PR efforts into one entry.** Collapse clusters that are obviously one initiative (e.g. titles like "migration PR 5/15", a series of "sesori_plugin_runtime — …" PRs, or a feature plus its follow-ups). Write a single descriptive bullet and append all the PR links: `([#223](…), [#226](…), …)`. Describe the *final shipped outcome*, not the mechanics of each PR.
 
@@ -183,6 +185,10 @@ Write to `RELEASE_NOTES_<version>.md` in the repo root:
 ## All PRs merged
 
 <verbatim list from the GitHub release (Mode A) OR generated list (Mode B)>
+
+## New Contributors
+
+<verbatim list from the source; omit this whole section when the source has none>
 ```
 
 Omit any subsection (New/Improved/Fixed/Other) that has no entries. If a target (App or Bridge) had no user-facing changes, write a single `- No user-facing changes` bullet under it.
@@ -192,7 +198,7 @@ Omit any subsection (New/Improved/Fixed/Other) that has no entries. If a target 
 ## Workflow Summary
 
 1. Determine **version** and **mode** (default = Mode A). Capture any highlight hints the user gave.
-2. **Mode A:** `gh release view <version>` → parse App/Bridge/All-PRs. **Mode B:** run `dart tool/generate_release_notes.dart` (with `GITHUB_TOKEN`) to produce the raw App/Bridge/All-PRs notes, then parse them the same way as Mode A. Do not re-derive the range, exclusions, or classification by hand.
+2. **Mode A:** `gh release view <version>` → parse App/Bridge/All-PRs/New-Contributors. **Mode B:** run `dart tool/generate_release_notes.dart` (with `GITHUB_TOKEN`) to produce the same raw sections, then parse them the same way as Mode A. Do not re-derive the range, exclusions, or classification by hand.
 3. Apply the **Post-Processing Rules** (merge clusters into final outcomes, drop noise, collapse fixes to unreleased code, omit disabled work, reframe perf/UX, order by impact, build Highlights).
 4. For unclear-benefit or unclear-shipping PRs, inspect the diff (`gh pr diff <n>`) before asking the user. Do not ask about clearly same-release repairs or availability decisions the user already supplied; apply the defaults above.
 5. Write `RELEASE_NOTES_<version>.md`. Report the path and a short summary of editorial decisions made (what was merged, dropped, flagged).
@@ -201,6 +207,6 @@ Omit any subsection (New/Improved/Fixed/Other) that has no entries. If a target 
 
 - This skill writes a **file only** — it never edits or publishes the GitHub release.
 - Default behavior is **always Mode A** (start from existing GitHub release notes). Only switch to Mode B on an explicit instruction to ignore the existing notes.
-- The **All PRs merged** section is never trimmed or curated.
+- The **All PRs merged** and **New Contributors** sections are never trimmed or curated.
 - Confirm the resolved previous tag in Mode B. Surface an omission candidate only when shipping history remains ambiguous after inspection; collapse clear same-release repair clusters automatically.
 - Repo is `sesori-ai/sesori_apps_monorepo`; requires authenticated `gh`.

--- a/tool/generate_release_notes.dart
+++ b/tool/generate_release_notes.dart
@@ -57,6 +57,9 @@ void main(final List<String> args) async {
       }
     }
 
+    // The section is cosmetic, but this runs in the production release path:
+    // never fail a release over it. Per-author isolation keeps one bad lookup
+    // from dropping everyone else's credit.
     final firstContributionUrls = await _resolveFirstContributions(api: api, from: fromTag, entries: entries);
 
     final notes = _render(
@@ -332,7 +335,7 @@ class _PrEntry {
 
   final int number;
   final String title;
-  final String author;
+  final String? author;
   final String url;
   final bool touchesApp;
   final bool touchesBridge;
@@ -342,8 +345,8 @@ class _PrEntry {
 Future<_PrEntry?> _loadPr({required _GitHubApi api, required int number}) async {
   final pr = await api.getJson(path: '/repos/${api.repo}/pulls/$number') as Map<String, dynamic>;
 
-  final author = ((pr['user'] as Map<String, dynamic>?)?['login'] as String?) ?? 'unknown';
-  if (_excludedAuthors.contains(author)) {
+  final author = (pr['user'] as Map<String, dynamic>?)?['login'] as String?;
+  if (author != null && _excludedAuthors.contains(author)) {
     return null;
   }
   final labels = (pr['labels'] as List<dynamic>? ?? [])
@@ -416,25 +419,32 @@ Future<Map<String, String>> _resolveFirstContributions({
     return const {};
   }
 
-  final baseCommit = await api.getJson(path: '/repos/${api.repo}/commits/$from') as Map<String, dynamic>;
-  final until = ((baseCommit['commit'] as Map<String, dynamic>)['committer'] as Map<String, dynamic>)['date'] as String;
-
   final checked = <String>{};
   final firstContributionUrls = <String, String>{};
   for (final entry in entries) {
-    if (!checked.add(entry.author)) {
+    final author = entry.author;
+    if (author == null || !checked.add(author)) {
       continue;
     }
-    final earlier =
-        await api.getJson(
-              path:
-                  '/repos/${api.repo}/commits'
-                  '?author=${Uri.encodeQueryComponent(entry.author)}'
-                  '&until=${Uri.encodeQueryComponent(until)}&per_page=1',
-            )
-            as List<dynamic>;
-    if (earlier.isEmpty) {
-      firstContributionUrls[entry.author] = entry.url;
+    // `sha=$from` scopes the lookup to history reachable from the previous
+    // stable tag, so a commit authored long ago but merged after that tag
+    // (rebase, cherry-pick, long-lived branch) correctly still counts as new.
+    try {
+      final earlier =
+          await api.getJson(
+                path:
+                    '/repos/${api.repo}/commits'
+                    '?author=${Uri.encodeQueryComponent(author)}'
+                    '&sha=${Uri.encodeQueryComponent(from)}&per_page=1',
+              )
+              as List<dynamic>;
+      if (earlier.isEmpty) {
+        firstContributionUrls[author] = entry.url;
+      }
+    } catch (error) {
+      // Omitting one credit beats failing the release; a wrong "first
+      // contribution" claim would be worse than a missing one.
+      stderr.writeln('Could not check prior commits for @$author, omitting from New Contributors: $error');
     }
   }
   return firstContributionUrls;
@@ -503,7 +513,9 @@ String _render({
   if (entries.isNotEmpty) {
     buffer.write('\n### All PRs merged\n');
     for (final entry in entries) {
-      buffer.writeln('* ${entry.title} by @${entry.author} in ${entry.url}');
+      final author = entry.author;
+      final attribution = author == null ? '' : ' by @$author';
+      buffer.writeln('* ${entry.title}$attribution in ${entry.url}');
     }
   } else {
     buffer.write('\nNo pull requests merged in this range.\n');

--- a/tool/generate_release_notes.dart
+++ b/tool/generate_release_notes.dart
@@ -57,11 +57,14 @@ void main(final List<String> args) async {
       }
     }
 
+    final firstContributionUrls = await _resolveFirstContributions(api: api, from: fromTag, entries: entries);
+
     final notes = _render(
       repo: options.repo,
       from: fromTag,
       to: options.to,
       entries: entries,
+      firstContributionUrls: firstContributionUrls,
     );
 
     if (options.output != null) {
@@ -400,6 +403,43 @@ Future<_PrEntry?> _loadPr({required _GitHubApi api, required int number}) async 
   );
 }
 
+// A "new contributor" is an author with no commit in the repository at or
+// before the previous stable tag, matching what GitHub's own
+// --generate-notes reports. Entries arrive in compare order (oldest first),
+// so the first entry seen for an author is the PR to credit.
+Future<Map<String, String>> _resolveFirstContributions({
+  required _GitHubApi api,
+  required String from,
+  required List<_PrEntry> entries,
+}) async {
+  if (entries.isEmpty) {
+    return const {};
+  }
+
+  final baseCommit = await api.getJson(path: '/repos/${api.repo}/commits/$from') as Map<String, dynamic>;
+  final until = ((baseCommit['commit'] as Map<String, dynamic>)['committer'] as Map<String, dynamic>)['date'] as String;
+
+  final checked = <String>{};
+  final firstContributionUrls = <String, String>{};
+  for (final entry in entries) {
+    if (!checked.add(entry.author)) {
+      continue;
+    }
+    final earlier =
+        await api.getJson(
+              path:
+                  '/repos/${api.repo}/commits'
+                  '?author=${Uri.encodeQueryComponent(entry.author)}'
+                  '&until=${Uri.encodeQueryComponent(until)}&per_page=1',
+            )
+            as List<dynamic>;
+    if (earlier.isEmpty) {
+      firstContributionUrls[entry.author] = entry.url;
+    }
+  }
+  return firstContributionUrls;
+}
+
 final RegExp _conventionalPrefixPattern = RegExp(r'^(\w+)(\([^)]*\))?!?:\s*');
 
 String _bucketFor({required String title}) {
@@ -430,6 +470,7 @@ String _render({
   required String from,
   required String to,
   required List<_PrEntry> entries,
+  required Map<String, String> firstContributionUrls,
 }) {
   final buffer = StringBuffer('## What\'s Changed\n');
 
@@ -466,6 +507,13 @@ String _render({
     }
   } else {
     buffer.write('\nNo pull requests merged in this range.\n');
+  }
+
+  if (firstContributionUrls.isNotEmpty) {
+    buffer.write('\n## New Contributors\n');
+    for (final contribution in firstContributionUrls.entries) {
+      buffer.writeln('* @${contribution.key} made their first contribution in ${contribution.value}');
+    }
   }
 
   buffer.write('\n**Full Changelog**: https://github.com/$repo/compare/$from...$to\n');

--- a/tool/generate_release_notes.dart
+++ b/tool/generate_release_notes.dart
@@ -441,10 +441,12 @@ Future<Map<String, String>> _resolveFirstContributions({
       if (earlier.isEmpty) {
         firstContributionUrls[author] = entry.url;
       }
-    } catch (error) {
+    } catch (error, stackTrace) {
       // Omitting one credit beats failing the release; a wrong "first
       // contribution" claim would be worse than a missing one.
-      stderr.writeln('Could not check prior commits for @$author, omitting from New Contributors: $error');
+      stderr.writeln(
+        'Could not check prior commits for @$author, omitting from New Contributors: $error\n$stackTrace',
+      );
     }
   }
   return firstContributionUrls;


### PR DESCRIPTION
## Complexity

🌿 Straightforward. One self-contained addition to the release-notes generator plus the matching skill documentation. No production app or bridge code is touched.

## What

- `tool/generate_release_notes.dart` now emits a `## New Contributors` section, matching what GitHub's native `--generate-notes` produces and which we lost when we started rendering notes ourselves.
- A contributor counts as new when they have no commit in the repository at or before the previous stable tag. They are credited with the first PR of theirs in the release range.
- `.opencode/skills/release-notes/SKILL.md` is updated so the local release-notes workflow parses and preserves the new section verbatim in both Mode A (existing GitHub notes) and Mode B (generated notes), and never drops a contributor whose only PR was filtered from the narrative as chore/CI noise.

## Why

We want to thank contributors as part of a release and highlight first-time ones. The custom generator replaced GitHub's auto-notes and silently dropped that section; this restores it in the one place both CI paths (rolling internal pre-release and production release) already share.

## Risk and test focus

No user-visible product impact and no database impact. The only behavior change is extra Markdown at the end of generated release notes.

The added cost is one GitHub API call per unique author in the release range, on top of the existing per-PR calls, so the rate-limit profile is effectively unchanged. If the section were ever wrong, the failure mode is cosmetic text in a release body, not a broken release.

## Verification

- `dart analyze tool/generate_release_notes.dart` — no issues.
- Ran the generator against `v1.6.0...v1.7.0`: no new contributors reported, which matches the history (every author in that range had earlier commits).
- Ran it against `v1.7.0...main`: correctly reported `@hamza-imran75 made their first contribution in #772`, whose first-ever commit is inside that range.

## Expected result

Future releases include a `## New Contributors` section listing first-time authors, and the local `release-notes` skill carries that section through to `RELEASE_NOTES_<version>.md` untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the "New Contributors" section in generated release notes and ensures the release‑notes skill preserves it in both modes. Detection matches GitHub’s rules and is resilient so releases never fail over this section.

- **New Features**
  - `tool/generate_release_notes.dart` emits `## New Contributors` by finding authors with no commits reachable from the previous stable tag and credits their first PR; `.opencode/skills/release-notes/SKILL.md` parses and copies the section verbatim in Mode A and Mode B.

- **Bug Fixes**
  - Avoids adding "by @unknown" when PR author data is missing; attribution is omitted instead.
  - New‑contributor lookups are isolated per author and degrade gracefully (skip only that author on API errors, never fail the release).
  - Logs the stack trace for failed contributor lookups to aid debugging while still skipping only that author.

<sup>Written for commit fa3e04a257af7cd1c6c2555fecd299099bc5a8f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

