### PR TITLE
⚙️ fix(claude): preserve handled permission denials

### DIFF
--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_stream_message.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_stream_message.dart
@@ -478,11 +478,11 @@ final class ClaudeResultMessage extends ClaudeStreamMessage {
   final String? stopReason;
   final ClaudeTerminalReason terminalReason;
 
-  /// Tools refused without the host being asked.
+  /// Tools refused during the turn.
   ///
-  /// A non-empty list on an otherwise successful turn is the signature of a
-  /// missing `--permission-prompt-tool stdio`, so it is surfaced rather than
-  /// dropped.
+  /// Rejections answered through `can_use_tool` are correlated by `tool_use_id`
+  /// before presentation. An unmatched entry on an otherwise successful turn
+  /// indicates that the host was not asked, so it remains a diagnostic error.
   final List<Map<String, Object?>> permissionDenials;
   final List<String> errors;
   final int? apiErrorStatus;

--- a/bridge/sesori_plugin_claude/lib/src/claude_approval_registry.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_approval_registry.dart
@@ -10,11 +10,17 @@ typedef ClaudeApprovalResponder =
     });
 
 sealed class _PendingApproval {
-  const _PendingApproval({required this.id, required this.requestId, required this.sessionId});
+  const _PendingApproval({
+    required this.id,
+    required this.requestId,
+    required this.sessionId,
+    required this.toolUseId,
+  });
 
   final String id;
   final String requestId;
   final String sessionId;
+  final String? toolUseId;
 }
 
 final class _PendingPermission extends _PendingApproval {
@@ -22,6 +28,7 @@ final class _PendingPermission extends _PendingApproval {
     required super.id,
     required super.requestId,
     required super.sessionId,
+    required super.toolUseId,
     required this.tool,
     required this.description,
     required this.input,
@@ -41,6 +48,7 @@ sealed class _PendingQuestion extends _PendingApproval {
     required super.id,
     required super.requestId,
     required super.sessionId,
+    required super.toolUseId,
     required this.input,
     required this.questions,
   });
@@ -56,6 +64,7 @@ final class _AskUserQuestion extends _PendingQuestion {
     required super.id,
     required super.requestId,
     required super.sessionId,
+    required super.toolUseId,
     required super.input,
     required super.questions,
   });
@@ -75,6 +84,7 @@ final class _ExitPlanMode extends _PendingQuestion {
     required super.id,
     required super.requestId,
     required super.sessionId,
+    required super.toolUseId,
     required super.input,
     required super.questions,
   });
@@ -88,6 +98,7 @@ final class _UnknownInteraction extends _PendingQuestion {
     required super.id,
     required super.requestId,
     required super.sessionId,
+    required super.toolUseId,
     required super.input,
     required super.questions,
   });
@@ -128,6 +139,7 @@ final class ClaudeApprovalRegistry {
   final ClaudeApprovalResponder _respond;
   final Map<String, _PendingApproval> _pending = {};
   final Map<String, Set<String>> _allowedTools = {};
+  final Map<String, Set<String>> _handledDenialToolIds = {};
   int _sequence = 0;
 
   bool handle({required String sessionId, required ClaudeControlRequestMessage message}) {
@@ -137,6 +149,7 @@ final class ClaudeApprovalRegistry {
 
     final request = message.request;
     final tool = _nonEmptyString(request["tool_name"]) ?? "tool";
+    final toolUseId = _nonEmptyString(request["tool_use_id"]);
     final input = _map(request["input"]);
     final id = "br-${++_sequence}";
     if (request["requires_user_interaction"] == true) {
@@ -146,6 +159,7 @@ final class ClaudeApprovalRegistry {
           id: id,
           requestId: requestId,
           sessionId: attributedSessionId,
+          toolUseId: toolUseId,
           input: input,
           questions: questions,
         ),
@@ -153,6 +167,7 @@ final class ClaudeApprovalRegistry {
           id: id,
           requestId: requestId,
           sessionId: attributedSessionId,
+          toolUseId: toolUseId,
           input: input,
           questions: questions,
         ),
@@ -160,6 +175,7 @@ final class ClaudeApprovalRegistry {
           id: id,
           requestId: requestId,
           sessionId: attributedSessionId,
+          toolUseId: toolUseId,
           input: input,
           questions: questions,
         ),
@@ -180,6 +196,7 @@ final class ClaudeApprovalRegistry {
       id: id,
       requestId: requestId,
       sessionId: attributedSessionId,
+      toolUseId: toolUseId,
       tool: tool,
       description: _description(request),
       input: input,
@@ -227,6 +244,20 @@ final class ClaudeApprovalRegistry {
   List<String> allowedToolsForSession({required String sessionId}) =>
       List.unmodifiable(_allowedTools[sessionId] ?? const <String>{});
 
+  bool consumeHandledPermissionDenials({
+    required String sessionId,
+    required List<Map<String, Object?>> denials,
+  }) {
+    if (denials.isEmpty) return false;
+    final handled = _handledDenialToolIds[sessionId];
+    if (handled == null) return false;
+    final toolUseIds = denials.map((denial) => _nonEmptyString(denial["tool_use_id"])).toList(growable: false);
+    final allHandled = toolUseIds.every((toolUseId) => toolUseId != null && handled.contains(toolUseId));
+    handled.removeAll(toolUseIds.whereType<String>());
+    if (handled.isEmpty) _handledDenialToolIds.remove(sessionId);
+    return allHandled;
+  }
+
   bool hasPendingInput({required String sessionId}) => _pending.values.any((entry) => entry.sessionId == sessionId);
 
   bool hasPermission({required String id}) => _pending[id] is _PendingPermission;
@@ -252,6 +283,7 @@ final class ClaudeApprovalRegistry {
       PluginPermissionReply.reject => <String, Object?>{"behavior": "deny", "message": "User denied permission."},
     };
     if (!_respond(sessionId: entry.sessionId, requestId: entry.requestId, payload: payload)) return false;
+    if (reply == PluginPermissionReply.reject) _recordHandledDenial(entry);
     if (reply == PluginPermissionReply.always && entry.allowAlways) {
       final allowedTools = _allowedTools.putIfAbsent(entry.sessionId, () => {});
       for (final suggestion in entry.suggestions) {
@@ -313,11 +345,13 @@ final class ClaudeApprovalRegistry {
     _pending.clear();
     _allowedTools.clear();
     entries.forEach(_cancel);
+    _handledDenialToolIds.clear();
   }
 
   void forgetSession({required String sessionId}) {
     cancelForSession(sessionId: sessionId);
     _allowedTools.remove(sessionId);
+    _handledDenialToolIds.remove(sessionId);
   }
 
   void _cancel(_PendingApproval entry) {
@@ -345,11 +379,20 @@ final class ClaudeApprovalRegistry {
     }
   }
 
-  bool _deny({required _PendingApproval entry, required String message}) => _respond(
-    sessionId: entry.sessionId,
-    requestId: entry.requestId,
-    payload: {"behavior": "deny", "message": message},
-  );
+  bool _deny({required _PendingApproval entry, required String message}) {
+    final responded = _respond(
+      sessionId: entry.sessionId,
+      requestId: entry.requestId,
+      payload: {"behavior": "deny", "message": message},
+    );
+    if (responded) _recordHandledDenial(entry);
+    return responded;
+  }
+
+  void _recordHandledDenial(_PendingApproval entry) {
+    final toolUseId = entry.toolUseId;
+    if (toolUseId != null) (_handledDenialToolIds[entry.sessionId] ??= {}).add(toolUseId);
+  }
 }
 
 Iterable<String> _allowedToolRules(Map<String, Object?> suggestion) sync* {

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -422,7 +422,7 @@ String _retryMessage(ClaudeAssistantError error) => switch (error) {
 };
 
 ({String name, String message}) _resultError(ClaudeResultMessage result) {
-  if (result.permissionDenials.isNotEmpty) {
+  if (!result.isError && result.subtype == ClaudeResultSubtype.success && result.permissionDenials.isNotEmpty) {
     return (name: "permission_denied", message: "Claude Code denied a tool without requesting permission.");
   }
   if (result.apiErrorStatus == 401 || result.apiErrorStatus == 403) {

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -498,14 +498,12 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
 
   void _handleProcessEvent(ClaudeSessionProcessEvent event) {
     if (event case ClaudeSessionProcessMessage(:final message)) {
-      if (message is ClaudeResultMessage &&
-          !message.isError &&
-          message.subtype == ClaudeResultSubtype.success &&
-          _approvals.consumeHandledPermissionDenials(
-            sessionId: event.sessionId,
-            denials: message.permissionDenials,
-          )) {
-        return;
+      if (message is ClaudeResultMessage) {
+        final denialsWereHandled = _approvals.consumeHandledPermissionDenials(
+          sessionId: event.sessionId,
+          denials: message.permissionDenials,
+        );
+        if (!message.isError && message.subtype == ClaudeResultSubtype.success && denialsWereHandled) return;
       }
       if (message is ClaudeInitMessage && message.sessionId != event.sessionId) {
         Log.e("[claude] backend reported a different session id; stopping the session");

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -499,6 +499,8 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
   void _handleProcessEvent(ClaudeSessionProcessEvent event) {
     if (event case ClaudeSessionProcessMessage(:final message)) {
       if (message is ClaudeResultMessage &&
+          !message.isError &&
+          message.subtype == ClaudeResultSubtype.success &&
           _approvals.consumeHandledPermissionDenials(
             sessionId: event.sessionId,
             denials: message.permissionDenials,

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -498,6 +498,13 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
 
   void _handleProcessEvent(ClaudeSessionProcessEvent event) {
     if (event case ClaudeSessionProcessMessage(:final message)) {
+      if (message is ClaudeResultMessage &&
+          _approvals.consumeHandledPermissionDenials(
+            sessionId: event.sessionId,
+            denials: message.permissionDenials,
+          )) {
+        return;
+      }
       if (message is ClaudeInitMessage && message.sessionId != event.sessionId) {
         Log.e("[claude] backend reported a different session id; stopping the session");
         unawaited(_sessions.deleteSession(sessionId: event.sessionId));

--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
@@ -234,7 +234,7 @@ final class ClaudeSessionProcessRepository {
       accepted: true,
       outcome: Future.any<ClaudeResultMessage?>([result, exit]).then((message) {
         if (process.interrupted) return const ClaudeTurnInterrupted();
-        if (message == null || message.isError || message.permissionDenials.isNotEmpty) {
+        if (message == null || message.isError) {
           return const ClaudeTurnFailed();
         }
         return const ClaudeTurnCompleted();

--- a/bridge/sesori_plugin_claude/test/claude_approval_registry_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_approval_registry_test.dart
@@ -243,6 +243,25 @@ void main() {
       expect(responses.every((response) => response.payload["behavior"] == "deny"), isTrue);
       expect(events.whereType<BridgeSsePermissionReplied>(), hasLength(1));
       expect(events.whereType<BridgeSseQuestionRejected>(), hasLength(1));
+      expect(
+        registry.consumeHandledPermissionDenials(
+          sessionId: "session-1",
+          denials: const [
+            {"tool_use_id": "toolu-permission-request"},
+            {"tool_use_id": "toolu-question-request"},
+          ],
+        ),
+        isTrue,
+      );
+      expect(
+        registry.consumeHandledPermissionDenials(
+          sessionId: "session-1",
+          denials: const [
+            {"tool_use_id": "toolu-unprompted"},
+          ],
+        ),
+        isFalse,
+      );
 
       handle(sessionId: "session-1", message: _permission());
       handle(
@@ -322,6 +341,10 @@ ClaudeControlRequestMessage _request({
     ClaudeStreamMessage.parse({
           "type": "control_request",
           "request_id": requestId,
-          "request": {"subtype": "can_use_tool", ...request},
+          "request": {
+            "subtype": "can_use_tool",
+            "tool_use_id": "toolu-$requestId",
+            ...request,
+          },
         })
         as ClaudeControlRequestMessage;

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -316,6 +316,15 @@ void main() {
       final error = shared.Message.fromJson(errorEvent.info) as shared.MessageError;
       expect(error.errorName, "api_error");
       expect(error.errorMessage, "Claude Code could not complete the API request (HTTP 500).");
+      expect(
+        harness.approvals.consumeHandledPermissionDenials(
+          sessionId: testSessionId,
+          denials: const [
+            {"tool_use_id": "toolu-1"},
+          ],
+        ),
+        isFalse,
+      );
       await subscription.cancel();
     });
 

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -4,6 +4,7 @@ import "dart:io";
 import "package:claude_plugin/claude_plugin.dart";
 import "package:claude_plugin/claude_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" as shared;
 import "package:test/test.dart";
 
 import "support/claude_stream_client_test_factory.dart";
@@ -271,6 +272,50 @@ void main() {
       expect(retry.next, DateTime.utc(2026, 8, 11, 12).millisecondsSinceEpoch + 1000);
       expect(events.whereType<BridgeSseSessionStatus>().last.status["next"], retry.next);
       expect(harness.plugin.getActiveSessionsSummary().single.activeSessions.single.isRetrying, isTrue);
+      await subscription.cancel();
+    });
+
+    test("preserves an error result after a handled permission denial", () async {
+      final events = <BridgeSseEvent>[];
+      final subscription = harness.plugin.events.listen(events.add);
+      await harness.createSession();
+      final process = harness.processes.single;
+      await waitForFrame(process, "user");
+      process.emit({
+        "type": "control_request",
+        "request_id": "permission-1",
+        "request": {
+          "subtype": "can_use_tool",
+          "tool_name": "Write",
+          "tool_use_id": "toolu-1",
+          "input": {"file_path": "a.dart"},
+        },
+      });
+      await pump();
+      await harness.plugin.replyToPermission(
+        requestId: "br-1",
+        sessionId: testSessionId,
+        reply: PluginPermissionReply.reject,
+      );
+
+      process.emit({
+        "type": "result",
+        "subtype": "success",
+        "session_id": testSessionId,
+        "uuid": "result-error",
+        "is_error": true,
+        "terminal_reason": "api_error",
+        "api_error_status": 500,
+        "permission_denials": [
+          {"tool_name": "Write", "tool_use_id": "toolu-1"},
+        ],
+      });
+      await pump();
+
+      final errorEvent = events.whereType<BridgeSseMessageUpdated>().last;
+      final error = shared.Message.fromJson(errorEvent.info) as shared.MessageError;
+      expect(error.errorName, "api_error");
+      expect(error.errorMessage, "Claude Code could not complete the API request (HTTP 500).");
       await subscription.cancel();
     });
 

--- a/bridge/sesori_plugin_claude/test/claude_session_process_repository_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_session_process_repository_test.dart
@@ -56,6 +56,23 @@ void main() {
       expect(harness.specs.last.launch, isA<ClaudeNewSession>());
     });
 
+    test("classifies a successful result with permission denials as a completed transport turn", () async {
+      await _ensure(repository, createNew: true);
+      final turn = repository.sendTurn(
+        sessionId: testSessionId,
+        parts: const [PluginPromptPart.text(text: "hello")],
+      );
+      await waitForFrame(harness.processes.single, "user");
+      harness.processes.single.emit({
+        ..._result(),
+        "permission_denials": [
+          {"tool_name": "Write", "tool_use_id": "toolu-1"},
+        ],
+      });
+
+      expect(await turn.outcome, isA<ClaudeTurnCompleted>());
+    });
+
     test("classifies an unexpected process exit as a failed turn", () async {
       await _ensure(repository, createNew: true);
       final exits = <ClaudeSessionProcessExited>[];


### PR DESCRIPTION
## Complexity

⚙️ Moderate: the fix correlates approval state across the registry, process outcome, and plugin event boundary.

## What

- Track explicitly denied Claude tool-use IDs in the approval registry.
- Suppress result denial errors only when every denial matches a handled request on an otherwise-successful result.
- Treat a successful CLI result as a completed transport turn even when it reports denied tools.
- Preserve genuine API and terminal errors when they accompany handled denial IDs.

## Why

Claude completes a user-rejected tool turn successfully and includes that rejection in `permission_denials`. The bridge previously misclassified the handled rejection as a failed session and displayed `Claude Code denied a tool without requesting permission.`

## Risk and test focus

Moderate risk around denial correlation and session isolation. Review handled versus unprompted denial behavior, cleanup, and `tool_use_id` matching. There is no database impact. The user-visible impact is removal of false errors after an explicit rejection; genuine unprompted denials and error results remain errors.

## Expected result

Rejecting a Claude permission leaves the tool card failed, lets the model continue, and returns the session idle without a false terminal error. Unprompted denials and genuine result failures continue to surface diagnostically.

## Verification

- Focused approval, process, plugin, and dispatcher tests.
- `dart test` (199 tests).
- `dart analyze --fatal-infos`.
- Architecture implementation review: approved with no findings.
- Live iPhone 17 simulator: rejected Write stayed absent, model replied `FIXED REJECT OK`, session returned idle, and no new denial error appeared.
