### PR TITLE
🚧 [claude-code-plugin] feat(claude): implement the plugin API surface [step 12/17]

### DIFF
--- a/.plan/active/claude-code-plugin/PLAN.md
+++ b/.plan/active/claude-code-plugin/PLAN.md
@@ -466,7 +466,7 @@ binary level, and `markReady` on the next success.
 | `getSessions(projectId)` | catalog scan filtered by normalized directory |
 | `getCommands` | slash commands from `system/init`; `PluginCommandSource.command` |
 | `getSessionOptions` | aggregate agents, providers, and commands; `refresh` re-probes |
-| `createSession` | pre-generate the session UUID, spawn with `--session-id`, dispatch the first prompt through the turn queue; **the id reported on `system/init` is authoritative** and is cross-checked against the pre-generated UUID (see Session Identity below) |
+| `createSession` | pre-generate the session UUID, spawn with `--session-id`, dispatch the first prompt through the turn queue, and fail closed if `system/init` violates that pre-bound identity (see Session Identity below) |
 | `renameSession` | optimistic only; the mobile database is authoritative (Cursor precedent) |
 | `deleteSession` | kill the resident process, cancel approvals, delete the transcript, forget caches |
 | `archiveSession` / `deleteWorkspace` | no-ops under the best-effort contract |
@@ -499,12 +499,17 @@ inside reported the same `sessionId`. Multi-turn residency on one process is
 verified the same way — two turns ran on a single process that stayed alive
 between them and exited cleanly only when stdin closed.
 
-The contract is nonetheless defensive rather than trusting: the `session_id`
-reported on `system/init` is the source of truth, cross-checked against the
-pre-generated UUID. A mismatch is logged and the reported id wins, because it is
-the one the transcript is named after. Note that `init` is emitted when a turn
-starts, not when the process spawns, so the check happens on the first turn —
-which is exactly when `createSession` dispatches its first prompt.
+The contract is nonetheless defensive rather than trusting: `system/init`
+cross-checks its `session_id` against the pre-generated UUID. A mismatch fails
+closed by tearing down the process and surfacing a session error. Adopting a
+different id after `createSession` has returned would require migrating process
+residency, queued turns, approvals, event-dispatcher state, and persisted client
+identity atomically; partial migration would silently split one session across
+those owners. Live verification shows Claude honors `--session-id`, so broad
+rekey machinery for a state no supported flow produces is less safe than
+stopping. Note that `init` is emitted when a turn starts, not when the process
+spawns, so the check happens on the first turn — exactly when `createSession`
+dispatches its first prompt.
 
 ### Respawn state durability
 

--- a/.plan/active/claude-code-plugin/PROTOCOL.md
+++ b/.plan/active/claude-code-plugin/PROTOCOL.md
@@ -430,10 +430,10 @@ Consequence for Step 11: the picker sends `set_permission_mode`, and the
 `{name, description, argumentHint}`, and `system/init` carries a
 `slash_commands` list as well.
 
-**OPEN:** whether sending `/command args` as ordinary turn text actually
-dispatches the command in stream-json mode. Verify before Step 12 wires
-`sendCommand`; if it does not, `sendCommand` degrades to a
-`PluginOperationException`.
+**Verified against CLI 2.1.226.** Sending `/help` as an ordinary stream-json
+user text block after `initialize` produced `system/init`, an assistant reply,
+and a successful terminal `result`. `sendCommand` therefore dispatches
+`/command args` through the same serialized turn path as a prompt.
 
 ## 8. Authentication
 

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -376,9 +376,9 @@
   completes successfully. Review fixes added backend-acceptance receipts,
   restart-safe removal of bridge-owned worktree context from visible history,
   visible prompt/command synthesis, retry snapshots, and complete deletion
-  fencing. All 186 package tests, `dart analyze --fatal-infos`, and
-  `git diff --check` pass. The final diff is 1,418 changed lines across 16 files:
-  1,357 additions and 61 deletions, with no generated files changed. It remains
+  fencing. All 187 package tests, `dart analyze --fatal-infos`, and
+  `git diff --check` pass. The final diff is 1,472 changed lines across 16 files:
+  1,407 additions and 65 deletions, with no generated files changed. It remains
   within the 1,200-1,500 estimate and below the 1,500-line soft cap.
 
   Architecture implementation review rejected the original identity mismatch

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -373,9 +373,13 @@
   exact slash-command dispatch, launch-only effort respawn, not-found behavior,
   active summaries, delete fencing, and idempotent persisted cleanup. A live
   CLI 2.1.226 probe confirmed `/help` sent as ordinary stream-json user text
-  completes successfully. All 180 package tests, `dart analyze --fatal-infos`,
-  and `git diff --check` pass. The measured diff is 922 changed lines across 10
-  files, below the 1,200-1,500 estimate and the 1,500-line soft cap.
+  completes successfully. Review fixes added backend-acceptance receipts,
+  restart-safe removal of bridge-owned worktree context from visible history,
+  visible prompt/command synthesis, retry snapshots, and complete deletion
+  fencing. All 186 package tests, `dart analyze --fatal-infos`, and
+  `git diff --check` pass. The final diff is 1,418 changed lines across 16 files:
+  1,357 additions and 61 deletions, with no generated files changed. It remains
+  within the 1,200-1,500 estimate and below the 1,500-line soft cap.
 
   Architecture implementation review rejected the original identity mismatch
   policy because the plan said the reported id should replace the pre-bound id.

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -376,9 +376,9 @@
   completes successfully. Review fixes added backend-acceptance receipts,
   restart-safe removal of bridge-owned worktree context from visible history,
   visible prompt/command synthesis, retry snapshots, and complete deletion
-  fencing. All 187 package tests, `dart analyze --fatal-infos`, and
-  `git diff --check` pass. The final diff is 1,472 changed lines across 16 files:
-  1,407 additions and 65 deletions, with no generated files changed. It remains
+  fencing. All 186 package tests, `dart analyze --fatal-infos`, and
+  `git diff --check` pass. The final diff is 1,468 changed lines across 17 files:
+  1,387 additions and 81 deletions, with no generated files changed. It remains
   within the 1,200-1,500 estimate and below the 1,500-line soft cap.
 
   Architecture implementation review rejected the original identity mismatch

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -5,11 +5,11 @@
 - **Plan slug:** `claude-code-plugin`
 - **Implementation base:** `origin/main` at
   `035fae84` (Step 12 started after Step 11 merged)
-- **Series state:** Steps 1-11/17 merged; Step 12/17 implementation complete
-- **Current step:** 12/17 — full plugin API surface ready for PR
+- **Series state:** Steps 1-11/17 merged; Step 12/17 PR open
+- **Current step:** 12/17 — full plugin API surface in review
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737),
   merged 2026-08-04 as `6d641532`
-- **Next action:** Open the Step 12 PR against `main`, then wait for explicit
+- **Next action:** Wait for Step 12 PR #813 to merge, then wait for explicit
   direction before starting Step 13
 
 ## Plan Review
@@ -56,7 +56,7 @@
 | [x] | 9/17 | `claude-code-plugin-approvals` | `🚧 [claude-code-plugin] feat(claude): add permission and question registry [step 9/17]` | 1,100-1,500 | [PR #805](https://github.com/sesori-ai/sesori_apps_monorepo/pull/805) merged 2026-08-10 as `8280e691` |
 | [x] | 10/17 | `claude-code-plugin-session-service` | `🚧 [claude-code-plugin] feat(claude): add session residency and turn queue [step 10/17]` | 1,200-1,500 | [PR #808](https://github.com/sesori-ai/sesori_apps_monorepo/pull/808) merged 2026-08-11 as `fcca943c` |
 | [x] | 11/17 | `claude-code-plugin-catalog-service` | `⚙️ [claude-code-plugin] feat(claude): add model and agent catalog [step 11/17]` | 900-1,300 | [PR #809](https://github.com/sesori-ai/sesori_apps_monorepo/pull/809) merged 2026-08-11 as `ca521672` |
-| [ ] | 12/17 | `claude-code-plugin-plugin-impl` | `🚧 [claude-code-plugin] feat(claude): implement the plugin API surface [step 12/17]` | 1,200-1,500 | Implementation complete; PR pending |
+| [ ] | 12/17 | `claude-code-plugin-plugin-impl` | `🚧 [claude-code-plugin] feat(claude): implement the plugin API surface [step 12/17]` | 1,200-1,500 | [PR #813](https://github.com/sesori-ai/sesori_apps_monorepo/pull/813) open against `main` |
 | [ ] | 13/17 | `claude-code-plugin-descriptor` | `⚙️ [claude-code-plugin] feat(claude): add descriptor and lifecycle [step 13/17]` | 1,100-1,500 | Not started |
 | [ ] | 14/17 | `claude-code-plugin-activation` | `⚙️ [claude-code-plugin] feat(claude): register the Claude Code harness [step 14/17]` | 250-500 | Not started |
 | [ ] | 15/17 | `claude-code-plugin-client-polish` | `🌿 [claude-code-plugin] feat(client): add Claude Code branding [step 15/17]` | 400-800 | Not started |

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -4,13 +4,13 @@
 
 - **Plan slug:** `claude-code-plugin`
 - **Implementation base:** `origin/main` at
-  `fcca943c` (Step 11 started after Step 10 merged)
-- **Series state:** Steps 1-10/17 merged; Step 11/17 PR open
-- **Current step:** 11/17 — model and agent catalog in review
+  `035fae84` (Step 12 started after Step 11 merged)
+- **Series state:** Steps 1-11/17 merged; Step 12/17 implementation complete
+- **Current step:** 12/17 — full plugin API surface ready for PR
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737),
   merged 2026-08-04 as `6d641532`
-- **Next action:** Wait for Step 11 PR #809 to merge, then wait for explicit
-  direction before starting Step 12
+- **Next action:** Open the Step 12 PR against `main`, then wait for explicit
+  direction before starting Step 13
 
 ## Plan Review
 
@@ -55,8 +55,8 @@
 | [x] | 8/17 | `claude-code-plugin-event-mapper` | `🚧 [claude-code-plugin] feat(claude): map stream events to SSE [step 8/17]` | 1,200-1,500 | [PR #803](https://github.com/sesori-ai/sesori_apps_monorepo/pull/803) merged 2026-08-10 as `944e07e7` |
 | [x] | 9/17 | `claude-code-plugin-approvals` | `🚧 [claude-code-plugin] feat(claude): add permission and question registry [step 9/17]` | 1,100-1,500 | [PR #805](https://github.com/sesori-ai/sesori_apps_monorepo/pull/805) merged 2026-08-10 as `8280e691` |
 | [x] | 10/17 | `claude-code-plugin-session-service` | `🚧 [claude-code-plugin] feat(claude): add session residency and turn queue [step 10/17]` | 1,200-1,500 | [PR #808](https://github.com/sesori-ai/sesori_apps_monorepo/pull/808) merged 2026-08-11 as `fcca943c` |
-| [ ] | 11/17 | `claude-code-plugin-catalog-service` | `⚙️ [claude-code-plugin] feat(claude): add model and agent catalog [step 11/17]` | 900-1,300 | [PR #809](https://github.com/sesori-ai/sesori_apps_monorepo/pull/809) open against `main` |
-| [ ] | 12/17 | `claude-code-plugin-plugin-impl` | `🚧 [claude-code-plugin] feat(claude): implement the plugin API surface [step 12/17]` | 1,200-1,500 | Not started |
+| [x] | 11/17 | `claude-code-plugin-catalog-service` | `⚙️ [claude-code-plugin] feat(claude): add model and agent catalog [step 11/17]` | 900-1,300 | [PR #809](https://github.com/sesori-ai/sesori_apps_monorepo/pull/809) merged 2026-08-11 as `ca521672` |
+| [ ] | 12/17 | `claude-code-plugin-plugin-impl` | `🚧 [claude-code-plugin] feat(claude): implement the plugin API surface [step 12/17]` | 1,200-1,500 | Implementation complete; PR pending |
 | [ ] | 13/17 | `claude-code-plugin-descriptor` | `⚙️ [claude-code-plugin] feat(claude): add descriptor and lifecycle [step 13/17]` | 1,100-1,500 | Not started |
 | [ ] | 14/17 | `claude-code-plugin-activation` | `⚙️ [claude-code-plugin] feat(claude): register the Claude Code harness [step 14/17]` | 250-500 | Not started |
 | [ ] | 15/17 | `claude-code-plugin-client-polish` | `🌿 [claude-code-plugin] feat(client): add Claude Code branding [step 15/17]` | 400-800 | Not started |
@@ -358,7 +358,44 @@
   including generated Freezed/JSON output, within the 900-1,300 estimate and
   below the 1,500-line soft cap.
 
+- Step 12/17 (2026-08-11): added `ClaudePlugin` as the Layer-4 implementation
+  of `BridgeDerivedProjectsPluginApi` and `PersistedSessionCleanupApi` over the
+  Step 3-11 components. It owns the buffered event surface, fresh and refreshed
+  catalog discovery, created-session attribution, contract error translation,
+  transcript history and cleanup, prompt/command dispatch, interaction replies,
+  activity summaries, and idempotent disposal. Existing owners gained only the
+  state and operations needed at their boundaries: queue-safe process selection,
+  launch-only effort respawn, deletion fencing/status snapshots, pending-input
+  queries, and honest transcript-delete failures.
+
+  Focused contract tests cover pre-session catalog discovery and reuse,
+  buffered creation events, generated identity, fail-closed identity mismatch,
+  exact slash-command dispatch, launch-only effort respawn, not-found behavior,
+  active summaries, delete fencing, and idempotent persisted cleanup. A live
+  CLI 2.1.226 probe confirmed `/help` sent as ordinary stream-json user text
+  completes successfully. All 180 package tests, `dart analyze --fatal-infos`,
+  and `git diff --check` pass. The measured diff is 922 changed lines across 10
+  files, below the 1,200-1,500 estimate and the 1,500-line soft cap.
+
+  Architecture implementation review rejected the original identity mismatch
+  policy because the plan said the reported id should replace the pre-bound id.
+  The user chose fail-closed on 2026-08-11: live probes show `--session-id` is
+  honored, while adopting a new id after creation would require atomic migration
+  across every session owner. `PLAN.md` now records teardown plus a session
+  error as the safe response. That explicit decision supersedes the review and
+  was not re-reviewed.
+
 ## Findings And Plan Deltas
+
+- **2026-08-11 — Session identity mismatches fail closed:** architecture review
+  exposed that the plan's old "reported id wins" wording required broad atomic
+  rekeying after `createSession` had already returned. Because live verification
+  proves Claude honors the pre-bound `--session-id`, the user chose to stop and
+  surface an error if that invariant is ever violated rather than add migration
+  machinery for a state no supported flow produces.
+- **2026-08-11 — Slash text dispatch verified:** CLI 2.1.226 accepted `/help`
+  as an ordinary stream-json user text block and completed with a successful
+  result. `sendCommand` can use the normal serialized turn path.
 
 - **2026-08-04 — Most of `projects/` is not sessions:** the Step 2 capture came
   from one freshly created transcript, which made the tree look uniform. In a

--- a/bridge/sesori_plugin_claude/lib/claude_plugin.dart
+++ b/bridge/sesori_plugin_claude/lib/claude_plugin.dart
@@ -20,6 +20,7 @@ export "src/api/models/claude_transcript_record_dto.dart";
 export "src/claude_approval_registry.dart";
 export "src/claude_event_dispatcher.dart";
 export "src/claude_history_mapper.dart";
+export "src/claude_plugin_impl.dart";
 export "src/models/claude_agent_selection.dart";
 export "src/models/claude_effort_level.dart";
 export "src/models/claude_permission_mode.dart";

--- a/bridge/sesori_plugin_claude/lib/src/api/claude_stream_client.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/claude_stream_client.dart
@@ -155,7 +155,7 @@ class ClaudeStreamClient {
     try {
       _handshake = await sendControlRequest(subtype: "initialize");
     } on Object catch (error, stack) {
-      Log.e("[$_logTag] initialize handshake failed", error, stack);
+      if (!_disposed) Log.e("[$_logTag] initialize handshake failed", error, stack);
       await _teardownConnection(
         gracefulTimeout: const Duration(seconds: 5),
         pendingError: StateError("ClaudeStreamClient handshake failed"),

--- a/bridge/sesori_plugin_claude/lib/src/claude_approval_registry.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_approval_registry.dart
@@ -220,6 +220,12 @@ final class ClaudeApprovalRegistry {
   List<String> allowedToolsForSession({required String sessionId}) =>
       List.unmodifiable(_allowedTools[sessionId] ?? const <String>{});
 
+  bool hasPendingInput({required String sessionId}) => _pending.values.any((entry) => entry.sessionId == sessionId);
+
+  bool hasPermission({required String id}) => _pending[id] is _PendingPermission;
+
+  bool hasQuestion({required String id}) => _pending[id] is _PendingQuestion;
+
   bool replyPermission({required String id, required PluginPermissionReply reply}) {
     final entry = _pending[id];
     if (entry is! _PendingPermission) return false;

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -46,7 +46,7 @@ final class ClaudeEventDispatcher {
     );
   }
 
-  List<BridgeSseEvent> map({required ClaudeStreamMessage message}) {
+  List<BridgeSseEvent> map({required ClaudeStreamMessage message, DateTime? now}) {
     if (message.sessionId case final sessionId? when sessionId.isNotEmpty) {
       if (message
           case ClaudeAssistantMessage(parentToolUseId: final String _) ||
@@ -58,7 +58,7 @@ final class ClaudeEventDispatcher {
         ClaudeStreamEventMessage() => _mapStream(sessionId: sessionId, message: message),
         ClaudeAssistantMessage() => _mapAssistant(sessionId: sessionId, message: message),
         ClaudeUserMessage() => _mapUser(sessionId: sessionId, message: message),
-        ClaudeApiRetryMessage() => _mapRetry(sessionId: sessionId, message: message),
+        ClaudeApiRetryMessage() => _mapRetry(sessionId: sessionId, message: message, now: now ?? DateTime.now()),
         ClaudeResultMessage() => _mapResult(sessionId: sessionId, message: message),
         ClaudeInitMessage() ||
         ClaudeStatusMessage() ||
@@ -294,6 +294,7 @@ final class ClaudeEventDispatcher {
   List<BridgeSseEvent> _mapRetry({
     required String sessionId,
     required ClaudeApiRetryMessage message,
+    required DateTime now,
   }) {
     final attempt = message.attempt;
     final delay = message.retryDelayMs;
@@ -304,7 +305,7 @@ final class ClaudeEventDispatcher {
         status: shared.SessionStatus.retry(
           attempt: attempt,
           message: _retryMessage(message.error),
-          next: DateTime.now().millisecondsSinceEpoch + delay,
+          next: now.millisecondsSinceEpoch + delay,
         ).toJson(),
       ),
     ];

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -32,6 +32,20 @@ final class ClaudeEventDispatcher {
     _tools.forgetSession(sessionId: sessionId);
   }
 
+  PluginSessionStatus? retryStatus({
+    required ClaudeApiRetryMessage message,
+    required DateTime now,
+  }) {
+    final attempt = message.attempt;
+    final delay = message.retryDelayMs;
+    if (attempt == null || delay == null) return null;
+    return PluginSessionStatus.retry(
+      attempt: attempt,
+      message: _retryMessage(message.error),
+      next: now.millisecondsSinceEpoch + delay,
+    );
+  }
+
   List<BridgeSseEvent> map({required ClaudeStreamMessage message}) {
     if (message.sessionId case final sessionId? when sessionId.isNotEmpty) {
       if (message

--- a/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
@@ -59,7 +59,7 @@ final class ClaudeHistoryMapper {
           }
 
           final parts = _content.mapParts(
-            content: record.content,
+            content: _visibleUserContent(record.content),
             sessionId: sessionId,
             messageId: record.id,
           );
@@ -164,3 +164,30 @@ final class _AssistantHistoryMessage extends _ClaudeHistoryEntry {
 
 PluginMessageTime? _messageTime(DateTime? timestamp) =>
     timestamp == null ? null : PluginMessageTime(created: timestamp.millisecondsSinceEpoch, completed: null);
+
+Object? _visibleUserContent(Object? content) {
+  if (content is! List) return content;
+  final visible = <Object?>[];
+  for (final block in content) {
+    if (block is Map && block["type"] == "text" && block["text"] is String) {
+      final text = _stripBridgeContext(block["text"]! as String);
+      if (text != null && text.isNotEmpty) visible.add({...block.cast<String, Object?>(), "text": text});
+    } else {
+      visible.add(block);
+    }
+  }
+  return visible;
+}
+
+String? _stripBridgeContext(String text) {
+  const marker = "[SYSTEM CONTEXT \u2014 IMPORTANT]";
+  final markerIndex = text.indexOf(marker);
+  if (markerIndex < 0) return text;
+  final envelopeEnd = text.indexOf("\n---", markerIndex);
+  if (envelopeEnd < 0) return text;
+  final trailing = text.substring(envelopeEnd + "\n---".length).trim();
+  if (markerIndex == 0) return trailing.isEmpty ? null : trailing;
+  final prefix = text.substring(0, markerIndex).trimRight();
+  if (!prefix.startsWith("/")) return text;
+  return trailing.isEmpty ? prefix : "$prefix $trailing";
+}

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -505,8 +505,11 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
         return;
       }
       if (message is ClaudeApiRetryMessage) {
-        final status = _eventDispatcher.retryStatus(message: message, now: _clock.now());
+        final now = _clock.now();
+        final status = _eventDispatcher.retryStatus(message: message, now: now);
         if (status != null) _sessions.recordRetryStatus(sessionId: event.sessionId, status: status);
+        _eventDispatcher.map(message: message, now: now).forEach(_eventBuffer.add);
+        return;
       }
       _eventDispatcher.map(message: message).forEach(_eventBuffer.add);
     }

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -1,0 +1,485 @@
+import "dart:async";
+
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show normalizeProjectDirectory;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "api/models/claude_stream_message.dart";
+import "claude_approval_registry.dart";
+import "claude_event_dispatcher.dart";
+import "claude_history_mapper.dart";
+import "models/claude_agent_selection.dart";
+import "models/claude_effort_level.dart";
+import "models/claude_permission_mode.dart";
+import "repositories/claude_backend_catalog_repository.dart";
+import "repositories/claude_session_process_repository.dart";
+import "repositories/claude_transcript_catalog_repository.dart";
+import "services/claude_catalog_service.dart";
+import "services/claude_session_service.dart";
+
+typedef ClaudeSessionIdGenerator = String Function();
+
+/// Backend-neutral Claude Code plugin API over the stream-json components.
+final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements PersistedSessionCleanupApi {
+  ClaudePlugin({
+    required ClaudeSessionProcessRepository processes,
+    required ClaudeTranscriptCatalogRepository transcripts,
+    required ClaudeSessionService sessions,
+    required ClaudeCatalogService catalogService,
+    required ClaudeApprovalRegistry approvals,
+    required ClaudeEventDispatcher eventDispatcher,
+    required ClaudeHistoryMapper history,
+    required BufferedUntilFirstListener<BridgeSseEvent> eventBuffer,
+    required ServerClock clock,
+    required ClaudeSessionIdGenerator generateSessionId,
+    required String launchDirectory,
+  }) : _processes = processes,
+       _transcripts = transcripts,
+       _sessions = sessions,
+       _catalogService = catalogService,
+       _approvals = approvals,
+       _eventDispatcher = eventDispatcher,
+       _history = history,
+       _eventBuffer = eventBuffer,
+       _clock = clock,
+       _generateSessionId = generateSessionId,
+       _catalogSessionId = generateSessionId(),
+       _launchDirectory = normalizeProjectDirectory(directory: launchDirectory) {
+    _sessionEvents = _sessions.events.listen(_eventBuffer.add);
+    _processEvents = _processes.events.listen(_handleProcessEvent);
+  }
+
+  static const String pluginId = "claude";
+
+  final ClaudeSessionProcessRepository _processes;
+  final ClaudeTranscriptCatalogRepository _transcripts;
+  final ClaudeSessionService _sessions;
+  final ClaudeCatalogService _catalogService;
+  final ClaudeApprovalRegistry _approvals;
+  final ClaudeEventDispatcher _eventDispatcher;
+  final ClaudeHistoryMapper _history;
+  final BufferedUntilFirstListener<BridgeSseEvent> _eventBuffer;
+  final ServerClock _clock;
+  final ClaudeSessionIdGenerator _generateSessionId;
+  final String _catalogSessionId;
+  final String _launchDirectory;
+  final Map<String, PluginSession> _createdSessions = {};
+  late final StreamSubscription<BridgeSseEvent> _sessionEvents;
+  late final StreamSubscription<ClaudeSessionProcessEvent> _processEvents;
+  ClaudeBackendCatalog? _catalog;
+  Future<void>? _disposeFuture;
+  bool _disposed = false;
+
+  @override
+  String get id => pluginId;
+
+  @override
+  Stream<BridgeSseEvent> get events => _eventBuffer.stream;
+
+  @override
+  String get launchDirectory => _launchDirectory;
+
+  @override
+  Future<List<PluginSession>> getSessions(String projectId, {int? start, int? limit}) async {
+    final persisted = await _transcripts.getSessions(projectId: projectId, start: null, limit: null);
+    final target = normalizeProjectDirectory(directory: projectId);
+    final combined = _mergeSessions(persisted, [
+      for (final session in _createdSessions.values)
+        if (session.directory == target) session,
+    ]);
+    return _page(combined, start: start, limit: limit);
+  }
+
+  @override
+  Future<List<PluginSession>> listAllSessions({required Set<String> knownDirectories}) async => _mergeSessions(
+    await _transcripts.listAllSessions(knownDirectories: knownDirectories),
+    _createdSessions.values,
+  );
+
+  @override
+  Future<List<PluginCommand>> getCommands({required String? projectId}) async =>
+      (await _getCatalog(refresh: false)).commands;
+
+  @override
+  Future<PluginSessionOptionsDiscoveryResult> getSessionOptions({
+    required String projectId,
+    required PluginSessionOptionsDiscoveryMode discoveryMode,
+  }) async {
+    final catalog = await _getCatalog(refresh: discoveryMode == PluginSessionOptionsDiscoveryMode.refresh);
+    return PluginSessionOptionsDiscoveryResult.observed(
+      options: PluginSessionOptions(
+        agents: catalog.agents,
+        providers: catalog.providers,
+        commands: catalog.commands,
+        completeness: PluginSessionOptionsCompleteness.complete,
+      ),
+    );
+  }
+
+  @override
+  Future<PluginSession> createSession({
+    required String directory,
+    required String? parentSessionId,
+    required List<PluginPromptPart> parts,
+    required String? userVisibleText,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async {
+    _requireTurn(parts: parts, operation: "createSession");
+    _validateModel(model);
+    _effort(variant);
+    _permissionMode(agent);
+    final sessionId = _generateSessionId();
+    final normalized = normalizeProjectDirectory(directory: directory);
+    final now = _clock.now().millisecondsSinceEpoch;
+    final session = PluginSession(
+      id: sessionId,
+      projectID: normalized,
+      directory: normalized,
+      parentID: parentSessionId,
+      title: null,
+      time: PluginSessionTime(created: now, updated: now, archived: null),
+    );
+    _createdSessions[sessionId] = session;
+    _eventBuffer.add(BridgeSseSessionCreated(info: session.toJson()));
+    _enqueue(
+      sessionId: sessionId,
+      directory: normalized,
+      createNew: true,
+      parts: parts,
+      variant: variant,
+      agent: agent,
+      model: model,
+    );
+    return session;
+  }
+
+  @override
+  Future<PluginSession> renameSession({required String sessionId, required String title}) async {
+    final existing = _findSession(sessionId);
+    if (existing == null) throw const PluginOperationException.notFound("renameSession", message: "session not found");
+    final renamed = existing.copyWith(title: title);
+    if (_createdSessions.containsKey(sessionId)) _createdSessions[sessionId] = renamed;
+    _eventBuffer.add(BridgeSseSessionUpdated(info: renamed.toJson(), titleChanged: true));
+    return renamed;
+  }
+
+  @override
+  Future<void> deleteSession(String sessionId) async {
+    final existing = _findSession(sessionId);
+    final known =
+        existing != null ||
+        _processes.isResident(sessionId: sessionId) ||
+        _sessions.sessionStatuses.containsKey(sessionId);
+    if (!known) throw const PluginOperationException.notFound("deleteSession", message: "session not found");
+    await _sessions.deleteSession(sessionId: sessionId);
+    _transcripts.deleteSession(sessionId: sessionId);
+    _createdSessions.remove(sessionId);
+    _eventDispatcher.forgetSession(sessionId: sessionId);
+    if (existing != null) _eventBuffer.add(BridgeSseSessionDeleted(info: existing.toJson()));
+    _eventBuffer.add(const BridgeSseProjectUpdated());
+  }
+
+  @override
+  Future<void> archiveSession({required String sessionId}) async {}
+
+  @override
+  Future<void> deleteWorkspace({required String projectId, required String worktreePath}) async {}
+
+  @override
+  Future<List<PluginSession>> getChildSessions(String sessionId) async => const [];
+
+  @override
+  Future<Map<String, PluginSessionStatus>> getSessionStatuses() async => _sessions.sessionStatuses;
+
+  @override
+  Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId) async {
+    if (_transcripts.findTranscriptPath(sessionId: sessionId) == null) {
+      if (_createdSessions.containsKey(sessionId)) return const [];
+      throw const PluginOperationException.notFound("getSessionMessages", message: "session not found");
+    }
+    try {
+      return _history.map(
+        sessionId: sessionId,
+        records: await _transcripts.readTranscriptRecordsInIsolate(sessionId: sessionId),
+      );
+    } on Object catch (error) {
+      throw PluginOperationException(
+        "getSessionMessages",
+        message: "Claude history read failed",
+        cause: error,
+      );
+    }
+  }
+
+  @override
+  Future<void> sendPrompt({
+    required String sessionId,
+    required List<PluginPromptPart> parts,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async {
+    _requireTurn(parts: parts, operation: "sendPrompt");
+    final directory = _directoryForSession(sessionId);
+    if (directory == null) throw const PluginOperationException.notFound("sendPrompt", message: "session not found");
+    _enqueue(
+      sessionId: sessionId,
+      directory: directory,
+      createNew: false,
+      parts: parts,
+      variant: variant,
+      agent: agent,
+      model: model,
+    );
+  }
+
+  @override
+  Future<void> sendCommand({
+    required String sessionId,
+    required String command,
+    required String arguments,
+    required String? userVisibleArguments,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) => sendPrompt(
+    sessionId: sessionId,
+    parts: [PluginPromptPart.text(text: arguments.isEmpty ? "/$command" : "/$command $arguments")],
+    variant: variant,
+    agent: agent,
+    model: model,
+  );
+
+  @override
+  Future<void> abortSession({required String sessionId}) => _sessions.abort(sessionId: sessionId);
+
+  @override
+  Future<List<PluginAgent>> getAgents({required String projectId}) async => (await _getCatalog(refresh: false)).agents;
+
+  @override
+  Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async =>
+      _approvals.pendingQuestionsForSession(sessionId: sessionId);
+
+  @override
+  Future<List<PluginPendingPermission>> getPendingPermissions({required String sessionId}) async =>
+      _approvals.pendingPermissionsForSession(sessionId: sessionId);
+
+  @override
+  Future<List<PluginPendingQuestion>> getProjectQuestions({required String projectId}) async {
+    final sessions = await getSessions(projectId);
+    return [
+      for (final session in sessions) ..._approvals.pendingQuestionsForSession(sessionId: session.id),
+    ];
+  }
+
+  @override
+  Future<void> replyToQuestion({
+    required String questionId,
+    required String sessionId,
+    required List<List<String>> answers,
+  }) async {
+    if (!_approvals.hasQuestion(id: questionId)) {
+      throw const PluginOperationException.notFound("replyToQuestion", message: "question not found");
+    }
+    if (!_approvals.replyQuestion(id: questionId, answers: answers)) {
+      throw const PluginOperationException("replyToQuestion", message: "Claude rejected the question response");
+    }
+  }
+
+  @override
+  Future<void> rejectQuestion({required String questionId, required String? sessionId}) async {
+    if (!_approvals.hasQuestion(id: questionId)) {
+      throw const PluginOperationException.notFound("rejectQuestion", message: "question not found");
+    }
+    if (!_approvals.rejectQuestion(id: questionId)) {
+      throw const PluginOperationException("rejectQuestion", message: "Claude rejected the question response");
+    }
+  }
+
+  @override
+  Future<void> replyToPermission({
+    required String requestId,
+    required String sessionId,
+    required PluginPermissionReply reply,
+  }) async {
+    if (!_approvals.hasPermission(id: requestId)) {
+      throw const PluginOperationException.notFound("replyToPermission", message: "permission not found");
+    }
+    if (!_approvals.replyPermission(id: requestId, reply: reply)) {
+      throw const PluginOperationException("replyToPermission", message: "Claude rejected the permission response");
+    }
+  }
+
+  @override
+  Future<bool> healthCheck() async => !_disposed;
+
+  @override
+  Future<PluginProvidersResult> getProviders({required String projectId}) async =>
+      (await _getCatalog(refresh: false)).providers;
+
+  @override
+  List<PluginProjectActivitySummary> getActiveSessionsSummary() {
+    final byProject = <String, List<PluginActiveSession>>{};
+    for (final entry in _sessions.sessionStatuses.entries) {
+      final running = entry.value is PluginSessionStatusBusy || entry.value is PluginSessionStatusRetry;
+      final awaitingInput = _approvals.hasPendingInput(sessionId: entry.key);
+      if (!running && !awaitingInput) continue;
+      final directory = _directoryForSession(entry.key);
+      if (directory == null) continue;
+      (byProject[directory] ??= []).add(
+        PluginActiveSession(
+          id: entry.key,
+          mainAgentRunning: running,
+          awaitingInput: awaitingInput,
+          isRetrying: entry.value is PluginSessionStatusRetry,
+          childSessionIds: const [],
+        ),
+      );
+    }
+    return [
+      for (final entry in byProject.entries) PluginProjectActivitySummary(id: entry.key, activeSessions: entry.value),
+    ];
+  }
+
+  @override
+  Future<void> deletePersistedSession({required String backendSessionId}) async {
+    _transcripts.deleteSession(sessionId: backendSessionId);
+  }
+
+  @override
+  Future<void> dispose() => _disposeFuture ??= _dispose();
+
+  Future<void> _dispose() async {
+    _disposed = true;
+    await _sessionEvents.cancel();
+    await _processEvents.cancel();
+    await _sessions.dispose();
+    _createdSessions.clear();
+    _eventDispatcher.forgetSession(sessionId: _catalogSessionId);
+    await _eventBuffer.close();
+  }
+
+  Future<ClaudeBackendCatalog> _getCatalog({required bool refresh}) async {
+    final cached = _catalog;
+    if (!refresh && cached != null) return cached;
+    await _processes.ensureResident(
+      sessionId: _catalogSessionId,
+      directory: _launchDirectory,
+      createNew: true,
+      model: null,
+      effort: null,
+      permissionMode: null,
+      allowedTools: const [],
+    );
+    return _catalog = await _catalogService.getCatalog(
+      sessionId: _catalogSessionId,
+      refresh: refresh,
+    );
+  }
+
+  void _enqueue({
+    required String sessionId,
+    required String directory,
+    required bool createNew,
+    required List<PluginPromptPart> parts,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) {
+    _validateModel(model);
+    final effort = _effort(variant);
+    final permissionMode = _permissionMode(agent);
+    _eventDispatcher.beginTurn(sessionId: sessionId);
+    _sessions.enqueueTurn(
+      sessionId: sessionId,
+      directory: directory,
+      createNew: createNew,
+      parts: parts,
+      model: model?.modelID,
+      effort: effort,
+      permissionMode: permissionMode,
+    );
+  }
+
+  void _validateModel(({String providerID, String modelID})? model) {
+    if (model == null) return;
+    if (model.providerID != ClaudeBackendCatalogRepository.providerId || model.modelID.trim().isEmpty) {
+      throw const PluginOperationException("sendPrompt", statusCode: 400, message: "unsupported model");
+    }
+  }
+
+  ClaudeEffortLevel? _effort(PluginSessionVariant? variant) {
+    if (variant == null) return null;
+    final effort = ClaudeEffortLevel.tryParse(variant.id);
+    if (effort == null) {
+      throw const PluginOperationException("sendPrompt", statusCode: 400, message: "unsupported Claude effort");
+    }
+    return effort;
+  }
+
+  ClaudePermissionMode? _permissionMode(String? agent) {
+    if (agent == null) return null;
+    final selection = ClaudeAgentSelection.tryParse(agent);
+    if (selection == null) {
+      throw const PluginOperationException("sendPrompt", statusCode: 400, message: "unsupported Claude agent");
+    }
+    return selection.permissionMode;
+  }
+
+  PluginSession? _findSession(String sessionId) {
+    final created = _createdSessions[sessionId];
+    if (created != null) return created;
+    final record = _transcripts.findSessionById(sessionId: sessionId);
+    if (record == null) return null;
+    final directory = normalizeProjectDirectory(directory: record.cwd);
+    final createdAt = (record.createdAt ?? record.updatedAt)?.millisecondsSinceEpoch;
+    final updatedAt = (record.updatedAt ?? record.createdAt)?.millisecondsSinceEpoch;
+    return PluginSession(
+      id: record.id,
+      projectID: directory,
+      directory: directory,
+      parentID: null,
+      title: record.title,
+      time: createdAt == null || updatedAt == null
+          ? null
+          : PluginSessionTime(created: createdAt, updated: updatedAt, archived: null),
+    );
+  }
+
+  String? _directoryForSession(String sessionId) => _findSession(sessionId)?.directory;
+
+  void _handleProcessEvent(ClaudeSessionProcessEvent event) {
+    if (event case ClaudeSessionProcessMessage(:final message)) {
+      if (message is ClaudeInitMessage && message.sessionId != event.sessionId) {
+        Log.e("[claude] backend reported a different session id; stopping the session");
+        unawaited(_sessions.deleteSession(sessionId: event.sessionId));
+        _eventBuffer.add(BridgeSseSessionError(sessionID: event.sessionId));
+        return;
+      }
+      _eventDispatcher.map(message: message).forEach(_eventBuffer.add);
+    }
+  }
+}
+
+void _requireTurn({required List<PluginPromptPart> parts, required String operation}) {
+  if (parts.isEmpty) {
+    throw PluginOperationException(operation, statusCode: 400, message: "prompt must not be empty");
+  }
+}
+
+List<PluginSession> _mergeSessions(Iterable<PluginSession> persisted, Iterable<PluginSession> created) {
+  final byId = {for (final session in persisted) session.id: session};
+  for (final session in created) {
+    byId.putIfAbsent(session.id, () => session);
+  }
+  return byId.values.toList(growable: false);
+}
+
+List<PluginSession> _page(List<PluginSession> sessions, {required int? start, required int? limit}) {
+  final from = (start ?? 0).clamp(0, sessions.length);
+  if (from >= sessions.length) return const [];
+  final count = limit?.clamp(0, sessions.length);
+  final until = count == null ? sessions.length : (from + count).clamp(from, sessions.length);
+  return sessions.sublist(from, until);
+}

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:rxdart/rxdart.dart";
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show normalizeProjectDirectory;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
@@ -44,8 +45,8 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
        _generateSessionId = generateSessionId,
        _catalogSessionId = generateSessionId(),
        _launchDirectory = normalizeProjectDirectory(directory: launchDirectory) {
-    _sessionEvents = _sessions.events.listen(_eventBuffer.add);
-    _processEvents = _processes.events.listen(_handleProcessEvent);
+    _sessions.events.listen(_eventBuffer.add).addTo(_subscriptions);
+    _processes.events.listen(_handleProcessEvent).addTo(_subscriptions);
   }
 
   static const String pluginId = "claude";
@@ -63,11 +64,12 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
   final String _catalogSessionId;
   final String _launchDirectory;
   final Map<String, PluginSession> _createdSessions = {};
-  late final StreamSubscription<BridgeSseEvent> _sessionEvents;
-  late final StreamSubscription<ClaudeSessionProcessEvent> _processEvents;
+  final Set<String> _unstartedSessions = {};
+  final CompositeSubscription _subscriptions = CompositeSubscription();
   ClaudeBackendCatalog? _catalog;
   Future<void>? _disposeFuture;
   bool _disposed = false;
+  int _messageSequence = 0;
 
   @override
   String get id => pluginId;
@@ -125,10 +127,9 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
     required String? agent,
     required ({String providerID, String modelID})? model,
   }) async {
-    _requireTurn(parts: parts, operation: "createSession");
-    _validateModel(model);
-    _effort(variant);
-    _permissionMode(agent);
+    _validateModel(model, operation: "createSession");
+    _effort(variant, operation: "createSession");
+    _permissionMode(agent, operation: "createSession");
     final sessionId = _generateSessionId();
     final normalized = normalizeProjectDirectory(directory: directory);
     final now = _clock.now().millisecondsSinceEpoch;
@@ -141,16 +142,32 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
       time: PluginSessionTime(created: now, updated: now, archived: null),
     );
     _createdSessions[sessionId] = session;
+    _unstartedSessions.add(sessionId);
     _eventBuffer.add(BridgeSseSessionCreated(info: session.toJson()));
-    _enqueue(
-      sessionId: sessionId,
-      directory: normalized,
-      createNew: true,
-      parts: parts,
-      variant: variant,
-      agent: agent,
-      model: model,
-    );
+    if (parts.isNotEmpty) {
+      try {
+        await _enqueue(
+          sessionId: sessionId,
+          directory: normalized,
+          createNew: true,
+          parts: parts,
+          variant: variant,
+          agent: agent,
+          model: model,
+          operation: "createSession",
+        );
+        _unstartedSessions.remove(sessionId);
+      } on Object {
+        await _sessions.deleteSession(sessionId: sessionId);
+        _createdSessions.remove(sessionId);
+        _unstartedSessions.remove(sessionId);
+        _eventDispatcher.forgetSession(sessionId: sessionId);
+        _eventBuffer.add(BridgeSseSessionDeleted(info: session.toJson()));
+        _eventBuffer.add(const BridgeSseProjectUpdated());
+        rethrow;
+      }
+    }
+    _emitVisibleUserMessage(sessionId: sessionId, text: userVisibleText);
     return session;
   }
 
@@ -173,11 +190,19 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
         _sessions.sessionStatuses.containsKey(sessionId);
     if (!known) throw const PluginOperationException.notFound("deleteSession", message: "session not found");
     await _sessions.deleteSession(sessionId: sessionId);
-    _transcripts.deleteSession(sessionId: sessionId);
-    _createdSessions.remove(sessionId);
-    _eventDispatcher.forgetSession(sessionId: sessionId);
-    if (existing != null) _eventBuffer.add(BridgeSseSessionDeleted(info: existing.toJson()));
-    _eventBuffer.add(const BridgeSseProjectUpdated());
+    try {
+      try {
+        _transcripts.deleteSession(sessionId: sessionId);
+      } on Object catch (error) {
+        throw PluginOperationException("deleteSession", message: "Claude transcript deletion failed", cause: error);
+      }
+    } finally {
+      _createdSessions.remove(sessionId);
+      _unstartedSessions.remove(sessionId);
+      _eventDispatcher.forgetSession(sessionId: sessionId);
+      if (existing != null) _eventBuffer.add(BridgeSseSessionDeleted(info: existing.toJson()));
+      _eventBuffer.add(const BridgeSseProjectUpdated());
+    }
   }
 
   @override
@@ -223,15 +248,17 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
     _requireTurn(parts: parts, operation: "sendPrompt");
     final directory = _directoryForSession(sessionId);
     if (directory == null) throw const PluginOperationException.notFound("sendPrompt", message: "session not found");
-    _enqueue(
+    await _enqueue(
       sessionId: sessionId,
       directory: directory,
-      createNew: false,
+      createNew: _unstartedSessions.contains(sessionId),
       parts: parts,
       variant: variant,
       agent: agent,
       model: model,
+      operation: "sendPrompt",
     );
+    _unstartedSessions.remove(sessionId);
   }
 
   @override
@@ -243,13 +270,26 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
     required PluginSessionVariant? variant,
     required String? agent,
     required ({String providerID, String modelID})? model,
-  }) => sendPrompt(
-    sessionId: sessionId,
-    parts: [PluginPromptPart.text(text: arguments.isEmpty ? "/$command" : "/$command $arguments")],
-    variant: variant,
-    agent: agent,
-    model: model,
-  );
+  }) async {
+    final directory = _directoryForSession(sessionId);
+    if (directory == null) throw const PluginOperationException.notFound("sendCommand", message: "session not found");
+    await _enqueue(
+      sessionId: sessionId,
+      directory: directory,
+      createNew: _unstartedSessions.contains(sessionId),
+      parts: [PluginPromptPart.text(text: arguments.isEmpty ? "/$command" : "/$command $arguments")],
+      variant: variant,
+      agent: agent,
+      model: model,
+      operation: "sendCommand",
+    );
+    _unstartedSessions.remove(sessionId);
+    final visible = userVisibleArguments?.trim();
+    _emitVisibleUserMessage(
+      sessionId: sessionId,
+      text: visible == null || visible.isEmpty ? "/$command" : "/$command $visible",
+    );
+  }
 
   @override
   Future<void> abortSession({required String sessionId}) => _sessions.abort(sessionId: sessionId);
@@ -352,10 +392,10 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
 
   Future<void> _dispose() async {
     _disposed = true;
-    await _sessionEvents.cancel();
-    await _processEvents.cancel();
+    await _subscriptions.cancel();
     await _sessions.dispose();
     _createdSessions.clear();
+    _unstartedSessions.clear();
     _eventDispatcher.forgetSession(sessionId: _catalogSessionId);
     await _eventBuffer.close();
   }
@@ -378,7 +418,7 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
     );
   }
 
-  void _enqueue({
+  Future<void> _enqueue({
     required String sessionId,
     required String directory,
     required bool createNew,
@@ -386,43 +426,50 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
     required PluginSessionVariant? variant,
     required String? agent,
     required ({String providerID, String modelID})? model,
-  }) {
-    _validateModel(model);
-    final effort = _effort(variant);
-    final permissionMode = _permissionMode(agent);
+    required String operation,
+  }) async {
+    _validateModel(model, operation: operation);
+    final effort = _effort(variant, operation: operation);
+    final permissionMode = _permissionMode(agent, operation: operation);
     _eventDispatcher.beginTurn(sessionId: sessionId);
-    _sessions.enqueueTurn(
-      sessionId: sessionId,
-      directory: directory,
-      createNew: createNew,
-      parts: parts,
-      model: model?.modelID,
-      effort: effort,
-      permissionMode: permissionMode,
-    );
-  }
-
-  void _validateModel(({String providerID, String modelID})? model) {
-    if (model == null) return;
-    if (model.providerID != ClaudeBackendCatalogRepository.providerId || model.modelID.trim().isEmpty) {
-      throw const PluginOperationException("sendPrompt", statusCode: 400, message: "unsupported model");
+    try {
+      await _sessions.enqueueTurn(
+        sessionId: sessionId,
+        directory: directory,
+        createNew: createNew,
+        parts: parts,
+        model: model?.modelID,
+        effort: effort,
+        permissionMode: permissionMode,
+      );
+    } on PluginOperationException {
+      rethrow;
+    } on Object catch (error) {
+      throw PluginOperationException(operation, message: "Claude did not accept the turn", cause: error);
     }
   }
 
-  ClaudeEffortLevel? _effort(PluginSessionVariant? variant) {
+  void _validateModel(({String providerID, String modelID})? model, {required String operation}) {
+    if (model == null) return;
+    if (model.providerID != ClaudeBackendCatalogRepository.providerId || model.modelID.trim().isEmpty) {
+      throw PluginOperationException(operation, statusCode: 400, message: "unsupported model");
+    }
+  }
+
+  ClaudeEffortLevel? _effort(PluginSessionVariant? variant, {required String operation}) {
     if (variant == null) return null;
     final effort = ClaudeEffortLevel.tryParse(variant.id);
     if (effort == null) {
-      throw const PluginOperationException("sendPrompt", statusCode: 400, message: "unsupported Claude effort");
+      throw PluginOperationException(operation, statusCode: 400, message: "unsupported Claude effort");
     }
     return effort;
   }
 
-  ClaudePermissionMode? _permissionMode(String? agent) {
+  ClaudePermissionMode? _permissionMode(String? agent, {required String operation}) {
     if (agent == null) return null;
     final selection = ClaudeAgentSelection.tryParse(agent);
     if (selection == null) {
-      throw const PluginOperationException("sendPrompt", statusCode: 400, message: "unsupported Claude agent");
+      throw PluginOperationException(operation, statusCode: 400, message: "unsupported Claude agent");
     }
     return selection.permissionMode;
   }
@@ -457,8 +504,49 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
         _eventBuffer.add(BridgeSseSessionError(sessionID: event.sessionId));
         return;
       }
+      if (message is ClaudeApiRetryMessage) {
+        final status = _eventDispatcher.retryStatus(message: message, now: _clock.now());
+        if (status != null) _sessions.recordRetryStatus(sessionId: event.sessionId, status: status);
+      }
       _eventDispatcher.map(message: message).forEach(_eventBuffer.add);
     }
+  }
+
+  void _emitVisibleUserMessage({required String sessionId, required String? text}) {
+    final visible = text?.trim();
+    if (visible == null || visible.isEmpty) return;
+    final messageId = "sesori-user-${++_messageSequence}";
+    final now = _clock.now().millisecondsSinceEpoch;
+    _eventBuffer.add(
+      BridgeSseMessageUpdated(
+        info: PluginMessage.user(
+          id: messageId,
+          sessionID: sessionId,
+          agent: null,
+          time: PluginMessageTime(created: now, completed: now),
+        ).toJson(),
+      ),
+    );
+    _eventBuffer.add(
+      BridgeSseMessagePartUpdated(
+        part: PluginMessagePart(
+          id: "$messageId-text",
+          sessionID: sessionId,
+          messageID: messageId,
+          type: PluginMessagePartType.text,
+          text: visible,
+          tool: null,
+          state: null,
+          prompt: null,
+          description: null,
+          agent: null,
+          agentName: null,
+          attempt: null,
+          retryError: null,
+          attachment: null,
+        ),
+      ),
+    );
   }
 }
 

--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
@@ -293,21 +293,9 @@ final class ClaudeSessionProcessRepository {
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;
-    for (final sessionId in {..._resident.keys, ..._connecting.keys}) {
-      _sessionGenerations[sessionId] = (_sessionGenerations[sessionId] ?? 0) + 1;
-    }
-    final connections = _connecting.values.toList(growable: false);
-    final sessionIds = _resident.keys.toList(growable: false);
+    final sessionIds = {..._resident.keys, ..._connecting.keys}.toList(growable: false);
     for (final sessionId in sessionIds) {
       await teardown(sessionId: sessionId);
-    }
-    for (final connection in connections) {
-      try {
-        await connection;
-      } on Object {
-        // A connection invalidated by disposal reports its own typed failure to
-        // the turn awaiting it. Disposal only waits for its child to be reaped.
-      }
     }
     await _events.close();
   }

--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
@@ -140,7 +140,20 @@ final class ClaudeSessionProcessRepository {
     required List<String> allowedTools,
   }) async {
     if (_disposed) throw StateError("Claude process repository is disposed");
-    if (_resident.containsKey(sessionId)) return;
+    final resident = _resident[sessionId];
+    if (resident != null) {
+      if (resident.appliedEffort != effort) {
+        await teardown(sessionId: sessionId);
+      } else {
+        await _applySelection(
+          sessionId: sessionId,
+          process: resident,
+          model: model,
+          permissionMode: permissionMode,
+        );
+        return;
+      }
+    }
     final existing = _connecting[sessionId];
     if (existing != null) {
       await existing;
@@ -163,6 +176,28 @@ final class ClaudeSessionProcessRepository {
       await connection;
     } finally {
       if (identical(_connecting[sessionId], connection)) unawaited(_connecting.remove(sessionId));
+    }
+  }
+
+  Future<void> _applySelection({
+    required String sessionId,
+    required _ResidentProcess process,
+    required String? model,
+    required ClaudePermissionMode? permissionMode,
+  }) async {
+    if (process.appliedModel != model) {
+      await process.client.sendControlRequest(
+        subtype: "set_model",
+        params: {"model": model == "default" ? null : model},
+      );
+      process.appliedModel = model;
+    }
+    if (process.appliedPermissionMode != permissionMode) {
+      await process.client.sendControlRequest(
+        subtype: "set_permission_mode",
+        params: {"mode": permissionMode?.controlValue ?? ClaudePermissionMode.auto.controlValue},
+      );
+      process.appliedPermissionMode = permissionMode;
     }
   }
 

--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
@@ -25,6 +25,13 @@ final class ClaudeTurnInterrupted extends ClaudeTurnOutcome {
   const ClaudeTurnInterrupted();
 }
 
+final class ClaudeTurnDispatch {
+  const ClaudeTurnDispatch({required this.accepted, required this.outcome});
+
+  final bool accepted;
+  final Future<ClaudeTurnOutcome> outcome;
+}
+
 sealed class ClaudeSessionProcessEvent {
   const ClaudeSessionProcessEvent({required this.sessionId});
 
@@ -146,7 +153,6 @@ final class ClaudeSessionProcessRepository {
         await teardown(sessionId: sessionId);
       } else {
         await _applySelection(
-          sessionId: sessionId,
           process: resident,
           model: model,
           permissionMode: permissionMode,
@@ -180,7 +186,6 @@ final class ClaudeSessionProcessRepository {
   }
 
   Future<void> _applySelection({
-    required String sessionId,
     required _ResidentProcess process,
     required String? model,
     required ClaudePermissionMode? permissionMode,
@@ -201,16 +206,19 @@ final class ClaudeSessionProcessRepository {
     }
   }
 
-  Future<ClaudeTurnOutcome> sendTurn({
+  ClaudeTurnDispatch sendTurn({
     required String sessionId,
     required List<PluginPromptPart> parts,
-  }) async {
+  }) {
     final process = _resident[sessionId];
     if (process == null) throw StateError("Claude session is not resident: $sessionId");
     final content = _promptContent(parts);
     if (content.isEmpty) {
       Log.w("[claude] turn contains no supported prompt parts");
-      return const ClaudeTurnFailed();
+      return ClaudeTurnDispatch(
+        accepted: false,
+        outcome: Future.value(const ClaudeTurnFailed()),
+      );
     }
 
     process.interrupted = false;
@@ -221,12 +229,16 @@ final class ClaudeSessionProcessRepository {
     final exit = process.client.processExit.then<ClaudeResultMessage?>((_) => null);
     process.client.sendUserMessage(content: content);
     _startedSessions.add(sessionId);
-    final message = await Future.any<ClaudeResultMessage?>([result, exit]);
-    if (process.interrupted) return const ClaudeTurnInterrupted();
-    if (message == null || message.isError || message.permissionDenials.isNotEmpty) {
-      return const ClaudeTurnFailed();
-    }
-    return const ClaudeTurnCompleted();
+    return ClaudeTurnDispatch(
+      accepted: true,
+      outcome: Future.any<ClaudeResultMessage?>([result, exit]).then((message) {
+        if (process.interrupted) return const ClaudeTurnInterrupted();
+        if (message == null || message.isError || message.permissionDenials.isNotEmpty) {
+          return const ClaudeTurnFailed();
+        }
+        return const ClaudeTurnCompleted();
+      }),
+    );
   }
 
   Future<Map<String, Object?>> sendControlRequest({
@@ -254,14 +266,24 @@ final class ClaudeSessionProcessRepository {
 
   Future<void> teardown({required String sessionId}) async {
     _sessionGenerations[sessionId] = (_sessionGenerations[sessionId] ?? 0) + 1;
+    final connection = _connecting[sessionId];
     final process = _resident.remove(sessionId);
-    if (process == null) return;
-    try {
-      await process.cancelMessages();
-    } on Object catch (error, stack) {
-      Log.w("[claude] failed to cancel process message subscription", error, stack);
-    } finally {
-      await process.client.dispose();
+    if (process != null) {
+      try {
+        await process.cancelMessages();
+      } on Object catch (error, stack) {
+        Log.w("[claude] failed to cancel process message subscription", error, stack);
+      } finally {
+        await process.client.dispose();
+      }
+    }
+    if (connection != null) {
+      try {
+        await connection;
+      } on Object {
+        // This teardown invalidated the connection generation. The connecting
+        // caller receives the cancellation; teardown only waits for child reap.
+      }
     }
   }
 

--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
@@ -102,6 +102,7 @@ final class ClaudeSessionProcessRepository {
   final Map<String, String> _environment;
   final Map<String, _ResidentProcess> _resident = {};
   final Map<String, Future<void>> _connecting = {};
+  final Map<String, ClaudeStreamClient> _connectingClients = {};
   final Map<String, int> _sessionGenerations = {};
   final Set<String> _startedSessions = {};
   final StreamController<ClaudeSessionProcessEvent> _events = StreamController.broadcast();
@@ -267,6 +268,7 @@ final class ClaudeSessionProcessRepository {
   Future<void> teardown({required String sessionId}) async {
     _sessionGenerations[sessionId] = (_sessionGenerations[sessionId] ?? 0) + 1;
     final connection = _connecting[sessionId];
+    final connectingClient = _connectingClients[sessionId];
     final process = _resident.remove(sessionId);
     if (process != null) {
       try {
@@ -277,6 +279,7 @@ final class ClaudeSessionProcessRepository {
         await process.client.dispose();
       }
     }
+    if (connectingClient != null) await connectingClient.dispose();
     if (connection != null) {
       try {
         await connection;
@@ -339,7 +342,14 @@ final class ClaudeSessionProcessRepository {
       ),
       processFactory: _processFactory,
     );
-    await client.connect();
+    _connectingClients[sessionId] = client;
+    try {
+      await client.connect();
+    } finally {
+      if (identical(_connectingClients[sessionId], client)) {
+        _connectingClients.remove(sessionId);
+      }
+    }
     if (_disposed || (_sessionGenerations[sessionId] ?? 0) != generation) {
       await client.dispose();
       throw StateError("Claude session residency was cancelled");

--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_transcript_catalog_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_transcript_catalog_repository.dart
@@ -102,18 +102,12 @@ class ClaudeTranscriptCatalogRepository {
     return path == null ? null : _readSessionRecord(path);
   }
 
-  /// Deletes a session's transcript. Returns false when it was not found or the
-  /// delete failed; the caller decides whether that is an error.
+  /// Deletes a session's transcript. Returns false only when it was not found.
   bool deleteSession({required String sessionId}) {
     final path = findTranscriptPath(sessionId: sessionId);
     if (path == null) return false;
-    try {
-      _transcriptApi.deleteTranscript(transcriptPath: path);
-      return true;
-    } on Object catch (error, stackTrace) {
-      Log.w("[claude] failed to delete transcript for session $sessionId", error, stackTrace);
-      return false;
-    }
+    _transcriptApi.deleteTranscript(transcriptPath: path);
+    return true;
   }
 
   List<String> _listTranscriptPaths() => _transcriptApi.listTranscriptPaths();

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
@@ -45,6 +45,11 @@ final class ClaudeSessionService {
   Stream<PluginWorkState> get workState => _workState.stream;
   PluginWorkState get currentWorkState => _workState.current;
 
+  Map<String, PluginSessionStatus> get sessionStatuses => Map.unmodifiable({
+    for (final entry in _turns.entries)
+      entry.key: entry.value.pending > 0 ? const PluginSessionStatus.busy() : const PluginSessionStatus.idle(),
+  });
+
   void enqueueTurn({
     required String sessionId,
     required String directory,
@@ -134,6 +139,18 @@ final class ClaudeSessionService {
     } on Object catch (error, stack) {
       Log.w("[claude] interrupt failed for $sessionId", error, stack);
     }
+  }
+
+  Future<void> deleteSession({required String sessionId}) async {
+    final state = _turns.remove(sessionId);
+    if (state != null) {
+      state.generation++;
+      state.idleGeneration++;
+    }
+    _approvals.forgetSession(sessionId: sessionId);
+    await _processes.teardown(sessionId: sessionId);
+    _processes.forgetSession(sessionId: sessionId);
+    _syncWorkState();
   }
 
   Future<void> dispose() => _disposeFuture ??= _dispose();

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
@@ -68,7 +68,6 @@ final class ClaudeSessionService {
     }
     final acceptance = Completer<void>();
     final state = _turns.putIfAbsent(sessionId, _SessionTurnState.new);
-    final queuedBehindActiveTurn = state.pending > 0;
     _retryStatuses.remove(sessionId);
     state.pending++;
     state.idleGeneration++;
@@ -92,7 +91,6 @@ final class ClaudeSessionService {
         acceptance: acceptance,
       ),
     );
-    if (queuedBehindActiveTurn) acceptance.complete();
     return acceptance.future;
   }
 

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
@@ -34,9 +34,11 @@ final class ClaudeSessionService {
   final ServerClock _clock;
   final Duration _idleTimeout;
   final Map<String, _SessionTurnState> _turns = {};
+  final Map<String, PluginSessionStatus> _retryStatuses = {};
   final StreamController<BridgeSseEvent> _events = StreamController.broadcast();
   final PluginWorkStateController _workState = PluginWorkStateController(initial: PluginWorkState.idle);
   final Set<Future<void>> _inFlightTeardowns = {};
+  final Map<String, Future<void>> _teardownsBySession = {};
   late final StreamSubscription<ClaudeSessionProcessEvent> _processEvents;
   Future<void>? _disposeFuture;
   bool _disposed = false;
@@ -47,10 +49,12 @@ final class ClaudeSessionService {
 
   Map<String, PluginSessionStatus> get sessionStatuses => Map.unmodifiable({
     for (final entry in _turns.entries)
-      entry.key: entry.value.pending > 0 ? const PluginSessionStatus.busy() : const PluginSessionStatus.idle(),
+      entry.key:
+          _retryStatuses[entry.key] ??
+          (entry.value.pending > 0 ? const PluginSessionStatus.busy() : const PluginSessionStatus.idle()),
   });
 
-  void enqueueTurn({
+  Future<void> enqueueTurn({
     required String sessionId,
     required String directory,
     required bool createNew,
@@ -59,8 +63,12 @@ final class ClaudeSessionService {
     required ClaudeEffortLevel? effort,
     required ClaudePermissionMode? permissionMode,
   }) {
-    if (_disposed || parts.isEmpty) return;
+    if (_disposed || parts.isEmpty) {
+      return Future.error(StateError("Claude session cannot accept the turn"));
+    }
+    final acceptance = Completer<void>();
     final state = _turns.putIfAbsent(sessionId, _SessionTurnState.new);
+    _retryStatuses.remove(sessionId);
     state.pending++;
     state.idleGeneration++;
     if (state.pending == 1) {
@@ -80,8 +88,10 @@ final class ClaudeSessionService {
         permissionMode: permissionMode,
         state: state,
         generation: generation,
+        acceptance: acceptance,
       ),
     );
+    return acceptance.future;
   }
 
   Future<void> _runTurn({
@@ -94,8 +104,12 @@ final class ClaudeSessionService {
     required ClaudePermissionMode? permissionMode,
     required _SessionTurnState state,
     required int generation,
+    required Completer<void> acceptance,
   }) async {
-    if (!_isCurrent(sessionId: sessionId, state: state, generation: generation)) return _finish(sessionId, state, null);
+    if (!_isCurrent(sessionId: sessionId, state: state, generation: generation)) {
+      if (!acceptance.isCompleted) acceptance.completeError(StateError("Claude turn was cancelled before acceptance"));
+      return _finish(sessionId, state, null);
+    }
     try {
       await _processes.ensureResident(
         sessionId: sessionId,
@@ -107,14 +121,23 @@ final class ClaudeSessionService {
         allowedTools: _approvals.allowedToolsForSession(sessionId: sessionId),
       );
       if (!_isCurrent(sessionId: sessionId, state: state, generation: generation)) {
+        if (!acceptance.isCompleted) {
+          acceptance.completeError(StateError("Claude turn was cancelled before acceptance"));
+        }
         return _finish(sessionId, state, null);
       }
-      final outcome = await _processes.sendTurn(sessionId: sessionId, parts: parts);
+      final dispatch = _processes.sendTurn(sessionId: sessionId, parts: parts);
+      if (!dispatch.accepted) {
+        throw StateError("Claude rejected the turn before dispatch");
+      }
+      acceptance.complete();
+      final outcome = await dispatch.outcome;
       if (!_isCurrent(sessionId: sessionId, state: state, generation: generation)) {
         return _finish(sessionId, state, null);
       }
       _finish(sessionId, state, outcome);
     } on Object catch (error, stack) {
+      if (!acceptance.isCompleted) acceptance.completeError(error, stack);
       if (_isCurrent(sessionId: sessionId, state: state, generation: generation)) {
         Log.w("[claude] queued turn failed for $sessionId", error, stack);
         _finish(sessionId, state, const ClaudeTurnFailed());
@@ -147,7 +170,10 @@ final class ClaudeSessionService {
       state.generation++;
       state.idleGeneration++;
     }
+    _retryStatuses.remove(sessionId);
     _approvals.forgetSession(sessionId: sessionId);
+    final existingTeardown = _teardownsBySession[sessionId];
+    if (existingTeardown != null) await existingTeardown;
     await _processes.teardown(sessionId: sessionId);
     _processes.forgetSession(sessionId: sessionId);
     _syncWorkState();
@@ -173,6 +199,7 @@ final class ClaudeSessionService {
       !_disposed && identical(_turns[sessionId], state) && state.generation == generation;
 
   void _finish(String sessionId, _SessionTurnState state, ClaudeTurnOutcome? outcome) {
+    _retryStatuses.remove(sessionId);
     if (state.pending > 0) state.pending--;
     if (!identical(_turns[sessionId], state)) return;
     if (outcome is ClaudeTurnFailed) _emit(BridgeSseSessionError(sessionID: sessionId));
@@ -196,10 +223,14 @@ final class ClaudeSessionService {
       }
       final teardown = _processes.teardown(sessionId: sessionId);
       _inFlightTeardowns.add(teardown);
+      _teardownsBySession[sessionId] = teardown;
       try {
         await teardown;
       } finally {
         _inFlightTeardowns.remove(teardown);
+        if (identical(_teardownsBySession[sessionId], teardown)) {
+          unawaited(_teardownsBySession.remove(sessionId));
+        }
         if (identical(_turns[sessionId], state) && state.pending == 0 && state.idleGeneration == generation) {
           _turns.remove(sessionId);
         }
@@ -212,6 +243,10 @@ final class ClaudeSessionService {
 
   void _emit(BridgeSseEvent event) {
     if (!_events.isClosed) _events.add(event);
+  }
+
+  void recordRetryStatus({required String sessionId, required PluginSessionStatus status}) {
+    if (_turns.containsKey(sessionId)) _retryStatuses[sessionId] = status;
   }
 
   void _handleProcessEvent(ClaudeSessionProcessEvent event) {

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
@@ -68,6 +68,7 @@ final class ClaudeSessionService {
     }
     final acceptance = Completer<void>();
     final state = _turns.putIfAbsent(sessionId, _SessionTurnState.new);
+    final queuedBehindActiveTurn = state.pending > 0;
     _retryStatuses.remove(sessionId);
     state.pending++;
     state.idleGeneration++;
@@ -91,6 +92,7 @@ final class ClaudeSessionService {
         acceptance: acceptance,
       ),
     );
+    if (queuedBehindActiveTurn) acceptance.complete();
     return acceptance.future;
   }
 
@@ -130,7 +132,7 @@ final class ClaudeSessionService {
       if (!dispatch.accepted) {
         throw StateError("Claude rejected the turn before dispatch");
       }
-      acceptance.complete();
+      if (!acceptance.isCompleted) acceptance.complete();
       final outcome = await dispatch.outcome;
       if (!_isCurrent(sessionId: sessionId, state: state, generation: generation)) {
         return _finish(sessionId, state, null);

--- a/bridge/sesori_plugin_claude/pubspec.yaml
+++ b/bridge/sesori_plugin_claude/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   sesori_shared:
     path: ../../shared/sesori_shared
   path: ^1.9.1
+  rxdart: ^0.28.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.12.0
 

--- a/bridge/sesori_plugin_claude/test/claude_history_mapper_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_history_mapper_test.dart
@@ -128,6 +128,49 @@ void main() {
       );
     });
 
+    test("removes bridge worktree context from visible prompt and command history", () async {
+      const context = """
+[SYSTEM CONTEXT \u2014 IMPORTANT]
+A dedicated git worktree and branch have been created for this session:
+- Branch: private-branch
+- Worktree path: /private/worktree
+- Based on: main
+
+IMPORTANT: Do NOT create new worktrees.
+
+---
+""";
+      _writeTranscript(
+        temp: temp,
+        records: [
+          _messageRecord(
+            type: "user",
+            uuid: "initial-user",
+            timestamp: "2026-08-09T10:00:00Z",
+            content: [
+              {"type": "text", "text": context},
+              {"type": "text", "text": "visible prompt"},
+            ],
+          ),
+          _messageRecord(
+            type: "user",
+            uuid: "command-user",
+            timestamp: "2026-08-09T10:00:01Z",
+            content: [
+              {"type": "text", "text": "/review ${context.trimRight()}\n\nvisible args"},
+            ],
+          ),
+        ],
+      );
+
+      final messages = mapper.map(
+        sessionId: _sessionId,
+        records: await transcripts.readTranscriptRecordsInIsolate(sessionId: _sessionId),
+      );
+
+      expect(messages.map((message) => message.parts.single.text), ["visible prompt", "/review visible args"]);
+    });
+
     test("skips sidechain, metadata, transcript-only, and unsupported records", () async {
       _writeTranscript(
         temp: temp,

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -67,6 +67,33 @@ void main() {
       await subscription.cancel();
     });
 
+    test("shows only userVisibleText while sending full execution context", () async {
+      final events = <BridgeSseEvent>[];
+      final subscription = harness.plugin.events.listen(events.add);
+
+      await harness.plugin.createSession(
+        directory: "/tmp/project",
+        parentSessionId: null,
+        parts: const [
+          PluginPromptPart.text(text: _worktreeContext),
+          PluginPromptPart.text(text: "visible prompt"),
+        ],
+        userVisibleText: "visible prompt",
+        variant: null,
+        agent: "Default",
+        model: (providerID: "anthropic", modelID: "default"),
+      );
+      await pump();
+
+      final visibleParts = events.whereType<BridgeSseMessagePartUpdated>().where(
+        (event) => event.part.type == PluginMessagePartType.text,
+      );
+      expect(visibleParts.single.part.text, "visible prompt");
+      final executionText = _userTexts(harness.processes.single).join("\n");
+      expect(executionText, contains("private-branch"));
+      await subscription.cancel();
+    });
+
     test("fails closed when init violates the pre-bound session identity", () async {
       final events = <BridgeSseEvent>[];
       final subscription = harness.plugin.events.listen(events.add);
@@ -91,11 +118,13 @@ void main() {
       await waitForFrame(first, "user");
       first.emit(_result());
       await pump();
+      final events = <BridgeSseEvent>[];
+      final subscription = harness.plugin.events.listen(events.add);
 
       await harness.plugin.sendCommand(
         sessionId: testSessionId,
         command: "review",
-        arguments: "src",
+        arguments: "${_worktreeContext.trimRight()}\n\nsrc",
         userVisibleArguments: "src",
         variant: null,
         agent: "Plan",
@@ -103,7 +132,44 @@ void main() {
       );
       final permission = await _waitForControl(first, "set_permission_mode");
       expect(_request(permission)["mode"], "plan");
-      await _waitForUserText(first, "/review src");
+      await _waitForUserText(first, "/review ${_worktreeContext.trimRight()}\n\nsrc");
+      await pump();
+      final visible = events.whereType<BridgeSseMessagePartUpdated>().where(
+        (event) => event.part.text == "/review src",
+      );
+      expect(visible, hasLength(1));
+      await subscription.cancel();
+    });
+
+    test("creates an empty session and reports command initialization failure", () async {
+      await harness.close();
+      harness = _PluginHarness(failInitialize: true);
+      final session = await harness.plugin.createSession(
+        directory: "/tmp/project",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: "Default",
+        model: (providerID: "anthropic", modelID: "default"),
+      );
+
+      await expectLater(
+        harness.plugin.sendCommand(
+          sessionId: session.id,
+          command: "review",
+          arguments: "src",
+          userVisibleArguments: "src",
+          variant: null,
+          agent: "Default",
+          model: (providerID: "anthropic", modelID: "default"),
+        ),
+        throwsA(
+          isA<PluginOperationException>()
+              .having((error) => error.operation, "operation", "sendCommand")
+              .having((error) => error.cause, "cause", isNotNull),
+        ),
+      );
     });
 
     test("respawns between turns when launch-only effort changes", () async {
@@ -164,6 +230,46 @@ void main() {
       );
     });
 
+    test("finishes in-memory deletion when transcript cleanup fails", () async {
+      await harness.close();
+      harness = _PluginHarness(failTranscriptDelete: true);
+      final session = await harness.createSession();
+
+      await expectLater(
+        harness.plugin.deleteSession(session.id),
+        throwsA(
+          isA<PluginOperationException>()
+              .having((error) => error.operation, "operation", "deleteSession")
+              .having((error) => error.cause, "cause", isA<StateError>()),
+        ),
+      );
+
+      expect(await harness.plugin.getSessions("/tmp/project"), isEmpty);
+      expect(await harness.plugin.getSessionStatuses(), isEmpty);
+    });
+
+    test("preserves API retry status for snapshots and activity", () async {
+      await harness.createSession();
+      final process = harness.processes.single;
+      process.emit({
+        "type": "system",
+        "subtype": "api_retry",
+        "session_id": testSessionId,
+        "uuid": "retry-1",
+        "attempt": 2,
+        "max_retries": 5,
+        "retry_delay_ms": 1000,
+        "error_status": 429,
+        "error": "rate_limit",
+      });
+      await pump();
+
+      final retry = (await harness.plugin.getSessionStatuses())[testSessionId]! as PluginSessionStatusRetry;
+      expect(retry.attempt, 2);
+      expect(retry.next, DateTime.utc(2026, 8, 11, 12).millisecondsSinceEpoch + 1000);
+      expect(harness.plugin.getActiveSessionsSummary().single.activeSessions.single.isRetrying, isTrue);
+    });
+
     test("persisted cleanup is idempotent for an absent transcript", () async {
       await harness.plugin.deletePersistedSession(backendSessionId: testSessionId);
       await harness.plugin.deletePersistedSession(backendSessionId: testSessionId);
@@ -172,7 +278,7 @@ void main() {
 }
 
 final class _PluginHarness {
-  _PluginHarness() {
+  _PluginHarness({this.failInitialize = false, bool failTranscriptDelete = false}) {
     temporary = Directory.systemTemp.createTempSync("claude-plugin-test-");
     final eventBuffer = BufferedUntilFirstListener<BridgeSseEvent>();
     processRepository = ClaudeSessionProcessRepository(
@@ -180,7 +286,7 @@ final class _PluginHarness {
         final process = FakeClaudeProcess();
         specs.add(spec);
         processes.add(process);
-        unawaited(_answerControls(process));
+        unawaited(_answerControls(process, failInitialize: failInitialize));
         return process;
       },
       binaryPath: "claude",
@@ -198,7 +304,9 @@ final class _PluginHarness {
     );
     const content = ClaudeContentMapper();
     final transcripts = ClaudeTranscriptCatalogRepository(
-      transcriptApi: ClaudeTranscriptApi(environment: {"CLAUDE_CONFIG_DIR": temporary.path}),
+      transcriptApi: failTranscriptDelete
+          ? _ThrowingDeleteTranscriptApi()
+          : ClaudeTranscriptApi(environment: {"CLAUDE_CONFIG_DIR": temporary.path}),
     );
     plugin = ClaudePlugin(
       processes: processRepository,
@@ -225,6 +333,7 @@ final class _PluginHarness {
   late final ClaudePlugin plugin;
   final List<ClaudeLaunchSpec> specs = [];
   final List<FakeClaudeProcess> processes = [];
+  final bool failInitialize;
   var _idIndex = 0;
 
   String _nextId() => [otherTestSessionId, testSessionId][_idIndex++];
@@ -258,7 +367,7 @@ final class _NeverIdleClock extends ServerClock {
   Future<void> delay({required Duration duration}) => Completer<void>().future;
 }
 
-Future<void> _answerControls(FakeClaudeProcess process) async {
+Future<void> _answerControls(FakeClaudeProcess process, {required bool failInitialize}) async {
   final answered = <String>{};
   while (!process.killed) {
     for (final frame in process.written) {
@@ -266,6 +375,13 @@ Future<void> _answerControls(FakeClaudeProcess process) async {
       final requestId = frame["request_id"]! as String;
       if (!answered.add(requestId)) continue;
       final subtype = _request(frame)["subtype"];
+      if (subtype == "initialize" && failInitialize) {
+        process.emit({
+          "type": "control_response",
+          "response": {"subtype": "error", "request_id": requestId, "error": "probe failure"},
+        });
+        continue;
+      }
       process.emitControlResponse(
         requestId: requestId,
         payload: subtype == "initialize" || subtype == "list_models" ? sampleHandshake : const {},
@@ -312,3 +428,30 @@ Map<String, Object?> _result() => {
   "session_id": testSessionId,
   "is_error": false,
 };
+
+final class _ThrowingDeleteTranscriptApi extends ClaudeTranscriptApi {
+  _ThrowingDeleteTranscriptApi() : super(environment: const {});
+
+  bool deleteAttempted = false;
+
+  @override
+  List<String> listTranscriptPaths() => deleteAttempted ? const [] : ["/tmp/$testSessionId.jsonl"];
+
+  @override
+  void deleteTranscript({required String transcriptPath}) {
+    deleteAttempted = true;
+    throw StateError("delete failed");
+  }
+}
+
+const _worktreeContext = """
+[SYSTEM CONTEXT \u2014 IMPORTANT]
+A dedicated git worktree and branch have been created for this session:
+- Branch: private-branch
+- Worktree path: /private/worktree
+- Based on: main
+
+IMPORTANT: Do NOT create new worktrees.
+
+---
+""";

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -141,6 +141,28 @@ void main() {
       await subscription.cancel();
     });
 
+    test("accepts a queued command without waiting for the active turn result", () async {
+      await harness.createSession();
+      final process = harness.processes.single;
+      await waitForFrame(process, "user");
+
+      await harness.plugin
+          .sendCommand(
+            sessionId: testSessionId,
+            command: "review",
+            arguments: "src",
+            userVisibleArguments: "src",
+            variant: null,
+            agent: "Default",
+            model: (providerID: "anthropic", modelID: "default"),
+          )
+          .timeout(const Duration(seconds: 1));
+      expect(_userTexts(process), isNot(contains("/review src")));
+
+      process.emit(_result());
+      await _waitForUserText(process, "/review src");
+    });
+
     test("creates an empty session and reports command initialization failure", () async {
       await harness.close();
       harness = _PluginHarness(failInitialize: true);
@@ -251,6 +273,8 @@ void main() {
     test("preserves API retry status for snapshots and activity", () async {
       await harness.createSession();
       final process = harness.processes.single;
+      final events = <BridgeSseEvent>[];
+      final subscription = harness.plugin.events.listen(events.add);
       process.emit({
         "type": "system",
         "subtype": "api_retry",
@@ -267,7 +291,9 @@ void main() {
       final retry = (await harness.plugin.getSessionStatuses())[testSessionId]! as PluginSessionStatusRetry;
       expect(retry.attempt, 2);
       expect(retry.next, DateTime.utc(2026, 8, 11, 12).millisecondsSinceEpoch + 1000);
+      expect(events.whereType<BridgeSseSessionStatus>().last.status["next"], retry.next);
       expect(harness.plugin.getActiveSessionsSummary().single.activeSessions.single.isRetrying, isTrue);
+      await subscription.cancel();
     });
 
     test("persisted cleanup is idempotent for an absent transcript", () async {

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -141,28 +141,6 @@ void main() {
       await subscription.cancel();
     });
 
-    test("accepts a queued command without waiting for the active turn result", () async {
-      await harness.createSession();
-      final process = harness.processes.single;
-      await waitForFrame(process, "user");
-
-      await harness.plugin
-          .sendCommand(
-            sessionId: testSessionId,
-            command: "review",
-            arguments: "src",
-            userVisibleArguments: "src",
-            variant: null,
-            agent: "Default",
-            model: (providerID: "anthropic", modelID: "default"),
-          )
-          .timeout(const Duration(seconds: 1));
-      expect(_userTexts(process), isNot(contains("/review src")));
-
-      process.emit(_result());
-      await _waitForUserText(process, "/review src");
-    });
-
     test("creates an empty session and reports command initialization failure", () async {
       await harness.close();
       harness = _PluginHarness(failInitialize: true);

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -1,0 +1,314 @@
+import "dart:async";
+import "dart:io";
+
+import "package:claude_plugin/claude_plugin.dart";
+import "package:claude_plugin/claude_testing.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+import "support/claude_stream_client_test_factory.dart";
+
+void main() {
+  group("ClaudePlugin", () {
+    late _PluginHarness harness;
+
+    setUp(() {
+      harness = _PluginHarness();
+    });
+
+    tearDown(() => harness.close());
+
+    test("discovers and caches a complete catalog before any user session", () async {
+      final options = await harness.plugin.getSessionOptions(
+        projectId: "/tmp/project",
+        discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+      );
+
+      final observed = options as PluginSessionOptionsDiscoveryObserved;
+      expect(observed.options.agents.map((agent) => agent.name), ["Default", "Plan"]);
+      expect(observed.options.providers.providers.single.models, hasLength(2));
+      expect(observed.options.commands.single.name, "review");
+      expect(harness.processes, hasLength(1));
+
+      await harness.plugin.getCommands(projectId: null);
+      expect(harness.processes, hasLength(1));
+
+      await harness.plugin.getSessionOptions(
+        projectId: "/tmp/project",
+        discoveryMode: PluginSessionOptionsDiscoveryMode.refresh,
+      );
+      expect(_controlSubtypes(harness.processes.single), contains("list_models"));
+    });
+
+    test("creates under the generated id and buffers creation before listening", () async {
+      final session = await harness.createSession();
+      expect(session.id, testSessionId);
+      expect(session.directory, "/tmp/project");
+
+      final events = <BridgeSseEvent>[];
+      final subscription = harness.plugin.events.listen(events.add);
+      await pump();
+      expect(events.first, isA<BridgeSseSessionCreated>());
+      expect(events.whereType<BridgeSseSessionStatus>().single.sessionID, testSessionId);
+
+      final process = harness.processes.single;
+      final user = await waitForFrame(process, "user");
+      expect(user["session_id"], testSessionId);
+      expect((user["message"]! as Map)["content"], [
+        {"type": "text", "text": "hello"},
+      ]);
+
+      final statuses = await harness.plugin.getSessionStatuses();
+      expect(statuses[testSessionId], isA<PluginSessionStatusBusy>());
+      final summary = harness.plugin.getActiveSessionsSummary().single;
+      expect(summary.id, "/tmp/project");
+      expect(summary.activeSessions.single.id, testSessionId);
+      expect(summary.activeSessions.single.mainAgentRunning, isTrue);
+      await subscription.cancel();
+    });
+
+    test("fails closed when init violates the pre-bound session identity", () async {
+      final events = <BridgeSseEvent>[];
+      final subscription = harness.plugin.events.listen(events.add);
+      await harness.createSession();
+      final process = harness.processes.single;
+      await waitForFrame(process, "user");
+
+      process.emit(sampleInit(sessionId: otherTestSessionId));
+      for (var attempt = 0; attempt < 50 && !process.killed; attempt++) {
+        await pump();
+      }
+
+      expect(process.killed, isTrue);
+      expect(events.whereType<BridgeSseSessionError>().single.sessionID, testSessionId);
+      expect(await harness.plugin.getSessionStatuses(), isEmpty);
+      await subscription.cancel();
+    });
+
+    test("dispatches a slash command as an accepted queued turn", () async {
+      await harness.createSession();
+      final first = harness.processes.single;
+      await waitForFrame(first, "user");
+      first.emit(_result());
+      await pump();
+
+      await harness.plugin.sendCommand(
+        sessionId: testSessionId,
+        command: "review",
+        arguments: "src",
+        userVisibleArguments: "src",
+        variant: null,
+        agent: "Plan",
+        model: (providerID: "anthropic", modelID: "small"),
+      );
+      final permission = await _waitForControl(first, "set_permission_mode");
+      expect(_request(permission)["mode"], "plan");
+      await _waitForUserText(first, "/review src");
+    });
+
+    test("respawns between turns when launch-only effort changes", () async {
+      await harness.createSession();
+      final first = harness.processes.single;
+      await waitForFrame(first, "user");
+      first.emit(_result());
+      await pump();
+
+      await harness.plugin.sendPrompt(
+        sessionId: testSessionId,
+        parts: const [PluginPromptPart.text(text: "deeper")],
+        variant: const PluginSessionVariant(id: "high"),
+        agent: "Default",
+        model: (providerID: "anthropic", modelID: "default"),
+      );
+      for (var attempt = 0; attempt < 50 && harness.processes.length < 2; attempt++) {
+        await pump();
+      }
+
+      expect(harness.processes, hasLength(2));
+      expect(harness.specs.last.launch, isA<ClaudeResumedSession>());
+      expect(harness.specs.last.effort, ClaudeEffortLevel.high);
+      await waitForFrame(harness.processes.last, "user");
+    });
+
+    test("throws not found instead of creating a process for an unknown session", () async {
+      await expectLater(
+        harness.plugin.sendPrompt(
+          sessionId: otherTestSessionId,
+          parts: const [PluginPromptPart.text(text: "hello")],
+          variant: null,
+          agent: null,
+          model: null,
+        ),
+        throwsA(isA<PluginOperationException>().having((error) => error.isNotFound, "not found", isTrue)),
+      );
+      await expectLater(
+        harness.plugin.getSessionMessages(otherTestSessionId),
+        throwsA(isA<PluginOperationException>().having((error) => error.isNotFound, "not found", isTrue)),
+      );
+      expect(harness.processes, isEmpty);
+    });
+
+    test("delete fences the turn, reaps the process, and forgets the session", () async {
+      final session = await harness.createSession();
+      final process = harness.processes.single;
+      await waitForFrame(process, "user");
+
+      await harness.plugin.deleteSession(session.id);
+
+      expect(process.killed, isTrue);
+      expect(await harness.plugin.getSessions("/tmp/project"), isEmpty);
+      expect(await harness.plugin.getSessionStatuses(), isEmpty);
+      await expectLater(
+        harness.plugin.deleteSession(session.id),
+        throwsA(isA<PluginOperationException>().having((error) => error.isNotFound, "not found", isTrue)),
+      );
+    });
+
+    test("persisted cleanup is idempotent for an absent transcript", () async {
+      await harness.plugin.deletePersistedSession(backendSessionId: testSessionId);
+      await harness.plugin.deletePersistedSession(backendSessionId: testSessionId);
+    });
+  });
+}
+
+final class _PluginHarness {
+  _PluginHarness() {
+    temporary = Directory.systemTemp.createTempSync("claude-plugin-test-");
+    final eventBuffer = BufferedUntilFirstListener<BridgeSseEvent>();
+    processRepository = ClaudeSessionProcessRepository(
+      processFactory: (spec) async {
+        final process = FakeClaudeProcess();
+        specs.add(spec);
+        processes.add(process);
+        unawaited(_answerControls(process));
+        return process;
+      },
+      binaryPath: "claude",
+      environment: const {},
+    );
+    approvals = ClaudeApprovalRegistry(
+      emit: eventBuffer.add,
+      respond: processRepository.answerControlRequest,
+    );
+    sessionService = ClaudeSessionService(
+      processes: processRepository,
+      approvals: approvals,
+      clock: const _NeverIdleClock(),
+      idleTimeout: const Duration(minutes: 5),
+    );
+    const content = ClaudeContentMapper();
+    final transcripts = ClaudeTranscriptCatalogRepository(
+      transcriptApi: ClaudeTranscriptApi(environment: {"CLAUDE_CONFIG_DIR": temporary.path}),
+    );
+    plugin = ClaudePlugin(
+      processes: processRepository,
+      transcripts: transcripts,
+      sessions: sessionService,
+      catalogService: ClaudeCatalogService(
+        catalog: const ClaudeBackendCatalogRepository(),
+        processes: processRepository,
+      ),
+      approvals: approvals,
+      eventDispatcher: ClaudeEventDispatcher(content: content, tools: ClaudeToolTracker()),
+      history: const ClaudeHistoryMapper(content: content),
+      eventBuffer: eventBuffer,
+      clock: const _NeverIdleClock(),
+      generateSessionId: _nextId,
+      launchDirectory: "/tmp/project",
+    );
+  }
+
+  late final Directory temporary;
+  late final ClaudeSessionProcessRepository processRepository;
+  late final ClaudeApprovalRegistry approvals;
+  late final ClaudeSessionService sessionService;
+  late final ClaudePlugin plugin;
+  final List<ClaudeLaunchSpec> specs = [];
+  final List<FakeClaudeProcess> processes = [];
+  var _idIndex = 0;
+
+  String _nextId() => [otherTestSessionId, testSessionId][_idIndex++];
+
+  Future<PluginSession> createSession() => plugin.createSession(
+    directory: "/tmp/project",
+    parentSessionId: null,
+    parts: const [PluginPromptPart.text(text: "hello")],
+    userVisibleText: "hello",
+    variant: null,
+    agent: "Default",
+    model: (providerID: "anthropic", modelID: "default"),
+  );
+
+  Future<void> close() async {
+    await plugin.dispose();
+    for (final process in processes) {
+      await process.close();
+    }
+    temporary.deleteSync(recursive: true);
+  }
+}
+
+final class _NeverIdleClock extends ServerClock {
+  const _NeverIdleClock();
+
+  @override
+  DateTime now() => DateTime.utc(2026, 8, 11, 12);
+
+  @override
+  Future<void> delay({required Duration duration}) => Completer<void>().future;
+}
+
+Future<void> _answerControls(FakeClaudeProcess process) async {
+  final answered = <String>{};
+  while (!process.killed) {
+    for (final frame in process.written) {
+      if (frame["type"] != "control_request") continue;
+      final requestId = frame["request_id"]! as String;
+      if (!answered.add(requestId)) continue;
+      final subtype = _request(frame)["subtype"];
+      process.emitControlResponse(
+        requestId: requestId,
+        payload: subtype == "initialize" || subtype == "list_models" ? sampleHandshake : const {},
+      );
+    }
+    await pump();
+  }
+}
+
+Future<Map<String, Object?>> _waitForControl(FakeClaudeProcess process, String subtype) async {
+  for (var attempt = 0; attempt < 50; attempt++) {
+    for (final frame in process.written) {
+      if (frame["type"] == "control_request" && _request(frame)["subtype"] == subtype) return frame;
+    }
+    await pump();
+  }
+  throw StateError("no '$subtype' control request written");
+}
+
+Future<void> _waitForUserText(FakeClaudeProcess process, String text) async {
+  for (var attempt = 0; attempt < 50; attempt++) {
+    if (_userTexts(process).contains(text)) return;
+    await pump();
+  }
+  throw StateError("no user turn containing '$text' written");
+}
+
+Map<String, Object?> _request(Map<String, Object?> frame) => (frame["request"]! as Map).cast<String, Object?>();
+
+Iterable<String?> _controlSubtypes(FakeClaudeProcess process) => process.written
+    .where((frame) => frame["type"] == "control_request")
+    .map((frame) => _request(frame)["subtype"] as String?);
+
+List<String> _userTexts(FakeClaudeProcess process) => [
+  for (final frame in process.written)
+    if (frame["type"] == "user")
+      for (final block in ((frame["message"]! as Map)["content"]! as List))
+        if (block is Map && block["type"] == "text") block["text"]! as String,
+];
+
+Map<String, Object?> _result() => {
+  "type": "result",
+  "subtype": "success",
+  "session_id": testSessionId,
+  "is_error": false,
+};

--- a/bridge/sesori_plugin_claude/test/claude_session_process_repository_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_session_process_repository_test.dart
@@ -99,10 +99,10 @@ void main() {
       await pump();
 
       final disposal = repository.dispose();
-      gate.complete();
 
       await expectLater(residency, throwsStateError);
-      await disposal;
+      await disposal.timeout(const Duration(seconds: 1));
+      gate.complete();
       expect(repository.isResident(sessionId: testSessionId), isFalse);
       expect(harness.processes.single.killed, isTrue);
     });

--- a/bridge/sesori_plugin_claude/test/claude_session_process_repository_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_session_process_repository_test.dart
@@ -34,9 +34,10 @@ void main() {
         sessionId: testSessionId,
         parts: const [PluginPromptPart.text(text: "hello")],
       );
+      expect(turn.accepted, isTrue);
       await waitForFrame(harness.processes.single, "user");
       harness.processes.single.emit(_result());
-      expect(await turn, isA<ClaudeTurnCompleted>());
+      expect(await turn.outcome, isA<ClaudeTurnCompleted>());
 
       await repository.teardown(sessionId: testSessionId);
       await _ensure(repository, createNew: true);
@@ -67,10 +68,11 @@ void main() {
         sessionId: testSessionId,
         parts: const [PluginPromptPart.text(text: "hello")],
       );
+      expect(turn.accepted, isTrue);
       await waitForFrame(harness.processes.single, "user");
       harness.processes.single.exit(1);
 
-      expect(await turn, isA<ClaudeTurnFailed>());
+      expect(await turn.outcome, isA<ClaudeTurnFailed>());
       await pump();
       expect(exits.single.sessionId, testSessionId);
       expect(exits.single.interrupted, isFalse);
@@ -80,12 +82,13 @@ void main() {
     test("drops unsupported inline data instead of sending it as an image", () async {
       await _ensure(repository, createNew: true);
 
-      final outcome = await repository.sendTurn(
+      final dispatch = repository.sendTurn(
         sessionId: testSessionId,
         parts: const [PluginPromptPart.fileData(mime: "application/pdf", base64: "secret", filename: "a.pdf")],
       );
 
-      expect(outcome, isA<ClaudeTurnFailed>());
+      expect(dispatch.accepted, isFalse);
+      expect(await dispatch.outcome, isA<ClaudeTurnFailed>());
       expect(harness.processes.single.written.where((frame) => frame["type"] == "user"), isEmpty);
     });
 

--- a/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
@@ -154,6 +154,28 @@ void main() {
       await first;
       expect(completed, isTrue);
     });
+
+    test("delete waits for an in-flight idle teardown", () async {
+      await harness.dispose();
+      harness = _ServiceHarness(stdinCloseCompletes: false);
+      harness.enqueue("first");
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+      process.emit(_result());
+      await harness.waitForIdle();
+      harness.clock.elapse();
+      await _waitForStdinClose(process);
+
+      final deletion = harness.service.deleteSession(sessionId: testSessionId);
+      var completed = false;
+      unawaited(deletion.then((_) => completed = true));
+      await pump();
+      expect(completed, isFalse);
+
+      process.completeStdinClose();
+      await deletion;
+      expect(completed, isTrue);
+    });
   });
 }
 
@@ -202,14 +224,18 @@ final class _ServiceHarness {
   }
 
   void enqueue(String text, {String? model}) {
-    service.enqueueTurn(
-      sessionId: testSessionId,
-      directory: "/tmp/project",
-      createNew: true,
-      parts: [PluginPromptPart.text(text: text)],
-      model: model,
-      effort: null,
-      permissionMode: null,
+    unawaited(
+      service
+          .enqueueTurn(
+            sessionId: testSessionId,
+            directory: "/tmp/project",
+            createNew: true,
+            parts: [PluginPromptPart.text(text: text)],
+            model: model,
+            effort: null,
+            permissionMode: null,
+          )
+          .catchError((Object _) {}),
     );
   }
 


### PR DESCRIPTION
## Complexity

🚧 Complex: implements the complete plugin contract over process residency, serialized turns, transcript persistence, live events, interactions, and lifecycle cleanup.

## What

- Add `ClaudePlugin` implementing `BridgeDerivedProjectsPluginApi` and `PersistedSessionCleanupApi` over the Step 3-11 components.
- Provide buffered live events, catalog discovery, session creation/reads/rename/delete, history replay, prompt and command dispatch, pending interactions, provider options, activity summaries, and idempotent disposal.
- Apply model and permission changes inside serialized turns and transparently respawn/resume when launch-only effort changes.
- Add owner-level deletion fencing, status/pending snapshots, and honest transcript cleanup failure propagation.
- Keep bridge-owned execution context out of synthesized and replayed user messages while preserving the full backend payload.
- Record live `/command args` verification and the user-approved fail-closed session identity policy.

## Why

Steps 3-11 established the Claude-specific transport and domain components. This step exposes them through the backend-neutral plugin API seam consumed by the bridge and keeps process, queue, approval, transcript, and mapping state in their existing owners.

## Risk and test focus

Risk is high but isolated to the app-invisible Claude plugin package until Step 14 registration. Focus on event ordering, generated/pre-bound identity, queue-safe selection changes, effort-triggered resume, not-found translation, deletion fencing, interaction replies, catalog reuse/refresh, and complete process cleanup.

## Expected result

No user-visible or database change in this step because Claude remains unregistered. Internally, Step 13 can wrap a complete headless `ClaudePlugin` in descriptor/lifecycle setup.

## Verification

- `dart test test/claude_plugin_impl_test.dart` (12 contract tests)
- `dart test` (186 package tests)
- `dart analyze --fatal-infos`
- `git diff --check origin/main...HEAD`
- Live Claude CLI 2.1.226: `/help` as ordinary stream-json turn text produced an assistant reply and successful result
- Architecture review: event-buffer and Layer-4 ownership approved; identity finding superseded by explicit user choice to fail closed, recorded in the plan
- Diff: 1,468 changed lines across 17 files (1,387 additions, 81 deletions, no generated files), within the planned 1,200-1,500 estimate and soft cap

## Series

Step 12/17 of `.plan/active/claude-code-plugin`. The Step 13 descriptor/lifecycle is the next consumer.
