### PR TITLE
🌿 [claude-code-plugin] docs: record Claude Code live verification [step 16/17]

### DIFF
--- a/.plan/active/claude-code-plugin/E2E.md
+++ b/.plan/active/claude-code-plugin/E2E.md
@@ -1,0 +1,100 @@
+# Claude Code Harness Plugin: Simulator E2E
+
+## Status
+
+- **Date:** 2026-08-11
+- **Result:** passed for the Beta gate, with one upstream-only plan-mode check
+  not observable during repeated service overloads
+- **Product baseline:** Steps 1-15 plus focused live-gate fixes PR #821, #823,
+  #825, and #826, ending at `ea1bc354`
+- **Scope:** Step 16/17 of `claude-code-plugin`
+
+The run verified Claude Code through the same client, relay, bridge, plugin, and
+real CLI path used by the product. It also found four product defects. Each was
+fixed in a focused PR and the affected live scenario was repeated before this
+record was finalized.
+
+## Environment
+
+- iPhone 17 Pro Max simulator running iOS 26.5.
+- Installed Sesori app (`com.sesori.app`), signed into the same account as the
+  bridge.
+- Source bridge on `127.0.0.1:9977`, using
+  `/Users/daniil/.local/share/sesori-dev` as its isolated data directory.
+- Real logged-in Claude Code CLI 2.1.226 on PATH.
+- Isolated project `/Users/daniil/Developer/sesori-claude-e2e`.
+- Hybrid assertions through the simulator and the bridge debug HTTP router.
+- YOLO mode disabled for permission and question checks.
+
+## Initial Snapshot
+
+`GET /plugin` reported Claude Code setup `ready`, display name `Claude Code`,
+and `supportsPromptAttachments: true`. `POST /session/options` returned real
+Claude agents, models, effort variants, and slash commands. The app's new-task
+picker showed Claude Code with its bundled brand mark.
+
+## Test Record
+
+| ID | Check | Exact action | Observed result |
+|---|---|---|---|
+| E2E-01 | Ready discovery | Read `GET /plugin` from the source bridge. | Claude was `ready`, named `Claude Code`, and advertised prompt attachments. |
+| E2E-02 | Missing runtime | Restarted with `--claude-bin /definitely/missing/claude`. | Harnesses showed `Runtime missing` and the action hint "Install Claude Code or fix the configured binary path, then retry setup detection." Other harnesses stayed ready. |
+| E2E-03 | Picker branding | Opened a new task and selected the coding tool. | Claude Code appeared with its coral brand mark and correct display name. |
+| E2E-04 | First streamed turn | Sent `Reply exactly E2E OK.` in a new Claude session. | The session row appeared, the reply streamed, and completed as `E2E OK`. |
+| E2E-05 | Reasoning | Selected high effort and sent a reasoning/tool prompt. | A Thought part rendered before the answer. |
+| E2E-06 | Tool lifecycle | Asked Claude to list the project directory. | A Bash card progressed through Running to Done with bounded output, followed by `LIST OK`. |
+| E2E-07 | Once and reject | Created one file with **Once**, then rejected another Write request. | Once created the file. Reject left its file absent, rendered Write/Failed with the denial, and the model continued with `FIXED REJECT OK` without a false terminal error after PR #825. |
+| E2E-08 | Always safety | Tapped **Always Allow** on Write, then requested another Write; separately captured Bash suggestions. | The first write succeeded. The next prompted again because Claude offered only `setMode(session)` for Write and `addRules(localSettings)` plus broader updates for Bash. The registry correctly rejected those unsafe/non-session-rule suggestions and degraded to Once, matching the locked security contract. |
+| E2E-09 | Question | Asked Claude to use AskUserQuestion with Alpha/Beta choices and selected Alpha. | A native question card rendered; the answer reached Claude and produced `QUESTION OK Alpha`. |
+| E2E-10 | Plan approval | Repeated three minimal Plan-agent prompts requesting ExitPlanMode, including a direct no-delegation form. | Claude's service returned `Our servers are currently overloaded` each time before ExitPlanMode. The card/reply path remains covered by the live 2.1.226 protocol capture and focused plugin tests; no product defect was observed. |
+| E2E-11 | Models | Switched mid-session from default to `cx/gpt-5.4-mini` and sent a turn. | The catalog showed real models, the turn returned `MODEL OK`, and the navbar changed to `claude - gpt-5.4-mini`. A later default-model turn restored `gpt-5.6-terra`. |
+| E2E-12 | Stop | Stopped a long-running delegated Agent turn, then stopped an active `/review` command after PR #826. | Both returned idle within five seconds. The merged fix prevented a new generic terminal error after the explicit stop. |
+| E2E-13 | Abort pending permission | Raised a Write permission and called `/session/abort` while its card was open. | The card and pending snapshot cleared, the file stayed absent, the tool showed cancellation, and the merged interrupt fix suppresses the false terminal result error. |
+| E2E-14 | Restart and resume | Restarted the source bridge against the same data directory, reopened the session, and sent `RESUME OK`. | The session list and full history survived, and the follow-up resumed successfully. |
+| E2E-15 | External session | Started a real Claude session in an external terminal, ran an explicit Claude catalog import, then pulled to refresh the project. | The external untitled session appeared at the top of the project with the other imported Claude transcripts. |
+| E2E-16 | Image input | Attached the simulator's magenta-flower photo and asked for five words. | Claude replied `Brilliant magenta flowers amid yellow blooms.`, correctly describing the image. |
+| E2E-17 | Slash commands | Opened the command picker, inspected the real catalog, and ran `/autocompact auto`. | The picker listed built-in and project commands; the selected command completed with `Auto-compact window set to auto`. |
+| E2E-18 | Idle reap and resume | Waited more than five minutes after an idle turn, checked process state, then sent `IDLE OK`. | The resident Claude process was reaped, a new `--resume` process spawned, and the follow-up completed transparently. |
+| E2E-18a | Model after reap | Compared the navbar before and after the resumed reply. | The navbar stayed on `gpt-5.6-terra`, matching the default model reapplied by the plugin. |
+| E2E-18b | Always after reap | Evaluated the grant available from the live CLI before testing restoration. | No eligible session-scoped `addRules` grant was offered, so there was no safe grant to restore. The plugin preserved the same intentional Once degradation across respawn; synthetic tests cover restoration when an eligible grant exists. |
+| E2E-19 | Harness policy | Disabled and re-enabled Claude Code from Settings > Harnesses. | Disable removed runtime/work controls. Re-enable restored setup Ready, runtime Active, and work Idle. The client briefly showed a recovered connection-confirmation warning after the committed enabled state was already visible. |
+| E2E-20 | Logs and cleanup | Inspected debug logs, stopped each source bridge, and checked for `claude ... stream-json` processes. | Logs contained no unhandled bridge/plugin exceptions. Every shutdown left no Claude process; idle reap also removed the resident process before the next turn. |
+
+## Focused Fixes Found By The Run
+
+1. PR #821 preserved the host environment without duplicating it as launch
+   overrides, unblocking real session options and process startup.
+2. PR #823 attributed `can_use_tool` frames from their resident process because
+   the real CLI omits `session_id` on control requests.
+3. PR #825 correlated handled denial `tool_use_id` values so explicit rejection
+   continued normally without being misreported as an unprompted denial.
+4. PR #826 carried the point-in-time interrupted state on process events so Stop
+   and abort did not append a false terminal result error.
+
+## Non-Blocking Limitations
+
+1. **ExitPlanMode service overload:** three live Plan-agent attempts reached the
+   real CLI and then received Anthropic overload results before the interaction
+   request. The exact CLI 2.1.226 ExitPlanMode shape and approval response were
+   verified during protocol grounding, and focused tests cover the client-facing
+   registry path. This is an upstream availability limitation, not a code path
+   that failed the run.
+2. **No safely expressible Always grant:** the current CLI offered only broader
+   session mode changes or a rule persisted to local settings. The plugin must
+   not widen or persist permissions to make the E2E row pass. It therefore
+   degrades to Once exactly as `PROTOCOL.md` requires.
+3. **Recovered enable confirmation warning:** re-enabling Claude committed and
+   returned Ready/Active/Idle, while the client briefly reported that the
+   connection changed before confirmation. The resulting harness state and all
+   subsequent operations were correct; this is not Claude-specific.
+
+## Cleanup And Restored State
+
+- Restored the normal Claude binary configuration after the missing-runtime
+  check.
+- Left Claude enabled, setup-ready, and YOLO mode off in durable bridge state.
+- Stopped the final source bridge and confirmed no Claude stream-json process
+  remained.
+- Left the isolated project and its test transcripts in place so the recorded
+  restart, external-import, and history evidence remains reproducible.
+- The run consumed the developer's own Claude quota using minimal prompts.

--- a/.plan/active/claude-code-plugin/E2E.md
+++ b/.plan/active/claude-code-plugin/E2E.md
@@ -20,9 +20,9 @@ record was finalized.
 - Installed Sesori app (`com.sesori.app`), signed into the same account as the
   bridge.
 - Source bridge on `127.0.0.1:9977`, using
-  `/Users/daniil/.local/share/sesori-dev` as its isolated data directory.
+  `$HOME/.local/share/sesori-dev` as its isolated data directory.
 - Real logged-in Claude Code CLI 2.1.226 on PATH.
-- Isolated project `/Users/daniil/Developer/sesori-claude-e2e`.
+- Isolated project `$HOME/Developer/sesori-claude-e2e`.
 - Hybrid assertions through the simulator and the bridge debug HTTP router.
 - YOLO mode disabled for permission and question checks.
 

--- a/.plan/active/claude-code-plugin/PLAN.md
+++ b/.plan/active/claude-code-plugin/PLAN.md
@@ -923,7 +923,7 @@ quota, so prompts stay minimal.
 | E2E-05 | An extended-thinking prompt renders a reasoning part |
 | E2E-06 | A file-listing prompt renders a tool card through to Done with output |
 | E2E-07 | A file-creating prompt raises a permission card; approve once succeeds, reject continues the turn with a denial |
-| E2E-08 | Approving always lets the next same-tool call proceed without a prompt |
+| E2E-08 | Always sends only an eligible session-scoped `addRules` grant; when Claude offers none, it safely degrades to once and the next same-tool call prompts again |
 | E2E-09 | A question-provoking prompt renders a question card and the answer reaches the turn |
 | E2E-10 | Plan agent plus a change request yields an ExitPlanMode card; approval resumes execution in default mode |
 | E2E-11 | The catalog lists real models and a mid-session switch updates the nav-bar subtitle after the next reply |
@@ -935,7 +935,7 @@ quota, so prompts stay minimal.
 | E2E-17 | The command catalog lists slash commands and one executes |
 | E2E-18 | A follow-up after the idle-reap window resumes transparently |
 | E2E-18a | After an idle reap, the model shown in the nav-bar subtitle still matches the model the plugin believes is applied |
-| E2E-18b | After an idle reap, a tool previously granted "always" runs without prompting again |
+| E2E-18b | After an idle reap, an eligible session-scoped grant is restored; when no eligible grant was offered, the same safe degradation remains |
 | E2E-19 | The harness settings card disables and re-enables Claude Code |
 | E2E-20 | The debug-level bridge log has no unhandled errors and no `claude` process leaks after shutdown |
 

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -3,15 +3,13 @@
 ## Current State
 
 - **Plan slug:** `claude-code-plugin`
-- **Implementation base:** `origin/main` at
-  `c3d21c78` (focused fix started after Step 15 merged)
-- **Series state:** Steps 1-15/17 merged; Step 16/17 blocked by a live launch
-  failure; focused fix PR #821 open
-- **Current step:** focused launch-environment fix in review
+- **Implementation base:** `origin/main` at `ea1bc354`
+- **Series state:** Steps 1-15/17 and all four Step 16 live-gate fixes merged;
+  Step 16 verification and documentation complete locally
+- **Current step:** Step 16/17 ready for review
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737),
   merged 2026-08-04 as `6d641532`
-- **Next action:** Monitor focused fix PR #821, then resume Step 16 live
-  verification after it merges
+- **Next action:** Open and monitor the Step 16 documentation PR
 
 ## Plan Review
 
@@ -61,7 +59,7 @@
 | [x] | 13/17 | `claude-code-plugin-descriptor` | `⚙️ [claude-code-plugin] feat(claude): add descriptor and lifecycle [step 13/17]` | 1,100-1,500 | [PR #815](https://github.com/sesori-ai/sesori_apps_monorepo/pull/815) merged 2026-08-11 as `ba2f6f7b` |
 | [x] | 14/17 | `claude-code-plugin-activation` | `⚙️ [claude-code-plugin] feat(claude): register the Claude Code harness [step 14/17]` | 250-500 | [PR #816](https://github.com/sesori-ai/sesori_apps_monorepo/pull/816) merged 2026-08-11 as `85438e1d` |
 | [x] | 15/17 | `claude-code-plugin-client-polish` | `🌿 [claude-code-plugin] feat(client): add Claude Code branding [step 15/17]` | 400-800 | [PR #817](https://github.com/sesori-ai/sesori_apps_monorepo/pull/817) merged 2026-08-11 as `c3d21c78` |
-| [ ] | 16/17 | `claude-code-plugin-e2e` | `🌿 [claude-code-plugin] docs: record Claude Code live verification [step 16/17]` | 200-500 | Not started |
+| [ ] | 16/17 | `claude-code-plugin-e2e` | `🌿 [claude-code-plugin] docs: record Claude Code live verification [step 16/17]` | 200-500 | Live verification complete locally; PR pending |
 | [ ] | 17/17 | `claude-code-plugin-retire` | `🌱 [claude-code-plugin] docs: retire Claude Code plugin plan [step 17/17]` | 50-200 | Not started |
 
 ## Exact PR Titles
@@ -478,10 +476,47 @@
   pass. The final diff is 44 changed lines (36 additions and 8 deletions),
   measured with the matching `--numstat` command; generated lines: 0.
   A source bridge against the isolated E2E data directory then reported Claude
-  setup ready and returned HTTP 200 with real agents, providers, models, and commands from the
-  exact `/session/options` request that previously returned 502. Step 16 remains
-  paused until [PR #821](https://github.com/sesori-ai/sesori_apps_monorepo/pull/821)
-  merges. No database or persisted-data change.
+  setup ready and returned HTTP 200 with real agents, providers, models, and
+  commands from the exact `/session/options` request that previously returned
+  502. PR #821 merged as `83c73a7b`. No database or persisted-data change.
+
+- Step 16 approval-attribution fix (2026-08-11): live Write requests stayed
+  Running without a permission card because real `can_use_tool` frames contain
+  no `session_id`. The process event already owns authoritative attribution, so
+  PR #823 passes that session id explicitly into the approval registry. Focused
+  tests, all 197 package tests, fatal analysis, and a repeated simulator Write
+  passed; PR #823 merged as `3708d348`.
+
+- Step 16 handled-denial fix (2026-08-11): rejecting a live permission correctly
+  denied the tool and let the model continue, but the successful result's
+  `permission_denials` produced a false terminal error. PR #825 correlates
+  handled denials by `tool_use_id`, preserves genuine result errors, and treats
+  the CLI's successful result as transport completion. All 199 package tests,
+  fatal analysis, architecture review, and the repeated simulator rejection
+  passed; PR #825 merged as `336b8795`.
+
+- Step 16 interrupt-result fix (2026-08-11): Stop and pending-permission abort
+  returned idle and cleaned up, but their terminal result frame still rendered a
+  generic error. PR #826 snapshots resident interruption state on process events
+  and suppresses only that terminal mapping after denial cleanup. All 200 package
+  tests, fatal analysis, and architecture review passed; PR #826 merged as
+  `ea1bc354`.
+
+- Step 16/17 local verification (2026-08-11): completed the simulator matrix
+  against the source bridge and real Claude CLI 2.1.226. Setup, branding,
+  streaming, reasoning, tools, Once/reject permissions, questions, models,
+  interruption, pending abort, restart/history, external import, images,
+  commands, idle reap/model restore, settings policy, logs, and process cleanup
+  passed. `E2E.md` records exact evidence. ExitPlanMode was blocked by three
+  upstream overload responses; its real wire shape and approval path remain
+  covered by protocol capture and focused tests. The live CLI offered no safe
+  session-scoped `addRules` suggestion, so Always correctly degraded to Once
+  rather than applying broader or durable permission updates. README now marks
+  Claude Code Beta. No database migration or analytics change.
+
+  Documentation validation is `git diff --cached --check`; no Dart or Flutter
+  suites were rerun for this documentation-only step. The final diff is 169
+  changed lines, below the 200-500 estimate because the evidence fit one compact record.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/claude-code-plugin/TRACKER.md
+++ b/.plan/active/claude-code-plugin/TRACKER.md
@@ -5,11 +5,11 @@
 - **Plan slug:** `claude-code-plugin`
 - **Implementation base:** `origin/main` at `ea1bc354`
 - **Series state:** Steps 1-15/17 and all four Step 16 live-gate fixes merged;
-  Step 16 verification and documentation complete locally
-- **Current step:** Step 16/17 ready for review
+  Step 16/17 in review as PR #828
+- **Current step:** Step 16/17 in review
 - **Plan PR:** [#737](https://github.com/sesori-ai/sesori_apps_monorepo/pull/737),
   merged 2026-08-04 as `6d641532`
-- **Next action:** Open and monitor the Step 16 documentation PR
+- **Next action:** Monitor Step 16 PR #828
 
 ## Plan Review
 
@@ -59,7 +59,7 @@
 | [x] | 13/17 | `claude-code-plugin-descriptor` | `⚙️ [claude-code-plugin] feat(claude): add descriptor and lifecycle [step 13/17]` | 1,100-1,500 | [PR #815](https://github.com/sesori-ai/sesori_apps_monorepo/pull/815) merged 2026-08-11 as `ba2f6f7b` |
 | [x] | 14/17 | `claude-code-plugin-activation` | `⚙️ [claude-code-plugin] feat(claude): register the Claude Code harness [step 14/17]` | 250-500 | [PR #816](https://github.com/sesori-ai/sesori_apps_monorepo/pull/816) merged 2026-08-11 as `85438e1d` |
 | [x] | 15/17 | `claude-code-plugin-client-polish` | `🌿 [claude-code-plugin] feat(client): add Claude Code branding [step 15/17]` | 400-800 | [PR #817](https://github.com/sesori-ai/sesori_apps_monorepo/pull/817) merged 2026-08-11 as `c3d21c78` |
-| [ ] | 16/17 | `claude-code-plugin-e2e` | `🌿 [claude-code-plugin] docs: record Claude Code live verification [step 16/17]` | 200-500 | Live verification complete locally; PR pending |
+| [ ] | 16/17 | `claude-code-plugin-e2e` | `🌿 [claude-code-plugin] docs: record Claude Code live verification [step 16/17]` | 200-500 | [PR #828](https://github.com/sesori-ai/sesori_apps_monorepo/pull/828) open; live verification complete |
 | [ ] | 17/17 | `claude-code-plugin-retire` | `🌱 [claude-code-plugin] docs: retire Claude Code plugin plan [step 17/17]` | 50-200 | Not started |
 
 ## Exact PR Titles

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
   </a>
 </p>
 
-<h1 align="center">Run OpenCode, Codex, and Cursor from your phone.</h1>
+<h1 align="center">Run OpenCode, Codex, Cursor, and Claude Code from your phone.</h1>
 
 <p align="center">
-  Sesori is the mobile cockpit for your AI coding sessions — <a href="https://opencode.ai" target="_blank" rel="noopener">OpenCode</a>, <a href="https://github.com/openai/codex" target="_blank" rel="noopener">Codex</a>, and <a href="https://cursor.com" target="_blank" rel="noopener">Cursor</a> today, with <a href="https://claude.com" target="_blank" rel="noopener">Claude Code</a> coming soon.<br/>
+  Sesori is the mobile cockpit for your AI coding sessions — <a href="https://opencode.ai" target="_blank" rel="noopener">OpenCode</a>, <a href="https://github.com/openai/codex" target="_blank" rel="noopener">Codex</a>, <a href="https://cursor.com" target="_blank" rel="noopener">Cursor</a>, and <a href="https://claude.com" target="_blank" rel="noopener">Claude Code</a>.<br/>
   Leave your laptop. Take the session.
 </p>
 
@@ -144,7 +144,7 @@ Your laptop and phone perform an ephemeral X25519 key exchange, then encrypt eve
 | [OpenCode](https://opencode.ai) | Available | Deep native integration. |
 | [OpenAI Codex CLI](https://github.com/openai/codex) | Beta | Enabled by default in an upcoming release. |
 | [Cursor](https://cursor.com) | Beta | ACP-based Cursor plugin; enabled by default in an upcoming release. |
-| [Claude Code](https://claude.com) | Coming soon | Plugin architecture already supports multi-assistant backends. |
+| [Claude Code](https://claude.com) | Beta | Native stream-json integration; enabled by default in an upcoming release. |
 
 ---
 


### PR DESCRIPTION
## Complexity

🌿 Straightforward: this records an extensive completed live run and updates product support copy without changing runtime code.

## What

- Add the Claude Code simulator E2E record covering the full Step 16 matrix.
- Record the four focused fixes discovered and merged during the live gate.
- Correct the Always rows to match the locked safe-degradation contract.
- Mark Claude Code Beta in the README and include it in the top-level product copy.

## Why

Claude Code support has now been exercised through the real app, relay, source bridge, plugin, and logged-in CLI. The durable evidence and remaining upstream limitations need to be explicit before retiring the implementation plan.

## Risk and test focus

Low implementation risk because the PR changes documentation only. Review factual consistency among `E2E.md`, the plan, tracker, README, and merged fix PRs. There is no database or runtime-code impact. The user-visible impact is that README support status changes from Coming soon to Beta.

## Expected result

Reviewers can audit the live Beta gate and its limitations, and repository visitors see Claude Code as a supported Beta assistant. No persisted-data or runtime behavior changes.

## Verification

- iPhone 17 Pro Max simulator on iOS 26.5 against a source-run bridge and real Claude CLI 2.1.226.
- Hybrid UI and debug-router assertions recorded in `.plan/active/claude-code-plugin/E2E.md`.
- Four live-gate fixes merged as PR #821, #823, #825, and #826.
- `git diff --cached --check`.
- No Dart or Flutter suites rerun for this documentation-only step.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the full Step 16 end-to-end verification for the Claude Code plugin and marks Claude Code as Beta across the docs. Documentation-only; no runtime or data changes.

- **New Features**
  - Added `E2E.md` with the full simulator matrix across client, relay, bridge, plugin, and the real CLI (2.1.226), including the safe Always-degradation evidence and noted limitations.
  - Clarified the permission model in `PLAN.md`: Always only sends eligible session-scoped `addRules`; when none are offered it degrades to Once, and only eligible grants are restored after idle reap.
  - Updated `TRACKER.md` to reflect the merged live-gate fixes, the current implementation base, and the open Step 16 PR; updated `README.md` headline and support table to list Claude Code as Beta.
  - Redacted local paths in `E2E.md` to remove environment-specific details.

<sup>Written for commit 53036097565671d31224b82cb8425ec27505beb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

