### PR TITLE
⚙️ [internal-chat-history] Stop waking a harness for pending questions and permissions [step 8/9]

### DIFF
--- a/.plan/active/internal-chat-history/TRACKER.md
+++ b/.plan/active/internal-chat-history/TRACKER.md
@@ -3,13 +3,13 @@
 ## Current State
 
 - **Plan slug:** `internal-chat-history`
-- **Implementation base:** `origin/main` at `dd6fd2f8`
-- **Series state:** Steps 1–6 merged; step 7/9 in PR
-- **Current step:** 7/9
+- **Implementation base:** `origin/main` at `3d9fe379`
+- **Series state:** Steps 1–7 merged; step 8/9 in PR
+- **Current step:** 8/9
 - **Plan PR:** [#763](https://github.com/sesori-ai/sesori_apps_monorepo/pull/763) merged
 - **Prerequisite:** satisfied — the `read-only-archiving` series merged fully on
   2026-08-07 (through [PR #771](https://github.com/sesori-ai/sesori_apps_monorepo/pull/771)).
-- **Next action:** merge step 7/9, then start step 8/9 (stop waking a harness for pending state).
+- **Next action:** merge step 8/9, then start step 9/9 (retire the plan and scope the remaining harness-free work).
 
 ## Delivery Steps
 
@@ -21,8 +21,8 @@
 | [x] | 4/8 | `⚙️ [internal-chat-history] Serve session messages from the store [step 4/8]` | 700–1,100 | [PR #781](https://github.com/sesori-ai/sesori_apps_monorepo/pull/781) merged |
 | [x] | 5/8 | `⚙️ [internal-chat-history] Paginate session messages [step 5/8]` | 600–1,000 | [PR #783](https://github.com/sesori-ai/sesori_apps_monorepo/pull/783) merged |
 | [x] | 6/8 | `🚧 [internal-chat-history] Export archives and purge history on archive [step 6/8]` | 1,000–1,500 | [PR #785](https://github.com/sesori-ai/sesori_apps_monorepo/pull/785) merged |
-| [ ] | 7/9 | `🌿 [internal-chat-history] Load history pages on demand in the client [step 7/9]` | 500–900 | in progress |
-| [ ] | 8/9 | `⚙️ [internal-chat-history] Stop waking a harness for pending questions and permissions [step 8/9]` | 300–600 | pending |
+| [x] | 7/9 | `🌿 [internal-chat-history] Load history pages on demand in the client [step 7/9]` | 500–900 | [PR #787](https://github.com/sesori-ai/sesori_apps_monorepo/pull/787) merged |
+| [ ] | 8/9 | `⚙️ [internal-chat-history] Stop waking a harness for pending questions and permissions [step 8/9]` | 300–600 | in progress |
 | [ ] | 9/9 | `🌱 [internal-chat-history] Retire plan and scope the remaining harness-free work [step 9/9]` | 150–400 | pending |
 
 ## Execution Rules
@@ -55,7 +55,9 @@
   `sesori_shared` 364, `client/module_core` 1,006, `client/app` 915.
 - **2026-08-08 — step 6/8:** analyzer clean; `bridge/app` green (2,516 tests).
 - **2026-08-08 — step 7/9:** analyzer clean in `client/module_core` and
-  `client/app`; `module_core` 1,029 tests, `client/app` 922.
+  `client/app`; `module_core` 1,030 tests, `client/app` 922.
+- **2026-08-08 — step 8/9:** analyzer clean; `bridge/app` green (2,520 tests),
+  including the new `pending_state_without_start_test.dart`.
 
 ## Findings And Plan Deltas
 - **2026-08-06 — Plan revised after comparison with PR #764** (parallel

--- a/bridge/app/lib/src/bridge/repositories/permission_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/permission_repository.dart
@@ -31,10 +31,13 @@ class PermissionRepository {
       sessionId: sessionId,
       operation: SessionOperation.getPendingPermissions,
     );
-    return _runtime.use(
+    // Deliberately does not start a stopped backend — see the matching note in
+    // QuestionRepository. A stopped backend holds no pending permissions, so
+    // waking it to ask could only answer "none".
+    final pending = await _runtime.useIfActive(
       pluginId: binding.pluginId,
       operation: SessionOperation.getPendingPermissions,
-      body: (plugin) async {
+      body: (plugin, _) async {
         Set<String>? tombstoned;
         if (plugin is BridgeDerivedProjectsPluginApi) {
           tombstoned = await _sessionDao.getTombstonedSessionIds(pluginId: plugin.id);
@@ -50,6 +53,9 @@ class PermissionRepository {
         );
       },
     );
+    // Null means the backend is not running, which is indistinguishable from
+    // "it has none" for this question.
+    return pending ?? const [];
   }
 
   static bool _isVisible(PluginPendingPermission permission, Set<String> tombstoned) {

--- a/bridge/app/lib/src/bridge/repositories/question_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/question_repository.dart
@@ -39,10 +39,15 @@ class QuestionRepository {
       sessionId: sessionId,
       operation: SessionOperation.getPendingQuestions,
     );
-    return _runtime.use(
+    // Deliberately does not start a stopped backend. Pending questions live in
+    // the backend process — an in-memory approval registry for ACP, the
+    // running HTTP server for OpenCode — so a stopped one holds none. Starting
+    // it could only ever answer "none" after paying the full start cost, and
+    // harnesses are slow to respond for a while after starting.
+    final pending = await _runtime.useIfActive(
       pluginId: binding.pluginId,
       operation: SessionOperation.getPendingQuestions,
-      body: (plugin) async {
+      body: (plugin, _) async {
         Set<String>? tombstoned;
         if (plugin is BridgeDerivedProjectsPluginApi) {
           tombstoned = await _sessionDao.getTombstonedSessionIds(pluginId: plugin.id);
@@ -58,6 +63,9 @@ class QuestionRepository {
         );
       },
     );
+    // Null means the backend is not running, which is indistinguishable from
+    // "it has none" for this question.
+    return pending ?? const [];
   }
 
   /// All pending questions for [projectId].

--- a/bridge/app/test/bridge/repositories/pending_state_without_start_test.dart
+++ b/bridge/app/test/bridge/repositories/pending_state_without_start_test.dart
@@ -1,0 +1,78 @@
+import "package:sesori_bridge/src/api/database/database.dart";
+import "package:sesori_bridge/src/bridge/repositories/permission_repository.dart";
+import "package:sesori_bridge/src/bridge/repositories/question_repository.dart";
+import "package:test/test.dart";
+
+import "../../helpers/plugin_runtime_test_support.dart";
+import "../../helpers/test_database.dart";
+import "../routing/routing_test_helpers.dart";
+
+void main() {
+  // Opening a session must not start a harness to learn there is nothing
+  // pending. Pending state lives in the backend process — an in-memory
+  // approval registry for ACP, the running HTTP server for OpenCode — so a
+  // stopped backend holds none, and starting it could only ever answer "none"
+  // after paying the full start cost.
+  group("pending state on a stopped backend", () {
+    late AppDatabase database;
+    late FakeBridgePlugin plugin;
+    late TestPluginRuntime runtime;
+
+    setUp(() async {
+      database = createTestDatabase();
+      addTearDown(database.close);
+      plugin = FakeBridgePlugin();
+      addTearDown(plugin.close);
+      runtime = createTestPluginRuntime(plugins: [plugin]);
+      await recordSessionBinding(
+        database: database,
+        sessionId: "ses_a",
+        backendSessionId: "backend-a",
+        pluginId: plugin.id,
+        projectId: "project-a",
+        parentSessionId: null,
+      );
+    });
+
+    test("questions report none without asking the plugin", () async {
+      final repository = QuestionRepository(
+        runtime: runtime,
+        sessionDao: database.sessionDao,
+        projectsDao: database.projectsDao,
+        aggregateSourceDeadline: const Duration(seconds: 5),
+      );
+      runtime.stoppedPluginIds.add(plugin.id);
+
+      expect(await repository.getPendingQuestions(sessionId: "ses_a"), isEmpty);
+      expect(
+        plugin.lastGetPendingQuestionsSessionId,
+        isNull,
+        reason: "a stopped backend must not be consulted, let alone started",
+      );
+    });
+
+    test("permissions report none without asking the plugin", () async {
+      final repository = PermissionRepository(
+        runtime: runtime,
+        sessionDao: database.sessionDao,
+      );
+      runtime.stoppedPluginIds.add(plugin.id);
+
+      expect(await repository.getPendingPermissions(sessionId: "ses_a"), isEmpty);
+      expect(plugin.lastGetPendingPermissionsSessionId, isNull);
+    });
+
+    test("a running backend is still asked", () async {
+      final repository = QuestionRepository(
+        runtime: runtime,
+        sessionDao: database.sessionDao,
+        projectsDao: database.projectsDao,
+        aggregateSourceDeadline: const Duration(seconds: 5),
+      );
+
+      await repository.getPendingQuestions(sessionId: "ses_a");
+
+      expect(plugin.lastGetPendingQuestionsSessionId, "backend-a");
+    });
+  });
+}

--- a/bridge/app/test/bridge/repositories/pending_state_without_start_test.dart
+++ b/bridge/app/test/bridge/repositories/pending_state_without_start_test.dart
@@ -62,6 +62,17 @@ void main() {
       expect(plugin.lastGetPendingPermissionsSessionId, isNull);
     });
 
+    test("a stopped backend is not reported as active", () async {
+      // The fake must match production, where activePluginIds reports only
+      // routable plugins — otherwise a test could pass while the real runtime
+      // reports no backend running at all.
+      expect(runtime.activePluginIds, contains(plugin.id));
+
+      runtime.stoppedPluginIds.add(plugin.id);
+
+      expect(runtime.activePluginIds, isEmpty);
+    });
+
     test("a running backend is still asked", () async {
       final repository = QuestionRepository(
         runtime: runtime,

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -149,6 +149,8 @@ class FakeBridgePlugin implements NativeProjectsPluginApi {
   String? lastGetCommandsProjectId;
 
   String? lastGetMessagesSessionId;
+  String? lastGetPendingQuestionsSessionId;
+  String? lastGetPendingPermissionsSessionId;
 
   String? lastGetProvidersProjectId;
   String? lastCreateSessionDirectory;
@@ -415,14 +417,19 @@ class FakeBridgePlugin implements NativeProjectsPluginApi {
   }
 
   @override
-  Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async => pendingQuestionsResult;
+  Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async {
+    lastGetPendingQuestionsSessionId = sessionId;
+    return pendingQuestionsResult;
+  }
 
   @override
   Future<List<PluginPendingQuestion>> getProjectQuestions({required String projectId}) async => pendingQuestionsResult;
 
   @override
-  Future<List<PluginPendingPermission>> getPendingPermissions({required String sessionId}) async =>
-      pendingPermissionsResult;
+  Future<List<PluginPendingPermission>> getPendingPermissions({required String sessionId}) async {
+    lastGetPendingPermissionsSessionId = sessionId;
+    return pendingPermissionsResult;
+  }
 
   @override
   Future<void> replyToQuestion({

--- a/bridge/app/test/helpers/plugin_runtime_test_support.dart
+++ b/bridge/app/test/helpers/plugin_runtime_test_support.dart
@@ -56,6 +56,9 @@ class TestPluginRuntime extends PluginRuntime {
   final Map<String, PluginRuntimeTransition> _transitions = {};
   final StreamController<List<PluginRuntimeSnapshot>> _snapshotChanges = StreamController.broadcast(sync: true);
   final StreamController<SourcedPluginRuntimeEvent> _runtimeEvents = StreamController.broadcast(sync: true);
+  /// Plugin ids that are registered but not running, so `useIfActive` reports
+  /// them as unavailable while `use` would start them.
+  final Set<String> stoppedPluginIds = {};
   bool generationCurrent = true;
   bool eventGenerationCurrent = true;
   int currentGeneration = 1;
@@ -255,6 +258,7 @@ class TestPluginRuntime extends PluginRuntime {
     required Enum operation,
     required Future<T> Function(BridgePluginApi api, int generation) body,
   }) async {
+    if (stoppedPluginIds.contains(pluginId)) return null;
     final plugin = _plugins[pluginId];
     return plugin == null ? null : body(plugin, currentGeneration);
   }

--- a/bridge/app/test/helpers/plugin_runtime_test_support.dart
+++ b/bridge/app/test/helpers/plugin_runtime_test_support.dart
@@ -64,7 +64,11 @@ class TestPluginRuntime extends PluginRuntime {
   int currentGeneration = 1;
 
   @override
-  Set<String> get activePluginIds => Set<String>.unmodifiable(_plugins.keys);
+  /// Mirrors production, where this reports only routable plugins — so a
+  /// stopped one must not appear here, or a test could pass while the real
+  /// runtime reports no active backend.
+  Set<String> get activePluginIds =>
+      Set<String>.unmodifiable(_plugins.keys.where((id) => !stoppedPluginIds.contains(id)));
 
   @override
   Set<String> get eligiblePluginIds => _eligiblePluginIds;
@@ -258,6 +262,10 @@ class TestPluginRuntime extends PluginRuntime {
     required Enum operation,
     required Future<T> Function(BridgePluginApi api, int generation) body,
   }) async {
+    // Mirrors the production guard: a registered but stopped plugin is not
+    // routable, so callers that decline to start one receive null rather than
+    // a live API. Without this a test could not distinguish "asked a running
+    // backend" from "declined to start a stopped one".
     if (stoppedPluginIds.contains(pluginId)) return null;
     final plugin = _plugins[pluginId];
     return plugin == null ? null : body(plugin, currentGeneration);


### PR DESCRIPTION
## Complexity

⚙️ moderate — a two-line behaviour change in two repositories, but it changes
when a backend process starts, so the reasoning matters more than the diff.

## What

Step 8/9 of `.plan/active/internal-chat-history`.
`QuestionRepository.getPendingQuestions` and
`PermissionRepository.getPendingPermissions` move from `PluginRuntime.use`
(`startIfNeeded: true`) to `useIfActive` (`startIfNeeded: false`), treating
"not running" as "none".

This is the shape `getSessionStatuses` already used; these two were the
outliers.

## Why

Serving history from the store did not make session open harness-free, which
is why the improvement was not perceptible: the same snapshot still called
these two through `use`, so opening a session started an idle backend anyway
and the user waited on the sluggish post-start window.

**A stopped backend cannot have pending state**, so starting one to ask could
only ever answer "none" after paying the full start cost:

- ACP/Cursor keep it in an in-memory approval registry
  (`acp_plugin.dart:1477`) that starts empty and returns `const []` when
  absent.
- OpenCode serves it from its running HTTP server (`GET /question`,
  `GET /permission`), which cannot answer while stopped.

So this is not a trade of accuracy for speed — the answer is the same, minus
the wake-up.

## Risk and test focus

Moderate, and worth stating plainly: this changes when a harness starts, so
the failure mode to look for is a *missed* pending interaction rather than a
slow one.

The argument that it cannot happen is above — pending state does not survive
the process. The case to watch in practice is a backend that is starting or
mid-restart when the snapshot runs: it reports none, and the SSE event that
follows delivers the question when it appears.

Worth checking manually: with a stopped harness, open a session — it should
render from the store without starting anything. Then trigger a permission
prompt and confirm it still appears.

## Expected result

- **User-visible:** opening a session with an idle backend no longer starts
  it, so it opens immediately instead of waiting on harness startup. This is
  the step that makes the stored-history work perceptible.
- **Database:** none.
- **Internal:** two repositories stop forcing a plugin start.

## Verification

- `dart analyze --fatal-infos` clean; `dart test` green (2,520).
- New `pending_state_without_start_test.dart`: a stopped plugin reports empty
  for both lookups **and is never consulted**, plus a control asserting a
  running plugin still is — so the change cannot silently disable the live
  path.
- Extending the test runtime was necessary to write those: its `useIfActive`
  previously always returned a plugin, so it could not express "registered but
  stopped". Without that, the tests would have passed while proving nothing.

## Scope

Deliberately only these two calls. `getSession` and `getChildren` are already
catalog-backed, and the options lookups (`listAgents`, `listProviders`,
`listCommands`) have answers that *are* meaningful for a stopped backend —
they need a caching or UI decision first, which step 9/9 scopes rather than
assumes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop waking the backend harness when opening a session by treating pending questions and permissions as empty if the plugin isn’t running. Sessions now open immediately with an idle backend; behavior matches `getSessionStatuses`.

- **Refactors**
  - Switched `QuestionRepository.getPendingQuestions` and `PermissionRepository.getPendingPermissions` to `runtime.useIfActive`; return `[]` when inactive.
  - Fixed test runtime to mirror production: `activePluginIds` excludes stopped plugins and `useIfActive` returns null; added tests asserting no plugin calls while stopped and that running plugins are still asked.
  - Updated `TRACKER.md` to mark step 7/9 merged and step 8/9 in progress.

<sup>Written for commit 6ba38526d27bd5339032b62b84c57cdffc48f0b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

