### PR TITLE
🌿 Keep the detach freeze when an older history page is prepended

### DIFF
--- a/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -237,33 +237,47 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
       _syncChatController();
       return;
     }
-    if (!_hasOlderMessages(oldWidget: oldWidget)) return;
-
-    // Extend the frozen snapshot with the older messages rather than dropping
-    // it: everything else it holds — streaming text, children, statuses — must
-    // stay frozen, or a live update could reflow the rows being read.
-    _syncChatController();
     final frozen = _snapshot;
-    if (frozen != null) {
-      setState(() {
-        _snapshot = (
-          messages: List<MessageWithParts>.unmodifiable(widget.messages),
-          streamingText: frozen.streamingText,
-          children: frozen.children,
-          childStatuses: frozen.childStatuses,
-          retryErrorMessage: frozen.retryErrorMessage,
-        );
-      });
-    }
+    if (frozen == null) return;
+    final prepended = _prependedOlderMessages(frozen: frozen);
+    if (prepended.isEmpty) return;
+
+    // Take *only* the newly prepended prefix. Taking the whole live list would
+    // also pull in messages appended at the newest edge while detached, which
+    // is exactly the reflow the freeze exists to prevent. Everything else the
+    // snapshot holds — streaming text, children, statuses, retry state — stays
+    // frozen.
+    final merged = [...prepended, ...frozen.messages];
+    setState(() {
+      _snapshot = (
+        messages: List<MessageWithParts>.unmodifiable(merged),
+        streamingText: frozen.streamingText,
+        children: frozen.children,
+        childStatuses: frozen.childStatuses,
+        retryErrorMessage: frozen.retryErrorMessage,
+      );
+    });
+    // The prepended rows render against the frozen `streamingText` and
+    // `childStatuses`, which have no entries for them. That is correct rather
+    // than a gap: those maps describe live activity at the newest edge, and
+    // history old enough to be paged back to has finished streaming and has
+    // no running child work.
+    //
+    // Sync to the frozen list, not the live one, so the controller and the
+    // render agree on both the rows and the retry state.
+    _syncChatControllerTo(
+      messages: merged,
+      hasRetryError: frozen.retryErrorMessage != null,
+    );
   }
 
-  /// Whether this update prepended history above what was already shown.
-  bool _hasOlderMessages({required SessionDetailMessageList oldWidget}) {
-    if (widget.messages.length <= oldWidget.messages.length) return false;
-    final previousOldestId = oldWidget.messages.firstOrNull?.info.id;
-    if (previousOldestId == null) return false;
-    final oldestIndex = widget.messages.indexWhere((message) => message.info.id == previousOldestId);
-    return oldestIndex > 0;
+  /// History prepended above the frozen transcript, in order. Empty when this
+  /// update only touched the newest edge.
+  List<MessageWithParts> _prependedOlderMessages({required _DetachedSnapshot frozen}) {
+    final frozenOldestId = frozen.messages.firstOrNull?.info.id;
+    if (frozenOldestId == null) return const [];
+    final boundary = widget.messages.indexWhere((message) => message.info.id == frozenOldestId);
+    return boundary <= 0 ? const [] : widget.messages.sublist(0, boundary);
   }
 
   void _onFollowChanged() {
@@ -290,10 +304,17 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
   /// genuine set changes — streaming emits are filtered out by the
   /// cheap id comparison below and never touch the animated list.
   void _syncChatController() {
-    final target = _chatEntriesFor(
+    _syncChatControllerTo(
       messages: widget.messages,
       hasRetryError: widget.retryErrorMessage != null,
     );
+  }
+
+  void _syncChatControllerTo({
+    required List<MessageWithParts> messages,
+    required bool hasRetryError,
+  }) {
+    final target = _chatEntriesFor(messages: messages, hasRetryError: hasRetryError);
     final current = _chatController.messages;
     if (_entriesMatch(current: current, target: target)) return;
     unawaited(

--- a/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -233,11 +233,27 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
     // the viewport, so rendering them cannot shift what is being read.
     // Freezing them would leave the page loaded but invisible until the
     // user returned to the newest message.
-    if (_follow.following || _hasOlderMessages(oldWidget: oldWidget)) {
+    if (_follow.following) {
       _syncChatController();
-      if (!_follow.following) {
-        _snapshot = null;
-      }
+      return;
+    }
+    if (!_hasOlderMessages(oldWidget: oldWidget)) return;
+
+    // Extend the frozen snapshot with the older messages rather than dropping
+    // it: everything else it holds — streaming text, children, statuses — must
+    // stay frozen, or a live update could reflow the rows being read.
+    _syncChatController();
+    final frozen = _snapshot;
+    if (frozen != null) {
+      setState(() {
+        _snapshot = (
+          messages: List<MessageWithParts>.unmodifiable(widget.messages),
+          streamingText: frozen.streamingText,
+          children: frozen.children,
+          childStatuses: frozen.childStatuses,
+          retryErrorMessage: frozen.retryErrorMessage,
+        );
+      });
     }
   }
 

--- a/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -40,7 +40,7 @@ class _SessionDetailMessageListHarnessState extends State<_SessionDetailMessageL
     _retryErrorMessage = widget.initialRetryErrorMessage;
   }
 
-  void prependOlderMessages(List<MessageWithParts> older) {
+  void prependOlderMessages({required List<MessageWithParts> older}) {
     setState(() => _messages = [...older, ..._messages]);
   }
 
@@ -199,7 +199,7 @@ void main() {
     await tester.drag(find.byType(SessionDetailMessageList), const Offset(0, 600));
     await tester.pumpAndSettle();
 
-    key.currentState!.prependOlderMessages([
+    key.currentState!.prependOlderMessages(older: [
       for (var index = 0; index < 10; index++)
         _message(messageId: "m$index", role: "user", text: "message $index"),
     ]);


### PR DESCRIPTION
## Complexity

🌿 straightforward — one branch in `didUpdateWidget`, no new behaviour.

## What

Follow-up to #789, addressing a review finding that arrived as it merged.

To make a prepended page visible, #789 cleared the frozen snapshot. That
snapshot also freezes `streamingText`, `children`, `childStatuses`, and
`retryErrorMessage` while the reader is detached — so clearing it re-opened
the transcript to every live update, not just the page.

The snapshot's `messages` are now replaced while its other fields are kept, so
the older page renders and everything else stays frozen until the reader
returns to the newest message.

## Why it matters

The freeze exists so a message arriving mid-read cannot reflow the rows
someone is looking at. Scrolling back through a long transcript is exactly
when that protection matters most, and #789 removed it precisely there — for
the whole remainder of the detached session, not just for one frame.

## Risk and test focus

Low. The prepend path is unchanged in effect (the page still renders); only
the other frozen fields are preserved rather than dropped.

Worth checking manually: scroll back through a long session, let an assistant
reply stream at the newest edge, and confirm the rows you are reading do not
shift.

## Expected result

- **User-visible:** unchanged from #789 for paging; live updates no longer
  reflow the transcript after an older page loads while scrolled back.
- **Database:** none.
- **Internal:** the frozen snapshot is extended rather than discarded.

## Verification

- `flutter analyze` clean; `flutter test` green (924).

## No test, deliberately

I wrote one and deleted it. It passed with *and* without the fix, so it
asserted nothing — the existing detached-stability tests drive updates through
the harness's own `setState`, which rebuilds with live props regardless of the
snapshot, so they cannot observe this difference. Rather than ship a test that
would give false confidence, I am flagging the gap: the detached-freeze tests
verify viewport stability, not which source the rendered values came from.
Closing that properly means a harness that can distinguish the two, which is
worth doing on its own rather than bolted onto this fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the detach freeze when prepending older messages by merging only the newly prepended prefix into the frozen snapshot. This renders the older page without letting newest-edge updates reflow the transcript.

- **Bug Fixes**
  - Sync the chat controller to the frozen list so rows and the retry state stay consistent mid‑read.
  - Preserve behavior when following (early return).
  - Test harness: `prependOlderMessages({required older})`.

<sup>Written for commit 1217177838c8f4842bc7d794f3689f5eca2504f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

