### PR TITLE
⚙️ [codex-mobile-login] feat(protocol): describe harness authentication [step 4/8]

### DIFF
--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -86,7 +86,7 @@
   app. The required architecture implementation review could not run because
   the review sub-agent failed before reading code with the internal task-store
   schema error `no such column: replacement_seq`. `git diff --check
-  origin/main...HEAD` passes, and `git diff --numstat origin/main...HEAD` reports 905
+  origin/main...HEAD` passes, and `git diff --numstat origin/main...HEAD` reports 976
   additions and 25 deletions. Committed as `0b418a3a`, pushed, and opened as
   [PR #834](https://github.com/sesori-ai/sesori_apps_monorepo/pull/834).
 

--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -86,7 +86,7 @@
   app. The required architecture implementation review could not run because
   the review sub-agent failed before reading code with the internal task-store
   schema error `no such column: replacement_seq`. `git diff --check
-  origin/main` passes, and `git diff --numstat origin/main` reports 905
+  origin/main...HEAD` passes, and `git diff --numstat origin/main...HEAD` reports 905
   additions and 25 deletions. Committed as `0b418a3a`, pushed, and opened as
   [PR #834](https://github.com/sesori-ai/sesori_apps_monorepo/pull/834).
 

--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -3,12 +3,12 @@
 ## Current State
 
 - **Plan slug:** `codex-mobile-login`
-- **Series state:** Step 3 merged; Step 4 in local development
-- **Current step:** 4/8 locally
+- **Series state:** Step 4 PR open
+- **Current step:** 4/8 in review
 - **Implementation base:** Step 3 merge commit `3af28a81`
 - **Plan PR:** [#824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824)
-- **Current PR:** None; Step 4 is being verified locally
-- **Next action:** Verify and publish Step 4
+- **Current PR:** [#834](https://github.com/sesori-ai/sesori_apps_monorepo/pull/834)
+- **Next action:** Monitor Step 4 review/CI and implement Step 5 locally
 
 ## Plan Review
 
@@ -29,7 +29,7 @@
 | [x] | 1/8 | `🌱 [codex-mobile-login] docs: plan mobile Codex login [step 1/8]` | 450-850 | [PR #824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824) merged |
 | [x] | 2/8 | `⚙️ [codex-mobile-login] refactor(codex): prepare authentication primitives [step 2/8]` | 850-1,400 | [PR #827](https://github.com/sesori-ai/sesori_apps_monorepo/pull/827) merged |
 | [x] | 3/8 | `🚧 [codex-mobile-login] feat(codex): implement device authentication [step 3/8]` | 850-1,450 | [PR #833](https://github.com/sesori-ai/sesori_apps_monorepo/pull/833) merged |
-| [ ] | 4/8 | `⚙️ [codex-mobile-login] feat(protocol): describe harness authentication [step 4/8]` | 650-1,200 | Local development |
+| [ ] | 4/8 | `⚙️ [codex-mobile-login] feat(protocol): describe harness authentication [step 4/8]` | 650-1,200 | [PR #834](https://github.com/sesori-ai/sesori_apps_monorepo/pull/834) open |
 | [ ] | 5/8 | `🚧 [codex-mobile-login] feat(bridge): expose harness authentication [step 5/8]` | 950-1,500 | Pending |
 | [ ] | 6/8 | `🚧 [codex-mobile-login] feat(client): orchestrate harness authentication [step 6/8]` | 900-1,500 | Pending |
 | [ ] | 7/8 | `⚙️ [codex-mobile-login] feat(app): add mobile Codex login [step 7/8]` | 750-1,350 | Pending |
@@ -87,7 +87,8 @@
   the review sub-agent failed before reading code with the internal task-store
   schema error `no such column: replacement_seq`. `git diff --check
   origin/main` passes, and `git diff --numstat origin/main` reports 905
-  additions and 25 deletions.
+  additions and 25 deletions. Committed as `0b418a3a`, pushed, and opened as
+  [PR #834](https://github.com/sesori-ai/sesori_apps_monorepo/pull/834).
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -3,12 +3,12 @@
 ## Current State
 
 - **Plan slug:** `codex-mobile-login`
-- **Series state:** Steps 1-2 merged; Step 3 PR open
-- **Current step:** 3/8
+- **Series state:** Step 3 PR open; Step 4 in local development
+- **Current step:** 4/8 locally, blocked from publication on Step 3 merge
 - **Implementation base:** Step 2 merge commit `67310433`
 - **Plan PR:** [#824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824)
 - **Current PR:** [#833](https://github.com/sesori-ai/sesori_apps_monorepo/pull/833)
-- **Next action:** Monitor Step 3 review/CI and begin Step 4 locally
+- **Next action:** Monitor Step 3 review/CI and implement Step 4 locally
 
 ## Plan Review
 
@@ -29,7 +29,7 @@
 | [x] | 1/8 | `🌱 [codex-mobile-login] docs: plan mobile Codex login [step 1/8]` | 450-850 | [PR #824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824) merged |
 | [x] | 2/8 | `⚙️ [codex-mobile-login] refactor(codex): prepare authentication primitives [step 2/8]` | 850-1,400 | [PR #827](https://github.com/sesori-ai/sesori_apps_monorepo/pull/827) merged |
 | [ ] | 3/8 | `🚧 [codex-mobile-login] feat(codex): implement device authentication [step 3/8]` | 850-1,450 | [PR #833](https://github.com/sesori-ai/sesori_apps_monorepo/pull/833) open |
-| [ ] | 4/8 | `⚙️ [codex-mobile-login] feat(protocol): describe harness authentication [step 4/8]` | 650-1,200 | Pending |
+| [ ] | 4/8 | `⚙️ [codex-mobile-login] feat(protocol): describe harness authentication [step 4/8]` | 650-1,200 | Local development |
 | [ ] | 5/8 | `🚧 [codex-mobile-login] feat(bridge): expose harness authentication [step 5/8]` | 950-1,500 | Pending |
 | [ ] | 6/8 | `🚧 [codex-mobile-login] feat(client): orchestrate harness authentication [step 6/8]` | 900-1,500 | Pending |
 | [ ] | 7/8 | `⚙️ [codex-mobile-login] feat(app): add mobile Codex login [step 7/8]` | 750-1,350 | Pending |
@@ -118,3 +118,6 @@
   Service ownership with private login-ID correlation, HTTPS validation,
   abort-driven upstream cancellation, sanitized remote failures, and awaited
   child cleanup. No route or client capability is exposed yet.
+- **2026-08-12 - Step 4 started:** Created local branch
+  `codex-mobile-login-shared-contracts` from the Step 3 PR branch. It remains
+  local until Step 3 merges.

--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -3,12 +3,12 @@
 ## Current State
 
 - **Plan slug:** `codex-mobile-login`
-- **Series state:** Step 3 PR open; Step 4 in local development
-- **Current step:** 4/8 locally, blocked from publication on Step 3 merge
-- **Implementation base:** Step 2 merge commit `67310433`
+- **Series state:** Step 3 merged; Step 4 in local development
+- **Current step:** 4/8 locally
+- **Implementation base:** Step 3 merge commit `3af28a81`
 - **Plan PR:** [#824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824)
-- **Current PR:** [#833](https://github.com/sesori-ai/sesori_apps_monorepo/pull/833)
-- **Next action:** Monitor Step 3 review/CI and implement Step 4 locally
+- **Current PR:** None; Step 4 is being verified locally
+- **Next action:** Verify and publish Step 4
 
 ## Plan Review
 
@@ -28,7 +28,7 @@
 |---|---|---|---:|---|
 | [x] | 1/8 | `🌱 [codex-mobile-login] docs: plan mobile Codex login [step 1/8]` | 450-850 | [PR #824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824) merged |
 | [x] | 2/8 | `⚙️ [codex-mobile-login] refactor(codex): prepare authentication primitives [step 2/8]` | 850-1,400 | [PR #827](https://github.com/sesori-ai/sesori_apps_monorepo/pull/827) merged |
-| [ ] | 3/8 | `🚧 [codex-mobile-login] feat(codex): implement device authentication [step 3/8]` | 850-1,450 | [PR #833](https://github.com/sesori-ai/sesori_apps_monorepo/pull/833) open |
+| [x] | 3/8 | `🚧 [codex-mobile-login] feat(codex): implement device authentication [step 3/8]` | 850-1,450 | [PR #833](https://github.com/sesori-ai/sesori_apps_monorepo/pull/833) merged |
 | [ ] | 4/8 | `⚙️ [codex-mobile-login] feat(protocol): describe harness authentication [step 4/8]` | 650-1,200 | Local development |
 | [ ] | 5/8 | `🚧 [codex-mobile-login] feat(bridge): expose harness authentication [step 5/8]` | 950-1,500 | Pending |
 | [ ] | 6/8 | `🚧 [codex-mobile-login] feat(client): orchestrate harness authentication [step 6/8]` | 900-1,500 | Pending |
@@ -80,6 +80,14 @@
   with the internal task-store schema error `no such column: replacement_seq`.
   Committed as `36ec1eca`, pushed, and opened as
   [PR #833](https://github.com/sesori-ai/sesori_apps_monorepo/pull/833).
+- Step 4: Full `sesori_shared` tests pass (389 tests), focused client SSE
+  classification tests pass, and fatal-info analysis reports no issues in
+  `sesori_shared`, bridge app, client core, desktop core, mobile app, or desktop
+  app. The required architecture implementation review could not run because
+  the review sub-agent failed before reading code with the internal task-store
+  schema error `no such column: replacement_seq`. `git diff --check
+  origin/main` passes, and `git diff --numstat origin/main` reports 905
+  additions and 25 deletions.
 
 ## Findings And Plan Deltas
 
@@ -121,3 +129,9 @@
 - **2026-08-12 - Step 4 started:** Created local branch
   `codex-mobile-login-shared-contracts` from the Step 3 PR branch. It remains
   local until Step 3 merges.
+- **2026-08-12 - Step 3 merged:** Rebased Step 4 onto merge commit `3af28a81`
+  after PR #833 merged with cancellation-precedence review fixes.
+- **2026-08-12 - Step 4 implementation:** Added backend-neutral authentication
+  capability/state metadata, typed device-code challenge, sealed terminal
+  progress, typed conflicts, and one global progress SSE event. Challenge data
+  remains request-scoped and absent from management snapshots and SSE.

--- a/client/module_core/lib/src/capabilities/server_connection/models/sse_event.dart
+++ b/client/module_core/lib/src/capabilities/server_connection/models/sse_event.dart
@@ -38,6 +38,7 @@ class SseEvent {
     SesoriCatalogImportProgress() ||
     SesoriPluginManagementChanged() ||
     SesoriPluginInstallProgress() ||
+    SesoriPluginAuthenticationProgress() ||
     SesoriCommandCatalogUpdated() ||
     SesoriPtyCreated() ||
     SesoriPtyUpdated() ||

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -829,6 +829,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
       SesoriCatalogImportProgress() ||
       SesoriPluginManagementChanged() ||
       SesoriPluginInstallProgress() ||
+      SesoriPluginAuthenticationProgress() ||
       SesoriSessionsUpdated() ||
       SesoriSessionDeleted() ||
       SesoriSessionDiff() ||
@@ -912,6 +913,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
             SesoriCatalogImportProgress() ||
             SesoriPluginManagementChanged() ||
             SesoriPluginInstallProgress() ||
+            SesoriPluginAuthenticationProgress() ||
             SesoriSessionsUpdated() ||
             SesoriMessageUpdated() ||
             SesoriMessageRemoved() ||

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -122,6 +122,7 @@ class SessionListCubit extends Cubit<SessionListState> {
             SesoriCatalogImportProgress() ||
             SesoriPluginManagementChanged() ||
             SesoriPluginInstallProgress() ||
+            SesoriPluginAuthenticationProgress() ||
             SesoriCommandCatalogUpdated() ||
             SesoriSessionDiff() ||
             SesoriSessionError() ||

--- a/client/module_core/lib/src/services/sse_event_tracker.dart
+++ b/client/module_core/lib/src/services/sse_event_tracker.dart
@@ -106,6 +106,7 @@ class SseEventTracker with Disposable {
             SesoriCatalogImportProgress() ||
             SesoriPluginManagementChanged() ||
             SesoriPluginInstallProgress() ||
+            SesoriPluginAuthenticationProgress() ||
             SesoriCommandCatalogUpdated() ||
             SesoriSessionDiff() ||
             SesoriSessionError() ||

--- a/client/module_core/test/capabilities/server_connection/models/sse_event_test.dart
+++ b/client/module_core/test/capabilities/server_connection/models/sse_event_test.dart
@@ -37,4 +37,16 @@ void main() {
     expect(event.sessionId, isNull);
     expect(event.data, isNot(isA<SesoriSessionEvent>()));
   });
+
+  test("pluginAuthenticationProgress is a global plugin event", () {
+    final event = SseEvent(
+      data: const SesoriSseEvent.pluginAuthenticationProgress(
+        pluginId: "codex",
+        progress: PluginAuthenticationProgress.completed(),
+      ),
+    );
+
+    expect(event.sessionId, isNull);
+    expect(event.data, isNot(isA<SesoriSessionEvent>()));
+  });
 }

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -27,6 +27,9 @@ idle suspension, the management snapshot, and lifecycle commands.
 - Interactive authentication is optional per descriptor. A capable harness owns its
   backend process and credentials, exposes only a safe challenge and sanitized terminal
   state, cancels cooperatively, and settles process cleanup before the operation ends.
+- Shared management metadata advertises authentication independently and reports idle,
+  in-progress, or fail-closed unknown state. Device-code challenges remain request-scoped;
+  only sealed completed, failed, or cancelled progress enters the global SSE stream.
 
 ## Regression Levels
 
@@ -53,6 +56,9 @@ directories. Restore eligibility, timeouts, and sessions afterwards.
   snapshot tokens that miss real changes.
 - A control offered for an undeclared capability, a supported control missing, a busy
   harness accepting a safe command, or idle suspension on a resident or busy harness.
+- A missing authentication state from an older bridge decoding as anything but idle, a
+  future state or conflict reason failing open, challenge data entering snapshots/SSE, or
+  a failed progress payload without its required sanitized message.
 - One failing harness taking down the rest of the bridge, or an empty picker
   instead of the explicit no-harness state when none is usable.
 

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.dart
@@ -99,7 +99,13 @@ sealed class PluginAuthenticationChallengeResponse with _$PluginAuthenticationCh
   }
 }
 
-@Freezed(unionKey: "type", fromJson: true, toJson: true, copyWith: false)
+@Freezed(
+  unionKey: "type",
+  fallbackUnion: "unknown",
+  fromJson: true,
+  toJson: true,
+  copyWith: false,
+)
 sealed class PluginAuthenticationProgress with _$PluginAuthenticationProgress {
   @FreezedUnionValue("completed")
   const factory PluginAuthenticationProgress.completed() = PluginAuthenticationCompletedProgress;
@@ -111,6 +117,8 @@ sealed class PluginAuthenticationProgress with _$PluginAuthenticationProgress {
 
   @FreezedUnionValue("cancelled")
   const factory PluginAuthenticationProgress.cancelled() = PluginAuthenticationCancelledProgress;
+
+  const factory PluginAuthenticationProgress.unknown() = PluginAuthenticationUnknownProgress;
 
   factory PluginAuthenticationProgress.fromJson(Map<String, dynamic> json) =>
       _$PluginAuthenticationProgressFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.dart
@@ -42,7 +42,9 @@ enum PluginRuntimeState {
 
 enum PluginManagementWorkState { idle, busy, unknown }
 
-enum PluginManagementCapability { lifecycle, setupRefresh, idleTimeout, install, unknown }
+enum PluginManagementCapability { lifecycle, setupRefresh, idleTimeout, install, authentication, unknown }
+
+enum PluginAuthenticationState { idle, inProgress, unknown }
 
 enum PluginStopMode { safe, force }
 
@@ -52,12 +54,22 @@ enum PluginInstallPhase { downloading, verifying, extracting, finalizing, comple
 
 enum PluginLifecycleConflictReason { inFlight, busy, workStateUnknown, transitioning, notEnabled, unsupported, unknown }
 
+enum PluginAuthenticationConflictReason { inFlight, setupNotRequired, unsupported, unknown }
+
+enum PluginAuthenticationChallengeType { deviceCode }
+
 @Freezed(fromJson: true, toJson: true)
 sealed class PluginManagementMetadata with _$PluginManagementMetadata {
   const factory PluginManagementMetadata({
     required PluginSetupMetadata setup,
     @JsonKey(unknownEnumValue: PluginRuntimeState.unknown) required PluginRuntimeState runtimeState,
     @JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) required PluginManagementWorkState workState,
+    // COMPATIBILITY 2026-08-12 (v1.9.0): Older bridge payloads omit
+    // authenticationState, which honestly means no authentication operation
+    // was active. Remove @Default after the minimum supported bridge sends it.
+    @JsonKey(unknownEnumValue: PluginAuthenticationState.unknown)
+    @Default(PluginAuthenticationState.idle)
+    PluginAuthenticationState authenticationState,
     required int idleTimeoutMins,
     required bool hasIdleTimeoutOverride,
     @JsonKey(unknownEnumValue: PluginManagementCapability.unknown)
@@ -66,6 +78,42 @@ sealed class PluginManagementMetadata with _$PluginManagementMetadata {
   }) = _PluginManagementMetadata;
 
   factory PluginManagementMetadata.fromJson(Map<String, dynamic> json) => _$PluginManagementMetadataFromJson(json);
+}
+
+@Freezed(unionKey: "type", fromJson: true, toJson: true, copyWith: false)
+sealed class PluginAuthenticationChallengeResponse with _$PluginAuthenticationChallengeResponse {
+  @FreezedUnionValue("deviceCode")
+  const factory PluginAuthenticationChallengeResponse.deviceCode({
+    @Default(PluginAuthenticationChallengeType.deviceCode) PluginAuthenticationChallengeType type,
+    required String verificationUrl,
+    required String userCode,
+  }) = PluginAuthenticationDeviceCodeChallengeResponse;
+
+  factory PluginAuthenticationChallengeResponse.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    if (json["type"] != "deviceCode") {
+      throw const FormatException("Unsupported plugin authentication challenge type");
+    }
+    return _$PluginAuthenticationChallengeResponseFromJson(json);
+  }
+}
+
+@Freezed(unionKey: "type", fromJson: true, toJson: true, copyWith: false)
+sealed class PluginAuthenticationProgress with _$PluginAuthenticationProgress {
+  @FreezedUnionValue("completed")
+  const factory PluginAuthenticationProgress.completed() = PluginAuthenticationCompletedProgress;
+
+  @FreezedUnionValue("failed")
+  const factory PluginAuthenticationProgress.failed({
+    required String message,
+  }) = PluginAuthenticationFailedProgress;
+
+  @FreezedUnionValue("cancelled")
+  const factory PluginAuthenticationProgress.cancelled() = PluginAuthenticationCancelledProgress;
+
+  factory PluginAuthenticationProgress.fromJson(Map<String, dynamic> json) =>
+      _$PluginAuthenticationProgressFromJson(json);
 }
 
 @Freezed(fromJson: true, toJson: true)
@@ -154,4 +202,17 @@ sealed class PluginLifecycleConflict with _$PluginLifecycleConflict {
   }) = _PluginLifecycleConflict;
 
   factory PluginLifecycleConflict.fromJson(Map<String, dynamic> json) => _$PluginLifecycleConflictFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: true)
+sealed class PluginAuthenticationConflict with _$PluginAuthenticationConflict {
+  const factory PluginAuthenticationConflict({
+    required String pluginId,
+    @JsonKey(unknownEnumValue: PluginAuthenticationConflictReason.unknown)
+    required List<PluginAuthenticationConflictReason> reasons,
+    required PluginManagementMetadata current,
+  }) = _PluginAuthenticationConflict;
+
+  factory PluginAuthenticationConflict.fromJson(Map<String, dynamic> json) =>
+      _$PluginAuthenticationConflictFromJson(json);
 }

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.freezed.dart
@@ -289,11 +289,8 @@ PluginAuthenticationProgress _$PluginAuthenticationProgressFromJson(
           );
         
           default:
-            throw CheckedFromJsonException(
-  json,
-  'type',
-  'PluginAuthenticationProgress',
-  'Invalid union type "${json['type']}"!'
+            return PluginAuthenticationUnknownProgress.fromJson(
+  json
 );
         }
       
@@ -438,6 +435,45 @@ int get hashCode => runtimeType.hashCode;
 @override
 String toString() {
   return 'PluginAuthenticationProgress.cancelled()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class PluginAuthenticationUnknownProgress implements PluginAuthenticationProgress {
+  const PluginAuthenticationUnknownProgress({final  String? $type}): $type = $type ?? 'unknown';
+  factory PluginAuthenticationUnknownProgress.fromJson(Map<String, dynamic> json) => _$PluginAuthenticationUnknownProgressFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PluginAuthenticationUnknownProgressToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationUnknownProgress);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'PluginAuthenticationProgress.unknown()';
 }
 
 

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.freezed.dart
@@ -15,7 +15,10 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$PluginManagementMetadata {
 
- PluginSetupMetadata get setup;@JsonKey(unknownEnumValue: PluginRuntimeState.unknown) PluginRuntimeState get runtimeState;@JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) PluginManagementWorkState get workState; int get idleTimeoutMins; bool get hasIdleTimeoutOverride;@JsonKey(unknownEnumValue: PluginManagementCapability.unknown) Set<PluginManagementCapability> get managementCapabilities; String? get actionHint;
+ PluginSetupMetadata get setup;@JsonKey(unknownEnumValue: PluginRuntimeState.unknown) PluginRuntimeState get runtimeState;@JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) PluginManagementWorkState get workState;// COMPATIBILITY 2026-08-12 (v1.9.0): Older bridge payloads omit
+// authenticationState, which honestly means no authentication operation
+// was active. Remove @Default after the minimum supported bridge sends it.
+@JsonKey(unknownEnumValue: PluginAuthenticationState.unknown) PluginAuthenticationState get authenticationState; int get idleTimeoutMins; bool get hasIdleTimeoutOverride;@JsonKey(unknownEnumValue: PluginManagementCapability.unknown) Set<PluginManagementCapability> get managementCapabilities; String? get actionHint;
 /// Create a copy of PluginManagementMetadata
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +31,16 @@ $PluginManagementMetadataCopyWith<PluginManagementMetadata> get copyWith => _$Pl
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginManagementMetadata&&(identical(other.setup, setup) || other.setup == setup)&&(identical(other.runtimeState, runtimeState) || other.runtimeState == runtimeState)&&(identical(other.workState, workState) || other.workState == workState)&&(identical(other.idleTimeoutMins, idleTimeoutMins) || other.idleTimeoutMins == idleTimeoutMins)&&(identical(other.hasIdleTimeoutOverride, hasIdleTimeoutOverride) || other.hasIdleTimeoutOverride == hasIdleTimeoutOverride)&&const DeepCollectionEquality().equals(other.managementCapabilities, managementCapabilities)&&(identical(other.actionHint, actionHint) || other.actionHint == actionHint));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginManagementMetadata&&(identical(other.setup, setup) || other.setup == setup)&&(identical(other.runtimeState, runtimeState) || other.runtimeState == runtimeState)&&(identical(other.workState, workState) || other.workState == workState)&&(identical(other.authenticationState, authenticationState) || other.authenticationState == authenticationState)&&(identical(other.idleTimeoutMins, idleTimeoutMins) || other.idleTimeoutMins == idleTimeoutMins)&&(identical(other.hasIdleTimeoutOverride, hasIdleTimeoutOverride) || other.hasIdleTimeoutOverride == hasIdleTimeoutOverride)&&const DeepCollectionEquality().equals(other.managementCapabilities, managementCapabilities)&&(identical(other.actionHint, actionHint) || other.actionHint == actionHint));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,setup,runtimeState,workState,idleTimeoutMins,hasIdleTimeoutOverride,const DeepCollectionEquality().hash(managementCapabilities),actionHint);
+int get hashCode => Object.hash(runtimeType,setup,runtimeState,workState,authenticationState,idleTimeoutMins,hasIdleTimeoutOverride,const DeepCollectionEquality().hash(managementCapabilities),actionHint);
 
 @override
 String toString() {
-  return 'PluginManagementMetadata(setup: $setup, runtimeState: $runtimeState, workState: $workState, idleTimeoutMins: $idleTimeoutMins, hasIdleTimeoutOverride: $hasIdleTimeoutOverride, managementCapabilities: $managementCapabilities, actionHint: $actionHint)';
+  return 'PluginManagementMetadata(setup: $setup, runtimeState: $runtimeState, workState: $workState, authenticationState: $authenticationState, idleTimeoutMins: $idleTimeoutMins, hasIdleTimeoutOverride: $hasIdleTimeoutOverride, managementCapabilities: $managementCapabilities, actionHint: $actionHint)';
 }
 
 
@@ -48,7 +51,7 @@ abstract mixin class $PluginManagementMetadataCopyWith<$Res>  {
   factory $PluginManagementMetadataCopyWith(PluginManagementMetadata value, $Res Function(PluginManagementMetadata) _then) = _$PluginManagementMetadataCopyWithImpl;
 @useResult
 $Res call({
- PluginSetupMetadata setup,@JsonKey(unknownEnumValue: PluginRuntimeState.unknown) PluginRuntimeState runtimeState,@JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) PluginManagementWorkState workState, int idleTimeoutMins, bool hasIdleTimeoutOverride,@JsonKey(unknownEnumValue: PluginManagementCapability.unknown) Set<PluginManagementCapability> managementCapabilities, String? actionHint
+ PluginSetupMetadata setup,@JsonKey(unknownEnumValue: PluginRuntimeState.unknown) PluginRuntimeState runtimeState,@JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) PluginManagementWorkState workState,@JsonKey(unknownEnumValue: PluginAuthenticationState.unknown) PluginAuthenticationState authenticationState, int idleTimeoutMins, bool hasIdleTimeoutOverride,@JsonKey(unknownEnumValue: PluginManagementCapability.unknown) Set<PluginManagementCapability> managementCapabilities, String? actionHint
 });
 
 
@@ -65,12 +68,13 @@ class _$PluginManagementMetadataCopyWithImpl<$Res>
 
 /// Create a copy of PluginManagementMetadata
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? setup = null,Object? runtimeState = null,Object? workState = null,Object? idleTimeoutMins = null,Object? hasIdleTimeoutOverride = null,Object? managementCapabilities = null,Object? actionHint = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? setup = null,Object? runtimeState = null,Object? workState = null,Object? authenticationState = null,Object? idleTimeoutMins = null,Object? hasIdleTimeoutOverride = null,Object? managementCapabilities = null,Object? actionHint = freezed,}) {
   return _then(_self.copyWith(
 setup: null == setup ? _self.setup : setup // ignore: cast_nullable_to_non_nullable
 as PluginSetupMetadata,runtimeState: null == runtimeState ? _self.runtimeState : runtimeState // ignore: cast_nullable_to_non_nullable
 as PluginRuntimeState,workState: null == workState ? _self.workState : workState // ignore: cast_nullable_to_non_nullable
-as PluginManagementWorkState,idleTimeoutMins: null == idleTimeoutMins ? _self.idleTimeoutMins : idleTimeoutMins // ignore: cast_nullable_to_non_nullable
+as PluginManagementWorkState,authenticationState: null == authenticationState ? _self.authenticationState : authenticationState // ignore: cast_nullable_to_non_nullable
+as PluginAuthenticationState,idleTimeoutMins: null == idleTimeoutMins ? _self.idleTimeoutMins : idleTimeoutMins // ignore: cast_nullable_to_non_nullable
 as int,hasIdleTimeoutOverride: null == hasIdleTimeoutOverride ? _self.hasIdleTimeoutOverride : hasIdleTimeoutOverride // ignore: cast_nullable_to_non_nullable
 as bool,managementCapabilities: null == managementCapabilities ? _self.managementCapabilities : managementCapabilities // ignore: cast_nullable_to_non_nullable
 as Set<PluginManagementCapability>,actionHint: freezed == actionHint ? _self.actionHint : actionHint // ignore: cast_nullable_to_non_nullable
@@ -95,12 +99,16 @@ $PluginSetupMetadataCopyWith<$Res> get setup {
 @JsonSerializable()
 
 class _PluginManagementMetadata implements PluginManagementMetadata {
-  const _PluginManagementMetadata({required this.setup, @JsonKey(unknownEnumValue: PluginRuntimeState.unknown) required this.runtimeState, @JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) required this.workState, required this.idleTimeoutMins, required this.hasIdleTimeoutOverride, @JsonKey(unknownEnumValue: PluginManagementCapability.unknown) required final  Set<PluginManagementCapability> managementCapabilities, required this.actionHint}): _managementCapabilities = managementCapabilities;
+  const _PluginManagementMetadata({required this.setup, @JsonKey(unknownEnumValue: PluginRuntimeState.unknown) required this.runtimeState, @JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) required this.workState, @JsonKey(unknownEnumValue: PluginAuthenticationState.unknown) this.authenticationState = PluginAuthenticationState.idle, required this.idleTimeoutMins, required this.hasIdleTimeoutOverride, @JsonKey(unknownEnumValue: PluginManagementCapability.unknown) required final  Set<PluginManagementCapability> managementCapabilities, required this.actionHint}): _managementCapabilities = managementCapabilities;
   factory _PluginManagementMetadata.fromJson(Map<String, dynamic> json) => _$PluginManagementMetadataFromJson(json);
 
 @override final  PluginSetupMetadata setup;
 @override@JsonKey(unknownEnumValue: PluginRuntimeState.unknown) final  PluginRuntimeState runtimeState;
 @override@JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) final  PluginManagementWorkState workState;
+// COMPATIBILITY 2026-08-12 (v1.9.0): Older bridge payloads omit
+// authenticationState, which honestly means no authentication operation
+// was active. Remove @Default after the minimum supported bridge sends it.
+@override@JsonKey(unknownEnumValue: PluginAuthenticationState.unknown) final  PluginAuthenticationState authenticationState;
 @override final  int idleTimeoutMins;
 @override final  bool hasIdleTimeoutOverride;
  final  Set<PluginManagementCapability> _managementCapabilities;
@@ -125,16 +133,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginManagementMetadata&&(identical(other.setup, setup) || other.setup == setup)&&(identical(other.runtimeState, runtimeState) || other.runtimeState == runtimeState)&&(identical(other.workState, workState) || other.workState == workState)&&(identical(other.idleTimeoutMins, idleTimeoutMins) || other.idleTimeoutMins == idleTimeoutMins)&&(identical(other.hasIdleTimeoutOverride, hasIdleTimeoutOverride) || other.hasIdleTimeoutOverride == hasIdleTimeoutOverride)&&const DeepCollectionEquality().equals(other._managementCapabilities, _managementCapabilities)&&(identical(other.actionHint, actionHint) || other.actionHint == actionHint));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginManagementMetadata&&(identical(other.setup, setup) || other.setup == setup)&&(identical(other.runtimeState, runtimeState) || other.runtimeState == runtimeState)&&(identical(other.workState, workState) || other.workState == workState)&&(identical(other.authenticationState, authenticationState) || other.authenticationState == authenticationState)&&(identical(other.idleTimeoutMins, idleTimeoutMins) || other.idleTimeoutMins == idleTimeoutMins)&&(identical(other.hasIdleTimeoutOverride, hasIdleTimeoutOverride) || other.hasIdleTimeoutOverride == hasIdleTimeoutOverride)&&const DeepCollectionEquality().equals(other._managementCapabilities, _managementCapabilities)&&(identical(other.actionHint, actionHint) || other.actionHint == actionHint));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,setup,runtimeState,workState,idleTimeoutMins,hasIdleTimeoutOverride,const DeepCollectionEquality().hash(_managementCapabilities),actionHint);
+int get hashCode => Object.hash(runtimeType,setup,runtimeState,workState,authenticationState,idleTimeoutMins,hasIdleTimeoutOverride,const DeepCollectionEquality().hash(_managementCapabilities),actionHint);
 
 @override
 String toString() {
-  return 'PluginManagementMetadata(setup: $setup, runtimeState: $runtimeState, workState: $workState, idleTimeoutMins: $idleTimeoutMins, hasIdleTimeoutOverride: $hasIdleTimeoutOverride, managementCapabilities: $managementCapabilities, actionHint: $actionHint)';
+  return 'PluginManagementMetadata(setup: $setup, runtimeState: $runtimeState, workState: $workState, authenticationState: $authenticationState, idleTimeoutMins: $idleTimeoutMins, hasIdleTimeoutOverride: $hasIdleTimeoutOverride, managementCapabilities: $managementCapabilities, actionHint: $actionHint)';
 }
 
 
@@ -145,7 +153,7 @@ abstract mixin class _$PluginManagementMetadataCopyWith<$Res> implements $Plugin
   factory _$PluginManagementMetadataCopyWith(_PluginManagementMetadata value, $Res Function(_PluginManagementMetadata) _then) = __$PluginManagementMetadataCopyWithImpl;
 @override @useResult
 $Res call({
- PluginSetupMetadata setup,@JsonKey(unknownEnumValue: PluginRuntimeState.unknown) PluginRuntimeState runtimeState,@JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) PluginManagementWorkState workState, int idleTimeoutMins, bool hasIdleTimeoutOverride,@JsonKey(unknownEnumValue: PluginManagementCapability.unknown) Set<PluginManagementCapability> managementCapabilities, String? actionHint
+ PluginSetupMetadata setup,@JsonKey(unknownEnumValue: PluginRuntimeState.unknown) PluginRuntimeState runtimeState,@JsonKey(unknownEnumValue: PluginManagementWorkState.unknown) PluginManagementWorkState workState,@JsonKey(unknownEnumValue: PluginAuthenticationState.unknown) PluginAuthenticationState authenticationState, int idleTimeoutMins, bool hasIdleTimeoutOverride,@JsonKey(unknownEnumValue: PluginManagementCapability.unknown) Set<PluginManagementCapability> managementCapabilities, String? actionHint
 });
 
 
@@ -162,12 +170,13 @@ class __$PluginManagementMetadataCopyWithImpl<$Res>
 
 /// Create a copy of PluginManagementMetadata
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? setup = null,Object? runtimeState = null,Object? workState = null,Object? idleTimeoutMins = null,Object? hasIdleTimeoutOverride = null,Object? managementCapabilities = null,Object? actionHint = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? setup = null,Object? runtimeState = null,Object? workState = null,Object? authenticationState = null,Object? idleTimeoutMins = null,Object? hasIdleTimeoutOverride = null,Object? managementCapabilities = null,Object? actionHint = freezed,}) {
   return _then(_PluginManagementMetadata(
 setup: null == setup ? _self.setup : setup // ignore: cast_nullable_to_non_nullable
 as PluginSetupMetadata,runtimeState: null == runtimeState ? _self.runtimeState : runtimeState // ignore: cast_nullable_to_non_nullable
 as PluginRuntimeState,workState: null == workState ? _self.workState : workState // ignore: cast_nullable_to_non_nullable
-as PluginManagementWorkState,idleTimeoutMins: null == idleTimeoutMins ? _self.idleTimeoutMins : idleTimeoutMins // ignore: cast_nullable_to_non_nullable
+as PluginManagementWorkState,authenticationState: null == authenticationState ? _self.authenticationState : authenticationState // ignore: cast_nullable_to_non_nullable
+as PluginAuthenticationState,idleTimeoutMins: null == idleTimeoutMins ? _self.idleTimeoutMins : idleTimeoutMins // ignore: cast_nullable_to_non_nullable
 as int,hasIdleTimeoutOverride: null == hasIdleTimeoutOverride ? _self.hasIdleTimeoutOverride : hasIdleTimeoutOverride // ignore: cast_nullable_to_non_nullable
 as bool,managementCapabilities: null == managementCapabilities ? _self._managementCapabilities : managementCapabilities // ignore: cast_nullable_to_non_nullable
 as Set<PluginManagementCapability>,actionHint: freezed == actionHint ? _self.actionHint : actionHint // ignore: cast_nullable_to_non_nullable
@@ -186,6 +195,256 @@ $PluginSetupMetadataCopyWith<$Res> get setup {
   });
 }
 }
+
+PluginAuthenticationChallengeResponse _$PluginAuthenticationChallengeResponseFromJson(
+  Map<String, dynamic> json
+) {
+    return PluginAuthenticationDeviceCodeChallengeResponse.fromJson(
+      json
+    );
+}
+
+/// @nodoc
+mixin _$PluginAuthenticationChallengeResponse {
+
+ PluginAuthenticationChallengeType get type; String get verificationUrl; String get userCode;
+
+  /// Serializes this PluginAuthenticationChallengeResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationChallengeResponse&&(identical(other.type, type) || other.type == type)&&(identical(other.verificationUrl, verificationUrl) || other.verificationUrl == verificationUrl)&&(identical(other.userCode, userCode) || other.userCode == userCode));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type,verificationUrl,userCode);
+
+@override
+String toString() {
+  return 'PluginAuthenticationChallengeResponse(type: $type, verificationUrl: $verificationUrl, userCode: $userCode)';
+}
+
+
+}
+
+
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class PluginAuthenticationDeviceCodeChallengeResponse implements PluginAuthenticationChallengeResponse {
+  const PluginAuthenticationDeviceCodeChallengeResponse({this.type = PluginAuthenticationChallengeType.deviceCode, required this.verificationUrl, required this.userCode});
+  factory PluginAuthenticationDeviceCodeChallengeResponse.fromJson(Map<String, dynamic> json) => _$PluginAuthenticationDeviceCodeChallengeResponseFromJson(json);
+
+@override@JsonKey() final  PluginAuthenticationChallengeType type;
+@override final  String verificationUrl;
+@override final  String userCode;
+
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PluginAuthenticationDeviceCodeChallengeResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationDeviceCodeChallengeResponse&&(identical(other.type, type) || other.type == type)&&(identical(other.verificationUrl, verificationUrl) || other.verificationUrl == verificationUrl)&&(identical(other.userCode, userCode) || other.userCode == userCode));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type,verificationUrl,userCode);
+
+@override
+String toString() {
+  return 'PluginAuthenticationChallengeResponse.deviceCode(type: $type, verificationUrl: $verificationUrl, userCode: $userCode)';
+}
+
+
+}
+
+
+
+
+PluginAuthenticationProgress _$PluginAuthenticationProgressFromJson(
+  Map<String, dynamic> json
+) {
+        switch (json['type']) {
+                  case 'completed':
+          return PluginAuthenticationCompletedProgress.fromJson(
+            json
+          );
+                case 'failed':
+          return PluginAuthenticationFailedProgress.fromJson(
+            json
+          );
+                case 'cancelled':
+          return PluginAuthenticationCancelledProgress.fromJson(
+            json
+          );
+        
+          default:
+            throw CheckedFromJsonException(
+  json,
+  'type',
+  'PluginAuthenticationProgress',
+  'Invalid union type "${json['type']}"!'
+);
+        }
+      
+}
+
+/// @nodoc
+mixin _$PluginAuthenticationProgress {
+
+
+
+  /// Serializes this PluginAuthenticationProgress to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationProgress);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'PluginAuthenticationProgress()';
+}
+
+
+}
+
+
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class PluginAuthenticationCompletedProgress implements PluginAuthenticationProgress {
+  const PluginAuthenticationCompletedProgress({final  String? $type}): $type = $type ?? 'completed';
+  factory PluginAuthenticationCompletedProgress.fromJson(Map<String, dynamic> json) => _$PluginAuthenticationCompletedProgressFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PluginAuthenticationCompletedProgressToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationCompletedProgress);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'PluginAuthenticationProgress.completed()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class PluginAuthenticationFailedProgress implements PluginAuthenticationProgress {
+  const PluginAuthenticationFailedProgress({required this.message, final  String? $type}): $type = $type ?? 'failed';
+  factory PluginAuthenticationFailedProgress.fromJson(Map<String, dynamic> json) => _$PluginAuthenticationFailedProgressFromJson(json);
+
+ final  String message;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PluginAuthenticationFailedProgressToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationFailedProgress&&(identical(other.message, message) || other.message == message));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,message);
+
+@override
+String toString() {
+  return 'PluginAuthenticationProgress.failed(message: $message)';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class PluginAuthenticationCancelledProgress implements PluginAuthenticationProgress {
+  const PluginAuthenticationCancelledProgress({final  String? $type}): $type = $type ?? 'cancelled';
+  factory PluginAuthenticationCancelledProgress.fromJson(Map<String, dynamic> json) => _$PluginAuthenticationCancelledProgressFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PluginAuthenticationCancelledProgressToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationCancelledProgress);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'PluginAuthenticationProgress.cancelled()';
+}
+
+
+}
+
+
+
 
 
 /// @nodoc
@@ -941,6 +1200,170 @@ as PluginManagementMetadata,
 }
 
 /// Create a copy of PluginLifecycleConflict
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PluginManagementMetadataCopyWith<$Res> get current {
+  
+  return $PluginManagementMetadataCopyWith<$Res>(_self.current, (value) {
+    return _then(_self.copyWith(current: value));
+  });
+}
+}
+
+
+/// @nodoc
+mixin _$PluginAuthenticationConflict {
+
+ String get pluginId;@JsonKey(unknownEnumValue: PluginAuthenticationConflictReason.unknown) List<PluginAuthenticationConflictReason> get reasons; PluginManagementMetadata get current;
+/// Create a copy of PluginAuthenticationConflict
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PluginAuthenticationConflictCopyWith<PluginAuthenticationConflict> get copyWith => _$PluginAuthenticationConflictCopyWithImpl<PluginAuthenticationConflict>(this as PluginAuthenticationConflict, _$identity);
+
+  /// Serializes this PluginAuthenticationConflict to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationConflict&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId)&&const DeepCollectionEquality().equals(other.reasons, reasons)&&(identical(other.current, current) || other.current == current));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,pluginId,const DeepCollectionEquality().hash(reasons),current);
+
+@override
+String toString() {
+  return 'PluginAuthenticationConflict(pluginId: $pluginId, reasons: $reasons, current: $current)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PluginAuthenticationConflictCopyWith<$Res>  {
+  factory $PluginAuthenticationConflictCopyWith(PluginAuthenticationConflict value, $Res Function(PluginAuthenticationConflict) _then) = _$PluginAuthenticationConflictCopyWithImpl;
+@useResult
+$Res call({
+ String pluginId,@JsonKey(unknownEnumValue: PluginAuthenticationConflictReason.unknown) List<PluginAuthenticationConflictReason> reasons, PluginManagementMetadata current
+});
+
+
+$PluginManagementMetadataCopyWith<$Res> get current;
+
+}
+/// @nodoc
+class _$PluginAuthenticationConflictCopyWithImpl<$Res>
+    implements $PluginAuthenticationConflictCopyWith<$Res> {
+  _$PluginAuthenticationConflictCopyWithImpl(this._self, this._then);
+
+  final PluginAuthenticationConflict _self;
+  final $Res Function(PluginAuthenticationConflict) _then;
+
+/// Create a copy of PluginAuthenticationConflict
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? pluginId = null,Object? reasons = null,Object? current = null,}) {
+  return _then(_self.copyWith(
+pluginId: null == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String,reasons: null == reasons ? _self.reasons : reasons // ignore: cast_nullable_to_non_nullable
+as List<PluginAuthenticationConflictReason>,current: null == current ? _self.current : current // ignore: cast_nullable_to_non_nullable
+as PluginManagementMetadata,
+  ));
+}
+/// Create a copy of PluginAuthenticationConflict
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PluginManagementMetadataCopyWith<$Res> get current {
+  
+  return $PluginManagementMetadataCopyWith<$Res>(_self.current, (value) {
+    return _then(_self.copyWith(current: value));
+  });
+}
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _PluginAuthenticationConflict implements PluginAuthenticationConflict {
+  const _PluginAuthenticationConflict({required this.pluginId, @JsonKey(unknownEnumValue: PluginAuthenticationConflictReason.unknown) required final  List<PluginAuthenticationConflictReason> reasons, required this.current}): _reasons = reasons;
+  factory _PluginAuthenticationConflict.fromJson(Map<String, dynamic> json) => _$PluginAuthenticationConflictFromJson(json);
+
+@override final  String pluginId;
+ final  List<PluginAuthenticationConflictReason> _reasons;
+@override@JsonKey(unknownEnumValue: PluginAuthenticationConflictReason.unknown) List<PluginAuthenticationConflictReason> get reasons {
+  if (_reasons is EqualUnmodifiableListView) return _reasons;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_reasons);
+}
+
+@override final  PluginManagementMetadata current;
+
+/// Create a copy of PluginAuthenticationConflict
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PluginAuthenticationConflictCopyWith<_PluginAuthenticationConflict> get copyWith => __$PluginAuthenticationConflictCopyWithImpl<_PluginAuthenticationConflict>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PluginAuthenticationConflictToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginAuthenticationConflict&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId)&&const DeepCollectionEquality().equals(other._reasons, _reasons)&&(identical(other.current, current) || other.current == current));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,pluginId,const DeepCollectionEquality().hash(_reasons),current);
+
+@override
+String toString() {
+  return 'PluginAuthenticationConflict(pluginId: $pluginId, reasons: $reasons, current: $current)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PluginAuthenticationConflictCopyWith<$Res> implements $PluginAuthenticationConflictCopyWith<$Res> {
+  factory _$PluginAuthenticationConflictCopyWith(_PluginAuthenticationConflict value, $Res Function(_PluginAuthenticationConflict) _then) = __$PluginAuthenticationConflictCopyWithImpl;
+@override @useResult
+$Res call({
+ String pluginId,@JsonKey(unknownEnumValue: PluginAuthenticationConflictReason.unknown) List<PluginAuthenticationConflictReason> reasons, PluginManagementMetadata current
+});
+
+
+@override $PluginManagementMetadataCopyWith<$Res> get current;
+
+}
+/// @nodoc
+class __$PluginAuthenticationConflictCopyWithImpl<$Res>
+    implements _$PluginAuthenticationConflictCopyWith<$Res> {
+  __$PluginAuthenticationConflictCopyWithImpl(this._self, this._then);
+
+  final _PluginAuthenticationConflict _self;
+  final $Res Function(_PluginAuthenticationConflict) _then;
+
+/// Create a copy of PluginAuthenticationConflict
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? pluginId = null,Object? reasons = null,Object? current = null,}) {
+  return _then(_PluginAuthenticationConflict(
+pluginId: null == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String,reasons: null == reasons ? _self._reasons : reasons // ignore: cast_nullable_to_non_nullable
+as List<PluginAuthenticationConflictReason>,current: null == current ? _self.current : current // ignore: cast_nullable_to_non_nullable
+as PluginManagementMetadata,
+  ));
+}
+
+/// Create a copy of PluginAuthenticationConflict
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.g.dart
@@ -143,6 +143,14 @@ Map<String, dynamic> _$PluginAuthenticationCancelledProgressToJson(
   PluginAuthenticationCancelledProgress instance,
 ) => <String, dynamic>{'type': instance.$type};
 
+PluginAuthenticationUnknownProgress
+_$PluginAuthenticationUnknownProgressFromJson(Map json) =>
+    PluginAuthenticationUnknownProgress($type: json['type'] as String?);
+
+Map<String, dynamic> _$PluginAuthenticationUnknownProgressToJson(
+  PluginAuthenticationUnknownProgress instance,
+) => <String, dynamic>{'type': instance.$type};
+
 _PluginManagementResponse _$PluginManagementResponseFromJson(Map json) =>
     _PluginManagementResponse(
       snapshotToken: json['snapshotToken'] as String?,

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_management.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_management.g.dart
@@ -21,6 +21,13 @@ _PluginManagementMetadata _$PluginManagementMetadataFromJson(Map json) =>
         json['workState'],
         unknownValue: PluginManagementWorkState.unknown,
       ),
+      authenticationState:
+          $enumDecodeNullable(
+            _$PluginAuthenticationStateEnumMap,
+            json['authenticationState'],
+            unknownValue: PluginAuthenticationState.unknown,
+          ) ??
+          PluginAuthenticationState.idle,
       idleTimeoutMins: (json['idleTimeoutMins'] as num).toInt(),
       hasIdleTimeoutOverride: json['hasIdleTimeoutOverride'] as bool,
       managementCapabilities: (json['managementCapabilities'] as List<dynamic>)
@@ -41,6 +48,8 @@ Map<String, dynamic> _$PluginManagementMetadataToJson(
   'setup': instance.setup.toJson(),
   'runtimeState': _$PluginRuntimeStateEnumMap[instance.runtimeState]!,
   'workState': _$PluginManagementWorkStateEnumMap[instance.workState]!,
+  'authenticationState':
+      _$PluginAuthenticationStateEnumMap[instance.authenticationState]!,
   'idleTimeoutMins': instance.idleTimeoutMins,
   'hasIdleTimeoutOverride': instance.hasIdleTimeoutOverride,
   'managementCapabilities': instance.managementCapabilities
@@ -67,13 +76,72 @@ const _$PluginManagementWorkStateEnumMap = {
   PluginManagementWorkState.unknown: 'unknown',
 };
 
+const _$PluginAuthenticationStateEnumMap = {
+  PluginAuthenticationState.idle: 'idle',
+  PluginAuthenticationState.inProgress: 'inProgress',
+  PluginAuthenticationState.unknown: 'unknown',
+};
+
 const _$PluginManagementCapabilityEnumMap = {
   PluginManagementCapability.lifecycle: 'lifecycle',
   PluginManagementCapability.setupRefresh: 'setupRefresh',
   PluginManagementCapability.idleTimeout: 'idleTimeout',
   PluginManagementCapability.install: 'install',
+  PluginManagementCapability.authentication: 'authentication',
   PluginManagementCapability.unknown: 'unknown',
 };
+
+PluginAuthenticationDeviceCodeChallengeResponse
+_$PluginAuthenticationDeviceCodeChallengeResponseFromJson(Map json) =>
+    PluginAuthenticationDeviceCodeChallengeResponse(
+      type:
+          $enumDecodeNullable(
+            _$PluginAuthenticationChallengeTypeEnumMap,
+            json['type'],
+          ) ??
+          PluginAuthenticationChallengeType.deviceCode,
+      verificationUrl: json['verificationUrl'] as String,
+      userCode: json['userCode'] as String,
+    );
+
+Map<String, dynamic> _$PluginAuthenticationDeviceCodeChallengeResponseToJson(
+  PluginAuthenticationDeviceCodeChallengeResponse instance,
+) => <String, dynamic>{
+  'type': _$PluginAuthenticationChallengeTypeEnumMap[instance.type]!,
+  'verificationUrl': instance.verificationUrl,
+  'userCode': instance.userCode,
+};
+
+const _$PluginAuthenticationChallengeTypeEnumMap = {
+  PluginAuthenticationChallengeType.deviceCode: 'deviceCode',
+};
+
+PluginAuthenticationCompletedProgress
+_$PluginAuthenticationCompletedProgressFromJson(Map json) =>
+    PluginAuthenticationCompletedProgress($type: json['type'] as String?);
+
+Map<String, dynamic> _$PluginAuthenticationCompletedProgressToJson(
+  PluginAuthenticationCompletedProgress instance,
+) => <String, dynamic>{'type': instance.$type};
+
+PluginAuthenticationFailedProgress _$PluginAuthenticationFailedProgressFromJson(
+  Map json,
+) => PluginAuthenticationFailedProgress(
+  message: json['message'] as String,
+  $type: json['type'] as String?,
+);
+
+Map<String, dynamic> _$PluginAuthenticationFailedProgressToJson(
+  PluginAuthenticationFailedProgress instance,
+) => <String, dynamic>{'message': instance.message, 'type': instance.$type};
+
+PluginAuthenticationCancelledProgress
+_$PluginAuthenticationCancelledProgressFromJson(Map json) =>
+    PluginAuthenticationCancelledProgress($type: json['type'] as String?);
+
+Map<String, dynamic> _$PluginAuthenticationCancelledProgressToJson(
+  PluginAuthenticationCancelledProgress instance,
+) => <String, dynamic>{'type': instance.$type};
 
 _PluginManagementResponse _$PluginManagementResponseFromJson(Map json) =>
     _PluginManagementResponse(
@@ -232,4 +300,39 @@ const _$PluginLifecycleConflictReasonEnumMap = {
   PluginLifecycleConflictReason.notEnabled: 'notEnabled',
   PluginLifecycleConflictReason.unsupported: 'unsupported',
   PluginLifecycleConflictReason.unknown: 'unknown',
+};
+
+_PluginAuthenticationConflict _$PluginAuthenticationConflictFromJson(
+  Map json,
+) => _PluginAuthenticationConflict(
+  pluginId: json['pluginId'] as String,
+  reasons: (json['reasons'] as List<dynamic>)
+      .map(
+        (e) => $enumDecode(
+          _$PluginAuthenticationConflictReasonEnumMap,
+          e,
+          unknownValue: PluginAuthenticationConflictReason.unknown,
+        ),
+      )
+      .toList(),
+  current: PluginManagementMetadata.fromJson(
+    Map<String, dynamic>.from(json['current'] as Map),
+  ),
+);
+
+Map<String, dynamic> _$PluginAuthenticationConflictToJson(
+  _PluginAuthenticationConflict instance,
+) => <String, dynamic>{
+  'pluginId': instance.pluginId,
+  'reasons': instance.reasons
+      .map((e) => _$PluginAuthenticationConflictReasonEnumMap[e]!)
+      .toList(),
+  'current': instance.current.toJson(),
+};
+
+const _$PluginAuthenticationConflictReasonEnumMap = {
+  PluginAuthenticationConflictReason.inFlight: 'inFlight',
+  PluginAuthenticationConflictReason.setupNotRequired: 'setupNotRequired',
+  PluginAuthenticationConflictReason.unsupported: 'unsupported',
+  PluginAuthenticationConflictReason.unknown: 'unknown',
 };

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
@@ -68,6 +68,14 @@ sealed class SesoriSseEvent with _$SesoriSseEvent {
     required String? message,
   }) = SesoriPluginInstallProgress;
 
+  /// Terminal progress for one plugin authentication operation. Challenges are
+  /// request-scoped and never enter SSE replay or persistence.
+  @FreezedUnionValue("plugin.authentication.progress")
+  const factory SesoriSseEvent.pluginAuthenticationProgress({
+    required String pluginId,
+    required PluginAuthenticationProgress progress,
+  }) = SesoriPluginAuthenticationProgress;
+
   /// Invalidates the process-wide slash-command catalog for one plugin.
   @FreezedUnionValue("command.catalog.updated")
   const factory SesoriSseEvent.commandCatalogUpdated({

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.freezed.dart
@@ -43,6 +43,10 @@ SesoriSseEvent _$SesoriSseEventFromJson(
           return SesoriPluginInstallProgress.fromJson(
             json
           );
+                case 'plugin.authentication.progress':
+          return SesoriPluginAuthenticationProgress.fromJson(
+            json
+          );
                 case 'command.catalog.updated':
           return SesoriCommandCatalogUpdated.fromJson(
             json
@@ -673,6 +677,81 @@ as String,phase: null == phase ? _self.phase : phase // ignore: cast_nullable_to
 as PluginInstallPhase,percent: freezed == percent ? _self.percent : percent // ignore: cast_nullable_to_non_nullable
 as int?,message: freezed == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
 as String?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class SesoriPluginAuthenticationProgress implements SesoriSseEvent {
+  const SesoriPluginAuthenticationProgress({required this.pluginId, required this.progress, final  String? $type}): $type = $type ?? 'plugin.authentication.progress';
+  factory SesoriPluginAuthenticationProgress.fromJson(Map<String, dynamic> json) => _$SesoriPluginAuthenticationProgressFromJson(json);
+
+ final  String pluginId;
+ final  PluginAuthenticationProgress progress;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of SesoriSseEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SesoriPluginAuthenticationProgressCopyWith<SesoriPluginAuthenticationProgress> get copyWith => _$SesoriPluginAuthenticationProgressCopyWithImpl<SesoriPluginAuthenticationProgress>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SesoriPluginAuthenticationProgressToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SesoriPluginAuthenticationProgress&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId)&&(identical(other.progress, progress) || other.progress == progress));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,pluginId,progress);
+
+@override
+String toString() {
+  return 'SesoriSseEvent.pluginAuthenticationProgress(pluginId: $pluginId, progress: $progress)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SesoriPluginAuthenticationProgressCopyWith<$Res> implements $SesoriSseEventCopyWith<$Res> {
+  factory $SesoriPluginAuthenticationProgressCopyWith(SesoriPluginAuthenticationProgress value, $Res Function(SesoriPluginAuthenticationProgress) _then) = _$SesoriPluginAuthenticationProgressCopyWithImpl;
+@useResult
+$Res call({
+ String pluginId, PluginAuthenticationProgress progress
+});
+
+
+
+
+}
+/// @nodoc
+class _$SesoriPluginAuthenticationProgressCopyWithImpl<$Res>
+    implements $SesoriPluginAuthenticationProgressCopyWith<$Res> {
+  _$SesoriPluginAuthenticationProgressCopyWithImpl(this._self, this._then);
+
+  final SesoriPluginAuthenticationProgress _self;
+  final $Res Function(SesoriPluginAuthenticationProgress) _then;
+
+/// Create a copy of SesoriSseEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? pluginId = null,Object? progress = null,}) {
+  return _then(SesoriPluginAuthenticationProgress(
+pluginId: null == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String,progress: null == progress ? _self.progress : progress // ignore: cast_nullable_to_non_nullable
+as PluginAuthenticationProgress,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.g.dart
@@ -102,6 +102,24 @@ const _$PluginInstallPhaseEnumMap = {
   PluginInstallPhase.unknown: 'unknown',
 };
 
+SesoriPluginAuthenticationProgress _$SesoriPluginAuthenticationProgressFromJson(
+  Map json,
+) => SesoriPluginAuthenticationProgress(
+  pluginId: json['pluginId'] as String,
+  progress: PluginAuthenticationProgress.fromJson(
+    Map<String, dynamic>.from(json['progress'] as Map),
+  ),
+  $type: json['type'] as String?,
+);
+
+Map<String, dynamic> _$SesoriPluginAuthenticationProgressToJson(
+  SesoriPluginAuthenticationProgress instance,
+) => <String, dynamic>{
+  'pluginId': instance.pluginId,
+  'progress': instance.progress.toJson(),
+  'type': instance.$type,
+};
+
 SesoriCommandCatalogUpdated _$SesoriCommandCatalogUpdatedFromJson(Map json) =>
     SesoriCommandCatalogUpdated(
       pluginId: json['pluginId'] as String,

--- a/shared/sesori_shared/test/models/plugin_management_contract_test.dart
+++ b/shared/sesori_shared/test/models/plugin_management_contract_test.dart
@@ -148,6 +148,7 @@ void main() {
       PluginAuthenticationProgress.completed(),
       PluginAuthenticationProgress.failed(message: "Sanitized failure"),
       PluginAuthenticationProgress.cancelled(),
+      PluginAuthenticationProgress.unknown(),
     ];
 
     expect(
@@ -168,6 +169,7 @@ void main() {
       "message": "Sanitized failure",
     });
     expect(progress[2].toJson(), {"type": "cancelled"});
+    expect(progress[3].toJson(), {"type": "unknown"});
   });
 
   test("authentication variants require their exact fields", () {
@@ -199,8 +201,8 @@ void main() {
       throwsA(anything),
     );
     expect(
-      () => PluginAuthenticationProgress.fromJson({"type": "future"}),
-      throwsA(anything),
+      PluginAuthenticationProgress.fromJson({"type": "future"}),
+      const PluginAuthenticationProgress.unknown(),
     );
   });
 

--- a/shared/sesori_shared/test/models/plugin_management_contract_test.dart
+++ b/shared/sesori_shared/test/models/plugin_management_contract_test.dart
@@ -11,6 +11,7 @@ void main() {
     ),
     runtimeState: PluginRuntimeState.active,
     workState: PluginManagementWorkState.idle,
+    authenticationState: PluginAuthenticationState.idle,
     idleTimeoutMins: 0,
     hasIdleTimeoutOverride: true,
     managementCapabilities: {
@@ -45,6 +46,7 @@ void main() {
         "setup",
         "runtimeState",
         "workState",
+        "authenticationState",
         "idleTimeoutMins",
         "hasIdleTimeoutOverride",
         "managementCapabilities",
@@ -90,14 +92,131 @@ void main() {
   });
 
   test("install capability round-trips on the wire", () {
-    final json = plugin.copyWith(
-      managementCapabilities: {PluginManagementCapability.install},
-    ).toJson();
+    final json = plugin
+        .copyWith(
+          managementCapabilities: {PluginManagementCapability.install},
+        )
+        .toJson();
 
     expect(json["managementCapabilities"], ["install"]);
     expect(
       PluginManagementMetadata.fromJson(json).managementCapabilities,
       {PluginManagementCapability.install},
+    );
+  });
+
+  test("authentication capability and state round-trip", () {
+    final json = plugin
+        .copyWith(
+          authenticationState: PluginAuthenticationState.inProgress,
+          managementCapabilities: {PluginManagementCapability.authentication},
+        )
+        .toJson();
+
+    expect(json["authenticationState"], "inProgress");
+    expect(json["managementCapabilities"], ["authentication"]);
+    expect(
+      PluginManagementMetadata.fromJson(json).authenticationState,
+      PluginAuthenticationState.inProgress,
+    );
+  });
+
+  test("older management payloads default authentication state to idle", () {
+    final json = plugin.toJson()..remove("authenticationState");
+
+    expect(
+      PluginManagementMetadata.fromJson(json).authenticationState,
+      PluginAuthenticationState.idle,
+    );
+  });
+
+  test("future authentication states decode to unknown", () {
+    final json = plugin.toJson()..["authenticationState"] = "futureState";
+
+    expect(
+      PluginManagementMetadata.fromJson(json).authenticationState,
+      PluginAuthenticationState.unknown,
+    );
+  });
+
+  test("authentication challenge and progress variants round-trip", () {
+    const challenge = PluginAuthenticationChallengeResponse.deviceCode(
+      verificationUrl: "https://auth.example/device",
+      userCode: "ABCD-EFGH",
+    );
+    const progress = <PluginAuthenticationProgress>[
+      PluginAuthenticationProgress.completed(),
+      PluginAuthenticationProgress.failed(message: "Sanitized failure"),
+      PluginAuthenticationProgress.cancelled(),
+    ];
+
+    expect(
+      PluginAuthenticationChallengeResponse.fromJson(challenge.toJson()),
+      challenge,
+    );
+    for (final event in progress) {
+      expect(PluginAuthenticationProgress.fromJson(event.toJson()), event);
+    }
+    expect(challenge.toJson(), {
+      "type": "deviceCode",
+      "verificationUrl": "https://auth.example/device",
+      "userCode": "ABCD-EFGH",
+    });
+    expect(progress[0].toJson(), {"type": "completed"});
+    expect(progress[1].toJson(), {
+      "type": "failed",
+      "message": "Sanitized failure",
+    });
+    expect(progress[2].toJson(), {"type": "cancelled"});
+  });
+
+  test("authentication variants require their exact fields", () {
+    expect(
+      () => PluginAuthenticationChallengeResponse.fromJson({
+        "type": "deviceCode",
+        "userCode": "ABCD-EFGH",
+      }),
+      throwsA(anything),
+    );
+    for (final json in const [
+      <String, dynamic>{
+        "verificationUrl": "https://auth.example/device",
+        "userCode": "ABCD-EFGH",
+      },
+      <String, dynamic>{
+        "type": "future",
+        "verificationUrl": "https://auth.example/device",
+        "userCode": "ABCD-EFGH",
+      },
+    ]) {
+      expect(
+        () => PluginAuthenticationChallengeResponse.fromJson(json),
+        throwsA(isA<FormatException>()),
+      );
+    }
+    expect(
+      () => PluginAuthenticationProgress.fromJson({"type": "failed"}),
+      throwsA(anything),
+    );
+    expect(
+      () => PluginAuthenticationProgress.fromJson({"type": "future"}),
+      throwsA(anything),
+    );
+  });
+
+  test("authentication conflicts round-trip and unknown reasons fail closed", () {
+    const conflict = PluginAuthenticationConflict(
+      pluginId: "codex",
+      reasons: [PluginAuthenticationConflictReason.setupNotRequired],
+      current: plugin,
+    );
+    final json = conflict.toJson();
+
+    expect(PluginAuthenticationConflict.fromJson(json), conflict);
+    json["reasons"] = ["futureReason"];
+    expect(
+      PluginAuthenticationConflict.fromJson(json).reasons,
+      [PluginAuthenticationConflictReason.unknown],
     );
   });
 

--- a/shared/sesori_shared/test/models/sesori_sse_event_test.dart
+++ b/shared/sesori_shared/test/models/sesori_sse_event_test.dart
@@ -41,6 +41,22 @@ void main() {
     expect(events.first, isNot(isA<SesoriSessionEvent>()));
   });
 
+  test('future plugin authentication progress fails closed to unknown', () {
+    final event = SesoriSseEvent.fromJson({
+      'type': 'plugin.authentication.progress',
+      'pluginId': 'codex',
+      'progress': {'type': 'future'},
+    });
+
+    expect(
+      event,
+      const SesoriSseEvent.pluginAuthenticationProgress(
+        pluginId: 'codex',
+        progress: PluginAuthenticationProgress.unknown(),
+      ),
+    );
+  });
+
   group('plugin install progress', () {
     test('round-trips a downloading phase with percent', () {
       const event = SesoriSseEvent.pluginInstallProgress(

--- a/shared/sesori_shared/test/models/sesori_sse_event_test.dart
+++ b/shared/sesori_shared/test/models/sesori_sse_event_test.dart
@@ -12,6 +12,35 @@ void main() {
     expect(SesoriSseEvent.fromJson(json), event);
   });
 
+  test('plugin authentication progress round-trips terminal variants', () {
+    const events = <SesoriSseEvent>[
+      SesoriSseEvent.pluginAuthenticationProgress(
+        pluginId: 'codex',
+        progress: PluginAuthenticationProgress.completed(),
+      ),
+      SesoriSseEvent.pluginAuthenticationProgress(
+        pluginId: 'codex',
+        progress: PluginAuthenticationProgress.failed(
+          message: 'Sanitized failure',
+        ),
+      ),
+      SesoriSseEvent.pluginAuthenticationProgress(
+        pluginId: 'codex',
+        progress: PluginAuthenticationProgress.cancelled(),
+      ),
+    ];
+
+    for (final event in events) {
+      expect(SesoriSseEvent.fromJson(event.toJson()), event);
+    }
+    expect(events.first.toJson(), {
+      'type': 'plugin.authentication.progress',
+      'pluginId': 'codex',
+      'progress': {'type': 'completed'},
+    });
+    expect(events.first, isNot(isA<SesoriSessionEvent>()));
+  });
+
   group('plugin install progress', () {
     test('round-trips a downloading phase with percent', () {
       const event = SesoriSseEvent.pluginInstallProgress(


### PR DESCRIPTION
## Complexity

⚙️ Moderate. This adds a forward-compatible shared wire vocabulary and one global SSE variant, with generated model and downstream exhaustive-switch fallout.

## What

- Advertise plugin authentication capability and idle/in-progress/unknown management state.
- Add typed device-code challenge responses, sealed terminal progress, and typed authentication conflicts.
- Add the global `plugin.authentication.progress` SSE event while keeping challenges request-scoped.
- Preserve old-bridge compatibility by decoding omitted authentication state as idle and future values as unknown.

## Why

The bridge and clients need backend-neutral contracts before exposing Codex device authentication through management routes and mobile presentation.

## Risk and test focus

The main risks are wire compatibility, accidentally exposing ephemeral challenge data through snapshots or SSE, malformed/future discriminators failing open, and exhaustive event handling regressions.

## Expected result

New peers can describe and observe harness authentication safely. Old apps ignore the new capability/event, and new apps decode old bridge snapshots as authentication idle. There is no database or persisted-data impact; challenge data remains in memory only.

## Verification

- `dart test` in `shared/sesori_shared` (389 tests)
- `dart analyze --fatal-infos` in shared, bridge app, client core, and desktop core
- `flutter analyze --fatal-infos` in mobile and desktop apps
- Focused client global-SSE classification tests
- `git diff --check origin/main`

Architecture implementation review was attempted but the review sub-agent failed before reading code with the task-store error `no such column: replacement_seq`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backend‑neutral contracts for plugin authentication and a global SSE event so clients can observe terminal progress without exposing challenge data. Adds fail‑closed handling for future progress types, and keeps older bridges compatible by defaulting missing auth state to idle and decoding unknown values to unknown.

- New Features
  - Extend management metadata with authentication capability and `authenticationState` (idle, inProgress, unknown).
  - Add typed device‑code `PluginAuthenticationChallengeResponse` (request‑scoped only; never in snapshots/SSE).
  - Add sealed `PluginAuthenticationProgress` (completed, failed{message}, cancelled; future variants decode to unknown) and `PluginAuthenticationConflict`.
  - Emit global SSE `plugin.authentication.progress` with `{pluginId, progress}` and update client SSE classification/tests.

<sup>Written for commit 82f19af09073a1a7693f2995c55d6c18dae0be9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

