### PR TITLE
⚙️ Keep external OpenCode history capture active

### DIFF
--- a/bridge/app/lib/src/api/database/daos/session_dao.dart
+++ b/bridge/app/lib/src/api/database/daos/session_dao.dart
@@ -261,6 +261,14 @@ class SessionDao extends DatabaseAccessor<AppDatabase> with _$SessionDaoMixin {
     return {for (final row in rows) row.backendSessionId: row};
   }
 
+  Future<Set<String>> getSessionIdsForPlugin({required String pluginId}) async {
+    final query = selectOnly(sessionTable)
+      ..addColumns([sessionTable.sessionId])
+      ..where(sessionTable.pluginId.equals(pluginId));
+    final rows = await query.get();
+    return {for (final row in rows) row.read(sessionTable.sessionId)!};
+  }
+
   Future<Set<String>> getAllSessionIds() async {
     final query = selectOnly(sessionTable)..addColumns([sessionTable.sessionId]);
     final rows = await query.get();

--- a/bridge/app/lib/src/api/database/history/chat_history_dao.dart
+++ b/bridge/app/lib/src/api/database/history/chat_history_dao.dart
@@ -241,6 +241,19 @@ class ChatHistoryDao extends DatabaseAccessor<ChatHistoryDatabase> with _$ChatHi
     );
   }
 
+  Future<void> clearSyncedAtForSessions({required List<String> sessionIds}) {
+    if (sessionIds.isEmpty) return Future<void>.value();
+    return transaction(() async {
+      for (var start = 0; start < sessionIds.length; start += _maxBindVariables) {
+        final end = start + _maxBindVariables;
+        final chunk = sessionIds.sublist(start, end > sessionIds.length ? sessionIds.length : end);
+        await (update(historySyncStateTable)..where((table) => table.sessionId.isIn(chunk))).write(
+          const HistorySyncStateTableCompanion(syncedAt: Value(null)),
+        );
+      }
+    });
+  }
+
   /// Every session id the store holds rows for.
   Future<Set<String>> getStoredSessionIds() async {
     final rows = await (selectOnly(historyMessagesTable, distinct: true)

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -545,14 +545,7 @@ class Orchestrator {
       source: catalogImportRepository.backendActivity,
       chatHistoryService: chatHistoryService,
     );
-    final normalizedPluginEvents = sessionEventDispatcher.events.doOnListen(() {
-      for (final listener in pluginEventListeners) {
-        listener.start();
-      }
-      sessionBindingCommitListener.start();
-      sessionDeletionListener.start();
-      chatHistoryListener.start();
-    });
+    final normalizedPluginEvents = sessionEventDispatcher.events;
     final restartDispatcher = BridgeRestartDispatcher(restartService: _restartService);
     final router = RequestRouter(
       handlers: [
@@ -927,6 +920,41 @@ class OrchestratorSession {
       return Future.error(StateError("OrchestratorSession has already started"), StackTrace.current);
     }
 
+    _sessionAbortService.abortStartedSessions
+        .listen(_completionListener.markSessionAbortPending)
+        .addTo(_subscriptions);
+    _sessionAbortService.abortedSessions.listen(_completionListener.markSessionAborted).addTo(_subscriptions);
+    _sessionAbortService.abortFailedSessions.listen(_completionListener.clearPendingAbort).addTo(_subscriptions);
+    _completionListener.start();
+    _pluginEvents
+        .listen(
+          (source) {
+            unawaited(_processPluginEventInOrder(source));
+          },
+          onError: (Object e, StackTrace st) {
+            Log.w("plugin event stream error: $e");
+            unawaited(
+              _failureReporter.recordFailure(
+                error: e,
+                stackTrace: st,
+                uniqueIdentifier: "bridge.plugin.events",
+                fatal: false,
+                reason: "plugin event stream failure",
+                information: const [],
+              ),
+            );
+          },
+          onDone: () {
+            Log.w("plugin event stream closed");
+          },
+        )
+        .addTo(_subscriptions);
+    _chatHistoryListener.start();
+    _sessionBindingCommitListener.start();
+    _sessionDeletionListener.start();
+    for (final listener in _pluginEventListeners) {
+      listener.start();
+    }
     _sessionOptionsCreationRefreshListener.start();
     _sessionOptionsChangedRefreshListener.start();
     _viewedProjectPrRefreshListener.start();
@@ -1013,12 +1041,6 @@ class OrchestratorSession {
         return;
       }
 
-      _sessionAbortService.abortStartedSessions
-          .listen(_completionListener.markSessionAbortPending)
-          .addTo(_subscriptions);
-      _sessionAbortService.abortedSessions.listen(_completionListener.markSessionAborted).addTo(_subscriptions);
-      _sessionAbortService.abortFailedSessions.listen(_completionListener.clearPendingAbort).addTo(_subscriptions);
-      _completionListener.start();
       _maintenanceListener.start();
       _projectActivityService.changes
           .listen((change) {
@@ -1039,31 +1061,6 @@ class OrchestratorSession {
           _statusNotifier?.handleProjectsSummary(summary: startupSummary);
         }
       }
-      Log.d("subscribing to plugin event stream...");
-      _pluginEvents
-          .listen(
-            (source) {
-              unawaited(_processPluginEventInOrder(source));
-            },
-            onError: (Object e, StackTrace st) {
-              Log.w("plugin event stream error: $e");
-              unawaited(
-                _failureReporter.recordFailure(
-                  error: e,
-                  stackTrace: st,
-                  uniqueIdentifier: "bridge.plugin.events",
-                  fatal: false,
-                  reason: "plugin event stream failure",
-                  information: const [],
-                ),
-              );
-            },
-            onDone: () {
-              Log.w("plugin event stream closed");
-            },
-          )
-          .addTo(_subscriptions);
-      Log.d("plugin event stream subscribed");
       _prSyncService.renderedChanges
           .listen((change) {
             _enqueueWireEvent(SesoriSseEvent.sessionsUpdated(projectID: change.projectId));

--- a/bridge/app/lib/src/bridge/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/chat_history_repository.dart
@@ -243,6 +243,10 @@ class ChatHistoryRepository {
     return _chatHistoryDao.clearSyncedAt(sessionId: sessionId);
   }
 
+  Future<void> clearSyncedAtForSessions({required List<String> sessionIds}) {
+    return _chatHistoryDao.clearSyncedAtForSessions(sessionIds: sessionIds);
+  }
+
   Future<Set<String>> getStoredSessionIds() => _chatHistoryDao.getStoredSessionIds();
 
   /// Writes the session's audit file and copies its attachment bytes beside

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -1127,6 +1127,10 @@ class SessionRepository {
     return existing;
   }
 
+  Future<Set<String>> getStoredSessionIdsForPlugin({required String pluginId}) {
+    return _sessionDao.getSessionIdsForPlugin(pluginId: pluginId);
+  }
+
   /// The subset of [sessionIds] the catalog reports as archived.
   ///
   /// Distinguishes "the archive completed" from "an export ran but the archive

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -888,9 +888,12 @@ class BridgeRuntimeRunner {
       final sessionStart = activeRuntime.session.start();
       sessionStart.ignore();
       sessionRun = activeRuntime.session.waitUntilStopped();
-      // Arm ordered shutdown before eager startup so a signal or control
-      // request aborts a plugin that is still establishing its event stream.
-      activeRuntime.session.shutdownRequested.then((_) => shutdownCoordinator.shutdown()).ignore();
+      // Abort eager startup promptly, but defer the full coordinator until all
+      // startup resources have registered their teardown actions below.
+      activeRuntime.session.shutdownRequested.then((_) {
+        startAbortController.abort();
+        activePluginRuntime.beginShutdown();
+      }).ignore();
       await activePluginRuntime.startEager(pluginIds: startupPolicy.eagerPluginIds);
       await startDebugServerIfRequested(
         debugPort: options.debugPort,
@@ -926,6 +929,11 @@ class BridgeRuntimeRunner {
       } else {
         onboardingPreparation = null;
       }
+
+      // Start the ordered shutdown once every startup resource has registered
+      // its teardown. If shutdown was already requested, Future.then schedules
+      // this immediately and joins the same memoized shutdown used in finally.
+      activeRuntime.session.shutdownRequested.then((_) => shutdownCoordinator.shutdown()).ignore();
 
       final startResult = await sessionStart;
       if (startResult == OrchestratorSessionStartResult.ready) {

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -654,6 +654,7 @@ class BridgeRuntimeRunner {
                 (
                   id: descriptor.id,
                   displayName: descriptor.displayName,
+                  activationPolicy: descriptor.activationPolicy(config: pluginConfigs[descriptor.id]!),
                   residencyPolicy: descriptor.residencyPolicy(config: pluginConfigs[descriptor.id]!),
                   sessionOptionsScope: descriptor.sessionOptionsScope,
                   managementCapabilities: descriptor.managementCapabilities(config: pluginConfigs[descriptor.id]!),
@@ -887,6 +888,7 @@ class BridgeRuntimeRunner {
       final sessionStart = activeRuntime.session.start();
       sessionStart.ignore();
       sessionRun = activeRuntime.session.waitUntilStopped();
+      await activePluginRuntime.startEager(pluginIds: startupPolicy.eagerPluginIds);
       await startDebugServerIfRequested(
         debugPort: options.debugPort,
         runtime: activeRuntime,

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -888,6 +888,9 @@ class BridgeRuntimeRunner {
       final sessionStart = activeRuntime.session.start();
       sessionStart.ignore();
       sessionRun = activeRuntime.session.waitUntilStopped();
+      // Arm ordered shutdown before eager startup so a signal or control
+      // request aborts a plugin that is still establishing its event stream.
+      activeRuntime.session.shutdownRequested.then((_) => shutdownCoordinator.shutdown()).ignore();
       await activePluginRuntime.startEager(pluginIds: startupPolicy.eagerPluginIds);
       await startDebugServerIfRequested(
         debugPort: options.debugPort,
@@ -923,18 +926,6 @@ class BridgeRuntimeRunner {
       } else {
         onboardingPreparation = null;
       }
-
-      // Start the ordered shutdown the moment the session begins shutting down
-      // (any trigger: signal, supervised logout/restart, control-channel loss),
-      // so the coordinator's signal phase interrupts in-flight agent work and
-      // its backstop bounds the session teardown itself — a teardown blocked
-      // on agent-coupled requests must not hang the process with no deadline.
-      // Registered after startup wiring so every phase action and disposable
-      // above is in place (no agent-coupled work can exist before startup
-      // completes anyway). The runner's finally joins the same (memoized)
-      // shutdown future and applies the exit-code policy there, so this
-      // early-start copy only marks its error as handled.
-      activeRuntime.session.shutdownRequested.then((_) => shutdownCoordinator.shutdown()).ignore();
 
       final startResult = await sessionStart;
       if (startResult == OrchestratorSessionStartResult.ready) {

--- a/bridge/app/lib/src/bridge/services/chat_history_service.dart
+++ b/bridge/app/lib/src/bridge/services/chat_history_service.dart
@@ -106,6 +106,31 @@ class ChatHistoryService {
     );
   }
 
+  /// Marks this plugin's stored live transcripts incomplete across an event
+  /// stream gap. Later captures preserve that state because only a full
+  /// backfill writes a non-null sync marker.
+  Future<void> invalidatePluginHistory({required String pluginId}) async {
+    try {
+      final results = await Future.wait<Set<String>>([
+        _chatHistoryRepository.getStoredSessionIds(),
+        _sessionRepository.getStoredSessionIdsForPlugin(pluginId: pluginId),
+      ]);
+      final sessionIds = results[0].intersection(results[1]).toList(growable: false)..sort();
+      if (sessionIds.isEmpty) return;
+      await _enqueueAll(
+        sessionIds: sessionIds,
+        write: () => _chatHistoryRepository.clearSyncedAtForSessions(sessionIds: sessionIds),
+      );
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        "Failed to invalidate chat history after the $pluginId event stream connected; "
+        "stored transcripts may remain stale until a later invalidation succeeds",
+        error,
+        stackTrace,
+      );
+    }
+  }
+
   /// Records a finalized message from the live event stream.
   Future<void> captureMessage({required String sessionId, required Message message}) {
     return _capture(

--- a/bridge/app/lib/src/listeners/chat_history_listener.dart
+++ b/bridge/app/lib/src/listeners/chat_history_listener.dart
@@ -29,7 +29,7 @@ class ChatHistoryListener {
   void start() {
     if (_subscription != null || _disposed) return;
     _subscription = _source.listen(
-      (sourced) => _track(capture: _capture(event: sourced.event)),
+      (sourced) => _track(capture: _capture(pluginId: sourced.pluginId, event: sourced.event)),
       // Source errors are surfaced by the dispatcher's own consumers; capture
       // simply has nothing to store for a failed event.
       onError: (Object _) {},
@@ -43,8 +43,9 @@ class ChatHistoryListener {
     unawaited(capture.whenComplete(() => _pendingCaptures.remove(capture)));
   }
 
-  Future<void> _capture({required BridgeSseEvent event}) {
+  Future<void> _capture({required String pluginId, required BridgeSseEvent event}) {
     return switch (event) {
+      BridgeSseServerConnected() => _chatHistoryService.invalidatePluginHistory(pluginId: pluginId),
       BridgeSseMessageUpdated(:final info) => _captureMessage(info: info),
       BridgeSseMessagePartUpdated(:final part) => _chatHistoryService.capturePart(
         sessionId: part.sessionID,

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -27,6 +27,7 @@ typedef PluginCompositionView = ({
 typedef RegisteredPluginMetadata = ({
   String id,
   String displayName,
+  PluginActivationPolicy activationPolicy,
   PluginResidencyPolicy residencyPolicy,
   PluginSessionOptionsScope sessionOptionsScope,
   Set<PluginControlCapability> managementCapabilities,
@@ -35,6 +36,7 @@ typedef RegisteredPluginMetadata = ({
 
 typedef PluginStartupPolicy = ({
   List<String> eligiblePluginIds,
+  List<String> eagerPluginIds,
   String? defaultPluginId,
 });
 
@@ -159,6 +161,13 @@ class PluginLifecycleService {
     _applyAccess();
     _rebuildMetadata();
     final defaultPluginId = _selectableDefaultPluginId();
+    final eagerPluginIds = List<String>.unmodifiable([
+      for (final plugin in registeredPlugins)
+        if (eligiblePluginIds.contains(plugin.id) &&
+            setupReadyPluginIds.contains(plugin.id) &&
+            plugin.activationPolicy == PluginActivationPolicy.eager)
+          plugin.id,
+    ]);
     _metadataSubject = BehaviorSubject<List<PluginMetadata>>.seeded(_orderedMetadata());
     _readyPluginIdsSubject = BehaviorSubject<List<String>>.seeded(
       _buildReadyPluginIds(_lifecycleRepository.snapshot),
@@ -169,6 +178,7 @@ class PluginLifecycleService {
     _runtimeSubscription = _lifecycleRepository.snapshots.listen(_applyRuntimeSnapshots);
     return (
       eligiblePluginIds: eligiblePluginIds,
+      eagerPluginIds: eagerPluginIds,
       defaultPluginId: defaultPluginId,
     );
   }

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -41,6 +41,7 @@ void main() {
               (
                 id: "opencode",
                 displayName: "OpenCode",
+                activationPolicy: PluginActivationPolicy.onDemand,
                 residencyPolicy: PluginResidencyPolicy.transient,
                 sessionOptionsScope: PluginSessionOptionsScope.project,
                 managementCapabilities: defaultManagementCapabilities,
@@ -193,8 +194,9 @@ void main() {
   });
 
   group("OrchestratorSession SSE error recovery", () {
-    test("local options listener starts before an initial relay connect failure", () async {
+    test("local plugin listeners start before an initial relay connect failure", () async {
       final plugin = _ThrowingSummaryPlugin();
+      final connectGate = Completer<void>();
       final database = createTestDatabase();
       final lifecycleService = await createSinglePluginLifecycleService(plugin: plugin);
       final httpClient = http.Client();
@@ -206,7 +208,7 @@ void main() {
           sseReplayWindow: Duration(minutes: 1),
           yolo: false,
         ),
-        client: _ThrowingConnectRelayClient(),
+        client: _ThrowingConnectRelayClient(connectGate: connectGate.future),
         legacyMissingPluginId: plugin.id,
         pluginLifecycleService: lifecycleService,
         pluginRuntime: runtimeForLifecycleService(service: lifecycleService),
@@ -233,17 +235,22 @@ void main() {
 
       await expectLater(session.waitUntilStopped(), throwsA(isA<StateError>()));
       final localWireEventsDone = session.localWireEvents.drain<void>();
+      final localPluginEvent = session.localWireEvents.firstWhere((event) => event is SesoriVcsBranchUpdated);
       final startFuture = session.start();
       final stopped = session.waitUntilStopped();
       stopped.ignore();
       expect(identical(stopped, session.waitUntilStopped()), isTrue);
+
+      plugin.add(const BridgeSseVcsBranchUpdated());
+      expect(await localPluginEvent.timeout(const Duration(seconds: 2)), isA<SesoriVcsBranchUpdated>());
+      connectGate.complete();
 
       await expectLater(startFuture, throwsA(isA<Exception>()));
       await expectLater(stopped, throwsA(isA<Exception>()));
       await expectLater(localWireEventsDone, completes);
       await expectLater(session.start(), throwsA(isA<StateError>()));
 
-      expect(plugin.subscribeCount, equals(1));
+      expect(plugin.subscribeCount, equals(2));
 
       await lifecycleService.dispose();
       httpClient.close();
@@ -573,15 +580,19 @@ class _ThrowingSummaryPlugin implements NativeProjectsPluginApi {
 }
 
 class _ThrowingConnectRelayClient extends RelayClient {
-  _ThrowingConnectRelayClient()
-    : super(
+  _ThrowingConnectRelayClient({required Future<void> connectGate})
+    : _connectGate = connectGate,
+      super(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
         bridgeIdProvider: FakeBridgeIdProvider(),
       );
 
+  final Future<void> _connectGate;
+
   @override
   Future<RelayConnection> connect() async {
+    await _connectGate;
     throw StateError("connect failed");
   }
 }

--- a/bridge/app/test/bridge/routing/get_plugin_setup_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_plugin_setup_handler_test.dart
@@ -34,6 +34,7 @@ void main() {
                 (
                   id: "ready",
                   displayName: "Ready",
+                  activationPolicy: PluginActivationPolicy.onDemand,
                   residencyPolicy: PluginResidencyPolicy.transient,
                   sessionOptionsScope: PluginSessionOptionsScope.project,
                   managementCapabilities: defaultManagementCapabilities,
@@ -42,6 +43,7 @@ void main() {
                 (
                   id: "blocked",
                   displayName: "Blocked",
+                  activationPolicy: PluginActivationPolicy.onDemand,
                   residencyPolicy: PluginResidencyPolicy.transient,
                   sessionOptionsScope: PluginSessionOptionsScope.project,
                   managementCapabilities: defaultManagementCapabilities,

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -837,6 +837,9 @@ class _NoopSessionRepository implements SessionRepository {
   int captureProjectionTimestamp() => DateTime.now().millisecondsSinceEpoch;
 
   @override
+  Future<Set<String>> getStoredSessionIdsForPlugin({required String pluginId}) async => const {};
+
+  @override
   Future<SessionFamilyScope> resolveSessionFamily({
     required String sessionId,
     required SessionOperation operation,
@@ -1089,6 +1092,9 @@ class FakeSessionRepository implements SessionRepository {
 
   @override
   int captureProjectionTimestamp() => DateTime.now().millisecondsSinceEpoch;
+
+  @override
+  Future<Set<String>> getStoredSessionIdsForPlugin({required String pluginId}) async => const {};
 
   @override
   Future<void> dispose() async {}

--- a/bridge/app/test/bridge/services/chat_history_capture_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_capture_test.dart
@@ -5,6 +5,9 @@ import "dart:typed_data";
 import "package:sesori_bridge/src/bridge/repositories/models/stored_session.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/services/chat_history_reconcile_service.dart";
+import "package:sesori_bridge/src/bridge/services/session_event_dispatcher.dart";
+import "package:sesori_bridge/src/listeners/chat_history_listener.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -76,6 +79,90 @@ void main() {
       expect(state!.syncedAt, isNull, reason: "only a completed backfill may claim a complete transcript");
       expect(state.watermark, greaterThan(0));
       expect(state.backendActivityAt, greaterThan(0));
+    });
+
+    test("an event-stream gap invalidates only this plugin's stored history", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [_messageWithParts(id: "m1")],
+        pluginSessionIds: const {
+          "opencode": {"ses_a"},
+          "codex": {"ses_b"},
+        },
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      await history.service.backfillSession(sessionId: "ses_a");
+      await history.service.backfillSession(sessionId: "ses_b");
+      expect((await history.repository.getSyncState(sessionId: "ses_a"))!.syncedAt, isNotNull);
+      expect((await history.repository.getSyncState(sessionId: "ses_b"))!.syncedAt, isNotNull);
+
+      await history.service.invalidatePluginHistory(pluginId: "opencode");
+      await history.service.captureMessage(
+        sessionId: "ses_a",
+        message: _message(id: "m2"),
+      );
+
+      expect(
+        (await history.repository.getSyncState(sessionId: "ses_a"))!.syncedAt,
+        isNull,
+        reason: "live captures cannot claim that events missed during the gap were recovered",
+      );
+      expect(
+        (await history.repository.getSyncState(sessionId: "ses_b"))!.syncedAt,
+        isNotNull,
+        reason: "another plugin's transcript did not cross the event-stream gap",
+      );
+    });
+
+    test("a server-connected event invalidates its source plugin", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [_messageWithParts(id: "m1")],
+        pluginSessionIds: const {
+          "opencode": {"ses_a"},
+        },
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      await history.service.backfillSession(sessionId: "ses_a");
+      final source = StreamController<NormalizedSourcedBridgeEvent>();
+      final listener = ChatHistoryListener(
+        source: source.stream,
+        chatHistoryService: history.service,
+      )..start();
+
+      source.add((
+        pluginId: "opencode",
+        generation: 1,
+        event: const BridgeSseServerConnected(),
+        allowDuringStop: false,
+        terminalHandoffConsumed: null,
+      ));
+      await source.close();
+      await listener.dispose();
+
+      expect((await history.repository.getSyncState(sessionId: "ses_a"))!.syncedAt, isNull);
+    });
+
+    test("an invalidation failure does not fail listener teardown", () async {
+      final repository = _FakeSessionRepository(
+        transcript: const [],
+        pluginSessionLookupError: StateError("database unavailable"),
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      final source = StreamController<NormalizedSourcedBridgeEvent>();
+      final listener = ChatHistoryListener(
+        source: source.stream,
+        chatHistoryService: history.service,
+      )..start();
+
+      source.add((
+        pluginId: "opencode",
+        generation: 1,
+        event: const BridgeSseServerConnected(),
+        allowDuringStop: false,
+        terminalHandoffConsumed: null,
+      ));
+      await source.close();
+
+      await expectLater(listener.dispose(), completes);
     });
 
     test("inline attachment bytes are spilled to disk, never stored in the database", () async {
@@ -332,12 +419,16 @@ class _FakeSessionRepository implements SessionRepository {
   _FakeSessionRepository({
     required this.transcript,
     this.error,
+    this.pluginSessionLookupError,
     this.existingSessionIds = const {},
+    this.pluginSessionIds = const {},
   });
 
   final List<MessageWithParts> transcript;
   final Object? error;
+  final Object? pluginSessionLookupError;
   final Set<String> existingSessionIds;
+  final Map<String, Set<String>> pluginSessionIds;
   int fetchCount = 0;
 
   /// Runs while the fetch is in flight, so a test can interleave live events.
@@ -361,6 +452,16 @@ class _FakeSessionRepository implements SessionRepository {
   @override
   Future<Set<String>> getExistingSessionIds({required Set<String> sessionIds}) async =>
       sessionIds.intersection(existingSessionIds);
+
+  @override
+  Future<Set<String>> getStoredSessionIdsForPlugin({required String pluginId}) async {
+    final failure = pluginSessionLookupError;
+    if (failure != null) throw failure;
+    return pluginSessionIds[pluginId] ?? const {};
+  }
+
+  @override
+  Future<Set<String>> getArchivedSessionIds({required Set<String> sessionIds}) async => const {};
 
   /// Not archived: these suites exercise the live-store path.
   @override

--- a/bridge/app/test/helpers/plugin_lifecycle_test_support.dart
+++ b/bridge/app/test/helpers/plugin_lifecycle_test_support.dart
@@ -43,6 +43,7 @@ Future<PluginLifecycleService> createPluginLifecycleService({
               (
                 id: plugin.id,
                 displayName: plugin.id,
+                activationPolicy: PluginActivationPolicy.onDemand,
                 residencyPolicy: PluginResidencyPolicy.transient,
                 sessionOptionsScope: PluginSessionOptionsScope.project,
                 managementCapabilities: defaultManagementCapabilities,

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -24,6 +24,7 @@ void main() {
         (
           id: "zeta",
           displayName: "Zeta",
+          activationPolicy: PluginActivationPolicy.onDemand,
           residencyPolicy: PluginResidencyPolicy.transient,
           sessionOptionsScope: PluginSessionOptionsScope.project,
           managementCapabilities: defaultManagementCapabilities,
@@ -32,6 +33,7 @@ void main() {
         (
           id: "beta",
           displayName: "Beta",
+          activationPolicy: PluginActivationPolicy.onDemand,
           residencyPolicy: PluginResidencyPolicy.transient,
           sessionOptionsScope: PluginSessionOptionsScope.plugin,
           managementCapabilities: defaultManagementCapabilities,
@@ -40,6 +42,7 @@ void main() {
         (
           id: "alpha",
           displayName: "Alpha",
+          activationPolicy: PluginActivationPolicy.onDemand,
           residencyPolicy: PluginResidencyPolicy.transient,
           sessionOptionsScope: PluginSessionOptionsScope.project,
           managementCapabilities: defaultManagementCapabilities,
@@ -60,6 +63,7 @@ void main() {
 
     expect(policy.eligiblePluginIds, ["alpha", "zeta"]);
     expect(policy.defaultPluginId, "alpha");
+    expect(policy.eagerPluginIds, isEmpty);
     expect(service.compositionView.eligiblePluginIds, ["alpha", "zeta"]);
     expect(service.compositionView.orderedPluginIds, ["alpha", "beta", "zeta"]);
     final sessionOptionsScopeById = service.compositionView.sessionOptionsScopeById;
@@ -76,6 +80,65 @@ void main() {
     expect(runtime.snapshot.singleWhere((entry) => entry.pluginId == "zeta").state, PluginRuntimeState.blocked);
   });
 
+  test("eager plugins activate only when eligible and setup-ready", () {
+    final runtime = createRegisteredTestPluginRuntime(pluginIds: const ["wombat", "xenon", "yeti", "zebra"]);
+    addTearDown(runtime.dispose);
+    final service = _service(
+      runtime: runtime,
+      plugins: const [
+        (
+          id: "zebra",
+          displayName: "Zebra",
+          activationPolicy: PluginActivationPolicy.eager,
+          residencyPolicy: PluginResidencyPolicy.transient,
+          sessionOptionsScope: PluginSessionOptionsScope.project,
+          managementCapabilities: defaultManagementCapabilities,
+          supportsPromptAttachments: false,
+        ),
+        (
+          id: "yeti",
+          displayName: "Yeti",
+          activationPolicy: PluginActivationPolicy.eager,
+          residencyPolicy: PluginResidencyPolicy.transient,
+          sessionOptionsScope: PluginSessionOptionsScope.project,
+          managementCapabilities: defaultManagementCapabilities,
+          supportsPromptAttachments: false,
+        ),
+        (
+          id: "xenon",
+          displayName: "Xenon",
+          activationPolicy: PluginActivationPolicy.eager,
+          residencyPolicy: PluginResidencyPolicy.transient,
+          sessionOptionsScope: PluginSessionOptionsScope.plugin,
+          managementCapabilities: defaultManagementCapabilities,
+          supportsPromptAttachments: false,
+        ),
+        (
+          id: "wombat",
+          displayName: "Wombat",
+          activationPolicy: PluginActivationPolicy.onDemand,
+          residencyPolicy: PluginResidencyPolicy.transient,
+          sessionOptionsScope: PluginSessionOptionsScope.project,
+          managementCapabilities: defaultManagementCapabilities,
+          supportsPromptAttachments: false,
+        ),
+      ],
+    );
+    addTearDown(service.dispose);
+
+    final policy = service.initialize(
+      disabledPluginIds: const {"yeti"},
+      setupById: const {
+        "zebra": PluginSetupReady(),
+        "yeti": PluginSetupReady(),
+        "xenon": PluginSetupRuntimeMissing(actionHint: "Install Xenon."),
+        "wombat": PluginSetupReady(),
+      },
+    );
+
+    expect(policy.eagerPluginIds, ["zebra"]);
+  });
+
   test("prefers OpenCode as the default before falling back to alphabetical setup readiness", () async {
     final opencode = _FakePluginApi(id: "opencode");
     final alpha = _FakePluginApi(id: "alpha");
@@ -87,6 +150,7 @@ void main() {
         (
           id: "alpha",
           displayName: "Alpha",
+          activationPolicy: PluginActivationPolicy.onDemand,
           residencyPolicy: PluginResidencyPolicy.transient,
           sessionOptionsScope: PluginSessionOptionsScope.project,
           managementCapabilities: defaultManagementCapabilities,
@@ -95,6 +159,7 @@ void main() {
         (
           id: "opencode",
           displayName: "OpenCode",
+          activationPolicy: PluginActivationPolicy.onDemand,
           residencyPolicy: PluginResidencyPolicy.transient,
           sessionOptionsScope: PluginSessionOptionsScope.project,
           managementCapabilities: defaultManagementCapabilities,
@@ -130,6 +195,7 @@ void main() {
         (
           id: "opencode",
           displayName: "OpenCode",
+          activationPolicy: PluginActivationPolicy.onDemand,
           residencyPolicy: PluginResidencyPolicy.transient,
           sessionOptionsScope: PluginSessionOptionsScope.project,
           managementCapabilities: defaultManagementCapabilities,
@@ -138,6 +204,7 @@ void main() {
         (
           id: "alpha",
           displayName: "Alpha",
+          activationPolicy: PluginActivationPolicy.onDemand,
           residencyPolicy: PluginResidencyPolicy.transient,
           sessionOptionsScope: PluginSessionOptionsScope.project,
           managementCapabilities: defaultManagementCapabilities,
@@ -167,6 +234,7 @@ void main() {
         (
           id: "opencode",
           displayName: "OpenCode",
+          activationPolicy: PluginActivationPolicy.onDemand,
           residencyPolicy: PluginResidencyPolicy.transient,
           sessionOptionsScope: PluginSessionOptionsScope.project,
           managementCapabilities: defaultManagementCapabilities,
@@ -175,6 +243,7 @@ void main() {
         (
           id: "cursor",
           displayName: "Cursor",
+          activationPolicy: PluginActivationPolicy.onDemand,
           residencyPolicy: PluginResidencyPolicy.transient,
           sessionOptionsScope: PluginSessionOptionsScope.plugin,
           managementCapabilities: defaultManagementCapabilities,
@@ -237,6 +306,7 @@ void main() {
               (
                 id: "opencode",
                 displayName: "OpenCode",
+                activationPolicy: PluginActivationPolicy.onDemand,
                 residencyPolicy: PluginResidencyPolicy.resident,
                 sessionOptionsScope: PluginSessionOptionsScope.project,
                 managementCapabilities: defaultManagementCapabilities,
@@ -245,6 +315,7 @@ void main() {
               (
                 id: "alpha",
                 displayName: "Alpha",
+                activationPolicy: PluginActivationPolicy.onDemand,
                 residencyPolicy: PluginResidencyPolicy.transient,
                 sessionOptionsScope: PluginSessionOptionsScope.project,
                 managementCapabilities: defaultManagementCapabilities,
@@ -253,6 +324,7 @@ void main() {
               (
                 id: "beta",
                 displayName: "Beta",
+                activationPolicy: PluginActivationPolicy.onDemand,
                 residencyPolicy: PluginResidencyPolicy.transient,
                 sessionOptionsScope: PluginSessionOptionsScope.plugin,
                 managementCapabilities: defaultManagementCapabilities,
@@ -385,6 +457,7 @@ void main() {
             (
               id: "external",
               displayName: "External",
+              activationPolicy: PluginActivationPolicy.onDemand,
               residencyPolicy: PluginResidencyPolicy.resident,
               sessionOptionsScope: PluginSessionOptionsScope.plugin,
               managementCapabilities: {PluginControlCapability.setupRefresh},
@@ -393,6 +466,7 @@ void main() {
             (
               id: "managed",
               displayName: "Managed",
+              activationPolicy: PluginActivationPolicy.onDemand,
               residencyPolicy: PluginResidencyPolicy.transient,
               sessionOptionsScope: PluginSessionOptionsScope.project,
               managementCapabilities: defaultManagementCapabilities,
@@ -422,6 +496,7 @@ void main() {
             (
               id: "alpha",
               displayName: "Alpha",
+              activationPolicy: PluginActivationPolicy.onDemand,
               residencyPolicy: PluginResidencyPolicy.transient,
               sessionOptionsScope: PluginSessionOptionsScope.project,
               managementCapabilities: defaultManagementCapabilities,
@@ -485,6 +560,7 @@ void main() {
             (
               id: "alpha",
               displayName: "Alpha",
+              activationPolicy: PluginActivationPolicy.onDemand,
               residencyPolicy: PluginResidencyPolicy.transient,
               sessionOptionsScope: PluginSessionOptionsScope.project,
               managementCapabilities: defaultManagementCapabilities,
@@ -493,6 +569,7 @@ void main() {
             (
               id: "beta",
               displayName: "Beta",
+              activationPolicy: PluginActivationPolicy.onDemand,
               residencyPolicy: PluginResidencyPolicy.transient,
               sessionOptionsScope: PluginSessionOptionsScope.plugin,
               managementCapabilities: defaultManagementCapabilities,
@@ -612,6 +689,7 @@ void main() {
               (
                 id: "managed",
                 displayName: "Managed",
+                activationPolicy: PluginActivationPolicy.onDemand,
                 residencyPolicy: PluginResidencyPolicy.transient,
                 sessionOptionsScope: PluginSessionOptionsScope.project,
                 managementCapabilities: {PluginControlCapability.idleTimeout},
@@ -620,6 +698,7 @@ void main() {
               (
                 id: "external",
                 displayName: "External",
+                activationPolicy: PluginActivationPolicy.onDemand,
                 residencyPolicy: PluginResidencyPolicy.transient,
                 sessionOptionsScope: PluginSessionOptionsScope.plugin,
                 managementCapabilities: {PluginControlCapability.setupRefresh},
@@ -736,6 +815,7 @@ void main() {
               (
                 id: "one",
                 displayName: "One",
+                activationPolicy: PluginActivationPolicy.onDemand,
                 residencyPolicy: PluginResidencyPolicy.transient,
                 sessionOptionsScope: PluginSessionOptionsScope.project,
                 managementCapabilities: defaultManagementCapabilities,
@@ -990,6 +1070,7 @@ void main() {
               (
                 id: "one",
                 displayName: "One",
+                activationPolicy: PluginActivationPolicy.onDemand,
                 residencyPolicy: PluginResidencyPolicy.transient,
                 sessionOptionsScope: PluginSessionOptionsScope.project,
                 managementCapabilities: defaultManagementCapabilities,
@@ -1045,6 +1126,7 @@ void main() {
               (
                 id: "one",
                 displayName: "One",
+                activationPolicy: PluginActivationPolicy.onDemand,
                 residencyPolicy: PluginResidencyPolicy.transient,
                 sessionOptionsScope: PluginSessionOptionsScope.project,
                 managementCapabilities: defaultManagementCapabilities,
@@ -1102,6 +1184,7 @@ void main() {
               (
                 id: "one",
                 displayName: "One",
+                activationPolicy: PluginActivationPolicy.onDemand,
                 residencyPolicy: PluginResidencyPolicy.transient,
                 sessionOptionsScope: PluginSessionOptionsScope.project,
                 managementCapabilities: defaultManagementCapabilities,
@@ -1146,6 +1229,7 @@ void main() {
               (
                 id: "one",
                 displayName: "One",
+                activationPolicy: PluginActivationPolicy.onDemand,
                 residencyPolicy: PluginResidencyPolicy.transient,
                 sessionOptionsScope: PluginSessionOptionsScope.project,
                 managementCapabilities: defaultManagementCapabilities,
@@ -1640,6 +1724,7 @@ void main() {
         (
           id: "beta",
           displayName: "Beta",
+          activationPolicy: PluginActivationPolicy.onDemand,
           residencyPolicy: PluginResidencyPolicy.transient,
           sessionOptionsScope: PluginSessionOptionsScope.plugin,
           managementCapabilities: defaultManagementCapabilities,
@@ -1648,6 +1733,7 @@ void main() {
         (
           id: "alpha",
           displayName: "Alpha",
+          activationPolicy: PluginActivationPolicy.onDemand,
           residencyPolicy: PluginResidencyPolicy.transient,
           sessionOptionsScope: PluginSessionOptionsScope.project,
           managementCapabilities: defaultManagementCapabilities,
@@ -1699,6 +1785,7 @@ void main() {
         (
           id: "alpha",
           displayName: "Alpha",
+          activationPolicy: PluginActivationPolicy.onDemand,
           residencyPolicy: PluginResidencyPolicy.transient,
           sessionOptionsScope: PluginSessionOptionsScope.project,
           managementCapabilities: defaultManagementCapabilities,
@@ -1729,6 +1816,7 @@ void main() {
             (
               id: "one",
               displayName: "One",
+              activationPolicy: PluginActivationPolicy.onDemand,
               residencyPolicy: PluginResidencyPolicy.transient,
               sessionOptionsScope: PluginSessionOptionsScope.project,
               managementCapabilities: defaultManagementCapabilities,
@@ -1762,6 +1850,7 @@ void main() {
             (
               id: "one",
               displayName: "One",
+              activationPolicy: PluginActivationPolicy.onDemand,
               residencyPolicy: PluginResidencyPolicy.transient,
               sessionOptionsScope: PluginSessionOptionsScope.project,
               managementCapabilities: defaultManagementCapabilities,
@@ -1812,6 +1901,7 @@ void main() {
             (
               id: "one",
               displayName: "One",
+              activationPolicy: PluginActivationPolicy.onDemand,
               residencyPolicy: PluginResidencyPolicy.transient,
               sessionOptionsScope: PluginSessionOptionsScope.project,
               managementCapabilities: defaultManagementCapabilities,
@@ -1857,6 +1947,7 @@ void main() {
             (
               id: "one",
               displayName: "One",
+              activationPolicy: PluginActivationPolicy.onDemand,
               residencyPolicy: PluginResidencyPolicy.resident,
               sessionOptionsScope: PluginSessionOptionsScope.project,
               managementCapabilities: defaultManagementCapabilities,
@@ -1928,6 +2019,7 @@ PluginLifecycleService _singleIdleService({
         (
           id: "one",
           displayName: "One",
+          activationPolicy: PluginActivationPolicy.onDemand,
           residencyPolicy: residencyPolicy,
           sessionOptionsScope: PluginSessionOptionsScope.project,
           managementCapabilities: managementCapabilities,
@@ -1957,6 +2049,7 @@ PluginLifecycleService _commandService({
       (
         id: "one",
         displayName: "One",
+        activationPolicy: PluginActivationPolicy.onDemand,
         residencyPolicy: PluginResidencyPolicy.transient,
         sessionOptionsScope: PluginSessionOptionsScope.project,
         managementCapabilities: managementCapabilities,

--- a/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
+++ b/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
@@ -9,6 +9,7 @@ export "src/host/host_process_service.dart";
 export "src/host/plugin_host.dart";
 export "src/lifecycle/bridge_plugin.dart";
 export "src/lifecycle/bridge_plugin_descriptor.dart";
+export "src/lifecycle/plugin_activation_policy.dart";
 export "src/lifecycle/plugin_authentication_required_exception.dart";
 export "src/lifecycle/plugin_config.dart";
 export "src/lifecycle/plugin_control_capability.dart";

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin_descriptor.dart
@@ -3,6 +3,7 @@ import "package:meta/meta.dart";
 import "../host/host_process_service.dart";
 import "../host/plugin_host.dart";
 import "bridge_plugin.dart";
+import "plugin_activation_policy.dart";
 import "plugin_config.dart";
 import "plugin_control_capability.dart";
 import "plugin_option.dart";
@@ -66,6 +67,15 @@ abstract class BridgePluginDescriptor {
   /// default applies the bridge's configured timeout.
   PluginResidencyPolicy residencyPolicy({required PluginConfig config}) {
     return PluginResidencyPolicy.transient;
+  }
+
+  /// Declares whether this adapter starts on demand or with the bridge.
+  ///
+  /// Eager activation is for a backend whose lifecycle is independent from
+  /// the bridge and can therefore produce events before any client request.
+  /// The default keeps ordinary managed plugins demand-driven.
+  PluginActivationPolicy activationPolicy({required PluginConfig config}) {
+    return PluginActivationPolicy.onDemand;
   }
 
   /// Declares the management operations Sesori may perform under [config].

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_activation_policy.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_activation_policy.dart
@@ -1,0 +1,8 @@
+/// When an eligible, setup-ready plugin adapter should be activated.
+enum PluginActivationPolicy {
+  /// Start only when a concrete plugin operation needs the adapter.
+  onDemand,
+
+  /// Start with the bridge so an independently running backend is monitored.
+  eager,
+}

--- a/bridge/sesori_plugin_interface/test/lifecycle/bridge_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_interface/test/lifecycle/bridge_plugin_descriptor_test.dart
@@ -26,6 +26,15 @@ void main() {
       );
     });
 
+    test('activates on demand by default', () {
+      const descriptor = _MinimalDescriptor();
+
+      expect(
+        descriptor.activationPolicy(config: const PluginConfig.empty()),
+        PluginActivationPolicy.onDemand,
+      );
+    });
+
     test('supports every management capability by default', () {
       const descriptor = _MinimalDescriptor();
 

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -153,6 +153,10 @@ class OpenCodePlugin implements OpenCodeManagedApi {
     // rollback): starting the transport now would revive it after teardown.
     if (!_disposed) {
       _sseConnection.start();
+      // A successful cold-start is about to expose this generation to prompt
+      // operations. Wait until OpenCode has registered the event listener so
+      // the prompt's first message/part frames cannot precede it.
+      if (coldStartError == null) await _sseConnection.firstConnected;
     }
     if (coldStartError != null) {
       Error.throwWithStackTrace(coldStartError, coldStartStackTrace ?? StackTrace.current);

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -152,7 +152,7 @@ class OpenCodePlugin implements OpenCodeManagedApi {
     // background initialize from a failed attach probe, or an aborted-start
     // rollback): starting the transport now would revive it after teardown.
     if (!_disposed) {
-      _sseConnection.start();
+      _sseConnection.start(recoverOnFirstConnect: coldStartError != null);
       // A successful cold-start is about to expose this generation to prompt
       // operations. Wait until OpenCode has registered the event listener so
       // the prompt's first message/part frames cannot precede it.

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
@@ -272,6 +272,11 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
   }
 
   @override
+  PluginActivationPolicy activationPolicy({required PluginConfig config}) {
+    return config.flag(_OpenCodeConfigKey.noAutoStart) ? PluginActivationPolicy.eager : PluginActivationPolicy.onDemand;
+  }
+
+  @override
   Set<PluginControlCapability> managementCapabilities({required PluginConfig config}) {
     if (config.flag(_OpenCodeConfigKey.noAutoStart)) {
       return const {PluginControlCapability.setupRefresh};

--- a/bridge/sesori_plugin_opencode/lib/src/sse/sse_connection.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse/sse_connection.dart
@@ -15,6 +15,9 @@ class SseConnection {
   bool _active = false;
   int _generation = 0;
   http.Client? _currentClient;
+  final Completer<void> _firstConnected = Completer<void>();
+
+  Future<void> get firstConnected => _firstConnected.future;
 
   SseConnection({
     required String targetUrl,
@@ -43,6 +46,7 @@ class SseConnection {
     _generation++;
     _currentClient?.close();
     _currentClient = null;
+    if (!_firstConnected.isCompleted) _firstConnected.complete();
   }
 
   Future<void> _streamLoop(int generation) async {
@@ -75,6 +79,7 @@ class SseConnection {
         // The transport is live: signal connected on the first connect and on
         // every reconnect (the lifecycle status follows the live stream).
         _onConnected?.call();
+        if (!_firstConnected.isCompleted) _firstConnected.complete();
 
         if (!isFirstConnect && _onReconnect != null) {
           final reconnectSw = Stopwatch()..start();

--- a/bridge/sesori_plugin_opencode/lib/src/sse/sse_connection.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse/sse_connection.dart
@@ -33,11 +33,16 @@ class SseConnection {
        _onConnected = onConnected,
        _onDisconnected = onDisconnected;
 
-  void start() {
+  void start({required bool recoverOnFirstConnect}) {
     if (_active) return;
     _active = true;
     _generation++;
-    unawaited(_streamLoop(_generation));
+    unawaited(
+      _streamLoop(
+        _generation,
+        recoverOnFirstConnect: recoverOnFirstConnect,
+      ),
+    );
   }
 
   void stop() {
@@ -49,8 +54,9 @@ class SseConnection {
     if (!_firstConnected.isCompleted) _firstConnected.complete();
   }
 
-  Future<void> _streamLoop(int generation) async {
+  Future<void> _streamLoop(int generation, {required bool recoverOnFirstConnect}) async {
     var isFirstConnect = true;
+    var shouldRecoverOnFirstConnect = recoverOnFirstConnect;
     var reconnectDelay = const Duration(seconds: 1);
 
     while (_active && _generation == generation) {
@@ -81,16 +87,17 @@ class SseConnection {
         _onConnected?.call();
         if (!_firstConnected.isCompleted) _firstConnected.complete();
 
-        if (!isFirstConnect && _onReconnect != null) {
+        if ((!isFirstConnect || shouldRecoverOnFirstConnect) && _onReconnect != null) {
           final reconnectSw = Stopwatch()..start();
-          Log.v("[sse-conn] reconnect: running onReconnect cold-start");
+          Log.v("[sse-conn] connection recovery: running cold-start");
           await _onReconnect();
           if (!_active || _generation != generation) {
-            Log.v("[sse-conn] reconnect: shutdown requested during onReconnect, dropping");
+            Log.v("[sse-conn] connection recovery: shutdown requested during cold-start, dropping");
             return;
           }
-          Log.v("[sse-conn] reconnect: onReconnect cold-start finished in ${reconnectSw.elapsedMilliseconds}ms");
+          Log.v("[sse-conn] connection recovery: cold-start finished in ${reconnectSw.elapsedMilliseconds}ms");
         }
+        shouldRecoverOnFirstConnect = false;
         isFirstConnect = false;
         reconnectDelay = const Duration(seconds: 1);
         await _readStream(response, generation);

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -45,6 +45,36 @@ void main() {
       expect(server.requestLog.where((entry) => entry.contains("/global/event")), isEmpty);
     });
 
+    test("initialize waits until the SSE listener is connected", () async {
+      server.holdSseResponse = Completer<void>();
+      final plugin = OpenCodePlugin(serverUrl: server.baseUrl, autoInitialize: false);
+      addTearDown(plugin.dispose);
+      var completed = false;
+      final initialize = plugin.initialize().whenComplete(() => completed = true);
+      while (!server.requestLog.contains("GET /global/event")) {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(completed, isFalse);
+
+      server.holdSseResponse!.complete();
+      await initialize.timeout(const Duration(seconds: 1));
+      expect(completed, isTrue);
+    });
+
+    test("dispose unblocks initialize while the SSE listener is connecting", () async {
+      server.holdSseResponse = Completer<void>();
+      final plugin = OpenCodePlugin(serverUrl: server.baseUrl, autoInitialize: false);
+      final initialize = plugin.initialize();
+      while (!server.requestLog.contains("GET /global/event")) {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+
+      await plugin.dispose().timeout(const Duration(seconds: 1));
+      await initialize.timeout(const Duration(seconds: 1));
+    });
+
     test("getProjects maps internal projects to plugin projects", () async {
       final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
 
@@ -952,6 +982,7 @@ class _FakeOpenCodeServer {
   /// When set, `GET /project` waits on this gate before responding, so a test
   /// can hold a cold-start in flight.
   Completer<void>? holdProjects;
+  Completer<void>? holdSseResponse;
   Map<String, dynamic>? lastPromptBody;
   String? lastPromptDirectoryHeader;
   Map<String, dynamic>? lastCommandBody;
@@ -1791,6 +1822,7 @@ class _FakeOpenCodeServer {
       }
 
       if (request.method == "GET" && path == "/global/event") {
+        await holdSseResponse?.future;
         if (!acceptSseConnections) {
           request.response.statusCode = HttpStatus.serviceUnavailable;
           await request.response.close();

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -75,6 +75,18 @@ void main() {
       await initialize.timeout(const Duration(seconds: 1));
     });
 
+    test("first SSE connection retries a failed cold start", () async {
+      server.projectFailuresRemaining = 1;
+      final plugin = OpenCodePlugin(serverUrl: server.baseUrl, autoInitialize: false);
+      addTearDown(plugin.dispose);
+      final recovered = plugin.events.firstWhere((event) => event is BridgeSseProjectUpdated);
+
+      await expectLater(plugin.initialize(), throwsA(isA<OpenCodeApiException>()));
+      await recovered.timeout(const Duration(seconds: 2));
+
+      expect(server.requestLog.where((entry) => entry == "GET /project"), hasLength(2));
+    });
+
     test("getProjects maps internal projects to plugin projects", () async {
       final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
 
@@ -983,6 +995,7 @@ class _FakeOpenCodeServer {
   /// can hold a cold-start in flight.
   Completer<void>? holdProjects;
   Completer<void>? holdSseResponse;
+  int projectFailuresRemaining = 0;
   Map<String, dynamic>? lastPromptBody;
   String? lastPromptDirectoryHeader;
   Map<String, dynamic>? lastCommandBody;
@@ -1044,6 +1057,12 @@ class _FakeOpenCodeServer {
         final hold = holdProjects;
         if (hold != null) {
           await hold.future;
+        }
+        if (projectFailuresRemaining > 0) {
+          projectFailuresRemaining--;
+          request.response.statusCode = HttpStatus.internalServerError;
+          await request.response.close();
+          return;
         }
         await _sendJson(request.response, _projects.values.toList());
         return;

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_test.dart
@@ -54,6 +54,21 @@ void main() {
       );
     });
 
+    test("eagerly attaches only in no-auto-start mode", () {
+      expect(
+        descriptor.activationPolicy(
+          config: const PluginConfig(values: {"no-auto-start": true}),
+        ),
+        PluginActivationPolicy.eager,
+      );
+      expect(
+        descriptor.activationPolicy(
+          config: const PluginConfig(values: {"no-auto-start": false}),
+        ),
+        PluginActivationPolicy.onDemand,
+      );
+    });
+
     test("allows only setup refresh in --no-auto-start mode", () {
       expect(
         descriptor.managementCapabilities(


### PR DESCRIPTION
## Complexity

Moderate. This coordinates plugin activation policy, bridge-session listener ordering, OpenCode SSE readiness, and history consistency across the plugin interface, OpenCode plugin, and bridge app.

## What

- Add a backend-neutral eager activation policy and select it for external OpenCode attach mode.
- Start the local plugin event pipeline before relay connection and eagerly attach setup-ready external backends.
- Wait for the initial OpenCode SSE transport connection before a successful cold start exposes prompt operations.
- Clear only the chat-history sync markers belonging to the reconnected plugin, preserving stored rows and triggering lazy transcript backfill on the next read.

## Why

An externally managed OpenCode server can outlive the bridge. After a bridge restart, the on-demand adapter did not reconnect until a phone requested it, so OpenCode events emitted in that gap were never observed and an incomplete stored transcript could remain marked as synchronized.

## Risk and test focus

The primary risks are startup ordering, an unavailable external server, cross-plugin history isolation, and teardown while SSE attachment is pending. Cached transcripts remain readable while the external server is offline; continuity is invalidated only after an actual SSE connection. There are no wire-contract or database-schema changes.

## Expected result

A setup-ready external OpenCode backend is monitored from bridge startup without requiring a connected phone. Any unobservable bridge or SSE gap invalidates only that backend's existing live-history completeness markers, and the next session read repairs the transcript through the existing lazy backfill path.

## Verification

- `dart analyze --fatal-infos` in `bridge/app`
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_interface`
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_opencode`
- `dart test test/bridge/services/chat_history_capture_test.dart test/bridge/orchestrator_error_recovery_test.dart test/services/plugin_lifecycle_service_test.dart` in `bridge/app`
- `dart test test/opencode_plugin_impl_test.dart test/runtime/open_code_plugin_descriptor_test.dart` in `bridge/sesori_plugin_opencode`
- `dart test test/lifecycle/bridge_plugin_descriptor_test.dart` in `bridge/sesori_plugin_interface`
- Architecture implementation review: approved with no findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps external OpenCode event capture active from bridge startup and preserves chat history across SSE gaps. Waits for the first SSE connection before exposing prompt operations, retries a failed cold start on first connect, and cancels eager startup promptly on shutdown.

- **New Features**
  - Added `PluginActivationPolicy` (`onDemand`, `eager`); OpenCode selects `eager` in `--no-auto-start` mode.
  - Runtime identifies `eagerPluginIds` and starts setup‑ready eager plugins during bootstrap.
  - On BridgeSseServerConnected, only that plugin’s sessions have `syncedAt` cleared via a bulk DAO for efficient updates.

- **Bug Fixes**
  - OpenCode `initialize()` waits for the SSE listener; `dispose()` unblocks the wait. First SSE connect retries a failed cold start.
  - Orchestrator starts local plugin listeners and subscribes to plugin events earlier, so events are captured even if the initial relay connect fails.
  - Eager startup now cancels immediately on shutdown (separate early abort), while the ordered shutdown coordinator starts after all startup teardowns are registered.

<sup>Written for commit 6cc9558c2df760ff07aaadae0eb1d4bc6a4c1816. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

