### PR TITLE
🌱 [attachment-references] docs: plan lazy transcript attachments [step 1/11]

### DIFF
--- a/.plan/active/attachment-references/PLAN.md
+++ b/.plan/active/attachment-references/PLAN.md
@@ -42,8 +42,8 @@ viewer actions without making bridge content public or readable by the relay.
 6. GIF and animated WebP previews are static first frames; their originals
    animate in the viewer through Flutter's normal image codec.
 7. Thumbnails survive app restarts in an app-private bounded cache. Originals
-   fetched for viewing remain temporary and are not persisted as an offline
-   media library.
+   fetched for viewing remain temporary, are released when the viewer closes,
+   and are not persisted as an offline media library.
 8. Bridge-owned transcript images support up to 20 MB each and 50 MB aggregate
    per existing logical attachment collection. The existing four-candidate
    collection limit remains unchanged.
@@ -249,7 +249,8 @@ The concrete bridge owners are:
   encodes one rendition. It owns no files, cache decisions, or queue.
 - `ChatHistoryRepository` remains the Layer-2 aggregate owner of live/archive
   attachment files. New methods store an original, read an original or derived
-  thumbnail from the live and archived spill roots, and atomically persist a
+  thumbnail from the live and archived spill roots, project a stored message's
+  attachment collection for capable/legacy delivery, and atomically persist a
   generated thumbnail through the existing Layer-1 storage APIs.
 - `MessageAttachmentService` in
   `bridge/app/lib/src/bridge/services/message_attachment_service.dart` requires
@@ -290,23 +291,36 @@ behavior.
 Do not coordinate `ChatHistoryListener` and `Orchestrator` with callbacks,
 acknowledgements, or another event stream.
 
-For a mapped `SesoriSseEvent.messagePartUpdated` containing bridge-owned inline
-images, the injected `MessageAttachmentService` calls a named
-`ChatHistoryRepository.storeAttachmentOriginal` method and awaits that
-repository operation before a reference variant can be enqueued. The
-repository alone reaches the same live `AttachmentSpillStorage` used by history
-capture. The service returns:
+`ChatHistoryService.requiresAwaitedAttachmentCapture(part:)` is the single
+predicate for whether a shared message part contains inline images in its file
+slot or tool attachments. Both consumers call that same service-owned method.
+For those events only, `ChatHistoryListener` deliberately skips its ordinary
+unawaited part capture and Orchestrator calls a named
+`ChatHistoryService.capturePartForDelivery` method after mapping/truncation and
+before wire delivery. Non-image parts and every other history event retain the
+existing listener path.
+
+`capturePartForDelivery` enters the existing per-session queue, performs the one
+decode/spill/database write through `ChatHistoryRepository`, advances the same
+sync state as ordinary capture, and returns a sealed result containing:
 
 - a reference-shaped event for capable subscribers; and
 - a legacy event with the existing 5 MiB inline/metadata budget for old
   subscribers.
 
-`ChatHistoryListener` reaches the same repository seam through
-`ChatHistoryService` and may reach the content-addressed write before or after
-that projection. The write is atomic and idempotent, so the concrete ordinary
-race is harmless and does not justify a lock or listener dependency. If the
-awaited materialization fails, the bridge logs the original error and sends a
+This makes the write outcome directly available to wire delivery without a
+callback, result registry, or second event. It also joins archive
+export/flip/purge ordering instead of writing a new live spill outside the
+session queue. If capture fails, the method logs the original error, clears
+`syncedAt`, and returns a typed unavailable result; Orchestrator sends the mapped
 legacy-safe inline/metadata shape rather than a dangling identifier.
+
+Legacy projection evaluates the complete persisted logical collection, not
+only the current SSE part. Tool attachments are already one part; ordered ACP
+assistant image parts are projected against earlier stored sibling parts. This
+preserves the released 5 MiB aggregate decision even after plugin trackers can
+retain 50 MB for capable clients, without adding mutable bridge-side collection
+accounting.
 
 `SSEManager` records attachment delivery mode with each subscriber queue and
 selects the corresponding event when enqueuing. Orphan queues retain their
@@ -362,7 +376,9 @@ Add `AttachmentThumbnailStorage` under
 read, atomic write, list metadata, and delete within a caller-supplied scope. Its
 `FlutterAttachmentThumbnailStorage` implementation under
 `client/app/lib/core/platform/` resolves the OS app-private cache directory and
-performs only those IO primitives. It does not construct keys, choose eviction,
+performs only those IO primitives. It requires the existing
+`TemporaryDirectoryClient` constructor dependency rather than calling
+`path_provider` statically. It does not construct keys, choose eviction,
 coalesce requests, or react to authentication.
 
 `MessageImageRepository` in `module_core` owns scoped key construction,
@@ -371,7 +387,11 @@ total-size/oldest-file pruning policy. Keys include account, bridge, session,
 attachment id, and rendition version; only encoded thumbnails are persisted.
 A small `MessageThumbnailCacheService` in `module_core` requires
 `MessageImageRepository` plus the existing authenticated-account transition
-source and owns account-scope cleanup on logout/local account removal.
+source and owns account-scope cleanup on logout/local account removal. Cleanup
+first retires the account generation, rejects new or late writes for that
+generation, awaits its already-started fetch/write futures, and only then
+deletes the scope. A later completion therefore cannot recreate decrypted
+thumbnail content after logout.
 
 Do not add a persistent database, cache index, background cache worker, or full
 original cache. The OS may evict cache files at any time; a miss simply refetches
@@ -380,10 +400,14 @@ the thumbnail.
 Extend the existing `MessageImageCubit` in `module_core` to own thumbnail and
 original load intents through `MessageImageRepository`. Its sealed state models
 preview loading/ready/failure independently from original loading/ready/failure.
-`FilePartWidget` continues to construct that cubit at the existing composition
-seam; Flutter widgets only render emitted encoded bytes through standard
-`MemoryImage`/`ResizeImage` providers and dispatch retry/open intents back to the
-cubit. No Flutter provider or feature widget calls the repository directly.
+Every attachment collection threads its authoritative `MessagePart.sessionID`
+as a required value through `FilePartWidget` into the cubit and repository; no
+loader or cache key reads a global current-session fallback. `FilePartWidget`
+continues to construct the cubit at the existing composition seam. Flutter
+widgets only render emitted encoded bytes through standard
+`MemoryImage`/`ResizeImage` providers and dispatch retry/open/close intents back
+to the cubit. No Flutter provider or feature widget calls the repository
+directly.
 
 ### 7. Presentation
 
@@ -401,7 +425,10 @@ For a stored image, the viewer receives thumbnail bytes from
 opening. On success it replaces the standard in-memory provider without closing
 the route and constructs the existing original-backed action state. On failure
 it retains the thumbnail, shows retry, and leaves original actions unavailable.
-Do not add page swiping or another viewer route.
+Viewer route completion always dispatches `releaseOriginal`, returning the
+tile-owned cubit to thumbnail-ready state and dropping encoded original bytes;
+the repository coalesces only in-flight original requests and retains no
+completed original cache. Do not add page swiping or another viewer route.
 
 ## Compatibility Matrix
 
@@ -419,7 +446,7 @@ subscription because multiple app versions may use one bridge concurrently.
 
 | Failure | User outcome | Local observability |
 |---|---|---|
-| Live spill write fails before reference emission | Legacy-safe image or metadata remains in the live event; no dangling reference. | Bridge logs original error, stack, session/part operation context, and no content. |
+| Queued live capture fails before reference emission | Projection returns unavailable; the mapped legacy-safe image or metadata remains in the live event, with no dangling reference. | Bridge logs original error, stack, session/part operation context, and no content. |
 | Original was purged or missing | Cached thumbnail remains visible; viewer reports unavailable and offers retry. | Fetch route returns 404; storage error context remains local. |
 | Thumbnail decode is unsupported or unsafe | Stable square error tile with retry; original is not deleted. | Bridge reports bounded rendition failure without payload data. |
 | Thumbnail cache read is corrupt | Cache entry is removed and fetched again. | Client logs cache operation context without paths in analytics. |
@@ -480,6 +507,8 @@ baseline is intentionally raised in a separate task.
 |---|---|---|---|
 | Reference history images | Observed ordinary flow: every open/reload sends paged inline originals. | Repeated bandwidth, base64 work, and memory. | Implement. |
 | Reference live images | Observed ordinary flow: finalized part events and replay queues carry full snapshots. | Duplicate live/reconnect traffic and bridge queue memory. | Implement with per-subscriber shaping. |
+| Queue live capture and projection together | Archive and live activity can overlap for one session. | A post-copy spill could be purged before the emitted reference is usable. | One awaited service call reuses the existing per-session queue. |
+| Project the complete legacy collection | ACP assistant images arrive as separate part updates. | Per-event shaping could exceed the released 5 MiB aggregate behavior. | Query bounded stored sibling parts; no mutable accounting registry. |
 | Serialize thumbnail generation | Ordinary page can request several uncached previews together. | Concurrent full decodes can spike bridge memory. | One coarse lane, no keyed lock registry. |
 | Persist one bridge thumbnail | Multiple devices/cache eviction can request the same derived image. | Repeated CPU-heavy decode. | One versioned sibling file, existing purge lifecycle. |
 | Chunk/resume transfers | Theoretical benefit for this bounded image-only scope; no observed failed 20 MB attachment flow. | A failed transfer retries the complete image. | Accept and defer. |
@@ -512,7 +541,7 @@ baseline is intentionally raised in a separate task.
 
 | Step | Exact PR title | Estimate | Boundary |
 |---|---|---:|---|
-| 1/11 | `🌱 [attachment-references] docs: plan lazy transcript attachments [step 1/11]` | 650-1,050 | Active plan/tracker and upload considerations only. |
+| 1/11 | `🌱 [attachment-references] docs: plan lazy transcript attachments [step 1/11]` | 650-1,100 | Active plan/tracker and upload considerations only. |
 | 2/11 | `🚧 [attachment-references] feat(protocol): describe stored transcript images [step 2/11]` | 900-1,450 | Shared variant, rendition models, delivery mode defaults, generated code, exhaustive compile-safe consumers. No peer enables references. |
 | 3/11 | `⚙️ [attachment-references] feat(bridge): serve stored image renditions [step 3/11]` | 900-1,400 | Versioned thumbnail storage/builder, live/archive lookup, typed fetch handler, decode/size/security tests. |
 | 4/11 | `⚙️ [attachment-references] feat(bridge): reference images in history pages [step 4/11]` | 700-1,150 | Capability-aware active/archive projection and legacy budget preservation. |
@@ -587,17 +616,21 @@ receive lightweight references in history pages.
 
 ### Step 5/11 - Live references
 
-- Materialize mapped live inline images through
-  `MessageAttachmentService -> ChatHistoryRepository -> AttachmentSpillStorage`
-  before emitting references.
+- Add `ChatHistoryService.requiresAwaitedAttachmentCapture(part:)` as the one
+  predicate used by `ChatHistoryListener` and Orchestrator; the listener skips
+  only those inline-image parts and retains its path for all others.
+- Add one awaited `ChatHistoryService.capturePartForDelivery` call that joins the
+  per-session queue, persists once, and returns typed reference/legacy shapes.
 - Produce reference and legacy-safe event shapes without a new event type.
+- Calculate legacy eligibility from the complete stored logical collection so
+  separate ACP image-part updates preserve the released aggregate limit.
 - Store subscriber delivery mode with active/orphan queues and only adopt a
   matching-mode orphan.
 - Ensure reference queues never retain original base64 while legacy queues keep
   released behavior.
 - Cover multiple simultaneous old/new subscribers, reconnect replay, write
-  failure fallback, tool updates, event ordering, generation fencing, and local
-  debug behavior.
+  failure fallback, ACP multi-part legacy budgeting, archive/capture ordering,
+  one materialization per event, generation fencing, and local debug behavior.
 - Run bridge app SSE/orchestrator/storage tests, full bridge app tests, fatal
   analysis, and architecture implementation review.
 
@@ -634,6 +667,8 @@ larger backend-produced raster originals.
 - Coalesce concurrent requests for the same scoped rendition in memory.
 - Extend `MessageImageCubit` to own preview/original load and retry intents; the
   Flutter shell consumes state and never calls the repository directly.
+- Require message-owned `sessionId` through widget, cubit, repository request,
+  and cache key; never infer it from global route/connection state.
 - Keep both delivery-mode call sites set to `inline`.
 - Run module_core focused/full tests, codegen/DI generation, analysis, downstream
   mobile analysis, and architecture implementation review.
@@ -645,10 +680,12 @@ when supplied in a test fixture.
 
 - Add dumb `AttachmentThumbnailStorage` file primitives in module_core and
   `FlutterAttachmentThumbnailStorage` over the app-private OS cache directory.
+- Inject the existing `TemporaryDirectoryClient` into the Flutter storage
+  adapter; do not call static `path_provider` APIs from the adapter.
 - Keep scoped keys, corruption recovery, in-flight coalescing, oldest-on-write
   pruning in `MessageImageRepository`; add `MessageThumbnailCacheService` for
-  authenticated-scope cleanup; keep backup exclusion in the platform IO
-  configuration.
+  generation-fenced authenticated-scope cleanup that settles in-flight writes
+  before deletion; keep backup exclusion in the platform IO configuration.
 - Integrate the cache behind `MessageImageRepository` and the existing
   `MessageImageCubit`; widgets render emitted bytes with standard Flutter image
   providers and receive no repository, public URL, or relay/auth token.
@@ -678,14 +715,17 @@ presentation; stored delivery remains disabled.
 
 - Open stored images with the thumbnail already visible, automatically load the
   original, retain the thumbnail on failure, and retry the complete original.
+- Release original bytes from the tile-owned cubit when the viewer route closes;
+  retain only thumbnail-ready state and no completed-original repository cache.
 - Enable copy/share/save only after validated original bytes arrive.
 - Preserve current single-image gestures, route/back behavior, Hero transition,
   remote open-original action, and animated-original behavior.
 - Set history requests and SSE subscriptions to `storedReference`.
 - Cover all four app/bridge compatibility pairings, live/history/archive parity,
   cache cold/warm behavior, original timeout/retry, missing-after-thumbnail,
-  action gating, GIF/WebP preview/original behavior, and no eager original
-  request while scrolling.
+  logout during fetch/write, required session scoping, original release after
+  close, action gating, GIF/WebP preview/original behavior, and no eager
+  original request while scrolling.
 - Run module_core and mobile focused/full tests, analysis/codegen, a local bridge
   integration check with cold/warm history and reconnect, and architecture
   implementation review.
@@ -707,7 +747,9 @@ Expected result: no user-visible, wire, database, or runtime behavior change.
 
 | Risk | Mitigation |
 |---|---|
-| Reference event outruns file persistence. | Await one idempotent spill write before enqueue; fetch does not depend on the later DB row. |
+| Reference event outruns file persistence. | Await the single queued image-part capture and its typed result before enqueue. |
+| Archive races live materialization. | Capture, projection, export, flip, and purge share the existing per-session queue. |
+| Legacy ACP image parts exceed their old aggregate budget. | Project each event against the complete stored logical collection, not only the current part. |
 | Old app receives an unknown source and hides it. | Default both independent delivery surfaces to inline and shape per subscriber/request. |
 | New app requests a route from an old bridge. | It only calls the route for a received `stored_image`; old bridges never emit that variant. |
 | A page triggers several expensive decodes. | One fixed rendition, lazy generation, decoded-pixel ceiling, and one coarse generation lane. |
@@ -726,6 +768,13 @@ routes live writes through `ChatHistoryRepository`, names the bridge builder,
 service, and handler with required dependencies, keeps cache policy in
 `module_core`, and routes image loading through `MessageImageCubit`. Subsequent
 PR review further moved the thumbnail builder beside Layer-2 attachment mapping,
-made attachment parse failures content-redacted, and named the timeout path
-through both client transport layers. Per repository process, the corrected
-draft was not re-reviewed merely to obtain an approval verdict.
+made attachment parse failures content-redacted, named the timeout path through
+both client transport layers, and then consolidated live capture/projection on
+the existing session queue. It also pins message-owned session scope, releases
+viewer originals, injects the directory client, and generation-fences logout
+cleanup. Per repository process, the corrected draft was not re-reviewed merely
+to obtain an approval verdict. A focused second architecture review accepted the
+revised capture, legacy collection, viewer, cache, and session-scope seams but
+rejected the unnamed capture-split predicate. The plan now assigns that invariant
+to `ChatHistoryService.requiresAwaitedAttachmentCapture(part:)`; this direct
+finding correction was not reviewed again.

--- a/.plan/active/attachment-references/PLAN.md
+++ b/.plan/active/attachment-references/PLAN.md
@@ -241,8 +241,9 @@ Generate the thumbnail lazily on the first request and persist it atomically.
 The concrete bridge owners are:
 
 - `AttachmentThumbnailBuilder` in
-  `bridge/app/lib/src/foundation/attachment_thumbnail_builder.dart` is a pure,
-  zero-collaborator byte transformation over the pure-Dart image codec. It runs
+  `bridge/app/lib/src/bridge/repositories/builders/attachment_thumbnail_builder.dart`
+  is a pure, zero-collaborator Layer-2 transformation over the pure-Dart image
+  codec, beside the attachment projection/mapping policy it implements. It runs
   off the main isolate, reads metadata first, rejects dimensions/pixel counts
   above its documented decode-memory ceiling, bakes orientation, crops, and
   encodes one rendition. It owns no files, cache decisions, or queue.
@@ -343,9 +344,18 @@ stored image. Continue validating MIME, byte length, and magic bytes after
 fetch; a bridge response is authenticated and encrypted but still treated as
 untrusted image input.
 
-Use an attachment-specific request timeout long enough for one 20 MB original
-on an ordinary mobile connection. This is not resumability: a disconnect or
-timeout retries the complete image.
+The attachment API uses a sensitive-response mode on `RelayHttpApiClient`.
+Malformed JSON or DTO fields retain the caught error/stack in a typed local log,
+but the returned `JsonParsingError` carries only a fixed privacy-safe marker;
+the decrypted response body and its base64 field are never retained in an API
+error or interpolated into diagnostics.
+
+Add a named `RelayHttpApiClient.postWithTimeout` path and thread its required
+duration through `_sendViaRelay` into a required per-request timeout on
+`RelayClient.sendRequest`. Ordinary API methods continue to pass the existing
+30-second default explicitly; `MessageAttachmentApi` passes the longer bounded
+attachment timeout. This is not resumability: a disconnect or timeout retries
+the complete image.
 
 Add `AttachmentThumbnailStorage` under
 `client/module_core/lib/src/foundation/platform/` as a dumb file-IO capability:
@@ -367,14 +377,13 @@ Do not add a persistent database, cache index, background cache worker, or full
 original cache. The OS may evict cache files at any time; a miss simply refetches
 the thumbnail.
 
-`StoredAttachmentImageProvider` lives with session-detail presentation under
-`client/app/lib/features/session_detail/widgets/`. It delegates byte loading to
-a required `MessageImageRepository` constructor dependency rather than opening
-a URL or resolving DI itself. The session-detail composition root resolves that
-repository once and passes it through the attachment collection/tile
-constructors. Provider equality uses the scoped attachment identity, so
-Flutter's in-memory `ImageCache` and the app-private encoded cache cooperate
-without bypassing client layers.
+Extend the existing `MessageImageCubit` in `module_core` to own thumbnail and
+original load intents through `MessageImageRepository`. Its sealed state models
+preview loading/ready/failure independently from original loading/ready/failure.
+`FilePartWidget` continues to construct that cubit at the existing composition
+seam; Flutter widgets only render emitted encoded bytes through standard
+`MemoryImage`/`ResizeImage` providers and dispatch retry/open intents back to the
+cubit. No Flutter provider or feature widget calls the repository directly.
 
 ### 7. Presentation
 
@@ -387,11 +396,12 @@ be grouped.
 Inline images from old bridges and directly fetched HTTPS images use the same
 square presentation. Their existing bytes/URL paths remain unchanged.
 
-For a stored image, the viewer receives the loaded thumbnail immediately and
-starts the original request after opening. On success it replaces the provider
-without closing the route and constructs the existing original-backed action
-state. On failure it retains the thumbnail, shows retry, and leaves original
-actions unavailable. Do not add page swiping or another viewer route.
+For a stored image, the viewer receives thumbnail bytes from
+`MessageImageCubit` immediately and dispatches the original-load intent after
+opening. On success it replaces the standard in-memory provider without closing
+the route and constructs the existing original-backed action state. On failure
+it retains the thumbnail, shows retry, and leaves original actions unavailable.
+Do not add page swiping or another viewer route.
 
 ## Compatibility Matrix
 
@@ -509,7 +519,7 @@ baseline is intentionally raised in a separate task.
 | 5/11 | `🚧 [attachment-references] feat(bridge): reference images in live events [step 5/11]` | 1,100-1,500 | Awaited materialization, dual event shapes, subscriber/orphan delivery mode, SSE memory/compatibility coverage. |
 | 6/11 | `⚙️ [attachment-references] feat(bridge): retain larger transcript images [step 6/11]` | 900-1,450 | OpenCode, Codex, ACP, Cursor, and Claude output limits move to 20 MB each/50 MB aggregate while legacy projection stays 5 MiB. |
 | 7/11 | `⚙️ [attachment-references] feat(client): load stored image renditions [step 7/11]` | 850-1,350 | Typed API/repository/state support, validation, timeout, request coalescing, but delivery mode remains inline. |
-| 8/11 | `⚙️ [attachment-references] feat(client): cache encrypted image previews [step 8/11]` | 850-1,350 | Platform cache boundary/adapter, scoped atomic storage/pruning/cleanup, Flutter image provider, tests. |
+| 8/11 | `⚙️ [attachment-references] feat(client): cache encrypted image previews [step 8/11]` | 850-1,350 | Platform cache boundary/adapter, scoped atomic storage/pruning/cleanup, Cubit integration, tests. |
 | 9/11 | `⚙️ [attachment-references] feat(client): render square attachment grids [step 9/11]` | 900-1,450 | Square/grid/overlay/loading/error presentation for existing and reference-capable attachment widgets; capability remains disabled. |
 | 10/11 | `⚙️ [attachment-references] feat(client): load originals in the image viewer [step 10/11]` | 900-1,450 | Thumbnail-first viewer, original retry/actions, enable history/SSE reference mode, end-to-end compatibility tests. |
 | 11/11 | `🌱 [attachment-references] docs: retire lazy transcript attachments [step 11/11]` | 50-200 | Final evidence and plan move to completed. |
@@ -542,8 +552,9 @@ the documented defaults.
 
 ### Step 3/11 - Bridge rendition endpoint
 
-- Add zero-collaborator `AttachmentThumbnailBuilder` in bridge foundation with
-  the pure-Dart thumbnail dependency and bounded, off-main-isolate decoding.
+- Add zero-collaborator `AttachmentThumbnailBuilder` beside bridge repository
+  mapping/building policy with the pure-Dart thumbnail dependency and bounded,
+  off-main-isolate decoding.
 - Extend spill storage for versioned derived thumbnails using existing atomic
   write, archive-copy, hardening, and purge conventions.
 - Add live-then-archive original/thumbnail methods to
@@ -613,9 +624,16 @@ larger backend-produced raster originals.
 - Extend image loading state to distinguish preview availability from original
   loading/failure without flattening them into nullable booleans.
 - Retain MIME/signature/size validation for inline, remote, and stored sources.
-- Add complete-request retry semantics and an attachment-specific timeout; do
-  not add chunk offsets or fake progress.
+- Add sensitive-response parsing so malformed attachment responses retain no
+  decrypted body/base64 in `JsonParsingError` or diagnostics.
+- Thread a required attachment timeout from a named `RelayHttpApiClient` method
+  through `_sendViaRelay` and `RelayClient.sendRequest`; prove ordinary requests
+  retain their 30-second default and attachment requests survive beyond it.
+- Add complete-request retry semantics; do not add chunk offsets or fake
+  progress.
 - Coalesce concurrent requests for the same scoped rendition in memory.
+- Extend `MessageImageCubit` to own preview/original load and retry intents; the
+  Flutter shell consumes state and never calls the repository directly.
 - Keep both delivery-mode call sites set to `inline`.
 - Run module_core focused/full tests, codegen/DI generation, analysis, downstream
   mobile analysis, and architecture implementation review.
@@ -631,12 +649,11 @@ when supplied in a test fixture.
   pruning in `MessageImageRepository`; add `MessageThumbnailCacheService` for
   authenticated-scope cleanup; keep backup exclusion in the platform IO
   configuration.
-- Add `StoredAttachmentImageProvider` in the app session-detail presentation
-  package. The session-detail composition root injects its required
-  `MessageImageRepository`; the provider receives no public URL or relay/auth
-  token and never resolves the repository itself.
-- Run module_core tests, app platform/provider tests, codegen/DI generation,
-  mobile analysis/tests, and architecture implementation review.
+- Integrate the cache behind `MessageImageRepository` and the existing
+  `MessageImageCubit`; widgets render emitted bytes with standard Flutter image
+  providers and receive no repository, public URL, or relay/auth token.
+- Run module_core tests, app platform/cache tests, codegen/DI generation, mobile
+  analysis/tests, and architecture implementation review.
 
 Expected result: no reference delivery is enabled, but stored-image fixtures
 reuse cached encoded thumbnails across widget remounts/app initialization.
@@ -707,6 +724,8 @@ owners, Flutter cache policy incorrectly left ambiguous at the platform
 adapter, and image-provider ownership/injection left unspecified. The draft now
 routes live writes through `ChatHistoryRepository`, names the bridge builder,
 service, and handler with required dependencies, keeps cache policy in
-`module_core`, and places an explicitly injected provider in the app
-session-detail package. Per repository process, the corrected draft was not
-re-reviewed merely to obtain an approval verdict.
+`module_core`, and routes image loading through `MessageImageCubit`. Subsequent
+PR review further moved the thumbnail builder beside Layer-2 attachment mapping,
+made attachment parse failures content-redacted, and named the timeout path
+through both client transport layers. Per repository process, the corrected
+draft was not re-reviewed merely to obtain an approval verdict.

--- a/.plan/active/attachment-references/PLAN.md
+++ b/.plan/active/attachment-references/PLAN.md
@@ -168,15 +168,17 @@ Add a new image-specific attachment source to `MessageAttachment`:
 ```text
 stored_image
   attachmentId
+  bridgeId
   mime
   filename?
   byteLength
 ```
 
 The exact identifier remains an opaque client contract even if the first bridge
-implementation uses the existing content address internally. Every fetch also
-requires `sessionId`, and the client cache key includes bridge and session
-scope; clients must not treat the identifier as a globally reusable URL.
+implementation uses the existing content address internally. `bridgeId` is the
+required identity from the bridge's existing `BridgeIdProvider`; every fetch
+also requires `sessionId`. Clients must not treat the identifier as a globally
+reusable URL.
 
 Keep `fallbackUnion: "unknown"`. A capable reference must nevertheless never be
 sent to an old app because that app currently hides unknown attachment sources.
@@ -252,21 +254,22 @@ The concrete bridge owners are:
   thumbnail from the live and archived spill roots, project a stored message's
   attachment collection for capable/legacy delivery, and atomically persist a
   generated thumbnail through the existing Layer-1 storage APIs.
-- `MessageAttachmentService` in
-  `bridge/app/lib/src/bridge/services/message_attachment_service.dart` requires
-  `ChatHistoryRepository` and `AttachmentThumbnailBuilder`. It owns lazy
-  rendition selection and one coarse generation lane so a page of uncached
-  previews cannot launch many full-image decodes concurrently. It does not
-  touch `AttachmentSpillStorage` directly.
+- `ChatHistoryService` requires `AttachmentThumbnailBuilder` and the existing
+  `BridgeIdProvider`; its attachment-read method enters the existing
+  per-session queue before live/archive selection, and it owns one coarse
+  generation lane inside that queue so a page of uncached previews cannot
+  launch many full-image decodes concurrently. It does not touch
+  `AttachmentSpillStorage` directly.
 - `GetSessionAttachmentHandler` in
   `bridge/app/lib/src/bridge/routing/get_session_attachment_handler.dart`
-  requires `MessageAttachmentService` and maps typed route success/failure only.
+  requires `ChatHistoryService` and maps typed route success/failure only.
 
 The single service lane addresses an ordinary reachable flow with meaningful
 memory impact; no per-session or per-digest lock registry is needed. A rejected
 thumbnail does not delete or invalidate the original. Fetch tries the live
-spill root, then the archived spill root. Existing archive-copy and purge
-ordering remains authoritative.
+spill root, then the archived spill root. Original reads and the final derived
+write remain inside the existing session queue, so archive-copy and purge cannot
+interleave and a completed generation cannot recreate a purged session root.
 
 ### 3. History and archive projection
 
@@ -381,17 +384,23 @@ performs only those IO primitives. It requires the existing
 `path_provider` statically. It does not construct keys, choose eviction,
 coalesce requests, or react to authentication.
 
-`MessageImageRepository` in `module_core` owns scoped key construction,
-validation, corruption recovery, one in-flight fetch per key, and the simple
-total-size/oldest-file pruning policy. Keys include account, bridge, session,
-attachment id, and rendition version; only encoded thumbnails are persisted.
-A small `MessageThumbnailCacheService` in `module_core` requires
-`MessageImageRepository` plus the existing authenticated-account transition
-source and owns account-scope cleanup on logout/local account removal. Cleanup
-first retires the account generation, rejects new or late writes for that
-generation, awaits its already-started fetch/write futures, and only then
+`MessageImageRepository` in `module_core` requires `AuthSession` and owns scoped
+key construction, validation, corruption recovery, one in-flight fetch per key,
+and the simple total-size/oldest-file pruning policy. At each stored-image load
+boundary it captures the authenticated `AuthUser.id` from
+`AuthSession.currentState`, takes `bridgeId` from the required `stored_image`
+field, and receives the message-owned `sessionId`; these values form the cache
+scope with attachment id and rendition version. No cache operation reads a
+global current-bridge fallback. Only encoded thumbnails are persisted.
+
+An eager `@singleton` `MessageThumbnailCacheService` in `module_core` requires
+`MessageImageRepository` plus `AuthSession`, subscribes during core DI
+initialization, and owns account-scope cleanup on logout/local account removal.
+Cleanup first retires the account generation, rejects new or late writes for
+that generation, awaits its already-started fetch/write futures, and only then
 deletes the scope. A later completion therefore cannot recreate decrypted
-thumbnail content after logout.
+thumbnail content after logout. Its `@disposeMethod` cancels the auth
+subscription during dependency-container teardown.
 
 Do not add a persistent database, cache index, background cache worker, or full
 original cache. The OS may evict cache files at any time; a miss simply refetches
@@ -401,8 +410,9 @@ Extend the existing `MessageImageCubit` in `module_core` to own thumbnail and
 original load intents through `MessageImageRepository`. Its sealed state models
 preview loading/ready/failure independently from original loading/ready/failure.
 Every attachment collection threads its authoritative `MessagePart.sessionID`
-as a required value through `FilePartWidget` into the cubit and repository; no
-loader or cache key reads a global current-session fallback. `FilePartWidget`
+as a required value through `FilePartWidget` into the cubit and repository; the
+stored reference supplies its authoritative bridge identity. No loader or cache
+key reads global current-session or current-bridge state. `FilePartWidget`
 continues to construct the cubit at the existing composition seam. Flutter
 widgets only render emitted encoded bytes through standard
 `MemoryImage`/`ResizeImage` providers and dispatch retry/open/close intents back
@@ -543,7 +553,7 @@ baseline is intentionally raised in a separate task.
 |---|---|---:|---|
 | 1/11 | `🌱 [attachment-references] docs: plan lazy transcript attachments [step 1/11]` | 650-1,100 | Active plan/tracker and upload considerations only. |
 | 2/11 | `🚧 [attachment-references] feat(protocol): describe stored transcript images [step 2/11]` | 900-1,450 | Shared variant, rendition models, delivery mode defaults, generated code, exhaustive compile-safe consumers. No peer enables references. |
-| 3/11 | `⚙️ [attachment-references] feat(bridge): serve stored image renditions [step 3/11]` | 900-1,400 | Versioned thumbnail storage/builder, live/archive lookup, typed fetch handler, decode/size/security tests. |
+| 3/11 | `⚙️ [attachment-references] feat(bridge): serve stored image renditions [step 3/11]` | 900-1,400 | Versioned thumbnail storage/builder, session-queued live/archive lookup, typed fetch handler, decode/size/security tests. |
 | 4/11 | `⚙️ [attachment-references] feat(bridge): reference images in history pages [step 4/11]` | 700-1,150 | Capability-aware active/archive projection and legacy budget preservation. |
 | 5/11 | `🚧 [attachment-references] feat(bridge): reference images in live events [step 5/11]` | 1,100-1,500 | Awaited materialization, dual event shapes, subscriber/orphan delivery mode, SSE memory/compatibility coverage. |
 | 6/11 | `⚙️ [attachment-references] feat(bridge): retain larger transcript images [step 6/11]` | 900-1,450 | OpenCode, Codex, ACP, Cursor, and Claude output limits move to 20 MB each/50 MB aggregate while legacy projection stays 5 MiB. |
@@ -568,7 +578,8 @@ Expected result: no user-visible, wire, database, or runtime behavior change.
 ### Step 2/11 - Shared contract
 
 - Add `MessageAttachment.storedImage` and update every exhaustive in-repo
-  consumer to a safe compile-time placeholder without enabling delivery.
+  consumer to a safe compile-time placeholder without enabling delivery. Its
+  required `bridgeId` comes from the bridge's existing `BridgeIdProvider`.
 - Add `MessageAttachmentDelivery` with legacy `inline` defaults on
   `SessionMessagesRequest` and `RelaySseSubscribe`.
 - Add typed attachment rendition request/response models and exports.
@@ -587,12 +598,13 @@ the documented defaults.
 - Extend spill storage for versioned derived thumbnails using existing atomic
   write, archive-copy, hardening, and purge conventions.
 - Add live-then-archive original/thumbnail methods to
-  `ChatHistoryRepository`; add `MessageAttachmentService(repository, builder)`
-  for lazy selection and the single generation lane; and register
-  `GetSessionAttachmentHandler(service)` for `POST /session/attachment`.
+  `ChatHistoryRepository`; extend `ChatHistoryService(repository, builder)` with
+  session-queued rendition selection and the single generation lane; and
+  register `GetSessionAttachmentHandler(chatHistoryService)` for
+  `POST /session/attachment`.
 - Cover original/thumbnail success, first-frame behavior, transparency,
   orientation, concurrent generation, corrupt/oversized input, missing files,
-  archive lookup, traversal rejection, and response bounds.
+  archive lookup, generation racing purge, traversal rejection, and response bounds.
 - Run bridge app focused/full tests, fatal analysis, build/codegen as required,
   and architecture implementation review.
 
@@ -668,7 +680,9 @@ larger backend-produced raster originals.
 - Extend `MessageImageCubit` to own preview/original load and retry intents; the
   Flutter shell consumes state and never calls the repository directly.
 - Require message-owned `sessionId` through widget, cubit, repository request,
-  and cache key; never infer it from global route/connection state.
+  and cache key. Capture account scope from `AuthSession.currentState` at the
+  repository boundary and take bridge scope from the stored reference; never
+  infer either identity from global route/connection state.
 - Keep both delivery-mode call sites set to `inline`.
 - Run module_core focused/full tests, codegen/DI generation, analysis, downstream
   mobile analysis, and architecture implementation review.
@@ -683,14 +697,16 @@ when supplied in a test fixture.
 - Inject the existing `TemporaryDirectoryClient` into the Flutter storage
   adapter; do not call static `path_provider` APIs from the adapter.
 - Keep scoped keys, corruption recovery, in-flight coalescing, oldest-on-write
-  pruning in `MessageImageRepository`; add `MessageThumbnailCacheService` for
-  generation-fenced authenticated-scope cleanup that settles in-flight writes
-  before deletion; keep backup exclusion in the platform IO configuration.
+  pruning in `MessageImageRepository`; register `MessageThumbnailCacheService`
+  as an eager core singleton for generation-fenced authenticated-scope cleanup
+  that settles in-flight writes before deletion and disposes its auth
+  subscription; keep backup exclusion in the platform IO configuration.
 - Integrate the cache behind `MessageImageRepository` and the existing
   `MessageImageCubit`; widgets render emitted bytes with standard Flutter image
   providers and receive no repository, public URL, or relay/auth token.
 - Run module_core tests, app platform/cache tests, codegen/DI generation, mobile
-  analysis/tests, and architecture implementation review.
+  analysis/tests including account-switch and eager-cleanup activation, and
+  architecture implementation review.
 
 Expected result: no reference delivery is enabled, but stored-image fixtures
 reuse cached encoded thumbnails across widget remounts/app initialization.
@@ -749,6 +765,7 @@ Expected result: no user-visible, wire, database, or runtime behavior change.
 |---|---|
 | Reference event outruns file persistence. | Await the single queued image-part capture and its typed result before enqueue. |
 | Archive races live materialization. | Capture, projection, export, flip, and purge share the existing per-session queue. |
+| Thumbnail generation races archive or purge. | Original selection, generation, and final derived write share the existing per-session queue. |
 | Legacy ACP image parts exceed their old aggregate budget. | Project each event against the complete stored logical collection, not only the current part. |
 | Old app receives an unknown source and hides it. | Default both independent delivery surfaces to inline and shape per subscriber/request. |
 | New app requests a route from an old bridge. | It only calls the route for a received `stored_image`; old bridges never emit that variant. |
@@ -765,7 +782,7 @@ actionable findings: one live materialization layer skip plus unnamed bridge
 owners, Flutter cache policy incorrectly left ambiguous at the platform
 adapter, and image-provider ownership/injection left unspecified. The draft now
 routes live writes through `ChatHistoryRepository`, names the bridge builder,
-service, and handler with required dependencies, keeps cache policy in
+handler with required dependencies, keeps cache policy in
 `module_core`, and routes image loading through `MessageImageCubit`. Subsequent
 PR review further moved the thumbnail builder beside Layer-2 attachment mapping,
 made attachment parse failures content-redacted, named the timeout path through

--- a/.plan/active/attachment-references/PLAN.md
+++ b/.plan/active/attachment-references/PLAN.md
@@ -1,0 +1,712 @@
+# Lazy Transcript Attachments
+
+## Status
+
+- **Plan slug:** `attachment-references`
+- **Status:** Step 1/11 - plan ready for review
+- **Plan date:** 2026-08-10
+- **Repository:** `sesori-ai/sesori_apps_monorepo`
+- **Implementation base:** `origin/main` at `944e07e7`
+- **Delivery:** one plan PR, nine sequential implementation PRs, and one
+  plan-retirement PR
+- **Related future work:** prompt-upload decisions are recorded separately in
+  `.plan/drafts/prompt-attachment-uploads/CONSIDERATIONS.md`; they are not part
+  of this series.
+
+## Goal
+
+Stop carrying bridge-owned raster image originals inside every transcript page
+and live message-part event. Capable clients receive small attachment metadata
+with a session-scoped attachment identifier, load one fixed thumbnail on
+demand, and fetch the original only when the user opens it.
+
+The visible result is a stable square attachment presentation that loads
+quickly, uses an app-private thumbnail cache, and preserves the existing image
+viewer actions without making bridge content public or readable by the relay.
+
+## Success Criteria
+
+1. A capable app opening a 50-message history page receives no bridge-owned
+   original image bytes in that page.
+2. A capable app receiving a live `message.part.updated` event receives the
+   attachment reference inside that existing event, not a second attachment
+   event.
+3. A referenced image is addressable only within its owning bridge session and
+   remains E2E encrypted while crossing the relay.
+4. Chat first renders a fixed square tile. The tile reserves its space while
+   loading, center-crops the thumbnail, overlays available filename/type/size
+   metadata, and offers an in-place retry after failure.
+5. Tapping a referenced image opens the existing single-image viewer with the
+   thumbnail immediately visible, automatically fetches the original, then
+   enables the existing copy, share, and save actions against the original.
+6. GIF and animated WebP previews are static first frames; their originals
+   animate in the viewer through Flutter's normal image codec.
+7. Thumbnails survive app restarts in an app-private bounded cache. Originals
+   fetched for viewing remain temporary and are not persisted as an offline
+   media library.
+8. Bridge-owned transcript images support up to 20 MB each and 50 MB aggregate
+   per existing logical attachment collection. The existing four-candidate
+   collection limit remains unchanged.
+9. Released compatibility is preserved in every direction: old apps receive
+   the existing bounded inline/metadata shapes, and new apps continue to render
+   inline images from old bridges.
+10. Archive, session deletion, history purge, and missing-spill behavior remain
+    correct without adding an attachment table, refcounting, or a new cleanup
+    lifecycle.
+11. HTTPS remote image attachments retain their current phone-fetched behavior;
+    this work neither snapshots them on the bridge nor weakens their existing
+    URL, redirect, MIME, signature, timeout, and size checks.
+
+## Locked Product Decisions
+
+### Chat presentation
+
+- One attachment uses a larger square tile; multiple attachments in an existing
+  collection use a responsive two-column square grid.
+- The preview uses center crop. The viewer uses contain and reveals the full,
+  uncropped original.
+- Every tile has a bottom metadata overlay. Missing values are omitted rather
+  than represented with empty strings.
+- Loading and error states retain the same square dimensions to prevent chat
+  reflow. A failed thumbnail has an explicit retry action.
+- A cached thumbnail remains visible if the original is unavailable. The viewer
+  explains the failure and offers retry instead of replacing the preview.
+- The current viewer remains scoped to one image. Swipe galleries across a
+  message or session are deferred because they conflict with the existing
+  pinch, pan, double-tap zoom, Hero, and drag-dismiss gesture system.
+- Metadata-only and unsupported files use the same square footprint with a file
+  icon and available metadata. This plan does not make their bytes downloadable
+  or openable.
+
+### Delivery and privacy
+
+- The attachment reference is part of the current `MessageAttachment` carried
+  by `message.part.updated` and history responses. There is no new SSE event.
+- Bridge content has no public or relay-hosted URL. The client loads it through
+  the existing encrypted relay request path.
+- `cached_network_image`, an in-app loopback HTTP server, and a relay plaintext
+  proxy are intentionally not used.
+- One thumbnail or original is returned per request as bounded base64 in JSON.
+  There is no binary framing, chunking, range request, or resumable transfer in
+  this plan.
+- The app caches only thumbnails on disk. The cache is scoped by account,
+  bridge, session, attachment, rendition version, and is cleared when its
+  authenticated local scope is removed.
+- Remote HTTPS images continue to be fetched by the phone as today. Their
+  third-party origin and existing privacy behavior are not disguised as a
+  bridge-owned attachment.
+
+## Explicitly Excluded
+
+- Prompt/composer upload references. See the separate considerations document.
+- Restart-safe attachment drafts, upload queues, upload percentages, upload
+  cancellation/resume, and cross-device draft synchronization.
+- Video playback, video posters, PDF rendering, document opening, generic file
+  downloads, SVG rendering, and audio playback.
+- Camera and file-picker expansion.
+- Full-screen image galleries or session-wide media browsing.
+- A relay-server route, public URL, plaintext relay cache, room-key disclosure,
+  or any other trust-posture change.
+- A new binary relay message, chunk/range protocol, or transfer registry.
+- Multiple thumbnail sizes, adaptive quality tiers, or network-specific image
+  variants.
+- Cross-session content deduplication, attachment refcounts, a new attachment
+  database table, or a background attachment garbage collector.
+- Client-side persistence of full transcript originals.
+
+## Current Behavior And Evidence
+
+### Transport cost
+
+- `MessageAttachment.inlineImage` stores base64 directly in the shared message
+  part (`shared/sesori_shared/lib/src/models/sesori/message_part.dart`).
+- `POST /session/messages` returns 50 messages per client page
+  (`client/module_core/lib/src/services/session_detail_load_service.dart`). A
+  page can therefore repeat several full images even when no image is visible.
+- `BridgeEventMapper` maps a finalized `BridgeSseMessagePartUpdated` to the full
+  shared part. `SSEManager` retains that event independently for each live or
+  orphan subscriber queue, so inline bytes also increase bridge memory and
+  reconnect replay traffic.
+- Relay request/response and SSE bodies are strings. The relay forwards opaque
+  encrypted frames and enforces a 64 MiB frame ceiling. It has no HTTP content
+  proxy, binary body, streaming, or range primitive.
+
+### Existing storage already solves original persistence
+
+- `AttachmentSpillStorage` stores decoded originals under
+  `history/attachments/<session>/<sha256>` with atomic, idempotent,
+  content-addressed writes and hardened permissions.
+- `ChatHistoryRepository` currently converts `inline_image` to an internal
+  `stored_file` reference before database/archive persistence, then reads and
+  base64-encodes the original again on every history response.
+- Archive export copies the session spill directory before live purge. Session
+  deletion and archive deletion already remove their respective spill
+  directories.
+- The completed internal-history plan explicitly identified an on-demand
+  attachment route as the upgrade path. This work uses that path rather than
+  replacing the history store.
+
+### Existing client behavior
+
+- `MessageImageRepository` validates raster MIME, decoded size, HTTPS redirects,
+  and magic bytes before returning image bytes.
+- Every `FilePartWidget` creates its own `MessageImageCubit`; inline bytes are
+  decoded and remote bytes fetched before the current variable-aspect preview
+  appears.
+- `file_part_widget.dart` uses `BoxFit.contain` with only a maximum height, so
+  message layout varies by source aspect ratio.
+- `ImageAttachmentViewer` already owns Hero transition, contain rendering,
+  pinch/pan, double-tap zoom, drag-dismiss, copy, share, save, and remote
+  open-original behavior. Replacing it is unnecessary.
+
+## Architecture
+
+### 1. Shared wire contract
+
+Add a new image-specific attachment source to `MessageAttachment`:
+
+```text
+stored_image
+  attachmentId
+  mime
+  filename?
+  byteLength
+```
+
+The exact identifier remains an opaque client contract even if the first bridge
+implementation uses the existing content address internally. Every fetch also
+requires `sessionId`, and the client cache key includes bridge and session
+scope; clients must not treat the identifier as a globally reusable URL.
+
+Keep `fallbackUnion: "unknown"`. A capable reference must nevertheless never be
+sent to an old app because that app currently hides unknown attachment sources.
+
+Add one closed delivery mode enum:
+
+```text
+MessageAttachmentDelivery.inline
+MessageAttachmentDelivery.storedReference
+```
+
+Use it in both existing request surfaces:
+
+- `SessionMessagesRequest.attachmentDelivery`, defaulting to `inline` for old
+  apps; and
+- `RelaySseSubscribe.attachmentDelivery`, defaulting to `inline` for old apps.
+
+New fields use a dated compatibility default tied to the first production
+release that ships them. Old bridges ignore the extra JSON field. New apps must
+continue to support all existing attachment variants when an old bridge
+returns inline data.
+
+Add typed shared request/response models for `POST /session/attachment`:
+
+```text
+SessionAttachmentRequest
+  sessionId
+  attachmentId
+  rendition: thumbnail | original
+
+SessionAttachmentResponse
+  mime
+  base64
+  byteLength
+```
+
+The endpoint returns one rendition only. It uses 404 for a missing/purged
+original and an explicit non-success response when a thumbnail cannot be
+decoded. Raw filesystem errors stay in local bridge logs; remote errors remain
+content-safe.
+
+### 2. Stored originals and one thumbnail rendition
+
+Continue using `AttachmentSpillStorage` for originals. Extend the same
+session-scoped directory with a versioned derived-thumbnail filename so archive
+copy and session purge automatically include it. Do not introduce a new table
+or independent retention policy.
+
+The thumbnail contract is fixed for this series:
+
+- 512 x 512 physical pixels;
+- center crop;
+- first frame for animated input;
+- orientation baked before crop;
+- opaque output encoded as bounded-quality JPEG;
+- alpha-bearing output encoded as PNG; and
+- a rendition-version suffix in the derived filename, so a future algorithm can
+  coexist without mutating an existing file in place.
+
+Generate the thumbnail lazily on the first request and persist it atomically.
+
+The concrete bridge owners are:
+
+- `AttachmentThumbnailBuilder` in
+  `bridge/app/lib/src/foundation/attachment_thumbnail_builder.dart` is a pure,
+  zero-collaborator byte transformation over the pure-Dart image codec. It runs
+  off the main isolate, reads metadata first, rejects dimensions/pixel counts
+  above its documented decode-memory ceiling, bakes orientation, crops, and
+  encodes one rendition. It owns no files, cache decisions, or queue.
+- `ChatHistoryRepository` remains the Layer-2 aggregate owner of live/archive
+  attachment files. New methods store an original, read an original or derived
+  thumbnail from the live and archived spill roots, and atomically persist a
+  generated thumbnail through the existing Layer-1 storage APIs.
+- `MessageAttachmentService` in
+  `bridge/app/lib/src/bridge/services/message_attachment_service.dart` requires
+  `ChatHistoryRepository` and `AttachmentThumbnailBuilder`. It owns lazy
+  rendition selection and one coarse generation lane so a page of uncached
+  previews cannot launch many full-image decodes concurrently. It does not
+  touch `AttachmentSpillStorage` directly.
+- `GetSessionAttachmentHandler` in
+  `bridge/app/lib/src/bridge/routing/get_session_attachment_handler.dart`
+  requires `MessageAttachmentService` and maps typed route success/failure only.
+
+The single service lane addresses an ordinary reachable flow with meaningful
+memory impact; no per-session or per-digest lock registry is needed. A rejected
+thumbnail does not delete or invalidate the original. Fetch tries the live
+spill root, then the archived spill root. Existing archive-copy and purge
+ordering remains authoritative.
+
+### 3. History and archive projection
+
+Thread `MessageAttachmentDelivery` from `GetSessionMessagesHandler` through
+`ChatHistoryService` into `ChatHistoryRepository`.
+
+For an internal `stored_file` reference:
+
+- `storedReference` returns `stored_image` metadata without reading or
+  base64-encoding the original; existing stored records without byte length
+  derive it from the spill file; and
+- `inline` preserves the released response shape, but sends at most the current
+  5 MiB legacy collection budget and degrades excess images to `metadata` in
+  collection order.
+
+The same projection applies to active database pages and archived audit pages.
+A missing original remains `metadata`, matching current fail-soft history
+behavior.
+
+### 4. Live event projection and ordering
+
+Do not coordinate `ChatHistoryListener` and `Orchestrator` with callbacks,
+acknowledgements, or another event stream.
+
+For a mapped `SesoriSseEvent.messagePartUpdated` containing bridge-owned inline
+images, the injected `MessageAttachmentService` calls a named
+`ChatHistoryRepository.storeAttachmentOriginal` method and awaits that
+repository operation before a reference variant can be enqueued. The
+repository alone reaches the same live `AttachmentSpillStorage` used by history
+capture. The service returns:
+
+- a reference-shaped event for capable subscribers; and
+- a legacy event with the existing 5 MiB inline/metadata budget for old
+  subscribers.
+
+`ChatHistoryListener` reaches the same repository seam through
+`ChatHistoryService` and may reach the content-addressed write before or after
+that projection. The write is atomic and idempotent, so the concrete ordinary
+race is harmless and does not justify a lock or listener dependency. If the
+awaited materialization fails, the bridge logs the original error and sends a
+legacy-safe inline/metadata shape rather than a dangling identifier.
+
+`SSEManager` records attachment delivery mode with each subscriber queue and
+selects the corresponding event when enqueuing. Orphan queues retain their
+mode; reconnect adoption uses only an orphan with the same mode. This avoids an
+old app receiving a queued reference after a different capable connection and
+does not require a global client capability registry.
+
+Only message-part events with bridge-owned images need dual shapes. All other
+SSE events remain one object. The local debug SSE stream retains the legacy
+shape unless its own explicit capability surface is added by a future need.
+
+### 5. Limits and backend boundaries
+
+Keep the released 5 MiB `maxInlineMessageAttachmentBytes` as the legacy-wire
+budget. Add separate bridge-reference limits:
+
+- 20 MB decoded per image;
+- 50 MB decoded aggregate per logical message/tool attachment collection; and
+- the existing maximum of four output image candidates per collection.
+
+Update output-image mapping in OpenCode, Codex, ACP, Cursor, and the in-repo
+Claude plugin in lockstep. These are internal plugin contracts, so they receive
+no compatibility shims. Prompt-input limits do not change in this series.
+
+The bridge applies the legacy projection after plugin mapping, which preserves
+old-app behavior: images that were previously metadata because they exceeded
+5 MiB remain metadata for an old app, while a capable app can fetch the retained
+larger original.
+
+### 6. Client loading and cache ownership
+
+Add a Layer-1 attachment API over `RelayHttpApiClient`, then extend
+`MessageImageRepository` to load `thumbnail` and `original` renditions for a
+stored image. Continue validating MIME, byte length, and magic bytes after
+fetch; a bridge response is authenticated and encrypted but still treated as
+untrusted image input.
+
+Use an attachment-specific request timeout long enough for one 20 MB original
+on an ordinary mobile connection. This is not resumability: a disconnect or
+timeout retries the complete image.
+
+Add `AttachmentThumbnailStorage` under
+`client/module_core/lib/src/foundation/platform/` as a dumb file-IO capability:
+read, atomic write, list metadata, and delete within a caller-supplied scope. Its
+`FlutterAttachmentThumbnailStorage` implementation under
+`client/app/lib/core/platform/` resolves the OS app-private cache directory and
+performs only those IO primitives. It does not construct keys, choose eviction,
+coalesce requests, or react to authentication.
+
+`MessageImageRepository` in `module_core` owns scoped key construction,
+validation, corruption recovery, one in-flight fetch per key, and the simple
+total-size/oldest-file pruning policy. Keys include account, bridge, session,
+attachment id, and rendition version; only encoded thumbnails are persisted.
+A small `MessageThumbnailCacheService` in `module_core` requires
+`MessageImageRepository` plus the existing authenticated-account transition
+source and owns account-scope cleanup on logout/local account removal.
+
+Do not add a persistent database, cache index, background cache worker, or full
+original cache. The OS may evict cache files at any time; a miss simply refetches
+the thumbnail.
+
+`StoredAttachmentImageProvider` lives with session-detail presentation under
+`client/app/lib/features/session_detail/widgets/`. It delegates byte loading to
+a required `MessageImageRepository` constructor dependency rather than opening
+a URL or resolving DI itself. The session-detail composition root resolves that
+repository once and passes it through the attachment collection/tile
+constructors. Provider equality uses the scoped attachment identity, so
+Flutter's in-memory `ImageCache` and the app-private encoded cache cooperate
+without bypassing client layers.
+
+### 7. Presentation
+
+Introduce one reusable session-detail attachment collection widget that owns
+square sizing, grid layout, metadata overlay, and per-tile states. Use it for
+the attachment lists already owned by user messages and tool states. Preserve
+assistant text/image/tool chronology; only contiguous assistant file parts may
+be grouped.
+
+Inline images from old bridges and directly fetched HTTPS images use the same
+square presentation. Their existing bytes/URL paths remain unchanged.
+
+For a stored image, the viewer receives the loaded thumbnail immediately and
+starts the original request after opening. On success it replaces the provider
+without closing the route and constructs the existing original-backed action
+state. On failure it retains the thumbnail, shows retry, and leaves original
+actions unavailable. Do not add page swiping or another viewer route.
+
+## Compatibility Matrix
+
+| App | Bridge | Result |
+|---|---|---|
+| Old | Old | Existing inline/remote/metadata behavior. |
+| Old | New | Missing delivery mode defaults to inline. Existing 5 MiB visible behavior is preserved; newly retained larger images degrade to metadata. |
+| New | Old | Unknown request fields are ignored. The app receives and renders existing inline/remote/metadata variants. |
+| New | New | History and live events carry stored references; thumbnail and original fetches remain E2E. |
+
+Compatibility applies independently to paged history requests and each live SSE
+subscription because multiple app versions may use one bridge concurrently.
+
+## Failure And Recovery Contract
+
+| Failure | User outcome | Local observability |
+|---|---|---|
+| Live spill write fails before reference emission | Legacy-safe image or metadata remains in the live event; no dangling reference. | Bridge logs original error, stack, session/part operation context, and no content. |
+| Original was purged or missing | Cached thumbnail remains visible; viewer reports unavailable and offers retry. | Fetch route returns 404; storage error context remains local. |
+| Thumbnail decode is unsupported or unsafe | Stable square error tile with retry; original is not deleted. | Bridge reports bounded rendition failure without payload data. |
+| Thumbnail cache read is corrupt | Cache entry is removed and fetched again. | Client logs cache operation context without paths in analytics. |
+| Original fetch times out or connection drops | Viewer keeps thumbnail and offers full retry. | Client preserves the typed transport failure. |
+| Old client would exceed legacy inline budget | That attachment becomes metadata, matching previous visible behavior. | No repeated warning per attachment; one bounded collection degradation signal is sufficient. |
+
+## Security And Privacy
+
+- Relay E2E framing and room-key handling are unchanged.
+- Every fetch requires the owning `sessionId` plus a syntactically valid
+  attachment id. Storage resolution remains under the encoded session directory
+  and rejects path traversal.
+- The first identifier implementation may reuse the content address inside the
+  encrypted contract, but clients treat it as opaque and scope caches by bridge
+  and session. Cross-session/public addressing is not provided.
+- No source path, prompt, transcript, attachment bytes, URL, filename, raw id,
+  or error text enters analytics.
+- Thumbnail cache files contain decrypted user content. They remain app-private,
+  are excluded from backup where the platform requires explicit configuration,
+  and are cleared with the local authenticated scope.
+- Image decode concurrency and decoded-pixel bounds protect both the headless
+  bridge and mobile renderer from compressed images with disproportionate memory
+  requirements.
+
+## Analytics
+
+No analytics event is added for passive preview rendering or viewer taps. There
+is no current product decision that requires measuring those UI interactions,
+and attachment metadata is privacy-sensitive.
+
+The separately considered prompt-upload work may add only a bounded
+`has_attachments` parameter to the existing authoritative accepted-message and
+session-created outcomes. It is not part of this series.
+
+## Cleanup Assessment
+
+Small directly caused cleanup is included:
+
+- capable history reads stop rehydrating and base64-encoding stored originals;
+- capable SSE queues stop retaining original bytes; and
+- client reference previews stop requiring a full-original decode before a chat
+  tile appears.
+
+Compatibility prevents deleting these paths now:
+
+- internal `stored_file` to `inline_image` rehydration remains for old apps;
+- `MessageAttachment.inlineImage` and its client validation remain for old
+  bridges and legacy live delivery; and
+- plugin-side legacy metadata mapping remains the old-client fallback.
+
+No database column, table, cache, flag, job, or listener becomes wholly obsolete.
+Do not remove compatibility paths until the relevant production app/bridge
+baseline is intentionally raised in a separate task.
+
+## Proportionality And Accepted Risk
+
+| Decision | Evidence level | If omitted | Chosen response |
+|---|---|---|---|
+| Reference history images | Observed ordinary flow: every open/reload sends paged inline originals. | Repeated bandwidth, base64 work, and memory. | Implement. |
+| Reference live images | Observed ordinary flow: finalized part events and replay queues carry full snapshots. | Duplicate live/reconnect traffic and bridge queue memory. | Implement with per-subscriber shaping. |
+| Serialize thumbnail generation | Ordinary page can request several uncached previews together. | Concurrent full decodes can spike bridge memory. | One coarse lane, no keyed lock registry. |
+| Persist one bridge thumbnail | Multiple devices/cache eviction can request the same derived image. | Repeated CPU-heavy decode. | One versioned sibling file, existing purge lifecycle. |
+| Chunk/resume transfers | Theoretical benefit for this bounded image-only scope; no observed failed 20 MB attachment flow. | A failed transfer retries the complete image. | Accept and defer. |
+| Gallery swiping | Convenience only; current viewer already opens every image. | User closes viewer to choose another tile. | Accept and defer. |
+| Document/video support | No current ordinary production byte source. | Metadata tiles remain non-openable. | Accept and defer. |
+| New attachment table/refcount | Existing session-scoped content files and purge already own lifetime. | No cross-session dedup or independent lookup metadata. | Accept and avoid. |
+
+## Delivery Rules
+
+- The series has exactly eleven PRs. Every title below is fixed and uses the
+  `attachment-references` slug.
+- Step 1 raises this plan, tracker, and the upload considerations document.
+- Step 11 records final evidence and moves this directory from `.plan/active/`
+  to `.plan/completed/`.
+- Merge in numeric order. A successor may target its immediate predecessor, but
+  each PR must remain independently buildable and safe at its own base.
+- Target no more than 1,500 changed lines per PR, including generated output and
+  tests. Update this plan before opening a step that cannot fit coherently.
+- Generated Freezed/JSON/DI files change only through their generators.
+- The capability remains disabled in production client requests until Step 10,
+  after bridge fetch, compatibility, cache, presentation, and viewer behavior
+  exist together.
+- Internal plugin contracts update all in-repository consumers in lockstep.
+- Run architecture implementation review for Steps 2-5, 7-8, and 10. Step 6 is
+  a bounded policy/limit migration and Step 9 is presentation-only; neither
+  needs architecture review unless implementation changes their scope.
+- Do not add prompt-upload behavior opportunistically to any step.
+
+## Delivery Sequence
+
+| Step | Exact PR title | Estimate | Boundary |
+|---|---|---:|---|
+| 1/11 | `🌱 [attachment-references] docs: plan lazy transcript attachments [step 1/11]` | 650-1,050 | Active plan/tracker and upload considerations only. |
+| 2/11 | `🚧 [attachment-references] feat(protocol): describe stored transcript images [step 2/11]` | 900-1,450 | Shared variant, rendition models, delivery mode defaults, generated code, exhaustive compile-safe consumers. No peer enables references. |
+| 3/11 | `⚙️ [attachment-references] feat(bridge): serve stored image renditions [step 3/11]` | 900-1,400 | Versioned thumbnail storage/builder, live/archive lookup, typed fetch handler, decode/size/security tests. |
+| 4/11 | `⚙️ [attachment-references] feat(bridge): reference images in history pages [step 4/11]` | 700-1,150 | Capability-aware active/archive projection and legacy budget preservation. |
+| 5/11 | `🚧 [attachment-references] feat(bridge): reference images in live events [step 5/11]` | 1,100-1,500 | Awaited materialization, dual event shapes, subscriber/orphan delivery mode, SSE memory/compatibility coverage. |
+| 6/11 | `⚙️ [attachment-references] feat(bridge): retain larger transcript images [step 6/11]` | 900-1,450 | OpenCode, Codex, ACP, Cursor, and Claude output limits move to 20 MB each/50 MB aggregate while legacy projection stays 5 MiB. |
+| 7/11 | `⚙️ [attachment-references] feat(client): load stored image renditions [step 7/11]` | 850-1,350 | Typed API/repository/state support, validation, timeout, request coalescing, but delivery mode remains inline. |
+| 8/11 | `⚙️ [attachment-references] feat(client): cache encrypted image previews [step 8/11]` | 850-1,350 | Platform cache boundary/adapter, scoped atomic storage/pruning/cleanup, Flutter image provider, tests. |
+| 9/11 | `⚙️ [attachment-references] feat(client): render square attachment grids [step 9/11]` | 900-1,450 | Square/grid/overlay/loading/error presentation for existing and reference-capable attachment widgets; capability remains disabled. |
+| 10/11 | `⚙️ [attachment-references] feat(client): load originals in the image viewer [step 10/11]` | 900-1,450 | Thumbnail-first viewer, original retry/actions, enable history/SSE reference mode, end-to-end compatibility tests. |
+| 11/11 | `🌱 [attachment-references] docs: retire lazy transcript attachments [step 11/11]` | 50-200 | Final evidence and plan move to completed. |
+
+## Step Details And Verification
+
+### Step 1/11 - Plan
+
+- Add this `PLAN.md`, `TRACKER.md`, and the separate prompt-upload
+  `CONSIDERATIONS.md`.
+- Record architecture plan review and apply valid findings before opening the
+  PR.
+- Run `git diff --check`. No Dart or Flutter suites are needed.
+
+Expected result: no user-visible, wire, database, or runtime behavior change.
+
+### Step 2/11 - Shared contract
+
+- Add `MessageAttachment.storedImage` and update every exhaustive in-repo
+  consumer to a safe compile-time placeholder without enabling delivery.
+- Add `MessageAttachmentDelivery` with legacy `inline` defaults on
+  `SessionMessagesRequest` and `RelaySseSubscribe`.
+- Add typed attachment rendition request/response models and exports.
+- Keep existing inline, remote, metadata, unknown, and prompt request contracts.
+- Regenerate shared code; run shared model/protocol tests, affected bridge/client
+  compile tests, shared analysis, and architecture implementation review.
+
+Expected result: no user-visible behavior; new and old JSON shapes decode with
+the documented defaults.
+
+### Step 3/11 - Bridge rendition endpoint
+
+- Add zero-collaborator `AttachmentThumbnailBuilder` in bridge foundation with
+  the pure-Dart thumbnail dependency and bounded, off-main-isolate decoding.
+- Extend spill storage for versioned derived thumbnails using existing atomic
+  write, archive-copy, hardening, and purge conventions.
+- Add live-then-archive original/thumbnail methods to
+  `ChatHistoryRepository`; add `MessageAttachmentService(repository, builder)`
+  for lazy selection and the single generation lane; and register
+  `GetSessionAttachmentHandler(service)` for `POST /session/attachment`.
+- Cover original/thumbnail success, first-frame behavior, transparency,
+  orientation, concurrent generation, corrupt/oversized input, missing files,
+  archive lookup, traversal rejection, and response bounds.
+- Run bridge app focused/full tests, fatal analysis, build/codegen as required,
+  and architecture implementation review.
+
+Expected result: no normal client calls the endpoint yet; a typed request can
+retrieve one E2E-ready rendition from an existing spill file.
+
+### Step 4/11 - History references
+
+- Thread delivery mode through handler, service, active page, and archived page
+  reads.
+- Project internal `stored_file` to `stored_image` without reading originals for
+  capable requests.
+- Preserve legacy inline collection budgets and metadata degradation.
+- Cover mixed inline/remote/metadata/stored parts, tool attachment order, old
+  stored records without size metadata, missing files, pagination, and archive
+  parity.
+- Run bridge app tests, fatal analysis, and architecture implementation review.
+
+Expected result: default requests are unchanged; explicit capable requests
+receive lightweight references in history pages.
+
+### Step 5/11 - Live references
+
+- Materialize mapped live inline images through
+  `MessageAttachmentService -> ChatHistoryRepository -> AttachmentSpillStorage`
+  before emitting references.
+- Produce reference and legacy-safe event shapes without a new event type.
+- Store subscriber delivery mode with active/orphan queues and only adopt a
+  matching-mode orphan.
+- Ensure reference queues never retain original base64 while legacy queues keep
+  released behavior.
+- Cover multiple simultaneous old/new subscribers, reconnect replay, write
+  failure fallback, tool updates, event ordering, generation fencing, and local
+  debug behavior.
+- Run bridge app SSE/orchestrator/storage tests, full bridge app tests, fatal
+  analysis, and architecture implementation review.
+
+Expected result: explicitly capable SSE subscriptions receive references; old
+subscriptions remain unchanged.
+
+### Step 6/11 - Larger backend outputs
+
+- Separate reference-retention limits from the released inline-wire limit.
+- Update OpenCode, Codex, ACP, Cursor, and Claude transcript output mapping to 20
+  MB per image, 50 MB aggregate, and the existing candidate-count bound.
+- Keep prompt input limits and backend-specific parsing inside their plugins.
+- Prove old delivery degrades exactly where it did before and capable delivery
+  retains/fetches larger originals live and after replay/backfill.
+- Run focused and full tests plus fatal analysis in every changed plugin and
+  bridge app limit-projection tests.
+
+Expected result: no regression for old apps; capable requests can later access
+larger backend-produced raster originals.
+
+### Step 7/11 - Client data layer
+
+- Add the typed attachment API/repository methods for thumbnail and original.
+- Extend image loading state to distinguish preview availability from original
+  loading/failure without flattening them into nullable booleans.
+- Retain MIME/signature/size validation for inline, remote, and stored sources.
+- Add complete-request retry semantics and an attachment-specific timeout; do
+  not add chunk offsets or fake progress.
+- Coalesce concurrent requests for the same scoped rendition in memory.
+- Keep both delivery-mode call sites set to `inline`.
+- Run module_core focused/full tests, codegen/DI generation, analysis, downstream
+  mobile analysis, and architecture implementation review.
+
+Expected result: no user-visible behavior; the client can load a stored image
+when supplied in a test fixture.
+
+### Step 8/11 - Client thumbnail cache
+
+- Add dumb `AttachmentThumbnailStorage` file primitives in module_core and
+  `FlutterAttachmentThumbnailStorage` over the app-private OS cache directory.
+- Keep scoped keys, corruption recovery, in-flight coalescing, oldest-on-write
+  pruning in `MessageImageRepository`; add `MessageThumbnailCacheService` for
+  authenticated-scope cleanup; keep backup exclusion in the platform IO
+  configuration.
+- Add `StoredAttachmentImageProvider` in the app session-detail presentation
+  package. The session-detail composition root injects its required
+  `MessageImageRepository`; the provider receives no public URL or relay/auth
+  token and never resolves the repository itself.
+- Run module_core tests, app platform/provider tests, codegen/DI generation,
+  mobile analysis/tests, and architecture implementation review.
+
+Expected result: no reference delivery is enabled, but stored-image fixtures
+reuse cached encoded thumbnails across widget remounts/app initialization.
+
+### Step 9/11 - Square attachment presentation
+
+- Add one attachment collection/grid widget and migrate user/tool collections
+  plus contiguous assistant file parts without changing chronology.
+- Render square center-cropped images, metadata overlays, stable loaders,
+  explicit retries, and square metadata-file fallbacks.
+- Preserve current remote URL safety and viewer behavior.
+- Cover one/two/four attachments, narrow/wide layouts, user/assistant/tool
+  contexts, accessibility, long/missing metadata, reduced motion, loading,
+  rejection, and retry.
+- Run focused session-detail widget tests, full mobile tests, and mobile
+  analysis.
+
+Expected result: current inline and remote attachments adopt the final square
+presentation; stored delivery remains disabled.
+
+### Step 10/11 - Viewer and activation
+
+- Open stored images with the thumbnail already visible, automatically load the
+  original, retain the thumbnail on failure, and retry the complete original.
+- Enable copy/share/save only after validated original bytes arrive.
+- Preserve current single-image gestures, route/back behavior, Hero transition,
+  remote open-original action, and animated-original behavior.
+- Set history requests and SSE subscriptions to `storedReference`.
+- Cover all four app/bridge compatibility pairings, live/history/archive parity,
+  cache cold/warm behavior, original timeout/retry, missing-after-thumbnail,
+  action gating, GIF/WebP preview/original behavior, and no eager original
+  request while scrolling.
+- Run module_core and mobile focused/full tests, analysis/codegen, a local bridge
+  integration check with cold/warm history and reconnect, and architecture
+  implementation review.
+
+Expected result: capable app/bridge pairs deliver the complete approved user
+experience; old peer combinations remain usable.
+
+### Step 11/11 - Retire plan
+
+- Confirm Steps 1-10 merged in order and record final PRs and verification.
+- Move `.plan/active/attachment-references/` to
+  `.plan/completed/attachment-references/` in one commit.
+- Run `git diff --check`. No Dart/Flutter suites or architecture review are
+  needed for this documentation-only step.
+
+Expected result: no user-visible, wire, database, or runtime behavior change.
+
+## Material Risks
+
+| Risk | Mitigation |
+|---|---|
+| Reference event outruns file persistence. | Await one idempotent spill write before enqueue; fetch does not depend on the later DB row. |
+| Old app receives an unknown source and hides it. | Default both independent delivery surfaces to inline and shape per subscriber/request. |
+| New app requests a route from an old bridge. | It only calls the route for a received `stored_image`; old bridges never emit that variant. |
+| A page triggers several expensive decodes. | One fixed rendition, lazy generation, decoded-pixel ceiling, and one coarse generation lane. |
+| A full 20 MB response is slow on cellular. | Dedicated timeout, thumbnail remains visible, whole-image retry; chunking remains a documented upgrade path. |
+| Thumbnail cache leaks decrypted content through backups or account reuse. | App-private cache, scoped keys, backup exclusion, and authenticated-scope cleanup. |
+| Plugin limit bump creates an oversized legacy frame. | Legacy projection retains the independent 5 MiB collection budget before SSE/history serialization. |
+| Active Claude work changes relevant mapper files. | Rebase Step 6 on then-current main and update every in-repo plugin consumer in lockstep; do not preserve unpublished intermediate shapes. |
+
+## Plan Review Record
+
+Architecture plan review rejected the first draft on 2026-08-10 with four
+actionable findings: one live materialization layer skip plus unnamed bridge
+owners, Flutter cache policy incorrectly left ambiguous at the platform
+adapter, and image-provider ownership/injection left unspecified. The draft now
+routes live writes through `ChatHistoryRepository`, names the bridge builder,
+service, and handler with required dependencies, keeps cache policy in
+`module_core`, and places an explicitly injected provider in the app
+session-detail package. Per repository process, the corrected draft was not
+re-reviewed merely to obtain an approval verdict.

--- a/.plan/active/attachment-references/PLAN.md
+++ b/.plan/active/attachment-references/PLAN.md
@@ -395,14 +395,14 @@ field, and receives the message-owned `sessionId`; these values form the cache
 scope with attachment id and rendition version. No cache operation reads a
 global current-bridge fallback. Only encoded thumbnails are persisted.
 
-An eager `@singleton` `MessageThumbnailCacheService` in `module_core` requires
-`MessageImageRepository` plus `AuthSession`, subscribes during core DI
-initialization, and owns account-scope cleanup on logout/local account removal.
-Cleanup first retires the account generation, rejects new or late writes for
-that generation, awaits its already-started fetch/write futures, and only then
-deletes the scope. A later completion therefore cannot recreate decrypted
-thumbnail content after logout. Its `@disposeMethod` cancels the auth
-subscription during dependency-container teardown.
+A `@lazySingleton` `MessageThumbnailCacheService` in `module_core` requires
+`MessageImageRepository` plus `AuthSession` and owns account-scope cleanup. The
+mobile shell resolves it once immediately after `configureCoreDependencies`,
+after registering its storage adapter; construction subscribes to auth before
+any session UI can cache a thumbnail. Desktop neither binds nor resolves this
+mobile cache path. Cleanup retires the account generation, rejects late writes,
+settles started fetch/write futures, and only then deletes the scope. Its
+`@disposeMethod` cancels the subscription during container teardown.
 
 Do not add a persistent database, cache index, background cache worker, or full
 original cache. The OS may evict cache files at any time; a miss simply refetches
@@ -701,15 +701,15 @@ when supplied in a test fixture.
   adapter; do not call static `path_provider` APIs from the adapter.
 - Keep scoped keys, corruption recovery, in-flight coalescing, oldest-on-write
   pruning in `MessageImageRepository`; register `MessageThumbnailCacheService`
-  as an eager core singleton for generation-fenced authenticated-scope cleanup
-  that settles in-flight writes before deletion and disposes its auth
-  subscription; keep backup exclusion in the platform IO configuration.
+  as a lazy core singleton, explicitly resolve it during mobile DI after the
+  storage binding, and retain generation-fenced cleanup/disposal; keep backup
+  exclusion in the platform IO configuration.
 - Integrate the cache behind `MessageImageRepository` and the existing
   `MessageImageCubit`; widgets render emitted bytes with standard Flutter image
   providers and receive no repository, public URL, or relay/auth token.
 - Run module_core tests, app platform/cache tests, codegen/DI generation, mobile
-  analysis/tests including account-switch and eager-cleanup activation, and
-  architecture implementation review.
+  analysis/tests including account-switch/mobile activation and desktop DI
+  startup without the storage binding, and architecture implementation review.
 
 Expected result: no reference delivery is enabled, but stored-image fixtures
 reuse cached encoded thumbnails across widget remounts/app initialization.

--- a/.plan/active/attachment-references/PLAN.md
+++ b/.plan/active/attachment-references/PLAN.md
@@ -267,9 +267,10 @@ The concrete bridge owners are:
 The single service lane addresses an ordinary reachable flow with meaningful
 memory impact; no per-session or per-digest lock registry is needed. A rejected
 thumbnail does not delete or invalidate the original. Fetch tries the live
-spill root, then the archived spill root. Original reads and the final derived
-write remain inside the existing session queue, so archive-copy and purge cannot
-interleave and a completed generation cannot recreate a purged session root.
+spill root, then the archived spill root. Source selection, original read, and
+the final derived write remain inside the existing session queue. The thumbnail
+is persisted beside its source original, so archive and purge cannot interleave
+or cause generation to recreate a purged live root.
 
 ### 3. History and archive projection
 
@@ -362,10 +363,11 @@ fetch; a bridge response is authenticated and encrypted but still treated as
 untrusted image input.
 
 The attachment API uses a sensitive-response mode on `RelayHttpApiClient`.
-Malformed JSON or DTO fields retain the caught error/stack in a typed local log,
-but the returned `JsonParsingError` carries only a fixed privacy-safe marker;
-the decrypted response body and its base64 field are never retained in an API
-error or interpolated into diagnostics.
+Malformed JSON or DTO fields log source-free parser details (type, message,
+offset, stack, and operation context), never the caught exception whose
+`FormatException.source` may retain decrypted bytes. The returned
+`JsonParsingError` carries only a fixed privacy-safe marker; no response body or
+base64 field is retained in an API error or diagnostics.
 
 Add a named `RelayHttpApiClient.postWithTimeout` path and thread its required
 duration through `_sendViaRelay` into a required per-request timeout on
@@ -477,9 +479,9 @@ subscription because multiple app versions may use one bridge concurrently.
 - Thumbnail cache files contain decrypted user content. They remain app-private,
   are excluded from backup where the platform requires explicit configuration,
   and are cleared with the local authenticated scope.
-- Image decode concurrency and decoded-pixel bounds protect both the headless
-  bridge and mobile renderer from compressed images with disproportionate memory
-  requirements.
+- Decode concurrency and decoded-pixel bounds protect bridge thumbnail
+  generation from disproportionate memory requirements. Original rendering
+  retains the existing Flutter codec behavior and remains lazy behind the preview.
 
 ## Analytics
 
@@ -598,8 +600,9 @@ the documented defaults.
 - Extend spill storage for versioned derived thumbnails using existing atomic
   write, archive-copy, hardening, and purge conventions.
 - Add live-then-archive original/thumbnail methods to
-  `ChatHistoryRepository`; extend `ChatHistoryService(repository, builder)` with
-  session-queued rendition selection and the single generation lane; and
+  `ChatHistoryRepository`; extend
+  `ChatHistoryService(repository, builder, bridgeIdProvider)` with session-queued
+  rendition selection and the single generation lane; and
   register `GetSessionAttachmentHandler(chatHistoryService)` for
   `POST /session/attachment`.
 - Cover original/thumbnail success, first-frame behavior, transparency,
@@ -669,8 +672,8 @@ larger backend-produced raster originals.
 - Extend image loading state to distinguish preview availability from original
   loading/failure without flattening them into nullable booleans.
 - Retain MIME/signature/size validation for inline, remote, and stored sources.
-- Add sensitive-response parsing so malformed attachment responses retain no
-  decrypted body/base64 in `JsonParsingError` or diagnostics.
+- Add source-free sensitive-response diagnostics and assert malformed attachment
+  body/base64 substrings never reach `JsonParsingError`, logs, or diagnostics.
 - Thread a required attachment timeout from a named `RelayHttpApiClient` method
   through `_sendViaRelay` and `RelayClient.sendRequest`; prove ordinary requests
   retain their 30-second default and attachment requests survive beyond it.

--- a/.plan/active/attachment-references/TRACKER.md
+++ b/.plan/active/attachment-references/TRACKER.md
@@ -22,13 +22,15 @@
   `GetSessionAttachmentHandler` have explicit placement/dependencies; cache
   policy and auth cleanup stay in module_core while the Flutter adapter is dumb
   IO; stored-image loading stays in `MessageImageCubit` and the shell renders
-  emitted bytes without repository access
+  emitted bytes without repository access. A focused second review accepted the
+  revised seams and assigned its one unnamed capture predicate finding to
+  `ChatHistoryService.requiresAwaitedAttachmentCapture(part:)`.
 
 ## Delivery Steps
 
 | Done | Step | Exact PR title | Changed-line target | State |
 |---|---|---|---:|---|
-| [ ] | 1/11 | `🌱 [attachment-references] docs: plan lazy transcript attachments [step 1/11]` | 650-1,050 | [PR #807](https://github.com/sesori-ai/sesori_apps_monorepo/pull/807) open |
+| [ ] | 1/11 | `🌱 [attachment-references] docs: plan lazy transcript attachments [step 1/11]` | 650-1,100 | [PR #807](https://github.com/sesori-ai/sesori_apps_monorepo/pull/807) open |
 | [ ] | 2/11 | `🚧 [attachment-references] feat(protocol): describe stored transcript images [step 2/11]` | 900-1,450 | Pending |
 | [ ] | 3/11 | `⚙️ [attachment-references] feat(bridge): serve stored image renditions [step 3/11]` | 900-1,400 | Pending |
 | [ ] | 4/11 | `⚙️ [attachment-references] feat(bridge): reference images in history pages [step 4/11]` | 700-1,150 | Pending |
@@ -64,7 +66,8 @@
 
 - Step 1: Architecture review completed with four findings applied; corrected
   draft intentionally not re-reviewed. The initial documentation commit is 986
-  changed lines, within its 650-1,050 target, and `git diff --check` passes. No
+  changed lines, within its current 650-1,100 target, and `git diff --check`
+  passes. No
   Dart/Flutter suites were run for this documentation-only step. Committed as
   `6998f477`, pushed, and opened as
   [PR #807](https://github.com/sesori-ai/sesori_apps_monorepo/pull/807).
@@ -89,3 +92,12 @@
   attachment mapping, made malformed attachment responses content-redacted,
   threaded the longer timeout through both relay client layers, and kept all
   preview/original intents in `MessageImageCubit`.
+- **2026-08-10 - PR review root seam:** Moved only inline-image part capture to
+  one awaited `ChatHistoryService.capturePartForDelivery` call, eliminating the
+  archive race and duplicate decode while preserving legacy ACP aggregate
+  budgeting from complete stored collection state. Also required message-owned
+  session scope, viewer-close original release, injected directory lookup, and
+  generation-fenced logout cleanup.
+- **2026-08-10 - Step 1 review budget:** Raised the documentation target from
+  1,050 to 1,100 changed lines to record the valid second-round review findings;
+  the step remains well below the repository's 1,500-line soft cap.

--- a/.plan/active/attachment-references/TRACKER.md
+++ b/.plan/active/attachment-references/TRACKER.md
@@ -3,11 +3,11 @@
 ## Current State
 
 - **Plan slug:** `attachment-references`
-- **Series state:** Step 1 ready
+- **Series state:** Step 1 PR open
 - **Current step:** 1/11
 - **Implementation base:** `origin/main` at `944e07e7`
-- **Plan PR:** Not opened
-- **Next action:** Commit, push, and open Step 1
+- **Plan PR:** [#807](https://github.com/sesori-ai/sesori_apps_monorepo/pull/807)
+- **Next action:** Monitor Step 1 review and CI; begin Step 2 only after merge
 
 ## Plan Review
 
@@ -28,7 +28,7 @@
 
 | Done | Step | Exact PR title | Changed-line target | State |
 |---|---|---|---:|---|
-| [ ] | 1/11 | `🌱 [attachment-references] docs: plan lazy transcript attachments [step 1/11]` | 650-1,050 | Ready to open |
+| [ ] | 1/11 | `🌱 [attachment-references] docs: plan lazy transcript attachments [step 1/11]` | 650-1,050 | [PR #807](https://github.com/sesori-ai/sesori_apps_monorepo/pull/807) open |
 | [ ] | 2/11 | `🚧 [attachment-references] feat(protocol): describe stored transcript images [step 2/11]` | 900-1,450 | Pending |
 | [ ] | 3/11 | `⚙️ [attachment-references] feat(bridge): serve stored image renditions [step 3/11]` | 900-1,400 | Pending |
 | [ ] | 4/11 | `⚙️ [attachment-references] feat(bridge): reference images in history pages [step 4/11]` | 700-1,150 | Pending |
@@ -63,9 +63,11 @@
 ## Verification Log
 
 - Step 1: Architecture review completed with four findings applied; corrected
-  draft intentionally not re-reviewed. The documentation diff is 984 changed
-  lines, within its 650-1,050 target, and `git diff --check` passes. No
-  Dart/Flutter suites were run for this documentation-only step.
+  draft intentionally not re-reviewed. The initial documentation commit is 986
+  changed lines, within its 650-1,050 target, and `git diff --check` passes. No
+  Dart/Flutter suites were run for this documentation-only step. Committed as
+  `6998f477`, pushed, and opened as
+  [PR #807](https://github.com/sesori-ai/sesori_apps_monorepo/pull/807).
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/attachment-references/TRACKER.md
+++ b/.plan/active/attachment-references/TRACKER.md
@@ -66,7 +66,7 @@
 
 - Step 1: Architecture review completed with four findings applied; corrected
   draft intentionally not re-reviewed. Against merge base `944e07e7`,
-  `git diff --numstat` reports 1,094 additions and 0 deletions across the three
+  `git diff --numstat` reports 1,097 additions and 0 deletions across the three
   plan documents, within the 650-1,100 target; `git diff --check` passes. No
   Dart/Flutter suites were run for this documentation-only step. Committed as
   `6998f477`, pushed, and opened as
@@ -102,7 +102,7 @@
   1,050 to 1,100 changed lines to record the valid second-round review findings;
   the step remains well below the repository's 1,500-line soft cap.
 - **2026-08-10 - PR review lifecycle closure:** Routed rendition reads and
-  thumbnail generation through the existing history session queue, made bridge
-  identity part of stored references, captured authenticated account scope at
-  the repository boundary, and made cache cleanup an eager disposable core
-  singleton.
+  source-root thumbnail writes through the history session queue, made bridge
+  identity/account scope explicit, made cache cleanup eager and disposable, and
+  required source-free parser diagnostics. Declined later bot suggestions that
+  added machinery only to already-safe or self-healing failure paths.

--- a/.plan/active/attachment-references/TRACKER.md
+++ b/.plan/active/attachment-references/TRACKER.md
@@ -1,0 +1,85 @@
+# Lazy Transcript Attachments: Tracker
+
+## Current State
+
+- **Plan slug:** `attachment-references`
+- **Series state:** Step 1 ready
+- **Current step:** 1/11
+- **Implementation base:** `origin/main` at `944e07e7`
+- **Plan PR:** Not opened
+- **Next action:** Commit, push, and open Step 1
+
+## Plan Review
+
+- **Verdict:** First draft rejected with actionable findings; all findings
+  applied directly; corrected draft not re-reviewed merely for approval
+- **Reviewer:** `architecture-plan-review`
+- **Reviewed scope:** `.plan/active/attachment-references/PLAN.md` against the
+  current bridge/shared/client architecture, with tracker and upload
+  considerations checked for scope consistency
+- **Applied findings:** live writes now route through `ChatHistoryRepository`;
+  `AttachmentThumbnailBuilder`, `MessageAttachmentService`, and
+  `GetSessionAttachmentHandler` have explicit placement/dependencies; cache
+  policy and auth cleanup stay in module_core while the Flutter adapter is dumb
+  IO; `StoredAttachmentImageProvider` has explicit app ownership and
+  constructor-injected repository access
+
+## Delivery Steps
+
+| Done | Step | Exact PR title | Changed-line target | State |
+|---|---|---|---:|---|
+| [ ] | 1/11 | `🌱 [attachment-references] docs: plan lazy transcript attachments [step 1/11]` | 650-1,050 | Ready to open |
+| [ ] | 2/11 | `🚧 [attachment-references] feat(protocol): describe stored transcript images [step 2/11]` | 900-1,450 | Pending |
+| [ ] | 3/11 | `⚙️ [attachment-references] feat(bridge): serve stored image renditions [step 3/11]` | 900-1,400 | Pending |
+| [ ] | 4/11 | `⚙️ [attachment-references] feat(bridge): reference images in history pages [step 4/11]` | 700-1,150 | Pending |
+| [ ] | 5/11 | `🚧 [attachment-references] feat(bridge): reference images in live events [step 5/11]` | 1,100-1,500 | Pending |
+| [ ] | 6/11 | `⚙️ [attachment-references] feat(bridge): retain larger transcript images [step 6/11]` | 900-1,450 | Pending |
+| [ ] | 7/11 | `⚙️ [attachment-references] feat(client): load stored image renditions [step 7/11]` | 850-1,350 | Pending |
+| [ ] | 8/11 | `⚙️ [attachment-references] feat(client): cache encrypted image previews [step 8/11]` | 850-1,350 | Pending |
+| [ ] | 9/11 | `⚙️ [attachment-references] feat(client): render square attachment grids [step 9/11]` | 900-1,450 | Pending |
+| [ ] | 10/11 | `⚙️ [attachment-references] feat(client): load originals in the image viewer [step 10/11]` | 900-1,450 | Pending |
+| [ ] | 11/11 | `🌱 [attachment-references] docs: retire lazy transcript attachments [step 11/11]` | 50-200 | Pending |
+
+## Locked Decisions
+
+- Transcript viewing and prompt upload are separate efforts.
+- References live inside existing message-part payloads; no attachment SSE
+  event is added.
+- Bridge-owned content remains E2E and has no public/network-image URL.
+- One bounded JSON/base64 image is transferred per request; no chunks, ranges,
+  resume, or determinate progress.
+- Bridge thumbnails are fixed square first-frame renditions and are persisted
+  under the existing session spill lifecycle.
+- The app persists thumbnails only; full originals remain temporary.
+- Chat uses center-cropped square grids with metadata overlays and stable retry
+  states.
+- The existing single-image viewer remains; no gallery swiping.
+- Remote HTTPS behavior remains phone-fetched and unchanged.
+- Reference delivery supports 20 MB per image and 50 MB per collection; legacy
+  inline delivery remains bounded at 5 MiB.
+- Documents, video, prompt uploads, camera/file picker expansion, and full-image
+  offline storage are excluded.
+
+## Verification Log
+
+- Step 1: Architecture review completed with four findings applied; corrected
+  draft intentionally not re-reviewed. The documentation diff is 984 changed
+  lines, within its 650-1,050 target, and `git diff --check` passes. No
+  Dart/Flutter suites were run for this documentation-only step.
+
+## Findings And Plan Deltas
+
+- **2026-08-10 - Scope split:** The user approved one active transcript-viewing
+  plan and a separate considerations-only record for prompt uploads rather than
+  one coupled implementation series.
+- **2026-08-10 - Lean transfer:** The user approved one image per encrypted
+  request, indeterminate loading, complete-image retry, and deferring chunks,
+  resumability, and byte percentages.
+- **2026-08-10 - Lean composer follow-up:** The user approved deferring
+  restart-safe attachment drafts, send-before-upload completion, upload-state
+  queued bubbles, all picker sources, and EXIF preservation after transforms.
+- **2026-08-10 - Lean viewer:** The user approved square grids and retained the
+  current single-image viewer without gallery swiping.
+- **2026-08-10 - Architecture review:** Applied the repository-layer live-write
+  seam, named bridge owners, module_core cache-policy ownership, and explicit
+  app-provider injection requested by the reviewer. No scope expansion.

--- a/.plan/active/attachment-references/TRACKER.md
+++ b/.plan/active/attachment-references/TRACKER.md
@@ -103,6 +103,6 @@
   the step remains well below the repository's 1,500-line soft cap.
 - **2026-08-10 - PR review lifecycle closure:** Routed rendition reads and
   source-root thumbnail writes through the history session queue, made bridge
-  identity/account scope explicit, made cache cleanup eager and disposable, and
-  required source-free parser diagnostics. Declined later bot suggestions that
+  identity/account scope explicit, made cache cleanup mobile-activated and
+  disposable, and required source-free diagnostics. Declined suggestions that
   added machinery only to already-safe or self-healing failure paths.

--- a/.plan/active/attachment-references/TRACKER.md
+++ b/.plan/active/attachment-references/TRACKER.md
@@ -18,7 +18,7 @@
   current bridge/shared/client architecture, with tracker and upload
   considerations checked for scope consistency
 - **Applied findings:** live writes now route through `ChatHistoryRepository`;
-  `AttachmentThumbnailBuilder`, `MessageAttachmentService`, and
+  `AttachmentThumbnailBuilder`, `ChatHistoryService`, and
   `GetSessionAttachmentHandler` have explicit placement/dependencies; cache
   policy and auth cleanup stay in module_core while the Flutter adapter is dumb
   IO; stored-image loading stays in `MessageImageCubit` and the shell renders
@@ -65,9 +65,9 @@
 ## Verification Log
 
 - Step 1: Architecture review completed with four findings applied; corrected
-  draft intentionally not re-reviewed. The initial documentation commit is 986
-  changed lines, within its current 650-1,100 target, and `git diff --check`
-  passes. No
+  draft intentionally not re-reviewed. Against merge base `944e07e7`,
+  `git diff --numstat` reports 1,094 additions and 0 deletions across the three
+  plan documents, within the 650-1,100 target; `git diff --check` passes. No
   Dart/Flutter suites were run for this documentation-only step. Committed as
   `6998f477`, pushed, and opened as
   [PR #807](https://github.com/sesori-ai/sesori_apps_monorepo/pull/807).
@@ -101,3 +101,8 @@
 - **2026-08-10 - Step 1 review budget:** Raised the documentation target from
   1,050 to 1,100 changed lines to record the valid second-round review findings;
   the step remains well below the repository's 1,500-line soft cap.
+- **2026-08-10 - PR review lifecycle closure:** Routed rendition reads and
+  thumbnail generation through the existing history session queue, made bridge
+  identity part of stored references, captured authenticated account scope at
+  the repository boundary, and made cache cleanup an eager disposable core
+  singleton.

--- a/.plan/active/attachment-references/TRACKER.md
+++ b/.plan/active/attachment-references/TRACKER.md
@@ -21,8 +21,8 @@
   `AttachmentThumbnailBuilder`, `MessageAttachmentService`, and
   `GetSessionAttachmentHandler` have explicit placement/dependencies; cache
   policy and auth cleanup stay in module_core while the Flutter adapter is dumb
-  IO; `StoredAttachmentImageProvider` has explicit app ownership and
-  constructor-injected repository access
+  IO; stored-image loading stays in `MessageImageCubit` and the shell renders
+  emitted bytes without repository access
 
 ## Delivery Steps
 
@@ -83,5 +83,9 @@
 - **2026-08-10 - Lean viewer:** The user approved square grids and retained the
   current single-image viewer without gallery swiping.
 - **2026-08-10 - Architecture review:** Applied the repository-layer live-write
-  seam, named bridge owners, module_core cache-policy ownership, and explicit
-  app-provider injection requested by the reviewer. No scope expansion.
+  seam, named bridge owners, module_core cache-policy ownership, and Cubit-owned
+  image loading requested by reviewers. No scope expansion.
+- **2026-08-10 - PR review:** Moved thumbnail transformation beside Layer-2
+  attachment mapping, made malformed attachment responses content-redacted,
+  threaded the longer timeout through both relay client layers, and kept all
+  preview/original intents in `MessageImageCubit`.

--- a/.plan/drafts/prompt-attachment-uploads/CONSIDERATIONS.md
+++ b/.plan/drafts/prompt-attachment-uploads/CONSIDERATIONS.md
@@ -1,0 +1,189 @@
+# Prompt Attachment Upload Considerations
+
+## Status
+
+- **State:** Discussion record only; not an active implementation plan
+- **Date:** 2026-08-10
+- **Depends on:** the attachment fetch/reference contract being implemented and
+  proven by `.plan/active/attachment-references/`
+- **No fixed PR count, titles, branches, estimates, or architecture are approved
+  by this document.** Create a fresh active plan from then-current code before
+  implementation.
+
+## Purpose
+
+Preserve the product decisions and code findings from the attachment-sharing
+discussion without coupling prompt upload work to transcript viewing. The
+future plan should reuse proven concepts where useful, but it must re-inspect
+the code, backend runtimes, and production evidence rather than treating this
+document as an implementation specification.
+
+## Current User Problem
+
+Selected prompt images are currently held as in-memory `ComposerAttachment`
+objects and base64-encoded inside the final create/send request:
+
+- gallery selection requests a 2048-pixel edge and JPEG quality 85;
+- clipboard paste is supported;
+- attachment count is not bounded;
+- the composer allows 50 MB aggregate because that base64 request barely fits
+  the relay's 64 MiB frame;
+- Codex independently rejects more than 5 MiB aggregate because its outbound
+  path reuses the transcript inline-image constant;
+- attachments clear when Send is tapped, before bridge acceptance;
+- new-session failure can therefore lose selected images and text; and
+- there is no upload progress, upload retry, or cancellation boundary.
+
+OpenCode, Codex, and Cursor currently advertise prompt-image support. Generic
+ACP support remains agent-capability dependent, and Claude image input still
+requires its active plugin plan's live verification before capability is
+advertised.
+
+## Agreed Lean User Experience
+
+### Selection
+
+- Image-only first.
+- Start with native multi-select gallery plus clipboard paste.
+- Defer direct camera capture and generic Files/image-file selection until usage
+  evidence justifies their platform permissions, cancellation paths, and tests.
+- Allow at most 10 images.
+- Use one product policy initially: at most 20 MB per image and 50 MB aggregate
+  per prompt.
+- Preserve selected bytes and metadata exactly when they fit.
+- Only resize/recompress an image when required to meet the limit. An optimized
+  copy must preserve visual orientation but does not promise complete EXIF/GPS
+  round-tripping.
+
+### Preparation and sending
+
+- A selected image may upload to bridge staging immediately in the background
+  so it is usually ready before Send.
+- Show an indeterminate preparing/uploading state, then ready or failed. Do not
+  promise a byte percentage without a chunked transfer primitive.
+- Disable Send until every selected attachment is ready.
+- Upload failure keeps the text and selected images editable in the composer
+  with Retry and Remove actions.
+- Only after all attachment references are ready does the existing prompt queue
+  own the submission. Do not put partial upload state inside
+  `QueuedSessionSubmission`.
+- Do not clear text or attachments until the bridge has accepted the create or
+  prompt request. A failed new-session request must remain retryable.
+
+### Lifetime
+
+- Attachment drafts are local to the selecting device.
+- The first upload version does not promise attachment restoration after app
+  restart. Text draft behavior remains independent.
+- A selection can remain staged in the current process while disconnected and
+  begin/retry after reconnection.
+- Do not build seven-day persistent upload drafts, cross-phone synchronization,
+  or account/bridge draft migration in the first version.
+- Bridge staging still needs a simple bounded expiry/startup sweep so a killed
+  app cannot leave files forever. The future plan must choose that TTL from the
+  actual upload/send lifecycle rather than inheriting the discarded seven-day
+  draft requirement.
+
+## One-Image-Per-Request Tradeoff
+
+The approved lean direction sends one bounded image per encrypted relay request
+instead of introducing binary/chunk/range messages.
+
+Benefits:
+
+- reuses the current request/response routing and E2E trust posture;
+- no partial-file offset protocol;
+- no resumable-upload registry;
+- no chunk idempotency or completion transaction;
+- no fake progress aggregation; and
+- much smaller implementation and recovery state space.
+
+Accepted UX costs:
+
+- progress is indeterminate rather than a true percentage;
+- a disconnect or timeout retries the complete image, not the remaining bytes;
+- removing an image updates the UI immediately, but a whole frame already
+  handed to the socket may finish consuming network before bridge cleanup; and
+- the maximum individual image must remain comfortably below the relay frame
+  ceiling after base64 and JSON overhead.
+
+At 20 MB decoded, one image expands to roughly 27 MB before framing and remains
+below the current 64 MiB ceiling. The future plan should add an
+attachment-specific timeout and verify transfer/memory behavior on a slow real
+mobile connection before locking the limit. Chunking should be reconsidered
+only for demonstrated unreliable-network failures, larger generic files, or
+video/range playback.
+
+## Backend Mapping Direction To Reassess
+
+Once an upload is complete, the bridge can avoid re-inlining it into the plugin
+request where the backend supports a local reference:
+
+- Codex can consume a local-image path;
+- OpenCode can consume a local file URL/path through its file part;
+- ACP can consume a resource link when its declared prompt image capability is
+  verified; and
+- Claude may still require base64 at its plugin boundary, subject to the active
+  Claude plan's live verification and upstream limits.
+
+Backend-specific mapping remains in each plugin. The shared client/bridge
+contract carries only the upload reference and safe metadata.
+
+Remove Codex's current outbound 5 MiB aggregate restriction when this reference
+path exists. Keep the agreed 20 MB per-image and 50 MB per-prompt Sesori policy
+unless implementation-time evidence supports a safer/simple alternative. Do
+not add a rich backend limit matrix in the first version.
+
+## Privacy And Cleanup
+
+- Preserve original metadata for unmodified selections, as explicitly chosen by
+  the user.
+- If optimization is required, preserve orientation but do not add a fragile
+  cross-format EXIF reconstruction subsystem.
+- Staged files and thumbnails are source-adjacent user data. Keep them in
+  hardened app/bridge-private storage and remove them after acceptance/expiry,
+  explicit removal, logout scope removal, or failed/cancelled staging as
+  appropriate to the future design.
+- Never report names, paths, bytes, MIME values, sizes, attachment ids, prompts,
+  or backend errors to analytics.
+
+## Analytics Consideration
+
+The user approved adding only a bounded `has_attachments` value to the existing
+authoritative `session_message_sent` and `session_created_with_message`
+outcomes. Emit it only after bridge acceptance, through
+`ProductAnalyticsService`, with no new viewer-open event.
+
+A future implementation must update the closed analytics model, exact wire
+tests, curated BigQuery transforms/fixtures, and reporting coverage according
+to the analytics skill. Analytics failure must remain isolated from prompt
+success.
+
+## Explicitly Deferred
+
+- Determinate byte percentages.
+- Chunking, resumable offsets, range transfer, or parallel chunk lanes.
+- Send-before-ready and an upload-aware queued message bubble.
+- Restart-safe attachment drafts and seven-day local/bridge draft retention.
+- Cross-device draft synchronization or handoff.
+- Camera and generic file picker sources.
+- Video, PDF, document, audio, and generic file uploads.
+- Backend-specific dynamic count/format/size capability matrices.
+- Preserving all EXIF fields after resize/re-encoding.
+- Reusing uploads across prompts or sessions.
+
+## Questions For A Future Active Plan
+
+1. Does a 20 MB one-frame upload complete reliably within an
+   attachment-specific timeout on the slowest supported real mobile connection?
+2. What simple bridge staging TTL covers ordinary composition/backend
+   consumption without creating restart-safe draft semantics?
+3. When may OpenCode/Codex safely release a staged local file after their
+   asynchronous prompt endpoint reports acceptance?
+4. Should file-picker images join the first release if real usage shows gallery
+   and clipboard cannot reach common developer screenshots?
+5. Which client owner should retain selected attachment state without coupling
+   upload lifecycle to the existing prompt queue?
+6. Can the future upload request use the transcript attachment reference models
+   honestly, or do its independent unsent/expiring states require a separate
+   sealed contract?


### PR DESCRIPTION
## Complexity

Trivial (`🌱`): documentation-only planning artifacts with no production, wire, database, generated-code, or runtime change.

## What

- Adds the active 11-step `attachment-references` implementation plan and tracker.
- Locks the lean E2E transcript-image approach: references inside existing message parts, on-demand encrypted thumbnail/original requests, legacy inline compatibility, and square cached previews.
- Records prompt-upload decisions separately as considerations only, without coupling them to this implementation series.

## Why

Transcript pages and live events currently repeat full base64 image originals even though the bridge already stores those bytes separately. The plan defines a compatible path to lazy thumbnails and originals while explicitly excluding public URLs, chunking, resumable drafts, upload-aware queues, video/document support, and gallery swiping.

## Risk and test focus

Risk is low because this PR changes documentation only. Review should focus on bidirectional client/bridge compatibility, E2E trust preservation, session-queued capture/rendition/archive ordering, complete-collection legacy budgeting, account/bridge-scoped cache cleanup, and whether each implementation step remains coherent below the 1,500-line soft cap.

Architecture review findings are incorporated. The finalized seams use `ChatHistoryService`'s session queue and source-matched roots for rendition lifecycle, required message/bridge identity plus authenticated account scope, source-free parser diagnostics, viewer-close original release, and eager generation-fenced logout cleanup.

## Expected result

No user-visible behavior, persisted/database impact, wire change, runtime effect, dependency change, or analytics change. Reviewers receive an implementation-ready transcript attachment plan plus a clearly non-executable upload considerations record.

## Verification

- `git diff --check 944e07e7..HEAD`
- Documentation diff: 1,097 additions and 0 deletions, within the Step 1 target of 650-1,100
- Architecture plan review completed and findings applied
- All current automated review threads assessed and answered; fully addressed bot threads resolved
- No Dart or Flutter suites run because this step is documentation-only

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an 11-step plan and tracker for lazy transcript image attachments—replace inline base64 with stored references, on‑demand encrypted thumbnail/original fetches, and square cached previews to cut bandwidth and memory. Documentation-only; now explicitly scopes thumbnail cache activation to mobile (DI-bound adapter, lazy singleton resolved after storage binding, disposable with auth‑scoped cleanup) and retains lifecycle hardening (generation‑fenced logout cleanup, viewer‑close original release) plus prior review fixes (awaited live capture via `ChatHistoryRepository` using `ChatHistoryService.requiresAwaitedAttachmentCapture(part:)`, explicit builder/service/handler owners, cache policy in `module_core`, `MessageImageCubit` ownership, content‑redacted attachment parsing, and an attachment‑specific timeout); prompt‑upload considerations remain separate and out of scope.

<sup>Written for commit 79078f84c6c089ff680415bc232c88e6b3aac267. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

