### PR TITLE
⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]

### DIFF
--- a/.plan/active/claude-code-plugin/PLAN.md
+++ b/.plan/active/claude-code-plugin/PLAN.md
@@ -626,7 +626,7 @@ transport field, cache, flag, job, or test was found.
 |---|---|---|---:|
 | 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 1,200-1,400 |
 | 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 1,100-1,500 |
-| 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,200-1,500 |
+| 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,200-1,500 (recorded overage) |
 | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,200-1,500 |
 | 5/17 | `claude-code-plugin-content-mapper` | `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]` | 1,000-1,400 |
 | 6/17 | `claude-code-plugin-history-mapper` | `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]` | 1,000-1,400 |
@@ -701,6 +701,16 @@ in the PR that introduces it. The step total is unchanged.
 - Cover framing, exit mid-request, generation fencing, redaction, and
   unknown-type absorption.
 - Verify: focused and full package tests, fatal analysis, implementation review.
+
+**Recorded overage: ~1,730 changed lines against a 1,500 soft cap.** A split was
+looked for first, as the delivery rules require, and none is coherent. The only
+natural seam is between the message parser and the transport, but the parser's
+sole production consumer *is* the transport, so splitting there would ship a
+parser exercised only by tests — the "preparatory PR introduces unused
+architecture" anti-pattern this repository has already ruled against. Trimming
+tests is not the right lever either: at roughly 0.67 test lines per production
+line this step is already below the repository's typical 1.2–1.9× ratio. The
+work is one coherent layer with no generated code, so it is delivered whole.
 
 ### Step 4/17 — Enumerate Transcript Sessions
 

--- a/.plan/active/claude-code-plugin/PROTOCOL.md
+++ b/.plan/active/claude-code-plugin/PROTOCOL.md
@@ -98,6 +98,24 @@ supervised child. Not yet probed; resolve before the descriptor lands.
 `rate_limit_event` and `system/status` were **not** in the plan's research. They
 confirm why tolerant unknown-type absorption is mandatory rather than defensive.
 
+**`system`/`init` is turn-triggered, not spawn-triggered.** Verified in Step 3 by
+driving the real CLI through `ClaudeStreamClient`: after `connect()` completed
+its `initialize` handshake in ~1.1 s, no `init` frame had arrived two seconds
+later, and the only frame seen was the handshake's own control response. The
+Step 2 captures agree — `init` appears after the first user turn is written.
+
+Consequences:
+
+- The `initialize` control **response** is the only connect-time catalog. Nothing
+  in the connect path may require `init`.
+- `init.capabilities` — and therefore capability detection — is unavailable until
+  a turn has run. For `interrupt.cancel_queued` this is harmless: the SDK
+  documents that older CLIs ignore the field and behave as if it were false, so
+  it can always be sent rather than gated on a capability that may not have
+  arrived yet.
+- `init.permissionMode` likewise cannot be read before the first turn; the
+  launch flag is the authority for the starting mode.
+
 ### `stream_event` inner events
 
 Observed for a plain text turn, in order: `message_start`,

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -46,7 +46,7 @@
 |---|---|---|---|---:|---|
 | [x] | 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 1,200-1,400 | [PR #737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737) merged; see the verification log for the measured diff |
 | [x] | 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 1,100-1,500 | [PR #752](https://github.com/sesori-ai/sesori_apps_monorepo/pull/752) open; see the verification log for the measured diff |
-| [ ] | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,200-1,500 | Not started |
+| [x] | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,200-1,500 (recorded overage) | Complete locally; awaiting step 2 merge before its PR opens |
 | [ ] | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,200-1,500 | Not started |
 | [ ] | 5/17 | `claude-code-plugin-content-mapper` | `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]` | 1,000-1,400 | Not started |
 | [ ] | 6/17 | `claude-code-plugin-history-mapper` | `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]` | 1,000-1,400 | Not started |
@@ -165,6 +165,21 @@
   estimates for 3, 4, and 5 were raised to absorb them and the step total is
   unchanged.
 
+- Step 3/17 (2026-08-04): added `ClaudeStreamMessage` with its dispatching
+  parser, `ClaudeStreamClient`, the host process seam, `FakeClaudeProcess`, and
+  the `claude_testing.dart` barrel. `dart analyze --fatal-infos` and all 48
+  package tests pass, and `git diff --check` passes.
+
+  The transport was also driven against the real `claude` 2.1.221: the
+  `initialize` handshake completed in ~1.1 s returning 5 models and 66 commands,
+  effort levels came back as first-party per-model data, and teardown exited the
+  process with 143 (SIGTERM), confirming the graceful path. That run also
+  produced the `system/init` timing correction below.
+
+  Recorded overage at ~1,730 changed lines against the 1,500 soft cap; the
+  rationale is in `PLAN.md` under Step 3. No coherent split exists because the
+  parser's only production consumer is the transport itself.
+
 ## Findings And Plan Deltas
 
 - **2026-08-05 — `always` must filter suggestions, not echo them (from PR #752
@@ -253,3 +268,9 @@
   same payload carries PII (email, org) that must never be logged.
 - **2026-08-04 — `rename_session` exists:** the control API supports renaming, so
   Step 12's optimistic-only rename should be revisited against it.
+- **2026-08-04 — `system/init` is turn-triggered, not spawn-triggered:** proved in
+  Step 3 by driving the real CLI. Nothing in the connect path may depend on the
+  `init` frame; the `initialize` control response is the only connect-time
+  catalog. Capability detection is therefore unavailable until a turn has run,
+  which is safe for `interrupt.cancel_queued` because older CLIs ignore that
+  field rather than rejecting it.

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -176,9 +176,14 @@
   process with 143 (SIGTERM), confirming the graceful path. That run also
   produced the `system/init` timing correction below.
 
-  Recorded overage at ~1,730 changed lines against the 1,500 soft cap; the
-  rationale is in `PLAN.md` under Step 3. No coherent split exists because the
-  parser's only production consumer is the transport itself.
+  Recorded overage: **1,767 changed lines** against the 1,500 soft cap, measured
+  after the rebase onto the Step 2 branch with
+  `git diff --numstat claude-code-plugin-protocol-scaffold HEAD`. An earlier
+  estimate of ~1,730 predates that rebase and is superseded. The rationale is in
+  `PLAN.md` under Step 3: no coherent split exists because the parser's only
+  production consumer is the transport itself, so splitting would ship
+  unconsumed architecture. Tests are 0.67x source, below the repository's
+  1.2-1.9x norm, so the overage is production code rather than test bulk.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -4,12 +4,12 @@
 
 - **Plan slug:** `claude-code-plugin`
 - **Implementation base:** `origin/main` at
-  `22f65807` (Step 2 rebased onto it after Step 1 merged)
-- **Series state:** Step 1/17 merged; Step 2/17 open for review
-- **Current step:** 2/17 — protocol ground truth and package scaffold
+  `7e460bc9` (Step 3 rebased onto it after Step 2 merged)
+- **Series state:** Steps 1-2/17 merged; Step 3/17 complete locally
+- **Current step:** 3/17 — stream-json transport
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737),
   merged 2026-08-04 as `6d641532`
-- **Next action:** Step 3 stream-json transport
+- **Next action:** Open the Step 3 PR against `main`
 
 ## Plan Review
 
@@ -45,8 +45,8 @@
 | Done | Step | Branch | Exact PR title | Changed-line target | State |
 |---|---|---|---|---:|---|
 | [x] | 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 1,200-1,400 | [PR #737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737) merged; see the verification log for the measured diff |
-| [x] | 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 1,100-1,500 | [PR #752](https://github.com/sesori-ai/sesori_apps_monorepo/pull/752) open; see the verification log for the measured diff |
-| [x] | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,200-1,500 (recorded overage) | Complete locally; awaiting step 2 merge before its PR opens |
+| [x] | 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 1,100-1,500 | [PR #752](https://github.com/sesori-ai/sesori_apps_monorepo/pull/752) merged 2026-08-09 as `7e460bc9`; see the verification log for the measured diff |
+| [x] | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,200-1,500 (recorded overage) | Complete locally and rebased onto merged Step 2; ready to open against `main` |
 | [ ] | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,200-1,500 | Not started |
 | [ ] | 5/17 | `claude-code-plugin-content-mapper` | `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]` | 1,000-1,400 | Not started |
 | [ ] | 6/17 | `claude-code-plugin-history-mapper` | `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]` | 1,000-1,400 | Not started |
@@ -167,8 +167,10 @@
 
 - Step 3/17 (2026-08-04): added `ClaudeStreamMessage` with its dispatching
   parser, `ClaudeStreamClient`, the host process seam, `FakeClaudeProcess`, and
-  the `claude_testing.dart` barrel. `dart analyze --fatal-infos` and all 48
-  package tests pass, and `git diff --check` passes.
+  the `claude_testing.dart` barrel. `dart analyze --fatal-infos`, all 53 package
+  tests, and `git diff --check` pass. Architecture implementation review of
+  `origin/main..claude-code-plugin-stream-client` returned `APPROVED` with no
+  actionable findings.
 
   The transport was also driven against the real `claude` 2.1.221: the
   `initialize` handshake completed in ~1.1 s returning 5 models and 66 commands,
@@ -176,14 +178,15 @@
   process with 143 (SIGTERM), confirming the graceful path. That run also
   produced the `system/init` timing correction below.
 
-  Recorded overage: **1,767 changed lines** against the 1,500 soft cap, measured
-  after the rebase onto the Step 2 branch with
-  `git diff --numstat claude-code-plugin-protocol-scaffold HEAD`. An earlier
-  estimate of ~1,730 predates that rebase and is superseded. The rationale is in
-  `PLAN.md` under Step 3: no coherent split exists because the parser's only
-  production consumer is the transport itself, so splitting would ship
-  unconsumed architecture. Tests are 0.67x source, below the repository's
-  1.2-1.9x norm, so the overage is production code rather than test bulk.
+  Recorded overage: **1,793 changed lines** against the 1,500 soft cap, measured
+  after the rebase onto merged Step 2 with
+  `git diff $(git merge-base origin/main HEAD) --numstat`. The earlier 1,767-line
+  figure was measured before the final tracker handoff onto merged `main` and is
+  superseded. The rationale is in `PLAN.md` under Step 3: no coherent split
+  exists because the parser's only production consumer is the transport itself,
+  so splitting would ship unconsumed architecture. Tests are 0.67x source,
+  below the repository's 1.2-1.9x norm, so the overage is production code rather
+  than test bulk.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -5,11 +5,11 @@
 - **Plan slug:** `claude-code-plugin`
 - **Implementation base:** `origin/main` at
   `7e460bc9` (Step 3 rebased onto it after Step 2 merged)
-- **Series state:** Steps 1-2/17 merged; Step 3/17 complete locally
+- **Series state:** Steps 1-2/17 merged; Step 3/17 PR open
 - **Current step:** 3/17 — stream-json transport
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737),
   merged 2026-08-04 as `6d641532`
-- **Next action:** Open the Step 3 PR against `main`
+- **Next action:** Address review feedback and merge the Step 3 PR
 
 ## Plan Review
 
@@ -46,7 +46,7 @@
 |---|---|---|---|---:|---|
 | [x] | 1/17 | `claude-code-support` | `🌱 [claude-code-plugin] docs: plan Claude Code harness plugin [step 1/17]` | 1,200-1,400 | [PR #737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737) merged; see the verification log for the measured diff |
 | [x] | 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 1,100-1,500 | [PR #752](https://github.com/sesori-ai/sesori_apps_monorepo/pull/752) merged 2026-08-09 as `7e460bc9`; see the verification log for the measured diff |
-| [x] | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,200-1,500 (recorded overage) | Complete locally and rebased onto merged Step 2; ready to open against `main` |
+| [ ] | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,200-1,500 (recorded overage) | [PR #792](https://github.com/sesori-ai/sesori_apps_monorepo/pull/792) open against `main` |
 | [ ] | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,200-1,500 | Not started |
 | [ ] | 5/17 | `claude-code-plugin-content-mapper` | `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]` | 1,000-1,400 | Not started |
 | [ ] | 6/17 | `claude-code-plugin-history-mapper` | `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]` | 1,000-1,400 | Not started |

--- a/bridge/sesori_plugin_claude/lib/claude_plugin.dart
+++ b/bridge/sesori_plugin_claude/lib/claude_plugin.dart
@@ -10,5 +10,8 @@
 library;
 
 export "src/api/claude_launch_spec.dart";
+export "src/api/claude_process_factory.dart";
+export "src/api/claude_stream_client.dart";
+export "src/api/models/claude_stream_message.dart";
 export "src/models/claude_effort_level.dart";
 export "src/models/claude_permission_mode.dart";

--- a/bridge/sesori_plugin_claude/lib/claude_testing.dart
+++ b/bridge/sesori_plugin_claude/lib/claude_testing.dart
@@ -1,0 +1,6 @@
+/// Test doubles for the Claude Code plugin, shared with packages that compose
+/// it. Not exported from `claude_plugin.dart` — production code must never
+/// depend on a fake process.
+library;
+
+export "src/testing/fake_claude_process.dart";

--- a/bridge/sesori_plugin_claude/lib/src/api/claude_launch_spec.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/claude_launch_spec.dart
@@ -55,11 +55,11 @@ class ClaudeLaunchSpec {
     required this.model,
     required this.effort,
     required this.permissionMode,
-    this.environment = const {},
-  }) {
-    if (environment.containsKey("HOME")) {
+    Map<String, String> environment = const {},
+  }) : environment = Map.unmodifiable(environment) {
+    if (this.environment.containsKey("HOME")) {
       throw ArgumentError.value(
-        environment,
+        this.environment,
         "environment",
         "must not override HOME; use CLAUDE_CONFIG_DIR for isolation",
       );

--- a/bridge/sesori_plugin_claude/lib/src/api/claude_launch_spec.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/claude_launch_spec.dart
@@ -50,14 +50,27 @@ final RegExp _uuidPattern = RegExp(
 class ClaudeLaunchSpec {
   ClaudeLaunchSpec({
     required this.binaryPath,
+    required this.workingDirectory,
     required this.launch,
     required this.model,
     required this.effort,
     required this.permissionMode,
+    this.environment = const {},
   });
 
   /// The `claude` executable: a `--claude-bin` override or a PATH name.
   final String binaryPath;
+
+  /// The session's directory, which becomes the process's working directory and
+  /// therefore the project the session belongs to.
+  final String workingDirectory;
+
+  /// Extra environment entries merged over the bridge's own environment.
+  ///
+  /// `HOME` must never appear here. Overriding it breaks macOS keychain lookup
+  /// and makes a logged-in user look logged out. Test isolation uses
+  /// `CLAUDE_CONFIG_DIR` instead.
+  final Map<String, String> environment;
 
   /// Whether this launch creates or resumes a session.
   final ClaudeSessionLaunch launch;

--- a/bridge/sesori_plugin_claude/lib/src/api/claude_launch_spec.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/claude_launch_spec.dart
@@ -56,7 +56,15 @@ class ClaudeLaunchSpec {
     required this.effort,
     required this.permissionMode,
     this.environment = const {},
-  });
+  }) {
+    if (environment.containsKey("HOME")) {
+      throw ArgumentError.value(
+        environment,
+        "environment",
+        "must not override HOME; use CLAUDE_CONFIG_DIR for isolation",
+      );
+    }
+  }
 
   /// The `claude` executable: a `--claude-bin` override or a PATH name.
   final String binaryPath;

--- a/bridge/sesori_plugin_claude/lib/src/api/claude_process_factory.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/claude_process_factory.dart
@@ -1,0 +1,58 @@
+import "dart:io" as io;
+
+import "claude_launch_spec.dart";
+
+/// The slice of `dart:io`'s [io.Process] the Claude transport actually uses.
+///
+/// Kept narrow so tests can supply an in-memory fake without implementing the
+/// full [io.Process] surface.
+abstract class ClaudeProcessHandle {
+  Stream<List<int>> get stdout;
+  Stream<List<int>> get stderr;
+  io.IOSink get stdin;
+  Future<int> get exitCode;
+  bool kill([io.ProcessSignal signal = io.ProcessSignal.sigterm]);
+}
+
+/// Spawns a [ClaudeProcessHandle] for a launch spec. Injected into
+/// [ClaudeStreamClient] so tests can substitute a fake process.
+typedef ClaudeProcessFactory = Future<ClaudeProcessHandle> Function(ClaudeLaunchSpec spec);
+
+/// Default factory: spawns a real OS process via [io.Process.start].
+///
+/// `runInShell` on Windows is required because an npm-installed `claude` is a
+/// `.cmd` shim rather than a native executable.
+Future<ClaudeProcessHandle> defaultClaudeProcessFactory(ClaudeLaunchSpec spec) async {
+  final process = await io.Process.start(
+    spec.binaryPath,
+    spec.arguments,
+    workingDirectory: spec.workingDirectory,
+    // includeParentEnvironment defaults to true, so these entries merge over
+    // the inherited environment. That inheritance is what lets the CLI find the
+    // user's existing login.
+    environment: spec.environment,
+    runInShell: io.Platform.isWindows,
+  );
+  return _RealClaudeProcess(process);
+}
+
+class _RealClaudeProcess implements ClaudeProcessHandle {
+  _RealClaudeProcess(this._process);
+
+  final io.Process _process;
+
+  @override
+  Stream<List<int>> get stdout => _process.stdout;
+
+  @override
+  Stream<List<int>> get stderr => _process.stderr;
+
+  @override
+  io.IOSink get stdin => _process.stdin;
+
+  @override
+  Future<int> get exitCode => _process.exitCode;
+
+  @override
+  bool kill([io.ProcessSignal signal = io.ProcessSignal.sigterm]) => _process.kill(signal);
+}

--- a/bridge/sesori_plugin_claude/lib/src/api/claude_stream_client.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/claude_stream_client.dart
@@ -1,0 +1,398 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io" as io;
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
+import "claude_launch_spec.dart";
+import "claude_process_factory.dart";
+import "models/claude_stream_message.dart";
+
+/// A control request that the CLI answered with a failure, or that could not be
+/// delivered at all.
+class ClaudeControlException implements Exception {
+  ClaudeControlException({required this.subtype, required this.message});
+
+  final String subtype;
+  final String message;
+
+  @override
+  String toString() => "ClaudeControlException($subtype, $message)";
+}
+
+/// Speaks the stream-json protocol to exactly one `claude` process.
+///
+/// One process serves one session. The process stays alive only while its stdin
+/// stays open, so this client owns that pipe for the session's whole residency
+/// and closing it is what ends the process.
+///
+/// The transport mechanics — line framing, connection-generation fencing across
+/// teardown, broken-pipe absorption, failing pending requests on exit, and
+/// SIGTERM-then-SIGKILL termination — are ported from `AcpStdioClient`, where
+/// they are load-bearing.
+class ClaudeStreamClient {
+  ClaudeStreamClient({
+    required ClaudeLaunchSpec launchSpec,
+    ClaudeProcessFactory? processFactory,
+    Duration controlTimeout = const Duration(seconds: 60),
+    String logTag = "claude",
+  }) : _launchSpec = launchSpec,
+       _processFactory = processFactory ?? defaultClaudeProcessFactory,
+       _controlTimeout = controlTimeout,
+       _logTag = logTag;
+
+  final ClaudeLaunchSpec _launchSpec;
+  final ClaudeProcessFactory _processFactory;
+  final Duration _controlTimeout;
+  final String _logTag;
+
+  ClaudeProcessHandle? _process;
+  StreamSubscription<String>? _stdoutSubscription;
+  StreamSubscription<String>? _stderrSubscription;
+  bool _disposed = false;
+  int _nextRequestId = 1;
+  int _connectionGeneration = 0;
+
+  final Map<String, Completer<Map<String, Object?>>> _pending = {};
+  final StreamController<ClaudeStreamMessage> _messages = StreamController.broadcast();
+  Completer<int> _exited = Completer<int>();
+  ClaudeInitMessage? _init;
+  Map<String, Object?>? _handshake;
+
+  /// Every parsed stdout frame, including unknown ones (broadcast).
+  Stream<ClaudeStreamMessage> get messages => _messages.stream;
+
+  /// The `system`/`init` frame, once seen.
+  ///
+  /// Null until the session's first turn: the CLI emits this frame when a turn
+  /// starts, not when the process spawns. Nothing in the connect path may
+  /// require it, and capability detection through [ClaudeInitMessage.supports]
+  /// is unavailable until a turn has run.
+  ClaudeInitMessage? get init => _init;
+
+  /// The `initialize` control response: the command, agent, model, and account
+  /// catalog in one payload. Null until [connect] completes.
+  Map<String, Object?>? get handshake => _handshake;
+
+  /// Completes with the process's exit code.
+  Future<int> get processExit => _exited.future;
+
+  bool get isConnected => _process != null && !_disposed && !_exited.isCompleted;
+
+  /// Spawns the process, wires the framing, and performs the `initialize`
+  /// handshake.
+  ///
+  /// A failed handshake tears the connection down and rethrows rather than
+  /// returning a half-live client: the handshake is the only source of the
+  /// session's catalog, and continuing without it would surface an empty model
+  /// and command list as if the backend genuinely had none.
+  Future<void> connect() async {
+    if (_process != null) throw StateError("ClaudeStreamClient already connected");
+    if (_disposed) throw StateError("ClaudeStreamClient is disposed");
+
+    final generation = ++_connectionGeneration;
+    final process = await _processFactory(_launchSpec);
+    if (_disposed || generation != _connectionGeneration) {
+      // Teardown ran while the spawn was in flight and saw no process to reap.
+      // Kill it here rather than leaking it past teardown.
+      try {
+        process.kill(io.ProcessSignal.sigkill);
+      } on Object catch (error, stack) {
+        Log.w("[$_logTag] failed to reap process spawned during teardown", error, stack);
+      }
+      throw StateError(
+        _disposed ? "ClaudeStreamClient disposed during connect" : "ClaudeStreamClient reset during connect",
+      );
+    }
+    final exited = Completer<int>();
+    _exited = exited;
+    _process = process;
+
+    // Broken pipes surface asynchronously on `stdin.done` rather than from
+    // `add`, so an unexpected exit would otherwise raise an unhandled async
+    // error. The exit itself is logged below.
+    unawaited(process.stdin.done.catchError((Object _) {}));
+
+    _stdoutSubscription = process.stdout
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen(
+          (line) {
+            if (generation == _connectionGeneration) _handleLine(line);
+          },
+          onError: (Object error, StackTrace stack) {
+            if (generation != _connectionGeneration) return;
+            Log.w("[$_logTag] stdout stream error: ${_redactForLog("$error")}");
+            _failPending(error, stack);
+          },
+          cancelOnError: false,
+        );
+
+    _stderrSubscription = process.stderr
+        // A crashing child can emit non-UTF-8 bytes on stderr, and a decoder
+        // that throws there would take out the diagnostic stream exactly when
+        // it matters most.
+        .transform(const Utf8Decoder(allowMalformed: true))
+        .transform(const LineSplitter())
+        .listen(
+          (line) => Log.d("[$_logTag][stderr] ${_redactForLog(line)}"),
+          onError: (Object error, StackTrace stack) => Log.w("[$_logTag] stderr stream error", error, stack),
+          cancelOnError: false,
+        );
+
+    unawaited(
+      process.exitCode.then((code) {
+        if (!exited.isCompleted) exited.complete(code);
+        if (generation != _connectionGeneration) return;
+        if (!_disposed) Log.w("[$_logTag] process exited with code $code");
+        _failPending(
+          ClaudeControlException(subtype: "<process>", message: "claude process exited with code $code"),
+          StackTrace.current,
+        );
+      }),
+    );
+
+    try {
+      _handshake = await sendControlRequest(subtype: "initialize");
+    } on Object catch (error, stack) {
+      Log.e("[$_logTag] initialize handshake failed", error, stack);
+      await _teardownConnection(
+        gracefulTimeout: const Duration(seconds: 5),
+        pendingError: StateError("ClaudeStreamClient handshake failed"),
+      );
+      rethrow;
+    }
+  }
+
+  /// Sends a user turn. Content blocks are built by the caller.
+  void sendUserMessage({required List<Map<String, Object?>> content}) {
+    final process = _process;
+    if (process == null) return;
+    _writeFrame(process, {
+      "type": "user",
+      "message": {"role": "user", "content": content},
+      "session_id": _launchSpec.launch.sessionId,
+    });
+  }
+
+  /// Sends a control request and awaits its response payload.
+  ///
+  /// Throws [ClaudeControlException] when the CLI answers with a failure, when
+  /// the frame cannot be written, or when the process has already exited;
+  /// [TimeoutException] when no reply arrives.
+  Future<Map<String, Object?>> sendControlRequest({
+    required String subtype,
+    Map<String, Object?> params = const {},
+  }) async {
+    final process = _process;
+    if (process == null) {
+      throw ClaudeControlException(subtype: subtype, message: "not connected");
+    }
+    // The exit handler deliberately leaves _process set, so without this a
+    // request issued after the process died would write to a dead pipe and then
+    // block for the full timeout awaiting a reply that can never come.
+    if (_exited.isCompleted) {
+      throw ClaudeControlException(subtype: subtype, message: "claude process has exited");
+    }
+
+    final requestId = "sesori-${_nextRequestId++}";
+    final completer = Completer<Map<String, Object?>>();
+    _pending[requestId] = completer;
+
+    if (!_writeFrame(process, {
+      "type": "control_request",
+      "request_id": requestId,
+      "request": {"subtype": subtype, ...params},
+    })) {
+      // The frame never left the bridge, so no reply is coming. Fail now rather
+      // than orphaning the request until it times out.
+      _pending.remove(requestId);
+      throw ClaudeControlException(subtype: subtype, message: "failed to write control request");
+    }
+
+    try {
+      return await completer.future.timeout(_controlTimeout);
+    } on TimeoutException {
+      _pending.remove(requestId);
+      rethrow;
+    }
+  }
+
+  /// Answers a CLI-originated control request, e.g. a `can_use_tool` ask.
+  void sendControlResponse({required String requestId, required Map<String, Object?> payload}) {
+    final process = _process;
+    if (process == null) return;
+    _writeFrame(process, {
+      "type": "control_response",
+      "response": {"subtype": "success", "request_id": requestId, "response": payload},
+    });
+  }
+
+  /// Answers a CLI-originated control request with a failure.
+  void sendControlResponseError({required String requestId, required String message}) {
+    final process = _process;
+    if (process == null) return;
+    _writeFrame(process, {
+      "type": "control_response",
+      "response": {"subtype": "error", "request_id": requestId, "error": message},
+    });
+  }
+
+  bool _writeFrame(ClaudeProcessHandle process, Map<String, Object?> envelope) {
+    try {
+      process.stdin.add(utf8.encode("${jsonEncode(envelope)}\n"));
+      return true;
+    } on Object catch (error, stack) {
+      Log.w("[$_logTag] failed to write frame", error, stack);
+      return false;
+    }
+  }
+
+  void _handleLine(String line) {
+    if (line.trim().isEmpty) return;
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(line);
+    } on Object catch (error) {
+      // A FormatException can embed a snippet of the offending frame.
+      Log.w("[$_logTag] failed to parse frame: ${_redactForLog("$error")}");
+      return;
+    }
+    if (decoded is! Map) {
+      Log.d("[$_logTag] non-object frame: ${_redactForLog(line)}");
+      return;
+    }
+
+    final message = ClaudeStreamMessage.parse(decoded.cast<String, Object?>());
+    switch (message) {
+      case ClaudeInitMessage():
+        _init = message;
+      case ClaudeControlResponseMessage(:final requestId):
+        final completer = requestId == null ? null : _pending.remove(requestId);
+        if (completer == null) {
+          Log.d("[$_logTag] control response for unknown request_id=$requestId");
+        } else if (message.isSuccess) {
+          completer.complete(message.payload);
+        } else {
+          completer.completeError(
+            ClaudeControlException(
+              subtype: "<response>",
+              message: message.error ?? "control request failed",
+            ),
+          );
+        }
+      case ClaudeUnknownMessage(:final type, :final subtype):
+        // Debug, never a warning per line: the protocol adds message types
+        // frequently and a warning would drown the log on a routine upgrade.
+        Log.d("[$_logTag] unmodelled frame type=$type subtype=$subtype");
+      case ClaudeStatusMessage():
+      case ClaudeAssistantMessage():
+      case ClaudeUserMessage():
+      case ClaudeStreamEventMessage():
+      case ClaudeResultMessage():
+      case ClaudeControlRequestMessage():
+      case ClaudeRateLimitMessage():
+        break;
+    }
+
+    if (!_messages.isClosed) _messages.add(message);
+  }
+
+  /// Masks JSON-style secret values before logging a frame. A best-effort
+  /// string scrub rather than a JSON re-encode, so a partial or non-JSON frame
+  /// is still redacted.
+  static final RegExp _secretKeyValue = RegExp(
+    r'("(?:token|authorization|api[_-]?key|secret|password|bearer)"\s*:\s*)"(?:\\.|[^"\\])*"',
+    caseSensitive: false,
+  );
+
+  String _redactForLog(String frame) => frame.replaceAllMapped(_secretKeyValue, (m) => '${m.group(1)}"***"');
+
+  void _failPending(Object error, StackTrace stack) {
+    final inflight = List<Completer<Map<String, Object?>>>.from(_pending.values);
+    _pending.clear();
+    for (final completer in inflight) {
+      if (!completer.isCompleted) completer.completeError(error, stack);
+    }
+  }
+
+  /// Terminates the process, fails in-flight requests, and closes the stream.
+  Future<void> dispose({Duration gracefulTimeout = const Duration(seconds: 5)}) async {
+    if (_disposed) return;
+    _disposed = true;
+    await _teardownConnection(
+      gracefulTimeout: gracefulTimeout,
+      pendingError: StateError("ClaudeStreamClient disposed"),
+    );
+    try {
+      await _messages.close();
+    } on Object catch (error, stack) {
+      Log.w("[$_logTag] failed to close message stream", error, stack);
+    }
+  }
+
+  Future<void> _teardownConnection({
+    required Duration gracefulTimeout,
+    required Object pendingError,
+  }) async {
+    // Invalidate callbacks before the first await so a late frame from this
+    // process cannot affect a connection established afterwards.
+    _connectionGeneration++;
+    final process = _process;
+    _process = null;
+
+    Future<void>? stdoutCancellation;
+    try {
+      stdoutCancellation = _stdoutSubscription?.cancel();
+    } on Object catch (error, stack) {
+      Log.w("[$_logTag] failed to cancel stdout subscription", error, stack);
+    }
+    _stdoutSubscription = null;
+
+    Future<void>? stderrCancellation;
+    try {
+      stderrCancellation = _stderrSubscription?.cancel();
+    } on Object catch (error, stack) {
+      Log.w("[$_logTag] failed to cancel stderr subscription", error, stack);
+    }
+    _stderrSubscription = null;
+
+    _failPending(pendingError, StackTrace.current);
+
+    if (process != null) {
+      try {
+        // Closing stdin is the protocol's own shutdown signal, so try it before
+        // signalling. A broken pipe here is expected and already absorbed.
+        await process.stdin.close();
+      } on Object catch (error) {
+        Log.d("[$_logTag] closing stdin during teardown failed: $error");
+      }
+      try {
+        if (io.Platform.isWindows) {
+          process.kill(io.ProcessSignal.sigkill);
+        } else {
+          process.kill(io.ProcessSignal.sigterm);
+          try {
+            await process.exitCode.timeout(gracefulTimeout);
+          } on TimeoutException {
+            process.kill(io.ProcessSignal.sigkill);
+          }
+        }
+      } on Object catch (error, stack) {
+        Log.w("[$_logTag] failed to stop process during teardown", error, stack);
+      }
+    }
+
+    // Isolate each step so one failure does not skip the rest.
+    try {
+      await stdoutCancellation;
+    } on Object catch (error, stack) {
+      Log.w("[$_logTag] failed to cancel stdout subscription", error, stack);
+    }
+    try {
+      await stderrCancellation;
+    } on Object catch (error, stack) {
+      Log.w("[$_logTag] failed to cancel stderr subscription", error, stack);
+    }
+  }
+}

--- a/bridge/sesori_plugin_claude/lib/src/api/claude_stream_client.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/claude_stream_client.dart
@@ -33,11 +33,11 @@ class ClaudeControlException implements Exception {
 class ClaudeStreamClient {
   ClaudeStreamClient({
     required ClaudeLaunchSpec launchSpec,
-    ClaudeProcessFactory? processFactory,
+    required ClaudeProcessFactory processFactory,
     Duration controlTimeout = const Duration(seconds: 60),
     String logTag = "claude",
   }) : _launchSpec = launchSpec,
-       _processFactory = processFactory ?? defaultClaudeProcessFactory,
+       _processFactory = processFactory,
        _controlTimeout = controlTimeout,
        _logTag = logTag;
 
@@ -165,14 +165,29 @@ class ClaudeStreamClient {
   }
 
   /// Sends a user turn. Content blocks are built by the caller.
+  ///
+  /// Throws [ClaudeControlException] when the process has already exited or the
+  /// frame cannot be written. Calls after explicit teardown remain a no-op so a
+  /// late UI callback cannot revive a disposed session.
   void sendUserMessage({required List<Map<String, Object?>> content}) {
     final process = _process;
     if (process == null) return;
-    _writeFrame(process, {
+    if (_exited.isCompleted) {
+      throw ClaudeControlException(
+        subtype: "<user>",
+        message: "claude process has exited",
+      );
+    }
+    if (!_writeFrame(process, {
       "type": "user",
       "message": {"role": "user", "content": content},
       "session_id": _launchSpec.launch.sessionId,
-    });
+    })) {
+      throw ClaudeControlException(
+        subtype: "<user>",
+        message: "failed to write user turn",
+      );
+    }
   }
 
   /// Sends a control request and awaits its response payload.
@@ -202,7 +217,7 @@ class ClaudeStreamClient {
     if (!_writeFrame(process, {
       "type": "control_request",
       "request_id": requestId,
-      "request": {"subtype": subtype, ...params},
+      "request": {...params, "subtype": subtype},
     })) {
       // The frame never left the bridge, so no reply is coming. Fail now rather
       // than orphaning the request until it times out.
@@ -363,9 +378,9 @@ class ClaudeStreamClient {
       try {
         // Closing stdin is the protocol's own shutdown signal, so try it before
         // signalling. A broken pipe here is expected and already absorbed.
-        await process.stdin.close();
-      } on Object catch (error) {
-        Log.d("[$_logTag] closing stdin during teardown failed: $error");
+        await process.stdin.close().timeout(gracefulTimeout);
+      } on Object catch (error, stack) {
+        Log.w("[$_logTag] closing stdin during teardown failed", error, stack);
       }
       try {
         if (io.Platform.isWindows) {

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_stream_message.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_stream_message.dart
@@ -1,0 +1,403 @@
+import "../../models/claude_permission_mode.dart";
+
+/// One line of the CLI's stream-json stdout.
+///
+/// The wire discriminator is two levels deep — `type`, then `subtype` for
+/// `system` frames — so these are hand-written sealed variants with a
+/// dispatching parser rather than a generated union. That also matches the
+/// transport-envelope precedent in `AcpStdioClient`, which hand-writes its
+/// notification and request envelopes; generated DTOs in this package are
+/// reserved for content shapes.
+///
+/// Every variant keeps the raw frame so later mappers can reach fields this
+/// build does not model, and so an unrecognized frame is never lost.
+///
+/// Verified against Claude CLI 2.1.221 — see
+/// `.plan/active/claude-code-plugin/PROTOCOL.md` section 2.
+sealed class ClaudeStreamMessage {
+  const ClaudeStreamMessage({required this.sessionId, required this.uuid, required this.raw});
+
+  /// The session this frame belongs to. Present on every observed frame, but
+  /// nullable because the transport must not drop a frame that omits it.
+  final String? sessionId;
+
+  /// The CLI's own id for this frame.
+  final String? uuid;
+
+  /// The undecoded frame.
+  final Map<String, Object?> raw;
+
+  /// Parses one decoded stdout line.
+  ///
+  /// Never throws and never returns null: anything unrecognized becomes
+  /// [ClaudeUnknownMessage], because the protocol gains message types
+  /// frequently and a strict parser would drop a whole turn over one new frame.
+  static ClaudeStreamMessage parse(Map<String, Object?> json) {
+    final sessionId = json["session_id"] as String?;
+    final uuid = json["uuid"] as String?;
+    final type = json["type"];
+    if (type is! String) {
+      return ClaudeUnknownMessage(type: null, subtype: null, sessionId: sessionId, uuid: uuid, raw: json);
+    }
+    final subtype = json["subtype"] as String?;
+
+    switch (type) {
+      case "system":
+        return switch (subtype) {
+          "init" => ClaudeInitMessage.fromJson(json, sessionId: sessionId, uuid: uuid),
+          "status" => ClaudeStatusMessage(
+            status: json["status"] as String?,
+            sessionId: sessionId,
+            uuid: uuid,
+            raw: json,
+          ),
+          _ => ClaudeUnknownMessage(type: type, subtype: subtype, sessionId: sessionId, uuid: uuid, raw: json),
+        };
+      case "assistant":
+        return ClaudeAssistantMessage.fromJson(json, sessionId: sessionId, uuid: uuid);
+      case "user":
+        return ClaudeUserMessage(
+          message: _mapOrEmpty(json["message"]),
+          parentToolUseId: json["parent_tool_use_id"] as String?,
+          sessionId: sessionId,
+          uuid: uuid,
+          raw: json,
+        );
+      case "stream_event":
+        return ClaudeStreamEventMessage.fromJson(json, sessionId: sessionId, uuid: uuid);
+      case "result":
+        return ClaudeResultMessage.fromJson(json, sessionId: sessionId, uuid: uuid);
+      case "control_request":
+        return ClaudeControlRequestMessage.fromJson(json, sessionId: sessionId, uuid: uuid);
+      case "control_response":
+        return ClaudeControlResponseMessage.fromJson(json, sessionId: sessionId, uuid: uuid);
+      case "rate_limit_event":
+        return ClaudeRateLimitMessage(
+          info: _mapOrEmpty(json["rate_limit_info"]),
+          sessionId: sessionId,
+          uuid: uuid,
+          raw: json,
+        );
+      default:
+        return ClaudeUnknownMessage(type: type, subtype: subtype, sessionId: sessionId, uuid: uuid, raw: json);
+    }
+  }
+}
+
+Map<String, Object?> _mapOrEmpty(Object? value) =>
+    value is Map ? value.cast<String, Object?>() : const <String, Object?>{};
+
+List<String> _stringList(Object? value) =>
+    value is List ? [for (final entry in value) if (entry is String) entry] : const <String>[];
+
+/// `system`/`init` — the per-process handshake frame.
+final class ClaudeInitMessage extends ClaudeStreamMessage {
+  const ClaudeInitMessage({
+    required this.model,
+    required this.permissionMode,
+    required this.capabilities,
+    required this.tools,
+    required this.slashCommands,
+    required this.cliVersion,
+    required this.cwd,
+    required super.sessionId,
+    required super.uuid,
+    required super.raw,
+  });
+
+  factory ClaudeInitMessage.fromJson(
+    Map<String, Object?> json, {
+    required String? sessionId,
+    required String? uuid,
+  }) {
+    return ClaudeInitMessage(
+      model: json["model"] as String?,
+      permissionMode: ClaudePermissionMode.tryParse(json["permissionMode"] as String?),
+      capabilities: _stringList(json["capabilities"]),
+      tools: _stringList(json["tools"]),
+      slashCommands: _stringList(json["slash_commands"]),
+      cliVersion: json["claude_code_version"] as String?,
+      cwd: json["cwd"] as String?,
+      sessionId: sessionId,
+      uuid: uuid,
+      raw: json,
+    );
+  }
+
+  /// The selected model token, which carries a context-window suffix that the
+  /// per-message model does not — prefer the message's own model when stamping.
+  final String? model;
+
+  final ClaudePermissionMode? permissionMode;
+
+  /// Feature flags to detect against rather than sniffing versions, e.g.
+  /// `interrupt_cancel_queued_v1`.
+  final List<String> capabilities;
+
+  final List<String> tools;
+  final List<String> slashCommands;
+  final String? cliVersion;
+  final String? cwd;
+
+  bool supports(String capability) => capabilities.contains(capability);
+}
+
+/// `system`/`status` — a coarse work-state signal such as `requesting`.
+final class ClaudeStatusMessage extends ClaudeStreamMessage {
+  const ClaudeStatusMessage({
+    required this.status,
+    required super.sessionId,
+    required super.uuid,
+    required super.raw,
+  });
+
+  final String? status;
+}
+
+/// A complete assistant message.
+///
+/// Ordering trap: this frame arrives *before* the turn's `content_block_stop`,
+/// `message_delta`, and `message_stop` stream events, not after them.
+final class ClaudeAssistantMessage extends ClaudeStreamMessage {
+  const ClaudeAssistantMessage({
+    required this.message,
+    required this.messageId,
+    required this.model,
+    required this.parentToolUseId,
+    required super.sessionId,
+    required super.uuid,
+    required super.raw,
+  });
+
+  factory ClaudeAssistantMessage.fromJson(
+    Map<String, Object?> json, {
+    required String? sessionId,
+    required String? uuid,
+  }) {
+    final message = _mapOrEmpty(json["message"]);
+    return ClaudeAssistantMessage(
+      message: message,
+      messageId: message["id"] as String?,
+      model: message["model"] as String?,
+      parentToolUseId: json["parent_tool_use_id"] as String?,
+      sessionId: sessionId,
+      uuid: uuid,
+      raw: json,
+    );
+  }
+
+  /// The raw Anthropic message. Content blocks are typed in the content mapper,
+  /// not here, so the transport stays independent of block shapes.
+  final Map<String, Object?> message;
+
+  final String? messageId;
+
+  /// The resolved model for this message. This, not the init model, is what
+  /// assistant envelopes are stamped with.
+  final String? model;
+
+  /// Non-null marks subagent traffic.
+  final String? parentToolUseId;
+}
+
+/// A user frame. Also carries `tool_result` blocks that complete tool calls.
+final class ClaudeUserMessage extends ClaudeStreamMessage {
+  const ClaudeUserMessage({
+    required this.message,
+    required this.parentToolUseId,
+    required super.sessionId,
+    required super.uuid,
+    required super.raw,
+  });
+
+  final Map<String, Object?> message;
+  final String? parentToolUseId;
+}
+
+/// A raw Anthropic streaming event carrying token-level deltas.
+final class ClaudeStreamEventMessage extends ClaudeStreamMessage {
+  const ClaudeStreamEventMessage({
+    required this.event,
+    required this.eventType,
+    required this.parentToolUseId,
+    required super.sessionId,
+    required super.uuid,
+    required super.raw,
+  });
+
+  factory ClaudeStreamEventMessage.fromJson(
+    Map<String, Object?> json, {
+    required String? sessionId,
+    required String? uuid,
+  }) {
+    final event = _mapOrEmpty(json["event"]);
+    return ClaudeStreamEventMessage(
+      event: event,
+      eventType: event["type"] as String?,
+      parentToolUseId: json["parent_tool_use_id"] as String?,
+      sessionId: sessionId,
+      uuid: uuid,
+      raw: json,
+    );
+  }
+
+  final Map<String, Object?> event;
+
+  /// `message_start`, `content_block_start`, `content_block_delta`,
+  /// `content_block_stop`, `message_delta`, or `message_stop`.
+  final String? eventType;
+
+  final String? parentToolUseId;
+}
+
+/// The end of a turn.
+final class ClaudeResultMessage extends ClaudeStreamMessage {
+  const ClaudeResultMessage({
+    required this.subtype,
+    required this.isError,
+    required this.result,
+    required this.stopReason,
+    required this.terminalReason,
+    required this.permissionDenials,
+    required super.sessionId,
+    required super.uuid,
+    required super.raw,
+  });
+
+  factory ClaudeResultMessage.fromJson(
+    Map<String, Object?> json, {
+    required String? sessionId,
+    required String? uuid,
+  }) {
+    final denials = json["permission_denials"];
+    return ClaudeResultMessage(
+      subtype: json["subtype"] as String?,
+      isError: json["is_error"] as bool? ?? false,
+      result: json["result"] as String?,
+      stopReason: json["stop_reason"] as String?,
+      terminalReason: json["terminal_reason"] as String?,
+      permissionDenials: denials is List
+          ? [for (final entry in denials) if (entry is Map) entry.cast<String, Object?>()]
+          : const <Map<String, Object?>>[],
+      sessionId: sessionId,
+      uuid: uuid,
+      raw: json,
+    );
+  }
+
+  final String? subtype;
+  final bool isError;
+  final String? result;
+  final String? stopReason;
+  final String? terminalReason;
+
+  /// Tools refused without the host being asked.
+  ///
+  /// A non-empty list on an otherwise successful turn is the signature of a
+  /// missing `--permission-prompt-tool stdio`, so it is surfaced rather than
+  /// dropped.
+  final List<Map<String, Object?>> permissionDenials;
+}
+
+/// A CLI-originated control request, notably `can_use_tool`.
+final class ClaudeControlRequestMessage extends ClaudeStreamMessage {
+  const ClaudeControlRequestMessage({
+    required this.requestId,
+    required this.subtype,
+    required this.request,
+    required super.sessionId,
+    required super.uuid,
+    required super.raw,
+  });
+
+  factory ClaudeControlRequestMessage.fromJson(
+    Map<String, Object?> json, {
+    required String? sessionId,
+    required String? uuid,
+  }) {
+    final request = _mapOrEmpty(json["request"]);
+    return ClaudeControlRequestMessage(
+      requestId: json["request_id"] as String?,
+      subtype: request["subtype"] as String?,
+      request: request,
+      sessionId: sessionId,
+      uuid: uuid,
+      raw: json,
+    );
+  }
+
+  /// Echo this when responding.
+  final String? requestId;
+
+  final String? subtype;
+  final Map<String, Object?> request;
+}
+
+/// A reply to a control request we sent.
+final class ClaudeControlResponseMessage extends ClaudeStreamMessage {
+  const ClaudeControlResponseMessage({
+    required this.requestId,
+    required this.isSuccess,
+    required this.payload,
+    required this.error,
+    required super.sessionId,
+    required super.uuid,
+    required super.raw,
+  });
+
+  factory ClaudeControlResponseMessage.fromJson(
+    Map<String, Object?> json, {
+    required String? sessionId,
+    required String? uuid,
+  }) {
+    final response = _mapOrEmpty(json["response"]);
+    final subtype = response["subtype"] as String?;
+    return ClaudeControlResponseMessage(
+      requestId: response["request_id"] as String?,
+      // Anything that is not an explicit success is treated as a failure, so a
+      // subtype this build does not know cannot be mistaken for one.
+      isSuccess: subtype == "success",
+      payload: _mapOrEmpty(response["response"]),
+      error: response["error"] as String?,
+      sessionId: sessionId,
+      uuid: uuid,
+      raw: json,
+    );
+  }
+
+  final String? requestId;
+  final bool isSuccess;
+  final Map<String, Object?> payload;
+  final String? error;
+}
+
+/// Rate-limit state pushed alongside a turn.
+final class ClaudeRateLimitMessage extends ClaudeStreamMessage {
+  const ClaudeRateLimitMessage({
+    required this.info,
+    required super.sessionId,
+    required super.uuid,
+    required super.raw,
+  });
+
+  final Map<String, Object?> info;
+
+  String? get status => info["status"] as String?;
+}
+
+/// Any frame this build does not model.
+///
+/// Absorbed deliberately: `rate_limit_event` and `system`/`status` were both
+/// absent from the protocol research and present in the first live capture.
+final class ClaudeUnknownMessage extends ClaudeStreamMessage {
+  const ClaudeUnknownMessage({
+    required this.type,
+    required this.subtype,
+    required super.sessionId,
+    required super.uuid,
+    required super.raw,
+  });
+
+  final String? type;
+  final String? subtype;
+}

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_stream_message.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_stream_message.dart
@@ -278,7 +278,7 @@ final class ClaudeResultMessage extends ClaudeStreamMessage {
     final denials = json["permission_denials"];
     return ClaudeResultMessage(
       subtype: _stringOrNull(json["subtype"]),
-      isError: json["is_error"] is bool && json["is_error"]! as bool,
+      isError: json["is_error"] == true,
       result: _stringOrNull(json["result"]),
       stopReason: _stringOrNull(json["stop_reason"]),
       terminalReason: _stringOrNull(json["terminal_reason"]),

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_stream_message.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_stream_message.dart
@@ -33,20 +33,20 @@ sealed class ClaudeStreamMessage {
   /// [ClaudeUnknownMessage], because the protocol gains message types
   /// frequently and a strict parser would drop a whole turn over one new frame.
   static ClaudeStreamMessage parse(Map<String, Object?> json) {
-    final sessionId = json["session_id"] as String?;
-    final uuid = json["uuid"] as String?;
+    final sessionId = _stringOrNull(json["session_id"]);
+    final uuid = _stringOrNull(json["uuid"]);
     final type = json["type"];
     if (type is! String) {
       return ClaudeUnknownMessage(type: null, subtype: null, sessionId: sessionId, uuid: uuid, raw: json);
     }
-    final subtype = json["subtype"] as String?;
+    final subtype = _stringOrNull(json["subtype"]);
 
     switch (type) {
       case "system":
         return switch (subtype) {
           "init" => ClaudeInitMessage.fromJson(json, sessionId: sessionId, uuid: uuid),
           "status" => ClaudeStatusMessage(
-            status: json["status"] as String?,
+            status: _stringOrNull(json["status"]),
             sessionId: sessionId,
             uuid: uuid,
             raw: json,
@@ -58,7 +58,7 @@ sealed class ClaudeStreamMessage {
       case "user":
         return ClaudeUserMessage(
           message: _mapOrEmpty(json["message"]),
-          parentToolUseId: json["parent_tool_use_id"] as String?,
+          parentToolUseId: _stringOrNull(json["parent_tool_use_id"]),
           sessionId: sessionId,
           uuid: uuid,
           raw: json,
@@ -84,11 +84,17 @@ sealed class ClaudeStreamMessage {
   }
 }
 
+String? _stringOrNull(Object? value) => value is String ? value : null;
+
 Map<String, Object?> _mapOrEmpty(Object? value) =>
     value is Map ? value.cast<String, Object?>() : const <String, Object?>{};
 
-List<String> _stringList(Object? value) =>
-    value is List ? [for (final entry in value) if (entry is String) entry] : const <String>[];
+List<String> _stringList(Object? value) => value is List
+    ? [
+        for (final entry in value)
+          if (entry is String) entry,
+      ]
+    : const <String>[];
 
 /// `system`/`init` — the per-process handshake frame.
 final class ClaudeInitMessage extends ClaudeStreamMessage {
@@ -111,13 +117,13 @@ final class ClaudeInitMessage extends ClaudeStreamMessage {
     required String? uuid,
   }) {
     return ClaudeInitMessage(
-      model: json["model"] as String?,
-      permissionMode: ClaudePermissionMode.tryParse(json["permissionMode"] as String?),
+      model: _stringOrNull(json["model"]),
+      permissionMode: ClaudePermissionMode.tryParse(_stringOrNull(json["permissionMode"])),
       capabilities: _stringList(json["capabilities"]),
       tools: _stringList(json["tools"]),
       slashCommands: _stringList(json["slash_commands"]),
-      cliVersion: json["claude_code_version"] as String?,
-      cwd: json["cwd"] as String?,
+      cliVersion: _stringOrNull(json["claude_code_version"]),
+      cwd: _stringOrNull(json["cwd"]),
       sessionId: sessionId,
       uuid: uuid,
       raw: json,
@@ -177,9 +183,9 @@ final class ClaudeAssistantMessage extends ClaudeStreamMessage {
     final message = _mapOrEmpty(json["message"]);
     return ClaudeAssistantMessage(
       message: message,
-      messageId: message["id"] as String?,
-      model: message["model"] as String?,
-      parentToolUseId: json["parent_tool_use_id"] as String?,
+      messageId: _stringOrNull(message["id"]),
+      model: _stringOrNull(message["model"]),
+      parentToolUseId: _stringOrNull(json["parent_tool_use_id"]),
       sessionId: sessionId,
       uuid: uuid,
       raw: json,
@@ -233,8 +239,8 @@ final class ClaudeStreamEventMessage extends ClaudeStreamMessage {
     final event = _mapOrEmpty(json["event"]);
     return ClaudeStreamEventMessage(
       event: event,
-      eventType: event["type"] as String?,
-      parentToolUseId: json["parent_tool_use_id"] as String?,
+      eventType: _stringOrNull(event["type"]),
+      parentToolUseId: _stringOrNull(json["parent_tool_use_id"]),
       sessionId: sessionId,
       uuid: uuid,
       raw: json,
@@ -271,13 +277,16 @@ final class ClaudeResultMessage extends ClaudeStreamMessage {
   }) {
     final denials = json["permission_denials"];
     return ClaudeResultMessage(
-      subtype: json["subtype"] as String?,
-      isError: json["is_error"] as bool? ?? false,
-      result: json["result"] as String?,
-      stopReason: json["stop_reason"] as String?,
-      terminalReason: json["terminal_reason"] as String?,
+      subtype: _stringOrNull(json["subtype"]),
+      isError: json["is_error"] is bool && json["is_error"]! as bool,
+      result: _stringOrNull(json["result"]),
+      stopReason: _stringOrNull(json["stop_reason"]),
+      terminalReason: _stringOrNull(json["terminal_reason"]),
       permissionDenials: denials is List
-          ? [for (final entry in denials) if (entry is Map) entry.cast<String, Object?>()]
+          ? [
+              for (final entry in denials)
+                if (entry is Map) entry.cast<String, Object?>(),
+            ]
           : const <Map<String, Object?>>[],
       sessionId: sessionId,
       uuid: uuid,
@@ -317,8 +326,8 @@ final class ClaudeControlRequestMessage extends ClaudeStreamMessage {
   }) {
     final request = _mapOrEmpty(json["request"]);
     return ClaudeControlRequestMessage(
-      requestId: json["request_id"] as String?,
-      subtype: request["subtype"] as String?,
+      requestId: _stringOrNull(json["request_id"]),
+      subtype: _stringOrNull(request["subtype"]),
       request: request,
       sessionId: sessionId,
       uuid: uuid,
@@ -351,14 +360,14 @@ final class ClaudeControlResponseMessage extends ClaudeStreamMessage {
     required String? uuid,
   }) {
     final response = _mapOrEmpty(json["response"]);
-    final subtype = response["subtype"] as String?;
+    final subtype = _stringOrNull(response["subtype"]);
     return ClaudeControlResponseMessage(
-      requestId: response["request_id"] as String?,
+      requestId: _stringOrNull(response["request_id"]),
       // Anything that is not an explicit success is treated as a failure, so a
       // subtype this build does not know cannot be mistaken for one.
       isSuccess: subtype == "success",
       payload: _mapOrEmpty(response["response"]),
-      error: response["error"] as String?,
+      error: _stringOrNull(response["error"]),
       sessionId: sessionId,
       uuid: uuid,
       raw: json,
@@ -382,7 +391,7 @@ final class ClaudeRateLimitMessage extends ClaudeStreamMessage {
 
   final Map<String, Object?> info;
 
-  String? get status => info["status"] as String?;
+  String? get status => _stringOrNull(info["status"]);
 }
 
 /// Any frame this build does not model.

--- a/bridge/sesori_plugin_claude/lib/src/testing/fake_claude_process.dart
+++ b/bridge/sesori_plugin_claude/lib/src/testing/fake_claude_process.dart
@@ -6,10 +6,12 @@ import "../api/claude_process_factory.dart";
 
 /// In-memory [ClaudeProcessHandle] for transport and plugin tests.
 class FakeClaudeProcess implements ClaudeProcessHandle {
+  FakeClaudeProcess({bool stdinCloseCompletes = true}) : _stdin = CapturingIOSink(closeCompletes: stdinCloseCompletes);
+
   final StreamController<List<int>> _stdout = StreamController<List<int>>();
   final StreamController<List<int>> _stderr = StreamController<List<int>>();
   final Completer<int> _exit = Completer<int>();
-  final CapturingIOSink _stdin = CapturingIOSink();
+  final CapturingIOSink _stdin;
 
   bool _stdoutTapped = false;
   bool _stderrTapped = false;
@@ -98,6 +100,9 @@ class FakeClaudeProcess implements ClaudeProcessHandle {
 /// Minimal [IOSink] capturing `add`-ed bytes and decoding complete ndjson lines
 /// into [frames]. Only [add] and [close] are exercised by the transport.
 class CapturingIOSink implements IOSink {
+  CapturingIOSink({bool closeCompletes = true}) : _closeCompleter = closeCompletes ? null : Completer<void>();
+
+  final Completer<void>? _closeCompleter;
   final List<int> _buffer = [];
   final List<Map<String, Object?>> frames = [];
 
@@ -129,7 +134,10 @@ class CapturingIOSink implements IOSink {
   Future<void> addStream(Stream<List<int>> stream) async {}
 
   @override
-  Future<void> close() async => closed = true;
+  Future<void> close() {
+    closed = true;
+    return _closeCompleter?.future ?? Future<void>.value();
+  }
 
   @override
   Future<void> get done => Future<void>.value();

--- a/bridge/sesori_plugin_claude/lib/src/testing/fake_claude_process.dart
+++ b/bridge/sesori_plugin_claude/lib/src/testing/fake_claude_process.dart
@@ -1,0 +1,151 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+
+import "../api/claude_process_factory.dart";
+
+/// In-memory [ClaudeProcessHandle] for transport and plugin tests.
+class FakeClaudeProcess implements ClaudeProcessHandle {
+  final StreamController<List<int>> _stdout = StreamController<List<int>>();
+  final StreamController<List<int>> _stderr = StreamController<List<int>>();
+  final Completer<int> _exit = Completer<int>();
+  final CapturingIOSink _stdin = CapturingIOSink();
+
+  bool _stdoutTapped = false;
+  bool _stderrTapped = false;
+
+  /// Signals the fake received a kill, so teardown tests can assert it.
+  bool killed = false;
+
+  @override
+  Stream<List<int>> get stdout {
+    _stdoutTapped = true;
+    return _stdout.stream;
+  }
+
+  @override
+  Stream<List<int>> get stderr {
+    _stderrTapped = true;
+    return _stderr.stream;
+  }
+
+  @override
+  IOSink get stdin => _stdin;
+
+  @override
+  Future<int> get exitCode => _exit.future;
+
+  @override
+  bool kill([ProcessSignal signal = ProcessSignal.sigterm]) {
+    killed = true;
+    if (!_exit.isCompleted) _exit.complete(-15);
+    return true;
+  }
+
+  /// Frames the client wrote to stdin, decoded from ndjson.
+  List<Map<String, Object?>> get written => _stdin.frames;
+
+  /// Pushes one stdout frame as an ndjson line.
+  void emit(Map<String, Object?> message) {
+    if (_stdout.isClosed) return;
+    _stdout.add(utf8.encode("${jsonEncode(message)}\n"));
+  }
+
+  /// Pushes raw stdout bytes, for framing and malformed-input tests.
+  void emitRaw(List<int> bytes) {
+    if (_stdout.isClosed) return;
+    _stdout.add(bytes);
+  }
+
+  /// Pushes raw stderr bytes. Used to prove a crashing child's non-UTF-8 output
+  /// does not take down the diagnostic stream.
+  void emitStderrRaw(List<int> bytes) {
+    if (_stderr.isClosed) return;
+    _stderr.add(bytes);
+  }
+
+  /// Answers the pending control request with `request_id` [requestId].
+  void emitControlResponse({required String requestId, required Map<String, Object?> payload}) {
+    emit({
+      "type": "control_response",
+      "response": {"subtype": "success", "request_id": requestId, "response": payload},
+    });
+  }
+
+  /// Answers a control request with a failure.
+  void emitControlError({required String requestId, required String error}) {
+    emit({
+      "type": "control_response",
+      "response": {"subtype": "error", "request_id": requestId, "error": error},
+    });
+  }
+
+  /// Completes the process with [code], simulating an exit.
+  void exit(int code) {
+    if (!_exit.isCompleted) _exit.complete(code);
+  }
+
+  Future<void> close() async {
+    // A single-subscription controller's `close()` future only completes once
+    // its stream has been listened to, so drain any never-tapped stream first.
+    if (!_stdoutTapped) _stdout.stream.listen(null);
+    if (!_stderrTapped) _stderr.stream.listen(null);
+    await _stdout.close();
+    await _stderr.close();
+  }
+}
+
+/// Minimal [IOSink] capturing `add`-ed bytes and decoding complete ndjson lines
+/// into [frames]. Only [add] and [close] are exercised by the transport.
+class CapturingIOSink implements IOSink {
+  final List<int> _buffer = [];
+  final List<Map<String, Object?>> frames = [];
+
+  /// Whether the transport closed stdin, which is the protocol's own shutdown
+  /// signal.
+  bool closed = false;
+
+  @override
+  Encoding encoding = utf8;
+
+  @override
+  void add(List<int> data) {
+    _buffer.addAll(data);
+    while (true) {
+      final index = _buffer.indexOf(10);
+      if (index < 0) break;
+      final line = utf8.decode(_buffer.sublist(0, index));
+      _buffer.removeRange(0, index + 1);
+      if (line.trim().isNotEmpty) {
+        frames.add((jsonDecode(line) as Map).cast<String, Object?>());
+      }
+    }
+  }
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future<void> addStream(Stream<List<int>> stream) async {}
+
+  @override
+  Future<void> close() async => closed = true;
+
+  @override
+  Future<void> get done => Future<void>.value();
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  void write(Object? object) {}
+
+  @override
+  void writeAll(Iterable<dynamic> objects, [String separator = ""]) {}
+
+  @override
+  void writeCharCode(int charCode) {}
+
+  @override
+  void writeln([Object? object = ""]) {}
+}

--- a/bridge/sesori_plugin_claude/test/claude_launch_spec_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_launch_spec_test.dart
@@ -15,6 +15,7 @@ void main() {
     }) {
       return ClaudeLaunchSpec(
         binaryPath: "claude",
+        workingDirectory: "/tmp/project",
         launch: launch,
         model: model,
         effort: effort,

--- a/bridge/sesori_plugin_claude/test/claude_launch_spec_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_launch_spec_test.dart
@@ -100,6 +100,21 @@ void main() {
       expect(arguments, containsAllInOrder(["--permission-mode", "plan"]));
     });
 
+    test("rejects a HOME override", () {
+      expect(
+        () => ClaudeLaunchSpec(
+          binaryPath: "claude",
+          workingDirectory: "/tmp/project",
+          launch: ClaudeNewSession(sessionId: _newSessionId),
+          model: null,
+          effort: null,
+          permissionMode: null,
+          environment: const {"HOME": "/tmp/test-home"},
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
     test("spells the standard mode the way the command line expects", () {
       final arguments = specFor(
         ClaudeNewSession(sessionId: _newSessionId),

--- a/bridge/sesori_plugin_claude/test/claude_launch_spec_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_launch_spec_test.dart
@@ -115,6 +115,24 @@ void main() {
       );
     });
 
+    test("keeps environment overrides immutable", () {
+      final environment = {"CLAUDE_CONFIG_DIR": "/tmp/claude-config"};
+      final spec = ClaudeLaunchSpec(
+        binaryPath: "claude",
+        workingDirectory: "/tmp/project",
+        launch: ClaudeNewSession(sessionId: _newSessionId),
+        model: null,
+        effort: null,
+        permissionMode: null,
+        environment: environment,
+      );
+
+      environment["HOME"] = "/tmp/test-home";
+
+      expect(spec.environment, {"CLAUDE_CONFIG_DIR": "/tmp/claude-config"});
+      expect(() => spec.environment["HOME"] = "/tmp/test-home", throwsUnsupportedError);
+    });
+
     test("spells the standard mode the way the command line expects", () {
       final arguments = specFor(
         ClaudeNewSession(sessionId: _newSessionId),

--- a/bridge/sesori_plugin_claude/test/claude_stream_client_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_stream_client_test.dart
@@ -88,7 +88,10 @@ void main() {
       connected.fake.emitRaw(
         ndjson([
           {"type": "system", "subtype": "status", "status": "requesting"},
-          {"type": "stream_event", "event": {"type": "message_stop"}},
+          {
+            "type": "stream_event",
+            "event": {"type": "message_stop"},
+          },
           {"type": "result", "subtype": "success"},
         ]),
       );
@@ -197,6 +200,25 @@ void main() {
       expect(request["model"], "small");
     });
 
+    test("does not let params replace the requested subtype", () async {
+      final connected = await connectTestClient();
+      addTearDown(connected.client.dispose);
+
+      unawaited(
+        connected.client
+            .sendControlRequest(
+              subtype: "set_model",
+              params: {"subtype": "interrupt", "model": "small"},
+            )
+            .catchError((Object _) => <String, Object?>{}),
+      );
+      await pump();
+
+      final request = connected.fake.written.last["request"]! as Map;
+      expect(request["subtype"], "set_model");
+      expect(request["model"], "small");
+    });
+
     test("ignores a response for an unknown request id", () async {
       final connected = await connectTestClient();
       addTearDown(connected.client.dispose);
@@ -279,6 +301,18 @@ void main() {
       expect((message["content"]! as List).single, {"type": "text", "text": "hello"});
     });
 
+    test("fails a user turn after the process exits", () async {
+      final connected = await connectTestClient();
+      addTearDown(connected.client.dispose);
+      connected.fake.exit(1);
+      await pump(10);
+
+      expect(
+        () => connected.client.sendUserMessage(content: const []),
+        throwsA(isA<ClaudeControlException>()),
+      );
+    });
+
     test("answers a control request with a success payload", () async {
       final connected = await connectTestClient();
       addTearDown(connected.client.dispose);
@@ -312,9 +346,11 @@ void main() {
       await connected.client.dispose();
       final before = connected.fake.written.length;
 
-      connected.client.sendUserMessage(content: [
-        {"type": "text", "text": "late"},
-      ]);
+      connected.client.sendUserMessage(
+        content: [
+          {"type": "text", "text": "late"},
+        ],
+      );
       connected.client.sendControlResponse(requestId: "ask-3", payload: const {});
       await pump();
 
@@ -332,6 +368,18 @@ void main() {
       // before signalling.
       expect((connected.fake.stdin as CapturingIOSink).closed, isTrue);
       expect(connected.fake.killed, isTrue);
+      expect(connected.client.isConnected, isFalse);
+    });
+
+    test("terminates when closing stdin stalls", () async {
+      final fake = FakeClaudeProcess(stdinCloseCompletes: false);
+      final connected = await connectTestClient(process: fake);
+
+      await connected.client.dispose(
+        gracefulTimeout: const Duration(milliseconds: 20),
+      );
+
+      expect(fake.killed, isTrue);
       expect(connected.client.isConnected, isFalse);
     });
 

--- a/bridge/sesori_plugin_claude/test/claude_stream_client_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_stream_client_test.dart
@@ -1,0 +1,361 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:claude_plugin/claude_plugin.dart";
+import "package:claude_plugin/claude_testing.dart";
+import "package:test/test.dart";
+
+import "support/claude_stream_client_test_factory.dart";
+
+void main() {
+  group("connect", () {
+    test("performs the initialize handshake and retains its catalog", () async {
+      final connected = await connectTestClient(handshake: sampleHandshake);
+      addTearDown(connected.client.dispose);
+
+      final request = await waitForFrame(connected.fake, "control_request");
+      expect((request["request"]! as Map)["subtype"], "initialize");
+
+      // One handshake yields commands, agents and models together, which is
+      // why the catalog service needs no separate startup probes.
+      expect(connected.client.handshake, isNotNull);
+      expect(connected.client.handshake!["models"], hasLength(2));
+      expect(connected.client.handshake!["commands"], hasLength(1));
+      expect(connected.client.isConnected, isTrue);
+    });
+
+    test("tears down and rethrows when the handshake fails", () async {
+      final fake = FakeClaudeProcess();
+      addTearDown(fake.close);
+      final client = ClaudeStreamClient(
+        launchSpec: testLaunchSpec(),
+        processFactory: (_) async => fake,
+        controlTimeout: const Duration(seconds: 5),
+      );
+
+      final connecting = client.connect();
+      final request = await waitForFrame(fake, "control_request");
+      fake.emitControlError(requestId: request["request_id"]! as String, error: "boom");
+
+      // Continuing without the catalog would surface an empty model and command
+      // list as if the backend genuinely had none.
+      await expectLater(connecting, throwsA(isA<ClaudeControlException>()));
+      expect(client.isConnected, isFalse);
+      expect(fake.killed, isTrue);
+    });
+
+    test("refuses a second connect and a connect after dispose", () async {
+      final connected = await connectTestClient();
+      await expectLater(connected.client.connect(), throwsStateError);
+
+      await connected.client.dispose();
+      await expectLater(connected.client.connect(), throwsStateError);
+    });
+
+    test("reaps a process that spawned while teardown was in flight", () async {
+      final fake = FakeClaudeProcess();
+      addTearDown(fake.close);
+      final spawnGate = Completer<void>();
+      final client = ClaudeStreamClient(
+        launchSpec: testLaunchSpec(),
+        processFactory: (_) async {
+          await spawnGate.future;
+          return fake;
+        },
+      );
+
+      final connecting = client.connect();
+      await pump();
+      // Dispose sees no process to reap, because the spawn has not returned.
+      final disposing = client.dispose();
+      spawnGate.complete();
+
+      await expectLater(connecting, throwsStateError);
+      await disposing;
+      // Without the post-spawn generation check the subprocess would leak.
+      expect(fake.killed, isTrue);
+    });
+  });
+
+  group("framing", () {
+    test("splits several frames arriving in one chunk", () async {
+      final connected = await connectTestClient();
+      addTearDown(connected.client.dispose);
+
+      final seen = <ClaudeStreamMessage>[];
+      connected.client.messages.listen(seen.add);
+
+      connected.fake.emitRaw(
+        ndjson([
+          {"type": "system", "subtype": "status", "status": "requesting"},
+          {"type": "stream_event", "event": {"type": "message_stop"}},
+          {"type": "result", "subtype": "success"},
+        ]),
+      );
+      connected.fake.emitRaw(utf8.encode("\n"));
+      await pump(10);
+
+      expect(seen.map((message) => message.runtimeType.toString()), [
+        "ClaudeStatusMessage",
+        "ClaudeStreamEventMessage",
+        "ClaudeResultMessage",
+      ]);
+    });
+
+    test("reassembles a frame split across chunks", () async {
+      final connected = await connectTestClient();
+      addTearDown(connected.client.dispose);
+
+      final seen = <ClaudeStreamMessage>[];
+      connected.client.messages.listen(seen.add);
+
+      connected.fake.emitRaw(utf8.encode('{"type":"result","sub'));
+      await pump();
+      expect(seen, isEmpty);
+
+      connected.fake.emitRaw(utf8.encode('type":"success"}\n'));
+      await pump(10);
+
+      expect(seen.single, isA<ClaudeResultMessage>());
+    });
+
+    test("skips blank and unparseable lines without dropping the stream", () async {
+      final connected = await connectTestClient();
+      addTearDown(connected.client.dispose);
+
+      final seen = <ClaudeStreamMessage>[];
+      connected.client.messages.listen(seen.add);
+
+      connected.fake.emitRaw(utf8.encode('\n   \nnot json\n[1,2,3]\n{"type":"result"}\n'));
+      await pump(10);
+
+      // Only the valid object frame survives; the rest are absorbed.
+      expect(seen.single, isA<ClaudeResultMessage>());
+    });
+
+    test("survives non-UTF-8 bytes on stderr", () async {
+      final connected = await connectTestClient();
+      addTearDown(connected.client.dispose);
+
+      final seen = <ClaudeStreamMessage>[];
+      connected.client.messages.listen(seen.add);
+
+      // A crashing child emits raw bytes; a strict decoder would throw here and
+      // take the diagnostic stream down exactly when it matters most.
+      connected.fake.emitStderrRaw([0xC3, 0x28, 0xA0, 0xA1]);
+      await pump();
+      connected.fake.emit({"type": "result", "subtype": "success"});
+      await pump(10);
+
+      expect(seen.single, isA<ClaudeResultMessage>());
+      expect(connected.client.isConnected, isTrue);
+    });
+
+    test("captures the init frame as it passes through", () async {
+      final connected = await connectTestClient();
+      addTearDown(connected.client.dispose);
+
+      expect(connected.client.init, isNull);
+      connected.fake.emit(sampleInit());
+      await pump(10);
+
+      expect(connected.client.init?.cliVersion, "2.1.221");
+      expect(connected.client.init?.permissionMode, ClaudePermissionMode.auto);
+    });
+  });
+
+  group("control requests", () {
+    test("correlates a response to its request by id", () async {
+      final connected = await connectTestClient();
+      addTearDown(connected.client.dispose);
+
+      final pending = connected.client.sendControlRequest(
+        subtype: "list_models",
+      );
+      final frames = connected.fake.written.where((frame) => frame["type"] == "control_request").toList();
+      final requestId = frames.last["request_id"]! as String;
+      expect(requestId, isNot("sesori-1"), reason: "the handshake already used the first id");
+
+      connected.fake.emitControlResponse(requestId: requestId, payload: {"models": <Object?>[]});
+      expect(await pending, {"models": <Object?>[]});
+    });
+
+    test("carries request params alongside the subtype", () async {
+      final connected = await connectTestClient();
+      addTearDown(connected.client.dispose);
+
+      unawaited(
+        connected.client
+            .sendControlRequest(subtype: "set_model", params: {"model": "small"})
+            .catchError((Object _) => <String, Object?>{}),
+      );
+      await pump();
+
+      final frame = connected.fake.written.last;
+      final request = frame["request"]! as Map;
+      expect(request["subtype"], "set_model");
+      expect(request["model"], "small");
+    });
+
+    test("ignores a response for an unknown request id", () async {
+      final connected = await connectTestClient();
+      addTearDown(connected.client.dispose);
+
+      connected.fake.emitControlResponse(requestId: "not-ours", payload: {"a": 1});
+      await pump(10);
+
+      // Absorbed, and the client stays usable.
+      expect(connected.client.isConnected, isTrue);
+    });
+
+    test("fails an in-flight request when the process exits", () async {
+      final connected = await connectTestClient();
+      addTearDown(connected.client.dispose);
+
+      // Attach the expectation before the error is delivered: an in-flight
+      // future that completes with an error while unobserved surfaces as an
+      // unhandled zone error rather than reaching the assertion.
+      final pending = connected.client.sendControlRequest(subtype: "list_models");
+      final expectation = expectLater(pending, throwsA(isA<ClaudeControlException>()));
+      await pump();
+      connected.fake.exit(1);
+
+      await expectation;
+    });
+
+    test("fails fast once the process has exited", () async {
+      final connected = await connectTestClient();
+      addTearDown(connected.client.dispose);
+
+      connected.fake.exit(0);
+      await pump(10);
+
+      // Without the exit check this would write to a dead pipe and then block
+      // for the full control timeout awaiting a reply that can never come.
+      await expectLater(
+        connected.client.sendControlRequest(subtype: "list_models"),
+        throwsA(isA<ClaudeControlException>()),
+      );
+      expect(connected.client.isConnected, isFalse);
+    });
+
+    test("times out when no reply arrives", () async {
+      final connected = await connectTestClient(controlTimeout: const Duration(milliseconds: 50));
+      addTearDown(connected.client.dispose);
+
+      await expectLater(
+        connected.client.sendControlRequest(subtype: "list_models"),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
+
+    test("fails an in-flight request on dispose", () async {
+      final connected = await connectTestClient();
+
+      final pending = connected.client.sendControlRequest(subtype: "list_models");
+      final expectation = expectLater(pending, throwsStateError);
+      await pump();
+      await connected.client.dispose();
+
+      await expectation;
+    });
+  });
+
+  group("outbound frames", () {
+    test("writes a user turn carrying the session id", () async {
+      final connected = await connectTestClient(sessionId: otherTestSessionId);
+      addTearDown(connected.client.dispose);
+
+      connected.client.sendUserMessage(
+        content: [
+          {"type": "text", "text": "hello"},
+        ],
+      );
+      final frame = await waitForFrame(connected.fake, "user");
+
+      expect(frame["session_id"], otherTestSessionId);
+      final message = frame["message"]! as Map;
+      expect(message["role"], "user");
+      expect((message["content"]! as List).single, {"type": "text", "text": "hello"});
+    });
+
+    test("answers a control request with a success payload", () async {
+      final connected = await connectTestClient();
+      addTearDown(connected.client.dispose);
+
+      connected.client.sendControlResponse(
+        requestId: "ask-1",
+        payload: {"behavior": "allow"},
+      );
+      final frame = await waitForFrame(connected.fake, "control_response");
+
+      final response = frame["response"]! as Map;
+      expect(response["subtype"], "success");
+      expect(response["request_id"], "ask-1");
+      expect(response["response"], {"behavior": "allow"});
+    });
+
+    test("answers a control request with an error", () async {
+      final connected = await connectTestClient();
+      addTearDown(connected.client.dispose);
+
+      connected.client.sendControlResponseError(requestId: "ask-2", message: "no");
+      await pump();
+
+      final response = connected.fake.written.last["response"]! as Map;
+      expect(response["subtype"], "error");
+      expect(response["error"], "no");
+    });
+
+    test("drops outbound writes after teardown instead of throwing", () async {
+      final connected = await connectTestClient();
+      await connected.client.dispose();
+      final before = connected.fake.written.length;
+
+      connected.client.sendUserMessage(content: [
+        {"type": "text", "text": "late"},
+      ]);
+      connected.client.sendControlResponse(requestId: "ask-3", payload: const {});
+      await pump();
+
+      expect(connected.fake.written, hasLength(before));
+    });
+  });
+
+  group("teardown", () {
+    test("closes stdin and terminates the process", () async {
+      final connected = await connectTestClient();
+
+      await connected.client.dispose();
+
+      // Closing stdin is the protocol's own shutdown signal, so it is tried
+      // before signalling.
+      expect((connected.fake.stdin as CapturingIOSink).closed, isTrue);
+      expect(connected.fake.killed, isTrue);
+      expect(connected.client.isConnected, isFalse);
+    });
+
+    test("is idempotent", () async {
+      final connected = await connectTestClient();
+
+      await connected.client.dispose();
+      await connected.client.dispose();
+
+      expect(connected.client.isConnected, isFalse);
+    });
+
+    test("ignores frames from a process torn down earlier", () async {
+      final connected = await connectTestClient();
+      final seen = <ClaudeStreamMessage>[];
+      connected.client.messages.listen(seen.add);
+
+      await connected.client.dispose();
+      connected.fake.emit({"type": "result", "subtype": "success"});
+      await pump(10);
+
+      // Generation fencing: a late frame from the dead process must not reach
+      // consumers of a connection established afterwards.
+      expect(seen, isEmpty);
+    });
+  });
+}

--- a/bridge/sesori_plugin_claude/test/claude_stream_message_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_stream_message_test.dart
@@ -1,0 +1,195 @@
+import "package:claude_plugin/claude_plugin.dart";
+import "package:test/test.dart";
+
+import "support/claude_stream_client_test_factory.dart";
+
+void main() {
+  group("ClaudeStreamMessage.parse", () {
+    test("reads the init handshake frame", () {
+      final message = ClaudeStreamMessage.parse(sampleInit());
+
+      expect(message, isA<ClaudeInitMessage>());
+      final init = message as ClaudeInitMessage;
+      expect(init.sessionId, testSessionId);
+      expect(init.model, "test-model-large[1m]");
+      expect(init.permissionMode, ClaudePermissionMode.auto);
+      expect(init.tools, ["Read", "Write"]);
+      expect(init.slashCommands, ["review"]);
+      expect(init.cliVersion, "2.1.221");
+      expect(init.cwd, "/tmp/project");
+    });
+
+    test("exposes init capabilities for feature detection", () {
+      final init = ClaudeStreamMessage.parse(sampleInit()) as ClaudeInitMessage;
+
+      // Capability detection is how the plugin decides what a given CLI build
+      // supports, instead of comparing version strings.
+      expect(init.supports("interrupt_cancel_queued_v1"), isTrue);
+      expect(init.supports("some_future_capability"), isFalse);
+    });
+
+    test("prefers the message model over the init model on an assistant frame", () {
+      // The init model carries a context-window selection suffix that the
+      // resolved per-message model does not; envelopes stamp the latter.
+      final message =
+          ClaudeStreamMessage.parse({
+                "type": "assistant",
+                "session_id": "session-1",
+                "message": {"id": "msg_1", "model": "test-model-large", "content": <Object?>[]},
+              })
+              as ClaudeAssistantMessage;
+
+      expect(message.model, "test-model-large");
+      expect(message.messageId, "msg_1");
+      expect(message.parentToolUseId, isNull);
+    });
+
+    test("marks subagent traffic by parent tool use id", () {
+      final message =
+          ClaudeStreamMessage.parse({
+                "type": "assistant",
+                "message": {"id": "msg_2", "content": <Object?>[]},
+                "parent_tool_use_id": "toolu_parent",
+              })
+              as ClaudeAssistantMessage;
+
+      expect(message.parentToolUseId, "toolu_parent");
+    });
+
+    test("reads a stream event and its inner type", () {
+      final message =
+          ClaudeStreamMessage.parse({
+                "type": "stream_event",
+                "event": {
+                  "type": "content_block_delta",
+                  "index": 0,
+                  "delta": {"type": "text_delta", "text": "po"},
+                },
+              })
+              as ClaudeStreamEventMessage;
+
+      expect(message.eventType, "content_block_delta");
+      expect(message.event["index"], 0);
+    });
+
+    test("reads a result frame including its permission denials", () {
+      // A non-empty denial list on an otherwise successful turn is the
+      // signature of a missing --permission-prompt-tool stdio, so it must
+      // survive parsing rather than being dropped.
+      final message =
+          ClaudeStreamMessage.parse({
+                "type": "result",
+                "subtype": "success",
+                "is_error": false,
+                "result": "done",
+                "stop_reason": "end_turn",
+                "terminal_reason": "completed",
+                "permission_denials": [
+                  {"tool_name": "Write", "tool_use_id": "toolu_1"},
+                ],
+              })
+              as ClaudeResultMessage;
+
+      expect(message.subtype, "success");
+      expect(message.isError, isFalse);
+      expect(message.stopReason, "end_turn");
+      expect(message.terminalReason, "completed");
+      expect(message.permissionDenials, hasLength(1));
+      expect(message.permissionDenials.single["tool_name"], "Write");
+    });
+
+    test("reads a can_use_tool control request", () {
+      final message =
+          ClaudeStreamMessage.parse({
+                "type": "control_request",
+                "request_id": "req-uuid",
+                "request": {
+                  "subtype": "can_use_tool",
+                  "tool_name": "Write",
+                  "tool_use_id": "toolu_1",
+                  "input": {"file_path": "/tmp/x"},
+                },
+              })
+              as ClaudeControlRequestMessage;
+
+      expect(message.requestId, "req-uuid");
+      expect(message.subtype, "can_use_tool");
+      expect(message.request["tool_name"], "Write");
+    });
+
+    test("treats any non-success control response subtype as a failure", () {
+      final failure =
+          ClaudeStreamMessage.parse({
+                "type": "control_response",
+                "response": {"subtype": "error", "request_id": "sesori-1", "error": "nope"},
+              })
+              as ClaudeControlResponseMessage;
+      expect(failure.isSuccess, isFalse);
+      expect(failure.error, "nope");
+
+      // A subtype this build does not know must not be mistaken for success.
+      final unknown =
+          ClaudeStreamMessage.parse({
+                "type": "control_response",
+                "response": {"subtype": "deferred", "request_id": "sesori-2"},
+              })
+              as ClaudeControlResponseMessage;
+      expect(unknown.isSuccess, isFalse);
+    });
+
+    test("reads the rate limit frame the research missed", () {
+      final message =
+          ClaudeStreamMessage.parse({
+                "type": "rate_limit_event",
+                "rate_limit_info": {"status": "allowed", "rateLimitType": "five_hour"},
+              })
+              as ClaudeRateLimitMessage;
+
+      expect(message.status, "allowed");
+    });
+
+    test("absorbs unknown types and unknown system subtypes", () {
+      final unknownType = ClaudeStreamMessage.parse({"type": "some_future_event", "session_id": "s"});
+      expect(unknownType, isA<ClaudeUnknownMessage>());
+      expect((unknownType as ClaudeUnknownMessage).type, "some_future_event");
+
+      final unknownSubtype = ClaudeStreamMessage.parse({"type": "system", "subtype": "future_subtype"});
+      expect(unknownSubtype, isA<ClaudeUnknownMessage>());
+      expect((unknownSubtype as ClaudeUnknownMessage).subtype, "future_subtype");
+    });
+
+    test("absorbs a frame with a missing or non-string type", () {
+      expect(ClaudeStreamMessage.parse({"session_id": "s"}), isA<ClaudeUnknownMessage>());
+      expect(ClaudeStreamMessage.parse({"type": 7}), isA<ClaudeUnknownMessage>());
+    });
+
+    test("tolerates malformed nested payloads without throwing", () {
+      // Every nested read is defensive: a wrong-typed member must degrade to an
+      // empty map rather than take down the frame.
+      final assistant =
+          ClaudeStreamMessage.parse({"type": "assistant", "message": "not-a-map"}) as ClaudeAssistantMessage;
+      expect(assistant.message, isEmpty);
+      expect(assistant.messageId, isNull);
+
+      final result =
+          ClaudeStreamMessage.parse({"type": "result", "permission_denials": "not-a-list"})
+              as ClaudeResultMessage;
+      expect(result.permissionDenials, isEmpty);
+
+      final init = ClaudeStreamMessage.parse({
+            "type": "system",
+            "subtype": "init",
+            "capabilities": "not-a-list",
+            "tools": [1, "Read"],
+          })
+          as ClaudeInitMessage;
+      expect(init.capabilities, isEmpty);
+      expect(init.tools, ["Read"]);
+    });
+
+    test("keeps the raw frame on every variant", () {
+      final json = {"type": "result", "subtype": "success", "custom_field": 42};
+      expect(ClaudeStreamMessage.parse(json).raw["custom_field"], 42);
+    });
+  });
+}

--- a/bridge/sesori_plugin_claude/test/claude_stream_message_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_stream_message_test.dart
@@ -163,6 +163,27 @@ void main() {
       expect(ClaudeStreamMessage.parse({"type": 7}), isA<ClaudeUnknownMessage>());
     });
 
+    test("tolerates wrong-typed scalar fields without throwing", () {
+      final result =
+          ClaudeStreamMessage.parse({
+                "type": "result",
+                "session_id": 1,
+                "uuid": false,
+                "subtype": <Object?>[],
+                "is_error": "false",
+                "result": 2,
+                "stop_reason": true,
+              })
+              as ClaudeResultMessage;
+
+      expect(result.sessionId, isNull);
+      expect(result.uuid, isNull);
+      expect(result.subtype, isNull);
+      expect(result.isError, isFalse);
+      expect(result.result, isNull);
+      expect(result.stopReason, isNull);
+    });
+
     test("tolerates malformed nested payloads without throwing", () {
       // Every nested read is defensive: a wrong-typed member must degrade to an
       // empty map rather than take down the frame.
@@ -172,17 +193,17 @@ void main() {
       expect(assistant.messageId, isNull);
 
       final result =
-          ClaudeStreamMessage.parse({"type": "result", "permission_denials": "not-a-list"})
-              as ClaudeResultMessage;
+          ClaudeStreamMessage.parse({"type": "result", "permission_denials": "not-a-list"}) as ClaudeResultMessage;
       expect(result.permissionDenials, isEmpty);
 
-      final init = ClaudeStreamMessage.parse({
-            "type": "system",
-            "subtype": "init",
-            "capabilities": "not-a-list",
-            "tools": [1, "Read"],
-          })
-          as ClaudeInitMessage;
+      final init =
+          ClaudeStreamMessage.parse({
+                "type": "system",
+                "subtype": "init",
+                "capabilities": "not-a-list",
+                "tools": [1, "Read"],
+              })
+              as ClaudeInitMessage;
       expect(init.capabilities, isEmpty);
       expect(init.tools, ["Read"]);
     });

--- a/bridge/sesori_plugin_claude/test/support/claude_stream_client_test_factory.dart
+++ b/bridge/sesori_plugin_claude/test/support/claude_stream_client_test_factory.dart
@@ -1,0 +1,133 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:claude_plugin/claude_plugin.dart";
+import "package:claude_plugin/claude_testing.dart";
+
+/// Yields to the event loop so stream events queued by the fake are delivered.
+Future<void> pump([int times = 4]) async {
+  for (var i = 0; i < times; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+/// Waits for a frame of [type] the client wrote to stdin, polling rather than
+/// assuming a fixed number of microtasks.
+///
+/// Throws [StateError] on exhaustion so a missing frame fails loudly instead of
+/// timing the whole suite out.
+Future<Map<String, Object?>> waitForFrame(
+  FakeClaudeProcess fake,
+  String type, {
+  int attempts = 50,
+}) async {
+  for (var i = 0; i < attempts; i++) {
+    for (final frame in fake.written) {
+      if (frame["type"] == type) return frame;
+    }
+    await pump();
+  }
+  throw StateError(
+    "no '$type' frame written after $attempts attempts; saw: "
+    "${fake.written.map((frame) => frame["type"]).toList()}",
+  );
+}
+
+/// A real UUID: `ClaudeSessionLaunch` rejects anything else, because the CLI
+/// does.
+const String testSessionId = "11111111-2222-4333-8444-555555555555";
+
+/// A second valid id, for assertions that must show a value is carried through
+/// rather than defaulted.
+const String otherTestSessionId = "99999999-8888-4777-8666-555555555555";
+
+ClaudeLaunchSpec testLaunchSpec({String sessionId = testSessionId}) {
+  return ClaudeLaunchSpec(
+    binaryPath: "claude",
+    workingDirectory: "/tmp/project",
+    launch: ClaudeNewSession(sessionId: sessionId),
+    model: null,
+    effort: null,
+    permissionMode: null,
+  );
+}
+
+/// A connected client and its fake process.
+typedef ConnectedClient = ({ClaudeStreamClient client, FakeClaudeProcess fake});
+
+/// Connects a client against a fake, answering the `initialize` handshake that
+/// [ClaudeStreamClient.connect] performs.
+///
+/// `connect()` cannot be awaited before the handshake is answered, so the
+/// connect future is started, the request is awaited off the fake, and only
+/// then is the response emitted.
+Future<ConnectedClient> connectTestClient({
+  FakeClaudeProcess? process,
+  Map<String, Object?> handshake = const {},
+  Duration controlTimeout = const Duration(seconds: 5),
+  String sessionId = testSessionId,
+}) async {
+  final fake = process ?? FakeClaudeProcess();
+  final client = ClaudeStreamClient(
+    launchSpec: testLaunchSpec(sessionId: sessionId),
+    processFactory: (_) async => fake,
+    controlTimeout: controlTimeout,
+  );
+
+  final connected = client.connect();
+  final request = await waitForFrame(fake, "control_request");
+  fake.emitControlResponse(
+    requestId: request["request_id"]! as String,
+    payload: handshake,
+  );
+  await connected;
+  return (client: client, fake: fake);
+}
+
+/// The `initialize` catalog shape, trimmed from a real capture with every
+/// identifier replaced by a synthetic value.
+Map<String, Object?> get sampleHandshake => {
+  "commands": [
+    {"name": "review", "description": "Review a pull request", "argumentHint": ""},
+  ],
+  "agents": [
+    {"name": "general-purpose", "description": "General-purpose agent"},
+  ],
+  "models": [
+    {
+      "value": "default",
+      "resolvedModel": "test-model-large",
+      "displayName": "Default (recommended)",
+      "description": "Best for everyday tasks",
+      "supportsEffort": true,
+      "supportedEffortLevels": ["low", "medium", "high", "xhigh", "max"],
+    },
+    {
+      "value": "small",
+      "resolvedModel": "test-model-small",
+      "displayName": "Small",
+      "description": "Fastest for quick answers",
+    },
+  ],
+  "output_style": "default",
+  "account": {"apiProvider": "firstParty", "subscriptionType": "max"},
+};
+
+/// A `system`/`init` frame, trimmed from a real capture.
+Map<String, Object?> sampleInit({String sessionId = testSessionId}) => {
+  "type": "system",
+  "subtype": "init",
+  "session_id": sessionId,
+  "uuid": "init-uuid",
+  "model": "test-model-large[1m]",
+  "permissionMode": "auto",
+  "capabilities": ["interrupt_receipt_v1", "interrupt_cancel_queued_v1"],
+  "tools": ["Read", "Write"],
+  "slash_commands": ["review"],
+  "claude_code_version": "2.1.221",
+  "cwd": "/tmp/project",
+};
+
+/// Encodes [frames] as one ndjson byte block, for framing tests.
+List<int> ndjson(List<Map<String, Object?>> frames) =>
+    utf8.encode(frames.map(jsonEncode).join("\n"));


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this adds a stateful stdio transport, open protocol-envelope parsing, process lifecycle handling, and request correlation inside the new Claude Code plugin package.

## What

- Add the typed `ClaudeStreamMessage` parser and control-envelope models, including tolerant unknown-frame handling.
- Add `ClaudeStreamClient` for process launch, stream-json framing, the `initialize` handshake, correlated control requests, outbound turns, and teardown.
- Add the host-process factory seam, `FakeClaudeProcess`, the public testing barrel, and focused transport/parser coverage.
- Record the verified `system/init` timing and the Step 3 delivery handoff in the active plan artifacts.

## Why

The Claude Code plugin needs a protocol-faithful stream-json transport before later steps can enumerate transcripts, map events, manage permissions, or compose the plugin API. Retaining the one-shot `initialize` catalog also avoids redundant startup probes in Step 11.

## Risk and test focus

**Risk: moderate.** Focus review on fragmented/malformed framing, request-id correlation, process exit during an in-flight request, teardown races, frame-log redaction, and tolerance of protocol variants added by newer CLI versions. This package is not registered with the bridge yet, so there is no user-visible runtime path in this step.

## Expected result

No user-visible or database change. The unregistered Claude Code package can launch the CLI over stdio, complete the `initialize` control handshake, exchange stream-json frames safely, and shut down without leaking pending requests.

## Changed-line overage

The diff is 1,793 changed lines versus the 1,500-line soft target. The plan records why there is no coherent split: the parser’s only production consumer is the transport itself, so separating them would land unconsumed architecture; test volume is already below the repository norm.

## Verification

- `dart pub get`
- `dart analyze --fatal-infos`
- `dart test` — 53 tests passed
- `git diff --check`
- Architecture implementation review of `origin/main..claude-code-plugin-stream-client` — APPROVED, no actionable findings
- Existing live CLI verification: `initialize` completed against Claude Code 2.1.221, returning 5 models and 66 commands; teardown followed the SIGTERM path

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a stream‑json transport to `claude_plugin` with a stateful stdio client that launches the Claude CLI, completes `initialize`, streams frames, and shuts down cleanly. No user-visible change yet; this package is not registered with the bridge.

- New Features
  - Added `ClaudeStreamClient` for process launch, ndjson framing, `initialize`, request-id correlation, and SIGTERM→SIGKILL teardown.
  - Introduced `ClaudeStreamMessage` variants with tolerant parsing; unknown frames absorbed; raw frame retained for future mappers.
  - Added `ClaudeProcessFactory` seam and `FakeClaudeProcess` for in-memory tests; new `claude_testing.dart` barrel exports the fake.
  - Extended `ClaudeLaunchSpec` with `workingDirectory` and merged, immutable `environment`; rejects `HOME` overrides to avoid breaking keychain/login.
  - Transport hardening: secret redaction in logs, lenient UTF‑8 on stderr, generation fencing across teardown, fail-pending-on-exit, and Windows spawn via `runInShell`.
  - Exported `ClaudeStreamClient`, `ClaudeProcessFactory`, and `ClaudeStreamMessage` from `claude_plugin.dart`; documented that `system/init` is turn‑triggered and connect relies only on the `initialize` response.

<sup>Written for commit d9411f9e4b75578d639f229384b9bfc10da73e64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

