### PR TITLE
🚧 [attachment-references] feat(protocol): describe stored transcript images [step 2/11]

### DIFF
--- a/.plan/active/attachment-references/PLAN.md
+++ b/.plan/active/attachment-references/PLAN.md
@@ -554,7 +554,7 @@ baseline is intentionally raised in a separate task.
 | Step | Exact PR title | Estimate | Boundary |
 |---|---|---:|---|
 | 1/11 | `🌱 [attachment-references] docs: plan lazy transcript attachments [step 1/11]` | 650-1,100 | Active plan/tracker and upload considerations only. |
-| 2/11 | `🚧 [attachment-references] feat(protocol): describe stored transcript images [step 2/11]` | 900-1,450 | Shared variant, rendition models, delivery mode defaults, generated code, exhaustive compile-safe consumers. No peer enables references. |
+| 2/11 | `🚧 [attachment-references] feat(protocol): describe stored transcript images [step 2/11]` | 750-1,100 | Shared variant, rendition models, delivery mode defaults, generated code, exhaustive compile-safe consumers. No peer enables references. |
 | 3/11 | `⚙️ [attachment-references] feat(bridge): serve stored image renditions [step 3/11]` | 900-1,400 | Versioned thumbnail storage/builder, session-queued live/archive lookup, typed fetch handler, decode/size/security tests. |
 | 4/11 | `⚙️ [attachment-references] feat(bridge): reference images in history pages [step 4/11]` | 700-1,150 | Capability-aware active/archive projection and legacy budget preservation. |
 | 5/11 | `🚧 [attachment-references] feat(bridge): reference images in live events [step 5/11]` | 1,100-1,500 | Awaited materialization, dual event shapes, subscriber/orphan delivery mode, SSE memory/compatibility coverage. |

--- a/.plan/active/attachment-references/TRACKER.md
+++ b/.plan/active/attachment-references/TRACKER.md
@@ -3,11 +3,11 @@
 ## Current State
 
 - **Plan slug:** `attachment-references`
-- **Series state:** Step 1 PR open
-- **Current step:** 1/11
-- **Implementation base:** `origin/main` at `944e07e7`
+- **Series state:** Step 2 implementation complete; PR preparation
+- **Current step:** 2/11
+- **Implementation base:** `origin/main` at `3803df12`
 - **Plan PR:** [#807](https://github.com/sesori-ai/sesori_apps_monorepo/pull/807)
-- **Next action:** Monitor Step 1 review and CI; begin Step 2 only after merge
+- **Next action:** Commit and open the Step 2 shared-contract PR
 
 ## Plan Review
 
@@ -30,8 +30,8 @@
 
 | Done | Step | Exact PR title | Changed-line target | State |
 |---|---|---|---:|---|
-| [ ] | 1/11 | `🌱 [attachment-references] docs: plan lazy transcript attachments [step 1/11]` | 650-1,100 | [PR #807](https://github.com/sesori-ai/sesori_apps_monorepo/pull/807) open |
-| [ ] | 2/11 | `🚧 [attachment-references] feat(protocol): describe stored transcript images [step 2/11]` | 900-1,450 | Pending |
+| [x] | 1/11 | `🌱 [attachment-references] docs: plan lazy transcript attachments [step 1/11]` | 650-1,100 | [PR #807](https://github.com/sesori-ai/sesori_apps_monorepo/pull/807) merged |
+| [ ] | 2/11 | `🚧 [attachment-references] feat(protocol): describe stored transcript images [step 2/11]` | 750-1,100 | Implementation complete; PR pending |
 | [ ] | 3/11 | `⚙️ [attachment-references] feat(bridge): serve stored image renditions [step 3/11]` | 900-1,400 | Pending |
 | [ ] | 4/11 | `⚙️ [attachment-references] feat(bridge): reference images in history pages [step 4/11]` | 700-1,150 | Pending |
 | [ ] | 5/11 | `🚧 [attachment-references] feat(bridge): reference images in live events [step 5/11]` | 1,100-1,500 | Pending |
@@ -71,6 +71,12 @@
   Dart/Flutter suites were run for this documentation-only step. Committed as
   `6998f477`, pushed, and opened as
   [PR #807](https://github.com/sesori-ai/sesori_apps_monorepo/pull/807).
+- Step 2: Added stored-image identity, inline-default delivery capability on
+  history and SSE requests, and typed rendition DTOs; regenerated shared code
+  and kept bridge/client behavior explicitly inline with metadata placeholders.
+  Shared full tests, focused bridge/client tests, and source analysis across
+  shared, bridge, mobile, module_core, and desktop pass. Architecture
+  implementation review approved the contract and compatibility boundaries.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/attachment-references/TRACKER.md
+++ b/.plan/active/attachment-references/TRACKER.md
@@ -3,11 +3,12 @@
 ## Current State
 
 - **Plan slug:** `attachment-references`
-- **Series state:** Step 2 implementation complete; PR preparation
+- **Series state:** Step 2 PR open
 - **Current step:** 2/11
 - **Implementation base:** `origin/main` at `3803df12`
 - **Plan PR:** [#807](https://github.com/sesori-ai/sesori_apps_monorepo/pull/807)
-- **Next action:** Commit and open the Step 2 shared-contract PR
+- **Current PR:** [#812](https://github.com/sesori-ai/sesori_apps_monorepo/pull/812)
+- **Next action:** Monitor Step 2 review/CI and begin Step 3 locally
 
 ## Plan Review
 
@@ -31,7 +32,7 @@
 | Done | Step | Exact PR title | Changed-line target | State |
 |---|---|---|---:|---|
 | [x] | 1/11 | `🌱 [attachment-references] docs: plan lazy transcript attachments [step 1/11]` | 650-1,100 | [PR #807](https://github.com/sesori-ai/sesori_apps_monorepo/pull/807) merged |
-| [ ] | 2/11 | `🚧 [attachment-references] feat(protocol): describe stored transcript images [step 2/11]` | 750-1,100 | Implementation complete; PR pending |
+| [ ] | 2/11 | `🚧 [attachment-references] feat(protocol): describe stored transcript images [step 2/11]` | 750-1,100 | [PR #812](https://github.com/sesori-ai/sesori_apps_monorepo/pull/812) open |
 | [ ] | 3/11 | `⚙️ [attachment-references] feat(bridge): serve stored image renditions [step 3/11]` | 900-1,400 | Pending |
 | [ ] | 4/11 | `⚙️ [attachment-references] feat(bridge): reference images in history pages [step 4/11]` | 700-1,150 | Pending |
 | [ ] | 5/11 | `🚧 [attachment-references] feat(bridge): reference images in live events [step 5/11]` | 1,100-1,500 | Pending |
@@ -77,6 +78,8 @@
   Shared full tests, focused bridge/client tests, and source analysis across
   shared, bridge, mobile, module_core, and desktop pass. Architecture
   implementation review approved the contract and compatibility boundaries.
+  Committed as `9753d350`, pushed, and opened as
+  [PR #812](https://github.com/sesori-ai/sesori_apps_monorepo/pull/812).
 
 ## Findings And Plan Deltas
 

--- a/client/app/lib/features/session_detail/widgets/file_part_widget.dart
+++ b/client/app/lib/features/session_detail/widgets/file_part_widget.dart
@@ -64,6 +64,7 @@ class _FilePartContent extends StatelessWidget {
   String? get _attachmentFilename => switch (attachment) {
     MessageAttachmentInlineImage(:final filename) ||
     MessageAttachmentRemoteUrl(:final filename) ||
+    MessageAttachmentStoredImage(:final filename) ||
     MessageAttachmentMetadata(:final filename) => filename,
     MessageAttachmentUnknown() => null,
   };
@@ -85,7 +86,9 @@ class _FilePartContent extends StatelessWidget {
         uri: attachment.safeRemoteUri,
         icon: Icons.image_outlined,
       ),
-      MessageAttachmentMetadata() || MessageAttachmentUnknown() => _buildFallbackAttachment(
+      MessageAttachmentStoredImage() ||
+      MessageAttachmentMetadata() ||
+      MessageAttachmentUnknown() => _buildFallbackAttachment(
         context: context,
         imageLoadFailed: false,
       ),
@@ -106,6 +109,13 @@ class _FilePartContent extends StatelessWidget {
         icon: imageLoadFailed ? Icons.broken_image : Icons.insert_drive_file,
       ),
       MessageAttachmentMetadata(:final mime, :final filename) => _buildFileTile(
+        prego: prego,
+        filename: _displayFilename(filename: filename),
+        mime: _displayMime(mime: mime),
+        uri: null,
+        icon: Icons.insert_drive_file,
+      ),
+      MessageAttachmentStoredImage(:final mime, :final filename) => _buildFileTile(
         prego: prego,
         filename: _displayFilename(filename: filename),
         mime: _displayMime(mime: mime),

--- a/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
+++ b/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
@@ -127,6 +127,24 @@ void main() {
 
   tearDown(() => GetIt.instance.reset());
 
+  testWidgets("renders stored images as metadata until reference delivery is enabled", (tester) async {
+    const attachment = MessageAttachment.storedImage(
+      attachmentId: "attachment-1",
+      bridgeId: "bridge-1",
+      mime: "image/png",
+      filename: "preview.png",
+      byteLength: 1024,
+    );
+
+    await tester.pumpWidget(_app(child: const FilePartWidget(attachment: attachment)));
+    await tester.pumpAndSettle();
+
+    expect(find.text("preview.png"), findsOneWidget);
+    expect(find.text("image/png"), findsOneWidget);
+    expect(find.byType(Image), findsNothing);
+    expect(find.byKey(FilePartWidget.previewTapTargetKey), findsNothing);
+  });
+
   testWidgets("renders a bounded inline image without a network request", (tester) async {
     const attachment = MessageAttachment.inlineImage(
       mime: "image/png",

--- a/client/module_core/lib/src/api/session_api.dart
+++ b/client/module_core/lib/src/api/session_api.dart
@@ -238,7 +238,12 @@ class SessionApi {
     return _client.post(
       "/session/messages",
       fromJson: MessageWithPartsResponse.fromJson,
-      body: SessionMessagesRequest(sessionId: sessionId, limit: limit, before: before),
+      body: SessionMessagesRequest(
+        sessionId: sessionId,
+        limit: limit,
+        before: before,
+        attachmentDelivery: MessageAttachmentDelivery.inline,
+      ),
     );
   }
 

--- a/client/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/client/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -425,7 +425,11 @@ class RelayClient {
 
     final controller = StreamController<RelaySseEvent>.broadcast();
     _sseController = controller;
-    unawaited(_sendEncryptedMessage(RelayMessage.sseSubscribe(path: path)));
+    unawaited(
+      _sendEncryptedMessage(
+        RelayMessage.sseSubscribe(path: path, attachmentDelivery: MessageAttachmentDelivery.inline),
+      ),
+    );
     return controller.stream;
   }
 

--- a/client/module_core/lib/src/repositories/message_image_repository.dart
+++ b/client/module_core/lib/src/repositories/message_image_repository.dart
@@ -74,7 +74,7 @@ class MessageImageRepository {
     MessageAttachmentRemoteUrl(:final mime) =>
       _supportedRasterMimes.contains(_normalizedMime(mime: mime)) &&
           attachment.safeRemoteUri?.scheme.toLowerCase() == "https",
-    MessageAttachmentMetadata() || MessageAttachmentUnknown() => false,
+    MessageAttachmentStoredImage() || MessageAttachmentMetadata() || MessageAttachmentUnknown() => false,
   };
 
   Future<MessageImageLoadResult> load({required MessageAttachment attachment}) async {
@@ -91,6 +91,7 @@ class MessageImageRepository {
         filename: filename,
       ),
       MessageAttachmentMetadata() ||
+      MessageAttachmentStoredImage() ||
       MessageAttachmentUnknown() => Future<MessageImageLoadResult>.value(const MessageImageLoadUnsupported()),
     };
   }

--- a/client/module_core/test/repositories/message_image_repository_test.dart
+++ b/client/module_core/test/repositories/message_image_repository_test.dart
@@ -98,6 +98,29 @@ void main() {
     expect(requests, 0);
   });
 
+  test("does not load stored images before reference delivery is enabled", () async {
+    var requests = 0;
+    final repository = MessageImageRepository(
+      api: MessageImageApi(
+        client: MockClient((_) async {
+          requests++;
+          return http.Response("unexpected", 200);
+        }),
+      ),
+    );
+    const attachment = MessageAttachment.storedImage(
+      attachmentId: "attachment-1",
+      bridgeId: "bridge-1",
+      mime: "image/png",
+      filename: "preview.png",
+      byteLength: 1024,
+    );
+
+    expect(repository.canLoad(attachment: attachment), isFalse);
+    expect(await repository.load(attachment: attachment), isA<MessageImageLoadUnsupported>());
+    expect(requests, 0);
+  });
+
   test("rejects an HTTPS redirect that downgrades to HTTP", () async {
     var requests = 0;
     final repository = MessageImageRepository(

--- a/shared/sesori_shared/lib/sesori_shared.dart
+++ b/shared/sesori_shared/lib/sesori_shared.dart
@@ -73,6 +73,7 @@ export "src/models/sesori/send_prompt_request.dart";
 export "src/models/sesori/sesori_sse_event.dart";
 export "src/models/sesori/session.dart";
 export "src/models/sesori/session_archived_rejection.dart";
+export "src/models/sesori/session_attachment.dart";
 export "src/models/sesori/session_cleanup_rejection.dart";
 export "src/models/sesori/session_diffs_response.dart";
 export "src/models/sesori/session_options_error_response.dart";

--- a/shared/sesori_shared/lib/src/models/sesori/bridge_setting_update.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/bridge_setting_update.g.dart
@@ -6,7 +6,8 @@ part of 'bridge_setting_update.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-PullRequestRefreshIntervalSettingUpdate _$PullRequestRefreshIntervalSettingUpdateFromJson(Map json) =>
+PullRequestRefreshIntervalSettingUpdate
+_$PullRequestRefreshIntervalSettingUpdateFromJson(Map json) =>
     PullRequestRefreshIntervalSettingUpdate(
       intervalSeconds: strictIntJsonConverter.fromJson(json['intervalSeconds']),
       $type: json['type'] as String?,
@@ -24,10 +25,8 @@ YoloSettingUpdate _$YoloSettingUpdateFromJson(Map json) => YoloSettingUpdate(
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$YoloSettingUpdateToJson(YoloSettingUpdate instance) => <String, dynamic>{
-  'enabled': instance.enabled,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$YoloSettingUpdateToJson(YoloSettingUpdate instance) =>
+    <String, dynamic>{'enabled': instance.enabled, 'type': instance.$type};
 
 UnknownBridgeSettingUpdate _$UnknownBridgeSettingUpdateFromJson(Map json) =>
     UnknownBridgeSettingUpdate($type: json['type'] as String?);
@@ -49,7 +48,8 @@ _$PullRequestRefreshIntervalOutOfRangeSettingUpdateRejectionFromJson(
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$PullRequestRefreshIntervalOutOfRangeSettingUpdateRejectionToJson(
+Map<String, dynamic>
+_$PullRequestRefreshIntervalOutOfRangeSettingUpdateRejectionToJson(
   PullRequestRefreshIntervalOutOfRangeSettingUpdateRejection instance,
 ) => <String, dynamic>{
   'minimumIntervalSeconds': ?strictIntJsonConverter.toJson(
@@ -61,7 +61,8 @@ Map<String, dynamic> _$PullRequestRefreshIntervalOutOfRangeSettingUpdateRejectio
   'type': instance.$type,
 };
 
-UnknownBridgeSettingUpdateRejection _$UnknownBridgeSettingUpdateRejectionFromJson(Map json) =>
+UnknownBridgeSettingUpdateRejection
+_$UnknownBridgeSettingUpdateRejectionFromJson(Map json) =>
     UnknownBridgeSettingUpdateRejection($type: json['type'] as String?);
 
 Map<String, dynamic> _$UnknownBridgeSettingUpdateRejectionToJson(

--- a/shared/sesori_shared/lib/src/models/sesori/bridge_settings_response.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/bridge_settings_response.g.dart
@@ -6,14 +6,15 @@ part of 'bridge_settings_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_BridgeSettingsResponse _$BridgeSettingsResponseFromJson(Map json) => _BridgeSettingsResponse(
-  pullRequestRefresh: PullRequestRefreshSettingsResponse.fromJson(
-    Map<String, dynamic>.from(json['pullRequestRefresh'] as Map),
-  ),
-  yolo: YoloSettingsResponse.fromJson(
-    Map<String, dynamic>.from(json['yolo'] as Map),
-  ),
-);
+_BridgeSettingsResponse _$BridgeSettingsResponseFromJson(Map json) =>
+    _BridgeSettingsResponse(
+      pullRequestRefresh: PullRequestRefreshSettingsResponse.fromJson(
+        Map<String, dynamic>.from(json['pullRequestRefresh'] as Map),
+      ),
+      yolo: YoloSettingsResponse.fromJson(
+        Map<String, dynamic>.from(json['yolo'] as Map),
+      ),
+    );
 
 Map<String, dynamic> _$BridgeSettingsResponseToJson(
   _BridgeSettingsResponse instance,

--- a/shared/sesori_shared/lib/src/models/sesori/message_part.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_part.dart
@@ -101,6 +101,9 @@ enum MessagePartType {
   compaction,
 }
 
+@JsonEnum()
+enum MessageAttachmentDelivery { inline, storedReference }
+
 @Freezed(fromJson: true, toJson: true)
 sealed class MessagePart with _$MessagePart {
   const factory MessagePart({
@@ -150,6 +153,15 @@ sealed class MessageAttachment with _$MessageAttachment {
     required String? filename,
   }) = MessageAttachmentRemoteUrl;
 
+  @FreezedUnionValue("stored_image")
+  const factory MessageAttachment.storedImage({
+    required String attachmentId,
+    required String bridgeId,
+    required String mime,
+    required String? filename,
+    required int byteLength,
+  }) = MessageAttachmentStoredImage;
+
   const factory MessageAttachment.metadata({
     required String mime,
     required String? filename,
@@ -166,7 +178,10 @@ extension MessageAttachmentSafety on MessageAttachment {
   Uri? get safeRemoteUri {
     final rawUrl = switch (this) {
       MessageAttachmentRemoteUrl(:final url) => url,
-      MessageAttachmentInlineImage() || MessageAttachmentMetadata() || MessageAttachmentUnknown() => null,
+      MessageAttachmentInlineImage() ||
+      MessageAttachmentStoredImage() ||
+      MessageAttachmentMetadata() ||
+      MessageAttachmentUnknown() => null,
     };
     if (rawUrl == null) return null;
 

--- a/shared/sesori_shared/lib/src/models/sesori/message_part.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_part.freezed.dart
@@ -244,6 +244,10 @@ MessageAttachment _$MessageAttachmentFromJson(
           return MessageAttachmentRemoteUrl.fromJson(
             json
           );
+                case 'stored_image':
+          return MessageAttachmentStoredImage.fromJson(
+            json
+          );
                 case 'metadata':
           return MessageAttachmentMetadata.fromJson(
             json
@@ -426,6 +430,83 @@ mime: null == mime ? _self.mime : mime // ignore: cast_nullable_to_non_nullable
 as String,url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
 as String,filename: freezed == filename ? _self.filename : filename // ignore: cast_nullable_to_non_nullable
 as String?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class MessageAttachmentStoredImage implements MessageAttachment {
+  const MessageAttachmentStoredImage({required this.attachmentId, required this.bridgeId, required this.mime, required this.filename, required this.byteLength, final  String? $type}): $type = $type ?? 'stored_image';
+  factory MessageAttachmentStoredImage.fromJson(Map<String, dynamic> json) => _$MessageAttachmentStoredImageFromJson(json);
+
+ final  String attachmentId;
+ final  String bridgeId;
+ final  String mime;
+ final  String? filename;
+ final  int byteLength;
+
+@JsonKey(name: 'source')
+final String $type;
+
+
+/// Create a copy of MessageAttachment
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MessageAttachmentStoredImageCopyWith<MessageAttachmentStoredImage> get copyWith => _$MessageAttachmentStoredImageCopyWithImpl<MessageAttachmentStoredImage>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$MessageAttachmentStoredImageToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MessageAttachmentStoredImage&&(identical(other.attachmentId, attachmentId) || other.attachmentId == attachmentId)&&(identical(other.bridgeId, bridgeId) || other.bridgeId == bridgeId)&&(identical(other.mime, mime) || other.mime == mime)&&(identical(other.filename, filename) || other.filename == filename)&&(identical(other.byteLength, byteLength) || other.byteLength == byteLength));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,attachmentId,bridgeId,mime,filename,byteLength);
+
+
+
+}
+
+/// @nodoc
+abstract mixin class $MessageAttachmentStoredImageCopyWith<$Res> implements $MessageAttachmentCopyWith<$Res> {
+  factory $MessageAttachmentStoredImageCopyWith(MessageAttachmentStoredImage value, $Res Function(MessageAttachmentStoredImage) _then) = _$MessageAttachmentStoredImageCopyWithImpl;
+@useResult
+$Res call({
+ String attachmentId, String bridgeId, String mime, String? filename, int byteLength
+});
+
+
+
+
+}
+/// @nodoc
+class _$MessageAttachmentStoredImageCopyWithImpl<$Res>
+    implements $MessageAttachmentStoredImageCopyWith<$Res> {
+  _$MessageAttachmentStoredImageCopyWithImpl(this._self, this._then);
+
+  final MessageAttachmentStoredImage _self;
+  final $Res Function(MessageAttachmentStoredImage) _then;
+
+/// Create a copy of MessageAttachment
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? attachmentId = null,Object? bridgeId = null,Object? mime = null,Object? filename = freezed,Object? byteLength = null,}) {
+  return _then(MessageAttachmentStoredImage(
+attachmentId: null == attachmentId ? _self.attachmentId : attachmentId // ignore: cast_nullable_to_non_nullable
+as String,bridgeId: null == bridgeId ? _self.bridgeId : bridgeId // ignore: cast_nullable_to_non_nullable
+as String,mime: null == mime ? _self.mime : mime // ignore: cast_nullable_to_non_nullable
+as String,filename: freezed == filename ? _self.filename : filename // ignore: cast_nullable_to_non_nullable
+as String?,byteLength: null == byteLength ? _self.byteLength : byteLength // ignore: cast_nullable_to_non_nullable
+as int,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/message_part.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_part.g.dart
@@ -92,6 +92,27 @@ Map<String, dynamic> _$MessageAttachmentRemoteUrlToJson(
   'source': instance.$type,
 };
 
+MessageAttachmentStoredImage _$MessageAttachmentStoredImageFromJson(Map json) =>
+    MessageAttachmentStoredImage(
+      attachmentId: json['attachmentId'] as String,
+      bridgeId: json['bridgeId'] as String,
+      mime: json['mime'] as String,
+      filename: json['filename'] as String?,
+      byteLength: (json['byteLength'] as num).toInt(),
+      $type: json['source'] as String?,
+    );
+
+Map<String, dynamic> _$MessageAttachmentStoredImageToJson(
+  MessageAttachmentStoredImage instance,
+) => <String, dynamic>{
+  'attachmentId': instance.attachmentId,
+  'bridgeId': instance.bridgeId,
+  'mime': instance.mime,
+  'filename': ?instance.filename,
+  'byteLength': instance.byteLength,
+  'source': instance.$type,
+};
+
 MessageAttachmentMetadata _$MessageAttachmentMetadataFromJson(Map json) =>
     MessageAttachmentMetadata(
       mime: json['mime'] as String,

--- a/shared/sesori_shared/lib/src/models/sesori/pending_question.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/pending_question.g.dart
@@ -6,13 +6,15 @@ part of 'pending_question.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_PendingQuestionResponse _$PendingQuestionResponseFromJson(Map json) => _PendingQuestionResponse(
-  data: (json['data'] as List<dynamic>)
-      .map(
-        (e) => PendingQuestion.fromJson(Map<String, dynamic>.from(e as Map)),
-      )
-      .toList(),
-);
+_PendingQuestionResponse _$PendingQuestionResponseFromJson(Map json) =>
+    _PendingQuestionResponse(
+      data: (json['data'] as List<dynamic>)
+          .map(
+            (e) =>
+                PendingQuestion.fromJson(Map<String, dynamic>.from(e as Map)),
+          )
+          .toList(),
+    );
 
 Map<String, dynamic> _$PendingQuestionResponseToJson(
   _PendingQuestionResponse instance,
@@ -27,9 +29,10 @@ _PendingQuestion _$PendingQuestionFromJson(Map json) => _PendingQuestion(
       .toList(),
 );
 
-Map<String, dynamic> _$PendingQuestionToJson(_PendingQuestion instance) => <String, dynamic>{
-  'id': instance.id,
-  'sessionID': instance.sessionID,
-  'displaySessionId': ?instance.displaySessionId,
-  'questions': instance.questions.map((e) => e.toJson()).toList(),
-};
+Map<String, dynamic> _$PendingQuestionToJson(_PendingQuestion instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'sessionID': instance.sessionID,
+      'displaySessionId': ?instance.displaySessionId,
+      'questions': instance.questions.map((e) => e.toJson()).toList(),
+    };

--- a/shared/sesori_shared/lib/src/models/sesori/session.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.dart
@@ -1,6 +1,7 @@
 import "package:freezed_annotation/freezed_annotation.dart";
 
 import "agent_info.dart";
+import "message_part.dart";
 import "plugin_identity.dart";
 import "pull_request_info.dart";
 
@@ -145,6 +146,9 @@ sealed class SessionMessagesRequest with _$SessionMessagesRequest {
     /// Exclusive cursor: return messages ordered strictly before this one.
     /// Null starts from the newest message.
     required int? before,
+
+    // COMPATIBILITY 2026-08-10 (v1.9.0): Apps predating stored transcript images omit attachmentDelivery and require inline payloads. Remove @Default after the minimum supported app sends this field.
+    @Default(MessageAttachmentDelivery.inline) MessageAttachmentDelivery attachmentDelivery,
   }) = _SessionMessagesRequest;
 
   factory SessionMessagesRequest.fromJson(Map<String, dynamic> json) => _$SessionMessagesRequestFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/session.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.freezed.dart
@@ -1345,7 +1345,8 @@ mixin _$SessionMessagesRequest {
 // COMPATIBILITY 2026-08-08 (v1.7.2): Apps that predate pagination omit limit and mean the full transcript. Make this required and drop the unpaged read path once those apps are unsupported.
  int? get limit;/// Exclusive cursor: return messages ordered strictly before this one.
 /// Null starts from the newest message.
- int? get before;
+ int? get before;// COMPATIBILITY 2026-08-10 (v1.9.0): Apps predating stored transcript images omit attachmentDelivery and require inline payloads. Remove @Default after the minimum supported app sends this field.
+ MessageAttachmentDelivery get attachmentDelivery;
 /// Create a copy of SessionMessagesRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1358,16 +1359,16 @@ $SessionMessagesRequestCopyWith<SessionMessagesRequest> get copyWith => _$Sessio
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionMessagesRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.limit, limit) || other.limit == limit)&&(identical(other.before, before) || other.before == before));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionMessagesRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.limit, limit) || other.limit == limit)&&(identical(other.before, before) || other.before == before)&&(identical(other.attachmentDelivery, attachmentDelivery) || other.attachmentDelivery == attachmentDelivery));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,sessionId,limit,before);
+int get hashCode => Object.hash(runtimeType,sessionId,limit,before,attachmentDelivery);
 
 @override
 String toString() {
-  return 'SessionMessagesRequest(sessionId: $sessionId, limit: $limit, before: $before)';
+  return 'SessionMessagesRequest(sessionId: $sessionId, limit: $limit, before: $before, attachmentDelivery: $attachmentDelivery)';
 }
 
 
@@ -1378,7 +1379,7 @@ abstract mixin class $SessionMessagesRequestCopyWith<$Res>  {
   factory $SessionMessagesRequestCopyWith(SessionMessagesRequest value, $Res Function(SessionMessagesRequest) _then) = _$SessionMessagesRequestCopyWithImpl;
 @useResult
 $Res call({
- String sessionId, int? limit, int? before
+ String sessionId, int? limit, int? before, MessageAttachmentDelivery attachmentDelivery
 });
 
 
@@ -1395,12 +1396,13 @@ class _$SessionMessagesRequestCopyWithImpl<$Res>
 
 /// Create a copy of SessionMessagesRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? sessionId = null,Object? limit = freezed,Object? before = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? sessionId = null,Object? limit = freezed,Object? before = freezed,Object? attachmentDelivery = null,}) {
   return _then(_self.copyWith(
 sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
 as String,limit: freezed == limit ? _self.limit : limit // ignore: cast_nullable_to_non_nullable
 as int?,before: freezed == before ? _self.before : before // ignore: cast_nullable_to_non_nullable
-as int?,
+as int?,attachmentDelivery: null == attachmentDelivery ? _self.attachmentDelivery : attachmentDelivery // ignore: cast_nullable_to_non_nullable
+as MessageAttachmentDelivery,
   ));
 }
 
@@ -1412,7 +1414,7 @@ as int?,
 @JsonSerializable()
 
 class _SessionMessagesRequest implements SessionMessagesRequest {
-  const _SessionMessagesRequest({required this.sessionId, required this.limit, required this.before});
+  const _SessionMessagesRequest({required this.sessionId, required this.limit, required this.before, this.attachmentDelivery = MessageAttachmentDelivery.inline});
   factory _SessionMessagesRequest.fromJson(Map<String, dynamic> json) => _$SessionMessagesRequestFromJson(json);
 
 @override final  String sessionId;
@@ -1423,6 +1425,8 @@ class _SessionMessagesRequest implements SessionMessagesRequest {
 /// Exclusive cursor: return messages ordered strictly before this one.
 /// Null starts from the newest message.
 @override final  int? before;
+// COMPATIBILITY 2026-08-10 (v1.9.0): Apps predating stored transcript images omit attachmentDelivery and require inline payloads. Remove @Default after the minimum supported app sends this field.
+@override@JsonKey() final  MessageAttachmentDelivery attachmentDelivery;
 
 /// Create a copy of SessionMessagesRequest
 /// with the given fields replaced by the non-null parameter values.
@@ -1437,16 +1441,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionMessagesRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.limit, limit) || other.limit == limit)&&(identical(other.before, before) || other.before == before));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionMessagesRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.limit, limit) || other.limit == limit)&&(identical(other.before, before) || other.before == before)&&(identical(other.attachmentDelivery, attachmentDelivery) || other.attachmentDelivery == attachmentDelivery));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,sessionId,limit,before);
+int get hashCode => Object.hash(runtimeType,sessionId,limit,before,attachmentDelivery);
 
 @override
 String toString() {
-  return 'SessionMessagesRequest(sessionId: $sessionId, limit: $limit, before: $before)';
+  return 'SessionMessagesRequest(sessionId: $sessionId, limit: $limit, before: $before, attachmentDelivery: $attachmentDelivery)';
 }
 
 
@@ -1457,7 +1461,7 @@ abstract mixin class _$SessionMessagesRequestCopyWith<$Res> implements $SessionM
   factory _$SessionMessagesRequestCopyWith(_SessionMessagesRequest value, $Res Function(_SessionMessagesRequest) _then) = __$SessionMessagesRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String sessionId, int? limit, int? before
+ String sessionId, int? limit, int? before, MessageAttachmentDelivery attachmentDelivery
 });
 
 
@@ -1474,12 +1478,13 @@ class __$SessionMessagesRequestCopyWithImpl<$Res>
 
 /// Create a copy of SessionMessagesRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? sessionId = null,Object? limit = freezed,Object? before = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? sessionId = null,Object? limit = freezed,Object? before = freezed,Object? attachmentDelivery = null,}) {
   return _then(_SessionMessagesRequest(
 sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
 as String,limit: freezed == limit ? _self.limit : limit // ignore: cast_nullable_to_non_nullable
 as int?,before: freezed == before ? _self.before : before // ignore: cast_nullable_to_non_nullable
-as int?,
+as int?,attachmentDelivery: null == attachmentDelivery ? _self.attachmentDelivery : attachmentDelivery // ignore: cast_nullable_to_non_nullable
+as MessageAttachmentDelivery,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/session.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.g.dart
@@ -165,6 +165,12 @@ _SessionMessagesRequest _$SessionMessagesRequestFromJson(Map json) =>
       sessionId: json['sessionId'] as String,
       limit: (json['limit'] as num?)?.toInt(),
       before: (json['before'] as num?)?.toInt(),
+      attachmentDelivery:
+          $enumDecodeNullable(
+            _$MessageAttachmentDeliveryEnumMap,
+            json['attachmentDelivery'],
+          ) ??
+          MessageAttachmentDelivery.inline,
     );
 
 Map<String, dynamic> _$SessionMessagesRequestToJson(
@@ -173,4 +179,11 @@ Map<String, dynamic> _$SessionMessagesRequestToJson(
   'sessionId': instance.sessionId,
   'limit': ?instance.limit,
   'before': ?instance.before,
+  'attachmentDelivery':
+      _$MessageAttachmentDeliveryEnumMap[instance.attachmentDelivery]!,
+};
+
+const _$MessageAttachmentDeliveryEnumMap = {
+  MessageAttachmentDelivery.inline: 'inline',
+  MessageAttachmentDelivery.storedReference: 'storedReference',
 };

--- a/shared/sesori_shared/lib/src/models/sesori/session_attachment.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session_attachment.dart
@@ -17,7 +17,7 @@ sealed class SessionAttachmentRequest with _$SessionAttachmentRequest {
   factory SessionAttachmentRequest.fromJson(Map<String, dynamic> json) => _$SessionAttachmentRequestFromJson(json);
 }
 
-@Freezed(fromJson: true, toJson: true)
+@Freezed(fromJson: true, toJson: true, toStringOverride: false)
 sealed class SessionAttachmentResponse with _$SessionAttachmentResponse {
   const factory SessionAttachmentResponse({
     required String mime,

--- a/shared/sesori_shared/lib/src/models/sesori/session_attachment.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session_attachment.dart
@@ -1,0 +1,29 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "session_attachment.freezed.dart";
+part "session_attachment.g.dart";
+
+@JsonEnum()
+enum SessionAttachmentRendition { thumbnail, original }
+
+@Freezed(fromJson: true, toJson: true)
+sealed class SessionAttachmentRequest with _$SessionAttachmentRequest {
+  const factory SessionAttachmentRequest({
+    required String sessionId,
+    required String attachmentId,
+    required SessionAttachmentRendition rendition,
+  }) = _SessionAttachmentRequest;
+
+  factory SessionAttachmentRequest.fromJson(Map<String, dynamic> json) => _$SessionAttachmentRequestFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: true)
+sealed class SessionAttachmentResponse with _$SessionAttachmentResponse {
+  const factory SessionAttachmentResponse({
+    required String mime,
+    required String base64,
+    required int byteLength,
+  }) = _SessionAttachmentResponse;
+
+  factory SessionAttachmentResponse.fromJson(Map<String, dynamic> json) => _$SessionAttachmentResponseFromJson(json);
+}

--- a/shared/sesori_shared/lib/src/models/sesori/session_attachment.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session_attachment.freezed.dart
@@ -175,10 +175,6 @@ bool operator ==(Object other) {
 @override
 int get hashCode => Object.hash(runtimeType,mime,base64,byteLength);
 
-@override
-String toString() {
-  return 'SessionAttachmentResponse(mime: $mime, base64: $base64, byteLength: $byteLength)';
-}
 
 
 }
@@ -249,10 +245,6 @@ bool operator ==(Object other) {
 @override
 int get hashCode => Object.hash(runtimeType,mime,base64,byteLength);
 
-@override
-String toString() {
-  return 'SessionAttachmentResponse(mime: $mime, base64: $base64, byteLength: $byteLength)';
-}
 
 
 }

--- a/shared/sesori_shared/lib/src/models/sesori/session_attachment.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session_attachment.freezed.dart
@@ -1,0 +1,294 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'session_attachment.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$SessionAttachmentRequest {
+
+ String get sessionId; String get attachmentId; SessionAttachmentRendition get rendition;
+/// Create a copy of SessionAttachmentRequest
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SessionAttachmentRequestCopyWith<SessionAttachmentRequest> get copyWith => _$SessionAttachmentRequestCopyWithImpl<SessionAttachmentRequest>(this as SessionAttachmentRequest, _$identity);
+
+  /// Serializes this SessionAttachmentRequest to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionAttachmentRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.attachmentId, attachmentId) || other.attachmentId == attachmentId)&&(identical(other.rendition, rendition) || other.rendition == rendition));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,sessionId,attachmentId,rendition);
+
+@override
+String toString() {
+  return 'SessionAttachmentRequest(sessionId: $sessionId, attachmentId: $attachmentId, rendition: $rendition)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SessionAttachmentRequestCopyWith<$Res>  {
+  factory $SessionAttachmentRequestCopyWith(SessionAttachmentRequest value, $Res Function(SessionAttachmentRequest) _then) = _$SessionAttachmentRequestCopyWithImpl;
+@useResult
+$Res call({
+ String sessionId, String attachmentId, SessionAttachmentRendition rendition
+});
+
+
+
+
+}
+/// @nodoc
+class _$SessionAttachmentRequestCopyWithImpl<$Res>
+    implements $SessionAttachmentRequestCopyWith<$Res> {
+  _$SessionAttachmentRequestCopyWithImpl(this._self, this._then);
+
+  final SessionAttachmentRequest _self;
+  final $Res Function(SessionAttachmentRequest) _then;
+
+/// Create a copy of SessionAttachmentRequest
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? sessionId = null,Object? attachmentId = null,Object? rendition = null,}) {
+  return _then(_self.copyWith(
+sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
+as String,attachmentId: null == attachmentId ? _self.attachmentId : attachmentId // ignore: cast_nullable_to_non_nullable
+as String,rendition: null == rendition ? _self.rendition : rendition // ignore: cast_nullable_to_non_nullable
+as SessionAttachmentRendition,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _SessionAttachmentRequest implements SessionAttachmentRequest {
+  const _SessionAttachmentRequest({required this.sessionId, required this.attachmentId, required this.rendition});
+  factory _SessionAttachmentRequest.fromJson(Map<String, dynamic> json) => _$SessionAttachmentRequestFromJson(json);
+
+@override final  String sessionId;
+@override final  String attachmentId;
+@override final  SessionAttachmentRendition rendition;
+
+/// Create a copy of SessionAttachmentRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SessionAttachmentRequestCopyWith<_SessionAttachmentRequest> get copyWith => __$SessionAttachmentRequestCopyWithImpl<_SessionAttachmentRequest>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SessionAttachmentRequestToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionAttachmentRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.attachmentId, attachmentId) || other.attachmentId == attachmentId)&&(identical(other.rendition, rendition) || other.rendition == rendition));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,sessionId,attachmentId,rendition);
+
+@override
+String toString() {
+  return 'SessionAttachmentRequest(sessionId: $sessionId, attachmentId: $attachmentId, rendition: $rendition)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SessionAttachmentRequestCopyWith<$Res> implements $SessionAttachmentRequestCopyWith<$Res> {
+  factory _$SessionAttachmentRequestCopyWith(_SessionAttachmentRequest value, $Res Function(_SessionAttachmentRequest) _then) = __$SessionAttachmentRequestCopyWithImpl;
+@override @useResult
+$Res call({
+ String sessionId, String attachmentId, SessionAttachmentRendition rendition
+});
+
+
+
+
+}
+/// @nodoc
+class __$SessionAttachmentRequestCopyWithImpl<$Res>
+    implements _$SessionAttachmentRequestCopyWith<$Res> {
+  __$SessionAttachmentRequestCopyWithImpl(this._self, this._then);
+
+  final _SessionAttachmentRequest _self;
+  final $Res Function(_SessionAttachmentRequest) _then;
+
+/// Create a copy of SessionAttachmentRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? sessionId = null,Object? attachmentId = null,Object? rendition = null,}) {
+  return _then(_SessionAttachmentRequest(
+sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
+as String,attachmentId: null == attachmentId ? _self.attachmentId : attachmentId // ignore: cast_nullable_to_non_nullable
+as String,rendition: null == rendition ? _self.rendition : rendition // ignore: cast_nullable_to_non_nullable
+as SessionAttachmentRendition,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$SessionAttachmentResponse {
+
+ String get mime; String get base64; int get byteLength;
+/// Create a copy of SessionAttachmentResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SessionAttachmentResponseCopyWith<SessionAttachmentResponse> get copyWith => _$SessionAttachmentResponseCopyWithImpl<SessionAttachmentResponse>(this as SessionAttachmentResponse, _$identity);
+
+  /// Serializes this SessionAttachmentResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionAttachmentResponse&&(identical(other.mime, mime) || other.mime == mime)&&(identical(other.base64, base64) || other.base64 == base64)&&(identical(other.byteLength, byteLength) || other.byteLength == byteLength));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,mime,base64,byteLength);
+
+@override
+String toString() {
+  return 'SessionAttachmentResponse(mime: $mime, base64: $base64, byteLength: $byteLength)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SessionAttachmentResponseCopyWith<$Res>  {
+  factory $SessionAttachmentResponseCopyWith(SessionAttachmentResponse value, $Res Function(SessionAttachmentResponse) _then) = _$SessionAttachmentResponseCopyWithImpl;
+@useResult
+$Res call({
+ String mime, String base64, int byteLength
+});
+
+
+
+
+}
+/// @nodoc
+class _$SessionAttachmentResponseCopyWithImpl<$Res>
+    implements $SessionAttachmentResponseCopyWith<$Res> {
+  _$SessionAttachmentResponseCopyWithImpl(this._self, this._then);
+
+  final SessionAttachmentResponse _self;
+  final $Res Function(SessionAttachmentResponse) _then;
+
+/// Create a copy of SessionAttachmentResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? mime = null,Object? base64 = null,Object? byteLength = null,}) {
+  return _then(_self.copyWith(
+mime: null == mime ? _self.mime : mime // ignore: cast_nullable_to_non_nullable
+as String,base64: null == base64 ? _self.base64 : base64 // ignore: cast_nullable_to_non_nullable
+as String,byteLength: null == byteLength ? _self.byteLength : byteLength // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _SessionAttachmentResponse implements SessionAttachmentResponse {
+  const _SessionAttachmentResponse({required this.mime, required this.base64, required this.byteLength});
+  factory _SessionAttachmentResponse.fromJson(Map<String, dynamic> json) => _$SessionAttachmentResponseFromJson(json);
+
+@override final  String mime;
+@override final  String base64;
+@override final  int byteLength;
+
+/// Create a copy of SessionAttachmentResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SessionAttachmentResponseCopyWith<_SessionAttachmentResponse> get copyWith => __$SessionAttachmentResponseCopyWithImpl<_SessionAttachmentResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SessionAttachmentResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionAttachmentResponse&&(identical(other.mime, mime) || other.mime == mime)&&(identical(other.base64, base64) || other.base64 == base64)&&(identical(other.byteLength, byteLength) || other.byteLength == byteLength));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,mime,base64,byteLength);
+
+@override
+String toString() {
+  return 'SessionAttachmentResponse(mime: $mime, base64: $base64, byteLength: $byteLength)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SessionAttachmentResponseCopyWith<$Res> implements $SessionAttachmentResponseCopyWith<$Res> {
+  factory _$SessionAttachmentResponseCopyWith(_SessionAttachmentResponse value, $Res Function(_SessionAttachmentResponse) _then) = __$SessionAttachmentResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ String mime, String base64, int byteLength
+});
+
+
+
+
+}
+/// @nodoc
+class __$SessionAttachmentResponseCopyWithImpl<$Res>
+    implements _$SessionAttachmentResponseCopyWith<$Res> {
+  __$SessionAttachmentResponseCopyWithImpl(this._self, this._then);
+
+  final _SessionAttachmentResponse _self;
+  final $Res Function(_SessionAttachmentResponse) _then;
+
+/// Create a copy of SessionAttachmentResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? mime = null,Object? base64 = null,Object? byteLength = null,}) {
+  return _then(_SessionAttachmentResponse(
+mime: null == mime ? _self.mime : mime // ignore: cast_nullable_to_non_nullable
+as String,base64: null == base64 ? _self.base64 : base64 // ignore: cast_nullable_to_non_nullable
+as String,byteLength: null == byteLength ? _self.byteLength : byteLength // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/shared/sesori_shared/lib/src/models/sesori/session_attachment.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session_attachment.g.dart
@@ -1,0 +1,45 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'session_attachment.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_SessionAttachmentRequest _$SessionAttachmentRequestFromJson(Map json) =>
+    _SessionAttachmentRequest(
+      sessionId: json['sessionId'] as String,
+      attachmentId: json['attachmentId'] as String,
+      rendition: $enumDecode(
+        _$SessionAttachmentRenditionEnumMap,
+        json['rendition'],
+      ),
+    );
+
+Map<String, dynamic> _$SessionAttachmentRequestToJson(
+  _SessionAttachmentRequest instance,
+) => <String, dynamic>{
+  'sessionId': instance.sessionId,
+  'attachmentId': instance.attachmentId,
+  'rendition': _$SessionAttachmentRenditionEnumMap[instance.rendition]!,
+};
+
+const _$SessionAttachmentRenditionEnumMap = {
+  SessionAttachmentRendition.thumbnail: 'thumbnail',
+  SessionAttachmentRendition.original: 'original',
+};
+
+_SessionAttachmentResponse _$SessionAttachmentResponseFromJson(Map json) =>
+    _SessionAttachmentResponse(
+      mime: json['mime'] as String,
+      base64: json['base64'] as String,
+      byteLength: (json['byteLength'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$SessionAttachmentResponseToJson(
+  _SessionAttachmentResponse instance,
+) => <String, dynamic>{
+  'mime': instance.mime,
+  'base64': instance.base64,
+  'byteLength': instance.byteLength,
+};

--- a/shared/sesori_shared/lib/src/protocol/messages.dart
+++ b/shared/sesori_shared/lib/src/protocol/messages.dart
@@ -1,5 +1,7 @@
 import "package:freezed_annotation/freezed_annotation.dart";
 
+import "../models/sesori/message_part.dart";
+
 part "messages.freezed.dart";
 part "messages.g.dart";
 
@@ -26,7 +28,11 @@ sealed class RelayMessage with _$RelayMessage {
   const factory RelayMessage.sseEvent({required String data}) = RelaySseEvent;
 
   @FreezedUnionValue("sse_subscribe")
-  const factory RelayMessage.sseSubscribe({required String path}) = RelaySseSubscribe;
+  const factory RelayMessage.sseSubscribe({
+    required String path,
+    // COMPATIBILITY 2026-08-10 (v1.9.0): Apps predating stored transcript images omit attachmentDelivery and require inline payloads. Remove @Default after the minimum supported app sends this field.
+    @Default(MessageAttachmentDelivery.inline) MessageAttachmentDelivery attachmentDelivery,
+  }) = RelaySseSubscribe;
 
   @FreezedUnionValue("sse_unsubscribe")
   const factory RelayMessage.sseUnsubscribe() = RelaySseUnsubscribe;

--- a/shared/sesori_shared/lib/src/protocol/messages.freezed.dart
+++ b/shared/sesori_shared/lib/src/protocol/messages.freezed.dart
@@ -361,10 +361,12 @@ as String,
 @JsonSerializable()
 
 class RelaySseSubscribe implements RelayMessage {
-  const RelaySseSubscribe({required this.path, final  String? $type}): $type = $type ?? 'sse_subscribe';
+  const RelaySseSubscribe({required this.path, this.attachmentDelivery = MessageAttachmentDelivery.inline, final  String? $type}): $type = $type ?? 'sse_subscribe';
   factory RelaySseSubscribe.fromJson(Map<String, dynamic> json) => _$RelaySseSubscribeFromJson(json);
 
  final  String path;
+// COMPATIBILITY 2026-08-10 (v1.9.0): Apps predating stored transcript images omit attachmentDelivery and require inline payloads. Remove @Default after the minimum supported app sends this field.
+@JsonKey() final  MessageAttachmentDelivery attachmentDelivery;
 
 @JsonKey(name: 'type')
 final String $type;
@@ -383,16 +385,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RelaySseSubscribe&&(identical(other.path, path) || other.path == path));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RelaySseSubscribe&&(identical(other.path, path) || other.path == path)&&(identical(other.attachmentDelivery, attachmentDelivery) || other.attachmentDelivery == attachmentDelivery));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,path);
+int get hashCode => Object.hash(runtimeType,path,attachmentDelivery);
 
 @override
 String toString() {
-  return 'RelayMessage.sseSubscribe(path: $path)';
+  return 'RelayMessage.sseSubscribe(path: $path, attachmentDelivery: $attachmentDelivery)';
 }
 
 
@@ -403,7 +405,7 @@ abstract mixin class $RelaySseSubscribeCopyWith<$Res> implements $RelayMessageCo
   factory $RelaySseSubscribeCopyWith(RelaySseSubscribe value, $Res Function(RelaySseSubscribe) _then) = _$RelaySseSubscribeCopyWithImpl;
 @useResult
 $Res call({
- String path
+ String path, MessageAttachmentDelivery attachmentDelivery
 });
 
 
@@ -420,10 +422,11 @@ class _$RelaySseSubscribeCopyWithImpl<$Res>
 
 /// Create a copy of RelayMessage
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? path = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? path = null,Object? attachmentDelivery = null,}) {
   return _then(RelaySseSubscribe(
 path: null == path ? _self.path : path // ignore: cast_nullable_to_non_nullable
-as String,
+as String,attachmentDelivery: null == attachmentDelivery ? _self.attachmentDelivery : attachmentDelivery // ignore: cast_nullable_to_non_nullable
+as MessageAttachmentDelivery,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/protocol/messages.g.dart
+++ b/shared/sesori_shared/lib/src/protocol/messages.g.dart
@@ -50,11 +50,27 @@ Map<String, dynamic> _$RelaySseEventToJson(RelaySseEvent instance) =>
 
 RelaySseSubscribe _$RelaySseSubscribeFromJson(Map json) => RelaySseSubscribe(
   path: json['path'] as String,
+  attachmentDelivery:
+      $enumDecodeNullable(
+        _$MessageAttachmentDeliveryEnumMap,
+        json['attachmentDelivery'],
+      ) ??
+      MessageAttachmentDelivery.inline,
   $type: json['type'] as String?,
 );
 
 Map<String, dynamic> _$RelaySseSubscribeToJson(RelaySseSubscribe instance) =>
-    <String, dynamic>{'path': instance.path, 'type': instance.$type};
+    <String, dynamic>{
+      'path': instance.path,
+      'attachmentDelivery':
+          _$MessageAttachmentDeliveryEnumMap[instance.attachmentDelivery]!,
+      'type': instance.$type,
+    };
+
+const _$MessageAttachmentDeliveryEnumMap = {
+  MessageAttachmentDelivery.inline: 'inline',
+  MessageAttachmentDelivery.storedReference: 'storedReference',
+};
 
 RelaySseUnsubscribe _$RelaySseUnsubscribeFromJson(Map json) =>
     RelaySseUnsubscribe($type: json['type'] as String?);

--- a/shared/sesori_shared/test/models/message_attachment_test.dart
+++ b/shared/sesori_shared/test/models/message_attachment_test.dart
@@ -100,5 +100,26 @@ void main() {
 
       expect(MessageAttachment.fromJson(attachment.toJson()), attachment);
     });
+
+    test("stored images round-trip with scoped opaque identity", () {
+      const attachment = MessageAttachment.storedImage(
+        attachmentId: "sha256-opaque",
+        bridgeId: "bridge-1",
+        mime: "image/png",
+        filename: "image.png",
+        byteLength: 1234,
+      );
+
+      expect(attachment.safeRemoteUri, isNull);
+      expect(attachment.toJson(), {
+        "source": "stored_image",
+        "attachmentId": "sha256-opaque",
+        "bridgeId": "bridge-1",
+        "mime": "image/png",
+        "filename": "image.png",
+        "byteLength": 1234,
+      });
+      expect(MessageAttachment.fromJson(attachment.toJson()), attachment);
+    });
   });
 }

--- a/shared/sesori_shared/test/models/session_attachment_test.dart
+++ b/shared/sesori_shared/test/models/session_attachment_test.dart
@@ -1,0 +1,57 @@
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("older history and SSE requests default to inline attachments", () {
+    final history = SessionMessagesRequest.fromJson(const {
+      "sessionId": "session-1",
+      "limit": 20,
+      "before": 40,
+    });
+    final subscription = RelayMessage.fromJson(const {
+      "type": "sse_subscribe",
+      "path": "/events",
+    });
+
+    expect(history.attachmentDelivery, MessageAttachmentDelivery.inline);
+    expect(
+      subscription,
+      const RelayMessage.sseSubscribe(
+        path: "/events",
+        attachmentDelivery: MessageAttachmentDelivery.inline,
+      ),
+    );
+  });
+
+  test("stored-reference delivery serializes on both request surfaces", () {
+    const history = SessionMessagesRequest(
+      sessionId: "session-1",
+      limit: 20,
+      before: null,
+      attachmentDelivery: MessageAttachmentDelivery.storedReference,
+    );
+    const subscription = RelayMessage.sseSubscribe(
+      path: "/events",
+      attachmentDelivery: MessageAttachmentDelivery.storedReference,
+    );
+
+    expect(history.toJson()["attachmentDelivery"], "storedReference");
+    expect(subscription.toJson()["attachmentDelivery"], "storedReference");
+  });
+
+  test("attachment rendition request and response round-trip", () {
+    const request = SessionAttachmentRequest(
+      sessionId: "session-1",
+      attachmentId: "attachment-1",
+      rendition: SessionAttachmentRendition.thumbnail,
+    );
+    const response = SessionAttachmentResponse(
+      mime: "image/jpeg",
+      base64: "aGVsbG8=",
+      byteLength: 5,
+    );
+
+    expect(SessionAttachmentRequest.fromJson(request.toJson()), request);
+    expect(SessionAttachmentResponse.fromJson(response.toJson()), response);
+  });
+}

--- a/shared/sesori_shared/test/models/session_attachment_test.dart
+++ b/shared/sesori_shared/test/models/session_attachment_test.dart
@@ -53,5 +53,6 @@ void main() {
 
     expect(SessionAttachmentRequest.fromJson(request.toJson()), request);
     expect(SessionAttachmentResponse.fromJson(response.toJson()), response);
+    expect(response.toString(), isNot(contains("aGVsbG8=")));
   });
 }


### PR DESCRIPTION
## Complexity

Complex (`🚧`): shared wire contracts and generated unions change across bridge, mobile, and desktop consumers with bidirectional released-peer compatibility requirements.

## What

- Adds the scoped `stored_image` message attachment variant with required bridge and attachment identity.
- Adds inline-default attachment delivery modes to paged history and SSE subscription requests.
- Adds typed thumbnail/original rendition request and response models.
- Keeps both production request surfaces explicitly inline and renders stored-image fixtures as non-loadable metadata until later steps enable delivery.

## Why

Later bridge and client steps need a backend-neutral contract for lightweight transcript image references before either peer can emit or fetch them. Landing the contract first makes every in-repository consumer exhaustive while preserving current behavior.

## Risk and test focus

Risk is moderate and concentrated in JSON compatibility and exhaustive union handling. Review should focus on old-app/new-bridge defaults, new-app/old-bridge unknown-field tolerance, required bridge/session scope, and proving no production path enables stored references yet.

## Expected result

No user-visible or database/persisted-data change. Existing apps and bridges continue exchanging inline attachments; the new models are available for subsequent implementation steps only.

## Verification

- Shared full test suite: passed
- Shared analysis: passed
- Focused bridge history/routing/orchestrator tests: passed
- Focused module_core image repository/Cubit tests: passed
- Focused mobile attachment widget tests: passed
- Source analysis passed for shared, bridge app (`--fatal-infos`), module_core, mobile, and desktop
- Architecture implementation review: approved
- `git diff --check`: passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines stored transcript image references in the shared protocol and keeps delivery inline by default so production behavior doesn’t change. Adds a `stored_image` attachment, typed rendition models, and explicit delivery flags; clients still treat stored images as metadata.

- **New Features**
  - Added `stored_image` attachment with `attachmentId`, `bridgeId`, `mime`, `filename`, `byteLength`.
  - Introduced `MessageAttachmentDelivery` with default `inline` on `SessionMessagesRequest` and `RelayMessage.sseSubscribe`; clients explicitly pass `inline` on history and SSE requests.
  - Added typed rendition DTOs: `SessionAttachmentRequest`/`SessionAttachmentResponse` with `SessionAttachmentRendition` (`thumbnail` | `original`); exported in `sesori_shared`.
  - UI/clients: stored images render as non-loadable metadata; `MessageImageRepository` rejects loading them.

- **Bug Fixes**
  - Redacted raw bytes from `SessionAttachmentResponse.toString()` to prevent logging base64 image data.

<sup>Written for commit c96ecf16f2b6493c4d5ada8a53b78114a22c0705. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

