### PR TITLE
⚙️ [claude-code-plugin] feat(claude): register the Claude Code harness [step 14/17]

### DIFF
--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -433,13 +433,15 @@
 
   `dart pub get`, full `make analyze`, every bridge module test suite (including
   all 2,532 app tests), app and shared `dart analyze --fatal-infos`, and
-  `git diff --check` pass. The source-run `dart run app/bin/bridge.dart
-  --version` smoke reports `1.8.0`. Architecture implementation review of the
+  `git diff $(git merge-base origin/main HEAD) --check` pass. The source-run
+  `dart run app/bin/bridge.dart --version` smoke reports `1.8.0`. Architecture
+  implementation review of the
   full Step 14 diff against `origin/main` returned `APPROVED` with no findings;
   it confirmed the bridge dependency direction, designated registry seam, and
-  additive shared identity remain valid. The final diff is 42 changed lines (33
-  additions and 9 deletions), below the 250-500 estimate because the existing
-  registry seam required no extra plumbing. No generated files or database
+  additive shared identity remain valid. The final diff is 44 changed lines (35
+  additions and 9 deletions), measured with `git diff $(git merge-base
+  origin/main HEAD) --numstat`, below the 250-500 estimate because the existing
+  registry seam required no extra plumbing. Generated lines: 0. No database
   state change in this step.
 
 ## Findings And Plan Deltas

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -4,13 +4,13 @@
 
 - **Plan slug:** `claude-code-plugin`
 - **Implementation base:** `origin/main` at
-  `f0d705bc` (Step 13 started after Step 12 merged)
-- **Series state:** Steps 1-12/17 merged; Step 13/17 PR open
-- **Current step:** 13/17 — descriptor and lifecycle in review
+  `ba2f6f7b` (Step 14 started after Step 13 merged)
+- **Series state:** Steps 1-13/17 merged; Step 14/17 ready for review
+- **Current step:** 14/17 — Claude Code harness registration verified
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737),
   merged 2026-08-04 as `6d641532`
-- **Next action:** Monitor Step 13 PR #815, then wait for explicit direction
-  after merge before starting Step 14
+- **Next action:** Open and monitor the Step 14 PR, then wait for explicit
+  direction after merge before starting Step 15
 
 ## Plan Review
 
@@ -57,8 +57,8 @@
 | [x] | 10/17 | `claude-code-plugin-session-service` | `🚧 [claude-code-plugin] feat(claude): add session residency and turn queue [step 10/17]` | 1,200-1,500 | [PR #808](https://github.com/sesori-ai/sesori_apps_monorepo/pull/808) merged 2026-08-11 as `fcca943c` |
 | [x] | 11/17 | `claude-code-plugin-catalog-service` | `⚙️ [claude-code-plugin] feat(claude): add model and agent catalog [step 11/17]` | 900-1,300 | [PR #809](https://github.com/sesori-ai/sesori_apps_monorepo/pull/809) merged 2026-08-11 as `ca521672` |
 | [x] | 12/17 | `claude-code-plugin-plugin-impl` | `🚧 [claude-code-plugin] feat(claude): implement the plugin API surface [step 12/17]` | 1,200-1,500 | [PR #813](https://github.com/sesori-ai/sesori_apps_monorepo/pull/813) merged 2026-08-11 as `f0d705bc` |
-| [ ] | 13/17 | `claude-code-plugin-descriptor` | `⚙️ [claude-code-plugin] feat(claude): add descriptor and lifecycle [step 13/17]` | 1,100-1,500 | [PR #815](https://github.com/sesori-ai/sesori_apps_monorepo/pull/815) open against `main` |
-| [ ] | 14/17 | `claude-code-plugin-activation` | `⚙️ [claude-code-plugin] feat(claude): register the Claude Code harness [step 14/17]` | 250-500 | Not started |
+| [x] | 13/17 | `claude-code-plugin-descriptor` | `⚙️ [claude-code-plugin] feat(claude): add descriptor and lifecycle [step 13/17]` | 1,100-1,500 | [PR #815](https://github.com/sesori-ai/sesori_apps_monorepo/pull/815) merged 2026-08-11 as `ba2f6f7b` |
+| [ ] | 14/17 | `claude-code-plugin-activation` | `⚙️ [claude-code-plugin] feat(claude): register the Claude Code harness [step 14/17]` | 250-500 | Implemented and verified on `claude-code-plugin-activation`; ready to open against `main` |
 | [ ] | 15/17 | `claude-code-plugin-client-polish` | `🌿 [claude-code-plugin] feat(client): add Claude Code branding [step 15/17]` | 400-800 | Not started |
 | [ ] | 16/17 | `claude-code-plugin-e2e` | `🌿 [claude-code-plugin] docs: record Claude Code live verification [step 16/17]` | 200-500 | Not started |
 | [ ] | 17/17 | `claude-code-plugin-retire` | `🌱 [claude-code-plugin] docs: retire Claude Code plugin plan [step 17/17]` | 50-200 | Not started |
@@ -421,6 +421,26 @@
   diff against `main` returned `APPROVED` with no findings. It confirmed the
   descriptor composition, lifecycle ownership, host process seam, and package
   dependency direction preserve the bridge architecture.
+
+- Step 14/17 local implementation (2026-08-11): added `Harness.claude` as the
+  shared built-in identity, added the Claude package to the bridge app's
+  workspace dependencies, and registered `ClaudePluginDescriptor` at
+  `plugin_registry.dart`, the sole concrete-plugin composition point. Updated
+  the registry assertion to cover all four bundled harnesses while leaving the
+  OpenCode preferred default unchanged. Existing backend-neutral session
+  analytics already instrument authoritative outcomes, so this registration
+  adds no provider-specific analytics event.
+
+  `dart pub get`, full `make analyze`, every bridge module test suite (including
+  all 2,532 app tests), app and shared `dart analyze --fatal-infos`, and
+  `git diff --check` pass. The source-run `dart run app/bin/bridge.dart
+  --version` smoke reports `1.8.0`. Architecture implementation review of the
+  full Step 14 diff against `origin/main` returned `APPROVED` with no findings;
+  it confirmed the bridge dependency direction, designated registry seam, and
+  additive shared identity remain valid. The final diff is 42 changed lines (33
+  additions and 9 deletions), below the 250-500 estimate because the existing
+  registry seam required no extra plumbing. No generated files or database
+  state change in this step.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -5,12 +5,12 @@
 - **Plan slug:** `claude-code-plugin`
 - **Implementation base:** `origin/main` at
   `ba2f6f7b` (Step 14 started after Step 13 merged)
-- **Series state:** Steps 1-13/17 merged; Step 14/17 ready for review
-- **Current step:** 14/17 — Claude Code harness registration verified
+- **Series state:** Steps 1-13/17 merged; Step 14/17 PR open
+- **Current step:** 14/17 — Claude Code harness registration in review
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737),
   merged 2026-08-04 as `6d641532`
-- **Next action:** Open and monitor the Step 14 PR, then wait for explicit
-  direction after merge before starting Step 15
+- **Next action:** Monitor Step 14 PR #816, then wait for explicit direction
+  after merge before starting Step 15
 
 ## Plan Review
 
@@ -58,7 +58,7 @@
 | [x] | 11/17 | `claude-code-plugin-catalog-service` | `⚙️ [claude-code-plugin] feat(claude): add model and agent catalog [step 11/17]` | 900-1,300 | [PR #809](https://github.com/sesori-ai/sesori_apps_monorepo/pull/809) merged 2026-08-11 as `ca521672` |
 | [x] | 12/17 | `claude-code-plugin-plugin-impl` | `🚧 [claude-code-plugin] feat(claude): implement the plugin API surface [step 12/17]` | 1,200-1,500 | [PR #813](https://github.com/sesori-ai/sesori_apps_monorepo/pull/813) merged 2026-08-11 as `f0d705bc` |
 | [x] | 13/17 | `claude-code-plugin-descriptor` | `⚙️ [claude-code-plugin] feat(claude): add descriptor and lifecycle [step 13/17]` | 1,100-1,500 | [PR #815](https://github.com/sesori-ai/sesori_apps_monorepo/pull/815) merged 2026-08-11 as `ba2f6f7b` |
-| [ ] | 14/17 | `claude-code-plugin-activation` | `⚙️ [claude-code-plugin] feat(claude): register the Claude Code harness [step 14/17]` | 250-500 | Implemented and verified on `claude-code-plugin-activation`; ready to open against `main` |
+| [ ] | 14/17 | `claude-code-plugin-activation` | `⚙️ [claude-code-plugin] feat(claude): register the Claude Code harness [step 14/17]` | 250-500 | [PR #816](https://github.com/sesori-ai/sesori_apps_monorepo/pull/816) open against `main` |
 | [ ] | 15/17 | `claude-code-plugin-client-polish` | `🌿 [claude-code-plugin] feat(client): add Claude Code branding [step 15/17]` | 400-800 | Not started |
 | [ ] | 16/17 | `claude-code-plugin-e2e` | `🌿 [claude-code-plugin] docs: record Claude Code live verification [step 16/17]` | 200-500 | Not started |
 | [ ] | 17/17 | `claude-code-plugin-retire` | `🌱 [claude-code-plugin] docs: retire Claude Code plugin plan [step 17/17]` | 50-200 | Not started |

--- a/bridge/app/lib/src/bridge/runtime/plugin_registry.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_registry.dart
@@ -1,3 +1,4 @@
+import "package:claude_plugin/claude_plugin.dart" show ClaudePluginDescriptor;
 import "package:codex_plugin/codex_plugin.dart" show CodexPluginDescriptor;
 import "package:cursor_plugin/cursor_plugin.dart" show CursorPluginDescriptor;
 import "package:opencode_plugin/opencode_plugin.dart" show OpenCodePluginDescriptor;
@@ -11,6 +12,7 @@ const List<BridgePluginDescriptor> knownPlugins = [
   OpenCodePluginDescriptor(),
   CodexPluginDescriptor(),
   CursorPluginDescriptor(),
+  ClaudePluginDescriptor(),
 ];
 
 /// Product-preferred default when OpenCode is selectable. Lifecycle policy

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -33,6 +33,8 @@ dependencies:
     path: ../sesori_plugin_acp
   cursor_plugin:
     path: ../sesori_plugin_cursor
+  claude_plugin:
+    path: ../sesori_plugin_claude
   meta: ^1.19.0
   # Pinned lock-step with drift_dev: 2.34.1+ requires analyzer ^13, but the
   # workspace is held on analyzer 10 by injectable_generator. drift_dev is

--- a/bridge/app/test/bridge/runtime/plugin_registry_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_registry_test.dart
@@ -5,7 +5,7 @@ void main() {
   test("registry contains every bundled plugin exactly once", () {
     final ids = knownPlugins.map((plugin) => plugin.id).toList();
 
-    expect(ids, containsAll(["opencode", "codex", "cursor"]));
+    expect(ids, containsAll(["opencode", "codex", "cursor", "claude"]));
     expect(ids.toSet(), hasLength(ids.length));
   });
 

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_identity.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_identity.dart
@@ -4,7 +4,7 @@
 /// bridges can advertise harnesses unknown to an older client. Use [name] when
 /// producing or matching a built-in plugin ID and retain a fallback for values
 /// not represented by this enum.
-enum Harness { opencode, codex, cursor }
+enum Harness { opencode, codex, cursor, claude }
 
 // COMPATIBILITY 2026-07-13 (v1.5.0): Old peers omit pluginId and mean OpenCode. Remove constant/export with defaults.
 const String legacyMissingPluginId = "opencode";


### PR DESCRIPTION
## Complexity

⚙️ Moderate: the code change is small, but it activates a new backend across the shared identity contract and bridge app composition root.

## What

- add `claude` to the shared built-in `Harness` identities
- add the Claude plugin package to the bridge app dependencies
- register `ClaudePluginDescriptor` in the sole plugin registry composition point
- update the bundled-plugin registry assertion
- keep OpenCode as the preferred default

## Why

Steps 2-13 implemented and lifecycle-wrapped the Claude Code plugin while keeping it app-invisible. This activation step makes that completed plugin available to the bridge and clients.

## Risk and test focus

Moderate risk because bridge startup now inspects and may start one more independently managed plugin. Test focus is shared identity compatibility, plugin registration uniqueness, dependency resolution, full bridge analysis/tests, and source-run CLI startup. Existing harness routing and the OpenCode default must remain unchanged.

## Expected result

Users with a supported, authenticated Claude Code CLI can see and use the Claude harness through the bridge; older clients retain the existing unknown-harness fallback until Step 15 adds branding. No database schema or persisted-data change.

## Verification

- `dart pub get` in `bridge`
- `make analyze` in `bridge`
- `make test` in `bridge` (all module suites; 2,532 app tests)
- `dart analyze --fatal-infos` in `bridge/app`
- `dart analyze --fatal-infos` in `shared/sesori_shared`
- `dart run app/bin/bridge.dart --version` reports `1.8.0`
- `git diff --check`
- architecture implementation review: APPROVED, no findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activate the Claude Code harness in the bridge so the plugin can be discovered and started. OpenCode stays the default and older clients keep working; activation metrics are documented for reproducibility.

- **New Features**
  - Register `ClaudePluginDescriptor` in the plugin registry (`knownPlugins`).
  - Add `Harness.claude` to the shared built-in identities.
  - Add `claude_plugin` to bridge app dependencies.
  - Update the registry test to assert `opencode`, `codex`, `cursor`, and `claude`.
  - No schema or analytics changes.

<sup>Written for commit d814f6a2336743770c85f9ce49d134db931a7fc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

