### PR TITLE
⚙️ [pi-harness] feat(acp): bridge form elicitations [step 5/21]

### DIFF
--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -3,14 +3,15 @@
 ## Current State
 
 - **Plan slug:** `pi-harness`
-- **Implementation base:** `origin/main` at `ca550a7b`
-- **Series state:** Step 4/21 plan revision in progress
-- **Current step:** 4/21, expand the plan to Oh My Pi
+- **Implementation base:** `origin/main` at `82351fc2`
+- **Series state:** Step 5/21 ACP form and close support in progress
+- **Current step:** 5/21, bridge ACP form elicitations
 - **Plan PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/811
 - **Step 2 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/819
 - **Step 3 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/820
 - **Step 4 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/829
-- **Next action:** address Step 4 review feedback and monitor it to merge
+- **Step 5 PR:** pending
+- **Next action:** implement and verify Step 5
 
 ## Locked Decisions
 
@@ -41,8 +42,8 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 | [x] | 1/21 | `🌱 [pi-harness] docs: plan Pi harness support [step 1/21]` | 1,400-1,500 (recorded overage) | Merged as PR #811; title normalized |
 | [x] | 2/21 | `⚙️ [pi-harness] feat(pi): scaffold the protocol package [step 2/21]` | 900-1,300 | Merged as PR #819; title normalized |
 | [x] | 3/21 | `🚧 [pi-harness] feat(pi): add the JSONL RPC transport [step 3/21]` | 1,200-1,500 (recorded overage) | Merged as PR #820; title normalized |
-| [ ] | 4/21 | `🌱 [pi-harness] docs: expand the plan to Oh My Pi [step 4/21]` | 1,500-1,600 (recorded overage) | Open as PR #829 |
-| [ ] | 5/21 | `⚙️ [pi-harness] feat(acp): bridge form elicitations [step 5/21]` | 900-1,300 | Not started |
+| [x] | 4/21 | `🌱 [pi-harness] docs: expand the plan to Oh My Pi [step 4/21]` | 1,500-1,600 (recorded overage) | Merged as PR #829 |
+| [ ] | 5/21 | `⚙️ [pi-harness] feat(acp): bridge form elicitations [step 5/21]` | 900-1,300 | In progress |
 | [ ] | 6/21 | `⚙️ [pi-harness] feat(omp): add the ACP plugin core [step 6/21]` | 900-1,300 | Not started |
 | [ ] | 7/21 | `🚧 [pi-harness] feat(omp): expose options and persisted cleanup [step 7/21]` | 1,100-1,500 | Not started |
 | [ ] | 8/21 | `🚧 [pi-harness] feat(runtime): install direct binary assets [step 8/21]` | 900-1,300 | Blocked on runtime dependency |
@@ -165,6 +166,31 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 - `git diff --check $(git merge-base origin/main HEAD)..HEAD`: pass.
 - Diff: +1,327/-378 = 1,705 changed lines; generated lines: 0; tests run: 0.
 - Dart/Flutter suites: not run for this documentation-only step.
+
+### Step 5/21
+
+- Added standard ACP form elicitation for string, string-enum, and boolean
+  properties with typed accept, decline, cancel, privacy-safe unsupported
+  handling, and capability opt-in; URL elicitation and terminal auth stay absent.
+- Added the connection-scoped session-config repository, opt-in process-wide
+  prompt lane, fail-closed selection policy with bound empty-session recovery,
+  and privacy-safe post-dispatch failure hook. Cursor keeps existing defaults.
+- Added capability-aware `session/close`: active target work is cancelled and
+  awaited before close, while queued work behind another process-wide turn does
+  not block deletion. Timeout preserves retryable local state.
+- Updated Cursor consumers in lockstep and regression contracts for forms and
+  close-capable deletion.
+- `dart analyze --fatal-infos` from `bridge/sesori_plugin_acp/` and
+  `bridge/sesori_plugin_cursor/`: pass.
+- `dart test` from `bridge/sesori_plugin_acp/`: pass, 237 tests.
+- `dart test` from `bridge/sesori_plugin_cursor/`: pass, 126 tests.
+- Architecture implementation review rejected three duplicated connection/lane
+  ownership and target-settlement gaps; all were corrected. Second review:
+  approved with no findings.
+- No database, persisted-data, client/bridge wire-contract, or client-UI change. Existing
+  Cursor selection and elicitation advertisement remain unchanged.
+- `git diff --check $(git merge-base origin/main HEAD)..HEAD`: pass.
+- Diff: +1,201/-98 = 1,299 changed lines; generated lines: 0; tests run: 363.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -10,8 +10,8 @@
 - **Step 2 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/819
 - **Step 3 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/820
 - **Step 4 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/829
-- **Step 5 PR:** pending
-- **Next action:** implement and verify Step 5
+- **Step 5 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/832
+- **Next action:** monitor Step 5 review and CI to merge
 
 ## Locked Decisions
 
@@ -43,7 +43,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 | [x] | 2/21 | `⚙️ [pi-harness] feat(pi): scaffold the protocol package [step 2/21]` | 900-1,300 | Merged as PR #819; title normalized |
 | [x] | 3/21 | `🚧 [pi-harness] feat(pi): add the JSONL RPC transport [step 3/21]` | 1,200-1,500 (recorded overage) | Merged as PR #820; title normalized |
 | [x] | 4/21 | `🌱 [pi-harness] docs: expand the plan to Oh My Pi [step 4/21]` | 1,500-1,600 (recorded overage) | Merged as PR #829 |
-| [ ] | 5/21 | `⚙️ [pi-harness] feat(acp): bridge form elicitations [step 5/21]` | 900-1,300 | In progress |
+| [ ] | 5/21 | `⚙️ [pi-harness] feat(acp): bridge form elicitations [step 5/21]` | 900-1,300 | Open as PR #832 |
 | [ ] | 6/21 | `⚙️ [pi-harness] feat(omp): add the ACP plugin core [step 6/21]` | 900-1,300 | Not started |
 | [ ] | 7/21 | `🚧 [pi-harness] feat(omp): expose options and persisted cleanup [step 7/21]` | 1,100-1,500 | Not started |
 | [ ] | 8/21 | `🚧 [pi-harness] feat(runtime): install direct binary assets [step 8/21]` | 900-1,300 | Blocked on runtime dependency |

--- a/bridge/sesori_plugin_acp/lib/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/acp_plugin.dart
@@ -15,6 +15,7 @@ export "src/acp_session_configuration_tracker.dart";
 export "src/acp_session_loader.dart";
 export "src/acp_session_options_service.dart";
 export "src/acp_stdio_client.dart";
+export "src/repositories/acp_session_config_repository.dart";
 export "src/repositories/mappers/acp_content_mapper.dart";
 // Plugin-lifecycle housing: the BridgePlugin wrapper + the host-backed process
 // factory a descriptor uses to run an ACP agent under the bridge's lifecycle.

--- a/bridge/sesori_plugin_acp/lib/acp_testing.dart
+++ b/bridge/sesori_plugin_acp/lib/acp_testing.dart
@@ -1,3 +1,4 @@
 // Test utilities for ACP harness packages (FakeAcpProcess etc.). Import from
 // test code only: `package:acp_plugin/acp_testing.dart`.
 export "src/testing/fake_acp_process.dart";
+export "src/testing/test_acp_plugin.dart";

--- a/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
@@ -133,6 +133,7 @@ class AcpApprovalRegistry {
   /// unresolved (a request stamped with "" is dropped by the mobile client).
   String resolveSessionId(Map<String, dynamic> params) {
     final rawSessionId = params["sessionId"];
+    if (rawSessionId != null && rawSessionId is! String) return "";
     final explicit = rawSessionId is String ? rawSessionId.trim() : null;
     if (explicit != null && explicit.isNotEmpty) return explicit;
     return _activeSessionResolver?.call() ?? "";

--- a/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
@@ -132,7 +132,8 @@ class AcpApprovalRegistry {
   /// Returns "" only when neither is available — the caller must treat that as
   /// unresolved (a request stamped with "" is dropped by the mobile client).
   String resolveSessionId(Map<String, dynamic> params) {
-    final explicit = (params["sessionId"] as String?)?.trim();
+    final rawSessionId = params["sessionId"];
+    final explicit = rawSessionId is String ? rawSessionId.trim() : null;
     if (explicit != null && explicit.isNotEmpty) return explicit;
     return _activeSessionResolver?.call() ?? "";
   }
@@ -435,10 +436,7 @@ class AcpApprovalRegistry {
           acpId: request.id,
           sessionId: sessionId,
           questions: questions,
-          replyBuilder: (answers) => {
-            "action": "accept",
-            "content": form.buildContent(answers: answers),
-          },
+          replyBuilder: (answers) => form.buildResponse(answers: answers),
           resolutionBuilder: (resolution) => {
             "action": switch (resolution) {
               AcpQuestionResolution.declined => "decline",

--- a/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
@@ -4,6 +4,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "acp_protocol.dart";
 import "acp_stdio_client.dart";
+import "repositories/mappers/acp_elicitation_mapper.dart";
 
 typedef AcpResponder = void Function(Object id, Object? result);
 typedef AcpErrorResponder = void Function(Object id, int code, String message);
@@ -12,6 +13,9 @@ typedef AcpErrorResponder = void Function(Object id, int code, String message);
 /// bridge's `List<List<String>>` answers (outer = per question, inner =
 /// selected values).
 typedef AcpQuestionReplyBuilder = Object? Function(List<List<String>> answers);
+typedef AcpQuestionResolutionBuilder = Object? Function(AcpQuestionResolution resolution);
+
+enum AcpQuestionResolution { declined, cancelled }
 
 enum _PendingKind { permission, question }
 
@@ -24,6 +28,7 @@ class _PendingApproval {
     this.params = const {},
     this.questions = const [],
     this.replyBuilder,
+    this.resolutionBuilder,
   });
 
   final String bridgeRequestId;
@@ -41,6 +46,10 @@ class _PendingApproval {
 
   /// Builds the reply payload (question kind only).
   final AcpQuestionReplyBuilder? replyBuilder;
+
+  /// Builds protocol-specific decline/cancel results. Null preserves the
+  /// existing JSON-RPC error response used by harness extension questions.
+  final AcpQuestionResolutionBuilder? resolutionBuilder;
 }
 
 /// Routes ACP server-originated requests to the bridge SSE stream and answers
@@ -136,6 +145,7 @@ class AcpApprovalRegistry {
     required String sessionId,
     required List<PluginQuestionInfo> questions,
     required AcpQuestionReplyBuilder replyBuilder,
+    required AcpQuestionResolutionBuilder? resolutionBuilder,
   }) {
     _pending[bridgeRequestId] = _PendingApproval(
       bridgeRequestId: bridgeRequestId,
@@ -144,6 +154,7 @@ class AcpApprovalRegistry {
       kind: _PendingKind.question,
       questions: questions,
       replyBuilder: replyBuilder,
+      resolutionBuilder: resolutionBuilder,
     );
   }
 
@@ -253,7 +264,11 @@ class AcpApprovalRegistry {
           ),
         );
       } else {
-        _respondError(entry.acpId, -32603, questionErrorMessage);
+        _resolveQuestion(
+          entry,
+          resolution: AcpQuestionResolution.cancelled,
+          fallbackErrorMessage: questionErrorMessage,
+        );
         _emit(
           BridgeSseQuestionRejected(
             requestID: entry.bridgeRequestId,
@@ -316,7 +331,11 @@ class AcpApprovalRegistry {
   bool rejectQuestion(String bridgeRequestId) {
     final entry = _pending.remove(bridgeRequestId);
     if (entry == null || entry.kind != _PendingKind.question) return false;
-    _respondError(entry.acpId, -32603, "user rejected");
+    _resolveQuestion(
+      entry,
+      resolution: AcpQuestionResolution.declined,
+      fallbackErrorMessage: "user rejected",
+    );
     _emit(
       BridgeSseQuestionRejected(
         requestID: bridgeRequestId,
@@ -332,6 +351,10 @@ class AcpApprovalRegistry {
   void _handle(AcpServerRequest request) {
     if (request.method == AcpMethods.sessionRequestPermission) {
       _handlePermission(request);
+      return;
+    }
+    if (request.method == AcpMethods.elicitationCreate) {
+      _handleElicitation(request);
       return;
     }
     if (fireAndForgetExtensionMethods.contains(request.method)) {
@@ -391,6 +414,60 @@ class AcpApprovalRegistry {
         allowAlways: allowAlways,
       ),
     );
+  }
+
+  void _handleElicitation(AcpServerRequest request) {
+    final sessionId = resolveSessionId(request.params);
+    if (sessionId.isEmpty) {
+      Log.w("[acp] elicitation with no resolvable session; cancelling");
+      _respond(request.id, const {"action": "cancel"});
+      return;
+    }
+    final form = const AcpElicitationMapper().parse(params: request.params);
+    switch (form) {
+      case AcpUnsupportedElicitationForm(:final reason):
+        Log.w("[acp] declining elicitation: $reason");
+        _respond(request.id, const {"action": "decline"});
+      case AcpSupportedElicitationForm(:final questions):
+        final bridgeId = generateBridgeId();
+        addPendingQuestion(
+          bridgeRequestId: bridgeId,
+          acpId: request.id,
+          sessionId: sessionId,
+          questions: questions,
+          replyBuilder: (answers) => {
+            "action": "accept",
+            "content": form.buildContent(answers: answers),
+          },
+          resolutionBuilder: (resolution) => {
+            "action": switch (resolution) {
+              AcpQuestionResolution.declined => "decline",
+              AcpQuestionResolution.cancelled => "cancel",
+            },
+          },
+        );
+        _emit(
+          BridgeSseQuestionAsked(
+            id: bridgeId,
+            sessionID: sessionId,
+            displaySessionId: sessionId,
+            questions: questions,
+          ),
+        );
+    }
+  }
+
+  void _resolveQuestion(
+    _PendingApproval entry, {
+    required AcpQuestionResolution resolution,
+    required String fallbackErrorMessage,
+  }) {
+    final builder = entry.resolutionBuilder;
+    if (builder == null) {
+      _respondError(entry.acpId, -32603, fallbackErrorMessage);
+      return;
+    }
+    _respond(entry.acpId, builder(resolution));
   }
 
   /// Derives the tool hint and human description from a permission request's

--- a/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
@@ -129,8 +129,9 @@ class AcpApprovalRegistry {
 
   /// The session a server request belongs to: its explicit `sessionId` when
   /// present, otherwise the active turn's session (see [_activeSessionResolver]).
-  /// Returns "" only when neither is available — the caller must treat that as
-  /// unresolved (a request stamped with "" is dropped by the mobile client).
+  /// Returns "" when no session can be resolved, including a present malformed
+  /// `sessionId`; the caller must treat that as unresolved (a request stamped
+  /// with "" is dropped by the mobile client).
   String resolveSessionId(Map<String, dynamic> params) {
     final rawSessionId = params["sessionId"];
     if (rawSessionId != null && rawSessionId is! String) return "";

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -14,6 +14,7 @@ import "acp_protocol.dart";
 import "acp_session_loader.dart";
 import "acp_session_options_service.dart";
 import "acp_stdio_client.dart";
+import "repositories/acp_session_config_repository.dart";
 import "repositories/mappers/acp_content_mapper.dart";
 
 /// Base [BridgeDerivedProjectsPluginApi] implementation for any ACP (Agent
@@ -123,6 +124,14 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   /// decisions live on this class — the state object only holds fields.
   final Map<String, _SessionTurnState> _turnStates = {};
 
+  /// Shared tail used only by agents that cannot correlate sessionless server
+  /// requests while multiple prompts are in flight.
+  Future<void> _processTurnTail = Future<void>.value();
+
+  /// Exact selection retained when an already-created empty session cannot be
+  /// configured yet. Its first prompt retries before dispatch.
+  final Map<String, _TurnSelection> _pendingSelections = {};
+
   /// Sessions with a `session/prompt` currently in flight, in dispatch order.
   /// Per-session serialization guarantees a session appears at most once.
   final List<String> _inFlightTurnSessions = [];
@@ -187,6 +196,18 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   /// (e.g. Cursor's `parameterizedModelPicker`).
   Map<String, dynamic>? get initializeCapabilityMeta => null;
 
+  /// Whether this agent should be told the client supports standard ACP forms.
+  bool get supportsFormElicitation => false;
+
+  /// Whether prompts across all sessions share one dispatch lane.
+  bool get serializesPromptsProcessWide => false;
+
+  /// Whether a turn must stop when its requested selection cannot be applied.
+  bool get failsTurnOnSelectionError => false;
+
+  /// Maximum time deletion waits for a cancelled target turn before close.
+  Duration get sessionCloseSettlementTimeout => const Duration(seconds: 5);
+
   /// Maps the user-selected slash command to the command name sent to the ACP
   /// agent. The original name remains authoritative for client-facing events.
   String commandForDispatch({required String command}) => command;
@@ -228,12 +249,19 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   /// effect. Base does nothing (the agent's defaults are used). Cursor overrides
   /// to drive its model / mode / effort `session/set_config_option` calls.
   Future<void> applyTurnSelection({
-    required AcpStdioClient client,
+    required AcpSessionConfigRepository configRepository,
     required String sessionId,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,
     required String? agent,
   }) async {}
+
+  /// Additional privacy-safe events for a prompt failure. The generic session
+  /// error is always emitted separately.
+  Iterable<BridgeSseEvent> mapPromptFailure({
+    required String sessionId,
+    required Object error,
+  }) => const [];
 
   /// Invoked when the agent subprocess is torn down for a respawn (see
   /// [resetConnectionAfterExit]). The replacement process starts with none of
@@ -337,6 +365,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       params: buildInitializeParams(
         clientName: clientName,
         clientVersion: clientVersion,
+        formElicitation: supportsFormElicitation,
         capabilityMeta: initializeCapabilityMeta,
       ),
     );
@@ -750,13 +779,38 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     if (parts.isEmpty) {
       // No first turn to carry the selection: apply it now so the session's
       // model/mode are in place for whichever turn comes first later.
-      await applyTurnSelection(
-        client: client,
-        sessionId: session.sessionId,
-        model: model,
-        variant: variant,
-        agent: agent,
-      );
+      try {
+        await _runOnProcessLane(
+          () async => applyTurnSelection(
+            configRepository: AcpSessionConfigRepository(
+              client: await _connectedClient(),
+            ),
+            sessionId: session.sessionId,
+            model: model,
+            variant: variant,
+            agent: agent,
+          ),
+        );
+      } on Object catch (error, stack) {
+        if (!failsTurnOnSelectionError) rethrow;
+        _pendingSelections[session.sessionId] = _TurnSelection(
+          model: model,
+          variant: variant,
+          agent: agent,
+        );
+        Log.w(
+          "[$id] initial selection for ${session.sessionId} failed; retrying before first turn",
+          error,
+          stack,
+        );
+        _eventBuffer.add(
+          const BridgeSseTuiToastShow(
+            title: "Session options not applied",
+            message: "The selected options will be retried before the first turn.",
+            variant: "warning",
+          ),
+        );
+      }
     } else {
       // A fresh session has an empty chain, so this dispatches immediately;
       // the selection is applied inside the turn like every other prompt.
@@ -769,6 +823,16 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       );
     }
     return created;
+  }
+
+  Future<T> _runOnProcessLane<T>(Future<T> Function() operation) {
+    if (!serializesPromptsProcessWide) return operation();
+    final result = _processTurnTail.then((_) => operation());
+    _processTurnTail = result.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace __) {},
+    );
+    return result;
   }
 
   @override
@@ -1005,17 +1069,16 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     final expectedGeneration = state.generation;
     // Each link isolates its own failure (_runTurn never throws), so one
     // failed turn cannot poison the chain for the turns queued behind it.
-    state.tail = state.tail.then(
-      (_) => _runTurn(
-        sessionId: sessionId,
-        state: state,
-        expectedGeneration: expectedGeneration,
-        blocks: blocks,
-        model: model,
-        variant: variant,
-        agent: agent,
-      ),
+    Future<void> operation() => _runTurn(
+      sessionId: sessionId,
+      state: state,
+      expectedGeneration: expectedGeneration,
+      blocks: blocks,
+      model: model,
+      variant: variant,
+      agent: agent,
     );
+    state.tail = serializesPromptsProcessWide ? _runOnProcessLane(operation) : state.tail.then((_) => operation());
   }
 
   /// Runs one serialized turn: resolves the live client, makes the session
@@ -1046,6 +1109,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       _finishTurn(sessionId: sessionId, state: state, failed: false, refused: false);
       return;
     }
+    state.activeSettlement = Completer<void>();
     final AcpStdioClient client;
     try {
       client = await _connectedClient();
@@ -1076,18 +1140,30 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       _finishTurn(sessionId: sessionId, state: state, failed: false, refused: false);
       return;
     }
+    final pendingSelection = _pendingSelections[sessionId];
+    final selectedModel = model ?? pendingSelection?.model;
+    final selectedVariant = variant ?? pendingSelection?.variant;
+    final selectedAgent = agent ?? pendingSelection?.agent;
     try {
       await applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: sessionId,
-        model: model,
-        variant: variant,
-        agent: agent,
+        model: selectedModel,
+        variant: selectedVariant,
+        agent: selectedAgent,
       );
+      _pendingSelections.remove(sessionId);
     } on Object catch (error, stack) {
-      // Selection is best-effort (the Cursor override is already fail-soft):
-      // the turn proceeds on the agent's current settings.
-      Log.w("[$id] applyTurnSelection for $sessionId failed; prompting with current settings", error, stack);
+      if (failsTurnOnSelectionError) {
+        Log.w("[$id] applyTurnSelection for $sessionId failed; dropping turn", error, stack);
+        _finishTurn(sessionId: sessionId, state: state, failed: true, refused: false);
+        return;
+      }
+      Log.w(
+        "[$id] applyTurnSelection for $sessionId failed; prompting with current settings",
+        error,
+        stack,
+      );
     }
     if (state.generation != expectedGeneration) {
       _finishTurn(sessionId: sessionId, state: state, failed: false, refused: false);
@@ -1118,6 +1194,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       // session error, not a silent idle.
       Log.w("[$id] session/prompt for $sessionId failed after dispatch", error, stack);
       _finishTurn(sessionId: sessionId, state: state, failed: true, refused: false);
+      mapPromptFailure(sessionId: sessionId, error: error).forEach(_eventBuffer.add);
     }
   }
 
@@ -1131,6 +1208,9 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     required bool refused,
   }) {
     _inFlightTurnSessions.remove(sessionId);
+    final settlement = state.activeSettlement;
+    state.activeSettlement = null;
+    if (settlement != null && !settlement.isCompleted) settlement.complete();
     if (state.pending > 0) state.pending--;
     // A session deleted mid-turn already dropped this state object from
     // [_turnStates]; its detached accounting above must still settle, but it
@@ -1243,13 +1323,32 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
 
   @override
   Future<void> deleteSession(String sessionId) async {
-    if ((_turnStates[sessionId]?.pending ?? 0) > 0) {
+    final state = _turnStates[sessionId];
+    if ((state?.pending ?? 0) > 0) {
       await abortSession(sessionId: sessionId);
     }
     _approvalRegistry?.cancelForSession(sessionId);
-    // The state object is dropped here; a still-settling cancelled turn holds
-    // its own reference, so its accounting completes harmlessly off-map.
+    final canClose = _initResult?.agentCapabilities.closeSession ?? false;
+    if (canClose && _residentSessions.contains(sessionId)) {
+      try {
+        await state?.activeSettlement?.future.timeout(
+          sessionCloseSettlementTimeout,
+        );
+        final client = await _connectedClient();
+        await client.request(
+          method: AcpMethods.sessionClose,
+          params: {"sessionId": sessionId},
+        );
+      } on Object catch (error) {
+        throw PluginOperationException(
+          "deleteSession",
+          message: "ACP session did not settle and close",
+          cause: error,
+        );
+      }
+    }
     _turnStates.remove(sessionId);
+    _pendingSelections.remove(sessionId);
     _inFlightTurnSessions.remove(sessionId);
     if (_lastTurnSessionId == sessionId) _lastTurnSessionId = null;
     _sessionStatuses.remove(sessionId);
@@ -1631,10 +1730,27 @@ class _SessionTurnState {
   /// Completion of the session's most recently queued turn.
   Future<void> tail = Future<void>.value();
 
+  /// Settlement of this session's currently executing connect/load/selection/
+  /// prompt operation. Queued turns blocked on another session's process lane
+  /// do not participate in deletion's close deadline.
+  Completer<void>? activeSettlement;
+
   /// Turns enqueued but not yet finished (including the running one).
   int pending = 0;
 
   /// Bumped by abort/delete; a queued turn dispatches only if the generation
   /// it captured at enqueue time is still current.
   int generation = 0;
+}
+
+class _TurnSelection {
+  const _TurnSelection({
+    required this.model,
+    required this.variant,
+    required this.agent,
+  });
+
+  final ({String providerID, String modelID})? model;
+  final PluginSessionVariant? variant;
+  final String? agent;
 }

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1339,11 +1339,14 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
           method: AcpMethods.sessionClose,
           params: {"sessionId": sessionId},
         );
-      } on Object catch (error) {
-        throw PluginOperationException(
-          "deleteSession",
-          message: "ACP session did not settle and close",
-          cause: error,
+      } on Object catch (error, stackTrace) {
+        Error.throwWithStackTrace(
+          PluginOperationException(
+            "deleteSession",
+            message: "ACP session did not settle and close",
+            cause: error,
+          ),
+          stackTrace,
         );
       }
     }

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -24,9 +24,9 @@ import "repositories/mappers/acp_content_mapper.dart";
 /// so the bridge derives the project list from [listAllSessions] and owns all
 /// project/session persistence itself; the plugin stores nothing on disk.
 ///
-/// Concrete so a vanilla ACP harness needs only an [id] + [agentDisplayName]
-/// (the "config row" case). Harnesses with quirks (e.g. Cursor's model
-/// selection and `cursor/*` extensions) subclass and override the hooks:
+/// Backend adapters subclass this and must declare their protocol policies.
+/// Harnesses with quirks (e.g. Cursor's model selection and `cursor/*`
+/// extensions) also override the relevant behavior hooks:
 /// [buildApprovalRegistry], [applyTurnSelection], [authMethodId],
 /// [initializeCapabilityMeta], [commandForDispatch], [getAgents],
 /// [getProviders].
@@ -34,7 +34,7 @@ import "repositories/mappers/acp_content_mapper.dart";
 /// Unlike the codex plugin (which connects to a process listening on a ws
 /// port), this owns the agent subprocess: it spawns lazily on first use and
 /// reaps it on [dispose].
-class AcpPlugin extends BridgeDerivedProjectsPluginApi {
+abstract class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   AcpPlugin({
     required this.id,
     required this.agentDisplayName,
@@ -183,30 +183,30 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   /// enumeration; reset on respawn since a replacement process may comply.
   bool _bareSessionListUnsupported = false;
 
-  // --- Overridable hooks ---
+  // --- Required backend policies and overridable hooks ---
 
-  String get clientName => "sesori-bridge";
-  String get clientVersion => "0.0.0";
+  String get clientName;
+  String get clientVersion;
 
   /// Auth method id to call if the agent reports it requires auth. `null`
   /// uses the first advertised method.
-  String? get authMethodId => null;
+  String? get authMethodId;
 
   /// Non-standard capability hints sent under `clientCapabilities._meta`
   /// (e.g. Cursor's `parameterizedModelPicker`).
-  Map<String, dynamic>? get initializeCapabilityMeta => null;
+  Map<String, dynamic>? get initializeCapabilityMeta;
 
   /// Whether this agent should be told the client supports standard ACP forms.
-  bool get supportsFormElicitation => false;
+  bool get supportsFormElicitation;
 
   /// Whether prompts across all sessions share one dispatch lane.
-  bool get serializesPromptsProcessWide => false;
+  bool get serializesPromptsProcessWide;
 
   /// Whether a turn must stop when its requested selection cannot be applied.
-  bool get failsTurnOnSelectionError => false;
+  bool get failsTurnOnSelectionError;
 
   /// Maximum time deletion waits for a cancelled target turn before close.
-  Duration get sessionCloseSettlementTimeout => const Duration(seconds: 5);
+  Duration get sessionCloseSettlementTimeout;
 
   /// Maps the user-selected slash command to the command name sent to the ACP
   /// agent. The original name remains authoritative for client-facing events.

--- a/bridge/sesori_plugin_acp/lib/src/acp_protocol.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_protocol.dart
@@ -22,9 +22,11 @@ abstract final class AcpMethods {
   static const String sessionResume = "session/resume";
   static const String sessionPrompt = "session/prompt";
   static const String sessionCancel = "session/cancel";
+  static const String sessionClose = "session/close";
   static const String sessionUpdate = "session/update";
   static const String sessionRequestPermission = "session/request_permission";
   static const String sessionSetConfigOption = "session/set_config_option";
+  static const String elicitationCreate = "elicitation/create";
 }
 
 /// An auth method advertised by the agent in the `initialize` result.
@@ -48,6 +50,7 @@ class AcpAgentCapabilities {
     required this.loadSession,
     required this.listSessions,
     required this.resumeSession,
+    required this.closeSession,
     required this.raw,
   });
 
@@ -62,6 +65,9 @@ class AcpAgentCapabilities {
   /// strictly richer.
   final bool resumeSession;
 
+  /// Whether `session/close` is supported.
+  final bool closeSession;
+
   /// Full raw capabilities object for harness-specific probing.
   final Map<String, dynamic> raw;
 
@@ -73,10 +79,12 @@ class AcpAgentCapabilities {
     // non-false value signals support.
     final list = session?["list"];
     final resume = session?["resume"];
+    final close = session?["close"];
     return AcpAgentCapabilities(
       loadSession: json["loadSession"] == true,
       listSessions: list != null && list != false,
       resumeSession: resume != null && resume != false,
+      closeSession: close != null && close != false,
       raw: json,
     );
   }
@@ -138,11 +146,13 @@ class AcpTimestampMsConverter implements JsonConverter<int?, Object?> {
 sealed class AcpSessionInfo with _$AcpSessionInfo {
   const factory AcpSessionInfo({
     @Default("") String sessionId,
+
     /// The session's working directory. Required by the spec, but kept
     /// nullable — a missing value falls back to the directory the caller
     /// scanned.
     required String? cwd,
     required String? title,
+
     /// Last-activity time in epoch milliseconds (see [AcpTimestampMsConverter]).
     @AcpTimestampMsConverter() @JsonKey(name: "updatedAt") required int? updatedAtMs,
   }) = _AcpSessionInfo;
@@ -175,6 +185,7 @@ List<AcpSessionInfo> _sessionInfosFromJson(Object? raw) {
 sealed class AcpSessionListResult with _$AcpSessionListResult {
   const factory AcpSessionListResult({
     @JsonKey(fromJson: _sessionInfosFromJson) @Default(<AcpSessionInfo>[]) List<AcpSessionInfo> sessions,
+
     /// Opaque continuation token — a non-empty value means more pages exist.
     required String? nextCursor,
   }) = _AcpSessionListResult;
@@ -246,10 +257,14 @@ class AcpPromptResult {
 ///
 /// [meta] carries non-standard capability hints under `_meta` (e.g. Cursor's
 /// `parameterizedModelPicker`).
-Map<String, dynamic> buildClientCapabilities({Map<String, dynamic>? meta}) {
+Map<String, dynamic> buildClientCapabilities({
+  required bool formElicitation,
+  Map<String, dynamic>? meta,
+}) {
   return <String, dynamic>{
     "fs": {"readTextFile": false, "writeTextFile": false},
     "terminal": false,
+    if (formElicitation) "elicitation": {"form": <String, dynamic>{}},
     "_meta": ?meta,
   };
 }
@@ -258,12 +273,16 @@ Map<String, dynamic> buildClientCapabilities({Map<String, dynamic>? meta}) {
 Map<String, dynamic> buildInitializeParams({
   required String clientName,
   required String clientVersion,
+  required bool formElicitation,
   String? clientTitle,
   Map<String, dynamic>? capabilityMeta,
 }) {
   return <String, dynamic>{
     "protocolVersion": acpProtocolVersion,
-    "clientCapabilities": buildClientCapabilities(meta: capabilityMeta),
+    "clientCapabilities": buildClientCapabilities(
+      formElicitation: formElicitation,
+      meta: capabilityMeta,
+    ),
     "clientInfo": {
       "name": clientName,
       "title": clientTitle,
@@ -273,13 +292,9 @@ Map<String, dynamic> buildInitializeParams({
 }
 
 /// Builds a single text [ContentBlock] for a prompt.
-Map<String, dynamic> textContentBlock(String text) =>
-    <String, dynamic>{"type": "text", "text": text};
+Map<String, dynamic> textContentBlock(String text) => <String, dynamic>{"type": "text", "text": text};
 
 List<Map<String, dynamic>> _mapList(Object? raw) {
   if (raw is! List) return const [];
-  return raw
-      .whereType<Map<dynamic, dynamic>>()
-      .map((m) => m.cast<String, dynamic>())
-      .toList(growable: false);
+  return raw.whereType<Map<dynamic, dynamic>>().map((m) => m.cast<String, dynamic>()).toList(growable: false);
 }

--- a/bridge/sesori_plugin_acp/lib/src/repositories/acp_session_config_repository.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/acp_session_config_repository.dart
@@ -1,0 +1,25 @@
+import "../acp_protocol.dart";
+import "../acp_stdio_client.dart";
+
+/// Connection-scoped access to standard ACP session configuration writes.
+class AcpSessionConfigRepository {
+  AcpSessionConfigRepository({required AcpStdioClient client}) : _client = client;
+
+  final AcpStdioClient _client;
+
+  Future<AcpNewSessionResult?> setConfigOption({
+    required String sessionId,
+    required String configId,
+    required String value,
+  }) async {
+    final raw = await _client.request(
+      method: AcpMethods.sessionSetConfigOption,
+      params: {
+        "sessionId": sessionId,
+        "configId": configId,
+        "value": value,
+      },
+    );
+    return raw is Map ? AcpNewSessionResult.fromJson(raw.cast<String, dynamic>()) : null;
+  }
+}

--- a/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_elicitation_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_elicitation_mapper.dart
@@ -1,0 +1,253 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+const int _maxTextLength = 500;
+const String _suggestedTextLabel = "Use suggested text";
+
+sealed class AcpElicitationForm {
+  const AcpElicitationForm();
+}
+
+final class AcpSupportedElicitationForm extends AcpElicitationForm {
+  const AcpSupportedElicitationForm({
+    required this.questions,
+    required List<AcpElicitationField> fields,
+  }) : _fields = fields;
+
+  final List<PluginQuestionInfo> questions;
+  final List<AcpElicitationField> _fields;
+
+  Map<String, Object?> buildContent({required List<List<String>> answers}) {
+    final content = <String, Object?>{};
+    for (var index = 0; index < _fields.length; index++) {
+      final selected = index < answers.length ? answers[index] : const <String>[];
+      final value = _fields[index].encode(selected: selected);
+      if (value != null) content[_fields[index].key] = value;
+    }
+    return content;
+  }
+}
+
+final class AcpUnsupportedElicitationForm extends AcpElicitationForm {
+  const AcpUnsupportedElicitationForm({required this.reason});
+
+  /// Privacy-safe structural reason. Never contains labels, defaults, or text.
+  final String reason;
+}
+
+sealed class AcpElicitationField {
+  const AcpElicitationField({required this.key});
+
+  final String key;
+
+  Object? encode({required List<String> selected});
+}
+
+final class _StringField extends AcpElicitationField {
+  const _StringField({required super.key, required this.suggestedText});
+
+  final String? suggestedText;
+
+  @override
+  Object? encode({required List<String> selected}) {
+    if (selected.isEmpty) return null;
+    final value = selected.first;
+    if (value == _suggestedTextLabel && suggestedText != null) return suggestedText;
+    return value;
+  }
+}
+
+final class _BooleanField extends AcpElicitationField {
+  const _BooleanField({required super.key});
+
+  @override
+  Object? encode({required List<String> selected}) {
+    if (selected.isEmpty) return null;
+    return switch (selected.first) {
+      "Yes" => true,
+      "No" => false,
+      _ => null,
+    };
+  }
+}
+
+final class _EnumField extends AcpElicitationField {
+  const _EnumField({required super.key, required this.valuesByLabel});
+
+  final Map<String, String> valuesByLabel;
+
+  @override
+  Object? encode({required List<String> selected}) => selected.isEmpty ? null : valuesByLabel[selected.first];
+}
+
+/// Maps the standard ACP v1 `elicitation/create` form shape to Sesori questions.
+class AcpElicitationMapper {
+  const AcpElicitationMapper();
+
+  AcpElicitationForm parse({required Map<String, dynamic> params}) {
+    final mode = params["mode"];
+    if (mode != "form") {
+      return AcpUnsupportedElicitationForm(
+        reason: "unsupported elicitation mode: ${_token(mode)}",
+      );
+    }
+    final schema = _map(params["requestedSchema"]);
+    if (schema == null || schema["type"] != "object") {
+      return AcpUnsupportedElicitationForm(
+        reason: "unsupported schema type: ${_token(schema?["type"])}",
+      );
+    }
+    final properties = _map(schema["properties"]);
+    if (properties == null || properties.isEmpty) {
+      return const AcpUnsupportedElicitationForm(reason: "form has no properties");
+    }
+
+    final requestMessage = _bounded(_string(params["message"]) ?? "Input requested");
+    final schemaTitle = _bounded(_string(schema["title"]) ?? requestMessage);
+    final questions = <PluginQuestionInfo>[];
+    final fields = <AcpElicitationField>[];
+    for (final entry in properties.entries) {
+      final property = _map(entry.value);
+      if (property == null) {
+        return const AcpUnsupportedElicitationForm(reason: "property is not an object");
+      }
+      final mapped = _mapProperty(
+        key: entry.key,
+        property: property,
+        requestMessage: requestMessage,
+        schemaTitle: schemaTitle,
+      );
+      if (mapped == null) {
+        return AcpUnsupportedElicitationForm(
+          reason: "unsupported property type: ${_token(property["type"])}",
+        );
+      }
+      questions.add(mapped.question);
+      fields.add(mapped.field);
+    }
+    return AcpSupportedElicitationForm(questions: questions, fields: fields);
+  }
+
+  ({PluginQuestionInfo question, AcpElicitationField field})? _mapProperty({
+    required String key,
+    required Map<String, dynamic> property,
+    required String requestMessage,
+    required String schemaTitle,
+  }) {
+    final title = _bounded(_string(property["title"]) ?? schemaTitle);
+    final questionText = _bounded(
+      _string(property["description"]) ?? _string(property["title"]) ?? requestMessage,
+    );
+    switch (property["type"]) {
+      case "boolean":
+        return (
+          question: PluginQuestionInfo(
+            question: questionText,
+            header: title,
+            options: const [
+              PluginQuestionOption(label: "Yes", description: ""),
+              PluginQuestionOption(label: "No", description: ""),
+            ],
+            multiple: false,
+            custom: false,
+          ),
+          field: _BooleanField(key: key),
+        );
+      case "string":
+        final choices = _enumChoices(property);
+        final hasChoices = property.containsKey("enum") || property.containsKey("oneOf");
+        if (hasChoices && choices == null) return null;
+        if (choices != null) {
+          return (
+            question: PluginQuestionInfo(
+              question: questionText,
+              header: title,
+              options: [
+                for (final choice in choices)
+                  PluginQuestionOption(label: choice.label, description: choice.description),
+              ],
+              multiple: false,
+              custom: false,
+            ),
+            field: _EnumField(
+              key: key,
+              valuesByLabel: {for (final choice in choices) choice.label: choice.value},
+            ),
+          );
+        }
+        final suggested = _string(property["default"]);
+        return (
+          question: PluginQuestionInfo(
+            question: questionText,
+            header: title,
+            options: [
+              if (suggested != null)
+                PluginQuestionOption(
+                  label: _suggestedTextLabel,
+                  description: _bounded(suggested),
+                ),
+            ],
+            multiple: false,
+            custom: true,
+          ),
+          field: _StringField(key: key, suggestedText: suggested),
+        );
+      default:
+        return null;
+    }
+  }
+
+  List<({String label, String value, String description})>? _enumChoices(
+    Map<String, dynamic> property,
+  ) {
+    final rawOneOf = property["oneOf"];
+    if (rawOneOf is List) {
+      final choices = <({String label, String value, String description})>[];
+      final usedLabels = <String>{};
+      for (final raw in rawOneOf) {
+        final item = _map(raw);
+        final value = _string(item?["const"]);
+        if (item == null || value == null) return null;
+        final baseLabel = _string(item["title"]) ?? value;
+        final label = _uniqueLabel(base: baseLabel, used: usedLabels);
+        choices.add((
+          label: label,
+          value: value,
+          description: _bounded(_string(item["description"]) ?? ""),
+        ));
+      }
+      return choices.isEmpty ? null : choices;
+    }
+    final rawEnum = property["enum"];
+    if (rawEnum is! List) return null;
+    final values = rawEnum.whereType<String>().toList(growable: false);
+    if (values.length != rawEnum.length || values.isEmpty) return null;
+    final usedLabels = <String>{};
+    return [
+      for (final value in values)
+        (
+          label: _uniqueLabel(base: value, used: usedLabels),
+          value: value,
+          description: "",
+        ),
+    ];
+  }
+
+  static String _uniqueLabel({required String base, required Set<String> used}) {
+    var label = base;
+    var suffix = 2;
+    while (!used.add(label)) {
+      label = "$base ($suffix)";
+      suffix++;
+    }
+    return label;
+  }
+
+  static Map<String, dynamic>? _map(Object? value) => value is Map ? value.cast<String, dynamic>() : null;
+
+  static String? _string(Object? value) => value is String && value.isNotEmpty ? value : null;
+
+  static String _token(Object? value) => value is String ? value : value.runtimeType.toString();
+
+  static String _bounded(String value) =>
+      value.length <= _maxTextLength ? value : "${value.substring(0, _maxTextLength)}...";
+}

--- a/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_elicitation_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_elicitation_mapper.dart
@@ -16,14 +16,16 @@ final class AcpSupportedElicitationForm extends AcpElicitationForm {
   final List<PluginQuestionInfo> questions;
   final List<AcpElicitationField> _fields;
 
-  Map<String, Object?> buildContent({required List<List<String>> answers}) {
+  Map<String, Object?> buildResponse({required List<List<String>> answers}) {
     final content = <String, Object?>{};
     for (var index = 0; index < _fields.length; index++) {
       final selected = index < answers.length ? answers[index] : const <String>[];
-      final value = _fields[index].encode(selected: selected);
-      if (value != null) content[_fields[index].key] = value;
+      final field = _fields[index];
+      final value = field.encode(selected: selected);
+      if (value == null && field.required) return const {"action": "decline"};
+      if (value != null) content[field.key] = value;
     }
-    return content;
+    return {"action": "accept", "content": content};
   }
 }
 
@@ -35,15 +37,16 @@ final class AcpUnsupportedElicitationForm extends AcpElicitationForm {
 }
 
 sealed class AcpElicitationField {
-  const AcpElicitationField({required this.key});
+  const AcpElicitationField({required this.key, required this.required});
 
   final String key;
+  final bool required;
 
   Object? encode({required List<String> selected});
 }
 
 final class _StringField extends AcpElicitationField {
-  const _StringField({required super.key, required this.suggestedText});
+  const _StringField({required super.key, required super.required, required this.suggestedText});
 
   final String? suggestedText;
 
@@ -57,7 +60,7 @@ final class _StringField extends AcpElicitationField {
 }
 
 final class _BooleanField extends AcpElicitationField {
-  const _BooleanField({required super.key});
+  const _BooleanField({required super.key, required super.required});
 
   @override
   Object? encode({required List<String> selected}) {
@@ -71,7 +74,7 @@ final class _BooleanField extends AcpElicitationField {
 }
 
 final class _EnumField extends AcpElicitationField {
-  const _EnumField({required super.key, required this.valuesByLabel});
+  const _EnumField({required super.key, required super.required, required this.valuesByLabel});
 
   final Map<String, String> valuesByLabel;
 
@@ -100,6 +103,14 @@ class AcpElicitationMapper {
     if (properties == null || properties.isEmpty) {
       return const AcpUnsupportedElicitationForm(reason: "form has no properties");
     }
+    final rawRequired = schema["required"];
+    if (rawRequired != null &&
+        (rawRequired is! List ||
+            rawRequired.whereType<String>().length != rawRequired.length ||
+            rawRequired.whereType<String>().any((key) => !properties.containsKey(key)))) {
+      return const AcpUnsupportedElicitationForm(reason: "invalid required properties");
+    }
+    final requiredKeys = rawRequired is List ? rawRequired.whereType<String>().toSet() : const <String>{};
 
     final requestMessage = _bounded(_string(params["message"]) ?? "Input requested");
     final schemaTitle = _bounded(_string(schema["title"]) ?? requestMessage);
@@ -115,6 +126,7 @@ class AcpElicitationMapper {
         property: property,
         requestMessage: requestMessage,
         schemaTitle: schemaTitle,
+        required: requiredKeys.contains(entry.key),
       );
       if (mapped == null) {
         return AcpUnsupportedElicitationForm(
@@ -132,6 +144,7 @@ class AcpElicitationMapper {
     required Map<String, dynamic> property,
     required String requestMessage,
     required String schemaTitle,
+    required bool required,
   }) {
     final title = _bounded(_string(property["title"]) ?? schemaTitle);
     final questionText = _bounded(
@@ -150,7 +163,7 @@ class AcpElicitationMapper {
             multiple: false,
             custom: false,
           ),
-          field: _BooleanField(key: key),
+          field: _BooleanField(key: key, required: required),
         );
       case "string":
         final choices = _enumChoices(property);
@@ -170,6 +183,7 @@ class AcpElicitationMapper {
             ),
             field: _EnumField(
               key: key,
+              required: required,
               valuesByLabel: {for (final choice in choices) choice.label: choice.value},
             ),
           );
@@ -189,7 +203,7 @@ class AcpElicitationMapper {
             multiple: false,
             custom: true,
           ),
-          field: _StringField(key: key, suggestedText: suggested),
+          field: _StringField(key: key, required: required, suggestedText: suggested),
         );
       default:
         return null;
@@ -205,9 +219,9 @@ class AcpElicitationMapper {
       final usedLabels = <String>{};
       for (final raw in rawOneOf) {
         final item = _map(raw);
-        final value = _string(item?["const"]);
+        final value = _enumValue(item?["const"]);
         if (item == null || value == null) return null;
-        final baseLabel = _string(item["title"]) ?? value;
+        final baseLabel = _bounded(_string(item["title"]) ?? _enumDisplayValue(value));
         final label = _uniqueLabel(base: baseLabel, used: usedLabels);
         choices.add((
           label: label,
@@ -225,7 +239,7 @@ class AcpElicitationMapper {
     return [
       for (final value in values)
         (
-          label: _uniqueLabel(base: value, used: usedLabels),
+          label: _uniqueLabel(base: _bounded(_enumDisplayValue(value)), used: usedLabels),
           value: value,
           description: "",
         ),
@@ -245,6 +259,10 @@ class AcpElicitationMapper {
   static Map<String, dynamic>? _map(Object? value) => value is Map ? value.cast<String, dynamic>() : null;
 
   static String? _string(Object? value) => value is String && value.isNotEmpty ? value : null;
+
+  static String? _enumValue(Object? value) => value is String ? value : null;
+
+  static String _enumDisplayValue(String value) => value.isEmpty ? "Empty string" : value;
 
   static String _token(Object? value) => value is String ? value : value.runtimeType.toString();
 

--- a/bridge/sesori_plugin_acp/lib/src/testing/test_acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/testing/test_acp_plugin.dart
@@ -1,0 +1,40 @@
+import "../acp_plugin.dart";
+
+/// Neutral ACP adapter for testing the reusable base behavior.
+class TestAcpPlugin extends AcpPlugin {
+  TestAcpPlugin({
+    required super.id,
+    required super.agentDisplayName,
+    required super.launchSpec,
+    required super.launchDirectory,
+    required super.eventMapper,
+    required super.contentMapper,
+    required super.commandTracker,
+    required super.sessionOptionsService,
+    super.processFactory,
+  });
+
+  @override
+  String get clientName => "sesori-bridge";
+
+  @override
+  String get clientVersion => "0.0.0";
+
+  @override
+  String? get authMethodId => null;
+
+  @override
+  Map<String, dynamic>? get initializeCapabilityMeta => null;
+
+  @override
+  bool get supportsFormElicitation => false;
+
+  @override
+  bool get serializesPromptsProcessWide => false;
+
+  @override
+  bool get failsTurnOnSelectionError => false;
+
+  @override
+  Duration get sessionCloseSettlementTimeout => const Duration(seconds: 5);
+}

--- a/bridge/sesori_plugin_acp/test/acp_approval_registry_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_approval_registry_test.dart
@@ -195,6 +195,7 @@ void main() {
           PluginQuestionInfo(question: "Pick", header: "H", options: [], multiple: false, custom: false),
         ],
         replyBuilder: (answers) => null,
+        resolutionBuilder: null,
       );
       responds.clear();
       errors.clear();
@@ -224,6 +225,7 @@ void main() {
           PluginQuestionInfo(question: "q", header: "h", options: [], multiple: false, custom: false),
         ],
         replyBuilder: (answers) => null,
+        resolutionBuilder: null,
       );
       responds.clear();
       errors.clear();
@@ -287,6 +289,7 @@ void main() {
           ),
         ],
         replyBuilder: (answers) => {"selected": answers.first.first},
+        resolutionBuilder: null,
       );
 
       expect(registry.pendingForSession("s1"), hasLength(1));

--- a/bridge/sesori_plugin_acp/test/acp_commands_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_commands_test.dart
@@ -94,7 +94,7 @@ void main() {
       emitted = <BridgeSseEvent>[];
       final configurationTracker = AcpSessionConfigurationTracker();
       final commandTracker = AcpCommandTracker();
-      plugin = AcpPlugin(
+      plugin = TestAcpPlugin(
         id: "acp",
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
@@ -232,7 +232,7 @@ void main() {
     final emitted = <BridgeSseEvent>[];
     final configurationTracker = AcpSessionConfigurationTracker();
     final commandTracker = AcpCommandTracker();
-    final plugin = AcpPlugin(
+    final plugin = TestAcpPlugin(
       id: "acp",
       agentDisplayName: "ACP",
       launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),

--- a/bridge/sesori_plugin_acp/test/acp_elicitation_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_elicitation_test.dart
@@ -38,6 +38,7 @@ void main() {
       String? sessionId = "session-1",
       Object? mode = "form",
       required Map<String, Object?> properties,
+      List<String> requiredKeys = const [],
     }) => AcpServerRequest(
       id: id,
       method: AcpMethods.elicitationCreate,
@@ -49,6 +50,7 @@ void main() {
           "type": "object",
           "title": "Extension options",
           "properties": properties,
+          if (requiredKeys.isNotEmpty) "required": requiredKeys,
         },
       },
     );
@@ -155,6 +157,52 @@ void main() {
       });
     });
 
+    test("declines the form when a required property is unanswered", () async {
+      requests.add(
+        form(
+          properties: {
+            "requiredName": {"type": "string"},
+            "optionalNote": {"type": "string"},
+          },
+          requiredKeys: const ["requiredName"],
+        ),
+      );
+      await pump();
+      final asked = emitted.single as BridgeSseQuestionAsked;
+
+      registry.replyQuestion(asked.id, [
+        const [],
+        ["optional"],
+      ]);
+
+      expect(responses.single.$2, const {"action": "decline"});
+    });
+
+    test("maps an empty-string enum value through a non-empty label", () async {
+      requests.add(
+        form(
+          properties: {
+            "value": {
+              "type": "string",
+              "enum": [""],
+            },
+          },
+        ),
+      );
+      await pump();
+      final asked = emitted.single as BridgeSseQuestionAsked;
+      final label = asked.questions.single.options.single.label;
+      expect(label, isNotEmpty);
+
+      registry.replyQuestion(asked.id, [
+        [label],
+      ]);
+      expect(responses.single.$2, {
+        "action": "accept",
+        "content": {"value": ""},
+      });
+    });
+
     test("declines unsupported modes and property schemas without pending state", () async {
       requests.add(
         form(
@@ -195,6 +243,29 @@ void main() {
       await pump();
 
       expect(responses.single.$2, const {"action": "cancel"});
+      expect(emitted, isEmpty);
+    });
+
+    test("cancels a form with a non-string session id", () async {
+      requests.add(
+        const AcpServerRequest(
+          id: 42,
+          method: AcpMethods.elicitationCreate,
+          params: {
+            "sessionId": 7,
+            "mode": "form",
+            "requestedSchema": {
+              "type": "object",
+              "properties": {
+                "name": {"type": "string"},
+              },
+            },
+          },
+        ),
+      );
+      await pump();
+
+      expect(responses.single, (42, const {"action": "cancel"}));
       expect(emitted, isEmpty);
     });
 

--- a/bridge/sesori_plugin_acp/test/acp_elicitation_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_elicitation_test.dart
@@ -247,6 +247,16 @@ void main() {
     });
 
     test("cancels a form with a non-string session id", () async {
+      await registry.dispose();
+      registry = AcpApprovalRegistry(
+        emit: emitted.add,
+        respond: (id, result) => responses.add((id, result)),
+        respondError: (id, code, message) => errors.add((id, code, message)),
+        onFireAndForgetNotification: (_) {},
+        activeSessionResolver: () => "active-session",
+      );
+      registry.attach(requests.stream);
+
       requests.add(
         const AcpServerRequest(
           id: 42,

--- a/bridge/sesori_plugin_acp/test/acp_elicitation_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_elicitation_test.dart
@@ -1,0 +1,254 @@
+import "dart:async";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ACP form elicitations", () {
+    late StreamController<AcpServerRequest> requests;
+    late List<BridgeSseEvent> emitted;
+    late List<(Object, Object?)> responses;
+    late List<(Object, int, String)> errors;
+    late AcpApprovalRegistry registry;
+
+    setUp(() {
+      requests = StreamController<AcpServerRequest>.broadcast();
+      emitted = [];
+      responses = [];
+      errors = [];
+      registry = AcpApprovalRegistry(
+        emit: emitted.add,
+        respond: (id, result) => responses.add((id, result)),
+        respondError: (id, code, message) => errors.add((id, code, message)),
+        onFireAndForgetNotification: (_) {},
+      );
+      registry.attach(requests.stream);
+    });
+
+    tearDown(() async {
+      await registry.dispose();
+      await requests.close();
+    });
+
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+    AcpServerRequest form({
+      Object id = 41,
+      String? sessionId = "session-1",
+      Object? mode = "form",
+      required Map<String, Object?> properties,
+    }) => AcpServerRequest(
+      id: id,
+      method: AcpMethods.elicitationCreate,
+      params: {
+        "sessionId": ?sessionId,
+        "mode": mode,
+        "message": "Configure extension",
+        "requestedSchema": {
+          "type": "object",
+          "title": "Extension options",
+          "properties": properties,
+        },
+      },
+    );
+
+    test("maps enum, boolean, and string fields to typed accepted content", () async {
+      final suggested = List.filled(120, "draft ").join();
+      requests.add(
+        form(
+          properties: {
+            "strategy": {
+              "type": "string",
+              "title": "Strategy",
+              "enum": ["safe", "fast"],
+            },
+            "confirm": {
+              "type": "boolean",
+              "title": "Continue?",
+            },
+            "notes": {
+              "type": "string",
+              "title": "Notes",
+              "default": suggested,
+            },
+          },
+        ),
+      );
+      await pump();
+
+      final asked = emitted.single as BridgeSseQuestionAsked;
+      expect(asked.sessionID, "session-1");
+      expect(asked.questions, hasLength(3));
+      expect(asked.questions[0].options.map((option) => option.label), ["safe", "fast"]);
+      expect(asked.questions[1].options.map((option) => option.label), ["Yes", "No"]);
+      expect(asked.questions[2].custom, isTrue);
+      expect(asked.questions[2].options.single.description.length, lessThan(suggested.length));
+
+      expect(
+        registry.replyQuestion(asked.id, [
+          ["fast"],
+          ["Yes"],
+          ["Use suggested text"],
+        ]),
+        isTrue,
+      );
+      expect(responses.single.$2, {
+        "action": "accept",
+        "content": {
+          "strategy": "fast",
+          "confirm": true,
+          "notes": suggested,
+        },
+      });
+      expect(errors, isEmpty);
+    });
+
+    test("maps titled oneOf choices back to their const values", () async {
+      requests.add(
+        form(
+          properties: {
+            "plan": {
+              "type": "string",
+              "oneOf": [
+                {"const": "accept", "title": "Approve", "description": "Run it"},
+                {"const": "refine", "title": "Approve", "description": "Change it"},
+              ],
+            },
+          },
+        ),
+      );
+      await pump();
+
+      final asked = emitted.single as BridgeSseQuestionAsked;
+      expect(asked.questions.single.options.map((option) => option.label), ["Approve", "Approve (2)"]);
+      registry.replyQuestion(asked.id, [
+        ["Approve (2)"],
+      ]);
+
+      expect(responses.single.$2, {
+        "action": "accept",
+        "content": {"plan": "refine"},
+      });
+    });
+
+    test("omits unanswered optional properties", () async {
+      requests.add(
+        form(
+          properties: {
+            "first": {"type": "string"},
+            "second": {"type": "string"},
+          },
+        ),
+      );
+      await pump();
+      final asked = emitted.single as BridgeSseQuestionAsked;
+
+      registry.replyQuestion(asked.id, [
+        ["value"],
+        const [],
+      ]);
+
+      expect(responses.single.$2, {
+        "action": "accept",
+        "content": {"first": "value"},
+      });
+    });
+
+    test("declines unsupported modes and property schemas without pending state", () async {
+      requests.add(
+        form(
+          id: 1,
+          mode: "url",
+          properties: {
+            "url": {"type": "string"},
+          },
+        ),
+      );
+      requests.add(
+        form(
+          id: 2,
+          properties: {
+            "count": {"type": "integer", "default": "private-value"},
+          },
+        ),
+      );
+      await pump();
+
+      expect(responses, [
+        (1, const {"action": "decline"}),
+        (2, const {"action": "decline"}),
+      ]);
+      expect(emitted, isEmpty);
+      expect(registry.pendingForSession("session-1"), isEmpty);
+    });
+
+    test("cancels a form that has no resolvable session", () async {
+      requests.add(
+        form(
+          sessionId: null,
+          properties: {
+            "name": {"type": "string"},
+          },
+        ),
+      );
+      await pump();
+
+      expect(responses.single.$2, const {"action": "cancel"});
+      expect(emitted, isEmpty);
+    });
+
+    test("attributes a sessionless form to the active turn", () async {
+      await registry.dispose();
+      registry = AcpApprovalRegistry(
+        emit: emitted.add,
+        respond: (id, result) => responses.add((id, result)),
+        respondError: (id, code, message) => errors.add((id, code, message)),
+        onFireAndForgetNotification: (_) {},
+        activeSessionResolver: () => "active-session",
+      );
+      registry.attach(requests.stream);
+
+      requests.add(
+        form(
+          sessionId: null,
+          properties: {
+            "name": {"type": "string"},
+          },
+        ),
+      );
+      await pump();
+
+      expect((emitted.single as BridgeSseQuestionAsked).sessionID, "active-session");
+    });
+
+    test("reject declines while abort and disposal cancel", () async {
+      Future<String> ask({required Object id}) async {
+        requests.add(
+          form(
+            id: id,
+            properties: {
+              "name": {"type": "string"},
+            },
+          ),
+        );
+        await pump();
+        return emitted.whereType<BridgeSseQuestionAsked>().last.id;
+      }
+
+      final rejected = await ask(id: 1);
+      registry.rejectQuestion(rejected);
+      expect(responses.last.$2, const {"action": "decline"});
+
+      final aborted = await ask(id: 2);
+      registry.cancelForSession("session-1");
+      expect(responses.last.$2, const {"action": "cancel"});
+      expect(registry.replyQuestion(aborted, const []), isFalse);
+
+      await ask(id: 3);
+      await registry.dispose();
+      expect(responses.last.$2, const {"action": "cancel"});
+      expect(emitted.whereType<BridgeSseQuestionRejected>(), hasLength(3));
+    });
+  });
+}

--- a/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
@@ -20,7 +20,7 @@ void main() {
       fake = FakeAcpProcess();
       final configurationTracker = AcpSessionConfigurationTracker();
       final commandTracker = AcpCommandTracker();
-      plugin = AcpPlugin(
+      plugin = TestAcpPlugin(
         id: "acp",
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
@@ -309,7 +309,7 @@ void main() {
       final availableFakes = [liveFake, replayFake];
       final configurationTracker = AcpSessionConfigurationTracker();
       final commandTracker = AcpCommandTracker();
-      final createdPlugin = AcpPlugin(
+      final createdPlugin = TestAcpPlugin(
         id: "acp",
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),

--- a/bridge/sesori_plugin_acp/test/acp_initialize_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_initialize_test.dart
@@ -17,7 +17,7 @@ void main() {
       fakes.clear();
       final configurationTracker = AcpSessionConfigurationTracker();
       final commandTracker = AcpCommandTracker();
-      plugin = AcpPlugin(
+      plugin = TestAcpPlugin(
         id: "acp",
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),

--- a/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
@@ -19,7 +19,7 @@ void main() {
       emitted = [];
       final configurationTracker = AcpSessionConfigurationTracker();
       final commandTracker = AcpCommandTracker();
-      plugin = AcpPlugin(
+      plugin = TestAcpPlugin(
         id: "acp",
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),

--- a/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
@@ -844,6 +844,7 @@ void main() {
           sessionId: session.id,
           questions: const [question],
           replyBuilder: (answers) => null,
+          resolutionBuilder: null,
         );
       }
 

--- a/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
@@ -735,7 +735,7 @@ void main() {
     test("a broken history replay surfaces as a typed failure, not an empty thread", () async {
       final configurationTracker = AcpSessionConfigurationTracker();
       final commandTracker = AcpCommandTracker();
-      final failingPlugin = AcpPlugin(
+      final failingPlugin = TestAcpPlugin(
         id: "acp",
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
@@ -863,7 +863,7 @@ Future<AcpProcessHandle> _throwReplayProcess(AcpLaunchSpec _) async {
 /// [AcpPlugin] that captures the approval registry built at connect so tests
 /// can register pending questions directly (the base registry only creates
 /// questions through harness extension handlers).
-class _RegistryCapturingAcpPlugin extends AcpPlugin {
+class _RegistryCapturingAcpPlugin extends TestAcpPlugin {
   _RegistryCapturingAcpPlugin({
     required super.id,
     required super.agentDisplayName,

--- a/bridge/sesori_plugin_acp/test/acp_protocol_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_protocol_test.dart
@@ -10,7 +10,10 @@ void main() {
         "protocolVersion": 1,
         "agentCapabilities": {
           "loadSession": true,
-          "sessionCapabilities": {"list": <String, dynamic>{}},
+          "sessionCapabilities": {
+            "list": <String, dynamic>{},
+            "close": <String, dynamic>{},
+          },
         },
         "authMethods": [
           {"id": "cursor_login", "name": "Cursor Login"},
@@ -19,6 +22,7 @@ void main() {
       expect(init.protocolVersion, 1);
       expect(init.agentCapabilities.loadSession, isTrue);
       expect(init.agentCapabilities.listSessions, isTrue);
+      expect(init.agentCapabilities.closeSession, isTrue);
       expect(init.requiresAuth, isTrue);
       expect(init.authMethods.single.id, "cursor_login");
     });
@@ -27,7 +31,28 @@ void main() {
       final init = AcpInitializeResult.fromJson(const {"protocolVersion": 1});
       expect(init.agentCapabilities.loadSession, isFalse);
       expect(init.agentCapabilities.listSessions, isFalse);
+      expect(init.agentCapabilities.closeSession, isFalse);
       expect(init.requiresAuth, isFalse);
+    });
+  });
+
+  group("ACP client capabilities", () {
+    test("advertises only form elicitation when enabled", () {
+      final capabilities = buildClientCapabilities(
+        formElicitation: true,
+      );
+      expect(capabilities["elicitation"], {
+        "form": <String, dynamic>{},
+      });
+      expect(capabilities, isNot(contains("auth")));
+      expect(capabilities["terminal"], isFalse);
+    });
+
+    test("omits elicitation when disabled", () {
+      expect(
+        buildClientCapabilities(formElicitation: false),
+        isNot(contains("elicitation")),
+      );
     });
   });
 

--- a/bridge/sesori_plugin_acp/test/acp_reconnect_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_reconnect_test.dart
@@ -16,7 +16,7 @@ void main() {
       fakes.clear();
       final configurationTracker = AcpSessionConfigurationTracker();
       final commandTracker = AcpCommandTracker();
-      plugin = AcpPlugin(
+      plugin = TestAcpPlugin(
         id: "acp",
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),

--- a/bridge/sesori_plugin_acp/test/acp_resume_only_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_only_test.dart
@@ -19,7 +19,7 @@ void main() {
       fake = FakeAcpProcess();
       final configurationTracker = AcpSessionConfigurationTracker();
       final commandTracker = AcpCommandTracker();
-      plugin = AcpPlugin(
+      plugin = TestAcpPlugin(
         id: "acp",
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),

--- a/bridge/sesori_plugin_acp/test/acp_resume_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_test.dart
@@ -18,7 +18,7 @@ void main() {
       fake = FakeAcpProcess();
       final configurationTracker = AcpSessionConfigurationTracker();
       final commandTracker = AcpCommandTracker();
-      plugin = AcpPlugin(
+      plugin = TestAcpPlugin(
         id: "acp",
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),

--- a/bridge/sesori_plugin_acp/test/acp_step5_policy_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_step5_policy_test.dart
@@ -5,7 +5,7 @@ import "package:acp_plugin/acp_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
-class _PolicyPlugin extends AcpPlugin {
+class _PolicyPlugin extends TestAcpPlugin {
   _PolicyPlugin({
     required this.processWide,
     required this.failClosed,

--- a/bridge/sesori_plugin_acp/test/acp_step5_policy_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_step5_policy_test.dart
@@ -1,0 +1,300 @@
+import "dart:async";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+class _PolicyPlugin extends AcpPlugin {
+  _PolicyPlugin({
+    required this.processWide,
+    required this.failClosed,
+    required this.forms,
+    required this.closeTimeout,
+    required super.eventMapper,
+    required super.contentMapper,
+    required super.commandTracker,
+    required super.sessionOptionsService,
+    required AcpProcessFactory super.processFactory,
+  }) : super(
+         id: "acp",
+         agentDisplayName: "ACP",
+         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+         launchDirectory: "/repo",
+       );
+
+  final bool processWide;
+  final bool failClosed;
+  final bool forms;
+  final Duration closeTimeout;
+  int selectionFailures = 0;
+
+  @override
+  bool get serializesPromptsProcessWide => processWide;
+
+  @override
+  bool get failsTurnOnSelectionError => failClosed;
+
+  @override
+  bool get supportsFormElicitation => forms;
+
+  @override
+  Duration get sessionCloseSettlementTimeout => closeTimeout;
+
+  @override
+  Future<void> applyTurnSelection({
+    required AcpSessionConfigRepository configRepository,
+    required String sessionId,
+    required ({String providerID, String modelID})? model,
+    required PluginSessionVariant? variant,
+    required String? agent,
+  }) async {
+    if (selectionFailures > 0) {
+      selectionFailures--;
+      throw StateError("selection rejected");
+    }
+  }
+}
+
+void main() {
+  group("ACP Step 5 turn policies", () {
+    late FakeAcpProcess fake;
+    late _PolicyPlugin plugin;
+    late List<BridgeSseEvent> events;
+
+    _PolicyPlugin buildPlugin({
+      required bool processWide,
+      required bool failClosed,
+      bool forms = false,
+      Duration closeTimeout = const Duration(seconds: 1),
+    }) {
+      final configurationTracker = AcpSessionConfigurationTracker();
+      final commandTracker = AcpCommandTracker();
+      return _PolicyPlugin(
+        processWide: processWide,
+        failClosed: failClosed,
+        forms: forms,
+        closeTimeout: closeTimeout,
+        contentMapper: const AcpContentMapper(),
+        eventMapper: AcpEventMapper(
+          launchDirectory: "/repo",
+          agentId: "acp",
+          pluginId: "acp",
+          configurationTracker: configurationTracker,
+          contentMapper: const AcpContentMapper(),
+        ),
+        commandTracker: commandTracker,
+        sessionOptionsService: AcpSessionOptionsService(
+          configurationTracker: configurationTracker,
+          commandTracker: commandTracker,
+          pluginId: "acp",
+          agentDisplayName: "ACP",
+        ),
+        processFactory: (_) async => fake,
+      );
+    }
+
+    setUp(() {
+      fake = FakeAcpProcess();
+      events = [];
+      plugin = buildPlugin(processWide: false, failClosed: false);
+      plugin.events.listen(events.add);
+    });
+
+    tearDown(() async {
+      await plugin.dispose();
+      await fake.close();
+    });
+
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+    List<Map<String, dynamic>> frames(String method) =>
+        fake.written.where((frame) => frame["method"] == method).toList(growable: false);
+
+    Future<Map<String, dynamic>> waitForFrameCount(String method, int count) async {
+      for (var i = 0; i < 200; i++) {
+        final matches = frames(method);
+        if (matches.length >= count) return matches[count - 1];
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+      throw StateError("agent never wrote $count '$method' frame(s)");
+    }
+
+    void respond(Map<String, dynamic> frame, Map<String, dynamic> result) {
+      fake.emit({"jsonrpc": "2.0", "id": frame["id"], "result": result});
+    }
+
+    Future<void> connect({bool close = false}) async {
+      final connecting = plugin.ensureConnected();
+      final initialize = await waitForFrameCount(AcpMethods.initialize, 1);
+      respond(initialize, {
+        "protocolVersion": 1,
+        "agentCapabilities": {
+          "sessionCapabilities": {
+            if (close) "close": <String, dynamic>{},
+          },
+        },
+        "authMethods": <Object?>[],
+      });
+      expect(await connecting, isTrue);
+    }
+
+    Future<PluginSession> create(String id) async {
+      final expectedFrame = frames(AcpMethods.sessionNew).length + 1;
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final frame = await waitForFrameCount(AcpMethods.sessionNew, expectedFrame);
+      respond(frame, {"sessionId": id});
+      return creating;
+    }
+
+    Future<void> send(String sessionId, String text) => plugin.sendPrompt(
+      sessionId: sessionId,
+      parts: [PluginPromptPart.text(text: text)],
+      variant: null,
+      agent: null,
+      model: null,
+    );
+
+    test("opt-in process lane serializes prompts across sessions", () async {
+      await plugin.dispose();
+      plugin = buildPlugin(processWide: true, failClosed: false);
+      plugin.events.listen(events.add);
+      await connect();
+      final first = await create("first");
+      final second = await create("second");
+
+      await send(first.id, "one");
+      final firstPrompt = await waitForFrameCount(AcpMethods.sessionPrompt, 1);
+      await send(second.id, "two");
+      await pump();
+      expect(frames(AcpMethods.sessionPrompt), hasLength(1));
+
+      respond(firstPrompt, {"stopReason": "end_turn"});
+      final secondPrompt = await waitForFrameCount(AcpMethods.sessionPrompt, 2);
+      expect((secondPrompt["params"] as Map)["sessionId"], second.id);
+      respond(secondPrompt, {"stopReason": "end_turn"});
+    });
+
+    test("form capability is advertised only by an opted-in plugin", () async {
+      await plugin.dispose();
+      plugin = buildPlugin(processWide: false, failClosed: false, forms: true);
+      plugin.events.listen(events.add);
+
+      final connecting = plugin.ensureConnected();
+      final initialize = await waitForFrameCount(AcpMethods.initialize, 1);
+      final params = (initialize["params"] as Map).cast<String, dynamic>();
+      final capabilities = (params["clientCapabilities"] as Map).cast<String, dynamic>();
+      expect(capabilities["elicitation"], {
+        "form": <String, dynamic>{},
+      });
+      respond(initialize, {
+        "protocolVersion": 1,
+        "agentCapabilities": <String, dynamic>{},
+        "authMethods": <Object?>[],
+      });
+      expect(await connecting, isTrue);
+    });
+
+    test("fail-closed selection stops before prompt dispatch", () async {
+      await plugin.dispose();
+      plugin = buildPlugin(processWide: false, failClosed: true);
+      plugin.events.listen(events.add);
+      await connect();
+      final session = await create("session-1");
+      plugin.selectionFailures = 1;
+
+      await send(session.id, "do not dispatch");
+      for (var i = 0; i < 20 && events.whereType<BridgeSseSessionError>().isEmpty; i++) {
+        await pump();
+      }
+
+      expect(frames(AcpMethods.sessionPrompt), isEmpty);
+      expect(events.whereType<BridgeSseSessionError>(), hasLength(1));
+    });
+
+    test("empty-session selection failure stays bound and retries on first prompt", () async {
+      await plugin.dispose();
+      plugin = buildPlugin(processWide: false, failClosed: true);
+      plugin.events.listen(events.add);
+      await connect();
+      plugin.selectionFailures = 1;
+
+      final session = await create("session-1");
+      await pump();
+      expect(session.id, "session-1");
+      expect(events.whereType<BridgeSseTuiToastShow>(), hasLength(1));
+
+      await send(session.id, "retry");
+      final prompt = await waitForFrameCount(AcpMethods.sessionPrompt, 1);
+      respond(prompt, {"stopReason": "end_turn"});
+    });
+
+    test("close waits for cancelled prompt settlement before dropping state", () async {
+      await connect(close: true);
+      final session = await create("session-1");
+      await send(session.id, "long turn");
+      final prompt = await waitForFrameCount(AcpMethods.sessionPrompt, 1);
+
+      final deleting = plugin.deleteSession(session.id);
+      await waitForFrameCount(AcpMethods.sessionCancel, 1);
+      expect(frames(AcpMethods.sessionClose), isEmpty);
+
+      respond(prompt, {"stopReason": "cancelled"});
+      final close = await waitForFrameCount(AcpMethods.sessionClose, 1);
+      respond(close, const {});
+      await deleting;
+      expect(await plugin.getSessionStatuses(), isNot(contains(session.id)));
+    });
+
+    test("deleting a queued session does not wait behind another session", () async {
+      await plugin.dispose();
+      plugin = buildPlugin(processWide: true, failClosed: false);
+      plugin.events.listen(events.add);
+      await connect(close: true);
+      final running = await create("running");
+      final queued = await create("queued");
+      await send(running.id, "long turn");
+      final runningPrompt = await waitForFrameCount(AcpMethods.sessionPrompt, 1);
+      await send(queued.id, "never dispatch");
+
+      final deleting = plugin.deleteSession(queued.id);
+      final close = await waitForFrameCount(AcpMethods.sessionClose, 1);
+      expect((close["params"] as Map)["sessionId"], queued.id);
+      respond(close, const {});
+      await deleting;
+
+      respond(runningPrompt, {"stopReason": "end_turn"});
+      await pump();
+      expect(frames(AcpMethods.sessionPrompt), hasLength(1));
+    });
+
+    test("close timeout fails deletion and preserves local session state", () async {
+      await plugin.dispose();
+      plugin = buildPlugin(
+        processWide: false,
+        failClosed: false,
+        closeTimeout: const Duration(milliseconds: 20),
+      );
+      plugin.events.listen(events.add);
+      await connect(close: true);
+      final session = await create("session-1");
+      await send(session.id, "stuck turn");
+      await waitForFrameCount(AcpMethods.sessionPrompt, 1);
+
+      await expectLater(
+        plugin.deleteSession(session.id),
+        throwsA(isA<PluginOperationException>()),
+      );
+      expect(await plugin.getSessionStatuses(), contains(session.id));
+      expect(frames(AcpMethods.sessionClose), isEmpty);
+    });
+  });
+}

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -24,7 +24,7 @@ class _GatedSelectionPlugin extends AcpPlugin {
 
   @override
   Future<void> applyTurnSelection({
-    required AcpStdioClient client,
+    required AcpSessionConfigRepository configRepository,
     required String sessionId,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -7,7 +7,7 @@ import "package:test/test.dart";
 
 /// An [AcpPlugin] whose [applyTurnSelection] blocks on a test-controlled gate,
 /// so a test can land an abort while a turn is mid-selection.
-class _GatedSelectionPlugin extends AcpPlugin {
+class _GatedSelectionPlugin extends TestAcpPlugin {
   _GatedSelectionPlugin({
     required super.id,
     required super.agentDisplayName,
@@ -59,7 +59,7 @@ void main() {
       fake = FakeAcpProcess();
       final configurationTracker = AcpSessionConfigurationTracker();
       final commandTracker = AcpCommandTracker();
-      plugin = AcpPlugin(
+      plugin = TestAcpPlugin(
         id: "acp",
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
@@ -376,7 +376,7 @@ void main() {
       await plugin.dispose();
       final configurationTracker = AcpSessionConfigurationTracker();
       final commandTracker = AcpCommandTracker();
-      plugin = AcpPlugin(
+      plugin = TestAcpPlugin(
         id: "acp",
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
@@ -735,7 +735,7 @@ void main() {
       final spawned = <FakeAcpProcess>[];
       final configurationTracker = AcpSessionConfigurationTracker();
       final commandTracker = AcpCommandTracker();
-      final respawning = AcpPlugin(
+      final respawning = TestAcpPlugin(
         id: "acp",
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),

--- a/bridge/sesori_plugin_cursor/lib/src/api/cursor_catalog_probe_api.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/api/cursor_catalog_probe_api.dart
@@ -34,6 +34,7 @@ class CursorCatalogProbeApi {
         params: buildInitializeParams(
           clientName: "sesori-bridge",
           clientVersion: "0.0.0",
+          formElicitation: false,
           capabilityMeta: const {"parameterizedModelPicker": true},
         ),
         timeout: _remaining(timeout: timeout, stopwatch: stopwatch),

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_approval_registry.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_approval_registry.dart
@@ -24,10 +24,9 @@ class CursorApprovalRegistry extends AcpApprovalRegistry {
     super.idGenerator,
     super.activeSessionResolver,
   }) : super(
-         respond: (id, result) =>
-             client.respondToServerRequest(id: id, result: result),
-         respondError: (id, code, message) => client
-             .respondToServerRequestWithError(id: id, code: code, message: message),
+         respond: (id, result) => client.respondToServerRequest(id: id, result: result),
+         respondError: (id, code, message) =>
+             client.respondToServerRequestWithError(id: id, code: code, message: message),
        );
 
   @override
@@ -130,6 +129,7 @@ class CursorApprovalRegistry extends AcpApprovalRegistry {
       sessionId: sessionId,
       questions: pluginQuestions,
       replyBuilder: (answers) => _buildAskReply(metas, answers),
+      resolutionBuilder: null,
     );
     emit(
       BridgeSseQuestionAsked(
@@ -151,9 +151,7 @@ class CursorApprovalRegistry extends AcpApprovalRegistry {
     final out = <Map<String, dynamic>>[];
     for (var i = 0; i < metas.length; i++) {
       final selectedLabels = i < answers.length ? answers[i] : const <String>[];
-      final ids = selectedLabels
-          .map((label) => metas[i].labelToId[label] ?? label)
-          .toList(growable: false);
+      final ids = selectedLabels.map((label) => metas[i].labelToId[label] ?? label).toList(growable: false);
       out.add({"id": metas[i].id, "selectedOptionIds": ids});
     }
     return {"questions": out};
@@ -174,9 +172,7 @@ class CursorApprovalRegistry extends AcpApprovalRegistry {
       return;
     }
     final name = _str(params["name"]) ?? "Plan";
-    final overview = _str(params["overview"]) ??
-        _str(params["plan"]) ??
-        "Review the proposed plan.";
+    final overview = _str(params["overview"]) ?? _str(params["plan"]) ?? "Review the proposed plan.";
 
     final questions = [
       PluginQuestionInfo(
@@ -198,10 +194,10 @@ class CursorApprovalRegistry extends AcpApprovalRegistry {
       sessionId: sessionId,
       questions: questions,
       replyBuilder: (answers) {
-        final accepted = answers.isNotEmpty &&
-            answers.first.any((a) => a.toLowerCase() == "accept");
+        final accepted = answers.isNotEmpty && answers.first.any((a) => a.toLowerCase() == "accept");
         return {"accepted": accepted};
       },
+      resolutionBuilder: null,
     );
     emit(
       BridgeSseQuestionAsked(

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
@@ -191,7 +191,7 @@ class CursorPlugin extends AcpPlugin implements PersistedSessionCleanupApi {
 
   @override
   Future<void> applyTurnSelection({
-    required AcpStdioClient client,
+    required AcpSessionConfigRepository configRepository,
     required String sessionId,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,
@@ -210,7 +210,7 @@ class CursorPlugin extends AcpPlugin implements PersistedSessionCleanupApi {
       var applied = true;
       if (targetModel != _appliedModelId) {
         applied = await _setConfig(
-          client: client,
+          configRepository: configRepository,
           sessionId: sessionId,
           configId: modelConfigId,
           value: targetModel,
@@ -236,7 +236,7 @@ class CursorPlugin extends AcpPlugin implements PersistedSessionCleanupApi {
         _catalogTracker.hasModeOption(modeId: requestedMode) &&
         requestedMode != _appliedModeId) {
       if (await _setConfig(
-        client: client,
+        configRepository: configRepository,
         sessionId: sessionId,
         configId: modeConfigId,
         value: requestedMode,
@@ -256,7 +256,7 @@ class CursorPlugin extends AcpPlugin implements PersistedSessionCleanupApi {
         requestedThoughtLevel != _appliedThoughtLevelId &&
         thoughtLevel.variants.contains(requestedThoughtLevel)) {
       if (await _setConfig(
-        client: client,
+        configRepository: configRepository,
         sessionId: sessionId,
         configId: thoughtLevel.configId,
         value: requestedThoughtLevel,
@@ -267,24 +267,18 @@ class CursorPlugin extends AcpPlugin implements PersistedSessionCleanupApi {
   }
 
   Future<bool> _setConfig({
-    required AcpStdioClient client,
+    required AcpSessionConfigRepository configRepository,
     required String sessionId,
     required String configId,
     required String value,
   }) async {
     try {
-      final raw = await client.request(
-        method: AcpMethods.sessionSetConfigOption,
-        params: {
-          "sessionId": sessionId,
-          "configId": configId,
-          "value": value,
-        },
+      final result = await configRepository.setConfigOption(
+        sessionId: sessionId,
+        configId: configId,
+        value: value,
       );
-      if (raw is Map) {
-        final result = AcpNewSessionResult.fromJson(
-          raw.cast<String, dynamic>(),
-        );
+      if (result != null) {
         final capture = _catalogService.captureSessionConfig(
           result: result,
           fromNewSession: false,

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
@@ -141,10 +141,28 @@ class CursorPlugin extends AcpPlugin implements PersistedSessionCleanupApi {
   String? _appliedThoughtLevelId;
 
   @override
+  String get clientName => "sesori-bridge";
+
+  @override
+  String get clientVersion => "0.0.0";
+
+  @override
   String? get authMethodId => "cursor_login";
 
   @override
   Map<String, dynamic>? get initializeCapabilityMeta => const {"parameterizedModelPicker": true};
+
+  @override
+  bool get supportsFormElicitation => false;
+
+  @override
+  bool get serializesPromptsProcessWide => false;
+
+  @override
+  bool get failsTurnOnSelectionError => false;
+
+  @override
+  Duration get sessionCloseSettlementTimeout => const Duration(seconds: 5);
 
   @override
   AcpApprovalRegistry buildApprovalRegistry(AcpStdioClient client) {

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
@@ -335,7 +335,7 @@ void main() {
       await client.connect();
 
       final applying = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: const PluginSessionVariant(id: "high"),
@@ -362,7 +362,7 @@ void main() {
       expect(sets[2]["value"], "high");
 
       final again = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: const PluginSessionVariant(id: "high"),
@@ -384,7 +384,7 @@ void main() {
       await client.connect();
 
       final applying = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "gpt-5.4"),
         variant: null,
@@ -418,7 +418,7 @@ void main() {
       await client.connect();
 
       final first = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "gpt-5.4"),
         variant: const PluginSessionVariant(id: "high"),
@@ -433,7 +433,7 @@ void main() {
       await first;
 
       final second = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: const PluginSessionVariant(id: "high"),
@@ -466,7 +466,7 @@ void main() {
       await client.connect();
 
       final first = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "gpt-5.4"),
         variant: const PluginSessionVariant(id: "high"),
@@ -500,7 +500,7 @@ void main() {
       await first;
 
       final second = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: const PluginSessionVariant(id: "high"),
@@ -552,7 +552,7 @@ void main() {
       await client.connect();
 
       final applying = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: const PluginSessionVariant(id: "high"),
@@ -584,7 +584,7 @@ void main() {
       await client.connect();
 
       final selectingHigh = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: const PluginSessionVariant(id: "high"),
@@ -617,7 +617,7 @@ void main() {
       await selectingHigh;
 
       final restoringDefault = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: null,
@@ -646,7 +646,7 @@ void main() {
       await client.connect();
 
       final applying = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "not-a-real-model"),
         variant: null,
@@ -691,7 +691,7 @@ void main() {
       );
 
       await plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "s1",
         model: null,
         variant: null,
@@ -712,7 +712,7 @@ void main() {
       await client.connect();
 
       final applying = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "gpt-5.4"),
         variant: const PluginSessionVariant(id: "not-a-real-effort"),
@@ -743,7 +743,7 @@ void main() {
       await client.connect();
 
       final selecting = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "sA",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: null,
@@ -758,7 +758,7 @@ void main() {
       await selecting;
 
       final defaulting = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "sB",
         model: null,
         variant: null,
@@ -791,7 +791,7 @@ void main() {
       await client.connect();
 
       final a = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "sA",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: null,
@@ -806,7 +806,7 @@ void main() {
       await a;
 
       final b = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "sB",
         model: (providerID: "cursor", modelID: "gpt-5.4"),
         variant: null,
@@ -820,7 +820,7 @@ void main() {
       await b;
 
       final aAgain = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "sA",
         model: null,
         variant: null,
@@ -853,7 +853,7 @@ void main() {
       await client.connect();
 
       final applying = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: null,
@@ -884,7 +884,7 @@ void main() {
       await client.connect();
 
       final a = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "sA",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: null,
@@ -899,7 +899,7 @@ void main() {
       await a;
 
       final b = plugin.applyTurnSelection(
-        client: client,
+        configRepository: AcpSessionConfigRepository(client: client),
         sessionId: "sB",
         model: (providerID: "cursor", modelID: "gpt-5.4"),
         variant: null,
@@ -929,7 +929,7 @@ void main() {
 
       Future<void> applyOnce() async {
         final applying = plugin.applyTurnSelection(
-          client: client,
+          configRepository: AcpSessionConfigRepository(client: client),
           sessionId: "s1",
           model: (providerID: "cursor", modelID: "sonnet-4.6"),
           variant: const PluginSessionVariant(id: "high"),

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -14,6 +14,14 @@ reaches the backend so the turn continues.
   are allowed.
 - Allow once, allow always, and reject each reach the backend with the meaning
   the user chose. Once is never escalated to a broader grant.
+- A plugin advertising ACP form elicitation maps supported string, string-enum,
+  and boolean properties to questions and returns typed content under the
+  backend's original property keys. Reject returns `decline`; abort, process
+  exit, and disposal return `cancel`; unsupported schemas are declined without
+  exposing prompt/default content in diagnostics.
+- A sessionless backend request is attributed only when the plugin can identify
+  one active originating turn. A backend requiring exact form correlation must
+  serialize its prompts rather than displaying the request on another session.
 - Resolving a request retires it in the pending list, on every open surface, and
   in completion-notification suppression.
 - Child or sub-agent requests surface under their display root.
@@ -28,7 +36,7 @@ reaches the backend so the turn continues.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Live plugin, one representative plugin: a permission raised by a real turn appears as pending and one reply lets the turn proceed. |
-| L2 Routine | Live plugin, representative: question variants (single, multiple, custom, reject), per-session and per-project pending listing, repeated or unknown request ids answered without corrupting state. |
+| L2 Routine | Live plugin, representative: question variants (single, multiple, custom, reject), typed ACP scalar forms where supported, unsupported-form decline, abort cancellation, per-session and per-project pending listing, repeated or unknown request ids answered without corrupting state. |
 | L3 Release | Client end to end on the release-target client platform, every supporting production plugin: both request kinds per plugin, per-plugin "always" availability, child attribution, archived-session refusal, and pending requests suppressing completion notifications until resolved. |
 | L4 Extended | Relay integration, every supporting production plugin: per-session empty lists while stopped or terminally failed, project-wide question unavailability with no active plugin, pending state re-read after restart, competing replies to one request, two logical clients observing one request and its retirement, and reconnect inside the replay window. |
 | L5 Full | Headless bridge and live plugin for malformed requests and degenerate option sets; packaged or external on alternate client platforms for an older client omitting the rejection owner and an older bridge not declaring "always". Every supporting production plugin where applicable. |
@@ -47,6 +55,8 @@ different combination than the previous recorded run.
   backend actually offered.
 - An answer does not reach the backend, arrives with a different scope than the
   user chose, or leaves the turn blocked.
+- An ACP form answer changes scalar type, uses a display label instead of the
+  backend value, reaches the wrong session, or remains pending after abort.
 - A resolved request stays visible, keeps suppressing notifications, or returns
   after reconnect.
 - Reading pending state starts an intentionally stopped backend.

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -19,9 +19,10 @@ reaches the backend so the turn continues.
   backend's original property keys. Reject returns `decline`; abort, process
   exit, and disposal return `cancel`; unsupported schemas are declined without
   exposing prompt/default content in diagnostics.
-- A sessionless backend request is attributed only when the plugin can identify
-  one active originating turn. A backend requiring exact form correlation must
-  serialize its prompts rather than displaying the request on another session.
+- A sessionless backend request is attributed to the most recently dispatched
+  active turn, falling back to the last dispatched turn at its settlement
+  boundary. A backend requiring exact form correlation must serialize prompts
+  process-wide so another session cannot become the attribution target.
 - Resolving a request retires it in the pending list, on every open surface, and
   in completion-notification suppression.
 - Child or sub-agent requests surface under their display root.

--- a/docs/regression/session-archiving-and-deletion.md
+++ b/docs/regression/session-archiving-and-deletion.md
@@ -22,6 +22,10 @@ entirely along with its transcript and, optionally, its worktree and branch.
   reconciliation. Worktree and branch cleanup happens only when requested;
   unsafe cleanup (unstaged changes, branch mismatch, shared worktree) is refused
   with its issues and proceeds only on a forced retry.
+- For a backend that advertises session close, deleting an active session first
+  cancels its turn and pending input, waits within a bounded deadline for that
+  session to settle, then closes it before local plugin state is removed. A
+  timeout or close failure remains observable and leaves local state retryable.
 - Cleanup safety rejection happens before mutation. Once cleanup starts, a later
   visible failure can leave an earlier requested step complete, such as a removed
   worktree with its branch still present; retry can finish the residue. The session
@@ -35,7 +39,7 @@ entirely along with its transcript and, optionally, its worktree and branch.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Headless bridge, one representative plugin: a session archives, stays readable, and refuses a later non-deletion mutation. |
-| L2 Routine | Headless bridge, representative: deletion removes the session immediately and purges its history and archive record, with a simulated purge failure logged and recovered by startup reconciliation; export and purge observed as a pair with honest completeness; cleanup rejection issues reported without deleting anything. |
+| L2 Routine | Headless bridge, representative: deletion removes the session immediately and purges its history and archive record, with a simulated purge failure logged and recovered by startup reconciliation; export and purge observed as a pair with honest completeness; cleanup rejection issues reported without deleting anything; a close-capable ACP session orders cancel, settlement, and close, while timeout preserves retryable state. |
 | L3 Release | Client end to end on the release-target client platform, every supporting production plugin: archive from the session list, read-only detail and archived listing, delete with and without worktree/branch cleanup, refusals presented to the user. |
 | L4 Extended | Relay integration, every supporting production plugin: archive or delete with a live turn, pending requests, or a stopped plugin; competing archive/delete/mutation on one family; a second client observing retirement; shared worktree and forced retry; bridge restart between export and flip. |
 | L5 Full | Headless bridge for unreadable or version-mismatched audit records, failed export, startup reconciliation, missing worktrees, and dirty or diverged repositories; packaged or external for released-client unarchive intent. Every supporting production plugin where backend export participates. |
@@ -57,6 +61,8 @@ branches that remain after the asserted cleanup behavior.
   record, or a partial export is recorded as complete.
 - Deletion residue survives startup reconciliation without an observable failure
   and later retry, or cleanup removes a worktree or branch that was not requested.
+- A close-capable backend is closed while its prompt is still settling, emits
+  late events after local removal, or reports timeout/close failure as success.
 - Unsafe cleanup proceeds without a forced retry, a refusal omits the blocking
   issues, partial cleanup is reported as success or deletes the session, a
   concurrent mutation interleaves, or a client presents archiving as reversible.


### PR DESCRIPTION
## Complexity

⚙️ Moderate: this extends the shared ACP request and turn lifecycle while preserving Cursor behavior and adding bounded close coordination.

## What

- Maps standard ACP v1 form elicitations into Sesori questions with typed string, enum, and boolean replies.
- Adds protocol-correct accept, decline, and cancel resolution across reply, abort, exit, and disposal.
- Adds opt-in process-wide prompt serialization and fail-closed selection seams for OMP.
- Replaces the raw selection client hook with a connection-scoped ACP configuration repository.
- Parses `session/close` capability and orders active cancellation, target settlement, close, and local cleanup.
- Updates Cursor consumers in lockstep without changing its selection or elicitation defaults.

## Why

Oh My Pi exposes extension dialogs through standard ACP forms and sends sessionless server requests. The shared ACP layer needs protocol-correct forms, exact correlation hooks, and safe close behavior before the OMP plugin can be added without duplicating transport logic.

## Risk and test focus

Moderate risk in ACP pending-input resolution, turn ordering, selection failure, reconnect behavior, and deletion. Focus on typed form content, decline/cancel cleanup, process-wide versus per-session lanes, close timeout behavior, and unchanged Cursor model/mode/effort selection.

## Expected result

Supporting ACP plugins can opt into form elicitation and exact process-wide request correlation. Close-capable ACP sessions settle before removal. There is no database, persisted-data, client/bridge wire-contract, or client-UI change; Cursor keeps its existing form advertisement and best-effort selection behavior.

## Verification

- `dart analyze --fatal-infos` in `bridge/sesori_plugin_acp/`
- `dart test` in `bridge/sesori_plugin_acp/` — 237 tests
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_cursor/`
- `dart test` in `bridge/sesori_plugin_cursor/` — 126 tests
- `git diff --check`
- Architecture implementation review approved after three ownership/settlement corrections
- Diff: +1,201/-98 = 1,299 changed lines; generated lines: 0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bridges ACP v1 form elicitations to questions with typed replies and correct accept/decline/cancel handling, and adds bounded `session/close`. Enforces explicit backend policy flags while keeping Cursor defaults and the wire/UI unchanged.

- **New Features**
  - Map `elicitation/create` (string, enum, boolean) to questions; decline unsupported schemas with privacy‑safe reasons; attribute sessionless requests only to the active turn.
  - Advertise form support in `initialize` only when enabled.
  - Require ACP adapters to declare backend policies: form support, process‑wide prompt serialization, selection failure mode, and close‑settlement timeout.
  - Add connection‑scoped `AcpSessionConfigRepository` for `session/set_config_option`.
  - Optional process‑wide prompt serialization; per‑session dispatch remains default.
  - Optional fail‑closed selection with retry before the first prompt on empty sessions; prompt failure hook added.
  - Implement `session/close`: cancel active work, await settlement, close, then cleanup; timeout surfaces error and leaves state retryable; queued turns behind a process‑wide lane don’t block deletion.
  - `sesori_plugin_cursor`: switched to the config repository and declares policies; selection and elicitation behavior unchanged.

- **Bug Fixes**
  - Hardened form parsing and resolution: validate schemas and required keys, bound long text, dedupe enum labels, and reject malformed or non‑string `sessionId` values (forms without a resolvable session are cancelled); declines remain privacy‑safe.

<sup>Written for commit 76d5c3792ec507f523075d1918eb678c1c290670. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

