### PR TITLE
🌿 fix(claude): attribute permission requests to sessions

### DIFF
--- a/bridge/sesori_plugin_claude/lib/src/claude_approval_registry.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_approval_registry.dart
@@ -130,10 +130,10 @@ final class ClaudeApprovalRegistry {
   final Map<String, Set<String>> _allowedTools = {};
   int _sequence = 0;
 
-  bool handle({required ClaudeControlRequestMessage message}) {
-    final sessionId = _nonEmptyString(message.sessionId);
+  bool handle({required String sessionId, required ClaudeControlRequestMessage message}) {
+    final attributedSessionId = _nonEmptyString(sessionId);
     final requestId = _nonEmptyString(message.requestId);
-    if (message.subtype != "can_use_tool" || sessionId == null || requestId == null) return false;
+    if (message.subtype != "can_use_tool" || attributedSessionId == null || requestId == null) return false;
 
     final request = message.request;
     final tool = _nonEmptyString(request["tool_name"]) ?? "tool";
@@ -145,34 +145,41 @@ final class ClaudeApprovalRegistry {
         "AskUserQuestion" => _AskUserQuestion(
           id: id,
           requestId: requestId,
-          sessionId: sessionId,
+          sessionId: attributedSessionId,
           input: input,
           questions: questions,
         ),
         "ExitPlanMode" => _ExitPlanMode(
           id: id,
           requestId: requestId,
-          sessionId: sessionId,
+          sessionId: attributedSessionId,
           input: input,
           questions: questions,
         ),
         _ => _UnknownInteraction(
           id: id,
           requestId: requestId,
-          sessionId: sessionId,
+          sessionId: attributedSessionId,
           input: input,
           questions: questions,
         ),
       };
       _pending[id] = pending;
-      _emit(BridgeSseQuestionAsked(id: id, sessionID: sessionId, displaySessionId: sessionId, questions: questions));
+      _emit(
+        BridgeSseQuestionAsked(
+          id: id,
+          sessionID: attributedSessionId,
+          displaySessionId: attributedSessionId,
+          questions: questions,
+        ),
+      );
       return true;
     }
 
     final pending = _PendingPermission(
       id: id,
       requestId: requestId,
-      sessionId: sessionId,
+      sessionId: attributedSessionId,
       tool: tool,
       description: _description(request),
       input: input,
@@ -183,8 +190,8 @@ final class ClaudeApprovalRegistry {
     _emit(
       BridgeSsePermissionAsked(
         requestID: id,
-        sessionID: sessionId,
-        displaySessionId: sessionId,
+        sessionID: attributedSessionId,
+        displaySessionId: attributedSessionId,
         tool: pending.tool,
         description: pending.description,
         allowAlways: pending.allowAlways,

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
@@ -270,7 +270,7 @@ final class ClaudeSessionService {
     switch (event) {
       case final ClaudeSessionProcessMessage event:
         final request = event.controlRequest;
-        if (request != null) _approvals.handle(message: request);
+        if (request != null) _approvals.handle(sessionId: event.sessionId, message: request);
       case ClaudeSessionProcessExited():
         _approvals.cancelForSession(sessionId: event.sessionId);
     }

--- a/bridge/sesori_plugin_claude/test/claude_approval_registry_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_approval_registry_test.dart
@@ -20,9 +20,13 @@ void main() {
       );
     });
 
+    bool handle({required String sessionId, required ClaudeControlRequestMessage message}) =>
+        registry.handle(sessionId: sessionId, message: message);
+
     test("surfaces a permission with sanitized detail and capability", () {
       expect(
-        registry.handle(
+        handle(
+          sessionId: "session-1",
           message: _request(
             requestId: "request-1",
             request: {
@@ -47,7 +51,7 @@ void main() {
     });
 
     test("once allows only the current input", () {
-      registry.handle(message: _permission());
+      handle(sessionId: "session-1", message: _permission());
 
       expect(registry.replyPermission(id: "br-1", reply: PluginPermissionReply.once), isTrue);
 
@@ -59,7 +63,8 @@ void main() {
     });
 
     test("always sends only session-scoped addRules suggestions", () {
-      registry.handle(
+      handle(
+        sessionId: "session-1",
         message: _permission(
           suggestions: const [
             {
@@ -103,7 +108,10 @@ void main() {
       {"type": "addRules", "destination": "cliArg"},
     ]) {
       test("always rejects ${suggestion["type"]}/${suggestion["destination"]}", () {
-        registry.handle(message: _permission(suggestions: [suggestion]));
+        handle(
+          sessionId: "session-1",
+          message: _permission(suggestions: [suggestion]),
+        );
 
         registry.replyPermission(id: "br-1", reply: PluginPermissionReply.always);
 
@@ -115,7 +123,8 @@ void main() {
     }
 
     test("suppressed always degrades safely even if an older client sends it", () {
-      registry.handle(
+      handle(
+        sessionId: "session-1",
         message: _permission(
           suppressAlways: true,
           suggestions: const [
@@ -140,7 +149,8 @@ void main() {
     });
 
     test("AskUserQuestion maps answers by full question text", () {
-      registry.handle(
+      handle(
+        sessionId: "session-1",
         message: _request(
           requestId: "question-request",
           request: {
@@ -185,7 +195,8 @@ void main() {
     });
 
     test("ExitPlanMode approval preserves the plan input", () {
-      registry.handle(
+      handle(
+        sessionId: "session-1",
         message: _request(
           requestId: "plan-request",
           request: {
@@ -211,8 +222,9 @@ void main() {
     });
 
     test("reject and teardown deny requests and emit clearing events", () {
-      registry.handle(message: _permission());
-      registry.handle(
+      handle(sessionId: "session-1", message: _permission());
+      handle(
+        sessionId: "session-1",
         message: _request(
           requestId: "question-request",
           request: {
@@ -232,8 +244,9 @@ void main() {
       expect(events.whereType<BridgeSsePermissionReplied>(), hasLength(1));
       expect(events.whereType<BridgeSseQuestionRejected>(), hasLength(1));
 
-      registry.handle(message: _permission());
-      registry.handle(
+      handle(sessionId: "session-1", message: _permission());
+      handle(
+        sessionId: "session-1",
         message: _request(
           requestId: "question-request-2",
           request: {
@@ -256,10 +269,10 @@ void main() {
     });
 
     test("dispose cancels pending requests across sessions", () {
-      registry.handle(message: _permission());
-      registry.handle(
+      handle(sessionId: "session-1", message: _permission());
+      handle(
+        sessionId: "session-2",
         message: _request(
-          sessionId: "session-2",
           requestId: "request-2",
           request: {"tool_name": "Read", "input": <String, Object?>{}},
         ),
@@ -277,7 +290,7 @@ void main() {
         emit: events.add,
         respond: ({required sessionId, required requestId, required payload}) => false,
       );
-      registry.handle(message: _permission());
+      handle(sessionId: "session-1", message: _permission());
       events.clear();
 
       expect(registry.replyPermission(id: "br-1", reply: PluginPermissionReply.once), isFalse);
@@ -303,14 +316,11 @@ ClaudeControlRequestMessage _permission({
 );
 
 ClaudeControlRequestMessage _request({
-  String sessionId = "session-1",
   required String requestId,
   required Map<String, Object?> request,
 }) =>
     ClaudeStreamMessage.parse({
           "type": "control_request",
-          "session_id": sessionId,
-          "uuid": "frame-$requestId",
           "request_id": requestId,
           "request": {"subtype": "can_use_tool", ...request},
         })

--- a/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
@@ -74,7 +74,6 @@ void main() {
       process.emit({
         "type": "control_request",
         "request_id": "permission-1",
-        "session_id": testSessionId,
         "request": {
           "subtype": "can_use_tool",
           "tool_name": "Write",


### PR DESCRIPTION
## Complexity

🌿 Straightforward: the resident process event supplies attribution missing from the CLI frame.

## What

- Pass the authoritative process session ID into Claude's approval registry.
- Model permission control frames in tests without synthetic `session_id` or `uuid` fields.

## Why

Claude CLI 2.1.226 emits `can_use_tool` frames with only `type`, `request_id`, and `request`. The registry previously required `message.sessionId`, dropped the live request, and left the tool running without a permission card.

## Risk and test focus

The change is local to Claude permission and question attribution. Focus review on multi-session isolation and approval response routing. There is no database impact. The user-visible impact is that Claude permission and question cards now appear and can be answered.

## Expected result

Claude tool permission requests are attributed to their resident session, surfaced to clients, and complete after a response.

## Verification

- `dart test test/claude_approval_registry_test.dart test/claude_session_service_test.dart`
- `dart test` (197 tests)
- `dart analyze --fatal-infos`
- Live iPhone 17 simulator: `Write` permission card appeared with Reject/Once/Always Allow; Once created the requested file and completed the turn.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Claude tool permission and question requests by attributing them to the correct process session, restoring permission cards and proper reply routing across sessions.

- **Bug Fixes**
  - Pass the process `sessionId` into `ClaudeApprovalRegistry.handle`, since CLI frames omit it.
  - Emit permission/question events with the attributed `sessionId` to ensure multi-session isolation.
  - Update tests to model real frames (no synthetic `session_id`/`uuid`) and verify process-exit cleanup.

<sup>Written for commit 94add1f7892b03c1849666f875a83b55dd2c878d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

