### PR TITLE
🚧 [codex-mobile-login] feat(codex): implement device authentication [step 3/8]

### DIFF
--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -73,7 +73,9 @@
   [PR #827](https://github.com/sesori-ai/sesori_apps_monorepo/pull/827).
 - Step 3: `dart test` passes all 152 plugin-interface tests and all 357 Codex
   plugin tests. `dart analyze --fatal-infos` reports no issues in both packages,
-  and `git diff --check` passes. The required architecture implementation
+  `git diff --check origin/main...HEAD` passes, and
+  `git diff --numstat origin/main...HEAD` reports 850 additions and 27 deletions.
+  The required architecture implementation
   review could not run because the review sub-agent failed before reading code
   with the internal task-store schema error `no such column: replacement_seq`.
   Committed as `36ec1eca`, pushed, and opened as

--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -3,12 +3,12 @@
 ## Current State
 
 - **Plan slug:** `codex-mobile-login`
-- **Series state:** Step 2 PR open; Step 3 in local development
-- **Current step:** 3/8 locally, blocked from publication on Step 2 merge
-- **Implementation base:** `origin/main` at `ea1bc354` (includes Step 1)
+- **Series state:** Steps 1-2 merged; Step 3 ready for publication
+- **Current step:** 3/8
+- **Implementation base:** Step 2 merge commit `67310433`
 - **Plan PR:** [#824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824)
-- **Current PR:** [#827](https://github.com/sesori-ai/sesori_apps_monorepo/pull/827)
-- **Next action:** Monitor Step 2 review/CI and implement Step 3 locally
+- **Current PR:** Pending
+- **Next action:** Publish Step 3 and begin Step 4 locally
 
 ## Plan Review
 
@@ -27,8 +27,8 @@
 | Done | Step | Exact PR title | Changed-line target | State |
 |---|---|---|---:|---|
 | [x] | 1/8 | `🌱 [codex-mobile-login] docs: plan mobile Codex login [step 1/8]` | 450-850 | [PR #824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824) merged |
-| [ ] | 2/8 | `⚙️ [codex-mobile-login] refactor(codex): prepare authentication primitives [step 2/8]` | 850-1,400 | [PR #827](https://github.com/sesori-ai/sesori_apps_monorepo/pull/827) open |
-| [ ] | 3/8 | `🚧 [codex-mobile-login] feat(codex): implement device authentication [step 3/8]` | 850-1,450 | Local development |
+| [x] | 2/8 | `⚙️ [codex-mobile-login] refactor(codex): prepare authentication primitives [step 2/8]` | 850-1,400 | [PR #827](https://github.com/sesori-ai/sesori_apps_monorepo/pull/827) merged |
+| [ ] | 3/8 | `🚧 [codex-mobile-login] feat(codex): implement device authentication [step 3/8]` | 850-1,450 | Ready for publication |
 | [ ] | 4/8 | `⚙️ [codex-mobile-login] feat(protocol): describe harness authentication [step 4/8]` | 650-1,200 | Pending |
 | [ ] | 5/8 | `🚧 [codex-mobile-login] feat(bridge): expose harness authentication [step 5/8]` | 950-1,500 | Pending |
 | [ ] | 6/8 | `🚧 [codex-mobile-login] feat(client): orchestrate harness authentication [step 6/8]` | 900-1,500 | Pending |
@@ -71,6 +71,11 @@
   schema error (`no such column: replacement_seq`). Committed as `3d71e4cf`,
   rebased onto `origin/main`, pushed, and opened as
   [PR #827](https://github.com/sesori-ai/sesori_apps_monorepo/pull/827).
+- Step 3: `dart test` passes all 152 plugin-interface tests and all 357 Codex
+  plugin tests. `dart analyze --fatal-infos` reports no issues in both packages,
+  and `git diff --check` passes. The required architecture implementation
+  review could not run because the review sub-agent failed before reading code
+  with the internal task-store schema error `no such column: replacement_seq`.
 
 ## Findings And Plan Deltas
 
@@ -104,3 +109,8 @@
 - **2026-08-11 - Step 3 started:** Created local branch
   `codex-mobile-login-device-authentication` from the Step 2 PR branch. It
   remains local until Step 2 merges.
+- **2026-08-12 - Step 3 implementation:** Added the optional descriptor
+  capability and safe sealed events, then composed Codex Client/API/Repository/
+  Service ownership with private login-ID correlation, HTTPS validation,
+  abort-driven upstream cancellation, sanitized remote failures, and awaited
+  child cleanup. No route or client capability is exposed yet.

--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -3,12 +3,12 @@
 ## Current State
 
 - **Plan slug:** `codex-mobile-login`
-- **Series state:** Steps 1-2 merged; Step 3 ready for publication
+- **Series state:** Steps 1-2 merged; Step 3 PR open
 - **Current step:** 3/8
 - **Implementation base:** Step 2 merge commit `67310433`
 - **Plan PR:** [#824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824)
-- **Current PR:** Pending
-- **Next action:** Publish Step 3 and begin Step 4 locally
+- **Current PR:** [#833](https://github.com/sesori-ai/sesori_apps_monorepo/pull/833)
+- **Next action:** Monitor Step 3 review/CI and begin Step 4 locally
 
 ## Plan Review
 
@@ -28,7 +28,7 @@
 |---|---|---|---:|---|
 | [x] | 1/8 | `🌱 [codex-mobile-login] docs: plan mobile Codex login [step 1/8]` | 450-850 | [PR #824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824) merged |
 | [x] | 2/8 | `⚙️ [codex-mobile-login] refactor(codex): prepare authentication primitives [step 2/8]` | 850-1,400 | [PR #827](https://github.com/sesori-ai/sesori_apps_monorepo/pull/827) merged |
-| [ ] | 3/8 | `🚧 [codex-mobile-login] feat(codex): implement device authentication [step 3/8]` | 850-1,450 | Ready for publication |
+| [ ] | 3/8 | `🚧 [codex-mobile-login] feat(codex): implement device authentication [step 3/8]` | 850-1,450 | [PR #833](https://github.com/sesori-ai/sesori_apps_monorepo/pull/833) open |
 | [ ] | 4/8 | `⚙️ [codex-mobile-login] feat(protocol): describe harness authentication [step 4/8]` | 650-1,200 | Pending |
 | [ ] | 5/8 | `🚧 [codex-mobile-login] feat(bridge): expose harness authentication [step 5/8]` | 950-1,500 | Pending |
 | [ ] | 6/8 | `🚧 [codex-mobile-login] feat(client): orchestrate harness authentication [step 6/8]` | 900-1,500 | Pending |
@@ -76,6 +76,8 @@
   and `git diff --check` passes. The required architecture implementation
   review could not run because the review sub-agent failed before reading code
   with the internal task-store schema error `no such column: replacement_seq`.
+  Committed as `36ec1eca`, pushed, and opened as
+  [PR #833](https://github.com/sesori-ai/sesori_apps_monorepo/pull/833).
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -3,12 +3,12 @@
 ## Current State
 
 - **Plan slug:** `codex-mobile-login`
-- **Series state:** Step 1 merged; Step 2 PR open
-- **Current step:** 2/8
+- **Series state:** Step 2 PR open; Step 3 in local development
+- **Current step:** 3/8 locally, blocked from publication on Step 2 merge
 - **Implementation base:** `origin/main` at `ea1bc354` (includes Step 1)
 - **Plan PR:** [#824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824)
 - **Current PR:** [#827](https://github.com/sesori-ai/sesori_apps_monorepo/pull/827)
-- **Next action:** Monitor Step 2 review/CI and begin Step 3 locally
+- **Next action:** Monitor Step 2 review/CI and implement Step 3 locally
 
 ## Plan Review
 
@@ -28,7 +28,7 @@
 |---|---|---|---:|---|
 | [x] | 1/8 | `🌱 [codex-mobile-login] docs: plan mobile Codex login [step 1/8]` | 450-850 | [PR #824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824) merged |
 | [ ] | 2/8 | `⚙️ [codex-mobile-login] refactor(codex): prepare authentication primitives [step 2/8]` | 850-1,400 | [PR #827](https://github.com/sesori-ai/sesori_apps_monorepo/pull/827) open |
-| [ ] | 3/8 | `🚧 [codex-mobile-login] feat(codex): implement device authentication [step 3/8]` | 850-1,450 | Pending |
+| [ ] | 3/8 | `🚧 [codex-mobile-login] feat(codex): implement device authentication [step 3/8]` | 850-1,450 | Local development |
 | [ ] | 4/8 | `⚙️ [codex-mobile-login] feat(protocol): describe harness authentication [step 4/8]` | 650-1,200 | Pending |
 | [ ] | 5/8 | `🚧 [codex-mobile-login] feat(bridge): expose harness authentication [step 5/8]` | 950-1,500 | Pending |
 | [ ] | 6/8 | `🚧 [codex-mobile-login] feat(client): orchestrate harness authentication [step 6/8]` | 900-1,500 | Pending |
@@ -101,3 +101,6 @@
   Server transport with bounded child cleanup, and typed account start/cancel/
   completion API models. Existing WebSocket generation behavior remains
   unchanged and no bridge or client capability is exposed yet.
+- **2026-08-11 - Step 3 started:** Created local branch
+  `codex-mobile-login-device-authentication` from the Step 2 PR branch. It
+  remains local until Step 2 merges.

--- a/bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart
@@ -24,13 +24,16 @@ class CodexAppServerApi {
         ),
       );
 
-  Future<CodexDeviceLoginStartResponseDto> startDeviceLogin() async {
+  Future<CodexDeviceLoginStartResponseDto> startDeviceLogin({
+    Duration timeout = const Duration(seconds: 30),
+  }) async {
     const params = CodexDeviceLoginStartParamsDto(
       type: CodexAccountLoginType.chatgptDeviceCode,
     );
     final result = await _client.request(
       method: "account/login/start",
       params: params.toJson(),
+      timeout: timeout,
     );
     return _decodeAccountResponse(
       result: result,
@@ -41,10 +44,12 @@ class CodexAppServerApi {
 
   Future<CodexAccountLoginCancelResponseDto> cancelLogin({
     required String loginId,
+    Duration timeout = const Duration(seconds: 30),
   }) async {
     final result = await _client.request(
       method: "account/login/cancel",
       params: CodexAccountLoginCancelParamsDto(loginId: loginId).toJson(),
+      timeout: timeout,
     );
     return _decodeAccountResponse(
       result: result,

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_authentication_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_authentication_repository.dart
@@ -48,7 +48,10 @@ class CodexAuthenticationRepository {
     _completion = completion;
     _completionSubscription = _appServerApi.accountLoginCompletions.listen(
       (event) {
-        if (event.loginId != _loginId || completion.isCompleted) return;
+        final loginId = _loginId;
+        if (loginId == null || event.loginId != loginId || completion.isCompleted) {
+          return;
+        }
         if (event.success) {
           completion.complete();
         } else {

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_authentication_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_authentication_repository.dart
@@ -1,0 +1,109 @@
+import "dart:async";
+
+import "../api/codex_app_server_api.dart";
+import "../api/models/codex_account_dto.dart";
+
+final class CodexAuthenticationChallenge {
+  const CodexAuthenticationChallenge({
+    required this.verificationUri,
+    required this.userCode,
+  });
+
+  final Uri verificationUri;
+  final String userCode;
+}
+
+final class CodexAuthenticationException implements Exception {
+  const CodexAuthenticationException({
+    required this.message,
+    required this.cause,
+  });
+
+  final String message;
+  final Object? cause;
+
+  @override
+  String toString() => "CodexAuthenticationException: $message";
+}
+
+/// Owns Codex's private login identifier and completion correlation.
+class CodexAuthenticationRepository {
+  CodexAuthenticationRepository({
+    required CodexAppServerApi appServerApi,
+    required Duration requestTimeout,
+  }) : _appServerApi = appServerApi,
+       _requestTimeout = requestTimeout;
+
+  final CodexAppServerApi _appServerApi;
+  final Duration _requestTimeout;
+  StreamSubscription<CodexAccountLoginCompletedNotificationDto>? _completionSubscription;
+  Completer<void>? _completion;
+  String? _loginId;
+
+  Future<CodexAuthenticationChallenge> start() async {
+    if (_completion != null) {
+      throw StateError("Codex authentication already started");
+    }
+    final completion = Completer<void>();
+    _completion = completion;
+    _completionSubscription = _appServerApi.accountLoginCompletions.listen(
+      (event) {
+        if (event.loginId != _loginId || completion.isCompleted) return;
+        if (event.success) {
+          completion.complete();
+        } else {
+          completion.completeError(
+            CodexAuthenticationException(
+              message: "Codex device login did not complete",
+              cause: event.error,
+            ),
+            StackTrace.current,
+          );
+        }
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        if (!completion.isCompleted) {
+          completion.completeError(error, stackTrace);
+        }
+      },
+    );
+
+    final response = await _appServerApi.startDeviceLogin(
+      timeout: _requestTimeout,
+    );
+    _loginId = response.loginId;
+    final verificationUri = Uri.tryParse(response.verificationUrl);
+    if (verificationUri == null || verificationUri.scheme != "https" || verificationUri.host.isEmpty) {
+      throw const CodexAuthenticationException(
+        message: "Codex returned an invalid device verification URL",
+        cause: null,
+      );
+    }
+    return CodexAuthenticationChallenge(
+      verificationUri: verificationUri,
+      userCode: response.userCode,
+    );
+  }
+
+  Future<void> waitForCompletion() {
+    final completion = _completion;
+    if (completion == null) {
+      throw StateError("Codex authentication has not started");
+    }
+    return completion.future;
+  }
+
+  Future<void> cancel() async {
+    final loginId = _loginId;
+    if (loginId == null) return;
+    await _appServerApi.cancelLogin(
+      loginId: loginId,
+      timeout: _requestTimeout,
+    );
+  }
+
+  Future<void> dispose() async {
+    await _completionSubscription?.cancel();
+    _completionSubscription = null;
+  }
+}

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
@@ -404,6 +404,9 @@ class CodexPluginDescriptor extends BridgePluginDescriptor implements Interactiv
           stateDirectory: stateDirectory,
           aborted: aborted,
         );
+    if (aborted.isAborted) {
+      throw const PluginStartAbortedException();
+    }
     if (selection case CodexRuntimeNotSelected()) {
       yield const PluginAuthenticationFailed(
         message: "No supported Codex runtime is available for login.",

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
@@ -8,6 +8,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 import "package:sesori_shared/sesori_shared.dart" show Harness;
 
+import "../api/codex_app_server_api.dart";
 import "../api/codex_rollout_api.dart";
 import "../api/codex_tool_outcome_storage.dart";
 import "../api/parsers/codex_command_execution_parser.dart";
@@ -17,12 +18,15 @@ import "../codex_config_reader.dart";
 import "../codex_event_mapper.dart";
 import "../codex_metadata_repository.dart";
 import "../codex_plugin_impl.dart";
+import "../codex_stdio_app_server_client.dart";
+import "../repositories/codex_authentication_repository.dart";
 import "../repositories/codex_catalog_repository.dart";
 import "../repositories/codex_message_repository.dart";
 import "../repositories/codex_tool_lifecycle_tracker.dart";
 import "../repositories/codex_tool_outcome_repository.dart";
 import "../repositories/mappers/codex_image_attachment_mapper.dart";
 import "../repositories/mappers/codex_rollout_tool_mapper.dart";
+import "../services/codex_authentication_service.dart";
 import "../services/codex_rollout_tailer.dart";
 import "../services/codex_session_service.dart";
 import "codex_bridge_plugin.dart";
@@ -126,7 +130,7 @@ CodexManagedApi _defaultBuildApi({
 ///
 /// The optional constructor parameters are test seams; the registered
 /// descriptor is `const CodexPluginDescriptor()`.
-class CodexPluginDescriptor extends BridgePluginDescriptor {
+class CodexPluginDescriptor extends BridgePluginDescriptor implements InteractivePluginAuthenticationDescriptor {
   const CodexPluginDescriptor({
     CodexManagedApiFactory? buildApi,
     Iterable<int>? candidatePorts,
@@ -378,6 +382,51 @@ class CodexPluginDescriptor extends BridgePluginDescriptor {
       maxCapturedOutputCharactersPerStream: null,
       desktopAppCliCandidates: _desktopAppCliCandidates,
     ).provision(host: host);
+  }
+
+  @override
+  Stream<PluginAuthenticationEvent> authenticate({
+    required PluginConfig config,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+    required String stateDirectory,
+    required StartAbortSignal aborted,
+  }) async* {
+    final selection =
+        await CodexRuntimeSelectionService(
+          processes: processes,
+          versionProbeTimeout: _versionProbeTimeout,
+          maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
+          desktopAppCliCandidates: _desktopAppCliCandidates,
+        ).select(
+          config: config,
+          environment: environment,
+          stateDirectory: stateDirectory,
+          aborted: aborted,
+        );
+    if (selection case CodexRuntimeNotSelected()) {
+      yield const PluginAuthenticationFailed(
+        message: "No supported Codex runtime is available for login.",
+      );
+      return;
+    }
+
+    final client = CodexStdioAppServerClient(
+      processes: processes,
+      executable: (selection as CodexRuntimeSelected).binaryPath,
+      environment: environment,
+      shutdownTimeout: codexGracefulShutdownWait,
+    );
+    final api = CodexAppServerApi(client: client);
+    yield* CodexAuthenticationService(
+      client: client,
+      repository: CodexAuthenticationRepository(
+        appServerApi: api,
+        requestTimeout: _versionProbeTimeout,
+      ),
+      aborted: aborted,
+      requestTimeout: _versionProbeTimeout,
+    ).authenticate();
   }
 
   String _normalizedStatusOutput(CommandResult result) {

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_authentication_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_authentication_service.dart
@@ -36,7 +36,19 @@ class CodexAuthenticationService {
         verificationUri: challenge.verificationUri,
         userCode: challenge.userCode,
       );
-      await _abortable(_repository.waitForCompletion());
+      await _abortable(
+        Future.any<void>([
+          _repository.waitForCompletion(),
+          _client.processExit.then<void>((exitCode) {
+            throw CodexAuthenticationException(
+              message: "Codex App Server exited during device login",
+              cause: StateError(
+                "Codex App Server exited with code $exitCode",
+              ),
+            );
+          }),
+        ]),
+      );
       yield const PluginAuthenticationCompleted();
     } on PluginStartAbortedException {
       rethrow;

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_authentication_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_authentication_service.dart
@@ -1,0 +1,75 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../codex_stdio_app_server_client.dart";
+import "../repositories/codex_authentication_repository.dart";
+
+class CodexAuthenticationService {
+  CodexAuthenticationService({
+    required CodexStdioAppServerClient client,
+    required CodexAuthenticationRepository repository,
+    required StartAbortSignal aborted,
+    required Duration requestTimeout,
+  }) : _client = client,
+       _repository = repository,
+       _aborted = aborted,
+       _requestTimeout = requestTimeout;
+
+  final CodexStdioAppServerClient _client;
+  final CodexAuthenticationRepository _repository;
+  final StartAbortSignal _aborted;
+  final Duration _requestTimeout;
+  late final Future<Never> _abort = _abortOperation();
+
+  Stream<PluginAuthenticationEvent> authenticate() async* {
+    try {
+      await _abortable(
+        _client.connect(
+          clientName: "sesori-bridge",
+          clientVersion: "0.0.0",
+          timeout: _requestTimeout,
+        ),
+      );
+      final challenge = await _abortable(_repository.start());
+      yield PluginAuthenticationDeviceCodeChallenge(
+        verificationUri: challenge.verificationUri,
+        userCode: challenge.userCode,
+      );
+      await _abortable(_repository.waitForCompletion());
+      yield const PluginAuthenticationCompleted();
+    } on PluginStartAbortedException {
+      rethrow;
+    } on Object catch (error, stackTrace) {
+      final localError = error is CodexAuthenticationException ? error.cause ?? error : error;
+      Log.w("[codex] device authentication failed", localError, stackTrace);
+      yield const PluginAuthenticationFailed(
+        message: "Codex login could not be completed. Retry the login flow.",
+      );
+    } finally {
+      await _repository.dispose();
+      await _client.dispose();
+    }
+  }
+
+  Future<T> _abortable<T>(Future<T> work) {
+    if (_aborted.isAborted) {
+      return Future<T>.error(const PluginStartAbortedException());
+    }
+    return Future.any<T>([
+      work,
+      _abort,
+    ]);
+  }
+
+  Future<Never> _abortOperation() async {
+    await _aborted.whenAborted;
+    try {
+      await _repository.cancel();
+    } on Object catch (error, stackTrace) {
+      Log.w("[codex] failed to cancel device authentication", error, stackTrace);
+    }
+    await _client.dispose();
+    throw const PluginStartAbortedException();
+  }
+}

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_authentication_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_authentication_service.dart
@@ -40,6 +40,9 @@ class CodexAuthenticationService {
         Future.any<void>([
           _repository.waitForCompletion(),
           _client.processExit.then<void>((exitCode) {
+            if (_aborted.isAborted) {
+              throw const PluginStartAbortedException();
+            }
             throw CodexAuthenticationException(
               message: "Codex App Server exited during device login",
               cause: StateError(

--- a/bridge/sesori_plugin_codex/test/codex_authentication_repository_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_authentication_repository_test.dart
@@ -8,13 +8,20 @@ import "package:test/test.dart";
 void main() {
   group("CodexAuthenticationRepository", () {
     test("retains the login id and ignores unrelated completions", () async {
-      final transport = _AuthenticationTransport();
+      final startResponse = Completer<void>();
+      final transport = _AuthenticationTransport(
+        startResponse: startResponse.future,
+      );
       final repository = CodexAuthenticationRepository(
         appServerApi: CodexAppServerApi(client: transport),
         requestTimeout: const Duration(seconds: 2),
       );
 
-      final challenge = await repository.start();
+      final challengeFuture = repository.start();
+      await _eventLoop();
+      transport.complete(loginId: null, success: true);
+      startResponse.complete();
+      final challenge = await challengeFuture;
       expect(challenge.verificationUri, Uri.https("auth.example", "/device"));
       expect(challenge.userCode, "PRIVATE-CODE");
 
@@ -100,9 +107,11 @@ Future<void> _eventLoop() => Future<void>.delayed(Duration.zero);
 class _AuthenticationTransport implements CodexAppServerTransport {
   _AuthenticationTransport({
     this.verificationUrl = "https://auth.example/device",
+    this.startResponse,
   });
 
   final String verificationUrl;
+  final Future<void>? startResponse;
   final StreamController<CodexServerNotification> _notifications =
       StreamController<CodexServerNotification>.broadcast();
   final List<String> cancelLoginIds = <String>[];
@@ -119,6 +128,7 @@ class _AuthenticationTransport implements CodexAppServerTransport {
   }) async {
     timeouts.add(timeout);
     if (method == "account/login/start") {
+      await startResponse;
       return {
         "type": "chatgptDeviceCode",
         "loginId": "private-login",
@@ -131,7 +141,7 @@ class _AuthenticationTransport implements CodexAppServerTransport {
   }
 
   void complete({
-    required String loginId,
+    required String? loginId,
     required bool success,
     String? error,
   }) {

--- a/bridge/sesori_plugin_codex/test/codex_authentication_repository_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_authentication_repository_test.dart
@@ -1,0 +1,145 @@
+import "dart:async";
+
+import "package:codex_plugin/src/api/codex_app_server_api.dart";
+import "package:codex_plugin/src/codex_app_server_client.dart";
+import "package:codex_plugin/src/repositories/codex_authentication_repository.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("CodexAuthenticationRepository", () {
+    test("retains the login id and ignores unrelated completions", () async {
+      final transport = _AuthenticationTransport();
+      final repository = CodexAuthenticationRepository(
+        appServerApi: CodexAppServerApi(client: transport),
+        requestTimeout: const Duration(seconds: 2),
+      );
+
+      final challenge = await repository.start();
+      expect(challenge.verificationUri, Uri.https("auth.example", "/device"));
+      expect(challenge.userCode, "PRIVATE-CODE");
+
+      var completed = false;
+      unawaited(
+        repository.waitForCompletion().then((_) {
+          completed = true;
+        }),
+      );
+      transport.complete(loginId: "stale-login", success: true);
+      await _eventLoop();
+      expect(completed, isFalse);
+
+      transport.complete(loginId: "private-login", success: true);
+      await repository.waitForCompletion();
+      expect(completed, isTrue);
+      await repository.dispose();
+    });
+
+    test("preserves an upstream completion failure as the cause", () async {
+      final transport = _AuthenticationTransport();
+      final repository = CodexAuthenticationRepository(
+        appServerApi: CodexAppServerApi(client: transport),
+        requestTimeout: const Duration(seconds: 2),
+      );
+      await repository.start();
+
+      transport.complete(
+        loginId: "private-login",
+        success: false,
+        error: "private workspace policy detail",
+      );
+
+      await expectLater(
+        repository.waitForCompletion(),
+        throwsA(
+          isA<CodexAuthenticationException>().having(
+            (error) => error.cause,
+            "cause",
+            "private workspace policy detail",
+          ),
+        ),
+      );
+      await repository.dispose();
+    });
+
+    test("cancels only with the retained private login id", () async {
+      final transport = _AuthenticationTransport();
+      final repository = CodexAuthenticationRepository(
+        appServerApi: CodexAppServerApi(client: transport),
+        requestTimeout: const Duration(seconds: 2),
+      );
+
+      await repository.cancel();
+      await repository.start();
+      await repository.cancel();
+
+      expect(transport.cancelLoginIds, ["private-login"]);
+      expect(transport.timeouts, everyElement(const Duration(seconds: 2)));
+      await repository.dispose();
+    });
+
+    test("rejects a non-HTTPS verification URL", () async {
+      final transport = _AuthenticationTransport(
+        verificationUrl: "http://auth.example/device",
+      );
+      final repository = CodexAuthenticationRepository(
+        appServerApi: CodexAppServerApi(client: transport),
+        requestTimeout: const Duration(seconds: 2),
+      );
+
+      await expectLater(
+        repository.start(),
+        throwsA(isA<CodexAuthenticationException>()),
+      );
+      await repository.dispose();
+    });
+  });
+}
+
+Future<void> _eventLoop() => Future<void>.delayed(Duration.zero);
+
+class _AuthenticationTransport implements CodexAppServerTransport {
+  _AuthenticationTransport({
+    this.verificationUrl = "https://auth.example/device",
+  });
+
+  final String verificationUrl;
+  final StreamController<CodexServerNotification> _notifications =
+      StreamController<CodexServerNotification>.broadcast();
+  final List<String> cancelLoginIds = <String>[];
+  final List<Duration> timeouts = <Duration>[];
+
+  @override
+  Stream<CodexServerNotification> get notifications => _notifications.stream;
+
+  @override
+  Future<dynamic> request({
+    required String method,
+    Object? params,
+    Duration timeout = const Duration(seconds: 30),
+  }) async {
+    timeouts.add(timeout);
+    if (method == "account/login/start") {
+      return {
+        "type": "chatgptDeviceCode",
+        "loginId": "private-login",
+        "verificationUrl": verificationUrl,
+        "userCode": "PRIVATE-CODE",
+      };
+    }
+    cancelLoginIds.add((params! as Map<String, dynamic>)["loginId"]! as String);
+    return {"status": "canceled"};
+  }
+
+  void complete({
+    required String loginId,
+    required bool success,
+    String? error,
+  }) {
+    _notifications.add(
+      CodexServerNotification(
+        method: "account/login/completed",
+        params: {"loginId": loginId, "success": success, "error": error},
+      ),
+    );
+  }
+}

--- a/bridge/sesori_plugin_codex/test/codex_authentication_service_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_authentication_service_test.dart
@@ -1,0 +1,205 @@
+import "dart:async";
+
+import "package:codex_plugin/src/codex_app_server_client.dart";
+import "package:codex_plugin/src/codex_stdio_app_server_client.dart";
+import "package:codex_plugin/src/repositories/codex_authentication_repository.dart";
+import "package:codex_plugin/src/services/codex_authentication_service.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("CodexAuthenticationService", () {
+    test("emits a challenge then completion and cleans up", () async {
+      final client = _FakeStdioClient();
+      final repository = _FakeAuthenticationRepository();
+      final service = CodexAuthenticationService(
+        client: client,
+        repository: repository,
+        aborted: StartAbortSignal.never,
+        requestTimeout: const Duration(seconds: 2),
+      );
+
+      final events = service.authenticate().toList();
+      await repository.started;
+      repository.complete();
+
+      expect(
+        await events,
+        [
+          isA<PluginAuthenticationDeviceCodeChallenge>()
+              .having(
+                (event) => event.verificationUri,
+                "verificationUri",
+                Uri.https("auth.example", "/device"),
+              )
+              .having((event) => event.userCode, "userCode", "PRIVATE-CODE"),
+          isA<PluginAuthenticationCompleted>(),
+        ],
+      );
+      expect(repository.disposed, isTrue);
+      expect(client.disposed, isTrue);
+    });
+
+    test("aborts, cancels upstream, and cleans up", () async {
+      final client = _FakeStdioClient();
+      final repository = _FakeAuthenticationRepository();
+      final abort = StartAbortController();
+      final service = CodexAuthenticationService(
+        client: client,
+        repository: repository,
+        aborted: abort.signal,
+        requestTimeout: const Duration(seconds: 2),
+      );
+      final events = service.authenticate().toList();
+      await repository.started;
+
+      abort.abort();
+
+      await expectLater(
+        events,
+        throwsA(isA<PluginStartAbortedException>()),
+      );
+      expect(repository.cancelled, isTrue);
+      expect(repository.disposed, isTrue);
+      expect(client.disposed, isTrue);
+    });
+
+    test("sanitizes repository failures and cleans up", () async {
+      final client = _FakeStdioClient();
+      final repository = _FakeAuthenticationRepository();
+      final service = CodexAuthenticationService(
+        client: client,
+        repository: repository,
+        aborted: StartAbortSignal.never,
+        requestTimeout: const Duration(seconds: 2),
+      );
+      final events = service.authenticate().toList();
+      await repository.started;
+      await Future<void>.delayed(Duration.zero);
+      repository.fail("private workspace policy detail");
+
+      final result = await events;
+      expect(
+        result.last,
+        isA<PluginAuthenticationFailed>().having(
+          (event) => event.message,
+          "message",
+          isNot(contains("private workspace policy detail")),
+        ),
+      );
+      expect(repository.disposed, isTrue);
+      expect(client.disposed, isTrue);
+    });
+
+    test("sanitizes child connection failures and cleans up", () async {
+      final client = _FakeStdioClient(
+        connectError: StateError("private child process detail"),
+      );
+      final repository = _FakeAuthenticationRepository();
+      final service = CodexAuthenticationService(
+        client: client,
+        repository: repository,
+        aborted: StartAbortSignal.never,
+        requestTimeout: const Duration(seconds: 2),
+      );
+
+      final events = await service.authenticate().toList();
+
+      expect(events, hasLength(1));
+      expect(
+        events.single,
+        isA<PluginAuthenticationFailed>().having(
+          (event) => event.message,
+          "message",
+          isNot(contains("private child process detail")),
+        ),
+      );
+      expect(repository.disposed, isTrue);
+      expect(client.disposed, isTrue);
+    });
+  });
+}
+
+class _FakeAuthenticationRepository implements CodexAuthenticationRepository {
+  final Completer<void> _started = Completer<void>();
+  final Completer<void> _completion = Completer<void>();
+  bool cancelled = false;
+  bool disposed = false;
+
+  Future<void> get started => _started.future;
+
+  @override
+  Future<CodexAuthenticationChallenge> start() async {
+    _started.complete();
+    return CodexAuthenticationChallenge(
+      verificationUri: Uri.https("auth.example", "/device"),
+      userCode: "PRIVATE-CODE",
+    );
+  }
+
+  @override
+  Future<void> waitForCompletion() => _completion.future;
+
+  void complete() => _completion.complete();
+
+  void fail(String detail) => _completion.completeError(
+    CodexAuthenticationException(
+      message: "Codex device login did not complete",
+      cause: detail,
+    ),
+  );
+
+  @override
+  Future<void> cancel() async {
+    cancelled = true;
+  }
+
+  @override
+  Future<void> dispose() async {
+    disposed = true;
+  }
+}
+
+class _FakeStdioClient implements CodexStdioAppServerClient {
+  _FakeStdioClient({this.connectError});
+
+  final Object? connectError;
+  bool disposed = false;
+
+  @override
+  Future<CodexInitializeResult> connect({
+    required String clientName,
+    required String clientVersion,
+    required Duration timeout,
+  }) async {
+    final error = connectError;
+    if (error != null) throw error;
+    return const CodexInitializeResult(
+      userAgent: "codex_cli_rs/0.146.0",
+      codexHome: "/private/codex-home",
+      platformOs: "macos",
+      platformFamily: "unix",
+    );
+  }
+
+  @override
+  Future<void> dispose() async {
+    disposed = true;
+  }
+
+  @override
+  Stream<CodexServerNotification> get notifications => const Stream.empty();
+
+  @override
+  Future<int> get processExit => Completer<int>().future;
+
+  @override
+  Future<dynamic> request({
+    required String method,
+    Object? params,
+    Duration timeout = const Duration(seconds: 30),
+  }) => throw UnimplementedError();
+
+  @override
+  Stream<CodexServerRequest> get serverRequests => const Stream.empty();
+}

--- a/bridge/sesori_plugin_codex/test/codex_authentication_service_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_authentication_service_test.dart
@@ -117,6 +117,28 @@ void main() {
       expect(repository.disposed, isTrue);
       expect(client.disposed, isTrue);
     });
+
+    test("settles with failure when the child exits after challenge", () async {
+      final client = _FakeStdioClient();
+      final repository = _FakeAuthenticationRepository();
+      final service = CodexAuthenticationService(
+        client: client,
+        repository: repository,
+        aborted: StartAbortSignal.never,
+        requestTimeout: const Duration(seconds: 2),
+      );
+      final events = service.authenticate().toList();
+      await repository.started;
+      await Future<void>.delayed(Duration.zero);
+
+      client.exit(7);
+
+      final result = await events.timeout(const Duration(milliseconds: 100));
+      expect(result.first, isA<PluginAuthenticationDeviceCodeChallenge>());
+      expect(result.last, isA<PluginAuthenticationFailed>());
+      expect(repository.disposed, isTrue);
+      expect(client.disposed, isTrue);
+    });
   });
 }
 
@@ -164,6 +186,7 @@ class _FakeStdioClient implements CodexStdioAppServerClient {
   _FakeStdioClient({this.connectError});
 
   final Object? connectError;
+  final Completer<int> _exit = Completer<int>();
   bool disposed = false;
 
   @override
@@ -187,11 +210,13 @@ class _FakeStdioClient implements CodexStdioAppServerClient {
     disposed = true;
   }
 
+  void exit(int code) => _exit.complete(code);
+
   @override
   Stream<CodexServerNotification> get notifications => const Stream.empty();
 
   @override
-  Future<int> get processExit => Completer<int>().future;
+  Future<int> get processExit => _exit.future;
 
   @override
   Future<dynamic> request({

--- a/bridge/sesori_plugin_codex/test/codex_authentication_service_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_authentication_service_test.dart
@@ -64,6 +64,37 @@ void main() {
       expect(client.disposed, isTrue);
     });
 
+    test("preserves abort while child exits during cancellation", () async {
+      final client = _FakeStdioClient();
+      final cancelGate = Completer<void>();
+      final repository = _FakeAuthenticationRepository(
+        cancelGate: cancelGate.future,
+      );
+      final abort = StartAbortController();
+      final service = CodexAuthenticationService(
+        client: client,
+        repository: repository,
+        aborted: abort.signal,
+        requestTimeout: const Duration(seconds: 2),
+      );
+      final events = service.authenticate().toList();
+      await repository.started;
+      await Future<void>.delayed(Duration.zero);
+
+      abort.abort();
+      await Future<void>.delayed(Duration.zero);
+      client.exit(7);
+
+      await expectLater(
+        events,
+        throwsA(isA<PluginStartAbortedException>()),
+      );
+      cancelGate.complete();
+      expect(repository.cancelled, isTrue);
+      expect(repository.disposed, isTrue);
+      expect(client.disposed, isTrue);
+    });
+
     test("sanitizes repository failures and cleans up", () async {
       final client = _FakeStdioClient();
       final repository = _FakeAuthenticationRepository();
@@ -143,6 +174,9 @@ void main() {
 }
 
 class _FakeAuthenticationRepository implements CodexAuthenticationRepository {
+  _FakeAuthenticationRepository({this.cancelGate});
+
+  final Future<void>? cancelGate;
   final Completer<void> _started = Completer<void>();
   final Completer<void> _completion = Completer<void>();
   bool cancelled = false;
@@ -174,6 +208,7 @@ class _FakeAuthenticationRepository implements CodexAuthenticationRepository {
   @override
   Future<void> cancel() async {
     cancelled = true;
+    await cancelGate;
   }
 
   @override

--- a/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
@@ -16,6 +16,10 @@ void main() {
     test("declares project-scoped session options", () {
       expect(const CodexPluginDescriptor().sessionOptionsScope, PluginSessionOptionsScope.project);
       expect(const CodexPluginDescriptor().supportsPromptAttachments, isTrue);
+      expect(
+        const CodexPluginDescriptor(),
+        isA<InteractivePluginAuthenticationDescriptor>(),
+      );
     });
 
     test("advertises install without an explicit binary override", () {
@@ -139,14 +143,15 @@ void main() {
         ],
       );
 
-      final result = await const CodexPluginDescriptor(
-        desktopAppCliCandidates: [appCli],
-      ).inspectSetup(
-        config: config,
-        processes: processes,
-        environment: const <String, String>{},
-        stateDirectory: stateDirectory,
-      );
+      final result =
+          await const CodexPluginDescriptor(
+            desktopAppCliCandidates: [appCli],
+          ).inspectSetup(
+            config: config,
+            processes: processes,
+            environment: const <String, String>{},
+            stateDirectory: stateDirectory,
+          );
 
       expect(result, const PluginSetupReady());
       expect(processes.spawnedExecutables, ["codex", appCli, appCli]);
@@ -177,14 +182,15 @@ void main() {
         ],
       );
 
-      final result = await const CodexPluginDescriptor(
-        desktopAppCliCandidates: [appCli],
-      ).inspectSetup(
-        config: config,
-        processes: processes,
-        environment: const <String, String>{},
-        stateDirectory: stateDirectory,
-      );
+      final result =
+          await const CodexPluginDescriptor(
+            desktopAppCliCandidates: [appCli],
+          ).inspectSetup(
+            config: config,
+            processes: processes,
+            environment: const <String, String>{},
+            stateDirectory: stateDirectory,
+          );
 
       expect(result, const PluginSetupReady());
       expect(processes.spawnedExecutables, ["codex", appCli, managedBinaryPath, managedBinaryPath]);

--- a/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:convert";
 import "dart:io";
 
@@ -211,6 +212,33 @@ void main() {
       expect(result, isA<PluginSetupRuntimeMissing>());
     });
 
+    test("authentication preserves abort after runtime selection", () async {
+      final processes = _ProbeProcessService(
+        processSequence: [
+          _ProbeProcess(
+            pid: 10,
+            stdoutBytes: utf8.encode("codex 0.100.0\n"),
+            exitCode: Future<int>.value(0),
+          ),
+        ],
+      );
+
+      await expectLater(
+        descriptor
+            .authenticate(
+              config: const PluginConfig(
+                values: {"port": null, "bin": "/custom/codex"},
+              ),
+              processes: processes,
+              environment: const <String, String>{},
+              stateDirectory: stateDirectory,
+              aborted: _AbortOnThirdCheck(),
+            )
+            .toList(),
+        throwsA(isA<PluginStartAbortedException>()),
+      );
+    });
+
     test("reports an outdated explicitly configured runtime as unavailable", () async {
       const explicitConfig = PluginConfig(
         values: {"port": null, "bin": "/custom/codex"},
@@ -403,4 +431,14 @@ class _ProbeProcess implements SpawnedProcess {
 
   @override
   ProcessIdentity get identity => throw UnimplementedError();
+}
+
+class _AbortOnThirdCheck implements StartAbortSignal {
+  int _checks = 0;
+
+  @override
+  bool get isAborted => ++_checks >= 3;
+
+  @override
+  Future<void> get whenAborted => Completer<void>().future;
 }

--- a/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
+++ b/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
@@ -10,6 +10,7 @@ export "src/host/plugin_host.dart";
 export "src/lifecycle/bridge_plugin.dart";
 export "src/lifecycle/bridge_plugin_descriptor.dart";
 export "src/lifecycle/plugin_activation_policy.dart";
+export "src/lifecycle/plugin_authentication.dart";
 export "src/lifecycle/plugin_authentication_required_exception.dart";
 export "src/lifecycle/plugin_config.dart";
 export "src/lifecycle/plugin_control_capability.dart";

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_authentication.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_authentication.dart
@@ -1,0 +1,43 @@
+import "../host/host_process_service.dart";
+import "plugin_config.dart";
+import "start_abort_signal.dart";
+
+/// Optional descriptor capability for an interactive backend login flow.
+abstract interface class InteractivePluginAuthenticationDescriptor {
+  /// Starts one plugin-owned authentication operation.
+  ///
+  /// The first actionable event is a challenge. The plugin must release every
+  /// process and subscription it owns before the stream completes or errors.
+  /// Aborting settles with `PluginStartAbortedException` after cleanup.
+  Stream<PluginAuthenticationEvent> authenticate({
+    required PluginConfig config,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+    required String stateDirectory,
+    required StartAbortSignal aborted,
+  });
+}
+
+sealed class PluginAuthenticationEvent {
+  const PluginAuthenticationEvent();
+}
+
+final class PluginAuthenticationDeviceCodeChallenge extends PluginAuthenticationEvent {
+  const PluginAuthenticationDeviceCodeChallenge({
+    required this.verificationUri,
+    required this.userCode,
+  });
+
+  final Uri verificationUri;
+  final String userCode;
+}
+
+final class PluginAuthenticationCompleted extends PluginAuthenticationEvent {
+  const PluginAuthenticationCompleted();
+}
+
+final class PluginAuthenticationFailed extends PluginAuthenticationEvent {
+  const PluginAuthenticationFailed({required this.message});
+
+  final String message;
+}

--- a/bridge/sesori_plugin_interface/test/lifecycle/plugin_authentication_test.dart
+++ b/bridge/sesori_plugin_interface/test/lifecycle/plugin_authentication_test.dart
@@ -1,0 +1,35 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("authentication events expose only variant-specific safe data", () {
+    final events = <PluginAuthenticationEvent>[
+      PluginAuthenticationDeviceCodeChallenge(
+        verificationUri: Uri.https("auth.example", "/device"),
+        userCode: "CODE",
+      ),
+      const PluginAuthenticationCompleted(),
+      const PluginAuthenticationFailed(message: "Sanitized failure"),
+    ];
+
+    expect(
+      events[0],
+      isA<PluginAuthenticationDeviceCodeChallenge>()
+          .having(
+            (event) => event.verificationUri,
+            "verificationUri",
+            Uri.https("auth.example", "/device"),
+          )
+          .having((event) => event.userCode, "userCode", "CODE"),
+    );
+    expect(events[1], isA<PluginAuthenticationCompleted>());
+    expect(
+      events[2],
+      isA<PluginAuthenticationFailed>().having(
+        (event) => event.message,
+        "message",
+        "Sanitized failure",
+      ),
+    );
+  });
+}

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -24,6 +24,9 @@ idle suspension, the management snapshot, and lifecycle commands.
 - A busy harness conflicts explicitly, forcing needs confirmation and is sent once, the
   snapshot changes only on real content change with a new token, and a terminal failure
   removes only that harness's routing and new-session choice.
+- Interactive authentication is optional per descriptor. A capable harness owns its
+  backend process and credentials, exposes only a safe challenge and sanitized terminal
+  state, cancels cooperatively, and settles process cleanup before the operation ends.
 
 ## Regression Levels
 
@@ -57,8 +60,9 @@ directories. Restore eligibility, timeouts, and sessions afterwards.
 
 - The harness set comes from the current registry; unregistered in-development harnesses
   are out of scope, and no lifecycle path installs a runtime.
-- Backend authentication happens on the bridge machine and ends this scope, and a forced
-  disable leaves work interrupted.
+- Backend authentication and credential persistence happen on the bridge machine; the
+  released management route and client presentation remain outside this document until
+  their planned steps land. A forced disable leaves work interrupted.
 - Idle windows are minutes-order, so observing a real elapse belongs at L4 or above.
 
 ## Sources


### PR DESCRIPTION
## Complexity

🚧 Complex. This adds a cross-package optional capability plus an authentication state machine that owns backend subprocess cleanup, cancellation, privacy boundaries, and typed completion correlation.

## What

- Add an optional descriptor authentication capability with sealed safe challenge/completed/failed events.
- Add Codex authentication repository and service layers over the stdio App Server primitives.
- Keep the private login ID and raw upstream failure inside the Codex plugin while emitting only the verification URI, user code, and sanitized terminal state.
- Compose device authentication from `CodexPluginDescriptor` using the same executable selection and bridge environment as setup and startup.
- Add regression coverage for stale completion IDs, HTTPS validation, cancellation, failure sanitization, child failure, cleanup, and capability presence.

## Why

Authentication-required Codex setup cannot acquire the normal live plugin API. The descriptor therefore needs a narrow optional flow that can authenticate through a short-lived local App Server before Codex becomes routable, without leaking backend concepts into shared bridge orchestration.

## Risk and test focus

Risk is high because this is security-sensitive subprocess and authentication lifecycle code. Focus review on private login-ID containment, challenge/error logging, abort races, upstream cancellation, process cleanup before stream settlement, stale notification filtering, and preserving backend-neutral interface contracts.

## Expected result

No user-visible, route, database, or persisted-data change. The Codex descriptor can perform device authentication through the optional plugin seam; no bridge/client consumer invokes it yet.

## Verification

- `dart test` in `bridge/sesori_plugin_interface` (152 tests passed)
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_interface`
- `dart test` in `bridge/sesori_plugin_codex` (357 tests passed)
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_codex`
- `git diff --check`
- Architecture implementation review was attempted, but the review sub-agent failed before reading code with internal task-store error `no such column: replacement_seq`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional device authentication for Codex via the `CodexPluginDescriptor`. Streams a device-code challenge, validates HTTPS, cancels on abort, and cleanly settles interrupted logins; no client routes are exposed yet.

- **New Features**
  - Added `InteractivePluginAuthenticationDescriptor` to `sesori_plugin_interface` (exported); `CodexPluginDescriptor` implements it and runs auth via the stdio App Server.
  - Introduced `CodexAuthenticationService` and `CodexAuthenticationRepository` in `sesori_plugin_codex` to own login flow, completion correlation, and cleanup; fails clearly if no supported runtime is available.
  - Emits only safe events: challenge (`verificationUri`, `userCode`), completed, failed (sanitized message); enforces HTTPS and keeps the private login ID internal.
  - Added timeouts to `startDeviceLogin` and `cancelLogin` in `CodexAppServerApi`; cooperative abort cancels upstream and shuts down.
  - Added tests for repository/service flows (stale completion IDs, cancellation, failure sanitization, cleanup); updated regression docs and the plan tracker.

- **Bug Fixes**
  - Settles interrupted device logins as failed when the App Server exits mid-flow and preserves upstream cancellation on abort even if the App Server exits during cancellation, ensuring the stream completes and resources are cleaned up.

<sup>Written for commit 13e6b4a6c97c78b3389593f4b87116ae988139d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

