### PR TITLE
🌱 [internal-chat-history] Retire plan and scope the remaining harness-free work [step 9/9]

### DIFF
--- a/.plan/completed/internal-chat-history/PLAN.md
+++ b/.plan/completed/internal-chat-history/PLAN.md
@@ -3,12 +3,15 @@
 ## Status
 
 - **Plan slug:** `internal-chat-history`
-- **Status:** Active — plan raised, implementation not started
+- **Status:** **Complete** — all eight implementation steps and two follow-up
+  fixes merged. Moved here from `.plan/active/` on 2026-08-08.
 - **Plan date:** 2026-08-06 (revised 2026-08-06 after comparison with the
   parallel `session-history-store` draft, PR #764; its superior mechanisms
   were merged into this plan and that draft is superseded)
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
-- **Base:** `main` at `232974e1`
+- **Base:** `main` at `232974e1` (merged through `e884a580`)
+- **Follow-up:** serving agents/providers/commands on a stopped backend is
+  assessed in § Step 9/9, pending product decisions.
 - **Prerequisite (satisfied 2026-08-07):** the `read-only-archiving` plan has
   landed and merged fully. It removed unarchive end to end and made archived
   sessions read-only; this plan builds its archive export/purge on that
@@ -583,48 +586,91 @@ Scope limits, deliberately:
 
 ## Step 9/9: Remaining Harness-Free Session Open (assessment, not implementation)
 
-Serving history from the store removes one plugin call from session open, but
-the snapshot still wakes an idle backend through other calls, so the user does
-not perceive the win. Step 9/9 retires this plan **and** produces an aligned,
-code-informed assessment of what it would take to open a session with every
-harness stopped. Deliverable is a written proposal — a follow-up plan — not an
-implementation, so this series stays scoped.
+This series is complete. Opening a session now serves history from
+`chat_history.db`, never starts a harness to learn there is no pending
+interaction, pages older messages on both sides, and archives transcripts
+without touching a backend.
 
-Observed on 2026-08-08 against a bridge running step 4/8: the store served
-history correctly (`chat_history.db` populated, sessions `synced_at` with a
-current watermark), yet opening a session still felt unchanged because the
-remaining calls started the backend anyway.
+One group of calls still starts an idle backend, so a fully stopped harness is
+not yet a fully passive session open. This section is the code-informed
+assessment for a follow-up plan, written after steps 1–8 landed.
 
-Calls in `SessionDetailLoadService._loadSnapshot` still to classify, each as
-"can it be answered without the plugin?" (pending questions and permissions
-are handled in step 8/9 and excluded here):
+### What the session-open snapshot actually calls
 
-- `getSession`, `getChildren` — already catalog-backed in the common path;
-  confirm no plugin fallback fires for a stored session.
-- `listAgents` / `listProviders` / `listCommands` — plugin-backed, but a
-  session-options cache already exists (`session_options_cache_table`);
-  assess whether the cached snapshot can answer an open on a stopped backend.
-- `getSessionStatuses` — already correct: uses `useIfActive`
-  (`startIfNeeded: false`), so it degrades instead of starting. This is the
-  shape the others should be measured against.
+`SessionDetailLoadService._loadSnapshot` fires, with each call classified
+against the merged code:
 
-Questions to answer explicitly, with the user, before any implementation:
+| Call | Bridge path | Starts a stopped backend? |
+|---|---|---|
+| history | `ChatHistoryService.getSessionMessages` | No — served from `chat_history.db` |
+| `getSession` | `SessionRepository.getSessionForProject` | No — pure `_sessionDao.getSession` read |
+| `getChildren` | `SessionRepository.getChildSessions` | No — pure `_sessionDao.getChildCatalogSessions` read |
+| `getSessionStatuses` | `useIfActive` | No — degrades to empty when stopped |
+| `getPendingQuestions` / `getPendingPermissions` | `useIfActive` (step 8/9) | No — empty when stopped |
+| `listAgents` | `AgentRepository.getAgents` → `_runtime.use` | **Yes** |
+| `listProviders` | `ProviderRepository.getProviders` → `_runtime.use` | **Yes** |
+| `listCommands` | `SessionRepository.getCommands` → `_runtime.use` | **Yes** |
 
-0. What should a backend that never auto-starts (for example OpenCode
-   configured not to start on demand) do for each of these? That case makes
-   "start it to find out" not merely slow but unavailable, so it is the
-   sharpest test of every answer below.
-1. Which of these must be live-accurate, and which may serve a bridge-side
-   cached or empty answer while the backend is stopped?
-2. What should the UI show for a stopped-backend field — last known value,
-   empty, or an explicit "unavailable until the backend starts" state? A
-   silently empty pending-questions list is a correctness risk if a question
-   really is outstanding.
-3. Does opening a session imply intent to *use* it (so a deliberate,
-   non-blocking background start is right), or should the backend start only
-   when the user actually acts?
-4. Given harnesses respond poorly right after starting, should any such start
-   be explicitly backgrounded so it never blocks first paint?
+So a stopped backend is now woken only to render the agent, provider, and
+command pickers the composer needs. History, catalog reads, status, and
+pending state are all answered without it.
+
+### Why these three differ from the step 8/9 pair
+
+`useIfActive`-returning-empty was correct for pending questions and
+permissions because that state **cannot exist** on a stopped backend — ACP
+keeps it in an in-memory registry, OpenCode in its running HTTP server. Agents,
+providers, and commands are the opposite: they are **configuration the backend
+genuinely has while stopped** (read from disk / config), so returning an empty
+list would not be a faithful "none", it would be a lie that silently removes
+the composer's options.
+
+### A cache already exists that could answer them
+
+`session_options_cache_table` persists exactly this data
+(`SessionOptionsService.loadDynamic` serves it with a 30-day retention, no
+plugin call, when the cached revision matches the current project resolution).
+But the session-**detail** open path does not use it — it calls the raw
+`/agent`, `/provider`, `/command` routes, which go straight to `_runtime.use`.
+The cache serves the create-session composer flow (`/session/options`) instead.
+
+The bridge therefore already has the machinery to serve these three without a
+start; it is simply wired to the wrong consumer.
+
+### Open questions for the follow-up plan (need user decisions)
+
+0. **The no-auto-start backend is the decisive case.** A backend launched with
+   `--opencode-no-auto-start` (as the reporter runs) cannot be started on
+   demand at all, so "start it to find out" is *unavailable*, not merely slow.
+   Against such a backend, opening a session must have a non-starting answer
+   for agents/providers/commands or the composer cannot render.
+1. **Fresh vs cached vs empty.** Must the three pickers be live-accurate on
+   every open, or may a fresh-enough cached snapshot answer while the backend
+   is stopped (matching the composer flow's 30-day cache)?
+2. **What the UI shows when the backend is stopped and the cache is cold.**
+   Last-known value, empty with an "unavailable until the backend starts"
+   affordance, or block the composer? Empty is a correctness risk here (unlike
+   pending questions) because the options genuinely exist.
+3. **Does opening imply intent?** A deliberate, non-blocking background start
+   on open would let the pickers populate shortly after first paint — but that
+   reintroduces the harness-start-on-open cost this whole series removes.
+4. **First-paint budget.** Any start that remains must be backgrounded so it
+   never blocks the transcript rendering.
+
+### Recommended direction
+
+Serve the three pickers from the options cache when it is fresh and the
+backend is stopped, refreshing in the background when the backend is running,
+and show an explicit "starting the backend to load options" affordance only
+when the cache is cold and the backend *can* be started. A no-auto-start
+backend with a cold cache is the one case that needs a real UI decision
+(question 2).
+
+This direction reuses `SessionOptionsService.loadDynamic` instead of adding a
+third options path, keeps the composer functional on a stopped backend, and
+leaves the aggressive "start on open" behaviour in the past. The one honest
+residue is config staleness while a backend is stopped, which the 30-day
+retention already bounds for the composer.
 
 ## Verification
 

--- a/.plan/completed/internal-chat-history/PLAN.md
+++ b/.plan/completed/internal-chat-history/PLAN.md
@@ -10,8 +10,10 @@
   were merged into this plan and that draft is superseded)
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Base:** `main` at `232974e1` (merged through `e884a580`)
-- **Follow-up:** serving agents/providers/commands on a stopped backend is
-  assessed in § Step 9/9, pending product decisions.
+- **Follow-up:** two groups of calls can still start a stopped backend —
+  agents/providers/commands, and history on a cold or stale session (backfill
+  through `_runtime.use`). Both are assessed in § Step 9/9, pending product
+  decisions.
 - **Prerequisite (satisfied 2026-08-07):** the `read-only-archiving` plan has
   landed and merged fully. It removed unarchive end to end and made archived
   sessions read-only; this plan builds its archive export/purge on that
@@ -745,6 +747,15 @@ Either require a `complete` entry on the stopped-backend path or carry the
 incomplete state to the UI. The one honest residue is config staleness while a
 backend is stopped, which the 30-day retention already bounds for the
 composer.
+
+**Capability gating, for older bridges.** `loadCacheOnly` is exposed via
+`/session/options?refresh=false`, which is unavailable on a published older
+bridge whose `supportsSessionOptions` defaults to false — for those, the three
+raw `/agent`, `/provider`, `/command` routes are the only option-loading path.
+The follow-up must gate the cache-only call on the advertised capability and
+retain the legacy raw requests (or explicitly degrade) for older bridges,
+otherwise a newer app's session composer silently loses its options against
+them. This is the usual older-peer rule applied to a new capability.
 
 ## Verification
 

--- a/.plan/completed/internal-chat-history/PLAN.md
+++ b/.plan/completed/internal-chat-history/PLAN.md
@@ -757,6 +757,24 @@ retain the legacy raw requests (or explicitly degrade) for older bridges,
 otherwise a newer app's session composer silently loses its options against
 them. This is the usual older-peer rule applied to a new capability.
 
+**Wiring only `loadCacheOnly` is not enough to deliver the promised behavior.**
+The recommendation says "refresh in the background when the backend is
+running", but `loadCacheOnly` never refreshes — on a cold or stale cache it
+returns `SessionOptionsCacheUnavailable` and stops. The alternative modes on
+the route are both wrong for this purpose: no `refresh` param runs
+`loadDynamic`, which falls back to activation and can start a stopped backend,
+and `refresh=true` runs `refreshExplicit`, which definitely does. What the
+follow-up actually needs is an **active-only refresh** — and
+`SessionOptionsService.refreshActiveOnly` (`session_options_service.dart:170`)
+already exists with exactly that semantics, but it is internal and not exposed
+on the route. The follow-up must expose it as an active-only bridge operation
+(or provide an equivalent atomic bridge-side selection between cache-only and
+active-only refresh). Doing the selection client-side from observed state
+would race a backend going dormant, so the decision belongs on the bridge.
+Without this, "refresh in the background when running" is unimplementable, and
+opening a session would either never refresh cold options or wake the
+backend.
+
 ## Verification
 
 - Per-PR: owning-package tests + analyzer; migration verifier fixtures for

--- a/.plan/completed/internal-chat-history/PLAN.md
+++ b/.plan/completed/internal-chat-history/PLAN.md
@@ -586,10 +586,12 @@ Scope limits, deliberately:
 
 ## Step 9/9: Remaining Harness-Free Session Open (assessment, not implementation)
 
-This series is complete. Opening a session now serves history from
-`chat_history.db`, never starts a harness to learn there is no pending
-interaction, pages older messages on both sides, and archives transcripts
-without touching a backend.
+This series is complete. Opening a session with current, previously synced
+history serves that history from `chat_history.db`, never starts a harness to
+learn there is no pending interaction, and pages older messages on both sides.
+Archiving never deletes the backend's stored transcript; it can still touch —
+and start — the backend when bringing the store current or notifying the
+plugin (see the archive note below).
 
 One group of calls still starts an idle backend, so a fully stopped harness is
 not yet a fully passive session open. This section is the code-informed
@@ -602,7 +604,7 @@ against the merged code:
 
 | Call | Bridge path | Starts a stopped backend? |
 |---|---|---|
-| history | `ChatHistoryService.getSessionMessages` | No — served from `chat_history.db` |
+| history | `ChatHistoryService.getSessionMessages` | No *when the store is current* — served from `chat_history.db`. A session with no sync row, a null `syncedAt`, or a stale watermark triggers `backfillSession`, which reaches `SessionRepository.getSessionMessages` → `_runtime.use` and **can start a stopped backend**. See the cold/stale note below. |
 | `getSession` | `SessionRepository.getSessionForProject` | No — pure `_sessionDao.getSession` read |
 | `getChildren` | `SessionRepository.getChildSessions` | No — pure `_sessionDao.getChildCatalogSessions` read |
 | `getSessionStatuses` | `useIfActive` | No — degrades to empty when stopped |
@@ -611,9 +613,34 @@ against the merged code:
 | `listProviders` | `ProviderRepository.getProviders` → `_runtime.use` | **Yes** |
 | `listCommands` | `SessionRepository.getCommands` → `_runtime.use` | **Yes** |
 
-So a stopped backend is now woken only to render the agent, provider, and
-command pickers the composer needs. History, catalog reads, status, and
-pending state are all answered without it.
+So a stopped backend is woken for two groups, not one: the three picker calls
+**and** any history read on a cold or stale session (a session never synced,
+or advanced outside Sesori since the last sync). A session with current,
+previously synced history answers entirely from the store; catalog reads,
+status, and pending state never wake it.
+
+**Cold/stale history is a real gap, not a corner case.** Opening a session the
+bridge has never backfilled, or one advanced through the backend CLI since its
+last sync, starts the backend purely to fetch history — and against a
+`--opencode-no-auto-start` backend that open fails at history, before the
+composer options ever matter. The follow-up plan must decide what a cold or
+stale session means for a stopped backend: serve what the store has with an
+explicit "possibly incomplete" marker, or block open until the backend is
+started. Serving stale history without a marker is a correctness risk (the
+store may be missing messages the backend has); failing the open outright
+defeats the point of the feature for first-time opens.
+
+### Archive can still touch the backend (for the record)
+
+The success criterion "archiving exports without starting the backend" is not
+what the code does. `ChatHistoryService.exportSessionHistory` backfills
+through `_runtime.use` whenever the stored transcript is missing or stale, and
+`SessionLifecycleService._doArchive` calls `notifySessionArchived` — also
+`_runtime.use` — even when history is current. What the series *does*
+guarantee is narrower but still the point: **archiving never modifies or
+deletes the backend's stored transcript**, so the export/purge is never the
+only copy. A stopped backend can be started by archiving, but never destroyed
+by it.
 
 ### Why these three differ from the step 8/9 pair
 
@@ -666,11 +693,17 @@ when the cache is cold and the backend *can* be started. A no-auto-start
 backend with a cold cache is the one case that needs a real UI decision
 (question 2).
 
-This direction reuses `SessionOptionsService.loadDynamic` instead of adding a
-third options path, keeps the composer functional on a stopped backend, and
-leaves the aggressive "start on open" behaviour in the past. The one honest
-residue is config staleness while a backend is stopped, which the 30-day
-retention already bounds for the composer.
+This direction needs a **cache-only variant of the options loader**, not a
+straight reuse of `SessionOptionsService.loadDynamic`. `loadDynamic` falls
+back to `_refresh` with `SessionOptionsCaptureActivation.mayActivate` when the
+cache is absent or stale, and that refresh reaches `_runtime.useWithGeneration`
+— it starts the stopped backend the follow-up is trying not to start, and
+fails outright against a `--no-auto-start` backend before the cold-cache
+affordance can be shown. The follow-up must add a `loadCacheOnly` (or an
+active-only refresh) for the stopped-backend path, reusing `loadDynamic`'s
+cache read and resolution logic without its activation fallback. The one
+honest residue is config staleness while a backend is stopped, which the
+30-day retention already bounds for the composer.
 
 ## Verification
 

--- a/.plan/completed/internal-chat-history/PLAN.md
+++ b/.plan/completed/internal-chat-history/PLAN.md
@@ -636,11 +636,16 @@ The success criterion "archiving exports without starting the backend" is not
 what the code does. `ChatHistoryService.exportSessionHistory` backfills
 through `_runtime.use` whenever the stored transcript is missing or stale, and
 `SessionLifecycleService._doArchive` calls `notifySessionArchived` — also
-`_runtime.use` — even when history is current. What the series *does*
-guarantee is narrower but still the point: **archiving never modifies or
-deletes the backend's stored transcript**, so the export/purge is never the
-only copy. A stopped backend can be started by archiving, but never destroyed
-by it.
+`_runtime.use` — even when history is current. Archiving also **modifies**
+backend session state, not just history: `OpenCodePlugin.archiveSession`
+PATCHes the session's `time.archived` field
+(`bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart:573`).
+
+What the series *does* guarantee is narrower but still the point: **archiving
+never deletes the backend's stored history** (the transcript messages remain,
+retained, even though the archived flag is set), so the export/purge is never
+the only copy. A stopped backend can be started and its session state modified
+by archiving, but its transcript is never destroyed.
 
 ### Why these three differ from the step 8/9 pair
 
@@ -693,17 +698,28 @@ when the cache is cold and the backend *can* be started. A no-auto-start
 backend with a cold cache is the one case that needs a real UI decision
 (question 2).
 
-This direction needs a **cache-only variant of the options loader**, not a
-straight reuse of `SessionOptionsService.loadDynamic`. `loadDynamic` falls
-back to `_refresh` with `SessionOptionsCaptureActivation.mayActivate` when the
-cache is absent or stale, and that refresh reaches `_runtime.useWithGeneration`
-— it starts the stopped backend the follow-up is trying not to start, and
-fails outright against a `--no-auto-start` backend before the cold-cache
-affordance can be shown. The follow-up must add a `loadCacheOnly` (or an
-active-only refresh) for the stopped-backend path, reusing `loadDynamic`'s
-cache read and resolution logic without its activation fallback. The one
-honest residue is config staleness while a backend is stopped, which the
-30-day retention already bounds for the composer.
+This direction must **wire the existing `SessionOptionsService.loadCacheOnly`**
+(`bridge/app/lib/src/bridge/services/session_options_service.dart:136`) into
+the stopped-backend session-detail path, not add a new loader. `loadCacheOnly`
+already implements exactly the needed semantics: it reads the valid cache,
+returns `SessionOptionsCacheUnavailable` when absent or stale, and never falls
+back to `_refresh` or activation — unlike `loadDynamic`, whose cache-miss path
+refreshes with `SessionOptionsCaptureActivation.mayActivate` via
+`_runtime.useWithGeneration`, starting the stopped backend the follow-up is
+trying not to start and failing outright against a `--no-auto-start` backend
+before a cold-cache affordance can be shown. The remaining work is to expose
+`loadCacheOnly` through the session-detail client flow and handle its
+`SessionOptionsCacheUnavailable` outcome.
+
+One caveat to resolve in that work: `loadCacheOnly` returns `cached.response`
+without checking the entry's `completeness`, and the cache can hold a
+`partial` observation (ACP records one before its command tracker has a
+snapshot; Codex when model or command discovery falls back). Serving a partial
+entry as authoritative would silently present an incomplete options list.
+Either require a `complete` entry on the stopped-backend path or carry the
+incomplete state to the UI. The one honest residue is config staleness while a
+backend is stopped, which the 30-day retention already bounds for the
+composer.
 
 ## Verification
 

--- a/.plan/completed/internal-chat-history/PLAN.md
+++ b/.plan/completed/internal-chat-history/PLAN.md
@@ -593,9 +593,11 @@ Archiving never deletes the backend's stored transcript; it can still touch —
 and start — the backend when bringing the store current or notifying the
 plugin (see the archive note below).
 
-One group of calls still starts an idle backend, so a fully stopped harness is
-not yet a fully passive session open. This section is the code-informed
-assessment for a follow-up plan, written after steps 1–8 landed.
+Two groups of calls can still start an idle backend, so a fully stopped
+harness is not yet a fully passive session open: the three picker lookups
+**and** history on a cold or stale session (backfill). This section is the
+code-informed assessment for a follow-up plan, written after steps 1–8
+landed.
 
 ### What the session-open snapshot actually calls
 
@@ -657,6 +659,18 @@ genuinely has while stopped** (read from disk / config), so returning an empty
 list would not be a faithful "none", it would be a lie that silently removes
 the composer's options.
 
+**One caveat to that reasoning, for the follow-up:** `useIfActive` keys off the
+bridge runtime slot, not the backend. In OpenCode's attach mode the bridge
+does not own the server — it connects to an independently owned one and never
+kills it, so that server can outlive a bridge restart while holding pending
+questions or permissions. If the follow-up moves the pickers to cache-only and
+no remaining `_runtime.use` call activates the plugin, `useIfActive` returns
+null purely because the slot is not routable — not because the backend is
+stopped — and the client would get an empty pending list despite a live
+external server. The follow-up must distinguish "bridge runtime inactive" from
+"backend unavailable" for externally owned servers, or step 8/9's reasoning
+would silently miss pending interactions in that mode.
+
 ### A cache already exists that could answer them
 
 `session_options_cache_table` persists exactly this data
@@ -675,7 +689,11 @@ start; it is simply wired to the wrong consumer.
    `--opencode-no-auto-start` (as the reporter runs) cannot be started on
    demand at all, so "start it to find out" is *unavailable*, not merely slow.
    Against such a backend, opening a session must have a non-starting answer
-   for agents/providers/commands or the composer cannot render.
+   for agents/providers/commands, or the composer **degrades** — the client
+   already renders a loaded snapshot when these fail, with agents and commands
+   as empty lists and providers null (`session_detail_load_service.dart`), so
+   the real problem is a composer that silently loses its options, not a
+   blocked one.
 1. **Fresh vs cached vs empty.** Must the three pickers be live-accurate on
    every open, or may a fresh-enough cached snapshot answer while the backend
    is stopped (matching the composer flow's 30-day cache)?
@@ -697,6 +715,13 @@ and show an explicit "starting the backend to load options" affordance only
 when the cache is cold and the backend *can* be started. A no-auto-start
 backend with a cold cache is the one case that needs a real UI decision
 (question 2).
+
+**Archived sessions should skip the pickers entirely, not route them through
+the cache.** `SessionDetailBody` always renders archived sessions in the
+read-only variant with no composer or mutating controls
+(`session_detail_body.dart`), yet `_loadSnapshot` still launches all three
+picker requests. Wasting option work on a UI that cannot consume it would
+otherwise retain the cache-miss handling the follow-up is adding.
 
 This direction must **wire the existing `SessionOptionsService.loadCacheOnly`**
 (`bridge/app/lib/src/bridge/services/session_options_service.dart:136`) into

--- a/.plan/completed/internal-chat-history/TRACKER.md
+++ b/.plan/completed/internal-chat-history/TRACKER.md
@@ -9,12 +9,15 @@
 - **Plan PR:** [#763](https://github.com/sesori-ai/sesori_apps_monorepo/pull/763) merged
 - **Prerequisite:** satisfied — the `read-only-archiving` series merged fully on
   2026-08-07 (through [PR #771](https://github.com/sesori-ai/sesori_apps_monorepo/pull/771)).
-- **Next action:** none — the series is complete. Two groups of remaining
+- **Next action:** none — the series is complete. Three groups of remaining
   harness-free work are assessed in `PLAN.md` § Step 9/9 for a follow-up plan
   pending product decisions: agents/providers/commands on a stopped backend,
-  and history on a cold or stale session (which backfills through
-  `_runtime.use` and fails a first-time or stale open when a no-auto-start
-  backend is unavailable).
+  history on a cold or stale session (which backfills through `_runtime.use`
+  and fails a first-time or stale open when a no-auto-start backend is
+  unavailable), and the attach-mode pending-state gap (an independently owned
+  OpenCode server can outlive a bridge restart holding pending interactions
+  while `useIfActive` returns null because the runtime slot is inactive, so
+  bridge inactivity must be distinguished from backend unavailability).
 
 ## Delivery Steps
 

--- a/.plan/completed/internal-chat-history/TRACKER.md
+++ b/.plan/completed/internal-chat-history/TRACKER.md
@@ -9,9 +9,12 @@
 - **Plan PR:** [#763](https://github.com/sesori-ai/sesori_apps_monorepo/pull/763) merged
 - **Prerequisite:** satisfied — the `read-only-archiving` series merged fully on
   2026-08-07 (through [PR #771](https://github.com/sesori-ai/sesori_apps_monorepo/pull/771)).
-- **Next action:** none — the series is complete. The remaining harness-free work
-  (agents/providers/commands on a stopped backend) is assessed in `PLAN.md`
-  § Step 9/9 for a follow-up plan pending product decisions.
+- **Next action:** none — the series is complete. Two groups of remaining
+  harness-free work are assessed in `PLAN.md` § Step 9/9 for a follow-up plan
+  pending product decisions: agents/providers/commands on a stopped backend,
+  and history on a cold or stale session (which backfills through
+  `_runtime.use` and fails a first-time or stale open when a no-auto-start
+  backend is unavailable).
 
 ## Delivery Steps
 

--- a/.plan/completed/internal-chat-history/TRACKER.md
+++ b/.plan/completed/internal-chat-history/TRACKER.md
@@ -3,13 +3,15 @@
 ## Current State
 
 - **Plan slug:** `internal-chat-history`
-- **Implementation base:** `origin/main` at `3d9fe379`
-- **Series state:** Steps 1–7 merged; step 8/9 in PR
-- **Current step:** 8/9
+- **Implementation base:** `origin/main` at `e884a580`
+- **Series state:** Complete — all steps merged
+- **Current step:** retired (plan moved to `.plan/completed/`)
 - **Plan PR:** [#763](https://github.com/sesori-ai/sesori_apps_monorepo/pull/763) merged
 - **Prerequisite:** satisfied — the `read-only-archiving` series merged fully on
   2026-08-07 (through [PR #771](https://github.com/sesori-ai/sesori_apps_monorepo/pull/771)).
-- **Next action:** merge step 8/9, then start step 9/9 (retire the plan and scope the remaining harness-free work).
+- **Next action:** none — the series is complete. The remaining harness-free work
+  (agents/providers/commands on a stopped backend) is assessed in `PLAN.md`
+  § Step 9/9 for a follow-up plan pending product decisions.
 
 ## Delivery Steps
 
@@ -22,8 +24,8 @@
 | [x] | 5/8 | `⚙️ [internal-chat-history] Paginate session messages [step 5/8]` | 600–1,000 | [PR #783](https://github.com/sesori-ai/sesori_apps_monorepo/pull/783) merged |
 | [x] | 6/8 | `🚧 [internal-chat-history] Export archives and purge history on archive [step 6/8]` | 1,000–1,500 | [PR #785](https://github.com/sesori-ai/sesori_apps_monorepo/pull/785) merged |
 | [x] | 7/9 | `🌿 [internal-chat-history] Load history pages on demand in the client [step 7/9]` | 500–900 | [PR #787](https://github.com/sesori-ai/sesori_apps_monorepo/pull/787) merged |
-| [ ] | 8/9 | `⚙️ [internal-chat-history] Stop waking a harness for pending questions and permissions [step 8/9]` | 300–600 | in progress |
-| [ ] | 9/9 | `🌱 [internal-chat-history] Retire plan and scope the remaining harness-free work [step 9/9]` | 150–400 | pending |
+| [x] | 8/9 | `⚙️ [internal-chat-history] Stop waking a harness for pending questions and permissions [step 8/9]` | 300–600 | [PR #788](https://github.com/sesori-ai/sesori_apps_monorepo/pull/788) merged |
+| [x] | 9/9 | `🌱 [internal-chat-history] Retire plan and scope the remaining harness-free work [step 9/9]` | 150–400 | in progress |
 
 ## Execution Rules
 
@@ -137,3 +139,11 @@
   ([PR #786](https://github.com/sesori-ai/sesori_apps_monorepo/pull/786)).
   Raised separately from the series because it changed code step 6 had already
   shipped.
+- **2026-08-08 — Step 9/9: series complete.** All implementation steps merged
+  (1–8, plus the two follow-up fixes for paging render and the detach freeze).
+  The remaining harness-starting calls in session open are the three options
+  lookups (`listAgents`, `listProviders`, `listCommands`), which still use
+  `_runtime.use`. The assessment in `PLAN.md` § Step 9/9 recommends serving
+  them from the existing `session_options_cache_table` when the backend is
+  stopped, and flags the `--no-auto-start` backend as the decisive case
+  needing a product decision. Follow-up plan pending those decisions.

--- a/.plan/completed/internal-chat-history/TRACKER.md
+++ b/.plan/completed/internal-chat-history/TRACKER.md
@@ -141,9 +141,15 @@
   shipped.
 - **2026-08-08 — Step 9/9: series complete.** All implementation steps merged
   (1–8, plus the two follow-up fixes for paging render and the detach freeze).
-  The remaining harness-starting calls in session open are the three options
-  lookups (`listAgents`, `listProviders`, `listCommands`), which still use
-  `_runtime.use`. The assessment in `PLAN.md` § Step 9/9 recommends serving
-  them from the existing `session_options_cache_table` when the backend is
-  stopped, and flags the `--no-auto-start` backend as the decisive case
-  needing a product decision. Follow-up plan pending those decisions.
+  Two groups of calls can still start a stopped backend in session open: the
+  three options lookups (`listAgents`, `listProviders`, `listCommands`), which
+  use `_runtime.use`, and **history on a cold or stale session**, which
+  backfills through `_runtime.use` when the store is missing, unsynced, or
+  behind observed backend activity. Current, previously synced history is
+  served entirely from the store. The assessment in `PLAN.md` § Step 9/9
+  recommends wiring the existing `SessionOptionsService.loadCacheOnly` (not
+  `loadDynamic`, whose cache-miss path starts the backend) into the
+  stopped-backend path, requires a `complete` cache entry so a `partial`
+  snapshot is not served as authoritative, and flags the `--no-auto-start`
+  backend as the decisive case needing a product decision. Follow-up plan
+  pending those decisions.


### PR DESCRIPTION
## Complexity

🌱 trivial — moves the plan to `.plan/completed/` and records the follow-up
assessment. No code.

## What

Final step of the `internal-chat-history` series. All eight implementation
steps and two follow-up fixes have merged; this retires the plan.

- Moves `.plan/active/internal-chat-history/` to `.plan/completed/`.
- Finishes the step 9/9 assessment with the actual classified calls.

## The assessment (verified against merged code)

The session-open snapshot now answers every call without a harness except
three. `listAgents`, `listProviders`, and `listCommands` still use
`PluginRuntime.use`, so a fully stopped backend is woken only to render the
composer's pickers.

These three differ from the pending-state pair addressed in step 8/9:
`useIfActive`-returning-empty was faithful there because pending state cannot
exist on a stopped backend. Agents/providers/commands are configuration the
backend genuinely has while stopped, so empty would be a lie, not a "none".

A cache already answers them without a start — `session_options_cache_table`
via `SessionOptionsService.loadDynamic` — but it serves the composer flow, not
the session-detail open path, which hits raw `/agent`, `/provider`, `/command`.

**Recommended direction:** serve the three from the cache when fresh and the
backend is stopped, refresh in the background when running, and show an
explicit affordance only when the cache is cold and the backend *can* start.
The decisive case is a `--no-auto-start` backend (which the reporter runs):
"start it to find out" is unavailable there, not merely slow, so it forces the
one real product decision — what a cold-cache, stopped-backend composer shows.

This is written up in `PLAN.md` § Step 9/9 as the basis for a follow-up plan,
pending those product decisions.

## Why

The series' goal was to make opening a session fast and to stop waking
harnesses for data the bridge already holds. That goal is met except for the
three pickers, and the assessment records exactly what remains so it is not
lost with the plan.

## Risk and test focus

None. Documentation and a directory move only.

## Expected result

- **User-visible:** none.
- **Database:** none.
- **Internal:** the plan is retired and the remaining harness-free work is
  scoped for a follow-up plan with the open product decisions stated.

## Verification

No code changed; no test suite run is warranted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires the `internal-chat-history` plan by moving it to `.plan/completed/` and finalizes step 9/9 with a code-verified assessment of the remaining harness-free work. Adds an active-only options refresh requirement to avoid waking stopped backends.

- **Assessment**
  - Two groups still start a stopped backend: cold/stale history backfill and `listAgents`/`listProviders`/`listCommands`.
  - Serve options from `session_options_cache_table` via `SessionOptionsService.loadCacheOnly` (not `loadDynamic`); require a complete cache entry or surface incompleteness.
  - Gate cache-only on the bridge’s `supportsSessionOptions` (`/session/options?refresh=false`); fall back to raw `/agent`, `/provider`, `/command` on older bridges to avoid silently losing options.
  - Expose an active-only refresh (`SessionOptionsService.refreshActiveOnly`) so options can refresh in the background when running; `loadDynamic` may activate and `refreshExplicit` does activate, so the route must offer an active-only mode.
  - A failed options request does not block the composer; it renders with empty options. Skip picker loads entirely for archived sessions.

- **Notes**
  - In OpenCode attach mode, `useIfActive` reflects the bridge slot, not backend liveness; the follow-up must distinguish a non-routable slot from a live external server.
  - Archiving can export/notify and modify backend state; the guarantee is narrowed to “never deletes the backend’s stored transcript.”
  - The tracker now records both remaining backend-starting groups and the attach‑mode pending-state gap for a clean follow-up handoff.

<sup>Written for commit 6f07b8ae3d39d38b3b9b636dae29709b5f989f0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

