### PR TITLE
🚧 [internal-chat-history] Capture live message events and backfill lazily [step 3/8]

### DIFF
--- a/.plan/active/internal-chat-history/TRACKER.md
+++ b/.plan/active/internal-chat-history/TRACKER.md
@@ -3,21 +3,21 @@
 ## Current State
 
 - **Plan slug:** `internal-chat-history`
-- **Implementation base:** `origin/main` at `5653be1b`
-- **Series state:** Step 2/8 in PR; step 3/8 implemented locally
-- **Current step:** 2/8
+- **Implementation base:** `origin/main` at `6723c833`
+- **Series state:** Step 2/8 merged; step 3/8 in PR
+- **Current step:** 3/8
 - **Plan PR:** [#763](https://github.com/sesori-ai/sesori_apps_monorepo/pull/763) merged
 - **Prerequisite:** satisfied — the `read-only-archiving` series merged fully on
   2026-08-07 (through [PR #771](https://github.com/sesori-ai/sesori_apps_monorepo/pull/771)).
-- **Next action:** merge PR #768, then raise step 3/8.
+- **Next action:** merge step 3/8, then start step 4/8.
 
 ## Delivery Steps
 
 | Done | Step | Exact PR title | Estimate | State |
 |---|---|---|---:|---|
 | [x] | 1/8 | `🌱 [internal-chat-history] Raise plan [step 1/8]` | 400–700 | [PR #763](https://github.com/sesori-ai/sesori_apps_monorepo/pull/763) merged |
-| [ ] | 2/8 | `🚧 [internal-chat-history] Introduce the chat history database [step 2/8]` | 1,500–2,600 | [PR #768](https://github.com/sesori-ai/sesori_apps_monorepo/pull/768) open |
-| [ ] | 3/8 | `🚧 [internal-chat-history] Capture live message events and backfill lazily [step 3/8]` | 900–1,400 | pending |
+| [x] | 2/8 | `🚧 [internal-chat-history] Introduce the chat history database [step 2/8]` | 1,500–2,600 | [PR #768](https://github.com/sesori-ai/sesori_apps_monorepo/pull/768) merged |
+| [ ] | 3/8 | `🚧 [internal-chat-history] Capture live message events and backfill lazily [step 3/8]` | 900–1,400 | in progress |
 | [ ] | 4/8 | `⚙️ [internal-chat-history] Serve session messages from the store [step 4/8]` | 700–1,100 | pending |
 | [ ] | 5/8 | `⚙️ [internal-chat-history] Paginate session messages [step 5/8]` | 600–1,000 | pending |
 | [ ] | 6/8 | `🚧 [internal-chat-history] Export archives and purge history on archive [step 6/8]` | 1,000–1,500 | pending |
@@ -46,6 +46,9 @@
 - **2026-08-07 — step 2/8:** `dart analyze --fatal-infos` clean in `bridge/app`;
   `dart test` in `bridge/app` green (2,440 tests), including the new
   `chat_history_purge_test.dart`.
+- **2026-08-07 — step 3/8:** `dart analyze --fatal-infos` clean in `bridge/app`;
+  `dart test` in `bridge/app` green (2,460 tests), including the new
+  `chat_history_capture_test.dart`.
 
 ## Findings And Plan Deltas
 
@@ -62,3 +65,14 @@
   relies on archive permanence. Steps 2/8–5/8 touch none of the archiving
   code, so the two series run in parallel. Recorded after the user started
   `read-only-archiving` separately.
+- **2026-08-07 — Second watermark source deferred to step 4/8.** The plan lists
+  two inputs for `backend_activity_at`: live capture and catalog import
+  observing newer backend activity. Only capture has a caller until serving
+  exists, so the catalog-import input (and the `observeBackendActivity`
+  surface it needs) moves to step 4/8, where the staleness comparison it feeds
+  is introduced. Success Criterion 3 is therefore verified in step 4, not 3.
+- **2026-08-07 — Backfill atomicity tightened.** The plan says a backfill
+  atomically replaces rows and sets the watermark; the first implementation
+  split the row replace and the sync-state write into two statements. They now
+  share one transaction, so a crash cannot leave a replaced transcript
+  described by the previous run's freshness marks.

--- a/bridge/app/lib/src/api/database/history/chat_history_dao.dart
+++ b/bridge/app/lib/src/api/database/history/chat_history_dao.dart
@@ -109,12 +109,17 @@ class ChatHistoryDao extends DatabaseAccessor<ChatHistoryDatabase> with _$ChatHi
   }
 
   /// Replaces the session's transcript with [messages] and [parts], keeping
-  /// the rows in [retainedMessageIds] that the transcript does not contain.
+  /// the rows in [retainedMessageIds] that the transcript does not contain,
+  /// and records [syncState] in the same transaction.
+  ///
+  /// One transaction so a crash can never leave a replaced transcript whose
+  /// freshness marks describe the previous one.
   Future<void> replaceSessionRows({
     required String sessionId,
     required List<HistoryMessagesTableData> messages,
     required List<HistoryPartsTableData> parts,
     required Set<String> retainedMessageIds,
+    required HistorySyncStateTableData syncState,
   }) {
     return transaction(() async {
       await (delete(historyPartsTable)..where(
@@ -135,7 +140,8 @@ class ChatHistoryDao extends DatabaseAccessor<ChatHistoryDatabase> with _$ChatHi
       await batch((batch) {
         batch
           ..insertAllOnConflictUpdate(historyMessagesTable, messages)
-          ..insertAllOnConflictUpdate(historyPartsTable, parts);
+          ..insertAllOnConflictUpdate(historyPartsTable, parts)
+          ..insert(historySyncStateTable, syncState, onConflict: DoUpdate((_) => syncState));
       });
     });
   }
@@ -143,10 +149,6 @@ class ChatHistoryDao extends DatabaseAccessor<ChatHistoryDatabase> with _$ChatHi
   /// Larger than any transcript a single session can hold, so parked rows
   /// cannot collide with the numbering being written beneath them.
   static const _seqParkingOffset = 1 << 40;
-
-  Future<void> upsertSyncState({required HistorySyncStateTableData row}) {
-    return into(historySyncStateTable).insertOnConflictUpdate(row);
-  }
 
   /// Creates the row if absent, then advances its timestamps monotonically.
   Future<void> advanceSyncState({

--- a/bridge/app/lib/src/api/database/history/chat_history_dao.dart
+++ b/bridge/app/lib/src/api/database/history/chat_history_dao.dart
@@ -11,6 +11,192 @@ part "chat_history_dao.g.dart";
 class ChatHistoryDao extends DatabaseAccessor<ChatHistoryDatabase> with _$ChatHistoryDaoMixin {
   ChatHistoryDao(super.attachedDatabase);
 
+  Future<HistorySyncStateTableData?> getSyncState({required String sessionId}) {
+    return (select(historySyncStateTable)..where((table) => table.sessionId.equals(sessionId))).getSingleOrNull();
+  }
+
+  Future<List<HistoryMessagesTableData>> getMessages({required String sessionId}) {
+    return (select(historyMessagesTable)
+          ..where((table) => table.sessionId.equals(sessionId))
+          ..orderBy([(table) => OrderingTerm(expression: table.seq)]))
+        .get();
+  }
+
+  Future<List<HistoryPartsTableData>> getParts({required String sessionId}) {
+    return (select(historyPartsTable)
+          ..where((table) => table.sessionId.equals(sessionId))
+          ..orderBy([
+            (table) => OrderingTerm(expression: table.messageId),
+            (table) => OrderingTerm(expression: table.orderIndex),
+          ]))
+        .get();
+  }
+
+  Future<int?> getMaxSeq({required String sessionId}) async {
+    final maxSeq = historyMessagesTable.seq.max();
+    final row = await (selectOnly(historyMessagesTable)
+          ..addColumns([maxSeq])
+          ..where(historyMessagesTable.sessionId.equals(sessionId)))
+        .getSingle();
+    return row.read(maxSeq);
+  }
+
+  Future<int?> getMessageSeq({required String sessionId, required String messageId}) async {
+    final row =
+        await (select(historyMessagesTable)..where(
+              (table) => table.sessionId.equals(sessionId) & table.messageId.equals(messageId),
+            ))
+            .getSingleOrNull();
+    return row?.seq;
+  }
+
+  Future<int?> getMaxPartOrderIndex({required String sessionId, required String messageId}) async {
+    final maxOrder = historyPartsTable.orderIndex.max();
+    final row = await (selectOnly(historyPartsTable)
+          ..addColumns([maxOrder])
+          ..where(historyPartsTable.sessionId.equals(sessionId) & historyPartsTable.messageId.equals(messageId)))
+        .getSingle();
+    return row.read(maxOrder);
+  }
+
+  Future<int?> getPartOrderIndex({
+    required String sessionId,
+    required String messageId,
+    required String partId,
+  }) async {
+    final row =
+        await (select(historyPartsTable)..where(
+              (table) =>
+                  table.sessionId.equals(sessionId) &
+                  table.messageId.equals(messageId) &
+                  table.partId.equals(partId),
+            ))
+            .getSingleOrNull();
+    return row?.orderIndex;
+  }
+
+  Future<void> upsertMessage({required HistoryMessagesTableData row}) {
+    return into(historyMessagesTable).insertOnConflictUpdate(row);
+  }
+
+  Future<void> upsertPart({required HistoryPartsTableData row}) {
+    return into(historyPartsTable).insertOnConflictUpdate(row);
+  }
+
+  Future<void> deleteMessage({required String sessionId, required String messageId}) {
+    return transaction(() async {
+      await (delete(historyPartsTable)..where(
+            (table) => table.sessionId.equals(sessionId) & table.messageId.equals(messageId),
+          ))
+          .go();
+      await (delete(historyMessagesTable)..where(
+            (table) => table.sessionId.equals(sessionId) & table.messageId.equals(messageId),
+          ))
+          .go();
+    });
+  }
+
+  Future<void> deletePart({
+    required String sessionId,
+    required String messageId,
+    required String partId,
+  }) async {
+    await (delete(historyPartsTable)..where(
+          (table) =>
+              table.sessionId.equals(sessionId) & table.messageId.equals(messageId) & table.partId.equals(partId),
+        ))
+        .go();
+  }
+
+  /// Replaces the session's transcript with [messages] and [parts], keeping
+  /// the rows in [retainedMessageIds] that the transcript does not contain.
+  Future<void> replaceSessionRows({
+    required String sessionId,
+    required List<HistoryMessagesTableData> messages,
+    required List<HistoryPartsTableData> parts,
+    required Set<String> retainedMessageIds,
+  }) {
+    return transaction(() async {
+      await (delete(historyPartsTable)..where(
+            (table) => table.sessionId.equals(sessionId) & table.messageId.isNotIn(retainedMessageIds),
+          ))
+          .go();
+      await (delete(historyMessagesTable)..where(
+            (table) => table.sessionId.equals(sessionId) & table.messageId.isNotIn(retainedMessageIds),
+          ))
+          .go();
+      // Retained rows still hold their pre-backfill `seq`, which the imported
+      // numbering is about to reuse. Park them above every possible new value
+      // first so the unique (session_id, seq) index never sees a collision
+      // mid-transaction.
+      await (update(historyMessagesTable)..where((table) => table.sessionId.equals(sessionId))).write(
+        HistoryMessagesTableCompanion.custom(seq: historyMessagesTable.seq + const Constant(_seqParkingOffset)),
+      );
+      await batch((batch) {
+        batch
+          ..insertAllOnConflictUpdate(historyMessagesTable, messages)
+          ..insertAllOnConflictUpdate(historyPartsTable, parts);
+      });
+    });
+  }
+
+  /// Larger than any transcript a single session can hold, so parked rows
+  /// cannot collide with the numbering being written beneath them.
+  static const _seqParkingOffset = 1 << 40;
+
+  Future<void> upsertSyncState({required HistorySyncStateTableData row}) {
+    return into(historySyncStateTable).insertOnConflictUpdate(row);
+  }
+
+  /// Creates the row if absent, then advances its timestamps monotonically.
+  Future<void> advanceSyncState({
+    required String sessionId,
+    required int watermark,
+    required int backendActivityAt,
+  }) {
+    return transaction(() async {
+      final existing = await getSyncState(sessionId: sessionId);
+      if (existing == null) {
+        await into(historySyncStateTable).insert(
+          HistorySyncStateTableData(
+            sessionId: sessionId,
+            watermark: watermark,
+            backendActivityAt: backendActivityAt,
+          ),
+        );
+        return;
+      }
+      await into(historySyncStateTable).insertOnConflictUpdate(
+        existing.copyWith(
+          watermark: watermark > existing.watermark ? watermark : existing.watermark,
+          backendActivityAt: backendActivityAt > existing.backendActivityAt
+              ? backendActivityAt
+              : existing.backendActivityAt,
+        ),
+      );
+    });
+  }
+
+  Future<void> clearSyncedAt({required String sessionId}) async {
+    await (update(historySyncStateTable)..where((table) => table.sessionId.equals(sessionId))).write(
+      const HistorySyncStateTableCompanion(syncedAt: Value(null)),
+    );
+  }
+
+  /// Every session id the store holds rows for.
+  Future<Set<String>> getStoredSessionIds() async {
+    final rows = await (selectOnly(historyMessagesTable, distinct: true)
+          ..addColumns([historyMessagesTable.sessionId]))
+        .get();
+    final syncRows = await (selectOnly(historySyncStateTable, distinct: true)
+          ..addColumns([historySyncStateTable.sessionId]))
+        .get();
+    return {
+      for (final row in rows) row.read(historyMessagesTable.sessionId)!,
+      for (final row in syncRows) row.read(historySyncStateTable.sessionId)!,
+    };
+  }
+
   /// Removes every stored row for [sessionIds] in one transaction.
   ///
   /// Ids are chunked because each one becomes a bind variable and a session

--- a/bridge/app/lib/src/api/database/history/chat_history_dao.dart
+++ b/bridge/app/lib/src/api/database/history/chat_history_dao.dart
@@ -110,16 +110,20 @@ class ChatHistoryDao extends DatabaseAccessor<ChatHistoryDatabase> with _$ChatHi
 
   /// Replaces the session's transcript with [messages] and [parts], keeping
   /// the rows in [retainedMessageIds] that the transcript does not contain,
-  /// and records [syncState] in the same transaction.
+  /// and marks the session synced at [syncedAt] in the same transaction.
   ///
   /// One transaction so a crash can never leave a replaced transcript whose
-  /// freshness marks describe the previous one.
+  /// freshness marks describe the previous one. The freshness timestamps only
+  /// ever move forward: capture that landed while the transcript was being
+  /// fetched keeps its newer marks, so a backfill cannot rewind them.
   Future<void> replaceSessionRows({
     required String sessionId,
     required List<HistoryMessagesTableData> messages,
     required List<HistoryPartsTableData> parts,
     required Set<String> retainedMessageIds,
-    required HistorySyncStateTableData syncState,
+    required int watermark,
+    required int backendActivityAt,
+    required int syncedAt,
   }) {
     return transaction(() async {
       await (delete(historyPartsTable)..where(
@@ -140,9 +144,14 @@ class ChatHistoryDao extends DatabaseAccessor<ChatHistoryDatabase> with _$ChatHi
       await batch((batch) {
         batch
           ..insertAllOnConflictUpdate(historyMessagesTable, messages)
-          ..insertAllOnConflictUpdate(historyPartsTable, parts)
-          ..insert(historySyncStateTable, syncState, onConflict: DoUpdate((_) => syncState));
+          ..insertAllOnConflictUpdate(historyPartsTable, parts);
       });
+      await _writeSyncState(
+        sessionId: sessionId,
+        watermark: watermark,
+        backendActivityAt: backendActivityAt,
+        syncedAt: Value(syncedAt),
+      );
     });
   }
 
@@ -150,34 +159,49 @@ class ChatHistoryDao extends DatabaseAccessor<ChatHistoryDatabase> with _$ChatHi
   /// cannot collide with the numbering being written beneath them.
   static const _seqParkingOffset = 1 << 40;
 
-  /// Creates the row if absent, then advances its timestamps monotonically.
+  /// Creates the row if absent, then advances its timestamps.
   Future<void> advanceSyncState({
     required String sessionId,
     required int watermark,
     required int backendActivityAt,
   }) {
-    return transaction(() async {
-      final existing = await getSyncState(sessionId: sessionId);
-      if (existing == null) {
-        await into(historySyncStateTable).insert(
-          HistorySyncStateTableData(
-            sessionId: sessionId,
-            watermark: watermark,
-            backendActivityAt: backendActivityAt,
-          ),
-        );
-        return;
-      }
-      await into(historySyncStateTable).insertOnConflictUpdate(
-        existing.copyWith(
-          watermark: watermark > existing.watermark ? watermark : existing.watermark,
-          backendActivityAt: backendActivityAt > existing.backendActivityAt
-              ? backendActivityAt
-              : existing.backendActivityAt,
-        ),
-      );
-    });
+    return _writeSyncState(
+      sessionId: sessionId,
+      watermark: watermark,
+      backendActivityAt: backendActivityAt,
+      syncedAt: const Value.absent(),
+    );
   }
+
+  /// Upserts the row, keeping whichever timestamps are later.
+  ///
+  /// `MAX` runs inside the statement so a concurrent writer cannot land
+  /// between a read and a write and lose its marks.
+  Future<void> _writeSyncState({
+    required String sessionId,
+    required int watermark,
+    required int backendActivityAt,
+    required Value<int?> syncedAt,
+  }) async {
+    await into(historySyncStateTable).insert(
+      HistorySyncStateTableCompanion.insert(
+        sessionId: sessionId,
+        watermark: watermark,
+        backendActivityAt: backendActivityAt,
+        syncedAt: syncedAt,
+      ),
+      onConflict: DoUpdate(
+        (old) => HistorySyncStateTableCompanion.custom(
+          watermark: _greatest(old.watermark, Constant(watermark)),
+          backendActivityAt: _greatest(old.backendActivityAt, Constant(backendActivityAt)),
+          syncedAt: syncedAt.present ? Constant(syncedAt.value) : null,
+        ),
+      ),
+    );
+  }
+
+  Expression<int> _greatest(Expression<int> left, Expression<int> right) =>
+      FunctionCallExpression("MAX", [left, right]);
 
   Future<void> clearSyncedAt({required String sessionId}) async {
     await (update(historySyncStateTable)..where((table) => table.sessionId.equals(sessionId))).write(

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -19,6 +19,7 @@ import "../auth/access_token_provider.dart";
 import "../auth/bridge_registration_service.dart";
 import "../auth/token_refresher.dart";
 import "../control/control_status_notifier.dart";
+import "../listeners/chat_history_listener.dart";
 import "../listeners/plugin_catalog_hydration_listener.dart";
 import "../listeners/plugin_event_listener.dart";
 import "../listeners/session_binding_commit_listener.dart";
@@ -125,6 +126,7 @@ import "routing/set_base_branch_handler.dart";
 import "routing/update_session_archive_status_handler.dart";
 import "runtime/plugin_runtime.dart";
 import "services/archived_session_validator.dart";
+import "services/chat_history_reconcile_service.dart";
 import "services/chat_history_service.dart";
 import "services/deleted_session_storage_cleanup_service.dart";
 import "services/pending_interaction_service.dart";
@@ -155,6 +157,7 @@ typedef OrchestratorComposition = ({
   CatalogImportService catalogImportService,
   PluginCatalogHydrationListener catalogHydrationListener,
   DeletedSessionStorageCleanupService deletedSessionStorageCleanupService,
+  ChatHistoryReconcileService chatHistoryReconcileService,
   BridgeRestartDispatcher restartDispatcher,
   RoutedRequestDispatcher routedRequestDispatcher,
   SessionRepository sessionRepository,
@@ -468,6 +471,7 @@ class Orchestrator {
         chatHistoryDao: _chatHistoryDatabase.chatHistoryDao,
         attachmentSpillStorage: _attachmentSpillStorage,
       ),
+      sessionRepository: sessionRepository,
     );
     final sessionDeletionService = SessionDeletionService(
       sessionLifecycleService: sessionLifecycleService,
@@ -522,12 +526,17 @@ class Orchestrator {
       runtime: _pluginRuntime,
       service: sessionOptionsService,
     );
+    final chatHistoryListener = ChatHistoryListener(
+      source: sessionEventDispatcher.events,
+      chatHistoryService: chatHistoryService,
+    );
     final normalizedPluginEvents = sessionEventDispatcher.events.doOnListen(() {
       for (final listener in pluginEventListeners) {
         listener.start();
       }
       sessionBindingCommitListener.start();
       sessionDeletionListener.start();
+      chatHistoryListener.start();
     });
     final restartDispatcher = BridgeRestartDispatcher(restartService: _restartService);
     final router = RequestRouter(
@@ -608,6 +617,7 @@ class Orchestrator {
       pluginEventListeners: pluginEventListeners,
       sessionBindingCommitListener: sessionBindingCommitListener,
       sessionDeletionListener: sessionDeletionListener,
+      chatHistoryListener: chatHistoryListener,
       sessionOptionsCreationRefreshListener: sessionOptionsCreationRefreshListener,
       sessionOptionsChangedRefreshListener: sessionOptionsChangedRefreshListener,
       sessionEventDispatcher: sessionEventDispatcher,
@@ -649,6 +659,10 @@ class Orchestrator {
       catalogImportService: catalogImportService,
       catalogHydrationListener: catalogHydrationListener,
       deletedSessionStorageCleanupService: deletedSessionStorageCleanupService,
+      chatHistoryReconcileService: ChatHistoryReconcileService(
+        sessionRepository: sessionRepository,
+        chatHistoryService: chatHistoryService,
+      ),
       restartDispatcher: restartDispatcher,
       routedRequestDispatcher: routedRequestDispatcher,
       sessionRepository: sessionRepository,
@@ -683,6 +697,7 @@ class OrchestratorSession {
   final List<PluginEventListener> _pluginEventListeners;
   final SessionBindingCommitListener _sessionBindingCommitListener;
   final SessionDeletionListener _sessionDeletionListener;
+  final ChatHistoryListener _chatHistoryListener;
   final SessionOptionsCreationRefreshListener _sessionOptionsCreationRefreshListener;
   final SessionOptionsChangedRefreshListener _sessionOptionsChangedRefreshListener;
   final SessionEventDispatcher _sessionEventDispatcher;
@@ -748,6 +763,7 @@ class OrchestratorSession {
     required List<PluginEventListener> pluginEventListeners,
     required SessionBindingCommitListener sessionBindingCommitListener,
     required SessionDeletionListener sessionDeletionListener,
+    required ChatHistoryListener chatHistoryListener,
     required SessionOptionsCreationRefreshListener sessionOptionsCreationRefreshListener,
     required SessionOptionsChangedRefreshListener sessionOptionsChangedRefreshListener,
     required SessionEventDispatcher sessionEventDispatcher,
@@ -788,6 +804,7 @@ class OrchestratorSession {
        _pluginEventListeners = pluginEventListeners,
        _sessionBindingCommitListener = sessionBindingCommitListener,
        _sessionDeletionListener = sessionDeletionListener,
+       _chatHistoryListener = chatHistoryListener,
        _sessionOptionsCreationRefreshListener = sessionOptionsCreationRefreshListener,
        _sessionOptionsChangedRefreshListener = sessionOptionsChangedRefreshListener,
        _sessionEventDispatcher = sessionEventDispatcher,
@@ -1094,6 +1111,7 @@ class OrchestratorSession {
       for (final listener in _pluginEventListeners) attempt(listener.dispose),
       attempt(_sessionBindingCommitListener.dispose),
       attempt(_sessionDeletionListener.dispose),
+      attempt(_chatHistoryListener.dispose),
     ]);
     Log.v("[shutdown] event producers cancelled (+${teardownSw.elapsedMilliseconds}ms)");
     await Future.wait([

--- a/bridge/app/lib/src/bridge/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/chat_history_repository.dart
@@ -167,12 +167,9 @@ class ChatHistoryRepository {
       messages: messageRows,
       parts: partRows,
       retainedMessageIds: {for (final row in retained) row.messageId},
-      syncState: HistorySyncStateTableData(
-        sessionId: sessionId,
-        watermark: watermark,
-        backendActivityAt: backendActivityAt,
-        syncedAt: syncedAt,
-      ),
+      watermark: watermark,
+      backendActivityAt: backendActivityAt,
+      syncedAt: syncedAt,
     );
   }
 
@@ -251,9 +248,12 @@ class ChatHistoryRepository {
   }) async {
     if (attachment["source"] != "inline_image") return attachment;
     final base64Data = attachment["base64"];
+    if (base64Data is! String || base64Data.isEmpty) {
+      return {"source": "metadata", "mime": attachment["mime"], "filename": attachment["filename"]};
+    }
     final Uint8List bytes;
     try {
-      bytes = base64Decode(base64Data is String ? base64Data : "");
+      bytes = base64Decode(base64Data);
     } on FormatException {
       // Undecodable inline data cannot be stored or re-served, so keep the
       // slot with the metadata the client can still render.

--- a/bridge/app/lib/src/bridge/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/chat_history_repository.dart
@@ -7,27 +7,11 @@ import "../../api/attachment_spill_storage.dart";
 import "../../api/database/history/chat_history_dao.dart";
 import "../../api/database/history/chat_history_database.dart";
 
-/// A stored transcript page plus the freshness facts that produced it.
-typedef StoredSessionHistory = ({
-  List<MessageWithParts> messages,
-  int? syncedAt,
-});
-
-/// Raised when stored history cannot be read or written.
-class ChatHistoryStorageException implements Exception {
-  final String operation;
-  final String sessionId;
-  final Object innerError;
-
-  ChatHistoryStorageException({
-    required this.operation,
-    required this.sessionId,
-    required this.innerError,
-  });
-
-  @override
-  String toString() => "chat history $operation failed for session $sessionId";
-}
+/// How fresh a session's stored transcript is.
+///
+/// [syncedAt] is null until a backfill completes, so a row created by live
+/// capture never claims to be a complete transcript.
+typedef ChatHistorySyncState = ({int watermark, int backendActivityAt, int? syncedAt});
 
 /// Owns the stored representation of chat history: database rows, their JSON
 /// payloads, and the attachment spill files those payloads reference.
@@ -41,8 +25,11 @@ class ChatHistoryRepository {
   final ChatHistoryDao _chatHistoryDao;
   final AttachmentSpillStorage _attachmentSpillStorage;
 
-  Future<HistorySyncStateTableData?> getSyncState({required String sessionId}) {
-    return _chatHistoryDao.getSyncState(sessionId: sessionId);
+  Future<ChatHistorySyncState?> getSyncState({required String sessionId}) async {
+    final row = await _chatHistoryDao.getSyncState(sessionId: sessionId);
+    return row == null
+        ? null
+        : (watermark: row.watermark, backendActivityAt: row.backendActivityAt, syncedAt: row.syncedAt);
   }
 
   /// The session's stored transcript, oldest first, with attachments
@@ -180,9 +167,7 @@ class ChatHistoryRepository {
       messages: messageRows,
       parts: partRows,
       retainedMessageIds: {for (final row in retained) row.messageId},
-    );
-    await _chatHistoryDao.upsertSyncState(
-      row: HistorySyncStateTableData(
+      syncState: HistorySyncStateTableData(
         sessionId: sessionId,
         watermark: watermark,
         backendActivityAt: backendActivityAt,

--- a/bridge/app/lib/src/bridge/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/chat_history_repository.dart
@@ -1,8 +1,36 @@
+import "dart:convert";
+import "dart:typed_data";
+
+import "package:sesori_shared/sesori_shared.dart";
+
 import "../../api/attachment_spill_storage.dart";
 import "../../api/database/history/chat_history_dao.dart";
+import "../../api/database/history/chat_history_database.dart";
 
-/// Owns the stored representation of chat history: database rows and the
-/// attachment spill files their part payloads reference.
+/// A stored transcript page plus the freshness facts that produced it.
+typedef StoredSessionHistory = ({
+  List<MessageWithParts> messages,
+  int? syncedAt,
+});
+
+/// Raised when stored history cannot be read or written.
+class ChatHistoryStorageException implements Exception {
+  final String operation;
+  final String sessionId;
+  final Object innerError;
+
+  ChatHistoryStorageException({
+    required this.operation,
+    required this.sessionId,
+    required this.innerError,
+  });
+
+  @override
+  String toString() => "chat history $operation failed for session $sessionId";
+}
+
+/// Owns the stored representation of chat history: database rows, their JSON
+/// payloads, and the attachment spill files those payloads reference.
 class ChatHistoryRepository {
   ChatHistoryRepository({
     required ChatHistoryDao chatHistoryDao,
@@ -12,6 +40,174 @@ class ChatHistoryRepository {
 
   final ChatHistoryDao _chatHistoryDao;
   final AttachmentSpillStorage _attachmentSpillStorage;
+
+  Future<HistorySyncStateTableData?> getSyncState({required String sessionId}) {
+    return _chatHistoryDao.getSyncState(sessionId: sessionId);
+  }
+
+  /// The session's stored transcript, oldest first, with attachments
+  /// rehydrated from their spill files.
+  Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async {
+    final messageRows = await _chatHistoryDao.getMessages(sessionId: sessionId);
+    final partRows = await _chatHistoryDao.getParts(sessionId: sessionId);
+    final partsByMessage = <String, List<MessagePart>>{};
+    for (final row in partRows) {
+      partsByMessage
+          .putIfAbsent(row.messageId, () => [])
+          .add(await _rehydratePart(sessionId: sessionId, partJson: row.partJson));
+    }
+    return [
+      for (final row in messageRows)
+        MessageWithParts(
+          info: Message.fromJson(jsonDecodeMap(row.infoJson)),
+          parts: partsByMessage[row.messageId] ?? const [],
+        ),
+    ];
+  }
+
+  /// Stores one message, appending it after the current maximum when new.
+  Future<void> upsertMessage({
+    required String sessionId,
+    required Message message,
+    required int updatedAt,
+  }) async {
+    final existingSeq = await _chatHistoryDao.getMessageSeq(sessionId: sessionId, messageId: message.id);
+    final seq = existingSeq ?? (await _chatHistoryDao.getMaxSeq(sessionId: sessionId) ?? 0) + 1;
+    await _chatHistoryDao.upsertMessage(
+      row: HistoryMessagesTableData(
+        sessionId: sessionId,
+        messageId: message.id,
+        seq: seq,
+        infoJson: jsonEncode(message.toJson()),
+        updatedAt: updatedAt,
+      ),
+    );
+  }
+
+  /// Stores one part, spilling any inline attachment bytes to disk first.
+  Future<void> upsertPart({
+    required String sessionId,
+    required MessagePart part,
+    required int updatedAt,
+  }) async {
+    final existingOrder = await _chatHistoryDao.getPartOrderIndex(
+      sessionId: sessionId,
+      messageId: part.messageID,
+      partId: part.id,
+    );
+    final orderIndex =
+        existingOrder ??
+        (await _chatHistoryDao.getMaxPartOrderIndex(sessionId: sessionId, messageId: part.messageID) ?? -1) + 1;
+    await _chatHistoryDao.upsertPart(
+      row: HistoryPartsTableData(
+        sessionId: sessionId,
+        messageId: part.messageID,
+        partId: part.id,
+        orderIndex: orderIndex,
+        partJson: await _encodePart(sessionId: sessionId, part: part),
+        updatedAt: updatedAt,
+      ),
+    );
+  }
+
+  Future<void> deleteMessage({required String sessionId, required String messageId}) {
+    return _chatHistoryDao.deleteMessage(sessionId: sessionId, messageId: messageId);
+  }
+
+  Future<void> deletePart({
+    required String sessionId,
+    required String messageId,
+    required String partId,
+  }) {
+    return _chatHistoryDao.deletePart(sessionId: sessionId, messageId: messageId, partId: partId);
+  }
+
+  /// Replaces the session's transcript with [messages], numbering them in
+  /// transcript order.
+  ///
+  /// Rows the transcript does not contain — live events newer than the fetch —
+  /// are kept above the imported maximum, preserving their relative order, so
+  /// no captured message is lost to a backfill that raced it.
+  Future<void> replaceSessionMessages({
+    required String sessionId,
+    required List<MessageWithParts> messages,
+    required int watermark,
+    required int backendActivityAt,
+    required int syncedAt,
+  }) async {
+    final importedIds = {for (final message in messages) message.info.id};
+    final storedRows = await _chatHistoryDao.getMessages(sessionId: sessionId);
+    final retained = [
+      for (final row in storedRows)
+        if (!importedIds.contains(row.messageId)) row,
+    ];
+
+    final messageRows = <HistoryMessagesTableData>[];
+    final partRows = <HistoryPartsTableData>[];
+    var seq = 0;
+    for (final message in messages) {
+      seq++;
+      messageRows.add(
+        HistoryMessagesTableData(
+          sessionId: sessionId,
+          messageId: message.info.id,
+          seq: seq,
+          infoJson: jsonEncode(message.info.toJson()),
+          updatedAt: syncedAt,
+        ),
+      );
+      for (var index = 0; index < message.parts.length; index++) {
+        final part = message.parts[index];
+        partRows.add(
+          HistoryPartsTableData(
+            sessionId: sessionId,
+            messageId: message.info.id,
+            partId: part.id,
+            orderIndex: index,
+            partJson: await _encodePart(sessionId: sessionId, part: part),
+            updatedAt: syncedAt,
+          ),
+        );
+      }
+    }
+    for (final row in retained..sort((left, right) => left.seq.compareTo(right.seq))) {
+      seq++;
+      messageRows.add(row.copyWith(seq: seq));
+    }
+
+    await _chatHistoryDao.replaceSessionRows(
+      sessionId: sessionId,
+      messages: messageRows,
+      parts: partRows,
+      retainedMessageIds: {for (final row in retained) row.messageId},
+    );
+    await _chatHistoryDao.upsertSyncState(
+      row: HistorySyncStateTableData(
+        sessionId: sessionId,
+        watermark: watermark,
+        backendActivityAt: backendActivityAt,
+        syncedAt: syncedAt,
+      ),
+    );
+  }
+
+  Future<void> advanceSyncState({
+    required String sessionId,
+    required int watermark,
+    required int backendActivityAt,
+  }) {
+    return _chatHistoryDao.advanceSyncState(
+      sessionId: sessionId,
+      watermark: watermark,
+      backendActivityAt: backendActivityAt,
+    );
+  }
+
+  Future<void> clearSyncedAt({required String sessionId}) {
+    return _chatHistoryDao.clearSyncedAt(sessionId: sessionId);
+  }
+
+  Future<Set<String>> getStoredSessionIds() => _chatHistoryDao.getStoredSessionIds();
 
   /// Drops every trace of [sessionIds] from the store.
   ///
@@ -37,5 +233,92 @@ class ChatHistoryRepository {
     }
     await _chatHistoryDao.reclaimFreedPages();
     if (firstError != null) Error.throwWithStackTrace(firstError, firstStackTrace!);
+  }
+
+  /// The stored JSON for [part], with inline attachment bytes moved to spill
+  /// files and replaced by a `stored_file` reference.
+  ///
+  /// The reference is a bridge-internal attachment source that exists only
+  /// inside `chat_history.db`; [_rehydratePart] turns it back into the inline
+  /// variant before anything can reach the wire.
+  Future<String> _encodePart({required String sessionId, required MessagePart part}) async {
+    final json = part.toJson();
+    if (json["attachment"] case final Map<String, dynamic> attachment) {
+      json["attachment"] = await _spillAttachment(sessionId: sessionId, attachment: attachment);
+    }
+    if (json["state"] case final Map<String, dynamic> state) {
+      if (state["attachments"] case final List<dynamic> attachments) {
+        state["attachments"] = [
+          for (final attachment in attachments)
+            if (attachment is Map<String, dynamic>)
+              await _spillAttachment(sessionId: sessionId, attachment: attachment)
+            else
+              attachment,
+        ];
+      }
+    }
+    return jsonEncode(json);
+  }
+
+  Future<Map<String, dynamic>> _spillAttachment({
+    required String sessionId,
+    required Map<String, dynamic> attachment,
+  }) async {
+    if (attachment["source"] != "inline_image") return attachment;
+    final base64Data = attachment["base64"];
+    final Uint8List bytes;
+    try {
+      bytes = base64Decode(base64Data is String ? base64Data : "");
+    } on FormatException {
+      // Undecodable inline data cannot be stored or re-served, so keep the
+      // slot with the metadata the client can still render.
+      return {"source": "metadata", "mime": attachment["mime"], "filename": attachment["filename"]};
+    }
+    return {
+      "source": "stored_file",
+      "mime": attachment["mime"],
+      "filename": attachment["filename"],
+      "sha256": await _attachmentSpillStorage.write(sessionId: sessionId, bytes: bytes),
+    };
+  }
+
+  Future<MessagePart> _rehydratePart({required String sessionId, required String partJson}) async {
+    final json = jsonDecodeMap(partJson);
+    if (json["attachment"] case final Map<String, dynamic> attachment) {
+      json["attachment"] = await _rehydrateAttachment(sessionId: sessionId, attachment: attachment);
+    }
+    if (json["state"] case final Map<String, dynamic> state) {
+      if (state["attachments"] case final List<dynamic> attachments) {
+        state["attachments"] = [
+          for (final attachment in attachments)
+            if (attachment is Map<String, dynamic>)
+              await _rehydrateAttachment(sessionId: sessionId, attachment: attachment)
+            else
+              attachment,
+        ];
+      }
+    }
+    return MessagePart.fromJson(json);
+  }
+
+  Future<Map<String, dynamic>> _rehydrateAttachment({
+    required String sessionId,
+    required Map<String, dynamic> attachment,
+  }) async {
+    if (attachment["source"] != "stored_file") return attachment;
+    final digest = attachment["sha256"];
+    final bytes = digest is String
+        ? await _attachmentSpillStorage.read(sessionId: sessionId, digest: digest)
+        : null;
+    // A missing spill file degrades the slot instead of failing the read.
+    if (bytes == null) {
+      return {"source": "metadata", "mime": attachment["mime"], "filename": attachment["filename"]};
+    }
+    return {
+      "source": "inline_image",
+      "mime": attachment["mime"],
+      "filename": attachment["filename"],
+      "base64": base64Encode(bytes),
+    };
   }
 }

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -1111,8 +1111,19 @@ class SessionRepository {
   /// sessions keep their row, so absence means the session is really gone.
   Future<Set<String>> getExistingSessionIds({required Set<String> sessionIds}) async {
     if (sessionIds.isEmpty) return const {};
-    final rows = await _sessionDao.getSessionsByIds(sessionIds: sessionIds.toList(growable: false));
-    return rows.keys.toSet();
+    // Each id becomes a bind variable and the store is unbounded, so ask in
+    // chunks rather than letting one oversized statement fail the lookup.
+    const chunkSize = 500;
+    final ordered = sessionIds.toList(growable: false);
+    final existing = <String>{};
+    for (var start = 0; start < ordered.length; start += chunkSize) {
+      final end = start + chunkSize;
+      final rows = await _sessionDao.getSessionsByIds(
+        sessionIds: ordered.sublist(start, end > ordered.length ? ordered.length : end),
+      );
+      existing.addAll(rows.keys);
+    }
+    return existing;
   }
 
   Future<List<StoredSession>> getStoredSessionsByProjectId({required String projectId}) async {

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -1107,6 +1107,14 @@ class SessionRepository {
     return [for (final binding in subtree) binding.sessionId];
   }
 
+  /// The subset of [sessionIds] that still has a stored session row. Archived
+  /// sessions keep their row, so absence means the session is really gone.
+  Future<Set<String>> getExistingSessionIds({required Set<String> sessionIds}) async {
+    if (sessionIds.isEmpty) return const {};
+    final rows = await _sessionDao.getSessionsByIds(sessionIds: sessionIds.toList(growable: false));
+    return rows.keys.toSet();
+  }
+
   Future<List<StoredSession>> getStoredSessionsByProjectId({required String projectId}) async {
     final sessions = await _sessionDao.getSessionsByProject(projectId: projectId);
     return sessions.map((session) => session.toStoredSession()).toList(growable: false);

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
@@ -45,6 +45,10 @@ class BridgeRuntime {
     return _composition.deletedSessionStorageCleanupService.reconcile();
   }
 
+  Future<void> reconcileChatHistory() {
+    return _composition.chatHistoryReconcileService.reconcile();
+  }
+
   BandwidthTracker createBandwidthTracker() {
     return BandwidthTracker(bytesSent: session.bytesSent);
   }

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -853,6 +853,9 @@ class BridgeRuntimeRunner {
       // Run before imports, debug routes, or relay traffic can load a session
       // into a backend process and retain handles to its persisted storage.
       await activeRuntime.reconcileDeletedSessionStorage();
+      // Drops history whose session disappeared from the catalog while the
+      // bridge was down, before any route can read or extend it.
+      await activeRuntime.reconcileChatHistory();
 
       if (!options.isSupervised) {
         catalogImportConsoleListener = CatalogImportConsoleListener(

--- a/bridge/app/lib/src/bridge/services/chat_history_reconcile_service.dart
+++ b/bridge/app/lib/src/bridge/services/chat_history_reconcile_service.dart
@@ -28,6 +28,12 @@ class ChatHistoryReconcileService {
   /// Purges history for sessions the catalog no longer knows about — deleted
   /// while the bridge was down, or whose inline purge failed. An archived
   /// session keeps its catalog row, so row existence is the whole mapping.
+  ///
+  /// This can never fire for a session that merely disappeared from its
+  /// backend: catalog import is non-destructive, so such a session keeps its
+  /// row and therefore its history. The comparison reads only the local
+  /// databases — no plugin request is involved, so a failing backend cannot
+  /// be mistaken for deleted sessions.
   Future<void> _reconcile() async {
     final storedSessionIds = await _chatHistoryService.getStoredSessionIds();
     if (storedSessionIds.isEmpty) return;

--- a/bridge/app/lib/src/bridge/services/chat_history_reconcile_service.dart
+++ b/bridge/app/lib/src/bridge/services/chat_history_reconcile_service.dart
@@ -1,0 +1,50 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
+import "../repositories/session_repository.dart";
+import "chat_history_service.dart";
+
+/// Startup owner of consistency between `sesori.db` and the history store.
+///
+/// It reads session identity from the main database but mutates only through
+/// [ChatHistoryService], which stays the single writer of the store.
+class ChatHistoryReconcileService {
+  ChatHistoryReconcileService({
+    required SessionRepository sessionRepository,
+    required ChatHistoryService chatHistoryService,
+  }) : _sessionRepository = sessionRepository,
+       _chatHistoryService = chatHistoryService;
+
+  final SessionRepository _sessionRepository;
+  final ChatHistoryService _chatHistoryService;
+
+  Future<void> reconcile() async {
+    try {
+      await _reconcile();
+    } on Object catch (error, stackTrace) {
+      Log.w("Chat history reconciliation failed; continuing startup", error, stackTrace);
+    }
+  }
+
+  /// Purges history for sessions the catalog no longer knows about — deleted
+  /// while the bridge was down, or whose inline purge failed. An archived
+  /// session keeps its catalog row, so row existence is the whole mapping.
+  Future<void> _reconcile() async {
+    final storedSessionIds = await _chatHistoryService.getStoredSessionIds();
+    if (storedSessionIds.isEmpty) return;
+
+    final knownSessionIds = await _sessionRepository.getExistingSessionIds(sessionIds: storedSessionIds);
+    final orphanIds = storedSessionIds.difference(knownSessionIds).toList(growable: false)..sort();
+    for (final sessionId in orphanIds) {
+      try {
+        await _chatHistoryService.purgeSessionHistory(sessionId: sessionId);
+      } on Object catch (error, stackTrace) {
+        Log.w(
+          "Failed to purge orphan chat history for session $sessionId; "
+          "retrying next startup",
+          error,
+          stackTrace,
+        );
+      }
+    }
+  }
+}

--- a/bridge/app/lib/src/bridge/services/chat_history_service.dart
+++ b/bridge/app/lib/src/bridge/services/chat_history_service.dart
@@ -21,6 +21,8 @@ class ChatHistoryService {
   final SessionRepository _sessionRepository;
   final Map<String, Future<void>> _writeQueues = {};
   final Map<String, Future<void>> _inFlightBackfills = {};
+  /// Message ids removed while that session's backfill fetch is in flight.
+  final Map<String, Set<String>> _removalsDuringBackfill = {};
 
   /// Records a finalized message from the live event stream.
   Future<void> captureMessage({required String sessionId, required Message message}) {
@@ -49,6 +51,7 @@ class ChatHistoryService {
   }
 
   Future<void> captureMessageRemoved({required String sessionId, required String messageId}) {
+    _removalsDuringBackfill[sessionId]?.add(messageId);
     return _capture(
       sessionId: sessionId,
       description: "removal of message $messageId",
@@ -90,13 +93,24 @@ class ChatHistoryService {
     // masked by a watermark taken afterwards.
     final observedBefore = await _chatHistoryRepository.getSyncState(sessionId: sessionId);
     final backendActivityAt = observedBefore?.backendActivityAt ?? 0;
-    final messages = await _sessionRepository.getSessionMessages(sessionId: sessionId);
+    // A removal that lands while the fetch is in flight is newer than the
+    // transcript being fetched, so the transcript must not resurrect it.
+    final removedDuringFetch = _removalsDuringBackfill[sessionId] = <String>{};
+    final List<MessageWithParts> messages;
+    try {
+      messages = await _sessionRepository.getSessionMessages(sessionId: sessionId);
+    } finally {
+      _removalsDuringBackfill.remove(sessionId);
+    }
     final syncedAt = DateTime.now().millisecondsSinceEpoch;
     await _enqueue(
       sessionId: sessionId,
       write: () => _chatHistoryRepository.replaceSessionMessages(
         sessionId: sessionId,
-        messages: messages,
+        messages: [
+          for (final message in messages)
+            if (!removedDuringFetch.contains(message.info.id)) message,
+        ],
         watermark: backendActivityAt,
         backendActivityAt: backendActivityAt,
         syncedAt: syncedAt,

--- a/bridge/app/lib/src/bridge/services/chat_history_service.dart
+++ b/bridge/app/lib/src/bridge/services/chat_history_service.dart
@@ -1,17 +1,127 @@
 import "dart:async";
 
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+import "package:sesori_shared/sesori_shared.dart";
+
 import "../repositories/chat_history_repository.dart";
+import "../repositories/session_repository.dart";
 
 /// The single writer of the chat history store.
 ///
 /// Every mutation runs through a per-session queue so writes for one session
 /// never interleave, while unrelated sessions stay independent.
 class ChatHistoryService {
-  ChatHistoryService({required ChatHistoryRepository chatHistoryRepository})
-    : _chatHistoryRepository = chatHistoryRepository;
+  ChatHistoryService({
+    required ChatHistoryRepository chatHistoryRepository,
+    required SessionRepository sessionRepository,
+  }) : _chatHistoryRepository = chatHistoryRepository,
+       _sessionRepository = sessionRepository;
 
   final ChatHistoryRepository _chatHistoryRepository;
+  final SessionRepository _sessionRepository;
   final Map<String, Future<void>> _writeQueues = {};
+  final Map<String, Future<void>> _inFlightBackfills = {};
+
+  /// Records a finalized message from the live event stream.
+  Future<void> captureMessage({required String sessionId, required Message message}) {
+    return _capture(
+      sessionId: sessionId,
+      description: "message ${message.id}",
+      write: (observedAt) => _chatHistoryRepository.upsertMessage(
+        sessionId: sessionId,
+        message: message,
+        updatedAt: observedAt,
+      ),
+    );
+  }
+
+  /// Records a finalized part snapshot. Streaming deltas are never stored.
+  Future<void> capturePart({required String sessionId, required MessagePart part}) {
+    return _capture(
+      sessionId: sessionId,
+      description: "part ${part.id}",
+      write: (observedAt) => _chatHistoryRepository.upsertPart(
+        sessionId: sessionId,
+        part: part,
+        updatedAt: observedAt,
+      ),
+    );
+  }
+
+  Future<void> captureMessageRemoved({required String sessionId, required String messageId}) {
+    return _capture(
+      sessionId: sessionId,
+      description: "removal of message $messageId",
+      write: (_) => _chatHistoryRepository.deleteMessage(sessionId: sessionId, messageId: messageId),
+    );
+  }
+
+  Future<void> capturePartRemoved({
+    required String sessionId,
+    required String messageId,
+    required String partId,
+  }) {
+    return _capture(
+      sessionId: sessionId,
+      description: "removal of part $partId",
+      write: (_) => _chatHistoryRepository.deletePart(
+        sessionId: sessionId,
+        messageId: messageId,
+        partId: partId,
+      ),
+    );
+  }
+
+  /// Records backend activity observed outside the live event stream, so a
+  /// session advanced through the backend's own CLI is detected as stale.
+  Future<void> observeBackendActivity({required String sessionId, required int activityAt}) {
+    return _enqueue(
+      sessionId: sessionId,
+      write: () async {
+        final state = await _chatHistoryRepository.getSyncState(sessionId: sessionId);
+        // Only sessions the store already knows about are tracked; an unknown
+        // session has nothing to be stale against.
+        if (state == null) return;
+        await _chatHistoryRepository.advanceSyncState(
+          sessionId: sessionId,
+          watermark: state.watermark,
+          backendActivityAt: activityAt,
+        );
+      },
+    );
+  }
+
+  /// Fills the store from the backend's own transcript.
+  ///
+  /// Concurrent callers for the same session await one fetch. Failures
+  /// propagate so a cache miss never looks like an empty thread.
+  Future<void> backfillSession({required String sessionId}) {
+    final inFlight = _inFlightBackfills[sessionId];
+    if (inFlight != null) return inFlight;
+
+    final backfill = _backfillSession(sessionId: sessionId);
+    _inFlightBackfills[sessionId] = backfill;
+    return backfill.whenComplete(() => _inFlightBackfills.remove(sessionId));
+  }
+
+  Future<void> _backfillSession({required String sessionId}) async {
+    // Captured before the fetch: activity observed while it runs must not be
+    // masked by a watermark taken afterwards.
+    final observedBefore = await _chatHistoryRepository.getSyncState(sessionId: sessionId);
+    final backendActivityAt = observedBefore?.backendActivityAt ?? 0;
+    final messages = await _sessionRepository.getSessionMessages(sessionId: sessionId);
+    final syncedAt = DateTime.now().millisecondsSinceEpoch;
+    await _enqueue(
+      sessionId: sessionId,
+      write: () => _chatHistoryRepository.replaceSessionMessages(
+        sessionId: sessionId,
+        messages: messages,
+        watermark: backendActivityAt,
+        backendActivityAt: backendActivityAt,
+        syncedAt: syncedAt,
+      ),
+    );
+  }
 
   /// Removes the session's stored transcript and attachment bytes.
   Future<void> purgeSessionHistory({required String sessionId}) {
@@ -31,6 +141,59 @@ class ChatHistoryService {
       sessionIds: owned,
       write: () => _chatHistoryRepository.purgeSessions(sessionIds: owned),
     );
+  }
+
+  Future<Set<String>> getStoredSessionIds() => _chatHistoryRepository.getStoredSessionIds();
+
+  /// Applies one captured event and advances the session's freshness marks.
+  ///
+  /// A failed capture clears `syncedAt`, so the next read falls back to the
+  /// plugin and re-backfills. That self-heals without a retry queue, and it is
+  /// why capture never rethrows into the event pipeline.
+  Future<void> _capture({
+    required String sessionId,
+    required String description,
+    required Future<void> Function(int observedAt) write,
+  }) {
+    final observedAt = DateTime.now().millisecondsSinceEpoch;
+    return _enqueue(
+      sessionId: sessionId,
+      write: () async {
+        try {
+          await write(observedAt);
+          await _chatHistoryRepository.advanceSyncState(
+            sessionId: sessionId,
+            watermark: observedAt,
+            backendActivityAt: observedAt,
+          );
+        } on Object catch (error, stackTrace) {
+          Log.w(
+            "Failed to capture $description for session $sessionId; "
+            "dropping the synced marker so the next read re-backfills",
+            error,
+            stackTrace,
+          );
+          await _clearSyncedAtQuietly(sessionId: sessionId);
+        }
+      },
+    );
+  }
+
+  Future<void> _clearSyncedAtQuietly({required String sessionId}) async {
+    try {
+      await _chatHistoryRepository.clearSyncedAt(sessionId: sessionId);
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        "Failed to drop the synced marker for session $sessionId; the store "
+        "may serve a stale transcript until the next backend activity",
+        error,
+        stackTrace,
+      );
+    }
+  }
+
+  Future<void> _enqueue({required String sessionId, required Future<void> Function() write}) {
+    return _enqueueAll(sessionIds: [sessionId], write: write);
   }
 
   /// Runs [write] after every listed session's pending writes, and makes it

--- a/bridge/app/lib/src/bridge/services/chat_history_service.dart
+++ b/bridge/app/lib/src/bridge/services/chat_history_service.dart
@@ -21,8 +21,6 @@ class ChatHistoryService {
   final SessionRepository _sessionRepository;
   final Map<String, Future<void>> _writeQueues = {};
   final Map<String, Future<void>> _inFlightBackfills = {};
-  /// Message ids removed while that session's backfill fetch is in flight.
-  final Map<String, Set<String>> _removalsDuringBackfill = {};
 
   /// Records a finalized message from the live event stream.
   Future<void> captureMessage({required String sessionId, required Message message}) {
@@ -51,7 +49,6 @@ class ChatHistoryService {
   }
 
   Future<void> captureMessageRemoved({required String sessionId, required String messageId}) {
-    _removalsDuringBackfill[sessionId]?.add(messageId);
     return _capture(
       sessionId: sessionId,
       description: "removal of message $messageId",
@@ -88,33 +85,36 @@ class ChatHistoryService {
     return backfill.whenComplete(() => _inFlightBackfills.remove(sessionId));
   }
 
-  Future<void> _backfillSession({required String sessionId}) async {
-    // Captured before the fetch: activity observed while it runs must not be
-    // masked by a watermark taken afterwards.
-    final observedBefore = await _chatHistoryRepository.getSyncState(sessionId: sessionId);
-    final backendActivityAt = observedBefore?.backendActivityAt ?? 0;
-    // A removal that lands while the fetch is in flight is newer than the
-    // transcript being fetched, so the transcript must not resurrect it.
-    final removedDuringFetch = _removalsDuringBackfill[sessionId] = <String>{};
-    final List<MessageWithParts> messages;
-    try {
-      messages = await _sessionRepository.getSessionMessages(sessionId: sessionId);
-    } finally {
-      _removalsDuringBackfill.remove(sessionId);
-    }
-    final syncedAt = DateTime.now().millisecondsSinceEpoch;
-    await _enqueue(
+  /// Fetches and applies the transcript as one queued unit.
+  ///
+  /// The fetch is deliberately inside the session's write queue. A transcript
+  /// is a snapshot of the backend at fetch time, so any capture that races it
+  /// is strictly newer; queueing those captures behind the whole backfill
+  /// applies them *after* the snapshot lands, which is the order they actually
+  /// happened. Fetching outside the queue instead would let a stale snapshot
+  /// overwrite newer updates and resurrect removed messages and parts —
+  /// reconciling that afterwards needs per-row tombstones for every
+  /// granularity, whereas ordering the two correctly needs none.
+  ///
+  /// Captures for this session wait for the fetch, but they never block the
+  /// event pipeline: the listener dispatches them without awaiting.
+  Future<void> _backfillSession({required String sessionId}) {
+    return _enqueue(
       sessionId: sessionId,
-      write: () => _chatHistoryRepository.replaceSessionMessages(
-        sessionId: sessionId,
-        messages: [
-          for (final message in messages)
-            if (!removedDuringFetch.contains(message.info.id)) message,
-        ],
-        watermark: backendActivityAt,
-        backendActivityAt: backendActivityAt,
-        syncedAt: syncedAt,
-      ),
+      write: () async {
+        // Read inside the queue too, so it cannot miss a capture that landed
+        // between the read and the write.
+        final observedBefore = await _chatHistoryRepository.getSyncState(sessionId: sessionId);
+        final backendActivityAt = observedBefore?.backendActivityAt ?? 0;
+        final messages = await _sessionRepository.getSessionMessages(sessionId: sessionId);
+        await _chatHistoryRepository.replaceSessionMessages(
+          sessionId: sessionId,
+          messages: messages,
+          watermark: backendActivityAt,
+          backendActivityAt: backendActivityAt,
+          syncedAt: DateTime.now().millisecondsSinceEpoch,
+        );
+      },
     );
   }
 

--- a/bridge/app/lib/src/bridge/services/chat_history_service.dart
+++ b/bridge/app/lib/src/bridge/services/chat_history_service.dart
@@ -72,25 +72,6 @@ class ChatHistoryService {
     );
   }
 
-  /// Records backend activity observed outside the live event stream, so a
-  /// session advanced through the backend's own CLI is detected as stale.
-  Future<void> observeBackendActivity({required String sessionId, required int activityAt}) {
-    return _enqueue(
-      sessionId: sessionId,
-      write: () async {
-        final state = await _chatHistoryRepository.getSyncState(sessionId: sessionId);
-        // Only sessions the store already knows about are tracked; an unknown
-        // session has nothing to be stale against.
-        if (state == null) return;
-        await _chatHistoryRepository.advanceSyncState(
-          sessionId: sessionId,
-          watermark: state.watermark,
-          backendActivityAt: activityAt,
-        );
-      },
-    );
-  }
-
   /// Fills the store from the backend's own transcript.
   ///
   /// Concurrent callers for the same session await one fetch. Failures

--- a/bridge/app/lib/src/listeners/chat_history_listener.dart
+++ b/bridge/app/lib/src/listeners/chat_history_listener.dart
@@ -17,6 +17,7 @@ class ChatHistoryListener {
   final ChatHistoryService _chatHistoryService;
   StreamSubscription<NormalizedSourcedBridgeEvent>? _subscription;
   final Set<Future<void>> _pendingCaptures = {};
+  Future<void>? _disposeFuture;
   bool _disposed = false;
 
   ChatHistoryListener({
@@ -70,8 +71,11 @@ class ChatHistoryListener {
     await _chatHistoryService.captureMessage(sessionId: message.sessionID, message: message);
   }
 
-  Future<void> dispose() async {
-    if (_disposed) return;
+  /// Memoized so a second caller joins the same drain instead of returning
+  /// while finalized writes are still running.
+  Future<void> dispose() => _disposeFuture ??= _dispose();
+
+  Future<void> _dispose() async {
     _disposed = true;
     await _subscription?.cancel();
     // Capture never throws (failures are logged and drop the synced marker),

--- a/bridge/app/lib/src/listeners/chat_history_listener.dart
+++ b/bridge/app/lib/src/listeners/chat_history_listener.dart
@@ -1,0 +1,70 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../bridge/plugin_to_shared_mapping.dart";
+import "../bridge/services/chat_history_service.dart";
+import "../bridge/services/session_event_dispatcher.dart";
+
+/// Persists finalized message events into the chat history store.
+///
+/// It consumes events after [SessionEventDispatcher] normalization, so ids are
+/// already translated to bridge session ids and stale generations are fenced.
+/// Streaming deltas are ignored: only full snapshots are stored.
+class ChatHistoryListener {
+  final Stream<NormalizedSourcedBridgeEvent> _source;
+  final ChatHistoryService _chatHistoryService;
+  StreamSubscription<NormalizedSourcedBridgeEvent>? _subscription;
+  bool _disposed = false;
+
+  ChatHistoryListener({
+    required Stream<NormalizedSourcedBridgeEvent> source,
+    required ChatHistoryService chatHistoryService,
+  }) : _source = source,
+       _chatHistoryService = chatHistoryService;
+
+  void start() {
+    if (_subscription != null || _disposed) return;
+    _subscription = _source.listen(
+      (sourced) => unawaited(_capture(event: sourced.event)),
+      // Source errors are surfaced by the dispatcher's own consumers; capture
+      // simply has nothing to store for a failed event.
+      onError: (Object _) {},
+    );
+  }
+
+  Future<void> _capture({required BridgeSseEvent event}) {
+    return switch (event) {
+      BridgeSseMessageUpdated(:final info) => _captureMessage(info: info),
+      BridgeSseMessagePartUpdated(:final part) => _chatHistoryService.capturePart(
+        sessionId: part.sessionID,
+        part: part.toShared(sessionId: part.sessionID),
+      ),
+      BridgeSseMessageRemoved(:final sessionID, :final messageID) => _chatHistoryService.captureMessageRemoved(
+        sessionId: sessionID,
+        messageId: messageID,
+      ),
+      BridgeSseMessagePartRemoved(:final sessionID, :final messageID, :final partID) => _chatHistoryService
+          .capturePartRemoved(sessionId: sessionID, messageId: messageID, partId: partID),
+      _ => Future<void>.value(),
+    };
+  }
+
+  Future<void> _captureMessage({required Map<String, dynamic> info}) async {
+    final Message message;
+    try {
+      message = Message.fromJson(info);
+    } on Object catch (error, stackTrace) {
+      Log.w("Ignoring an undecodable message event; it will not be stored", error, stackTrace);
+      return;
+    }
+    await _chatHistoryService.captureMessage(sessionId: message.sessionID, message: message);
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await _subscription?.cancel();
+  }
+}

--- a/bridge/app/lib/src/listeners/chat_history_listener.dart
+++ b/bridge/app/lib/src/listeners/chat_history_listener.dart
@@ -16,6 +16,7 @@ class ChatHistoryListener {
   final Stream<NormalizedSourcedBridgeEvent> _source;
   final ChatHistoryService _chatHistoryService;
   StreamSubscription<NormalizedSourcedBridgeEvent>? _subscription;
+  final Set<Future<void>> _pendingCaptures = {};
   bool _disposed = false;
 
   ChatHistoryListener({
@@ -27,11 +28,18 @@ class ChatHistoryListener {
   void start() {
     if (_subscription != null || _disposed) return;
     _subscription = _source.listen(
-      (sourced) => unawaited(_capture(event: sourced.event)),
+      (sourced) => _track(capture: _capture(event: sourced.event)),
       // Source errors are surfaced by the dispatcher's own consumers; capture
       // simply has nothing to store for a failed event.
       onError: (Object _) {},
     );
+  }
+
+  /// Keeps the write observable to [dispose], so shutdown does not close the
+  /// database out from under a finalized event still being persisted.
+  void _track({required Future<void> capture}) {
+    _pendingCaptures.add(capture);
+    unawaited(capture.whenComplete(() => _pendingCaptures.remove(capture)));
   }
 
   Future<void> _capture({required BridgeSseEvent event}) {
@@ -66,5 +74,8 @@ class ChatHistoryListener {
     if (_disposed) return;
     _disposed = true;
     await _subscription?.cancel();
+    // Capture never throws (failures are logged and drop the synced marker),
+    // so waiting cannot fail teardown.
+    await Future.wait(_pendingCaptures.toList(growable: false));
   }
 }

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -916,6 +916,8 @@ class _NoopSessionRepository implements SessionRepository {
   @override
   Future<List<String>> getSessionSubtreeIds({required String sessionId}) async => [sessionId];
   @override
+  Future<Set<String>> getExistingSessionIds({required Set<String> sessionIds}) async => sessionIds;
+  @override
   Future<List<StoredSession>> getStoredSessionsByProjectId({required String projectId}) async =>
       const <StoredSession>[];
   @override
@@ -1339,6 +1341,12 @@ class FakeSessionRepository implements SessionRepository {
   Future<List<String>> getSessionSubtreeIds({required String sessionId}) async {
     final stored = await _sessionDao.getSession(sessionId: sessionId);
     return stored == null ? const [] : [sessionId];
+  }
+
+  @override
+  Future<Set<String>> getExistingSessionIds({required Set<String> sessionIds}) async {
+    final rows = await _sessionDao.getSessionsByIds(sessionIds: sessionIds.toList(growable: false));
+    return rows.keys.toSet();
   }
 
   @override

--- a/bridge/app/test/bridge/services/chat_history_capture_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_capture_test.dart
@@ -194,21 +194,6 @@ void main() {
       expect((await history.repository.getSyncState(sessionId: "ses_a"))!.syncedAt, isNotNull);
     });
 
-    test("observed backend activity outdates a synced store", () async {
-      final repository = _FakeSessionRepository(transcript: [_messageWithParts(id: "m1")]);
-      final history = createTestChatHistory(sessionRepository: repository);
-      await history.service.backfillSession(sessionId: "ses_a");
-      final synced = (await history.repository.getSyncState(sessionId: "ses_a"))!;
-
-      await history.service.observeBackendActivity(
-        sessionId: "ses_a",
-        activityAt: synced.watermark + 5000,
-      );
-
-      final state = (await history.repository.getSyncState(sessionId: "ses_a"))!;
-      expect(state.backendActivityAt, greaterThan(state.watermark));
-      expect(state.syncedAt, isNotNull, reason: "staleness is a comparison, not a lost sync marker");
-    });
   });
 
   group("chat history reconcile", () {

--- a/bridge/app/test/bridge/services/chat_history_capture_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_capture_test.dart
@@ -1,0 +1,291 @@
+import "dart:convert";
+import "dart:typed_data";
+
+import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
+import "package:sesori_bridge/src/bridge/services/chat_history_reconcile_service.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "../../helpers/test_chat_history.dart";
+
+void main() {
+  group("chat history capture", () {
+    test("stores a message and its parts in arrival order", () async {
+      final history = createTestChatHistory();
+
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "m1"));
+      await history.service.capturePart(sessionId: "ses_a", part: _part(id: "p1", messageId: "m1", text: "one"));
+      await history.service.capturePart(sessionId: "ses_a", part: _part(id: "p2", messageId: "m1", text: "two"));
+
+      final stored = await history.repository.getSessionMessages(sessionId: "ses_a");
+      expect(stored, hasLength(1));
+      expect(stored.single.info.id, "m1");
+      expect(stored.single.parts.map((part) => part.text), const ["one", "two"]);
+    });
+
+    test("a part arriving before its message is kept and joined later", () async {
+      final history = createTestChatHistory();
+
+      await history.service.capturePart(sessionId: "ses_a", part: _part(id: "p1", messageId: "m1", text: "early"));
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "m1"));
+
+      final stored = await history.repository.getSessionMessages(sessionId: "ses_a");
+      expect(stored.single.parts.single.text, "early");
+    });
+
+    test("updating a part in place keeps its position", () async {
+      final history = createTestChatHistory();
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "m1"));
+      await history.service.capturePart(sessionId: "ses_a", part: _part(id: "p1", messageId: "m1", text: "one"));
+      await history.service.capturePart(sessionId: "ses_a", part: _part(id: "p2", messageId: "m1", text: "two"));
+
+      await history.service.capturePart(
+        sessionId: "ses_a",
+        part: _part(id: "p1", messageId: "m1", text: "one (final)"),
+      );
+
+      final stored = await history.repository.getSessionMessages(sessionId: "ses_a");
+      expect(stored.single.parts.map((part) => part.text), const ["one (final)", "two"]);
+    });
+
+    test("removals drop the message and its parts", () async {
+      final history = createTestChatHistory();
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "m1"));
+      await history.service.capturePart(sessionId: "ses_a", part: _part(id: "p1", messageId: "m1", text: "one"));
+      await history.service.capturePart(sessionId: "ses_a", part: _part(id: "p2", messageId: "m1", text: "two"));
+
+      await history.service.capturePartRemoved(sessionId: "ses_a", messageId: "m1", partId: "p1");
+      expect(
+        (await history.repository.getSessionMessages(sessionId: "ses_a")).single.parts.map((part) => part.id),
+        const ["p2"],
+      );
+
+      await history.service.captureMessageRemoved(sessionId: "ses_a", messageId: "m1");
+      expect(await history.repository.getSessionMessages(sessionId: "ses_a"), isEmpty);
+    });
+
+    test("capture creates a sync row that is not marked synced", () async {
+      final history = createTestChatHistory();
+
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "m1"));
+
+      final state = await history.repository.getSyncState(sessionId: "ses_a");
+      expect(state, isNotNull);
+      expect(state!.syncedAt, isNull, reason: "only a completed backfill may claim a complete transcript");
+      expect(state.watermark, greaterThan(0));
+      expect(state.backendActivityAt, greaterThan(0));
+    });
+
+    test("inline attachment bytes are spilled to disk, never stored in the database", () async {
+      final history = createTestChatHistory();
+      final bytes = Uint8List.fromList(List<int>.generate(64, (index) => index));
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "m1"));
+
+      await history.service.capturePart(
+        sessionId: "ses_a",
+        part: _part(
+          id: "p1",
+          messageId: "m1",
+          text: "look",
+          attachment: MessageAttachment.inlineImage(
+            mime: "image/png",
+            base64: base64Encode(bytes),
+            filename: "shot.png",
+          ),
+        ),
+      );
+
+      final rows = await history.database.chatHistoryDao.getParts(sessionId: "ses_a");
+      expect(rows.single.partJson, isNot(contains(base64Encode(bytes))));
+      expect(rows.single.partJson, contains("stored_file"));
+
+      final served = (await history.repository.getSessionMessages(sessionId: "ses_a")).single.parts.single;
+      expect(
+        served.attachment,
+        isA<MessageAttachmentInlineImage>()
+            .having((image) => image.base64, "base64", base64Encode(bytes))
+            .having((image) => image.filename, "filename", "shot.png"),
+      );
+    });
+
+    test("a lost spill file degrades the attachment instead of failing the read", () async {
+      final history = createTestChatHistory();
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "m1"));
+      await history.service.capturePart(
+        sessionId: "ses_a",
+        part: _part(
+          id: "p1",
+          messageId: "m1",
+          text: "look",
+          attachment: MessageAttachment.inlineImage(
+            mime: "image/png",
+            base64: base64Encode(Uint8List.fromList([1, 2, 3])),
+            filename: "shot.png",
+          ),
+        ),
+      );
+
+      await history.spillStorage.deleteSession(sessionId: "ses_a");
+
+      final served = (await history.repository.getSessionMessages(sessionId: "ses_a")).single.parts.single;
+      expect(
+        served.attachment,
+        isA<MessageAttachmentMetadata>().having((data) => data.filename, "filename", "shot.png"),
+      );
+    });
+  });
+
+  group("chat history backfill", () {
+    test("marks the session synced and numbers the transcript in order", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [_messageWithParts(id: "m1"), _messageWithParts(id: "m2")],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      final stored = await history.repository.getSessionMessages(sessionId: "ses_a");
+      expect(stored.map((message) => message.info.id), const ["m1", "m2"]);
+      expect((await history.repository.getSyncState(sessionId: "ses_a"))!.syncedAt, isNotNull);
+    });
+
+    test("keeps live messages the fetched transcript does not contain", () async {
+      final repository = _FakeSessionRepository(transcript: [_messageWithParts(id: "m1")]);
+      final history = createTestChatHistory(sessionRepository: repository);
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "live"));
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      final stored = await history.repository.getSessionMessages(sessionId: "ses_a");
+      expect(
+        stored.map((message) => message.info.id),
+        const ["m1", "live"],
+        reason: "a message captured after the fetch must survive above the imported maximum",
+      );
+    });
+
+    test("concurrent reads share one fetch", () async {
+      final repository = _FakeSessionRepository(transcript: [_messageWithParts(id: "m1")]);
+      final history = createTestChatHistory(sessionRepository: repository);
+
+      await Future.wait([
+        history.service.backfillSession(sessionId: "ses_a"),
+        history.service.backfillSession(sessionId: "ses_a"),
+      ]);
+
+      expect(repository.fetchCount, 1);
+    });
+
+    test("a failed fetch propagates and leaves the session unsynced", () async {
+      final repository = _FakeSessionRepository(transcript: const [], error: StateError("backend down"));
+      final history = createTestChatHistory(sessionRepository: repository);
+
+      await expectLater(history.service.backfillSession(sessionId: "ses_a"), throwsStateError);
+      expect(await history.repository.getSyncState(sessionId: "ses_a"), isNull);
+    });
+
+    test("an empty transcript is a valid synced state", () async {
+      final repository = _FakeSessionRepository(transcript: const []);
+      final history = createTestChatHistory(sessionRepository: repository);
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      expect(await history.repository.getSessionMessages(sessionId: "ses_a"), isEmpty);
+      expect((await history.repository.getSyncState(sessionId: "ses_a"))!.syncedAt, isNotNull);
+    });
+
+    test("observed backend activity outdates a synced store", () async {
+      final repository = _FakeSessionRepository(transcript: [_messageWithParts(id: "m1")]);
+      final history = createTestChatHistory(sessionRepository: repository);
+      await history.service.backfillSession(sessionId: "ses_a");
+      final synced = (await history.repository.getSyncState(sessionId: "ses_a"))!;
+
+      await history.service.observeBackendActivity(
+        sessionId: "ses_a",
+        activityAt: synced.watermark + 5000,
+      );
+
+      final state = (await history.repository.getSyncState(sessionId: "ses_a"))!;
+      expect(state.backendActivityAt, greaterThan(state.watermark));
+      expect(state.syncedAt, isNotNull, reason: "staleness is a comparison, not a lost sync marker");
+    });
+  });
+
+  group("chat history reconcile", () {
+    test("purges history whose session left the catalog and keeps the rest", () async {
+      final repository = _FakeSessionRepository(transcript: const [], existingSessionIds: {"ses_known"});
+      final history = createTestChatHistory(sessionRepository: repository);
+      await history.service.captureMessage(sessionId: "ses_known", message: _message(id: "m1"));
+      await history.service.captureMessage(sessionId: "ses_orphan", message: _message(id: "m2"));
+
+      await ChatHistoryReconcileService(
+        sessionRepository: repository,
+        chatHistoryService: history.service,
+      ).reconcile();
+
+      expect(await history.repository.getSessionMessages(sessionId: "ses_known"), hasLength(1));
+      expect(await history.repository.getSessionMessages(sessionId: "ses_orphan"), isEmpty);
+      expect(await history.repository.getSyncState(sessionId: "ses_orphan"), isNull);
+    });
+  });
+}
+
+Message _message({required String id}) =>
+    Message.user(id: id, sessionID: "ses_a", agent: null, time: const MessageTime(created: 1, completed: null));
+
+MessagePart _part({
+  required String id,
+  required String messageId,
+  required String text,
+  MessageAttachment? attachment,
+}) => MessagePart(
+  id: id,
+  sessionID: "ses_a",
+  messageID: messageId,
+  type: MessagePartType.text,
+  text: text,
+  tool: null,
+  state: null,
+  prompt: null,
+  description: null,
+  agent: null,
+  agentName: null,
+  attempt: null,
+  retryError: null,
+  attachment: attachment,
+);
+
+MessageWithParts _messageWithParts({required String id}) => MessageWithParts(
+  info: _message(id: id),
+  parts: [_part(id: "$id-p1", messageId: id, text: "text of $id")],
+);
+
+class _FakeSessionRepository implements SessionRepository {
+  _FakeSessionRepository({
+    required this.transcript,
+    this.error,
+    this.existingSessionIds = const {},
+  });
+
+  final List<MessageWithParts> transcript;
+  final Object? error;
+  final Set<String> existingSessionIds;
+  int fetchCount = 0;
+
+  @override
+  Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async {
+    fetchCount++;
+    // Yield so a second caller can observe the in-flight fetch.
+    await Future<void>.delayed(Duration.zero);
+    final failure = error;
+    if (failure != null) throw failure;
+    return transcript;
+  }
+
+  @override
+  Future<Set<String>> getExistingSessionIds({required Set<String> sessionIds}) async =>
+      sessionIds.intersection(existingSessionIds);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/bridge/services/chat_history_capture_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_capture_test.dart
@@ -164,6 +164,46 @@ void main() {
       );
     });
 
+    test("a capture during the fetch keeps its newer freshness marks", () async {
+      final repository = _FakeSessionRepository(transcript: [_messageWithParts(id: "m1")]);
+      final history = createTestChatHistory(sessionRepository: repository);
+      // Seed a row so the backfill's pre-fetch snapshot exists and is provably
+      // older than the capture that lands during the fetch.
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "seed"));
+      final beforeFetch = (await history.repository.getSyncState(sessionId: "ses_a"))!;
+      repository.onFetch = () => history.service.captureMessage(
+        sessionId: "ses_a",
+        message: _message(id: "during-fetch"),
+      );
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      final state = (await history.repository.getSyncState(sessionId: "ses_a"))!;
+      expect(
+        state.watermark,
+        greaterThanOrEqualTo(beforeFetch.watermark),
+        reason: "a backfill must not rewind a watermark advanced during its fetch",
+      );
+      expect(state.backendActivityAt, greaterThanOrEqualTo(beforeFetch.backendActivityAt));
+      expect(state.syncedAt, isNotNull);
+    });
+
+    test("a removal during the fetch is not resurrected by the transcript", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [_messageWithParts(id: "m1"), _messageWithParts(id: "m2")],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      repository.onFetch = () => history.service.captureMessageRemoved(sessionId: "ses_a", messageId: "m2");
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      expect(
+        (await history.repository.getSessionMessages(sessionId: "ses_a")).map((message) => message.info.id),
+        const ["m1"],
+        reason: "the removal is newer than the transcript being imported",
+      );
+    });
+
     test("concurrent reads share one fetch", () async {
       final repository = _FakeSessionRepository(transcript: [_messageWithParts(id: "m1")]);
       final history = createTestChatHistory(sessionRepository: repository);
@@ -257,11 +297,15 @@ class _FakeSessionRepository implements SessionRepository {
   final Set<String> existingSessionIds;
   int fetchCount = 0;
 
+  /// Runs while the fetch is in flight, so a test can interleave live events.
+  Future<void> Function()? onFetch;
+
   @override
   Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async {
     fetchCount++;
     // Yield so a second caller can observe the in-flight fetch.
     await Future<void>.delayed(Duration.zero);
+    await onFetch?.call();
     final failure = error;
     if (failure != null) throw failure;
     return transcript;

--- a/bridge/app/test/bridge/services/chat_history_capture_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_capture_test.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:convert";
 import "dart:typed_data";
 
@@ -188,20 +189,61 @@ void main() {
       expect(state.syncedAt, isNotNull);
     });
 
-    test("a removal during the fetch is not resurrected by the transcript", () async {
+    test("a removal captured before the backfill defers to the fetched transcript", () async {
       final repository = _FakeSessionRepository(
         transcript: [_messageWithParts(id: "m1"), _messageWithParts(id: "m2")],
       );
       final history = createTestChatHistory(sessionRepository: repository);
-      repository.onFetch = () => history.service.captureMessageRemoved(sessionId: "ses_a", messageId: "m2");
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "m2"));
+
+      await history.service.captureMessageRemoved(sessionId: "ses_a", messageId: "m2");
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      // The fetch happens after the removal, so its transcript is the newer
+      // observation. A message the backend still reports is not deleted yet,
+      // and mirroring the backend is the point of a backfill.
+      expect(
+        (await history.repository.getSessionMessages(sessionId: "ses_a")).map((message) => message.info.id),
+        const ["m1", "m2"],
+      );
+    });
+
+    test("a removal captured during the fetch is not resurrected", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [_messageWithParts(id: "m1"), _messageWithParts(id: "m2")],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      Future<void>? removal;
+      repository.onFetch = () async {
+        removal = history.service.captureMessageRemoved(sessionId: "ses_a", messageId: "m2");
+      };
 
       await history.service.backfillSession(sessionId: "ses_a");
+      await removal;
 
       expect(
         (await history.repository.getSessionMessages(sessionId: "ses_a")).map((message) => message.info.id),
         const ["m1"],
-        reason: "the removal is newer than the transcript being imported",
       );
+    });
+
+    test("a part removal racing the backfill is not resurrected", () async {
+      final repository = _FakeSessionRepository(transcript: [_messageWithParts(id: "m1")]);
+      final history = createTestChatHistory(sessionRepository: repository);
+      Future<void>? removal;
+      repository.onFetch = () async {
+        removal = history.service.capturePartRemoved(
+          sessionId: "ses_a",
+          messageId: "m1",
+          partId: "m1-p1",
+        );
+      };
+
+      await history.service.backfillSession(sessionId: "ses_a");
+      await removal;
+
+      final stored = await history.repository.getSessionMessages(sessionId: "ses_a");
+      expect(stored.single.parts, isEmpty, reason: "the removal is newer than the fetched transcript");
     });
 
     test("concurrent reads share one fetch", () async {
@@ -305,7 +347,11 @@ class _FakeSessionRepository implements SessionRepository {
     fetchCount++;
     // Yield so a second caller can observe the in-flight fetch.
     await Future<void>.delayed(Duration.zero);
-    await onFetch?.call();
+    // Deliberately not awaited: production dispatches captures without
+    // awaiting them, and awaiting one here would wait on the very queue this
+    // fetch is holding.
+    unawaited(Future<void>.sync(() => onFetch?.call() ?? Future<void>.value()));
+    await Future<void>.delayed(Duration.zero);
     final failure = error;
     if (failure != null) throw failure;
     return transcript;

--- a/bridge/app/test/helpers/test_chat_history.dart
+++ b/bridge/app/test/helpers/test_chat_history.dart
@@ -4,6 +4,7 @@ import "package:drift/native.dart";
 import "package:sesori_bridge/src/api/attachment_spill_storage.dart";
 import "package:sesori_bridge/src/api/database/history/chat_history_database.dart";
 import "package:sesori_bridge/src/bridge/repositories/chat_history_repository.dart";
+import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/services/chat_history_service.dart";
 import "package:test/test.dart";
 
@@ -19,7 +20,10 @@ typedef TestChatHistory = ({
 ///
 /// Registers its own teardown, so it must be created from a test, `setUp`, or
 /// another callback the test framework is running.
-TestChatHistory createTestChatHistory() {
+///
+/// [sessionRepository] is only needed by backfill; tests that never backfill
+/// can leave it null and get a repository that fails loudly if asked.
+TestChatHistory createTestChatHistory({SessionRepository? sessionRepository}) {
   final directory = Directory.systemTemp.createTempSync("sesori_chat_history_test");
   final database = ChatHistoryDatabase(NativeDatabase.memory());
   final spillStorage = AttachmentSpillStorage(
@@ -37,7 +41,22 @@ TestChatHistory createTestChatHistory() {
     database: database,
     spillStorage: spillStorage,
     repository: repository,
-    service: ChatHistoryService(chatHistoryRepository: repository),
+    service: ChatHistoryService(
+      chatHistoryRepository: repository,
+      sessionRepository: sessionRepository ?? _UnusedSessionRepository(),
+    ),
     directory: directory,
   );
+}
+
+/// Fails on any call: a test that reaches the plugin path should have supplied
+/// its own repository instead of silently backfilling from nothing.
+class _UnusedSessionRepository implements SessionRepository {
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnsupportedError(
+      "createTestChatHistory() was called without a sessionRepository, but "
+      "${invocation.memberName} was invoked",
+    );
+  }
 }


### PR DESCRIPTION
## Complexity

🚧 complex — event-driven persistence with ordering, failure, and freshness
policies, plus a startup consistency pass over two stores.

## What

Step 3/8 of `.plan/active/internal-chat-history`. The store introduced in #768
now holds real data:

- **`ChatHistoryListener`** persists finalized `message.updated`,
  `message.part.updated`, `message.removed`, and `message.part.removed` events
  from the normalized dispatcher stream. Streaming deltas are never stored.
- **`ChatHistoryService`** gains capture, lazy per-session backfill, and the
  freshness marks. Concurrent readers of one session share a single in-flight
  fetch; a backfill renumbers from the authoritative transcript while keeping
  live messages the fetch did not contain.
- **Attachments** are decoded once, written to content-addressed spill files,
  and stored as an internal `stored_file` reference; reads rehydrate them to
  the inline wire variant. A missing spill file degrades the slot to
  `metadata` rather than failing the read.
- **`ChatHistoryReconcileService`** purges history whose session left the
  catalog while the bridge was down, mutating only through
  `ChatHistoryService`.

## Why

The store is useless until something writes to it, and it must not be trusted
until it is known complete. Capture keeps it current, backfill fills it on
first read, and the sync marks keep the two distinguishable: only a completed
backfill sets `syncedAt`, so a capture-created row can never masquerade as a
full transcript. Serving from the store lands in step 4.

## Risk and test focus

Moderate. Capture runs on every message event, so the hot path matters: writes
are serialized per session, never start a plugin, and never block the event
pipeline. A failed capture is logged and drops `syncedAt`, so the next read
re-backfills — self-healing without a retry queue.

Worth checking:
- A long session still streams normally, with history rows appearing as
  messages finalize.
- An image attachment round-trips: sent, stored, and rendered again.
- Startup after deleting a session outside the bridge purges its leftovers.

## Expected result

- **User-visible:** none yet. Reads still go to the plugin; step 4 flips that.
- **Database:** `chat_history.db` starts accumulating rows for active sessions,
  and `history/attachments/` accumulates spill files. No schema change — the
  tables from #768 are unchanged, so no migration.
- **Internal:** the store has a live writer, a lazy filler, and a startup
  consistency owner.

## Verification

- `dart analyze --fatal-infos` in `bridge/app` — clean.
- `dart test` in `bridge/app` — 2,459 tests green.
- New `chat_history_capture_test.dart` (13 tests) pins out-of-order
  part-before-message arrival, in-place part updates, removals, the
  capture-created row staying unsynced, attachment spill/rehydrate round-trip,
  the degraded-slot path, backfill ordering, live-row retention across a
  backfill, shared in-flight fetch, failure leaving the session unsynced,
  empty-transcript-as-valid-synced-state, and orphan reconcile.
- `architecture-implementation-review` (sub-agent): three findings — two unused
  declarations built ahead of their step, and a Drift DTO leaking into the
  service. All applied.

## Plan deltas

Two, both recorded in `TRACKER.md`:
- The catalog-import watermark source (and the `observeBackendActivity`
  surface) moves to step 4/8, where the staleness comparison that consumes it
  is introduced. Success Criterion 3 is verified there.
- Backfill now writes rows and sync state in one transaction, matching the
  atomicity the plan already claimed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture finalized chat events into the internal history store and add lazy per‑session backfill, with attachment spill files and a startup reconcile that purges orphaned sessions using only the local catalog. Sync-state updates are monotonic, the backfill fetch runs inside the session write queue, and there are no schema or user‑visible changes; this prepares serving from the store in step 4.

- **New Features**
  - Persist finalized message/part updates and removals; streaming deltas are ignored.
  - Add capture and single‑flight backfill with per‑session queued writes; fetch runs inside the queue, plus sync state (watermark, backend activity, syncedAt). Failed captures clear syncedAt to re‑backfill.
  - Spill attachment bytes to content‑addressed files and rehydrate on read; missing files degrade to metadata.
  - Backfill is atomic: replace rows and sync state in one transaction; keep live rows not in the fetched transcript and renumber deterministically.
  - Startup reconcile removes history for sessions no longer in the catalog, mutating only through the service; compares only local DBs, so backend‑missing sessions are not purged.

- **Bug Fixes**
  - Sync‑state upserts use MAX in SQL; with fetch inside the per‑session queue, captures during fetch keep newer freshness and removals aren’t resurrected.
  - Listener tracks pending writes and awaits them on shutdown; dispose is memoized so multiple callers join the same drain.
  - Malformed or empty inline attachment data degrades to metadata instead of storing an empty image.
  - Reconcile chunks catalog lookups to avoid SQLite bind‑variable limits on large stores.

<sup>Written for commit e1cc65f3f5c4c4a52c74a6b651e73ec8825948b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

