### PR TITLE
🌿 Enable Cursor prompt attachments

### DIFF
--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
@@ -118,6 +118,9 @@ class CursorPluginDescriptor extends BridgePluginDescriptor {
   PluginSessionOptionsScope get sessionOptionsScope => PluginSessionOptionsScope.plugin;
 
   @override
+  bool get supportsPromptAttachments => true;
+
+  @override
   List<PluginOption> get options => cliOptions;
 
   @override

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
@@ -27,6 +27,10 @@ void main() {
       expect(const CursorPluginDescriptor().sessionOptionsScope, PluginSessionOptionsScope.plugin);
     });
 
+    test("declares support for prompt attachments", () {
+      expect(const CursorPluginDescriptor().supportsPromptAttachments, isTrue);
+    });
+
     test("reports ready after version and read-only authentication probes", () async {
       final processes = _ProbeProcessService(
         processSequence: [


### PR DESCRIPTION
## Complexity
Straightforward plugin capability declaration and regression coverage.

## What
- Declare Cursor support for prompt attachments in its plugin descriptor.
- Add a descriptor regression test for the capability.

## Why
The client gates the image attachment UI on the bridge capability. Cursor already consumes inline image content successfully, but its descriptor reported that attachments were unsupported, so the UI was hidden.

## Risk and test focus
Low risk and limited to Cursor capability metadata. Focus on descriptor behavior, attachment UI visibility, image selection, and live Cursor image handling.

## Expected result
Cursor sessions expose the image attachment action and successfully receive attached images without changing other plugin capabilities or transport contracts.

## Verification
- `dart test` in `bridge/sesori_plugin_cursor` passed: 126 tests.
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_cursor` passed.
- Built and launched the iOS simulator app with `flutter run`.
- Verified the attachment action, photo picker, thumbnail, and live Cursor response describing the selected image.
- No user-visible or database schema impact beyond enabling the existing attachment UI path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Cursor prompt attachments by declaring support in the plugin descriptor. This makes the image attachment UI visible and allows Cursor sessions to receive attached images.

<sup>Written for commit 664730a83abbcf72b8f635d4856ce984eb938279. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

