### PR TITLE
⚙️ fix(claude): suppress errors after user interrupts

### DIFF
--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -497,12 +497,13 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
   String? _directoryForSession(String sessionId) => _findSession(sessionId)?.directory;
 
   void _handleProcessEvent(ClaudeSessionProcessEvent event) {
-    if (event case ClaudeSessionProcessMessage(:final message)) {
+    if (event case ClaudeSessionProcessMessage(:final message, :final interrupted)) {
       if (message is ClaudeResultMessage) {
         final denialsWereHandled = _approvals.consumeHandledPermissionDenials(
           sessionId: event.sessionId,
           denials: message.permissionDenials,
         );
+        if (interrupted) return;
         if (!message.isError && message.subtype == ClaudeResultSubtype.success && denialsWereHandled) return;
       }
       if (message is ClaudeInitMessage && message.sessionId != event.sessionId) {

--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
@@ -39,9 +39,14 @@ sealed class ClaudeSessionProcessEvent {
 }
 
 final class ClaudeSessionProcessMessage extends ClaudeSessionProcessEvent {
-  const ClaudeSessionProcessMessage({required super.sessionId, required this.message});
+  const ClaudeSessionProcessMessage({
+    required super.sessionId,
+    required this.message,
+    required this.interrupted,
+  });
 
   final ClaudeStreamMessage message;
+  final bool interrupted;
 
   ClaudeControlRequestMessage? get controlRequest => switch (message) {
     final ClaudeControlRequestMessage request => request,
@@ -356,7 +361,13 @@ final class ClaudeSessionProcessRepository {
         current?.appliedModel = message.model;
       }
       if (!_events.isClosed) {
-        _events.add(ClaudeSessionProcessMessage(sessionId: sessionId, message: message));
+        _events.add(
+          ClaudeSessionProcessMessage(
+            sessionId: sessionId,
+            message: message,
+            interrupted: process.interrupted,
+          ),
+        );
       }
     });
     _resident[sessionId] = process;

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -328,6 +328,32 @@ void main() {
       await subscription.cancel();
     });
 
+    test("suppresses the terminal result after an explicit interruption", () async {
+      final events = <BridgeSseEvent>[];
+      final subscription = harness.plugin.events.listen(events.add);
+      await harness.createSession();
+      final process = harness.processes.single;
+      await waitForFrame(process, "user");
+
+      await harness.plugin.abortSession(sessionId: testSessionId);
+      process.emit({
+        "type": "result",
+        "subtype": "error_during_execution",
+        "session_id": testSessionId,
+        "uuid": "interrupted-result",
+        "is_error": true,
+        "terminal_reason": "other",
+      });
+      await pump();
+
+      final errors = events
+          .whereType<BridgeSseMessageUpdated>()
+          .map((event) => shared.Message.fromJson(event.info))
+          .whereType<shared.MessageError>();
+      expect(errors, isEmpty);
+      await subscription.cancel();
+    });
+
     test("persisted cleanup is idempotent for an absent transcript", () async {
       await harness.plugin.deletePersistedSession(backendSessionId: testSessionId);
       await harness.plugin.deletePersistedSession(backendSessionId: testSessionId);


### PR DESCRIPTION
## Complexity

⚙️ Moderate: the fix carries an interruption snapshot across the process-event boundary so terminal presentation matches turn ownership.

## What

- Add the resident process's interruption state to each Claude process message event.
- Suppress terminal result error mapping after an explicit user interruption.
- Keep handled-denial correlation cleanup ahead of interruption suppression.

## Why

Live E2E showed that stopping active Claude work and aborting a pending permission both returned idle and cleaned up correctly, but the following result frame still rendered `Claude Code could not complete the request.`

## Risk and test focus

Moderate risk around event ordering and interruption state. Focus review on the point-in-time event snapshot, ordinary error results, denial cleanup, and the next turn resetting interruption state. There is no database impact. The user-visible impact is removal of false errors after the user presses Stop or aborts a pending permission.

## Expected result

Explicitly interrupted Claude turns return idle and may show Claude's interruption text/tool state, but do not append a false terminal error. Non-interrupted result failures remain unchanged.

## Verification

- Focused plugin, session-service, and process-repository tests.
- `dart test` (200 tests).
- `dart analyze --fatal-infos`.
- Architecture implementation review: approved with no findings.
- Live iPhone 17 simulator reproduced both false-error paths before the fix; the upstream backend was overloaded during the post-fix retry, so the exact fixed event path is covered by the plugin-boundary regression test.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress false terminal errors after a user interrupts a Claude turn. We now carry an interruption snapshot with each process message and skip error mapping when the user pressed Stop or aborted a pending permission.

- **Bug Fixes**
  - Include an `interrupted` snapshot in `ClaudeSessionProcessMessage` events.
  - Skip terminal result error mapping when `interrupted` is true, while still performing permission-denial cleanup.
  - Add a unit test to verify no error is emitted after an explicit interruption.

<sup>Written for commit 76e7127733c102e71c02855c221ff127236f4e48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

