### PR TITLE
🌱 [pi-harness] docs: plan Pi harness support [step 1/21]

### DIFF
--- a/.plan/active/pi-harness/PLAN.md
+++ b/.plan/active/pi-harness/PLAN.md
@@ -471,9 +471,11 @@ plugin startup.
 
 Project-scoped auth failures never escape as
 `PluginAuthenticationRequiredException`, which bridge core interprets as
-plugin-global auth loss. Synchronous calls use an ordinary cause-preserving
-operation failure; admitted turns emit existing `session.error` plus a bounded
-guidance toast. No new wire event is required.
+plugin-global auth loss. Catalog discovery returns
+`PluginSessionOptionsDiscoveryResult.failed` plus an existing bounded guidance
+toast; admitted turns emit existing `session.error` plus that toast. Other
+synchronous calls use ordinary cause-preserving operation failures. No new wire
+event is required.
 
 `ensureRuntime` uses `ManagedRuntimeProvisionService` and remains read-only.
 `installRuntime` uses `ManagedRuntimeInstallService` and the package-directory

--- a/.plan/active/pi-harness/PLAN.md
+++ b/.plan/active/pi-harness/PLAN.md
@@ -192,7 +192,7 @@ bridge/sesori_plugin_pi/
   pubspec.yaml, analysis_options.yaml, build.yaml
   lib/pi_plugin.dart, lib/pi_testing.dart
   lib/src/api/{pi_launch_spec,pi_process_factory,pi_rpc_client}.dart
-  lib/src/api/{pi_catalog_probe_api,pi_session_storage_api}.dart
+  lib/src/api/pi_session_storage_api.dart
   lib/src/api/models/                 # Pi wire DTOs only
   lib/src/models/                     # Pi domain variants/enums
   lib/src/repositories/{pi_session_catalog_repository,pi_session_process_repository}.dart
@@ -209,8 +209,7 @@ bridge/sesori_plugin_pi/
 
 The placement follows `Foundation -> API -> Repository -> Service -> Consumer`:
 
-- `api/` owns process invocation, wire framing, session-file input, and the
-  isolated catalog-probe process.
+- `api/` owns process invocation, wire framing, and session-file input.
 - repositories consume APIs and own mapping, without Layer-2 peer dependencies;
 - trackers own queryable Layer-2 catalog and tool state;
 - services and the Layer-3 event dispatcher coordinate repositories/trackers;
@@ -432,15 +431,14 @@ The next accepted turn resumes from the persisted session.
 
 ### Catalogs and selections
 
-`PiCatalogProbeApi` owns a short-lived project-cwd process launched through
-`PiProcessFactory` with `--mode rpc --no-session --approve`, and always tears it
-down after the bounded probe. `PiBackendCatalogRepository` consumes that API and
-maps Pi DTOs into plugin catalog values. `PiCatalogTracker` owns the last
-coherent snapshot for each normalized project; `PiCatalogService` only
-coordinates the repository and tracker.
+`PiBackendCatalogRepository` owns a bounded short-lived lease over the injected
+`PiProcessFactory`/`PiRpcClient` boundary, launched in project cwd with
+`--mode rpc --no-session --approve`. It maps Pi DTOs and always tears the client
+down. `PiCatalogTracker` owns the last coherent snapshot for each normalized
+project; `PiCatalogService` only coordinates the repository and tracker.
 
-The probe answers every `extension_ui_request` with deterministic cancellation,
-including no-timeout editor requests; no probe dialog enters session UI state.
+The repository answers every probe `extension_ui_request` with deterministic
+cancellation, including editor; no probe dialog enters session UI state.
 
 - `get_available_models` supplies provider/model IDs, display names, reasoning,
   and image support.
@@ -733,12 +731,11 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 
 ### Step 9/15: Expose models and commands
 
-- Add generated model/command DTOs, `PiCatalogProbeApi`,
-  `PiBackendCatalogRepository`, `PiCatalogTracker`, and coordinating
-  `PiCatalogService`.
-- Let the API own each project-cwd, no-session, approved process; let the
-  repository enumerate/map models, exact thinking variants, providers, and
-  commands; synthesize one Pi agent.
+- Add generated model/command DTOs, `PiBackendCatalogRepository`,
+  `PiCatalogTracker`, and coordinating `PiCatalogService`.
+- Let the repository own each bounded project-cwd, no-session client lease and
+  enumerate/map models, thinking variants, providers, and commands; synthesize
+  one Pi agent.
 - Preserve the initial state model as the default and order its provider first.
 - Implement project-scoped `reuse`/`refresh`, complete/partial observed results,
   explicit failed results, and atomic replacement of coherent snapshots only.

--- a/.plan/active/pi-harness/PLAN.md
+++ b/.plan/active/pi-harness/PLAN.md
@@ -223,8 +223,9 @@ Pi have materially different framing, request, event, and lifecycle contracts.
 One client owns one child process and:
 
 - launches from a typed `PiLaunchSpec`;
-- consumes stdout continuously through an LF-only UTF-8 framer so pipe
-  backpressure can never stall Pi;
+- consumes stdout and stderr continuously so neither pipe can stall Pi; stdout
+  uses the LF-only UTF-8 framer, while stderr retains only a bounded redacted
+  diagnostic tail;
 - decodes top-level response, event, extension-UI, and unknown envelopes;
 - correlates responses by request ID without assuming a prompt response arrives
   before agent events;
@@ -342,8 +343,10 @@ the final message repairs it. Live/replay parity is a direct test requirement.
 
 `PiExtensionUiService` coordinates the catalog repository, process repository,
 and tracker: it resolves display roots, routes Pi's exact response variants, and
-exposes notifications for the plugin consumer. Reject, timeout, abort, reap,
-exit, and disposal clear every card; no dialog state is persisted.
+exposes typed asked/replied/rejected lifecycle notifications after tracker
+mutation. `PiPlugin` maps those to `BridgeSseQuestionAsked`,
+`BridgeSseQuestionReplied`, and `BridgeSseQuestionRejected`. Reject, timeout,
+abort, reap, exit, and disposal reject every card; no state is persisted.
 
 At request time the service resolves the owning session's top-most imported
 parent from the catalog snapshot. The tracker stores `displaySessionId` and
@@ -371,11 +374,12 @@ dialogs, which appear as questions because Pi supplies no permission semantics.
 - merged session-tagged frame/exit streams.
 
 `PiSessionService` owns per-session turn admission, status/work state, abort,
-and idle reap. Admission marks the session busy and returns immediately; the
-lane later applies that turn's selection, dispatches, and tracks settlement.
-Post-admission connect/selection/prompt failures emit a session error rather
-than reopening the phone request. IDs are secure UUIDs validated by
-`PiLaunchSpec`.
+and idle reap. Prompt admission marks the session busy and returns immediately;
+the lane later applies selection, dispatches, and tracks settlement. A command
+queue item also owns an acceptance completer: `sendCommand` returns only after
+its correlated Pi prompt response succeeds, and pre-acceptance invalidation,
+connect/selection/dispatch failure, or exit completes it with an error. Later
+failures emit a session error. IDs are secure UUIDs validated by `PiLaunchSpec`.
 
 A generation-matched process exit before `agent_settled` fails the active turn
 and clears resident/dialog state. The lane re-resolves for the next admitted
@@ -398,9 +402,10 @@ non-image data are not fetched, stringified, or silently dropped: dispatch fails
 before acceptance with a privacy-safe `PluginOperationException` explaining
 that Pi supports inline image data only.
 
-Commands use Pi's normal `/name args` prompt path. After acceptance, the service
-holds the lane through a correlated `get_state` barrier and all earlier queued
-events. It treats a command as no-run only when no generation-matched
+Commands use Pi's normal `/name args` prompt path. The correlated successful
+prompt response completes `sendCommand` acceptance; the service then holds the
+lane through a `get_state` barrier and all earlier queued events. It treats a
+command as no-run only when no generation-matched
 `agent_start` arrived and state reports neither streaming nor pending messages;
 otherwise it waits for `agent_settled`. Command context uses the same marker
 scheme, and live/replay presentation uses only `userVisibleArguments`.
@@ -620,7 +625,8 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 - Add `FakePiProcess` and `pi_testing.dart` exports.
 - Cover split/multiple UTF-8 chunks, CRLF input tolerance, U+2028/U+2029 inside
   JSON strings, response/event reordering, unknown frames, process exit,
-  backpressure consumption, broken pipes, redaction, and teardown fencing.
+  stdout/verbose-stderr backpressure, broken pipes, bounded redaction, and
+  teardown fencing.
 
 ### Step 4/15: Enumerate persisted sessions
 
@@ -668,7 +674,7 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 ### Step 7/15: Bridge extension dialogs
 
 - Add `PiExtensionUiTracker` and coordinating `PiExtensionUiService` for
-  select/confirm/input/editor questions and notification toasts.
+  select/confirm/input/editor questions, lifecycle events, and notification toasts.
 - Implement exact value/confirmed/cancelled responses and session-keyed routing.
 - Resolve/store each dialog's display root and aggregate descendant cards for
   root-session queries.
@@ -691,17 +697,17 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 - Mint secure UUID session IDs in the service and validate Pi's ID grammar in
   `PiLaunchSpec`; map validated inline image data to RPC and reject path, URL,
   or non-image parts before prompt acceptance.
-- Apply model/thinking immediately before each queued turn; return on lane
-  admission, track dispatch through `agent_settled`, and surface later failures
-  through session events.
+- Apply model/thinking immediately before each queued turn; prompts return on
+  lane admission, commands await correlated backend acceptance, dispatch tracks
+  through `agent_settled`, and later failures surface through session events.
 - Abort by invalidating queued work, rejecting dialogs, sending `abort`, and
   tearing down the process so Pi's own hidden queues cannot continue.
 - Preserve concurrent turns across different sessions.
 - Cover spawn races, serialization, cross-session parallelism, lazy persistence,
   resume after reap, transient history/rename leases, ID/attachment validation,
-  immediate queued admission, response-before-`agent_start` command barriers,
-  command-without-run, post-acceptance exit, project-scoped auth/toast behavior,
-  abort, and shutdown.
+  immediate prompt admission, command acceptance/failure completers,
+  response-before-`agent_start` barriers, command-without-run, post-acceptance
+  exit, project-scoped auth/toast behavior, abort, and shutdown.
 
 ### Step 9/15: Expose models and commands
 

--- a/.plan/active/pi-harness/PLAN.md
+++ b/.plan/active/pi-harness/PLAN.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **Plan slug:** `pi-harness`
-- **Status:** Step 1/15, plan PR being prepared
+- **Status:** Step 1/15, plan PR open
 - **Plan date:** 2026-08-10
 - **Implementation base:** `origin/main` at
   `3803df12d2afa41abe6894df88146ad6543e9ec6`

--- a/.plan/active/pi-harness/PLAN.md
+++ b/.plan/active/pi-harness/PLAN.md
@@ -27,7 +27,7 @@ desktop surfaces without leaking Pi-specific behavior outside the plugin.
 - managed runtime install on every platform for which Pi publishes a release;
 - existing and Sesori-created Pi sessions grouped by their real working
   directories;
-- new, resumed, and parent-forked sessions;
+- new and resumed sessions;
 - persisted history and live text/reasoning streaming;
 - tool calls, partial output, completion, errors, retries, compaction, and
   abort;
@@ -55,9 +55,8 @@ desktop surfaces without leaking Pi-specific behavior outside the plugin.
 5. Existing sessions under the user's normal Pi session store import without
    reading prompt or transcript text merely to build the catalog. Explicit Pi
    names are used as titles; first prompts are not promoted into bridge titles.
-6. Parent session creation uses Pi's supported fork path, preserves history,
-   records the parent relationship, uses the requested target cwd, and keeps the
-   bridge-generated child ID.
+6. Imported Pi sessions retain resolvable `parentSession` relationships and
+   appear through the existing child-session catalog.
 7. Multiple Pi sessions may run concurrently. Each active session owns its own
    lazily spawned RPC process; idle processes are reaped and resume from their
    absolute session file on the next turn.
@@ -70,9 +69,9 @@ desktop surfaces without leaking Pi-specific behavior outside the plugin.
    than breaking the run.
 10. Pi's native no-permission-prompt behavior is preserved. The plugin reports
     no pending permissions and does not install a Sesori permission extension.
-11. Missing authentication becomes `authenticationRequired` with guidance to
-    run Pi locally and use `/login`; the bridge never initiates, stores, or
-    proxies provider credentials.
+11. Project-scoped discovery and prompt failures surface missing-auth guidance
+    to run Pi locally and use `/login`; cwd-less setup inspection never blocks a
+    valid project configuration as unauthenticated.
 12. Supported inline image data reaches Pi's RPC `images` field. Path, URL, and
     non-image variants fail visibly and never become accidental prompt strings.
 13. No Pi protocol value, path layout, provider assumption, tool name, or
@@ -96,7 +95,7 @@ load-bearing conclusions for this plan are:
   session list, delete, login, attach, or native permission protocol.
 - Catalog import therefore reads only bounded metadata from Pi's documented
   JSONL session files; it never reads transcript text merely to enumerate.
-- New, absolute-path resume, and parent-fork launch forms are supported; new
+- Upstream supports new, absolute-path resume, and parent-fork launches; new
   files appear only after the first assistant message is persisted.
 - Auth uses normal Pi environment/config or local `/login`; pending dialogs are
   process-local and cannot survive process replacement.
@@ -144,7 +143,7 @@ with the bridge user's permissions. The implementation must test that
 - New `bridge/sesori_plugin_pi/` pure-Dart package.
 - Bespoke strict-JSONL RPC, metadata-only session catalog, bridge-derived
   projects, and default/configured/known session roots.
-- Full existing plugin API mapping: new/resume/fork, rename/delete, history,
+- Full reachable plugin API mapping: new/resume, rename/delete, history,
   commands/prompts, abort, health, catalogs, summaries, and cleanup.
 - Per-session process residency with idle reap and full teardown.
 - Text, thinking, tools, image attachments, retry/compaction/status events.
@@ -159,6 +158,8 @@ with the bridge user's permissions. The implementation must test that
 - Provider login or credential entry from phone.
 - A Sesori permission-gate Pi extension.
 - Attaching to an already-running terminal Pi process.
+- Sesori-created parent forks; the current generic create flow supplies no
+  parent ID. Imported upstream parent relationships remain supported.
 - Pi TUI-only pickers/settings/themes/components/clipboard/raw input.
 - New relay routes, database schema, shared message-part variants, or a
   Pi-specific client state branch.
@@ -195,10 +196,10 @@ bridge/sesori_plugin_pi/
   lib/src/models/                     # Pi domain variants/enums
   lib/src/repositories/{pi_session_catalog_repository,pi_session_process_repository}.dart
   lib/src/repositories/pi_backend_catalog_repository.dart
-  lib/src/repositories/mappers/pi_content_mapper.dart
+  lib/src/repositories/mappers/{pi_content_mapper,pi_history_mapper}.dart
   lib/src/trackers/{pi_catalog_tracker,pi_tool_tracker}.dart
   lib/src/services/{pi_session_service,pi_catalog_service}.dart
-  lib/src/{pi_event_dispatcher,pi_history_mapper,pi_extension_ui_registry}.dart
+  lib/src/{pi_event_dispatcher,pi_extension_ui_registry}.dart
   lib/src/pi_plugin_impl.dart
   lib/src/runtime/{pi_runtime_manifest,pi_plugin_descriptor,pi_bridge_plugin}.dart
   lib/src/testing/fake_pi_process.dart
@@ -275,13 +276,12 @@ enough to invalidate a bridge-created row because Pi persists lazily.
 
 ### History and content mapping
 
-History acquires a client through `PiSessionProcessRepository`, uses Pi RPC
-`get_entries` and its `leafId`, then walks parent links to the active branch.
-The repository reuses a resident client when present; otherwise it opens a
-bounded non-resident lease for the resolved absolute session path and tears it
-down after the operation. Rename uses the same lease path. This retains
-pre-compaction history without turning read-only operations into resident
-sessions.
+`PiSessionProcessRepository.loadHistory` owns the client lease, RPC
+`get_entries`, `leafId` branch traversal, and invocation of the repository-local
+`PiHistoryMapper`; no `PiRpcClient` or Pi DTO escapes Layer 2. It reuses a
+resident client or opens a bounded non-resident lease for the resolved path and
+tears it down afterward. Rename uses the same lease path, while history retains
+pre-compaction entries without making reads resident.
 
 Mapping rules:
 
@@ -355,7 +355,7 @@ dialogs, which appear as questions because Pi supplies no permission semantics.
 `PiSessionProcessRepository` owns:
 
 - `sessionId -> resident PiRpcClient`;
-- new/resume/fork launch choice, using `PiSessionStorageApi` for absolute paths;
+- new/resume launch choice, using `PiSessionStorageApi` for absolute paths;
 - bounded resident-or-transient client leases for history and rename;
 - process connection generations and late-spawn rollback;
 - applied provider/model/thinking state;
@@ -369,6 +369,11 @@ applies its selected model and thinking level immediately before dispatch,
 waits only for Pi's prompt acceptance to report acceptance to the caller, and
 tracks the run through `agent_settled`. This prevents a model selection for a
 queued phone message from changing an earlier turn.
+
+A generation-matched process exit before `agent_settled` terminalizes the
+accepted turn as failed, rejects queued acceptance futures, clears resident and
+dialog state, and returns the session to idle. A later explicit turn resumes
+from the persisted file; no accepted turn remains indefinitely busy.
 
 `PiSessionProcessRepository` also maps prompts. Text remains text; inline
 `fileData` with a supported image MIME becomes Pi's base64 `images` field after
@@ -437,11 +442,12 @@ same protocol/E2E checks.
   are all assumed.
 - Managed pin: exact current tested stable release.
 
-`inspectSetup` mirrors managed precedence without mutation, then starts a
-bounded no-session RPC probe. No usable model or a typed authentication
-preflight failure becomes `PluginSetupAuthenticationRequired`; process timeout
-or unrecognized behavior becomes `PluginSetupUnknown` rather than a false auth
-claim.
+`inspectSetup` mirrors managed precedence and validates only runtime
+availability/version. Its contract has no project cwd, so an empty cwd-less
+model catalog is never classified as unauthenticated. Authentication is checked
+by the approved project-scoped catalog/prompt path, which preserves the typed
+failure cause and presents local `/login` guidance without globally blocking
+plugin startup.
 
 `ensureRuntime` uses `ManagedRuntimeProvisionService` and remains read-only.
 `installRuntime` uses `ManagedRuntimeInstallService` and the package-directory
@@ -463,7 +469,7 @@ user's telemetry choice remain Pi's.
 | `primeSessionDirectory` | retain bridge attribution until file metadata is observable |
 | `getCommands` | project-scoped throwaway RPC `get_commands` |
 | `getSessionOptions` | reuse/refresh through project tracker; observed complete/partial or failed |
-| `createSession` | bridge ID; new or `--fork` launch; enqueue first turn |
+| `createSession` | bridge ID; new launch; enqueue first turn |
 | `renameSession` | resident or bounded transient lease for RPC `set_session_name` |
 | `deleteSession` | stop resident process, clear dialogs/cache, resolve then delete exact JSONL file |
 | `deletePersistedSession` | resolve by ID and idempotently delete the exact file without spawning Pi |
@@ -569,12 +575,12 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
   baseline unless a newer pin is selected and the protocol record is updated.
 - Create `sesori_plugin_pi`, public/testing barrels, analysis config, and only
   the dependencies used in this step.
-- Add `PiLaunchSpec`, process handle/factory seam, new/resume/fork launch
+- Add `PiLaunchSpec`, process handle/factory seam, new/resume launch
   variants, `--approve`, and inherited-environment policy.
 - Add the closed Pi thinking-level enum and protocol fixture helpers.
 - Land Wave-1 workspace, Makefile, CI, and dependency-update inventory entries.
-- Unit-test exact argument vectors, absolute-path resume/fork behavior,
-  Windows entry name, and environment preservation.
+- Unit-test exact argument vectors, absolute-path resume behavior, Windows entry
+  name, and environment preservation.
 
 ### Step 3/15: Add the JSONL RPC transport
 
@@ -606,8 +612,8 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 ### Step 5/15: Replay Pi session history
 
 - Add the session-entry/message/content DTOs this step consumes and run codegen.
-- Add `PiContentMapper` and `PiHistoryMapper` over RPC `get_entries` plus
-  `leafId` active-branch traversal.
+- Add the history-only `PiSessionProcessRepository` operation plus repository
+  mappers over RPC `get_entries` and `leafId` active-branch traversal.
 - Map text, reasoning, images, tool calls/results, visible custom messages,
   bash execution, errors, and compaction under current size/privacy limits.
 - Keep replay message/part IDs deterministic for Step 6 live parity.
@@ -645,8 +651,8 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 
 ### Step 8/15: Manage session residency and turns
 
-- Add `PiSessionProcessRepository` and `PiSessionService` with one lazy process
-  per active session, generation-fenced connects, new/resume/fork launch,
+- Extend `PiSessionProcessRepository` and add `PiSessionService` with one lazy
+  process per active session, generation-fenced connects, new/resume launch,
   selection state, per-session turn lanes, merged events, and idle reap.
 - Mint secure UUID session IDs in the service and validate Pi's ID grammar in
   `PiLaunchSpec`; map validated inline image data to RPC and reject path, URL,
@@ -657,10 +663,10 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 - Abort by invalidating queued work, rejecting dialogs, sending `abort`, and
   tearing down the process so Pi's own hidden queues cannot continue.
 - Preserve concurrent turns across different sessions.
-- Cover spawn races, serialization, cross-session parallelism, lazy file
-  persistence, resume after reap, transient history/rename leases, fork
-  cwd/parent/ID, ID validation, attachment variants, queued selections,
-  command-without-run, auth failure, abort, and shutdown.
+- Cover spawn races, serialization, cross-session parallelism, lazy persistence,
+  resume after reap, transient history/rename leases, ID/attachment validation,
+  queued selections, command-without-run, post-acceptance process exit, auth
+  failure, abort, and shutdown.
 
 ### Step 9/15: Expose models and commands
 
@@ -696,13 +702,13 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 - Require merged package-directory runtime support from the dependency section.
 - Add `PiRuntimeManifest` with the six official assets, full-package layout,
   semantic pin/floor, URLs, and digests refreshed for the chosen stable release.
-- Add descriptor config/capability/setup inspection, read-only ensure, explicit
-  install, auth probe, start/abort rollback, and `PiBridgePlugin` lifecycle.
+- Add descriptor config/capability/runtime-only setup inspection, read-only
+  ensure, explicit install, start/abort rollback, and `PiBridgePlugin` lifecycle.
 - Set `PI_SKIP_VERSION_CHECK=1`, preserve other Pi environment/config, and pass
   `--approve` to every real/probe process.
 - Extend `update-backend-runtimes` with Pi release/API/digest/package checks.
 - Test runtime precedence, explicit-bin behavior, six targets, archive layout,
-  install capability, checksum failure, auth/unknown states, abort rollback,
+  install capability, checksum failure, cwd-less setup, abort rollback,
   lifecycle status/work state, and package asset preservation.
 - Perform a local managed install from the official asset and run `--version`
   plus an RPC `get_state` probe from the installed tree.
@@ -735,7 +741,7 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
   image prompt, live reasoning, read/edit/bash tools, model/thinking switch,
   skill/template/extension command, extension dialog, retry/error, abort,
   resume after process reap/bridge restart, rename, delete, external import,
-  documented terminal handoff, and parent fork.
+  documented terminal handoff, imported parent relationships, and missing auth.
 - Run the applicable mobile and desktop presentation paths and confirm no Pi
   logic exists outside declared identity/brand points.
 - Record redacted results and any protocol corrections in `PROTOCOL.md` and

--- a/.plan/active/pi-harness/PLAN.md
+++ b/.plan/active/pi-harness/PLAN.md
@@ -267,6 +267,9 @@ it is not-found rather than a guessed path.
 
 For each candidate JSONL file:
 
+- stream bytes through a bounded LF/discriminator scanner that retains only
+  header and `session_info` records; discard other/oversized bodies through the
+  newline without materializing or JSON-decoding them;
 - parse the bounded first session header;
 - inspect only `session_info` records for the latest explicit name;
 - use file mtime as updated time;
@@ -377,10 +380,10 @@ dialogs, which appear as questions because Pi supplies no permission semantics.
 `PiSessionService` owns per-session turn admission, status/work state, abort,
 and idle reap. Prompt admission marks the session busy and returns immediately;
 the lane later applies selection, dispatches, and tracks settlement. A command
-queue item also owns an acceptance completer: `sendCommand` returns only after
-its correlated Pi prompt response succeeds, and pre-acceptance invalidation,
-connect/selection/dispatch failure, or exit completes it with an error. Later
-failures emit a session error. IDs are secure UUIDs validated by `PiLaunchSpec`.
+is rejected synchronously while any turn is active/queued; otherwise its turn
+owns an acceptance completer and `sendCommand` returns only after the correlated
+Pi prompt response succeeds. Pre-acceptance failure/exit completes it with an
+error; later failures emit session events. IDs are secure UUIDs validated by `PiLaunchSpec`.
 
 A generation-matched process exit before `agent_settled` fails the active turn
 and clears resident/dialog state. The lane re-resolves for the next admitted
@@ -403,10 +406,10 @@ non-image data are not fetched, stringified, or silently dropped: dispatch fails
 before acceptance with a privacy-safe `PluginOperationException` explaining
 that Pi supports inline image data only.
 
-Commands use Pi's normal `/name args` prompt path. The correlated successful
-prompt response completes `sendCommand` acceptance; the service then holds the
-lane through a `get_state` barrier and all earlier queued events. It treats a
-command as no-run only when no generation-matched
+Commands use Pi's normal `/name args` prompt path only from an idle lane. The
+correlated successful prompt response completes `sendCommand` acceptance; the
+service then holds the lane through a `get_state` barrier and earlier protocol
+events. It treats a command as no-run only when no generation-matched
 `agent_start` arrived and state reports neither streaming nor pending messages;
 otherwise it waits for `agent_settled`. Command context uses the same marker
 scheme, and live/replay presentation uses only `userVisibleArguments`.
@@ -512,7 +515,7 @@ user's telemetry choice remain Pi's.
 | `getSessionStatuses` | session service work/queue state |
 | `getSessionMessages` | RPC entries/tree history mapper; throw on failure |
 | `sendPrompt` | admit exact turn immediately; later dispatch failures become events |
-| `sendCommand` | await correlated prompt acceptance; later run failures become events |
+| `sendCommand` | reject busy; otherwise await acceptance; event later failures |
 | `abortSession` | abort and process teardown, clearing queued work/dialogs |
 | `getAgents` | one synthesized primary Pi agent |
 | questions | extension UI service/tracker |
@@ -641,8 +644,9 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 - Scan metadata in an isolate, map explicit titles and parent paths, preserve
   lazy-new-session bridge attribution, and expose exact session paths privately.
 - Cover malformed headers, half-written final lines, title clear/replace,
-  duplicate roots/IDs, parent outside the first root, custom session dirs,
-  deleted cwd, symlinks, pagination, and privacy-safe diagnostics.
+  oversized non-metadata records, duplicate roots/IDs, parent outside the first
+  root, custom session dirs, deleted cwd, symlinks, pagination, and privacy-safe
+  diagnostics.
 - Validate against a synthetic tree and a privacy-preserving structural scan of
   a real Pi session root when available.
 
@@ -701,14 +705,14 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
   `PiLaunchSpec`; map validated inline image data to RPC and reject path, URL,
   or non-image parts before prompt acceptance.
 - Apply model/thinking immediately before each queued turn; prompts return on
-  lane admission, commands await correlated backend acceptance, dispatch tracks
-  through `agent_settled`, and later failures surface through session events.
+  lane admission, while commands reject busy and otherwise await correlated
+  backend acceptance; later run failures surface through session events.
 - Abort by invalidating queued work, rejecting dialogs, sending `abort`, and
   tearing down the process so Pi's own hidden queues cannot continue.
 - Preserve concurrent turns across different sessions.
 - Cover spawn races, serialization, cross-session parallelism, lazy persistence,
   resume after reap, transient history/rename leases, ID/attachment validation,
-  immediate prompt admission, command acceptance/failure completers,
+  immediate prompt admission, busy-command rejection, acceptance completers,
   response-before-`agent_start` barriers, command-without-run, post-acceptance
   exit, project-scoped auth/toast behavior, abort, and shutdown.
 

--- a/.plan/active/pi-harness/PLAN.md
+++ b/.plan/active/pi-harness/PLAN.md
@@ -69,9 +69,9 @@ desktop surfaces without leaking Pi-specific behavior outside the plugin.
    than breaking the run.
 10. Pi's native no-permission-prompt behavior is preserved. The plugin reports
     no pending permissions and does not install a Sesori permission extension.
-11. Project-scoped discovery and prompt failures surface missing-auth guidance
-    to run Pi locally and use `/login`; cwd-less setup inspection never blocks a
-    valid project configuration as unauthenticated.
+11. Project-scoped discovery and prompt failures use ordinary operation/session
+    failure plus an existing guidance toast for local `/login`; they never
+    disable Pi for other projects through plugin-global auth state.
 12. Supported inline image data reaches Pi's RPC `images` field. Path, URL, and
     non-image variants fail visibly and never become accidental prompt strings.
 13. No Pi protocol value, path layout, provider assumption, tool name, or
@@ -300,10 +300,10 @@ Mapping rules:
 - model/thinking/label/custom-state entries produce no chat message; and
 - unknown roles/blocks are ignored with bounded diagnostics.
 
-Pi messages do not carry a persistent message ID. The mapper derives the same
-plugin-local stable ID in live and replay paths from session, role, and the
-persisted millisecond timestamp, with the session entry ID as the fallback when
-timestamp is absent. Tool call IDs remain Pi's stable IDs.
+Pi messages do not carry a persistent message ID. Live and replay both derive
+IDs from session, role, timestamp-or-sentinel, and the occurrence ordinal among
+matching messages in event/active-branch order. This disambiguates synchronous
+same-millisecond custom messages. Tool call IDs remain Pi's stable IDs.
 
 History failures throw a cause-preserving `PluginOperationException`. Only a
 successfully loaded active branch with no visible messages returns `[]`.
@@ -387,6 +387,10 @@ before spawn and remove it only after the JSONL file is observable. Resolution
 prefers a file; otherwise the marker relaunches `--session-id` in its recorded
 cwd. Delete clears both, so external missing sessions are never resurrected.
 
+Creation emits a synthetic `BridgeSseSessionCreated` before admitting the first
+turn. Bridge core can then buffer early status/message/dialog events until the
+binding commit, matching the established ACP creation ordering.
+
 `PiSessionProcessRepository` also maps prompts. Text remains text; inline
 `fileData` with a supported image MIME becomes Pi's base64 `images` field after
 the existing attachment-size and base64 validation. `filePath`, `fileUrl`, and
@@ -465,6 +469,12 @@ by the approved project-scoped catalog/prompt path, which preserves the typed
 failure cause and presents local `/login` guidance without globally blocking
 plugin startup.
 
+Project-scoped auth failures never escape as
+`PluginAuthenticationRequiredException`, which bridge core interprets as
+plugin-global auth loss. Synchronous calls use an ordinary cause-preserving
+operation failure; admitted turns emit existing `session.error` plus a bounded
+guidance toast. No new wire event is required.
+
 `ensureRuntime` uses `ManagedRuntimeProvisionService` and remains read-only.
 `installRuntime` uses `ManagedRuntimeInstallService` and the package-directory
 layout. Install capability is declared only when no explicit bin is configured
@@ -485,7 +495,7 @@ user's telemetry choice remain Pi's.
 | `primeSessionDirectory` | retain bridge attribution until file metadata is observable |
 | `getCommands` | project-scoped throwaway RPC `get_commands` |
 | `getSessionOptions` | reuse/refresh through project tracker; observed complete/partial or failed |
-| `createSession` | bridge ID; new launch; enqueue only when `parts` is non-empty |
+| `createSession` | emit created, then admit first turn only when `parts` is non-empty |
 | `renameSession` | resident or bounded transient lease for RPC `set_session_name` |
 | `deleteSession` | stop resident process, clear dialogs/cache, resolve then delete exact JSONL file |
 | `deletePersistedSession` | resolve by ID and idempotently delete the exact file without spawning Pi |
@@ -637,7 +647,8 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
   empty history.
 - Cover branches, pre-compaction history, unknown entries, timestamp fallback,
   tool result folding, attachment bounds, hidden-context stripping, marker-like
-  prompt/command text, live/replay parity, and no payload logging.
+  prompt/command text, equal-timestamp ordinals, live/replay parity, and no
+  payload logging.
 
 ### Step 6/15: Map live messages and tools
 
@@ -687,7 +698,8 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 - Cover spawn races, serialization, cross-session parallelism, lazy persistence,
   resume after reap, transient history/rename leases, ID/attachment validation,
   immediate queued admission, response-before-`agent_start` command barriers,
-  command-without-run, post-acceptance exit, auth failure, abort, and shutdown.
+  command-without-run, post-acceptance exit, project-scoped auth/toast behavior,
+  abort, and shutdown.
 
 ### Step 9/15: Expose models and commands
 
@@ -704,7 +716,7 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
   data or credentials.
 - Cover custom providers, known provider mapping, duplicate IDs, reasoning and
   non-reasoning models, `max`, command sources, project-specific resources,
-  empty/auth state, probe exit, and refresh fallback.
+  empty/auth state without global teardown, probe exit, and refresh fallback.
 
 ### Step 10/15: Implement the plugin API
 
@@ -715,11 +727,12 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
   providers, health, summaries, and idempotent disposal.
 - Empty creation `parts` starts an idle session only; the bridge's subsequent
   `sendCommand` owns the first execution.
+- Emit session-created before first-turn admission so pre-commit events buffer.
 - Keep archive/workspace operations honest no-ops and permission methods
   honest empty/not-found results.
 - Cover full contract behavior, missing session/path, lazy persistence,
-  empty-parts command creation, buffered first event listener, operation errors
-  with causes, and disposal order.
+  empty-parts command creation, created-before-output ordering, buffered first
+  event listener, operation errors with causes, and disposal order.
 
 ### Step 11/15: Add managed runtime and lifecycle
 

--- a/.plan/active/pi-harness/PLAN.md
+++ b/.plan/active/pi-harness/PLAN.md
@@ -64,22 +64,23 @@ desktop surfaces without leaking Pi-specific behavior outside the plugin.
    because Pi is launched with `--approve`, and exposes exact thinking levels
    by probing a non-persisted RPC session rather than hardcoding provider rules.
 9. Pi extension `select`, `confirm`, `input`, and `editor` dialogs round-trip as
-   Sesori questions. Notifications become existing toast events. Unsupported
-   fire-and-forget UI decorations are parsed and deliberately ignored rather
-   than breaking the run.
+   Sesori questions. Notifications use existing toast events and render through
+   backend-neutral client presentation. Unsupported fire-and-forget decorations
+   are parsed and deliberately ignored rather than breaking the run.
 10. Pi's native no-permission-prompt behavior is preserved. The plugin reports
     no pending permissions and does not install a Sesori permission extension.
 11. Project-scoped discovery and prompt failures use ordinary operation/session
-    failure plus an existing guidance toast for local `/login`; they never
-    disable Pi for other projects through plugin-global auth state.
+    failure plus a rendered guidance toast for local `/login`; they never disable
+    Pi for other projects through plugin-global auth state.
 12. Supported inline image data reaches Pi's RPC `images` field. Path, URL, and
     non-image variants fail visibly and never become accidental prompt strings.
 13. No Pi protocol value, path layout, provider assumption, tool name, or
     runtime quirk escapes `bridge/sesori_plugin_pi/`. The intentional shared
-    exceptions are `Harness.pi`, plugin registration, and Pi brand presentation.
+    exceptions are Pi identity, registration, and branding. Existing toast
+    events gain backend-neutral presentation with no Pi-specific branch.
 14. No new relay route, database column, or `MessagePartType` is introduced.
-    Older clients continue to render an unknown `pi` plugin through existing
-    data-driven contracts.
+    Older clients render unknown `pi` through data-driven contracts but ignore
+    notification and `/login` toasts until upgraded; generic failures remain.
 15. Every implementation PR is independently buildable and normally stays at
     or below 1,500 changed lines, including tests and generated output.
 
@@ -296,8 +297,8 @@ Mapping rules:
 - tool-result messages update the originating tool part by `toolCallId`;
 - visible custom extension messages map conservatively to displayable text;
 - direct bash-execution messages map to a tool card;
-- compaction/branch summaries use existing hidden compaction semantics where
-  useful and never create a new part type;
+- successful compaction becomes the visible completed `compact` tool card used
+  by Codex without exposing summary text; branch-summary metadata is ignored;
 - model/thinking/label/custom-state entries produce no chat message; and
 - unknown roles/blocks are ignored with bounded diagnostics.
 
@@ -318,8 +319,8 @@ successfully loaded active branch with no visible messages returns `[]`.
   `tool_execution_start/update/end` running and terminal updates;
 - cumulative `tool_execution_update.partialResult` by replacement, never
   append;
-- `auto_retry_*` and compaction events into existing retry/status/compaction
-  signals;
+- `auto_retry_*` and compaction events into existing retry/status/compacted
+  signals plus the replay-equivalent visible compaction card;
 - authoritative assistant envelopes from `message_end`;
 - `agent_settled`, not `agent_end`, into true completion/idle; and
 - typed edit/write built-in tool completion into existing diff staleness rather
@@ -478,9 +479,9 @@ Project-scoped auth failures never escape as
 `PluginAuthenticationRequiredException`, which bridge core interprets as
 plugin-global auth loss. Catalog discovery returns
 `PluginSessionOptionsDiscoveryResult.failed` plus an existing bounded guidance
-toast; admitted turns emit existing `session.error` plus that toast. Other
-synchronous calls use ordinary cause-preserving operation failures. No new wire
-event is required.
+toast rendered by Step 13; admitted turns emit existing `session.error` plus
+that toast. Other synchronous calls use ordinary cause-preserving operation
+failures. No new wire event is required.
 
 `ensureRuntime` uses `ManagedRuntimeProvisionService` and remains read-only.
 `installRuntime` uses `ManagedRuntimeInstallService` and the package-directory
@@ -511,7 +512,7 @@ user's telemetry choice remain Pi's.
 | `getSessionStatuses` | session service work/queue state |
 | `getSessionMessages` | RPC entries/tree history mapper; throw on failure |
 | `sendPrompt` | admit exact turn immediately; later dispatch failures become events |
-| `sendCommand` | admit marked `/command arguments`; later failures become events |
+| `sendCommand` | await correlated prompt acceptance; later run failures become events |
 | `abortSession` | abort and process teardown, clearing queued work/dialogs |
 | `getAgents` | one synthesized primary Pi agent |
 | questions | extension UI service/tracker |
@@ -531,10 +532,11 @@ Step 12 adds `Harness.pi`, the app dependency, and the sole concrete registratio
 in `plugin_registry.dart`, then updates exact-set fixtures. OpenCode remains the
 preferred default; string plugin identity keeps this additive change wire-safe.
 
-Step 13 adds official light/dark Pi assets, brand/display-name cases, scalable
-README copy, managed-runtime/local-login/project-trust guidance, and the
-terminal handoff warning. Existing backend-neutral attachment capability drives
-composer behavior; no Pi-specific client state is added.
+Step 13 adds Pi assets/branding/docs plus backend-neutral toast presentation.
+`SseToastCubit` maps existing toast events into closed presentation variants;
+the relay-connected mobile shell renders them through its root messenger.
+Existing attachment capability drives composer behavior; no Pi checks enter
+shared client state.
 
 ## Analytics Assessment
 
@@ -542,6 +544,8 @@ No new analytics event is planned.
 
 - Pi session creation and message actions use existing authoritative product
   events.
+- Rendering transport toasts is transient presentation, not a product outcome
+  or reporting question.
 - Managed install already emits the bounded completed/failed harness install
   outcome.
 - Existing privacy rules deliberately keep harness identity and provider/model
@@ -553,17 +557,16 @@ a corresponding reporting question. This series does neither.
 ## Dependencies And Sequencing
 
 1. **Package-directory runtime support:** Step 11 depends on
-   `phone-harness-install` Step 5 landing `RuntimeAssetLayout.packageDirectory`
-   and generalized `RuntimeVersion`. Work is already committed on the dedicated
-   `phone-harness-install-cursor` branch as of this plan, but is not on `main`.
-   Do not duplicate or cherry-pick it into an earlier Pi step. If it is deferred,
-   pause before Pi Step 11 and ask whether to move that shared primitive into
-   this series.
-2. **Claude activation overlap:** the active `claude-code-plugin` series will
-   edit `Harness`, app pubspec, registry, CI/package inventories, and brand
-   lookup files before its Step 15. Pi steps touching those files rebase on the
-   merged Claude work; they never replace Claude's entries or preserve stale
-   exact-set assertions.
+   `phone-harness-install` Step 5 landing `RuntimeAssetLayout.packageDirectory`.
+   Its local branch also generalizes `RuntimeVersion`; Pi consumes that if it
+   lands, but its semantic pin does not independently require the generalization.
+   Do not duplicate or cherry-pick either primitive. If deferred, pause before
+   Step 11 and ask whether package-directory support moves into this series.
+2. **Claude activation overlap:** Claude's workspace/CI inventory has merged;
+   its outstanding activation still owns `Harness`, app pubspec, registry, and
+   exact-set fixtures, followed by branding. Pi Step 12 waits if Claude
+   activation is not merged, then Pi registration/client work rebases and
+   preserves every Claude entry rather than stale exact-set assertions.
 3. Every Pi PR targets `main` and follows the prior Pi step. No implementation
    worktree or successor PR is created by this plan PR.
 
@@ -588,7 +591,7 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
   15 moves it to `.plan/completed/pi-harness/`.
 - Every step follows repository line-count, generated-file, internal-contract,
   PR-body, sequential merge, and architecture-review rules.
-- Steps 2-12 run applicable codegen, focused/full owning-package tests, fatal
+- Steps 2-13 run applicable codegen, focused/full owning-package tests, fatal
   analysis, `git diff --check`, and architecture implementation review.
 
 ## Step Details And Verification
@@ -649,14 +652,14 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 - Add the history-only `PiSessionProcessRepository` operation plus repository
   mappers over RPC `get_entries` and `leafId` active-branch traversal.
 - Map text, reasoning, images, tool calls/results, visible custom messages,
-  bash execution, errors, and compaction under current size/privacy limits.
+  bash execution, errors, visible compaction cards, and branch-summary omission.
 - Keep replay message/part IDs deterministic for Step 6 live parity.
 - Throw cause-preserving failures; never turn transport/auth/parse failure into
   empty history.
 - Cover branches, pre-compaction history, unknown entries, timestamp fallback,
-  tool result folding, attachment bounds, hidden-context stripping, marker-like
-  prompt/command text, equal-timestamp ordinals, live/replay parity, and no
-  payload logging.
+  tool results, compaction parity, attachment bounds, hidden-context stripping,
+  marker-like prompt/command text, equal-timestamp ordinals, live/replay parity,
+  and no payload logging.
 
 ### Step 6/15: Map live messages and tools
 
@@ -674,7 +677,7 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 ### Step 7/15: Bridge extension dialogs
 
 - Add `PiExtensionUiTracker` and coordinating `PiExtensionUiService` for
-  select/confirm/input/editor questions, lifecycle events, and notification toasts.
+  select/confirm/input/editor questions, lifecycle events, and bounded toasts.
 - Implement exact value/confirmed/cancelled responses and session-keyed routing.
 - Resolve/store each dialog's display root and aggregate descendant cards for
   root-session queries.
@@ -764,7 +767,7 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
   plugin tests.
 - Update any build/runtime enumeration fixture that intentionally lists every
   registered plugin.
-- Rebase on merged Claude activation and keep OpenCode as preferred default.
+- Wait for and rebase on merged Claude activation; keep OpenCode preferred.
 - Verify shared identity tests, app registry/lifecycle/catalog tests, Pi suite,
   app fatal analysis, and implementation review.
 
@@ -772,11 +775,19 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 
 - Add official light/dark Pi SVGs and brand/display-name cases with widget/unit
   coverage.
+- Add backend-neutral `SseToastCubit` in `module_core` with sealed idle/show
+  state; each show carries a monotonic sequence, title/message, and closed
+  `info|success|warning|error` variant. Null/unknown maps to info; empty is ignored.
+- Render the cubit's title/message/variant from the mobile app root through its
+  `ScaffoldMessenger`, independent of the current route.
+- Do not instantiate relay state solely in desktop's current auth-only shell;
+  reuse the shared cubit when its relay/session surface lands.
 - Update README/bridge docs for Pi, managed install, local `/login`,
   `--pi-bin`, project trust, and terminal-session handoff.
 - Make headline copy scalable instead of appending a fourth hardcoded backend.
-- Verify affected client/module_prego tests, analysis, asset rendering, link
-  validity, and `git diff --check`.
+- Test pure-Dart event mapping and mobile root presentation, including auth
+  guidance, extension notifications, variants, duplicates, and empty payloads.
+- Verify client/module_prego analysis, asset rendering, links, and diff checks.
 
 ### Step 14/15: Verify the end-to-end integration
 

--- a/.plan/active/pi-harness/PLAN.md
+++ b/.plan/active/pi-harness/PLAN.md
@@ -388,9 +388,10 @@ dialogs, which appear as questions because Pi supplies no permission semantics.
 and idle reap. Prompt admission marks the session busy and returns immediately;
 the lane later applies selection, dispatches, and tracks settlement. A command
 is rejected synchronously while any turn is active/queued; otherwise its turn
-owns an acceptance completer and `sendCommand` returns only after the correlated
-Pi prompt response succeeds. Pre-acceptance failure/exit completes it with an
-error; later failures emit session events. IDs are secure UUIDs validated by `PiLaunchSpec`.
+owns an acceptance completer. `sendCommand` returns when either the correlated
+response succeeds or a generation-matched extension dialog proves Pi began
+handling it. Pre-acceptance failure/exit throws; later failures emit events.
+IDs are secure UUIDs validated by `PiLaunchSpec`.
 
 A correlated prompt `success: false` is terminal without `agent_settled`: emit
 the session error/auth toast, clear the active turn, advance the next queued
@@ -417,22 +418,23 @@ non-image data are not fetched, stringified, or silently dropped: dispatch fails
 before acceptance with a privacy-safe `PluginOperationException` explaining
 that Pi supports inline image data only.
 
-Commands use Pi's normal `/name args` prompt path only from an idle lane. The
-correlated successful prompt response completes `sendCommand` acceptance; the
-service then holds the lane through a `get_state` barrier and earlier protocol
-events. It treats a command as no-run only when no generation-matched
-`agent_start` arrived and state reports neither streaming nor pending messages;
-otherwise it waits for `agent_settled`. Command context uses the same marker
-scheme, and live/replay presentation uses only `userVisibleArguments`.
+Commands use Pi's normal `/name args` prompt path only from an idle lane. A
+dialog-first acceptance detaches the phone request while response/dialog failure
+continues through session events. Every prompt path, including manually typed
+slash commands, applies the same no-run classifier: after the prompt response,
+if no generation-matched `agent_start` arrived, hold the lane through a
+`get_state` barrier and earlier protocol events; settle when state is neither
+streaming nor pending, otherwise await `agent_settled`. Command context uses the
+same marker; presentation uses only `userVisibleArguments`.
 
 Abort invalidates the session generation, rejects pending dialogs and queued
 turns, sends Pi's `abort`, and tears down that session process. Teardown is
 required because Pi's RPC `abort` does not clear its steering/follow-up queues.
 The next accepted turn resumes from the persisted session.
 
-Delete first applies the same generation invalidation and rejects active/queued
-turns and dialogs, then stops the process and removes marker/file state. Its exit
-callback cannot advance the invalidated lane or relaunch deleted work.
+Delete resolves imported descendants, invalidates/rejects every affected lane
+and dialog, and stops their resident processes before removing only the named
+root's marker/file. Exit callbacks cannot advance or relaunch tombstoned work.
 
 ### Catalogs and selections
 
@@ -525,14 +527,14 @@ user's telemetry choice remain Pi's.
 | `getSessionOptions` | reuse/refresh through project tracker; observed complete/partial or failed |
 | `createSession` | emit created, then admit first turn only when `parts` is non-empty |
 | `renameSession` | resident or bounded transient lease for RPC `set_session_name` |
-| `deleteSession` | invalidate lane/dialogs, stop process, then delete marker/file |
+| `deleteSession` | stop root/descendant work, then delete the named root marker/file |
 | `deletePersistedSession` | resolve by ID and idempotently delete the exact file without spawning Pi |
 | `archiveSession`, `deleteWorkspace` | no-op under best-effort contracts |
 | `getChildSessions` | catalog filter by resolved parent ID |
 | `getSessionStatuses` | session service work/queue state |
 | `getSessionMessages` | RPC/file active-branch history; throw on non-fallback failure |
 | `sendPrompt` | admit exact turn immediately; later dispatch failures become events |
-| `sendCommand` | reject busy; otherwise await acceptance; event later failures |
+| `sendCommand` | reject busy; await response-or-dialog acceptance; event later failures |
 | `abortSession` | abort and process teardown, clearing queued work/dialogs |
 | `getAgents` | one synthesized primary Pi agent |
 | questions | extension UI service with owner/root/project tracker indexes |
@@ -730,9 +732,9 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 - Cover spawn races, serialization, cross-session parallelism, lazy persistence,
   resume after reap, transient history/rename leases, ID/attachment validation,
   immediate prompt admission, busy-command rejection, acceptance completers,
-  rejection followed by the next prompt, response-before-`agent_start` barriers,
-  command-without-run, post-acceptance exit, project-scoped auth/toast behavior,
-  abort, and shutdown.
+  dialog-first command acceptance, rejection followed by the next prompt,
+  response-before-`agent_start` barriers, typed-slash no-run, post-acceptance
+  exit, project-scoped auth/toast behavior, abort, and shutdown.
 
 ### Step 9/15: Expose models and commands
 
@@ -765,8 +767,8 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
   honest empty/not-found results.
 - Cover full contract behavior, missing session/path, lazy persistence,
   empty-parts command creation, created-before-output ordering, delete during an
-  active turn with a queued prompt, buffered first listener, cause-preserving
-  errors, and disposal order.
+  active turn with queued work, active-child root deletion, buffered first
+  listener, cause-preserving errors, and disposal order.
 
 ### Step 11/15: Add managed runtime and lifecycle
 

--- a/.plan/active/pi-harness/PLAN.md
+++ b/.plan/active/pi-harness/PLAN.md
@@ -197,9 +197,9 @@ bridge/sesori_plugin_pi/
   lib/src/repositories/{pi_session_catalog_repository,pi_session_process_repository}.dart
   lib/src/repositories/pi_backend_catalog_repository.dart
   lib/src/repositories/mappers/{pi_content_mapper,pi_history_mapper}.dart
-  lib/src/trackers/{pi_catalog_tracker,pi_tool_tracker}.dart
-  lib/src/services/{pi_session_service,pi_catalog_service}.dart
-  lib/src/{pi_event_dispatcher,pi_extension_ui_registry}.dart
+  lib/src/trackers/{pi_catalog_tracker,pi_tool_tracker,pi_extension_ui_tracker}.dart
+  lib/src/services/{pi_session_service,pi_catalog_service,pi_extension_ui_service}.dart
+  lib/src/pi_event_dispatcher.dart
   lib/src/pi_plugin_impl.dart
   lib/src/runtime/{pi_runtime_manifest,pi_plugin_descriptor,pi_bridge_plugin}.dart
   lib/src/testing/fake_pi_process.dart
@@ -213,8 +213,7 @@ The placement follows `Foundation -> API -> Repository -> Service -> Consumer`:
 - repositories consume APIs and own mapping, without Layer-2 peer dependencies;
 - trackers own queryable Layer-2 catalog and tool state;
 - services coordinate repositories and trackers; and
-- dispatch/extension registries live at `lib/src/` when they consume
-  multiple Layer-2 components.
+- the plugin implementation and event dispatcher are consumers.
 
 No generic RPC abstraction is extracted into shared packages. ACP, Claude, and
 Pi have materially different framing, request, event, and lifecycle contracts.
@@ -237,10 +236,10 @@ One client owns one child process and:
 - closes stdin first, then uses bounded SIGTERM/SIGKILL on POSIX and bounded
   process termination on Windows.
 
-The top-level open envelope is a small hand-written sealed dispatch boundary,
-matching the ACP and Claude transport precedent. Closed nested content shapes
-used by mappers are generated DTOs and land with their first consumer so codegen
-does not create unconsumed multi-thousand-line PRs.
+Only top-level discriminator routing and the unknown-envelope fallback are
+hand-written. Every known response, event, dialog, and nested payload uses a
+generated DTO; DTOs land with their first consumer so codegen does not create
+unconsumed multi-thousand-line PRs.
 
 ### Session catalog
 
@@ -286,9 +285,9 @@ pre-compaction entries without making reads resident.
 
 Mapping rules:
 
-- for creation, `userVisibleText` identifies the authored suffix; the repository
-  wraps only the proven leading execution context in a plugin-owned marker before
-  RPC, and the mapper strips that marker in both live and replay paths;
+- `userVisibleText` and `userVisibleArguments` identify authored suffixes; the
+  repository wraps only proven leading execution context in a plugin-owned
+  marker before RPC, and strips it in live and replay paths;
 - remaining user text/images become a user envelope plus text/file parts; an
   unprovable split fails creation rather than exposing or duplicating context;
 - assistant text, thinking, and tool calls become existing text, reasoning, and
@@ -330,7 +329,7 @@ the final message repairs it. Live/replay parity is a direct test requirement.
 
 ### Extension UI
 
-`PiExtensionUiRegistry` keeps pending dialog state per session:
+`PiExtensionUiTracker` keeps pending dialog state per session:
 
 | Pi method | Sesori mapping |
 |---|---|
@@ -341,17 +340,16 @@ the final message repairs it. Live/replay parity is a direct test requirement.
 | `notify` | existing `BridgeSseTuiToastShow` |
 | `setStatus`, `setWidget`, `setTitle`, `set_editor_text` | parsed, debug-recorded, deliberately ignored |
 
-The registry answers with Pi's exact `extension_ui_response` variants. Reject,
-timeout, abort, idle reap, process exit, and plugin disposal resolve or clear
-every pending card. Pi does not expose re-enumeration after process loss, so
-there is no persisted pending-dialog state.
+`PiExtensionUiService` coordinates the catalog repository, process repository,
+and tracker: it resolves display roots, routes Pi's exact response variants, and
+exposes notifications for the plugin consumer. Reject, timeout, abort, reap,
+exit, and disposal clear every card; no dialog state is persisted.
 
-At request time the registry resolves the owning session's top-most imported
-parent from the catalog snapshot, stores it as `displaySessionId`, and indexes
-the card by owner and display root. `getPendingQuestions(root)` returns the
-root's own and matching descendant cards without rescanning the session tree.
+At request time the service resolves the owning session's top-most imported
+parent from the catalog snapshot. The tracker stores `displaySessionId` and
+indexes by owner/root, so root queries need no session-tree rescan.
 
-`PluginQuestionInfo` has no editable-prefill field. For `editor`, the registry
+`PluginQuestionInfo` has no editable-prefill field. For `editor`, the service
 therefore appends a bounded, clearly labelled prefill excerpt to the question
 and tells the user that their answer is the complete replacement. Truncation is
 stated in the prompt; no hidden prefill is silently retained.
@@ -372,18 +370,17 @@ dialogs, which appear as questions because Pi supplies no permission semantics.
 - request dispatch and extension-dialog responses; and
 - merged session-tagged frame/exit streams.
 
-`PiSessionService` owns the per-session turn lane, status/work state, abort, and
-idle reap. It mints each new backend ID as a secure UUID and `PiLaunchSpec`
-validates that ID against Pi's documented grammar before process launch. A turn
-applies its selected model and thinking level immediately before dispatch,
-waits only for Pi's prompt acceptance to report acceptance to the caller, and
-tracks the run through `agent_settled`. This prevents a model selection for a
-queued phone message from changing an earlier turn.
+`PiSessionService` owns per-session turn admission, status/work state, abort,
+and idle reap. Admission marks the session busy and returns immediately; the
+lane later applies that turn's selection, dispatches, and tracks settlement.
+Post-admission connect/selection/prompt failures emit a session error rather
+than reopening the phone request. IDs are secure UUIDs validated by
+`PiLaunchSpec`.
 
-A generation-matched process exit before `agent_settled` terminalizes the
-accepted turn as failed, rejects queued acceptance futures, clears resident and
-dialog state, and returns the session to idle. A later explicit turn resolves
-through the file or pending-new marker; none remains indefinitely busy.
+A generation-matched process exit before `agent_settled` fails the active turn
+and clears resident/dialog state. The lane re-resolves for the next admitted
+turn and becomes idle only when its queue empties; resolution uses the file or
+pending-new marker, so none remains indefinitely busy.
 
 Creation asks `PiSessionStorageApi` to write a per-session pending-new marker
 before spawn and remove it only after the JSONL file is observable. Resolution
@@ -401,7 +398,8 @@ Commands use Pi's normal `/name args` prompt path. After acceptance, the service
 holds the lane through a correlated `get_state` barrier and all earlier queued
 events. It treats a command as no-run only when no generation-matched
 `agent_start` arrived and state reports neither streaming nor pending messages;
-otherwise it waits for `agent_settled`.
+otherwise it waits for `agent_settled`. Command context uses the same marker
+scheme, and live/replay presentation uses only `userVisibleArguments`.
 
 Abort invalidates the session generation, rejects pending dialogs and queued
 turns, sends Pi's `abort`, and tears down that session process. Teardown is
@@ -419,6 +417,8 @@ coordinates the repository and tracker.
 
 - `get_available_models` supplies provider/model IDs, display names, reasoning,
   and image support.
+- Initial `get_state.model` is captured before the thinking sweep; its provider
+  is ordered first and publishes that model as `defaultModelID`.
 - For each reasoning-capable model, the probe selects it and asks
   `get_available_thinking_levels`; this is safe because the session is
   in-memory.
@@ -493,13 +493,13 @@ user's telemetry choice remain Pi's.
 | `getChildSessions` | catalog filter by resolved parent ID |
 | `getSessionStatuses` | session service work/queue state |
 | `getSessionMessages` | RPC entries/tree history mapper; throw on failure |
-| `sendPrompt` | queue exact turn, return on acceptance |
-| `sendCommand` | `/command arguments`, return on acceptance |
+| `sendPrompt` | admit exact turn immediately; later dispatch failures become events |
+| `sendCommand` | admit marked `/command arguments`; later failures become events |
 | `abortSession` | abort and process teardown, clearing queued work/dialogs |
 | `getAgents` | one synthesized primary Pi agent |
-| questions | extension UI registry |
+| questions | extension UI service/tracker |
 | permissions | empty/not-found; Pi has no native permission protocol |
-| `healthCheck` | bounded RPC `get_state` round trip |
+| `healthCheck` | bounded resolved-binary `--version`, independent of project models |
 | `getProviders` | project-scoped catalog result |
 | `getActiveSessionsSummary` | synchronous session-service summary by cwd |
 | `dispose` | idempotent process/dialog/event teardown |
@@ -600,8 +600,8 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 
 ### Step 3/15: Add the JSONL RPC transport
 
-- Add the open top-level RPC envelope parser and response/error/event/dialog
-  variants consumed by the client.
+- Add hand-written discriminator/unknown routing plus generated DTOs for every
+  known response, event, dialog, and consumed nested payload.
 - Add `PiRpcClient` with strict LF framing, request IDs, asynchronous prompt
   acknowledgement, continuous stdout draining, bounded stderr diagnostics,
   pending failure on exit, and graceful/forced teardown.
@@ -637,7 +637,7 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
   empty history.
 - Cover branches, pre-compaction history, unknown entries, timestamp fallback,
   tool result folding, attachment bounds, hidden-context stripping, marker-like
-  authored text, live/replay parity, and no payload logging.
+  prompt/command text, live/replay parity, and no payload logging.
 
 ### Step 6/15: Map live messages and tools
 
@@ -654,8 +654,8 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 
 ### Step 7/15: Bridge extension dialogs
 
-- Add `PiExtensionUiRegistry` for select/confirm/input/editor questions and
-  notification toasts.
+- Add `PiExtensionUiTracker` and coordinating `PiExtensionUiService` for
+  select/confirm/input/editor questions and notification toasts.
 - Implement exact value/confirmed/cancelled responses and session-keyed routing.
 - Resolve/store each dialog's display root and aggregate descendant cards for
   root-session queries.
@@ -678,15 +678,15 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 - Mint secure UUID session IDs in the service and validate Pi's ID grammar in
   `PiLaunchSpec`; map validated inline image data to RPC and reject path, URL,
   or non-image parts before prompt acceptance.
-- Apply model/thinking immediately before each queued turn; return on prompt or
-  command acceptance, track through `agent_settled`, and handle extension
-  commands that settle without an agent run.
+- Apply model/thinking immediately before each queued turn; return on lane
+  admission, track dispatch through `agent_settled`, and surface later failures
+  through session events.
 - Abort by invalidating queued work, rejecting dialogs, sending `abort`, and
   tearing down the process so Pi's own hidden queues cannot continue.
 - Preserve concurrent turns across different sessions.
 - Cover spawn races, serialization, cross-session parallelism, lazy persistence,
   resume after reap, transient history/rename leases, ID/attachment validation,
-  queued selections, response-before-`agent_start` command barriers,
+  immediate queued admission, response-before-`agent_start` command barriers,
   command-without-run, post-acceptance exit, auth failure, abort, and shutdown.
 
 ### Step 9/15: Expose models and commands
@@ -697,6 +697,7 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 - Let the API own each project-cwd, no-session, approved process; let the
   repository enumerate/map models, exact thinking variants, providers, and
   commands; synthesize one Pi agent.
+- Preserve the initial state model as the default and order its provider first.
 - Implement project-scoped `reuse`/`refresh`, complete/partial observed results,
   explicit failed results, and atomic replacement of coherent snapshots only.
 - Classify no-model/auth preflight honestly without logging provider account
@@ -731,7 +732,7 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
   `--approve` to every real/probe process.
 - Extend `update-backend-runtimes` with Pi release/API/digest/package checks.
 - Test runtime precedence, explicit-bin behavior, six targets, archive layout,
-  install capability, checksum failure, cwd-less setup, abort rollback,
+  install capability, checksum failure, cwd-less setup/sessionless health,
   lifecycle status/work state, and package asset preservation.
 - Perform a local managed install from the official asset and run `--version`
   plus an RPC `get_state` probe from the installed tree.

--- a/.plan/active/pi-harness/PLAN.md
+++ b/.plan/active/pi-harness/PLAN.md
@@ -229,7 +229,8 @@ One client owns one child process and:
 - decodes top-level response, event, extension-UI, and unknown envelopes;
 - correlates responses by request ID without assuming a prompt response arrives
   before agent events;
-- exposes a broadcast event stream tagged later with its owning session ID;
+- buffers parsed frames until the first routing listener attaches, then exposes
+  a broadcast stream tagged later with its owning session ID;
 - never logs raw stdout frames, prompts, transcript content, tool payloads, or
   extension input;
 - redacts known credential fields from diagnostic strings;
@@ -429,6 +430,10 @@ turns, sends Pi's `abort`, and tears down that session process. Teardown is
 required because Pi's RPC `abort` does not clear its steering/follow-up queues.
 The next accepted turn resumes from the persisted session.
 
+Delete first applies the same generation invalidation and rejects active/queued
+turns and dialogs, then stops the process and removes marker/file state. Its exit
+callback cannot advance the invalidated lane or relaunch deleted work.
+
 ### Catalogs and selections
 
 `PiBackendCatalogRepository` owns a bounded short-lived lease over the injected
@@ -520,7 +525,7 @@ user's telemetry choice remain Pi's.
 | `getSessionOptions` | reuse/refresh through project tracker; observed complete/partial or failed |
 | `createSession` | emit created, then admit first turn only when `parts` is non-empty |
 | `renameSession` | resident or bounded transient lease for RPC `set_session_name` |
-| `deleteSession` | stop resident process, clear dialogs/cache, resolve then delete exact JSONL file |
+| `deleteSession` | invalidate lane/dialogs, stop process, then delete marker/file |
 | `deletePersistedSession` | resolve by ID and idempotently delete the exact file without spawning Pi |
 | `archiveSession`, `deleteWorkspace` | no-op under best-effort contracts |
 | `getChildSessions` | catalog filter by resolved parent ID |
@@ -643,8 +648,8 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 - Add `FakePiProcess` and `pi_testing.dart` exports.
 - Cover split/multiple UTF-8 chunks, CRLF input tolerance, U+2028/U+2029 inside
   JSON strings, response/event reordering, unknown frames, process exit,
-  stdout/verbose-stderr backpressure, broken pipes, bounded redaction, and
-  teardown fencing.
+  startup frames before router attachment, stdout/verbose-stderr backpressure,
+  broken pipes, bounded redaction, and teardown fencing.
 
 ### Step 4/15: Enumerate persisted sessions
 
@@ -759,8 +764,9 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 - Keep archive/workspace operations honest no-ops and permission methods
   honest empty/not-found results.
 - Cover full contract behavior, missing session/path, lazy persistence,
-  empty-parts command creation, created-before-output ordering, buffered first
-  event listener, operation errors with causes, and disposal order.
+  empty-parts command creation, created-before-output ordering, delete during an
+  active turn with a queued prompt, buffered first listener, cause-preserving
+  errors, and disposal order.
 
 ### Step 11/15: Add managed runtime and lifecycle
 

--- a/.plan/active/pi-harness/PLAN.md
+++ b/.plan/active/pi-harness/PLAN.md
@@ -260,8 +260,9 @@ Scans run in `Isolate.run`, deduplicate normalized absolute paths, and never
 follow an unbounded symlink tree.
 
 Both `PiSessionCatalogRepository` and `PiSessionProcessRepository` consume this
-Layer-1 resolver directly; neither repository depends on the other. A missing
-or duplicate ID is an explicit lookup failure rather than a guessed path.
+Layer-1 resolver directly; neither repository depends on the other. Duplicate
+paths fail. A missing file is new only with that API's pending marker; otherwise
+it is not-found rather than a guessed path.
 
 For each candidate JSONL file:
 
@@ -285,7 +286,11 @@ pre-compaction entries without making reads resident.
 
 Mapping rules:
 
-- user text and images become a user envelope plus text/file parts;
+- for creation, `userVisibleText` identifies the authored suffix; the repository
+  wraps only the proven leading execution context in a plugin-owned marker before
+  RPC, and the mapper strips that marker in both live and replay paths;
+- remaining user text/images become a user envelope plus text/file parts; an
+  unprovable split fails creation rather than exposing or duplicating context;
 - assistant text, thinking, and tool calls become existing text, reasoning, and
   tool parts;
 - tool-result messages update the originating tool part by `toolCallId`;
@@ -341,6 +346,11 @@ timeout, abort, idle reap, process exit, and plugin disposal resolve or clear
 every pending card. Pi does not expose re-enumeration after process loss, so
 there is no persisted pending-dialog state.
 
+At request time the registry resolves the owning session's top-most imported
+parent from the catalog snapshot, stores it as `displaySessionId`, and indexes
+the card by owner and display root. `getPendingQuestions(root)` returns the
+root's own and matching descendant cards without rescanning the session tree.
+
 `PluginQuestionInfo` has no editable-prefill field. For `editor`, the registry
 therefore appends a bounded, clearly labelled prefill excerpt to the question
 and tells the user that their answer is the complete replacement. Truncation is
@@ -355,7 +365,7 @@ dialogs, which appear as questions because Pi supplies no permission semantics.
 `PiSessionProcessRepository` owns:
 
 - `sessionId -> resident PiRpcClient`;
-- new/resume launch choice, using `PiSessionStorageApi` for absolute paths;
+- new/resume launch choice using `PiSessionStorageApi` paths/pending markers;
 - bounded resident-or-transient client leases for history and rename;
 - process connection generations and late-spawn rollback;
 - applied provider/model/thinking state;
@@ -372,8 +382,13 @@ queued phone message from changing an earlier turn.
 
 A generation-matched process exit before `agent_settled` terminalizes the
 accepted turn as failed, rejects queued acceptance futures, clears resident and
-dialog state, and returns the session to idle. A later explicit turn resumes
-from the persisted file; no accepted turn remains indefinitely busy.
+dialog state, and returns the session to idle. A later explicit turn resolves
+through the file or pending-new marker; none remains indefinitely busy.
+
+Creation asks `PiSessionStorageApi` to write a per-session pending-new marker
+before spawn and remove it only after the JSONL file is observable. Resolution
+prefers a file; otherwise the marker relaunches `--session-id` in its recorded
+cwd. Delete clears both, so external missing sessions are never resurrected.
 
 `PiSessionProcessRepository` also maps prompts. Text remains text; inline
 `fileData` with a supported image MIME becomes Pi's base64 `images` field after
@@ -382,10 +397,11 @@ non-image data are not fetched, stringified, or silently dropped: dispatch fails
 before acceptance with a privacy-safe `PluginOperationException` explaining
 that Pi supports inline image data only.
 
-Commands use Pi's normal `/name args` prompt path. An extension command can
-finish at acceptance without starting an agent run; the service checks current
-state rather than waiting forever for an `agent_settled` that will never be
-emitted.
+Commands use Pi's normal `/name args` prompt path. After acceptance, the service
+holds the lane through a correlated `get_state` barrier and all earlier queued
+events. It treats a command as no-run only when no generation-matched
+`agent_start` arrived and state reports neither streaming nor pending messages;
+otherwise it waits for `agent_settled`.
 
 Abort invalidates the session generation, rejects pending dialogs and queued
 turns, sends Pi's `abort`, and tears down that session process. Teardown is
@@ -469,7 +485,7 @@ user's telemetry choice remain Pi's.
 | `primeSessionDirectory` | retain bridge attribution until file metadata is observable |
 | `getCommands` | project-scoped throwaway RPC `get_commands` |
 | `getSessionOptions` | reuse/refresh through project tracker; observed complete/partial or failed |
-| `createSession` | bridge ID; new launch; enqueue first turn |
+| `createSession` | bridge ID; new launch; enqueue only when `parts` is non-empty |
 | `renameSession` | resident or bounded transient lease for RPC `set_session_name` |
 | `deleteSession` | stop resident process, clear dialogs/cache, resolve then delete exact JSONL file |
 | `deletePersistedSession` | resolve by ID and idempotently delete the exact file without spawning Pi |
@@ -620,7 +636,8 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 - Throw cause-preserving failures; never turn transport/auth/parse failure into
   empty history.
 - Cover branches, pre-compaction history, unknown entries, timestamp fallback,
-  tool result folding, attachment bounds, and no payload logging.
+  tool result folding, attachment bounds, hidden-context stripping, marker-like
+  authored text, live/replay parity, and no payload logging.
 
 ### Step 6/15: Map live messages and tools
 
@@ -640,20 +657,24 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 - Add `PiExtensionUiRegistry` for select/confirm/input/editor questions and
   notification toasts.
 - Implement exact value/confirmed/cancelled responses and session-keyed routing.
+- Resolve/store each dialog's display root and aggregate descendant cards for
+  root-session queries.
 - Present editor prefill as a bounded labelled excerpt and make full-replacement
   semantics explicit because the shared question contract has no prefill field.
 - Parse and explicitly degrade unsupported fire-and-forget UI methods.
 - Clear or reject on timeout, abort, process exit, idle reap, and disposal.
 - Keep permissions empty by the locked native-Pi decision.
 - Cover late replies, timeout races, process replacement, reject semantics,
-  multiline answers, prefill truncation/replacement, and sensitive prefill/title
-  non-logging.
+  imported parent chains, multiline answers, prefill truncation/replacement,
+  and sensitive prefill/title non-logging.
 
 ### Step 8/15: Manage session residency and turns
 
 - Extend `PiSessionProcessRepository` and add `PiSessionService` with one lazy
   process per active session, generation-fenced connects, new/resume launch,
   selection state, per-session turn lanes, merged events, and idle reap.
+- Persist privacy-safe pending-new markers until file observation; relaunch an
+  unpersisted session as new after child/bridge restart.
 - Mint secure UUID session IDs in the service and validate Pi's ID grammar in
   `PiLaunchSpec`; map validated inline image data to RPC and reject path, URL,
   or non-image parts before prompt acceptance.
@@ -665,8 +686,8 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 - Preserve concurrent turns across different sessions.
 - Cover spawn races, serialization, cross-session parallelism, lazy persistence,
   resume after reap, transient history/rename leases, ID/attachment validation,
-  queued selections, command-without-run, post-acceptance process exit, auth
-  failure, abort, and shutdown.
+  queued selections, response-before-`agent_start` command barriers,
+  command-without-run, post-acceptance exit, auth failure, abort, and shutdown.
 
 ### Step 9/15: Expose models and commands
 
@@ -691,11 +712,13 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 - Wire buffered plugin events, catalog/path lookup, session creation, rename,
   delete, child sessions, history, prompt/command, questions, statuses,
   providers, health, summaries, and idempotent disposal.
+- Empty creation `parts` starts an idle session only; the bridge's subsequent
+  `sendCommand` owns the first execution.
 - Keep archive/workspace operations honest no-ops and permission methods
   honest empty/not-found results.
 - Cover full contract behavior, missing session/path, lazy persistence,
-  buffered first event listener, operation errors with causes, and disposal
-  order.
+  empty-parts command creation, buffered first event listener, operation errors
+  with causes, and disposal order.
 
 ### Step 11/15: Add managed runtime and lifecycle
 

--- a/.plan/active/pi-harness/PLAN.md
+++ b/.plan/active/pi-harness/PLAN.md
@@ -1,0 +1,770 @@
+# Pi Harness Support
+
+## Status
+
+- **Plan slug:** `pi-harness`
+- **Status:** Step 1/15, plan PR being prepared
+- **Plan date:** 2026-08-10
+- **Implementation base:** `origin/main` at
+  `3803df12d2afa41abe6894df88146ad6543e9ec6`
+- **Upstream research baseline:** Pi Agent Harness `v0.84.1`, published
+  2026-08-07 from `earendil-works/pi`
+- **Plan delivery:** this document, `TRACKER.md`, and `PROTOCOL.md` are Step
+  1/15
+- **Delivery:** one planning PR, ten bridge package/runtime PRs, one activation
+  PR, one client/docs PR, one live-verification PR, and one plan-retirement PR
+
+## Goal
+
+Add the [Pi Agent Harness](https://github.com/earendil-works/pi) as a
+first-class Sesori coding backend. Sesori must be able to download a pinned Pi
+standalone release, verify it, preserve its complete runtime package, launch its
+documented JSONL RPC mode, and expose the useful Pi experience from phone and
+desktop surfaces without leaking Pi-specific behavior outside the plugin.
+
+"Full support" in this plan means:
+
+- managed runtime install on every platform for which Pi publishes a release;
+- existing and Sesori-created Pi sessions grouped by their real working
+  directories;
+- new, resumed, and parent-forked sessions;
+- persisted history and live text/reasoning streaming;
+- tool calls, partial output, completion, errors, retries, compaction, and
+  abort;
+- configured providers, models, model-specific thinking levels, Pi extensions,
+  skills, prompt templates, image prompts, and RPC-capable extension dialogs;
+- the existing plugin management, picker, catalog, relay, and client flows; and
+- explicit, honest degradation for Pi features that its RPC protocol does not
+  expose.
+
+## Success Criteria
+
+1. `GET /plugin` advertises `pi` with display name `Pi`, correct setup and
+   install capabilities, and a first-party brand mark.
+2. Tapping Install downloads the pinned standalone asset for the current
+   OS/architecture, checks its SHA-256, installs the complete extracted package
+   under Pi's isolated plugin runtime directory, and starts Pi when setup is
+   ready.
+3. A PATH Pi at or above the compatibility floor wins over the managed copy; a
+   too-old PATH Pi falls back to the exact managed pin; an explicit `--pi-bin`
+   remains authoritative and disables managed install.
+4. A new phone-created session uses a bridge-generated ID, launches in the
+   chosen project/worktree, streams text and thinking, renders tools through
+   pending/running/completed or error states, and remains resumable after the
+   bridge restarts.
+5. Existing sessions under the user's normal Pi session store import without
+   reading prompt or transcript text merely to build the catalog. Explicit Pi
+   names are used as titles; first prompts are not promoted into bridge titles.
+6. Parent session creation uses Pi's supported fork path, preserves history,
+   records the parent relationship, uses the requested target cwd, and keeps the
+   bridge-generated child ID.
+7. Multiple Pi sessions may run concurrently. Each active session owns its own
+   lazily spawned RPC process; idle processes are reaped and resume from their
+   absolute session file on the next turn.
+8. Model/provider discovery is project-scoped, includes project extensions
+   because Pi is launched with `--approve`, and exposes exact thinking levels
+   by probing a non-persisted RPC session rather than hardcoding provider rules.
+9. Pi extension `select`, `confirm`, `input`, and `editor` dialogs round-trip as
+   Sesori questions. Notifications become existing toast events. Unsupported
+   fire-and-forget UI decorations are parsed and deliberately ignored rather
+   than breaking the run.
+10. Pi's native no-permission-prompt behavior is preserved. The plugin reports
+    no pending permissions and does not install a Sesori permission extension.
+11. Missing authentication becomes `authenticationRequired` with guidance to
+    run Pi locally and use `/login`; the bridge never initiates, stores, or
+    proxies provider credentials.
+12. Supported inline image data reaches Pi's RPC `images` field. Path, URL, and
+    non-image variants fail visibly and never become accidental prompt strings.
+13. No Pi protocol value, path layout, provider assumption, tool name, or
+    runtime quirk escapes `bridge/sesori_plugin_pi/`. The intentional shared
+    exceptions are `Harness.pi`, plugin registration, and Pi brand presentation.
+14. No new relay route, database column, or `MessagePartType` is introduced.
+    Older clients continue to render an unknown `pi` plugin through existing
+    data-driven contracts.
+15. Every implementation PR is independently buildable and normally stays at
+    or below 1,500 changed lines, including tests and generated output.
+
+## Research Findings
+
+`PROTOCOL.md` is the canonical researched protocol/runtime record. The
+load-bearing conclusions for this plan are:
+
+- Pi exposes strict-LF JSONL RPC, not ACP, with request-ID correlation but no
+  handshake or capability version.
+- RPC controls one loaded session and exposes turns, history, models, commands,
+  tools, retries/compaction, abort, rename, and extension dialogs, but no global
+  session list, delete, login, attach, or native permission protocol.
+- Catalog import therefore reads only bounded metadata from Pi's documented
+  JSONL session files; it never reads transcript text merely to enumerate.
+- New, absolute-path resume, and parent-fork launch forms are supported; new
+  files appear only after the first assistant message is persisted.
+- Auth uses normal Pi environment/config or local `/login`; pending dialogs are
+  process-local and cannot survive process replacement.
+- Official standalone releases are complete package trees, not lone binaries.
+
+Pi `v0.84.1` publishes these six checksummed assets:
+
+| Target | Asset | SHA-256 |
+|---|---|---|
+| macOS arm64 | `pi-darwin-arm64.tar.gz` | `683c84261f40b870b4a7ccf181a48ad6ecd71853b0112d1bb617539530c6121d` |
+| macOS x64 | `pi-darwin-x64.tar.gz` | `f9060962b9cca5438d7fb97b60adae9c9302503d39b68d8aea8b891e2eb3e786` |
+| Linux arm64 | `pi-linux-arm64.tar.gz` | `ab95c058a4651b5ff5d8c878e524edfb776263c7a444f325505f247c056eecfc` |
+| Linux x64 | `pi-linux-x64.tar.gz` | `5634d7ebd18274b63af3371e942f342d74bea012389575c1d1ff15ce6ca80c2f` |
+| Windows arm64 | `pi-windows-arm64.zip` | `d118a96ddc5ba16b0b0ebf5fa4662d62f2a3682e0063d41ce3cf43d922f6eb66` |
+| Windows x64 | `pi-windows-x64.zip` | `20dd3a07cfe0bdc6919dfbc479c694798ec5ea88a9c60f6e12678cecae1e5dfa` |
+
+Unix archives wrap `pi/`; Windows is flat. Managed install uses the shared
+package-directory layout and never invokes npm or Pi's installer scripts.
+
+## Locked Product Decisions
+
+Confirmed with the user on 2026-08-10:
+
+1. The target is `earendil-works/pi` and its `pi` CLI.
+2. Preserve Pi's native no-permission-prompt policy.
+3. Use the user's normal Pi data and configuration. Do not override
+   `PI_CODING_AGENT_DIR`, `PI_CODING_AGENT_SESSION_DIR`, or `PI_PACKAGE_DIR` to
+   create a Sesori-only profile.
+4. Local Pi `/login` is sufficient. Phone/provider login is excluded.
+5. Launch RPC with `--approve`, always trusting project-local Pi settings,
+   extensions, skills, and prompt templates.
+6. Import external terminal-created sessions, but document a handoff: exit the
+   terminal Pi before continuing the same session from Sesori. Pi has no attach
+   API or reliable ownership marker, so no brittle process guard is added.
+7. OpenCode remains the preferred default plugin.
+
+Decision 5 is security-relevant. Pi project extensions execute arbitrary code
+with the bridge user's permissions. The implementation must test that
+`--approve` is always present and documentation must state the consequence.
+
+## Scope
+
+### Included
+
+- New `bridge/sesori_plugin_pi/` pure-Dart package.
+- Bespoke strict-JSONL RPC, metadata-only session catalog, bridge-derived
+  projects, and default/configured/known session roots.
+- Full existing plugin API mapping: new/resume/fork, rename/delete, history,
+  commands/prompts, abort, health, catalogs, summaries, and cleanup.
+- Per-session process residency with idle reap and full teardown.
+- Text, thinking, tools, image attachments, retry/compaction/status events.
+- Project-scoped model/provider/thinking/command discovery and one synthesized
+  primary Pi agent because upstream has no agent preset concept.
+- Extension dialogs and notifications that fit existing Sesori contracts.
+- Official managed runtime download, Pi identity/branding/guidance, and runtime
+  update-skill support.
+
+### Excluded
+
+- Provider login or credential entry from phone.
+- A Sesori permission-gate Pi extension.
+- Attaching to an already-running terminal Pi process.
+- Pi TUI-only pickers/settings/themes/components/clipboard/raw input.
+- New relay routes, database schema, shared message-part variants, or a
+  Pi-specific client state branch.
+- Generic files, Pi SDK embedding, npm installation, or bundled Node.
+- Provider/model/tool/command names in analytics.
+
+## Architecture
+
+### Plugin type and lifecycle
+
+`PiPlugin` extends `BridgeDerivedProjectsPluginApi` and implements
+`PersistedSessionCleanupApi`.
+
+- Pi has no project model. `listAllSessions` returns sessions with their real
+  header cwd and bridge core groups them into projects.
+- `sessionOptionsScope` is `project`, because `--approve` loads project-local
+  providers, extensions, skills, templates, and settings.
+- The plugin wrapper uses `SteadyPluginLifecycle`. There is no shared server,
+  socket, port, ownership file, or independently restartable daemon.
+- Child RPC processes are session resources owned by the plugin, not separate
+  bridge plugins.
+- The descriptor remains transient under normal bridge lifecycle policy.
+- Prompt attachments are declared supported because Pi RPC accepts images.
+
+### Package layout
+
+```text
+bridge/sesori_plugin_pi/
+  pubspec.yaml, analysis_options.yaml, build.yaml
+  lib/pi_plugin.dart, lib/pi_testing.dart
+  lib/src/api/{pi_launch_spec,pi_process_factory,pi_rpc_client}.dart
+  lib/src/api/{pi_catalog_probe_api,pi_session_storage_api}.dart
+  lib/src/api/models/                 # Pi wire DTOs only
+  lib/src/models/                     # Pi domain variants/enums
+  lib/src/repositories/{pi_session_catalog_repository,pi_session_process_repository}.dart
+  lib/src/repositories/pi_backend_catalog_repository.dart
+  lib/src/repositories/mappers/pi_content_mapper.dart
+  lib/src/trackers/{pi_catalog_tracker,pi_tool_tracker}.dart
+  lib/src/services/{pi_session_service,pi_catalog_service}.dart
+  lib/src/{pi_event_dispatcher,pi_history_mapper,pi_extension_ui_registry}.dart
+  lib/src/pi_plugin_impl.dart
+  lib/src/runtime/{pi_runtime_manifest,pi_plugin_descriptor,pi_bridge_plugin}.dart
+  lib/src/testing/fake_pi_process.dart
+  test/
+```
+
+The placement follows `Foundation -> API -> Repository -> Service -> Consumer`:
+
+- `api/` owns process invocation, wire framing, session-file input, and the
+  isolated catalog-probe process.
+- repositories consume APIs and own mapping, without Layer-2 peer dependencies;
+- trackers own queryable Layer-2 catalog and tool state;
+- services coordinate repositories and trackers; and
+- dispatch/history/extension registries live at `lib/src/` when they consume
+  multiple Layer-2 components.
+
+No generic RPC abstraction is extracted into shared packages. ACP, Claude, and
+Pi have materially different framing, request, event, and lifecycle contracts.
+
+### `PiRpcClient`
+
+One client owns one child process and:
+
+- launches from a typed `PiLaunchSpec`;
+- consumes stdout continuously through an LF-only UTF-8 framer so pipe
+  backpressure can never stall Pi;
+- decodes top-level response, event, extension-UI, and unknown envelopes;
+- correlates responses by request ID without assuming a prompt response arrives
+  before agent events;
+- exposes a broadcast event stream tagged later with its owning session ID;
+- never logs raw stdout frames, prompts, transcript content, tool payloads, or
+  extension input;
+- redacts known credential fields from diagnostic strings;
+- fails all pending requests on exit/teardown; and
+- closes stdin first, then uses bounded SIGTERM/SIGKILL on POSIX and bounded
+  process termination on Windows.
+
+The top-level open envelope is a small hand-written sealed dispatch boundary,
+matching the ACP and Claude transport precedent. Closed nested content shapes
+used by mappers are generated DTOs and land with their first consumer so codegen
+does not create unconsumed multi-thousand-line PRs.
+
+### Session catalog
+
+`PiSessionStorageApi` is the single resolver from a Pi session ID to its
+absolute JSONL path and resolves roots without directly reading `HOME`:
+
+1. inherited `PI_CODING_AGENT_SESSION_DIR`, when set;
+2. the normal Pi agent directory selected by inherited
+   `PI_CODING_AGENT_DIR`, otherwise `resolveUserHomeDirectory()` +
+   `/.pi/agent`;
+3. Pi's configured global session directory when present; and
+4. default per-cwd session directories under the normal `sessions/` tree,
+   including directories supplied through `knownDirectories`.
+
+The exact root precedence is verified against the pinned Pi source in Step 2.
+Scans run in `Isolate.run`, deduplicate normalized absolute paths, and never
+follow an unbounded symlink tree.
+
+Both `PiSessionCatalogRepository` and `PiSessionProcessRepository` consume this
+Layer-1 resolver directly; neither repository depends on the other. A missing
+or duplicate ID is an explicit lookup failure rather than a guessed path.
+
+For each candidate JSONL file:
+
+- parse the bounded first session header;
+- inspect only `session_info` records for the latest explicit name;
+- use file mtime as updated time;
+- map `parentSession` path to the parent header ID; and
+- skip malformed or half-written records without printing their source text.
+
+Catalog reads do not decode user/assistant/tool content. A missing file is not
+enough to invalidate a bridge-created row because Pi persists lazily.
+
+### History and content mapping
+
+History acquires a client through `PiSessionProcessRepository`, uses Pi RPC
+`get_entries` and its `leafId`, then walks parent links to the active branch.
+The repository reuses a resident client when present; otherwise it opens a
+bounded non-resident lease for the resolved absolute session path and tears it
+down after the operation. Rename uses the same lease path. This retains
+pre-compaction history without turning read-only operations into resident
+sessions.
+
+Mapping rules:
+
+- user text and images become a user envelope plus text/file parts;
+- assistant text, thinking, and tool calls become existing text, reasoning, and
+  tool parts;
+- tool-result messages update the originating tool part by `toolCallId`;
+- visible custom extension messages map conservatively to displayable text;
+- direct bash-execution messages map to a tool card;
+- compaction/branch summaries use existing hidden compaction semantics where
+  useful and never create a new part type;
+- model/thinking/label/custom-state entries produce no chat message; and
+- unknown roles/blocks are ignored with bounded diagnostics.
+
+Pi messages do not carry a persistent message ID. The mapper derives the same
+plugin-local stable ID in live and replay paths from session, role, and the
+persisted millisecond timestamp, with the session entry ID as the fallback when
+timestamp is absent. Tool call IDs remain Pi's stable IDs.
+
+History failures throw a cause-preserving `PluginOperationException`. Only a
+successfully loaded active branch with no visible messages returns `[]`.
+
+### Live events and tools
+
+`PiEventDispatcher` and `PiToolTracker` map:
+
+- `message_start/update/end` with content-index text/reasoning deltas;
+- `toolcall_end` into a pending tool part, followed by
+  `tool_execution_start/update/end` running and terminal updates;
+- cumulative `tool_execution_update.partialResult` by replacement, never
+  append;
+- `auto_retry_*` and compaction events into existing retry/status/compaction
+  signals;
+- authoritative assistant envelopes from `message_end`;
+- `agent_settled`, not `agent_end`, into true completion/idle; and
+- typed edit/write built-in tool completion into existing diff staleness rather
+  than leaking raw tool names upward.
+
+`message_end.message` is authoritative. Deltas build a provisional live part;
+the final message repairs it. Live/replay parity is a direct test requirement.
+
+### Extension UI
+
+`PiExtensionUiRegistry` keeps pending dialog state per session:
+
+| Pi method | Sesori mapping |
+|---|---|
+| `select` | one single-select question with supplied options |
+| `confirm` | one Yes/No question |
+| `input` | one custom-answer question |
+| `editor` | one custom-answer question with bounded labelled prefill in its prompt |
+| `notify` | existing `BridgeSseTuiToastShow` |
+| `setStatus`, `setWidget`, `setTitle`, `set_editor_text` | parsed, debug-recorded, deliberately ignored |
+
+The registry answers with Pi's exact `extension_ui_response` variants. Reject,
+timeout, abort, idle reap, process exit, and plugin disposal resolve or clear
+every pending card. Pi does not expose re-enumeration after process loss, so
+there is no persisted pending-dialog state.
+
+`PluginQuestionInfo` has no editable-prefill field. For `editor`, the registry
+therefore appends a bounded, clearly labelled prefill excerpt to the question
+and tells the user that their answer is the complete replacement. Truncation is
+stated in the prompt; no hidden prefill is silently retained.
+
+`getPendingPermissions` always returns `[]`; `replyToPermission` reports not
+found. A user's own permission extension can still ask through generic Pi
+dialogs, which appear as questions because Pi supplies no permission semantics.
+
+### Session processes and turns
+
+`PiSessionProcessRepository` owns:
+
+- `sessionId -> resident PiRpcClient`;
+- new/resume/fork launch choice, using `PiSessionStorageApi` for absolute paths;
+- bounded resident-or-transient client leases for history and rename;
+- process connection generations and late-spawn rollback;
+- applied provider/model/thinking state;
+- request dispatch and extension-dialog responses; and
+- merged session-tagged frame/exit streams.
+
+`PiSessionService` owns the per-session turn lane, status/work state, abort, and
+idle reap. It mints each new backend ID as a secure UUID and `PiLaunchSpec`
+validates that ID against Pi's documented grammar before process launch. A turn
+applies its selected model and thinking level immediately before dispatch,
+waits only for Pi's prompt acceptance to report acceptance to the caller, and
+tracks the run through `agent_settled`. This prevents a model selection for a
+queued phone message from changing an earlier turn.
+
+`PiSessionProcessRepository` also maps prompts. Text remains text; inline
+`fileData` with a supported image MIME becomes Pi's base64 `images` field after
+the existing attachment-size and base64 validation. `filePath`, `fileUrl`, and
+non-image data are not fetched, stringified, or silently dropped: dispatch fails
+before acceptance with a privacy-safe `PluginOperationException` explaining
+that Pi supports inline image data only.
+
+Commands use Pi's normal `/name args` prompt path. An extension command can
+finish at acceptance without starting an agent run; the service checks current
+state rather than waiting forever for an `agent_settled` that will never be
+emitted.
+
+Abort invalidates the session generation, rejects pending dialogs and queued
+turns, sends Pi's `abort`, and tears down that session process. Teardown is
+required because Pi's RPC `abort` does not clear its steering/follow-up queues.
+The next accepted turn resumes from the persisted session.
+
+### Catalogs and selections
+
+`PiCatalogProbeApi` owns a short-lived project-cwd process launched through
+`PiProcessFactory` with `--mode rpc --no-session --approve`, and always tears it
+down after the bounded probe. `PiBackendCatalogRepository` consumes that API and
+maps Pi DTOs into plugin catalog values. `PiCatalogTracker` owns the last
+coherent snapshot for each normalized project; `PiCatalogService` only
+coordinates the repository and tracker.
+
+- `get_available_models` supplies provider/model IDs, display names, reasoning,
+  and image support.
+- For each reasoning-capable model, the probe selects it and asks
+  `get_available_thinking_levels`; this is safe because the session is
+  in-memory.
+- Thinking values are parsed into a closed Pi enum at the boundary and exposed
+  as `PluginModel.variants` (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`,
+  and `max` when upstream returns them).
+- Providers use existing named `PluginProvider` variants where IDs match and
+  `custom` otherwise. Auth type stays `unknown`; Pi does not report one in the
+  model object.
+- `get_commands` maps extension/prompt-template/skill sources to existing
+  command source values.
+- One primary `PluginAgent` named `pi` represents the upstream harness. Pi has
+  no first-party agent preset list to expose.
+
+For `PluginSessionOptionsDiscoveryMode.reuse`, the service returns the tracked
+project snapshot when present and probes only when none exists. `refresh`
+always probes. A coherent full probe returns `observed` with `complete`; a
+usable snapshot missing an optional catalog component returns `observed` with
+`partial`. A total probe failure returns `failed` and never replaces the last
+good tracker snapshot. Bridge core remains the owner of durable cache and
+retention policy.
+
+### Runtime and setup
+
+`PiRuntimeManifest` is a `packageDirectory` manifest with semantic versions.
+The implementation starts from the researched `v0.84.1` pin and refreshes to
+the latest stable release at Step 11 if a newer release exists and passes the
+same protocol/E2E checks.
+
+- PATH executable: `pi`.
+- Managed entry: `pi` / `pi.exe`.
+- Release URLs:
+  `https://github.com/earendil-works/pi/releases/download/v<version>/<asset>`.
+- PATH floor: the oldest version whose exact RPC fields this plugin uses. The
+  initial plan floor is `0.84.1` because `agent_settled`, delta-only updates,
+  current command metadata, auth checks, and the documented session entry API
+  are all assumed.
+- Managed pin: exact current tested stable release.
+
+`inspectSetup` mirrors managed precedence without mutation, then starts a
+bounded no-session RPC probe. No usable model or a typed authentication
+preflight failure becomes `PluginSetupAuthenticationRequired`; process timeout
+or unrecognized behavior becomes `PluginSetupUnknown` rather than a false auth
+claim.
+
+`ensureRuntime` uses `ManagedRuntimeProvisionService` and remains read-only.
+`installRuntime` uses `ManagedRuntimeInstallService` and the package-directory
+layout. Install capability is declared only when no explicit bin is configured
+and the current platform has a pinned asset.
+
+The launch environment inherits the user's Pi variables and credentials. It
+sets `PI_SKIP_VERSION_CHECK=1` because Sesori owns managed runtime updates, but
+does not force `PI_OFFLINE` or `PI_TELEMETRY`; model/package behavior and the
+user's telemetry choice remain Pi's.
+
+### `BridgePluginApi` mapping
+
+| Contract | Pi implementation |
+|---|---|
+| `getSessions` | metadata catalog filtered by normalized cwd |
+| `listAllSessions` | global/custom-root metadata scan plus known directories |
+| `launchDirectory` | descriptor start cwd, matching derived-project plugins |
+| `primeSessionDirectory` | retain bridge attribution until file metadata is observable |
+| `getCommands` | project-scoped throwaway RPC `get_commands` |
+| `getSessionOptions` | reuse/refresh through project tracker; observed complete/partial or failed |
+| `createSession` | bridge ID; new or `--fork` launch; enqueue first turn |
+| `renameSession` | resident or bounded transient lease for RPC `set_session_name` |
+| `deleteSession` | stop resident process, clear dialogs/cache, resolve then delete exact JSONL file |
+| `deletePersistedSession` | resolve by ID and idempotently delete the exact file without spawning Pi |
+| `archiveSession`, `deleteWorkspace` | no-op under best-effort contracts |
+| `getChildSessions` | catalog filter by resolved parent ID |
+| `getSessionStatuses` | session service work/queue state |
+| `getSessionMessages` | RPC entries/tree history mapper; throw on failure |
+| `sendPrompt` | queue exact turn, return on acceptance |
+| `sendCommand` | `/command arguments`, return on acceptance |
+| `abortSession` | abort and process teardown, clearing queued work/dialogs |
+| `getAgents` | one synthesized primary Pi agent |
+| questions | extension UI registry |
+| permissions | empty/not-found; Pi has no native permission protocol |
+| `healthCheck` | bounded RPC `get_state` round trip |
+| `getProviders` | project-scoped catalog result |
+| `getActiveSessionsSummary` | synchronous session-service summary by cwd |
+| `dispose` | idempotent process/dialog/event teardown |
+
+## Registration And Client Work
+
+Step 2 adds the app-invisible package to the bridge workspace, Makefile, CI, and
+dependency-update inventory. The app does not depend on or register it until
+Step 12, after the complete plugin and descriptor exist.
+
+Step 12 adds `Harness.pi`, the app dependency, and the sole concrete registration
+in `plugin_registry.dart`, then updates exact-set fixtures. OpenCode remains the
+preferred default; string plugin identity keeps this additive change wire-safe.
+
+Step 13 adds official light/dark Pi assets, brand/display-name cases, scalable
+README copy, managed-runtime/local-login/project-trust guidance, and the
+terminal handoff warning. Existing backend-neutral attachment capability drives
+composer behavior; no Pi-specific client state is added.
+
+## Analytics Assessment
+
+No new analytics event is planned.
+
+- Pi session creation and message actions use existing authoritative product
+  events.
+- Managed install already emits the bounded completed/failed harness install
+  outcome.
+- Existing privacy rules deliberately keep harness identity and provider/model
+  names off the analytics wire.
+
+A Pi-specific adoption event would require reopening that privacy decision and
+a corresponding reporting question. This series does neither.
+
+## Dependencies And Sequencing
+
+1. **Package-directory runtime support:** Step 11 depends on
+   `phone-harness-install` Step 5 landing `RuntimeAssetLayout.packageDirectory`
+   and generalized `RuntimeVersion`. Work is already committed on the dedicated
+   `phone-harness-install-cursor` branch as of this plan, but is not on `main`.
+   Do not duplicate or cherry-pick it into an earlier Pi step. If it is deferred,
+   pause before Pi Step 11 and ask whether to move that shared primitive into
+   this series.
+2. **Claude activation overlap:** the active `claude-code-plugin` series will
+   edit `Harness`, app pubspec, registry, CI/package inventories, and brand
+   lookup files before its Step 15. Pi steps touching those files rebase on the
+   merged Claude work; they never replace Claude's entries or preserve stale
+   exact-set assertions.
+3. Every Pi PR targets `main` and follows the prior Pi step. No implementation
+   worktree or successor PR is created by this plan PR.
+
+## Cleanup Assessment
+
+This is additive and makes no production model, database field, transport field,
+cache, job, or listener obsolete.
+
+Directly caused cleanup is included:
+
+- README copy that hardcodes exactly three harness names becomes scalable;
+- the runtime update skill's stated backend list expands to include Pi; and
+- exact known-harness fixtures expand rather than adding fallback shims.
+
+The existing OpenCode compatibility default remains required for released peers
+that omit plugin identity. No unrelated plugin/runtime refactor is planned.
+
+## Delivery Rules
+
+- `TRACKER.md` is canonical for the fixed fifteen exact PR titles, complexity,
+  line targets, order, and current state. Step 1 raises this directory and Step
+  15 moves it to `.plan/completed/pi-harness/`.
+- Every step follows repository line-count, generated-file, internal-contract,
+  PR-body, sequential merge, and architecture-review rules.
+- Steps 2-12 run applicable codegen, focused/full owning-package tests, fatal
+  analysis, `git diff --check`, and architecture implementation review.
+
+## Step Details And Verification
+
+### Step 1/15: Raise the plan
+
+- Add `PLAN.md`, `TRACKER.md`, and researched `PROTOCOL.md` under
+  `.plan/active/pi-harness/`.
+- Record user decisions, upstream sources, release digests, dependencies,
+  fixed titles, estimates, risks, and verification.
+- Run architecture plan review, apply valid findings, `git diff --check`, and
+  Markdown/reference checks. No Dart/Flutter suites for documentation-only work.
+
+### Step 2/15: Scaffold the protocol package
+
+- Re-check the latest stable Pi release. Keep `0.84.1` as the compatibility
+  baseline unless a newer pin is selected and the protocol record is updated.
+- Create `sesori_plugin_pi`, public/testing barrels, analysis config, and only
+  the dependencies used in this step.
+- Add `PiLaunchSpec`, process handle/factory seam, new/resume/fork launch
+  variants, `--approve`, and inherited-environment policy.
+- Add the closed Pi thinking-level enum and protocol fixture helpers.
+- Land Wave-1 workspace, Makefile, CI, and dependency-update inventory entries.
+- Unit-test exact argument vectors, absolute-path resume/fork behavior,
+  Windows entry name, and environment preservation.
+
+### Step 3/15: Add the JSONL RPC transport
+
+- Add the open top-level RPC envelope parser and response/error/event/dialog
+  variants consumed by the client.
+- Add `PiRpcClient` with strict LF framing, request IDs, asynchronous prompt
+  acknowledgement, continuous stdout draining, bounded stderr diagnostics,
+  pending failure on exit, and graceful/forced teardown.
+- Add `FakePiProcess` and `pi_testing.dart` exports.
+- Cover split/multiple UTF-8 chunks, CRLF input tolerance, U+2028/U+2029 inside
+  JSON strings, response/event reordering, unknown frames, process exit,
+  backpressure consumption, broken pipes, redaction, and teardown fencing.
+
+### Step 4/15: Enumerate persisted sessions
+
+- Add minimal generated session-header/settings DTOs only where closed JSON
+  parsing warrants them.
+- Add `PiSessionStorageApi` and `PiSessionCatalogRepository` with environment,
+  normal config, default nested root, configured root, and known-directory
+  discovery.
+- Scan metadata in an isolate, map explicit titles and parent paths, preserve
+  lazy-new-session bridge attribution, and expose exact session paths privately.
+- Cover malformed headers, half-written final lines, title clear/replace,
+  duplicate roots/IDs, parent outside the first root, custom session dirs,
+  deleted cwd, symlinks, pagination, and privacy-safe diagnostics.
+- Validate against a synthetic tree and a privacy-preserving structural scan of
+  a real Pi session root when available.
+
+### Step 5/15: Replay Pi session history
+
+- Add the session-entry/message/content DTOs this step consumes and run codegen.
+- Add `PiContentMapper` and `PiHistoryMapper` over RPC `get_entries` plus
+  `leafId` active-branch traversal.
+- Map text, reasoning, images, tool calls/results, visible custom messages,
+  bash execution, errors, and compaction under current size/privacy limits.
+- Keep replay message/part IDs deterministic for Step 6 live parity.
+- Throw cause-preserving failures; never turn transport/auth/parse failure into
+  empty history.
+- Cover branches, pre-compaction history, unknown entries, timestamp fallback,
+  tool result folding, attachment bounds, and no payload logging.
+
+### Step 6/15: Map live messages and tools
+
+- Add `PiToolTracker` and top-level `PiEventDispatcher` over session-tagged RPC
+  frames and the content mapper.
+- Map message deltas/finals, tool start/cumulative update/end, retries,
+  compaction, typed failures, status, diff staleness, and true settlement.
+- Treat final messages/results as authoritative and prune all per-turn/session
+  state at exact boundaries.
+- Prove complete live shapes equal Step 5 replay shapes.
+- Cover interleaving, multiple content indices, tool-call args that become known
+  only at `toolcall_end`, duplicate terminal frames, provider errors, abort, and
+  unknown event absorption.
+
+### Step 7/15: Bridge extension dialogs
+
+- Add `PiExtensionUiRegistry` for select/confirm/input/editor questions and
+  notification toasts.
+- Implement exact value/confirmed/cancelled responses and session-keyed routing.
+- Present editor prefill as a bounded labelled excerpt and make full-replacement
+  semantics explicit because the shared question contract has no prefill field.
+- Parse and explicitly degrade unsupported fire-and-forget UI methods.
+- Clear or reject on timeout, abort, process exit, idle reap, and disposal.
+- Keep permissions empty by the locked native-Pi decision.
+- Cover late replies, timeout races, process replacement, reject semantics,
+  multiline answers, prefill truncation/replacement, and sensitive prefill/title
+  non-logging.
+
+### Step 8/15: Manage session residency and turns
+
+- Add `PiSessionProcessRepository` and `PiSessionService` with one lazy process
+  per active session, generation-fenced connects, new/resume/fork launch,
+  selection state, per-session turn lanes, merged events, and idle reap.
+- Mint secure UUID session IDs in the service and validate Pi's ID grammar in
+  `PiLaunchSpec`; map validated inline image data to RPC and reject path, URL,
+  or non-image parts before prompt acceptance.
+- Apply model/thinking immediately before each queued turn; return on prompt or
+  command acceptance, track through `agent_settled`, and handle extension
+  commands that settle without an agent run.
+- Abort by invalidating queued work, rejecting dialogs, sending `abort`, and
+  tearing down the process so Pi's own hidden queues cannot continue.
+- Preserve concurrent turns across different sessions.
+- Cover spawn races, serialization, cross-session parallelism, lazy file
+  persistence, resume after reap, transient history/rename leases, fork
+  cwd/parent/ID, ID validation, attachment variants, queued selections,
+  command-without-run, auth failure, abort, and shutdown.
+
+### Step 9/15: Expose models and commands
+
+- Add generated model/command DTOs, `PiCatalogProbeApi`,
+  `PiBackendCatalogRepository`, `PiCatalogTracker`, and coordinating
+  `PiCatalogService`.
+- Let the API own each project-cwd, no-session, approved process; let the
+  repository enumerate/map models, exact thinking variants, providers, and
+  commands; synthesize one Pi agent.
+- Implement project-scoped `reuse`/`refresh`, complete/partial observed results,
+  explicit failed results, and atomic replacement of coherent snapshots only.
+- Classify no-model/auth preflight honestly without logging provider account
+  data or credentials.
+- Cover custom providers, known provider mapping, duplicate IDs, reasoning and
+  non-reasoning models, `max`, command sources, project-specific resources,
+  empty/auth state, probe exit, and refresh fallback.
+
+### Step 10/15: Implement the plugin API
+
+- Add `PiPlugin` as the full composition root over Steps 3-9 and implement every
+  `BridgePluginApi`/`PersistedSessionCleanupApi` member.
+- Wire buffered plugin events, catalog/path lookup, session creation, rename,
+  delete, child sessions, history, prompt/command, questions, statuses,
+  providers, health, summaries, and idempotent disposal.
+- Keep archive/workspace operations honest no-ops and permission methods
+  honest empty/not-found results.
+- Cover full contract behavior, missing session/path, lazy persistence,
+  buffered first event listener, operation errors with causes, and disposal
+  order.
+
+### Step 11/15: Add managed runtime and lifecycle
+
+- Require merged package-directory runtime support from the dependency section.
+- Add `PiRuntimeManifest` with the six official assets, full-package layout,
+  semantic pin/floor, URLs, and digests refreshed for the chosen stable release.
+- Add descriptor config/capability/setup inspection, read-only ensure, explicit
+  install, auth probe, start/abort rollback, and `PiBridgePlugin` lifecycle.
+- Set `PI_SKIP_VERSION_CHECK=1`, preserve other Pi environment/config, and pass
+  `--approve` to every real/probe process.
+- Extend `update-backend-runtimes` with Pi release/API/digest/package checks.
+- Test runtime precedence, explicit-bin behavior, six targets, archive layout,
+  install capability, checksum failure, auth/unknown states, abort rollback,
+  lifecycle status/work state, and package asset preservation.
+- Perform a local managed install from the official asset and run `--version`
+  plus an RPC `get_state` probe from the installed tree.
+
+### Step 12/15: Register the Pi harness
+
+- Add `Harness.pi`, app dependency, registry import/descriptor, and exact known
+  plugin tests.
+- Update any build/runtime enumeration fixture that intentionally lists every
+  registered plugin.
+- Rebase on merged Claude activation and keep OpenCode as preferred default.
+- Verify shared identity tests, app registry/lifecycle/catalog tests, Pi suite,
+  app fatal analysis, and implementation review.
+
+### Step 13/15: Add Pi branding and guidance
+
+- Add official light/dark Pi SVGs and brand/display-name cases with widget/unit
+  coverage.
+- Update README/bridge docs for Pi, managed install, local `/login`,
+  `--pi-bin`, project trust, and terminal-session handoff.
+- Make headline copy scalable instead of appending a fourth hardcoded backend.
+- Verify affected client/module_prego tests, analysis, asset rendering, link
+  validity, and `git diff --check`.
+
+### Step 14/15: Verify the end-to-end integration
+
+- Pin a release/authenticated local account or API-key fixture without
+  committing credentials or captures.
+- Exercise phone-driven managed install, setup refresh, new session, text and
+  image prompt, live reasoning, read/edit/bash tools, model/thinking switch,
+  skill/template/extension command, extension dialog, retry/error, abort,
+  resume after process reap/bridge restart, rename, delete, external import,
+  documented terminal handoff, and parent fork.
+- Run the applicable mobile and desktop presentation paths and confirm no Pi
+  logic exists outside declared identity/brand points.
+- Record redacted results and any protocol corrections in `PROTOCOL.md` and
+  `TRACKER.md`; fix concrete failures in this PR without broad cleanup.
+- Verify package/app/client focused suites and fatal analysis.
+
+### Step 15/15: Retire the plan
+
+- Confirm Steps 1-14 merged and tracker/E2E evidence is complete.
+- Move `.plan/active/pi-harness/` to `.plan/completed/pi-harness/`.
+- Run `git diff --check`; no Dart/Flutter suites.
+
+## Evidence And Accepted Risks
+
+- Official docs/source, the `v0.84.1` x64 archive/digest, `pi --version`, and a
+  no-auth RPC probe were inspected; `PROTOCOL.md` records the evidence.
+- The absent handshake is handled by a tested floor/pin and tolerant unknown
+  variants, not invented negotiation.
+- Terminal ownership, process-local dialogs, lazy first-file visibility, and
+  ignored decorative UI are accepted limitations with explicit user impact.
+- Always-approved project code is a locked security decision with mandatory
+  documentation and argument tests.
+- Supply-chain checks require official assets, pinned digests, full-package
+  extraction, sentinel-last placement, and no npm execution.
+- Per-session lanes address reachable concurrent sends; no global lock or
+  cross-backend process registry is planned.
+
+## Plan Review Record
+
+Architecture plan review rejected the initial draft on six wiring gaps. All
+required corrections were applied; `TRACKER.md` records them. Per repository
+policy, the corrected plan was not re-reviewed merely for approval.

--- a/.plan/active/pi-harness/PLAN.md
+++ b/.plan/active/pi-harness/PLAN.md
@@ -290,9 +290,9 @@ pre-compaction entries without making reads resident.
 
 If a resolved persisted session cannot start RPC specifically because auth/model
 selection fails before request dispatch, `PiSessionStorageApi` reads the file
-entry DTOs, applies the pinned v1-v3 migration semantics in memory, and uses the
-last valid tree entry as leaf, matching upstream reload. The repository logs the
-cause before this fallback; arbitrary RPC/parse failures remain thrown.
+entry DTOs only. The repository-local mapper applies pinned v1-v3 migration in
+memory and selects the last valid tree entry as leaf, matching upstream reload.
+The repository logs the cause; arbitrary RPC/parse failures remain thrown.
 
 Mapping rules:
 
@@ -392,6 +392,10 @@ owns an acceptance completer and `sendCommand` returns only after the correlated
 Pi prompt response succeeds. Pre-acceptance failure/exit completes it with an
 error; later failures emit session events. IDs are secure UUIDs validated by `PiLaunchSpec`.
 
+A correlated prompt `success: false` is terminal without `agent_settled`: emit
+the session error/auth toast, clear the active turn, advance the next queued
+prompt, and return to idle when the queue is empty.
+
 A generation-matched process exit before `agent_settled` fails the active turn
 and clears resident/dialog state. The lane re-resolves for the next admitted
 turn and becomes idle only when its queue empties; resolution uses the file or
@@ -434,6 +438,9 @@ down after the bounded probe. `PiBackendCatalogRepository` consumes that API and
 maps Pi DTOs into plugin catalog values. `PiCatalogTracker` owns the last
 coherent snapshot for each normalized project; `PiCatalogService` only
 coordinates the repository and tracker.
+
+The probe answers every `extension_ui_request` with deterministic cancellation,
+including no-timeout editor requests; no probe dialog enters session UI state.
 
 - `get_available_models` supplies provider/model IDs, display names, reasoning,
   and image support.
@@ -720,8 +727,9 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 - Cover spawn races, serialization, cross-session parallelism, lazy persistence,
   resume after reap, transient history/rename leases, ID/attachment validation,
   immediate prompt admission, busy-command rejection, acceptance completers,
-  response-before-`agent_start` barriers, command-without-run, post-acceptance
-  exit, project-scoped auth/toast behavior, abort, and shutdown.
+  rejection followed by the next prompt, response-before-`agent_start` barriers,
+  command-without-run, post-acceptance exit, project-scoped auth/toast behavior,
+  abort, and shutdown.
 
 ### Step 9/15: Expose models and commands
 
@@ -738,7 +746,8 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
   data or credentials.
 - Cover custom providers, known provider mapping, duplicate IDs, reasoning and
   non-reasoning models, `max`, command sources, project-specific resources,
-  empty/auth state without global teardown, probe exit, and refresh fallback.
+  empty/auth state without global teardown, probe-dialog cancellation, probe
+  exit, and refresh fallback.
 
 ### Step 10/15: Implement the plugin API
 

--- a/.plan/active/pi-harness/PLAN.md
+++ b/.plan/active/pi-harness/PLAN.md
@@ -199,8 +199,8 @@ bridge/sesori_plugin_pi/
   lib/src/repositories/pi_backend_catalog_repository.dart
   lib/src/repositories/mappers/{pi_content_mapper,pi_history_mapper}.dart
   lib/src/trackers/{pi_catalog_tracker,pi_tool_tracker,pi_extension_ui_tracker}.dart
-  lib/src/services/{pi_session_service,pi_catalog_service,pi_extension_ui_service}.dart
-  lib/src/pi_event_dispatcher.dart
+  lib/src/services/{pi_session_service,pi_catalog_service}.dart
+  lib/src/services/{pi_extension_ui_service,pi_event_dispatcher}.dart
   lib/src/pi_plugin_impl.dart
   lib/src/runtime/{pi_runtime_manifest,pi_plugin_descriptor,pi_bridge_plugin}.dart
   lib/src/testing/fake_pi_process.dart
@@ -213,8 +213,8 @@ The placement follows `Foundation -> API -> Repository -> Service -> Consumer`:
   isolated catalog-probe process.
 - repositories consume APIs and own mapping, without Layer-2 peer dependencies;
 - trackers own queryable Layer-2 catalog and tool state;
-- services coordinate repositories and trackers; and
-- the plugin implementation and event dispatcher are consumers.
+- services and the Layer-3 event dispatcher coordinate repositories/trackers;
+- the plugin implementation is the consumer and composition root.
 
 No generic RPC abstraction is extracted into shared packages. ACP, Claude, and
 Pi have materially different framing, request, event, and lifecycle contracts.
@@ -288,6 +288,12 @@ resident client or opens a bounded non-resident lease for the resolved path and
 tears it down afterward. Rename uses the same lease path, while history retains
 pre-compaction entries without making reads resident.
 
+If a resolved persisted session cannot start RPC specifically because auth/model
+selection fails before request dispatch, `PiSessionStorageApi` reads the file
+entry DTOs, applies the pinned v1-v3 migration semantics in memory, and uses the
+last valid tree entry as leaf, matching upstream reload. The repository logs the
+cause before this fallback; arbitrary RPC/parse failures remain thrown.
+
 Mapping rules:
 
 - `userVisibleText` and `userVisibleArguments` identify authored suffixes; the
@@ -315,7 +321,7 @@ successfully loaded active branch with no visible messages returns `[]`.
 
 ### Live events and tools
 
-`PiEventDispatcher` and `PiToolTracker` map:
+Layer-3 `PiEventDispatcher` coordinates `PiToolTracker` and pure mappers to map:
 
 - `message_start/update/end` with content-index text/reasoning deltas;
 - `toolcall_end` into a pending tool part, followed by
@@ -353,8 +359,9 @@ mutation. `PiPlugin` maps those to `BridgeSseQuestionAsked`,
 abort, reap, exit, and disposal reject every card; no state is persisted.
 
 At request time the service resolves the owning session's top-most imported
-parent from the catalog snapshot. The tracker stores `displaySessionId` and
-indexes by owner/root, so root queries need no session-tree rescan.
+parent and normalized cwd from the catalog/process snapshot. The tracker stores
+`displaySessionId` plus `projectId` and indexes by owner/root/project, so root
+and `getProjectQuestions` queries need no session-tree rescan.
 
 `PluginQuestionInfo` has no editable-prefill field. For `editor`, the service
 therefore appends a bounded, clearly labelled prefill excerpt to the question
@@ -513,12 +520,12 @@ user's telemetry choice remain Pi's.
 | `archiveSession`, `deleteWorkspace` | no-op under best-effort contracts |
 | `getChildSessions` | catalog filter by resolved parent ID |
 | `getSessionStatuses` | session service work/queue state |
-| `getSessionMessages` | RPC entries/tree history mapper; throw on failure |
+| `getSessionMessages` | RPC/file active-branch history; throw on non-fallback failure |
 | `sendPrompt` | admit exact turn immediately; later dispatch failures become events |
 | `sendCommand` | reject busy; otherwise await acceptance; event later failures |
 | `abortSession` | abort and process teardown, clearing queued work/dialogs |
 | `getAgents` | one synthesized primary Pi agent |
-| questions | extension UI service/tracker |
+| questions | extension UI service with owner/root/project tracker indexes |
 | permissions | empty/not-found; Pi has no native permission protocol |
 | `healthCheck` | bounded resolved-binary `--version`, independent of project models |
 | `getProviders` | project-scoped catalog result |
@@ -653,22 +660,22 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
 ### Step 5/15: Replay Pi session history
 
 - Add the session-entry/message/content DTOs this step consumes and run codegen.
-- Add the history-only `PiSessionProcessRepository` operation plus repository
-  mappers over RPC `get_entries` and `leafId` active-branch traversal.
+- Add history DTO/file input plus the `PiSessionProcessRepository` operation and
+  mappers over RPC/file entries with active-branch traversal.
 - Map text, reasoning, images, tool calls/results, visible custom messages,
   bash execution, errors, visible compaction cards, and branch-summary omission.
 - Keep replay message/part IDs deterministic for Step 6 live parity.
 - Throw cause-preserving failures; never turn transport/auth/parse failure into
   empty history.
 - Cover branches, pre-compaction history, unknown entries, timestamp fallback,
-  tool results, compaction parity, attachment bounds, hidden-context stripping,
-  marker-like prompt/command text, equal-timestamp ordinals, live/replay parity,
-  and no payload logging.
+  no-model/auth file fallback, v1-v3 migration, tool results, compaction parity,
+  attachment bounds, hidden-context stripping, marker-like prompt/command text,
+  equal-timestamp ordinals, live/replay parity, and no payload logging.
 
 ### Step 6/15: Map live messages and tools
 
-- Add `PiToolTracker` and top-level `PiEventDispatcher` over session-tagged RPC
-  frames and the content mapper.
+- Add `PiToolTracker` and Layer-3 `PiEventDispatcher` over session-tagged RPC
+  frames and pure mappers.
 - Map message deltas/finals, tool start/cumulative update/end, retries,
   compaction, typed failures, status, diff staleness, and true settlement.
 - Treat final messages/results as authoritative and prune all per-turn/session
@@ -684,15 +691,15 @@ that omit plugin identity. No unrelated plugin/runtime refactor is planned.
   select/confirm/input/editor questions, lifecycle events, and bounded toasts.
 - Implement exact value/confirmed/cancelled responses and session-keyed routing.
 - Resolve/store each dialog's display root and aggregate descendant cards for
-  root-session queries.
+  root-session queries; index normalized cwd for project-level queries.
 - Present editor prefill as a bounded labelled excerpt and make full-replacement
   semantics explicit because the shared question contract has no prefill field.
 - Parse and explicitly degrade unsupported fire-and-forget UI methods.
 - Clear or reject on timeout, abort, process exit, idle reap, and disposal.
 - Keep permissions empty by the locked native-Pi decision.
 - Cover late replies, timeout races, process replacement, reject semantics,
-  imported parent chains, multiline answers, prefill truncation/replacement,
-  and sensitive prefill/title non-logging.
+  imported parent chains, project/worktree queries, multiline answers, prefill
+  truncation/replacement, and sensitive prefill/title non-logging.
 
 ### Step 8/15: Manage session residency and turns
 

--- a/.plan/active/pi-harness/PLAN.md
+++ b/.plan/active/pi-harness/PLAN.md
@@ -213,7 +213,7 @@ The placement follows `Foundation -> API -> Repository -> Service -> Consumer`:
 - repositories consume APIs and own mapping, without Layer-2 peer dependencies;
 - trackers own queryable Layer-2 catalog and tool state;
 - services coordinate repositories and trackers; and
-- dispatch/history/extension registries live at `lib/src/` when they consume
+- dispatch/extension registries live at `lib/src/` when they consume
   multiple Layer-2 components.
 
 No generic RPC abstraction is extracted into shared packages. ACP, Claude, and

--- a/.plan/active/pi-harness/PROTOCOL.md
+++ b/.plan/active/pi-harness/PROTOCOL.md
@@ -245,6 +245,10 @@ Entries are append order and include pre-compaction history and abandoned
 branches. Walk parent links from `leafId` to replay only the active branch.
 Unknown `since` returns `success: false`.
 
+The pinned file loader rebuilds its leaf as the last valid parsed entry. A
+read-only file fallback can reproduce that active branch without model/auth
+startup and must apply the loader's v1-v3 migration semantics in memory.
+
 ### Rename
 
 ```json

--- a/.plan/active/pi-harness/PROTOCOL.md
+++ b/.plan/active/pi-harness/PROTOCOL.md
@@ -1,0 +1,636 @@
+# Pi RPC And Runtime Protocol: Ground Truth
+
+## Status And Sources
+
+- **State:** researched from official docs/source and a live standalone binary.
+- **Pinned baseline:** Pi Agent Harness `v0.84.1`.
+- **Published:** 2026-08-07.
+- **Observed:** 2026-08-10 on macOS using the official x64 archive.
+- **Repository:** `https://github.com/earendil-works/pi`.
+- **Primary docs:** `packages/coding-agent/docs/rpc.md`,
+  `packages/coding-agent/docs/session-format.md`, and the package README.
+- **Primary source:** `rpc-types.ts`, `rpc-mode.ts`, `json-event.ts`,
+  `agent-session.ts`, `agent-session-runtime.ts`, `session-manager.ts`,
+  `main.ts`, and `scripts/build-binaries.sh` at tag `v0.84.1`.
+
+Official docs and source disagree in a few places. This document records source
+behavior where they differ. Step 2 rechecks the selected implementation pin,
+and Step 14 records live authenticated traces with all content redacted.
+
+## 1. Identity And Version
+
+- Binary: `pi` (`pi.exe` on Windows).
+- Version command: `pi --version` or `pi -v`.
+- `v0.84.1` output observed: exactly `0.84.1` on stdout, exit 0 (a Bun CPU
+  warning may appear on stderr in constrained x64 environments).
+- npm package: `@earendil-works/pi-coding-agent@0.84.1`.
+- npm engine: Node >=22.19.0. The managed integration does not use npm.
+- License: MIT.
+
+The RPC protocol has no version handshake and no capability-negotiation frame.
+The bridge version-gates the executable before launch and absorbs unknown
+frames/content variants.
+
+## 2. Invocation
+
+Base invocation:
+
+```text
+pi --mode rpc --approve <session-selection>
+```
+
+Session selection:
+
+```text
+# New, caller-owned ID
+--session-id <id>
+
+# Resume, always an absolute path
+--session </absolute/path/to/session.jsonl>
+
+# Parent fork into process cwd with caller-owned ID
+--fork </absolute/path/to/parent.jsonl> --session-id <id>
+
+# Discovery only, no persistence
+--no-session
+```
+
+Session ID grammar from `assertValidSessionId`:
+
+```text
+^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$
+```
+
+Important constraints:
+
+- `--fork` rejects `--session`, `--continue`, `--resume`, and `--no-session`.
+- `--session-id` rejects `--session`, `--continue`, and `--resume`.
+- `--fork` plus `--session-id` is explicitly valid.
+- RPC rejects `@file` CLI arguments. Images travel in the prompt command.
+- Bare `--session <id>` can trigger an interactive cross-project confirmation
+  on stdin. The plugin must always use an absolute file path.
+- `--approve` trusts project-local `.pi` settings/resources/extensions. This is
+  an explicit product decision and must be present on real and discovery
+  processes.
+- Process cwd is the new/forked session cwd. A resumed session's header cwd
+  becomes the effective runtime/tool cwd.
+
+Environment policy:
+
+- Inherit provider credentials and Pi's normal config/session/package
+  overrides.
+- Set `PI_SKIP_VERSION_CHECK=1` for supervised processes.
+- Do not force `PI_OFFLINE`; it changes model/package behavior.
+- Do not force `PI_TELEMETRY`; preserve the user's Pi setting.
+- Never override `HOME`; Sesori code resolves it with
+  `resolveUserHomeDirectory` when metadata scanning needs a default path.
+
+## 3. Framing
+
+- stdin commands: one JSON object followed by LF (`\n`).
+- stdout responses/events: one JSON object followed by LF.
+- Split only on LF.
+- Accept CRLF input by removing one trailing `\r` from the record.
+- Do not split on bare CR, U+2028, or U+2029.
+- UTF-8 chunks may split a multi-byte character or contain many records.
+- stderr is diagnostic only and never part of framing.
+
+Pi applies stdout backpressure to the agent. The bridge must install one
+unconditional stdout consumer as soon as the process starts and continue
+draining unknown/ignored events.
+
+## 4. Command And Response Envelope
+
+Every command accepts optional string `id`:
+
+```json
+{"id":"sesori-1","type":"get_state"}
+```
+
+Success:
+
+```json
+{"id":"sesori-1","type":"response","command":"get_state","success":true,"data":{}}
+```
+
+Failure:
+
+```json
+{"id":"sesori-1","type":"response","command":"get_state","success":false,"error":"..."}
+```
+
+Parse failure uses `command: "parse"` and no request ID.
+
+Response error strings are not typed. The plugin classifies only demonstrated
+preflight/auth/process cases and otherwise preserves the original error as a
+local cause while sending privacy-safe presentation upward.
+
+### Prompt acceptance ordering
+
+`prompt` is special. Its handler starts asynchronous preflight and returns no
+immediate response from the command switch. The success response is emitted by
+the preflight callback. Agent events may therefore arrive before or after the
+matching prompt response.
+
+Rules:
+
+- Correlate only by `id`; never infer from output order.
+- `success: true` means accepted, queued, or handled by an extension command.
+- A pre-acceptance failure emits one `success: false` response.
+- A post-acceptance model/tool/provider failure emits events/messages, not a
+  second response.
+
+## 5. Commands Used By Sesori
+
+### Prompt and control
+
+```json
+{"id":"p1","type":"prompt","message":"text","images":[]}
+{"id":"a1","type":"abort"}
+```
+
+When Pi itself is already streaming, `prompt` requires
+`streamingBehavior: "steer" | "followUp"`. The planned plugin serializes its
+own exact per-turn selection and normally dispatches only while idle.
+
+Pi also exposes `steer` and `follow_up`, but Sesori has no separate steering UI
+in this series.
+
+`abort` aborts retry/current agent work and waits for idle. It does not call
+Pi's `clearQueue()`, so hidden steering/follow-up queues survive. Sesori tears
+the process down after abort.
+
+### State
+
+```json
+{"id":"s1","type":"get_state"}
+```
+
+Response data fields:
+
+```text
+model, thinkingLevel, isStreaming, isCompacting,
+steeringMode, followUpMode, sessionFile, sessionId, sessionName,
+autoCompactionEnabled, messageCount, pendingMessageCount
+```
+
+Observed no-auth/no-session state in the official binary used an `unknown`
+model and returned an empty available-model list. Implementations must also
+handle upstream startup exiting before RPC when no model is selected.
+
+### Models and thinking
+
+```json
+{"id":"m1","type":"get_available_models"}
+{"id":"m2","type":"set_model","provider":"anthropic","modelId":"..."}
+{"id":"t1","type":"get_available_thinking_levels"}
+{"id":"t2","type":"set_thinking_level","level":"high"}
+```
+
+Closed thinking vocabulary in `v0.84.1`:
+
+```text
+off, minimal, low, medium, high, xhigh, max
+```
+
+`get_available_thinking_levels` describes the currently selected model.
+Enumerate exact levels by selecting each model in a `--no-session` process so
+model/thinking change entries are never persisted.
+
+### Commands
+
+```json
+{"id":"c1","type":"get_commands"}
+```
+
+Source shape in `v0.84.1`:
+
+```json
+{
+  "name":"skill:example",
+  "description":"...",
+  "source":"extension|prompt|skill",
+  "sourceInfo":{}
+}
+```
+
+The prose RPC doc still shows older `location`/`path` fields. Source
+`sourceInfo` is authoritative. Built-in TUI commands are absent and cannot be
+sent through this catalog.
+
+Invoke an available command through ordinary prompt text:
+
+```json
+{"id":"c2","type":"prompt","message":"/command arguments"}
+```
+
+An extension command may complete entirely during prompt preflight and emit no
+`agent_start`/`agent_settled` pair.
+
+### History/tree
+
+```json
+{"id":"h1","type":"get_entries"}
+{"id":"h2","type":"get_entries","since":"entry-id"}
+{"id":"h3","type":"get_tree"}
+```
+
+`get_entries` response:
+
+```json
+{"entries":[],"leafId":"entry-id-or-null"}
+```
+
+Entries are append order and include pre-compaction history and abandoned
+branches. Walk parent links from `leafId` to replay only the active branch.
+Unknown `since` returns `success: false`.
+
+### Rename
+
+```json
+{"id":"n1","type":"set_session_name","name":"New title"}
+```
+
+Name is trimmed, newline-normalized, and appended as a `session_info` entry.
+Empty names are rejected.
+
+### Other commands not exposed in v1 Sesori UI
+
+Pi also defines cycle-model/thinking, queue mode changes, manual compaction,
+auto-compaction/retry settings, direct bash, HTML export, runtime session
+switch/new/fork/clone, fork-message/tree reads, and last-assistant-text. They
+remain private protocol capabilities unless an existing `BridgePluginApi`
+operation needs them.
+
+## 6. Event Stream
+
+Top-level event types at `v0.84.1`:
+
+```text
+agent_start
+agent_end
+agent_settled
+turn_start
+turn_end
+message_start
+message_update
+message_end
+bash_execution_update
+tool_execution_start
+tool_execution_update
+tool_execution_end
+queue_update
+compaction_start
+compaction_end
+auto_retry_start
+auto_retry_end
+summarization_retry_scheduled
+summarization_retry_attempt_start
+summarization_retry_finished
+extension_error
+extension_ui_request
+```
+
+Canonical run shape:
+
+```text
+agent_start
+  turn_start
+    message_start(user)
+    message_end(user)
+    message_start(assistant)
+    message_update(... deltas ...)
+    message_end(assistant)
+    tool_execution_start/update/end (when tools run)
+    message_start/end(toolResult)
+  turn_end
+agent_end
+agent_settled
+```
+
+The exact tool/message interleaving can vary with sequential versus parallel
+tool execution and provider behavior. Correlate by message content index and
+tool call ID, not adjacency.
+
+### Completion
+
+- `agent_end` ends one low-level run and includes `willRetry`.
+- Retry, compaction recovery, or queued continuation may follow.
+- `agent_settled` means no automatic continuation remains. It is the only true
+  completion/idle signal for Sesori.
+
+### Message streaming
+
+`message_start` and `message_end` carry an `AgentMessage`.
+
+`message_update` intentionally omits cumulative message snapshots and strips
+the upstream `partial` field. It carries one `assistantMessageEvent`:
+
+```text
+text_start(contentIndex)
+text_delta(contentIndex, delta)
+text_end(contentIndex, content)
+thinking_start(contentIndex)
+thinking_delta(contentIndex, delta)
+thinking_end(contentIndex, content)
+toolcall_start(contentIndex)
+toolcall_delta(contentIndex, delta)
+toolcall_end(contentIndex, toolCall)
+```
+
+The full tool ID/name/arguments are guaranteed at `toolcall_end`; start/delta
+do not carry the stripped cumulative snapshot. `message_end.message` is final
+authority.
+
+### Tool execution
+
+Start:
+
+```json
+{"type":"tool_execution_start","toolCallId":"...","toolName":"bash","args":{}}
+```
+
+Update:
+
+```json
+{"type":"tool_execution_update","toolCallId":"...","toolName":"bash","args":{},"partialResult":{}}
+```
+
+`partialResult` is cumulative. Replace displayed output on each update.
+
+End:
+
+```json
+{"type":"tool_execution_end","toolCallId":"...","toolName":"bash","result":{},"isError":false}
+```
+
+Tool result content is an array of text/image blocks plus optional details and
+usage. Apply existing Sesori output and inline-attachment limits.
+
+### Retry and compaction
+
+- `auto_retry_start`: attempt, maxAttempts, delayMs, errorMessage.
+- `auto_retry_end`: success, attempt, optional finalError.
+- `compaction_start`: reason `manual|threshold|overflow`.
+- `compaction_end`: result or errorMessage, aborted, willRetry.
+- summarization retry events can occur around compaction/branch summaries.
+
+Raw provider error text can contain request details. Map typed/bounded status to
+the phone and retain useful raw diagnostics only in local logs when appropriate.
+
+## 7. Message And Entry Shapes
+
+### Session header
+
+First parsed session line:
+
+```json
+{
+  "type":"session",
+  "version":3,
+  "id":"session-id",
+  "timestamp":"ISO-8601",
+  "cwd":"/absolute/project",
+  "parentSession":"/optional/parent.jsonl"
+}
+```
+
+Session versions:
+
+- v1: linear legacy, no version field;
+- v2: tree IDs/parent IDs;
+- v3: current, custom-message role naming.
+
+Pi migrates old sessions when opened. The metadata scanner accepts old headers
+without mutating them.
+
+### Entry base
+
+Every non-header entry has:
+
+```text
+type, id, parentId, timestamp
+```
+
+Known entry types:
+
+```text
+message
+thinking_level_change
+model_change
+compaction
+branch_summary
+custom
+custom_message
+label
+session_info
+```
+
+### Agent messages
+
+User:
+
+```text
+role: user
+content: string | [text|image]
+timestamp: unix milliseconds
+```
+
+Assistant:
+
+```text
+role: assistant
+content: [text|thinking|toolCall]
+api, provider, model, usage, stopReason, errorMessage?, timestamp
+```
+
+Terminal stop reasons:
+
+```text
+stop, length, toolUse, error, aborted
+```
+
+Tool result:
+
+```text
+role: toolResult
+toolCallId, toolName, content, details?, usage?, isError, timestamp
+```
+
+Other roles:
+
+```text
+bashExecution
+custom
+branchSummary
+compactionSummary
+```
+
+Message IDs are not part of Pi's base user/assistant message objects. Session
+entry IDs are stable in replay, while live frames arrive before the entry ID is
+reported. Sesori uses a plugin-local deterministic timestamp identity and tests
+live/replay equality.
+
+### Session naming and persistence
+
+- Explicit names are latest `session_info.name`; trimmed empty explicitly clears
+  the name.
+- Default session files live under
+  `~/.pi/agent/sessions/--<encoded-cwd>--/<timestamp>_<id>.jsonl`.
+- `PI_CODING_AGENT_DIR`, `PI_CODING_AGENT_SESSION_DIR`, and settings can alter
+  roots.
+- A new persisted session computes its path immediately but does not create the
+  file until an assistant message exists.
+- File deletion is Pi's documented session deletion mechanism.
+
+Catalog privacy rule: do not use first user message as a Sesori title and do not
+decode message content merely to enumerate sessions.
+
+## 8. Models And Providers
+
+Model object fields:
+
+```text
+id, name, api, provider, baseUrl, reasoning,
+input, contextWindow, maxTokens, cost
+```
+
+`input` may contain `text` and `image`. The RPC prompt `images` field is an
+array of:
+
+```json
+{"type":"image","data":"base64","mimeType":"image/png"}
+```
+
+RPC image input is inserted directly into the user message. Pi's CLI `@file`
+resize path is separate and unavailable in RPC. Sesori applies its own existing
+attachment bounds before sending.
+
+Provider auth type is not included in model objects. The plugin maps known
+provider identities for presentation and uses `unknown` auth type.
+
+## 9. Extension UI
+
+Dialog requests on stdout:
+
+```text
+select:  id, title, options[], timeout?
+confirm: id, title, message, timeout?
+input:   id, title, placeholder?, timeout?
+editor:  id, title, prefill?
+```
+
+Responses on stdin:
+
+```json
+{"type":"extension_ui_response","id":"...","value":"..."}
+{"type":"extension_ui_response","id":"...","confirmed":true}
+{"type":"extension_ui_response","id":"...","cancelled":true}
+```
+
+Fire-and-forget requests:
+
+```text
+notify
+setStatus
+setWidget
+setTitle
+set_editor_text
+```
+
+Dialog promises live only in an in-process map. They cannot be re-enumerated or
+answered after process replacement. Timeouts auto-resolve inside Pi; the plugin
+mirrors the timeout to remove the phone card.
+
+Pi RPC declares `ctx.mode == "rpc"` and `ctx.hasUI == true`, but terminal-only
+custom components, headers/footers, theme changes, raw input, and editor
+inspection are unavailable or no-ops.
+
+## 10. Authentication
+
+Supported sources include:
+
+- provider environment variables;
+- `~/.pi/agent/auth.json`;
+- subscription OAuth written by interactive `/login`;
+- custom provider configuration/extensions; and
+- `--api-key` (not used by Sesori because command-line secrets are unsafe).
+
+There is no generic RPC login command.
+
+`pi auth check` requires a provider or model:
+
+```text
+pi auth check --provider <id> --json [--no-refresh]
+```
+
+Shape:
+
+```json
+{"status":"ready|not_ready|invalid","provider":"...","reason":"..."}
+```
+
+Because Pi may have many/custom project providers, setup first checks whether a
+no-session approved RPC process resolves any usable model. Provider-specific
+checks are used only when the provider is known. Prompt preflight remains the
+authoritative operational auth check.
+
+Action hint is local: run Pi, execute `/login`, then refresh setup. Auth output
+may contain credentials/account data and is never logged or forwarded.
+
+## 11. Official Standalone Distribution
+
+Release URL template:
+
+```text
+https://github.com/earendil-works/pi/releases/download/v<version>/<asset>
+```
+
+`v0.84.1` assets and SHA-256 values are recorded in `PLAN.md`.
+
+Archive layout:
+
+- macOS/Linux `.tar.gz`: wrapper directory `pi/`, entry `pi/pi`.
+- Windows `.zip`: flat package, entry `pi.exe`.
+
+Published package siblings include:
+
+```text
+assets/
+theme/
+export-html/
+native/
+node_modules/
+docs/
+examples/
+package.json
+README.md
+CHANGELOG.md
+photon_rs_bg.wasm
+```
+
+The release script builds x64 Bun baseline targets and arm64 targets. No other
+OS/architecture assets are promised. Managed capability is absent outside the
+six published targets.
+
+Pi's own startup network features:
+
+- version check, disabled by `PI_SKIP_VERSION_CHECK=1`;
+- install/update telemetry, controlled by user setting or `PI_TELEMETRY`; and
+- model/package refresh, disabled only by `PI_OFFLINE`.
+
+Sesori owns managed version updates but preserves the latter two user/runtime
+choices.
+
+## 12. Verification Still Required During Implementation
+
+- Refresh all source facts against the exact managed pin selected in Step 11.
+- Capture redacted authenticated event ordering and model readiness for API-key,
+  OAuth, and extension-defined providers.
+- Verify cross-platform custom roots and all six assets, including one live host
+  install; verify missing worktrees and parent-fork identity/path mapping.
+- Verify extension dialogs, editor-prefill degradation, supported inline image
+  MIME/size handling, and visible rejection of other attachment variants.
+- Measure cold start/RSS before choosing idle reap; add no process pool without
+  evidence.
+- Perform the documented terminal-to-Sesori handoff, never concurrent writers.

--- a/.plan/active/pi-harness/PROTOCOL.md
+++ b/.plan/active/pi-harness/PROTOCOL.md
@@ -256,32 +256,9 @@ Empty names are rejected.
 
 ## 6. Event Stream
 
-Top-level event types at `v0.84.1`:
-
-```text
-agent_start
-agent_end
-agent_settled
-turn_start
-turn_end
-message_start
-message_update
-message_end
-bash_execution_update
-tool_execution_start
-tool_execution_update
-tool_execution_end
-queue_update
-compaction_start
-compaction_end
-auto_retry_start
-auto_retry_end
-summarization_retry_scheduled
-summarization_retry_attempt_start
-summarization_retry_finished
-extension_error
-extension_ui_request
-```
+Top-level event types include agent/turn/message start-update-end, tool/bash
+execution, queue updates, compaction/retry/summarization lifecycle,
+`extension_error`, `extension_ui_request`, and final `agent_settled`.
 
 Typical order is `agent_start` -> `turn_start` -> user/assistant message frames
 and tool execution -> `turn_end` -> `agent_end` -> `agent_settled`.
@@ -548,10 +525,9 @@ Shape:
 {"status":"ready|not_ready|invalid","provider":"...","reason":"..."}
 ```
 
-Because Pi may have many/custom project providers, setup first checks whether a
-no-session approved RPC process resolves any usable model. Provider-specific
-checks are used only when the provider is known. Prompt preflight remains the
-authoritative operational auth check.
+Setup validates runtime only because it has no project cwd. Authentication is
+classified by approved project-scoped discovery or prompt preflight, where
+custom providers and models are loaded.
 
 Action hint is local: run Pi, execute `/login`, then refresh setup. Auth output
 may contain credentials/account data and is never logged or forwarded.

--- a/.plan/active/pi-harness/PROTOCOL.md
+++ b/.plan/active/pi-harness/PROTOCOL.md
@@ -283,22 +283,8 @@ extension_error
 extension_ui_request
 ```
 
-Canonical run shape:
-
-```text
-agent_start
-  turn_start
-    message_start(user)
-    message_end(user)
-    message_start(assistant)
-    message_update(... deltas ...)
-    message_end(assistant)
-    tool_execution_start/update/end (when tools run)
-    message_start/end(toolResult)
-  turn_end
-agent_end
-agent_settled
-```
+Typical order is `agent_start` -> `turn_start` -> user/assistant message frames
+and tool execution -> `turn_end` -> `agent_end` -> `agent_settled`.
 
 The exact tool/message interleaving can vary with sequential versus parallel
 tool execution and provider behavior. Correlate by message content index and
@@ -585,21 +571,8 @@ Archive layout:
 - macOS/Linux `.tar.gz`: wrapper directory `pi/`, entry `pi/pi`.
 - Windows `.zip`: flat package, entry `pi.exe`.
 
-Published package siblings include:
-
-```text
-assets/
-theme/
-export-html/
-native/
-node_modules/
-docs/
-examples/
-package.json
-README.md
-CHANGELOG.md
-photon_rs_bg.wasm
-```
+Published siblings include asset/theme/export/native/module trees, docs,
+examples, package metadata, and `photon_rs_bg.wasm`.
 
 The release script builds x64 Bun baseline targets and arm64 targets. No other
 OS/architecture assets are promised. Managed capability is absent outside the

--- a/.plan/active/pi-harness/PROTOCOL.md
+++ b/.plan/active/pi-harness/PROTOCOL.md
@@ -254,14 +254,6 @@ Unknown `since` returns `success: false`.
 Name is trimmed, newline-normalized, and appended as a `session_info` entry.
 Empty names are rejected.
 
-### Other commands not exposed in v1 Sesori UI
-
-Pi also defines cycle-model/thinking, queue mode changes, manual compaction,
-auto-compaction/retry settings, direct bash, HTML export, runtime session
-switch/new/fork/clone, fork-message/tree reads, and last-assistant-text. They
-remain private protocol capabilities unless an existing `BridgePluginApi`
-operation needs them.
-
 ## 6. Event Stream
 
 Top-level event types at `v0.84.1`:
@@ -628,7 +620,7 @@ choices.
 - Capture redacted authenticated event ordering and model readiness for API-key,
   OAuth, and extension-defined providers.
 - Verify cross-platform custom roots and all six assets, including one live host
-  install; verify missing worktrees and parent-fork identity/path mapping.
+  install; verify missing worktrees and imported-parent identity/path mapping.
 - Verify extension dialogs, editor-prefill degradation, supported inline image
   MIME/size handling, and visible rejection of other attachment variants.
 - Measure cold start/RSS before choosing idle reap; add no process pool without

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -67,8 +67,8 @@ OpenCode default, or no-new-analytics decisions without the user.
 - **Reviewer:** `architecture-plan-review` sub-agent, 2026-08-10
 - **Scope:** `PLAN.md`, with this tracker and `PROTOCOL.md` as supporting context
 - **Verdict:** initial draft rejected; corrected plan not re-reviewed
-- **Corrections:** added explicit catalog layers/cache semantics, path resolver
-  and transient leases, editor/attachment degradation, and ID ownership
+- **Corrections:** catalog layering; tracker/discovery semantics; session
+  path/lease ownership; editor prefill; attachment variants; session ID ownership
 
 ## Verification Log
 
@@ -76,7 +76,8 @@ OpenCode default, or no-new-analytics decisions without the user.
 
 - Architecture review: initial draft rejected; all six findings applied.
 - Upstream repository/tag, RPC/session docs, and all six release digests match.
-- `git diff --check`: pass; three documentation files, 1,496 additions.
+- `git diff --check origin/main...HEAD`: pass.
+- Diff: +1,497/-0 = 1,497 changed lines; generated lines: 0; tests run: 0.
 - Dart/Flutter suites: not run for this documentation-only step.
 - Commit `1bf4aea2`; PR https://github.com/sesori-ai/sesori_apps_monorepo/pull/811.
 
@@ -88,3 +89,5 @@ OpenCode default, or no-new-analytics decisions without the user.
   degradation, attachment variants, and session-ID ownership.
 - Duplicate research and delivery text was removed so Step 1 remains under the
   1,500-line soft cap without splitting the required initial plan artifacts.
+- PR review removed unreachable Sesori-created parent forks and moved auth
+  classification from cwd-less setup to project-scoped operations.

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -76,9 +76,9 @@ OpenCode default, or no-new-analytics decisions without the user.
   findings applied without re-review.
 - Upstream repository/tag, RPC/session docs, and all six release digests match.
 - `git diff --check $(git merge-base origin/main HEAD)..HEAD`: pass.
-- Diff: +1,499/-0 = 1,499 changed lines; generated lines: 0; tests run: 0.
+- Diff: +1,500/-0 = 1,500 changed lines; generated lines: 0; tests run: 0.
 - Dart/Flutter suites: not run for this documentation-only step.
-- Plan/content commit `6e544be8`; PR
+- Plan/content commit `813ca4ca`; PR
   https://github.com/sesori-ai/sesori_apps_monorepo/pull/811.
 
 ## Findings And Plan Deltas

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -95,3 +95,5 @@ OpenCode default, or no-new-analytics decisions without the user.
   pending-new recovery, command barriers, and empty-parts creation.
 - Later review aligned extension UI layers, RPC DTOs, lane admission, command
   projection, model defaults, health, and runtime-only setup.
+- Latest review pinned collision-free message IDs, scoped auth handling, and
+  created-before-first-turn event ordering.

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -80,7 +80,7 @@ OpenCode default, or no-new-analytics decisions without the user.
 - Recorded overage: final review gaps belong in the canonical initial plan and
   cannot form an independently valid implementation PR.
 - Dart/Flutter suites: not run for this documentation-only step.
-- Plan/content commit `9ac7b497`; PR
+- Plan content through `9ac7b497`; reproduce from the current PR head at
   https://github.com/sesori-ai/sesori_apps_monorepo/pull/811.
 
 ## Findings And Plan Deltas

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -76,11 +76,11 @@ OpenCode default, or no-new-analytics decisions without the user.
   findings applied without re-review.
 - Upstream repository/tag, RPC/session docs, and all six release digests match.
 - `git diff --check $(git merge-base origin/main HEAD)..HEAD`: pass.
-- Diff: +1,525/-0 = 1,525 changed lines; generated lines: 0; tests run: 0.
+- Diff: +1,527/-0 = 1,527 changed lines; generated lines: 0; tests run: 0.
 - Recorded overage: final review gaps belong in the canonical initial plan and
   cannot form an independently valid implementation PR.
 - Dart/Flutter suites: not run for this documentation-only step.
-- Plan content through `98658ced`; reproduce from the current PR head at
+- Plan content through `b65b19f2`; reproduce from the current PR head at
   https://github.com/sesori-ai/sesori_apps_monorepo/pull/811.
 
 ## Findings And Plan Deltas

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -97,3 +97,5 @@ OpenCode default, or no-new-analytics decisions without the user.
   projection, model defaults, health, and runtime-only setup.
 - Latest review pinned collision-free message IDs, scoped auth handling, and
   created-before-first-turn event ordering.
+- Follow-up review pinned stderr draining, question lifecycle events, and
+  command completion on backend acceptance.

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -72,12 +72,14 @@ OpenCode default, or no-new-analytics decisions without the user.
 
 ### Step 1/15
 
-- Architecture review: initial draft rejected; all six findings applied.
+- Architecture reviews: initial draft and toast delta rejected; all seven
+  findings applied without re-review.
 - Upstream repository/tag, RPC/session docs, and all six release digests match.
-- `git diff --check origin/main...HEAD`: pass.
-- Diff: +1,474/-0 = 1,474 changed lines; generated lines: 0; tests run: 0.
+- `git diff --check $(git merge-base origin/main HEAD)..HEAD`: pass.
+- Diff: +1,499/-0 = 1,499 changed lines; generated lines: 0; tests run: 0.
 - Dart/Flutter suites: not run for this documentation-only step.
-- Commit `1bf4aea2`; PR https://github.com/sesori-ai/sesori_apps_monorepo/pull/811.
+- Plan/content commit `6e544be8`; PR
+  https://github.com/sesori-ai/sesori_apps_monorepo/pull/811.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -76,11 +76,11 @@ OpenCode default, or no-new-analytics decisions without the user.
   findings applied without re-review.
 - Upstream repository/tag, RPC/session docs, and all six release digests match.
 - `git diff --check $(git merge-base origin/main HEAD)..HEAD`: pass.
-- Diff: +1,500/-0 = 1,500 changed lines; generated lines: 0; tests run: 0.
+- Diff: +1,513/-0 = 1,513 changed lines; generated lines: 0; tests run: 0.
 - Recorded overage: final review gaps belong in the canonical initial plan and
   cannot form an independently valid implementation PR.
 - Dart/Flutter suites: not run for this documentation-only step.
-- Plan/content commit `813ca4ca`; PR
+- Plan/content commit `72811b5c`; PR
   https://github.com/sesori-ai/sesori_apps_monorepo/pull/811.
 
 ## Findings And Plan Deltas

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -77,7 +77,7 @@ OpenCode default, or no-new-analytics decisions without the user.
 - Architecture review: initial draft rejected; all six findings applied.
 - Upstream repository/tag, RPC/session docs, and all six release digests match.
 - `git diff --check origin/main...HEAD`: pass.
-- Diff: +1,497/-0 = 1,497 changed lines; generated lines: 0; tests run: 0.
+- Diff: +1,495/-0 = 1,495 changed lines; generated lines: 0; tests run: 0.
 - Dart/Flutter suites: not run for this documentation-only step.
 - Commit `1bf4aea2`; PR https://github.com/sesori-ai/sesori_apps_monorepo/pull/811.
 
@@ -91,3 +91,5 @@ OpenCode default, or no-new-analytics decisions without the user.
   1,500-line soft cap without splitting the required initial plan artifacts.
 - PR review removed unreachable Sesori-created parent forks and moved auth
   classification from cwd-less setup to project-scoped operations.
+- Follow-up review pinned safe prompt projection, descendant dialogs,
+  pending-new recovery, command barriers, and empty-parts creation.

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -18,11 +18,10 @@ OpenCode default, or no-new-analytics decisions without the user.
 
 ## External Dependencies
 
-- Pi Step 11 requires `phone-harness-install` Step 5's
-  `RuntimeAssetLayout.packageDirectory` and generalized `RuntimeVersion` on
-  `main`. The work existed on local branch `phone-harness-install-cursor` at
-  `6054d7cd` when this plan was written, but had no PR. Do not duplicate it.
-- Pi activation/client steps rebase on the active Claude series and preserve all
+- Pi Step 11 strictly requires `RuntimeAssetLayout.packageDirectory`; the local
+  `phone-harness-install-cursor` branch at `6054d7cd` also generalizes
+  `RuntimeVersion`, which Pi consumes if merged but does not independently need.
+- Pi Step 12 waits for Claude activation; subsequent client work preserves all
   merged Claude identity, registry, package, CI, and brand entries.
 
 ## Delivery Steps
@@ -41,7 +40,7 @@ OpenCode default, or no-new-analytics decisions without the user.
 | [ ] | 10/15 | `🚧 [pi-harness] feat(pi): implement the plugin API [step 10/15]` | 1,100-1,500 | Not started |
 | [ ] | 11/15 | `🚧 [pi-harness] feat(pi): add managed runtime and lifecycle [step 11/15]` | 1,100-1,500 | Blocked on package-directory runtime support |
 | [ ] | 12/15 | `⚙️ [pi-harness] feat(pi): register the Pi harness [step 12/15]` | 250-500 | Not started |
-| [ ] | 13/15 | `🌿 [pi-harness] feat(client): add Pi branding and guidance [step 13/15]` | 400-800 | Not started |
+| [ ] | 13/15 | `⚙️ [pi-harness] feat(client): add Pi branding and guidance [step 13/15]` | 650-1,000 | Not started |
 | [ ] | 14/15 | `🌿 [pi-harness] test(pi): verify the end-to-end integration [step 14/15]` | 200-500 | Not started |
 | [ ] | 15/15 | `🌱 [pi-harness] docs: retire the Pi harness plan [step 15/15]` | 50-200 | Not started |
 
@@ -54,7 +53,7 @@ OpenCode default, or no-new-analytics decisions without the user.
 - Count additions plus deletions from the merge base, including generated code
   and tests; split coherently or record an unavoidable overage.
 - Generated outputs are regenerated, never hand-edited.
-- Steps 2-12 run focused/full owning-package tests, fatal analysis, diff checks,
+- Steps 2-13 run focused/full owning-package tests, fatal analysis, diff checks,
   and architecture implementation review.
 - Step 13 validates touched client/package assets and tests. Step 14 validates
   the live product path. Steps 1 and 15 are documentation-only.
@@ -64,11 +63,10 @@ OpenCode default, or no-new-analytics decisions without the user.
 
 ## Plan Review
 
-- **Reviewer:** `architecture-plan-review` sub-agent, 2026-08-10
-- **Scope:** `PLAN.md`, with this tracker and `PROTOCOL.md` as supporting context
-- **Verdict:** initial draft rejected; corrected plan not re-reviewed
-- **Corrections:** catalog layering; tracker/discovery semantics; session
-  path/lease ownership; editor prefill; attachment variants; session ID ownership
+- 2026-08-10: initial architecture draft rejected; six ownership, layering,
+  editor, attachment, and ID corrections applied without re-review.
+- 2026-08-11: toast delta rejected one effect-identity gap; monotonic show
+  sequence applied without re-review.
 
 ## Verification Log
 
@@ -83,19 +81,8 @@ OpenCode default, or no-new-analytics decisions without the user.
 
 ## Findings And Plan Deltas
 
-- `PROTOCOL.md` is canonical for upstream findings and runtime traps.
-- Architecture review clarified the catalog probe/repository/tracker/service
-  chain, session-path ownership, transient process leases, editor-prefill
-  degradation, attachment variants, and session-ID ownership.
-- Duplicate research and delivery text was removed so Step 1 remains under the
-  1,500-line soft cap without splitting the required initial plan artifacts.
-- PR review removed unreachable Sesori-created parent forks and moved auth
-  classification from cwd-less setup to project-scoped operations.
-- Follow-up review pinned safe prompt projection, descendant dialogs,
-  pending-new recovery, command barriers, and empty-parts creation.
-- Later review aligned extension UI layers, RPC DTOs, lane admission, command
-  projection, model defaults, health, and runtime-only setup.
-- Latest review pinned collision-free message IDs, scoped auth handling, and
-  created-before-first-turn event ordering.
-- Follow-up review pinned stderr draining, question lifecycle events, and
-  command completion on backend acceptance.
+- Architecture review corrected catalog/session ownership, editor degradation,
+  attachments, and ID ownership; later PR rounds corrected parent/auth scope,
+  replay/live identity, turn/creation ordering, dialogs, and process transport.
+- Deep review added rendered backend-neutral toasts, visible compaction parity,
+  current Claude/runtime sequencing, and refreshed verification bookkeeping.

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -28,7 +28,7 @@ OpenCode default, or no-new-analytics decisions without the user.
 
 | Done | Step | Exact PR title | Target | State |
 |---|---|---|---:|---|
-| [ ] | 1/15 | `🌱 [pi-harness] docs: plan Pi harness support [step 1/15]` | 1,400-1,500 | In review |
+| [ ] | 1/15 | `🌱 [pi-harness] docs: plan Pi harness support [step 1/15]` | 1,400-1,500 (recorded overage) | In review |
 | [ ] | 2/15 | `⚙️ [pi-harness] feat(pi): scaffold the protocol package [step 2/15]` | 900-1,300 | Not started |
 | [ ] | 3/15 | `🚧 [pi-harness] feat(pi): add the JSONL RPC transport [step 3/15]` | 1,200-1,500 | Not started |
 | [ ] | 4/15 | `⚙️ [pi-harness] feat(pi): enumerate persisted sessions [step 4/15]` | 1,000-1,400 | Not started |
@@ -77,6 +77,8 @@ OpenCode default, or no-new-analytics decisions without the user.
 - Upstream repository/tag, RPC/session docs, and all six release digests match.
 - `git diff --check $(git merge-base origin/main HEAD)..HEAD`: pass.
 - Diff: +1,500/-0 = 1,500 changed lines; generated lines: 0; tests run: 0.
+- Recorded overage: final review gaps belong in the canonical initial plan and
+  cannot form an independently valid implementation PR.
 - Dart/Flutter suites: not run for this documentation-only step.
 - Plan/content commit `813ca4ca`; PR
   https://github.com/sesori-ai/sesori_apps_monorepo/pull/811.
@@ -84,4 +86,4 @@ OpenCode default, or no-new-analytics decisions without the user.
 ## Findings And Plan Deltas
 
 - Reviews corrected architecture/lifecycle and added rendered toasts, visible
-  compaction, bounded catalog scans, command acceptance, and current sequencing.
+  compaction, bounded scans, history fallback, project questions, and sequencing.

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -83,8 +83,5 @@ OpenCode default, or no-new-analytics decisions without the user.
 
 ## Findings And Plan Deltas
 
-- Architecture review corrected catalog/session ownership, editor degradation,
-  attachments, and ID ownership; later PR rounds corrected parent/auth scope,
-  replay/live identity, turn/creation ordering, dialogs, and process transport.
-- Deep review added rendered backend-neutral toasts, visible compaction parity,
-  current Claude/runtime sequencing, and refreshed verification bookkeeping.
+- Reviews corrected architecture/lifecycle and added rendered toasts, visible
+  compaction, bounded catalog scans, command acceptance, and current sequencing.

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -76,11 +76,11 @@ OpenCode default, or no-new-analytics decisions without the user.
   findings applied without re-review.
 - Upstream repository/tag, RPC/session docs, and all six release digests match.
 - `git diff --check $(git merge-base origin/main HEAD)..HEAD`: pass.
-- Diff: +1,513/-0 = 1,513 changed lines; generated lines: 0; tests run: 0.
+- Diff: +1,522/-0 = 1,522 changed lines; generated lines: 0; tests run: 0.
 - Recorded overage: final review gaps belong in the canonical initial plan and
   cannot form an independently valid implementation PR.
 - Dart/Flutter suites: not run for this documentation-only step.
-- Plan/content commit `72811b5c`; PR
+- Plan/content commit `b065a97d`; PR
   https://github.com/sesori-ai/sesori_apps_monorepo/pull/811.
 
 ## Findings And Plan Deltas

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -1,0 +1,90 @@
+# Pi Harness Support: Tracker
+
+## Current State
+
+- **Plan slug:** `pi-harness`
+- **Implementation base:** `origin/main` at `3803df12`
+- **Series state:** Step 1/15 being prepared
+- **Current step:** 1/15, durable plan and protocol research
+- **Plan PR:** pending
+- **Next action:** validate, commit, push, and open Step 1
+
+## Locked Decisions
+
+`PLAN.md` is canonical. Execution must not reopen the confirmed target, native
+permissions, normal Pi data, local login, always-`--approve` project trust,
+documented terminal handoff, per-session residency, full-package install,
+OpenCode default, or no-new-analytics decisions without the user.
+
+## External Dependencies
+
+- Pi Step 11 requires `phone-harness-install` Step 5's
+  `RuntimeAssetLayout.packageDirectory` and generalized `RuntimeVersion` on
+  `main`. The work existed on local branch `phone-harness-install-cursor` at
+  `6054d7cd` when this plan was written, but had no PR. Do not duplicate it.
+- Pi activation/client steps rebase on the active Claude series and preserve all
+  merged Claude identity, registry, package, CI, and brand entries.
+
+## Delivery Steps
+
+| Done | Step | Exact PR title | Target | State |
+|---|---|---|---:|---|
+| [ ] | 1/15 | `🌱 [pi-harness] docs: plan Pi harness support [step 1/15]` | 1,400-1,500 | In progress |
+| [ ] | 2/15 | `⚙️ [pi-harness] feat(pi): scaffold the protocol package [step 2/15]` | 900-1,300 | Not started |
+| [ ] | 3/15 | `🚧 [pi-harness] feat(pi): add the JSONL RPC transport [step 3/15]` | 1,200-1,500 | Not started |
+| [ ] | 4/15 | `⚙️ [pi-harness] feat(pi): enumerate persisted sessions [step 4/15]` | 1,000-1,400 | Not started |
+| [ ] | 5/15 | `⚙️ [pi-harness] feat(pi): replay Pi session history [step 5/15]` | 1,100-1,500 | Not started |
+| [ ] | 6/15 | `🚧 [pi-harness] feat(pi): map live messages and tools [step 6/15]` | 1,200-1,500 | Not started |
+| [ ] | 7/15 | `⚙️ [pi-harness] feat(pi): bridge extension dialogs [step 7/15]` | 900-1,300 | Not started |
+| [ ] | 8/15 | `🚧 [pi-harness] feat(pi): manage session residency and turns [step 8/15]` | 1,200-1,500 | Not started |
+| [ ] | 9/15 | `⚙️ [pi-harness] feat(pi): expose models and commands [step 9/15]` | 900-1,300 | Not started |
+| [ ] | 10/15 | `🚧 [pi-harness] feat(pi): implement the plugin API [step 10/15]` | 1,100-1,500 | Not started |
+| [ ] | 11/15 | `🚧 [pi-harness] feat(pi): add managed runtime and lifecycle [step 11/15]` | 1,100-1,500 | Blocked on package-directory runtime support |
+| [ ] | 12/15 | `⚙️ [pi-harness] feat(pi): register the Pi harness [step 12/15]` | 250-500 | Not started |
+| [ ] | 13/15 | `🌿 [pi-harness] feat(client): add Pi branding and guidance [step 13/15]` | 400-800 | Not started |
+| [ ] | 14/15 | `🌿 [pi-harness] test(pi): verify the end-to-end integration [step 14/15]` | 200-500 | Not started |
+| [ ] | 15/15 | `🌱 [pi-harness] docs: retire the Pi harness plan [step 15/15]` | 50-200 | Not started |
+
+## Working Rules
+
+- One Pi-series implementation PR is open at a time; every PR targets `main`.
+- Merge in numeric order and rebase/merge current `origin/main` before opening
+  each step so concurrent Claude/runtime work is preserved.
+- Do not prepare implementation branches or worktrees from this plan PR.
+- Count additions plus deletions from the merge base, including generated code
+  and tests; split coherently or record an unavoidable overage.
+- Generated outputs are regenerated, never hand-edited.
+- Steps 2-12 run focused/full owning-package tests, fatal analysis, diff checks,
+  and architecture implementation review.
+- Step 13 validates touched client/package assets and tests. Step 14 validates
+  the live product path. Steps 1 and 15 are documentation-only.
+- Every PR body uses real multiline Markdown via `--body-file` and includes all
+  required review sections.
+- Start PR monitoring after every PR is opened.
+
+## Plan Review
+
+- **Reviewer:** `architecture-plan-review` sub-agent, 2026-08-10
+- **Scope:** `PLAN.md`, with this tracker and `PROTOCOL.md` as supporting context
+- **Verdict:** initial draft rejected; corrected plan not re-reviewed
+- **Corrections:** added explicit catalog layers/cache semantics, path resolver
+  and transient leases, editor/attachment degradation, and ID ownership
+
+## Verification Log
+
+### Step 1/15
+
+- Architecture review: initial draft rejected; all six findings applied.
+- Upstream repository/tag, RPC/session docs, and all six release digests match.
+- `git diff --check`: pass; three documentation files, 1,496 additions.
+- Dart/Flutter suites: not run for this documentation-only step.
+- Commit and PR link: pending.
+
+## Findings And Plan Deltas
+
+- `PROTOCOL.md` is canonical for upstream findings and runtime traps.
+- Architecture review clarified the catalog probe/repository/tracker/service
+  chain, session-path ownership, transient process leases, editor-prefill
+  degradation, attachment variants, and session-ID ownership.
+- Duplicate research and delivery text was removed so Step 1 remains under the
+  1,500-line soft cap without splitting the required initial plan artifacts.

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -4,10 +4,10 @@
 
 - **Plan slug:** `pi-harness`
 - **Implementation base:** `origin/main` at `3803df12`
-- **Series state:** Step 1/15 being prepared
+- **Series state:** Step 1/15 in review
 - **Current step:** 1/15, durable plan and protocol research
-- **Plan PR:** pending
-- **Next action:** validate, commit, push, and open Step 1
+- **Plan PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/811
+- **Next action:** monitor Step 1 and address review feedback
 
 ## Locked Decisions
 
@@ -29,7 +29,7 @@ OpenCode default, or no-new-analytics decisions without the user.
 
 | Done | Step | Exact PR title | Target | State |
 |---|---|---|---:|---|
-| [ ] | 1/15 | `🌱 [pi-harness] docs: plan Pi harness support [step 1/15]` | 1,400-1,500 | In progress |
+| [ ] | 1/15 | `🌱 [pi-harness] docs: plan Pi harness support [step 1/15]` | 1,400-1,500 | In review |
 | [ ] | 2/15 | `⚙️ [pi-harness] feat(pi): scaffold the protocol package [step 2/15]` | 900-1,300 | Not started |
 | [ ] | 3/15 | `🚧 [pi-harness] feat(pi): add the JSONL RPC transport [step 3/15]` | 1,200-1,500 | Not started |
 | [ ] | 4/15 | `⚙️ [pi-harness] feat(pi): enumerate persisted sessions [step 4/15]` | 1,000-1,400 | Not started |
@@ -78,7 +78,7 @@ OpenCode default, or no-new-analytics decisions without the user.
 - Upstream repository/tag, RPC/session docs, and all six release digests match.
 - `git diff --check`: pass; three documentation files, 1,496 additions.
 - Dart/Flutter suites: not run for this documentation-only step.
-- Commit and PR link: pending.
+- Commit `1bf4aea2`; PR https://github.com/sesori-ai/sesori_apps_monorepo/pull/811.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -76,11 +76,11 @@ OpenCode default, or no-new-analytics decisions without the user.
   findings applied without re-review.
 - Upstream repository/tag, RPC/session docs, and all six release digests match.
 - `git diff --check $(git merge-base origin/main HEAD)..HEAD`: pass.
-- Diff: +1,522/-0 = 1,522 changed lines; generated lines: 0; tests run: 0.
+- Diff: +1,519/-0 = 1,519 changed lines; generated lines: 0; tests run: 0.
 - Recorded overage: final review gaps belong in the canonical initial plan and
   cannot form an independently valid implementation PR.
 - Dart/Flutter suites: not run for this documentation-only step.
-- Plan/content commit `b065a97d`; PR
+- Plan/content commit `9ac7b497`; PR
   https://github.com/sesori-ai/sesori_apps_monorepo/pull/811.
 
 ## Findings And Plan Deltas

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -77,7 +77,7 @@ OpenCode default, or no-new-analytics decisions without the user.
 - Architecture review: initial draft rejected; all six findings applied.
 - Upstream repository/tag, RPC/session docs, and all six release digests match.
 - `git diff --check origin/main...HEAD`: pass.
-- Diff: +1,495/-0 = 1,495 changed lines; generated lines: 0; tests run: 0.
+- Diff: +1,474/-0 = 1,474 changed lines; generated lines: 0; tests run: 0.
 - Dart/Flutter suites: not run for this documentation-only step.
 - Commit `1bf4aea2`; PR https://github.com/sesori-ai/sesori_apps_monorepo/pull/811.
 
@@ -93,3 +93,5 @@ OpenCode default, or no-new-analytics decisions without the user.
   classification from cwd-less setup to project-scoped operations.
 - Follow-up review pinned safe prompt projection, descendant dialogs,
   pending-new recovery, command barriers, and empty-parts creation.
+- Later review aligned extension UI layers, RPC DTOs, lane admission, command
+  projection, model defaults, health, and runtime-only setup.

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -76,11 +76,11 @@ OpenCode default, or no-new-analytics decisions without the user.
   findings applied without re-review.
 - Upstream repository/tag, RPC/session docs, and all six release digests match.
 - `git diff --check $(git merge-base origin/main HEAD)..HEAD`: pass.
-- Diff: +1,519/-0 = 1,519 changed lines; generated lines: 0; tests run: 0.
+- Diff: +1,525/-0 = 1,525 changed lines; generated lines: 0; tests run: 0.
 - Recorded overage: final review gaps belong in the canonical initial plan and
   cannot form an independently valid implementation PR.
 - Dart/Flutter suites: not run for this documentation-only step.
-- Plan content through `9ac7b497`; reproduce from the current PR head at
+- Plan content through `98658ced`; reproduce from the current PR head at
   https://github.com/sesori-ai/sesori_apps_monorepo/pull/811.
 
 ## Findings And Plan Deltas


### PR DESCRIPTION
## Complexity

Trivial. This PR adds researched planning artifacts only; it changes no production code or contracts.

## What

- Defines the architecture and fixed 15-PR delivery sequence for first-class Pi Agent Harness support.
- Records the researched Pi v0.84.1 JSONL RPC, session, authentication, extension UI, and standalone-runtime behavior.
- Captures locked product decisions, supply-chain digests, dependencies, risks, and per-step verification.

## Why

Pi is not ACP and its standalone releases are package trees, so implementation needs a backend-specific transport, explicit session/process ownership, and package-directory managed installation. The durable plan keeps those decisions and protocol facts available across the implementation series.

## Risk and test focus

Risk is low because this is documentation-only. Review should focus on protocol accuracy, plugin-boundary containment, layer ownership, lifecycle semantics, security/privacy decisions, and whether each implementation step is independently actionable.

There is no user-visible, transport, persisted-data, or database impact.

## Expected result

The repository contains an implementation-ready Pi plan, protocol record, and tracker with one fixed sequence from package scaffolding through live verification and plan retirement.

## Verification

- Ran `architecture-plan-review`; the initial draft was rejected and all six required corrections were applied.
- Rechecked the upstream repository/tag, primary RPC/session docs, and all six official release digests.
- Confirmed exactly 15 tracker titles and 15 matching plan step sections.
- `git diff --check origin/main...HEAD`
- Final scope: 3 documentation files, 1,474 additions, within the 1,500-line soft cap.
- Dart/Flutter suites were not run because this step changes documentation only.
