### PR TITLE
⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]

### DIFF
--- a/.plan/active/claude-code-plugin/PLAN.md
+++ b/.plan/active/claude-code-plugin/PLAN.md
@@ -414,14 +414,15 @@ appear on the next enumeration.
 
 **`ClaudeHistoryMapper`** — lives at `lib/src/` for the same reason as the event
 mapper: it consumes a Layer-2 component.
-`ClaudeHistoryMapper({required ClaudeContentMapper content,
-required ClaudeTranscriptCatalogRepository transcripts})`.
+`ClaudeHistoryMapper({required ClaudeContentMapper content})`.
 
-Transcript records to `PluginMessageWithParts`, reusing the content mapper so
-replayed history matches live rendering. A failed load throws
-`PluginOperationException`; it never returns an empty list, because an empty list
-means a genuinely empty thread and the phone renders error-with-retry only for
-throws.
+Loaded transcript records to `PluginMessageWithParts`, reusing the content mapper
+so replayed history matches live rendering. The mapper stays a pure
+transformation; Step 12's `getSessionMessages` implementation reads through
+`ClaudeTranscriptCatalogRepository` and translates a failed load into a
+cause-preserving `PluginOperationException`. It never substitutes an empty list,
+because an empty list means a genuinely empty thread and the phone renders
+error-with-retry only for throws.
 
 **`ClaudePlugin`** — the Layer-4 composition root. It constructs one instance of
 each component and injects every collaborator explicitly:
@@ -760,8 +761,9 @@ the unused-architecture problem avoided in Step 3.
 - Add `ClaudeHistoryMapper` at `lib/src/` — not in `repositories/mappers/`,
   because it consumes the Layer-2 content mapper — producing
   `PluginMessageWithParts` from transcript records through the Step 5 mapper.
-- Prove throw-on-failure rather than empty-list, and record the shape parity that
-  Step 8 must match.
+- Prove the transcript repository throws on read failure rather than returning an
+  empty list; Step 12 translates that failure at the plugin API boundary. Record
+  the shape parity that Step 8 must match.
 - Verify: focused and full package tests, fatal analysis, implementation review.
 
 ### Step 7/17 — Track Tool Lifecycle

--- a/.plan/active/claude-code-plugin/PROTOCOL.md
+++ b/.plan/active/claude-code-plugin/PROTOCOL.md
@@ -495,6 +495,35 @@ Consequences for the catalog and history mapper:
   anomaly worth skipping.
 - `attachment` records are context attachments (memory files and similar), not
   user images.
+- A full-tree shape survey before Step 6 confirmed `attachment.attachment` is
+  always an internal context object: observed variants covered reminders,
+  skills, plans, hooks, directory state, allowed tools, and similar CLI
+  metadata. User-pasted images instead appear as `image` blocks in
+  `user.message.content`, so history replay skips `attachment` records and sends
+  user image blocks through the normal content mapper.
+- One persisted Anthropic assistant message is commonly split across multiple
+  transcript records: grouping by `message.id` found between 1 and 18 records
+  per message. The top-level record `uuid` was distinct from `message.id`, so it
+  is not an assistant message-id fallback.
+
+### History shape contract
+
+Step 6 established the history shape that Step 8 live mapping must match:
+
+- User envelopes use the transcript record `uuid`; assistant envelopes use the
+  nested Anthropic `message.id` and group every record carrying that id.
+- Assistant envelopes stamp `agent: claude`, `providerID: anthropic`, and the
+  nested message model. User envelopes keep `agent` null.
+- `time.created` is the persisted record timestamp in epoch milliseconds and
+  `time.completed` is null. Every part repeats the envelope's session and
+  message ids.
+- Assistant content blocks retain transcript order. A user `tool_result` record
+  updates the matching assistant `tool_use` part by tool id rather than becoming
+  a duplicate user or tool message.
+- Sidechain, meta, transcript-only, system, attachment, unknown, and records
+  without their role's persisted message identity do not produce messages.
+- A missing or unreadable transcript throws `PluginOperationException`; an
+  empty list means the transcript loaded but held no replayable messages.
 
 ### Enumeration cost
 
@@ -515,10 +544,6 @@ mtime — exact for an append-only file.
 Measured end to end on the surveyed tree: 37 ms to enumerate paths, **993 ms to
 scan 180 session headers** inside `Isolate.run`. Acceptable for a refresh-time
 operation off the main isolate; it would not be acceptable on it.
-
-**OPEN:** the `attachment.attachment` payload shape, and whether user-supplied
-images appear as `user` message content blocks or as `attachment` records.
-Resolve before Step 6.
 
 ## 10. Known Traps
 
@@ -551,7 +576,6 @@ Carried into their consuming steps rather than blocking the scaffold:
 | `AskUserQuestion` / `ExitPlanMode` live captures and answer-key shape | Step 9 |
 | Image content-block round-trip | Step 15 |
 | Slash-command dispatch in stream-json | Step 12 |
-| `attachment` record payload shape | Step 6 |
 | Auto-update / telemetry environment variables | Step 13 |
 
 ## 12. Captured Fixtures

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -5,11 +5,13 @@
 - **Plan slug:** `claude-code-plugin`
 - **Implementation base:** `origin/main` at
   `42cd0c72` (Step 5 synchronized with it after Step 4 merged)
-- **Series state:** Steps 1-4/17 merged; Step 5/17 PR open
-- **Current step:** 5/17 — content block mapper
+- **Series state:** Steps 1-4/17 merged; Step 5/17 PR open; Step 6/17 complete
+  locally
+- **Current step:** 6/17 — transcript history replay
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737),
   merged 2026-08-04 as `6d641532`
-- **Next action:** Address review feedback and merge the Step 5 PR
+- **Next action:** Merge the Step 5 PR, synchronize Step 6 with `main`, and open
+  the Step 6 PR
 
 ## Plan Review
 
@@ -49,7 +51,7 @@
 | [x] | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,200-1,500 (recorded overage) | [PR #792](https://github.com/sesori-ai/sesori_apps_monorepo/pull/792) merged 2026-08-09 as `9f139f8f`; see the verification log for the measured diff |
 | [x] | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,200-1,500 (recorded overage) | [PR #794](https://github.com/sesori-ai/sesori_apps_monorepo/pull/794) merged 2026-08-09 as `42cd0c72`; see the verification log for the measured diff |
 | [ ] | 5/17 | `claude-code-plugin-content-mapper` | `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]` | 1,000-1,400 | [PR #795](https://github.com/sesori-ai/sesori_apps_monorepo/pull/795) open against `main` |
-| [ ] | 6/17 | `claude-code-plugin-history-mapper` | `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]` | 1,000-1,400 | Not started |
+| [ ] | 6/17 | `claude-code-plugin-history-mapper` | `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]` | 1,000-1,400 | Implemented and verified locally; awaiting Step 5 merge |
 | [ ] | 7/17 | `claude-code-plugin-tool-tracker` | `⚙️ [claude-code-plugin] feat(claude): track tool lifecycle [step 7/17]` | 1,000-1,400 | Not started |
 | [ ] | 8/17 | `claude-code-plugin-event-mapper` | `🚧 [claude-code-plugin] feat(claude): map stream events to SSE [step 8/17]` | 1,200-1,500 | Not started |
 | [ ] | 9/17 | `claude-code-plugin-approvals` | `🚧 [claude-code-plugin] feat(claude): add permission and question registry [step 9/17]` | 1,100-1,500 | Not started |
@@ -209,11 +211,28 @@
   `ClaudeContentBlockDto` union and `ClaudeContentMapper` for text, thinking,
   tool use/results, inline images, metadata degradation, unknown blocks, exact
   tool-output bounds, and aggregate attachment budgeting. Generated DTO strings
-  do not expose tool or image payloads. `dart analyze --fatal-infos`, all 106
+  do not expose tool or image payloads. `dart analyze --fatal-infos`, all 107
   package tests, codegen, and `git diff --check` pass. Architecture
   implementation review of the Step 5 branch against Step 4 returned
   `APPROVED` with no findings. The measured diff is 1,317 changed lines, within
   the 1,000-1,400 estimate and under the soft cap.
+- Step 6/17 (2026-08-09): added generated nested transcript message DTO fields,
+  repository-normalized sealed user/assistant/unreplayable record variants, an
+  isolate-backed full transcript read, and top-level `ClaudeHistoryMapper`.
+  Replay groups assistant records by nested Anthropic message id, preserves
+  ordered user/assistant identity, timestamps, model and provider fields, folds
+  persisted tool results into their originating tool part, and skips internal
+  context and non-visible records. Missing/read failures retain their cause in a
+  `PluginOperationException` instead of returning an empty history. Full-tree
+  structural surveys resolved the attachment and identity questions without
+  printing paths, ids, prompts, transcript text, or tool payloads.
+
+  `dart analyze --fatal-infos`, all 110 package tests, codegen, and
+  `git diff --check` pass. Two architecture implementation-review passes found
+  one flattened role model and one invalid assistant-id fallback; both findings
+  were applied, and the second review reported no other in-scope violations.
+  The measured production/test diff is 800 changed lines against Step 5, below
+  the 1,000-1,400 estimate and the 1,500-line soft cap.
 
 ## Findings And Plan Deltas
 
@@ -250,6 +269,16 @@
   about 88% but is the user's own prompt text, so it is deliberately not used as
   a title fallback; untitled sessions map to a null title. Revisit only if this
   looks wrong in the Step 16 live run.
+- **2026-08-09 — Attachment records are internal context, while user images are
+  message blocks:** the full-tree shape survey found only reminder, skill, plan,
+  hook, directory, and related CLI context variants under `attachment`; pasted
+  images appeared under `user.message.content`. History therefore skips
+  attachment records and maps image blocks through `ClaudeContentMapper`.
+- **2026-08-09 — Assistant identity is nested and groups records:** one
+  `message.id` grouped 1-18 assistant records and never equaled the top-level
+  record UUID in the survey. History groups on nested `message.id`, never falls
+  back to record UUID, and keeps an identity-less assistant record attributable
+  to the catalog but unreplayable.
 - **2026-08-05 — `always` must filter suggestions, not echo them (from PR #752
   review):** the plan said `always` echoes the request's own
   `permission_suggestions`, treating "what the backend suggested" as a safe

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -220,10 +220,12 @@
   Replay groups assistant records by nested Anthropic message id, preserves
   ordered user/assistant identity, timestamps, model and provider fields, folds
   persisted tool results into their originating tool part, and skips internal
-  context and non-visible records. Missing/read failures retain their cause in a
-  `PluginOperationException` instead of returning an empty history. Full-tree
-  structural surveys resolved the attachment and identity questions without
-  printing paths, ids, prompts, transcript text, or tool payloads.
+  context and non-visible records. The mapper is a pure transformation over
+  loaded records; missing/read failures remain thrown for Step 12 to translate
+  into a cause-preserving `PluginOperationException` at the plugin API boundary,
+  instead of returning an empty history. Full-tree structural surveys resolved
+  the attachment and identity questions without printing paths, ids, prompts,
+  transcript text, or tool payloads.
 
   `dart analyze --fatal-infos`, all 110 package tests, codegen, and
   `git diff --check` pass. Two architecture implementation-review passes found

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -4,14 +4,12 @@
 
 - **Plan slug:** `claude-code-plugin`
 - **Implementation base:** `origin/main` at
-  `42cd0c72` (Step 5 synchronized with it after Step 4 merged)
-- **Series state:** Steps 1-4/17 merged; Step 5/17 PR open; Step 6/17 complete
-  locally
+  `1e40bf02` (Step 6 synchronized with it after Step 5 merged)
+- **Series state:** Steps 1-5/17 merged; Step 6/17 complete and ready for PR
 - **Current step:** 6/17 — transcript history replay
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737),
   merged 2026-08-04 as `6d641532`
-- **Next action:** Merge the Step 5 PR, synchronize Step 6 with `main`, and open
-  the Step 6 PR
+- **Next action:** Open the Step 6 PR, then begin Step 7 locally
 
 ## Plan Review
 
@@ -50,8 +48,8 @@
 | [x] | 2/17 | `claude-code-plugin-protocol-scaffold` | `⚙️ [claude-code-plugin] feat(claude): ground protocol and scaffold package [step 2/17]` | 1,100-1,500 | [PR #752](https://github.com/sesori-ai/sesori_apps_monorepo/pull/752) merged 2026-08-09 as `7e460bc9`; see the verification log for the measured diff |
 | [x] | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,200-1,500 (recorded overage) | [PR #792](https://github.com/sesori-ai/sesori_apps_monorepo/pull/792) merged 2026-08-09 as `9f139f8f`; see the verification log for the measured diff |
 | [x] | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,200-1,500 (recorded overage) | [PR #794](https://github.com/sesori-ai/sesori_apps_monorepo/pull/794) merged 2026-08-09 as `42cd0c72`; see the verification log for the measured diff |
-| [ ] | 5/17 | `claude-code-plugin-content-mapper` | `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]` | 1,000-1,400 | [PR #795](https://github.com/sesori-ai/sesori_apps_monorepo/pull/795) open against `main` |
-| [ ] | 6/17 | `claude-code-plugin-history-mapper` | `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]` | 1,000-1,400 | Implemented and verified locally; awaiting Step 5 merge |
+| [x] | 5/17 | `claude-code-plugin-content-mapper` | `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]` | 1,000-1,400 | [PR #795](https://github.com/sesori-ai/sesori_apps_monorepo/pull/795) merged 2026-08-10 as `cfb8cc45` |
+| [ ] | 6/17 | `claude-code-plugin-history-mapper` | `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]` | 1,000-1,400 | Implemented, verified, and synchronized with merged Step 5; ready for PR |
 | [ ] | 7/17 | `claude-code-plugin-tool-tracker` | `⚙️ [claude-code-plugin] feat(claude): track tool lifecycle [step 7/17]` | 1,000-1,400 | Not started |
 | [ ] | 8/17 | `claude-code-plugin-event-mapper` | `🚧 [claude-code-plugin] feat(claude): map stream events to SSE [step 8/17]` | 1,200-1,500 | Not started |
 | [ ] | 9/17 | `claude-code-plugin-approvals` | `🚧 [claude-code-plugin] feat(claude): add permission and question registry [step 9/17]` | 1,100-1,500 | Not started |

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -5,11 +5,11 @@
 - **Plan slug:** `claude-code-plugin`
 - **Implementation base:** `origin/main` at
   `1e40bf02` (Step 6 synchronized with it after Step 5 merged)
-- **Series state:** Steps 1-5/17 merged; Step 6/17 complete and ready for PR
+- **Series state:** Steps 1-5/17 merged; Step 6/17 PR open
 - **Current step:** 6/17 — transcript history replay
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737),
   merged 2026-08-04 as `6d641532`
-- **Next action:** Open the Step 6 PR, then begin Step 7 locally
+- **Next action:** Merge the Step 6 PR while Step 7 begins locally
 
 ## Plan Review
 
@@ -49,7 +49,7 @@
 | [x] | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,200-1,500 (recorded overage) | [PR #792](https://github.com/sesori-ai/sesori_apps_monorepo/pull/792) merged 2026-08-09 as `9f139f8f`; see the verification log for the measured diff |
 | [x] | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,200-1,500 (recorded overage) | [PR #794](https://github.com/sesori-ai/sesori_apps_monorepo/pull/794) merged 2026-08-09 as `42cd0c72`; see the verification log for the measured diff |
 | [x] | 5/17 | `claude-code-plugin-content-mapper` | `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]` | 1,000-1,400 | [PR #795](https://github.com/sesori-ai/sesori_apps_monorepo/pull/795) merged 2026-08-10 as `cfb8cc45` |
-| [ ] | 6/17 | `claude-code-plugin-history-mapper` | `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]` | 1,000-1,400 | Implemented, verified, and synchronized with merged Step 5; ready for PR |
+| [ ] | 6/17 | `claude-code-plugin-history-mapper` | `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]` | 1,000-1,400 | [PR #799](https://github.com/sesori-ai/sesori_apps_monorepo/pull/799) open against `main` |
 | [ ] | 7/17 | `claude-code-plugin-tool-tracker` | `⚙️ [claude-code-plugin] feat(claude): track tool lifecycle [step 7/17]` | 1,000-1,400 | Not started |
 | [ ] | 8/17 | `claude-code-plugin-event-mapper` | `🚧 [claude-code-plugin] feat(claude): map stream events to SSE [step 8/17]` | 1,200-1,500 | Not started |
 | [ ] | 9/17 | `claude-code-plugin-approvals` | `🚧 [claude-code-plugin] feat(claude): add permission and question registry [step 9/17]` | 1,100-1,500 | Not started |

--- a/bridge/sesori_plugin_claude/lib/claude_plugin.dart
+++ b/bridge/sesori_plugin_claude/lib/claude_plugin.dart
@@ -16,6 +16,7 @@ export "src/api/claude_transcript_api.dart";
 export "src/api/models/claude_content_block_dto.dart";
 export "src/api/models/claude_stream_message.dart";
 export "src/api/models/claude_transcript_record_dto.dart";
+export "src/claude_history_mapper.dart";
 export "src/models/claude_effort_level.dart";
 export "src/models/claude_permission_mode.dart";
 export "src/repositories/claude_transcript_catalog_repository.dart";

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_transcript_record_dto.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_transcript_record_dto.dart
@@ -12,7 +12,7 @@ typedef ClaudeTranscriptLineDto = ({ClaudeTranscriptRecordDto record, Map<String
 /// lets generated JSON decoding absorb missing and wrong-typed catalog fields;
 /// the repository maps it into the smaller sealed variants the catalog actually
 /// consumes.
-@Freezed(fromJson: true, toJson: false)
+@Freezed(fromJson: true, toJson: false, toStringOverride: false)
 sealed class ClaudeTranscriptRecordDto with _$ClaudeTranscriptRecordDto {
   const factory ClaudeTranscriptRecordDto({
     @JsonKey(fromJson: _stringOrNull) required String? type,
@@ -23,13 +23,32 @@ sealed class ClaudeTranscriptRecordDto with _$ClaudeTranscriptRecordDto {
     @JsonKey(fromJson: _stringOrNull) required String? gitBranch,
     @JsonKey(fromJson: _stringOrNull) required String? version,
     @JsonKey(fromJson: _stringOrNull) required String? aiTitle,
+    @JsonKey(fromJson: _stringOrNull) required String? uuid,
+    @JsonKey(fromJson: _boolOrNull) required bool? isMeta,
+    @JsonKey(fromJson: _boolOrNull) required bool? isVisibleInTranscriptOnly,
+    @JsonKey(fromJson: _messageOrNull) required ClaudeTranscriptMessageDto? message,
   }) = _ClaudeTranscriptRecordDto;
 
   factory ClaudeTranscriptRecordDto.fromJson(Map<String, dynamic> json) => _$ClaudeTranscriptRecordDtoFromJson(json);
 }
 
+/// The nested Anthropic message persisted by `user` and `assistant` records.
+@Freezed(fromJson: true, toJson: false, toStringOverride: false)
+sealed class ClaudeTranscriptMessageDto with _$ClaudeTranscriptMessageDto {
+  const factory ClaudeTranscriptMessageDto({
+    @JsonKey(fromJson: _stringOrNull) required String? id,
+    @JsonKey(fromJson: _stringOrNull) required String? model,
+    required Object? content,
+  }) = _ClaudeTranscriptMessageDto;
+
+  factory ClaudeTranscriptMessageDto.fromJson(Map<String, dynamic> json) => _$ClaudeTranscriptMessageDtoFromJson(json);
+}
+
 String? _stringOrNull(Object? value) => value is String ? value : null;
 
 bool? _boolOrNull(Object? value) => value is bool ? value : null;
+
+ClaudeTranscriptMessageDto? _messageOrNull(Object? value) =>
+    value is Map ? ClaudeTranscriptMessageDto.fromJson(value.cast<String, dynamic>()) : null;
 
 DateTime? _timestampOrNull(Object? value) => value is String ? DateTime.tryParse(value)?.toUtc() : null;

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_transcript_record_dto.freezed.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_transcript_record_dto.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ClaudeTranscriptRecordDto {
 
-@JsonKey(fromJson: _stringOrNull) String? get type;@JsonKey(fromJson: _stringOrNull) String? get sessionId;@JsonKey(fromJson: _stringOrNull) String? get cwd;@JsonKey(fromJson: _timestampOrNull) DateTime? get timestamp;@JsonKey(fromJson: _boolOrNull) bool? get isSidechain;@JsonKey(fromJson: _stringOrNull) String? get gitBranch;@JsonKey(fromJson: _stringOrNull) String? get version;@JsonKey(fromJson: _stringOrNull) String? get aiTitle;
+@JsonKey(fromJson: _stringOrNull) String? get type;@JsonKey(fromJson: _stringOrNull) String? get sessionId;@JsonKey(fromJson: _stringOrNull) String? get cwd;@JsonKey(fromJson: _timestampOrNull) DateTime? get timestamp;@JsonKey(fromJson: _boolOrNull) bool? get isSidechain;@JsonKey(fromJson: _stringOrNull) String? get gitBranch;@JsonKey(fromJson: _stringOrNull) String? get version;@JsonKey(fromJson: _stringOrNull) String? get aiTitle;@JsonKey(fromJson: _stringOrNull) String? get uuid;@JsonKey(fromJson: _boolOrNull) bool? get isMeta;@JsonKey(fromJson: _boolOrNull) bool? get isVisibleInTranscriptOnly;@JsonKey(fromJson: _messageOrNull) ClaudeTranscriptMessageDto? get message;
 /// Create a copy of ClaudeTranscriptRecordDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,17 +26,13 @@ $ClaudeTranscriptRecordDtoCopyWith<ClaudeTranscriptRecordDto> get copyWith => _$
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ClaudeTranscriptRecordDto&&(identical(other.type, type) || other.type == type)&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.isSidechain, isSidechain) || other.isSidechain == isSidechain)&&(identical(other.gitBranch, gitBranch) || other.gitBranch == gitBranch)&&(identical(other.version, version) || other.version == version)&&(identical(other.aiTitle, aiTitle) || other.aiTitle == aiTitle));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ClaudeTranscriptRecordDto&&(identical(other.type, type) || other.type == type)&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.isSidechain, isSidechain) || other.isSidechain == isSidechain)&&(identical(other.gitBranch, gitBranch) || other.gitBranch == gitBranch)&&(identical(other.version, version) || other.version == version)&&(identical(other.aiTitle, aiTitle) || other.aiTitle == aiTitle)&&(identical(other.uuid, uuid) || other.uuid == uuid)&&(identical(other.isMeta, isMeta) || other.isMeta == isMeta)&&(identical(other.isVisibleInTranscriptOnly, isVisibleInTranscriptOnly) || other.isVisibleInTranscriptOnly == isVisibleInTranscriptOnly)&&(identical(other.message, message) || other.message == message));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,type,sessionId,cwd,timestamp,isSidechain,gitBranch,version,aiTitle);
+int get hashCode => Object.hash(runtimeType,type,sessionId,cwd,timestamp,isSidechain,gitBranch,version,aiTitle,uuid,isMeta,isVisibleInTranscriptOnly,message);
 
-@override
-String toString() {
-  return 'ClaudeTranscriptRecordDto(type: $type, sessionId: $sessionId, cwd: $cwd, timestamp: $timestamp, isSidechain: $isSidechain, gitBranch: $gitBranch, version: $version, aiTitle: $aiTitle)';
-}
 
 
 }
@@ -46,11 +42,11 @@ abstract mixin class $ClaudeTranscriptRecordDtoCopyWith<$Res>  {
   factory $ClaudeTranscriptRecordDtoCopyWith(ClaudeTranscriptRecordDto value, $Res Function(ClaudeTranscriptRecordDto) _then) = _$ClaudeTranscriptRecordDtoCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(fromJson: _stringOrNull) String? type,@JsonKey(fromJson: _stringOrNull) String? sessionId,@JsonKey(fromJson: _stringOrNull) String? cwd,@JsonKey(fromJson: _timestampOrNull) DateTime? timestamp,@JsonKey(fromJson: _boolOrNull) bool? isSidechain,@JsonKey(fromJson: _stringOrNull) String? gitBranch,@JsonKey(fromJson: _stringOrNull) String? version,@JsonKey(fromJson: _stringOrNull) String? aiTitle
+@JsonKey(fromJson: _stringOrNull) String? type,@JsonKey(fromJson: _stringOrNull) String? sessionId,@JsonKey(fromJson: _stringOrNull) String? cwd,@JsonKey(fromJson: _timestampOrNull) DateTime? timestamp,@JsonKey(fromJson: _boolOrNull) bool? isSidechain,@JsonKey(fromJson: _stringOrNull) String? gitBranch,@JsonKey(fromJson: _stringOrNull) String? version,@JsonKey(fromJson: _stringOrNull) String? aiTitle,@JsonKey(fromJson: _stringOrNull) String? uuid,@JsonKey(fromJson: _boolOrNull) bool? isMeta,@JsonKey(fromJson: _boolOrNull) bool? isVisibleInTranscriptOnly,@JsonKey(fromJson: _messageOrNull) ClaudeTranscriptMessageDto? message
 });
 
 
-
+$ClaudeTranscriptMessageDtoCopyWith<$Res>? get message;
 
 }
 /// @nodoc
@@ -63,7 +59,7 @@ class _$ClaudeTranscriptRecordDtoCopyWithImpl<$Res>
 
 /// Create a copy of ClaudeTranscriptRecordDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? type = freezed,Object? sessionId = freezed,Object? cwd = freezed,Object? timestamp = freezed,Object? isSidechain = freezed,Object? gitBranch = freezed,Object? version = freezed,Object? aiTitle = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? type = freezed,Object? sessionId = freezed,Object? cwd = freezed,Object? timestamp = freezed,Object? isSidechain = freezed,Object? gitBranch = freezed,Object? version = freezed,Object? aiTitle = freezed,Object? uuid = freezed,Object? isMeta = freezed,Object? isVisibleInTranscriptOnly = freezed,Object? message = freezed,}) {
   return _then(_self.copyWith(
 type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
 as String?,sessionId: freezed == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
@@ -73,10 +69,26 @@ as DateTime?,isSidechain: freezed == isSidechain ? _self.isSidechain : isSidecha
 as bool?,gitBranch: freezed == gitBranch ? _self.gitBranch : gitBranch // ignore: cast_nullable_to_non_nullable
 as String?,version: freezed == version ? _self.version : version // ignore: cast_nullable_to_non_nullable
 as String?,aiTitle: freezed == aiTitle ? _self.aiTitle : aiTitle // ignore: cast_nullable_to_non_nullable
-as String?,
+as String?,uuid: freezed == uuid ? _self.uuid : uuid // ignore: cast_nullable_to_non_nullable
+as String?,isMeta: freezed == isMeta ? _self.isMeta : isMeta // ignore: cast_nullable_to_non_nullable
+as bool?,isVisibleInTranscriptOnly: freezed == isVisibleInTranscriptOnly ? _self.isVisibleInTranscriptOnly : isVisibleInTranscriptOnly // ignore: cast_nullable_to_non_nullable
+as bool?,message: freezed == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as ClaudeTranscriptMessageDto?,
   ));
 }
+/// Create a copy of ClaudeTranscriptRecordDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ClaudeTranscriptMessageDtoCopyWith<$Res>? get message {
+    if (_self.message == null) {
+    return null;
+  }
 
+  return $ClaudeTranscriptMessageDtoCopyWith<$Res>(_self.message!, (value) {
+    return _then(_self.copyWith(message: value));
+  });
+}
 }
 
 
@@ -85,7 +97,7 @@ as String?,
 @JsonSerializable(createToJson: false)
 
 class _ClaudeTranscriptRecordDto implements ClaudeTranscriptRecordDto {
-  const _ClaudeTranscriptRecordDto({@JsonKey(fromJson: _stringOrNull) required this.type, @JsonKey(fromJson: _stringOrNull) required this.sessionId, @JsonKey(fromJson: _stringOrNull) required this.cwd, @JsonKey(fromJson: _timestampOrNull) required this.timestamp, @JsonKey(fromJson: _boolOrNull) required this.isSidechain, @JsonKey(fromJson: _stringOrNull) required this.gitBranch, @JsonKey(fromJson: _stringOrNull) required this.version, @JsonKey(fromJson: _stringOrNull) required this.aiTitle});
+  const _ClaudeTranscriptRecordDto({@JsonKey(fromJson: _stringOrNull) required this.type, @JsonKey(fromJson: _stringOrNull) required this.sessionId, @JsonKey(fromJson: _stringOrNull) required this.cwd, @JsonKey(fromJson: _timestampOrNull) required this.timestamp, @JsonKey(fromJson: _boolOrNull) required this.isSidechain, @JsonKey(fromJson: _stringOrNull) required this.gitBranch, @JsonKey(fromJson: _stringOrNull) required this.version, @JsonKey(fromJson: _stringOrNull) required this.aiTitle, @JsonKey(fromJson: _stringOrNull) required this.uuid, @JsonKey(fromJson: _boolOrNull) required this.isMeta, @JsonKey(fromJson: _boolOrNull) required this.isVisibleInTranscriptOnly, @JsonKey(fromJson: _messageOrNull) required this.message});
   factory _ClaudeTranscriptRecordDto.fromJson(Map<String, dynamic> json) => _$ClaudeTranscriptRecordDtoFromJson(json);
 
 @override@JsonKey(fromJson: _stringOrNull) final  String? type;
@@ -96,6 +108,10 @@ class _ClaudeTranscriptRecordDto implements ClaudeTranscriptRecordDto {
 @override@JsonKey(fromJson: _stringOrNull) final  String? gitBranch;
 @override@JsonKey(fromJson: _stringOrNull) final  String? version;
 @override@JsonKey(fromJson: _stringOrNull) final  String? aiTitle;
+@override@JsonKey(fromJson: _stringOrNull) final  String? uuid;
+@override@JsonKey(fromJson: _boolOrNull) final  bool? isMeta;
+@override@JsonKey(fromJson: _boolOrNull) final  bool? isVisibleInTranscriptOnly;
+@override@JsonKey(fromJson: _messageOrNull) final  ClaudeTranscriptMessageDto? message;
 
 /// Create a copy of ClaudeTranscriptRecordDto
 /// with the given fields replaced by the non-null parameter values.
@@ -107,17 +123,13 @@ _$ClaudeTranscriptRecordDtoCopyWith<_ClaudeTranscriptRecordDto> get copyWith => 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ClaudeTranscriptRecordDto&&(identical(other.type, type) || other.type == type)&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.isSidechain, isSidechain) || other.isSidechain == isSidechain)&&(identical(other.gitBranch, gitBranch) || other.gitBranch == gitBranch)&&(identical(other.version, version) || other.version == version)&&(identical(other.aiTitle, aiTitle) || other.aiTitle == aiTitle));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ClaudeTranscriptRecordDto&&(identical(other.type, type) || other.type == type)&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.isSidechain, isSidechain) || other.isSidechain == isSidechain)&&(identical(other.gitBranch, gitBranch) || other.gitBranch == gitBranch)&&(identical(other.version, version) || other.version == version)&&(identical(other.aiTitle, aiTitle) || other.aiTitle == aiTitle)&&(identical(other.uuid, uuid) || other.uuid == uuid)&&(identical(other.isMeta, isMeta) || other.isMeta == isMeta)&&(identical(other.isVisibleInTranscriptOnly, isVisibleInTranscriptOnly) || other.isVisibleInTranscriptOnly == isVisibleInTranscriptOnly)&&(identical(other.message, message) || other.message == message));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,type,sessionId,cwd,timestamp,isSidechain,gitBranch,version,aiTitle);
+int get hashCode => Object.hash(runtimeType,type,sessionId,cwd,timestamp,isSidechain,gitBranch,version,aiTitle,uuid,isMeta,isVisibleInTranscriptOnly,message);
 
-@override
-String toString() {
-  return 'ClaudeTranscriptRecordDto(type: $type, sessionId: $sessionId, cwd: $cwd, timestamp: $timestamp, isSidechain: $isSidechain, gitBranch: $gitBranch, version: $version, aiTitle: $aiTitle)';
-}
 
 
 }
@@ -127,11 +139,11 @@ abstract mixin class _$ClaudeTranscriptRecordDtoCopyWith<$Res> implements $Claud
   factory _$ClaudeTranscriptRecordDtoCopyWith(_ClaudeTranscriptRecordDto value, $Res Function(_ClaudeTranscriptRecordDto) _then) = __$ClaudeTranscriptRecordDtoCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(fromJson: _stringOrNull) String? type,@JsonKey(fromJson: _stringOrNull) String? sessionId,@JsonKey(fromJson: _stringOrNull) String? cwd,@JsonKey(fromJson: _timestampOrNull) DateTime? timestamp,@JsonKey(fromJson: _boolOrNull) bool? isSidechain,@JsonKey(fromJson: _stringOrNull) String? gitBranch,@JsonKey(fromJson: _stringOrNull) String? version,@JsonKey(fromJson: _stringOrNull) String? aiTitle
+@JsonKey(fromJson: _stringOrNull) String? type,@JsonKey(fromJson: _stringOrNull) String? sessionId,@JsonKey(fromJson: _stringOrNull) String? cwd,@JsonKey(fromJson: _timestampOrNull) DateTime? timestamp,@JsonKey(fromJson: _boolOrNull) bool? isSidechain,@JsonKey(fromJson: _stringOrNull) String? gitBranch,@JsonKey(fromJson: _stringOrNull) String? version,@JsonKey(fromJson: _stringOrNull) String? aiTitle,@JsonKey(fromJson: _stringOrNull) String? uuid,@JsonKey(fromJson: _boolOrNull) bool? isMeta,@JsonKey(fromJson: _boolOrNull) bool? isVisibleInTranscriptOnly,@JsonKey(fromJson: _messageOrNull) ClaudeTranscriptMessageDto? message
 });
 
 
-
+@override $ClaudeTranscriptMessageDtoCopyWith<$Res>? get message;
 
 }
 /// @nodoc
@@ -144,7 +156,7 @@ class __$ClaudeTranscriptRecordDtoCopyWithImpl<$Res>
 
 /// Create a copy of ClaudeTranscriptRecordDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? type = freezed,Object? sessionId = freezed,Object? cwd = freezed,Object? timestamp = freezed,Object? isSidechain = freezed,Object? gitBranch = freezed,Object? version = freezed,Object? aiTitle = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? type = freezed,Object? sessionId = freezed,Object? cwd = freezed,Object? timestamp = freezed,Object? isSidechain = freezed,Object? gitBranch = freezed,Object? version = freezed,Object? aiTitle = freezed,Object? uuid = freezed,Object? isMeta = freezed,Object? isVisibleInTranscriptOnly = freezed,Object? message = freezed,}) {
   return _then(_ClaudeTranscriptRecordDto(
 type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
 as String?,sessionId: freezed == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
@@ -154,7 +166,148 @@ as DateTime?,isSidechain: freezed == isSidechain ? _self.isSidechain : isSidecha
 as bool?,gitBranch: freezed == gitBranch ? _self.gitBranch : gitBranch // ignore: cast_nullable_to_non_nullable
 as String?,version: freezed == version ? _self.version : version // ignore: cast_nullable_to_non_nullable
 as String?,aiTitle: freezed == aiTitle ? _self.aiTitle : aiTitle // ignore: cast_nullable_to_non_nullable
-as String?,
+as String?,uuid: freezed == uuid ? _self.uuid : uuid // ignore: cast_nullable_to_non_nullable
+as String?,isMeta: freezed == isMeta ? _self.isMeta : isMeta // ignore: cast_nullable_to_non_nullable
+as bool?,isVisibleInTranscriptOnly: freezed == isVisibleInTranscriptOnly ? _self.isVisibleInTranscriptOnly : isVisibleInTranscriptOnly // ignore: cast_nullable_to_non_nullable
+as bool?,message: freezed == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as ClaudeTranscriptMessageDto?,
+  ));
+}
+
+/// Create a copy of ClaudeTranscriptRecordDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ClaudeTranscriptMessageDtoCopyWith<$Res>? get message {
+    if (_self.message == null) {
+    return null;
+  }
+
+  return $ClaudeTranscriptMessageDtoCopyWith<$Res>(_self.message!, (value) {
+    return _then(_self.copyWith(message: value));
+  });
+}
+}
+
+
+/// @nodoc
+mixin _$ClaudeTranscriptMessageDto {
+
+@JsonKey(fromJson: _stringOrNull) String? get id;@JsonKey(fromJson: _stringOrNull) String? get model; Object? get content;
+/// Create a copy of ClaudeTranscriptMessageDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ClaudeTranscriptMessageDtoCopyWith<ClaudeTranscriptMessageDto> get copyWith => _$ClaudeTranscriptMessageDtoCopyWithImpl<ClaudeTranscriptMessageDto>(this as ClaudeTranscriptMessageDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ClaudeTranscriptMessageDto&&(identical(other.id, id) || other.id == id)&&(identical(other.model, model) || other.model == model)&&const DeepCollectionEquality().equals(other.content, content));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,model,const DeepCollectionEquality().hash(content));
+
+
+
+}
+
+/// @nodoc
+abstract mixin class $ClaudeTranscriptMessageDtoCopyWith<$Res>  {
+  factory $ClaudeTranscriptMessageDtoCopyWith(ClaudeTranscriptMessageDto value, $Res Function(ClaudeTranscriptMessageDto) _then) = _$ClaudeTranscriptMessageDtoCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(fromJson: _stringOrNull) String? id,@JsonKey(fromJson: _stringOrNull) String? model, Object? content
+});
+
+
+
+
+}
+/// @nodoc
+class _$ClaudeTranscriptMessageDtoCopyWithImpl<$Res>
+    implements $ClaudeTranscriptMessageDtoCopyWith<$Res> {
+  _$ClaudeTranscriptMessageDtoCopyWithImpl(this._self, this._then);
+
+  final ClaudeTranscriptMessageDto _self;
+  final $Res Function(ClaudeTranscriptMessageDto) _then;
+
+/// Create a copy of ClaudeTranscriptMessageDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? model = freezed,Object? content = freezed,}) {
+  return _then(_self.copyWith(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
+as String?,content: freezed == content ? _self.content : content ,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _ClaudeTranscriptMessageDto implements ClaudeTranscriptMessageDto {
+  const _ClaudeTranscriptMessageDto({@JsonKey(fromJson: _stringOrNull) required this.id, @JsonKey(fromJson: _stringOrNull) required this.model, required this.content});
+  factory _ClaudeTranscriptMessageDto.fromJson(Map<String, dynamic> json) => _$ClaudeTranscriptMessageDtoFromJson(json);
+
+@override@JsonKey(fromJson: _stringOrNull) final  String? id;
+@override@JsonKey(fromJson: _stringOrNull) final  String? model;
+@override final  Object? content;
+
+/// Create a copy of ClaudeTranscriptMessageDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ClaudeTranscriptMessageDtoCopyWith<_ClaudeTranscriptMessageDto> get copyWith => __$ClaudeTranscriptMessageDtoCopyWithImpl<_ClaudeTranscriptMessageDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ClaudeTranscriptMessageDto&&(identical(other.id, id) || other.id == id)&&(identical(other.model, model) || other.model == model)&&const DeepCollectionEquality().equals(other.content, content));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,model,const DeepCollectionEquality().hash(content));
+
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ClaudeTranscriptMessageDtoCopyWith<$Res> implements $ClaudeTranscriptMessageDtoCopyWith<$Res> {
+  factory _$ClaudeTranscriptMessageDtoCopyWith(_ClaudeTranscriptMessageDto value, $Res Function(_ClaudeTranscriptMessageDto) _then) = __$ClaudeTranscriptMessageDtoCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(fromJson: _stringOrNull) String? id,@JsonKey(fromJson: _stringOrNull) String? model, Object? content
+});
+
+
+
+
+}
+/// @nodoc
+class __$ClaudeTranscriptMessageDtoCopyWithImpl<$Res>
+    implements _$ClaudeTranscriptMessageDtoCopyWith<$Res> {
+  __$ClaudeTranscriptMessageDtoCopyWithImpl(this._self, this._then);
+
+  final _ClaudeTranscriptMessageDto _self;
+  final $Res Function(_ClaudeTranscriptMessageDto) _then;
+
+/// Create a copy of ClaudeTranscriptMessageDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? model = freezed,Object? content = freezed,}) {
+  return _then(_ClaudeTranscriptMessageDto(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
+as String?,content: freezed == content ? _self.content : content ,
   ));
 }
 

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_transcript_record_dto.g.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_transcript_record_dto.g.dart
@@ -16,4 +16,15 @@ _ClaudeTranscriptRecordDto _$ClaudeTranscriptRecordDtoFromJson(Map json) =>
       gitBranch: _stringOrNull(json['gitBranch']),
       version: _stringOrNull(json['version']),
       aiTitle: _stringOrNull(json['aiTitle']),
+      uuid: _stringOrNull(json['uuid']),
+      isMeta: _boolOrNull(json['isMeta']),
+      isVisibleInTranscriptOnly: _boolOrNull(json['isVisibleInTranscriptOnly']),
+      message: _messageOrNull(json['message']),
+    );
+
+_ClaudeTranscriptMessageDto _$ClaudeTranscriptMessageDtoFromJson(Map json) =>
+    _ClaudeTranscriptMessageDto(
+      id: _stringOrNull(json['id']),
+      model: _stringOrNull(json['model']),
+      content: json['content'],
     );

--- a/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
@@ -36,36 +36,31 @@ final class ClaudeHistoryMapper {
     final assistantsByToolId = <String, _AssistantHistoryMessage>{};
 
     for (final record in records) {
-      if (record is! ClaudeTranscriptMessageRecord ||
-          record.isSidechain == true ||
-          (record.sessionId != null && record.sessionId != sessionId) ||
-          record.isMeta == true ||
-          record.isVisibleInTranscriptOnly == true) {
-        continue;
-      }
-
-      final blocks = _content.map(content: record.content);
-      switch (record.kind) {
-        case ClaudeTranscriptMessageKind.assistant:
-          final messageId = _nonEmpty(record.messageId) ?? _nonEmpty(record.uuid);
-          if (messageId == null) continue;
-          final assistant = assistantsByMessageId.putIfAbsent(messageId, () {
+      switch (record) {
+        case ClaudeTranscriptAssistantRecord():
+          if (_skipRecord(record: record, sessionId: sessionId)) continue;
+          final blocks = _content.map(content: record.content);
+          final assistant = assistantsByMessageId.putIfAbsent(record.id, () {
             final created = _AssistantHistoryMessage(
-              id: messageId,
+              id: record.id,
               timestamp: record.timestamp,
-              model: _nonEmpty(record.model),
+              model: record.model,
             );
             entries.add(created);
             return created;
           });
           assistant.content.add(record.content);
-          assistant.model ??= _nonEmpty(record.model);
+          assistant.model ??= record.model;
           for (final block in blocks) {
             if (block case ClaudeMappedToolUseContentBlock(:final id)) {
               assistantsByToolId[id] = assistant;
             }
           }
-        case ClaudeTranscriptMessageKind.user:
+        case ClaudeTranscriptUserRecord():
+          if (_skipRecord(record: record, sessionId: sessionId) || record.isMeta || record.isVisibleInTranscriptOnly) {
+            continue;
+          }
+          final blocks = _content.map(content: record.content);
           final results = [
             for (final block in blocks)
               if (block is ClaudeMappedToolResultContentBlock) block,
@@ -78,19 +73,17 @@ final class ClaudeHistoryMapper {
             continue;
           }
 
-          final messageId = _nonEmpty(record.uuid);
-          if (messageId == null) continue;
           final parts = _content.mapParts(
             content: record.content,
             sessionId: sessionId,
-            messageId: messageId,
+            messageId: record.id,
           );
           if (!parts.any((part) => part.type.isVisible)) continue;
           entries.add(
             _UserHistoryMessage(
               message: PluginMessageWithParts(
                 info: PluginMessage.user(
-                  id: messageId,
+                  id: record.id,
                   sessionID: sessionId,
                   agent: null,
                   time: _messageTime(record.timestamp),
@@ -99,6 +92,11 @@ final class ClaudeHistoryMapper {
               ),
             ),
           );
+        case ClaudeTranscriptContextRecord() ||
+            ClaudeTranscriptUnreplayableMessageRecord() ||
+            ClaudeTranscriptTitleRecord() ||
+            ClaudeTranscriptUnknownRecord():
+          continue;
       }
     }
 
@@ -157,6 +155,9 @@ final class ClaudeHistoryMapper {
   }
 }
 
+bool _skipRecord({required ClaudeTranscriptAttributedRecord record, required String sessionId}) =>
+    record.isSidechain == true || (record.sessionId != null && record.sessionId != sessionId);
+
 sealed class _ClaudeHistoryEntry {
   const _ClaudeHistoryEntry();
 }
@@ -178,8 +179,3 @@ final class _AssistantHistoryMessage extends _ClaudeHistoryEntry {
 
 PluginMessageTime? _messageTime(DateTime? timestamp) =>
     timestamp == null ? null : PluginMessageTime(created: timestamp.millisecondsSinceEpoch, completed: null);
-
-String? _nonEmpty(String? value) {
-  final trimmed = value?.trim();
-  return trimmed == null || trimmed.isEmpty ? null : trimmed;
-}

--- a/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
@@ -1,6 +1,5 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
-import "repositories/claude_transcript_catalog_repository.dart";
 import "repositories/mappers/claude_content_mapper.dart";
 import "repositories/models/claude_transcript_record.dart";
 
@@ -9,28 +8,14 @@ import "repositories/models/claude_transcript_record.dart";
 final class ClaudeHistoryMapper {
   const ClaudeHistoryMapper({
     required ClaudeContentMapper content,
-    required ClaudeTranscriptCatalogRepository transcripts,
-  }) : _content = content,
-       _transcripts = transcripts;
+  }) : _content = content;
 
   final ClaudeContentMapper _content;
-  final ClaudeTranscriptCatalogRepository _transcripts;
 
-  Future<List<PluginMessageWithParts>> map({required String sessionId}) async {
-    final List<ClaudeTranscriptRecord> records;
-    try {
-      records = await _transcripts.readTranscriptRecordsInIsolate(sessionId: sessionId);
-    } on Object catch (error, stackTrace) {
-      Error.throwWithStackTrace(
-        PluginOperationException(
-          "read Claude session transcript",
-          message: "history read for $sessionId failed",
-          cause: error,
-        ),
-        stackTrace,
-      );
-    }
-
+  List<PluginMessageWithParts> map({
+    required String sessionId,
+    required List<ClaudeTranscriptRecord> records,
+  }) {
     final entries = <_ClaudeHistoryEntry>[];
     final assistantsByMessageId = <String, _AssistantHistoryMessage>{};
     final assistantsByToolId = <String, _AssistantHistoryMessage>{};

--- a/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
@@ -1,0 +1,185 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "repositories/claude_transcript_catalog_repository.dart";
+import "repositories/mappers/claude_content_mapper.dart";
+import "repositories/models/claude_transcript_record.dart";
+
+/// Maps Claude's persisted transcript into the same neutral message shapes used
+/// by live stream events.
+final class ClaudeHistoryMapper {
+  const ClaudeHistoryMapper({
+    required ClaudeContentMapper content,
+    required ClaudeTranscriptCatalogRepository transcripts,
+  }) : _content = content,
+       _transcripts = transcripts;
+
+  final ClaudeContentMapper _content;
+  final ClaudeTranscriptCatalogRepository _transcripts;
+
+  Future<List<PluginMessageWithParts>> map({required String sessionId}) async {
+    final List<ClaudeTranscriptRecord> records;
+    try {
+      records = await _transcripts.readTranscriptRecordsInIsolate(sessionId: sessionId);
+    } on Object catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        PluginOperationException(
+          "read Claude session transcript",
+          message: "history read for $sessionId failed",
+          cause: error,
+        ),
+        stackTrace,
+      );
+    }
+
+    final entries = <_ClaudeHistoryEntry>[];
+    final assistantsByMessageId = <String, _AssistantHistoryMessage>{};
+    final assistantsByToolId = <String, _AssistantHistoryMessage>{};
+
+    for (final record in records) {
+      if (record is! ClaudeTranscriptMessageRecord ||
+          record.isSidechain == true ||
+          (record.sessionId != null && record.sessionId != sessionId) ||
+          record.isMeta == true ||
+          record.isVisibleInTranscriptOnly == true) {
+        continue;
+      }
+
+      final blocks = _content.map(content: record.content);
+      switch (record.kind) {
+        case ClaudeTranscriptMessageKind.assistant:
+          final messageId = _nonEmpty(record.messageId) ?? _nonEmpty(record.uuid);
+          if (messageId == null) continue;
+          final assistant = assistantsByMessageId.putIfAbsent(messageId, () {
+            final created = _AssistantHistoryMessage(
+              id: messageId,
+              timestamp: record.timestamp,
+              model: _nonEmpty(record.model),
+            );
+            entries.add(created);
+            return created;
+          });
+          assistant.content.add(record.content);
+          assistant.model ??= _nonEmpty(record.model);
+          for (final block in blocks) {
+            if (block case ClaudeMappedToolUseContentBlock(:final id)) {
+              assistantsByToolId[id] = assistant;
+            }
+          }
+        case ClaudeTranscriptMessageKind.user:
+          final results = [
+            for (final block in blocks)
+              if (block is ClaudeMappedToolResultContentBlock) block,
+          ];
+          if (results.isNotEmpty) {
+            final targets = {
+              for (final result in results) ?assistantsByToolId[result.toolUseId],
+            };
+            if (targets.length == 1) targets.single.content.add(record.content);
+            continue;
+          }
+
+          final messageId = _nonEmpty(record.uuid);
+          if (messageId == null) continue;
+          final parts = _content.mapParts(
+            content: record.content,
+            sessionId: sessionId,
+            messageId: messageId,
+          );
+          if (!parts.any((part) => part.type.isVisible)) continue;
+          entries.add(
+            _UserHistoryMessage(
+              message: PluginMessageWithParts(
+                info: PluginMessage.user(
+                  id: messageId,
+                  sessionID: sessionId,
+                  agent: null,
+                  time: _messageTime(record.timestamp),
+                ),
+                parts: parts,
+              ),
+            ),
+          );
+      }
+    }
+
+    final messages = <PluginMessageWithParts>[];
+    for (final entry in entries) {
+      switch (entry) {
+        case _UserHistoryMessage(:final message):
+          messages.add(message);
+        case _AssistantHistoryMessage():
+          final message = _buildAssistant(entry: entry, sessionId: sessionId);
+          if (message != null) messages.add(message);
+      }
+    }
+    return messages;
+  }
+
+  PluginMessageWithParts? _buildAssistant({
+    required _AssistantHistoryMessage entry,
+    required String sessionId,
+  }) {
+    final mapped = _content.mapParts(
+      content: entry.content,
+      sessionId: sessionId,
+      messageId: entry.id,
+    );
+    final parts = <PluginMessagePart>[];
+    final toolIndexById = <String, int>{};
+    for (final part in mapped) {
+      if (part.type != PluginMessagePartType.tool) {
+        parts.add(part);
+        continue;
+      }
+      final existingIndex = toolIndexById[part.id];
+      if (existingIndex == null) {
+        toolIndexById[part.id] = parts.length;
+        parts.add(part);
+        continue;
+      }
+      final state = part.state;
+      if (state != null && state.status != PluginToolStatus.pending) {
+        parts[existingIndex] = parts[existingIndex].copyWith(state: state);
+      }
+    }
+    if (!parts.any((part) => part.type.isVisible)) return null;
+    return PluginMessageWithParts(
+      info: PluginMessage.assistant(
+        id: entry.id,
+        sessionID: sessionId,
+        agent: "claude",
+        modelID: entry.model,
+        providerID: "anthropic",
+        time: _messageTime(entry.timestamp),
+      ),
+      parts: List.unmodifiable(parts),
+    );
+  }
+}
+
+sealed class _ClaudeHistoryEntry {
+  const _ClaudeHistoryEntry();
+}
+
+final class _UserHistoryMessage extends _ClaudeHistoryEntry {
+  const _UserHistoryMessage({required this.message});
+
+  final PluginMessageWithParts message;
+}
+
+final class _AssistantHistoryMessage extends _ClaudeHistoryEntry {
+  _AssistantHistoryMessage({required this.id, required this.timestamp, required this.model});
+
+  final String id;
+  final DateTime? timestamp;
+  String? model;
+  final List<Object?> content = [];
+}
+
+PluginMessageTime? _messageTime(DateTime? timestamp) =>
+    timestamp == null ? null : PluginMessageTime(created: timestamp.millisecondsSinceEpoch, completed: null);
+
+String? _nonEmpty(String? value) {
+  final trimmed = value?.trim();
+  return trimmed == null || trimmed.isEmpty ? null : trimmed;
+}

--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_transcript_catalog_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_transcript_catalog_repository.dart
@@ -228,24 +228,43 @@ ClaudeTranscriptRecord _mapTranscriptRecord(ClaudeTranscriptLineDto line) {
     return ClaudeTranscriptUnknownRecord(type: null, sessionId: dto.sessionId, raw: line.raw);
   }
 
-  final messageKind = ClaudeTranscriptMessageKind.tryParse(type);
-  if (messageKind != null) {
-    return ClaudeTranscriptMessageRecord(
-      kind: messageKind,
-      uuid: dto.uuid,
-      messageId: dto.message?.id,
-      model: dto.message?.model,
-      content: dto.message?.content,
-      isMeta: dto.isMeta,
-      isVisibleInTranscriptOnly: dto.isVisibleInTranscriptOnly,
-      cwd: dto.cwd,
-      timestamp: dto.timestamp,
-      isSidechain: dto.isSidechain,
-      gitBranch: dto.gitBranch,
-      version: dto.version,
-      sessionId: dto.sessionId,
-      raw: line.raw,
-    );
+  if (type == ClaudeTranscriptUserRecord.wireType) {
+    final id = _nonEmpty(dto.uuid);
+    if (id != null) {
+      return ClaudeTranscriptUserRecord(
+        id: id,
+        content: dto.message?.content,
+        isMeta: dto.isMeta ?? false,
+        isVisibleInTranscriptOnly: dto.isVisibleInTranscriptOnly ?? false,
+        cwd: dto.cwd,
+        timestamp: dto.timestamp,
+        isSidechain: dto.isSidechain,
+        gitBranch: dto.gitBranch,
+        version: dto.version,
+        sessionId: dto.sessionId,
+        raw: line.raw,
+      );
+    }
+    return _unreplayableMessageRecord(line: line);
+  }
+
+  if (type == ClaudeTranscriptAssistantRecord.wireType) {
+    final id = _nonEmpty(dto.message?.id) ?? _nonEmpty(dto.uuid);
+    if (id != null) {
+      return ClaudeTranscriptAssistantRecord(
+        id: id,
+        model: _nonEmpty(dto.message?.model),
+        content: dto.message?.content,
+        cwd: dto.cwd,
+        timestamp: dto.timestamp,
+        isSidechain: dto.isSidechain,
+        gitBranch: dto.gitBranch,
+        version: dto.version,
+        sessionId: dto.sessionId,
+        raw: line.raw,
+      );
+    }
+    return _unreplayableMessageRecord(line: line);
   }
 
   final contextKind = ClaudeTranscriptContextKind.tryParse(type);
@@ -270,4 +289,17 @@ ClaudeTranscriptRecord _mapTranscriptRecord(ClaudeTranscriptLineDto line) {
   }
 
   return ClaudeTranscriptUnknownRecord(type: type, sessionId: dto.sessionId, raw: line.raw);
+}
+
+ClaudeTranscriptUnreplayableMessageRecord _unreplayableMessageRecord({required ClaudeTranscriptLineDto line}) {
+  final dto = line.record;
+  return ClaudeTranscriptUnreplayableMessageRecord(
+    cwd: dto.cwd,
+    timestamp: dto.timestamp,
+    isSidechain: dto.isSidechain,
+    gitBranch: dto.gitBranch,
+    version: dto.version,
+    sessionId: dto.sessionId,
+    raw: line.raw,
+  );
 }

--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_transcript_catalog_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_transcript_catalog_repository.dart
@@ -46,6 +46,18 @@ class ClaudeTranscriptCatalogRepository {
   /// Scanning hundreds of transcripts must not stall the bridge's event loop.
   Future<List<ClaudeSessionRecord>> listSessionRecordsInIsolate() => Isolate.run(listSessionRecords);
 
+  /// Reads and maps every record for one session.
+  List<ClaudeTranscriptRecord> readTranscriptRecords({required String sessionId}) {
+    final path = findTranscriptPath(sessionId: sessionId);
+    if (path == null) throw StateError("Claude transcript not found for session $sessionId");
+    return _transcriptApi.readTranscript(transcriptPath: path).map(_mapTranscriptRecord).toList(growable: false);
+  }
+
+  /// Full transcript reads can reach tens of megabytes, so keep them off the
+  /// bridge event loop.
+  Future<List<ClaudeTranscriptRecord>> readTranscriptRecordsInIsolate({required String sessionId}) =>
+      Isolate.run(() => readTranscriptRecords(sessionId: sessionId));
+
   /// Every session, for bridge-derived project discovery.
   ///
   /// [knownDirectories] is part of the discovery contract so a plugin can keep
@@ -133,7 +145,7 @@ class ClaudeTranscriptCatalogRepository {
     for (final line in header) {
       final record = _mapTranscriptRecord(line);
       switch (record) {
-        case ClaudeTranscriptContentRecord():
+        case ClaudeTranscriptAttributedRecord():
           // A subagent's records never describe the parent session.
           if (record.isSidechain ?? false) continue;
           // The filename is authoritative. A present record id is only a
@@ -216,10 +228,30 @@ ClaudeTranscriptRecord _mapTranscriptRecord(ClaudeTranscriptLineDto line) {
     return ClaudeTranscriptUnknownRecord(type: null, sessionId: dto.sessionId, raw: line.raw);
   }
 
-  final kind = ClaudeTranscriptContentKind.tryParse(type);
-  if (kind != null) {
-    return ClaudeTranscriptContentRecord(
-      kind: kind,
+  final messageKind = ClaudeTranscriptMessageKind.tryParse(type);
+  if (messageKind != null) {
+    return ClaudeTranscriptMessageRecord(
+      kind: messageKind,
+      uuid: dto.uuid,
+      messageId: dto.message?.id,
+      model: dto.message?.model,
+      content: dto.message?.content,
+      isMeta: dto.isMeta,
+      isVisibleInTranscriptOnly: dto.isVisibleInTranscriptOnly,
+      cwd: dto.cwd,
+      timestamp: dto.timestamp,
+      isSidechain: dto.isSidechain,
+      gitBranch: dto.gitBranch,
+      version: dto.version,
+      sessionId: dto.sessionId,
+      raw: line.raw,
+    );
+  }
+
+  final contextKind = ClaudeTranscriptContextKind.tryParse(type);
+  if (contextKind != null) {
+    return ClaudeTranscriptContextRecord(
+      kind: contextKind,
       cwd: dto.cwd,
       timestamp: dto.timestamp,
       isSidechain: dto.isSidechain,

--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_transcript_catalog_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_transcript_catalog_repository.dart
@@ -249,7 +249,7 @@ ClaudeTranscriptRecord _mapTranscriptRecord(ClaudeTranscriptLineDto line) {
   }
 
   if (type == ClaudeTranscriptAssistantRecord.wireType) {
-    final id = _nonEmpty(dto.message?.id) ?? _nonEmpty(dto.uuid);
+    final id = _nonEmpty(dto.message?.id);
     if (id != null) {
       return ClaudeTranscriptAssistantRecord(
         id: id,

--- a/bridge/sesori_plugin_claude/lib/src/repositories/models/claude_transcript_record.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/models/claude_transcript_record.dart
@@ -26,23 +26,6 @@ sealed class ClaudeTranscriptRecord {
   final Map<String, Object?> raw;
 }
 
-/// A transcript role that produces a user-visible message.
-enum ClaudeTranscriptMessageKind {
-  user(wireType: "user"),
-  assistant(wireType: "assistant");
-
-  const ClaudeTranscriptMessageKind({required this.wireType});
-
-  final String wireType;
-
-  static ClaudeTranscriptMessageKind? tryParse(String raw) {
-    for (final kind in values) {
-      if (kind.wireType == raw) return kind;
-    }
-    return null;
-  }
-}
-
 /// A non-message record that still attributes a transcript to a project.
 enum ClaudeTranscriptContextKind {
   attachment(wireType: "attachment"),
@@ -89,13 +72,10 @@ sealed class ClaudeTranscriptAttributedRecord extends ClaudeTranscriptRecord {
   final String? version;
 }
 
-/// A persisted user or assistant message record.
-final class ClaudeTranscriptMessageRecord extends ClaudeTranscriptAttributedRecord {
-  const ClaudeTranscriptMessageRecord({
-    required this.kind,
-    required this.uuid,
-    required this.messageId,
-    required this.model,
+/// A persisted user message.
+final class ClaudeTranscriptUserRecord extends ClaudeTranscriptAttributedRecord {
+  const ClaudeTranscriptUserRecord({
+    required this.id,
     required this.content,
     required this.isMeta,
     required this.isVisibleInTranscriptOnly,
@@ -108,13 +88,53 @@ final class ClaudeTranscriptMessageRecord extends ClaudeTranscriptAttributedReco
     required super.raw,
   });
 
-  final ClaudeTranscriptMessageKind kind;
-  final String? uuid;
-  final String? messageId;
+  static const String wireType = "user";
+
+  final String id;
+  final Object? content;
+  final bool isMeta;
+  final bool isVisibleInTranscriptOnly;
+}
+
+/// A persisted assistant message block.
+///
+/// Claude can split one Anthropic message across several transcript records;
+/// records carrying the same [id] belong to one plugin message.
+final class ClaudeTranscriptAssistantRecord extends ClaudeTranscriptAttributedRecord {
+  const ClaudeTranscriptAssistantRecord({
+    required this.id,
+    required this.model,
+    required this.content,
+    required super.cwd,
+    required super.timestamp,
+    required super.isSidechain,
+    required super.gitBranch,
+    required super.version,
+    required super.sessionId,
+    required super.raw,
+  });
+
+  static const String wireType = "assistant";
+
+  final String id;
   final String? model;
   final Object? content;
-  final bool? isMeta;
-  final bool? isVisibleInTranscriptOnly;
+}
+
+/// A user or assistant record with no usable persisted message identity.
+///
+/// It can still attribute the transcript to a project, but cannot be replayed
+/// as a plugin message without inventing an id.
+final class ClaudeTranscriptUnreplayableMessageRecord extends ClaudeTranscriptAttributedRecord {
+  const ClaudeTranscriptUnreplayableMessageRecord({
+    required super.cwd,
+    required super.timestamp,
+    required super.isSidechain,
+    required super.gitBranch,
+    required super.version,
+    required super.sessionId,
+    required super.raw,
+  });
 }
 
 /// Internal context attached by Claude rather than a user-visible message.

--- a/bridge/sesori_plugin_claude/lib/src/repositories/models/claude_transcript_record.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/models/claude_transcript_record.dart
@@ -9,9 +9,6 @@
 /// capture had recorded six, so absorbing the unrecognized rest is the primary
 /// requirement rather than modelling each one as a generated union variant.
 ///
-/// Only the fields the session catalog consumes are modelled here. Message
-/// content lands with the history mapper that reads it.
-///
 /// Verified against Claude CLI 2.1.221 — see
 /// `.plan/active/claude-code-plugin/PROTOCOL.md` section 9.
 sealed class ClaudeTranscriptRecord {
@@ -29,22 +26,16 @@ sealed class ClaudeTranscriptRecord {
   final Map<String, Object?> raw;
 }
 
-/// The record types that carry a working directory and a wall-clock time.
-///
-/// These four behave identically for the catalog, so they are one variant with
-/// a closed scalar kind rather than four variants with identical fields. They
-/// diverge once message content is modelled; the variant splits then.
-enum ClaudeTranscriptContentKind {
+/// A transcript role that produces a user-visible message.
+enum ClaudeTranscriptMessageKind {
   user(wireType: "user"),
-  assistant(wireType: "assistant"),
-  attachment(wireType: "attachment"),
-  system(wireType: "system");
+  assistant(wireType: "assistant");
 
-  const ClaudeTranscriptContentKind({required this.wireType});
+  const ClaudeTranscriptMessageKind({required this.wireType});
 
   final String wireType;
 
-  static ClaudeTranscriptContentKind? tryParse(String raw) {
+  static ClaudeTranscriptMessageKind? tryParse(String raw) {
     for (final kind in values) {
       if (kind.wireType == raw) return kind;
     }
@@ -52,10 +43,26 @@ enum ClaudeTranscriptContentKind {
   }
 }
 
-/// A `user`, `assistant`, `attachment`, or `system` record.
-final class ClaudeTranscriptContentRecord extends ClaudeTranscriptRecord {
-  const ClaudeTranscriptContentRecord({
-    required this.kind,
+/// A non-message record that still attributes a transcript to a project.
+enum ClaudeTranscriptContextKind {
+  attachment(wireType: "attachment"),
+  system(wireType: "system");
+
+  const ClaudeTranscriptContextKind({required this.wireType});
+
+  final String wireType;
+
+  static ClaudeTranscriptContextKind? tryParse(String raw) {
+    for (final kind in values) {
+      if (kind.wireType == raw) return kind;
+    }
+    return null;
+  }
+}
+
+/// Common project and timestamp fields on message and context records.
+sealed class ClaudeTranscriptAttributedRecord extends ClaudeTranscriptRecord {
+  const ClaudeTranscriptAttributedRecord({
     required this.cwd,
     required this.timestamp,
     required this.isSidechain,
@@ -64,8 +71,6 @@ final class ClaudeTranscriptContentRecord extends ClaudeTranscriptRecord {
     required super.sessionId,
     required super.raw,
   });
-
-  final ClaudeTranscriptContentKind kind;
 
   /// The directory the session ran in. This is what the bridge groups sessions
   /// by, so the munged transcript directory name is never un-munged.
@@ -84,14 +89,57 @@ final class ClaudeTranscriptContentRecord extends ClaudeTranscriptRecord {
   final String? version;
 }
 
+/// A persisted user or assistant message record.
+final class ClaudeTranscriptMessageRecord extends ClaudeTranscriptAttributedRecord {
+  const ClaudeTranscriptMessageRecord({
+    required this.kind,
+    required this.uuid,
+    required this.messageId,
+    required this.model,
+    required this.content,
+    required this.isMeta,
+    required this.isVisibleInTranscriptOnly,
+    required super.cwd,
+    required super.timestamp,
+    required super.isSidechain,
+    required super.gitBranch,
+    required super.version,
+    required super.sessionId,
+    required super.raw,
+  });
+
+  final ClaudeTranscriptMessageKind kind;
+  final String? uuid;
+  final String? messageId;
+  final String? model;
+  final Object? content;
+  final bool? isMeta;
+  final bool? isVisibleInTranscriptOnly;
+}
+
+/// Internal context attached by Claude rather than a user-visible message.
+final class ClaudeTranscriptContextRecord extends ClaudeTranscriptAttributedRecord {
+  const ClaudeTranscriptContextRecord({
+    required this.kind,
+    required super.cwd,
+    required super.timestamp,
+    required super.isSidechain,
+    required super.gitBranch,
+    required super.version,
+    required super.sessionId,
+    required super.raw,
+  });
+
+  final ClaudeTranscriptContextKind kind;
+}
+
 /// An `ai-title` record — the session title, written by the CLI itself.
 final class ClaudeTranscriptTitleRecord extends ClaudeTranscriptRecord {
   const ClaudeTranscriptTitleRecord({required this.title, required super.sessionId, required super.raw});
 
   static const String wireType = "ai-title";
 
-  /// Non-empty by construction; [ClaudeTranscriptRecord.parse] rejects a blank
-  /// title rather than storing one.
+  /// Non-empty by construction; the repository rejects a blank title.
   final String title;
 }
 

--- a/bridge/sesori_plugin_claude/test/claude_history_mapper_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_history_mapper_test.dart
@@ -19,10 +19,7 @@ void main() {
       transcripts = ClaudeTranscriptCatalogRepository(
         transcriptApi: ClaudeTranscriptApi(environment: {"CLAUDE_CONFIG_DIR": temp.path}),
       );
-      mapper = ClaudeHistoryMapper(
-        content: const ClaudeContentMapper(),
-        transcripts: transcripts,
-      );
+      mapper = const ClaudeHistoryMapper(content: ClaudeContentMapper());
     });
 
     tearDown(() => temp.deleteSync(recursive: true));
@@ -91,7 +88,10 @@ void main() {
         ],
       );
 
-      final messages = await mapper.map(sessionId: _sessionId);
+      final messages = mapper.map(
+        sessionId: _sessionId,
+        records: await transcripts.readTranscriptRecordsInIsolate(sessionId: _sessionId),
+      );
 
       expect(messages, hasLength(2));
       final user = messages[0];
@@ -158,17 +158,19 @@ void main() {
         ],
       );
 
-      expect(await mapper.map(sessionId: _sessionId), isEmpty);
+      expect(
+        mapper.map(
+          sessionId: _sessionId,
+          records: await transcripts.readTranscriptRecordsInIsolate(sessionId: _sessionId),
+        ),
+        isEmpty,
+      );
     });
 
-    test("throws a plugin operation failure when the transcript cannot load", () async {
+    test("does not convert a missing transcript into empty history", () async {
       expect(
-        () => mapper.map(sessionId: _sessionId),
-        throwsA(
-          isA<PluginOperationException>()
-              .having((error) => error.operation, "operation", "read Claude session transcript")
-              .having((error) => error.cause, "cause", isA<StateError>()),
-        ),
+        () => transcripts.readTranscriptRecordsInIsolate(sessionId: _sessionId),
+        throwsA(isA<StateError>()),
       );
     });
   });

--- a/bridge/sesori_plugin_claude/test/claude_history_mapper_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_history_mapper_test.dart
@@ -1,0 +1,196 @@
+import "dart:convert";
+import "dart:io";
+
+import "package:claude_plugin/claude_plugin.dart";
+import "package:path/path.dart" as p;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+const _sessionId = "11111111-2222-4333-8444-555555555555";
+
+void main() {
+  group("ClaudeHistoryMapper", () {
+    late Directory temp;
+    late ClaudeTranscriptCatalogRepository transcripts;
+    late ClaudeHistoryMapper mapper;
+
+    setUp(() {
+      temp = Directory.systemTemp.createTempSync("claude-history-mapper-");
+      transcripts = ClaudeTranscriptCatalogRepository(
+        transcriptApi: ClaudeTranscriptApi(environment: {"CLAUDE_CONFIG_DIR": temp.path}),
+      );
+      mapper = ClaudeHistoryMapper(
+        content: const ClaudeContentMapper(),
+        transcripts: transcripts,
+      );
+    });
+
+    tearDown(() => temp.deleteSync(recursive: true));
+
+    test("replays ordered user and grouped assistant messages", () async {
+      _writeTranscript(
+        temp: temp,
+        records: [
+          _messageRecord(
+            type: "user",
+            uuid: "user-uuid",
+            timestamp: "2026-08-09T10:00:00Z",
+            content: [
+              {"type": "text", "text": "question"},
+              {
+                "type": "image",
+                "source": {"type": "base64", "media_type": "image/png", "data": "AA=="},
+              },
+            ],
+          ),
+          _messageRecord(
+            type: "assistant",
+            uuid: "assistant-record-1",
+            timestamp: "2026-08-09T10:00:01Z",
+            messageId: "assistant-message-id",
+            model: "claude-test-model",
+            content: [
+              {"type": "thinking", "thinking": "reasoning", "signature": "opaque"},
+            ],
+          ),
+          _messageRecord(
+            type: "assistant",
+            uuid: "assistant-record-2",
+            timestamp: "2026-08-09T10:00:02Z",
+            messageId: "assistant-message-id",
+            model: "claude-test-model",
+            content: [
+              {"type": "tool_use", "id": "toolu-1", "name": "Read", "input": <String, Object?>{}},
+            ],
+          ),
+          _messageRecord(
+            type: "assistant",
+            uuid: "assistant-record-3",
+            timestamp: "2026-08-09T10:00:03Z",
+            messageId: "assistant-message-id",
+            model: "claude-test-model",
+            content: [
+              {"type": "text", "text": "answer"},
+            ],
+          ),
+          _messageRecord(
+            type: "user",
+            uuid: "tool-result-record",
+            timestamp: "2026-08-09T10:00:04Z",
+            content: [
+              {"type": "tool_result", "tool_use_id": "toolu-1", "content": "file contents"},
+            ],
+          ),
+          {
+            "type": "attachment",
+            "sessionId": _sessionId,
+            "uuid": "context-record",
+            "timestamp": "2026-08-09T10:00:05Z",
+            "attachment": {"type": "directory", "content": "private context"},
+          },
+        ],
+      );
+
+      final messages = await mapper.map(sessionId: _sessionId);
+
+      expect(messages, hasLength(2));
+      final user = messages[0];
+      expect(user.info, isA<PluginMessageUser>());
+      expect(user.info.id, "user-uuid");
+      expect(user.info.time?.created, DateTime.parse("2026-08-09T10:00:00Z").millisecondsSinceEpoch);
+      expect(user.parts.map((part) => part.type), [PluginMessagePartType.text, PluginMessagePartType.file]);
+
+      final assistant = messages[1];
+      expect(assistant.info, isA<PluginMessageAssistant>());
+      expect(assistant.info.id, "assistant-message-id");
+      expect((assistant.info as PluginMessageAssistant).agent, "claude");
+      expect((assistant.info as PluginMessageAssistant).modelID, "claude-test-model");
+      expect((assistant.info as PluginMessageAssistant).providerID, "anthropic");
+      expect(assistant.info.time?.created, DateTime.parse("2026-08-09T10:00:01Z").millisecondsSinceEpoch);
+      expect(assistant.info.time?.completed, isNull);
+      expect(assistant.parts.map((part) => part.type), [
+        PluginMessagePartType.reasoning,
+        PluginMessagePartType.tool,
+        PluginMessagePartType.text,
+      ]);
+      final tool = assistant.parts[1];
+      expect(tool.id, "toolu-1");
+      expect(tool.tool, "Read");
+      expect(tool.state?.status, PluginToolStatus.completed);
+      expect(tool.state?.output, "file contents");
+      expect(
+        assistant.parts,
+        everyElement(
+          predicate<PluginMessagePart>((part) {
+            return part.sessionID == _sessionId && part.messageID == "assistant-message-id";
+          }),
+        ),
+      );
+    });
+
+    test("skips sidechain, metadata, transcript-only, and unsupported records", () async {
+      _writeTranscript(
+        temp: temp,
+        records: [
+          _messageRecord(type: "user", uuid: "sidechain", content: "hidden", isSidechain: true),
+          _messageRecord(type: "user", uuid: "meta", content: "hidden", isMeta: true),
+          _messageRecord(
+            type: "user",
+            uuid: "transcript-only",
+            content: "hidden",
+            isVisibleInTranscriptOnly: true,
+          ),
+          _messageRecord(type: "user", uuid: "malformed", content: 42),
+          _messageRecord(
+            type: "assistant",
+            uuid: "malformed-assistant",
+            messageId: "malformed-assistant-message",
+            content: 42,
+          ),
+          {"type": "future-record", "sessionId": _sessionId},
+        ],
+      );
+
+      expect(await mapper.map(sessionId: _sessionId), isEmpty);
+    });
+
+    test("throws a plugin operation failure when the transcript cannot load", () async {
+      expect(
+        () => mapper.map(sessionId: _sessionId),
+        throwsA(
+          isA<PluginOperationException>()
+              .having((error) => error.operation, "operation", "read Claude session transcript")
+              .having((error) => error.cause, "cause", isA<StateError>()),
+        ),
+      );
+    });
+  });
+}
+
+Map<String, Object?> _messageRecord({
+  required String type,
+  required String uuid,
+  required Object? content,
+  String timestamp = "2026-08-09T10:00:00Z",
+  String? messageId,
+  String? model,
+  bool? isSidechain,
+  bool? isMeta,
+  bool? isVisibleInTranscriptOnly,
+}) => {
+  "type": type,
+  "sessionId": _sessionId,
+  "uuid": uuid,
+  "timestamp": timestamp,
+  "isSidechain": ?isSidechain,
+  "isMeta": ?isMeta,
+  "isVisibleInTranscriptOnly": ?isVisibleInTranscriptOnly,
+  "message": {"id": ?messageId, "model": ?model, "content": content},
+};
+
+void _writeTranscript({required Directory temp, required List<Map<String, Object?>> records}) {
+  final project = Directory(p.join(temp.path, "projects", "-workspace"))..createSync(recursive: true);
+  File(p.join(project.path, "$_sessionId.jsonl")).writeAsStringSync(
+    records.map(jsonEncode).join("\n"),
+  );
+}

--- a/bridge/sesori_plugin_claude/test/claude_history_mapper_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_history_mapper_test.dart
@@ -147,6 +147,13 @@ void main() {
             messageId: "malformed-assistant-message",
             content: 42,
           ),
+          _messageRecord(
+            type: "assistant",
+            uuid: "record-id-is-not-a-message-id",
+            content: [
+              {"type": "text", "text": "hidden"},
+            ],
+          ),
           {"type": "future-record", "sessionId": _sessionId},
         ],
       );


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this adds transcript DTO/domain normalization and identity-sensitive history replay across the Claude plugin's API, repository, and mapper layers.

## What

- Add nested transcript message fields and sealed user, assistant, context, and unreplayable record variants.
- Add isolate-backed full transcript loading with preserved read failures.
- Add `ClaudeHistoryMapper` to replay ordered user and assistant messages, group split assistant records by Anthropic message id, and fold persisted tool results into their originating tool parts.
- Preserve timestamps, model/provider metadata, message identities, and content-mapper parity while skipping internal or non-visible records.
- Record the observed transcript shapes and Step 6 delivery state in the plan tracker.

`ClaudeHistoryMapper` is exported now and will be composed into `ClaudePlugin` in Step 12, its explicitly planned production consumer.

## Why

Claude sessions must replay from persisted JSONL transcripts after a bridge restart using the same backend-neutral message shapes as live events. This step establishes that replay boundary without leaking Claude-specific transcript concepts outside the plugin package.

## Risk and test focus

Moderate risk. The main risks are inventing or merging message identities incorrectly, exposing internal transcript records, losing tool results, and turning transcript read failures into a misleading empty history. Review should focus on assistant grouping, record filtering, tool-result folding, and cause-preserving failures.

## Expected result

No user-visible change yet because the Claude plugin is not registered until Step 14. No database or persisted-data changes. Internally, Claude transcript history can be mapped into ordered `PluginMessageWithParts` values for the later plugin composition step.

## Verification

- `dart test` in `bridge/sesori_plugin_claude` — 110 tests passed
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_claude` — no issues
- `git diff --check main...HEAD`
- Code generation previously rerun for the generated DTO changes
- Two architecture implementation-review passes completed; the final pass reported no remaining in-scope findings
- 875 changed lines against `main`, including generated files, tests, protocol notes, and tracker updates

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements transcript history replay for the Claude plugin. Maps JSONL transcripts into ordered `PluginMessageWithParts` with correct identities, grouped tool runs, and preserved metadata.

- **New Features**
  - Exported `ClaudeHistoryMapper`. Groups assistant records by nested Anthropic `message.id` and folds user `tool_result` into the originating `tool_use`.
  - Made the mapper a pure transform. `ClaudeTranscriptCatalogRepository` now does isolate-backed full transcript reads and propagates read failures (no empty-list fallback); Step 12 will translate them to `PluginOperationException`.
  - Added nested message fields and sealed user/assistant/context/unreplayable roles. Preserves timestamps, session/message IDs, model, and `providerID: anthropic`.
  - Skips sidechain, meta, transcript-only, system, attachment, unknown, and identity-less records. Updated protocol/tracker notes with the Step 6 history shape and verification.

<sup>Written for commit 34f41865eff2da2a530fcc69fad392a1dbf72ff6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

