### PR TITLE
🌿 Keep the live session screen when its notification is tapped

### DIFF
--- a/client/app/lib/core/platform/go_router_route_source.dart
+++ b/client/app/lib/core/platform/go_router_route_source.dart
@@ -29,7 +29,7 @@ class GoRouterRouteSource implements RouteSource, Disposable {
   ValueStream<AppRouteDef?> get currentRouteStream => _currentRouteStream.stream;
 
   @override
-  String? get currentPath => _currentPath(_routerDelegate.currentConfiguration);
+  String? get currentLocation => _currentLocation(_routerDelegate.currentConfiguration);
 
   @override
   FutureOr<void> onDispose() {
@@ -53,6 +53,31 @@ class GoRouterRouteSource implements RouteSource, Disposable {
   /// match tree from the top instead reports what the user is actually looking
   /// at.
   static String? _currentPath(RouteMatchList configuration) => _topMatchedLocation(configuration.matches);
+
+  /// As [_currentPath], but keeping the query string.
+  ///
+  /// A match on its own carries no query — only the [RouteMatchList] owning it
+  /// does, via [RouteMatchList.uri]. An imperatively pushed route brings its
+  /// own list, so descending into it reports the pushed location's query
+  /// rather than the last `go`/`replace` one.
+  static String? _currentLocation(RouteMatchList configuration) =>
+      _topLocation(matches: configuration.matches, owner: configuration);
+
+  static String? _topLocation({
+    required List<RouteMatchBase> matches,
+    required RouteMatchList owner,
+  }) {
+    for (final match in matches.reversed) {
+      final location = switch (match) {
+        ImperativeRouteMatch(:final matches) => _topLocation(matches: matches.matches, owner: matches),
+        ShellRouteMatch(:final matches) => _topLocation(matches: matches, owner: owner),
+        RouteMatch() => owner.uri.toString(),
+        _ => null,
+      };
+      if (location != null) return location;
+    }
+    return null;
+  }
 
   static String? _topMatchedLocation(List<RouteMatchBase> matches) {
     for (final match in matches.reversed) {

--- a/client/app/lib/core/platform/go_router_route_source.dart
+++ b/client/app/lib/core/platform/go_router_route_source.dart
@@ -29,6 +29,9 @@ class GoRouterRouteSource implements RouteSource, Disposable {
   ValueStream<AppRouteDef?> get currentRouteStream => _currentRouteStream.stream;
 
   @override
+  String? get currentPath => _currentPath(_routerDelegate.currentConfiguration);
+
+  @override
   FutureOr<void> onDispose() {
     _routerDelegate.removeListener(_onRouteChanged);
     _currentRouteStream.close();

--- a/client/app/test/core/platform/go_router_route_source_test.dart
+++ b/client/app/test/core/platform/go_router_route_source_test.dart
@@ -84,6 +84,32 @@ void main() {
     expect(routeSource.currentRouteStream.value, AppRouteDef.settings);
   });
 
+  testWidgets("currentLocation keeps the query of a pushed route", (tester) async {
+    await pumpRouter(tester);
+    router.go(const AppRoute.projects().buildPath());
+    await tester.pumpAndSettle();
+
+    unawaited(
+      router.push<void>(
+        const AppRoute.sessionDetail(
+          projectId: "p1",
+          projectName: null,
+          sessionId: "s1",
+          sessionTitle: null,
+          readOnly: true,
+        ).buildPath(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // `readOnly` lives in the query and is the only thing separating the
+    // read-only session screen from the editable one, so a location that drops
+    // the query cannot tell them apart.
+    final location = Uri.parse(routeSource.currentLocation!);
+    expect(location.path, "/projects/p1/sessions/s1");
+    expect(location.queryParameters["readOnly"], "true");
+  });
+
   testWidgets("reports pushed screens nested in the session shell", (tester) async {
     await pumpRouter(tester);
     router.go(const AppRoute.projects().buildPath());

--- a/client/app/test/helpers/test_helpers.dart
+++ b/client/app/test/helpers/test_helpers.dart
@@ -327,10 +327,13 @@ MockProjectViewingService stubbedProjectViewingService() {
 class MockRouteSource extends Mock implements RouteSource {
   final BehaviorSubject<AppRouteDef?> _currentRoute;
 
-  MockRouteSource({AppRouteDef? initialRoute}) : _currentRoute = BehaviorSubject.seeded(initialRoute);
+  MockRouteSource({AppRouteDef? initialRoute, this.currentPath}) : _currentRoute = BehaviorSubject.seeded(initialRoute);
 
   @override
   ValueStream<AppRouteDef?> get currentRouteStream => _currentRoute.stream;
+
+  @override
+  String? currentPath;
 
   AppRouteDef? get currentRoute => _currentRoute.value;
 

--- a/client/app/test/helpers/test_helpers.dart
+++ b/client/app/test/helpers/test_helpers.dart
@@ -327,13 +327,13 @@ MockProjectViewingService stubbedProjectViewingService() {
 class MockRouteSource extends Mock implements RouteSource {
   final BehaviorSubject<AppRouteDef?> _currentRoute;
 
-  MockRouteSource({AppRouteDef? initialRoute, this.currentPath}) : _currentRoute = BehaviorSubject.seeded(initialRoute);
+  MockRouteSource({AppRouteDef? initialRoute, this.currentLocation}) : _currentRoute = BehaviorSubject.seeded(initialRoute);
 
   @override
   ValueStream<AppRouteDef?> get currentRouteStream => _currentRoute.stream;
 
   @override
-  String? currentPath;
+  String? currentLocation;
 
   AppRouteDef? get currentRoute => _currentRoute.value;
 

--- a/client/module_core/lib/src/di/injection.config.dart
+++ b/client/module_core/lib/src/di/injection.config.dart
@@ -192,14 +192,6 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i176.VoiceApi>(
       () => _i176.VoiceApi(gh<_i442.AuthenticatedHttpApiClient>()),
     );
-    gh.lazySingleton<_i516.NotificationOpenDispatcher>(
-      () => _i516.NotificationOpenDispatcher(
-        authSession: gh<_i442.AuthSession>(),
-        pushMessagingSource: gh<_i330.PushMessagingSource>(),
-        localNotificationClient: gh<_i1037.LocalNotificationClient>(),
-        routeDispatcher: gh<_i951.RouteDispatcher>(),
-      ),
-    );
     gh.lazySingleton<_i198.ComposerDraftRepository>(
       () => _i198.ComposerDraftRepository(
         storage: gh<_i64.ComposerDraftStorage>(),
@@ -231,6 +223,15 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i197.ProductAnalyticsPreferenceStorage>(
       () => _i197.ProductAnalyticsPreferenceStorage(
         storage: gh<_i442.SecureStorage>(),
+      ),
+    );
+    gh.lazySingleton<_i516.NotificationOpenDispatcher>(
+      () => _i516.NotificationOpenDispatcher(
+        authSession: gh<_i442.AuthSession>(),
+        pushMessagingSource: gh<_i330.PushMessagingSource>(),
+        localNotificationClient: gh<_i1037.LocalNotificationClient>(),
+        routeDispatcher: gh<_i951.RouteDispatcher>(),
+        routeSource: gh<_i366.RouteSource>(),
       ),
     );
     gh.lazySingleton<_i205.BridgeRepository>(

--- a/client/module_core/lib/src/platform/route_source.dart
+++ b/client/module_core/lib/src/platform/route_source.dart
@@ -10,6 +10,15 @@ import "../routing/app_routes.dart";
 /// See also: [LifecycleSource] for app-level lifecycle.
 abstract interface class RouteSource {
   ValueStream<AppRouteDef?> get currentRouteStream;
+
+  /// Concrete path of the topmost route, with path parameters substituted and
+  /// no query string — for example `/projects/p1/sessions/s1`.
+  ///
+  /// [currentRouteStream] identifies only which *kind* of page is visible.
+  /// Callers that must distinguish one session (or project) from another need
+  /// the resolved path. Null before the router resolves its first
+  /// configuration.
+  String? get currentPath;
 }
 
 extension RouteSourceX on RouteSource {

--- a/client/module_core/lib/src/platform/route_source.dart
+++ b/client/module_core/lib/src/platform/route_source.dart
@@ -11,14 +11,16 @@ import "../routing/app_routes.dart";
 abstract interface class RouteSource {
   ValueStream<AppRouteDef?> get currentRouteStream;
 
-  /// Concrete path of the topmost route, with path parameters substituted and
-  /// no query string — for example `/projects/p1/sessions/s1`.
+  /// Resolved location of the topmost route — path parameters substituted and
+  /// the query string kept, for example
+  /// `/projects/p1/sessions/s1?readOnly=true`.
   ///
   /// [currentRouteStream] identifies only which *kind* of page is visible.
-  /// Callers that must distinguish one session (or project) from another need
-  /// the resolved path. Null before the router resolves its first
-  /// configuration.
-  String? get currentPath;
+  /// Callers that must distinguish one session from another, or one variant of
+  /// a screen from another, need the resolved location. The query is part of
+  /// that: `readOnly` alone separates the editable session detail from the
+  /// read-only one. Null before the router resolves its first configuration.
+  String? get currentLocation;
 }
 
 extension RouteSourceX on RouteSource {

--- a/client/module_core/lib/src/routing/app_routes.dart
+++ b/client/module_core/lib/src/routing/app_routes.dart
@@ -360,6 +360,23 @@ class AppRouteSessionDetail extends AppRoute {
     };
     return _appendQuery(path: base, queryParameters: queryParams);
   }
+
+  /// Whether [location] — a resolved location as reported by
+  /// `RouteSource.currentLocation` — already shows this session in its
+  /// editable form.
+  ///
+  /// The read-only variant of a session (background tasks and subtasks open
+  /// that way) shares this route's path and differs only by query, so a plain
+  /// path comparison would treat the two as interchangeable. They are not: the
+  /// read-only screen renders without the composer or mutating controls, so a
+  /// caller that wants the editable screen must still navigate to it.
+  ///
+  /// [projectName] and [sessionTitle] are display-only and deliberately
+  /// ignored — the same session labelled differently is still the same screen.
+  bool showsEditableLocation({required Uri location}) {
+    if (location.path != Uri.parse(buildPath()).path) return false;
+    return location.queryParameters[_readOnlyQueryParam] != true.toString();
+  }
 }
 
 class AppRouteSessionDiffs extends AppRoute {

--- a/client/module_core/lib/src/routing/notification_open_dispatcher.dart
+++ b/client/module_core/lib/src/routing/notification_open_dispatcher.dart
@@ -113,7 +113,7 @@ class NotificationOpenDispatcher {
   }
 
   void _dispatch(NotificationOpenRequest request) {
-    final sessionDetail = AppRoute.sessionDetail(
+    final sessionDetail = AppRouteSessionDetail(
       projectId: request.projectId,
       projectName: null,
       sessionId: request.sessionId,
@@ -127,7 +127,8 @@ class NotificationOpenDispatcher {
     // one on top, the notification asks for something the user is looking at:
     // the mounted screen surfaces the prompt through its own event stream, so
     // navigating again only costs a reload.
-    if (_routeSource.currentPath == Uri.parse(sessionDetail.buildPath()).path) {
+    final location = _routeSource.currentLocation;
+    if (location != null && sessionDetail.showsEditableLocation(location: Uri.parse(location))) {
       return;
     }
 

--- a/client/module_core/lib/src/routing/notification_open_dispatcher.dart
+++ b/client/module_core/lib/src/routing/notification_open_dispatcher.dart
@@ -8,6 +8,7 @@ import "../platform/local_notification_client.dart";
 import "../platform/notification_open_request.dart";
 import "../platform/push_messaging_source.dart";
 import "../platform/route_dispatcher.dart";
+import "../platform/route_source.dart";
 import "app_routes.dart";
 
 @lazySingleton
@@ -16,6 +17,7 @@ class NotificationOpenDispatcher {
   final PushMessagingSource _pushMessagingSource;
   final LocalNotificationClient _localNotificationClient;
   final RouteDispatcher _routeDispatcher;
+  final RouteSource _routeSource;
 
   StreamSubscription<AuthState>? _authSubscription;
   StreamSubscription<NotificationOpenRequest>? _pushOpenSubscription;
@@ -29,10 +31,12 @@ class NotificationOpenDispatcher {
     required PushMessagingSource pushMessagingSource,
     required LocalNotificationClient localNotificationClient,
     required RouteDispatcher routeDispatcher,
+    required RouteSource routeSource,
   }) : _authSession = authSession,
        _pushMessagingSource = pushMessagingSource,
        _localNotificationClient = localNotificationClient,
-       _routeDispatcher = routeDispatcher;
+       _routeDispatcher = routeDispatcher,
+       _routeSource = routeSource;
 
   Future<void> start() async {
     if (_disposed) {
@@ -109,6 +113,24 @@ class NotificationOpenDispatcher {
   }
 
   void _dispatch(NotificationOpenRequest request) {
+    final sessionDetail = AppRoute.sessionDetail(
+      projectId: request.projectId,
+      projectName: null,
+      sessionId: request.sessionId,
+      sessionTitle: request.sessionTitle,
+      readOnly: false,
+    );
+
+    // Replacing the stack tears down the live session detail screen and builds
+    // a new one, whose cubit starts from `loading` and refetches the whole
+    // session before any prompt can be shown. When that screen is already the
+    // one on top, the notification asks for something the user is looking at:
+    // the mounted screen surfaces the prompt through its own event stream, so
+    // navigating again only costs a reload.
+    if (_routeSource.currentPath == Uri.parse(sessionDetail.buildPath()).path) {
+      return;
+    }
+
     _routeDispatcher.replaceStack(
       stack: RouteStack(
         paths: [
@@ -118,13 +140,7 @@ class NotificationOpenDispatcher {
             projectName: null,
             supportsDedicatedWorktrees: null,
           ),
-          AppRoute.sessionDetail(
-            projectId: request.projectId,
-            projectName: null,
-            sessionId: request.sessionId,
-            sessionTitle: request.sessionTitle,
-            readOnly: false,
-          ),
+          sessionDetail,
         ].map((route) => route.buildPath()).toList(growable: false),
       ),
     );

--- a/client/module_core/test/helpers/test_helpers.dart
+++ b/client/module_core/test/helpers/test_helpers.dart
@@ -221,13 +221,13 @@ class MockConnectionService extends Mock implements ConnectionService {
 class MockRouteSource extends Mock implements RouteSource {
   final BehaviorSubject<AppRouteDef?> _currentRoute;
 
-  MockRouteSource({AppRouteDef? initialRoute, this.currentPath}) : _currentRoute = BehaviorSubject.seeded(initialRoute);
+  MockRouteSource({AppRouteDef? initialRoute, this.currentLocation}) : _currentRoute = BehaviorSubject.seeded(initialRoute);
 
   @override
   ValueStream<AppRouteDef?> get currentRouteStream => _currentRoute.stream;
 
   @override
-  String? currentPath;
+  String? currentLocation;
 
   AppRouteDef? get currentRoute => _currentRoute.value;
 

--- a/client/module_core/test/helpers/test_helpers.dart
+++ b/client/module_core/test/helpers/test_helpers.dart
@@ -221,10 +221,13 @@ class MockConnectionService extends Mock implements ConnectionService {
 class MockRouteSource extends Mock implements RouteSource {
   final BehaviorSubject<AppRouteDef?> _currentRoute;
 
-  MockRouteSource({AppRouteDef? initialRoute}) : _currentRoute = BehaviorSubject.seeded(initialRoute);
+  MockRouteSource({AppRouteDef? initialRoute, this.currentPath}) : _currentRoute = BehaviorSubject.seeded(initialRoute);
 
   @override
   ValueStream<AppRouteDef?> get currentRouteStream => _currentRoute.stream;
+
+  @override
+  String? currentPath;
 
   AppRouteDef? get currentRoute => _currentRoute.value;
 

--- a/client/module_core/test/routing/analytics_route_listener_test.dart
+++ b/client/module_core/test/routing/analytics_route_listener_test.dart
@@ -14,6 +14,9 @@ class _FakeRouteSource implements RouteSource {
   @override
   ValueStream<AppRouteDef?> get currentRouteStream => routes.stream;
 
+  @override
+  String? currentPath;
+
   void emit({required AppRouteDef? route}) => routes.add(route);
 
   Future<void> dispose() => routes.close();

--- a/client/module_core/test/routing/analytics_route_listener_test.dart
+++ b/client/module_core/test/routing/analytics_route_listener_test.dart
@@ -15,7 +15,7 @@ class _FakeRouteSource implements RouteSource {
   ValueStream<AppRouteDef?> get currentRouteStream => routes.stream;
 
   @override
-  String? currentPath;
+  String? currentLocation;
 
   void emit({required AppRouteDef? route}) => routes.add(route);
 

--- a/client/module_core/test/routing/notification_open_dispatcher_test.dart
+++ b/client/module_core/test/routing/notification_open_dispatcher_test.dart
@@ -7,6 +7,7 @@ import "package:sesori_dart_core/src/platform/notification_open_request.dart";
 import "package:sesori_dart_core/src/platform/push_messaging_source.dart";
 import "package:sesori_dart_core/src/platform/push_notification_message.dart";
 import "package:sesori_dart_core/src/platform/route_dispatcher.dart";
+import "package:sesori_dart_core/src/platform/route_source.dart";
 import "package:sesori_dart_core/src/routing/app_routes.dart";
 import "package:sesori_dart_core/src/routing/notification_open_dispatcher.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -18,6 +19,7 @@ void main() {
     late FakePushMessagingSource pushMessagingSource;
     late FakeLocalNotificationClient localNotificationClient;
     late RecordingRouteDispatcher routeDispatcher;
+    late FakeRouteSource routeSource;
     late NotificationOpenDispatcher dispatcher;
 
     setUp(() {
@@ -25,11 +27,13 @@ void main() {
       pushMessagingSource = FakePushMessagingSource();
       localNotificationClient = FakeLocalNotificationClient();
       routeDispatcher = RecordingRouteDispatcher();
+      routeSource = FakeRouteSource();
       dispatcher = NotificationOpenDispatcher(
         authSession: authSession,
         pushMessagingSource: pushMessagingSource,
         localNotificationClient: localNotificationClient,
         routeDispatcher: routeDispatcher,
+        routeSource: routeSource,
       );
     });
 
@@ -69,6 +73,47 @@ void main() {
           ).buildPath(),
         ]),
       );
+    });
+
+    test("leaves the stack alone when that session detail is already on top", () async {
+      routeSource.currentPath = "/projects/project-1/sessions/session-1";
+      pushMessagingSource.initialOpenRequest = const NotificationOpenRequest(
+        projectId: "project-1",
+        sessionId: "session-1",
+        sessionTitle: "Weekly planning",
+      );
+
+      await dispatcher.start();
+
+      // Rebuilding would tear down the live screen and force a full reload
+      // before the prompt could show; the mounted screen already surfaces it.
+      expect(routeDispatcher.replacedStacks, isEmpty);
+    });
+
+    test("rebuilds the stack when a different session is on top", () async {
+      routeSource.currentPath = "/projects/project-1/sessions/session-2";
+      pushMessagingSource.initialOpenRequest = const NotificationOpenRequest(
+        projectId: "project-1",
+        sessionId: "session-1",
+        sessionTitle: "Weekly planning",
+      );
+
+      await dispatcher.start();
+
+      expect(routeDispatcher.replacedStacks, hasLength(1));
+    });
+
+    test("rebuilds the stack when a pushed screen sits above that session", () async {
+      routeSource.currentPath = "/projects/project-1/sessions/session-1/diffs";
+      pushMessagingSource.initialOpenRequest = const NotificationOpenRequest(
+        projectId: "project-1",
+        sessionId: "session-1",
+        sessionTitle: "Weekly planning",
+      );
+
+      await dispatcher.start();
+
+      expect(routeDispatcher.replacedStacks, hasLength(1));
     });
 
     test("latest pending notification wins after auth replay", () async {
@@ -290,6 +335,16 @@ class RecordingRouteDispatcher implements RouteDispatcher {
   void replaceStack({required RouteStack stack}) {
     replacedStacks.add(stack);
   }
+}
+
+class FakeRouteSource implements RouteSource {
+  @override
+  String? currentPath;
+
+  final BehaviorSubject<AppRouteDef?> _currentRoute = BehaviorSubject.seeded(null);
+
+  @override
+  ValueStream<AppRouteDef?> get currentRouteStream => _currentRoute.stream;
 }
 
 AuthState _authenticatedState() {

--- a/client/module_core/test/routing/notification_open_dispatcher_test.dart
+++ b/client/module_core/test/routing/notification_open_dispatcher_test.dart
@@ -76,7 +76,9 @@ void main() {
     });
 
     test("leaves the stack alone when that session detail is already on top", () async {
-      routeSource.currentPath = "/projects/project-1/sessions/session-1";
+      // Display-only query parameters differ from what the notification would
+      // build; they must not defeat the match.
+      routeSource.currentLocation = "/projects/project-1/sessions/session-1?readOnly=false&title=Renamed";
       pushMessagingSource.initialOpenRequest = const NotificationOpenRequest(
         projectId: "project-1",
         sessionId: "session-1",
@@ -90,8 +92,24 @@ void main() {
       expect(routeDispatcher.replacedStacks, isEmpty);
     });
 
+    test("rebuilds when that session is shown read-only", () async {
+      // Background tasks and subtasks open the same session on the read-only
+      // route, which renders without the composer. The notification wants the
+      // editable screen, so it must still navigate.
+      routeSource.currentLocation = "/projects/project-1/sessions/session-1?readOnly=true";
+      pushMessagingSource.initialOpenRequest = const NotificationOpenRequest(
+        projectId: "project-1",
+        sessionId: "session-1",
+        sessionTitle: "Weekly planning",
+      );
+
+      await dispatcher.start();
+
+      expect(routeDispatcher.replacedStacks, hasLength(1));
+    });
+
     test("rebuilds the stack when a different session is on top", () async {
-      routeSource.currentPath = "/projects/project-1/sessions/session-2";
+      routeSource.currentLocation = "/projects/project-1/sessions/session-2";
       pushMessagingSource.initialOpenRequest = const NotificationOpenRequest(
         projectId: "project-1",
         sessionId: "session-1",
@@ -104,7 +122,7 @@ void main() {
     });
 
     test("rebuilds the stack when a pushed screen sits above that session", () async {
-      routeSource.currentPath = "/projects/project-1/sessions/session-1/diffs";
+      routeSource.currentLocation = "/projects/project-1/sessions/session-1/diffs";
       pushMessagingSource.initialOpenRequest = const NotificationOpenRequest(
         projectId: "project-1",
         sessionId: "session-1",
@@ -339,7 +357,7 @@ class RecordingRouteDispatcher implements RouteDispatcher {
 
 class FakeRouteSource implements RouteSource {
   @override
-  String? currentPath;
+  String? currentLocation;
 
   final BehaviorSubject<AppRouteDef?> _currentRoute = BehaviorSubject.seeded(null);
 

--- a/client/module_core/test/services/project_viewing_service_test.dart
+++ b/client/module_core/test/services/project_viewing_service_test.dart
@@ -30,6 +30,9 @@ class _FakeRouteSource implements RouteSource {
 
   @override
   ValueStream<AppRouteDef?> get currentRouteStream => routes.stream;
+
+  @override
+  String? currentPath;
 }
 
 const _config = ServerConnectionConfig(relayHost: "relay.example.com", authToken: "token");

--- a/client/module_core/test/services/project_viewing_service_test.dart
+++ b/client/module_core/test/services/project_viewing_service_test.dart
@@ -32,7 +32,7 @@ class _FakeRouteSource implements RouteSource {
   ValueStream<AppRouteDef?> get currentRouteStream => routes.stream;
 
   @override
-  String? currentPath;
+  String? currentLocation;
 }
 
 const _config = ServerConnectionConfig(relayHost: "relay.example.com", authToken: "token");


### PR DESCRIPTION
## Complexity

🌿 Straightforward — one guard in one method, plus a read-only addition to an
existing interface. Breadth comes only from test fakes implementing it.

## What

- `NotificationOpenDispatcher` skips the navigation stack replace when the
  target session detail is already the topmost route **and** is showing its
  editable form.
- `RouteSource` gains `currentLocation`: the resolved location of the topmost
  route, including imperatively pushed ones, with the query string kept.
- `AppRouteSessionDetail.showsEditableLocation` owns the comparison, beside the
  `buildPath` that owns the query parameter names.

## Why

Tapping a notification always replaced the whole stack. When that session's
screen was already on top, `go('/projects')` tore it down and rebuilt it, so a
fresh `SessionDetailCubit` started from `loading` and refetched the session
before the permission or question prompt could appear.

That is the loading pause after tapping a notification. Opening the app
directly never shows it, because the mounted screen survives and the prompt
arrives through the cubit's live event stream.

`currentRouteStream` reports only which *kind* of page is visible, so it cannot
tell one session from another — hence the new member rather than reusing it.

The location has to carry the query, because `readOnly` lives there and is all
that separates the read-only session screen (how background tasks and subtasks
open) from the editable one. Comparing paths alone would treat them as
interchangeable and strand the user on the read-only screen. On the GoRouter
side that needed its own walker: a match holds no query, only the
`RouteMatchList` owning it does, so a pushed route must be descended into or it
reports the last `go`/`replace` query instead.

## Risk and test focus

Low. The failure mode would be a notification that stops navigating.

Focus on notification taps: for the session already open, for the same session
shown read-only, for a different session, on cold start, and with a pushed
screen (diffs, settings) above the target. Permission and question prompts
share this path.

## Expected result

**User-visible:** tapping a notification for the session already open and
editable goes straight to the chat with no spinner; the prompt appears as it
does when opening the app directly. Every other notification tap — including
one for that session while it is shown read-only — navigates exactly as before.

**Database:** no change.

**Internal:** `RouteSource` gains a read-only member; no behavior change for
existing consumers.

## Verification

- `module_core`: 1026 tests pass, including four new cases (already on top,
  shown read-only, different session, pushed screen above the target).
- `app`: 923 tests pass, including one pinning that `currentLocation` keeps a
  pushed route's query. Analyzer clean with `--fatal-infos` in both.
- On a Pixel 10 Pro: no spinner when already on the session, and correct
  navigation when not on the detail screen. Device logs confirmed the surviving
  cubit took the silent-refresh path instead of rebuilding. The cold-start and
  pushed-screen cases are covered by tests but were not hand-verified.

Out of scope: the refresh itself takes ~13s on this connection, which this PR
avoids paying unnecessarily but does not make cheaper. Tracked separately.