### PR TITLE
⚙️ [internal-chat-history] Paginate session messages [step 5/8]

### DIFF
--- a/.plan/active/internal-chat-history/PLAN.md
+++ b/.plan/active/internal-chat-history/PLAN.md
@@ -136,8 +136,10 @@ Consequences for this feature, all satisfied by the current design:
   databases.
 - New SSE event types or changes to the client's reload triggers (owned by
   the separate `session-refresh-reconnects` assessment).
-- Trimming what non-message data the session snapshot sends (explicitly
-  deferred by the user).
+- Trimming what non-message data the session snapshot sends. Serving history
+  without starting a harness does not by itself make session open harness-free,
+  because the same snapshot still issues plugin-starting calls (see step 8/8,
+  which aligns on the follow-up rather than implementing it here).
 - Compression of archive files, retention windows for active-session
   history, content-hash dedup across sessions.
 - Changes to the `BridgePluginApi.getSessionMessages` contract — it remains
@@ -521,12 +523,56 @@ expected and recorded here as unavoidable.
 | 5/8 | `⚙️ [internal-chat-history] Paginate session messages [step 5/8]` | 600–1,000 | `SessionMessagesRequest`/`nextCursor` shared fields, bridge paging over `seq`, compatibility tests both directions. |
 | 6/8 | `🚧 [internal-chat-history] Export archives and purge history on archive [step 6/8]` | 1,000–1,500 | `ArchivedSessionStorage`, export → cleanup → flip → purge sequencing, archived read path (`seq`-cursor from the audit file), incremental vacuum, reconcile audit-file behaviors, delete-path archive cleanup. |
 | 7/8 | `🌿 [internal-chat-history] Load history pages on demand in the client [step 7/8]` | 500–900 | Latest-page initial load, load-older affordance, complete-when-no-cursor, page-merge cubit state, tests. |
-| 8/8 | `🌱 [internal-chat-history] Retire plan [step 8/8]` | 50–150 | Move plan to `.plan/completed/`. |
+| 8/8 | `🌱 [internal-chat-history] Retire plan and scope the harness-free session open [step 8/8]` | 150–400 | Move plan to `.plan/completed/`, and record the follow-up assessment for the remaining plugin-starting calls in the session-open snapshot (below). |
 
 Steps merge in numeric order; each PR is independently valid at its base.
 Bridge serving (4) precedes the wire change (5); archived reads (6) reuse the
 serving path; the client adopts paging last (7) against a bridge that already
 serves both shapes.
+
+## Step 8/8: Harness-Free Session Open (assessment, not implementation)
+
+Serving history from the store removes one plugin call from session open, but
+the snapshot still wakes an idle backend through other calls, so the user does
+not perceive the win. Step 8/8 retires this plan **and** produces an aligned,
+code-informed assessment of what it would take to open a session with every
+harness stopped. Deliverable is a written proposal — a follow-up plan — not an
+implementation, so this series stays scoped.
+
+Observed on 2026-08-08 against a bridge running step 4/8: the store served
+history correctly (`chat_history.db` populated, sessions `synced_at` with a
+current watermark), yet opening a session still felt unchanged because the
+remaining calls started the backend anyway.
+
+Calls in `SessionDetailLoadService._loadSnapshot` to classify, each as
+"can it be answered without the plugin?":
+
+- `getPendingQuestions` / `getPendingPermissions` — `_runtime.use(...)`, which
+  is `startIfNeeded: true`. These are the primary offenders: a stopped backend
+  has no pending interaction to report, so waking it to ask is close to
+  pointless.
+- `getSession`, `getChildren` — already catalog-backed in the common path;
+  confirm no plugin fallback fires for a stored session.
+- `listAgents` / `listProviders` / `listCommands` — plugin-backed, but a
+  session-options cache already exists (`session_options_cache_table`);
+  assess whether the cached snapshot can answer an open on a stopped backend.
+- `getSessionStatuses` — already correct: uses `useIfActive`
+  (`startIfNeeded: false`), so it degrades instead of starting. This is the
+  shape the others should be measured against.
+
+Questions to answer explicitly, with the user, before any implementation:
+
+1. Which of these must be live-accurate, and which may serve a bridge-side
+   cached or empty answer while the backend is stopped?
+2. What should the UI show for a stopped-backend field — last known value,
+   empty, or an explicit "unavailable until the backend starts" state? A
+   silently empty pending-questions list is a correctness risk if a question
+   really is outstanding.
+3. Does opening a session imply intent to *use* it (so a deliberate,
+   non-blocking background start is right), or should the backend start only
+   when the user actually acts?
+4. Given harnesses respond poorly right after starting, should any such start
+   be explicitly backgrounded so it never blocks first paint?
 
 ## Verification
 

--- a/.plan/active/internal-chat-history/TRACKER.md
+++ b/.plan/active/internal-chat-history/TRACKER.md
@@ -3,13 +3,13 @@
 ## Current State
 
 - **Plan slug:** `internal-chat-history`
-- **Implementation base:** `origin/main` at `6723c833`
-- **Series state:** Step 2/8 merged; step 3/8 in PR
-- **Current step:** 3/8
+- **Implementation base:** `origin/main` at `4a50b6a9`
+- **Series state:** Steps 1–4 merged; step 5/8 in PR
+- **Current step:** 5/8
 - **Plan PR:** [#763](https://github.com/sesori-ai/sesori_apps_monorepo/pull/763) merged
 - **Prerequisite:** satisfied — the `read-only-archiving` series merged fully on
   2026-08-07 (through [PR #771](https://github.com/sesori-ai/sesori_apps_monorepo/pull/771)).
-- **Next action:** merge step 3/8, then start step 4/8.
+- **Next action:** merge step 5/8, then start step 6/8 (archive export and purge).
 
 ## Delivery Steps
 
@@ -17,12 +17,12 @@
 |---|---|---|---:|---|
 | [x] | 1/8 | `🌱 [internal-chat-history] Raise plan [step 1/8]` | 400–700 | [PR #763](https://github.com/sesori-ai/sesori_apps_monorepo/pull/763) merged |
 | [x] | 2/8 | `🚧 [internal-chat-history] Introduce the chat history database [step 2/8]` | 1,500–2,600 | [PR #768](https://github.com/sesori-ai/sesori_apps_monorepo/pull/768) merged |
-| [ ] | 3/8 | `🚧 [internal-chat-history] Capture live message events and backfill lazily [step 3/8]` | 900–1,400 | in progress |
-| [ ] | 4/8 | `⚙️ [internal-chat-history] Serve session messages from the store [step 4/8]` | 700–1,100 | pending |
-| [ ] | 5/8 | `⚙️ [internal-chat-history] Paginate session messages [step 5/8]` | 600–1,000 | pending |
+| [x] | 3/8 | `🚧 [internal-chat-history] Capture live message events and backfill lazily [step 3/8]` | 900–1,400 | [PR #776](https://github.com/sesori-ai/sesori_apps_monorepo/pull/776) merged |
+| [x] | 4/8 | `⚙️ [internal-chat-history] Serve session messages from the store [step 4/8]` | 700–1,100 | [PR #781](https://github.com/sesori-ai/sesori_apps_monorepo/pull/781) merged |
+| [ ] | 5/8 | `⚙️ [internal-chat-history] Paginate session messages [step 5/8]` | 600–1,000 | in progress |
 | [ ] | 6/8 | `🚧 [internal-chat-history] Export archives and purge history on archive [step 6/8]` | 1,000–1,500 | pending |
 | [ ] | 7/8 | `🌿 [internal-chat-history] Load history pages on demand in the client [step 7/8]` | 500–900 | pending |
-| [ ] | 8/8 | `🌱 [internal-chat-history] Retire plan [step 8/8]` | 50–150 | pending |
+| [ ] | 8/8 | `🌱 [internal-chat-history] Retire plan and scope the harness-free session open [step 8/8]` | 150–400 | pending |
 
 ## Execution Rules
 
@@ -49,6 +49,10 @@
 - **2026-08-07 — step 3/8:** `dart analyze --fatal-infos` clean in `bridge/app`;
   `dart test` in `bridge/app` green (2,460 tests), including the new
   `chat_history_capture_test.dart`.
+- **2026-08-08 — step 4/8:** analyzer clean; `bridge/app` green (2,475 tests).
+- **2026-08-08 — step 5/8:** analyzer clean in `bridge/app`, `sesori_shared`,
+  `client/module_core`, and `client/app`; `bridge/app` 2,493 tests,
+  `sesori_shared` 364, `client/module_core` 1,006, `client/app` 915.
 
 ## Findings And Plan Deltas
 - **2026-08-06 — Plan revised after comparison with PR #764** (parallel
@@ -96,3 +100,12 @@
   the gap: the merged catalog `updatedAt` is moved by renames, and the import
   clock would mark every such session stale on every import and wake its
   harness. Recorded in `PLAN.md` § Known Limits instead.
+- **2026-08-08 — Step 8/8 widened to scope a harness-free session open.**
+  Running a bridge on step 4/8 showed the store serving history correctly while
+  session open still felt unchanged: the same snapshot calls
+  `getPendingQuestions`/`getPendingPermissions` (and the options lookups)
+  through `PluginRuntime.use`, which starts an idle backend. Serving history
+  locally therefore does not deliver a harness-free open on its own. Step 8/8
+  now retires the plan *and* produces an aligned written assessment of the
+  remaining plugin-starting calls; implementation stays out of this series.
+  Recorded per user direction after observing it on a live bridge.

--- a/bridge/app/lib/src/api/database/history/chat_history_dao.dart
+++ b/bridge/app/lib/src/api/database/history/chat_history_dao.dart
@@ -15,16 +15,48 @@ class ChatHistoryDao extends DatabaseAccessor<ChatHistoryDatabase> with _$ChatHi
     return (select(historySyncStateTable)..where((table) => table.sessionId.equals(sessionId))).getSingleOrNull();
   }
 
-  Future<List<HistoryMessagesTableData>> getMessages({required String sessionId}) {
-    return (select(historyMessagesTable)
-          ..where((table) => table.sessionId.equals(sessionId))
-          ..orderBy([(table) => OrderingTerm(expression: table.seq)]))
-        .get();
+  /// The session's messages oldest-first.
+  ///
+  /// With [limit] set, returns the newest [limit] messages ordered strictly
+  /// below [before] (or from the newest when [before] is null), still
+  /// oldest-first within the page.
+  Future<List<HistoryMessagesTableData>> getMessages({
+    required String sessionId,
+    int? limit,
+    int? before,
+  }) async {
+    if (limit == null) {
+      return (select(historyMessagesTable)
+            ..where((table) => table.sessionId.equals(sessionId))
+            ..orderBy([(table) => OrderingTerm(expression: table.seq)]))
+          .get();
+    }
+    // Take the newest rows first so the limit selects the right end of the
+    // transcript, then flip the page back into reading order.
+    final page =
+        await (select(historyMessagesTable)
+              ..where(
+                (table) => before == null
+                    ? table.sessionId.equals(sessionId)
+                    : table.sessionId.equals(sessionId) & table.seq.isSmallerThanValue(before),
+              )
+              ..orderBy([(table) => OrderingTerm(expression: table.seq, mode: OrderingMode.desc)])
+              ..limit(limit))
+            .get();
+    return page.reversed.toList(growable: false);
   }
 
-  Future<List<HistoryPartsTableData>> getParts({required String sessionId}) {
+  /// Parts of [messageIds], or of the whole session when [messageIds] is null.
+  Future<List<HistoryPartsTableData>> getParts({
+    required String sessionId,
+    List<String>? messageIds,
+  }) {
     return (select(historyPartsTable)
-          ..where((table) => table.sessionId.equals(sessionId))
+          ..where(
+            (table) => messageIds == null
+                ? table.sessionId.equals(sessionId)
+                : table.sessionId.equals(sessionId) & table.messageId.isIn(messageIds),
+          )
           ..orderBy([
             (table) => OrderingTerm(expression: table.messageId),
             (table) => OrderingTerm(expression: table.orderIndex),

--- a/bridge/app/lib/src/bridge/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/chat_history_repository.dart
@@ -66,8 +66,9 @@ class ChatHistoryRepository {
         ),
     ];
     // A full page implies there may be more; a short one proves there is not,
-    // which avoids an extra count query on every read.
-    final hasOlder = limit != null && messageRows.length == limit;
+    // which avoids an extra count query on every read. An empty page is never
+    // "full": there is nothing older to point a cursor at.
+    final hasOlder = limit != null && messageRows.isNotEmpty && messageRows.length == limit;
     return (
       messages: messages,
       nextCursor: hasOlder ? messageRows.first.seq : null,

--- a/bridge/app/lib/src/bridge/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/chat_history_repository.dart
@@ -7,6 +7,10 @@ import "../../api/attachment_spill_storage.dart";
 import "../../api/database/history/chat_history_dao.dart";
 import "../../api/database/history/chat_history_database.dart";
 
+/// One page of stored history, oldest-first, plus the cursor for the next
+/// older page (null when the caller has reached the start of the transcript).
+typedef ChatHistoryPage = ({List<MessageWithParts> messages, int? nextCursor});
+
 /// How fresh a session's stored transcript is.
 ///
 /// [syncedAt] is null until a backfill completes, so a row created by live
@@ -34,22 +38,40 @@ class ChatHistoryRepository {
 
   /// The session's stored transcript, oldest first, with attachments
   /// rehydrated from their spill files.
-  Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async {
-    final messageRows = await _chatHistoryDao.getMessages(sessionId: sessionId);
-    final partRows = await _chatHistoryDao.getParts(sessionId: sessionId);
+  Future<ChatHistoryPage> getSessionMessages({
+    required String sessionId,
+    int? limit,
+    int? before,
+  }) async {
+    final messageRows = await _chatHistoryDao.getMessages(
+      sessionId: sessionId,
+      limit: limit,
+      before: before,
+    );
+    final partRows = await _chatHistoryDao.getParts(
+      sessionId: sessionId,
+      messageIds: limit == null ? null : [for (final row in messageRows) row.messageId],
+    );
     final partsByMessage = <String, List<MessagePart>>{};
     for (final row in partRows) {
       partsByMessage
           .putIfAbsent(row.messageId, () => [])
           .add(await _rehydratePart(sessionId: sessionId, partJson: row.partJson));
     }
-    return [
+    final messages = [
       for (final row in messageRows)
         MessageWithParts(
           info: Message.fromJson(jsonDecodeMap(row.infoJson)),
           parts: partsByMessage[row.messageId] ?? const [],
         ),
     ];
+    // A full page implies there may be more; a short one proves there is not,
+    // which avoids an extra count query on every read.
+    final hasOlder = limit != null && messageRows.length == limit;
+    return (
+      messages: messages,
+      nextCursor: hasOlder ? messageRows.first.seq : null,
+    );
   }
 
   /// Stores one message, appending it after the current maximum when new.

--- a/bridge/app/lib/src/bridge/routing/get_session_messages_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_session_messages_handler.dart
@@ -28,6 +28,12 @@ class GetSessionMessagesHandler extends BodyRequestHandler<SessionMessagesReques
     if (sessionId.isEmpty) {
       throw buildErrorResponse(request, 400, "empty session id");
     }
+    // A non-positive limit has no honest answer: it is neither "the whole
+    // transcript" (null) nor a page anyone can page onward from, so refuse it
+    // rather than returning an empty page that never terminates.
+    if (body.limit case final limit? when limit <= 0) {
+      throw buildErrorResponse(request, 400, "limit must be greater than zero");
+    }
 
     final page = await _chatHistoryService.getSessionMessages(
       sessionId: sessionId,

--- a/bridge/app/lib/src/bridge/routing/get_session_messages_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_session_messages_handler.dart
@@ -3,8 +3,9 @@ import "package:sesori_shared/sesori_shared.dart";
 import "../services/chat_history_service.dart";
 import "request_handler.dart";
 
-/// Handles `POST /session/messages` — returns all messages for a session.
-class GetSessionMessagesHandler extends BodyRequestHandler<SessionIdRequest, MessageWithPartsResponse> {
+/// Handles `POST /session/messages` — returns a page of a session's messages,
+/// or the whole transcript when the request carries no limit.
+class GetSessionMessagesHandler extends BodyRequestHandler<SessionMessagesRequest, MessageWithPartsResponse> {
   final ChatHistoryService _chatHistoryService;
 
   GetSessionMessagesHandler({required ChatHistoryService chatHistoryService})
@@ -12,13 +13,13 @@ class GetSessionMessagesHandler extends BodyRequestHandler<SessionIdRequest, Mes
       super(
         HttpMethod.post,
         "/session/messages",
-        fromJson: SessionIdRequest.fromJson,
+        fromJson: SessionMessagesRequest.fromJson,
       );
 
   @override
   Future<MessageWithPartsResponse> handle(
     RelayRequest request, {
-    required SessionIdRequest body,
+    required SessionMessagesRequest body,
     required Map<String, String> pathParams,
     required Map<String, String> queryParams,
     required String? fragment,
@@ -28,8 +29,11 @@ class GetSessionMessagesHandler extends BodyRequestHandler<SessionIdRequest, Mes
       throw buildErrorResponse(request, 400, "empty session id");
     }
 
-    return MessageWithPartsResponse(
-      messages: await _chatHistoryService.getSessionMessages(sessionId: sessionId),
+    final page = await _chatHistoryService.getSessionMessages(
+      sessionId: sessionId,
+      limit: body.limit,
+      before: body.before,
     );
+    return MessageWithPartsResponse(messages: page.messages, nextCursor: page.nextCursor);
   }
 }

--- a/bridge/app/lib/src/bridge/services/chat_history_service.dart
+++ b/bridge/app/lib/src/bridge/services/chat_history_service.dart
@@ -22,13 +22,20 @@ class ChatHistoryService {
   final Map<String, Future<void>> _writeQueues = {};
   final Map<String, Future<void>> _inFlightBackfills = {};
 
-  /// The session's messages, served from the store whenever it is known to be
-  /// current and falling back to the backend otherwise.
+  /// One page of the session's messages, served from the store whenever it is
+  /// known to be current and falling back to the backend otherwise.
+  ///
+  /// A null [limit] returns the whole transcript, which is what an app that
+  /// predates pagination asks for.
   ///
   /// The store is preferred only when a backfill has completed *and* no
   /// backend activity has been observed past the captured watermark, so a
   /// session advanced outside Sesori still reads correctly.
-  Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async {
+  Future<ChatHistoryPage> getSessionMessages({
+    required String sessionId,
+    int? limit,
+    int? before,
+  }) async {
     // Both the freshness decision and the read run inside the session queue,
     // so they observe one state. Deciding outside it would let queued work —
     // an observed import, or a failed capture clearing `syncedAt` — commit
@@ -41,7 +48,11 @@ class ChatHistoryService {
         if (state == null || state.syncedAt == null || state.watermark < state.backendActivityAt) {
           return null;
         }
-        return _chatHistoryRepository.getSessionMessages(sessionId: sessionId);
+        return _chatHistoryRepository.getSessionMessages(
+          sessionId: sessionId,
+          limit: limit,
+          before: before,
+        );
       },
     );
     if (decided != null) return decided;
@@ -51,7 +62,11 @@ class ChatHistoryService {
     // any capture that raced its fetch.
     return _enqueueRead(
       sessionId: sessionId,
-      read: () => _chatHistoryRepository.getSessionMessages(sessionId: sessionId),
+      read: () => _chatHistoryRepository.getSessionMessages(
+        sessionId: sessionId,
+        limit: limit,
+        before: before,
+      ),
     );
   }
 

--- a/bridge/app/test/bridge/routing/get_session_messages_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_session_messages_handler_test.dart
@@ -36,6 +36,21 @@ void main() {
       expect(handler.canHandle(makeRequest("GET", "/session")), isFalse);
     });
 
+    test("returns 400 for a non-positive limit", () async {
+      for (final limit in const [0, -1]) {
+        await expectLater(
+          () => handler.handle(
+            makeRequest("POST", "/session/messages"),
+            body: SessionMessagesRequest(sessionId: "session-1", limit: limit, before: null),
+            pathParams: const {},
+            queryParams: const {},
+            fragment: null,
+          ),
+          throwsA(isA<RelayResponse>().having((response) => response.status, "status", 400)),
+        );
+      }
+    });
+
     test("returns 400 when session id is empty", () async {
       await expectLater(
         () => handler.handle(

--- a/bridge/app/test/bridge/routing/get_session_messages_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_session_messages_handler_test.dart
@@ -40,7 +40,7 @@ void main() {
       await expectLater(
         () => handler.handle(
           makeRequest("POST", "/session/messages"),
-          body: const SessionIdRequest(sessionId: ""),
+          body: const SessionMessagesRequest(sessionId: "", limit: null, before: null),
           pathParams: {},
           queryParams: {},
           fragment: null,
@@ -52,7 +52,7 @@ void main() {
     test("uses request body sessionId as the session ID passed to plugin", () async {
       await handler.handle(
         makeRequest("POST", "/session/messages"),
-        body: const SessionIdRequest(sessionId: "session-xyz"),
+        body: const SessionMessagesRequest(sessionId: "session-xyz", limit: null, before: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -63,7 +63,7 @@ void main() {
     test("returns typed response", () async {
       final response = await handler.handle(
         makeRequest("POST", "/session/messages"),
-        body: const SessionIdRequest(sessionId: "s1"),
+        body: const SessionMessagesRequest(sessionId: "s1", limit: null, before: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -74,7 +74,7 @@ void main() {
     test("returns empty list when plugin has no messages", () async {
       final response = await handler.handle(
         makeRequest("POST", "/session/messages"),
-        body: const SessionIdRequest(sessionId: "s1"),
+        body: const SessionMessagesRequest(sessionId: "s1", limit: null, before: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -108,7 +108,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/session/messages"),
-        body: const SessionIdRequest(sessionId: "s1"),
+        body: const SessionMessagesRequest(sessionId: "s1", limit: null, before: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -124,7 +124,7 @@ void main() {
         makeRequest(
           "POST",
           "/session/messages",
-          body: jsonEncode(const SessionIdRequest(sessionId: "s1").toJson()),
+          body: jsonEncode(const SessionMessagesRequest(sessionId: "s1", limit: null, before: null).toJson()),
         ),
         pathParams: {},
         queryParams: {},

--- a/bridge/app/test/bridge/services/chat_history_capture_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_capture_test.dart
@@ -18,7 +18,7 @@ void main() {
       await history.service.capturePart(sessionId: "ses_a", part: _part(id: "p1", messageId: "m1", text: "one"));
       await history.service.capturePart(sessionId: "ses_a", part: _part(id: "p2", messageId: "m1", text: "two"));
 
-      final stored = await history.repository.getSessionMessages(sessionId: "ses_a");
+      final stored = (await history.repository.getSessionMessages(sessionId: "ses_a")).messages;
       expect(stored, hasLength(1));
       expect(stored.single.info.id, "m1");
       expect(stored.single.parts.map((part) => part.text), const ["one", "two"]);
@@ -30,7 +30,7 @@ void main() {
       await history.service.capturePart(sessionId: "ses_a", part: _part(id: "p1", messageId: "m1", text: "early"));
       await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "m1"));
 
-      final stored = await history.repository.getSessionMessages(sessionId: "ses_a");
+      final stored = (await history.repository.getSessionMessages(sessionId: "ses_a")).messages;
       expect(stored.single.parts.single.text, "early");
     });
 
@@ -45,7 +45,7 @@ void main() {
         part: _part(id: "p1", messageId: "m1", text: "one (final)"),
       );
 
-      final stored = await history.repository.getSessionMessages(sessionId: "ses_a");
+      final stored = (await history.repository.getSessionMessages(sessionId: "ses_a")).messages;
       expect(stored.single.parts.map((part) => part.text), const ["one (final)", "two"]);
     });
 
@@ -57,12 +57,12 @@ void main() {
 
       await history.service.capturePartRemoved(sessionId: "ses_a", messageId: "m1", partId: "p1");
       expect(
-        (await history.repository.getSessionMessages(sessionId: "ses_a")).single.parts.map((part) => part.id),
+        (await history.repository.getSessionMessages(sessionId: "ses_a")).messages.single.parts.map((part) => part.id),
         const ["p2"],
       );
 
       await history.service.captureMessageRemoved(sessionId: "ses_a", messageId: "m1");
-      expect(await history.repository.getSessionMessages(sessionId: "ses_a"), isEmpty);
+      expect((await history.repository.getSessionMessages(sessionId: "ses_a")).messages, isEmpty);
     });
 
     test("capture creates a sync row that is not marked synced", () async {
@@ -100,7 +100,7 @@ void main() {
       expect(rows.single.partJson, isNot(contains(base64Encode(bytes))));
       expect(rows.single.partJson, contains("stored_file"));
 
-      final served = (await history.repository.getSessionMessages(sessionId: "ses_a")).single.parts.single;
+      final served = (await history.repository.getSessionMessages(sessionId: "ses_a")).messages.single.parts.single;
       expect(
         served.attachment,
         isA<MessageAttachmentInlineImage>()
@@ -128,7 +128,7 @@ void main() {
 
       await history.spillStorage.deleteSession(sessionId: "ses_a");
 
-      final served = (await history.repository.getSessionMessages(sessionId: "ses_a")).single.parts.single;
+      final served = (await history.repository.getSessionMessages(sessionId: "ses_a")).messages.single.parts.single;
       expect(
         served.attachment,
         isA<MessageAttachmentMetadata>().having((data) => data.filename, "filename", "shot.png"),
@@ -145,7 +145,7 @@ void main() {
 
       await history.service.backfillSession(sessionId: "ses_a");
 
-      final stored = await history.repository.getSessionMessages(sessionId: "ses_a");
+      final stored = (await history.repository.getSessionMessages(sessionId: "ses_a")).messages;
       expect(stored.map((message) => message.info.id), const ["m1", "m2"]);
       expect((await history.repository.getSyncState(sessionId: "ses_a"))!.syncedAt, isNotNull);
     });
@@ -157,7 +157,7 @@ void main() {
 
       await history.service.backfillSession(sessionId: "ses_a");
 
-      final stored = await history.repository.getSessionMessages(sessionId: "ses_a");
+      final stored = (await history.repository.getSessionMessages(sessionId: "ses_a")).messages;
       expect(
         stored.map((message) => message.info.id),
         const ["m1", "live"],
@@ -203,7 +203,7 @@ void main() {
       // observation. A message the backend still reports is not deleted yet,
       // and mirroring the backend is the point of a backfill.
       expect(
-        (await history.repository.getSessionMessages(sessionId: "ses_a")).map((message) => message.info.id),
+        (await history.repository.getSessionMessages(sessionId: "ses_a")).messages.map((message) => message.info.id),
         const ["m1", "m2"],
       );
     });
@@ -222,7 +222,7 @@ void main() {
       await removal;
 
       expect(
-        (await history.repository.getSessionMessages(sessionId: "ses_a")).map((message) => message.info.id),
+        (await history.repository.getSessionMessages(sessionId: "ses_a")).messages.map((message) => message.info.id),
         const ["m1"],
       );
     });
@@ -242,7 +242,7 @@ void main() {
       await history.service.backfillSession(sessionId: "ses_a");
       await removal;
 
-      final stored = await history.repository.getSessionMessages(sessionId: "ses_a");
+      final stored = (await history.repository.getSessionMessages(sessionId: "ses_a")).messages;
       expect(stored.single.parts, isEmpty, reason: "the removal is newer than the fetched transcript");
     });
 
@@ -272,7 +272,7 @@ void main() {
 
       await history.service.backfillSession(sessionId: "ses_a");
 
-      expect(await history.repository.getSessionMessages(sessionId: "ses_a"), isEmpty);
+      expect((await history.repository.getSessionMessages(sessionId: "ses_a")).messages, isEmpty);
       expect((await history.repository.getSyncState(sessionId: "ses_a"))!.syncedAt, isNotNull);
     });
 
@@ -290,8 +290,8 @@ void main() {
         chatHistoryService: history.service,
       ).reconcile();
 
-      expect(await history.repository.getSessionMessages(sessionId: "ses_known"), hasLength(1));
-      expect(await history.repository.getSessionMessages(sessionId: "ses_orphan"), isEmpty);
+      expect((await history.repository.getSessionMessages(sessionId: "ses_known")).messages, hasLength(1));
+      expect((await history.repository.getSessionMessages(sessionId: "ses_orphan")).messages, isEmpty);
       expect(await history.repository.getSyncState(sessionId: "ses_orphan"), isNull);
     });
   });

--- a/bridge/app/test/bridge/services/chat_history_no_harness_start_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_no_harness_start_test.dart
@@ -52,7 +52,7 @@ void main() {
     expect(plugin.lastGetMessagesSessionId, "backend-a");
 
     plugin.lastGetMessagesSessionId = null;
-    final served = await history.service.getSessionMessages(sessionId: "ses_a");
+    final served = (await history.service.getSessionMessages(sessionId: "ses_a")).messages;
 
     expect(served.single.info.id, "m1");
     expect(

--- a/bridge/app/test/bridge/services/chat_history_pagination_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_pagination_test.dart
@@ -85,6 +85,15 @@ void main() {
       expect(next.nextCursor, isNull);
     });
 
+    test("an empty page never claims there is more", () async {
+      // A page that returned nothing cannot point a cursor at anything older,
+      // so it must terminate rather than invite another request.
+      final page = await history.repository.getSessionMessages(sessionId: "ses_a", limit: 0);
+
+      expect(page.messages, isEmpty);
+      expect(page.nextCursor, isNull);
+    });
+
     test("a session with no stored messages pages cleanly", () async {
       // ses_b was never backfilled, so the store holds nothing for it.
       final page = await history.repository.getSessionMessages(sessionId: "ses_b", limit: 5);

--- a/bridge/app/test/bridge/services/chat_history_pagination_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_pagination_test.dart
@@ -1,0 +1,157 @@
+import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "../../helpers/test_chat_history.dart";
+
+void main() {
+  group("paging over stored history", () {
+    late TestChatHistory history;
+
+    setUp(() async {
+      final repository = _FakeSessionRepository(
+        transcript: [for (var index = 1; index <= 10; index++) _messageWithParts(id: "m$index")],
+      );
+      history = createTestChatHistory(sessionRepository: repository);
+      await history.service.backfillSession(sessionId: "ses_a");
+    });
+
+    test("no limit returns the whole transcript with no cursor", () async {
+      final page = await history.service.getSessionMessages(sessionId: "ses_a");
+
+      expect(page.messages, hasLength(10));
+      expect(page.messages.first.info.id, "m1");
+      expect(page.nextCursor, isNull, reason: "an unpaged read is always complete");
+    });
+
+    test("a limit returns the newest page, oldest-first within it", () async {
+      final page = await history.service.getSessionMessages(sessionId: "ses_a", limit: 3);
+
+      expect(page.messages.map((message) => message.info.id), const ["m8", "m9", "m10"]);
+      expect(page.nextCursor, isNotNull);
+    });
+
+    test("the cursor is exclusive, so pages do not overlap", () async {
+      final first = await history.service.getSessionMessages(sessionId: "ses_a", limit: 3);
+      final second = await history.service.getSessionMessages(
+        sessionId: "ses_a",
+        limit: 3,
+        before: first.nextCursor,
+      );
+
+      expect(second.messages.map((message) => message.info.id), const ["m5", "m6", "m7"]);
+      expect(
+        second.messages.map((message) => message.info.id).toSet().intersection(
+          first.messages.map((message) => message.info.id).toSet(),
+        ),
+        isEmpty,
+      );
+    });
+
+    test("paging back reaches the start exactly once", () async {
+      final seen = <String>[];
+      int? cursor;
+      var pages = 0;
+      while (true) {
+        final page = await history.service.getSessionMessages(sessionId: "ses_a", limit: 4, before: cursor);
+        seen.insertAll(0, page.messages.map((message) => message.info.id));
+        pages++;
+        if (page.nextCursor == null) break;
+        cursor = page.nextCursor;
+        expect(pages, lessThan(10), reason: "paging must terminate");
+      }
+
+      expect(seen, [for (var index = 1; index <= 10; index++) "m$index"]);
+    });
+
+    test("a page carries the parts of its own messages only", () async {
+      final page = await history.service.getSessionMessages(sessionId: "ses_a", limit: 2);
+
+      expect(page.messages.every((message) => message.parts.length == 1), isTrue);
+      expect(page.messages.last.parts.single.messageID, "m10");
+    });
+
+    test("an exact-fit page still reports a cursor, and the next page ends it", () async {
+      final page = await history.service.getSessionMessages(sessionId: "ses_a", limit: 10);
+      expect(page.messages, hasLength(10));
+      expect(page.nextCursor, isNotNull, reason: "a full page cannot prove it is the last");
+
+      final next = await history.service.getSessionMessages(
+        sessionId: "ses_a",
+        limit: 10,
+        before: page.nextCursor,
+      );
+      expect(next.messages, isEmpty);
+      expect(next.nextCursor, isNull);
+    });
+
+    test("a session with no stored messages pages cleanly", () async {
+      // ses_b was never backfilled, so the store holds nothing for it.
+      final page = await history.repository.getSessionMessages(sessionId: "ses_b", limit: 5);
+
+      expect(page.messages, isEmpty);
+      expect(page.nextCursor, isNull);
+    });
+  });
+
+  group("wire compatibility", () {
+    test("an older app's body decodes, meaning the full transcript", () {
+      // What a pre-pagination client sends: sessionId only.
+      final request = SessionMessagesRequest.fromJson(const {"sessionId": "ses_a"});
+
+      expect(request.sessionId, "ses_a");
+      expect(request.limit, isNull);
+      expect(request.before, isNull);
+    });
+
+    test("an older bridge's response decodes as a complete transcript", () {
+      // What a pre-pagination bridge returns: no nextCursor field at all.
+      final response = MessageWithPartsResponse.fromJson(const {"messages": <Map<String, dynamic>>[]});
+
+      expect(response.nextCursor, isNull, reason: "absence means complete, so no load-older affordance");
+    });
+
+    test("a paging request round-trips", () {
+      const request = SessionMessagesRequest(sessionId: "ses_a", limit: 20, before: 40);
+
+      expect(SessionMessagesRequest.fromJson(request.toJson()), request);
+    });
+  });
+}
+
+Message _message({required String id}) =>
+    Message.user(id: id, sessionID: "ses_a", agent: null, time: const MessageTime(created: 1, completed: null));
+
+MessageWithParts _messageWithParts({required String id}) => MessageWithParts(
+  info: _message(id: id),
+  parts: [
+    MessagePart(
+      id: "$id-p1",
+      sessionID: "ses_a",
+      messageID: id,
+      type: MessagePartType.text,
+      text: "text of $id",
+      tool: null,
+      state: null,
+      prompt: null,
+      description: null,
+      agent: null,
+      agentName: null,
+      attempt: null,
+      retryError: null,
+      attachment: null,
+    ),
+  ],
+);
+
+class _FakeSessionRepository implements SessionRepository {
+  _FakeSessionRepository({required this.transcript});
+
+  final List<MessageWithParts> transcript;
+
+  @override
+  Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async => transcript;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/bridge/services/chat_history_serving_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_serving_test.dart
@@ -108,7 +108,7 @@ void main() {
         sessionId: "ses_a",
         activityAt: synced.watermark + 5000,
       );
-      final served = await history.service.getSessionMessages(sessionId: "ses_a");
+      final served = (await history.service.getSessionMessages(sessionId: "ses_a")).messages;
       await observed;
 
       expect(
@@ -132,7 +132,7 @@ void main() {
         sessionId: "ses_a",
         activityAt: synced.watermark + 5000,
       );
-      final served = await reading;
+      final served = (await reading).messages;
       await observing;
 
       expect(served.map((message) => message.info.id), const ["m1"]);
@@ -141,7 +141,7 @@ void main() {
 
       repository.transcript = [_messageWithParts(id: "m1"), _messageWithParts(id: "m2")];
       expect(
-        (await history.service.getSessionMessages(sessionId: "ses_a")).map((message) => message.info.id),
+        (await history.service.getSessionMessages(sessionId: "ses_a")).messages.map((message) => message.info.id),
         const ["m1", "m2"],
         reason: "the next read sees the staleness recorded during the previous one",
       );

--- a/bridge/app/test/bridge/services/chat_history_serving_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_serving_test.dart
@@ -14,7 +14,7 @@ void main() {
       );
       final history = createTestChatHistory(sessionRepository: repository);
 
-      final served = await history.service.getSessionMessages(sessionId: "ses_a");
+      final served = (await history.service.getSessionMessages(sessionId: "ses_a")).messages;
 
       expect(served, equals(repository.transcript), reason: "store-served output must equal plugin-served output");
       expect(repository.fetchCount, 1);
@@ -25,7 +25,7 @@ void main() {
       final history = createTestChatHistory(sessionRepository: repository);
       await history.service.getSessionMessages(sessionId: "ses_a");
 
-      final served = await history.service.getSessionMessages(sessionId: "ses_a");
+      final served = (await history.service.getSessionMessages(sessionId: "ses_a")).messages;
 
       expect(repository.fetchCount, 1, reason: "a synced store must not cold-start the backend");
       expect(served.map((message) => message.info.id), const ["m1"]);
@@ -44,7 +44,7 @@ void main() {
       repository.transcript = [_messageWithParts(id: "m1"), _messageWithParts(id: "m2")];
 
       expect(
-        (await history.service.getSessionMessages(sessionId: "ses_a")).map((message) => message.info.id),
+        (await history.service.getSessionMessages(sessionId: "ses_a")).messages.map((message) => message.info.id),
         const ["m1", "m2"],
         reason: "a session advanced outside Sesori must be re-read",
       );
@@ -85,7 +85,7 @@ void main() {
         unawaited(history.service.captureMessageRemoved(sessionId: "ses_a", messageId: "m2"));
       };
 
-      final served = await history.service.getSessionMessages(sessionId: "ses_a");
+      final served = (await history.service.getSessionMessages(sessionId: "ses_a")).messages;
 
       expect(
         served.map((message) => message.info.id),
@@ -151,8 +151,8 @@ void main() {
       final repository = _FakeSessionRepository(transcript: const []);
       final history = createTestChatHistory(sessionRepository: repository);
 
-      expect(await history.service.getSessionMessages(sessionId: "ses_a"), isEmpty);
-      expect(await history.service.getSessionMessages(sessionId: "ses_a"), isEmpty);
+      expect((await history.service.getSessionMessages(sessionId: "ses_a")).messages, isEmpty);
+      expect((await history.service.getSessionMessages(sessionId: "ses_a")).messages, isEmpty);
       expect(repository.fetchCount, 1, reason: "empty is a valid synced state, not a cache miss");
     });
 

--- a/client/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/client/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -150,7 +150,7 @@ void main() {
         isA<SessionDetailLoaded>(),
       ],
       verify: (_) {
-        verify(() => mockSessionService.getMessages(sessionId: sessionId)).called(1);
+        verify(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before"))).called(1);
         verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(1);
         verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
         verify(() => mockSessionService.getSessionStatuses()).called(1);
@@ -177,7 +177,7 @@ void main() {
       "initial load failure emits SessionDetailFailed",
       build: () {
         when(
-          () => mockSessionService.getMessages(sessionId: sessionId),
+          () => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before")),
         ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
 
         return SessionDetailCubit(
@@ -228,7 +228,7 @@ void main() {
         isA<SessionDetailLoaded>(),
       ],
       verify: (_) {
-        verify(() => mockSessionService.getMessages(sessionId: sessionId)).called(2);
+        verify(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before"))).called(2);
         verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(2);
         verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(2);
         verify(() => mockSessionService.getSessionStatuses()).called(2);
@@ -991,8 +991,8 @@ void main() {
       "SSE message.updated adds message to state",
       build: () {
         when(
-          () => mockSessionService.getMessages(sessionId: sessionId),
-        ).thenAnswer((_) async => ApiResponse.success(const MessageWithPartsResponse(messages: <MessageWithParts>[])));
+          () => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before")),
+        ).thenAnswer((_) async => ApiResponse.success(const MessageWithPartsResponse(messages: <MessageWithParts>[], nextCursor: null)));
 
         return SessionDetailCubit(
           mockConnectionService,
@@ -1341,18 +1341,18 @@ void main() {
       final completeSlowRefresh = Completer<void>();
 
       when(
-        () => mockSessionRepository.getMessages(sessionId: any(named: "sessionId")),
+        () => mockSessionRepository.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")),
       ).thenAnswer((_) {
         getMessagesCallCount += 1;
         if (getMessagesCallCount == 2) {
           slowRefreshStarted.complete();
           return completeSlowRefresh.future.then(
-            (_) => ApiResponse.success(MessageWithPartsResponse(messages: [testMessageWithParts()])),
+            (_) => ApiResponse.success(MessageWithPartsResponse(messages: [testMessageWithParts()], nextCursor: null)),
           );
         }
 
         return Future<ApiResponse<MessageWithPartsResponse>>.value(
-          ApiResponse.success(MessageWithPartsResponse(messages: [testMessageWithParts()])),
+          ApiResponse.success(MessageWithPartsResponse(messages: [testMessageWithParts()], nextCursor: null)),
         );
       });
 
@@ -1907,18 +1907,18 @@ void main() {
       final completeSlowRefresh = Completer<void>();
 
       when(
-        () => mockSessionRepository.getMessages(sessionId: any(named: "sessionId")),
+        () => mockSessionRepository.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")),
       ).thenAnswer((_) {
         getMessagesCallCount += 1;
         if (getMessagesCallCount == 2) {
           slowRefreshStarted.complete();
           return completeSlowRefresh.future.then(
-            (_) => ApiResponse.success(MessageWithPartsResponse(messages: [testMessageWithParts()])),
+            (_) => ApiResponse.success(MessageWithPartsResponse(messages: [testMessageWithParts()], nextCursor: null)),
           );
         }
 
         return Future<ApiResponse<MessageWithPartsResponse>>.value(
-          ApiResponse.success(MessageWithPartsResponse(messages: [testMessageWithParts()])),
+          ApiResponse.success(MessageWithPartsResponse(messages: [testMessageWithParts()], nextCursor: null)),
         );
       });
 
@@ -2307,7 +2307,7 @@ void main() {
 
       test("a failed load never declares the view", () async {
         when(
-          () => mockSessionService.getMessages(sessionId: sessionId),
+          () => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before")),
         ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
         final viewingService = stubbedSessionViewingService();
         final projectViewingService = stubbedProjectViewingService();
@@ -2424,7 +2424,7 @@ void main() {
 
         // The post-resume silent refresh completed and re-declared the view.
         verify(() => viewingService.setViewingSession(sessionId)).called(1);
-        verify(() => mockSessionService.getMessages(sessionId: sessionId)).called(greaterThanOrEqualTo(1));
+        verify(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before"))).called(greaterThanOrEqualTo(1));
       });
     });
   });
@@ -2489,10 +2489,10 @@ void _stubAllDefaults(
   required BehaviorSubject<ConnectionStatus> connectionStatus,
 }) {
   when(
-    () => service.getMessages(sessionId: any(named: "sessionId")),
+    () => service.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")),
   ).thenAnswer(
     (_) => Future<ApiResponse<MessageWithPartsResponse>>.value(
-      ApiResponse.success(MessageWithPartsResponse(messages: [testMessageWithParts()])),
+      ApiResponse.success(MessageWithPartsResponse(messages: [testMessageWithParts()], nextCursor: null)),
     ),
   );
   when(

--- a/client/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/client/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -150,7 +150,11 @@ void main() {
         isA<SessionDetailLoaded>(),
       ],
       verify: (_) {
-        verify(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before"))).called(1);
+        verify(() => mockSessionService.getMessages(
+          sessionId: sessionId,
+          limit: any(named: "limit"),
+          before: any(named: "before"),
+        )).called(1);
         verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(1);
         verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
         verify(() => mockSessionService.getSessionStatuses()).called(1);
@@ -177,7 +181,11 @@ void main() {
       "initial load failure emits SessionDetailFailed",
       build: () {
         when(
-          () => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before")),
+          () => mockSessionService.getMessages(
+            sessionId: sessionId,
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
         ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
 
         return SessionDetailCubit(
@@ -228,7 +236,11 @@ void main() {
         isA<SessionDetailLoaded>(),
       ],
       verify: (_) {
-        verify(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before"))).called(2);
+        verify(() => mockSessionService.getMessages(
+          sessionId: sessionId,
+          limit: any(named: "limit"),
+          before: any(named: "before"),
+        )).called(2);
         verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(2);
         verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(2);
         verify(() => mockSessionService.getSessionStatuses()).called(2);
@@ -991,8 +1003,14 @@ void main() {
       "SSE message.updated adds message to state",
       build: () {
         when(
-          () => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before")),
-        ).thenAnswer((_) async => ApiResponse.success(const MessageWithPartsResponse(messages: <MessageWithParts>[], nextCursor: null)));
+          () => mockSessionService.getMessages(
+            sessionId: sessionId,
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).thenAnswer((_) async => ApiResponse.success(
+          const MessageWithPartsResponse(messages: <MessageWithParts>[], nextCursor: null),
+        ));
 
         return SessionDetailCubit(
           mockConnectionService,
@@ -1341,7 +1359,11 @@ void main() {
       final completeSlowRefresh = Completer<void>();
 
       when(
-        () => mockSessionRepository.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")),
+        () => mockSessionRepository.getMessages(
+          sessionId: any(named: "sessionId"),
+          limit: any(named: "limit"),
+          before: any(named: "before"),
+        ),
       ).thenAnswer((_) {
         getMessagesCallCount += 1;
         if (getMessagesCallCount == 2) {
@@ -1907,7 +1929,11 @@ void main() {
       final completeSlowRefresh = Completer<void>();
 
       when(
-        () => mockSessionRepository.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")),
+        () => mockSessionRepository.getMessages(
+          sessionId: any(named: "sessionId"),
+          limit: any(named: "limit"),
+          before: any(named: "before"),
+        ),
       ).thenAnswer((_) {
         getMessagesCallCount += 1;
         if (getMessagesCallCount == 2) {
@@ -2307,7 +2333,11 @@ void main() {
 
       test("a failed load never declares the view", () async {
         when(
-          () => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before")),
+          () => mockSessionService.getMessages(
+            sessionId: sessionId,
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
         ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
         final viewingService = stubbedSessionViewingService();
         final projectViewingService = stubbedProjectViewingService();
@@ -2424,7 +2454,13 @@ void main() {
 
         // The post-resume silent refresh completed and re-declared the view.
         verify(() => viewingService.setViewingSession(sessionId)).called(1);
-        verify(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before"))).called(greaterThanOrEqualTo(1));
+        verify(
+          () => mockSessionService.getMessages(
+            sessionId: sessionId,
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).called(greaterThanOrEqualTo(1));
       });
     });
   });
@@ -2489,7 +2525,11 @@ void _stubAllDefaults(
   required BehaviorSubject<ConnectionStatus> connectionStatus,
 }) {
   when(
-    () => service.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")),
+    () => service.getMessages(
+      sessionId: any(named: "sessionId"),
+      limit: any(named: "limit"),
+      before: any(named: "before"),
+    ),
   ).thenAnswer(
     (_) => Future<ApiResponse<MessageWithPartsResponse>>.value(
       ApiResponse.success(MessageWithPartsResponse(messages: [testMessageWithParts()], nextCursor: null)),

--- a/client/app/test/helpers/test_helpers.dart
+++ b/client/app/test/helpers/test_helpers.dart
@@ -422,9 +422,17 @@ void delegateSessionRepositoryToService({
     ),
   );
   when(
-    () => repository.getMessages(sessionId: any(named: "sessionId")),
+    () => repository.getMessages(
+      sessionId: any(named: "sessionId"),
+      limit: any(named: "limit"),
+      before: any(named: "before"),
+    ),
   ).thenAnswer(
-    (invocation) => service.getMessages(sessionId: invocation.namedArguments[#sessionId]! as String),
+    (invocation) => service.getMessages(
+      sessionId: invocation.namedArguments[#sessionId]! as String,
+      limit: invocation.namedArguments[#limit] as int?,
+      before: invocation.namedArguments[#before] as int?,
+    ),
   );
   when(
     () => repository.getPendingQuestions(sessionId: any(named: "sessionId")),

--- a/client/module_core/lib/src/api/session_api.dart
+++ b/client/module_core/lib/src/api/session_api.dart
@@ -223,11 +223,17 @@ class SessionApi {
     );
   }
 
-  Future<ApiResponse<MessageWithPartsResponse>> getMessages({required String sessionId}) {
+  /// A page of the session's messages. A null [limit] requests the whole
+  /// transcript, which is also what an older bridge always returns.
+  Future<ApiResponse<MessageWithPartsResponse>> getMessages({
+    required String sessionId,
+    required int? limit,
+    required int? before,
+  }) {
     return _client.post(
       "/session/messages",
       fromJson: MessageWithPartsResponse.fromJson,
-      body: SessionIdRequest(sessionId: sessionId),
+      body: SessionMessagesRequest(sessionId: sessionId, limit: limit, before: before),
     );
   }
 

--- a/client/module_core/lib/src/capabilities/session/session_service.dart
+++ b/client/module_core/lib/src/capabilities/session/session_service.dart
@@ -63,8 +63,12 @@ class SessionService {
     return _repository.rejectQuestion(requestId: requestId, sessionId: sessionId);
   }
 
-  Future<ApiResponse<MessageWithPartsResponse>> getMessages({required String sessionId}) {
-    return _repository.getMessages(sessionId: sessionId);
+  Future<ApiResponse<MessageWithPartsResponse>> getMessages({
+    required String sessionId,
+    required int? limit,
+    required int? before,
+  }) {
+    return _repository.getMessages(sessionId: sessionId, limit: limit, before: before);
   }
 
   Future<ApiResponse<PendingQuestionResponse>> getPendingQuestions({required String sessionId}) {

--- a/client/module_core/lib/src/repositories/session_repository.dart
+++ b/client/module_core/lib/src/repositories/session_repository.dart
@@ -66,8 +66,12 @@ class SessionRepository {
     return _api.rejectQuestion(requestId: requestId, sessionId: sessionId);
   }
 
-  Future<ApiResponse<MessageWithPartsResponse>> getMessages({required String sessionId}) {
-    return _api.getMessages(sessionId: sessionId);
+  Future<ApiResponse<MessageWithPartsResponse>> getMessages({
+    required String sessionId,
+    required int? limit,
+    required int? before,
+  }) {
+    return _api.getMessages(sessionId: sessionId, limit: limit, before: before);
   }
 
   Future<ApiResponse<PendingQuestionResponse>> getPendingQuestions({required String sessionId}) {

--- a/client/module_core/lib/src/services/session_detail_load_service.dart
+++ b/client/module_core/lib/src/services/session_detail_load_service.dart
@@ -44,7 +44,9 @@ class SessionDetailLoadService {
 
     try {
       final routeProjectId = projectId.normalize();
-      final messagesFuture = _repository.getMessages(sessionId: sessionId);
+      // Paging policy lands in step 7/8; until then the initial snapshot keeps
+    // asking for the whole transcript, exactly as before.
+    final messagesFuture = _repository.getMessages(sessionId: sessionId, limit: null, before: null);
       final childrenFuture = _repository.getChildren(sessionId: sessionId);
       final sessionResponse = await _repository.getSession(sessionId: sessionId);
       final session = switch (sessionResponse) {

--- a/client/module_core/lib/src/services/session_detail_load_service.dart
+++ b/client/module_core/lib/src/services/session_detail_load_service.dart
@@ -45,8 +45,8 @@ class SessionDetailLoadService {
     try {
       final routeProjectId = projectId.normalize();
       // Paging policy lands in step 7/8; until then the initial snapshot keeps
-    // asking for the whole transcript, exactly as before.
-    final messagesFuture = _repository.getMessages(sessionId: sessionId, limit: null, before: null);
+      // asking for the whole transcript, exactly as before.
+      final messagesFuture = _repository.getMessages(sessionId: sessionId, limit: null, before: null);
       final childrenFuture = _repository.getChildren(sessionId: sessionId);
       final sessionResponse = await _repository.getSession(sessionId: sessionId);
       final session = switch (sessionResponse) {

--- a/client/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
@@ -287,7 +287,7 @@ void main() {
       );
 
       expect(result, isFalse);
-      verify(() => mockSessionService.getMessages(sessionId: sessionId)).called(1);
+      verify(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before"))).called(1);
       verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getSessionStatuses()).called(1);
@@ -447,7 +447,7 @@ void main() {
 
     test("non-loaded state buffers permission events and replays after loaded", () async {
       final messagesCompleter = Completer<ApiResponse<MessageWithPartsResponse>>();
-      when(() => mockSessionService.getMessages(sessionId: sessionId)).thenAnswer((_) => messagesCompleter.future);
+      when(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before"))).thenAnswer((_) => messagesCompleter.future);
 
       final cubit = _buildCubit(
         sessionId: sessionId,
@@ -473,7 +473,7 @@ void main() {
 
       expect(cubit.state, const SessionDetailState.loading());
 
-      messagesCompleter.complete(ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()])));
+      messagesCompleter.complete(ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)));
       await _awaitLoaded(cubit);
 
       // The buffered permission event should have been replayed after load
@@ -738,10 +738,10 @@ SessionDetailCubit _buildCubit({
 
 void _stubLoadApis(MockSessionService service, {required String sessionId}) {
   when(
-    () => service.getMessages(sessionId: any(named: "sessionId")),
+    () => service.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")),
   ).thenAnswer(
     (_) => Future<ApiResponse<MessageWithPartsResponse>>.value(
-      ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()])),
+      ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
     ),
   );
   when(

--- a/client/module_core/test/cubits/session_detail/session_detail_reconnect_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_reconnect_test.dart
@@ -109,7 +109,7 @@ void main() {
     await _awaitLoaded(cubit);
 
     expect(cubit.state, isA<SessionDetailLoaded>());
-    verify(() => mockSessionService.getMessages(sessionId: _sessionId)).called(1);
+    verify(() => mockSessionService.getMessages(sessionId: _sessionId, limit: any(named: "limit"), before: any(named: "before"))).called(1);
   });
 
   test("reloads immediately when waiting result arrives after connection already recovered", () async {
@@ -318,8 +318,8 @@ void main() {
 
 void _stubLoadApis(MockSessionService service) {
   when(
-    () => service.getMessages(sessionId: _sessionId),
-  ).thenAnswer((_) async => ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()])));
+    () => service.getMessages(sessionId: _sessionId, limit: any(named: "limit"), before: any(named: "before")),
+  ).thenAnswer((_) async => ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)));
   when(
     () => service.getPendingQuestions(sessionId: _sessionId),
   ).thenAnswer((_) async => ApiResponse.success(const PendingQuestionResponse(data: <PendingQuestion>[])));

--- a/client/module_core/test/cubits/session_detail/session_detail_stale_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_stale_test.dart
@@ -141,9 +141,9 @@ void main() {
         connectionStatus.add(connectionLostStatus);
         await pumpEventQueue();
 
-        when(() => mockSessionService.getMessages(sessionId: sessionId)).thenAnswer(
+        when(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before"))).thenAnswer(
           (_) async =>
-              ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts(messageId: "msg-refreshed")])),
+              ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts(messageId: "msg-refreshed")], nextCursor: null)),
         );
 
         final emitted = <SessionDetailState>[];
@@ -153,7 +153,7 @@ void main() {
         mockConnectionService.emitDataMayBeStale();
         await pumpEventQueue();
 
-        verifyNever(() => mockSessionService.getMessages(sessionId: sessionId));
+        verifyNever(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before")));
         verifyNever(() => mockSessionService.getPendingQuestions(sessionId: sessionId));
         verifyNever(() => mockSessionService.getChildren(sessionId: sessionId));
         verifyNever(() => mockSessionService.getSessionStatuses());
@@ -205,9 +205,9 @@ void main() {
       await _awaitLoaded(cubit);
       clearInteractions(mockSessionService);
 
-      when(() => mockSessionService.getMessages(sessionId: sessionId)).thenAnswer(
+      when(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before"))).thenAnswer(
         (_) async =>
-            ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts(messageId: "msg-immediate")])),
+            ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts(messageId: "msg-immediate")], nextCursor: null)),
       );
 
       final emitted = <SessionDetailState>[];
@@ -217,7 +217,7 @@ void main() {
       mockConnectionService.emitDataMayBeStale();
       await pumpEventQueue();
 
-      verify(() => mockSessionService.getMessages(sessionId: sessionId)).called(1);
+      verify(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before"))).called(1);
       verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getSessionStatuses()).called(1);
@@ -424,7 +424,7 @@ void main() {
       clearInteractions(mockSessionService);
 
       final messagesCompleter = Completer<ApiResponse<MessageWithPartsResponse>>();
-      when(() => mockSessionService.getMessages(sessionId: sessionId)).thenAnswer((_) => messagesCompleter.future);
+      when(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before"))).thenAnswer((_) => messagesCompleter.future);
       when(
         () => mockSessionService.getPendingQuestions(sessionId: sessionId),
       ).thenAnswer((_) async => ApiResponse.success(const PendingQuestionResponse(data: <PendingQuestion>[])));
@@ -468,7 +468,7 @@ void main() {
       await pumpEventQueue();
 
       messagesCompleter.complete(
-        ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts(messageId: "msg-race")])),
+        ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts(messageId: "msg-race")], nextCursor: null)),
       );
       await pumpEventQueue();
 
@@ -498,9 +498,9 @@ void main() {
 
       await _awaitLoaded(cubit);
 
-      when(() => mockSessionService.getMessages(sessionId: sessionId)).thenAnswer(
+      when(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before"))).thenAnswer(
         (_) async => ApiResponse.success(
-          MessageWithPartsResponse(messages: [_messageWithParts(messageId: "msg-provider-fallback")]),
+          MessageWithPartsResponse(messages: [_messageWithParts(messageId: "msg-provider-fallback")], nextCursor: null),
         ),
       );
       when(
@@ -521,7 +521,7 @@ void main() {
 
     test("stale signal is ignored when state is SessionDetailLoading", () async {
       final messagesCompleter = Completer<ApiResponse<MessageWithPartsResponse>>();
-      when(() => mockSessionService.getMessages(sessionId: sessionId)).thenAnswer((_) => messagesCompleter.future);
+      when(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before"))).thenAnswer((_) => messagesCompleter.future);
 
       final cubit = SessionDetailCubit(
         mockConnectionService,
@@ -542,7 +542,7 @@ void main() {
       mockConnectionService.emitDataMayBeStale();
       await pumpEventQueue();
 
-      verify(() => mockSessionService.getMessages(sessionId: sessionId)).called(1);
+      verify(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before"))).called(1);
       verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getPendingPermissions(sessionId: any(named: "sessionId"))).called(1);
       verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
@@ -560,14 +560,14 @@ void main() {
         ),
       ).called(1);
 
-      messagesCompleter.complete(ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()])));
+      messagesCompleter.complete(ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)));
       await _awaitLoaded(cubit);
       await cubit.close();
     });
 
     test("stale signal is ignored when state is SessionDetailFailed", () async {
       when(
-        () => mockSessionService.getMessages(sessionId: sessionId),
+        () => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before")),
       ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
 
       final cubit = SessionDetailCubit(
@@ -591,7 +591,7 @@ void main() {
       mockConnectionService.emitDataMayBeStale();
       await pumpEventQueue();
 
-      verify(() => mockSessionService.getMessages(sessionId: sessionId)).called(1);
+      verify(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before"))).called(1);
       expect(cubit.state, isA<SessionDetailFailed>());
     });
 
@@ -629,7 +629,7 @@ void main() {
         final error = StateError("silent refresh sentinel");
 
         when(
-          () => mockSessionService.getMessages(sessionId: sessionId),
+          () => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before")),
         ).thenThrow(error);
 
         final emitted = <SessionDetailState>[];
@@ -696,13 +696,13 @@ void main() {
       );
       var messageLoads = 0;
       when(
-        () => mockSessionService.getMessages(sessionId: any(named: "sessionId")),
+        () => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")),
       ).thenAnswer((_) async {
         messageLoads++;
         if (messageLoads == 1) {
           return ApiResponse.error(ApiError.generic());
         }
-        return ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()]));
+        return ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null));
       });
 
       mockConnectionService.emitDataMayBeStale();
@@ -750,12 +750,12 @@ void main() {
       final firstMessages = Completer<ApiResponse<MessageWithPartsResponse>>();
       var messageLoads = 0;
       when(
-        () => mockSessionService.getMessages(sessionId: any(named: "sessionId")),
+        () => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")),
       ).thenAnswer((_) {
         messageLoads++;
         if (messageLoads == 1) return firstMessages.future;
         return Future.value(
-          ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()])),
+          ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
         );
       });
 
@@ -802,7 +802,7 @@ void main() {
       reset(mockSessionService);
 
       final messagesCompleter = Completer<ApiResponse<MessageWithPartsResponse>>();
-      when(() => mockSessionService.getMessages(sessionId: sessionId)).thenAnswer((_) => messagesCompleter.future);
+      when(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before"))).thenAnswer((_) => messagesCompleter.future);
       when(
         () => mockSessionService.getPendingQuestions(sessionId: sessionId),
       ).thenAnswer((_) async => ApiResponse.success(const PendingQuestionResponse(data: <PendingQuestion>[])));
@@ -843,11 +843,11 @@ void main() {
       await pumpEventQueue();
 
       messagesCompleter.complete(
-        ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts(messageId: "msg-coalesced")])),
+        ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts(messageId: "msg-coalesced")], nextCursor: null)),
       );
       await pumpEventQueue();
 
-      verify(() => mockSessionService.getMessages(sessionId: sessionId)).called(1);
+      verify(() => mockSessionService.getMessages(sessionId: sessionId, limit: any(named: "limit"), before: any(named: "before"))).called(1);
       verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getPendingPermissions(sessionId: any(named: "sessionId"))).called(1);
       verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
@@ -903,16 +903,16 @@ void main() {
       mockConnectionService.emitDataMayBeStale();
       mockConnectionService.emitDataMayBeStale();
       await pumpEventQueue();
-      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"))).called(1);
+      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before"))).called(1);
 
       // Once the cooldown elapses, the queued signals collapse into exactly
       // one trailing refresh...
       await Future<void>.delayed(const Duration(milliseconds: 120));
-      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"))).called(1);
+      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before"))).called(1);
 
       // ...and a drained queue schedules nothing further.
       await Future<void>.delayed(const Duration(milliseconds: 150));
-      verifyNever(() => mockSessionService.getMessages(sessionId: any(named: "sessionId")));
+      verifyNever(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")));
     });
 
     test("a queued signal survives a refresh that outlives the cooldown window", () async {
@@ -950,31 +950,31 @@ void main() {
       // the entire cooldown window.
       final messagesCompleter = Completer<ApiResponse<MessageWithPartsResponse>>();
       when(
-        () => mockSessionService.getMessages(sessionId: any(named: "sessionId")),
+        () => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")),
       ).thenAnswer((_) => messagesCompleter.future);
 
       mockConnectionService.emitDataMayBeStale();
       mockConnectionService.emitDataMayBeStale();
       await pumpEventQueue();
-      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"))).called(1);
+      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before"))).called(1);
 
       // The cooldown elapses while the first refresh is still in flight; the
       // queued signal must be retained, not silently coalesced into the
       // stale in-flight run.
       await Future<void>.delayed(const Duration(milliseconds: 120));
       when(
-        () => mockSessionService.getMessages(sessionId: any(named: "sessionId")),
+        () => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")),
       ).thenAnswer(
-        (_) async => ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()])),
+        (_) async => ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
       );
       messagesCompleter.complete(
-        ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()])),
+        ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
       );
 
       // Once the next window elapses, the retained signal produces the
       // trailing refresh against fresh data.
       await Future<void>.delayed(const Duration(milliseconds: 150));
-      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"))).called(1);
+      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before"))).called(1);
     });
 
     test("the trailing refresh runs as soon as a slow refresh completes, not a window later", () async {
@@ -1010,27 +1010,27 @@ void main() {
 
       final messagesCompleter = Completer<ApiResponse<MessageWithPartsResponse>>();
       when(
-        () => mockSessionService.getMessages(sessionId: any(named: "sessionId")),
+        () => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")),
       ).thenAnswer((_) => messagesCompleter.future);
 
       mockConnectionService.emitDataMayBeStale();
       mockConnectionService.emitDataMayBeStale();
       await Future<void>.delayed(const Duration(milliseconds: 120));
-      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"))).called(1);
+      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before"))).called(1);
 
       // The minimum interval elapsed mid-refresh; when the slow refresh
       // finally completes, the queued trailing refresh must start right away
       // rather than waiting out another full cooldown window.
       when(
-        () => mockSessionService.getMessages(sessionId: any(named: "sessionId")),
+        () => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")),
       ).thenAnswer(
-        (_) async => ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()])),
+        (_) async => ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
       );
       messagesCompleter.complete(
-        ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()])),
+        ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
       );
       await pumpEventQueue();
-      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"))).called(1);
+      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before"))).called(1);
     });
 
     test("the queue is held while hidden and consumed by the resume refresh", () async {
@@ -1068,22 +1068,22 @@ void main() {
       mockConnectionService.emitDataMayBeStale();
       mockConnectionService.emitDataMayBeStale();
       await pumpEventQueue();
-      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"))).called(1);
+      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before"))).called(1);
 
       // Backgrounding cancels the cooldown: the queued trailing refresh must
       // not spend the radio while the app is hidden.
       lifecycle.emitState(LifecycleState.paused);
       await Future<void>.delayed(const Duration(milliseconds: 300));
-      verifyNever(() => mockSessionService.getMessages(sessionId: any(named: "sessionId")));
+      verifyNever(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")));
 
       // The resume bypass refresh consumes the held signal...
       lifecycle.emitState(LifecycleState.resumed);
       await pumpEventQueue();
-      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"))).called(1);
+      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before"))).called(1);
 
       // ...so nothing further fires afterwards.
       await Future<void>.delayed(const Duration(milliseconds: 300));
-      verifyNever(() => mockSessionService.getMessages(sessionId: any(named: "sessionId")));
+      verifyNever(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")));
     });
 
     test("a failed resume refresh preserves hidden staleness until a snapshot succeeds", () async {
@@ -1119,13 +1119,13 @@ void main() {
       );
       var messageLoads = 0;
       when(
-        () => mockSessionService.getMessages(sessionId: any(named: "sessionId")),
+        () => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")),
       ).thenAnswer((_) async {
         messageLoads++;
         if (messageLoads == 1) {
           return ApiResponse.error(ApiError.generic());
         }
-        return ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()]));
+        return ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null));
       });
 
       lifecycle.emitState(LifecycleState.paused);
@@ -1178,14 +1178,14 @@ void main() {
 
       final messagesCompleter = Completer<ApiResponse<MessageWithPartsResponse>>();
       when(
-        () => mockSessionService.getMessages(sessionId: any(named: "sessionId")),
+        () => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")),
       ).thenAnswer((_) => messagesCompleter.future);
 
       // Refresh A starts and stays in flight; a second signal queues.
       mockConnectionService.emitDataMayBeStale();
       mockConnectionService.emitDataMayBeStale();
       await pumpEventQueue();
-      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"))).called(1);
+      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before"))).called(1);
 
       // Pause cancels the cooldown (the only armed trailing trigger); the
       // resume bypass finds A still in flight and cannot start a refresh.
@@ -1196,25 +1196,25 @@ void main() {
       // When A finally completes, the queued signal must still produce the
       // trailing refresh instead of being stranded.
       when(
-        () => mockSessionService.getMessages(sessionId: any(named: "sessionId")),
+        () => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")),
       ).thenAnswer(
-        (_) async => ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()])),
+        (_) async => ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
       );
       messagesCompleter.complete(
-        ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()])),
+        ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
       );
       await pumpEventQueue();
-      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"))).called(1);
+      verify(() => mockSessionService.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before"))).called(1);
     });
   });
 }
 
 void _stubLoadApis(MockSessionService service, {required String sessionId}) {
   when(
-    () => service.getMessages(sessionId: any(named: "sessionId")),
+    () => service.getMessages(sessionId: any(named: "sessionId"), limit: any(named: "limit"), before: any(named: "before")),
   ).thenAnswer(
     (_) => Future<ApiResponse<MessageWithPartsResponse>>.value(
-      ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()])),
+      ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
     ),
   );
   when(

--- a/client/module_core/test/helpers/test_helpers.dart
+++ b/client/module_core/test/helpers/test_helpers.dart
@@ -297,9 +297,17 @@ void delegateSessionRepositoryToService({
     ),
   );
   when(
-    () => repository.getMessages(sessionId: any(named: "sessionId")),
+    () => repository.getMessages(
+      sessionId: any(named: "sessionId"),
+      limit: any(named: "limit"),
+      before: any(named: "before"),
+    ),
   ).thenAnswer(
-    (invocation) => service.getMessages(sessionId: invocation.namedArguments[#sessionId]! as String),
+    (invocation) => service.getMessages(
+      sessionId: invocation.namedArguments[#sessionId]! as String,
+      limit: invocation.namedArguments[#limit] as int?,
+      before: invocation.namedArguments[#before] as int?,
+    ),
   );
   when(
     () => repository.getPendingQuestions(sessionId: any(named: "sessionId")),

--- a/client/module_core/test/repositories/session_repository_test.dart
+++ b/client/module_core/test/repositories/session_repository_test.dart
@@ -18,8 +18,8 @@ void main() {
     final api = MockSessionApi();
     final repository = SessionRepository(api: api);
 
-    when(() => api.getMessages(sessionId: "session-1")).thenAnswer(
-      (_) async => ApiResponse.success(const MessageWithPartsResponse(messages: <MessageWithParts>[])),
+    when(() => api.getMessages(sessionId: "session-1", limit: null, before: null)).thenAnswer(
+      (_) async => ApiResponse.success(const MessageWithPartsResponse(messages: <MessageWithParts>[], nextCursor: null)),
     );
     when(() => api.getPendingQuestions(sessionId: "session-1")).thenAnswer(
       (_) async => ApiResponse.success(const PendingQuestionResponse(data: <PendingQuestion>[])),
@@ -75,7 +75,7 @@ void main() {
     when(
       () => api.rejectQuestion(requestId: "question-1", sessionId: "session-1"),
     ).thenAnswer((_) async => ApiResponse.success(null));
-    await repository.getMessages(sessionId: "session-1");
+    await repository.getMessages(sessionId: "session-1", limit: null, before: null);
     await repository.getPendingQuestions(sessionId: "session-1");
     await repository.getPendingPermissions(sessionId: "session-1");
     await repository.getChildren(sessionId: "session-1");
@@ -100,7 +100,7 @@ void main() {
       ],
     );
     await repository.rejectQuestion(requestId: "question-1", sessionId: "session-1");
-    verify(() => api.getMessages(sessionId: "session-1")).called(1);
+    verify(() => api.getMessages(sessionId: "session-1", limit: null, before: null)).called(1);
     verify(() => api.getPendingQuestions(sessionId: "session-1")).called(1);
     verify(() => api.getPendingPermissions(sessionId: "session-1")).called(1);
     verify(() => api.getChildren(sessionId: "session-1")).called(1);

--- a/client/module_core/test/services/session_detail_load_service_test.dart
+++ b/client/module_core/test/services/session_detail_load_service_test.dart
@@ -192,7 +192,7 @@ void main() {
     test("connected API failure does not auto-loop", () async {
       connectionStatus.add(connectedStatus);
       when(
-        () => repository.getMessages(sessionId: "session-1"),
+        () => repository.getMessages(sessionId: "session-1", limit: null, before: null),
       ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
       when(
         () => repository.getPendingQuestions(sessionId: "session-1"),
@@ -227,7 +227,7 @@ void main() {
       final result = await service.load(sessionId: "session-1", projectId: "project-1");
 
       expect(result, isA<SessionDetailLoadResultFailed>());
-      verify(() => repository.getMessages(sessionId: "session-1")).called(1);
+      verify(() => repository.getMessages(sessionId: "session-1", limit: null, before: null)).called(1);
     });
 
     test("load falls back to carried title state when canonical title is unavailable", () async {
@@ -353,8 +353,10 @@ void _stubRepositorySnapshot({
   String? canonicalSessionTitle = "Canonical title",
 }) {
   when(
-    () => repository.getMessages(sessionId: "session-1"),
-  ).thenAnswer((_) async => ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()])));
+    () => repository.getMessages(sessionId: "session-1", limit: null, before: null),
+  ).thenAnswer(
+    (_) async => ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
+  );
   when(
     () => repository.getPendingQuestions(sessionId: "session-1"),
   ).thenAnswer((_) async => ApiResponse.success(const PendingQuestionResponse(data: <PendingQuestion>[])));

--- a/shared/sesori_shared/lib/src/models/sesori/message_with_parts.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_with_parts.dart
@@ -12,6 +12,12 @@ part "message_with_parts.g.dart";
 sealed class MessageWithPartsResponse with _$MessageWithPartsResponse {
   const factory MessageWithPartsResponse({
     required List<MessageWithParts> messages,
+
+    /// Cursor for the next older page, to be sent back verbatim as the
+    /// request's `before`. Null means the transcript is complete — either
+    /// because everything was returned, or because the bridge predates
+    /// pagination and always returns everything.
+    required int? nextCursor,
   }) = _MessageWithPartsResponse;
 
   factory MessageWithPartsResponse.fromJson(Map<String, dynamic> json) => _$MessageWithPartsResponseFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/message_with_parts.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_with_parts.dart
@@ -14,9 +14,8 @@ sealed class MessageWithPartsResponse with _$MessageWithPartsResponse {
     required List<MessageWithParts> messages,
 
     /// Cursor for the next older page, to be sent back verbatim as the
-    /// request's `before`. Null means the transcript is complete — either
-    /// because everything was returned, or because the bridge predates
-    /// pagination and always returns everything.
+    /// request's `before`. Null means the transcript is complete.
+    // COMPATIBILITY 2026-08-08 (v1.7.2): Bridges that predate pagination omit nextCursor, which decodes to null and correctly means "complete". Make this required once those bridges are unsupported.
     required int? nextCursor,
   }) = _MessageWithPartsResponse;
 

--- a/shared/sesori_shared/lib/src/models/sesori/message_with_parts.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_with_parts.freezed.dart
@@ -16,9 +16,8 @@ T _$identity<T>(T value) => value;
 mixin _$MessageWithPartsResponse {
 
  List<MessageWithParts> get messages;/// Cursor for the next older page, to be sent back verbatim as the
-/// request's `before`. Null means the transcript is complete — either
-/// because everything was returned, or because the bridge predates
-/// pagination and always returns everything.
+/// request's `before`. Null means the transcript is complete.
+// COMPATIBILITY 2026-08-08 (v1.7.2): Bridges that predate pagination omit nextCursor, which decodes to null and correctly means "complete". Make this required once those bridges are unsupported.
  int? get nextCursor;
 /// Create a copy of MessageWithPartsResponse
 /// with the given fields replaced by the non-null parameter values.
@@ -96,9 +95,8 @@ class _MessageWithPartsResponse implements MessageWithPartsResponse {
 }
 
 /// Cursor for the next older page, to be sent back verbatim as the
-/// request's `before`. Null means the transcript is complete — either
-/// because everything was returned, or because the bridge predates
-/// pagination and always returns everything.
+/// request's `before`. Null means the transcript is complete.
+// COMPATIBILITY 2026-08-08 (v1.7.2): Bridges that predate pagination omit nextCursor, which decodes to null and correctly means "complete". Make this required once those bridges are unsupported.
 @override final  int? nextCursor;
 
 /// Create a copy of MessageWithPartsResponse

--- a/shared/sesori_shared/lib/src/models/sesori/message_with_parts.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_with_parts.freezed.dart
@@ -15,7 +15,11 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MessageWithPartsResponse {
 
- List<MessageWithParts> get messages;
+ List<MessageWithParts> get messages;/// Cursor for the next older page, to be sent back verbatim as the
+/// request's `before`. Null means the transcript is complete — either
+/// because everything was returned, or because the bridge predates
+/// pagination and always returns everything.
+ int? get nextCursor;
 /// Create a copy of MessageWithPartsResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +32,16 @@ $MessageWithPartsResponseCopyWith<MessageWithPartsResponse> get copyWith => _$Me
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MessageWithPartsResponse&&const DeepCollectionEquality().equals(other.messages, messages));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MessageWithPartsResponse&&const DeepCollectionEquality().equals(other.messages, messages)&&(identical(other.nextCursor, nextCursor) || other.nextCursor == nextCursor));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(messages));
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(messages),nextCursor);
 
 @override
 String toString() {
-  return 'MessageWithPartsResponse(messages: $messages)';
+  return 'MessageWithPartsResponse(messages: $messages, nextCursor: $nextCursor)';
 }
 
 
@@ -48,7 +52,7 @@ abstract mixin class $MessageWithPartsResponseCopyWith<$Res>  {
   factory $MessageWithPartsResponseCopyWith(MessageWithPartsResponse value, $Res Function(MessageWithPartsResponse) _then) = _$MessageWithPartsResponseCopyWithImpl;
 @useResult
 $Res call({
- List<MessageWithParts> messages
+ List<MessageWithParts> messages, int? nextCursor
 });
 
 
@@ -65,10 +69,11 @@ class _$MessageWithPartsResponseCopyWithImpl<$Res>
 
 /// Create a copy of MessageWithPartsResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? messages = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? messages = null,Object? nextCursor = freezed,}) {
   return _then(_self.copyWith(
 messages: null == messages ? _self.messages : messages // ignore: cast_nullable_to_non_nullable
-as List<MessageWithParts>,
+as List<MessageWithParts>,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 
@@ -80,7 +85,7 @@ as List<MessageWithParts>,
 @JsonSerializable()
 
 class _MessageWithPartsResponse implements MessageWithPartsResponse {
-  const _MessageWithPartsResponse({required final  List<MessageWithParts> messages}): _messages = messages;
+  const _MessageWithPartsResponse({required final  List<MessageWithParts> messages, required this.nextCursor}): _messages = messages;
   factory _MessageWithPartsResponse.fromJson(Map<String, dynamic> json) => _$MessageWithPartsResponseFromJson(json);
 
  final  List<MessageWithParts> _messages;
@@ -90,6 +95,11 @@ class _MessageWithPartsResponse implements MessageWithPartsResponse {
   return EqualUnmodifiableListView(_messages);
 }
 
+/// Cursor for the next older page, to be sent back verbatim as the
+/// request's `before`. Null means the transcript is complete — either
+/// because everything was returned, or because the bridge predates
+/// pagination and always returns everything.
+@override final  int? nextCursor;
 
 /// Create a copy of MessageWithPartsResponse
 /// with the given fields replaced by the non-null parameter values.
@@ -104,16 +114,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MessageWithPartsResponse&&const DeepCollectionEquality().equals(other._messages, _messages));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MessageWithPartsResponse&&const DeepCollectionEquality().equals(other._messages, _messages)&&(identical(other.nextCursor, nextCursor) || other.nextCursor == nextCursor));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_messages));
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_messages),nextCursor);
 
 @override
 String toString() {
-  return 'MessageWithPartsResponse(messages: $messages)';
+  return 'MessageWithPartsResponse(messages: $messages, nextCursor: $nextCursor)';
 }
 
 
@@ -124,7 +134,7 @@ abstract mixin class _$MessageWithPartsResponseCopyWith<$Res> implements $Messag
   factory _$MessageWithPartsResponseCopyWith(_MessageWithPartsResponse value, $Res Function(_MessageWithPartsResponse) _then) = __$MessageWithPartsResponseCopyWithImpl;
 @override @useResult
 $Res call({
- List<MessageWithParts> messages
+ List<MessageWithParts> messages, int? nextCursor
 });
 
 
@@ -141,10 +151,11 @@ class __$MessageWithPartsResponseCopyWithImpl<$Res>
 
 /// Create a copy of MessageWithPartsResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? messages = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? messages = null,Object? nextCursor = freezed,}) {
   return _then(_MessageWithPartsResponse(
 messages: null == messages ? _self._messages : messages // ignore: cast_nullable_to_non_nullable
-as List<MessageWithParts>,
+as List<MessageWithParts>,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/message_with_parts.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_with_parts.g.dart
@@ -14,12 +14,14 @@ _MessageWithPartsResponse _$MessageWithPartsResponseFromJson(Map json) =>
                 MessageWithParts.fromJson(Map<String, dynamic>.from(e as Map)),
           )
           .toList(),
+      nextCursor: (json['nextCursor'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$MessageWithPartsResponseToJson(
   _MessageWithPartsResponse instance,
 ) => <String, dynamic>{
   'messages': instance.messages.map((e) => e.toJson()).toList(),
+  'nextCursor': ?instance.nextCursor,
 };
 
 _MessageWithParts _$MessageWithPartsFromJson(Map json) => _MessageWithParts(

--- a/shared/sesori_shared/lib/src/models/sesori/session.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.dart
@@ -138,7 +138,8 @@ sealed class SessionMessagesRequest with _$SessionMessagesRequest {
     required String sessionId,
 
     /// Maximum messages to return, newest-first from [before]. Null means the
-    /// full transcript — what an app that predates pagination sends.
+    /// full transcript.
+    // COMPATIBILITY 2026-08-08 (v1.7.2): Apps that predate pagination omit limit and mean the full transcript. Make this required and drop the unpaged read path once those apps are unsupported.
     required int? limit,
 
     /// Exclusive cursor: return messages ordered strictly before this one.

--- a/shared/sesori_shared/lib/src/models/sesori/session.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.dart
@@ -125,3 +125,26 @@ sealed class SessionIdRequest with _$SessionIdRequest {
 
   factory SessionIdRequest.fromJson(Map<String, dynamic> json) => _$SessionIdRequestFromJson(json);
 }
+
+/// Request body for `POST /session/messages`.
+///
+/// A superset of [SessionIdRequest]: both new fields are optional, so an older
+/// app's body still decodes and an older bridge ignores what it does not know.
+/// Omitting [limit] returns the whole transcript, which is the pre-pagination
+/// behavior.
+@Freezed(fromJson: true, toJson: true)
+sealed class SessionMessagesRequest with _$SessionMessagesRequest {
+  const factory SessionMessagesRequest({
+    required String sessionId,
+
+    /// Maximum messages to return, newest-first from [before]. Null means the
+    /// full transcript — what an app that predates pagination sends.
+    required int? limit,
+
+    /// Exclusive cursor: return messages ordered strictly before this one.
+    /// Null starts from the newest message.
+    required int? before,
+  }) = _SessionMessagesRequest;
+
+  factory SessionMessagesRequest.fromJson(Map<String, dynamic> json) => _$SessionMessagesRequestFromJson(json);
+}

--- a/shared/sesori_shared/lib/src/models/sesori/session.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.freezed.dart
@@ -1341,7 +1341,8 @@ as String,
 mixin _$SessionMessagesRequest {
 
  String get sessionId;/// Maximum messages to return, newest-first from [before]. Null means the
-/// full transcript — what an app that predates pagination sends.
+/// full transcript.
+// COMPATIBILITY 2026-08-08 (v1.7.2): Apps that predate pagination omit limit and mean the full transcript. Make this required and drop the unpaged read path once those apps are unsupported.
  int? get limit;/// Exclusive cursor: return messages ordered strictly before this one.
 /// Null starts from the newest message.
  int? get before;
@@ -1416,7 +1417,8 @@ class _SessionMessagesRequest implements SessionMessagesRequest {
 
 @override final  String sessionId;
 /// Maximum messages to return, newest-first from [before]. Null means the
-/// full transcript — what an app that predates pagination sends.
+/// full transcript.
+// COMPATIBILITY 2026-08-08 (v1.7.2): Apps that predate pagination omit limit and mean the full transcript. Make this required and drop the unpaged read path once those apps are unsupported.
 @override final  int? limit;
 /// Exclusive cursor: return messages ordered strictly before this one.
 /// Null starts from the newest message.

--- a/shared/sesori_shared/lib/src/models/sesori/session.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.freezed.dart
@@ -1336,4 +1336,152 @@ as String,
 
 }
 
+
+/// @nodoc
+mixin _$SessionMessagesRequest {
+
+ String get sessionId;/// Maximum messages to return, newest-first from [before]. Null means the
+/// full transcript — what an app that predates pagination sends.
+ int? get limit;/// Exclusive cursor: return messages ordered strictly before this one.
+/// Null starts from the newest message.
+ int? get before;
+/// Create a copy of SessionMessagesRequest
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SessionMessagesRequestCopyWith<SessionMessagesRequest> get copyWith => _$SessionMessagesRequestCopyWithImpl<SessionMessagesRequest>(this as SessionMessagesRequest, _$identity);
+
+  /// Serializes this SessionMessagesRequest to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionMessagesRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.limit, limit) || other.limit == limit)&&(identical(other.before, before) || other.before == before));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,sessionId,limit,before);
+
+@override
+String toString() {
+  return 'SessionMessagesRequest(sessionId: $sessionId, limit: $limit, before: $before)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SessionMessagesRequestCopyWith<$Res>  {
+  factory $SessionMessagesRequestCopyWith(SessionMessagesRequest value, $Res Function(SessionMessagesRequest) _then) = _$SessionMessagesRequestCopyWithImpl;
+@useResult
+$Res call({
+ String sessionId, int? limit, int? before
+});
+
+
+
+
+}
+/// @nodoc
+class _$SessionMessagesRequestCopyWithImpl<$Res>
+    implements $SessionMessagesRequestCopyWith<$Res> {
+  _$SessionMessagesRequestCopyWithImpl(this._self, this._then);
+
+  final SessionMessagesRequest _self;
+  final $Res Function(SessionMessagesRequest) _then;
+
+/// Create a copy of SessionMessagesRequest
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? sessionId = null,Object? limit = freezed,Object? before = freezed,}) {
+  return _then(_self.copyWith(
+sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
+as String,limit: freezed == limit ? _self.limit : limit // ignore: cast_nullable_to_non_nullable
+as int?,before: freezed == before ? _self.before : before // ignore: cast_nullable_to_non_nullable
+as int?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _SessionMessagesRequest implements SessionMessagesRequest {
+  const _SessionMessagesRequest({required this.sessionId, required this.limit, required this.before});
+  factory _SessionMessagesRequest.fromJson(Map<String, dynamic> json) => _$SessionMessagesRequestFromJson(json);
+
+@override final  String sessionId;
+/// Maximum messages to return, newest-first from [before]. Null means the
+/// full transcript — what an app that predates pagination sends.
+@override final  int? limit;
+/// Exclusive cursor: return messages ordered strictly before this one.
+/// Null starts from the newest message.
+@override final  int? before;
+
+/// Create a copy of SessionMessagesRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SessionMessagesRequestCopyWith<_SessionMessagesRequest> get copyWith => __$SessionMessagesRequestCopyWithImpl<_SessionMessagesRequest>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SessionMessagesRequestToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionMessagesRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.limit, limit) || other.limit == limit)&&(identical(other.before, before) || other.before == before));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,sessionId,limit,before);
+
+@override
+String toString() {
+  return 'SessionMessagesRequest(sessionId: $sessionId, limit: $limit, before: $before)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SessionMessagesRequestCopyWith<$Res> implements $SessionMessagesRequestCopyWith<$Res> {
+  factory _$SessionMessagesRequestCopyWith(_SessionMessagesRequest value, $Res Function(_SessionMessagesRequest) _then) = __$SessionMessagesRequestCopyWithImpl;
+@override @useResult
+$Res call({
+ String sessionId, int? limit, int? before
+});
+
+
+
+
+}
+/// @nodoc
+class __$SessionMessagesRequestCopyWithImpl<$Res>
+    implements _$SessionMessagesRequestCopyWith<$Res> {
+  __$SessionMessagesRequestCopyWithImpl(this._self, this._then);
+
+  final _SessionMessagesRequest _self;
+  final $Res Function(_SessionMessagesRequest) _then;
+
+/// Create a copy of SessionMessagesRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? sessionId = null,Object? limit = freezed,Object? before = freezed,}) {
+  return _then(_SessionMessagesRequest(
+sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
+as String,limit: freezed == limit ? _self.limit : limit // ignore: cast_nullable_to_non_nullable
+as int?,before: freezed == before ? _self.before : before // ignore: cast_nullable_to_non_nullable
+as int?,
+  ));
+}
+
+
+}
+
 // dart format on

--- a/shared/sesori_shared/lib/src/models/sesori/session.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.g.dart
@@ -159,3 +159,18 @@ _SessionIdRequest _$SessionIdRequestFromJson(Map json) =>
 
 Map<String, dynamic> _$SessionIdRequestToJson(_SessionIdRequest instance) =>
     <String, dynamic>{'sessionId': instance.sessionId};
+
+_SessionMessagesRequest _$SessionMessagesRequestFromJson(Map json) =>
+    _SessionMessagesRequest(
+      sessionId: json['sessionId'] as String,
+      limit: (json['limit'] as num?)?.toInt(),
+      before: (json['before'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$SessionMessagesRequestToJson(
+  _SessionMessagesRequest instance,
+) => <String, dynamic>{
+  'sessionId': instance.sessionId,
+  'limit': ?instance.limit,
+  'before': ?instance.before,
+};


### PR DESCRIPTION
## Complexity

⚙️ moderate — additive wire fields plus keyset paging over an existing index,
with both compatibility directions to keep intact.

## What

Step 5/8 of `.plan/active/internal-chat-history`.

- `SessionMessagesRequest` supersedes `SessionIdRequest` for
  `POST /session/messages`, adding optional `limit` and `before`;
  `MessageWithPartsResponse` gains an optional `nextCursor`.
- The DAO pages over `seq`: it takes the newest rows first so the limit selects
  the right end of the transcript, then flips the page back into reading order.
  A page loads only its own messages' parts.
- The cursor is exclusive — `nextCursor` is the oldest returned `seq`, sent
  back verbatim as the next `before` — so pages never overlap.
- Client APIs, repository, and service thread `limit`/`before` through but
  still request the full transcript. Paging policy is step 7/8.

Also folds in a plan change you asked for (below).

## Why

The whole transcript ships in one relay frame today, with a 64 MiB ceiling and
inline images up to 5 MiB each, re-fetched on every reconnect and reload. Paging
bounds that. Doing it now, before the client adopts it, means the bridge can
serve both shapes while apps roll over.

## Risk and test focus

Moderate, concentrated in compatibility: this route is exercised by every
session open, and a mistake breaks published apps.

- Old app + new bridge: no `limit` sent → full transcript, unchanged.
- New app + old bridge: unknown fields ignored, no `nextCursor` → treated as
  complete, no load-older affordance.

Both are covered by tests that decode literal legacy payloads rather than
round-tripping the current model.

## Expected result

- **User-visible:** none yet. The client still asks for the whole transcript,
  so responses are identical.
- **Database:** no schema change, no migration. Paging uses the existing
  `(session_id, seq)` unique index.
- **Internal:** the route can serve a page; the client can start asking in
  step 7.

## Verification

- Analyzer clean in `bridge/app`, `sesori_shared`, `client/module_core`,
  `client/app`.
- Tests: `bridge/app` 2,493 · `sesori_shared` 364 · `client/module_core` 1,006
  · `client/app` 915.
- New `chat_history_pagination_test.dart`: newest-page selection, exclusive
  non-overlapping cursor, full paging back to the start exactly once,
  per-page parts, exact-fit page followed by an empty terminating page, empty
  session, and the two compatibility directions.

## Plan change included

Running a bridge on the merged step 4/8 showed the store serving history
correctly — `chat_history.db` populated, sessions synced with a current
watermark — while session open still felt unchanged. The reason is that the
same snapshot calls `getPendingQuestions` and `getPendingPermissions` through
`PluginRuntime.use`, which starts an idle backend, so the harness wakes anyway
and the history win is masked.

**Step 8/8 now retires the plan *and* produces an aligned written assessment**
of every remaining plugin-starting call in the session-open snapshot
(`getPendingQuestions`, `getPendingPermissions`, the options lookups, with
`getSessionStatuses` as the already-correct `useIfActive` reference), plus the
questions to settle first: which fields may serve cached or empty answers on a
stopped backend, what the UI shows for those, and whether opening a session
should start a backend at all. Implementation stays outside this series.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pagination to session message history so the bridge can serve pages and the client can request them. Validates page size, adds compatibility notes for pagination fields, and widens step 8 to scope a harness-free session open.

- **New Features**
  - `POST /session/messages` now takes `SessionMessagesRequest` with optional `limit` and `before`; the response adds `nextCursor` (exclusive, pages never overlap).
  - DAO/repository implement keyset paging over `seq` and load parts only for the page; a null `limit` returns the full transcript (pre-pagination behavior).
  - Client threads `limit`/`before` through `SessionApi`, `SessionRepository`, and `SessionService` but still requests the whole transcript; models include compatibility annotations. Compatibility preserved both ways; no schema change; new tests cover pagination and legacy interop.

- **Bug Fixes**
  - Reject non‑positive `limit` with 400 to prevent empty-page loops and a crash; repository omits `nextCursor` for empty pages.

<sup>Written for commit e556a59d8f06e30e97b5ab5ea7604f2a10826b58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

