### PR TITLE
🌿 Render an older history page loaded while scrolled back

### DIFF
--- a/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -227,9 +227,27 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
     // While detached the controller is intentionally left stale so the
     // list structure cannot shift under the reader; `_onFollowChanged`
     // re-syncs on reattach.
-    if (_follow.following) {
+    //
+    // Older pages are the exception: the reader is detached precisely
+    // because they scrolled back for them, and they are prepended *above*
+    // the viewport, so rendering them cannot shift what is being read.
+    // Freezing them would leave the page loaded but invisible until the
+    // user returned to the newest message.
+    if (_follow.following || _hasOlderMessages(oldWidget: oldWidget)) {
       _syncChatController();
+      if (!_follow.following) {
+        _snapshot = null;
+      }
     }
+  }
+
+  /// Whether this update prepended history above what was already shown.
+  bool _hasOlderMessages({required SessionDetailMessageList oldWidget}) {
+    if (widget.messages.length <= oldWidget.messages.length) return false;
+    final previousOldestId = oldWidget.messages.firstOrNull?.info.id;
+    if (previousOldestId == null) return false;
+    final oldestIndex = widget.messages.indexWhere((message) => message.info.id == previousOldestId);
+    return oldestIndex > 0;
   }
 
   void _onFollowChanged() {

--- a/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -13,11 +13,14 @@ class _SessionDetailMessageListHarness extends StatefulWidget {
   final Map<String, String> initialStreamingText;
   final String? initialRetryErrorMessage;
 
+  final Future<void> Function()? onLoadOlderMessages;
+
   const _SessionDetailMessageListHarness({
     super.key,
     required this.initialMessages,
     required this.initialStreamingText,
     this.initialRetryErrorMessage,
+    this.onLoadOlderMessages,
   });
 
   @override
@@ -35,6 +38,10 @@ class _SessionDetailMessageListHarnessState extends State<_SessionDetailMessageL
     _messages = widget.initialMessages;
     _streamingText = widget.initialStreamingText;
     _retryErrorMessage = widget.initialRetryErrorMessage;
+  }
+
+  void prependOlderMessages(List<MessageWithParts> older) {
+    setState(() => _messages = [...older, ..._messages]);
   }
 
   void appendNewestMessage(MessageWithParts message) {
@@ -63,7 +70,7 @@ class _SessionDetailMessageListHarnessState extends State<_SessionDetailMessageL
       home: Scaffold(
         body: SessionDetailMessageList(
           projectId: null,
-          onLoadOlderMessages: null,
+          onLoadOlderMessages: widget.onLoadOlderMessages,
           messages: _messages,
           streamingText: _streamingText,
           children: const <Session>[],
@@ -172,6 +179,68 @@ Future<void> _detachViewport(WidgetTester tester) async {
 }
 
 void main() {
+  testWidgets("an older page appears after it is prepended while scrolled back", (tester) async {
+    final key = GlobalKey<_SessionDetailMessageListHarnessState>();
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        key: key,
+        initialMessages: [
+          for (var index = 10; index < 40; index++)
+            _message(messageId: "m$index", role: "user", text: "message $index"),
+        ],
+        initialStreamingText: const {},
+        onLoadOlderMessages: () async {},
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Scrolling back detaches the follow tracker, which is what happens the
+    // moment a user reaches for older history.
+    await tester.drag(find.byType(SessionDetailMessageList), const Offset(0, 600));
+    await tester.pumpAndSettle();
+
+    key.currentState!.prependOlderMessages([
+      for (var index = 0; index < 10; index++)
+        _message(messageId: "m$index", role: "user", text: "message $index"),
+    ]);
+    await tester.pumpAndSettle();
+
+    // Scroll the rest of the way back to look for the oldest message.
+    for (var attempt = 0; attempt < 15; attempt++) {
+      await tester.drag(find.byType(SessionDetailMessageList), const Offset(0, 600));
+      await tester.pumpAndSettle();
+    }
+
+    expect(
+      find.textContaining("message 0"),
+      findsOneWidget,
+      reason: "an older page must render once loaded, not wait for the user to return to the newest message",
+    );
+  });
+
+  testWidgets("scrolling back through history requests the older page", (tester) async {
+    var requested = 0;
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        initialMessages: [
+          for (var index = 0; index < 40; index++)
+            _message(messageId: "m$index", role: "user", text: "message $index"),
+        ],
+        initialStreamingText: const {},
+        onLoadOlderMessages: () async => requested++,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Drag downward: in a reversed list that scrolls back through history.
+    for (var attempt = 0; attempt < 12 && requested == 0; attempt++) {
+      await tester.drag(find.byType(SessionDetailMessageList), const Offset(0, 600));
+      await tester.pumpAndSettle();
+    }
+
+    expect(requested, greaterThan(0), reason: "reaching the oldest message must load the next page");
+  });
+
   testWidgets("detached viewport stays stable when a new newest message arrives", (tester) async {
     await tester.binding.setSurfaceSize(const Size(900, 700));
     addTearDown(() => tester.binding.setSurfaceSize(null));


### PR DESCRIPTION
## Complexity

🌿 straightforward — one condition in `didUpdateWidget`, but it is the
difference between paging working and appearing entirely broken.

## What

Fixes pagination not working on `main`, reported after testing on macOS.

The message list deliberately freezes its chat controller while the user is
*detached* (scrolled away from the newest message), so live events cannot
shift the list under someone who is reading. Scrolling back to load older
history detaches by definition — so that freeze also swallowed the page the
user had just asked for.

An older page is the one update that is safe to apply while detached: it is
prepended **above** the viewport, so it cannot move what is being read. The
list now detects that case (the previously oldest message shifted down),
syncs it, and drops the frozen snapshot so the rows become visible.

## Why this looked like "pagination doesn't work"

Every layer below was working. Verified against the running bridge on the
reporter's machine:

```
POST /session/messages {"sessionId":"ses_446…","limit":3}
→ messages: 3, nextCursor: 1305
```

The request fired, the bridge paged correctly, the cubit merged the page, and
the state updated — the widget just never rendered it until the user scrolled
back to the bottom, at which point the reattach re-synced and the older
messages silently appeared. That also explains the "pull to refresh" feel:
the only visible response to reaching the top was the package's own loading
sliver, with no new content behind it.

## Risk and test focus

Low and contained: the freeze still applies to every other update, so the
protection it exists for — live events not shifting the transcript under a
reader — is unchanged. Only prepends are let through.

Worth checking manually: scroll back through a long session (the reporter's
5,698-message session is a good case) and confirm older messages appear
without needing to return to the bottom, while a message arriving live still
does not jog the viewport.

## Expected result

- **User-visible:** scrolling back through history loads and **renders** older
  messages continuously, which is what step 7/9 intended to ship.
- **Database:** none.
- **Internal:** `didUpdateWidget` gains one prepend-detection branch.

## Verification

- `flutter analyze` clean; `flutter test` green (924).
- Two new widget tests: scrolling back requests the older page, and a page
  prepended while detached actually renders. The second fails without this
  fix — I confirmed that before fixing.

## Note on the reported behaviour

The request is already automatic on reaching the oldest item, and the loading
indicator already exists and only shows while a page is in flight
(`flutter_chat_ui` renders it via `onEndReached` + its `LoadMore` sliver, and
we pass a null callback once `nextCursor` is null so it stops entirely). Those
parts were working; they just had nothing to show because the loaded page was
being frozen out. No custom loading row was needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes message history pagination so older pages render while you’re scrolled back, and avoids starting inactive backends just to check pending questions/permissions to speed up session open.

- **Bug Fixes**
  - Client: when an older page is prepended while detached, the list detects it, syncs the chat controller, and clears the frozen snapshot so new rows appear immediately.
  - Tests: added two widget tests to confirm scrolling back triggers a load and that prepended pages render while detached.

- **Refactors**
  - Bridge: `QuestionRepository.getPendingQuestions` and `PermissionRepository.getPendingPermissions` now use `useIfActive` and treat “not running” as “none,” avoiding waking a harness on session open.
  - Tests: added coverage to ensure stopped backends aren’t consulted, while running ones still are.

<sup>Written for commit 8f7da724ba6ff73e44e9358f61b572fa21b2cee3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

