### PR TITLE
⚙️ [internal-chat-history] Serve session messages from the store [step 4/8]

### DIFF
--- a/.plan/active/internal-chat-history/PLAN.md
+++ b/.plan/active/internal-chat-history/PLAN.md
@@ -73,6 +73,19 @@ Consequences for this feature, all satisfied by the current design:
 - Deferred backends stay deferred: a stopped harness with a synced store is
   never started to satisfy a read.
 
+## Known Limits
+
+- **Import-based staleness needs a backend-reported update time.** A plugin
+  that returns a session with no `time.updated` (Codex and ACP can, when the
+  underlying record carries no timestamp) gets no staleness signal from
+  catalog import. There is deliberately no fallback: the merged catalog
+  `updatedAt` is moved by bridge-local writes such as a rename, and the
+  import's own clock would mark every such session stale on every import and
+  wake its harness on the next open. Live capture keeps those sessions current
+  while the bridge runs; the residual gap is a session advanced through the
+  backend's CLI *while the bridge was down*, for a backend that reports no
+  update time. Revisit only if a backend in that position matters in practice.
+
 ## Why Now (observed problems)
 
 - Opening a session **cold-starts an idle backend** purely to read history:

--- a/.plan/active/internal-chat-history/PLAN.md
+++ b/.plan/active/internal-chat-history/PLAN.md
@@ -23,8 +23,12 @@ audit file and purge it from the database.
 
 ## Success Criteria
 
-1. Opening a previously synced session serves messages from the store without
-   starting the plugin backend, for all current backends.
+1. **Reading chat history never starts a harness.** Opening a previously
+   synced session serves messages from the store without starting the plugin
+   backend, for all current backends. This is a primary goal of the feature,
+   not a side effect: history must be readable while every harness is stopped.
+   The only read that may start one is the first-ever backfill of a session,
+   or a re-read after the backend itself advanced (Criterion 3).
 2. A live session's streamed messages and parts are queryable from the store
    immediately after they finalize, matching what a plugin history fetch
    would return (same visibility filtering and 500-rune tool-output bound).
@@ -43,6 +47,31 @@ audit file and purge it from the database.
    file.
 8. The 25 GB-class backend databases are never imported wholesale: backfill
    is lazy, per-session, on first read.
+9. **No work in this feature is triggered by a harness starting.** Nothing
+   here issues a request because a backend came up, and nothing batches
+   requests at startup (see Harness Startup Constraints).
+
+## Harness Startup Constraints (user-stated, 2026-08-08)
+
+Harnesses — OpenCode especially — are slow and unreliable for a period after
+they start. Early requests are sluggish or time out outright, which reads to
+the user as the app being unresponsive. Worse, requests issued during that
+window compete with the harness's own startup work, so a *user-initiated*
+action such as sending a message becomes slower because of background traffic
+we chose to send.
+
+Consequences for this feature, all satisfied by the current design:
+
+- **Never fetch history because a harness started.** Backfill is triggered by
+  a user opening a session, never by a lifecycle event. There is no
+  "warm the cache on startup" pass, and none may be added.
+- **Never batch requests at startup.** Nothing here iterates sessions issuing
+  plugin calls. Startup work (`ChatHistoryReconcileService`) reads only the
+  two local databases and never contacts a harness.
+- **Prefer serving stale-but-honest over waking a harness.** When the store is
+  current, it is served with no plugin call at all.
+- Deferred backends stay deferred: a stopped harness with a synced store is
+  never started to satisfy a read.
 
 ## Why Now (observed problems)
 

--- a/.plan/active/internal-chat-history/TRACKER.md
+++ b/.plan/active/internal-chat-history/TRACKER.md
@@ -51,7 +51,6 @@
   `chat_history_capture_test.dart`.
 
 ## Findings And Plan Deltas
-
 - **2026-08-06 — Plan revised after comparison with PR #764** (parallel
   draft, superseded): adopted watermark staleness, additive pagination
   fields, in-JSON stored-file attachment references with content-addressed
@@ -65,10 +64,21 @@
   relies on archive permanence. Steps 2/8–5/8 touch none of the archiving
   code, so the two series run in parallel. Recorded after the user started
   `read-only-archiving` separately.
+- **2026-08-07 — Second watermark source deferred to step 4/8.** The plan lists
+  two inputs for `backend_activity_at`: live capture and catalog import
+  observing newer backend activity. Only capture has a caller until serving
+  exists, so the catalog-import input (and the `observeBackendActivity`
+  surface it needs) moves to step 4/8, where the staleness comparison it feeds
+  is introduced. Success Criterion 3 is therefore verified in step 4, not 3.
 - **2026-08-07 — Second watermark source wired in step 4/8** as deferred
   below: `CatalogImportRepository` publishes a `backendActivity` stream as it
   commits an import, and `ChatHistoryActivityListener` feeds it into the
   store's staleness marks. Success Criterion 3 is verified here.
+- **2026-08-07 — Backfill atomicity tightened.** The plan says a backfill
+  atomically replaces rows and sets the watermark; the first implementation
+  split the row replace and the sync-state write into two statements. They now
+  share one transaction, so a crash cannot leave a replaced transcript
+  described by the previous run's freshness marks.
 - **2026-08-08 — Corrected the activity producer.** The first step-4 draft
   published from `SessionRepository`'s active-root hydration path, which only
   runs when an active session has no bridge binding — so for a normally
@@ -81,14 +91,8 @@
   feature may fetch on a lifecycle event or batch requests at startup, and
   "reading history never starts a harness" is now stated as a primary goal in
   Success Criterion 1 rather than left implicit.
-- **2026-08-07 — Second watermark source deferred to step 4/8.** The plan lists
-  two inputs for `backend_activity_at`: live capture and catalog import
-  observing newer backend activity. Only capture has a caller until serving
-  exists, so the catalog-import input (and the `observeBackendActivity`
-  surface it needs) moves to step 4/8, where the staleness comparison it feeds
-  is introduced. Success Criterion 3 is therefore verified in step 4, not 3.
-- **2026-08-07 — Backfill atomicity tightened.** The plan says a backfill
-  atomically replaces rows and sets the watermark; the first implementation
-  split the row replace and the sync-state write into two statements. They now
-  share one transaction, so a crash cannot leave a replaced transcript
-  described by the previous run's freshness marks.
+- **2026-08-08 — No fallback for a missing backend update time.** Review asked
+  for one when a plugin omits `time.updated`. Both candidates are worse than
+  the gap: the merged catalog `updatedAt` is moved by renames, and the import
+  clock would mark every such session stale on every import and wake its
+  harness. Recorded in `PLAN.md` § Known Limits instead.

--- a/.plan/active/internal-chat-history/TRACKER.md
+++ b/.plan/active/internal-chat-history/TRACKER.md
@@ -65,10 +65,22 @@
   relies on archive permanence. Steps 2/8–5/8 touch none of the archiving
   code, so the two series run in parallel. Recorded after the user started
   `read-only-archiving` separately.
-- **2026-08-07 — Second watermark source wired in step 4/8** as deferred below:
-  `SessionRepository` now publishes a `backendActivity` stream from catalog
-  import, and `ChatHistoryActivityListener` feeds it into the store's
-  staleness marks. Success Criterion 3 is verified here.
+- **2026-08-07 — Second watermark source wired in step 4/8** as deferred
+  below: `CatalogImportRepository` publishes a `backendActivity` stream as it
+  commits an import, and `ChatHistoryActivityListener` feeds it into the
+  store's staleness marks. Success Criterion 3 is verified here.
+- **2026-08-08 — Corrected the activity producer.** The first step-4 draft
+  published from `SessionRepository`'s active-root hydration path, which only
+  runs when an active session has no bridge binding — so for a normally
+  imported catalog nothing was ever published and Criterion 3 was unmet
+  despite being claimed. The producer now lives in the import commit, uses the
+  backend's own reported `updated` time (never the merged `updatedAt`, which a
+  rename moves), and is pinned by a test. Found by architecture review.
+- **2026-08-08 — Harness startup constraints recorded** in `PLAN.md` per user
+  direction: harnesses respond poorly right after starting, so nothing in this
+  feature may fetch on a lifecycle event or batch requests at startup, and
+  "reading history never starts a harness" is now stated as a primary goal in
+  Success Criterion 1 rather than left implicit.
 - **2026-08-07 — Second watermark source deferred to step 4/8.** The plan lists
   two inputs for `backend_activity_at`: live capture and catalog import
   observing newer backend activity. Only capture has a caller until serving

--- a/.plan/active/internal-chat-history/TRACKER.md
+++ b/.plan/active/internal-chat-history/TRACKER.md
@@ -65,6 +65,10 @@
   relies on archive permanence. Steps 2/8–5/8 touch none of the archiving
   code, so the two series run in parallel. Recorded after the user started
   `read-only-archiving` separately.
+- **2026-08-07 — Second watermark source wired in step 4/8** as deferred below:
+  `SessionRepository` now publishes a `backendActivity` stream from catalog
+  import, and `ChatHistoryActivityListener` feeds it into the store's
+  staleness marks. Success Criterion 3 is verified here.
 - **2026-08-07 — Second watermark source deferred to step 4/8.** The plan lists
   two inputs for `backend_activity_at`: live capture and catalog import
   observing newer backend activity. Only capture has a caller until serving

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -19,6 +19,7 @@ import "../auth/access_token_provider.dart";
 import "../auth/bridge_registration_service.dart";
 import "../auth/token_refresher.dart";
 import "../control/control_status_notifier.dart";
+import "../listeners/chat_history_activity_listener.dart";
 import "../listeners/chat_history_listener.dart";
 import "../listeners/plugin_catalog_hydration_listener.dart";
 import "../listeners/plugin_event_listener.dart";
@@ -530,6 +531,10 @@ class Orchestrator {
       source: sessionEventDispatcher.events,
       chatHistoryService: chatHistoryService,
     );
+    final chatHistoryActivityListener = ChatHistoryActivityListener(
+      source: sessionRepository.backendActivity,
+      chatHistoryService: chatHistoryService,
+    )..start();
     final normalizedPluginEvents = sessionEventDispatcher.events.doOnListen(() {
       for (final listener in pluginEventListeners) {
         listener.start();
@@ -565,7 +570,7 @@ class Orchestrator {
           sessionRepository: sessionRepository,
           prSyncService: prSyncService,
         ),
-        GetSessionMessagesHandler(sessionRepository: sessionRepository),
+        GetSessionMessagesHandler(chatHistoryService: chatHistoryService),
         GetSessionsHandler(
           sessionRepository: sessionRepository,
           prSyncService: prSyncService,
@@ -618,6 +623,7 @@ class Orchestrator {
       sessionBindingCommitListener: sessionBindingCommitListener,
       sessionDeletionListener: sessionDeletionListener,
       chatHistoryListener: chatHistoryListener,
+      chatHistoryActivityListener: chatHistoryActivityListener,
       sessionOptionsCreationRefreshListener: sessionOptionsCreationRefreshListener,
       sessionOptionsChangedRefreshListener: sessionOptionsChangedRefreshListener,
       sessionEventDispatcher: sessionEventDispatcher,
@@ -698,6 +704,7 @@ class OrchestratorSession {
   final SessionBindingCommitListener _sessionBindingCommitListener;
   final SessionDeletionListener _sessionDeletionListener;
   final ChatHistoryListener _chatHistoryListener;
+  final ChatHistoryActivityListener _chatHistoryActivityListener;
   final SessionOptionsCreationRefreshListener _sessionOptionsCreationRefreshListener;
   final SessionOptionsChangedRefreshListener _sessionOptionsChangedRefreshListener;
   final SessionEventDispatcher _sessionEventDispatcher;
@@ -764,6 +771,7 @@ class OrchestratorSession {
     required SessionBindingCommitListener sessionBindingCommitListener,
     required SessionDeletionListener sessionDeletionListener,
     required ChatHistoryListener chatHistoryListener,
+    required ChatHistoryActivityListener chatHistoryActivityListener,
     required SessionOptionsCreationRefreshListener sessionOptionsCreationRefreshListener,
     required SessionOptionsChangedRefreshListener sessionOptionsChangedRefreshListener,
     required SessionEventDispatcher sessionEventDispatcher,
@@ -805,6 +813,7 @@ class OrchestratorSession {
        _sessionBindingCommitListener = sessionBindingCommitListener,
        _sessionDeletionListener = sessionDeletionListener,
        _chatHistoryListener = chatHistoryListener,
+       _chatHistoryActivityListener = chatHistoryActivityListener,
        _sessionOptionsCreationRefreshListener = sessionOptionsCreationRefreshListener,
        _sessionOptionsChangedRefreshListener = sessionOptionsChangedRefreshListener,
        _sessionEventDispatcher = sessionEventDispatcher,
@@ -1112,6 +1121,7 @@ class OrchestratorSession {
       attempt(_sessionBindingCommitListener.dispose),
       attempt(_sessionDeletionListener.dispose),
       attempt(_chatHistoryListener.dispose),
+      attempt(_chatHistoryActivityListener.dispose),
     ]);
     Log.v("[shutdown] event producers cancelled (+${teardownSw.elapsedMilliseconds}ms)");
     await Future.wait([

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -532,9 +532,9 @@ class Orchestrator {
       chatHistoryService: chatHistoryService,
     );
     final chatHistoryActivityListener = ChatHistoryActivityListener(
-      source: sessionRepository.backendActivity,
+      source: catalogImportRepository.backendActivity,
       chatHistoryService: chatHistoryService,
-    )..start();
+    );
     final normalizedPluginEvents = sessionEventDispatcher.events.doOnListen(() {
       for (final listener in pluginEventListeners) {
         listener.start();
@@ -906,6 +906,7 @@ class OrchestratorSession {
     _sessionOptionsCreationRefreshListener.start();
     _sessionOptionsChangedRefreshListener.start();
     _viewedProjectPrRefreshListener.start();
+    _chatHistoryActivityListener.start();
     final readiness = Completer<OrchestratorSessionStartResult>();
     final lifecycleFuture = Future<void>.microtask(
       () => _runLifecycle(readiness: readiness),

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -63,12 +63,6 @@ typedef SessionBindingsCommitted = ({
 
 typedef SessionFamilyScope = ({String rootSessionId, String pluginId});
 
-/// Backend-owned activity for one session, as reported by the backend itself.
-///
-/// Deliberately separate from the catalog `updatedAt`, which bridge-local
-/// writes such as a rename also move.
-typedef SessionBackendActivity = ({String sessionId, int activityAt});
-
 /// The deleted root as clients see it, plus every session id removed with it.
 typedef DeletedSessionSubtree = ({Session session, List<String> sessionIds});
 
@@ -87,8 +81,6 @@ class SessionRepository {
   final Set<String> _deletedSessionIds = <String>{};
   final StreamController<SessionBindingsCommitted> _bindingCommitsController =
       StreamController<SessionBindingsCommitted>.broadcast(sync: true);
-  final StreamController<List<SessionBackendActivity>> _backendActivityController =
-      StreamController<List<SessionBackendActivity>>.broadcast(sync: true);
   final Map<String, Future<void>> _tombstoneLoads = <String, Future<void>>{};
   final Set<String> _tombstonesLoaded = <String>{};
   int _lastProjectionTimestamp = 0;
@@ -113,9 +105,6 @@ class SessionRepository {
 
   Stream<SessionBindingsCommitted> get bindingCommits => _bindingCommitsController.stream;
 
-  /// Backend activity observed while importing the catalog. Consumers use it
-  /// to notice sessions advanced outside Sesori.
-  Stream<List<SessionBackendActivity>> get backendActivity => _backendActivityController.stream;
 
   Future<SessionFamilyScope> resolveSessionFamily({
     required String sessionId,
@@ -884,11 +873,7 @@ class SessionRepository {
         pluginId: pluginId,
         sessions: observedRoots,
       );
-      return (
-        project: hydratedProject,
-        committedByBackendId: committedByBackendId,
-        observedRoots: observedRoots,
-      );
+      return (project: hydratedProject, committedByBackendId: committedByBackendId);
     });
     _publishBindingsCommitted(
       pluginId: pluginId,
@@ -896,13 +881,6 @@ class SessionRepository {
       generation: generation,
       kind: SessionBindingCommitKind.catalogSync,
       backendSessionIds: result.committedByBackendId.keys.toList(growable: false),
-    );
-    _publishBackendActivity(
-      activity: [
-        for (final root in result.observedRoots)
-          if (result.committedByBackendId[root.backendSessionId] case final binding?)
-            (sessionId: binding.sessionId, activityAt: root.updatedAt),
-      ],
     );
     return result.project;
   }
@@ -1492,10 +1470,7 @@ class SessionRepository {
     return timestamp;
   }
 
-  Future<void> dispose() async {
-    await _bindingCommitsController.close();
-    await _backendActivityController.close();
-  }
+  Future<void> dispose() => _bindingCommitsController.close();
 
   void _publishBindingsCommitted({
     required String pluginId,
@@ -1512,11 +1487,6 @@ class SessionRepository {
       kind: kind,
       backendSessionIds: List<String>.unmodifiable(backendSessionIds),
     ));
-  }
-
-  void _publishBackendActivity({required List<SessionBackendActivity> activity}) {
-    if (activity.isEmpty || _backendActivityController.isClosed) return;
-    _backendActivityController.add(List<SessionBackendActivity>.unmodifiable(activity));
   }
 
   Set<String> _tombstonesFor(String pluginId) {

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -63,6 +63,12 @@ typedef SessionBindingsCommitted = ({
 
 typedef SessionFamilyScope = ({String rootSessionId, String pluginId});
 
+/// Backend-owned activity for one session, as reported by the backend itself.
+///
+/// Deliberately separate from the catalog `updatedAt`, which bridge-local
+/// writes such as a rename also move.
+typedef SessionBackendActivity = ({String sessionId, int activityAt});
+
 /// The deleted root as clients see it, plus every session id removed with it.
 typedef DeletedSessionSubtree = ({Session session, List<String> sessionIds});
 
@@ -81,6 +87,8 @@ class SessionRepository {
   final Set<String> _deletedSessionIds = <String>{};
   final StreamController<SessionBindingsCommitted> _bindingCommitsController =
       StreamController<SessionBindingsCommitted>.broadcast(sync: true);
+  final StreamController<List<SessionBackendActivity>> _backendActivityController =
+      StreamController<List<SessionBackendActivity>>.broadcast(sync: true);
   final Map<String, Future<void>> _tombstoneLoads = <String, Future<void>>{};
   final Set<String> _tombstonesLoaded = <String>{};
   int _lastProjectionTimestamp = 0;
@@ -104,6 +112,10 @@ class SessionRepository {
        _aggregateSourceDeadline = aggregateSourceDeadline;
 
   Stream<SessionBindingsCommitted> get bindingCommits => _bindingCommitsController.stream;
+
+  /// Backend activity observed while importing the catalog. Consumers use it
+  /// to notice sessions advanced outside Sesori.
+  Stream<List<SessionBackendActivity>> get backendActivity => _backendActivityController.stream;
 
   Future<SessionFamilyScope> resolveSessionFamily({
     required String sessionId,
@@ -872,7 +884,11 @@ class SessionRepository {
         pluginId: pluginId,
         sessions: observedRoots,
       );
-      return (project: hydratedProject, committedByBackendId: committedByBackendId);
+      return (
+        project: hydratedProject,
+        committedByBackendId: committedByBackendId,
+        observedRoots: observedRoots,
+      );
     });
     _publishBindingsCommitted(
       pluginId: pluginId,
@@ -880,6 +896,13 @@ class SessionRepository {
       generation: generation,
       kind: SessionBindingCommitKind.catalogSync,
       backendSessionIds: result.committedByBackendId.keys.toList(growable: false),
+    );
+    _publishBackendActivity(
+      activity: [
+        for (final root in result.observedRoots)
+          if (result.committedByBackendId[root.backendSessionId] case final binding?)
+            (sessionId: binding.sessionId, activityAt: root.updatedAt),
+      ],
     );
     return result.project;
   }
@@ -1469,7 +1492,10 @@ class SessionRepository {
     return timestamp;
   }
 
-  Future<void> dispose() => _bindingCommitsController.close();
+  Future<void> dispose() async {
+    await _bindingCommitsController.close();
+    await _backendActivityController.close();
+  }
 
   void _publishBindingsCommitted({
     required String pluginId,
@@ -1486,6 +1512,11 @@ class SessionRepository {
       kind: kind,
       backendSessionIds: List<String>.unmodifiable(backendSessionIds),
     ));
+  }
+
+  void _publishBackendActivity({required List<SessionBackendActivity> activity}) {
+    if (activity.isEmpty || _backendActivityController.isClosed) return;
+    _backendActivityController.add(List<SessionBackendActivity>.unmodifiable(activity));
   }
 
   Set<String> _tombstonesFor(String pluginId) {

--- a/bridge/app/lib/src/bridge/routing/get_session_messages_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_session_messages_handler.dart
@@ -1,14 +1,14 @@
 import "package:sesori_shared/sesori_shared.dart";
 
-import "../repositories/session_repository.dart";
+import "../services/chat_history_service.dart";
 import "request_handler.dart";
 
 /// Handles `POST /session/messages` — returns all messages for a session.
 class GetSessionMessagesHandler extends BodyRequestHandler<SessionIdRequest, MessageWithPartsResponse> {
-  final SessionRepository _sessionRepository;
+  final ChatHistoryService _chatHistoryService;
 
-  GetSessionMessagesHandler({required SessionRepository sessionRepository})
-    : _sessionRepository = sessionRepository,
+  GetSessionMessagesHandler({required ChatHistoryService chatHistoryService})
+    : _chatHistoryService = chatHistoryService,
       super(
         HttpMethod.post,
         "/session/messages",
@@ -29,7 +29,7 @@ class GetSessionMessagesHandler extends BodyRequestHandler<SessionIdRequest, Mes
     }
 
     return MessageWithPartsResponse(
-      messages: await _sessionRepository.getSessionMessages(sessionId: sessionId),
+      messages: await _chatHistoryService.getSessionMessages(sessionId: sessionId),
     );
   }
 }

--- a/bridge/app/lib/src/bridge/services/chat_history_service.dart
+++ b/bridge/app/lib/src/bridge/services/chat_history_service.dart
@@ -244,11 +244,25 @@ class ChatHistoryService {
     return _enqueueAll(sessionIds: [sessionId], write: write);
   }
 
-  /// Runs [read] after the session's pending writes, without making it the new
-  /// tail — concurrent reads of one session stay parallel.
+  /// Runs [read] after the session's pending writes and holds the queue for
+  /// its duration, so a write enqueued while it runs commits after it rather
+  /// than underneath it.
+  ///
+  /// Reads of one session therefore serialize with each other too. That is
+  /// acceptable: a read is a bounded query against a local database, and it
+  /// buys a simple guarantee — whatever a read observed is what the caller
+  /// receives.
   Future<T> _enqueueRead<T>({required String sessionId, required Future<T> Function() read}) {
-    final pending = _writeQueues[sessionId];
-    return pending == null ? read() : pending.then((_) => read());
+    final pending = _writeQueues[sessionId] ?? Future<void>.value();
+    final result = pending.then((_) => read());
+    final tail = result.then<void>((_) {}, onError: (Object _) {});
+    _writeQueues[sessionId] = tail;
+    unawaited(
+      tail.whenComplete(() {
+        if (identical(_writeQueues[sessionId], tail)) _writeQueues.remove(sessionId);
+      }),
+    );
+    return result;
   }
 
   /// Runs [write] after every listed session's pending writes, and makes it

--- a/bridge/app/lib/src/bridge/services/chat_history_service.dart
+++ b/bridge/app/lib/src/bridge/services/chat_history_service.dart
@@ -29,15 +29,26 @@ class ChatHistoryService {
   /// backend activity has been observed past the captured watermark, so a
   /// session advanced outside Sesori still reads correctly.
   Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async {
-    final state = await _chatHistoryRepository.getSyncState(sessionId: sessionId);
-    if (state == null || state.syncedAt == null || state.watermark < state.backendActivityAt) {
-      await backfillSession(sessionId: sessionId);
-    }
-    // Read through the write queue so the response includes every capture
-    // that arrived before it — including events that landed while a backfill
-    // was fetching, which are queued behind that backfill. Reading outside the
-    // queue would serve the fetched snapshot and omit them, and the client
-    // would drop the SSE patch it had already applied.
+    // Both the freshness decision and the read run inside the session queue,
+    // so they observe one state. Deciding outside it would let queued work —
+    // an observed import, or a failed capture clearing `syncedAt` — commit
+    // between the decision and the read, and the caller would receive a
+    // transcript that the store already knew was stale.
+    final decided = await _enqueueRead(
+      sessionId: sessionId,
+      read: () async {
+        final state = await _chatHistoryRepository.getSyncState(sessionId: sessionId);
+        if (state == null || state.syncedAt == null || state.watermark < state.backendActivityAt) {
+          return null;
+        }
+        return _chatHistoryRepository.getSessionMessages(sessionId: sessionId);
+      },
+    );
+    if (decided != null) return decided;
+
+    await backfillSession(sessionId: sessionId);
+    // The backfill is itself queued, so this read lands after it and after
+    // any capture that raced its fetch.
     return _enqueueRead(
       sessionId: sessionId,
       read: () => _chatHistoryRepository.getSessionMessages(sessionId: sessionId),

--- a/bridge/app/lib/src/bridge/services/chat_history_service.dart
+++ b/bridge/app/lib/src/bridge/services/chat_history_service.dart
@@ -22,6 +22,40 @@ class ChatHistoryService {
   final Map<String, Future<void>> _writeQueues = {};
   final Map<String, Future<void>> _inFlightBackfills = {};
 
+  /// The session's messages, served from the store whenever it is known to be
+  /// current and falling back to the backend otherwise.
+  ///
+  /// The store is preferred only when a backfill has completed *and* no
+  /// backend activity has been observed past the captured watermark, so a
+  /// session advanced outside Sesori still reads correctly.
+  Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async {
+    final state = await _chatHistoryRepository.getSyncState(sessionId: sessionId);
+    if (state == null || state.syncedAt == null || state.watermark < state.backendActivityAt) {
+      await backfillSession(sessionId: sessionId);
+    }
+    return _chatHistoryRepository.getSessionMessages(sessionId: sessionId);
+  }
+
+  /// Records backend activity observed outside the live event stream, so a
+  /// session advanced through the backend's own CLI is detected as stale.
+  ///
+  /// Only sessions the store already knows about are tracked; an unknown
+  /// session has nothing to be stale against.
+  Future<void> observeBackendActivity({required String sessionId, required int activityAt}) {
+    return _enqueue(
+      sessionId: sessionId,
+      write: () async {
+        final state = await _chatHistoryRepository.getSyncState(sessionId: sessionId);
+        if (state == null) return;
+        await _chatHistoryRepository.advanceSyncState(
+          sessionId: sessionId,
+          watermark: state.watermark,
+          backendActivityAt: activityAt,
+        );
+      },
+    );
+  }
+
   /// Records a finalized message from the live event stream.
   Future<void> captureMessage({required String sessionId, required Message message}) {
     return _capture(

--- a/bridge/app/lib/src/bridge/services/chat_history_service.dart
+++ b/bridge/app/lib/src/bridge/services/chat_history_service.dart
@@ -33,7 +33,15 @@ class ChatHistoryService {
     if (state == null || state.syncedAt == null || state.watermark < state.backendActivityAt) {
       await backfillSession(sessionId: sessionId);
     }
-    return _chatHistoryRepository.getSessionMessages(sessionId: sessionId);
+    // Read through the write queue so the response includes every capture
+    // that arrived before it — including events that landed while a backfill
+    // was fetching, which are queued behind that backfill. Reading outside the
+    // queue would serve the fetched snapshot and omit them, and the client
+    // would drop the SSE patch it had already applied.
+    return _enqueueRead(
+      sessionId: sessionId,
+      read: () => _chatHistoryRepository.getSessionMessages(sessionId: sessionId),
+    );
   }
 
   /// Records backend activity observed outside the live event stream, so a
@@ -223,6 +231,13 @@ class ChatHistoryService {
 
   Future<void> _enqueue({required String sessionId, required Future<void> Function() write}) {
     return _enqueueAll(sessionIds: [sessionId], write: write);
+  }
+
+  /// Runs [read] after the session's pending writes, without making it the new
+  /// tail — concurrent reads of one session stay parallel.
+  Future<T> _enqueueRead<T>({required String sessionId, required Future<T> Function() read}) {
+    final pending = _writeQueues[sessionId];
+    return pending == null ? read() : pending.then((_) => read());
   }
 
   /// Runs [write] after every listed session's pending writes, and makes it

--- a/bridge/app/lib/src/listeners/chat_history_activity_listener.dart
+++ b/bridge/app/lib/src/listeners/chat_history_activity_listener.dart
@@ -2,16 +2,18 @@ import "dart:async";
 
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
-import "../bridge/repositories/session_repository.dart";
 import "../bridge/services/chat_history_service.dart";
+import "../repositories/catalog_import_repository.dart";
 
-/// Feeds backend activity observed by catalog import into the history store's
-/// staleness marks, so a session advanced through the backend's own CLI is
-/// re-read from the backend on next open.
+/// Feeds backend activity observed by a catalog import into the history
+/// store's staleness marks, so a session advanced through the backend's own
+/// CLI is re-read from the backend on next open.
 class ChatHistoryActivityListener {
   final Stream<List<SessionBackendActivity>> _source;
   final ChatHistoryService _chatHistoryService;
   StreamSubscription<List<SessionBackendActivity>>? _subscription;
+  final Set<Future<void>> _pendingWrites = {};
+  Future<void>? _disposeFuture;
   bool _disposed = false;
 
   ChatHistoryActivityListener({
@@ -22,12 +24,16 @@ class ChatHistoryActivityListener {
 
   void start() {
     if (_subscription != null || _disposed) return;
-    _subscription = _source.listen(
-      (activity) => unawaited(_record(activity: activity)),
-      // Import failures are surfaced by the import's own consumers; there is
-      // simply no activity to record for a failed observation.
-      onError: (Object _) {},
-    );
+    // The source only ever emits; import failures surface through the
+    // import's own consumers, so there is no error path to handle here.
+    _subscription = _source.listen((activity) => _track(write: _record(activity: activity)));
+  }
+
+  /// Keeps the write observable to [dispose], so shutdown does not close the
+  /// database out from under an in-flight staleness update.
+  void _track({required Future<void> write}) {
+    _pendingWrites.add(write);
+    unawaited(write.whenComplete(() => _pendingWrites.remove(write)));
   }
 
   Future<void> _record({required List<SessionBackendActivity> activity}) async {
@@ -48,9 +54,14 @@ class ChatHistoryActivityListener {
     }
   }
 
-  Future<void> dispose() async {
-    if (_disposed) return;
+  /// Memoized so a second caller joins the same drain instead of returning
+  /// while writes are still running.
+  Future<void> dispose() => _disposeFuture ??= _dispose();
+
+  Future<void> _dispose() async {
     _disposed = true;
     await _subscription?.cancel();
+    // _record never throws: each failure is logged and skipped.
+    await Future.wait(_pendingWrites.toList(growable: false));
   }
 }

--- a/bridge/app/lib/src/listeners/chat_history_activity_listener.dart
+++ b/bridge/app/lib/src/listeners/chat_history_activity_listener.dart
@@ -37,21 +37,22 @@ class ChatHistoryActivityListener {
   }
 
   Future<void> _record({required List<SessionBackendActivity> activity}) async {
-    for (final observed in activity) {
-      try {
-        await _chatHistoryService.observeBackendActivity(
-          sessionId: observed.sessionId,
-          activityAt: observed.activityAt,
-        );
-      } on Object catch (error, stackTrace) {
-        // A missed observation only costs a redundant plugin fetch later.
-        Log.w(
-          "Failed to record backend activity for session ${observed.sessionId}",
-          error,
-          stackTrace,
-        );
-      }
-    }
+    // Enqueue every session before awaiting any of them. Each session has its
+    // own write queue, so awaiting one at a time would let a read for a later
+    // session slip in before its staleness update was even queued.
+    await Future.wait([
+      for (final observed in activity)
+        _chatHistoryService
+            .observeBackendActivity(sessionId: observed.sessionId, activityAt: observed.activityAt)
+            .catchError((Object error, StackTrace stackTrace) {
+              // A missed observation only costs a redundant plugin fetch later.
+              Log.w(
+                "Failed to record backend activity for session ${observed.sessionId}",
+                error,
+                stackTrace,
+              );
+            }),
+    ]);
   }
 
   /// Memoized so a second caller joins the same drain instead of returning

--- a/bridge/app/lib/src/listeners/chat_history_activity_listener.dart
+++ b/bridge/app/lib/src/listeners/chat_history_activity_listener.dart
@@ -1,0 +1,56 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
+import "../bridge/repositories/session_repository.dart";
+import "../bridge/services/chat_history_service.dart";
+
+/// Feeds backend activity observed by catalog import into the history store's
+/// staleness marks, so a session advanced through the backend's own CLI is
+/// re-read from the backend on next open.
+class ChatHistoryActivityListener {
+  final Stream<List<SessionBackendActivity>> _source;
+  final ChatHistoryService _chatHistoryService;
+  StreamSubscription<List<SessionBackendActivity>>? _subscription;
+  bool _disposed = false;
+
+  ChatHistoryActivityListener({
+    required Stream<List<SessionBackendActivity>> source,
+    required ChatHistoryService chatHistoryService,
+  }) : _source = source,
+       _chatHistoryService = chatHistoryService;
+
+  void start() {
+    if (_subscription != null || _disposed) return;
+    _subscription = _source.listen(
+      (activity) => unawaited(_record(activity: activity)),
+      // Import failures are surfaced by the import's own consumers; there is
+      // simply no activity to record for a failed observation.
+      onError: (Object _) {},
+    );
+  }
+
+  Future<void> _record({required List<SessionBackendActivity> activity}) async {
+    for (final observed in activity) {
+      try {
+        await _chatHistoryService.observeBackendActivity(
+          sessionId: observed.sessionId,
+          activityAt: observed.activityAt,
+        );
+      } on Object catch (error, stackTrace) {
+        // A missed observation only costs a redundant plugin fetch later.
+        Log.w(
+          "Failed to record backend activity for session ${observed.sessionId}",
+          error,
+          stackTrace,
+        );
+      }
+    }
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await _subscription?.cancel();
+  }
+}

--- a/bridge/app/lib/src/repositories/catalog_import_repository.dart
+++ b/bridge/app/lib/src/repositories/catalog_import_repository.dart
@@ -16,6 +16,13 @@ import "../bridge/runtime/plugin_runtime.dart";
 import "models/catalog_import_control.dart";
 import "project_catalog_identity_calculator.dart";
 
+/// Backend-owned activity for one session, as reported by the backend itself.
+///
+/// Deliberately separate from the catalog `updatedAt`, which bridge-local
+/// writes such as a rename also move — comparing against that would mark the
+/// history store stale after an ordinary rename and cold-start the backend.
+typedef SessionBackendActivity = ({String sessionId, int activityAt});
+
 class CatalogImportRepository {
   CatalogImportRepository({
     required PluginRuntime runtime,
@@ -38,9 +45,22 @@ class CatalogImportRepository {
   final SessionDao _sessionDao;
   final CatalogHydrationsDao _catalogHydrationsDao;
   final ProjectCatalogIdentityCalculator _projectCatalogIdentityCalculator;
+  final StreamController<List<SessionBackendActivity>> _backendActivityController =
+      StreamController<List<SessionBackendActivity>>.broadcast(sync: true);
+
+  /// Backend activity observed by an import, published after the catalog is
+  /// committed. Consumers use it to notice sessions advanced outside Sesori.
+  Stream<List<SessionBackendActivity>> get backendActivity => _backendActivityController.stream;
 
   Set<String> get eligiblePluginIds => _runtime.eligiblePluginIds;
   Set<String> get importEligiblePluginIds => _runtime.startAllowedPluginIds;
+
+  void _publishBackendActivity({required List<SessionBackendActivity> activity}) {
+    if (activity.isEmpty || _backendActivityController.isClosed) return;
+    _backendActivityController.add(List<SessionBackendActivity>.unmodifiable(activity));
+  }
+
+  Future<void> dispose() => _backendActivityController.close();
 
   Future<CatalogHydrationDto?> getHydrationCompletion({required String pluginId}) {
     return _catalogHydrationsDao.getCompletion(
@@ -411,6 +431,9 @@ class CatalogImportRepository {
         final reservedIds = await _sessionDao.getAllSessionIds();
 
         var sessionRows = <SessionDto>[];
+        // The backend's own view of when each session last changed, used by
+        // the history store to notice sessions advanced outside Sesori.
+        final observedActivity = <SessionBackendActivity>[];
         final finalBindingsByBackendId = <String, ({String sessionId, String projectId})>{};
         var sessionsImported = 0;
         for (final observation in orderedSessions) {
@@ -434,6 +457,12 @@ class CatalogImportRepository {
             importStartedAt: importStartedAt,
           );
           sessionRows.add(row);
+          // Only the backend's reported time counts. Falling back to the
+          // merged `updatedAt` would leak bridge-local writes such as a
+          // rename into what is supposed to be backend-owned activity.
+          if (session.time?.updated case final updatedAt?) {
+            observedActivity.add((sessionId: row.sessionId, activityAt: updatedAt));
+          }
           finalBindingsByBackendId[session.id] = (
             sessionId: row.sessionId,
             projectId: row.projectId,
@@ -461,6 +490,7 @@ class CatalogImportRepository {
           );
         }
         requireCurrentGeneration();
+        _publishBackendActivity(activity: observedActivity);
         return (
           projectsImported: projectRows.length,
           sessionsImported: sessionsImported,

--- a/bridge/app/lib/src/repositories/catalog_import_repository.dart
+++ b/bridge/app/lib/src/repositories/catalog_import_repository.dart
@@ -457,9 +457,16 @@ class CatalogImportRepository {
             importStartedAt: importStartedAt,
           );
           sessionRows.add(row);
-          // Only the backend's reported time counts. Falling back to the
-          // merged `updatedAt` would leak bridge-local writes such as a
-          // rename into what is supposed to be backend-owned activity.
+          // Only the backend's own reported time counts as backend activity.
+          //
+          // There is deliberately no fallback for a plugin that omits it. The
+          // merged `row.updatedAt` is contaminated by bridge-local writes (a
+          // rename moves it), and the import's own clock would mark every such
+          // session stale on every import — waking its harness on the next
+          // open, which is the cost this feature exists to remove. A backend
+          // that reports no update time simply cannot support import-based
+          // staleness detection; live capture still keeps those sessions
+          // current while the bridge is running. See PLAN.md § Known Limits.
           if (session.time?.updated case final updatedAt?) {
             observedActivity.add((sessionId: row.sessionId, activityAt: updatedAt));
           }

--- a/bridge/app/lib/src/services/catalog_import_service.dart
+++ b/bridge/app/lib/src/services/catalog_import_service.dart
@@ -110,6 +110,7 @@ class CatalogImportService {
   Future<void> _drain() async {
     await Future.wait(_operations.values.toList(growable: false));
     await _progressController.close();
+    await _repository.dispose();
   }
 
   Future<void> _run({required String pluginId, required CatalogImportControl control}) async {

--- a/bridge/app/test/bridge/routing/get_session_messages_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_session_messages_handler_test.dart
@@ -5,6 +5,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/test_chat_history.dart";
 import "routing_test_helpers.dart";
 
 void main() {
@@ -15,7 +16,9 @@ void main() {
     setUp(() {
       plugin = FakeBridgePlugin();
       handler = GetSessionMessagesHandler(
-        sessionRepository: FakeSessionRepository(plugin: plugin),
+        chatHistoryService: createTestChatHistory(
+          sessionRepository: FakeSessionRepository(plugin: plugin),
+        ).service,
       );
     });
 

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -826,6 +826,9 @@ class _NoopSessionRepository implements SessionRepository {
   Stream<SessionBindingsCommitted> get bindingCommits => const Stream.empty();
 
   @override
+  Stream<List<SessionBackendActivity>> get backendActivity => const Stream.empty();
+
+  @override
   int captureProjectionTimestamp() => DateTime.now().millisecondsSinceEpoch;
 
   @override
@@ -1075,6 +1078,9 @@ class _NoopSessionRepository implements SessionRepository {
 class FakeSessionRepository implements SessionRepository {
   @override
   Stream<SessionBindingsCommitted> get bindingCommits => const Stream.empty();
+
+  @override
+  Stream<List<SessionBackendActivity>> get backendActivity => const Stream.empty();
 
   @override
   int captureProjectionTimestamp() => DateTime.now().millisecondsSinceEpoch;

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -825,8 +825,6 @@ class _NoopSessionRepository implements SessionRepository {
   @override
   Stream<SessionBindingsCommitted> get bindingCommits => const Stream.empty();
 
-  @override
-  Stream<List<SessionBackendActivity>> get backendActivity => const Stream.empty();
 
   @override
   int captureProjectionTimestamp() => DateTime.now().millisecondsSinceEpoch;
@@ -1079,8 +1077,6 @@ class FakeSessionRepository implements SessionRepository {
   @override
   Stream<SessionBindingsCommitted> get bindingCommits => const Stream.empty();
 
-  @override
-  Stream<List<SessionBackendActivity>> get backendActivity => const Stream.empty();
 
   @override
   int captureProjectionTimestamp() => DateTime.now().millisecondsSinceEpoch;

--- a/bridge/app/test/bridge/services/chat_history_no_harness_start_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_no_harness_start_test.dart
@@ -1,0 +1,64 @@
+import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+import "../../helpers/test_chat_history.dart";
+import "../../helpers/test_database.dart";
+import "../routing/routing_test_helpers.dart";
+
+void main() {
+  // Success Criterion 1: reading history must not start a harness. Harnesses
+  // respond poorly for a while after starting, so waking one to render a
+  // transcript the bridge already has is the exact cost this feature removes.
+  // Asserted against the real SessionRepository and plugin runtime, because a
+  // faked repository could not observe a start.
+  test("a synced session is served without starting the plugin", () async {
+    final database = createTestDatabase();
+    addTearDown(database.close);
+    final plugin = FakeBridgePlugin()
+      ..messagesResult = const [
+        PluginMessageWithParts(
+          info: PluginMessage.user(
+            id: "m1",
+            sessionID: "backend-a",
+            agent: null,
+            time: PluginMessageTime(created: 1, completed: null),
+          ),
+          parts: [],
+        ),
+      ];
+    addTearDown(plugin.close);
+
+    final sessionRepository = singlePluginSessionRepository(
+      plugin: plugin,
+      sessionDao: database.sessionDao,
+      projectsDao: database.projectsDao,
+      pullRequestDao: database.pullRequestDao,
+      unseenCalculator: const SessionUnseenCalculator(),
+    );
+    addTearDown(sessionRepository.dispose);
+    final history = createTestChatHistory(sessionRepository: sessionRepository);
+    await recordSessionBinding(
+      database: database,
+      sessionId: "ses_a",
+      backendSessionId: "backend-a",
+      pluginId: plugin.id,
+      projectId: "project-a",
+      parentSessionId: null,
+    );
+
+    // First read is allowed to reach the backend: nothing is stored yet.
+    await history.service.getSessionMessages(sessionId: "ses_a");
+    expect(plugin.lastGetMessagesSessionId, "backend-a");
+
+    plugin.lastGetMessagesSessionId = null;
+    final served = await history.service.getSessionMessages(sessionId: "ses_a");
+
+    expect(served.single.info.id, "m1");
+    expect(
+      plugin.lastGetMessagesSessionId,
+      isNull,
+      reason: "a synced store must render history with the harness untouched",
+    );
+  });
+}

--- a/bridge/app/test/bridge/services/chat_history_rename_staleness_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_rename_staleness_test.dart
@@ -1,0 +1,63 @@
+import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+import "../../helpers/test_chat_history.dart";
+import "../../helpers/test_database.dart";
+import "../routing/routing_test_helpers.dart";
+
+void main() {
+  // The staleness comparison must react to backend activity only. Renaming is
+  // a bridge-local write that moves the catalog `updatedAt`; if the store
+  // compared against that, every rename would cold-start the backend — the
+  // exact cost this feature exists to remove. Uses the real repository and DAO
+  // so the rename genuinely writes the column it would be compared against.
+  test("renaming a synced session does not re-fetch its history", () async {
+    final database = createTestDatabase();
+    addTearDown(database.close);
+    final plugin = FakeBridgePlugin()
+      ..messagesResult = const [
+        PluginMessageWithParts(
+          info: PluginMessage.user(
+            id: "m1",
+            sessionID: "backend-a",
+            agent: null,
+            time: PluginMessageTime(created: 1, completed: null),
+          ),
+          parts: [],
+        ),
+      ];
+    addTearDown(plugin.close);
+
+    final sessionRepository = singlePluginSessionRepository(
+      plugin: plugin,
+      sessionDao: database.sessionDao,
+      projectsDao: database.projectsDao,
+      pullRequestDao: database.pullRequestDao,
+      unseenCalculator: const SessionUnseenCalculator(),
+    );
+    addTearDown(sessionRepository.dispose);
+    final history = createTestChatHistory(sessionRepository: sessionRepository);
+
+    await recordSessionBinding(
+      database: database,
+      sessionId: "ses_a",
+      backendSessionId: "backend-a",
+      pluginId: plugin.id,
+      projectId: "project-a",
+      parentSessionId: null,
+    );
+    await history.service.getSessionMessages(sessionId: "ses_a");
+    expect(plugin.lastGetMessagesSessionId, isNotNull);
+
+    plugin.lastGetMessagesSessionId = null;
+    await sessionRepository.setSessionTitleIfStored(sessionId: "ses_a", title: "renamed");
+    await history.service.getSessionMessages(sessionId: "ses_a");
+
+    expect(
+      plugin.lastGetMessagesSessionId,
+      isNull,
+      reason: "a rename is a bridge-local write, not backend activity",
+    );
+  });
+}

--- a/bridge/app/test/bridge/services/chat_history_serving_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_serving_test.dart
@@ -95,6 +95,29 @@ void main() {
       expect(served.map((message) => message.info.id), contains("filler-24"));
     });
 
+    test("activity queued before a read still forces the re-read", () async {
+      final repository = _FakeSessionRepository(transcript: [_messageWithParts(id: "m1")]);
+      final history = createTestChatHistory(sessionRepository: repository);
+      await history.service.getSessionMessages(sessionId: "ses_a");
+      final synced = (await history.repository.getSyncState(sessionId: "ses_a"))!;
+      repository.transcript = [_messageWithParts(id: "m1"), _messageWithParts(id: "m2")];
+
+      // Not awaited: the staleness write is merely queued when the read is
+      // issued, which is what happens when an import commits concurrently.
+      final observed = history.service.observeBackendActivity(
+        sessionId: "ses_a",
+        activityAt: synced.watermark + 5000,
+      );
+      final served = await history.service.getSessionMessages(sessionId: "ses_a");
+      await observed;
+
+      expect(
+        served.map((message) => message.info.id),
+        const ["m1", "m2"],
+        reason: "the freshness decision must see writes already queued for the session",
+      );
+    });
+
     test("an empty transcript is served without re-fetching", () async {
       final repository = _FakeSessionRepository(transcript: const []);
       final history = createTestChatHistory(sessionRepository: repository);

--- a/bridge/app/test/bridge/services/chat_history_serving_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_serving_test.dart
@@ -118,6 +118,35 @@ void main() {
       );
     });
 
+    test("a staleness update enqueued during a read commits after it", () async {
+      final repository = _FakeSessionRepository(transcript: [_messageWithParts(id: "m1")]);
+      final history = createTestChatHistory(sessionRepository: repository);
+      await history.service.getSessionMessages(sessionId: "ses_a");
+      final synced = (await history.repository.getSyncState(sessionId: "ses_a"))!;
+
+      // Issue the read, then enqueue the staleness update while it is still
+      // running. The read must not observe a half-applied state, and the
+      // update must still land.
+      final reading = history.service.getSessionMessages(sessionId: "ses_a");
+      final observing = history.service.observeBackendActivity(
+        sessionId: "ses_a",
+        activityAt: synced.watermark + 5000,
+      );
+      final served = await reading;
+      await observing;
+
+      expect(served.map((message) => message.info.id), const ["m1"]);
+      final state = (await history.repository.getSyncState(sessionId: "ses_a"))!;
+      expect(state.backendActivityAt, greaterThan(state.watermark), reason: "the update still applied");
+
+      repository.transcript = [_messageWithParts(id: "m1"), _messageWithParts(id: "m2")];
+      expect(
+        (await history.service.getSessionMessages(sessionId: "ses_a")).map((message) => message.info.id),
+        const ["m1", "m2"],
+        reason: "the next read sees the staleness recorded during the previous one",
+      );
+    });
+
     test("an empty transcript is served without re-fetching", () async {
       final repository = _FakeSessionRepository(transcript: const []);
       final history = createTestChatHistory(sessionRepository: repository);

--- a/bridge/app/test/bridge/services/chat_history_serving_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_serving_test.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -66,6 +68,33 @@ void main() {
       );
     });
 
+    test("a read reflects captures that raced the backfill fetch", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [_messageWithParts(id: "m1"), _messageWithParts(id: "m2")],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      // Several captures land while the fetch is in flight, so they queue
+      // behind the backfill. Queue depth keeps the assertion about ordering
+      // rather than about microtask luck.
+      repository.onFetch = () {
+        for (var index = 0; index < 25; index++) {
+          unawaited(
+            history.service.captureMessage(sessionId: "ses_a", message: _message(id: "filler-$index")),
+          );
+        }
+        unawaited(history.service.captureMessageRemoved(sessionId: "ses_a", messageId: "m2"));
+      };
+
+      final served = await history.service.getSessionMessages(sessionId: "ses_a");
+
+      expect(
+        served.map((message) => message.info.id),
+        isNot(contains("m2")),
+        reason: "the queued removal is newer than the fetched snapshot",
+      );
+      expect(served.map((message) => message.info.id), contains("filler-24"));
+    });
+
     test("an empty transcript is served without re-fetching", () async {
       final repository = _FakeSessionRepository(transcript: const []);
       final history = createTestChatHistory(sessionRepository: repository);
@@ -114,9 +143,14 @@ class _FakeSessionRepository implements SessionRepository {
   final Object? error;
   int fetchCount = 0;
 
+  /// Runs while the fetch is in flight, so a test can interleave live events.
+  void Function()? onFetch;
+
   @override
   Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async {
     fetchCount++;
+    onFetch?.call();
+    await Future<void>.delayed(Duration.zero);
     final failure = error;
     if (failure != null) throw failure;
     return transcript;

--- a/bridge/app/test/bridge/services/chat_history_serving_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_serving_test.dart
@@ -1,0 +1,127 @@
+import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "../../helpers/test_chat_history.dart";
+
+void main() {
+  group("serving session messages", () {
+    test("first read backfills from the plugin and matches it exactly", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [_messageWithParts(id: "m1"), _messageWithParts(id: "m2")],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+
+      final served = await history.service.getSessionMessages(sessionId: "ses_a");
+
+      expect(served, equals(repository.transcript), reason: "store-served output must equal plugin-served output");
+      expect(repository.fetchCount, 1);
+    });
+
+    test("a second read is served from the store without touching the plugin", () async {
+      final repository = _FakeSessionRepository(transcript: [_messageWithParts(id: "m1")]);
+      final history = createTestChatHistory(sessionRepository: repository);
+      await history.service.getSessionMessages(sessionId: "ses_a");
+
+      final served = await history.service.getSessionMessages(sessionId: "ses_a");
+
+      expect(repository.fetchCount, 1, reason: "a synced store must not cold-start the backend");
+      expect(served.map((message) => message.info.id), const ["m1"]);
+    });
+
+    test("observed backend activity forces one re-read, then settles", () async {
+      final repository = _FakeSessionRepository(transcript: [_messageWithParts(id: "m1")]);
+      final history = createTestChatHistory(sessionRepository: repository);
+      await history.service.getSessionMessages(sessionId: "ses_a");
+      final synced = (await history.repository.getSyncState(sessionId: "ses_a"))!;
+
+      await history.service.observeBackendActivity(
+        sessionId: "ses_a",
+        activityAt: synced.watermark + 5000,
+      );
+      repository.transcript = [_messageWithParts(id: "m1"), _messageWithParts(id: "m2")];
+
+      expect(
+        (await history.service.getSessionMessages(sessionId: "ses_a")).map((message) => message.info.id),
+        const ["m1", "m2"],
+        reason: "a session advanced outside Sesori must be re-read",
+      );
+      expect(repository.fetchCount, 2);
+
+      await history.service.getSessionMessages(sessionId: "ses_a");
+      expect(repository.fetchCount, 2, reason: "the refreshed store is current again");
+    });
+
+    test("live capture alone keeps serving from the plugin", () async {
+      final repository = _FakeSessionRepository(transcript: [_messageWithParts(id: "m1")]);
+      final history = createTestChatHistory(sessionRepository: repository);
+
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "live"));
+      await history.service.getSessionMessages(sessionId: "ses_a");
+
+      expect(
+        repository.fetchCount,
+        1,
+        reason: "a capture-created row is not a complete transcript, so the first read must still backfill",
+      );
+    });
+
+    test("an empty transcript is served without re-fetching", () async {
+      final repository = _FakeSessionRepository(transcript: const []);
+      final history = createTestChatHistory(sessionRepository: repository);
+
+      expect(await history.service.getSessionMessages(sessionId: "ses_a"), isEmpty);
+      expect(await history.service.getSessionMessages(sessionId: "ses_a"), isEmpty);
+      expect(repository.fetchCount, 1, reason: "empty is a valid synced state, not a cache miss");
+    });
+
+    test("a fetch failure propagates instead of looking like an empty thread", () async {
+      final repository = _FakeSessionRepository(transcript: const [], error: StateError("backend down"));
+      final history = createTestChatHistory(sessionRepository: repository);
+
+      await expectLater(history.service.getSessionMessages(sessionId: "ses_a"), throwsStateError);
+    });
+  });
+}
+
+Message _message({required String id}) =>
+    Message.user(id: id, sessionID: "ses_a", agent: null, time: const MessageTime(created: 1, completed: null));
+
+MessagePart _part({required String id, required String messageId}) => MessagePart(
+  id: id,
+  sessionID: "ses_a",
+  messageID: messageId,
+  type: MessagePartType.text,
+  text: "text of $messageId",
+  tool: null,
+  state: null,
+  prompt: null,
+  description: null,
+  agent: null,
+  agentName: null,
+  attempt: null,
+  retryError: null,
+  attachment: null,
+);
+
+MessageWithParts _messageWithParts({required String id}) =>
+    MessageWithParts(info: _message(id: id), parts: [_part(id: "$id-p1", messageId: id)]);
+
+class _FakeSessionRepository implements SessionRepository {
+  _FakeSessionRepository({required this.transcript, this.error});
+
+  List<MessageWithParts> transcript;
+  final Object? error;
+  int fetchCount = 0;
+
+  @override
+  Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async {
+    fetchCount++;
+    final failure = error;
+    if (failure != null) throw failure;
+    return transcript;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/repositories/catalog_import_repository_test.dart
+++ b/bridge/app/test/repositories/catalog_import_repository_test.dart
@@ -330,6 +330,51 @@ void main() {
       expect(calculator.sawFirstRowOnSecondLookup, isTrue);
     });
 
+    test("publishes the backend's own activity for each imported session", () async {
+      final projectPath = "${directory.path}/activity";
+      final plugin = _NativeImportPlugin(
+        projects: [PluginProject(id: "activity", directory: projectPath)],
+        rootsByProject: {
+          projectPath: [
+            _pluginSession(id: "root-a", directory: projectPath, updatedAt: 4242),
+            _pluginSession(id: "root-b", directory: projectPath, updatedAt: 5353),
+          ],
+        },
+        childrenByParent: const {},
+      );
+      final repository = CatalogImportRepository(
+        runtime: createTestPluginRuntime(plugins: [plugin]),
+        projectsDao: database.projectsDao,
+        sessionDao: database.sessionDao,
+        catalogHydrationsDao: database.catalogHydrationsDao,
+        projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
+      );
+      final published = <SessionBackendActivity>[];
+      final subscription = repository.backendActivity.listen(published.addAll);
+      addTearDown(subscription.cancel);
+
+      await repository
+          .importCatalog(
+            pluginId: plugin.id,
+            control: CatalogImportControl(
+              explicitImportRequested: true,
+              hydrationMarkerRequested: false,
+            ),
+          )
+          .drain<void>();
+
+      final bindings = await database.sessionDao.getSessionsForPlugin(pluginId: plugin.id);
+      expect(
+        published.map((activity) => activity.activityAt).toList()..sort(),
+        const [4242, 5353],
+        reason: "the backend's reported update time is what staleness compares against",
+      );
+      expect(
+        published.map((activity) => activity.sessionId).toSet(),
+        {bindings["root-a"]!.sessionId, bindings["root-b"]!.sessionId},
+      );
+    });
+
     test("publishes projects before ancestry-ordered session batches of at most 512", () async {
       final projectPath = "${directory.path}/batched";
       final roots = [

--- a/bridge/app/test/routing/catalog_import_handlers_test.dart
+++ b/bridge/app/test/routing/catalog_import_handlers_test.dart
@@ -108,6 +108,12 @@ void main() {
 }
 
 class _HandlerCatalogImportRepository implements CatalogImportRepository {
+  @override
+  Stream<List<SessionBackendActivity>> get backendActivity => const Stream.empty();
+
+  @override
+  Future<void> dispose() async {}
+
   _HandlerCatalogImportRepository({this.release});
 
   final Completer<void>? release;

--- a/bridge/app/test/services/catalog_import_service_test.dart
+++ b/bridge/app/test/services/catalog_import_service_test.dart
@@ -281,6 +281,12 @@ void main() {
 }
 
 class _FakeCatalogImportRepository implements CatalogImportRepository {
+  @override
+  Stream<List<SessionBackendActivity>> get backendActivity => const Stream.empty();
+
+  @override
+  Future<void> dispose() async {}
+
   _FakeCatalogImportRepository({
     required this.completion,
     required this.hydrationGate,


### PR DESCRIPTION
## Complexity

⚙️ moderate — the read path flips to a new source with a freshness rule behind
it, but the wire contract and the stored schema are both unchanged.

## What

Step 4/8 of `.plan/active/internal-chat-history`. **This is the payoff step:
opening a session no longer wakes a harness.**

- `ChatHistoryService.getSessionMessages` serves from the store whenever a
  backfill has completed and no backend activity has been observed past the
  captured watermark; otherwise it backfills first and serves the result.
- `GetSessionMessagesHandler` routes through the service, so the handler makes
  no source decision and no longer depends on `SessionRepository`.
- `CatalogImportRepository` publishes the backend's own reported activity as
  it commits an import; `ChatHistoryActivityListener` feeds that into the
  store's staleness marks, so a session advanced through a backend CLI is
  re-read on next open.
- Reads drain the session's pending writes first, so a response cannot omit a
  capture that raced an in-flight backfill.

## Why

Opening a session used to cold-start an idle backend purely to read history,
and harnesses are slow or unresponsive for a while after starting — so the
wake was doubly expensive. A synced session is now rendered entirely from
`chat_history.db` with the harness untouched.

## Risk and test focus

Moderate, and concentrated in one place: the freshness rule decides whether a
read is correct. Too strict and every open wakes a backend; too loose and a
session advanced elsewhere renders stale.

Worth checking:
- Open a large Codex/OpenCode session twice — the second open should be
  instant with the backend stopped.
- Advance a session through the backend's own CLI, re-import, then open it —
  the new messages must appear.
- Rename a session, then reopen — must **not** re-fetch (pinned by test).

## Expected result

- **User-visible:** opening a previously synced session is fast and no longer
  starts its backend. Transcript content is unchanged.
- **Database:** no schema change and no migration. The existing store is now
  read as well as written.
- **Internal:** the plugin round-trip leaves the ordinary read path.

## Verification

- `dart analyze --fatal-infos` in `bridge/app` — clean.
- `dart test` in `bridge/app` — 2,473 tests green.
- New tests: store-vs-plugin golden equivalence, no-fetch on a synced re-read,
  staleness forcing exactly one re-read then settling, capture-only rows still
  backfilling, empty-as-valid-synced, failure propagation, reads reflecting
  captures that raced a backfill, the import publishing backend-reported
  activity, a rename not invalidating the store, and a synced read leaving the
  plugin untouched.
- `architecture-implementation-review` (sub-agent): three findings, all fixed —
  see below.

## Review and plan corrections

The reviewer caught that the activity stream was wired to the wrong producer:
it published from `SessionRepository`'s active-root hydration path, which only
runs when an active session has no bridge binding, so for a normally imported
catalog **nothing was ever published** and staleness detection did not work —
while the tracker claimed it was verified. The producer now lives in the
import commit and uses the backend's own `updated` time rather than the merged
`updatedAt` that a rename moves. Also fixed: the new listener now drains
pending writes on dispose (its peer already did, so shutdown could close the
database under an in-flight write) and starts at the established listener seam.

`PLAN.md` gains a **Harness Startup Constraints** section and a sharpened
Success Criterion 1: reading history must never start a harness, nothing may
fetch on a backend lifecycle event, and nothing may batch requests at startup.
That was an implicit assumption before; it is now stated, and the current
design already satisfies it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve session messages from the local chat-history store by default, so opening a synced session no longer starts a plugin harness. Synced sessions open fast; a freshness rule with a backend-activity watermark ensures correctness.

- **New Features**
  - `ChatHistoryService.getSessionMessages` serves from the store when backfill is complete and no newer backend activity is observed; otherwise it backfills first.
  - `GetSessionMessagesHandler` now routes through the chat history service; the handler no longer decides the source or depends on `SessionRepository`.
  - Catalog imports publish backend-reported session activity; a new activity listener marks sessions stale so CLI-advanced sessions are re-read on next open.
  - No API or database schema changes.

- **Bug Fixes**
  - Freshness decision and the read run inside and hold the session write queue, so no write can land between them; reads of one session serialize. This prevents omissions or resurrected messages and avoids decisions on stale state.
  - Staleness detection publishes from the import commit using the backend’s own `time.updated`; the activity listener enqueues all session updates before awaiting them and drains pending writes on dispose.

<sup>Written for commit 2f04fb509bb172e5d78f286f503bb7d4b006af12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

