### PR TITLE
🌿 Report imperatively pushed screens in analytics route source

### DIFF
--- a/client/app/lib/core/platform/go_router_route_source.dart
+++ b/client/app/lib/core/platform/go_router_route_source.dart
@@ -1,8 +1,8 @@
 import "dart:async";
 
+import "package:flutter/foundation.dart";
 import "package:get_it/get_it.dart";
 import "package:go_router/go_router.dart";
-import "package:flutter/foundation.dart";
 import "package:injectable/injectable.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
@@ -68,21 +68,22 @@ class GoRouterRouteSource implements RouteSource, Disposable {
 
   /// Routes sorted by match precedence, computed once — the route table is
   /// static.
-  static final _orderedRoutes = AppRouteDef.values.toList()..sort(_byMatchPrecedence);
+  static final _orderedRoutes = AppRouteDef.values.toList()
+    ..sort((a, b) => _compareMatchPrecedence(first: a, second: b));
 
   /// A literal segment beats a parameter at the first place the two paths
   /// disagree, so `/projects/:id/sessions/new` is tried before
   /// `/projects/:id/sessions/:sessionId` — otherwise `new` would be read as a
   /// session id. Failing that the deeper path wins, so `/projects/:id/sessions`
   /// is tried before `/projects`.
-  static int _byMatchPrecedence(AppRouteDef a, AppRouteDef b) {
-    final aSegments = a.path.split("/");
-    final bSegments = b.path.split("/");
-    for (var index = 0; index < aSegments.length && index < bSegments.length; index++) {
-      final aIsParameter = aSegments[index].startsWith(":");
-      if (aIsParameter != bSegments[index].startsWith(":")) return aIsParameter ? 1 : -1;
+  static int _compareMatchPrecedence({required AppRouteDef first, required AppRouteDef second}) {
+    final firstSegments = first.path.split("/");
+    final secondSegments = second.path.split("/");
+    for (var index = 0; index < firstSegments.length && index < secondSegments.length; index++) {
+      final firstIsParameter = firstSegments[index].startsWith(":");
+      if (firstIsParameter != secondSegments[index].startsWith(":")) return firstIsParameter ? 1 : -1;
     }
-    return bSegments.length.compareTo(aSegments.length);
+    return secondSegments.length.compareTo(firstSegments.length);
   }
 
   static final _regexByRoute = {

--- a/client/app/lib/core/platform/go_router_route_source.dart
+++ b/client/app/lib/core/platform/go_router_route_source.dart
@@ -2,8 +2,8 @@ import "dart:async";
 
 import "package:get_it/get_it.dart";
 import "package:go_router/go_router.dart";
+import "package:flutter/foundation.dart";
 import "package:injectable/injectable.dart";
-import "package:meta/meta.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 

--- a/client/app/lib/core/platform/go_router_route_source.dart
+++ b/client/app/lib/core/platform/go_router_route_source.dart
@@ -1,7 +1,9 @@
 import "dart:async";
 
 import "package:get_it/get_it.dart";
+import "package:go_router/go_router.dart";
 import "package:injectable/injectable.dart";
+import "package:meta/meta.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 
@@ -9,13 +11,18 @@ import "../routing/app_router.dart";
 
 @Singleton(as: RouteSource)
 class GoRouterRouteSource implements RouteSource, Disposable {
+  final GoRouterDelegate _routerDelegate;
   final BehaviorSubject<AppRouteDef?> _currentRouteStream;
 
-  GoRouterRouteSource()
-    : _currentRouteStream = BehaviorSubject.seeded(
-        _matchRoute(appRouter.routerDelegate.currentConfiguration.uri.path),
-      ) {
-    appRouter.routerDelegate.addListener(_onRouteChanged);
+  GoRouterRouteSource() : this._(routerDelegate: appRouter.routerDelegate);
+
+  @visibleForTesting
+  GoRouterRouteSource.test({required GoRouter router}) : this._(routerDelegate: router.routerDelegate);
+
+  GoRouterRouteSource._({required GoRouterDelegate routerDelegate})
+    : _routerDelegate = routerDelegate,
+      _currentRouteStream = BehaviorSubject.seeded(_matchRoute(_currentPath(routerDelegate.currentConfiguration))) {
+    routerDelegate.addListener(_onRouteChanged);
   }
 
   @override
@@ -23,27 +30,70 @@ class GoRouterRouteSource implements RouteSource, Disposable {
 
   @override
   FutureOr<void> onDispose() {
-    appRouter.routerDelegate.removeListener(_onRouteChanged);
+    _routerDelegate.removeListener(_onRouteChanged);
     _currentRouteStream.close();
   }
 
   void _onRouteChanged() {
-    final matchedRoute = _matchRoute(appRouter.routerDelegate.currentConfiguration.uri.path);
+    final matchedRoute = _matchRoute(_currentPath(_routerDelegate.currentConfiguration));
     if (_currentRouteStream.valueOrNull == matchedRoute) {
       return;
     }
     _currentRouteStream.add(matchedRoute);
   }
 
-  /// Routes sorted longest-path-first so `/projects/:id/sessions` is tried
-  /// before `/projects`. Computed once — the route table is static.
-  static final _orderedRoutes = AppRouteDef.values.toList()..sort((a, b) => b.path.length.compareTo(a.path.length));
+  /// The path of the topmost match, including imperatively pushed ones.
+  ///
+  /// [RouteMatchList.uri] deliberately omits [ImperativeRouteMatch] entries, so
+  /// it still reports the last `go`/`replace` destination while a `push`ed
+  /// screen — settings, new session, diffs — is the one on screen. Walking the
+  /// match tree from the top instead reports what the user is actually looking
+  /// at.
+  static String? _currentPath(RouteMatchList configuration) => _topMatchedLocation(configuration.matches);
+
+  static String? _topMatchedLocation(List<RouteMatchBase> matches) {
+    for (final match in matches.reversed) {
+      final location = switch (match) {
+        ImperativeRouteMatch(:final matches) => _topMatchedLocation(matches.matches),
+        ShellRouteMatch(:final matches) => _topMatchedLocation(matches),
+        RouteMatch(:final matchedLocation) => matchedLocation,
+        // go_router's match hierarchy is not sealed; unknown kinds contribute
+        // no path of their own.
+        _ => null,
+      };
+      if (location != null) return location;
+    }
+    return null;
+  }
+
+  /// Routes sorted by match precedence, computed once — the route table is
+  /// static.
+  static final _orderedRoutes = AppRouteDef.values.toList()..sort(_byMatchPrecedence);
+
+  /// A literal segment beats a parameter at the first place the two paths
+  /// disagree, so `/projects/:id/sessions/new` is tried before
+  /// `/projects/:id/sessions/:sessionId` — otherwise `new` would be read as a
+  /// session id. Failing that the deeper path wins, so `/projects/:id/sessions`
+  /// is tried before `/projects`.
+  static int _byMatchPrecedence(AppRouteDef a, AppRouteDef b) {
+    final aSegments = a.path.split("/");
+    final bSegments = b.path.split("/");
+    for (var index = 0; index < aSegments.length && index < bSegments.length; index++) {
+      final aIsParameter = aSegments[index].startsWith(":");
+      if (aIsParameter != bSegments[index].startsWith(":")) return aIsParameter ? 1 : -1;
+    }
+    return bSegments.length.compareTo(aSegments.length);
+  }
 
   static final _regexByRoute = {
     for (final route in AppRouteDef.values) route: _buildRegex(route),
   };
 
-  static AppRouteDef? _matchRoute(String path) {
+  @visibleForTesting
+  static AppRouteDef? matchRouteForTesting(String path) => _matchRoute(path);
+
+  static AppRouteDef? _matchRoute(String? path) {
+    if (path == null) return null;
     for (final route in _orderedRoutes) {
       if (_regexByRoute[route] case final regex?) {
         if (!regex.hasMatch(path)) {

--- a/client/app/test/core/platform/go_router_route_source_test.dart
+++ b/client/app/test/core/platform/go_router_route_source_test.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:go_router/go_router.dart";
@@ -76,7 +78,7 @@ void main() {
 
     // A push leaves RouteMatchList.uri on /projects, so only walking the match
     // tree reveals settings as the screen the user is actually on.
-    router.push<void>(const AppRoute.settings().buildPath());
+    unawaited(router.push<void>(const AppRoute.settings().buildPath()));
     await tester.pumpAndSettle();
 
     expect(routeSource.currentRouteStream.value, AppRouteDef.settings);
@@ -87,13 +89,15 @@ void main() {
     router.go(const AppRoute.projects().buildPath());
     await tester.pumpAndSettle();
 
-    router.push<void>(
-      const AppRoute.sessions(projectId: "p1", projectName: null, supportsDedicatedWorktrees: null).buildPath(),
+    unawaited(
+      router.push<void>(
+        const AppRoute.sessions(projectId: "p1", projectName: null, supportsDedicatedWorktrees: null).buildPath(),
+      ),
     );
     await tester.pumpAndSettle();
     expect(routeSource.currentRouteStream.value, AppRouteDef.sessions);
 
-    router.push<void>(const AppRoute.newSession(projectId: "p1", projectName: null).buildPath());
+    unawaited(router.push<void>(const AppRoute.newSession(projectId: "p1", projectName: null).buildPath()));
     await tester.pumpAndSettle();
 
     expect(routeSource.currentRouteStream.value, AppRouteDef.newSession);
@@ -103,9 +107,9 @@ void main() {
     await pumpRouter(tester);
     router.go(const AppRoute.projects().buildPath());
     await tester.pumpAndSettle();
-    router.push<void>(const AppRoute.settings().buildPath());
+    unawaited(router.push<void>(const AppRoute.settings().buildPath()));
     await tester.pumpAndSettle();
-    router.push<void>(const AppRoute.settingsProfile().buildPath());
+    unawaited(router.push<void>(const AppRoute.settingsProfile().buildPath()));
     await tester.pumpAndSettle();
     expect(routeSource.currentRouteStream.value, AppRouteDef.settingsProfile);
 

--- a/client/app/test/core/platform/go_router_route_source_test.dart
+++ b/client/app/test/core/platform/go_router_route_source_test.dart
@@ -1,0 +1,144 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:go_router/go_router.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_mobile/core/platform/go_router_route_source.dart";
+
+/// Mirrors the production route tree's shape — the session routes nested under
+/// a [ShellRoute] — with placeholder screens, so navigation needs no DI.
+GoRouter _router() {
+  return GoRouter(
+    initialLocation: AppRouteDef.splash.path,
+    routes: [
+      GoRoute(path: AppRouteDef.splash.path, builder: (_, _) => const Text("splash")),
+      GoRoute(
+        path: AppRouteDef.projects.path,
+        builder: (_, _) => const Text("projects"),
+        routes: [
+          ShellRoute(
+            builder: (_, _, child) => child,
+            routes: [
+              GoRoute(
+                path: ":$projectIdPathParam/sessions",
+                builder: (_, _) => const Text("sessions"),
+                routes: [
+                  GoRoute(path: "new", builder: (_, _) => const Text("new session")),
+                  GoRoute(path: ":$sessionIdPathParam", builder: (_, _) => const Text("session detail")),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+      GoRoute(
+        path: AppRouteDef.settings.path,
+        builder: (_, _) => const Text("settings"),
+        routes: [
+          GoRoute(path: "profile", builder: (_, _) => const Text("profile")),
+        ],
+      ),
+    ],
+  );
+}
+
+void main() {
+  late GoRouter router;
+  late GoRouterRouteSource routeSource;
+
+  setUp(() {
+    router = _router();
+    routeSource = GoRouterRouteSource.test(router: router);
+  });
+
+  tearDown(() async {
+    await routeSource.onDispose();
+    router.dispose();
+  });
+
+  Future<void> pumpRouter(WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets("reports declaratively navigated screens", (tester) async {
+    await pumpRouter(tester);
+
+    router.go(const AppRoute.projects().buildPath());
+    await tester.pumpAndSettle();
+
+    expect(routeSource.currentRouteStream.value, AppRouteDef.projects);
+  });
+
+  testWidgets("reports imperatively pushed screens", (tester) async {
+    await pumpRouter(tester);
+    router.go(const AppRoute.projects().buildPath());
+    await tester.pumpAndSettle();
+
+    // A push leaves RouteMatchList.uri on /projects, so only walking the match
+    // tree reveals settings as the screen the user is actually on.
+    router.push<void>(const AppRoute.settings().buildPath());
+    await tester.pumpAndSettle();
+
+    expect(routeSource.currentRouteStream.value, AppRouteDef.settings);
+  });
+
+  testWidgets("reports pushed screens nested in the session shell", (tester) async {
+    await pumpRouter(tester);
+    router.go(const AppRoute.projects().buildPath());
+    await tester.pumpAndSettle();
+
+    router.push<void>(
+      const AppRoute.sessions(projectId: "p1", projectName: null, supportsDedicatedWorktrees: null).buildPath(),
+    );
+    await tester.pumpAndSettle();
+    expect(routeSource.currentRouteStream.value, AppRouteDef.sessions);
+
+    router.push<void>(const AppRoute.newSession(projectId: "p1", projectName: null).buildPath());
+    await tester.pumpAndSettle();
+
+    expect(routeSource.currentRouteStream.value, AppRouteDef.newSession);
+  });
+
+  testWidgets("reports the revealed screen after popping a pushed screen", (tester) async {
+    await pumpRouter(tester);
+    router.go(const AppRoute.projects().buildPath());
+    await tester.pumpAndSettle();
+    router.push<void>(const AppRoute.settings().buildPath());
+    await tester.pumpAndSettle();
+    router.push<void>(const AppRoute.settingsProfile().buildPath());
+    await tester.pumpAndSettle();
+    expect(routeSource.currentRouteStream.value, AppRouteDef.settingsProfile);
+
+    router.pop<void>();
+    await tester.pumpAndSettle();
+
+    expect(routeSource.currentRouteStream.value, AppRouteDef.settings);
+  });
+
+  testWidgets("matches every route in the table to its own definition", (tester) async {
+    // Concrete locations for the whole table, so a new route cannot silently
+    // be swallowed by a sibling's parameter segment.
+    const locations = {
+      AppRouteDef.splash: "/splash",
+      AppRouteDef.login: "/login",
+      AppRouteDef.projects: "/projects",
+      AppRouteDef.settings: "/settings",
+      AppRouteDef.settingsNotifications: "/settings/notifications",
+      AppRouteDef.settingsHarnesses: "/settings/harnesses",
+      AppRouteDef.settingsProfile: "/settings/profile",
+      AppRouteDef.sessions: "/projects/p1/sessions",
+      AppRouteDef.newSession: "/projects/p1/sessions/new",
+      AppRouteDef.sessionDetail: "/projects/p1/sessions/s1",
+      AppRouteDef.sessionDiffs: "/projects/p1/sessions/s1/diffs",
+    };
+    expect(locations.keys, unorderedEquals(AppRouteDef.values));
+
+    for (final MapEntry(key: route, value: location) in locations.entries) {
+      expect(
+        GoRouterRouteSource.matchRouteForTesting(location),
+        route,
+        reason: "$location should match ${route.name}",
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Complexity

🌿 Straightforward. Two localized defects in one file, both in the path that
turns the router's state into an `AppRouteDef`. No new types, no DI changes, no
contract changes.

## What

`GoRouterRouteSource` derived the current screen from
`RouteMatchList.uri.path`. go_router documents that `uri` **only reflects
matches that are not `ImperativeRouteMatch`** (`match.dart:545-547`), so a
`push` never moved it. Walk the match tree from the topmost match instead,
unwrapping `ImperativeRouteMatch` and `ShellRouteMatch`.

That fix exposed a second defect the old path hid, because the affected route
was unreachable before: `_orderedRoutes` sorted longest-path-first, so
`/projects/:id/sessions/new` matched the longer `sessionDetail` template and
reported `session_detail` with `new` read as a session id. Order by match
precedence instead — a literal segment beats a parameter at the first differing
position, then deeper paths first.

## Why

Screen analytics only ever saw `go`/`replace` destinations. Splitting the
call sites:

| reported (`go`/`replace`) | silently missing (`push`) |
|---|---|
| `login`, `projects`, `session_detail` | `settings`, `settings_notifications`, `settings_profile`, `settings` (harnesses), `new_session`, `session_diffs`, `sessions` |

GA4 confirms it. Over the reporting window, `product_screen_viewed` contains
only `session_detail` (597), `projects` (517) and `sessions` (1 — from the
notification `replaceStack` and the delete-session `go`). Zero rows for any
settings screen, new session, or diffs. `597 + 517 + 1 = 1115`, exactly the
`GoRouter` screen-class row count, so the Firebase mirror itself was wired
correctly and was faithfully mirroring an incomplete source.

This defeats the `screen_usage` reporting the analytics plan specifies, and it
silently under-reports the settings and new-session surfaces that activation
questions depend on.

## Risk and test focus

**No user-visible impact.** Nothing about navigation, screen construction, or
routing behavior changes; only the analytics-facing derived value does.

**No database impact.** No schema, no persisted state, no wire contract.

**Analytics impact:** `product_screen_viewed` volume will rise once this ships,
and screens absent until now will start appearing. Historical `screen_usage`
before this release is not comparable for those screens — it is missing them,
not reporting them as zero.

Review focus is the match-tree walk and the new precedence comparator. The
comparator is exhaustively pinned against the real `AppRouteDef` table, so a
future route cannot silently be swallowed by a sibling's parameter segment.

## Verification

`client/app/test/core/platform/go_router_route_source_test.dart` (new, 5 tests):
declarative navigation, imperative push, push nested inside the session
`ShellRoute`, the screen revealed by a pop, and a full-table location →
`AppRouteDef` mapping that asserts every enum value is covered.

- Confirmed the new tests **fail** against the old `uri.path` implementation
  (3 of 5 fail) and pass with the fix, so they pin the actual defect.
- `flutter test test/core/routing test/core/platform` — 110 passed.
- `dart analyze` in `client/app` — clean.

## Expected result

Every screen the user reaches emits exactly one `product_screen_viewed` with
its pinned `AnalyticsScreen`, plus one matching Firebase-native `screen_view`
mirror, regardless of whether it was reached with `go`, `replace`, or `push`.
`/projects/:id/sessions/new` reports `new_session` rather than
`session_detail`.

### Not addressed here

The `(not set)` / `MainActivity` / `FlutterViewController` rows in the GA4
screenshots are Firebase *automatic* screen views. The disable flags
(`google_analytics_automatic_screen_reporting_enabled`,
`FirebaseAutomaticScreenReportingEnabled`) are present and correct, but first
shipped in #614 and were first released in v1.7.0 — pre-1.7 installs in the
field still auto-report. That decays on its own and needs no change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Analytics now reports the screen actually on display, including imperatively pushed screens from `go_router`. It also fixes route precedence so `/projects/:id/sessions/new` maps to `new_session`, not `session_detail`.

- **Bug Fixes**
  - Walk the `go_router` match tree (handles `ImperativeRouteMatch` and `ShellRouteMatch`) to derive the topmost matched path, instead of using `RouteMatchList.uri`.
  - Sort `AppRouteDef` by match precedence: literal segment beats parameter at first difference; if equal, deeper path wins.
  - Added widget tests for `go`/`replace`/`push` flows, pops, and a full route-table mapping; old logic fails these tests.
  - Small cleanup for testability and lints: inject `GoRouterDelegate`, add `GoRouterRouteSource.test` and `matchRouteForTesting`, import `@visibleForTesting` from `flutter/foundation`, sort imports, give the comparator named params, and unawait `router.push` futures in tests.

<sup>Written for commit 024d1d305d8f571f740af613697cde968f84d79f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

