### PR TITLE
⚙️ [codex-mobile-login] refactor(codex): prepare authentication primitives [step 2/8]

### DIFF
--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -3,12 +3,12 @@
 ## Current State
 
 - **Plan slug:** `codex-mobile-login`
-- **Series state:** Step 1 PR open
-- **Current step:** 1/8
-- **Implementation base:** `origin/main` at `3708d348`
+- **Series state:** Step 1 merged; Step 2 ready for publication
+- **Current step:** 2/8
+- **Implementation base:** Step 1 merge commit `de244964`
 - **Plan PR:** [#824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824)
-- **Current PR:** [#824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824)
-- **Next action:** Monitor Step 1 review/CI and begin Step 2 locally
+- **Current PR:** Pending
+- **Next action:** Publish Step 2 and begin Step 3 locally
 
 ## Plan Review
 
@@ -26,8 +26,8 @@
 
 | Done | Step | Exact PR title | Changed-line target | State |
 |---|---|---|---:|---|
-| [ ] | 1/8 | `🌱 [codex-mobile-login] docs: plan mobile Codex login [step 1/8]` | 450-850 | [PR #824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824) open |
-| [ ] | 2/8 | `⚙️ [codex-mobile-login] refactor(codex): prepare authentication primitives [step 2/8]` | 850-1,400 | Pending |
+| [x] | 1/8 | `🌱 [codex-mobile-login] docs: plan mobile Codex login [step 1/8]` | 450-850 | [PR #824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824) merged |
+| [ ] | 2/8 | `⚙️ [codex-mobile-login] refactor(codex): prepare authentication primitives [step 2/8]` | 850-1,400 | Ready for publication |
 | [ ] | 3/8 | `🚧 [codex-mobile-login] feat(codex): implement device authentication [step 3/8]` | 850-1,450 | Pending |
 | [ ] | 4/8 | `⚙️ [codex-mobile-login] feat(protocol): describe harness authentication [step 4/8]` | 650-1,200 | Pending |
 | [ ] | 5/8 | `🚧 [codex-mobile-login] feat(bridge): expose harness authentication [step 5/8]` | 950-1,500 | Pending |
@@ -61,6 +61,12 @@
   suites were run because this step changes documentation only. Committed as
   `e4213ff2`, pushed, and opened as
   [PR #824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824).
+- Step 2: `dart test` passes all 348 Codex plugin tests. Focused runtime,
+  setup, stdio transport, and typed account API tests pass, and
+  `dart analyze --fatal-infos` reports no issues. `git diff --check` passes.
+  The required architecture implementation review could not run because the
+  review sub-agent failed twice before reading code with an internal task-store
+  schema error (`no such column: replacement_seq`).
 
 ## Findings And Plan Deltas
 
@@ -77,6 +83,17 @@
   only.
 - **2026-08-11 - Architecture review:** Added explicit Codex Client/API/
   Repository/Service layers and changed terminal progress to sealed variants.
-- **2026-08-11 - Cleanup:** Reuse one Codex runtime resolver and replace
+- **2026-08-11 - Cleanup:** Reuse one Codex runtime selection service and replace
   local-terminal-only setup guidance; retain login-status inspection and
   compatibility behavior.
+- **2026-08-11 - Step 2 started:** Created local branch
+  `codex-mobile-login-primitives` from the Step 1 branch. Confirmed the runtime
+  selection service must preserve explicit/PATH/desktop/managed precedence and
+  setup failure classifications; the new stdio client will be a second
+  transport behind the typed Codex App Server API rather than changing the
+  normal WebSocket runtime.
+- **2026-08-11 - Step 2 implementation:** Added one shared executable selection
+  decision for setup/startup/authentication, a secret-safe stdio JSONL App
+  Server transport with bounded child cleanup, and typed account start/cancel/
+  completion API models. Existing WebSocket generation behavior remains
+  unchanged and no bridge or client capability is exposed yet.

--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -63,7 +63,9 @@
   [PR #824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824).
 - Step 2: `dart test` passes all 348 Codex plugin tests. Focused runtime,
   setup, stdio transport, and typed account API tests pass, and
-  `dart analyze --fatal-infos` reports no issues. `git diff --check` passes.
+  `dart analyze --fatal-infos` reports no issues.
+  `git diff --check origin/main...HEAD` passes, and
+  `git diff --numstat origin/main...HEAD` reports 2,478 additions and 169 deletions.
   The required architecture implementation review could not run because the
   review sub-agent failed twice before reading code with an internal task-store
   schema error (`no such column: replacement_seq`). Committed as `3d71e4cf`,

--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -5,7 +5,7 @@
 - **Plan slug:** `codex-mobile-login`
 - **Series state:** Step 1 merged; Step 2 ready for publication
 - **Current step:** 2/8
-- **Implementation base:** Step 1 merge commit `de244964`
+- **Implementation base:** `origin/main` at `ea1bc354` (includes Step 1)
 - **Plan PR:** [#824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824)
 - **Current PR:** Pending
 - **Next action:** Publish Step 2 and begin Step 3 locally

--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -3,12 +3,12 @@
 ## Current State
 
 - **Plan slug:** `codex-mobile-login`
-- **Series state:** Step 1 merged; Step 2 ready for publication
+- **Series state:** Step 1 merged; Step 2 PR open
 - **Current step:** 2/8
 - **Implementation base:** `origin/main` at `ea1bc354` (includes Step 1)
 - **Plan PR:** [#824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824)
-- **Current PR:** Pending
-- **Next action:** Publish Step 2 and begin Step 3 locally
+- **Current PR:** [#827](https://github.com/sesori-ai/sesori_apps_monorepo/pull/827)
+- **Next action:** Monitor Step 2 review/CI and begin Step 3 locally
 
 ## Plan Review
 
@@ -27,7 +27,7 @@
 | Done | Step | Exact PR title | Changed-line target | State |
 |---|---|---|---:|---|
 | [x] | 1/8 | `🌱 [codex-mobile-login] docs: plan mobile Codex login [step 1/8]` | 450-850 | [PR #824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824) merged |
-| [ ] | 2/8 | `⚙️ [codex-mobile-login] refactor(codex): prepare authentication primitives [step 2/8]` | 850-1,400 | Ready for publication |
+| [ ] | 2/8 | `⚙️ [codex-mobile-login] refactor(codex): prepare authentication primitives [step 2/8]` | 850-1,400 | [PR #827](https://github.com/sesori-ai/sesori_apps_monorepo/pull/827) open |
 | [ ] | 3/8 | `🚧 [codex-mobile-login] feat(codex): implement device authentication [step 3/8]` | 850-1,450 | Pending |
 | [ ] | 4/8 | `⚙️ [codex-mobile-login] feat(protocol): describe harness authentication [step 4/8]` | 650-1,200 | Pending |
 | [ ] | 5/8 | `🚧 [codex-mobile-login] feat(bridge): expose harness authentication [step 5/8]` | 950-1,500 | Pending |
@@ -66,7 +66,9 @@
   `dart analyze --fatal-infos` reports no issues. `git diff --check` passes.
   The required architecture implementation review could not run because the
   review sub-agent failed twice before reading code with an internal task-store
-  schema error (`no such column: replacement_seq`).
+  schema error (`no such column: replacement_seq`). Committed as `3d71e4cf`,
+  rebased onto `origin/main`, pushed, and opened as
+  [PR #827](https://github.com/sesori-ai/sesori_apps_monorepo/pull/827).
 
 ## Findings And Plan Deltas
 

--- a/bridge/sesori_plugin_codex/lib/codex_plugin.dart
+++ b/bridge/sesori_plugin_codex/lib/codex_plugin.dart
@@ -11,6 +11,7 @@ export "src/codex_config_reader.dart";
 export "src/codex_event_mapper.dart";
 export "src/codex_metadata_repository.dart";
 export "src/codex_plugin_impl.dart";
+export "src/codex_stdio_app_server_client.dart";
 export "src/repositories/mappers/codex_rollout_tool_mapper.dart";
 // Runtime lifecycle: the descriptor is the public entry point the bridge
 // registers in bin/bridge.dart.

--- a/bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart
@@ -2,6 +2,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
 import "../codex_app_server_client.dart";
 import "../models/codex_collaboration_mode.dart";
+import "models/codex_account_dto.dart";
 import "models/codex_collaboration_mode_dto.dart";
 import "models/codex_model_dto.dart";
 import "models/codex_skill_dto.dart";
@@ -11,9 +12,46 @@ import "models/codex_turn_input_dto.dart";
 
 /// Layer-1 typed boundary for migrated Codex app-server operations.
 class CodexAppServerApi {
-  CodexAppServerApi({required CodexAppServerClient client}) : _client = client;
+  CodexAppServerApi({required CodexAppServerTransport client}) : _client = client;
 
-  final CodexAppServerClient _client;
+  final CodexAppServerTransport _client;
+
+  Stream<CodexAccountLoginCompletedNotificationDto> get accountLoginCompletions => _client.notifications
+      .where((notification) => notification.method == "account/login/completed")
+      .map(
+        (notification) => CodexAccountLoginCompletedNotificationDto.fromJson(
+          notification.params,
+        ),
+      );
+
+  Future<CodexDeviceLoginStartResponseDto> startDeviceLogin() async {
+    const params = CodexDeviceLoginStartParamsDto(
+      type: CodexAccountLoginType.chatgptDeviceCode,
+    );
+    final result = await _client.request(
+      method: "account/login/start",
+      params: params.toJson(),
+    );
+    return _decodeAccountResponse(
+      result: result,
+      operation: "account/login/start",
+      decode: CodexDeviceLoginStartResponseDto.fromJson,
+    );
+  }
+
+  Future<CodexAccountLoginCancelResponseDto> cancelLogin({
+    required String loginId,
+  }) async {
+    final result = await _client.request(
+      method: "account/login/cancel",
+      params: CodexAccountLoginCancelParamsDto(loginId: loginId).toJson(),
+    );
+    return _decodeAccountResponse(
+      result: result,
+      operation: "account/login/cancel",
+      decode: CodexAccountLoginCancelResponseDto.fromJson,
+    );
+  }
 
   Future<CodexThreadEnvelopeDto> startThread({
     required String cwd,
@@ -144,5 +182,19 @@ class CodexAppServerApi {
       );
     }
     return CodexThreadEnvelopeDto.fromJson(result.cast<String, dynamic>());
+  }
+
+  T _decodeAccountResponse<T>({
+    required Object? result,
+    required String operation,
+    required T Function(Map<String, dynamic>) decode,
+  }) {
+    if (result is! Map) {
+      throw StateError(
+        "expected a Codex account response object from $operation, got "
+        "${result.runtimeType}",
+      );
+    }
+    return decode(result.cast<String, dynamic>());
   }
 }

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_account_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_account_dto.dart
@@ -1,0 +1,69 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "codex_account_dto.freezed.dart";
+part "codex_account_dto.g.dart";
+
+enum CodexAccountLoginType {
+  @JsonValue("chatgptDeviceCode")
+  chatgptDeviceCode,
+}
+
+enum CodexAccountLoginCancelStatus {
+  @JsonValue("canceled")
+  canceled,
+  @JsonValue("notFound")
+  notFound,
+  unknown,
+}
+
+@Freezed(fromJson: false, toJson: true)
+sealed class CodexDeviceLoginStartParamsDto with _$CodexDeviceLoginStartParamsDto {
+  const factory CodexDeviceLoginStartParamsDto({
+    required CodexAccountLoginType type,
+  }) = _CodexDeviceLoginStartParamsDto;
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CodexDeviceLoginStartResponseDto with _$CodexDeviceLoginStartResponseDto {
+  const factory CodexDeviceLoginStartResponseDto({
+    required CodexAccountLoginType type,
+    required String loginId,
+    required String verificationUrl,
+    required String userCode,
+  }) = _CodexDeviceLoginStartResponseDto;
+
+  factory CodexDeviceLoginStartResponseDto.fromJson(
+    Map<String, dynamic> json,
+  ) => _$CodexDeviceLoginStartResponseDtoFromJson(json);
+}
+
+@Freezed(fromJson: false, toJson: true)
+sealed class CodexAccountLoginCancelParamsDto with _$CodexAccountLoginCancelParamsDto {
+  const factory CodexAccountLoginCancelParamsDto({
+    required String loginId,
+  }) = _CodexAccountLoginCancelParamsDto;
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CodexAccountLoginCancelResponseDto with _$CodexAccountLoginCancelResponseDto {
+  const factory CodexAccountLoginCancelResponseDto({
+    @JsonKey(unknownEnumValue: CodexAccountLoginCancelStatus.unknown) required CodexAccountLoginCancelStatus status,
+  }) = _CodexAccountLoginCancelResponseDto;
+
+  factory CodexAccountLoginCancelResponseDto.fromJson(
+    Map<String, dynamic> json,
+  ) => _$CodexAccountLoginCancelResponseDtoFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CodexAccountLoginCompletedNotificationDto with _$CodexAccountLoginCompletedNotificationDto {
+  const factory CodexAccountLoginCompletedNotificationDto({
+    required String? loginId,
+    required bool success,
+    required String? error,
+  }) = _CodexAccountLoginCompletedNotificationDto;
+
+  factory CodexAccountLoginCompletedNotificationDto.fromJson(
+    Map<String, dynamic> json,
+  ) => _$CodexAccountLoginCompletedNotificationDtoFromJson(json);
+}

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_account_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_account_dto.freezed.dart
@@ -1,0 +1,682 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'codex_account_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$CodexDeviceLoginStartParamsDto {
+
+ CodexAccountLoginType get type;
+/// Create a copy of CodexDeviceLoginStartParamsDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexDeviceLoginStartParamsDtoCopyWith<CodexDeviceLoginStartParamsDto> get copyWith => _$CodexDeviceLoginStartParamsDtoCopyWithImpl<CodexDeviceLoginStartParamsDto>(this as CodexDeviceLoginStartParamsDto, _$identity);
+
+  /// Serializes this CodexDeviceLoginStartParamsDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexDeviceLoginStartParamsDto&&(identical(other.type, type) || other.type == type));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type);
+
+@override
+String toString() {
+  return 'CodexDeviceLoginStartParamsDto(type: $type)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexDeviceLoginStartParamsDtoCopyWith<$Res>  {
+  factory $CodexDeviceLoginStartParamsDtoCopyWith(CodexDeviceLoginStartParamsDto value, $Res Function(CodexDeviceLoginStartParamsDto) _then) = _$CodexDeviceLoginStartParamsDtoCopyWithImpl;
+@useResult
+$Res call({
+ CodexAccountLoginType type
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexDeviceLoginStartParamsDtoCopyWithImpl<$Res>
+    implements $CodexDeviceLoginStartParamsDtoCopyWith<$Res> {
+  _$CodexDeviceLoginStartParamsDtoCopyWithImpl(this._self, this._then);
+
+  final CodexDeviceLoginStartParamsDto _self;
+  final $Res Function(CodexDeviceLoginStartParamsDto) _then;
+
+/// Create a copy of CodexDeviceLoginStartParamsDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? type = null,}) {
+  return _then(_self.copyWith(
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as CodexAccountLoginType,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createFactory: false)
+
+class _CodexDeviceLoginStartParamsDto implements CodexDeviceLoginStartParamsDto {
+  const _CodexDeviceLoginStartParamsDto({required this.type});
+  
+
+@override final  CodexAccountLoginType type;
+
+/// Create a copy of CodexDeviceLoginStartParamsDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexDeviceLoginStartParamsDtoCopyWith<_CodexDeviceLoginStartParamsDto> get copyWith => __$CodexDeviceLoginStartParamsDtoCopyWithImpl<_CodexDeviceLoginStartParamsDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$CodexDeviceLoginStartParamsDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexDeviceLoginStartParamsDto&&(identical(other.type, type) || other.type == type));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type);
+
+@override
+String toString() {
+  return 'CodexDeviceLoginStartParamsDto(type: $type)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexDeviceLoginStartParamsDtoCopyWith<$Res> implements $CodexDeviceLoginStartParamsDtoCopyWith<$Res> {
+  factory _$CodexDeviceLoginStartParamsDtoCopyWith(_CodexDeviceLoginStartParamsDto value, $Res Function(_CodexDeviceLoginStartParamsDto) _then) = __$CodexDeviceLoginStartParamsDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ CodexAccountLoginType type
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexDeviceLoginStartParamsDtoCopyWithImpl<$Res>
+    implements _$CodexDeviceLoginStartParamsDtoCopyWith<$Res> {
+  __$CodexDeviceLoginStartParamsDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexDeviceLoginStartParamsDto _self;
+  final $Res Function(_CodexDeviceLoginStartParamsDto) _then;
+
+/// Create a copy of CodexDeviceLoginStartParamsDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? type = null,}) {
+  return _then(_CodexDeviceLoginStartParamsDto(
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as CodexAccountLoginType,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$CodexDeviceLoginStartResponseDto {
+
+ CodexAccountLoginType get type; String get loginId; String get verificationUrl; String get userCode;
+/// Create a copy of CodexDeviceLoginStartResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexDeviceLoginStartResponseDtoCopyWith<CodexDeviceLoginStartResponseDto> get copyWith => _$CodexDeviceLoginStartResponseDtoCopyWithImpl<CodexDeviceLoginStartResponseDto>(this as CodexDeviceLoginStartResponseDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexDeviceLoginStartResponseDto&&(identical(other.type, type) || other.type == type)&&(identical(other.loginId, loginId) || other.loginId == loginId)&&(identical(other.verificationUrl, verificationUrl) || other.verificationUrl == verificationUrl)&&(identical(other.userCode, userCode) || other.userCode == userCode));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type,loginId,verificationUrl,userCode);
+
+@override
+String toString() {
+  return 'CodexDeviceLoginStartResponseDto(type: $type, loginId: $loginId, verificationUrl: $verificationUrl, userCode: $userCode)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexDeviceLoginStartResponseDtoCopyWith<$Res>  {
+  factory $CodexDeviceLoginStartResponseDtoCopyWith(CodexDeviceLoginStartResponseDto value, $Res Function(CodexDeviceLoginStartResponseDto) _then) = _$CodexDeviceLoginStartResponseDtoCopyWithImpl;
+@useResult
+$Res call({
+ CodexAccountLoginType type, String loginId, String verificationUrl, String userCode
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexDeviceLoginStartResponseDtoCopyWithImpl<$Res>
+    implements $CodexDeviceLoginStartResponseDtoCopyWith<$Res> {
+  _$CodexDeviceLoginStartResponseDtoCopyWithImpl(this._self, this._then);
+
+  final CodexDeviceLoginStartResponseDto _self;
+  final $Res Function(CodexDeviceLoginStartResponseDto) _then;
+
+/// Create a copy of CodexDeviceLoginStartResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? type = null,Object? loginId = null,Object? verificationUrl = null,Object? userCode = null,}) {
+  return _then(_self.copyWith(
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as CodexAccountLoginType,loginId: null == loginId ? _self.loginId : loginId // ignore: cast_nullable_to_non_nullable
+as String,verificationUrl: null == verificationUrl ? _self.verificationUrl : verificationUrl // ignore: cast_nullable_to_non_nullable
+as String,userCode: null == userCode ? _self.userCode : userCode // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexDeviceLoginStartResponseDto implements CodexDeviceLoginStartResponseDto {
+  const _CodexDeviceLoginStartResponseDto({required this.type, required this.loginId, required this.verificationUrl, required this.userCode});
+  factory _CodexDeviceLoginStartResponseDto.fromJson(Map<String, dynamic> json) => _$CodexDeviceLoginStartResponseDtoFromJson(json);
+
+@override final  CodexAccountLoginType type;
+@override final  String loginId;
+@override final  String verificationUrl;
+@override final  String userCode;
+
+/// Create a copy of CodexDeviceLoginStartResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexDeviceLoginStartResponseDtoCopyWith<_CodexDeviceLoginStartResponseDto> get copyWith => __$CodexDeviceLoginStartResponseDtoCopyWithImpl<_CodexDeviceLoginStartResponseDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexDeviceLoginStartResponseDto&&(identical(other.type, type) || other.type == type)&&(identical(other.loginId, loginId) || other.loginId == loginId)&&(identical(other.verificationUrl, verificationUrl) || other.verificationUrl == verificationUrl)&&(identical(other.userCode, userCode) || other.userCode == userCode));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type,loginId,verificationUrl,userCode);
+
+@override
+String toString() {
+  return 'CodexDeviceLoginStartResponseDto(type: $type, loginId: $loginId, verificationUrl: $verificationUrl, userCode: $userCode)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexDeviceLoginStartResponseDtoCopyWith<$Res> implements $CodexDeviceLoginStartResponseDtoCopyWith<$Res> {
+  factory _$CodexDeviceLoginStartResponseDtoCopyWith(_CodexDeviceLoginStartResponseDto value, $Res Function(_CodexDeviceLoginStartResponseDto) _then) = __$CodexDeviceLoginStartResponseDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ CodexAccountLoginType type, String loginId, String verificationUrl, String userCode
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexDeviceLoginStartResponseDtoCopyWithImpl<$Res>
+    implements _$CodexDeviceLoginStartResponseDtoCopyWith<$Res> {
+  __$CodexDeviceLoginStartResponseDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexDeviceLoginStartResponseDto _self;
+  final $Res Function(_CodexDeviceLoginStartResponseDto) _then;
+
+/// Create a copy of CodexDeviceLoginStartResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? type = null,Object? loginId = null,Object? verificationUrl = null,Object? userCode = null,}) {
+  return _then(_CodexDeviceLoginStartResponseDto(
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as CodexAccountLoginType,loginId: null == loginId ? _self.loginId : loginId // ignore: cast_nullable_to_non_nullable
+as String,verificationUrl: null == verificationUrl ? _self.verificationUrl : verificationUrl // ignore: cast_nullable_to_non_nullable
+as String,userCode: null == userCode ? _self.userCode : userCode // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+mixin _$CodexAccountLoginCancelParamsDto {
+
+ String get loginId;
+/// Create a copy of CodexAccountLoginCancelParamsDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexAccountLoginCancelParamsDtoCopyWith<CodexAccountLoginCancelParamsDto> get copyWith => _$CodexAccountLoginCancelParamsDtoCopyWithImpl<CodexAccountLoginCancelParamsDto>(this as CodexAccountLoginCancelParamsDto, _$identity);
+
+  /// Serializes this CodexAccountLoginCancelParamsDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexAccountLoginCancelParamsDto&&(identical(other.loginId, loginId) || other.loginId == loginId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,loginId);
+
+@override
+String toString() {
+  return 'CodexAccountLoginCancelParamsDto(loginId: $loginId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexAccountLoginCancelParamsDtoCopyWith<$Res>  {
+  factory $CodexAccountLoginCancelParamsDtoCopyWith(CodexAccountLoginCancelParamsDto value, $Res Function(CodexAccountLoginCancelParamsDto) _then) = _$CodexAccountLoginCancelParamsDtoCopyWithImpl;
+@useResult
+$Res call({
+ String loginId
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexAccountLoginCancelParamsDtoCopyWithImpl<$Res>
+    implements $CodexAccountLoginCancelParamsDtoCopyWith<$Res> {
+  _$CodexAccountLoginCancelParamsDtoCopyWithImpl(this._self, this._then);
+
+  final CodexAccountLoginCancelParamsDto _self;
+  final $Res Function(CodexAccountLoginCancelParamsDto) _then;
+
+/// Create a copy of CodexAccountLoginCancelParamsDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? loginId = null,}) {
+  return _then(_self.copyWith(
+loginId: null == loginId ? _self.loginId : loginId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createFactory: false)
+
+class _CodexAccountLoginCancelParamsDto implements CodexAccountLoginCancelParamsDto {
+  const _CodexAccountLoginCancelParamsDto({required this.loginId});
+  
+
+@override final  String loginId;
+
+/// Create a copy of CodexAccountLoginCancelParamsDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexAccountLoginCancelParamsDtoCopyWith<_CodexAccountLoginCancelParamsDto> get copyWith => __$CodexAccountLoginCancelParamsDtoCopyWithImpl<_CodexAccountLoginCancelParamsDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$CodexAccountLoginCancelParamsDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexAccountLoginCancelParamsDto&&(identical(other.loginId, loginId) || other.loginId == loginId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,loginId);
+
+@override
+String toString() {
+  return 'CodexAccountLoginCancelParamsDto(loginId: $loginId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexAccountLoginCancelParamsDtoCopyWith<$Res> implements $CodexAccountLoginCancelParamsDtoCopyWith<$Res> {
+  factory _$CodexAccountLoginCancelParamsDtoCopyWith(_CodexAccountLoginCancelParamsDto value, $Res Function(_CodexAccountLoginCancelParamsDto) _then) = __$CodexAccountLoginCancelParamsDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String loginId
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexAccountLoginCancelParamsDtoCopyWithImpl<$Res>
+    implements _$CodexAccountLoginCancelParamsDtoCopyWith<$Res> {
+  __$CodexAccountLoginCancelParamsDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexAccountLoginCancelParamsDto _self;
+  final $Res Function(_CodexAccountLoginCancelParamsDto) _then;
+
+/// Create a copy of CodexAccountLoginCancelParamsDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? loginId = null,}) {
+  return _then(_CodexAccountLoginCancelParamsDto(
+loginId: null == loginId ? _self.loginId : loginId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$CodexAccountLoginCancelResponseDto {
+
+@JsonKey(unknownEnumValue: CodexAccountLoginCancelStatus.unknown) CodexAccountLoginCancelStatus get status;
+/// Create a copy of CodexAccountLoginCancelResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexAccountLoginCancelResponseDtoCopyWith<CodexAccountLoginCancelResponseDto> get copyWith => _$CodexAccountLoginCancelResponseDtoCopyWithImpl<CodexAccountLoginCancelResponseDto>(this as CodexAccountLoginCancelResponseDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexAccountLoginCancelResponseDto&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status);
+
+@override
+String toString() {
+  return 'CodexAccountLoginCancelResponseDto(status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexAccountLoginCancelResponseDtoCopyWith<$Res>  {
+  factory $CodexAccountLoginCancelResponseDtoCopyWith(CodexAccountLoginCancelResponseDto value, $Res Function(CodexAccountLoginCancelResponseDto) _then) = _$CodexAccountLoginCancelResponseDtoCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(unknownEnumValue: CodexAccountLoginCancelStatus.unknown) CodexAccountLoginCancelStatus status
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexAccountLoginCancelResponseDtoCopyWithImpl<$Res>
+    implements $CodexAccountLoginCancelResponseDtoCopyWith<$Res> {
+  _$CodexAccountLoginCancelResponseDtoCopyWithImpl(this._self, this._then);
+
+  final CodexAccountLoginCancelResponseDto _self;
+  final $Res Function(CodexAccountLoginCancelResponseDto) _then;
+
+/// Create a copy of CodexAccountLoginCancelResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,}) {
+  return _then(_self.copyWith(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as CodexAccountLoginCancelStatus,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexAccountLoginCancelResponseDto implements CodexAccountLoginCancelResponseDto {
+  const _CodexAccountLoginCancelResponseDto({@JsonKey(unknownEnumValue: CodexAccountLoginCancelStatus.unknown) required this.status});
+  factory _CodexAccountLoginCancelResponseDto.fromJson(Map<String, dynamic> json) => _$CodexAccountLoginCancelResponseDtoFromJson(json);
+
+@override@JsonKey(unknownEnumValue: CodexAccountLoginCancelStatus.unknown) final  CodexAccountLoginCancelStatus status;
+
+/// Create a copy of CodexAccountLoginCancelResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexAccountLoginCancelResponseDtoCopyWith<_CodexAccountLoginCancelResponseDto> get copyWith => __$CodexAccountLoginCancelResponseDtoCopyWithImpl<_CodexAccountLoginCancelResponseDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexAccountLoginCancelResponseDto&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status);
+
+@override
+String toString() {
+  return 'CodexAccountLoginCancelResponseDto(status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexAccountLoginCancelResponseDtoCopyWith<$Res> implements $CodexAccountLoginCancelResponseDtoCopyWith<$Res> {
+  factory _$CodexAccountLoginCancelResponseDtoCopyWith(_CodexAccountLoginCancelResponseDto value, $Res Function(_CodexAccountLoginCancelResponseDto) _then) = __$CodexAccountLoginCancelResponseDtoCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(unknownEnumValue: CodexAccountLoginCancelStatus.unknown) CodexAccountLoginCancelStatus status
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexAccountLoginCancelResponseDtoCopyWithImpl<$Res>
+    implements _$CodexAccountLoginCancelResponseDtoCopyWith<$Res> {
+  __$CodexAccountLoginCancelResponseDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexAccountLoginCancelResponseDto _self;
+  final $Res Function(_CodexAccountLoginCancelResponseDto) _then;
+
+/// Create a copy of CodexAccountLoginCancelResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? status = null,}) {
+  return _then(_CodexAccountLoginCancelResponseDto(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as CodexAccountLoginCancelStatus,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$CodexAccountLoginCompletedNotificationDto {
+
+ String? get loginId; bool get success; String? get error;
+/// Create a copy of CodexAccountLoginCompletedNotificationDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexAccountLoginCompletedNotificationDtoCopyWith<CodexAccountLoginCompletedNotificationDto> get copyWith => _$CodexAccountLoginCompletedNotificationDtoCopyWithImpl<CodexAccountLoginCompletedNotificationDto>(this as CodexAccountLoginCompletedNotificationDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexAccountLoginCompletedNotificationDto&&(identical(other.loginId, loginId) || other.loginId == loginId)&&(identical(other.success, success) || other.success == success)&&(identical(other.error, error) || other.error == error));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,loginId,success,error);
+
+@override
+String toString() {
+  return 'CodexAccountLoginCompletedNotificationDto(loginId: $loginId, success: $success, error: $error)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexAccountLoginCompletedNotificationDtoCopyWith<$Res>  {
+  factory $CodexAccountLoginCompletedNotificationDtoCopyWith(CodexAccountLoginCompletedNotificationDto value, $Res Function(CodexAccountLoginCompletedNotificationDto) _then) = _$CodexAccountLoginCompletedNotificationDtoCopyWithImpl;
+@useResult
+$Res call({
+ String? loginId, bool success, String? error
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexAccountLoginCompletedNotificationDtoCopyWithImpl<$Res>
+    implements $CodexAccountLoginCompletedNotificationDtoCopyWith<$Res> {
+  _$CodexAccountLoginCompletedNotificationDtoCopyWithImpl(this._self, this._then);
+
+  final CodexAccountLoginCompletedNotificationDto _self;
+  final $Res Function(CodexAccountLoginCompletedNotificationDto) _then;
+
+/// Create a copy of CodexAccountLoginCompletedNotificationDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? loginId = freezed,Object? success = null,Object? error = freezed,}) {
+  return _then(_self.copyWith(
+loginId: freezed == loginId ? _self.loginId : loginId // ignore: cast_nullable_to_non_nullable
+as String?,success: null == success ? _self.success : success // ignore: cast_nullable_to_non_nullable
+as bool,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexAccountLoginCompletedNotificationDto implements CodexAccountLoginCompletedNotificationDto {
+  const _CodexAccountLoginCompletedNotificationDto({required this.loginId, required this.success, required this.error});
+  factory _CodexAccountLoginCompletedNotificationDto.fromJson(Map<String, dynamic> json) => _$CodexAccountLoginCompletedNotificationDtoFromJson(json);
+
+@override final  String? loginId;
+@override final  bool success;
+@override final  String? error;
+
+/// Create a copy of CodexAccountLoginCompletedNotificationDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexAccountLoginCompletedNotificationDtoCopyWith<_CodexAccountLoginCompletedNotificationDto> get copyWith => __$CodexAccountLoginCompletedNotificationDtoCopyWithImpl<_CodexAccountLoginCompletedNotificationDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexAccountLoginCompletedNotificationDto&&(identical(other.loginId, loginId) || other.loginId == loginId)&&(identical(other.success, success) || other.success == success)&&(identical(other.error, error) || other.error == error));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,loginId,success,error);
+
+@override
+String toString() {
+  return 'CodexAccountLoginCompletedNotificationDto(loginId: $loginId, success: $success, error: $error)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexAccountLoginCompletedNotificationDtoCopyWith<$Res> implements $CodexAccountLoginCompletedNotificationDtoCopyWith<$Res> {
+  factory _$CodexAccountLoginCompletedNotificationDtoCopyWith(_CodexAccountLoginCompletedNotificationDto value, $Res Function(_CodexAccountLoginCompletedNotificationDto) _then) = __$CodexAccountLoginCompletedNotificationDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String? loginId, bool success, String? error
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexAccountLoginCompletedNotificationDtoCopyWithImpl<$Res>
+    implements _$CodexAccountLoginCompletedNotificationDtoCopyWith<$Res> {
+  __$CodexAccountLoginCompletedNotificationDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexAccountLoginCompletedNotificationDto _self;
+  final $Res Function(_CodexAccountLoginCompletedNotificationDto) _then;
+
+/// Create a copy of CodexAccountLoginCompletedNotificationDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? loginId = freezed,Object? success = null,Object? error = freezed,}) {
+  return _then(_CodexAccountLoginCompletedNotificationDto(
+loginId: freezed == loginId ? _self.loginId : loginId // ignore: cast_nullable_to_non_nullable
+as String?,success: null == success ? _self.success : success // ignore: cast_nullable_to_non_nullable
+as bool,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_account_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_account_dto.g.dart
@@ -1,0 +1,50 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'codex_account_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Map<String, dynamic> _$CodexDeviceLoginStartParamsDtoToJson(
+  _CodexDeviceLoginStartParamsDto instance,
+) => <String, dynamic>{'type': _$CodexAccountLoginTypeEnumMap[instance.type]!};
+
+const _$CodexAccountLoginTypeEnumMap = {
+  CodexAccountLoginType.chatgptDeviceCode: 'chatgptDeviceCode',
+};
+
+_CodexDeviceLoginStartResponseDto _$CodexDeviceLoginStartResponseDtoFromJson(
+  Map json,
+) => _CodexDeviceLoginStartResponseDto(
+  type: $enumDecode(_$CodexAccountLoginTypeEnumMap, json['type']),
+  loginId: json['loginId'] as String,
+  verificationUrl: json['verificationUrl'] as String,
+  userCode: json['userCode'] as String,
+);
+
+Map<String, dynamic> _$CodexAccountLoginCancelParamsDtoToJson(
+  _CodexAccountLoginCancelParamsDto instance,
+) => <String, dynamic>{'loginId': instance.loginId};
+
+_CodexAccountLoginCancelResponseDto _$CodexAccountLoginCancelResponseDtoFromJson(Map json) =>
+    _CodexAccountLoginCancelResponseDto(
+      status: $enumDecode(
+        _$CodexAccountLoginCancelStatusEnumMap,
+        json['status'],
+        unknownValue: CodexAccountLoginCancelStatus.unknown,
+      ),
+    );
+
+const _$CodexAccountLoginCancelStatusEnumMap = {
+  CodexAccountLoginCancelStatus.canceled: 'canceled',
+  CodexAccountLoginCancelStatus.notFound: 'notFound',
+  CodexAccountLoginCancelStatus.unknown: 'unknown',
+};
+
+_CodexAccountLoginCompletedNotificationDto _$CodexAccountLoginCompletedNotificationDtoFromJson(Map json) =>
+    _CodexAccountLoginCompletedNotificationDto(
+      loginId: json['loginId'] as String?,
+      success: json['success'] as bool,
+      error: json['error'] as String?,
+    );

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_tool_outcome_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_tool_outcome_dto.g.dart
@@ -6,16 +6,17 @@ part of 'codex_tool_outcome_dto.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_CodexToolOutcomeFileDto _$CodexToolOutcomeFileDtoFromJson(Map json) => _CodexToolOutcomeFileDto(
-  schemaVersion: (json['schemaVersion'] as num).toInt(),
-  errors: (json['errors'] as List<dynamic>)
-      .map(
-        (e) => CodexStoredToolErrorDto.fromJson(
-          Map<String, dynamic>.from(e as Map),
-        ),
-      )
-      .toList(),
-);
+_CodexToolOutcomeFileDto _$CodexToolOutcomeFileDtoFromJson(Map json) =>
+    _CodexToolOutcomeFileDto(
+      schemaVersion: (json['schemaVersion'] as num).toInt(),
+      errors: (json['errors'] as List<dynamic>)
+          .map(
+            (e) => CodexStoredToolErrorDto.fromJson(
+              Map<String, dynamic>.from(e as Map),
+            ),
+          )
+          .toList(),
+    );
 
 Map<String, dynamic> _$CodexToolOutcomeFileDtoToJson(
   _CodexToolOutcomeFileDto instance,
@@ -24,10 +25,11 @@ Map<String, dynamic> _$CodexToolOutcomeFileDtoToJson(
   'errors': instance.errors.map((e) => e.toJson()).toList(),
 };
 
-_CodexStoredToolErrorDto _$CodexStoredToolErrorDtoFromJson(Map json) => _CodexStoredToolErrorDto(
-  sessionId: json['sessionId'] as String,
-  callId: json['callId'] as String,
-);
+_CodexStoredToolErrorDto _$CodexStoredToolErrorDtoFromJson(Map json) =>
+    _CodexStoredToolErrorDto(
+      sessionId: json['sessionId'] as String,
+      callId: json['callId'] as String,
+    );
 
 Map<String, dynamic> _$CodexStoredToolErrorDtoToJson(
   _CodexStoredToolErrorDto instance,

--- a/bridge/sesori_plugin_codex/lib/src/codex_app_server_client.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_app_server_client.dart
@@ -80,6 +80,17 @@ class CodexServerRequest {
   final Map<String, dynamic> params;
 }
 
+/// Request and notification surface shared by Codex App Server transports.
+abstract interface class CodexAppServerTransport {
+  Stream<CodexServerNotification> get notifications;
+
+  Future<dynamic> request({
+    required String method,
+    Object? params,
+    Duration timeout = const Duration(seconds: 30),
+  });
+}
+
 /// Factory used by the WebSocket client to open the underlying channel.
 /// Injected for tests so we can swap in an in-memory transport.
 typedef CodexWebSocketChannelFactory = WebSocketChannel Function(Uri uri);
@@ -98,7 +109,7 @@ WebSocketChannel _defaultConnect(Uri uri) => WebSocketChannel.connect(uri);
 ///      by JSON-RPC `id`.
 ///   4. Listen on [notifications] and [serverRequests] for streaming events.
 ///   5. Call [dispose] to close the socket and fail any in-flight requests.
-class CodexAppServerClient {
+class CodexAppServerClient implements CodexAppServerTransport {
   CodexAppServerClient({
     required String serverUrl,
     String? capabilityToken,
@@ -133,6 +144,7 @@ class CodexAppServerClient {
   final StreamController<CodexServerRequest> _serverRequests = StreamController.broadcast();
 
   /// Server-originated notifications (broadcast).
+  @override
   Stream<CodexServerNotification> get notifications => _notifications.stream;
 
   /// Server-originated requests that expect a response (broadcast).
@@ -238,6 +250,7 @@ class CodexAppServerClient {
   ///
   /// Throws [CodexRpcException] on error responses, [TimeoutException] on
   /// timeout, [StateError] if the socket isn't open.
+  @override
   Future<dynamic> request({
     required String method,
     Object? params,

--- a/bridge/sesori_plugin_codex/lib/src/codex_stdio_app_server_client.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_stdio_app_server_client.dart
@@ -248,8 +248,8 @@ class CodexStdioAppServerClient implements CodexAppServerTransport {
   }
 
   void _handleExit({required int generation, required int code}) {
-    if (!_exited.isCompleted) _exited.complete(code);
     if (generation != _connectionGeneration) return;
+    if (!_exited.isCompleted) _exited.complete(code);
     _failPending(
       StateError("Codex App Server process exited before replying"),
       StackTrace.current,

--- a/bridge/sesori_plugin_codex/lib/src/codex_stdio_app_server_client.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_stdio_app_server_client.dart
@@ -1,0 +1,361 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io" as io;
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "codex_app_server_client.dart";
+
+final class _PendingRequest {
+  const _PendingRequest({required this.method, required this.completer});
+
+  final String method;
+  final Completer<dynamic> completer;
+}
+
+/// JSONL transport for a short-lived `codex app-server` stdio connection.
+class CodexStdioAppServerClient implements CodexAppServerTransport {
+  CodexStdioAppServerClient({
+    required HostProcessService processes,
+    required String executable,
+    required Map<String, String> environment,
+    required Duration shutdownTimeout,
+  }) : _processes = processes,
+       _executable = executable,
+       _environment = Map<String, String>.unmodifiable(environment),
+       _shutdownTimeout = shutdownTimeout;
+
+  final HostProcessService _processes;
+  final String _executable;
+  final Map<String, String> _environment;
+  final Duration _shutdownTimeout;
+
+  SpawnedProcess? _process;
+  StreamSubscription<String>? _stdoutSubscription;
+  StreamSubscription<List<int>>? _stderrSubscription;
+  Completer<int> _exited = Completer<int>();
+  final Map<Object, _PendingRequest> _pending = <Object, _PendingRequest>{};
+  final StreamController<CodexServerNotification> _notifications = StreamController.broadcast();
+  final StreamController<CodexServerRequest> _serverRequests = StreamController.broadcast();
+  int _nextId = 1;
+  int _connectionGeneration = 0;
+  bool _disposed = false;
+
+  @override
+  Stream<CodexServerNotification> get notifications => _notifications.stream;
+
+  Stream<CodexServerRequest> get serverRequests => _serverRequests.stream;
+
+  Future<int> get processExit => _exited.future;
+
+  Future<CodexInitializeResult> connect({
+    required String clientName,
+    required String clientVersion,
+    required Duration timeout,
+  }) async {
+    if (_process != null) {
+      throw StateError("CodexStdioAppServerClient already connected");
+    }
+    if (_disposed) {
+      throw StateError("CodexStdioAppServerClient is disposed");
+    }
+
+    final generation = ++_connectionGeneration;
+    final process = await _processes.spawn(
+      executable: _executable,
+      arguments: const ["app-server", "--listen", "stdio://"],
+      environment: _environment,
+      workingDirectory: null,
+      runInShell: io.Platform.isWindows,
+    );
+    if (_disposed || generation != _connectionGeneration) {
+      await _reapLateProcess(process);
+      throw StateError("CodexStdioAppServerClient disposed during connect");
+    }
+
+    _process = process;
+    _exited = Completer<int>();
+    unawaited(process.stdin.done.catchError((Object _) {}));
+    _stdoutSubscription = process.stdout
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen(
+          (line) {
+            if (generation == _connectionGeneration) _handleLine(line);
+          },
+          onError: (Object error, StackTrace stackTrace) {
+            if (generation == _connectionGeneration) {
+              Log.w("[codex][stdio] stdout stream failed", error, stackTrace);
+              _failPending(error, stackTrace);
+            }
+          },
+          cancelOnError: false,
+        );
+    // Stderr can include upstream account diagnostics. Drain it without
+    // retaining or logging its contents.
+    _stderrSubscription = process.stderr.listen(
+      (_) {},
+      onError: (Object error, StackTrace stackTrace) => Log.w("[codex][stdio] stderr stream failed", error, stackTrace),
+      cancelOnError: false,
+    );
+    unawaited(
+      process.exitCode.then(
+        (code) => _handleExit(generation: generation, code: code),
+        onError: (Object error, StackTrace stackTrace) {
+          if (generation != _connectionGeneration) return;
+          if (!_exited.isCompleted) _exited.completeError(error, stackTrace);
+          _failPending(error, stackTrace);
+        },
+      ),
+    );
+
+    try {
+      final raw = await request(
+        method: "initialize",
+        params: {
+          "clientInfo": {
+            "name": clientName,
+            "title": "Sesori Bridge",
+            "version": clientVersion,
+          },
+        },
+        timeout: timeout,
+      );
+      if (raw is! Map) {
+        throw CodexRpcException(
+          method: "initialize",
+          code: -32603,
+          message: "expected object result, got ${raw.runtimeType}",
+        );
+      }
+      final result = CodexInitializeResult.fromJson(
+        raw.cast<String, dynamic>(),
+      );
+      _notify(method: "initialized");
+      return result;
+    } on Object {
+      await _teardownConnection(
+        pendingError: StateError("Codex stdio initialization failed"),
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  Future<dynamic> request({
+    required String method,
+    Object? params,
+    Duration timeout = const Duration(seconds: 30),
+  }) async {
+    final process = _process;
+    if (process == null || _exited.isCompleted) {
+      throw StateError("CodexStdioAppServerClient is not connected");
+    }
+    final id = _nextId++;
+    final completer = Completer<dynamic>();
+    _pending[id] = _PendingRequest(method: method, completer: completer);
+    final envelope = <String, dynamic>{"id": id, "method": method};
+    if (params != null) envelope["params"] = params;
+    if (!_writeFrame(process: process, envelope: envelope)) {
+      _pending.remove(id);
+      throw StateError("CodexStdioAppServerClient failed to write $method request");
+    }
+    try {
+      return await completer.future.timeout(timeout);
+    } on TimeoutException {
+      _pending.remove(id);
+      rethrow;
+    }
+  }
+
+  void _notify({required String method, Object? params}) {
+    final process = _process;
+    if (process == null || _exited.isCompleted) return;
+    final envelope = <String, dynamic>{"method": method};
+    if (params != null) envelope["params"] = params;
+    _writeFrame(process: process, envelope: envelope);
+  }
+
+  bool _writeFrame({
+    required SpawnedProcess process,
+    required Map<String, dynamic> envelope,
+  }) {
+    try {
+      process.stdin.add(utf8.encode("${jsonEncode(envelope)}\n"));
+      return true;
+    } on Object catch (error, stackTrace) {
+      Log.w("[codex][stdio] failed to write protocol frame", error, stackTrace);
+      return false;
+    }
+  }
+
+  void _handleLine(String line) {
+    if (line.trim().isEmpty) return;
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(line);
+    } on Object {
+      final error = StateError("Codex App Server returned malformed JSON");
+      Log.w("[codex][stdio] ignored malformed stdout frame");
+      _failPending(error, StackTrace.current);
+      return;
+    }
+    if (decoded is! Map) {
+      Log.w("[codex][stdio] ignored non-object stdout frame");
+      return;
+    }
+    final map = decoded.cast<String, dynamic>();
+    final id = map["id"];
+    final method = map["method"];
+    if (id != null && method == null) {
+      final pending = _pending.remove(id);
+      if (pending == null) {
+        Log.d("[codex][stdio] ignored response for unknown request id");
+        return;
+      }
+      final rawError = map["error"];
+      if (map.containsKey("error")) {
+        final error = rawError is Map ? rawError.cast<String, dynamic>() : null;
+        final code = error?["code"];
+        final message = error?["message"];
+        pending.completer.completeError(
+          CodexRpcException(
+            method: pending.method,
+            code: code is int ? code : -32603,
+            message: message is String ? message : "unknown error",
+          ),
+        );
+      } else {
+        pending.completer.complete(map["result"]);
+      }
+      return;
+    }
+    if (method is! String) {
+      Log.d("[codex][stdio] ignored unrecognized stdout frame");
+      return;
+    }
+    final rawParams = map["params"];
+    final params = rawParams is Map ? rawParams.cast<String, dynamic>() : <String, dynamic>{};
+    if (id != null) {
+      _serverRequests.add(
+        CodexServerRequest(id: id as Object, method: method, params: params),
+      );
+    } else {
+      _notifications.add(
+        CodexServerNotification(method: method, params: params),
+      );
+    }
+  }
+
+  void _handleExit({required int generation, required int code}) {
+    if (!_exited.isCompleted) _exited.complete(code);
+    if (generation != _connectionGeneration) return;
+    _failPending(
+      StateError("Codex App Server process exited before replying"),
+      StackTrace.current,
+    );
+    if (!_disposed) {
+      Log.w("[codex][stdio] app-server process exited with code $code");
+    }
+  }
+
+  void _failPending(Object error, StackTrace stackTrace) {
+    final pending = _pending.values.toList(growable: false);
+    _pending.clear();
+    for (final request in pending) {
+      if (!request.completer.isCompleted) {
+        request.completer.completeError(error, stackTrace);
+      }
+    }
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await _teardownConnection(
+      pendingError: StateError("CodexStdioAppServerClient disposed"),
+    );
+    try {
+      await _notifications.close();
+    } on Object catch (error, stackTrace) {
+      Log.w("[codex][stdio] failed to close notifications", error, stackTrace);
+    }
+    try {
+      await _serverRequests.close();
+    } on Object catch (error, stackTrace) {
+      Log.w("[codex][stdio] failed to close server requests", error, stackTrace);
+    }
+  }
+
+  Future<void> _teardownConnection({required Object pendingError}) async {
+    _connectionGeneration++;
+    final process = _process;
+    _process = null;
+    _failPending(pendingError, StackTrace.current);
+
+    if (process != null) {
+      try {
+        await process.stdin.close().timeout(_shutdownTimeout);
+      } on Object catch (error, stackTrace) {
+        Log.w("[codex][stdio] failed to close app-server stdin", error, stackTrace);
+      }
+      if (!await _waitForExit(process)) {
+        try {
+          await _processes.signalGraceful(pid: process.pid);
+        } on Object catch (error, stackTrace) {
+          Log.w("[codex][stdio] failed to stop app-server gracefully", error, stackTrace);
+        }
+        if (!await _waitForExit(process)) {
+          try {
+            await _processes.signalForce(pid: process.pid);
+          } on Object catch (error, stackTrace) {
+            Log.w("[codex][stdio] failed to force-stop app-server", error, stackTrace);
+          }
+          await _waitForExit(process);
+        }
+      }
+    }
+
+    try {
+      await _stdoutSubscription?.cancel();
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        "[codex][stdio] failed to cancel stdout subscription",
+        error,
+        stackTrace,
+      );
+    }
+    _stdoutSubscription = null;
+    try {
+      await _stderrSubscription?.cancel();
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        "[codex][stdio] failed to cancel stderr subscription",
+        error,
+        stackTrace,
+      );
+    }
+    _stderrSubscription = null;
+  }
+
+  Future<bool> _waitForExit(SpawnedProcess process) async {
+    try {
+      await process.exitCode.timeout(_shutdownTimeout);
+      return true;
+    } on TimeoutException {
+      return false;
+    } on Object catch (error, stackTrace) {
+      Log.w("[codex][stdio] failed while awaiting app-server exit", error, stackTrace);
+      return true;
+    }
+  }
+
+  Future<void> _reapLateProcess(SpawnedProcess process) async {
+    try {
+      await _processes.signalForce(pid: process.pid);
+      await process.exitCode.timeout(_shutdownTimeout);
+    } on Object catch (error, stackTrace) {
+      Log.w("[codex][stdio] failed to reap process spawned during teardown", error, stackTrace);
+    }
+  }
+}

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
@@ -32,6 +32,7 @@ import "codex_ownership_record.dart";
 import "codex_record_mapper.dart";
 import "codex_runtime_manifest.dart";
 import "codex_runtime_policy.dart";
+import "codex_runtime_selection_service.dart";
 import "codex_status_reporter.dart";
 
 const int _setupProbeOutputLimit = 64 * 1024;
@@ -218,7 +219,7 @@ class CodexPluginDescriptor extends BridgePluginDescriptor {
   /// explicit `--codex-bin` override (that binary is authoritative) and a
   /// published release asset for this platform.
   bool _supportsManagedInstall({required PluginConfig config}) {
-    if (_explicitBin(config) != null) return false;
+    if (CodexRuntimeSelectionService.explicitBinary(config: config) != null) return false;
     final PlatformTarget target;
     try {
       target = PlatformTarget.current();
@@ -278,111 +279,53 @@ class CodexPluginDescriptor extends BridgePluginDescriptor {
     required Map<String, String> environment,
     required String stateDirectory,
   }) async {
-    final explicitBin = _explicitBin(config);
-    final hasExplicitBin = explicitBin != null;
-    const manifest = CodexRuntimeManifest();
-    var executable = explicitBin ?? manifest.pathExecutableName;
+    final selection =
+        await CodexRuntimeSelectionService(
+          processes: processes,
+          versionProbeTimeout: _versionProbeTimeout,
+          maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
+          desktopAppCliCandidates: _desktopAppCliCandidates,
+        ).select(
+          config: config,
+          environment: environment,
+          stateDirectory: stateDirectory,
+          aborted: StartAbortSignal.never,
+        );
+    if (selection case CodexRuntimeNotSelected(:final failure, :final hasExplicitBinary)) {
+      return switch (failure) {
+        CodexRuntimeSelectionFailure.executableMissing => PluginSetupRuntimeMissing(
+          actionHint: hasExplicitBinary
+              ? "Fix the configured Codex binary path, then restart the bridge."
+              : "Install Codex locally, then retry setup detection.",
+        ),
+        CodexRuntimeSelectionFailure.probeTimedOut => const PluginSetupUnknown(
+          actionHint: "Codex did not answer its setup check. Verify the local installation and retry.",
+        ),
+        CodexRuntimeSelectionFailure.probeFailed => const PluginSetupUnknown(
+          actionHint: "Codex setup could not be determined. Verify the local installation and retry.",
+        ),
+        CodexRuntimeSelectionFailure.nonZeroExit => const PluginSetupUnknown(
+          actionHint: "Codex did not answer its setup check. Verify the local installation and retry.",
+        ),
+        CodexRuntimeSelectionFailure.unrecognizedVersion => const PluginSetupUnknown(
+          actionHint: "Codex returned an unrecognized version. Update Codex and retry.",
+        ),
+        CodexRuntimeSelectionFailure.unsupportedVersion =>
+          hasExplicitBinary
+              ? const PluginSetupUnavailable(
+                  actionHint: "The configured Codex binary is too old. Update it and restart the bridge.",
+                )
+              : const PluginSetupRuntimeMissing(
+                  actionHint: "Update Codex locally, then retry setup detection.",
+                ),
+      };
+    }
+    final executable = (selection as CodexRuntimeSelected).binaryPath;
     final executor = HostProcessCommandExecutor(
       processes: processes,
       runInShell: io.Platform.isWindows,
       maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
     );
-    final versionValidator = RuntimeVersionValidator(
-      commandExecutor: executor,
-      runtimeId: manifest.runtimeId,
-      probeTimeout: _versionProbeTimeout,
-    );
-
-    // Fallback resolution mirroring ensureRuntime's precedence when the primary
-    // probe fails: a recent-enough desktop-app-bundled CLI, then the pinned
-    // managed runtime.
-    Future<bool> resolveManagedRuntime() async {
-      if (hasExplicitBin) return false;
-      for (final candidate in _resolveDesktopAppCliCandidates(environment: environment)) {
-        final candidateVersion = await versionValidator.detectVersion(
-          executable: candidate,
-          environment: environment,
-        );
-        if (candidateVersion != null && candidateVersion.compareTo(manifest.minPathVersion) >= 0) {
-          executable = candidate;
-          return true;
-        }
-      }
-      final managedExecutable = manifest.managedBinaryPath(stateDirectory: stateDirectory);
-      final managedVersion = await versionValidator.detectVersion(
-        executable: managedExecutable,
-        environment: environment,
-      );
-      if (managedVersion == null || managedVersion.compareTo(manifest.bundledVersion) != 0) {
-        return false;
-      }
-      executable = managedExecutable;
-      return true;
-    }
-
-    CommandResult? versionResult;
-    var runtimeResolved = false;
-    try {
-      versionResult = await executor.run(
-        executable,
-        const ["--version"],
-        environment: environment,
-        timeout: _versionProbeTimeout,
-      );
-    } on io.ProcessException {
-      runtimeResolved = await resolveManagedRuntime();
-      if (!runtimeResolved) {
-        return PluginSetupRuntimeMissing(
-          actionHint: hasExplicitBin
-              ? "Fix the configured Codex binary path, then restart the bridge."
-              : "Install Codex locally, then retry setup detection.",
-        );
-      }
-    } on TimeoutException {
-      runtimeResolved = await resolveManagedRuntime();
-      if (!runtimeResolved) {
-        return const PluginSetupUnknown(
-          actionHint: "Codex did not answer its setup check. Verify the local installation and retry.",
-        );
-      }
-    } on Object {
-      runtimeResolved = await resolveManagedRuntime();
-      if (!runtimeResolved) {
-        return const PluginSetupUnknown(
-          actionHint: "Codex setup could not be determined. Verify the local installation and retry.",
-        );
-      }
-    }
-
-    if (!runtimeResolved) {
-      if (versionResult!.exitCode != 0) {
-        if (!await resolveManagedRuntime()) {
-          return const PluginSetupUnknown(
-            actionHint: "Codex did not answer its setup check. Verify the local installation and retry.",
-          );
-        }
-      } else {
-        final version = versionValidator.parseVersionOutput(output: versionResult.stdout);
-        if (version == null) {
-          if (!await resolveManagedRuntime()) {
-            return const PluginSetupUnknown(
-              actionHint: "Codex returned an unrecognized version. Update Codex and retry.",
-            );
-          }
-        } else if (version.compareTo(manifest.minPathVersion) < 0) {
-          if (!await resolveManagedRuntime()) {
-            if (!hasExplicitBin) {
-              return const PluginSetupRuntimeMissing(
-                actionHint: "Update Codex locally, then retry setup detection.",
-              );
-            }
-            return const PluginSetupUnavailable(
-              actionHint: "The configured Codex binary is too old. Update it and restart the bridge.",
-            );
-          }
-        }
-      }
-    }
 
     final CommandResult loginResult;
     try {
@@ -411,17 +354,6 @@ class CodexPluginDescriptor extends BridgePluginDescriptor {
     );
   }
 
-  /// The explicit `--codex-bin` override path, or `null` when unset, empty, or
-  /// left at the bare default `codex` (which means "resolve via [ensureRuntime]":
-  /// a recent-enough PATH codex or the pinned managed download).
-  String? _explicitBin(PluginConfig config) {
-    final value = config.value("bin")?.trim();
-    if (value == null || value.isEmpty || value == "codex") {
-      return null;
-    }
-    return value;
-  }
-
   /// Resolves an existing codex runtime (a recent-enough PATH install, a
   /// recent-enough CLI bundled by the Codex desktop app, or the pinned managed
   /// runtime when already installed). Skipped when an explicit
@@ -430,7 +362,7 @@ class CodexPluginDescriptor extends BridgePluginDescriptor {
   /// and `start()` fails with guidance.
   @override
   Stream<RuntimeProvisionProgress> ensureRuntime({required PluginHost host}) async* {
-    if (_explicitBin(host.config) != null) {
+    if (CodexRuntimeSelectionService.explicitBinary(config: host.config) != null) {
       return;
     }
 
@@ -440,43 +372,17 @@ class CodexPluginDescriptor extends BridgePluginDescriptor {
       return;
     }
 
-    yield* _buildDefaultProvisionService(host: host).provision(host: host);
+    yield* CodexRuntimeSelectionService(
+      processes: host.processes,
+      versionProbeTimeout: _versionProbeTimeout,
+      maxCapturedOutputCharactersPerStream: null,
+      desktopAppCliCandidates: _desktopAppCliCandidates,
+    ).provision(host: host);
   }
 
   String _normalizedStatusOutput(CommandResult result) {
     final combined = "${result.stdout}\n${result.stderr}";
     return combined.replaceAll(RegExp(r"\x1B\[[0-?]*[ -/]*[@-~]"), "").trim().toLowerCase();
-  }
-
-  /// The injected desktop-app CLI candidates, or the platform's real ones.
-  List<String> _resolveDesktopAppCliCandidates({required Map<String, String> environment}) {
-    return _desktopAppCliCandidates ??
-        codexDesktopAppCliCandidates(
-          environment: environment,
-          os: PlatformOs.fromOperatingSystem(operatingSystem: io.Platform.operatingSystem),
-        );
-  }
-
-  /// Assembles the production resolver from the host's process service so
-  /// helper commands go through the host, never a raw spawn.
-  ManagedRuntimeProvisionService _buildDefaultProvisionService({
-    required PluginHost host,
-  }) {
-    const manifest = CodexRuntimeManifest();
-    final commandExecutor = HostProcessCommandExecutor(
-      processes: host.processes,
-      runInShell: io.Platform.isWindows,
-      maxCapturedOutputCharactersPerStream: null,
-    );
-    return ManagedRuntimeProvisionService(
-      manifest: manifest,
-      versionValidator: RuntimeVersionValidator(
-        commandExecutor: commandExecutor,
-        runtimeId: manifest.runtimeId,
-        probeTimeout: _versionProbeTimeout,
-      ),
-      fallbackExecutableCandidates: _resolveDesktopAppCliCandidates(environment: host.environment),
-    );
   }
 
   @override
@@ -490,7 +396,7 @@ class CodexPluginDescriptor extends BridgePluginDescriptor {
     // Precedence: an explicit --codex-bin override wins (trusted, no version
     // gate); otherwise the path ensureRuntime resolved (a recent PATH codex or
     // the managed download), exposed via the host.
-    final executablePath = _explicitBin(config) ?? host.provisionedRuntimePath;
+    final executablePath = CodexRuntimeSelectionService.explicitBinary(config: config) ?? host.provisionedRuntimePath;
     if (executablePath == null) {
       // Runtime provisioning failed and no explicit binary was given. codex has
       // no attach/degraded mode (its WebSocket client cannot reconnect), so it

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_selection_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_selection_service.dart
@@ -1,0 +1,290 @@
+import "dart:async";
+import "dart:io" as io;
+
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
+
+import "codex_desktop_app_locator.dart";
+import "codex_runtime_manifest.dart";
+
+enum CodexRuntimeSource { explicit, path, desktopApp, managed }
+
+enum CodexRuntimeSelectionFailure {
+  executableMissing,
+  probeTimedOut,
+  probeFailed,
+  nonZeroExit,
+  unrecognizedVersion,
+  unsupportedVersion,
+}
+
+sealed class CodexRuntimeSelection {
+  const CodexRuntimeSelection();
+}
+
+final class CodexRuntimeSelected extends CodexRuntimeSelection {
+  const CodexRuntimeSelected({
+    required this.binaryPath,
+    required this.source,
+    required this.version,
+    required this.rejectedPathVersion,
+  });
+
+  final String binaryPath;
+  final CodexRuntimeSource source;
+  final SemanticVersion version;
+  final SemanticVersion? rejectedPathVersion;
+}
+
+final class CodexRuntimeNotSelected extends CodexRuntimeSelection {
+  const CodexRuntimeNotSelected({
+    required this.failure,
+    required this.hasExplicitBinary,
+  });
+
+  final CodexRuntimeSelectionFailure failure;
+  final bool hasExplicitBinary;
+}
+
+sealed class _VersionProbe {
+  const _VersionProbe();
+}
+
+final class _VersionProbeSucceeded extends _VersionProbe {
+  const _VersionProbeSucceeded({required this.version});
+
+  final SemanticVersion version;
+}
+
+final class _VersionProbeFailed extends _VersionProbe {
+  const _VersionProbeFailed({required this.failure});
+
+  final CodexRuntimeSelectionFailure failure;
+}
+
+/// Selects the Codex executable shared by setup inspection, startup, and
+/// interactive authentication without installing or mutating runtime files.
+class CodexRuntimeSelectionService {
+  CodexRuntimeSelectionService({
+    required HostProcessService processes,
+    required Duration versionProbeTimeout,
+    required int? maxCapturedOutputCharactersPerStream,
+    required List<String>? desktopAppCliCandidates,
+  }) : _versionProbeTimeout = versionProbeTimeout,
+       _desktopAppCliCandidates = desktopAppCliCandidates,
+       _commandExecutor = HostProcessCommandExecutor(
+         processes: processes,
+         runInShell: io.Platform.isWindows,
+         maxCapturedOutputCharactersPerStream: maxCapturedOutputCharactersPerStream,
+       ),
+       _versionValidator = RuntimeVersionValidator(
+         commandExecutor: HostProcessCommandExecutor(
+           processes: processes,
+           runInShell: io.Platform.isWindows,
+           maxCapturedOutputCharactersPerStream: maxCapturedOutputCharactersPerStream,
+         ),
+         runtimeId: const CodexRuntimeManifest().runtimeId,
+         probeTimeout: versionProbeTimeout,
+       );
+
+  final Duration _versionProbeTimeout;
+  final List<String>? _desktopAppCliCandidates;
+  final CommandExecutor _commandExecutor;
+  final RuntimeVersionValidator _versionValidator;
+
+  static String? explicitBinary({required PluginConfig config}) {
+    final value = config.value("bin")?.trim();
+    if (value == null || value.isEmpty || value == "codex") return null;
+    return value;
+  }
+
+  Future<CodexRuntimeSelection> select({
+    required PluginConfig config,
+    required Map<String, String> environment,
+    required String stateDirectory,
+    required StartAbortSignal aborted,
+  }) async {
+    const manifest = CodexRuntimeManifest();
+    final explicit = explicitBinary(config: config);
+    if (explicit != null) {
+      final probe = await _probe(
+        executable: explicit,
+        environment: environment,
+        aborted: aborted,
+      );
+      return switch (probe) {
+        _VersionProbeSucceeded(:final version) when version.compareTo(manifest.minPathVersion) >= 0 =>
+          CodexRuntimeSelected(
+            binaryPath: explicit,
+            source: CodexRuntimeSource.explicit,
+            version: version,
+            rejectedPathVersion: null,
+          ),
+        _VersionProbeSucceeded() => const CodexRuntimeNotSelected(
+          failure: CodexRuntimeSelectionFailure.unsupportedVersion,
+          hasExplicitBinary: true,
+        ),
+        _VersionProbeFailed(:final failure) => CodexRuntimeNotSelected(
+          failure: failure,
+          hasExplicitBinary: true,
+        ),
+      };
+    }
+
+    final pathProbe = await _probe(
+      executable: manifest.pathExecutableName,
+      environment: environment,
+      aborted: aborted,
+    );
+    final pathVersion = switch (pathProbe) {
+      _VersionProbeSucceeded(:final version) => version,
+      _VersionProbeFailed() => null,
+    };
+    if (pathVersion != null && pathVersion.compareTo(manifest.minPathVersion) >= 0) {
+      return CodexRuntimeSelected(
+        binaryPath: manifest.pathExecutableName,
+        source: CodexRuntimeSource.path,
+        version: pathVersion,
+        rejectedPathVersion: null,
+      );
+    }
+
+    for (final candidate in _desktopCandidates(environment: environment)) {
+      final candidateProbe = await _probe(
+        executable: candidate,
+        environment: environment,
+        aborted: aborted,
+      );
+      if (candidateProbe case _VersionProbeSucceeded(
+        :final version,
+      ) when version.compareTo(manifest.minPathVersion) >= 0) {
+        return CodexRuntimeSelected(
+          binaryPath: candidate,
+          source: CodexRuntimeSource.desktopApp,
+          version: version,
+          rejectedPathVersion: pathVersion,
+        );
+      }
+    }
+
+    final managedPath = manifest.managedBinaryPath(stateDirectory: stateDirectory);
+    final managedProbe = await _probe(
+      executable: managedPath,
+      environment: environment,
+      aborted: aborted,
+    );
+    if (managedProbe case _VersionProbeSucceeded(:final version) when version.compareTo(manifest.bundledVersion) == 0) {
+      return CodexRuntimeSelected(
+        binaryPath: managedPath,
+        source: CodexRuntimeSource.managed,
+        version: version,
+        rejectedPathVersion: pathVersion,
+      );
+    }
+
+    final primaryFailure = switch (pathProbe) {
+      _VersionProbeSucceeded() => CodexRuntimeSelectionFailure.unsupportedVersion,
+      _VersionProbeFailed(:final failure) => failure,
+    };
+    return CodexRuntimeNotSelected(
+      failure: primaryFailure,
+      hasExplicitBinary: false,
+    );
+  }
+
+  Stream<RuntimeProvisionProgress> provision({required PluginHost host}) async* {
+    if (host.startAborted.isAborted) throw const PluginStartAbortedException();
+    yield const ProvisionResolving();
+    final result = await select(
+      config: host.config,
+      environment: host.environment,
+      stateDirectory: host.stateDirectory,
+      aborted: host.startAborted,
+    );
+    if (result case CodexRuntimeSelected(
+      :final binaryPath,
+      :final source,
+      :final version,
+      :final rejectedPathVersion,
+    )) {
+      const manifest = CodexRuntimeManifest();
+      if (source == CodexRuntimeSource.managed && rejectedPathVersion != null) {
+        yield ProvisionNotice(
+          message:
+              "Installed ${manifest.displayName} $rejectedPathVersion is older than the minimum supported "
+              "${manifest.minPathVersion}; using the existing managed ${manifest.displayName} "
+              "${manifest.bundledVersion} instead.",
+        );
+      }
+      Log.i("[codex] using ${source.name} ${manifest.displayName} $version");
+      yield ProvisionReady(binaryPath: binaryPath);
+      return;
+    }
+    const manifest = CodexRuntimeManifest();
+    yield ProvisionFailed(
+      message:
+          "No usable existing ${manifest.displayName} runtime was found. Install ${manifest.displayName} locally "
+          "and retry: ${manifest.installDocsUrl}",
+    );
+  }
+
+  Future<_VersionProbe> _probe({
+    required String executable,
+    required Map<String, String> environment,
+    required StartAbortSignal aborted,
+  }) async {
+    if (aborted.isAborted) throw const PluginStartAbortedException();
+    final CommandResult result;
+    try {
+      result = await _commandExecutor.run(
+        executable,
+        const ["--version"],
+        environment: environment,
+        timeout: _versionProbeTimeout,
+      );
+    } on io.ProcessException {
+      _throwIfAborted(aborted);
+      return const _VersionProbeFailed(
+        failure: CodexRuntimeSelectionFailure.executableMissing,
+      );
+    } on TimeoutException {
+      _throwIfAborted(aborted);
+      return const _VersionProbeFailed(
+        failure: CodexRuntimeSelectionFailure.probeTimedOut,
+      );
+    } on Object {
+      _throwIfAborted(aborted);
+      return const _VersionProbeFailed(
+        failure: CodexRuntimeSelectionFailure.probeFailed,
+      );
+    }
+    _throwIfAborted(aborted);
+    if (result.exitCode != 0) {
+      return const _VersionProbeFailed(
+        failure: CodexRuntimeSelectionFailure.nonZeroExit,
+      );
+    }
+    final version = _versionValidator.parseVersionOutput(output: result.stdout);
+    if (version == null) {
+      return const _VersionProbeFailed(
+        failure: CodexRuntimeSelectionFailure.unrecognizedVersion,
+      );
+    }
+    return _VersionProbeSucceeded(version: version);
+  }
+
+  void _throwIfAborted(StartAbortSignal aborted) {
+    if (aborted.isAborted) throw const PluginStartAbortedException();
+  }
+
+  List<String> _desktopCandidates({required Map<String, String> environment}) {
+    return _desktopAppCliCandidates ??
+        codexDesktopAppCliCandidates(
+          environment: environment,
+          os: PlatformOs.fromOperatingSystem(
+            operatingSystem: io.Platform.operatingSystem,
+          ),
+        );
+  }
+}

--- a/bridge/sesori_plugin_codex/test/codex_app_server_account_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_app_server_account_api_test.dart
@@ -1,0 +1,145 @@
+import "dart:async";
+
+import "package:codex_plugin/src/api/codex_app_server_api.dart";
+import "package:codex_plugin/src/api/models/codex_account_dto.dart";
+import "package:codex_plugin/src/codex_app_server_client.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("CodexAppServerApi account operations", () {
+    test("starts device login with a typed response", () async {
+      final transport = _FakeTransport(
+        responses: [
+          {
+            "type": "chatgptDeviceCode",
+            "loginId": "login-private",
+            "verificationUrl": "https://auth.example/device",
+            "userCode": "CODE-PRIVATE",
+          },
+        ],
+      );
+
+      final response = await CodexAppServerApi(
+        client: transport,
+      ).startDeviceLogin();
+
+      expect(response.type, CodexAccountLoginType.chatgptDeviceCode);
+      expect(response.loginId, "login-private");
+      expect(response.verificationUrl, "https://auth.example/device");
+      expect(response.userCode, "CODE-PRIVATE");
+      expect(transport.calls, hasLength(1));
+      expect(transport.calls.single.method, "account/login/start");
+      expect(transport.calls.single.params, {
+        "type": "chatgptDeviceCode",
+      });
+    });
+
+    test("rejects an unknown device login response type", () async {
+      final api = CodexAppServerApi(
+        client: _FakeTransport(
+          responses: [
+            {
+              "type": "browser",
+              "loginId": "login-private",
+              "verificationUrl": "https://auth.example/device",
+              "userCode": "CODE-PRIVATE",
+            },
+          ],
+        ),
+      );
+
+      await expectLater(api.startDeviceLogin(), throwsA(isA<ArgumentError>()));
+    });
+
+    test("cancels by private login id and preserves unknown statuses", () async {
+      final transport = _FakeTransport(
+        responses: [
+          {"status": "notFound"},
+          {"status": "futureStatus"},
+        ],
+      );
+      final api = CodexAppServerApi(client: transport);
+
+      final missing = await api.cancelLogin(loginId: "login-private");
+      final future = await api.cancelLogin(loginId: "login-private");
+
+      expect(missing.status, CodexAccountLoginCancelStatus.notFound);
+      expect(future.status, CodexAccountLoginCancelStatus.unknown);
+      expect(
+        transport.calls.map((call) => call.params),
+        everyElement(<String, dynamic>{"loginId": "login-private"}),
+      );
+    });
+
+    test("decodes only account login completion notifications", () async {
+      final transport = _FakeTransport(responses: const []);
+      final completions = CodexAppServerApi(
+        client: transport,
+      ).accountLoginCompletions;
+      final completionFuture = completions.first;
+
+      transport.notificationsController.add(
+        const CodexServerNotification(method: "account/updated", params: {}),
+      );
+      transport.notificationsController.add(
+        const CodexServerNotification(
+          method: "account/login/completed",
+          params: {
+            "loginId": "login-private",
+            "success": false,
+            "error": "private upstream error",
+          },
+        ),
+      );
+
+      final completion = await completionFuture;
+      expect(completion.loginId, "login-private");
+      expect(completion.success, isFalse);
+      expect(completion.error, "private upstream error");
+      await transport.dispose();
+    });
+
+    test("rejects malformed completion payloads", () async {
+      final transport = _FakeTransport(responses: const []);
+      final completionFuture = CodexAppServerApi(
+        client: transport,
+      ).accountLoginCompletions.first;
+
+      transport.notificationsController.add(
+        const CodexServerNotification(
+          method: "account/login/completed",
+          params: {"loginId": null, "success": "yes", "error": null},
+        ),
+      );
+
+      await expectLater(completionFuture, throwsA(isA<TypeError>()));
+      await transport.dispose();
+    });
+  });
+}
+
+typedef _TransportCall = ({String method, Object? params});
+
+class _FakeTransport implements CodexAppServerTransport {
+  _FakeTransport({required List<Object?> responses}) : _responses = List<Object?>.of(responses);
+
+  final List<Object?> _responses;
+  final List<_TransportCall> calls = <_TransportCall>[];
+  final StreamController<CodexServerNotification> notificationsController =
+      StreamController<CodexServerNotification>.broadcast();
+
+  @override
+  Stream<CodexServerNotification> get notifications => notificationsController.stream;
+
+  @override
+  Future<dynamic> request({
+    required String method,
+    Object? params,
+    Duration timeout = const Duration(seconds: 30),
+  }) async {
+    calls.add((method: method, params: params));
+    return _responses.removeAt(0);
+  }
+
+  Future<void> dispose() => notificationsController.close();
+}

--- a/bridge/sesori_plugin_codex/test/codex_stdio_app_server_client_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_stdio_app_server_client_test.dart
@@ -1,0 +1,352 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+
+import "package:codex_plugin/src/codex_app_server_client.dart";
+import "package:codex_plugin/src/codex_stdio_app_server_client.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  const environment = <String, String>{
+    "CODEX_HOME": "/private/codex-home",
+    "HTTPS_PROXY": "https://proxy.example",
+  };
+
+  CodexStdioAppServerClient client(
+    _FakeHostProcessService processes,
+  ) => CodexStdioAppServerClient(
+    processes: processes,
+    executable: "/managed/codex",
+    environment: environment,
+    shutdownTimeout: const Duration(milliseconds: 10),
+  );
+
+  Future<({Future<CodexInitializeResult> future})> startConnect(
+    CodexStdioAppServerClient appServerClient,
+    _FakeProcess process,
+  ) async {
+    final connect = appServerClient.connect(
+      clientName: "sesori-bridge",
+      clientVersion: "1.2.3",
+      timeout: const Duration(seconds: 1),
+    );
+    await process.waitForFrames(1);
+    return (future: connect);
+  }
+
+  void completeInitialize(_FakeProcess process) {
+    final id = process.frames.single["id"];
+    process.send({
+      "id": id,
+      "result": {
+        "userAgent": "codex_cli_rs/0.146.0",
+        "codexHome": "/private/codex-home",
+        "platformOs": "macos",
+        "platformFamily": "unix",
+      },
+    });
+  }
+
+  group("CodexStdioAppServerClient", () {
+    test("spawns stdio app-server and completes the handshake", () async {
+      final process = _FakeProcess(autoExitOnStdinClose: true);
+      final processes = _FakeHostProcessService(process);
+      final appServerClient = client(processes);
+      final connect = (await startConnect(appServerClient, process)).future;
+
+      expect(processes.executable, "/managed/codex");
+      expect(processes.arguments, ["app-server", "--listen", "stdio://"]);
+      expect(processes.environment, environment);
+      expect(process.frames.single, {
+        "id": 1,
+        "method": "initialize",
+        "params": {
+          "clientInfo": {
+            "name": "sesori-bridge",
+            "title": "Sesori Bridge",
+            "version": "1.2.3",
+          },
+        },
+      });
+
+      completeInitialize(process);
+      final result = await connect;
+      await process.waitForFrames(2);
+      expect(result.userAgent, "codex_cli_rs/0.146.0");
+      expect(process.frames.last, {"method": "initialized"});
+
+      await appServerClient.dispose();
+      expect(process.stdinClosed, isTrue);
+    });
+
+    test("correlates fragmented responses and coalesced notifications", () async {
+      final process = _FakeProcess(autoExitOnStdinClose: true);
+      final appServerClient = client(_FakeHostProcessService(process));
+      final connect = (await startConnect(appServerClient, process)).future;
+      completeInitialize(process);
+      await connect;
+      await process.waitForFrames(2);
+
+      final notifications = <CodexServerNotification>[];
+      final subscription = appServerClient.notifications.listen(
+        notifications.add,
+      );
+      final request = appServerClient.request(
+        method: "account/login/start",
+        params: const {"type": "chatgptDeviceCode"},
+      );
+      await process.waitForFrames(3);
+      final requestId = process.frames.last["id"];
+      final response = jsonEncode({
+        "id": requestId,
+        "result": {"ok": true},
+      });
+      process.stdoutController.add(utf8.encode(response.substring(0, 8)));
+      process.stdoutController.add(
+        utf8.encode(
+          "${response.substring(8)}\n"
+          '${jsonEncode({
+            "method": "first",
+            "params": {"value": 1},
+          })}\n'
+          '${jsonEncode({
+            "method": "second",
+            "params": {"value": 2},
+          })}\n',
+        ),
+      );
+
+      expect(await request, {"ok": true});
+      await _eventLoop();
+      expect(notifications.map((notification) => notification.method), [
+        "first",
+        "second",
+      ]);
+
+      await subscription.cancel();
+      await appServerClient.dispose();
+    });
+
+    test("surfaces typed RPC errors with the originating method", () async {
+      final process = _FakeProcess(autoExitOnStdinClose: true);
+      final appServerClient = client(_FakeHostProcessService(process));
+      final connect = (await startConnect(appServerClient, process)).future;
+      completeInitialize(process);
+      await connect;
+      await process.waitForFrames(2);
+
+      final request = appServerClient.request(
+        method: "account/login/start",
+      );
+      await process.waitForFrames(3);
+      process.send({
+        "id": process.frames.last["id"],
+        "error": {"code": -32600, "message": "private policy detail"},
+      });
+
+      await expectLater(
+        request,
+        throwsA(
+          isA<CodexRpcException>()
+              .having(
+                (error) => error.method,
+                "method",
+                "account/login/start",
+              )
+              .having((error) => error.code, "code", -32600),
+        ),
+      );
+      await appServerClient.dispose();
+    });
+
+    test("fails pending requests on malformed JSON and process exit", () async {
+      final process = _FakeProcess(autoExitOnStdinClose: true);
+      final appServerClient = client(_FakeHostProcessService(process));
+      final connect = (await startConnect(appServerClient, process)).future;
+      completeInitialize(process);
+      await connect;
+      await process.waitForFrames(2);
+
+      final malformedRequest = appServerClient.request(method: "first");
+      await process.waitForFrames(3);
+      process.stdoutController.add(
+        utf8.encode("not-json-CODE-PRIVATE\n"),
+      );
+      await expectLater(malformedRequest, throwsA(isA<StateError>()));
+
+      final exitedRequest = appServerClient.request(method: "second");
+      await process.waitForFrames(4);
+      process.completeExit(7);
+      await expectLater(exitedRequest, throwsA(isA<StateError>()));
+      await expectLater(
+        appServerClient.request(method: "after-exit"),
+        throwsA(isA<StateError>()),
+      );
+      await appServerClient.dispose();
+    });
+
+    test("cleans up after initialization failure", () async {
+      final process = _FakeProcess(autoExitOnStdinClose: true);
+      final appServerClient = client(_FakeHostProcessService(process));
+      final connect = (await startConnect(appServerClient, process)).future;
+      process.send({
+        "id": process.frames.single["id"],
+        "error": {"code": -32600, "message": "Not initialized"},
+      });
+
+      await expectLater(connect, throwsA(isA<CodexRpcException>()));
+      expect(process.stdinClosed, isTrue);
+      await appServerClient.dispose();
+    });
+
+    test("escalates bounded cleanup from graceful to force", () async {
+      final process = _FakeProcess(autoExitOnStdinClose: false);
+      final processes = _FakeHostProcessService(
+        process,
+        exitOnForceSignal: true,
+      );
+      final appServerClient = client(processes);
+      final connect = (await startConnect(appServerClient, process)).future;
+      completeInitialize(process);
+      await connect;
+
+      await appServerClient.dispose();
+
+      expect(processes.gracefulPids, [process.pid]);
+      expect(processes.forcePids, [process.pid]);
+      expect(await process.exitCode, -9);
+    });
+  });
+}
+
+Future<void> _eventLoop() => Future<void>.delayed(Duration.zero);
+
+class _FakeHostProcessService implements HostProcessService {
+  _FakeHostProcessService(
+    this.process, {
+    this.exitOnForceSignal = false,
+  });
+
+  final _FakeProcess process;
+  final bool exitOnForceSignal;
+  String? executable;
+  List<String>? arguments;
+  Map<String, String>? environment;
+  final List<int> gracefulPids = <int>[];
+  final List<int> forcePids = <int>[];
+
+  @override
+  Future<SpawnedProcess> spawn({
+    required String executable,
+    required List<String> arguments,
+    required Map<String, String>? environment,
+    required String? workingDirectory,
+    required bool runInShell,
+  }) async {
+    this.executable = executable;
+    this.arguments = arguments;
+    this.environment = environment;
+    return process;
+  }
+
+  @override
+  Future<ProcessIdentity?> inspect({required int pid}) async => null;
+
+  @override
+  Future<SignalResult> signalGraceful({required int pid}) async {
+    gracefulPids.add(pid);
+    return _signal(pid: pid, shutdownSignal: ShutdownSignal.graceful);
+  }
+
+  @override
+  Future<SignalResult> signalForce({required int pid}) async {
+    forcePids.add(pid);
+    if (exitOnForceSignal) process.completeExit(-9);
+    return _signal(pid: pid, shutdownSignal: ShutdownSignal.force);
+  }
+
+  SignalResult _signal({
+    required int pid,
+    required ShutdownSignal shutdownSignal,
+  }) => SignalResult(
+    pid: pid,
+    requestedSignal: shutdownSignal,
+    deliveredSignal: shutdownSignal == ShutdownSignal.force ? ProcessSignal.sigkill : ProcessSignal.sigterm,
+    wasRequested: true,
+    attemptedAt: DateTime.utc(2026, 8, 11),
+  );
+}
+
+class _FakeProcess implements SpawnedProcess {
+  _FakeProcess({required this.autoExitOnStdinClose}) {
+    _stdinController = StreamController<List<int>>(
+      onListen: () {},
+      onCancel: () {},
+    );
+    _stdin = IOSink(_stdinController.sink);
+    _stdinSubscription = _stdinController.stream
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen(
+          (line) {
+            frames.add((jsonDecode(line) as Map).cast<String, dynamic>());
+            _frameChanged.add(null);
+          },
+          onDone: () {
+            stdinClosed = true;
+            if (autoExitOnStdinClose) completeExit(0);
+          },
+        );
+  }
+
+  static int _nextPid = 100;
+
+  final bool autoExitOnStdinClose;
+  final StreamController<List<int>> stdoutController = StreamController<List<int>>();
+  final StreamController<List<int>> stderrController = StreamController<List<int>>();
+  final StreamController<void> _frameChanged = StreamController<void>.broadcast();
+  final Completer<int> _exit = Completer<int>();
+  final List<Map<String, dynamic>> frames = <Map<String, dynamic>>[];
+  late final StreamController<List<int>> _stdinController;
+  late final StreamSubscription<String> _stdinSubscription;
+  late final IOSink _stdin;
+  bool stdinClosed = false;
+
+  @override
+  final int pid = _nextPid++;
+
+  @override
+  Future<int> get exitCode => _exit.future;
+
+  @override
+  ProcessIdentity get identity => throw UnimplementedError();
+
+  @override
+  Stream<List<int>> get stderr => stderrController.stream;
+
+  @override
+  IOSink get stdin => _stdin;
+
+  @override
+  Stream<List<int>> get stdout => stdoutController.stream;
+
+  void send(Map<String, dynamic> frame) {
+    stdoutController.add(utf8.encode("${jsonEncode(frame)}\n"));
+  }
+
+  void completeExit(int code) {
+    if (_exit.isCompleted) return;
+    _exit.complete(code);
+    unawaited(stdoutController.close());
+    unawaited(stderrController.close());
+    unawaited(_stdinSubscription.cancel());
+    unawaited(_frameChanged.close());
+  }
+
+  Future<void> waitForFrames(int count) async {
+    while (frames.length < count) {
+      await _frameChanged.stream.first;
+    }
+  }
+}

--- a/bridge/sesori_plugin_codex/test/codex_stdio_app_server_client_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_stdio_app_server_client_test.dart
@@ -200,6 +200,43 @@ void main() {
       await appServerClient.dispose();
     });
 
+    test("ignores a stale child exit after reconnecting", () async {
+      final staleProcess = _FakeProcess(autoExitOnStdinClose: false);
+      final currentProcess = _FakeProcess(autoExitOnStdinClose: true);
+      final processes = _FakeHostProcessService(
+        staleProcess,
+        additionalProcesses: [currentProcess],
+      );
+      final appServerClient = client(processes);
+      final failedConnect = (await startConnect(appServerClient, staleProcess)).future;
+      staleProcess.send({
+        "id": staleProcess.frames.single["id"],
+        "error": {"code": -32600, "message": "Not initialized"},
+      });
+      await expectLater(failedConnect, throwsA(isA<CodexRpcException>()));
+
+      final currentConnect = (await startConnect(appServerClient, currentProcess)).future;
+      completeInitialize(currentProcess);
+      await currentConnect;
+      await currentProcess.waitForFrames(2);
+
+      staleProcess.completeExit(9);
+      await _eventLoop();
+      final request = appServerClient.request(method: "account/login/start");
+      await currentProcess
+          .waitForFrames(3)
+          .timeout(
+            const Duration(milliseconds: 100),
+          );
+      currentProcess.send({
+        "id": currentProcess.frames.last["id"],
+        "result": {"ok": true},
+      });
+
+      expect(await request, {"ok": true});
+      await appServerClient.dispose();
+    });
+
     test("escalates bounded cleanup from graceful to force", () async {
       final process = _FakeProcess(autoExitOnStdinClose: false);
       final processes = _FakeHostProcessService(
@@ -226,15 +263,18 @@ class _FakeHostProcessService implements HostProcessService {
   _FakeHostProcessService(
     this.process, {
     this.exitOnForceSignal = false,
-  });
+    List<_FakeProcess> additionalProcesses = const [],
+  }) : _spawnProcesses = [process, ...additionalProcesses];
 
   final _FakeProcess process;
+  final List<_FakeProcess> _spawnProcesses;
   final bool exitOnForceSignal;
   String? executable;
   List<String>? arguments;
   Map<String, String>? environment;
   final List<int> gracefulPids = <int>[];
   final List<int> forcePids = <int>[];
+  int _nextProcess = 0;
 
   @override
   Future<SpawnedProcess> spawn({
@@ -247,7 +287,7 @@ class _FakeHostProcessService implements HostProcessService {
     this.executable = executable;
     this.arguments = arguments;
     this.environment = environment;
-    return process;
+    return _spawnProcesses[_nextProcess++];
   }
 
   @override
@@ -262,7 +302,12 @@ class _FakeHostProcessService implements HostProcessService {
   @override
   Future<SignalResult> signalForce({required int pid}) async {
     forcePids.add(pid);
-    if (exitOnForceSignal) process.completeExit(-9);
+    if (exitOnForceSignal) {
+      final matchingProcess = _spawnProcesses.singleWhere(
+        (process) => process.pid == pid,
+      );
+      matchingProcess.completeExit(-9);
+    }
     return _signal(pid: pid, shutdownSignal: ShutdownSignal.force);
   }
 

--- a/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
@@ -205,6 +205,35 @@ void main() {
       expect(result, isA<PluginSetupRuntimeMissing>());
     });
 
+    test("reports an outdated explicitly configured runtime as unavailable", () async {
+      const explicitConfig = PluginConfig(
+        values: {"port": null, "bin": "/custom/codex"},
+      );
+      final processes = _ProbeProcessService(
+        processSequence: [
+          _ProbeProcess(
+            pid: 9,
+            stdoutBytes: utf8.encode("codex 0.100.0\n"),
+            exitCode: Future<int>.value(0),
+          ),
+        ],
+      );
+
+      final result = await descriptor.inspectSetup(
+        config: explicitConfig,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, isA<PluginSetupUnavailable>());
+      expect(
+        descriptor.managementCapabilities(config: explicitConfig),
+        isNot(contains(PluginControlCapability.install)),
+      );
+      expect(processes.spawnedExecutables, ["/custom/codex"]);
+    });
+
     test("reports authentication required without starting a login flow", () async {
       final processes = _ProbeProcessService(
         processSequence: [

--- a/bridge/sesori_plugin_codex/test/runtime/codex_runtime_selection_service_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_runtime_selection_service_test.dart
@@ -1,0 +1,291 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+
+import "package:codex_plugin/src/runtime/codex_runtime_manifest.dart";
+import "package:codex_plugin/src/runtime/codex_runtime_selection_service.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  const stateDirectory = "/state";
+  const defaultConfig = PluginConfig(values: {"bin": "codex"});
+  const environment = <String, String>{"PATH": "/custom/bin", "CODEX_HOME": "/codex-home"};
+
+  CodexRuntimeSelectionService service(
+    _FakeHostProcessService processes, {
+    List<String> desktopCandidates = const <String>[],
+    Duration timeout = const Duration(seconds: 1),
+  }) {
+    return CodexRuntimeSelectionService(
+      processes: processes,
+      versionProbeTimeout: timeout,
+      maxCapturedOutputCharactersPerStream: 64 * 1024,
+      desktopAppCliCandidates: desktopCandidates,
+    );
+  }
+
+  Future<CodexRuntimeSelection> select(
+    CodexRuntimeSelectionService selectionService, {
+    PluginConfig config = defaultConfig,
+    StartAbortSignal? aborted,
+  }) {
+    return selectionService.select(
+      config: config,
+      environment: environment,
+      stateDirectory: stateDirectory,
+      aborted: aborted ?? StartAbortSignal.never,
+    );
+  }
+
+  group("CodexRuntimeSelectionService", () {
+    test("treats an explicit binary as authoritative without fallback", () async {
+      final processes = _FakeHostProcessService([
+        _ProbeProcess(stdoutText: "codex 0.100.0\n", exitCode: 0),
+      ]);
+
+      final result = await select(
+        service(processes, desktopCandidates: const ["/desktop/codex"]),
+        config: const PluginConfig(values: {"bin": "/explicit/codex"}),
+      );
+
+      expect(
+        result,
+        isA<CodexRuntimeNotSelected>()
+            .having((value) => value.failure, "failure", CodexRuntimeSelectionFailure.unsupportedVersion)
+            .having((value) => value.hasExplicitBinary, "hasExplicitBinary", isTrue),
+      );
+      expect(processes.executables, ["/explicit/codex"]);
+    });
+
+    test("prefers a supported PATH runtime before desktop and managed", () async {
+      final processes = _FakeHostProcessService([
+        _ProbeProcess(stdoutText: "codex 0.140.0\n", exitCode: 0),
+      ]);
+
+      final result = await select(service(processes, desktopCandidates: const ["/desktop/codex"]));
+
+      expect(
+        result,
+        isA<CodexRuntimeSelected>()
+            .having((value) => value.binaryPath, "binaryPath", "codex")
+            .having((value) => value.source, "source", CodexRuntimeSource.path),
+      );
+      expect(processes.executables, ["codex"]);
+    });
+
+    test("prefers a supported desktop runtime after PATH", () async {
+      final processes = _FakeHostProcessService([
+        const ProcessException("codex", ["--version"], "missing", 2),
+        _ProbeProcess(stdoutText: "codex-cli 0.141.0\n", exitCode: 0),
+      ]);
+
+      final result = await select(service(processes, desktopCandidates: const ["/desktop/codex"]));
+
+      expect(
+        result,
+        isA<CodexRuntimeSelected>()
+            .having((value) => value.binaryPath, "binaryPath", "/desktop/codex")
+            .having((value) => value.source, "source", CodexRuntimeSource.desktopApp),
+      );
+      expect(processes.executables, ["codex", "/desktop/codex"]);
+    });
+
+    test("uses managed only after PATH and desktop and forwards the environment", () async {
+      const manifest = CodexRuntimeManifest();
+      final managedPath = manifest.managedBinaryPath(stateDirectory: stateDirectory);
+      final processes = _FakeHostProcessService([
+        _ProbeProcess(stdoutText: "codex 0.100.0\n", exitCode: 0),
+        const ProcessException("/desktop/codex", ["--version"], "missing", 2),
+        _ProbeProcess(stdoutText: "codex ${manifest.bundledVersion}\n", exitCode: 0),
+      ]);
+
+      final result = await select(service(processes, desktopCandidates: const ["/desktop/codex"]));
+
+      expect(
+        result,
+        isA<CodexRuntimeSelected>()
+            .having((value) => value.binaryPath, "binaryPath", managedPath)
+            .having((value) => value.source, "source", CodexRuntimeSource.managed)
+            .having((value) => value.rejectedPathVersion.toString(), "rejectedPathVersion", "0.100.0"),
+      );
+      expect(processes.executables, ["codex", "/desktop/codex", managedPath]);
+      expect(processes.environments, everyElement(environment));
+      expect(processes.arguments, everyElement(const ["--version"]));
+    });
+
+    test("requires the exact bundled managed version", () async {
+      const manifest = CodexRuntimeManifest();
+      final processes = _FakeHostProcessService([
+        const ProcessException("codex", ["--version"], "missing", 2),
+        _ProbeProcess(stdoutText: "codex 999.0.0\n", exitCode: 0),
+      ]);
+
+      final result = await select(service(processes));
+
+      expect(
+        result,
+        isA<CodexRuntimeNotSelected>()
+            .having((value) => value.failure, "failure", CodexRuntimeSelectionFailure.executableMissing)
+            .having((value) => value.hasExplicitBinary, "hasExplicitBinary", isFalse),
+      );
+      expect(processes.executables.last, manifest.managedBinaryPath(stateDirectory: stateDirectory));
+    });
+
+    test("classifies explicit probe failures", () async {
+      final cases = <(Object, CodexRuntimeSelectionFailure)>[
+        (
+          const ProcessException("/explicit/codex", ["--version"], "missing", 2),
+          CodexRuntimeSelectionFailure.executableMissing,
+        ),
+        (StateError("spawn failed"), CodexRuntimeSelectionFailure.probeFailed),
+        (_ProbeProcess(stdoutText: "codex 0.146.0\n", exitCode: 1), CodexRuntimeSelectionFailure.nonZeroExit),
+        (_ProbeProcess(stdoutText: "not a version\n", exitCode: 0), CodexRuntimeSelectionFailure.unrecognizedVersion),
+        (_ProbeProcess(stdoutText: "codex 0.100.0\n", exitCode: 0), CodexRuntimeSelectionFailure.unsupportedVersion),
+      ];
+
+      for (final (outcome, failure) in cases) {
+        final result = await select(
+          service(_FakeHostProcessService([outcome])),
+          config: const PluginConfig(values: {"bin": "/explicit/codex"}),
+        );
+        expect(
+          result,
+          isA<CodexRuntimeNotSelected>().having((value) => value.failure, "failure", failure),
+          reason: "$failure",
+        );
+      }
+    });
+
+    test("classifies a timed out probe", () async {
+      final processes = _FakeHostProcessService([
+        _ProbeProcess(stdoutText: "", exitCodeFuture: Completer<int>().future),
+      ]);
+
+      final result = await select(
+        service(processes, timeout: const Duration(milliseconds: 10)),
+        config: const PluginConfig(values: {"bin": "/explicit/codex"}),
+      );
+
+      expect(
+        result,
+        isA<CodexRuntimeNotSelected>().having(
+          (value) => value.failure,
+          "failure",
+          CodexRuntimeSelectionFailure.probeTimedOut,
+        ),
+      );
+      expect(processes.forceSignaledPids, hasLength(1));
+    });
+
+    test("aborts before spawning the first probe", () async {
+      final processes = _FakeHostProcessService(const <Object>[]);
+      final abort = StartAbortController()..abort();
+
+      await expectLater(
+        select(service(processes), aborted: abort.signal),
+        throwsA(isA<PluginStartAbortedException>()),
+      );
+      expect(processes.executables, isEmpty);
+    });
+
+    test("aborts at the boundary after a completed probe", () async {
+      final processes = _FakeHostProcessService([
+        _ProbeProcess(stdoutText: "codex 0.146.0\n", exitCode: 0),
+      ]);
+
+      await expectLater(
+        select(service(processes), aborted: _AbortOnSecondCheck()),
+        throwsA(isA<PluginStartAbortedException>()),
+      );
+      expect(processes.executables, ["codex"]);
+    });
+  });
+}
+
+class _FakeHostProcessService implements HostProcessService {
+  _FakeHostProcessService(this._outcomes);
+
+  final List<Object> _outcomes;
+  final List<String> executables = <String>[];
+  final List<List<String>> arguments = <List<String>>[];
+  final List<Map<String, String>?> environments = <Map<String, String>?>[];
+  final List<int> forceSignaledPids = <int>[];
+  int _nextOutcome = 0;
+
+  @override
+  Future<SpawnedProcess> spawn({
+    required String executable,
+    required List<String> arguments,
+    required Map<String, String>? environment,
+    required String? workingDirectory,
+    required bool runInShell,
+  }) async {
+    executables.add(executable);
+    this.arguments.add(List<String>.unmodifiable(arguments));
+    environments.add(environment == null ? null : Map<String, String>.unmodifiable(environment));
+    final outcome = _outcomes[_nextOutcome++];
+    if (outcome is SpawnedProcess) return outcome;
+    throw outcome;
+  }
+
+  @override
+  Future<ProcessIdentity?> inspect({required int pid}) async => null;
+
+  @override
+  Future<SignalResult> signalForce({required int pid}) async {
+    forceSignaledPids.add(pid);
+    return _signal(pid);
+  }
+
+  @override
+  Future<SignalResult> signalGraceful({required int pid}) async => _signal(pid);
+
+  SignalResult _signal(int pid) => SignalResult(
+    pid: pid,
+    requestedSignal: ShutdownSignal.force,
+    deliveredSignal: ProcessSignal.sigkill,
+    wasRequested: true,
+    attemptedAt: DateTime.utc(2026, 8, 11),
+  );
+}
+
+class _ProbeProcess implements SpawnedProcess {
+  _ProbeProcess({required String stdoutText, int? exitCode, Future<int>? exitCodeFuture})
+    : pid = _nextPid++,
+      _stdoutBytes = utf8.encode(stdoutText),
+      _exitCode = exitCodeFuture ?? Future<int>.value(exitCode!);
+
+  static int _nextPid = 1;
+
+  @override
+  final int pid;
+
+  final List<int> _stdoutBytes;
+  final Future<int> _exitCode;
+
+  @override
+  Future<int> get exitCode => _exitCode;
+
+  @override
+  Stream<List<int>> get stdout => Stream<List<int>>.value(_stdoutBytes);
+
+  @override
+  Stream<List<int>> get stderr => const Stream<List<int>>.empty();
+
+  @override
+  IOSink get stdin => throw UnimplementedError();
+
+  @override
+  ProcessIdentity get identity => throw UnimplementedError();
+}
+
+class _AbortOnSecondCheck implements StartAbortSignal {
+  int _checks = 0;
+
+  @override
+  bool get isAborted => ++_checks >= 2;
+
+  @override
+  Future<void> get whenAborted => Completer<void>().future;
+}


### PR DESCRIPTION
## Complexity

⚙️ Moderate. This introduces a second Codex App Server transport, typed account protocol models, and shared runtime-selection behavior with bounded child-process lifecycle handling.

## What

- Extract Codex executable selection so setup, startup, and future authentication share explicit/PATH/desktop/managed precedence.
- Add a secret-safe stdio JSONL App Server transport with request correlation, initialization, notification delivery, child-exit handling, and bounded cleanup.
- Add typed device-login start, cancel, and completion DTOs behind `CodexAppServerApi`.
- Preserve the existing WebSocket generation transport and behavior.

## Why

Codex device authorization runs through a short-lived stdio App Server process before the normal generation plugin is routable. These primitives establish that backend-local protocol and lifecycle boundary without exposing a bridge or client capability yet.

## Risk and test focus

Risk is medium because the change owns a local subprocess and handles authentication ceremony data. Focus review on executable precedence, exact JSONL framing, pending-request settlement, process cleanup, and ensuring raw frames, stderr, login IDs, URLs, user codes, and upstream errors are not logged remotely or persisted.

## Expected result

No user-visible or database/persisted-data change. Existing Codex session generation remains on WebSocket; the plugin gains local tested primitives for the later mobile login flow.

## Verification

- `dart test` in `bridge/sesori_plugin_codex` (348 tests passed)
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_codex`
- `git diff --check origin/main...HEAD`
- Architecture implementation review was attempted twice, but the review sub-agent failed before reading code with internal task-store error `no such column: replacement_seq`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a secret-safe stdio App Server transport and typed account login models to prepare the Codex device login flow, and ignores stale app-server exit events. No user-facing changes; existing WebSocket transport stays as-is.

- **New Features**
  - Added stdio JSONL App Server transport with request correlation, init, notifications, child-exit handling, and bounded shutdown.
  - Added typed device-login start/cancel/completed DTOs via `CodexAppServerApi`, including an `accountLoginCompletions` stream.
  - Exported the stdio client for plugin use.

- **Refactors**
  - Extracted executable selection into `CodexRuntimeSelectionService` with explicit/PATH/desktop/managed precedence and version probing.
  - Unified transports by introducing a `CodexAppServerTransport` interface implemented by the WebSocket and stdio clients.
  - Simplified `codex_plugin_descriptor` by delegating runtime discovery and selection.

<sup>Written for commit 5580aab43c3c731ddbd8020e7c9d50427c5fc259. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

