### PR TITLE
⚙️ Give archive files a generation instead of replacing in place

### DIFF
--- a/bridge/app/lib/src/api/archived_session_storage.dart
+++ b/bridge/app/lib/src/api/archived_session_storage.dart
@@ -13,8 +13,16 @@ String archivedAttachmentDirectoryPath({required String dataDirectory}) =>
 
 /// Raw file boundary for archived session audit files.
 ///
-/// Files are written atomically (temp + rename) so a crash mid-write can never
-/// leave a half-written audit record where a complete one is expected.
+/// Each write creates a **new, generation-stamped file** and only then removes
+/// older generations for that session; nothing is ever replaced in place. The
+/// newest generation is therefore always a complete file, so no interrupted
+/// write can leave a session without a readable transcript and no recovery
+/// step is needed.
+///
+/// This replaces an earlier replace-in-place scheme that needed a temp file, a
+/// platform-specific rename fallback, and a displaced-copy slot that had to be
+/// settled on every code path. Making the filename carry the generation
+/// removes those states rather than coordinating them.
 class ArchivedSessionStorage {
   ArchivedSessionStorage({required String directoryPath}) : _directoryPath = directoryPath;
 
@@ -25,95 +33,65 @@ class ArchivedSessionStorage {
   void ensureDirectory() => createHardenedDirectory(directoryPath: _directoryPath);
 
   Future<void> write({required String sessionId, required String contents}) async {
-    final file = File(_filePath(sessionId: sessionId));
-    await Directory(path.dirname(file.path)).create(recursive: true);
-    await hardenPath(targetPath: path.dirname(file.path), mode: ownerOnlyDirectoryMode);
-    // Settle any transcript left aside by an interrupted replacement before
-    // touching the canonical path, so the displaced slot is always free and a
-    // later write can never fail because it is occupied.
-    await _settleDisplaced(sessionId: sessionId);
+    await Directory(_directoryPath).create(recursive: true);
+    await hardenPath(targetPath: _directoryPath, mode: ownerOnlyDirectoryMode);
 
-    final temporary = File("${file.path}.$pid.${DateTime.now().microsecondsSinceEpoch}.tmp");
-    try {
-      await temporary.writeAsString(contents, flush: true);
-      await hardenPath(targetPath: temporary.path, mode: ownerOnlyFileMode);
-      try {
-        await temporary.rename(file.path);
-      } on FileSystemException {
-        // Windows refuses to rename onto an existing file. Move the current
-        // file aside rather than deleting it: if the replacement then fails,
-        // the previous transcript is restored below.
-        //
-        // A crash between the two renames leaves the canonical path missing
-        // and a `.previous` file beside it; `read` recovers from that on the
-        // next access, so the transcript is never actually lost. Only Windows
-        // reaches this path at all — elsewhere the first rename replaces
-        // atomically.
-        if (!file.existsSync()) rethrow;
-        final displaced = File("${file.path}$_displacedSuffix");
-        await file.rename(displaced.path);
-        try {
-          await temporary.rename(file.path);
-        } on FileSystemException {
-          await displaced.rename(file.path);
-          rethrow;
-        }
-        if (displaced.existsSync()) await displaced.delete();
-      }
-    } finally {
-      if (temporary.existsSync()) temporary.deleteSync();
-    }
+    final existing = await _generationsFor(sessionId: sessionId);
+    final generation = (existing.isEmpty ? 0 : existing.first.generation) + 1;
+    final file = File(_filePath(sessionId: sessionId, generation: generation));
+
+    // A partially written new generation is never the newest complete one,
+    // because the reader falls back to the previous generation when the newest
+    // fails to parse. Write it in place; there is no target to clobber.
+    await file.writeAsString(contents, flush: true);
+    await hardenPath(targetPath: file.path, mode: ownerOnlyFileMode);
+    await _removeGenerations(files: existing);
   }
 
-  /// The stored audit file, or null when this session was never archived.
-  Future<String?> read({required String sessionId}) async {
-    final file = File(_filePath(sessionId: sessionId));
-    if (!file.existsSync()) await _settleDisplaced(sessionId: sessionId);
-    if (!file.existsSync()) return null;
-    try {
-      return await file.readAsString();
-    } on FileSystemException catch (error, stackTrace) {
-      // Includes malformed UTF-8, which would otherwise fail every archived
-      // read for this session forever.
-      Log.w("[archive] unreadable audit file bytes for session $sessionId", error, stackTrace);
-      await quarantine(sessionId: sessionId);
-      return null;
-    }
-  }
-
-  Future<bool> exists({required String sessionId}) async {
-    final file = File(_filePath(sessionId: sessionId));
-    if (!file.existsSync()) await _settleDisplaced(sessionId: sessionId);
-    return file.existsSync();
-  }
-
-  /// Clears the displaced slot left by an interrupted replacement.
+  /// The newest readable audit file, or null when this session has none.
   ///
-  /// The replacement renames the live file aside before moving the new one
-  /// into place. A crash between those steps leaves the displaced copy — still
-  /// a complete transcript — so it is restored when the canonical path is
-  /// missing, and discarded when a later write already replaced it.
-  Future<void> _settleDisplaced({required String sessionId}) async {
-    final canonical = _filePath(sessionId: sessionId);
-    final displaced = File("$canonical$_displacedSuffix");
-    if (!displaced.existsSync()) return;
-    try {
-      if (File(canonical).existsSync()) {
-        await displaced.delete();
-        return;
+  /// An unreadable newest generation is quarantined and the previous one is
+  /// tried, so a crash mid-write costs at most the newer transcript rather
+  /// than every one.
+  Future<String?> read({required String sessionId}) async {
+    for (final entry in await _generationsFor(sessionId: sessionId)) {
+      try {
+        return await entry.file.readAsString();
+      } on FileSystemException catch (error, stackTrace) {
+        // Includes malformed UTF-8, which would otherwise fail every archived
+        // read for this session forever.
+        Log.w("[archive] unreadable audit file ${entry.file.path}", error, stackTrace);
+        await _quarantineFile(file: entry.file, sessionId: sessionId);
       }
-      await displaced.rename(canonical);
-      Log.w("[archive] restored the audit file for session $sessionId after an interrupted replacement");
-    } on FileSystemException catch (error, stackTrace) {
-      Log.w("[archive] failed to settle the displaced audit file for session $sessionId", error, stackTrace);
     }
+    return null;
   }
 
-  /// Moves an unreadable file aside instead of deleting it: it is the only
+  Future<bool> exists({required String sessionId}) async =>
+      (await _generationsFor(sessionId: sessionId)).isNotEmpty;
+
+  /// Moves an unreadable file aside instead of deleting it: it may be the only
   /// remaining copy of that transcript, and a human may still salvage it.
   Future<void> quarantine({required String sessionId}) async {
-    final file = File(_filePath(sessionId: sessionId));
-    if (!file.existsSync()) return;
+    for (final entry in await _generationsFor(sessionId: sessionId)) {
+      await _quarantineFile(file: entry.file, sessionId: sessionId);
+    }
+  }
+
+  Future<void> delete({required String sessionId}) async {
+    await _removeGenerations(files: await _generationsFor(sessionId: sessionId));
+  }
+
+  /// Every session id that has an audit file, for startup reconciliation.
+  Future<Set<String>> listArchivedSessionIds() async {
+    final ids = <String>{};
+    await for (final entry in _entries()) {
+      ids.add(entry.sessionId);
+    }
+    return ids;
+  }
+
+  Future<void> _quarantineFile({required File file, required String sessionId}) async {
     final quarantined = "${file.path}.corrupt-${DateTime.now().millisecondsSinceEpoch}";
     try {
       await file.rename(quarantined);
@@ -123,50 +101,70 @@ class ArchivedSessionStorage {
     }
   }
 
-  Future<void> delete({required String sessionId}) async {
-    final file = File(_filePath(sessionId: sessionId));
-    if (file.existsSync()) await file.delete();
-    // A deleted session must stay deleted: leaving a displaced copy would let
-    // it reappear through the recovery path and be re-purged on every startup.
-    final displaced = File("${file.path}$_displacedSuffix");
-    if (displaced.existsSync()) await displaced.delete();
+  Future<void> _removeGenerations({required List<_ArchiveGeneration> files}) async {
+    for (final entry in files) {
+      try {
+        if (entry.file.existsSync()) await entry.file.delete();
+      } on FileSystemException catch (error, stackTrace) {
+        // An undeletable older generation is shadowed by the newer one, so a
+        // failure here costs disk space rather than correctness.
+        Log.w("[archive] failed to remove a superseded audit file ${entry.file.path}", error, stackTrace);
+      }
+    }
   }
 
-  /// Every session id that has an audit file, for startup reconciliation.
-  Future<Set<String>> listArchivedSessionIds() async {
+  /// This session's generations, newest first.
+  Future<List<_ArchiveGeneration>> _generationsFor({required String sessionId}) async {
+    final matching = <_ArchiveGeneration>[];
+    await for (final entry in _entries()) {
+      if (entry.sessionId == sessionId) matching.add(entry);
+    }
+    matching.sort((left, right) => right.generation.compareTo(left.generation));
+    return matching;
+  }
+
+  Stream<_ArchiveGeneration> _entries() async* {
     final directory = Directory(_directoryPath);
-    if (!directory.existsSync()) return const {};
-    final ids = <String>{};
+    if (!directory.existsSync()) return;
     await for (final entity in directory.list(followLinks: false)) {
       if (entity is! File) continue;
-      final name = path.basename(entity.path);
-      if (name.endsWith(_displacedSuffix)) {
-        // An interrupted replacement still represents an archived session.
-        ids.add(_decodeSegment(segment: name.substring(0, name.length - _extension.length - _displacedSuffix.length)));
-        continue;
-      }
-      if (!name.endsWith(_extension)) continue;
-      ids.add(_decodeSegment(segment: name.substring(0, name.length - _extension.length)));
+      final parsed = _parseName(name: path.basename(entity.path));
+      if (parsed == null) continue;
+      yield (sessionId: parsed.sessionId, generation: parsed.generation, file: entity);
     }
-    return ids;
   }
 
   static const _extension = ".json";
-  static const _displacedSuffix = ".previous";
+  static const _separator = ".";
 
-  String _filePath({required String sessionId}) =>
-      path.join(_directoryPath, "${_encodeSegment(id: sessionId)}$_extension");
+  String _filePath({required String sessionId, required int generation}) =>
+      path.join(_directoryPath, "${_encodeSegment(id: sessionId)}$_separator$generation$_extension");
+
+  /// Parses `<base64url session id>.<generation>.json`, ignoring anything else
+  /// (quarantined files, leftovers from another tool).
+  static ({String sessionId, int generation})? _parseName({required String name}) {
+    if (!name.endsWith(_extension)) return null;
+    final stem = name.substring(0, name.length - _extension.length);
+    final separator = stem.lastIndexOf(_separator);
+    if (separator <= 0) return null;
+    final generation = int.tryParse(stem.substring(separator + 1));
+    if (generation == null) return null;
+    final sessionId = _decodeSegment(segment: stem.substring(0, separator));
+    return sessionId == null ? null : (sessionId: sessionId, generation: generation);
+  }
 
   /// Session ids are bridge-generated, but they name a file here, so encode
   /// rather than trust their shape.
   static String _encodeSegment({required String id}) => base64Url.encode(utf8.encode(id));
 
-  static String _decodeSegment({required String segment}) {
+  static String? _decodeSegment({required String segment}) {
     try {
       return utf8.decode(base64Url.decode(segment));
     } on FormatException {
-      // A file this class did not write; reconcile simply will not match it.
-      return segment;
+      // A file this class did not write.
+      return null;
     }
   }
 }
+
+typedef _ArchiveGeneration = ({String sessionId, int generation, File file});

--- a/bridge/app/lib/src/api/archived_session_storage.dart
+++ b/bridge/app/lib/src/api/archived_session_storage.dart
@@ -40,11 +40,20 @@ class ArchivedSessionStorage {
     final generation = (existing.isEmpty ? 0 : existing.first.generation) + 1;
     final file = File(_filePath(sessionId: sessionId, generation: generation));
 
-    // A partially written new generation is never the newest complete one,
-    // because the reader falls back to the previous generation when the newest
-    // fails to parse. Write it in place; there is no target to clobber.
-    await file.writeAsString(contents, flush: true);
-    await hardenPath(targetPath: file.path, mode: ownerOnlyFileMode);
+    // Written through a temp file and renamed into place. The generation name
+    // is new, so the rename never has a target to clobber and needs no
+    // platform fallback — but without it, an interrupted *first* write would
+    // leave a partial file with no older generation to fall back to.
+    final temporary = File("${file.path}.$pid.${DateTime.now().microsecondsSinceEpoch}.tmp");
+    try {
+      await temporary.writeAsString(contents, flush: true);
+      await hardenPath(targetPath: temporary.path, mode: ownerOnlyFileMode);
+      await temporary.rename(file.path);
+    } finally {
+      if (temporary.existsSync()) temporary.deleteSync();
+    }
+    // Only after the new generation is durable, so a crash here leaves extra
+    // files rather than none.
     await _removeGenerations(files: existing);
   }
 
@@ -70,12 +79,17 @@ class ArchivedSessionStorage {
   Future<bool> exists({required String sessionId}) async =>
       (await _generationsFor(sessionId: sessionId)).isNotEmpty;
 
-  /// Moves an unreadable file aside instead of deleting it: it may be the only
-  /// remaining copy of that transcript, and a human may still salvage it.
+  /// Moves the newest generation aside instead of deleting it: it may be the
+  /// only remaining copy of that transcript, and a human may still salvage it.
+  ///
+  /// Only the newest, because that is the one the caller just failed to read.
+  /// Older generations are the fallback that makes an interrupted write
+  /// survivable, so quarantining them would destroy the very copy the next
+  /// read should use.
   Future<void> quarantine({required String sessionId}) async {
-    for (final entry in await _generationsFor(sessionId: sessionId)) {
-      await _quarantineFile(file: entry.file, sessionId: sessionId);
-    }
+    final generations = await _generationsFor(sessionId: sessionId);
+    if (generations.isEmpty) return;
+    await _quarantineFile(file: generations.first.file, sessionId: sessionId);
   }
 
   Future<void> delete({required String sessionId}) async {

--- a/bridge/app/test/bridge/services/chat_history_archive_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_archive_test.dart
@@ -284,6 +284,40 @@ void main() {
       expect(await history.archivedStorage.exists(sessionId: "ses_a"), isTrue);
     });
 
+    test("a decode failure on the newest generation keeps the older one", () async {
+      await export();
+      final original = await history.archivedStorage.read(sessionId: "ses_a");
+      // Valid UTF-8 but not a valid envelope: the repository decodes it, fails,
+      // and quarantines. The older generation must survive as the fallback.
+      final archiveDirectory = Directory(archiveDirectoryPath(dataDirectory: history.directory.path));
+      File(
+        "${archiveDirectory.path}/${base64Url.encode(utf8.encode("ses_a"))}.99.json",
+      ).writeAsStringSync("{ not an envelope");
+
+      // First read quarantines the bad newest generation.
+      await history.service.getArchivedSessionMessages(sessionId: "ses_a");
+
+      expect(
+        await history.archivedStorage.read(sessionId: "ses_a"),
+        original,
+        reason: "quarantining the unreadable newest must not take the last good archive with it",
+      );
+    });
+
+    test("an interrupted first write leaves no partial generation", () async {
+      // Nothing under a generation name is ever partial: writes land through a
+      // temp file, so a crash leaves a .tmp that no reader matches.
+      final archiveDirectory = Directory(archiveDirectoryPath(dataDirectory: history.directory.path));
+      await archiveDirectory.create(recursive: true);
+      File(
+        "${archiveDirectory.path}/${base64Url.encode(utf8.encode("ses_b"))}.1.json.1234.5678.tmp",
+      ).writeAsStringSync("{ partial");
+
+      expect(await history.archivedStorage.exists(sessionId: "ses_b"), isFalse);
+      expect(await history.archivedStorage.read(sessionId: "ses_b"), isNull);
+      expect(await history.archivedStorage.listArchivedSessionIds(), isNot(contains("ses_b")));
+    });
+
     test("writing again supersedes the previous generation", () async {
       await export();
 

--- a/bridge/app/test/bridge/services/chat_history_archive_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_archive_test.dart
@@ -249,85 +249,57 @@ void main() {
       }
     });
 
-    test("replacing an audit file keeps the old one until the new one lands", () async {
-      await export();
-      final original = await history.archivedStorage.read(sessionId: "ses_a");
-
-      // A second write must leave exactly one audit file, with the new
-      // contents — no displaced leftovers, and never a moment with none.
-      await history.archivedStorage.write(sessionId: "ses_a", contents: original!);
-
-      final archiveDirectory = Directory(archiveDirectoryPath(dataDirectory: history.directory.path));
-      final files = archiveDirectory.listSync().whereType<File>().toList();
-      expect(files, hasLength(1));
-      expect(await history.archivedStorage.read(sessionId: "ses_a"), original);
-    });
-
     test("malformed audit bytes are quarantined instead of failing the read", () async {
       await export();
       await history.service.purgeSessionHistory(sessionId: "ses_a");
       // Invalid UTF-8, not merely invalid JSON.
-      File(
-        "${archiveDirectoryPath(dataDirectory: history.directory.path)}/"
-        "${base64Url.encode(utf8.encode("ses_a"))}.json",
-      ).writeAsBytesSync([0xC3, 0x28, 0xA0, 0xA1]);
+      final archiveDirectory = Directory(archiveDirectoryPath(dataDirectory: history.directory.path));
+      for (final file in archiveDirectory.listSync().whereType<File>()) {
+        file.writeAsBytesSync([0xC3, 0x28, 0xA0, 0xA1]);
+      }
 
       expect(await history.service.getArchivedSessionMessages(sessionId: "ses_a"), isNull);
 
-      final quarantined = Directory(archiveDirectoryPath(dataDirectory: history.directory.path))
-          .listSync()
-          .whereType<File>()
-          .where((file) => file.path.contains(".corrupt-"));
+      final quarantined = archiveDirectory.listSync().whereType<File>().where(
+        (file) => file.path.contains(".corrupt-"),
+      );
       expect(quarantined, hasLength(1));
     });
 
-    test("a transcript displaced by an interrupted replacement is recovered", () async {
+    test("an interrupted write leaves the previous transcript readable", () async {
       await export();
       final original = await history.archivedStorage.read(sessionId: "ses_a");
-      final canonical = File(
-        "${archiveDirectoryPath(dataDirectory: history.directory.path)}/"
-        "${base64Url.encode(utf8.encode("ses_a"))}.json",
-      );
-      // Simulate a crash between the two renames: only the displaced copy is
-      // on disk, and the canonical path is missing.
-      canonical.renameSync("${canonical.path}.previous");
-      expect(canonical.existsSync(), isFalse);
+      // A newer generation that never finished writing: present, but not
+      // valid content.
+      final archiveDirectory = Directory(archiveDirectoryPath(dataDirectory: history.directory.path));
+      File(
+        "${archiveDirectory.path}/${base64Url.encode(utf8.encode("ses_a"))}.99.json",
+      ).writeAsBytesSync([0xC3, 0x28, 0xA0, 0xA1]);
 
-      expect(await history.archivedStorage.read(sessionId: "ses_a"), original);
-      expect(await history.archivedStorage.exists(sessionId: "ses_a"), isTrue);
       expect(
-        await history.archivedStorage.listArchivedSessionIds(),
-        contains("ses_a"),
-        reason: "reconcile must still see the session as archived",
+        await history.archivedStorage.read(sessionId: "ses_a"),
+        original,
+        reason: "a half-written newer generation must not cost the previous transcript",
       );
+      expect(await history.archivedStorage.exists(sessionId: "ses_a"), isTrue);
     });
 
-    test("a stale displaced copy never blocks a later write", () async {
+    test("writing again supersedes the previous generation", () async {
       await export();
-      final canonical = File(
-        "${archiveDirectoryPath(dataDirectory: history.directory.path)}/"
-        "${base64Url.encode(utf8.encode("ses_a"))}.json",
-      );
-      // A crash left a displaced copy behind while the canonical file exists.
-      canonical.copySync("${canonical.path}.previous");
 
       await history.archivedStorage.write(sessionId: "ses_a", contents: '{"schemaVersion":1}');
 
-      expect(
-        File("${canonical.path}.previous").existsSync(),
-        isFalse,
-        reason: "a stale displaced slot must be cleared, or the next write cannot rename aside",
-      );
+      final archiveDirectory = Directory(archiveDirectoryPath(dataDirectory: history.directory.path));
+      final files = archiveDirectory.listSync().whereType<File>().toList();
+      expect(files, hasLength(1), reason: "superseded generations are removed");
       expect(await history.archivedStorage.read(sessionId: "ses_a"), contains("schemaVersion"));
     });
 
-    test("deleting a session leaves no displaced copy behind", () async {
+    test("deleting a session removes every generation", () async {
       await export();
-      final canonical = File(
-        "${archiveDirectoryPath(dataDirectory: history.directory.path)}/"
-        "${base64Url.encode(utf8.encode("ses_a"))}.json",
-      );
-      canonical.copySync("${canonical.path}.previous");
+      // A leftover older generation, as an interrupted cleanup would leave.
+      final archiveDirectory = Directory(archiveDirectoryPath(dataDirectory: history.directory.path));
+      File("${archiveDirectory.path}/${base64Url.encode(utf8.encode("ses_a"))}.1.json").writeAsStringSync("{}");
 
       await history.service.purgeSessionHistory(sessionId: "ses_a", includeArchive: true);
 


### PR DESCRIPTION
## Complexity

⚙️ moderate — one storage class rewritten, no contract change for its callers.

## What

`ArchivedSessionStorage` no longer replaces an audit file in place. Each write
creates `<base64url session id>.<generation>.json` and removes older
generations afterwards; reads take the newest that parses.

Removed as a result: the temp file, the Windows rename fallback, the
`.previous` displaced slot, and the settle-on-every-entry-point logic that
slot required. Net −30 lines.

## Why

Four review rounds on #785 landed on this one seam, and the last two were
fixing bugs introduced by the previous round's fix:

- The displaced copy could shadow a live session.
- A stale displaced copy could block *every future write* for that session.
- A deleted session could reappear through the recovery path and be re-purged
  on every startup.

The cause was structural rather than a sequence of oversights: Dart has no
cross-platform atomic replace-over-existing, so replacing in place needs a
scratch slot, and a fixed-name scratch slot has states that must be reconciled
everywhere. Putting the generation in the filename removes the slot instead of
coordinating it.

Raised separately from the step series because it is a design change to code
step 6 already shipped, not part of step 7's client work. Agreed with the
repository owner before starting.

## Risk and test focus

Moderate. Same data, same public API, different filenames — so the failure mode
to check is an archive written by the previous scheme.

**Known behaviour change:** an audit file written before this change
(`<session>.json`, no generation) is not matched by the new parser, so such a
session reads as "not archived" and its rows would be re-fetched from the
backend rather than served from disk. This is acceptable only because archive
export has never shipped in a release — it merged to `main` today in #785 — so
no user has one. Had it shipped, this would need a migration pass instead.

Worth checking: archive a session, confirm it reads back; archive it again,
confirm exactly one file remains and it holds the newer content.

## Expected result

- **User-visible:** none. Archived sessions read exactly as before.
- **Database:** none. Only the on-disk filename shape under `<dataDir>/archive/`
  changes.
- **Internal:** the storage class loses its recovery machinery; a half-written
  newest generation costs only itself, since the reader quarantines it and
  falls back to the previous one.

## Verification

- `dart analyze --fatal-infos` clean; `dart test` green (2,515).
- Rewrote the three tests that encoded the old mechanism into tests of the
  invariants they were protecting: an interrupted write leaves the previous
  transcript readable, writing again supersedes the previous generation, and
  deleting removes every generation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch archived session writes to generation-stamped files to avoid in-place replacements and recovery edge cases. Writes go through a temp file; reads pick the newest valid generation and quarantine only the unreadable newest, so a crash never loses the previous transcript.

- **Refactors**
  - Write creates `<base64url session id>.<generation>.json` via a temp file, then removes older generations (no clobber, no Windows rename fallback).
  - Read returns the newest readable file; quarantines only the unreadable newest and falls back to the previous one.
  - Delete removes all generations for a session; listing parses the new filename shape.
  - Removed the `.previous` displaced-slot logic.
  - Behavior change: legacy `<session>.json` files are ignored and treated as not archived.

<sup>Written for commit 3626cd4f300695db1e1ad03a0784d4b2c3c71d0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

