### PR TITLE
🌿 fix(claude): preserve host environment during launch

### DIFF
--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -6,13 +6,12 @@
 - **Implementation base:** `origin/main` at
   `c3d21c78` (focused fix started after Step 15 merged)
 - **Series state:** Steps 1-15/17 merged; Step 16/17 blocked by a live launch
-  failure; focused fix in progress
-- **Current step:** focused fix — preserve host environment without violating the
-  Claude launch override invariant
+  failure; focused fix PR #821 open
+- **Current step:** focused launch-environment fix in review
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737),
   merged 2026-08-04 as `6d641532`
-- **Next action:** Verify and merge the focused launch-environment fix, then
-  resume Step 16 live verification
+- **Next action:** Monitor focused fix PR #821, then resume Step 16 live
+  verification after it merges
 
 ## Plan Review
 
@@ -479,7 +478,8 @@
   against the isolated E2E data directory then reported Claude setup ready and
   returned HTTP 200 with real agents, providers, models, and commands from the
   exact `/session/options` request that previously returned 502. Step 16 remains
-  paused until this focused fix merges. No database or persisted-data change.
+  paused until [PR #821](https://github.com/sesori-ai/sesori_apps_monorepo/pull/821)
+  merges. No database or persisted-data change.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -473,10 +473,12 @@
   production composition preserves it through the host process seam without
   putting it in the launch spec.
 
-  All 10 focused descriptor tests, all 197 Claude package tests,
-  `dart analyze --fatal-infos`, and `git diff --check` pass. A source bridge
-  against the isolated E2E data directory then reported Claude setup ready and
-  returned HTTP 200 with real agents, providers, models, and commands from the
+  All 10 focused descriptor tests, all 197 Claude package tests, `dart analyze
+  --fatal-infos`, and `git diff $(git merge-base origin/main HEAD) --check`
+  pass. The final diff is 44 changed lines (36 additions and 8 deletions),
+  measured with the matching `--numstat` command; generated lines: 0.
+  A source bridge against the isolated E2E data directory then reported Claude
+  setup ready and returned HTTP 200 with real agents, providers, models, and commands from the
   exact `/session/options` request that previously returned 502. Step 16 remains
   paused until [PR #821](https://github.com/sesori-ai/sesori_apps_monorepo/pull/821)
   merges. No database or persisted-data change.

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -4,13 +4,15 @@
 
 - **Plan slug:** `claude-code-plugin`
 - **Implementation base:** `origin/main` at
-  `85438e1d` (Step 15 started after Step 14 merged)
-- **Series state:** Steps 1-14/17 merged; Step 15/17 PR open
-- **Current step:** 15/17 — Claude Code client branding in review
+  `c3d21c78` (focused fix started after Step 15 merged)
+- **Series state:** Steps 1-15/17 merged; Step 16/17 blocked by a live launch
+  failure; focused fix in progress
+- **Current step:** focused fix — preserve host environment without violating the
+  Claude launch override invariant
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737),
   merged 2026-08-04 as `6d641532`
-- **Next action:** Monitor Step 15 PR #817, then wait for explicit direction
-  after merge before starting Step 16
+- **Next action:** Verify and merge the focused launch-environment fix, then
+  resume Step 16 live verification
 
 ## Plan Review
 
@@ -59,7 +61,7 @@
 | [x] | 12/17 | `claude-code-plugin-plugin-impl` | `🚧 [claude-code-plugin] feat(claude): implement the plugin API surface [step 12/17]` | 1,200-1,500 | [PR #813](https://github.com/sesori-ai/sesori_apps_monorepo/pull/813) merged 2026-08-11 as `f0d705bc` |
 | [x] | 13/17 | `claude-code-plugin-descriptor` | `⚙️ [claude-code-plugin] feat(claude): add descriptor and lifecycle [step 13/17]` | 1,100-1,500 | [PR #815](https://github.com/sesori-ai/sesori_apps_monorepo/pull/815) merged 2026-08-11 as `ba2f6f7b` |
 | [x] | 14/17 | `claude-code-plugin-activation` | `⚙️ [claude-code-plugin] feat(claude): register the Claude Code harness [step 14/17]` | 250-500 | [PR #816](https://github.com/sesori-ai/sesori_apps_monorepo/pull/816) merged 2026-08-11 as `85438e1d` |
-| [ ] | 15/17 | `claude-code-plugin-client-polish` | `🌿 [claude-code-plugin] feat(client): add Claude Code branding [step 15/17]` | 400-800 | [PR #817](https://github.com/sesori-ai/sesori_apps_monorepo/pull/817) open against `main` |
+| [x] | 15/17 | `claude-code-plugin-client-polish` | `🌿 [claude-code-plugin] feat(client): add Claude Code branding [step 15/17]` | 400-800 | [PR #817](https://github.com/sesori-ai/sesori_apps_monorepo/pull/817) merged 2026-08-11 as `c3d21c78` |
 | [ ] | 16/17 | `claude-code-plugin-e2e` | `🌿 [claude-code-plugin] docs: record Claude Code live verification [step 16/17]` | 200-500 | Not started |
 | [ ] | 17/17 | `claude-code-plugin-retire` | `🌱 [claude-code-plugin] docs: retire Claude Code plugin plan [step 17/17]` | 50-200 | Not started |
 
@@ -460,6 +462,24 @@
   deletions), below the 400-800 estimate because the vector mark and existing
   mapping seam are compact. Architecture implementation review is not required
   for localized brand assets, mapping cases, tests, and plan corrections.
+
+- Step 16 live-gate fix (2026-08-11): the first simulator pass found Claude
+  setup ready while `POST /session/options` returned
+  `refreshFailedUnavailable`, blocking every real session before creation. The
+  descriptor passed the full host environment into `ClaudeLaunchSpec`; its
+  `HOME` key correctly violated the spec's explicit-override invariant before a
+  child could spawn. `HostClaudeProcessFactory` already inherits and forwards
+  the host environment, so the repository now receives no duplicate launch
+  overrides. The descriptor regression host includes `HOME`, proving the
+  production composition preserves it through the host process seam without
+  putting it in the launch spec.
+
+  All 10 focused descriptor tests, all 197 Claude package tests,
+  `dart analyze --fatal-infos`, and `git diff --check` pass. A source bridge
+  against the isolated E2E data directory then reported Claude setup ready and
+  returned HTTP 200 with real agents, providers, models, and commands from the
+  exact `/session/options` request that previously returned 502. Step 16 remains
+  paused until this focused fix merges. No database or persisted-data change.
 
 ## Findings And Plan Deltas
 

--- a/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
@@ -189,7 +189,9 @@ final class ClaudePluginDescriptor extends BridgePluginDescriptor {
     final processes = ClaudeSessionProcessRepository(
       processFactory: processFactory.spawn,
       binaryPath: binaryPath,
-      environment: host.environment,
+      // The host factory already inherits this environment. Launch specs carry
+      // only explicit overrides so they never shadow HOME and break keychain auth.
+      environment: const {},
     );
     final eventBuffer = BufferedUntilFirstListener<BridgeSseEvent>();
     final approvals = ClaudeApprovalRegistry(

--- a/bridge/sesori_plugin_claude/test/runtime/claude_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_claude/test/runtime/claude_plugin_descriptor_test.dart
@@ -237,6 +237,7 @@ void main() {
       expect(plugin.currentStatus, const PluginReady());
       expect(processes.runInShellValues, [Platform.isWindows, Platform.isWindows]);
       expect(processes.workingDirectories.every((directory) => directory != null), isTrue);
+      expect(processes.environments, everyElement(containsPair("HOME", "/Users/test")));
 
       liveProcess.completeExit(1);
       await _pump();
@@ -270,7 +271,10 @@ final class _PluginHost implements PluginHost {
   PluginConfig get config => const PluginConfig(values: {ClaudePluginDescriptor.binOption: "claude"});
 
   @override
-  Map<String, String> get environment => const {"CLAUDE_CONFIG_DIR": "/tmp/claude-descriptor-test"};
+  Map<String, String> get environment => const {
+    "CLAUDE_CONFIG_DIR": "/tmp/claude-descriptor-test",
+    "HOME": "/Users/test",
+  };
 
   @override
   ServerClock get clock => const ServerClock();


### PR DESCRIPTION
## Complexity

🌿 Straightforward: this corrects one composition argument and adds realistic host-environment regression coverage.

## What

- stop duplicating the full host environment into Claude launch-spec overrides
- continue forwarding the inherited environment through the host process factory
- exercise descriptor startup with a realistic `HOME` value and assert it reaches spawned children
- record the Step 16 live-gate failure and verification evidence

## Why

The first live Claude E2E pass found setup ready but every session-options request returned `refreshFailedUnavailable`. The duplicated `HOME` entry violated `ClaudeLaunchSpec` before a child process could spawn; unit tests had used an unrealistically narrow host environment.

## Risk and test focus

Low risk. Focus is preserving inherited environment values, especially macOS keychain-sensitive `HOME`, while keeping launch specs limited to explicit overrides. The exact live endpoint that failed before the fix must return a real catalog afterward.

## Expected result

Claude model, agent, and command discovery succeeds in a real source bridge, allowing users to create Claude sessions. No database or persisted-data change.

## Verification

- focused descriptor tests (10 passed)
- full `bridge/sesori_plugin_claude` suite (197 passed)
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_claude`
- source bridge reports Claude setup ready
- live `POST /session/options` changed from HTTP 502 `refreshFailedUnavailable` to HTTP 200 with the real catalog
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Claude launch to preserve the host environment without pushing it into launch overrides. Restores a valid `/session/options` response and unblocks session creation.

- **Bug Fixes**
  - Removed host env from `ClaudeLaunchSpec` overrides; descriptor now passes `{}`.
  - Preserves inherited `HOME` for macOS keychain auth; test asserts `HOME` reaches child processes.
  - `/session/options` now returns 200 with the real catalog; no database or persisted-data changes in `bridge/sesori_plugin_claude`.
  - Updated `.plan/active/claude-code-plugin/TRACKER.md` to record the fix, measurements (44-line diff), and Step 16 status.

<sup>Written for commit 189654b15409858269cfbbf5f9f677b26061fdea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

