### PR TITLE
⚙️ Persist ACP streamed text in session history

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -164,6 +164,7 @@ class AcpEventMapper {
     _turnSeq.remove(sessionId);
     _startedParts.remove(sessionId);
     _contentTrackers.remove(sessionId);
+    _textPartAccumulators.remove(sessionId);
     _sentUserSeq.remove(sessionId);
     _idlessAssistantSeq.remove(sessionId);
     _openIdlessAssistant.remove(sessionId);
@@ -202,6 +203,11 @@ class AcpEventMapper {
   /// exact for opaque session and ACP message identifiers.
   final Map<String, Map<String, AcpContentTracker>> _contentTrackers = {};
 
+  /// Text accumulated from ACP deltas until the serialized prompt turn settles.
+  /// ACP emits an empty part snapshot followed by deltas, while chat history
+  /// persists complete part snapshots only.
+  final Map<String, Map<String, _TextPartAccumulator>> _textPartAccumulators = {};
+
   /// Sequence for user messages accepted by this plugin. These are emitted
   /// locally because ACP agents do not reliably echo `user_message_chunk`.
   final Map<String, int> _sentUserSeq = {};
@@ -220,12 +226,35 @@ class AcpEventMapper {
     // dead weight — drop them to bound memory in long sessions.
     _startedParts.remove(sessionId);
     _contentTrackers.remove(sessionId);
+    _textPartAccumulators.remove(sessionId);
     _idlessAssistantSeq.remove(sessionId);
     _openIdlessAssistant.remove(sessionId);
     // Tool state is retained across a turn (so a reordered late `tool_call_update`
     // still merges onto its terminal state instead of blanking the card), and
     // cleared here at the turn boundary to keep it bounded.
     _liveTools.remove(sessionId);
+  }
+
+  /// Emits complete snapshots for text and reasoning parts streamed during the
+  /// current turn. The caller owns the turn boundary and must call this before
+  /// the next turn starts.
+  List<BridgeSseEvent> finalizeTurn({required String sessionId}) {
+    final accumulators = _textPartAccumulators.remove(sessionId);
+    if (accumulators == null) return const [];
+
+    return [
+      for (final accumulator in accumulators.values)
+        BridgeSseMessagePartUpdated(
+          part: _part(
+            partId: accumulator.partId,
+            messageId: accumulator.messageId,
+            sessionId: sessionId,
+            type: accumulator.type,
+            text: accumulator.text.toString(),
+            attachment: null,
+          ),
+        ),
+    ];
   }
 
   int _turn(String sessionId) => _turnSeq[sessionId] ?? 1;
@@ -508,6 +537,13 @@ class AcpEventMapper {
       final partId = "${identity.messageId}-${mutation.partIdSuffix}";
       switch (mutation) {
         case AcpTextDeltaMutation(:final delta):
+          _recordTextDelta(
+            sessionId: sessionId,
+            messageId: identity.messageId,
+            partId: partId,
+            type: PluginMessagePartType.text,
+            delta: delta,
+          );
           if (started.add(partId)) {
             events.add(
               BridgeSseMessagePartUpdated(
@@ -614,10 +650,35 @@ class AcpEventMapper {
         delta: text,
       ),
     );
+    _recordTextDelta(
+      sessionId: sessionId,
+      messageId: messageId,
+      partId: partId,
+      type: partType,
+      delta: text,
+    );
     if (role == _ChunkRole.assistant && !identity.hasAcpMessageId) {
       _openIdlessAssistant.add(sessionId);
     }
     return events;
+  }
+
+  void _recordTextDelta({
+    required String sessionId,
+    required String messageId,
+    required String partId,
+    required PluginMessagePartType type,
+    required String delta,
+  }) {
+    final accumulator = (_textPartAccumulators[sessionId] ??= {}).putIfAbsent(
+      partId,
+      () => _TextPartAccumulator(
+        partId: partId,
+        messageId: messageId,
+        type: type,
+      ),
+    );
+    accumulator.text.write(delta);
   }
 
   ({String messageId, bool hasAcpMessageId}) _chunkIdentity({
@@ -1003,6 +1064,19 @@ class _SessionSnapshot {
   String? title;
   int? createdMs;
   int? updatedMs;
+}
+
+class _TextPartAccumulator {
+  _TextPartAccumulator({
+    required this.partId,
+    required this.messageId,
+    required this.type,
+  });
+
+  final String partId;
+  final String messageId;
+  final PluginMessagePartType type;
+  final StringBuffer text = StringBuffer();
 }
 
 /// The last-rendered state of one live tool call, so a partial

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1140,6 +1140,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       _syncWorkState();
       return;
     }
+    eventMapper.finalizeTurn(sessionId: sessionId).forEach(_eventBuffer.add);
     if (state.pending == 0) {
       _sessionStatuses[sessionId] = const PluginSessionStatus.idle();
       _eventBuffer.add(BridgeSseSessionIdle(sessionID: sessionId));

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -60,6 +60,51 @@ void main() {
       expect(second.whereType<BridgeSseMessagePartDelta>().single.delta, "lo");
     });
 
+    test("finalizeTurn emits complete text and reasoning snapshots", () {
+      mapper.beginTurn("s1");
+      mapper.map(update({
+        "sessionUpdate": "agent_thought_chunk",
+        "content": {"type": "text", "text": "thinking"},
+      }));
+      mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "Hello "},
+      }));
+      mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "world"},
+      }));
+
+      final parts = mapper
+          .finalizeTurn(sessionId: "s1")
+          .whereType<BridgeSseMessagePartUpdated>()
+          .map((event) => event.part)
+          .toList();
+
+      expect(parts.map((part) => part.id), [
+        "s1-t1-assistant-a0-reasoning",
+        "s1-t1-assistant-a0-text",
+      ]);
+      expect(parts.map((part) => part.type), [
+        PluginMessagePartType.reasoning,
+        PluginMessagePartType.text,
+      ]);
+      expect(parts.map((part) => part.text), ["thinking", "Hello world"]);
+      expect(mapper.finalizeTurn(sessionId: "s1"), isEmpty);
+    });
+
+    test("forgetSession drops pending text snapshots", () {
+      mapper.beginTurn("s1");
+      mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "discarded"},
+      }));
+
+      mapper.forgetSession("s1");
+
+      expect(mapper.finalizeTurn(sessionId: "s1"), isEmpty);
+    });
+
     test("agent message content preserves mixed text and image order", () {
       mapper.beginTurn("s1");
       final events = mapper.map(update({

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -247,6 +247,88 @@ void main() {
       respondTo(prompt, {"stopReason": "end_turn"});
     });
 
+    test("a completed prompt emits a final text snapshot before idle", () async {
+      await connect();
+      final sessionId = await createSession(cwd, "s1");
+      emitted.clear();
+
+      await sendPrompt(sessionId, "describe it");
+      final prompt = await waitForFrame("session/prompt");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": sessionId,
+          "update": {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "The image shows "},
+          },
+        },
+      });
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": sessionId,
+          "update": {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "a garden."},
+          },
+        },
+      });
+      respondTo(prompt, {"stopReason": "end_turn"});
+      for (var i = 0; i < 20 && idleCount() == 0; i++) {
+        await pump();
+      }
+
+      final assistantParts = emitted
+          .whereType<BridgeSseMessagePartUpdated>()
+          .map((event) => event.part)
+          .where((part) => part.messageID.contains("-assistant"))
+          .toList();
+      expect(assistantParts.map((part) => part.text), ["", "The image shows a garden."]);
+      final snapshotIndex = emitted.indexWhere(
+        (event) => event is BridgeSseMessagePartUpdated && event.part.text == "The image shows a garden.",
+      );
+      final idleIndex = emitted.indexWhere((event) => event is BridgeSseSessionIdle);
+      expect(snapshotIndex, greaterThanOrEqualTo(0));
+      expect(idleIndex, greaterThan(snapshotIndex));
+    });
+
+    test("a failed prompt still emits a final partial text snapshot", () async {
+      await connect();
+      final sessionId = await createSession(cwd, "s1");
+      emitted.clear();
+
+      await sendPrompt(sessionId, "describe it");
+      final prompt = await waitForFrame("session/prompt");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": sessionId,
+          "update": {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "Partial answer"},
+          },
+        },
+      });
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": prompt["id"],
+        "error": {"code": -32000, "message": "agent failed"},
+      });
+      for (var i = 0; i < 20 && idleCount() == 0; i++) {
+        await pump();
+      }
+
+      expect(
+        emitted.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part.text),
+        contains("Partial answer"),
+      );
+      expect(emitted.whereType<BridgeSseSessionError>(), hasLength(1));
+    });
+
     test("a second prompt on one session dispatches only after the first turn completes", () async {
       await connect();
       final sessionId = await createSession(cwd, "s1");


### PR DESCRIPTION
## Complexity
Moderate ACP event-lifecycle and persistence fix with bounded per-session state.

## What
- Accumulate ACP text and reasoning deltas per message part during a prompt turn.
- Emit complete existing `messagePartUpdated` snapshots when the turn settles, before idle or error events.
- Clear accumulated text on turn boundaries and session deletion.
- Add mapper and plugin lifecycle regressions for successful and failed turns.

## Why
ACP emits an empty part snapshot followed by text deltas. The shared history listener intentionally persists snapshots and ignores deltas, so live assistant text disappeared after reopening a session. The fix materializes the backend-specific ACP stream into the existing snapshot contract without changing shared persistence behavior.

## Risk and test focus
The change is isolated to `sesori_plugin_acp`. Focus on multi-chunk text/reasoning accumulation, snapshot ordering before idle/error, partial output on failed turns, and cleanup on turn/session boundaries. No wire route or persisted schema changes.

## Expected result
ACP assistant text and reasoning remain available after app relaunch or bridge history reads, while live streaming behavior remains unchanged.

## Verification
- `dart test` in `bridge/sesori_plugin_acp` passed: 220 tests.
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_acp` passed.
- Architecture implementation review approved with no blocking findings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes loss of streamed ACP assistant text after reopening a session. We now accumulate deltas during a turn and emit a final snapshot so text and reasoning persist in history.

- **Bug Fixes**
  - Accumulate per-part text/reasoning deltas during a turn in `sesori_plugin_acp`.
  - On turn settle, `finalizeTurn(sessionId)` emits complete messagePartUpdated snapshots; the plugin calls it before idle/error.
  - Clear accumulators on turn boundaries and on `forgetSession`.
  - Added tests for accumulation, ordering, and partial output on failures; no wire or schema changes.

<sup>Written for commit 7a734f2b3b4c67480df574d0b05854ed770ba88f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

