### PR TITLE
⚙️ [claude-code-plugin] feat(claude): add descriptor and lifecycle [step 13/17]

### DIFF
--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -4,13 +4,13 @@
 
 - **Plan slug:** `claude-code-plugin`
 - **Implementation base:** `origin/main` at
-  `035fae84` (Step 12 started after Step 11 merged)
-- **Series state:** Steps 1-11/17 merged; Step 12/17 PR open
-- **Current step:** 12/17 — full plugin API surface in review
+  `f0d705bc` (Step 13 started after Step 12 merged)
+- **Series state:** Steps 1-12/17 merged; Step 13/17 ready for review
+- **Current step:** 13/17 — descriptor and lifecycle implemented and verified
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737),
   merged 2026-08-04 as `6d641532`
-- **Next action:** Wait for Step 12 PR #813 to merge, then wait for explicit
-  direction before starting Step 13
+- **Next action:** Open and monitor the Step 13 PR, then wait for explicit
+  direction after merge before starting Step 14
 
 ## Plan Review
 
@@ -56,8 +56,8 @@
 | [x] | 9/17 | `claude-code-plugin-approvals` | `🚧 [claude-code-plugin] feat(claude): add permission and question registry [step 9/17]` | 1,100-1,500 | [PR #805](https://github.com/sesori-ai/sesori_apps_monorepo/pull/805) merged 2026-08-10 as `8280e691` |
 | [x] | 10/17 | `claude-code-plugin-session-service` | `🚧 [claude-code-plugin] feat(claude): add session residency and turn queue [step 10/17]` | 1,200-1,500 | [PR #808](https://github.com/sesori-ai/sesori_apps_monorepo/pull/808) merged 2026-08-11 as `fcca943c` |
 | [x] | 11/17 | `claude-code-plugin-catalog-service` | `⚙️ [claude-code-plugin] feat(claude): add model and agent catalog [step 11/17]` | 900-1,300 | [PR #809](https://github.com/sesori-ai/sesori_apps_monorepo/pull/809) merged 2026-08-11 as `ca521672` |
-| [ ] | 12/17 | `claude-code-plugin-plugin-impl` | `🚧 [claude-code-plugin] feat(claude): implement the plugin API surface [step 12/17]` | 1,200-1,500 | [PR #813](https://github.com/sesori-ai/sesori_apps_monorepo/pull/813) open against `main` |
-| [ ] | 13/17 | `claude-code-plugin-descriptor` | `⚙️ [claude-code-plugin] feat(claude): add descriptor and lifecycle [step 13/17]` | 1,100-1,500 | Not started |
+| [x] | 12/17 | `claude-code-plugin-plugin-impl` | `🚧 [claude-code-plugin] feat(claude): implement the plugin API surface [step 12/17]` | 1,200-1,500 | [PR #813](https://github.com/sesori-ai/sesori_apps_monorepo/pull/813) merged 2026-08-11 as `f0d705bc` |
+| [ ] | 13/17 | `claude-code-plugin-descriptor` | `⚙️ [claude-code-plugin] feat(claude): add descriptor and lifecycle [step 13/17]` | 1,100-1,500 | Implemented and verified on `claude-code-plugin-descriptor`; ready to open against `main` |
 | [ ] | 14/17 | `claude-code-plugin-activation` | `⚙️ [claude-code-plugin] feat(claude): register the Claude Code harness [step 14/17]` | 250-500 | Not started |
 | [ ] | 15/17 | `claude-code-plugin-client-polish` | `🌿 [claude-code-plugin] feat(client): add Claude Code branding [step 15/17]` | 400-800 | Not started |
 | [ ] | 16/17 | `claude-code-plugin-e2e` | `🌿 [claude-code-plugin] docs: record Claude Code live verification [step 16/17]` | 200-500 | Not started |
@@ -388,6 +388,38 @@
   across every session owner. `PLAN.md` now records teardown plus a session
   error as the safe response. That explicit decision supersedes the review and
   was not re-reviewed.
+
+- Step 13/17 local implementation (2026-08-11): added the exported, unregistered
+  `ClaudePluginDescriptor` with the bare `bin` option, bounded host-routed
+  `--version` and `auth status` probes, a `SemanticVersion` floor of 2.1.221,
+  and a generated PII-excluding auth DTO that retains only nullable `loggedIn`.
+  Setup inspection returns ready, runtime missing, authentication required,
+  unavailable, or unknown, with a non-empty action hint for every non-ready
+  state and no `PluginSetupNotInspected` path.
+
+  Added `ClaudeBridgePlugin` over `SteadyPluginLifecycle`, explicit composition
+  of the Step 3-12 collaborators, host-backed Windows-shell process spawning,
+  entry and post-construction abort checks with `shutdown(budget: null)`
+  rollback, bounded active-work interruption, and plugin disposal. Typed spawn
+  outcomes degrade recoverably on binary launch failure and restore ready on a
+  later successful spawn; ordinary per-session exits do not alter plugin
+  lifecycle status. The descriptor is exported but remains absent from app
+  registration for Step 14.
+
+  Focused descriptor/session lifecycle tests pass (18 tests), including exact
+  probe order, all five setup states, auth PII exclusion, timeout force-kill,
+  both abort boundaries, rollback evidence, host process arguments, bounded
+  interruption, and degraded/ready/session-exit transitions. The full owning
+  package suite passes 197 tests, `dart analyze --fatal-infos` reports no
+  issues, generated DTO code was produced with `build_runner`, and
+  `git diff --check` passes. Before this tracker update, the implementation was
+  1,063 changed lines (all additions), within the 1,100-1,500 estimate once plan
+  evidence is included and below the 1,500-line soft cap.
+
+  Architecture implementation review of the full tracked and untracked Step 13
+  diff against `main` returned `APPROVED` with no findings. It confirmed the
+  descriptor composition, lifecycle ownership, host process seam, and package
+  dependency direction preserve the bridge architecture.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -413,8 +413,9 @@
   package suite passes 197 tests, `dart analyze --fatal-infos` reports no
   issues, generated DTO code was produced with `build_runner`, and
   `git diff --check` passes. Before this tracker update, the implementation was
-  1,063 changed lines (all additions), within the 1,100-1,500 estimate once plan
-  evidence is included and below the 1,500-line soft cap.
+  1,063 changed lines (all additions), including 145 generated lines, within the
+  1,100-1,500 estimate once plan evidence is included and below the 1,500-line
+  soft cap.
 
   Architecture implementation review of the full tracked and untracked Step 13
   diff against `main` returned `APPROVED` with no findings. It confirmed the

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -5,12 +5,12 @@
 - **Plan slug:** `claude-code-plugin`
 - **Implementation base:** `origin/main` at
   `f0d705bc` (Step 13 started after Step 12 merged)
-- **Series state:** Steps 1-12/17 merged; Step 13/17 ready for review
-- **Current step:** 13/17 — descriptor and lifecycle implemented and verified
+- **Series state:** Steps 1-12/17 merged; Step 13/17 PR open
+- **Current step:** 13/17 — descriptor and lifecycle in review
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737),
   merged 2026-08-04 as `6d641532`
-- **Next action:** Open and monitor the Step 13 PR, then wait for explicit
-  direction after merge before starting Step 14
+- **Next action:** Monitor Step 13 PR #815, then wait for explicit direction
+  after merge before starting Step 14
 
 ## Plan Review
 
@@ -57,7 +57,7 @@
 | [x] | 10/17 | `claude-code-plugin-session-service` | `🚧 [claude-code-plugin] feat(claude): add session residency and turn queue [step 10/17]` | 1,200-1,500 | [PR #808](https://github.com/sesori-ai/sesori_apps_monorepo/pull/808) merged 2026-08-11 as `fcca943c` |
 | [x] | 11/17 | `claude-code-plugin-catalog-service` | `⚙️ [claude-code-plugin] feat(claude): add model and agent catalog [step 11/17]` | 900-1,300 | [PR #809](https://github.com/sesori-ai/sesori_apps_monorepo/pull/809) merged 2026-08-11 as `ca521672` |
 | [x] | 12/17 | `claude-code-plugin-plugin-impl` | `🚧 [claude-code-plugin] feat(claude): implement the plugin API surface [step 12/17]` | 1,200-1,500 | [PR #813](https://github.com/sesori-ai/sesori_apps_monorepo/pull/813) merged 2026-08-11 as `f0d705bc` |
-| [ ] | 13/17 | `claude-code-plugin-descriptor` | `⚙️ [claude-code-plugin] feat(claude): add descriptor and lifecycle [step 13/17]` | 1,100-1,500 | Implemented and verified on `claude-code-plugin-descriptor`; ready to open against `main` |
+| [ ] | 13/17 | `claude-code-plugin-descriptor` | `⚙️ [claude-code-plugin] feat(claude): add descriptor and lifecycle [step 13/17]` | 1,100-1,500 | [PR #815](https://github.com/sesori-ai/sesori_apps_monorepo/pull/815) open against `main` |
 | [ ] | 14/17 | `claude-code-plugin-activation` | `⚙️ [claude-code-plugin] feat(claude): register the Claude Code harness [step 14/17]` | 250-500 | Not started |
 | [ ] | 15/17 | `claude-code-plugin-client-polish` | `🌿 [claude-code-plugin] feat(client): add Claude Code branding [step 15/17]` | 400-800 | Not started |
 | [ ] | 16/17 | `claude-code-plugin-e2e` | `🌿 [claude-code-plugin] docs: record Claude Code live verification [step 16/17]` | 200-500 | Not started |

--- a/bridge/sesori_plugin_claude/lib/claude_plugin.dart
+++ b/bridge/sesori_plugin_claude/lib/claude_plugin.dart
@@ -31,5 +31,7 @@ export "src/repositories/mappers/claude_content_mapper.dart";
 export "src/repositories/models/claude_session_record.dart";
 export "src/repositories/models/claude_transcript_record.dart";
 export "src/repositories/trackers/claude_tool_tracker.dart";
+export "src/runtime/claude_bridge_plugin.dart";
+export "src/runtime/claude_plugin_descriptor.dart";
 export "src/services/claude_catalog_service.dart";
 export "src/services/claude_session_service.dart";

--- a/bridge/sesori_plugin_claude/lib/src/api/claude_process_factory.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/claude_process_factory.dart
@@ -1,4 +1,7 @@
+import "dart:async";
 import "dart:io" as io;
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "claude_launch_spec.dart";
 
@@ -17,6 +20,90 @@ abstract class ClaudeProcessHandle {
 /// Spawns a [ClaudeProcessHandle] for a launch spec. Injected into
 /// [ClaudeStreamClient] so tests can substitute a fake process.
 typedef ClaudeProcessFactory = Future<ClaudeProcessHandle> Function(ClaudeLaunchSpec spec);
+
+sealed class ClaudeProcessSpawnEvent {
+  const ClaudeProcessSpawnEvent();
+}
+
+final class ClaudeProcessSpawnSucceeded extends ClaudeProcessSpawnEvent {
+  const ClaudeProcessSpawnSucceeded();
+}
+
+final class ClaudeProcessSpawnFailed extends ClaudeProcessSpawnEvent {
+  const ClaudeProcessSpawnFailed();
+}
+
+/// Routes Claude children through the bridge host and reports binary spawn
+/// outcomes separately from per-session process exits.
+final class HostClaudeProcessFactory {
+  HostClaudeProcessFactory({
+    required HostProcessService processes,
+    required Map<String, String> environment,
+  }) : _processes = processes,
+       _environment = Map.unmodifiable(environment);
+
+  final HostProcessService _processes;
+  final Map<String, String> _environment;
+  final StreamController<ClaudeProcessSpawnEvent> _events = StreamController.broadcast();
+
+  Stream<ClaudeProcessSpawnEvent> get events => _events.stream;
+
+  Future<ClaudeProcessHandle> spawn(ClaudeLaunchSpec spec) async {
+    try {
+      final process = await _processes.spawn(
+        executable: spec.binaryPath,
+        arguments: spec.arguments,
+        environment: {..._environment, ...spec.environment},
+        workingDirectory: spec.workingDirectory,
+        runInShell: io.Platform.isWindows,
+      );
+      if (!_events.isClosed) _events.add(const ClaudeProcessSpawnSucceeded());
+      return _HostClaudeProcessHandle(process: process, processes: _processes);
+    } on Object {
+      if (!_events.isClosed) _events.add(const ClaudeProcessSpawnFailed());
+      rethrow;
+    }
+  }
+
+  Future<void> dispose() => _events.close();
+}
+
+final class _HostClaudeProcessHandle implements ClaudeProcessHandle {
+  _HostClaudeProcessHandle({
+    required SpawnedProcess process,
+    required HostProcessService processes,
+  }) : _process = process,
+       _processes = processes;
+
+  final SpawnedProcess _process;
+  final HostProcessService _processes;
+
+  @override
+  Stream<List<int>> get stdout => _process.stdout;
+
+  @override
+  Stream<List<int>> get stderr => _process.stderr;
+
+  @override
+  io.IOSink get stdin => _process.stdin;
+
+  @override
+  Future<int> get exitCode => _process.exitCode;
+
+  @override
+  bool kill([io.ProcessSignal signal = io.ProcessSignal.sigterm]) {
+    unawaited(_signal(force: signal == io.ProcessSignal.sigkill));
+    return true;
+  }
+
+  Future<void> _signal({required bool force}) async {
+    try {
+      await (force ? _processes.signalForce(pid: _process.pid) : _processes.signalGraceful(pid: _process.pid));
+    } on Object catch (error, stackTrace) {
+      Log.w("[claude] failed to signal process ${_process.pid}", error, stackTrace);
+    }
+  }
+}
 
 /// Default factory: spawns a real OS process via [io.Process.start].
 ///

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_auth_status_dto.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_auth_status_dto.dart
@@ -1,0 +1,19 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "claude_auth_status_dto.freezed.dart";
+part "claude_auth_status_dto.g.dart";
+
+/// PII-free subset of `claude auth status`.
+///
+/// The source payload also contains account identity and organization fields;
+/// excluding them here prevents setup inspection from retaining those values.
+@Freezed(fromJson: true, toJson: false, toStringOverride: false)
+sealed class ClaudeAuthStatusDto with _$ClaudeAuthStatusDto {
+  const factory ClaudeAuthStatusDto({
+    @JsonKey(fromJson: _boolOrNull) required bool? loggedIn,
+  }) = _ClaudeAuthStatusDto;
+
+  factory ClaudeAuthStatusDto.fromJson(Map<String, dynamic> json) => _$ClaudeAuthStatusDtoFromJson(json);
+}
+
+bool? _boolOrNull(Object? value) => value is bool ? value : null;

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_auth_status_dto.freezed.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_auth_status_dto.freezed.dart
@@ -1,0 +1,135 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'claude_auth_status_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ClaudeAuthStatusDto {
+
+@JsonKey(fromJson: _boolOrNull) bool? get loggedIn;
+/// Create a copy of ClaudeAuthStatusDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ClaudeAuthStatusDtoCopyWith<ClaudeAuthStatusDto> get copyWith => _$ClaudeAuthStatusDtoCopyWithImpl<ClaudeAuthStatusDto>(this as ClaudeAuthStatusDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ClaudeAuthStatusDto&&(identical(other.loggedIn, loggedIn) || other.loggedIn == loggedIn));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,loggedIn);
+
+
+
+}
+
+/// @nodoc
+abstract mixin class $ClaudeAuthStatusDtoCopyWith<$Res>  {
+  factory $ClaudeAuthStatusDtoCopyWith(ClaudeAuthStatusDto value, $Res Function(ClaudeAuthStatusDto) _then) = _$ClaudeAuthStatusDtoCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(fromJson: _boolOrNull) bool? loggedIn
+});
+
+
+
+
+}
+/// @nodoc
+class _$ClaudeAuthStatusDtoCopyWithImpl<$Res>
+    implements $ClaudeAuthStatusDtoCopyWith<$Res> {
+  _$ClaudeAuthStatusDtoCopyWithImpl(this._self, this._then);
+
+  final ClaudeAuthStatusDto _self;
+  final $Res Function(ClaudeAuthStatusDto) _then;
+
+/// Create a copy of ClaudeAuthStatusDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? loggedIn = freezed,}) {
+  return _then(_self.copyWith(
+loggedIn: freezed == loggedIn ? _self.loggedIn : loggedIn // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _ClaudeAuthStatusDto implements ClaudeAuthStatusDto {
+  const _ClaudeAuthStatusDto({@JsonKey(fromJson: _boolOrNull) required this.loggedIn});
+  factory _ClaudeAuthStatusDto.fromJson(Map<String, dynamic> json) => _$ClaudeAuthStatusDtoFromJson(json);
+
+@override@JsonKey(fromJson: _boolOrNull) final  bool? loggedIn;
+
+/// Create a copy of ClaudeAuthStatusDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ClaudeAuthStatusDtoCopyWith<_ClaudeAuthStatusDto> get copyWith => __$ClaudeAuthStatusDtoCopyWithImpl<_ClaudeAuthStatusDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ClaudeAuthStatusDto&&(identical(other.loggedIn, loggedIn) || other.loggedIn == loggedIn));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,loggedIn);
+
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ClaudeAuthStatusDtoCopyWith<$Res> implements $ClaudeAuthStatusDtoCopyWith<$Res> {
+  factory _$ClaudeAuthStatusDtoCopyWith(_ClaudeAuthStatusDto value, $Res Function(_ClaudeAuthStatusDto) _then) = __$ClaudeAuthStatusDtoCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(fromJson: _boolOrNull) bool? loggedIn
+});
+
+
+
+
+}
+/// @nodoc
+class __$ClaudeAuthStatusDtoCopyWithImpl<$Res>
+    implements _$ClaudeAuthStatusDtoCopyWith<$Res> {
+  __$ClaudeAuthStatusDtoCopyWithImpl(this._self, this._then);
+
+  final _ClaudeAuthStatusDto _self;
+  final $Res Function(_ClaudeAuthStatusDto) _then;
+
+/// Create a copy of ClaudeAuthStatusDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? loggedIn = freezed,}) {
+  return _then(_ClaudeAuthStatusDto(
+loggedIn: freezed == loggedIn ? _self.loggedIn : loggedIn // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_auth_status_dto.g.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_auth_status_dto.g.dart
@@ -1,0 +1,10 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'claude_auth_status_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ClaudeAuthStatusDto _$ClaudeAuthStatusDtoFromJson(Map json) =>
+    _ClaudeAuthStatusDto(loggedIn: _boolOrNull(json['loggedIn']));

--- a/bridge/sesori_plugin_claude/lib/src/runtime/claude_bridge_plugin.dart
+++ b/bridge/sesori_plugin_claude/lib/src/runtime/claude_bridge_plugin.dart
@@ -1,0 +1,83 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../api/claude_process_factory.dart";
+import "../claude_plugin_impl.dart";
+import "../services/claude_session_service.dart";
+
+/// Lifecycle surface for the direct-CLI Claude stream-json plugin.
+final class ClaudeBridgePlugin with SteadyPluginLifecycle implements BridgePlugin {
+  ClaudeBridgePlugin({
+    required ClaudePlugin plugin,
+    required ClaudeSessionService sessions,
+    required HostClaudeProcessFactory processFactory,
+    required ServerClock clock,
+    required Duration statusDebounce,
+  }) : _plugin = plugin,
+       _sessions = sessions,
+       _processFactory = processFactory,
+       _clock = clock,
+       _statusDebounce = statusDebounce {
+    _spawnEvents = processFactory.events.listen(_handleSpawnEvent);
+    markReady();
+  }
+
+  final ClaudePlugin _plugin;
+  final ClaudeSessionService _sessions;
+  final HostClaudeProcessFactory _processFactory;
+  final ServerClock _clock;
+  final Duration _statusDebounce;
+  late final StreamSubscription<ClaudeProcessSpawnEvent> _spawnEvents;
+
+  @override
+  BridgePluginApi get api => _plugin;
+
+  @override
+  Stream<PluginWorkState> get workState => _sessions.workState;
+
+  @override
+  PluginWorkState get currentWorkState => _sessions.currentWorkState;
+
+  @override
+  ServerClock get statusClock => _clock;
+
+  @override
+  Duration get degradedDebounce => _statusDebounce;
+
+  @override
+  PluginDiagnostics describe() => const PluginDiagnostics(
+    pluginId: ClaudePlugin.pluginId,
+    endpoint: null,
+    details: {"transport": "claude-stream-json"},
+  );
+
+  @override
+  Future<Set<String>> interruptActiveWork({required Duration budget}) => _sessions.interruptActiveWork(budget: budget);
+
+  void _handleSpawnEvent(ClaudeProcessSpawnEvent event) {
+    switch (event) {
+      case ClaudeProcessSpawnSucceeded():
+        markReady();
+      case ClaudeProcessSpawnFailed():
+        markDegraded(
+          recoverable: true,
+          requiresUserAction: true,
+          userActionHint: "Verify the configured Claude binary and retry.",
+        );
+    }
+  }
+
+  @override
+  Future<void> onShutdown({required Duration? budget}) async {
+    try {
+      await _spawnEvents.cancel();
+    } finally {
+      try {
+        await _plugin.dispose();
+      } finally {
+        await _processFactory.dispose();
+      }
+    }
+  }
+}

--- a/bridge/sesori_plugin_claude/lib/src/runtime/claude_bridge_plugin.dart
+++ b/bridge/sesori_plugin_claude/lib/src/runtime/claude_bridge_plugin.dart
@@ -70,14 +70,27 @@ final class ClaudeBridgePlugin with SteadyPluginLifecycle implements BridgePlugi
 
   @override
   Future<void> onShutdown({required Duration? budget}) async {
-    try {
-      await _spawnEvents.cancel();
-    } finally {
+    Object? firstError;
+    StackTrace? firstStackTrace;
+
+    Future<void> attempt(Future<void> Function() cleanup) async {
       try {
-        await _plugin.dispose();
-      } finally {
-        await _processFactory.dispose();
+        await cleanup();
+      } on Object catch (error, stackTrace) {
+        firstError ??= error;
+        firstStackTrace ??= stackTrace;
       }
     }
+
+    try {
+      await _spawnEvents.cancel();
+    } on Object catch (error, stackTrace) {
+      firstError = error;
+      firstStackTrace = stackTrace;
+    }
+    await attempt(_plugin.dispose);
+    await attempt(_processFactory.dispose);
+    final error = firstError;
+    if (error != null) Error.throwWithStackTrace(error, firstStackTrace!);
   }
 }

--- a/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
@@ -1,0 +1,265 @@
+import "dart:async";
+import "dart:io" as io;
+import "dart:math";
+
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" show jsonDecodeMap;
+
+import "../api/claude_process_factory.dart";
+import "../api/claude_transcript_api.dart";
+import "../api/models/claude_auth_status_dto.dart";
+import "../claude_approval_registry.dart";
+import "../claude_event_dispatcher.dart";
+import "../claude_history_mapper.dart";
+import "../claude_plugin_impl.dart";
+import "../repositories/claude_backend_catalog_repository.dart";
+import "../repositories/claude_session_process_repository.dart";
+import "../repositories/claude_transcript_catalog_repository.dart";
+import "../repositories/mappers/claude_content_mapper.dart";
+import "../repositories/trackers/claude_tool_tracker.dart";
+import "../services/claude_catalog_service.dart";
+import "../services/claude_session_service.dart";
+import "claude_bridge_plugin.dart";
+
+const int _setupProbeOutputLimit = 64 * 1024;
+
+typedef ClaudeBridgePluginFactory =
+    ClaudeBridgePlugin Function({
+      required ClaudePlugin plugin,
+      required ClaudeSessionService sessions,
+      required HostClaudeProcessFactory processFactory,
+      required ServerClock clock,
+      required Duration statusDebounce,
+    });
+
+ClaudeBridgePlugin _defaultBuildBridgePlugin({
+  required ClaudePlugin plugin,
+  required ClaudeSessionService sessions,
+  required HostClaudeProcessFactory processFactory,
+  required ServerClock clock,
+  required Duration statusDebounce,
+}) => ClaudeBridgePlugin(
+  plugin: plugin,
+  sessions: sessions,
+  processFactory: processFactory,
+  clock: clock,
+  statusDebounce: statusDebounce,
+);
+
+/// Descriptor and composition root for the local Claude Code CLI plugin.
+final class ClaudePluginDescriptor extends BridgePluginDescriptor {
+  const ClaudePluginDescriptor({
+    Duration probeTimeout = const Duration(seconds: 10),
+    Duration sessionIdleTimeout = const Duration(minutes: 5),
+    Duration statusDebounce = const Duration(seconds: 5),
+    ClaudeBridgePluginFactory? buildBridgePlugin,
+  }) : _probeTimeout = probeTimeout,
+       _sessionIdleTimeout = sessionIdleTimeout,
+       _statusDebounce = statusDebounce,
+       _buildBridgePlugin = buildBridgePlugin;
+
+  static const String binOption = "bin";
+  static const String defaultBinary = "claude";
+  static const String minVersion = "2.1.221";
+  static final Random _secureRandom = Random.secure();
+
+  static const List<PluginOption> cliOptions = [
+    PluginValueOption(
+      name: binOption,
+      help: "Path to the Claude Code CLI binary",
+      defaultsTo: defaultBinary,
+      allowedValues: null,
+      valueHelp: "path",
+      validate: null,
+    ),
+  ];
+
+  final Duration _probeTimeout;
+  final Duration _sessionIdleTimeout;
+  final Duration _statusDebounce;
+  final ClaudeBridgePluginFactory? _buildBridgePlugin;
+
+  @override
+  String get id => ClaudePlugin.pluginId;
+
+  @override
+  String get displayName => "Claude Code";
+
+  @override
+  PluginProjectOwnership get projectOwnership => PluginProjectOwnership.bridgeDerived;
+
+  @override
+  PluginSessionOptionsScope get sessionOptionsScope => PluginSessionOptionsScope.plugin;
+
+  @override
+  bool get supportsPromptAttachments => true;
+
+  @override
+  List<PluginOption> get options => cliOptions;
+
+  @override
+  Future<PluginSetupStatus> inspectSetup({
+    required PluginConfig config,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+    required String stateDirectory,
+  }) async {
+    final executable = _binary(config);
+    final executor = HostProcessCommandExecutor(
+      processes: processes,
+      runInShell: io.Platform.isWindows,
+      maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
+    );
+    final CommandResult versionResult;
+    try {
+      versionResult = await executor.run(
+        executable,
+        const ["--version"],
+        environment: environment,
+        timeout: _probeTimeout,
+      );
+    } on io.ProcessException {
+      return const PluginSetupRuntimeMissing(
+        actionHint: "Install Claude Code or fix the configured binary path, then retry setup detection.",
+      );
+    } on Object {
+      return const PluginSetupUnknown(
+        actionHint: "Claude Code did not answer its version check. Verify the local installation and retry.",
+      );
+    }
+    if (versionResult.exitCode != 0) {
+      return const PluginSetupUnknown(
+        actionHint: "Claude Code did not answer its version check. Verify the local installation and retry.",
+      );
+    }
+    final version = _parseVersion(versionResult.stdout);
+    if (version == null) {
+      return const PluginSetupUnknown(
+        actionHint: "Claude Code returned an unrecognized version. Update it and retry setup detection.",
+      );
+    }
+    final minimum = SemanticVersion.parse(value: minVersion);
+    if (version.compareTo(minimum) < 0) {
+      return const PluginSetupUnavailable(
+        actionHint: "Update Claude Code to a supported version, then retry setup detection.",
+      );
+    }
+
+    final CommandResult authResult;
+    try {
+      authResult = await executor.run(
+        executable,
+        const ["auth", "status"],
+        environment: environment,
+        timeout: _probeTimeout,
+      );
+    } on Object {
+      return const PluginSetupUnknown(
+        actionHint: "Claude Code authentication could not be determined. Run `claude auth status` locally and retry.",
+      );
+    }
+    try {
+      final status = ClaudeAuthStatusDto.fromJson(jsonDecodeMap(authResult.stdout));
+      return switch (status.loggedIn) {
+        true => const PluginSetupReady(),
+        false => const PluginSetupAuthenticationRequired(
+          actionHint: "Run `claude auth login` on this machine, then retry setup detection.",
+        ),
+        null => const PluginSetupUnknown(
+          actionHint: "Claude Code authentication could not be determined. Run `claude auth status` locally and retry.",
+        ),
+      };
+    } on Object {
+      return const PluginSetupUnknown(
+        actionHint: "Claude Code authentication could not be determined. Run `claude auth status` locally and retry.",
+      );
+    }
+  }
+
+  @override
+  Future<ClaudeBridgePlugin> start(PluginHost host) async {
+    if (host.startAborted.isAborted) throw const PluginStartAbortedException();
+
+    final binaryPath = _binary(host.config);
+    final processFactory = HostClaudeProcessFactory(
+      processes: host.processes,
+      environment: host.environment,
+    );
+    final processes = ClaudeSessionProcessRepository(
+      processFactory: processFactory.spawn,
+      binaryPath: binaryPath,
+      environment: host.environment,
+    );
+    final eventBuffer = BufferedUntilFirstListener<BridgeSseEvent>();
+    final approvals = ClaudeApprovalRegistry(
+      emit: eventBuffer.add,
+      respond: processes.answerControlRequest,
+    );
+    final sessions = ClaudeSessionService(
+      processes: processes,
+      approvals: approvals,
+      clock: host.clock,
+      idleTimeout: _sessionIdleTimeout,
+    );
+    const content = ClaudeContentMapper();
+    final plugin = ClaudePlugin(
+      processes: processes,
+      transcripts: ClaudeTranscriptCatalogRepository(
+        transcriptApi: ClaudeTranscriptApi(environment: host.environment),
+      ),
+      sessions: sessions,
+      catalogService: ClaudeCatalogService(
+        catalog: const ClaudeBackendCatalogRepository(),
+        processes: processes,
+      ),
+      approvals: approvals,
+      eventDispatcher: ClaudeEventDispatcher(
+        content: content,
+        tools: ClaudeToolTracker(),
+      ),
+      history: const ClaudeHistoryMapper(content: content),
+      eventBuffer: eventBuffer,
+      clock: host.clock,
+      generateSessionId: _generateUuidV4,
+      launchDirectory: io.Directory.current.path,
+    );
+    final bridgePlugin = (_buildBridgePlugin ?? _defaultBuildBridgePlugin)(
+      plugin: plugin,
+      sessions: sessions,
+      processFactory: processFactory,
+      clock: host.clock,
+      statusDebounce: _statusDebounce,
+    );
+
+    if (host.startAborted.isAborted) {
+      try {
+        await bridgePlugin.shutdown(budget: null);
+      } on Object catch (error, stackTrace) {
+        Log.e("[claude] rollback after aborted start failed", error, stackTrace);
+      }
+      throw const PluginStartAbortedException();
+    }
+    return bridgePlugin;
+  }
+
+  String _binary(PluginConfig config) {
+    final configured = config.value(binOption)?.trim();
+    return configured == null || configured.isEmpty ? defaultBinary : configured;
+  }
+
+  static SemanticVersion? _parseVersion(String output) {
+    final match = RegExp(r"(?:^|\s)(\d+\.\d+\.\d+)(?:\s|$)").firstMatch(output);
+    final value = match?.group(1);
+    return value == null ? null : SemanticVersion.tryParse(value: value);
+  }
+
+  static String _generateUuidV4() {
+    final bytes = List<int>.generate(16, (_) => _secureRandom.nextInt(256));
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    final hex = bytes.map((byte) => byte.toRadixString(16).padLeft(2, "0")).join();
+    return "${hex.substring(0, 8)}-${hex.substring(8, 12)}-${hex.substring(12, 16)}-"
+        "${hex.substring(16, 20)}-${hex.substring(20)}";
+  }
+}

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
@@ -164,6 +164,23 @@ final class ClaudeSessionService {
     }
   }
 
+  Future<Set<String>> interruptActiveWork({required Duration budget}) {
+    return () async {
+      final activeSessionIds = <String>{
+        for (final entry in _turns.entries)
+          if (entry.value.pending > 0) entry.key,
+      };
+      if (activeSessionIds.isEmpty) return const <String>{};
+      await Future.wait([
+        for (final sessionId in activeSessionIds) abort(sessionId: sessionId),
+      ]);
+      if (currentWorkState != PluginWorkState.idle) {
+        await workState.firstWhere((state) => state == PluginWorkState.idle);
+      }
+      return Set<String>.unmodifiable(activeSessionIds);
+    }().timeout(budget);
+  }
+
   Future<void> deleteSession({required String sessionId}) async {
     final state = _turns.remove(sessionId);
     if (state != null) {

--- a/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
@@ -51,6 +51,22 @@ void main() {
       expect(_userFrames(process), hasLength(1));
     });
 
+    test("interruptActiveWork aborts and waits for active sessions within its budget", () async {
+      harness.enqueue("first");
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+
+      final interruption = harness.service.interruptActiveWork(
+        budget: const Duration(seconds: 1),
+      );
+      final interrupt = await _waitForControlSubtype(process, "interrupt");
+      process.emitControlResponse(requestId: interrupt["request_id"]! as String, payload: const {});
+      process.emit(_result());
+
+      expect(await interruption, {testSessionId});
+      expect(harness.service.currentWorkState, PluginWorkState.idle);
+    });
+
     test("routes control asks and clears them when the process exits", () async {
       harness.enqueue("first");
       final process = await harness.firstProcess;

--- a/bridge/sesori_plugin_claude/test/runtime/claude_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_claude/test/runtime/claude_plugin_descriptor_test.dart
@@ -1,0 +1,429 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+
+import "package:claude_plugin/claude_plugin.dart";
+import "package:claude_plugin/claude_testing.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  const config = PluginConfig(values: {ClaudePluginDescriptor.binOption: "claude"});
+
+  group("ClaudePluginDescriptor.inspectSetup", () {
+    test("declares the Claude plugin contract and bare bin option", () {
+      const descriptor = ClaudePluginDescriptor();
+      expect(descriptor.id, "claude");
+      expect(descriptor.displayName, "Claude Code");
+      expect(descriptor.projectOwnership, PluginProjectOwnership.bridgeDerived);
+      expect(descriptor.sessionOptionsScope, PluginSessionOptionsScope.plugin);
+      expect(descriptor.supportsPromptAttachments, isTrue);
+      expect(descriptor.options.single.name, "bin");
+      expect(ClaudePluginDescriptor.minVersion, "2.1.221");
+    });
+
+    test("reports ready after ordered version and typed auth probes", () async {
+      final processes = _ProcessService([
+        _ProbeProcess(stdoutText: "2.1.226 (Claude Code)\n", exitCode: Future.value(0)),
+        _ProbeProcess(
+          stdoutText: jsonEncode({
+            "loggedIn": true,
+            "email": "private@example.com",
+            "orgName": "Private Org",
+          }),
+          exitCode: Future.value(0),
+        ),
+      ]);
+
+      final status = await const ClaudePluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const {"PATH": "/bin"},
+        stateDirectory: "/state",
+      );
+
+      expect(status, const PluginSetupReady());
+      expect(processes.arguments, [
+        const ["--version"],
+        const ["auth", "status"],
+      ]);
+      expect(processes.environments, [
+        const {"PATH": "/bin"},
+        const {"PATH": "/bin"},
+      ]);
+    });
+
+    test("reports runtime missing when the version process cannot spawn", () async {
+      final status = await const ClaudePluginDescriptor().inspectSetup(
+        config: config,
+        processes: _ProcessService([
+          const ProcessException("claude", ["--version"], "missing", 2),
+        ]),
+        environment: const {},
+        stateDirectory: "/state",
+      );
+
+      _expectNonReady<PluginSetupRuntimeMissing>(status);
+    });
+
+    test("reports unavailable and skips auth for an outdated runtime", () async {
+      final processes = _ProcessService([
+        _ProbeProcess(stdoutText: "2.1.220 (Claude Code)\n", exitCode: Future.value(0)),
+      ]);
+
+      final status = await const ClaudePluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const {},
+        stateDirectory: "/state",
+      );
+
+      _expectNonReady<PluginSetupUnavailable>(status);
+      expect(processes.arguments, [
+        const ["--version"],
+      ]);
+    });
+
+    test("reports authentication required from loggedIn false only", () async {
+      final processes = _ProcessService([
+        _ProbeProcess(stdoutText: "2.1.221 (Claude Code)\n", exitCode: Future.value(0)),
+        _ProbeProcess(
+          stdoutText: '{"loggedIn":false,"email":"private@example.com"}',
+          exitCode: Future.value(1),
+        ),
+      ]);
+
+      final status = await const ClaudePluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const {},
+        stateDirectory: "/state",
+      );
+
+      _expectNonReady<PluginSetupAuthenticationRequired>(status);
+      expect(status.actionHint, isNot(contains("private@example.com")));
+    });
+
+    test("reports unknown for malformed auth without exposing its payload", () async {
+      final processes = _ProcessService([
+        _ProbeProcess(stdoutText: "2.1.221 (Claude Code)\n", exitCode: Future.value(0)),
+        _ProbeProcess(stdoutText: "private-account-output", exitCode: Future.value(0)),
+      ]);
+
+      final status = await const ClaudePluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const {},
+        stateDirectory: "/state",
+      );
+
+      _expectNonReady<PluginSetupUnknown>(status);
+      expect(status.actionHint, isNot(contains("private-account-output")));
+    });
+
+    test("bounds a hung version probe and force-kills it", () async {
+      final process = _ProbeProcess(stdoutText: "", exitCode: Completer<int>().future);
+      final processes = _ProcessService([process]);
+
+      final status =
+          await const ClaudePluginDescriptor(
+            probeTimeout: Duration(milliseconds: 10),
+          ).inspectSetup(
+            config: config,
+            processes: processes,
+            environment: const {},
+            stateDirectory: "/state",
+          );
+
+      _expectNonReady<PluginSetupUnknown>(status);
+      expect(processes.forceSignaledPids, [process.pid]);
+    });
+  });
+
+  group("ClaudePluginDescriptor.start", () {
+    test("rejects an entry abort without constructing a plugin", () async {
+      var constructed = false;
+      final descriptor = ClaudePluginDescriptor(
+        buildBridgePlugin:
+            ({
+              required plugin,
+              required sessions,
+              required processFactory,
+              required clock,
+              required statusDebounce,
+            }) {
+              constructed = true;
+              return ClaudeBridgePlugin(
+                plugin: plugin,
+                sessions: sessions,
+                processFactory: processFactory,
+                clock: clock,
+                statusDebounce: statusDebounce,
+              );
+            },
+      );
+
+      await expectLater(
+        descriptor.start(_PluginHost(startAborted: _AlwaysAbortedSignal(), processes: _ProcessService([]))),
+        throwsA(isA<PluginStartAbortedException>()),
+      );
+      expect(constructed, isFalse);
+    });
+
+    test("rolls back through shutdown on a post-construction abort", () async {
+      ClaudeBridgePlugin? constructed;
+      final descriptor = ClaudePluginDescriptor(
+        buildBridgePlugin:
+            ({
+              required plugin,
+              required sessions,
+              required processFactory,
+              required clock,
+              required statusDebounce,
+            }) {
+              return constructed = ClaudeBridgePlugin(
+                plugin: plugin,
+                sessions: sessions,
+                processFactory: processFactory,
+                clock: clock,
+                statusDebounce: statusDebounce,
+              );
+            },
+      );
+
+      await expectLater(
+        descriptor.start(_PluginHost(startAborted: _AbortOnSecondCheck(), processes: _ProcessService([]))),
+        throwsA(isA<PluginStartAbortedException>()),
+      );
+      expect(constructed?.currentStatus, const PluginStopped());
+    });
+
+    test("uses host spawning, degrades on spawn failure, and readies on retry", () async {
+      final liveProcess = _ProbeProcess(
+        stdoutText: "",
+        exitCode: Completer<int>().future,
+        keepStdoutOpen: true,
+      );
+      final processes = _ProcessService([
+        const ProcessException("claude", [], "missing", 2),
+        liveProcess,
+      ])..answerClaudeInitialize = true;
+      final plugin = await const ClaudePluginDescriptor(
+        statusDebounce: Duration.zero,
+      ).start(_PluginHost(startAborted: StartAbortSignal.never, processes: processes));
+      addTearDown(() async {
+        await plugin.shutdown(budget: null);
+        await liveProcess.close();
+      });
+
+      expect(plugin.currentStatus, const PluginReady());
+      await expectLater(
+        plugin.api.getSessionOptions(
+          projectId: "/tmp/project",
+          discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+        ),
+        throwsA(isA<ProcessException>()),
+      );
+      await _pump();
+      expect(plugin.currentStatus, isA<PluginDegraded>());
+      final degraded = plugin.currentStatus as PluginDegraded;
+      expect(degraded.recoverable, isTrue);
+      expect(degraded.userActionHint, isNotEmpty);
+
+      await plugin.api.getSessionOptions(
+        projectId: "/tmp/project",
+        discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+      );
+      expect(plugin.currentStatus, const PluginReady());
+      expect(processes.runInShellValues, [Platform.isWindows, Platform.isWindows]);
+      expect(processes.workingDirectories.every((directory) => directory != null), isTrue);
+
+      liveProcess.completeExit(1);
+      await _pump();
+      expect(plugin.currentStatus, const PluginReady());
+      expect(plugin.describe().details, {"transport": "claude-stream-json"});
+    });
+  });
+}
+
+void _expectNonReady<T extends PluginSetupStatus>(PluginSetupStatus status) {
+  expect(status, isA<T>());
+  expect(status, isNot(isA<PluginSetupNotInspected>()));
+  expect(status.actionHint, isNotEmpty);
+}
+
+Future<void> _pump() async {
+  await Future<void>.delayed(Duration.zero);
+  await Future<void>.delayed(Duration.zero);
+}
+
+final class _PluginHost implements PluginHost {
+  _PluginHost({required this.startAborted, required this.processes});
+
+  @override
+  final StartAbortSignal startAborted;
+
+  @override
+  final HostProcessService processes;
+
+  @override
+  PluginConfig get config => const PluginConfig(values: {ClaudePluginDescriptor.binOption: "claude"});
+
+  @override
+  Map<String, String> get environment => const {"CLAUDE_CONFIG_DIR": "/tmp/claude-descriptor-test"};
+
+  @override
+  ServerClock get clock => const ServerClock();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+final class _AlwaysAbortedSignal implements StartAbortSignal {
+  @override
+  bool get isAborted => true;
+
+  @override
+  Future<void> get whenAborted => Future.value();
+}
+
+final class _AbortOnSecondCheck implements StartAbortSignal {
+  int checks = 0;
+
+  @override
+  bool get isAborted => ++checks >= 2;
+
+  @override
+  Future<void> get whenAborted => Completer<void>().future;
+}
+
+final class _ProcessService implements HostProcessService {
+  _ProcessService(this._outcomes);
+
+  final List<Object> _outcomes;
+  final List<List<String>> arguments = [];
+  final List<Map<String, String>?> environments = [];
+  final List<bool> runInShellValues = [];
+  final List<String?> workingDirectories = [];
+  final List<int> forceSignaledPids = [];
+  bool answerClaudeInitialize = false;
+  var _index = 0;
+
+  @override
+  Future<SpawnedProcess> spawn({
+    required String executable,
+    required List<String> arguments,
+    required Map<String, String>? environment,
+    required String? workingDirectory,
+    required bool runInShell,
+  }) async {
+    this.arguments.add(List.unmodifiable(arguments));
+    environments.add(environment == null ? null : Map.unmodifiable(environment));
+    runInShellValues.add(runInShell);
+    workingDirectories.add(workingDirectory);
+    final outcome = _outcomes[_index++];
+    if (outcome is! SpawnedProcess) throw outcome;
+    if (answerClaudeInitialize && outcome is _ProbeProcess) {
+      unawaited(outcome.answerInitialize());
+    }
+    return outcome;
+  }
+
+  @override
+  Future<ProcessIdentity?> inspect({required int pid}) async => null;
+
+  @override
+  Future<SignalResult> signalGraceful({required int pid}) async {
+    final outcome = _outcomes.whereType<_ProbeProcess>().where((process) => process.pid == pid).firstOrNull;
+    outcome?.completeExit(-15);
+    return _signal(pid);
+  }
+
+  @override
+  Future<SignalResult> signalForce({required int pid}) async {
+    forceSignaledPids.add(pid);
+    final outcome = _outcomes.whereType<_ProbeProcess>().where((process) => process.pid == pid).firstOrNull;
+    outcome?.completeExit(-9);
+    return _signal(pid);
+  }
+
+  SignalResult _signal(int pid) => SignalResult(
+    pid: pid,
+    requestedSignal: ShutdownSignal.force,
+    deliveredSignal: ProcessSignal.sigkill,
+    wasRequested: true,
+    attemptedAt: DateTime.utc(2026, 8, 11),
+  );
+}
+
+final class _ProbeProcess implements SpawnedProcess {
+  _ProbeProcess({
+    required String stdoutText,
+    required Future<int> exitCode,
+    bool keepStdoutOpen = false,
+  }) : pid = _nextPid++,
+       _stdout = StreamController<List<int>>(),
+       _stdin = CapturingIOSink() {
+    if (stdoutText.isNotEmpty) _stdout.add(utf8.encode(stdoutText));
+    if (!keepStdoutOpen) unawaited(_stdout.close());
+    unawaited(exitCode.then(completeExit));
+  }
+
+  static var _nextPid = 100;
+
+  @override
+  final int pid;
+
+  final StreamController<List<int>> _stdout;
+  final Completer<int> _exit = Completer<int>();
+  final CapturingIOSink _stdin;
+
+  @override
+  Future<int> get exitCode => _exit.future;
+
+  @override
+  Stream<List<int>> get stdout => _stdout.stream;
+
+  @override
+  Stream<List<int>> get stderr => const Stream.empty();
+
+  @override
+  IOSink get stdin => _stdin;
+
+  @override
+  ProcessIdentity get identity => throw UnimplementedError();
+
+  void completeExit(int code) {
+    if (!_exit.isCompleted) _exit.complete(code);
+  }
+
+  Future<void> answerInitialize() async {
+    for (var attempt = 0; attempt < 100; attempt++) {
+      final initialize = _stdin.frames.where((frame) => frame["type"] == "control_request").firstOrNull;
+      if (initialize != null) {
+        final requestId = initialize["request_id"]! as String;
+        _stdout.add(
+          utf8.encode(
+            '${jsonEncode({
+              "type": "control_response",
+              "response": {
+                "subtype": "success",
+                "request_id": requestId,
+                "response": {
+                  "commands": <Object?>[],
+                  "models": <Object?>[],
+                },
+              },
+            })}\n',
+          ),
+        );
+        return;
+      }
+      await Future<void>.delayed(Duration.zero);
+    }
+  }
+
+  Future<void> close() async {
+    if (!_stdout.isClosed) await _stdout.close();
+  }
+}


### PR DESCRIPTION
## Complexity

⚙️ Moderate: this adds the Claude plugin's composition and lifecycle boundary, bounded setup probes, and host-process integration across several package layers.

## What

- add the exported but unregistered `ClaudePluginDescriptor` with the bare `bin` option
- inspect the Claude CLI version and authentication state through bounded host-process probes
- parse only the PII-safe `loggedIn` field from `claude auth status`
- compose the existing Claude API components behind `ClaudeBridgePlugin` and `SteadyPluginLifecycle`
- route child processes and signals through the bridge host, including Windows shell launching
- degrade on binary spawn failure, recover on a successful retry, and roll back an aborted start

## Why

The completed Claude plugin API needs a bridge-owned descriptor and lifecycle surface before it can be safely registered as a harness in Step 14.

## Risk and test focus

Moderate risk. The main focus is setup-state classification, auth-output privacy, process ownership and signalling, start cancellation, shutdown cleanup, and lifecycle recovery. The descriptor is not registered yet, so this PR does not expose Claude Code to users or alter existing harness routing.

## Expected result

No user-visible or database change. Internally, the Claude package can inspect local setup and construct a lifecycle-managed plugin through bridge host seams; app activation remains deferred to Step 14.

## Verification

- `dart analyze --fatal-infos` in `bridge/sesori_plugin_claude`
- `dart test` in `bridge/sesori_plugin_claude` (197 tests)
- `git diff --check`
- architecture implementation review: APPROVED, no findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Claude Code plugin descriptor and lifecycle with host-routed process management, bounded setup probes, and recoverable degradation. Prepares the plugin for registration in Step 14 without exposing it to users.

- **New Features**
  - Export unregistered `ClaudePluginDescriptor` (with `bin` option, default `claude`, min version `2.1.221`) and `ClaudeBridgePlugin`.
  - Inspect setup via host-routed `--version` and `auth status` with timeouts; return ready/runtime missing/auth required/unavailable/unknown with action hints.
  - Parse only the PII-safe `loggedIn` field from `auth status` using a typed DTO; discard other fields.
  - Add `HostClaudeProcessFactory` to spawn via `HostProcessService`, emit spawn success/failure, and use `runInShell` on Windows.
  - Add `ClaudeBridgePlugin` using `SteadyPluginLifecycle`; degrade (recoverable) on spawn failure and mark ready on success; per-session exits do not change status.
  - Support bounded interruption of active work via `ClaudeSessionService.interruptActiveWork`; handle entry/post-construction aborts with rollback via `shutdown(budget: null)`.

- **Bug Fixes**
  - Preserve the primary shutdown failure in `ClaudeBridgePlugin.onShutdown` by rethrowing the first error after cleanup attempts.

<sup>Written for commit 2b6432a49c4f0d5b49023722f9c5713473c91003. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

