### PR TITLE
⚙️ Load session detail options through the aggregate endpoint

### DIFF
--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -42,6 +42,7 @@ AgentInfo _testAgent({required String name, required String description, require
 SessionOptionsCatalog _testSessionOptionsCatalog() => SessionOptionsCatalog(
   agents: [_testAgent(name: "coder", description: "A coding assistant", variant: "xhigh")],
   providers: testProviderListResponse().items,
+  providersConnectedOnly: testProviderListResponse().connectedOnly,
   commands: const [],
 );
 
@@ -248,7 +249,7 @@ void main() {
       () => sessionRepository.loadSessionOptions(
         projectId: any(named: "projectId"),
         pluginId: any(named: "pluginId"),
-        forceRefresh: any(named: "forceRefresh"),
+        mode: any(named: "mode"),
       ),
     ).thenAnswer((invocation) async {
       final projectId = invocation.namedArguments[#projectId]! as String;
@@ -268,6 +269,7 @@ void main() {
             catalog: SessionOptionsCatalog(
               agents: agentData.agents,
               providers: providerData.items,
+              providersConnectedOnly: providerData.connectedOnly,
               commands: commandData.items,
             ),
           ),
@@ -299,6 +301,7 @@ void main() {
             catalog: SessionOptionsCatalog(
               agents: agentData.agents,
               providers: providerData.items,
+              providersConnectedOnly: providerData.connectedOnly,
               commands: commandData.items,
             ),
           ),
@@ -439,7 +442,7 @@ void main() {
       () => sessionRepository.loadSessionOptions(
         projectId: any(named: "projectId"),
         pluginId: any(named: "pluginId"),
-        forceRefresh: any(named: "forceRefresh"),
+        mode: any(named: "mode"),
       ),
     );
 
@@ -467,11 +470,12 @@ void main() {
       () => sessionRepository.loadSessionOptions(
         projectId: "project-1",
         pluginId: "plugin-1",
-        forceRefresh: false,
+        mode: SessionOptionsRequestMode.dynamic,
       ),
     ).thenAnswer((_) async => const SessionOptionsRepositoryCacheUnavailable());
     when(
-      () => sessionService.createSessionWithMessage(attachments: const [],
+      () => sessionService.createSessionWithMessage(
+        attachments: const [],
         projectId: any(named: "projectId"),
         pluginId: any(named: "pluginId"),
         text: any(named: "text"),
@@ -494,7 +498,8 @@ void main() {
     await tester.pumpAndSettle();
 
     verify(
-      () => sessionService.createSessionWithMessage(attachments: const [],
+      () => sessionService.createSessionWithMessage(
+        attachments: const [],
         projectId: "project-1",
         pluginId: "plugin-1",
         text: "use backend defaults",
@@ -513,7 +518,7 @@ void main() {
       () => sessionRepository.loadSessionOptions(
         projectId: "project-1",
         pluginId: "plugin-1",
-        forceRefresh: false,
+        mode: SessionOptionsRequestMode.dynamic,
       ),
     ).thenAnswer((_) async => const SessionOptionsRepositoryRefreshFailedUnavailable());
 
@@ -530,11 +535,11 @@ void main() {
       () => sessionRepository.loadSessionOptions(
         projectId: "project-1",
         pluginId: "plugin-1",
-        forceRefresh: any(named: "forceRefresh"),
+        mode: any(named: "mode"),
       ),
     ).thenAnswer((invocation) async {
-      final forceRefresh = invocation.namedArguments[#forceRefresh]! as bool;
-      return forceRefresh
+      final mode = invocation.namedArguments[#mode]! as SessionOptionsRequestMode;
+      return mode == SessionOptionsRequestMode.forceRefresh
           ? const SessionOptionsRepositoryRefreshFailedRetained()
           : SessionOptionsRepositoryAvailable(catalog: _testSessionOptionsCatalog());
     });
@@ -557,11 +562,11 @@ void main() {
       () => sessionRepository.loadSessionOptions(
         projectId: "project-1",
         pluginId: "plugin-1",
-        forceRefresh: any(named: "forceRefresh"),
+        mode: any(named: "mode"),
       ),
     ).thenAnswer((invocation) async {
-      final forceRefresh = invocation.namedArguments[#forceRefresh]! as bool;
-      return forceRefresh
+      final mode = invocation.namedArguments[#mode]! as SessionOptionsRequestMode;
+      return mode == SessionOptionsRequestMode.forceRefresh
           ? const SessionOptionsRepositoryRefreshFailedUnavailable()
           : SessionOptionsRepositoryAvailable(catalog: _testSessionOptionsCatalog());
     });
@@ -954,7 +959,8 @@ void main() {
 
     expect(find.widgetWithText(PregoPickerButton, "coder"), findsOneWidget);
     verifyNever(
-      () => sessionService.createSessionWithMessage(attachments: const [],
+      () => sessionService.createSessionWithMessage(
+        attachments: const [],
         projectId: any(named: "projectId"),
         pluginId: any(named: "pluginId"),
         text: any(named: "text"),
@@ -1150,7 +1156,8 @@ void main() {
     expect(find.byIcon(TablerRegular.arrow_up), findsNothing);
     await tester.pump();
     verifyNever(
-      () => sessionService.createSessionWithMessage(attachments: const [],
+      () => sessionService.createSessionWithMessage(
+        attachments: const [],
         projectId: any(named: "projectId"),
         pluginId: any(named: "pluginId"),
         text: any(named: "text"),
@@ -1291,7 +1298,8 @@ void main() {
   testWidgets("shows the loading overlay with accessible message during sending", (tester) async {
     final createCompleter = Completer<ApiResponse<Session>>();
     when(
-      () => sessionService.createSessionWithMessage(attachments: const [],
+      () => sessionService.createSessionWithMessage(
+        attachments: const [],
         projectId: any(named: "projectId"),
         pluginId: any(named: "pluginId"),
         text: any(named: "text"),
@@ -1322,7 +1330,8 @@ void main() {
   testWidgets("blocks submit UI while a session is sending", (tester) async {
     final createCompleter = Completer<ApiResponse<Session>>();
     when(
-      () => sessionService.createSessionWithMessage(attachments: const [],
+      () => sessionService.createSessionWithMessage(
+        attachments: const [],
         projectId: any(named: "projectId"),
         pluginId: any(named: "pluginId"),
         text: any(named: "text"),
@@ -1353,7 +1362,8 @@ void main() {
     expect(find.byIcon(TablerRegular.arrow_up), findsNothing);
 
     verify(
-      () => sessionService.createSessionWithMessage(attachments: const [],
+      () => sessionService.createSessionWithMessage(
+        attachments: const [],
         projectId: any(named: "projectId"),
         pluginId: any(named: "pluginId"),
         text: any(named: "text"),
@@ -1370,7 +1380,8 @@ void main() {
   testWidgets("shows snackbar and allows navigation when aborting while sending", (tester) async {
     final createCompleter = Completer<ApiResponse<Session>>();
     when(
-      () => sessionService.createSessionWithMessage(attachments: const [],
+      () => sessionService.createSessionWithMessage(
+        attachments: const [],
         projectId: any(named: "projectId"),
         pluginId: any(named: "pluginId"),
         text: any(named: "text"),
@@ -1413,7 +1424,8 @@ void main() {
   testWidgets("does not hijack navigation when creation completes after the user navigated away", (tester) async {
     final createCompleter = Completer<ApiResponse<Session>>();
     when(
-      () => sessionService.createSessionWithMessage(attachments: const [],
+      () => sessionService.createSessionWithMessage(
+        attachments: const [],
         projectId: any(named: "projectId"),
         pluginId: any(named: "pluginId"),
         text: any(named: "text"),
@@ -1461,7 +1473,8 @@ void main() {
   testWidgets("still navigates to session detail after creating a session", (tester) async {
     final createCompleter = Completer<ApiResponse<Session>>();
     when(
-      () => sessionService.createSessionWithMessage(attachments: const [],
+      () => sessionService.createSessionWithMessage(
+        attachments: const [],
         projectId: any(named: "projectId"),
         pluginId: any(named: "pluginId"),
         text: any(named: "text"),
@@ -1498,7 +1511,8 @@ void main() {
   testWidgets("does not show snackbar when auto-navigating after creating a session", (tester) async {
     final createCompleter = Completer<ApiResponse<Session>>();
     when(
-      () => sessionService.createSessionWithMessage(attachments: const [],
+      () => sessionService.createSessionWithMessage(
+        attachments: const [],
         projectId: any(named: "projectId"),
         pluginId: any(named: "pluginId"),
         text: any(named: "text"),
@@ -1533,7 +1547,8 @@ void main() {
   testWidgets("removes the loading overlay and keeps retry UI usable after an error", (tester) async {
     final createCompleter = Completer<ApiResponse<Session>>();
     when(
-      () => sessionService.createSessionWithMessage(attachments: const [],
+      () => sessionService.createSessionWithMessage(
+        attachments: const [],
         projectId: any(named: "projectId"),
         pluginId: any(named: "pluginId"),
         text: any(named: "text"),

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -305,9 +305,15 @@ void main() {
               commands: commandData.items,
             ),
           ),
-        (ErrorResponse(:final error), _, _) => LegacySessionOptionsRepositoryFailure(error: error),
-        (_, ErrorResponse(:final error), _) => LegacySessionOptionsRepositoryFailure(error: error),
-        (_, _, ErrorResponse(:final error)) => LegacySessionOptionsRepositoryFailure(error: error),
+        (ErrorResponse(:final error), _, _) => LegacySessionOptionsRepositoryFailure(
+          errors: [LegacySessionOptionError(source: LegacySessionOptionSource.agents, error: error)],
+        ),
+        (_, ErrorResponse(:final error), _) => LegacySessionOptionsRepositoryFailure(
+          errors: [LegacySessionOptionError(source: LegacySessionOptionSource.providers, error: error)],
+        ),
+        (_, _, ErrorResponse(:final error)) => LegacySessionOptionsRepositoryFailure(
+          errors: [LegacySessionOptionError(source: LegacySessionOptionSource.commands, error: error)],
+        ),
       };
     });
     when(

--- a/client/app/test/helpers/test_helpers.dart
+++ b/client/app/test/helpers/test_helpers.dart
@@ -23,6 +23,9 @@ import "package:sesori_dart_core/sesori_dart_core.dart"
         ProjectViewPaneClaim,
         ProjectViewingService,
         RouteSource,
+        SessionOptionsCatalog,
+        SessionOptionsRepositoryAvailable,
+        SessionOptionsRepositoryFailure,
         SessionOptionsRequestMode;
 import "package:sesori_dart_core/src/api/client/relay_http_client.dart";
 import "package:sesori_dart_core/src/api/project_api.dart";
@@ -484,6 +487,39 @@ void delegateSessionRepositoryToService({
       pluginId: invocation.namedArguments[#pluginId] as String,
     ),
   );
+  when(
+    () => repository.loadSessionOptions(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+      mode: any(named: "mode"),
+    ),
+  ).thenAnswer((invocation) async {
+    final projectId = invocation.namedArguments[#projectId]! as String;
+    final pluginId = invocation.namedArguments[#pluginId]! as String;
+    final (agents, providers, commands) = await (
+      service.listAgents(projectId: projectId, pluginId: pluginId),
+      service.listProviders(projectId: projectId, pluginId: pluginId),
+      service.listCommands(projectId: projectId, pluginId: pluginId),
+    ).wait;
+    return switch ((agents, providers, commands)) {
+      (
+        SuccessResponse(data: final agentData),
+        SuccessResponse(data: final providerData),
+        SuccessResponse(data: final commandData),
+      ) =>
+        SessionOptionsRepositoryAvailable(
+          catalog: SessionOptionsCatalog(
+            agents: agentData.agents,
+            providers: providerData.items,
+            providersConnectedOnly: providerData.connectedOnly,
+            commands: commandData.items,
+          ),
+        ),
+      (ErrorResponse(:final error), _, _) => SessionOptionsRepositoryFailure(error: error),
+      (_, ErrorResponse(:final error), _) => SessionOptionsRepositoryFailure(error: error),
+      (_, _, ErrorResponse(:final error)) => SessionOptionsRepositoryFailure(error: error),
+    };
+  });
   registerFallbackValue(const <ComposerAttachment>[]);
   when(
     () => repository.sendMessage(

--- a/client/app/test/helpers/test_helpers.dart
+++ b/client/app/test/helpers/test_helpers.dart
@@ -22,7 +22,8 @@ import "package:sesori_dart_core/sesori_dart_core.dart"
         ProjectViewClaim,
         ProjectViewPaneClaim,
         ProjectViewingService,
-        RouteSource;
+        RouteSource,
+        SessionOptionsRequestMode;
 import "package:sesori_dart_core/src/api/client/relay_http_client.dart";
 import "package:sesori_dart_core/src/api/project_api.dart";
 import "package:sesori_dart_core/src/api/session_api.dart";
@@ -537,6 +538,7 @@ void registerAllFallbackValues() {
   registerFallbackValue(ProjectViewClaim());
   registerFallbackValue(ProjectViewPaneClaim());
   registerFallbackValue(DateTime.utc(2000));
+  registerFallbackValue(SessionOptionsRequestMode.dynamic);
   registerFallbackValue(
     const ProductAnalyticsEvent.needHelpMenuOpened(surface: OnboardingSurface.connectSetup),
   );

--- a/client/module_core/lib/sesori_dart_core.dart
+++ b/client/module_core/lib/sesori_dart_core.dart
@@ -109,6 +109,7 @@ export "src/foundation/models/product_analytics/analytics_runtime_capability.dar
 export "src/foundation/models/product_analytics/installation_analytics_event.dart";
 export "src/foundation/models/product_analytics/product_analytics_event.dart";
 export "src/foundation/models/product_analytics/product_analytics_preference.dart";
+export "src/foundation/models/session_options/session_options_request_mode.dart";
 export "src/foundation/platform/analytics_client.dart";
 export "src/foundation/platform/image_clipboard.dart";
 export "src/foundation/platform/image_saver.dart";

--- a/client/module_core/lib/src/api/session_api.dart
+++ b/client/module_core/lib/src/api/session_api.dart
@@ -5,6 +5,7 @@ import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../foundation/models/composer/composer_attachment.dart";
+import "../foundation/models/session_options/session_options_request_mode.dart";
 import "../logging/logging.dart";
 import "client/relay_http_client.dart";
 
@@ -47,13 +48,17 @@ class SessionApi {
   Future<ApiResponse<SessionOptionsResponse>> loadSessionOptions({
     required String projectId,
     required String pluginId,
-    required bool forceRefresh,
+    required SessionOptionsRequestMode mode,
   }) {
     return _client.post(
       "/session/options",
       fromJson: SessionOptionsResponse.fromJson,
       body: PluginProjectIdRequest(projectId: projectId, pluginId: pluginId),
-      queryParameters: forceRefresh ? const {"refresh": "true"} : null,
+      queryParameters: switch (mode) {
+        SessionOptionsRequestMode.dynamic => null,
+        SessionOptionsRequestMode.cacheOnly => const {"refresh": "false"},
+        SessionOptionsRequestMode.forceRefresh => const {"refresh": "true"},
+      },
     );
   }
 

--- a/client/module_core/lib/src/foundation/models/session_options/session_options_request_mode.dart
+++ b/client/module_core/lib/src/foundation/models/session_options/session_options_request_mode.dart
@@ -1,0 +1,1 @@
+enum SessionOptionsRequestMode { dynamic, cacheOnly, forceRefresh }

--- a/client/module_core/lib/src/repositories/models/session_options_repository_result.dart
+++ b/client/module_core/lib/src/repositories/models/session_options_repository_result.dart
@@ -5,6 +5,7 @@ final class SessionOptionsCatalog {
   SessionOptionsCatalog({
     required List<AgentInfo> agents,
     required List<ProviderInfo> providers,
+    required this.providersConnectedOnly,
     required List<CommandInfo> commands,
   }) : agents = List.unmodifiable(agents),
        providers = List.unmodifiable(providers),
@@ -12,6 +13,7 @@ final class SessionOptionsCatalog {
 
   final List<AgentInfo> agents;
   final List<ProviderInfo> providers;
+  final bool providersConnectedOnly;
   final List<CommandInfo> commands;
 }
 
@@ -31,6 +33,13 @@ final class LegacySessionOptionsRepositoryFailure extends LegacySessionOptionsRe
   final ApiError error;
 }
 
+final class LegacySessionOptionsRepositoryPartial extends LegacySessionOptionsRepositoryResult {
+  const LegacySessionOptionsRepositoryPartial({required this.catalog, required this.error});
+
+  final SessionOptionsCatalog catalog;
+  final ApiError error;
+}
+
 sealed class SessionOptionsRepositoryResult {
   const SessionOptionsRepositoryResult();
 }
@@ -43,6 +52,10 @@ final class SessionOptionsRepositoryAvailable extends SessionOptionsRepositoryRe
 
 final class SessionOptionsRepositoryCacheUnavailable extends SessionOptionsRepositoryResult {
   const SessionOptionsRepositoryCacheUnavailable();
+}
+
+final class SessionOptionsRepositoryUnsupported extends SessionOptionsRepositoryResult {
+  const SessionOptionsRepositoryUnsupported();
 }
 
 final class SessionOptionsRepositoryProjectNotFound extends SessionOptionsRepositoryResult {

--- a/client/module_core/lib/src/repositories/models/session_options_repository_result.dart
+++ b/client/module_core/lib/src/repositories/models/session_options_repository_result.dart
@@ -21,6 +21,15 @@ sealed class LegacySessionOptionsRepositoryResult {
   const LegacySessionOptionsRepositoryResult();
 }
 
+enum LegacySessionOptionSource { agents, providers, commands }
+
+final class LegacySessionOptionError {
+  const LegacySessionOptionError({required this.source, required this.error});
+
+  final LegacySessionOptionSource source;
+  final ApiError error;
+}
+
 final class LegacySessionOptionsRepositoryAvailable extends LegacySessionOptionsRepositoryResult {
   const LegacySessionOptionsRepositoryAvailable({required this.catalog});
 
@@ -28,16 +37,18 @@ final class LegacySessionOptionsRepositoryAvailable extends LegacySessionOptions
 }
 
 final class LegacySessionOptionsRepositoryFailure extends LegacySessionOptionsRepositoryResult {
-  const LegacySessionOptionsRepositoryFailure({required this.error});
+  LegacySessionOptionsRepositoryFailure({required List<LegacySessionOptionError> errors})
+    : errors = List.unmodifiable(errors);
 
-  final ApiError error;
+  final List<LegacySessionOptionError> errors;
 }
 
 final class LegacySessionOptionsRepositoryPartial extends LegacySessionOptionsRepositoryResult {
-  const LegacySessionOptionsRepositoryPartial({required this.catalog, required this.error});
+  LegacySessionOptionsRepositoryPartial({required this.catalog, required List<LegacySessionOptionError> errors})
+    : errors = List.unmodifiable(errors);
 
   final SessionOptionsCatalog catalog;
-  final ApiError error;
+  final List<LegacySessionOptionError> errors;
 }
 
 sealed class SessionOptionsRepositoryResult {

--- a/client/module_core/lib/src/repositories/session_repository.dart
+++ b/client/module_core/lib/src/repositories/session_repository.dart
@@ -141,16 +141,19 @@ class SessionRepository {
         ErrorResponse() => const <CommandInfo>[],
       },
     );
-    final errors = <ApiError>[
-      if (agents case ErrorResponse(:final error)) error,
-      if (providers case ErrorResponse(:final error)) error,
-      if (commands case ErrorResponse(:final error)) error,
+    final errors = <LegacySessionOptionError>[
+      if (agents case ErrorResponse(:final error))
+        LegacySessionOptionError(source: LegacySessionOptionSource.agents, error: error),
+      if (providers case ErrorResponse(:final error))
+        LegacySessionOptionError(source: LegacySessionOptionSource.providers, error: error),
+      if (commands case ErrorResponse(:final error))
+        LegacySessionOptionError(source: LegacySessionOptionSource.commands, error: error),
     ];
     if (errors.isEmpty) return LegacySessionOptionsRepositoryAvailable(catalog: catalog);
     final anyAvailable = agents is SuccessResponse || providers is SuccessResponse || commands is SuccessResponse;
     return anyAvailable
-        ? LegacySessionOptionsRepositoryPartial(catalog: catalog, error: errors.first)
-        : LegacySessionOptionsRepositoryFailure(error: errors.first);
+        ? LegacySessionOptionsRepositoryPartial(catalog: catalog, errors: errors)
+        : LegacySessionOptionsRepositoryFailure(errors: errors);
   }
 
   Future<SessionOptionsRepositoryResult> loadSessionOptions({

--- a/client/module_core/lib/src/repositories/session_repository.dart
+++ b/client/module_core/lib/src/repositories/session_repository.dart
@@ -4,6 +4,7 @@ import "package:sesori_shared/sesori_shared.dart";
 
 import "../api/session_api.dart";
 import "../foundation/models/composer/composer_attachment.dart";
+import "../foundation/models/session_options/session_options_request_mode.dart";
 import "models/session_options_repository_result.dart";
 
 @lazySingleton
@@ -122,40 +123,58 @@ class SessionRepository {
       _api.listProviders(projectId: projectId, pluginId: pluginId),
       _api.listCommands(projectId: projectId, pluginId: pluginId),
     ).wait;
-    return switch ((agents, providers, commands)) {
-      (
-        SuccessResponse(data: final agentData),
-        SuccessResponse(data: final providerData),
-        SuccessResponse(data: final commandData),
-      ) =>
-        LegacySessionOptionsRepositoryAvailable(
-          catalog: SessionOptionsCatalog(
-            agents: agentData.agents,
-            providers: providerData.items,
-            commands: commandData.items,
-          ),
-        ),
-      (ErrorResponse(:final error), _, _) => LegacySessionOptionsRepositoryFailure(error: error),
-      (_, ErrorResponse(:final error), _) => LegacySessionOptionsRepositoryFailure(error: error),
-      (_, _, ErrorResponse(:final error)) => LegacySessionOptionsRepositoryFailure(error: error),
-    };
+    final catalog = SessionOptionsCatalog(
+      agents: switch (agents) {
+        SuccessResponse(:final data) => data.agents,
+        ErrorResponse() => const <AgentInfo>[],
+      },
+      providers: switch (providers) {
+        SuccessResponse(:final data) => data.items,
+        ErrorResponse() => const <ProviderInfo>[],
+      },
+      providersConnectedOnly: switch (providers) {
+        SuccessResponse(:final data) => data.connectedOnly,
+        ErrorResponse() => false,
+      },
+      commands: switch (commands) {
+        SuccessResponse(:final data) => data.items,
+        ErrorResponse() => const <CommandInfo>[],
+      },
+    );
+    final errors = <ApiError>[
+      if (agents case ErrorResponse(:final error)) error,
+      if (providers case ErrorResponse(:final error)) error,
+      if (commands case ErrorResponse(:final error)) error,
+    ];
+    if (errors.isEmpty) return LegacySessionOptionsRepositoryAvailable(catalog: catalog);
+    final anyAvailable = agents is SuccessResponse || providers is SuccessResponse || commands is SuccessResponse;
+    return anyAvailable
+        ? LegacySessionOptionsRepositoryPartial(catalog: catalog, error: errors.first)
+        : LegacySessionOptionsRepositoryFailure(error: errors.first);
   }
 
   Future<SessionOptionsRepositoryResult> loadSessionOptions({
     required String projectId,
     required String pluginId,
-    required bool forceRefresh,
+    required SessionOptionsRequestMode mode,
   }) async {
     final response = await _api.loadSessionOptions(
       projectId: projectId,
       pluginId: pluginId,
-      forceRefresh: forceRefresh,
+      mode: mode,
     );
+    return _mapSessionOptionsResponse(response: response);
+  }
+
+  SessionOptionsRepositoryResult _mapSessionOptionsResponse({
+    required ApiResponse<SessionOptionsResponse> response,
+  }) {
     return switch (response) {
       SuccessResponse(:final data) => SessionOptionsRepositoryAvailable(
         catalog: SessionOptionsCatalog(
           agents: data.agents.agents,
           providers: data.providers.items,
+          providersConnectedOnly: data.providers.connectedOnly,
           commands: data.commands.items,
         ),
       ),
@@ -164,20 +183,24 @@ class SessionRepository {
   }
 
   SessionOptionsRepositoryResult _mapSessionOptionsError({required ApiError error}) {
-    if (error case NonSuccessCodeError(:final rawErrorString)) {
-      try {
-        if (rawErrorString == null) return SessionOptionsRepositoryFailure(error: error);
-        final response = SessionOptionsErrorResponse.fromJson(jsonDecodeMap(rawErrorString));
-        return switch (response.code) {
-          SessionOptionsErrorCode.cacheUnavailable => const SessionOptionsRepositoryCacheUnavailable(),
-          SessionOptionsErrorCode.projectNotFound => SessionOptionsRepositoryProjectNotFound(error: error),
-          SessionOptionsErrorCode.refreshFailedRetained => const SessionOptionsRepositoryRefreshFailedRetained(),
-          SessionOptionsErrorCode.refreshFailedUnavailable => const SessionOptionsRepositoryRefreshFailedUnavailable(),
-          SessionOptionsErrorCode.unknown => SessionOptionsRepositoryFailure(error: error),
-        };
-      } on Object {
-        // The original transport error remains the explicit observable failure.
+    if (error case NonSuccessCodeError(:final errorCode, :final rawErrorString)) {
+      if (rawErrorString != null) {
+        try {
+          final response = SessionOptionsErrorResponse.fromJson(jsonDecodeMap(rawErrorString));
+          return switch (response.code) {
+            SessionOptionsErrorCode.cacheUnavailable => const SessionOptionsRepositoryCacheUnavailable(),
+            SessionOptionsErrorCode.projectNotFound => SessionOptionsRepositoryProjectNotFound(error: error),
+            SessionOptionsErrorCode.refreshFailedRetained => const SessionOptionsRepositoryRefreshFailedRetained(),
+            SessionOptionsErrorCode.refreshFailedUnavailable =>
+              const SessionOptionsRepositoryRefreshFailedUnavailable(),
+            SessionOptionsErrorCode.unknown => SessionOptionsRepositoryFailure(error: error),
+          };
+        } on Object {
+          // Route absence is classified below; other transport failures retain
+          // the original error as their explicit observable outcome.
+        }
       }
+      if (errorCode == 404) return const SessionOptionsRepositoryUnsupported();
     }
     return SessionOptionsRepositoryFailure(error: error);
   }

--- a/client/module_core/lib/src/services/new_session_options_service.dart
+++ b/client/module_core/lib/src/services/new_session_options_service.dart
@@ -5,6 +5,7 @@ import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../foundation/models/session_options/session_options_request_mode.dart";
+import "../logging/logging.dart";
 import "../repositories/models/session_options_repository_result.dart";
 import "../repositories/session_repository.dart";
 import "../utils/model_filter/default_model_selector.dart";
@@ -149,26 +150,41 @@ class NewSessionOptionsService {
     required NewSessionSelectionIntent? restoredSelection,
     required NewSessionOptionsData? previousOptions,
   }) async {
-    return switch (await _sessionRepository.loadLegacySessionOptions(projectId: projectId, pluginId: pluginId)) {
-      LegacySessionOptionsRepositoryAvailable(:final catalog) => NewSessionOptionsLoaded(
-        options: _resolve(
-          catalog: catalog,
-          restoredSelection: restoredSelection,
+    final result = await _sessionRepository.loadLegacySessionOptions(projectId: projectId, pluginId: pluginId);
+    switch (result) {
+      case LegacySessionOptionsRepositoryAvailable(:final catalog):
+        return NewSessionOptionsLoaded(
+          options: _resolve(
+            catalog: catalog,
+            restoredSelection: restoredSelection,
+            previousOptions: previousOptions,
+          ),
+          source: NewSessionOptionsSource.legacy,
+        );
+      case LegacySessionOptionsRepositoryPartial(:final catalog, :final errors):
+        _logLegacyErrors(errors);
+        return NewSessionOptionsLoaded(
+          options: _resolve(
+            catalog: catalog,
+            restoredSelection: restoredSelection,
+            previousOptions: previousOptions,
+          ),
+          source: NewSessionOptionsSource.legacy,
+        );
+      case LegacySessionOptionsRepositoryFailure(:final errors):
+        _logLegacyErrors(errors);
+        return _transientFailure(
+          error: errors.first.error,
+          source: NewSessionOptionsSource.legacy,
           previousOptions: previousOptions,
-        ),
-        source: NewSessionOptionsSource.legacy,
-      ),
-      LegacySessionOptionsRepositoryPartial(:final error) => _transientFailure(
-        error: error,
-        source: NewSessionOptionsSource.legacy,
-        previousOptions: previousOptions,
-      ),
-      LegacySessionOptionsRepositoryFailure(:final error) => _transientFailure(
-        error: error,
-        source: NewSessionOptionsSource.legacy,
-        previousOptions: previousOptions,
-      ),
-    };
+        );
+    }
+  }
+
+  void _logLegacyErrors(List<LegacySessionOptionError> errors) {
+    for (final failure in errors) {
+      loge("Failed to load legacy ${failure.source.name}", failure.error);
+    }
   }
 
   NewSessionOptionsLoadResult _transientFailure({

--- a/client/module_core/lib/src/services/new_session_options_service.dart
+++ b/client/module_core/lib/src/services/new_session_options_service.dart
@@ -4,6 +4,7 @@ import "package:injectable/injectable.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../foundation/models/session_options/session_options_request_mode.dart";
 import "../repositories/models/session_options_repository_result.dart";
 import "../repositories/session_repository.dart";
 import "../utils/model_filter/default_model_selector.dart";
@@ -104,7 +105,9 @@ class NewSessionOptionsService {
     final result = await _sessionRepository.loadSessionOptions(
       projectId: projectId,
       pluginId: pluginId,
-      forceRefresh: mode == NewSessionOptionsLoadMode.forcedRefresh,
+      mode: mode == NewSessionOptionsLoadMode.forcedRefresh
+          ? SessionOptionsRequestMode.forceRefresh
+          : SessionOptionsRequestMode.dynamic,
     );
     return switch (result) {
       SessionOptionsRepositoryAvailable(:final catalog) => NewSessionOptionsLoaded(
@@ -115,6 +118,7 @@ class NewSessionOptionsService {
         ),
         source: NewSessionOptionsSource.aggregate,
       ),
+      SessionOptionsRepositoryUnsupported() => const NewSessionOptionsUnsupported(),
       SessionOptionsRepositoryCacheUnavailable() => const NewSessionOptionsUnavailable(),
       SessionOptionsRepositoryProjectNotFound(:final error) => NewSessionOptionsFailureUnavailable(
         error: error,
@@ -153,6 +157,11 @@ class NewSessionOptionsService {
           previousOptions: previousOptions,
         ),
         source: NewSessionOptionsSource.legacy,
+      ),
+      LegacySessionOptionsRepositoryPartial(:final error) => _transientFailure(
+        error: error,
+        source: NewSessionOptionsSource.legacy,
+        previousOptions: previousOptions,
       ),
       LegacySessionOptionsRepositoryFailure(:final error) => _transientFailure(
         error: error,

--- a/client/module_core/lib/src/services/new_session_options_service.dart
+++ b/client/module_core/lib/src/services/new_session_options_service.dart
@@ -163,9 +163,24 @@ class NewSessionOptionsService {
         );
       case LegacySessionOptionsRepositoryPartial(:final catalog, :final errors):
         _logLegacyErrors(errors);
+        final failedSources = errors.map((failure) => failure.source).toSet();
+        final retainedCatalog = previousOptions == null
+            ? catalog
+            : SessionOptionsCatalog(
+                agents: failedSources.contains(LegacySessionOptionSource.agents)
+                    ? previousOptions.agents
+                    : catalog.agents,
+                providers: failedSources.contains(LegacySessionOptionSource.providers)
+                    ? previousOptions.providers
+                    : catalog.providers,
+                providersConnectedOnly: catalog.providersConnectedOnly,
+                commands: failedSources.contains(LegacySessionOptionSource.commands)
+                    ? previousOptions.commands
+                    : catalog.commands,
+              );
         return NewSessionOptionsLoaded(
           options: _resolve(
-            catalog: catalog,
+            catalog: retainedCatalog,
             restoredSelection: restoredSelection,
             previousOptions: previousOptions,
           ),

--- a/client/module_core/lib/src/services/session_detail_load_service.dart
+++ b/client/module_core/lib/src/services/session_detail_load_service.dart
@@ -216,11 +216,15 @@ class SessionDetailLoadService {
         switch (await _repository.loadLegacySessionOptions(projectId: normalizedProjectId, pluginId: pluginId)) {
           case LegacySessionOptionsRepositoryAvailable(:final catalog):
             return fromCatalog(catalog);
-          case LegacySessionOptionsRepositoryPartial(:final catalog, :final error):
-            loge("Failed to load some legacy session options", error);
+          case LegacySessionOptionsRepositoryPartial(:final catalog, :final errors):
+            for (final failure in errors) {
+              loge("Failed to load legacy ${failure.source.name}", failure.error);
+            }
             return fromCatalog(catalog);
-          case LegacySessionOptionsRepositoryFailure(:final error):
-            loge("Failed to load legacy session options", error);
+          case LegacySessionOptionsRepositoryFailure(:final errors):
+            for (final failure in errors) {
+              loge("Failed to load legacy ${failure.source.name}", failure.error);
+            }
             return unavailable;
         }
       case SessionOptionsRepositoryProjectNotFound(:final error) || SessionOptionsRepositoryFailure(:final error):

--- a/client/module_core/lib/src/services/session_detail_load_service.dart
+++ b/client/module_core/lib/src/services/session_detail_load_service.dart
@@ -4,6 +4,7 @@ import "package:sesori_shared/sesori_shared.dart";
 
 import "../capabilities/server_connection/connection_service.dart";
 import "../capabilities/server_connection/models/connection_status.dart";
+import "../foundation/models/session_options/session_options_request_mode.dart";
 import "../logging/logging.dart";
 import "../repositories/models/session_options_repository_result.dart";
 import "../repositories/plugin_repository.dart";
@@ -95,8 +96,15 @@ class SessionDetailLoadService {
       final fallbackContext = session == null ? await _loadProjectSessionContext(sessionId: sessionId) : null;
       final effectiveProjectId = routeProjectId ?? session?.projectID.normalize() ?? fallbackContext?.projectId;
       final pluginId = session?.pluginId ?? fallbackContext?.pluginId;
-      final optionsFuture = _loadSessionOptions(projectId: effectiveProjectId, pluginId: pluginId);
-      final promptAttachmentSupportFuture = _loadPromptAttachmentSupport(pluginId: pluginId);
+      final isArchived = session?.time?.archived != null;
+      final optionsFuture = isArchived
+          ? Future<_SessionDetailOptions>.value(
+              (agents: const <AgentInfo>[], providerData: null, commands: const <CommandInfo>[]),
+            )
+          : _loadSessionOptions(projectId: effectiveProjectId, pluginId: pluginId);
+      final promptAttachmentSupportFuture = isArchived
+          ? Future<bool?>.value(null)
+          : _loadPromptAttachmentSupport(pluginId: pluginId);
       // Stage 4 child discovery persists legacy bindings. Pending input must
       // observe those bindings rather than race the compatibility backfill.
       final childrenResponse = await childrenFuture;
@@ -158,7 +166,7 @@ class SessionDetailLoadService {
           canonicalSessionTitle: session?.title ?? fallbackContext?.sessionTitle,
           promptDefaults: promptDefaults,
           isRootSession: session != null ? session.parentID == null : null,
-          isArchived: session?.time?.archived != null,
+          isArchived: isArchived,
         ),
         isBridgeConnected: _connectionService.currentStatus is ConnectionConnected,
       );
@@ -182,7 +190,10 @@ class SessionDetailLoadService {
 
     _SessionDetailOptions fromCatalog(SessionOptionsCatalog catalog) => (
       agents: catalog.agents,
-      providerData: ProviderListResponse(items: catalog.providers, connectedOnly: true),
+      providerData: ProviderListResponse(
+        items: catalog.providers,
+        connectedOnly: catalog.providersConnectedOnly,
+      ),
       commands: catalog.commands,
     );
     const unavailable = (
@@ -194,16 +205,19 @@ class SessionDetailLoadService {
     final result = await _repository.loadSessionOptions(
       projectId: normalizedProjectId,
       pluginId: pluginId,
-      forceRefresh: false,
+      mode: SessionOptionsRequestMode.dynamic,
     );
     switch (result) {
       case SessionOptionsRepositoryAvailable(:final catalog):
         return fromCatalog(catalog);
-      case SessionOptionsRepositoryFailure(error: NonSuccessCodeError(errorCode: 404)):
+      case SessionOptionsRepositoryUnsupported():
         // COMPATIBILITY 2026-08-09 (v1.8.0): Published older bridges do not
         // expose /session/options. Remove this fallback with support for them.
         switch (await _repository.loadLegacySessionOptions(projectId: normalizedProjectId, pluginId: pluginId)) {
           case LegacySessionOptionsRepositoryAvailable(:final catalog):
+            return fromCatalog(catalog);
+          case LegacySessionOptionsRepositoryPartial(:final catalog, :final error):
+            loge("Failed to load some legacy session options", error);
             return fromCatalog(catalog);
           case LegacySessionOptionsRepositoryFailure(:final error):
             loge("Failed to load legacy session options", error);
@@ -213,7 +227,6 @@ class SessionDetailLoadService {
         loge("Failed to load session options", error);
         return unavailable;
       case SessionOptionsRepositoryCacheUnavailable():
-        logw("Session options cache is unavailable");
         return unavailable;
       case SessionOptionsRepositoryRefreshFailedRetained():
         logw("Failed to refresh session options; cached options were retained");

--- a/client/module_core/lib/src/services/session_detail_load_service.dart
+++ b/client/module_core/lib/src/services/session_detail_load_service.dart
@@ -37,11 +37,11 @@ class SessionDetailLoadService {
        _connectionService = connectionService;
 
   Future<SessionDetailLoadResult> load({required String sessionId, required String projectId}) {
-    return _loadSnapshot(sessionId: sessionId, projectId: projectId);
+    return _loadSnapshot(sessionId: sessionId, projectId: projectId, requireCompleteOptions: false);
   }
 
   Future<SessionDetailLoadResult> reload({required String sessionId, required String projectId}) {
-    return _loadSnapshot(sessionId: sessionId, projectId: projectId);
+    return _loadSnapshot(sessionId: sessionId, projectId: projectId, requireCompleteOptions: true);
   }
 
   /// One page of messages older than [before], for a load-older action.
@@ -70,6 +70,7 @@ class SessionDetailLoadService {
   Future<SessionDetailLoadResult> _loadSnapshot({
     required String sessionId,
     required String projectId,
+    required bool requireCompleteOptions,
   }) async {
     if (_connectionService.currentStatus is! ConnectionConnected) {
       return const SessionDetailLoadResult.waitingForConnection();
@@ -98,10 +99,20 @@ class SessionDetailLoadService {
       final pluginId = session?.pluginId ?? fallbackContext?.pluginId;
       final isArchived = session?.time?.archived != null;
       final optionsFuture = isArchived
-          ? Future<_SessionDetailOptions>.value(
-              (agents: const <AgentInfo>[], providerData: null, commands: const <CommandInfo>[]),
+          ? Future<_SessionDetailOptionsResult>.value(
+              const _SessionDetailOptionsAvailable(
+                options: (
+                  agents: <AgentInfo>[],
+                  providerData: null,
+                  commands: <CommandInfo>[],
+                ),
+              ),
             )
-          : _loadSessionOptions(projectId: effectiveProjectId, pluginId: pluginId);
+          : _loadSessionOptions(
+              projectId: effectiveProjectId,
+              pluginId: pluginId,
+              requireComplete: requireCompleteOptions,
+            );
       final promptAttachmentSupportFuture = isArchived
           ? Future<bool?>.value(null)
           : _loadPromptAttachmentSupport(pluginId: pluginId);
@@ -122,10 +133,14 @@ class SessionDetailLoadService {
         permissionsFuture,
         statusesFuture,
       ).wait;
-      final (options, supportsPromptAttachments) = await (
+      final (optionsResult, supportsPromptAttachments) = await (
         optionsFuture,
         promptAttachmentSupportFuture,
       ).wait;
+      final options = switch (optionsResult) {
+        _SessionDetailOptionsAvailable(:final options) => options,
+        _SessionDetailOptionsFailure(:final error, :final stackTrace) => Error.throwWithStackTrace(error, stackTrace),
+      };
       final promptDefaults = session?.promptDefaults;
 
       final (messages, olderMessagesCursor) = switch (messagesResponse) {
@@ -175,31 +190,38 @@ class SessionDetailLoadService {
     }
   }
 
-  Future<_SessionDetailOptions> _loadSessionOptions({
+  Future<_SessionDetailOptionsResult> _loadSessionOptions({
     required String? projectId,
     required String? pluginId,
+    required bool requireComplete,
   }) async {
     final normalizedProjectId = projectId?.normalize();
     if (normalizedProjectId == null || pluginId == null) {
-      return (
-        agents: const <AgentInfo>[],
-        providerData: const ProviderListResponse(items: <ProviderInfo>[], connectedOnly: false),
-        commands: const <CommandInfo>[],
+      return const _SessionDetailOptionsAvailable(
+        options: (
+          agents: <AgentInfo>[],
+          providerData: ProviderListResponse(items: <ProviderInfo>[], connectedOnly: false),
+          commands: <CommandInfo>[],
+        ),
       );
     }
 
-    _SessionDetailOptions fromCatalog(SessionOptionsCatalog catalog) => (
-      agents: catalog.agents,
-      providerData: ProviderListResponse(
-        items: catalog.providers,
-        connectedOnly: catalog.providersConnectedOnly,
+    _SessionDetailOptionsResult fromCatalog(SessionOptionsCatalog catalog) => _SessionDetailOptionsAvailable(
+      options: (
+        agents: catalog.agents,
+        providerData: ProviderListResponse(
+          items: catalog.providers,
+          connectedOnly: catalog.providersConnectedOnly,
+        ),
+        commands: catalog.commands,
       ),
-      commands: catalog.commands,
     );
-    const unavailable = (
-      agents: <AgentInfo>[],
-      providerData: null,
-      commands: <CommandInfo>[],
+    const unavailable = _SessionDetailOptionsAvailable(
+      options: (
+        agents: <AgentInfo>[],
+        providerData: null,
+        commands: <CommandInfo>[],
+      ),
     );
 
     final result = await _repository.loadSessionOptions(
@@ -217,25 +239,56 @@ class SessionDetailLoadService {
           case LegacySessionOptionsRepositoryAvailable(:final catalog):
             return fromCatalog(catalog);
           case LegacySessionOptionsRepositoryPartial(:final catalog, :final errors):
+            if (requireComplete) {
+              return _SessionDetailOptionsFailure(
+                error: _LegacySessionOptionsLoadError(errors: errors),
+                stackTrace: StackTrace.current,
+              );
+            }
             for (final failure in errors) {
               loge("Failed to load legacy ${failure.source.name}", failure.error);
             }
             return fromCatalog(catalog);
           case LegacySessionOptionsRepositoryFailure(:final errors):
+            if (requireComplete) {
+              return _SessionDetailOptionsFailure(
+                error: _LegacySessionOptionsLoadError(errors: errors),
+                stackTrace: StackTrace.current,
+              );
+            }
             for (final failure in errors) {
               loge("Failed to load legacy ${failure.source.name}", failure.error);
             }
             return unavailable;
         }
       case SessionOptionsRepositoryProjectNotFound(:final error) || SessionOptionsRepositoryFailure(:final error):
+        if (requireComplete) return _SessionDetailOptionsFailure(error: error, stackTrace: StackTrace.current);
         loge("Failed to load session options", error);
         return unavailable;
       case SessionOptionsRepositoryCacheUnavailable():
+        if (requireComplete) {
+          return _SessionDetailOptionsFailure(
+            error: StateError("Session options cache is unavailable"),
+            stackTrace: StackTrace.current,
+          );
+        }
         return unavailable;
       case SessionOptionsRepositoryRefreshFailedRetained():
+        if (requireComplete) {
+          return _SessionDetailOptionsFailure(
+            error: StateError("Session options refresh failed"),
+            stackTrace: StackTrace.current,
+          );
+        }
         logw("Failed to refresh session options; cached options were retained");
         return unavailable;
       case SessionOptionsRepositoryRefreshFailedUnavailable():
+        if (requireComplete) {
+          return _SessionDetailOptionsFailure(
+            error: StateError("Session options refresh failed with no cached options"),
+            stackTrace: StackTrace.current,
+          );
+        }
         logw("Failed to refresh session options and no cached options are available");
         return unavailable;
     }
@@ -331,6 +384,33 @@ typedef _SessionDetailOptions = ({
   ProviderListResponse? providerData,
   List<CommandInfo> commands,
 });
+
+sealed class _SessionDetailOptionsResult {
+  const _SessionDetailOptionsResult();
+}
+
+final class _SessionDetailOptionsAvailable extends _SessionDetailOptionsResult {
+  const _SessionDetailOptionsAvailable({required this.options});
+
+  final _SessionDetailOptions options;
+}
+
+final class _SessionDetailOptionsFailure extends _SessionDetailOptionsResult {
+  const _SessionDetailOptionsFailure({required this.error, required this.stackTrace});
+
+  // ignore: no_slop_linter/prefer_specific_type, transport and internal option failures share this outcome
+  final Object error;
+  final StackTrace stackTrace;
+}
+
+final class _LegacySessionOptionsLoadError implements Exception {
+  _LegacySessionOptionsLoadError({required List<LegacySessionOptionError> errors}) : errors = List.unmodifiable(errors);
+
+  final List<LegacySessionOptionError> errors;
+
+  @override
+  String toString() => errors.map((failure) => "${failure.source.name}: ${failure.error.toString()}").join("; ");
+}
 
 sealed class SessionDetailLoadResult {
   const SessionDetailLoadResult();

--- a/client/module_core/lib/src/services/session_detail_load_service.dart
+++ b/client/module_core/lib/src/services/session_detail_load_service.dart
@@ -5,6 +5,7 @@ import "package:sesori_shared/sesori_shared.dart";
 import "../capabilities/server_connection/connection_service.dart";
 import "../capabilities/server_connection/models/connection_status.dart";
 import "../logging/logging.dart";
+import "../repositories/models/session_options_repository_result.dart";
 import "../repositories/plugin_repository.dart";
 import "../repositories/project_repository.dart";
 import "../repositories/session_repository.dart";
@@ -94,9 +95,7 @@ class SessionDetailLoadService {
       final fallbackContext = session == null ? await _loadProjectSessionContext(sessionId: sessionId) : null;
       final effectiveProjectId = routeProjectId ?? session?.projectID.normalize() ?? fallbackContext?.projectId;
       final pluginId = session?.pluginId ?? fallbackContext?.pluginId;
-      final commandsFuture = _listCommands(projectId: effectiveProjectId, pluginId: pluginId);
-      final agentsFuture = _listAgents(projectId: effectiveProjectId, pluginId: pluginId);
-      final providersFuture = _listProviders(projectId: effectiveProjectId, pluginId: pluginId);
+      final optionsFuture = _loadSessionOptions(projectId: effectiveProjectId, pluginId: pluginId);
       final promptAttachmentSupportFuture = _loadPromptAttachmentSupport(pluginId: pluginId);
       // Stage 4 child discovery persists legacy bindings. Pending input must
       // observe those bindings rather than race the compatibility backfill.
@@ -115,10 +114,8 @@ class SessionDetailLoadService {
         permissionsFuture,
         statusesFuture,
       ).wait;
-      final (commandsResponse, agentsResponse, providersResponse, supportsPromptAttachments) = await (
-        commandsFuture,
-        agentsFuture,
-        providersFuture,
+      final (options, supportsPromptAttachments) = await (
+        optionsFuture,
         promptAttachmentSupportFuture,
       ).wait;
       final promptDefaults = session?.promptDefaults;
@@ -144,28 +141,6 @@ class SessionDetailLoadService {
         SuccessResponse(:final data) => data.statuses,
         ErrorResponse() => <String, SessionStatus>{},
       };
-      final agents = switch (agentsResponse) {
-        SuccessResponse(:final data) => data.agents,
-        ErrorResponse(:final error) => () {
-          loge("Failed to load agents: ${error.toString()}");
-          return <AgentInfo>[];
-        }(),
-      };
-      final providerData = switch (providersResponse) {
-        SuccessResponse(:final data) => data,
-        ErrorResponse(:final error) => () {
-          loge("Failed to load providers: ${error.toString()}");
-          return null;
-        }(),
-      };
-      final commands = switch (commandsResponse) {
-        SuccessResponse(:final data) => data.items,
-        ErrorResponse(:final error) => () {
-          loge("Failed to load commands: ${error.toString()}");
-          return <CommandInfo>[];
-        }(),
-      };
-
       return SessionDetailLoadResult.loaded(
         snapshot: SessionDetailSnapshot(
           projectId: effectiveProjectId,
@@ -177,9 +152,9 @@ class SessionDetailLoadService {
           pendingPermissions: pendingPermissions,
           childSessions: childSessions,
           statuses: statuses,
-          agents: agents,
-          providerData: providerData,
-          commands: commands,
+          agents: options.agents,
+          providerData: options.providerData,
+          commands: options.commands,
           canonicalSessionTitle: session?.title ?? fallbackContext?.sessionTitle,
           promptDefaults: promptDefaults,
           isRootSession: session != null ? session.parentID == null : null,
@@ -192,41 +167,61 @@ class SessionDetailLoadService {
     }
   }
 
-  Future<ApiResponse<Agents>> _listAgents({required String? projectId, required String? pluginId}) {
+  Future<_SessionDetailOptions> _loadSessionOptions({
+    required String? projectId,
+    required String? pluginId,
+  }) async {
     final normalizedProjectId = projectId?.normalize();
     if (normalizedProjectId == null || pluginId == null) {
-      // Without any project context there is no way to scope the agent list;
-      // an empty list keeps the UI consistent instead of guessing a project.
-      return Future<ApiResponse<Agents>>.value(
-        ApiResponse.success(const Agents(agents: <AgentInfo>[])),
+      return (
+        agents: const <AgentInfo>[],
+        providerData: const ProviderListResponse(items: <ProviderInfo>[], connectedOnly: false),
+        commands: const <CommandInfo>[],
       );
     }
 
-    return _repository.listAgents(projectId: normalizedProjectId, pluginId: pluginId);
-  }
+    _SessionDetailOptions fromCatalog(SessionOptionsCatalog catalog) => (
+      agents: catalog.agents,
+      providerData: ProviderListResponse(items: catalog.providers, connectedOnly: true),
+      commands: catalog.commands,
+    );
+    const unavailable = (
+      agents: <AgentInfo>[],
+      providerData: null,
+      commands: <CommandInfo>[],
+    );
 
-  Future<ApiResponse<CommandListResponse>> _listCommands({required String? projectId, required String? pluginId}) {
-    final normalizedProjectId = projectId?.normalize();
-    if (normalizedProjectId == null || pluginId == null) {
-      return Future<ApiResponse<CommandListResponse>>.value(
-        ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
-      );
+    final result = await _repository.loadSessionOptions(
+      projectId: normalizedProjectId,
+      pluginId: pluginId,
+      forceRefresh: false,
+    );
+    switch (result) {
+      case SessionOptionsRepositoryAvailable(:final catalog):
+        return fromCatalog(catalog);
+      case SessionOptionsRepositoryFailure(error: NonSuccessCodeError(errorCode: 404)):
+        // COMPATIBILITY 2026-08-09 (v1.8.0): Published older bridges do not
+        // expose /session/options. Remove this fallback with support for them.
+        switch (await _repository.loadLegacySessionOptions(projectId: normalizedProjectId, pluginId: pluginId)) {
+          case LegacySessionOptionsRepositoryAvailable(:final catalog):
+            return fromCatalog(catalog);
+          case LegacySessionOptionsRepositoryFailure(:final error):
+            loge("Failed to load legacy session options", error);
+            return unavailable;
+        }
+      case SessionOptionsRepositoryProjectNotFound(:final error) || SessionOptionsRepositoryFailure(:final error):
+        loge("Failed to load session options", error);
+        return unavailable;
+      case SessionOptionsRepositoryCacheUnavailable():
+        logw("Session options cache is unavailable");
+        return unavailable;
+      case SessionOptionsRepositoryRefreshFailedRetained():
+        logw("Failed to refresh session options; cached options were retained");
+        return unavailable;
+      case SessionOptionsRepositoryRefreshFailedUnavailable():
+        logw("Failed to refresh session options and no cached options are available");
+        return unavailable;
     }
-
-    return _repository.listCommands(projectId: normalizedProjectId, pluginId: pluginId);
-  }
-
-  Future<ApiResponse<ProviderListResponse>> _listProviders({required String? projectId, required String? pluginId}) {
-    final normalizedProjectId = projectId?.normalize();
-    if (normalizedProjectId == null || pluginId == null) {
-      // Without any project context there is no project to scope providers to;
-      // an empty list keeps the UI consistent instead of guessing a project.
-      return Future<ApiResponse<ProviderListResponse>>.value(
-        ApiResponse.success(const ProviderListResponse(items: <ProviderInfo>[], connectedOnly: false)),
-      );
-    }
-
-    return _repository.listProviders(projectId: normalizedProjectId, pluginId: pluginId);
   }
 
   Future<bool?> _loadPromptAttachmentSupport({required String? pluginId}) async {
@@ -313,6 +308,12 @@ class SessionDetailSnapshot {
 
 /// One page of history plus the cursor for the page before it.
 typedef SessionMessagePage = ({List<MessageWithParts> messages, int? olderMessagesCursor});
+
+typedef _SessionDetailOptions = ({
+  List<AgentInfo> agents,
+  ProviderListResponse? providerData,
+  List<CommandInfo> commands,
+});
 
 sealed class SessionDetailLoadResult {
   const SessionDetailLoadResult();

--- a/client/module_core/test/api/session_api_test.dart
+++ b/client/module_core/test/api/session_api_test.dart
@@ -6,6 +6,7 @@ import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_dart_core/src/api/client/relay_http_client.dart";
 import "package:sesori_dart_core/src/api/session_api.dart";
 import "package:sesori_dart_core/src/foundation/models/composer/composer_attachment.dart";
+import "package:sesori_dart_core/src/foundation/models/session_options/session_options_request_mode.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -43,7 +44,7 @@ void main() {
       final response = await api.loadSessionOptions(
         projectId: "project-1",
         pluginId: "plugin-1",
-        forceRefresh: false,
+        mode: SessionOptionsRequestMode.dynamic,
       );
 
       expect((response as SuccessResponse<SessionOptionsResponse>).data, options);
@@ -70,7 +71,7 @@ void main() {
       await api.loadSessionOptions(
         projectId: "project-1",
         pluginId: "plugin-1",
-        forceRefresh: true,
+        mode: SessionOptionsRequestMode.forceRefresh,
       );
 
       verify(
@@ -79,6 +80,32 @@ void main() {
           fromJson: any(named: "fromJson"),
           body: const PluginProjectIdRequest(projectId: "project-1", pluginId: "plugin-1"),
           queryParameters: const {"refresh": "true"},
+        ),
+      ).called(1);
+    });
+
+    test("loadSessionOptions sends refresh=false for cache-only loading", () async {
+      when(
+        () => client.post<SessionOptionsResponse>(
+          any(),
+          fromJson: any(named: "fromJson"),
+          body: any(named: "body"),
+          queryParameters: any(named: "queryParameters"),
+        ),
+      ).thenAnswer((_) async => ApiResponse.success(options));
+
+      await api.loadSessionOptions(
+        projectId: "project-1",
+        pluginId: "plugin-1",
+        mode: SessionOptionsRequestMode.cacheOnly,
+      );
+
+      verify(
+        () => client.post<SessionOptionsResponse>(
+          "/session/options",
+          fromJson: any(named: "fromJson"),
+          body: const PluginProjectIdRequest(projectId: "project-1", pluginId: "plugin-1"),
+          queryParameters: const {"refresh": "false"},
         ),
       ).called(1);
     });
@@ -105,7 +132,8 @@ void main() {
         ),
       ).thenAnswer((_) async => ApiResponse.success(session));
 
-      await api.createSessionWithMessage(attachments: const [],
+      await api.createSessionWithMessage(
+        attachments: const [],
         projectId: "project-1",
         pluginId: "plugin-1",
         text: "hello",
@@ -137,7 +165,8 @@ void main() {
         ),
       ).thenAnswer((_) async => ApiResponse<void>.success(null));
 
-      await api.sendMessage(attachments: const [],
+      await api.sendMessage(
+        attachments: const [],
         sessionId: "session-1",
         text: "hello",
         agent: "build",

--- a/client/module_core/test/cubits/new_session/new_session_plugin_selection_test.dart
+++ b/client/module_core/test/cubits/new_session/new_session_plugin_selection_test.dart
@@ -9,6 +9,7 @@ import "package:sesori_dart_core/src/cubits/new_session/new_session_cubit.dart";
 import "package:sesori_dart_core/src/cubits/new_session/new_session_state.dart";
 import "package:sesori_dart_core/src/errors/remote_failure_reason.dart";
 import "package:sesori_dart_core/src/foundation/models/composer/composer_draft.dart";
+import "package:sesori_dart_core/src/foundation/models/session_options/session_options_request_mode.dart";
 import "package:sesori_dart_core/src/repositories/models/plugin_discovery_snapshot.dart";
 import "package:sesori_dart_core/src/repositories/models/session_options_repository_result.dart";
 import "package:sesori_dart_core/src/services/models/new_session_options_source.dart";
@@ -498,7 +499,7 @@ void main() {
         () => sessionRepository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "plugin-a",
-          forceRefresh: any(named: "forceRefresh"),
+          mode: any(named: "mode"),
         ),
       ).thenAnswer((_) async {
         loadCalls++;
@@ -507,6 +508,7 @@ void main() {
                 catalog: SessionOptionsCatalog(
                   agents: const [],
                   providers: const [],
+                  providersConnectedOnly: false,
                   commands: [command],
                 ),
               )
@@ -534,7 +536,7 @@ void main() {
         () => sessionRepository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "plugin-a",
-          forceRefresh: any(named: "forceRefresh"),
+          mode: any(named: "mode"),
         ),
       ).thenAnswer((_) async {
         loadCalls++;
@@ -543,6 +545,7 @@ void main() {
           catalog: SessionOptionsCatalog(
             agents: const [],
             providers: _providerResponse().items,
+            providersConnectedOnly: false,
             commands: const [],
           ),
         );
@@ -577,6 +580,7 @@ void main() {
           catalog: SessionOptionsCatalog(
             agents: const [],
             providers: _providerResponse().items,
+            providersConnectedOnly: false,
             commands: const [],
           ),
         );
@@ -602,7 +606,7 @@ void main() {
         () => sessionRepository.loadSessionOptions(
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
-          forceRefresh: any(named: "forceRefresh"),
+          mode: any(named: "mode"),
         ),
       );
     });
@@ -625,6 +629,7 @@ void main() {
                 catalog: SessionOptionsCatalog(
                   agents: const [],
                   providers: const [],
+                  providersConnectedOnly: false,
                   commands: [command],
                 ),
               )
@@ -667,7 +672,7 @@ void main() {
         () => sessionRepository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "plugin-a",
-          forceRefresh: any(named: "forceRefresh"),
+          mode: any(named: "mode"),
         ),
       ).thenAnswer((_) async {
         loadCalls++;
@@ -676,6 +681,7 @@ void main() {
                 catalog: SessionOptionsCatalog(
                   agents: const [],
                   providers: const [],
+                  providersConnectedOnly: false,
                   commands: [command],
                 ),
               )
@@ -716,6 +722,7 @@ void main() {
           catalog: SessionOptionsCatalog(
             agents: const [],
             providers: const [],
+            providersConnectedOnly: false,
             commands: [command],
           ),
         );
@@ -762,6 +769,7 @@ void main() {
           catalog: SessionOptionsCatalog(
             agents: const [],
             providers: const [],
+            providersConnectedOnly: false,
             commands: [command],
           ),
         );
@@ -805,13 +813,14 @@ void main() {
         () => sessionRepository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "plugin-a",
-          forceRefresh: any(named: "forceRefresh"),
+          mode: any(named: "mode"),
         ),
       ).thenAnswer(
         (_) async => SessionOptionsRepositoryAvailable(
           catalog: SessionOptionsCatalog(
             agents: const [],
             providers: const [],
+            providersConnectedOnly: false,
             commands: [command],
           ),
         ),
@@ -847,7 +856,7 @@ void main() {
         () => sessionRepository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "plugin-a",
-          forceRefresh: any(named: "forceRefresh"),
+          mode: any(named: "mode"),
         ),
       ).thenAnswer((_) async {
         loadCalls++;
@@ -856,6 +865,7 @@ void main() {
                 catalog: SessionOptionsCatalog(
                   agents: const [],
                   providers: const [],
+                  providersConnectedOnly: false,
                   commands: [command],
                 ),
               )
@@ -883,7 +893,7 @@ void main() {
         () => sessionRepository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "plugin-a",
-          forceRefresh: any(named: "forceRefresh"),
+          mode: any(named: "mode"),
         ),
       ).thenAnswer((_) async {
         loadCalls++;
@@ -892,6 +902,7 @@ void main() {
                 catalog: SessionOptionsCatalog(
                   agents: const [],
                   providers: _providerResponse().items,
+                  providersConnectedOnly: false,
                   commands: const [],
                 ),
               )
@@ -1135,7 +1146,8 @@ void main() {
         (_) async => ApiResponse.success(_pluginSnapshot(bridgeId: null, plugins: [degraded])),
       );
       when(
-        () => sessionService.createSessionWithMessage(attachments: const [],
+        () => sessionService.createSessionWithMessage(
+          attachments: const [],
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
           text: any(named: "text"),
@@ -1151,7 +1163,8 @@ void main() {
       final cubit = buildCubit();
       addTearDown(cubit.close);
       await _waitForComposer(cubit);
-      await cubit.createSession(attachments: const [],
+      await cubit.createSession(
+        attachments: const [],
         text: "hello",
         dedicatedWorktree: true,
         command: null,
@@ -1162,7 +1175,8 @@ void main() {
       verify(() => sessionService.listProviders(projectId: "project-1", pluginId: "degraded")).called(1);
       verify(() => sessionService.listCommands(projectId: "project-1", pluginId: "degraded")).called(1);
       verify(
-        () => sessionService.createSessionWithMessage(attachments: const [],
+        () => sessionService.createSessionWithMessage(
+          attachments: const [],
           projectId: "project-1",
           pluginId: "degraded",
           text: "hello",
@@ -1204,7 +1218,8 @@ void main() {
       expect(state.selectedPlugin, unavailable);
       cubit.selectPlugin(pluginId: "failed");
       cubit.selectPlugin(pluginId: "unknown");
-      await cubit.createSession(attachments: const [],
+      await cubit.createSession(
+        attachments: const [],
         text: "blocked",
         dedicatedWorktree: true,
         command: null,
@@ -1214,7 +1229,8 @@ void main() {
       expect((cubit.state as NewSessionIdle).selectedPlugin, unavailable);
       _verifyNoComposerCalls(sessionService);
       verifyNever(
-        () => sessionService.createSessionWithMessage(attachments: const [],
+        () => sessionService.createSessionWithMessage(
+          attachments: const [],
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
           text: any(named: "text"),
@@ -1237,7 +1253,8 @@ void main() {
       await _waitUntil(() => cubit.state.agentModelData?.isLoading == false);
 
       expect(cubit.state.agentModelData?.plugin, isNull);
-      await cubit.createSession(attachments: const [],
+      await cubit.createSession(
+        attachments: const [],
         text: "blocked",
         dedicatedWorktree: true,
         command: null,
@@ -1379,7 +1396,8 @@ void main() {
         ..recordAgent(projectId: "project-1", pluginId: "plugin-a", agentName: "agent-a")
         ..recordAgent(projectId: "project-1", pluginId: "plugin-b", agentName: "agent-b");
       when(
-        () => sessionService.createSessionWithMessage(attachments: const [],
+        () => sessionService.createSessionWithMessage(
+          attachments: const [],
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
           text: any(named: "text"),
@@ -1395,7 +1413,8 @@ void main() {
       final cubit = buildCubit();
       addTearDown(cubit.close);
       await _waitForComposer(cubit);
-      await cubit.createSession(attachments: const [],
+      await cubit.createSession(
+        attachments: const [],
         text: "hello",
         dedicatedWorktree: true,
         command: null,
@@ -1411,7 +1430,8 @@ void main() {
         (_) async => ApiResponse.success(_pluginSnapshot(bridgeId: "br_test", plugins: [pluginA, pluginB])),
       );
       when(
-        () => sessionService.createSessionWithMessage(attachments: const [],
+        () => sessionService.createSessionWithMessage(
+          attachments: const [],
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
           text: any(named: "text"),
@@ -1437,7 +1457,8 @@ void main() {
         ),
       );
 
-      await cubit.createSession(attachments: const [],
+      await cubit.createSession(
+        attachments: const [],
         text: "hello",
         dedicatedWorktree: true,
         command: null,
@@ -1528,7 +1549,8 @@ void main() {
       });
       final createCompleter = Completer<ApiResponse<Session>>();
       when(
-        () => sessionService.createSessionWithMessage(attachments: const [],
+        () => sessionService.createSessionWithMessage(
+          attachments: const [],
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
           text: any(named: "text"),
@@ -1544,7 +1566,8 @@ void main() {
       addTearDown(cubit.close);
       await _waitForComposer(cubit);
 
-      final send = cubit.createSession(attachments: const [],
+      final send = cubit.createSession(
+        attachments: const [],
         text: "hello",
         dedicatedWorktree: true,
         command: null,
@@ -1574,7 +1597,8 @@ void main() {
         return ApiResponse.error(ApiError.nonSuccessCode(errorCode: 503, rawErrorString: null));
       });
       when(
-        () => sessionService.createSessionWithMessage(attachments: const [],
+        () => sessionService.createSessionWithMessage(
+          attachments: const [],
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
           text: any(named: "text"),
@@ -1605,11 +1629,12 @@ void main() {
         () => sessionRepository.loadSessionOptions(
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
-          forceRefresh: true,
+          mode: SessionOptionsRequestMode.forceRefresh,
         ),
       );
 
-      await cubit.createSession(attachments: const [],
+      await cubit.createSession(
+        attachments: const [],
         text: "hello",
         dedicatedWorktree: true,
         command: null,
@@ -1624,7 +1649,8 @@ void main() {
       );
       expect(cubit.canCreateSession, isFalse);
       verifyNever(
-        () => sessionService.createSessionWithMessage(attachments: const [],
+        () => sessionService.createSessionWithMessage(
+          attachments: const [],
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
           text: any(named: "text"),
@@ -1643,7 +1669,8 @@ void main() {
         (_) async => ApiResponse.success(_pluginSnapshot(bridgeId: null, plugins: [pluginA])),
       );
       when(
-        () => sessionService.createSessionWithMessage(attachments: const [],
+        () => sessionService.createSessionWithMessage(
+          attachments: const [],
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
           text: any(named: "text"),
@@ -1659,7 +1686,8 @@ void main() {
       final cubit = buildCubit();
       addTearDown(cubit.close);
       await _waitForComposer(cubit);
-      await cubit.createSession(attachments: const [],
+      await cubit.createSession(
+        attachments: const [],
         text: "hello",
         dedicatedWorktree: true,
         command: null,

--- a/client/module_core/test/cubits/new_session/new_session_plugin_selection_test.dart
+++ b/client/module_core/test/cubits/new_session/new_session_plugin_selection_test.dart
@@ -633,7 +633,14 @@ void main() {
                   commands: [command],
                 ),
               )
-            : LegacySessionOptionsRepositoryFailure(error: ApiError.generic());
+            : LegacySessionOptionsRepositoryFailure(
+                errors: [
+                  LegacySessionOptionError(
+                    source: LegacySessionOptionSource.providers,
+                    error: ApiError.generic(),
+                  ),
+                ],
+              );
       });
       final cubit = buildCubit(
         optionsService: NewSessionOptionsService(

--- a/client/module_core/test/cubits/session_detail/session_detail_stale_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_stale_test.dart
@@ -478,7 +478,7 @@ void main() {
       expect(refreshed.streamingText, {"part-race": "delta-during-refresh"});
     });
 
-    test("partial API failure: providers fail and refresh still succeeds with empty providers", () async {
+    test("option failure retains the prior snapshot while waiting for retry", () async {
       final cubit = SessionDetailCubit(
         mockConnectionService,
         loadService: loadService,
@@ -515,8 +515,8 @@ void main() {
 
       final loaded = cubit.state as SessionDetailLoaded;
       expect(loaded.isRefreshing, isFalse);
-      expect(loaded.messages.first.info.id, "msg-provider-fallback");
-      expect(loaded.availableProviders, isEmpty);
+      expect(loaded.messages.first.info.id, "msg-1");
+      expect(loaded.availableProviders, _providers().items);
     });
 
     test("stale signal is ignored when state is SessionDetailLoading", () async {
@@ -714,6 +714,56 @@ void main() {
 
       await Future<void>.delayed(const Duration(milliseconds: 150));
       expect(messageLoads, 2);
+    });
+
+    test("an option load failure preserves catalogs and retries until options load", () async {
+      final cubit = SessionDetailCubit(
+        mockConnectionService,
+        loadService: loadService,
+        promptDispatcher: promptDispatcher,
+        permissionRepository: mockPermissionRepository,
+        sessionViewingService: stubbedSessionViewingService(),
+        projectViewingService: stubbedProjectViewingService(),
+        lifecycleSource: FakeLifecycleSource(),
+        composerDraftRepository: inMemoryComposerDraftRepository(),
+        productAnalyticsService: stubbedProductAnalyticsService(),
+        sessionId: sessionId,
+        projectId: "project-1",
+        notificationCanceller: mockNotificationCanceller,
+        failureReporter: MockFailureReporter(),
+        eventRefreshMinInterval: const Duration(milliseconds: 100),
+      );
+      addTearDown(cubit.close);
+
+      await _awaitLoaded(cubit);
+      final before = cubit.state as SessionDetailLoaded;
+      var providerLoads = 0;
+      when(
+        () => mockSessionService.listProviders(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
+      ).thenAnswer((_) async {
+        providerLoads++;
+        return providerLoads == 1
+            ? ApiResponse<ProviderListResponse>.error(ApiError.generic())
+            : ApiResponse.success(_providers());
+      });
+
+      mockConnectionService.emitDataMayBeStale();
+      await pumpEventQueue();
+
+      expect(providerLoads, 1);
+      final afterFailure = cubit.state as SessionDetailLoaded;
+      expect(afterFailure.availableAgents, before.availableAgents);
+      expect(afterFailure.availableProviders, before.availableProviders);
+      expect(afterFailure.availableCommands, before.availableCommands);
+
+      await Future<void>.delayed(const Duration(milliseconds: 120));
+      expect(providerLoads, 2);
+
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      expect(providerLoads, 2);
     });
 
     test("a disconnected failed refresh waits for reconnect instead of retrying each cooldown", () async {

--- a/client/module_core/test/helpers/test_helpers.dart
+++ b/client/module_core/test/helpers/test_helpers.dart
@@ -11,6 +11,7 @@ import "package:sesori_dart_core/src/capabilities/server_connection/connection_s
 import "package:sesori_dart_core/src/capabilities/server_connection/server_connection_config.dart";
 import "package:sesori_dart_core/src/capabilities/session/session_service.dart";
 import "package:sesori_dart_core/src/foundation/models/product_analytics/product_analytics_event.dart";
+import "package:sesori_dart_core/src/foundation/models/session_options/session_options_request_mode.dart";
 import "package:sesori_dart_core/src/platform/lifecycle_source.dart";
 import "package:sesori_dart_core/src/platform/route_source.dart";
 import "package:sesori_dart_core/src/repositories/bridge_repository.dart";
@@ -325,6 +326,7 @@ void delegateSessionRepositoryToService({
     (invocation) => service.getChildren(sessionId: invocation.namedArguments[#sessionId]! as String),
   );
   when(() => repository.getSessionStatuses()).thenAnswer((_) => service.getSessionStatuses());
+  delegateSessionOptionsRepositoryToService(repository: repository, service: service);
   when(
     () => repository.listAgents(
       projectId: any(named: "projectId"),
@@ -359,7 +361,8 @@ void delegateSessionRepositoryToService({
     ),
   );
   when(
-    () => repository.sendMessage(attachments: const [],
+    () => repository.sendMessage(
+      attachments: const [],
       sessionId: any(named: "sessionId"),
       text: any(named: "text"),
       agent: any(named: "agent"),
@@ -368,7 +371,8 @@ void delegateSessionRepositoryToService({
       command: any(named: "command"),
     ),
   ).thenAnswer(
-    (invocation) => service.sendMessage(attachments: const [],
+    (invocation) => service.sendMessage(
+      attachments: const [],
       sessionId: invocation.namedArguments[#sessionId]! as String,
       text: invocation.namedArguments[#text]! as String,
       agent: invocation.namedArguments[#agent] as String?,
@@ -386,13 +390,7 @@ void delegateSessionOptionsRepositoryToService({
   required MockSessionRepository repository,
   required MockSessionService service,
 }) {
-  when(
-    () => repository.loadSessionOptions(
-      projectId: any(named: "projectId"),
-      pluginId: any(named: "pluginId"),
-      forceRefresh: any(named: "forceRefresh"),
-    ),
-  ).thenAnswer((invocation) async {
+  Future<SessionOptionsRepositoryResult> loadOptions(Invocation invocation) async {
     final projectId = invocation.namedArguments[#projectId]! as String;
     final pluginId = invocation.namedArguments[#pluginId]! as String;
     final (agents, providers, commands) = await (
@@ -410,6 +408,7 @@ void delegateSessionOptionsRepositoryToService({
           catalog: SessionOptionsCatalog(
             agents: agentData.agents,
             providers: providerData.items,
+            providersConnectedOnly: providerData.connectedOnly,
             commands: commandData.items,
           ),
         ),
@@ -417,7 +416,15 @@ void delegateSessionOptionsRepositoryToService({
       (_, ErrorResponse(:final error), _) => SessionOptionsRepositoryFailure(error: error),
       (_, _, ErrorResponse(:final error)) => SessionOptionsRepositoryFailure(error: error),
     };
-  });
+  }
+
+  when(
+    () => repository.loadSessionOptions(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+      mode: any(named: "mode"),
+    ),
+  ).thenAnswer(loadOptions);
 }
 
 void stubSessionRepositoryGetSession({
@@ -435,6 +442,7 @@ void registerAllFallbackValues() {
   registerFallbackValue(FakeUri());
   registerFallbackValue(StackTrace.empty);
   registerFallbackValue(const ProductAnalyticsEvent.analyticsSchemaReady());
+  registerFallbackValue(SessionOptionsRequestMode.dynamic);
   registerFallbackValue(ProjectViewClaim());
   registerFallbackValue(ProjectViewPaneClaim());
   registerFallbackValue(DateTime.utc(2026));

--- a/client/module_core/test/repositories/session_repository_test.dart
+++ b/client/module_core/test/repositories/session_repository_test.dart
@@ -2,6 +2,7 @@ import "dart:convert";
 
 import "package:mocktail/mocktail.dart";
 import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_dart_core/src/foundation/models/session_options/session_options_request_mode.dart";
 import "package:sesori_dart_core/src/repositories/models/session_options_repository_result.dart";
 import "package:sesori_dart_core/src/repositories/session_repository.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -19,7 +20,8 @@ void main() {
     final repository = SessionRepository(api: api);
 
     when(() => api.getMessages(sessionId: "session-1", limit: null, before: null)).thenAnswer(
-      (_) async => ApiResponse.success(const MessageWithPartsResponse(messages: <MessageWithParts>[], nextCursor: null)),
+      (_) async =>
+          ApiResponse.success(const MessageWithPartsResponse(messages: <MessageWithParts>[], nextCursor: null)),
     );
     when(() => api.getPendingQuestions(sessionId: "session-1")).thenAnswer(
       (_) async => ApiResponse.success(const PendingQuestionResponse(data: <PendingQuestion>[])),
@@ -51,7 +53,8 @@ void main() {
       (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
     );
     when(
-      () => api.sendMessage(attachments: const [],
+      () => api.sendMessage(
+        attachments: const [],
         sessionId: "session-1",
         text: "hello",
         agent: "build",
@@ -83,7 +86,8 @@ void main() {
     await repository.listAgents(projectId: "project-1", pluginId: "plugin-1");
     await repository.listProviders(projectId: "project-1", pluginId: "plugin-1");
     await repository.listCommands(projectId: "project-1", pluginId: "plugin-1");
-    await repository.sendMessage(attachments: const [],
+    await repository.sendMessage(
+      attachments: const [],
       sessionId: "session-1",
       text: "hello",
       agent: "build",
@@ -109,7 +113,8 @@ void main() {
     verify(() => api.listProviders(projectId: "project-1", pluginId: "plugin-1")).called(1);
     verify(() => api.listCommands(projectId: "project-1", pluginId: "plugin-1")).called(1);
     verify(
-      () => api.sendMessage(attachments: const [],
+      () => api.sendMessage(
+        attachments: const [],
         sessionId: "session-1",
         text: "hello",
         agent: "build",
@@ -183,6 +188,7 @@ void main() {
       isA<LegacySessionOptionsRepositoryAvailable>()
           .having((value) => value.catalog.agents, "agents", const [agent])
           .having((value) => value.catalog.providers, "providers", const [provider])
+          .having((value) => value.catalog.providersConnectedOnly, "connectedOnly", isFalse)
           .having((value) => value.catalog.commands, "commands", [command]),
     );
     verify(() => api.listAgents(projectId: "p1", pluginId: "plugin-1")).called(1);
@@ -190,7 +196,7 @@ void main() {
     verify(() => api.listCommands(projectId: "p1", pluginId: "plugin-1")).called(1);
   });
 
-  test("loadLegacySessionOptions maps each API failure", () async {
+  test("loadLegacySessionOptions preserves successful sources after each API failure", () async {
     for (final failureSource in _LegacyOptionsFailureSource.values) {
       final api = MockSessionApi();
       final repository = SessionRepository(api: api);
@@ -221,7 +227,7 @@ void main() {
 
       expect(
         result,
-        isA<LegacySessionOptionsRepositoryFailure>().having((value) => value.error, "error", error),
+        isA<LegacySessionOptionsRepositoryPartial>().having((value) => value.error, "error", error),
         reason: "failed to map $failureSource",
       );
       verify(() => api.listAgents(projectId: "p1", pluginId: "plugin-1")).called(1);
@@ -239,13 +245,17 @@ void main() {
       commands: CommandListResponse(items: <CommandInfo>[]),
     );
     when(
-      () => api.loadSessionOptions(projectId: "p1", pluginId: "plugin-1", forceRefresh: false),
+      () => api.loadSessionOptions(
+        projectId: "p1",
+        pluginId: "plugin-1",
+        mode: SessionOptionsRequestMode.dynamic,
+      ),
     ).thenAnswer((_) async => ApiResponse.success(response));
 
     final result = await repository.loadSessionOptions(
       projectId: "p1",
       pluginId: "plugin-1",
-      forceRefresh: false,
+      mode: SessionOptionsRequestMode.dynamic,
     );
 
     expect(
@@ -255,6 +265,30 @@ void main() {
           .having((value) => value.catalog.providers, "providers", response.providers.items)
           .having((value) => value.catalog.commands, "commands", response.commands.items),
     );
+  });
+
+  test("loadSessionOptions maps an unsupported aggregate route", () async {
+    final api = MockSessionApi();
+    final repository = SessionRepository(api: api);
+    when(
+      () => api.loadSessionOptions(
+        projectId: "p1",
+        pluginId: "plugin-1",
+        mode: SessionOptionsRequestMode.cacheOnly,
+      ),
+    ).thenAnswer(
+      (_) async => ApiResponse.error(
+        ApiError.nonSuccessCode(errorCode: 404, rawErrorString: null),
+      ),
+    );
+
+    final result = await repository.loadSessionOptions(
+      projectId: "p1",
+      pluginId: "plugin-1",
+      mode: SessionOptionsRequestMode.cacheOnly,
+    );
+
+    expect(result, isA<SessionOptionsRepositoryUnsupported>());
   });
 
   test("loadSessionOptions maps every typed code independently of HTTP status", () async {
@@ -269,7 +303,11 @@ void main() {
       final api = MockSessionApi();
       final repository = SessionRepository(api: api);
       when(
-        () => api.loadSessionOptions(projectId: "p1", pluginId: "plugin-1", forceRefresh: true),
+        () => api.loadSessionOptions(
+          projectId: "p1",
+          pluginId: "plugin-1",
+          mode: SessionOptionsRequestMode.forceRefresh,
+        ),
       ).thenAnswer(
         (_) async => ApiResponse.error(
           ApiError.nonSuccessCode(
@@ -282,7 +320,7 @@ void main() {
       final result = await repository.loadSessionOptions(
         projectId: "p1",
         pluginId: "plugin-1",
-        forceRefresh: true,
+        mode: SessionOptionsRequestMode.forceRefresh,
       );
 
       expect(result.runtimeType, expectedType, reason: "failed to map $code from HTTP $status");
@@ -294,7 +332,11 @@ void main() {
     final api = MockSessionApi();
     final repository = SessionRepository(api: api);
     when(
-      () => api.loadSessionOptions(projectId: "p1", pluginId: "plugin-1", forceRefresh: true),
+      () => api.loadSessionOptions(
+        projectId: "p1",
+        pluginId: "plugin-1",
+        mode: SessionOptionsRequestMode.forceRefresh,
+      ),
     ).thenAnswer(
       (_) async => ApiResponse.error(
         ApiError.nonSuccessCode(
@@ -309,7 +351,7 @@ void main() {
     final result = await repository.loadSessionOptions(
       projectId: "p1",
       pluginId: "plugin-1",
-      forceRefresh: true,
+      mode: SessionOptionsRequestMode.forceRefresh,
     );
 
     expect(result, isA<SessionOptionsRepositoryRefreshFailedRetained>());
@@ -325,13 +367,17 @@ void main() {
       final repository = SessionRepository(api: api);
       final error = ApiError.nonSuccessCode(errorCode: 599, rawErrorString: body);
       when(
-        () => api.loadSessionOptions(projectId: "p1", pluginId: "plugin-1", forceRefresh: false),
+        () => api.loadSessionOptions(
+          projectId: "p1",
+          pluginId: "plugin-1",
+          mode: SessionOptionsRequestMode.dynamic,
+        ),
       ).thenAnswer((_) async => ApiResponse.error(error));
 
       final result = await repository.loadSessionOptions(
         projectId: "p1",
         pluginId: "plugin-1",
-        forceRefresh: false,
+        mode: SessionOptionsRequestMode.dynamic,
       );
 
       expect(result, isA<SessionOptionsRepositoryFailure>().having((value) => value.error, "error", error));

--- a/client/module_core/test/repositories/session_repository_test.dart
+++ b/client/module_core/test/repositories/session_repository_test.dart
@@ -227,13 +227,47 @@ void main() {
 
       expect(
         result,
-        isA<LegacySessionOptionsRepositoryPartial>().having((value) => value.error, "error", error),
+        isA<LegacySessionOptionsRepositoryPartial>()
+            .having((value) => value.errors.single.source.name, "source", failureSource.name)
+            .having((value) => value.errors.single.error, "error", error),
         reason: "failed to map $failureSource",
       );
       verify(() => api.listAgents(projectId: "p1", pluginId: "plugin-1")).called(1);
       verify(() => api.listProviders(projectId: "p1", pluginId: "plugin-1")).called(1);
       verify(() => api.listCommands(projectId: "p1", pluginId: "plugin-1")).called(1);
     }
+  });
+
+  test("loadLegacySessionOptions preserves every source error", () async {
+    final api = MockSessionApi();
+    final repository = SessionRepository(api: api);
+    final agentsError = ApiError.generic();
+    final commandsError = ApiError.generic();
+    when(
+      () => api.listAgents(projectId: "p1", pluginId: "plugin-1"),
+    ).thenAnswer((_) async => ApiResponse<Agents>.error(agentsError));
+    when(
+      () => api.listProviders(projectId: "p1", pluginId: "plugin-1"),
+    ).thenAnswer(
+      (_) async => ApiResponse.success(const ProviderListResponse(connectedOnly: false, items: [])),
+    );
+    when(
+      () => api.listCommands(projectId: "p1", pluginId: "plugin-1"),
+    ).thenAnswer((_) async => ApiResponse<CommandListResponse>.error(commandsError));
+
+    final result = await repository.loadLegacySessionOptions(projectId: "p1", pluginId: "plugin-1");
+
+    expect(
+      result,
+      isA<LegacySessionOptionsRepositoryPartial>().having(
+        (value) => value.errors.map((failure) => (failure.source, failure.error)),
+        "errors",
+        [
+          (LegacySessionOptionSource.agents, agentsError),
+          (LegacySessionOptionSource.commands, commandsError),
+        ],
+      ),
+    );
   });
 
   test("loadSessionOptions maps a successful aggregate", () async {

--- a/client/module_core/test/services/new_session_options_service_test.dart
+++ b/client/module_core/test/services/new_session_options_service_test.dart
@@ -126,6 +126,53 @@ void main() {
       );
     });
 
+    test("partial legacy refresh retains prior data only for failed sources", () async {
+      final previousProviders = _providers().items;
+      final previous = NewSessionOptionsData(
+        agents: [_agent(name: "old-agent")],
+        providers: previousProviders,
+        commands: [_command(name: "old-command")],
+        selectedAgent: "old-agent",
+        selectedAgentModel: const AgentModel(providerID: "provider-a", modelID: "model-a", variant: null),
+        stagedCommand: null,
+        availableVariants: const [],
+      );
+      final catalog = SessionOptionsCatalog(
+        agents: [_agent(name: "new-agent")],
+        providers: const [],
+        providersConnectedOnly: false,
+        commands: [_command(name: "new-command")],
+      );
+      when(
+        () => repository.loadLegacySessionOptions(projectId: "project-1", pluginId: "plugin-1"),
+      ).thenAnswer(
+        (_) async => LegacySessionOptionsRepositoryPartial(
+          catalog: catalog,
+          errors: [
+            LegacySessionOptionError(
+              source: LegacySessionOptionSource.providers,
+              error: ApiError.generic(),
+            ),
+          ],
+        ),
+      );
+
+      final result =
+          await service.load(
+                projectId: "project-1",
+                pluginId: "plugin-1",
+                source: NewSessionOptionsSource.legacy,
+                mode: NewSessionOptionsLoadMode.forcedRefresh,
+                restoredSelection: null,
+                previousOptions: previous,
+              )
+              as NewSessionOptionsLoaded;
+
+      expect(result.options.agents.single.name, "new-agent");
+      expect(result.options.providers, previousProviders);
+      expect(result.options.commands.single.name, "new-command");
+    });
+
     test("legacy repository failure remains a legacy load failure", () async {
       final error = ApiError.generic();
       when(

--- a/client/module_core/test/services/new_session_options_service_test.dart
+++ b/client/module_core/test/services/new_session_options_service_test.dart
@@ -91,11 +91,50 @@ void main() {
       );
     });
 
+    test("partial legacy refresh preserves the available catalog", () async {
+      final error = ApiError.generic();
+      final catalog = SessionOptionsCatalog(
+        agents: const [],
+        providers: _providers().items,
+        providersConnectedOnly: false,
+        commands: [_command(name: "review")],
+      );
+      when(
+        () => repository.loadLegacySessionOptions(projectId: "project-1", pluginId: "plugin-1"),
+      ).thenAnswer(
+        (_) async => LegacySessionOptionsRepositoryPartial(
+          catalog: catalog,
+          errors: [LegacySessionOptionError(source: LegacySessionOptionSource.agents, error: error)],
+        ),
+      );
+
+      final result = await service.load(
+        projectId: "project-1",
+        pluginId: "plugin-1",
+        source: NewSessionOptionsSource.legacy,
+        mode: NewSessionOptionsLoadMode.forcedRefresh,
+        restoredSelection: null,
+        previousOptions: null,
+      );
+
+      expect(
+        result,
+        isA<NewSessionOptionsLoaded>()
+            .having((value) => value.source, "source", NewSessionOptionsSource.legacy)
+            .having((value) => value.options.providers, "providers", catalog.providers)
+            .having((value) => value.options.commands.single.name, "command", "review"),
+      );
+    });
+
     test("legacy repository failure remains a legacy load failure", () async {
       final error = ApiError.generic();
       when(
         () => repository.loadLegacySessionOptions(projectId: "project-1", pluginId: "plugin-1"),
-      ).thenAnswer((_) async => LegacySessionOptionsRepositoryFailure(error: error));
+      ).thenAnswer(
+        (_) async => LegacySessionOptionsRepositoryFailure(
+          errors: [LegacySessionOptionError(source: LegacySessionOptionSource.agents, error: error)],
+        ),
+      );
 
       final result = await service.load(
         projectId: "project-1",

--- a/client/module_core/test/services/new_session_options_service_test.dart
+++ b/client/module_core/test/services/new_session_options_service_test.dart
@@ -1,5 +1,6 @@
 import "package:mocktail/mocktail.dart";
 import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_dart_core/src/foundation/models/session_options/session_options_request_mode.dart";
 import "package:sesori_dart_core/src/repositories/models/session_options_repository_result.dart";
 import "package:sesori_dart_core/src/services/models/new_session_options_source.dart";
 import "package:sesori_dart_core/src/services/models/new_session_selection_intent.dart";
@@ -11,6 +12,8 @@ import "package:test/test.dart";
 import "../helpers/test_helpers.dart";
 
 void main() {
+  setUpAll(registerAllFallbackValues);
+
   group("NewSessionOptionsService", () {
     late MockSessionRepository repository;
     late NewSessionOptionsService service;
@@ -38,7 +41,7 @@ void main() {
         () => repository.loadSessionOptions(
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
-          forceRefresh: any(named: "forceRefresh"),
+          mode: any(named: "mode"),
         ),
       );
       verifyNever(
@@ -53,6 +56,7 @@ void main() {
       final catalog = SessionOptionsCatalog(
         agents: [_agent(name: "build")],
         providers: _providers().items,
+        providersConnectedOnly: false,
         commands: [_command(name: "review")],
       );
       when(
@@ -82,7 +86,7 @@ void main() {
         () => repository.loadSessionOptions(
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
-          forceRefresh: any(named: "forceRefresh"),
+          mode: any(named: "mode"),
         ),
       );
     });
@@ -112,7 +116,7 @@ void main() {
         () => repository.loadSessionOptions(
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
-          forceRefresh: any(named: "forceRefresh"),
+          mode: any(named: "mode"),
         ),
       );
     });
@@ -120,7 +124,11 @@ void main() {
     test("aggregate failure never falls back to the legacy repository", () async {
       final error = ApiError.nonSuccessCode(errorCode: 404, rawErrorString: null);
       when(
-        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", forceRefresh: false),
+        () => repository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "plugin-1",
+          mode: SessionOptionsRequestMode.dynamic,
+        ),
       ).thenAnswer((_) async => SessionOptionsRepositoryProjectNotFound(error: error));
 
       final result = await service.load(
@@ -155,10 +163,15 @@ void main() {
           _agent(name: "review"),
         ],
         providers: _providers().items,
+        providersConnectedOnly: false,
         commands: [_command(name: "review")],
       );
       when(
-        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", forceRefresh: false),
+        () => repository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "plugin-1",
+          mode: SessionOptionsRequestMode.dynamic,
+        ),
       ).thenAnswer((_) async => SessionOptionsRepositoryAvailable(catalog: catalog));
 
       final result =
@@ -193,10 +206,15 @@ void main() {
           ),
         ],
         providers: _providers().items,
+        providersConnectedOnly: false,
         commands: const [],
       );
       when(
-        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", forceRefresh: false),
+        () => repository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "plugin-1",
+          mode: SessionOptionsRequestMode.dynamic,
+        ),
       ).thenAnswer((_) async => SessionOptionsRepositoryAvailable(catalog: catalog));
 
       final result =
@@ -234,10 +252,15 @@ void main() {
       final catalog = SessionOptionsCatalog(
         agents: [_agent(name: "build")],
         providers: _providers().items,
+        providersConnectedOnly: false,
         commands: [refreshedCommand],
       );
       when(
-        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", forceRefresh: false),
+        () => repository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "plugin-1",
+          mode: SessionOptionsRequestMode.dynamic,
+        ),
       ).thenAnswer((_) async => SessionOptionsRepositoryAvailable(catalog: catalog));
 
       final result =
@@ -261,7 +284,11 @@ void main() {
 
     test("maps cache and refresh outcomes without retaining invalid options", () async {
       when(
-        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", forceRefresh: false),
+        () => repository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "plugin-1",
+          mode: SessionOptionsRequestMode.dynamic,
+        ),
       ).thenAnswer((_) async => const SessionOptionsRepositoryCacheUnavailable());
       final unavailable = await service.load(
         projectId: "project-1",
@@ -277,7 +304,7 @@ void main() {
         () => repository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "plugin-1",
-          forceRefresh: false,
+          mode: SessionOptionsRequestMode.dynamic,
         ),
       ).thenAnswer((_) async => const SessionOptionsRepositoryRefreshFailedUnavailable());
       final dynamicFailure = await service.load(
@@ -300,7 +327,11 @@ void main() {
         availableVariants: [],
       );
       when(
-        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", forceRefresh: true),
+        () => repository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "plugin-1",
+          mode: SessionOptionsRequestMode.forceRefresh,
+        ),
       ).thenAnswer((_) async => SessionOptionsRepositoryFailure(error: ApiError.generic()));
       final transientFailure = await service.load(
         projectId: "project-1",
@@ -318,7 +349,11 @@ void main() {
       );
 
       when(
-        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", forceRefresh: true),
+        () => repository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "plugin-1",
+          mode: SessionOptionsRequestMode.forceRefresh,
+        ),
       ).thenAnswer((_) async => const SessionOptionsRepositoryRefreshFailedRetained());
       final retained = await service.load(
         projectId: "project-1",
@@ -338,7 +373,11 @@ void main() {
       );
 
       when(
-        () => repository.loadSessionOptions(projectId: "project-1", pluginId: "plugin-1", forceRefresh: true),
+        () => repository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "plugin-1",
+          mode: SessionOptionsRequestMode.forceRefresh,
+        ),
       ).thenAnswer((_) async => const SessionOptionsRepositoryRefreshFailedUnavailable());
       final cleared = await service.load(
         projectId: "project-1",

--- a/client/module_core/test/services/session_detail_load_service_test.dart
+++ b/client/module_core/test/services/session_detail_load_service_test.dart
@@ -5,6 +5,7 @@ import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_dart_core/src/capabilities/server_connection/models/connection_status.dart";
 import "package:sesori_dart_core/src/capabilities/server_connection/server_connection_config.dart";
+import "package:sesori_dart_core/src/repositories/models/session_options_repository_result.dart";
 import "package:sesori_dart_core/src/repositories/project_repository.dart";
 import "package:sesori_dart_core/src/services/session_detail_load_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -70,15 +71,68 @@ void main() {
       final loaded = result as SessionDetailLoadResultLoaded;
       expect(loaded.isBridgeConnected, isTrue);
       expect(loaded.snapshot.messages, hasLength(1));
+      expect(loaded.snapshot.agents, hasLength(1));
+      expect(loaded.snapshot.providerData?.items, hasLength(1));
       expect(loaded.snapshot.commands, hasLength(1));
       expect(loaded.snapshot.canonicalSessionTitle, "Canonical title");
       expect(loaded.snapshot.isArchived, isFalse);
       expect(loaded.snapshot.supportsPromptAttachments, isTrue);
       verify(() => pluginRepository.listPlugins()).called(1);
-      verify(() => repository.listAgents(projectId: "project-1", pluginId: "plugin-1")).called(1);
-      verify(() => repository.listProviders(projectId: "project-1", pluginId: "plugin-1")).called(1);
-      verify(() => repository.listCommands(projectId: "project-1", pluginId: "plugin-1")).called(1);
+      verify(
+        () => repository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "plugin-1",
+          forceRefresh: false,
+        ),
+      ).called(1);
+      verifyNever(
+        () => repository.listAgents(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
+      );
+      verifyNever(
+        () => repository.listProviders(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
+      );
+      verifyNever(
+        () => repository.listCommands(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
+      );
       verifyNever(() => projectRepository.findSessionContext(sessionId: any(named: "sessionId")));
+    });
+
+    test("falls back to legacy options loading when the aggregate route is unsupported", () async {
+      connectionStatus.add(connectedStatus);
+      _stubRepositorySnapshot(repository: repository);
+      when(
+        () => repository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "plugin-1",
+          forceRefresh: false,
+        ),
+      ).thenAnswer(
+        (_) async => SessionOptionsRepositoryFailure(
+          error: ApiError.nonSuccessCode(errorCode: 404, rawErrorString: null),
+        ),
+      );
+      when(
+        () => repository.loadLegacySessionOptions(projectId: "project-1", pluginId: "plugin-1"),
+      ).thenAnswer(
+        (_) async => LegacySessionOptionsRepositoryAvailable(catalog: _sessionOptionsCatalog()),
+      );
+
+      final result = await service.load(sessionId: "session-1", projectId: "project-1");
+
+      expect(result, isA<SessionDetailLoadResultLoaded>());
+      expect((result as SessionDetailLoadResultLoaded).snapshot.commands, hasLength(1));
+      verify(
+        () => repository.loadLegacySessionOptions(projectId: "project-1", pluginId: "plugin-1"),
+      ).called(1);
     });
 
     test("the initial snapshot requests only the newest page", () async {
@@ -144,7 +198,13 @@ void main() {
       expect(result, isA<SessionDetailLoadResultLoaded>());
       final loaded = result as SessionDetailLoadResultLoaded;
       expect(loaded.snapshot.commands, hasLength(1));
-      verify(() => repository.listCommands(projectId: "project-1", pluginId: "plugin-1")).called(1);
+      verify(
+        () => repository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "plugin-1",
+          forceRefresh: false,
+        ),
+      ).called(1);
     });
 
     test("load uses catalog fallback plugin identity when session detail is unavailable", () async {
@@ -160,17 +220,17 @@ void main() {
           sessionTitle: "Recovered title",
         ),
       );
-      when(
-        () => repository.listCommands(projectId: "project-1", pluginId: "catalog-plugin"),
-      ).thenAnswer((_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])));
-
       final result = await service.load(sessionId: "session-1", projectId: "project-1");
 
       expect(result, isA<SessionDetailLoadResultLoaded>());
       expect((result as SessionDetailLoadResultLoaded).snapshot.canonicalSessionTitle, "Recovered title");
-      verify(() => repository.listAgents(projectId: "project-1", pluginId: "catalog-plugin")).called(1);
-      verify(() => repository.listProviders(projectId: "project-1", pluginId: "catalog-plugin")).called(1);
-      verify(() => repository.listCommands(projectId: "project-1", pluginId: "catalog-plugin")).called(1);
+      verify(
+        () => repository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "catalog-plugin",
+          forceRefresh: false,
+        ),
+      ).called(1);
     });
 
     test("initial load waits for connection readiness and then loads", () async {
@@ -209,7 +269,11 @@ void main() {
     test("connected API failure does not auto-loop", () async {
       connectionStatus.add(connectedStatus);
       when(
-        () => repository.getMessages(sessionId: "session-1", limit: any(named: "limit"), before: any(named: "before")),
+        () => repository.getMessages(
+          sessionId: "session-1",
+          limit: any(named: "limit"),
+          before: any(named: "before"),
+        ),
       ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
       when(
         () => repository.getPendingQuestions(sessionId: "session-1"),
@@ -223,28 +287,31 @@ void main() {
       when(() => repository.getSessionStatuses()).thenAnswer(
         (_) async => ApiResponse.success(const SessionStatusResponse(statuses: <String, SessionStatus>{})),
       );
+      stubSessionRepositoryGetSession(
+        repository: repository,
+        sessionId: "session-1",
+        session: testSession(id: "session-1"),
+      );
       when(
-        () => repository.listAgents(
-          projectId: any(named: "projectId"),
-          pluginId: any(named: "pluginId"),
-        ),
-      ).thenAnswer((_) async => ApiResponse.success(const Agents(agents: <AgentInfo>[])));
-      when(
-        () => repository.listProviders(
-          projectId: any(named: "projectId"),
-          pluginId: any(named: "pluginId"),
+        () => repository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "plugin-1",
+          forceRefresh: false,
         ),
       ).thenAnswer(
-        (_) async => ApiResponse.success(const ProviderListResponse(connectedOnly: false, items: <ProviderInfo>[])),
-      );
-      when(() => repository.listCommands(projectId: "project-1", pluginId: "catalog-plugin")).thenAnswer(
-        (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
+        (_) async => SessionOptionsRepositoryAvailable(catalog: _sessionOptionsCatalog()),
       );
 
       final result = await service.load(sessionId: "session-1", projectId: "project-1");
 
       expect(result, isA<SessionDetailLoadResultFailed>());
-      verify(() => repository.getMessages(sessionId: "session-1", limit: any(named: "limit"), before: any(named: "before"))).called(1);
+      verify(
+        () => repository.getMessages(
+          sessionId: "session-1",
+          limit: any(named: "limit"),
+          before: any(named: "before"),
+        ),
+      ).called(1);
     });
 
     test("load falls back to carried title state when canonical title is unavailable", () async {
@@ -271,8 +338,20 @@ void main() {
       // Providers must be requested with the project resolved from the session
       // context — never the raw blank route id, which backends would normalize
       // to the bridge process CWD (the wrong project).
-      verify(() => repository.listProviders(projectId: "project-1", pluginId: "plugin-1")).called(1);
-      verifyNever(() => repository.listProviders(projectId: "", pluginId: "plugin-1"));
+      verify(
+        () => repository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "plugin-1",
+          forceRefresh: false,
+        ),
+      ).called(1);
+      verifyNever(
+        () => repository.loadSessionOptions(
+          projectId: "",
+          pluginId: "plugin-1",
+          forceRefresh: false,
+        ),
+      );
     });
 
     test("no route project and no session metadata loads empty providers without a request", () async {
@@ -291,21 +370,10 @@ void main() {
       expect(loaded.snapshot.agents, isEmpty);
       expect(loaded.snapshot.commands, isEmpty);
       verifyNever(
-        () => repository.listAgents(
+        () => repository.loadSessionOptions(
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
-        ),
-      );
-      verifyNever(
-        () => repository.listProviders(
-          projectId: any(named: "projectId"),
-          pluginId: any(named: "pluginId"),
-        ),
-      );
-      verifyNever(
-        () => repository.listCommands(
-          projectId: any(named: "projectId"),
-          pluginId: any(named: "pluginId"),
+          forceRefresh: any(named: "forceRefresh"),
         ),
       );
     });
@@ -330,9 +398,10 @@ void main() {
       expect(result, isA<SessionDetailLoadResultLoaded>());
       expect(logs, contains(allOf(contains("Failed to load project session context"), contains(error.toString()))));
       verifyNever(
-        () => repository.listProviders(
+        () => repository.loadSessionOptions(
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
+          forceRefresh: any(named: "forceRefresh"),
         ),
       );
     });
@@ -350,17 +419,19 @@ void main() {
           sessionTitle: "Recovered title",
         ),
       );
-      when(() => repository.listCommands(projectId: "project-1", pluginId: "catalog-plugin")).thenAnswer(
-        (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
-      );
-
       final result = await service.load(sessionId: "session-1", projectId: "");
 
       expect(result, isA<SessionDetailLoadResultLoaded>());
       final loaded = result as SessionDetailLoadResultLoaded;
       expect(loaded.snapshot.projectId, "project-1");
       expect(loaded.snapshot.canonicalSessionTitle, "Recovered title");
-      verify(() => repository.listProviders(projectId: "project-1", pluginId: "catalog-plugin")).called(1);
+      verify(
+        () => repository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "catalog-plugin",
+          forceRefresh: false,
+        ),
+      ).called(1);
     });
   });
 }
@@ -370,7 +441,11 @@ void _stubRepositorySnapshot({
   String? canonicalSessionTitle = "Canonical title",
 }) {
   when(
-    () => repository.getMessages(sessionId: "session-1", limit: any(named: "limit"), before: any(named: "before")),
+    () => repository.getMessages(
+      sessionId: "session-1",
+      limit: any(named: "limit"),
+      before: any(named: "before"),
+    ),
   ).thenAnswer(
     (_) async => ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
   );
@@ -387,71 +462,56 @@ void _stubRepositorySnapshot({
     (_) async => ApiResponse.success(const SessionStatusResponse(statuses: <String, SessionStatus>{})),
   );
   when(
-    () => repository.listAgents(
+    () => repository.loadSessionOptions(
       projectId: any(named: "projectId"),
       pluginId: any(named: "pluginId"),
+      forceRefresh: false,
     ),
   ).thenAnswer(
-    (_) async => ApiResponse.success(
-      const Agents(
-        agents: [
-          AgentInfo(name: "build", description: "build", model: null, mode: AgentMode.primary),
-        ],
-      ),
-    ),
-  );
-  when(
-    () => repository.listProviders(
-      projectId: any(named: "projectId"),
-      pluginId: any(named: "pluginId"),
-    ),
-  ).thenAnswer(
-    (_) async => ApiResponse.success(
-      const ProviderListResponse(
-        connectedOnly: false,
-        items: [
-          ProviderInfo(
-            id: "openai",
-            name: "OpenAI",
-            defaultModelID: "gpt-4.1",
-            models: {
-              "gpt-4.1": ProviderModel(
-                id: "gpt-4.1",
-                providerID: "openai",
-                name: "GPT-4.1",
-                variants: [],
-                family: null,
-                releaseDate: null,
-              ),
-            },
-          ),
-        ],
-      ),
-    ),
-  );
-  when(() => repository.listCommands(projectId: "project-1", pluginId: "plugin-1")).thenAnswer(
-    (_) async => ApiResponse.success(
-      const CommandListResponse(
-        items: <CommandInfo>[
-          CommandInfo(
-            name: "review",
-            template: "/review",
-            hints: <String>[],
-            description: "Review file",
-            agent: null,
-            model: null,
-            provider: null,
-            source: CommandSource.command,
-            subtask: false,
-          ),
-        ],
-      ),
-    ),
+    (_) async => SessionOptionsRepositoryAvailable(catalog: _sessionOptionsCatalog()),
   );
   stubSessionRepositoryGetSession(
     repository: repository,
     sessionId: "session-1",
     session: testSession(id: "session-1", title: canonicalSessionTitle),
+  );
+}
+
+SessionOptionsCatalog _sessionOptionsCatalog() {
+  return SessionOptionsCatalog(
+    agents: const [
+      AgentInfo(name: "build", description: "build", model: null, mode: AgentMode.primary),
+    ],
+    providers: const [
+      ProviderInfo(
+        id: "openai",
+        name: "OpenAI",
+        defaultModelID: "gpt-4.1",
+        models: {
+          "gpt-4.1": ProviderModel(
+            id: "gpt-4.1",
+            providerID: "openai",
+            name: "GPT-4.1",
+            variants: [],
+            family: null,
+            releaseDate: null,
+          ),
+        },
+      ),
+    ],
+    commands: const [
+      CommandInfo(
+        name: "review",
+        template: "/review",
+        hints: <String>[],
+        description: "Review file",
+        agent: null,
+        model: null,
+        provider: null,
+        source: CommandSource.command,
+        subtask: false,
+      ),
+    ],
   );
 }
 

--- a/client/module_core/test/services/session_detail_load_service_test.dart
+++ b/client/module_core/test/services/session_detail_load_service_test.dart
@@ -131,7 +131,7 @@ void main() {
             providersConnectedOnly: catalog.providersConnectedOnly,
             commands: const <CommandInfo>[],
           ),
-          error: error,
+          errors: [LegacySessionOptionError(source: LegacySessionOptionSource.commands, error: error)],
         ),
       );
 

--- a/client/module_core/test/services/session_detail_load_service_test.dart
+++ b/client/module_core/test/services/session_detail_load_service_test.dart
@@ -5,6 +5,7 @@ import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_dart_core/src/capabilities/server_connection/models/connection_status.dart";
 import "package:sesori_dart_core/src/capabilities/server_connection/server_connection_config.dart";
+import "package:sesori_dart_core/src/foundation/models/session_options/session_options_request_mode.dart";
 import "package:sesori_dart_core/src/repositories/models/session_options_repository_result.dart";
 import "package:sesori_dart_core/src/repositories/project_repository.dart";
 import "package:sesori_dart_core/src/services/session_detail_load_service.dart";
@@ -82,7 +83,7 @@ void main() {
         () => repository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "plugin-1",
-          forceRefresh: false,
+          mode: SessionOptionsRequestMode.dynamic,
         ),
       ).called(1);
       verifyNever(
@@ -106,33 +107,41 @@ void main() {
       verifyNever(() => projectRepository.findSessionContext(sessionId: any(named: "sessionId")));
     });
 
-    test("falls back to legacy options loading when the aggregate route is unsupported", () async {
+    test("legacy fallback preserves successful options when one request fails", () async {
       connectionStatus.add(connectedStatus);
       _stubRepositorySnapshot(repository: repository);
+      final catalog = _sessionOptionsCatalog();
       when(
         () => repository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "plugin-1",
-          forceRefresh: false,
+          mode: SessionOptionsRequestMode.dynamic,
         ),
       ).thenAnswer(
-        (_) async => SessionOptionsRepositoryFailure(
-          error: ApiError.nonSuccessCode(errorCode: 404, rawErrorString: null),
-        ),
+        (_) async => const SessionOptionsRepositoryUnsupported(),
       );
+      final error = ApiError.generic();
       when(
         () => repository.loadLegacySessionOptions(projectId: "project-1", pluginId: "plugin-1"),
       ).thenAnswer(
-        (_) async => LegacySessionOptionsRepositoryAvailable(catalog: _sessionOptionsCatalog()),
+        (_) async => LegacySessionOptionsRepositoryPartial(
+          catalog: SessionOptionsCatalog(
+            agents: catalog.agents,
+            providers: catalog.providers,
+            providersConnectedOnly: catalog.providersConnectedOnly,
+            commands: const <CommandInfo>[],
+          ),
+          error: error,
+        ),
       );
 
       final result = await service.load(sessionId: "session-1", projectId: "project-1");
 
       expect(result, isA<SessionDetailLoadResultLoaded>());
-      expect((result as SessionDetailLoadResultLoaded).snapshot.commands, hasLength(1));
-      verify(
-        () => repository.loadLegacySessionOptions(projectId: "project-1", pluginId: "plugin-1"),
-      ).called(1);
+      final snapshot = (result as SessionDetailLoadResultLoaded).snapshot;
+      expect(snapshot.agents, hasLength(1));
+      expect(snapshot.providerData?.items, hasLength(1));
+      expect(snapshot.commands, isEmpty);
     });
 
     test("the initial snapshot requests only the newest page", () async {
@@ -181,7 +190,20 @@ void main() {
       final result = await service.load(sessionId: "session-1", projectId: "project-1");
 
       expect(result, isA<SessionDetailLoadResultLoaded>());
-      expect((result as SessionDetailLoadResultLoaded).snapshot.isArchived, isTrue);
+      final snapshot = (result as SessionDetailLoadResultLoaded).snapshot;
+      expect(snapshot.isArchived, isTrue);
+      expect(snapshot.agents, isEmpty);
+      expect(snapshot.providerData, isNull);
+      expect(snapshot.commands, isEmpty);
+      expect(snapshot.supportsPromptAttachments, isNull);
+      verifyNever(
+        () => repository.loadSessionOptions(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+          mode: any(named: "mode"),
+        ),
+      );
+      verifyNever(pluginRepository.listPlugins);
     });
 
     test("load gives the route project id precedence over session metadata", () async {
@@ -202,7 +224,7 @@ void main() {
         () => repository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "plugin-1",
-          forceRefresh: false,
+          mode: SessionOptionsRequestMode.dynamic,
         ),
       ).called(1);
     });
@@ -228,7 +250,7 @@ void main() {
         () => repository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "catalog-plugin",
-          forceRefresh: false,
+          mode: SessionOptionsRequestMode.dynamic,
         ),
       ).called(1);
     });
@@ -296,7 +318,7 @@ void main() {
         () => repository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "plugin-1",
-          forceRefresh: false,
+          mode: SessionOptionsRequestMode.dynamic,
         ),
       ).thenAnswer(
         (_) async => SessionOptionsRepositoryAvailable(catalog: _sessionOptionsCatalog()),
@@ -342,14 +364,14 @@ void main() {
         () => repository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "plugin-1",
-          forceRefresh: false,
+          mode: SessionOptionsRequestMode.dynamic,
         ),
       ).called(1);
       verifyNever(
         () => repository.loadSessionOptions(
           projectId: "",
           pluginId: "plugin-1",
-          forceRefresh: false,
+          mode: SessionOptionsRequestMode.dynamic,
         ),
       );
     });
@@ -373,7 +395,7 @@ void main() {
         () => repository.loadSessionOptions(
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
-          forceRefresh: any(named: "forceRefresh"),
+          mode: any(named: "mode"),
         ),
       );
     });
@@ -401,7 +423,7 @@ void main() {
         () => repository.loadSessionOptions(
           projectId: any(named: "projectId"),
           pluginId: any(named: "pluginId"),
-          forceRefresh: any(named: "forceRefresh"),
+          mode: any(named: "mode"),
         ),
       );
     });
@@ -429,7 +451,7 @@ void main() {
         () => repository.loadSessionOptions(
           projectId: "project-1",
           pluginId: "catalog-plugin",
-          forceRefresh: false,
+          mode: SessionOptionsRequestMode.dynamic,
         ),
       ).called(1);
     });
@@ -465,7 +487,7 @@ void _stubRepositorySnapshot({
     () => repository.loadSessionOptions(
       projectId: any(named: "projectId"),
       pluginId: any(named: "pluginId"),
-      forceRefresh: false,
+      mode: SessionOptionsRequestMode.dynamic,
     ),
   ).thenAnswer(
     (_) async => SessionOptionsRepositoryAvailable(catalog: _sessionOptionsCatalog()),
@@ -499,6 +521,7 @@ SessionOptionsCatalog _sessionOptionsCatalog() {
         },
       ),
     ],
+    providersConnectedOnly: true,
     commands: const [
       CommandInfo(
         name: "review",


### PR DESCRIPTION
## Complexity

Moderate: localized behavior, but the client API/repository mode contract and legacy compatibility result were made explicit across their in-repository consumers.

## What

- Replace the three session-detail agent, provider, and command requests with one aggregate session-options load.
- Model dynamic, cache-only, and forced-refresh behavior through one `SessionOptionsRequestMode` enum and one API/repository method.
- Keep session detail cache-first with dynamic loading, allowing a cold cache to start the harness and populate composer options.
- Preserve partial legacy option results when an older bridge does not expose `/session/options`.
- Skip option and prompt-attachment metadata loading for archived sessions, where the composer is not rendered.

## Why

Session detail bypassed the bridge's aggregate options cache and always called three harness-bound legacy routes. Opening a session therefore performed redundant requests and could acquire a stopped harness even when valid cached options already existed.

## Risk and test focus

There is no database or wire-shape impact. The user-visible impact is faster session opening and avoidance of unnecessary harness acquisition on aggregate cache hits. A cold aggregate cache may intentionally start the harness. Tests focus on request-mode encoding, aggregate field mapping, project/plugin scoping, archived sessions, partial legacy fallback, and shared session-detail fixtures.

## Expected result

Opening an active session detail uses one cache-first aggregate options request. Cached agents, models/providers, and commands avoid three live legacy calls; a cold cache may populate dynamically. Archived sessions do not request composer metadata. Published older bridges retain their legacy option path without discarding successful partial data.

## Verification

- `dart test` from `client/module_core` (1,033 tests)
- `dart analyze` from `client/module_core`
- `dart analyze` from `client/app`
- `flutter test test/features/new_session/new_session_screen_test.dart` from `client/app` (32 tests)
- Architecture implementation review: approved
