### PR TITLE
⚙️ [claude-code-plugin] feat(claude): track tool lifecycle [step 7/17]

### DIFF
--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -5,11 +5,11 @@
 - **Plan slug:** `claude-code-plugin`
 - **Implementation base:** `origin/main` at
   `d323c3c4` (Step 7 synchronized with it after Step 6 merged)
-- **Series state:** Steps 1-6/17 merged; Step 7/17 ready for PR
+- **Series state:** Steps 1-6/17 merged; Step 7/17 PR open
 - **Current step:** 7/17 — tool lifecycle tracking
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737),
   merged 2026-08-04 as `6d641532`
-- **Next action:** Open the Step 7 PR, then start Step 8 locally
+- **Next action:** Start Step 8 locally while Step 7 is in review
 
 ## Plan Review
 
@@ -50,7 +50,7 @@
 | [x] | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,200-1,500 (recorded overage) | [PR #794](https://github.com/sesori-ai/sesori_apps_monorepo/pull/794) merged 2026-08-09 as `42cd0c72`; see the verification log for the measured diff |
 | [x] | 5/17 | `claude-code-plugin-content-mapper` | `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]` | 1,000-1,400 | [PR #795](https://github.com/sesori-ai/sesori_apps_monorepo/pull/795) merged 2026-08-10 as `cfb8cc45` |
 | [x] | 6/17 | `claude-code-plugin-history-mapper` | `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]` | 1,000-1,400 | [PR #799](https://github.com/sesori-ai/sesori_apps_monorepo/pull/799) merged 2026-08-10 as `d323c3c4` |
-| [ ] | 7/17 | `claude-code-plugin-tool-tracker` | `⚙️ [claude-code-plugin] feat(claude): track tool lifecycle [step 7/17]` | 1,000-1,400 | Implemented, verified, and synchronized with merged Step 6; ready for PR |
+| [ ] | 7/17 | `claude-code-plugin-tool-tracker` | `⚙️ [claude-code-plugin] feat(claude): track tool lifecycle [step 7/17]` | 1,000-1,400 | [PR #800](https://github.com/sesori-ai/sesori_apps_monorepo/pull/800) open against `main` |
 | [ ] | 8/17 | `claude-code-plugin-event-mapper` | `🚧 [claude-code-plugin] feat(claude): map stream events to SSE [step 8/17]` | 1,200-1,500 | Not started |
 | [ ] | 9/17 | `claude-code-plugin-approvals` | `🚧 [claude-code-plugin] feat(claude): add permission and question registry [step 9/17]` | 1,100-1,500 | Not started |
 | [ ] | 10/17 | `claude-code-plugin-session-service` | `🚧 [claude-code-plugin] feat(claude): add session residency and turn queue [step 10/17]` | 1,200-1,500 | Not started |
@@ -246,7 +246,10 @@
   pass. Architecture implementation review first rejected raw edit-tool string
   decisions; the tracker now parses names into a closed tool-kind enum at its
   boundary, and the second review approved the step with no remaining findings.
-  After synchronization with merged Step 6, the measured diff is 575 lines
+  Cubic review identified that a duplicate result could replace the first
+  terminal status and payload; terminal results are now sticky across duplicate
+  frames, with a regression test. After synchronization with merged Step 6, the
+  measured diff is 617 changed lines
   against `origin/main`, below the 1,000-1,400 estimate and the 1,500-line soft
   cap.
 

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -4,14 +4,12 @@
 
 - **Plan slug:** `claude-code-plugin`
 - **Implementation base:** `origin/main` at
-  `1e40bf02` (Step 6 synchronized with it after Step 5 merged)
-- **Series state:** Steps 1-5/17 merged; Step 6/17 PR open; Step 7/17 complete
-  locally
-- **Current step:** 6/17 — transcript history replay
+  `d323c3c4` (Step 7 synchronized with it after Step 6 merged)
+- **Series state:** Steps 1-6/17 merged; Step 7/17 ready for PR
+- **Current step:** 7/17 — tool lifecycle tracking
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737),
   merged 2026-08-04 as `6d641532`
-- **Next action:** Merge the Step 6 PR, synchronize Step 7 with `main`, and open
-  the Step 7 PR
+- **Next action:** Open the Step 7 PR, then start Step 8 locally
 
 ## Plan Review
 
@@ -51,8 +49,8 @@
 | [x] | 3/17 | `claude-code-plugin-stream-client` | `⚙️ [claude-code-plugin] feat(claude): add stream-json transport [step 3/17]` | 1,200-1,500 (recorded overage) | [PR #792](https://github.com/sesori-ai/sesori_apps_monorepo/pull/792) merged 2026-08-09 as `9f139f8f`; see the verification log for the measured diff |
 | [x] | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,200-1,500 (recorded overage) | [PR #794](https://github.com/sesori-ai/sesori_apps_monorepo/pull/794) merged 2026-08-09 as `42cd0c72`; see the verification log for the measured diff |
 | [x] | 5/17 | `claude-code-plugin-content-mapper` | `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]` | 1,000-1,400 | [PR #795](https://github.com/sesori-ai/sesori_apps_monorepo/pull/795) merged 2026-08-10 as `cfb8cc45` |
-| [ ] | 6/17 | `claude-code-plugin-history-mapper` | `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]` | 1,000-1,400 | [PR #799](https://github.com/sesori-ai/sesori_apps_monorepo/pull/799) open against `main` |
-| [ ] | 7/17 | `claude-code-plugin-tool-tracker` | `⚙️ [claude-code-plugin] feat(claude): track tool lifecycle [step 7/17]` | 1,000-1,400 | Implemented and verified locally; awaiting Step 6 merge |
+| [x] | 6/17 | `claude-code-plugin-history-mapper` | `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]` | 1,000-1,400 | [PR #799](https://github.com/sesori-ai/sesori_apps_monorepo/pull/799) merged 2026-08-10 as `d323c3c4` |
+| [ ] | 7/17 | `claude-code-plugin-tool-tracker` | `⚙️ [claude-code-plugin] feat(claude): track tool lifecycle [step 7/17]` | 1,000-1,400 | Implemented, verified, and synchronized with merged Step 6; ready for PR |
 | [ ] | 8/17 | `claude-code-plugin-event-mapper` | `🚧 [claude-code-plugin] feat(claude): map stream events to SSE [step 8/17]` | 1,200-1,500 | Not started |
 | [ ] | 9/17 | `claude-code-plugin-approvals` | `🚧 [claude-code-plugin] feat(claude): add permission and question registry [step 9/17]` | 1,100-1,500 | Not started |
 | [ ] | 10/17 | `claude-code-plugin-session-service` | `🚧 [claude-code-plugin] feat(claude): add session residency and turn queue [step 10/17]` | 1,200-1,500 | Not started |
@@ -248,8 +246,9 @@
   pass. Architecture implementation review first rejected raw edit-tool string
   decisions; the tracker now parses names into a closed tool-kind enum at its
   boundary, and the second review approved the step with no remaining findings.
-  The measured production/test diff before this tracker entry is 555 lines
-  against Step 6, below the 1,000-1,400 estimate and the 1,500-line soft cap.
+  After synchronization with merged Step 6, the measured diff is 575 lines
+  against `origin/main`, below the 1,000-1,400 estimate and the 1,500-line soft
+  cap.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -5,11 +5,13 @@
 - **Plan slug:** `claude-code-plugin`
 - **Implementation base:** `origin/main` at
   `1e40bf02` (Step 6 synchronized with it after Step 5 merged)
-- **Series state:** Steps 1-5/17 merged; Step 6/17 PR open
+- **Series state:** Steps 1-5/17 merged; Step 6/17 PR open; Step 7/17 complete
+  locally
 - **Current step:** 6/17 — transcript history replay
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737),
   merged 2026-08-04 as `6d641532`
-- **Next action:** Merge the Step 6 PR while Step 7 begins locally
+- **Next action:** Merge the Step 6 PR, synchronize Step 7 with `main`, and open
+  the Step 7 PR
 
 ## Plan Review
 
@@ -50,7 +52,7 @@
 | [x] | 4/17 | `claude-code-plugin-transcript-catalog` | `⚙️ [claude-code-plugin] feat(claude): enumerate transcript sessions [step 4/17]` | 1,200-1,500 (recorded overage) | [PR #794](https://github.com/sesori-ai/sesori_apps_monorepo/pull/794) merged 2026-08-09 as `42cd0c72`; see the verification log for the measured diff |
 | [x] | 5/17 | `claude-code-plugin-content-mapper` | `⚙️ [claude-code-plugin] feat(claude): map content blocks to parts [step 5/17]` | 1,000-1,400 | [PR #795](https://github.com/sesori-ai/sesori_apps_monorepo/pull/795) merged 2026-08-10 as `cfb8cc45` |
 | [ ] | 6/17 | `claude-code-plugin-history-mapper` | `⚙️ [claude-code-plugin] feat(claude): replay transcript history [step 6/17]` | 1,000-1,400 | [PR #799](https://github.com/sesori-ai/sesori_apps_monorepo/pull/799) open against `main` |
-| [ ] | 7/17 | `claude-code-plugin-tool-tracker` | `⚙️ [claude-code-plugin] feat(claude): track tool lifecycle [step 7/17]` | 1,000-1,400 | Not started |
+| [ ] | 7/17 | `claude-code-plugin-tool-tracker` | `⚙️ [claude-code-plugin] feat(claude): track tool lifecycle [step 7/17]` | 1,000-1,400 | Implemented and verified locally; awaiting Step 6 merge |
 | [ ] | 8/17 | `claude-code-plugin-event-mapper` | `🚧 [claude-code-plugin] feat(claude): map stream events to SSE [step 8/17]` | 1,200-1,500 | Not started |
 | [ ] | 9/17 | `claude-code-plugin-approvals` | `🚧 [claude-code-plugin] feat(claude): add permission and question registry [step 9/17]` | 1,100-1,500 | Not started |
 | [ ] | 10/17 | `claude-code-plugin-session-service` | `🚧 [claude-code-plugin] feat(claude): add session residency and turn queue [step 10/17]` | 1,200-1,500 | Not started |
@@ -233,6 +235,18 @@
   were applied, and the second review reported no other in-scope violations.
   The measured production/test diff is 800 changed lines against Step 5, below
   the 1,000-1,400 estimate and the 1,500-line soft cap.
+
+- Step 7/17 (2026-08-10): added collaborator-free `ClaudeToolTracker` with
+  per-session and per-content-block correlation, ordered `input_json_delta`
+  buffering, complete-block repair, direct `tool_result` matching, sticky
+  terminal states, immutable output attachments, exact session cleanup, and
+  one-shot diff decisions for Claude's four first-party edit tools. Malformed
+  partial JSON remains observable without logging its source-bearing payload,
+  and unmatched results do not invent orphan tool cards.
+
+  `dart analyze --fatal-infos`, all 121 package tests, and `git diff --check`
+  pass. The measured production/test diff before this tracker entry is 537 lines
+  against Step 6, below the 1,000-1,400 estimate and the 1,500-line soft cap.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -245,7 +245,10 @@
   and unmatched results do not invent orphan tool cards.
 
   `dart analyze --fatal-infos`, all 121 package tests, and `git diff --check`
-  pass. The measured production/test diff before this tracker entry is 537 lines
+  pass. Architecture implementation review first rejected raw edit-tool string
+  decisions; the tracker now parses names into a closed tool-kind enum at its
+  boundary, and the second review approved the step with no remaining findings.
+  The measured production/test diff before this tracker entry is 555 lines
   against Step 6, below the 1,000-1,400 estimate and the 1,500-line soft cap.
 
 ## Findings And Plan Deltas

--- a/bridge/sesori_plugin_claude/lib/claude_plugin.dart
+++ b/bridge/sesori_plugin_claude/lib/claude_plugin.dart
@@ -23,3 +23,4 @@ export "src/repositories/claude_transcript_catalog_repository.dart";
 export "src/repositories/mappers/claude_content_mapper.dart";
 export "src/repositories/models/claude_session_record.dart";
 export "src/repositories/models/claude_transcript_record.dart";
+export "src/repositories/trackers/claude_tool_tracker.dart";

--- a/bridge/sesori_plugin_claude/lib/src/repositories/trackers/claude_tool_tracker.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/trackers/claude_tool_tracker.dart
@@ -177,14 +177,22 @@ final class _TrackedTool {
   _TrackedTool({
     required this.id,
     required this.messageId,
-    required this.name,
+    required String name,
     required this.input,
     required this.status,
-  });
+  }) : _name = name,
+       kind = _ClaudeToolKind.parse(name);
 
   final String id;
   final String messageId;
-  String name;
+  String get name => _name;
+  String _name;
+  set name(String value) {
+    _name = value;
+    kind = _ClaudeToolKind.parse(value);
+  }
+
+  _ClaudeToolKind kind;
   Object? input;
   PluginToolStatus status;
   String? output;
@@ -192,7 +200,7 @@ final class _TrackedTool {
   List<PluginMessageAttachment> attachments = const [];
   bool diffEmitted = false;
 
-  bool get isEdit => const {"edit", "multiedit", "notebookedit", "write"}.contains(name.toLowerCase());
+  bool get isEdit => kind == _ClaudeToolKind.edit;
 
   ClaudeTrackedTool snapshot({required bool sessionDiffRequired}) => ClaudeTrackedTool(
     id: id,
@@ -211,3 +219,13 @@ final class _TrackedTool {
 }
 
 bool _isTerminal(PluginToolStatus status) => status == PluginToolStatus.completed || status == PluginToolStatus.error;
+
+enum _ClaudeToolKind {
+  edit,
+  other;
+
+  static _ClaudeToolKind parse(String raw) => switch (raw.toLowerCase()) {
+    "edit" || "multiedit" || "notebookedit" || "write" => edit,
+    _ => other,
+  };
+}

--- a/bridge/sesori_plugin_claude/lib/src/repositories/trackers/claude_tool_tracker.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/trackers/claude_tool_tracker.dart
@@ -1,0 +1,213 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" show jsonDecodeMap;
+
+/// An immutable presentation snapshot of one Claude tool call.
+final class ClaudeTrackedTool {
+  const ClaudeTrackedTool({
+    required this.id,
+    required this.messageId,
+    required this.name,
+    required this.input,
+    required this.state,
+    required this.sessionDiffRequired,
+  });
+
+  final String id;
+  final String messageId;
+  final String name;
+  final Object? input;
+  final PluginToolState state;
+
+  /// Whether this update should emit the session's one-shot diff signal.
+  final bool sessionDiffRequired;
+}
+
+/// Tracks Claude `tool_use` blocks from their streamed start through the
+/// matching `tool_result` block.
+final class ClaudeToolTracker {
+  final Map<String, _SessionTools> _sessions = {};
+
+  ClaudeTrackedTool start({
+    required String sessionId,
+    required String messageId,
+    required int blockIndex,
+    required String toolId,
+    required String name,
+    required Object? input,
+  }) {
+    final session = _sessions.putIfAbsent(sessionId, _SessionTools.new);
+    final block = session.block(messageId: messageId, blockIndex: blockIndex)..toolId = toolId;
+    final tool = session.tools.putIfAbsent(
+      toolId,
+      () => _TrackedTool(
+        id: toolId,
+        messageId: messageId,
+        name: name,
+        input: input,
+        status: block.partialInput.isEmpty ? PluginToolStatus.pending : PluginToolStatus.running,
+      ),
+    );
+    tool.name = name;
+    if (input != null) tool.input = input;
+    if (!_isTerminal(tool.status) && block.partialInput.isNotEmpty) tool.status = PluginToolStatus.running;
+    return tool.snapshot(sessionDiffRequired: false);
+  }
+
+  /// Applies the complete tool block carried by an assistant message.
+  ///
+  /// Complete assistant messages arrive before `content_block_stop`, so this
+  /// enriches the tracked call without treating it as completed.
+  ClaudeTrackedTool upsertCompleteBlock({
+    required String sessionId,
+    required String messageId,
+    required int blockIndex,
+    required String toolId,
+    required String name,
+    required Object? input,
+  }) {
+    final session = _sessions.putIfAbsent(sessionId, _SessionTools.new);
+    session.block(messageId: messageId, blockIndex: blockIndex)
+      ..toolId = toolId
+      ..hasCompleteInput = true;
+    final tool = session.tools.putIfAbsent(
+      toolId,
+      () => _TrackedTool(
+        id: toolId,
+        messageId: messageId,
+        name: name,
+        input: input,
+        status: PluginToolStatus.running,
+      ),
+    );
+    tool.name = name;
+    tool.input = input;
+    if (!_isTerminal(tool.status)) tool.status = PluginToolStatus.running;
+    return tool.snapshot(sessionDiffRequired: false);
+  }
+
+  /// Buffers one `input_json_delta` fragment in wire order.
+  ClaudeTrackedTool? appendInput({
+    required String sessionId,
+    required String messageId,
+    required int blockIndex,
+    required String partialJson,
+  }) {
+    final session = _sessions.putIfAbsent(sessionId, _SessionTools.new);
+    final block = session.block(messageId: messageId, blockIndex: blockIndex);
+    if (partialJson.isNotEmpty) block.partialInput.write(partialJson);
+    final toolId = block.toolId;
+    if (toolId == null) return null;
+    final tool = session.tools[toolId];
+    if (tool == null) return null;
+    if (!_isTerminal(tool.status)) tool.status = PluginToolStatus.running;
+    return tool.snapshot(sessionDiffRequired: false);
+  }
+
+  /// Finalizes the buffered input for one content block.
+  ClaudeTrackedTool? stopInput({
+    required String sessionId,
+    required String messageId,
+    required int blockIndex,
+  }) {
+    final session = _sessions[sessionId];
+    final block = session?.blocks[messageId]?[blockIndex];
+    if (session == null || block == null) return null;
+    final toolId = block.toolId;
+    if (toolId == null) return null;
+    final tool = session.tools[toolId];
+    if (tool == null) return null;
+
+    if (!block.hasCompleteInput && block.partialInput.isNotEmpty) {
+      try {
+        tool.input = jsonDecodeMap(block.partialInput.toString());
+      } on FormatException {
+        // The exception embeds the partial JSON, which can contain source code
+        // or paths and has no diagnostic value beyond the failed decode.
+        Log.w(
+          "[claude] streamed tool input could not be decoded; retaining the tool without partial input",
+        );
+      }
+    }
+    if (!_isTerminal(tool.status)) tool.status = PluginToolStatus.running;
+    return tool.snapshot(sessionDiffRequired: false);
+  }
+
+  /// Applies a normalized `tool_result`. Unknown ids do not create orphan tool
+  /// cards because their originating message identity is unavailable.
+  ClaudeTrackedTool? complete({
+    required String sessionId,
+    required String toolId,
+    required String? output,
+    required bool isError,
+    required List<PluginMessageAttachment> attachments,
+  }) {
+    final tool = _sessions[sessionId]?.tools[toolId];
+    if (tool == null) return null;
+    tool
+      ..status = isError ? PluginToolStatus.error : PluginToolStatus.completed
+      ..output = isError ? null : output
+      ..error = isError ? output : null
+      ..attachments = List.unmodifiable(attachments);
+    final sessionDiffRequired = tool.isEdit && !tool.diffEmitted;
+    if (sessionDiffRequired) tool.diffEmitted = true;
+    return tool.snapshot(sessionDiffRequired: sessionDiffRequired);
+  }
+
+  /// Starts a new turn with no retained block or result correlation state.
+  void beginTurn({required String sessionId}) => _sessions.remove(sessionId);
+
+  void forgetSession({required String sessionId}) => _sessions.remove(sessionId);
+}
+
+final class _SessionTools {
+  final Map<String, _TrackedTool> tools = {};
+  final Map<String, Map<int, _StreamedToolBlock>> blocks = {};
+
+  _StreamedToolBlock block({required String messageId, required int blockIndex}) =>
+      blocks.putIfAbsent(messageId, () => {}).putIfAbsent(blockIndex, _StreamedToolBlock.new);
+}
+
+final class _StreamedToolBlock {
+  String? toolId;
+  bool hasCompleteInput = false;
+  final StringBuffer partialInput = StringBuffer();
+}
+
+final class _TrackedTool {
+  _TrackedTool({
+    required this.id,
+    required this.messageId,
+    required this.name,
+    required this.input,
+    required this.status,
+  });
+
+  final String id;
+  final String messageId;
+  String name;
+  Object? input;
+  PluginToolStatus status;
+  String? output;
+  String? error;
+  List<PluginMessageAttachment> attachments = const [];
+  bool diffEmitted = false;
+
+  bool get isEdit => const {"edit", "multiedit", "notebookedit", "write"}.contains(name.toLowerCase());
+
+  ClaudeTrackedTool snapshot({required bool sessionDiffRequired}) => ClaudeTrackedTool(
+    id: id,
+    messageId: messageId,
+    name: name,
+    input: input,
+    state: PluginToolState(
+      status: status,
+      title: null,
+      output: output,
+      error: error,
+      attachments: attachments,
+    ),
+    sessionDiffRequired: sessionDiffRequired,
+  );
+}
+
+bool _isTerminal(PluginToolStatus status) => status == PluginToolStatus.completed || status == PluginToolStatus.error;

--- a/bridge/sesori_plugin_claude/lib/src/repositories/trackers/claude_tool_tracker.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/trackers/claude_tool_tracker.dart
@@ -143,6 +143,7 @@ final class ClaudeToolTracker {
   }) {
     final tool = _sessions[sessionId]?.tools[toolId];
     if (tool == null) return null;
+    if (_isTerminal(tool.status)) return tool.snapshot(sessionDiffRequired: false);
     tool
       ..status = isError ? PluginToolStatus.error : PluginToolStatus.completed
       ..output = isError ? null : output

--- a/bridge/sesori_plugin_claude/test/claude_tool_tracker_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_tool_tracker_test.dart
@@ -202,6 +202,39 @@ void main() {
       expect(lateStop?.state.status, PluginToolStatus.completed);
     });
 
+    test("retains the first terminal result when a duplicate arrives", () {
+      tracker.start(
+        sessionId: "session-1",
+        messageId: "message-1",
+        blockIndex: 0,
+        toolId: "toolu-1",
+        name: "Write",
+        input: null,
+      );
+      final first = tracker.complete(
+        sessionId: "session-1",
+        toolId: "toolu-1",
+        output: "first failure",
+        isError: true,
+        attachments: const [],
+      );
+
+      final duplicate = tracker.complete(
+        sessionId: "session-1",
+        toolId: "toolu-1",
+        output: "later success",
+        isError: false,
+        attachments: const [PluginMessageAttachment.metadata(mime: "image/png", filename: null)],
+      );
+
+      expect(first?.sessionDiffRequired, isTrue);
+      expect(duplicate?.sessionDiffRequired, isFalse);
+      expect(duplicate?.state.status, PluginToolStatus.error);
+      expect(duplicate?.state.error, "first failure");
+      expect(duplicate?.state.output, isNull);
+      expect(duplicate?.state.attachments, isEmpty);
+    });
+
     test("edit-shaped results request one session diff", () {
       for (final name in ["Write", "Edit", "MultiEdit", "NotebookEdit"]) {
         tracker.start(

--- a/bridge/sesori_plugin_claude/test/claude_tool_tracker_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_tool_tracker_test.dart
@@ -1,0 +1,323 @@
+import "package:claude_plugin/claude_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ClaudeToolTracker", () {
+    late ClaudeToolTracker tracker;
+
+    setUp(() => tracker = ClaudeToolTracker());
+
+    test("tracks a tool from pending through streamed input", () {
+      final started = tracker.start(
+        sessionId: "session-1",
+        messageId: "message-1",
+        blockIndex: 2,
+        toolId: "toolu-1",
+        name: "Read",
+        input: const <String, Object?>{},
+      );
+      final delta = tracker.appendInput(
+        sessionId: "session-1",
+        messageId: "message-1",
+        blockIndex: 2,
+        partialJson: '{"file_',
+      );
+      tracker.appendInput(
+        sessionId: "session-1",
+        messageId: "message-1",
+        blockIndex: 2,
+        partialJson: 'path":"source.dart"}',
+      );
+      final stopped = tracker.stopInput(sessionId: "session-1", messageId: "message-1", blockIndex: 2);
+
+      expect(started.state.status, PluginToolStatus.pending);
+      expect(delta?.state.status, PluginToolStatus.running);
+      expect(stopped?.state.status, PluginToolStatus.running);
+      expect(stopped?.input, {"file_path": "source.dart"});
+    });
+
+    test("retains input deltas that arrive before their tool start", () {
+      expect(
+        tracker.appendInput(
+          sessionId: "session-1",
+          messageId: "message-1",
+          blockIndex: 0,
+          partialJson: '{"query":"value"}',
+        ),
+        isNull,
+      );
+
+      final started = tracker.start(
+        sessionId: "session-1",
+        messageId: "message-1",
+        blockIndex: 0,
+        toolId: "toolu-1",
+        name: "Grep",
+        input: const <String, Object?>{},
+      );
+      final stopped = tracker.stopInput(sessionId: "session-1", messageId: "message-1", blockIndex: 0);
+
+      expect(started.state.status, PluginToolStatus.running);
+      expect(stopped?.input, {"query": "value"});
+    });
+
+    test("complete blocks repair malformed partial input without completing the tool", () {
+      tracker.start(
+        sessionId: "session-1",
+        messageId: "message-1",
+        blockIndex: 0,
+        toolId: "toolu-1",
+        name: "Read",
+        input: const <String, Object?>{},
+      );
+      tracker.appendInput(
+        sessionId: "session-1",
+        messageId: "message-1",
+        blockIndex: 0,
+        partialJson: "{malformed",
+      );
+      final complete = tracker.upsertCompleteBlock(
+        sessionId: "session-1",
+        messageId: "message-1",
+        blockIndex: 0,
+        toolId: "toolu-1",
+        name: "Read",
+        input: const {"file_path": "source.dart"},
+      );
+      final stopped = tracker.stopInput(sessionId: "session-1", messageId: "message-1", blockIndex: 0);
+
+      expect(complete.state.status, PluginToolStatus.running);
+      expect(stopped?.state.status, PluginToolStatus.running);
+      expect(stopped?.input, {"file_path": "source.dart"});
+    });
+
+    test("malformed partial input does not fail or expose the tool card", () {
+      tracker.start(
+        sessionId: "session-1",
+        messageId: "message-1",
+        blockIndex: 0,
+        toolId: "toolu-1",
+        name: "Read",
+        input: null,
+      );
+      tracker.appendInput(
+        sessionId: "session-1",
+        messageId: "message-1",
+        blockIndex: 0,
+        partialJson: "{private-path",
+      );
+
+      final stopped = tracker.stopInput(sessionId: "session-1", messageId: "message-1", blockIndex: 0);
+
+      expect(stopped?.state.status, PluginToolStatus.running);
+      expect(stopped?.input, isNull);
+      expect(stopped.toString(), isNot(contains("private-path")));
+    });
+
+    test("matches successful and failed results without losing tool identity", () {
+      tracker.start(
+        sessionId: "session-1",
+        messageId: "message-1",
+        blockIndex: 0,
+        toolId: "toolu-success",
+        name: "Read",
+        input: null,
+      );
+      tracker.start(
+        sessionId: "session-1",
+        messageId: "message-1",
+        blockIndex: 1,
+        toolId: "toolu-error",
+        name: "Bash",
+        input: null,
+      );
+      const attachment = PluginMessageAttachment.metadata(mime: "image/png", filename: null);
+
+      final success = tracker.complete(
+        sessionId: "session-1",
+        toolId: "toolu-success",
+        output: "done",
+        isError: false,
+        attachments: [attachment],
+      );
+      final failure = tracker.complete(
+        sessionId: "session-1",
+        toolId: "toolu-error",
+        output: "failed",
+        isError: true,
+        attachments: const [],
+      );
+
+      expect(success?.messageId, "message-1");
+      expect(success?.name, "Read");
+      expect(success?.state.status, PluginToolStatus.completed);
+      expect(success?.state.output, "done");
+      expect(success?.state.attachments, [attachment]);
+      expect(() => success!.state.attachments.add(attachment), throwsUnsupportedError);
+      expect(failure?.state.status, PluginToolStatus.error);
+      expect(failure?.state.output, isNull);
+      expect(failure?.state.error, "failed");
+    });
+
+    test("ignores unmatched results instead of inventing an orphan tool", () {
+      expect(
+        tracker.complete(
+          sessionId: "session-1",
+          toolId: "unknown",
+          output: "private output",
+          isError: false,
+          attachments: const [],
+        ),
+        isNull,
+      );
+    });
+
+    test("terminal state does not regress after late stream updates", () {
+      tracker.start(
+        sessionId: "session-1",
+        messageId: "message-1",
+        blockIndex: 0,
+        toolId: "toolu-1",
+        name: "Read",
+        input: null,
+      );
+      tracker.complete(
+        sessionId: "session-1",
+        toolId: "toolu-1",
+        output: "done",
+        isError: false,
+        attachments: const [],
+      );
+
+      final lateDelta = tracker.appendInput(
+        sessionId: "session-1",
+        messageId: "message-1",
+        blockIndex: 0,
+        partialJson: "{}",
+      );
+      final lateStop = tracker.stopInput(sessionId: "session-1", messageId: "message-1", blockIndex: 0);
+
+      expect(lateDelta?.state.status, PluginToolStatus.completed);
+      expect(lateStop?.state.status, PluginToolStatus.completed);
+    });
+
+    test("edit-shaped results request one session diff", () {
+      for (final name in ["Write", "Edit", "MultiEdit", "NotebookEdit"]) {
+        tracker.start(
+          sessionId: name,
+          messageId: "message-1",
+          blockIndex: 0,
+          toolId: "toolu-1",
+          name: name,
+          input: null,
+        );
+
+        final first = tracker.complete(
+          sessionId: name,
+          toolId: "toolu-1",
+          output: name == "Edit" ? "failed" : "done",
+          isError: name == "Edit",
+          attachments: const [],
+        );
+        final duplicate = tracker.complete(
+          sessionId: name,
+          toolId: "toolu-1",
+          output: "done again",
+          isError: false,
+          attachments: const [],
+        );
+
+        expect(first?.sessionDiffRequired, isTrue, reason: name);
+        expect(duplicate?.sessionDiffRequired, isFalse, reason: name);
+      }
+    });
+
+    test("non-mutating tools do not request a session diff", () {
+      for (final name in ["Read", "Glob", "Grep", "Bash"]) {
+        tracker.start(
+          sessionId: name,
+          messageId: "message-1",
+          blockIndex: 0,
+          toolId: "toolu-1",
+          name: name,
+          input: null,
+        );
+
+        final result = tracker.complete(
+          sessionId: name,
+          toolId: "toolu-1",
+          output: "done",
+          isError: false,
+          attachments: const [],
+        );
+
+        expect(result?.sessionDiffRequired, isFalse, reason: name);
+      }
+    });
+
+    test("keeps concurrent blocks and sessions isolated", () {
+      for (final (sessionId, blockIndex, toolId) in [
+        ("session-1", 0, "toolu-1"),
+        ("session-1", 1, "toolu-2"),
+        ("session-2", 0, "toolu-1"),
+      ]) {
+        tracker.start(
+          sessionId: sessionId,
+          messageId: "message-1",
+          blockIndex: blockIndex,
+          toolId: toolId,
+          name: "Read",
+          input: null,
+        );
+        tracker.appendInput(
+          sessionId: sessionId,
+          messageId: "message-1",
+          blockIndex: blockIndex,
+          partialJson: '{"value":"$sessionId-$toolId"}',
+        );
+      }
+
+      expect(
+        tracker.stopInput(sessionId: "session-1", messageId: "message-1", blockIndex: 0)?.input,
+        {"value": "session-1-toolu-1"},
+      );
+      expect(
+        tracker.stopInput(sessionId: "session-1", messageId: "message-1", blockIndex: 1)?.input,
+        {"value": "session-1-toolu-2"},
+      );
+      expect(
+        tracker.stopInput(sessionId: "session-2", messageId: "message-1", blockIndex: 0)?.input,
+        {"value": "session-2-toolu-1"},
+      );
+    });
+
+    test("turn and session cleanup remove only the exact session", () {
+      for (final sessionId in ["session", "session-child"]) {
+        tracker.start(
+          sessionId: sessionId,
+          messageId: "message-1",
+          blockIndex: 0,
+          toolId: "toolu-1",
+          name: "Read",
+          input: null,
+        );
+      }
+
+      tracker.beginTurn(sessionId: "session");
+      expect(_complete(tracker, sessionId: "session"), isNull);
+      expect(_complete(tracker, sessionId: "session-child"), isNotNull);
+
+      tracker.forgetSession(sessionId: "session-child");
+      expect(_complete(tracker, sessionId: "session-child"), isNull);
+    });
+  });
+}
+
+ClaudeTrackedTool? _complete(ClaudeToolTracker tracker, {required String sessionId}) => tracker.complete(
+  sessionId: sessionId,
+  toolId: "toolu-1",
+  output: "done",
+  isError: false,
+  attachments: const [],
+);


### PR DESCRIPTION
## Complexity

⚙️ Moderate: this adds stateful per-session tool lifecycle correlation, streamed input reconstruction, and terminal-state handling behind the Claude plug-in boundary.

## What

- Add `ClaudeToolTracker` for pending, running, completed, and errored tool states.
- Correlate content-block deltas and direct tool results by session and tool-use identity.
- Detect one-shot session diff signals for Claude's first-party mutation tools.
- Cover malformed partial input, complete-block repair, sticky terminal states, immutable output, cleanup, and cross-session isolation.

`ClaudeEventMapper` in Step 8 is the production consumer of this tracker.

## Why

Claude emits tool starts, streamed JSON input, complete blocks, and results through different frame shapes. The tracker gives the event mapper one package-local, backend-normalized lifecycle boundary without leaking Claude protocol concepts outside the plug-in.

## Risk and test focus

Moderate risk, isolated to the not-yet-registered Claude plug-in package. Review correlation across sessions and content-block indexes, terminal-state stickiness, mutation-tool classification, malformed streamed JSON handling, and exact session cleanup.

## Expected result

No user-visible behavior until the Claude plug-in is registered in Step 14. No database or persisted-data change. Internally, Step 8 can map Claude tool frames to stable backend-neutral tool events and diff refresh signals.

## Verification

- `dart pub get` from `bridge/`
- `dart analyze --fatal-infos` from `bridge/sesori_plugin_claude/`
- `dart test` from `bridge/sesori_plugin_claude/` (121 tests)
- `git diff --check`
- Architecture implementation review approved after mutation tool names were parsed into a closed package-local enum at the boundary
- 575 changed lines against merged Step 6, below the 1,500-line soft cap

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ClaudeToolTracker` to `claude_plugin` to track Claude tool calls across a session, from start and streamed input to final result. Enables backend-neutral lifecycle events for the upcoming event mapper; no user-facing changes.

- **New Features**
  - Correlates `tool_use` and `tool_result` by session, message, block index, and tool id.
  - Buffers `input_json_delta` in order; repairs input with complete blocks; tolerates malformed JSON without logging payloads.
  - Keeps terminal states sticky; late deltas do not regress completed/error tools.
  - Emits a one-shot session diff for edit tools (`write`, `edit`, `multiedit`, `notebookedit`) via a closed enum.
  - Preserves attachments immutably; ignores unmatched results (no orphan tool cards).
  - Provides per-turn/session cleanup and isolates concurrent sessions/blocks.

- **Bug Fixes**
  - Retains the first terminal result when a duplicate `tool_result` arrives; later results are ignored.

<sup>Written for commit 4ae3dc4b71659ff85cb964a21a6ab40cebe7b1d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

