### PR TITLE
🚧 [codex-mobile-login] feat(bridge): expose harness authentication [step 5/8]

### DIFF
--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -3,12 +3,12 @@
 ## Current State
 
 - **Plan slug:** `codex-mobile-login`
-- **Series state:** Step 4 PR open
-- **Current step:** 4/8 in review
-- **Implementation base:** Step 3 merge commit `3af28a81`
+- **Series state:** Step 4 merged; Step 5 ready for publication
+- **Current step:** 5/8 locally
+- **Implementation base:** Step 4 merge commit `2bc60ae3`
 - **Plan PR:** [#824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824)
-- **Current PR:** [#834](https://github.com/sesori-ai/sesori_apps_monorepo/pull/834)
-- **Next action:** Monitor Step 4 review/CI and implement Step 5 locally
+- **Current PR:** None; Step 5 is being reverified after the Step 4 merge
+- **Next action:** Publish Step 5
 
 ## Plan Review
 
@@ -29,8 +29,8 @@
 | [x] | 1/8 | `🌱 [codex-mobile-login] docs: plan mobile Codex login [step 1/8]` | 450-850 | [PR #824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824) merged |
 | [x] | 2/8 | `⚙️ [codex-mobile-login] refactor(codex): prepare authentication primitives [step 2/8]` | 850-1,400 | [PR #827](https://github.com/sesori-ai/sesori_apps_monorepo/pull/827) merged |
 | [x] | 3/8 | `🚧 [codex-mobile-login] feat(codex): implement device authentication [step 3/8]` | 850-1,450 | [PR #833](https://github.com/sesori-ai/sesori_apps_monorepo/pull/833) merged |
-| [ ] | 4/8 | `⚙️ [codex-mobile-login] feat(protocol): describe harness authentication [step 4/8]` | 650-1,200 | [PR #834](https://github.com/sesori-ai/sesori_apps_monorepo/pull/834) open |
-| [ ] | 5/8 | `🚧 [codex-mobile-login] feat(bridge): expose harness authentication [step 5/8]` | 950-1,500 | Pending |
+| [x] | 4/8 | `⚙️ [codex-mobile-login] feat(protocol): describe harness authentication [step 4/8]` | 650-1,200 | [PR #834](https://github.com/sesori-ai/sesori_apps_monorepo/pull/834) merged |
+| [ ] | 5/8 | `🚧 [codex-mobile-login] feat(bridge): expose harness authentication [step 5/8]` | 950-1,500 | Local verification |
 | [ ] | 6/8 | `🚧 [codex-mobile-login] feat(client): orchestrate harness authentication [step 6/8]` | 900-1,500 | Pending |
 | [ ] | 7/8 | `⚙️ [codex-mobile-login] feat(app): add mobile Codex login [step 7/8]` | 750-1,350 | Pending |
 | [ ] | 8/8 | `🌱 [codex-mobile-login] docs: retire mobile Codex login plan [step 8/8]` | 50-200 | Pending |
@@ -94,7 +94,9 @@
   analysis reports no issues in all three packages. The required architecture
   implementation review could not run because the review sub-agent failed
   before reading code with the internal task-store schema error `no such
-  column: replacement_seq`.
+  column: replacement_seq`. Post-rebase focused tests pass (123 bridge app,
+  14 Codex descriptor, and plugin-interface authentication tests), fatal-info
+  analysis remains clean, and `git diff --check origin/main...HEAD` passes.
 
 ## Findings And Plan Deltas
 
@@ -149,3 +151,5 @@
   seams with start-or-join authentication, typed conflicts, cancellation,
   authoritative setup reinspection/start, terminal SSE, and awaited shutdown
   settlement. The successor remains local until Step 4 merges.
+- **2026-08-12 - Step 4 merged:** Rebased Step 5 onto merge commit `2bc60ae3`
+  after PR #834 merged with fail-closed future-progress compatibility.

--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -3,12 +3,12 @@
 ## Current State
 
 - **Plan slug:** `codex-mobile-login`
-- **Series state:** Step 4 merged; Step 5 ready for publication
-- **Current step:** 5/8 locally
+- **Series state:** Step 5 PR open
+- **Current step:** 5/8 in review
 - **Implementation base:** Step 4 merge commit `2bc60ae3`
 - **Plan PR:** [#824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824)
-- **Current PR:** None; Step 5 is being reverified after the Step 4 merge
-- **Next action:** Publish Step 5
+- **Current PR:** [#835](https://github.com/sesori-ai/sesori_apps_monorepo/pull/835)
+- **Next action:** Monitor Step 5 review/CI and implement Step 6 locally
 
 ## Plan Review
 
@@ -30,7 +30,7 @@
 | [x] | 2/8 | `⚙️ [codex-mobile-login] refactor(codex): prepare authentication primitives [step 2/8]` | 850-1,400 | [PR #827](https://github.com/sesori-ai/sesori_apps_monorepo/pull/827) merged |
 | [x] | 3/8 | `🚧 [codex-mobile-login] feat(codex): implement device authentication [step 3/8]` | 850-1,450 | [PR #833](https://github.com/sesori-ai/sesori_apps_monorepo/pull/833) merged |
 | [x] | 4/8 | `⚙️ [codex-mobile-login] feat(protocol): describe harness authentication [step 4/8]` | 650-1,200 | [PR #834](https://github.com/sesori-ai/sesori_apps_monorepo/pull/834) merged |
-| [ ] | 5/8 | `🚧 [codex-mobile-login] feat(bridge): expose harness authentication [step 5/8]` | 950-1,500 | Local verification |
+| [ ] | 5/8 | `🚧 [codex-mobile-login] feat(bridge): expose harness authentication [step 5/8]` | 950-1,500 | [PR #835](https://github.com/sesori-ai/sesori_apps_monorepo/pull/835) open |
 | [ ] | 6/8 | `🚧 [codex-mobile-login] feat(client): orchestrate harness authentication [step 6/8]` | 900-1,500 | Pending |
 | [ ] | 7/8 | `⚙️ [codex-mobile-login] feat(app): add mobile Codex login [step 7/8]` | 750-1,350 | Pending |
 | [ ] | 8/8 | `🌱 [codex-mobile-login] docs: retire mobile Codex login plan [step 8/8]` | 50-200 | Pending |
@@ -99,7 +99,8 @@
   analysis remains clean, `git diff --check origin/main...HEAD` passes, and
   `git diff --numstat origin/main...HEAD` reports 844 additions and 73
   deletions. The lower-than-estimated size reflects reuse of existing lifecycle
-  ownership rather than introducing a parallel coordinator.
+  ownership rather than introducing a parallel coordinator. Pushed and opened
+  as [PR #835](https://github.com/sesori-ai/sesori_apps_monorepo/pull/835).
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -96,7 +96,10 @@
   before reading code with the internal task-store schema error `no such
   column: replacement_seq`. Post-rebase focused tests pass (123 bridge app,
   14 Codex descriptor, and plugin-interface authentication tests), fatal-info
-  analysis remains clean, and `git diff --check origin/main...HEAD` passes.
+  analysis remains clean, `git diff --check origin/main...HEAD` passes, and
+  `git diff --numstat origin/main...HEAD` reports 844 additions and 73
+  deletions. The lower-than-estimated size reflects reuse of existing lifecycle
+  ownership rather than introducing a parallel coordinator.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -89,6 +89,12 @@
   origin/main...HEAD` passes, and `git diff --numstat origin/main...HEAD` reports 976
   additions and 25 deletions. Committed as `0b418a3a`, pushed, and opened as
   [PR #834](https://github.com/sesori-ai/sesori_apps_monorepo/pull/834).
+- Step 5 local: Full bridge app tests pass (2,542 tests), full Codex tests pass
+  (361 tests), and full plugin-interface tests pass (152 tests). Fatal-info
+  analysis reports no issues in all three packages. The required architecture
+  implementation review could not run because the review sub-agent failed
+  before reading code with the internal task-store schema error `no such
+  column: replacement_seq`.
 
 ## Findings And Plan Deltas
 
@@ -136,3 +142,10 @@
   capability/state metadata, typed device-code challenge, sealed terminal
   progress, typed conflicts, and one global progress SSE event. Challenge data
   remains request-scoped and absent from management snapshots and SSE.
+- **2026-08-12 - Step 5 started:** Created local branch
+  `codex-mobile-login-bridge-authentication` while Step 4 remains in review.
+- **2026-08-12 - Step 5 implementation:** Extended the existing runtime,
+  repository, lifecycle service, explicit router, and Orchestrator ownership
+  seams with start-or-join authentication, typed conflicts, cancellation,
+  authoritative setup reinspection/start, terminal SSE, and awaited shutdown
+  settlement. The successor remains local until Step 4 merges.

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -50,6 +50,7 @@ import "../routing/get_plugins_handler.dart";
 import "../routing/get_pull_request_refresh_settings_handler.dart";
 import "../routing/patch_bridge_settings_handler.dart";
 import "../routing/patch_plugin_idle_timeout_handler.dart";
+import "../routing/plugin_authentication_handlers.dart";
 import "../routing/post_plugin_lifecycle_command_handler.dart";
 import "../routing/start_catalog_import_handler.dart";
 import "../server/services/bridge_restart_service.dart";
@@ -558,6 +559,8 @@ class Orchestrator {
       handlers: [
         HealthCheckHandler(healthRepository: healthRepository),
         GetPluginManagementHandler(lifecycleService: _pluginLifecycleService),
+        PostPluginAuthenticationHandler(lifecycleService: _pluginLifecycleService),
+        DeletePluginAuthenticationHandler(lifecycleService: _pluginLifecycleService),
         PatchPluginIdleTimeoutHandler(lifecycleService: _pluginLifecycleService),
         GetBridgeSettingsHandler(settingsRepository: _bridgeSettingsRepository),
         GetPullRequestRefreshSettingsHandler(settingsService: pullRequestRefreshSettingsService),
@@ -654,6 +657,7 @@ class Orchestrator {
       catalogImportProgress: catalogImportService.progress,
       pluginManagementSnapshotTokens: _pluginLifecycleService.managementSnapshotTokens,
       pluginInstallProgress: _pluginLifecycleService.installProgress,
+      pluginAuthenticationProgress: _pluginLifecycleService.authenticationProgress,
       localWireEventsController: localWireEventsController,
       bytesSentController: bytesSentController,
       failureReporter: _failureReporter,
@@ -805,6 +809,7 @@ class OrchestratorSession {
     required Stream<CatalogImportProgress> catalogImportProgress,
     required Stream<String> pluginManagementSnapshotTokens,
     required Stream<PluginInstallProgressUpdate> pluginInstallProgress,
+    required Stream<PluginAuthenticationProgressUpdate> pluginAuthenticationProgress,
     required StreamController<int> bytesSentController,
     required StreamController<SesoriSseEvent> localWireEventsController,
     required FailureReporter failureReporter,
@@ -899,6 +904,16 @@ class OrchestratorSession {
           );
         })
         .addTo(_subscriptions);
+    pluginAuthenticationProgress
+        .listen((update) {
+          _enqueueWireEvent(
+            SesoriSseEvent.pluginAuthenticationProgress(
+              pluginId: update.pluginId,
+              progress: update.progress,
+            ),
+          );
+        })
+        .addTo(_subscriptions);
     _sessionPromptService.promptDefaultsChanges
         .listen((change) {
           _enqueueWireEvent(
@@ -933,9 +948,7 @@ class OrchestratorSession {
       return Future.error(StateError("OrchestratorSession has already started"), StackTrace.current);
     }
 
-    _sessionAbortService.abortStartedSessions
-        .listen(_completionListener.markSessionAbortPending)
-        .addTo(_subscriptions);
+    _sessionAbortService.abortStartedSessions.listen(_completionListener.markSessionAbortPending).addTo(_subscriptions);
     _sessionAbortService.abortedSessions.listen(_completionListener.markSessionAborted).addTo(_subscriptions);
     _sessionAbortService.abortFailedSessions.listen(_completionListener.clearPendingAbort).addTo(_subscriptions);
     _completionListener.start();

--- a/bridge/app/lib/src/bridge/runtime/plugin_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_runtime.dart
@@ -63,6 +63,13 @@ typedef SourcedPluginRuntimeEvent = ({
 });
 typedef SourcedPluginProvisionProgress = ({String pluginId, RuntimeProvisionProgress event});
 
+class PluginRuntimeAuthenticationOperation {
+  const PluginRuntimeAuthenticationOperation({required this.events, required this.abort});
+
+  final Stream<PluginAuthenticationEvent> events;
+  final void Function() abort;
+}
+
 sealed class PluginRuntimeCommandResult {
   const PluginRuntimeCommandResult({required this.snapshot});
 
@@ -129,6 +136,7 @@ class PluginRuntime {
   Future<void>? _disposeFuture;
   bool _apiDisposalStarted = false;
   final Set<StartAbortController> _installAbortControllers = <StartAbortController>{};
+  final Set<StartAbortController> _authenticationAbortControllers = <StartAbortController>{};
   final Map<BridgePluginApi, Future<void>> _apiDisposals = Map<BridgePluginApi, Future<void>>.identity();
 
   Stream<List<PluginRuntimeSnapshot>> get snapshots => _snapshotsSubject.stream;
@@ -242,6 +250,32 @@ class PluginRuntime {
     } finally {
       _installAbortControllers.remove(abortController);
     }
+  }
+
+  PluginRuntimeAuthenticationOperation authenticate({required String pluginId}) {
+    final slot = _requireSlot(pluginId);
+    if (_shuttingDown) throw const PluginStartAbortedException();
+    final descriptor = slot.registration.descriptor;
+    if (descriptor is! InteractivePluginAuthenticationDescriptor) {
+      throw StateError('Plugin "$pluginId" does not support interactive authentication.');
+    }
+    final authenticationDescriptor = descriptor as InteractivePluginAuthenticationDescriptor;
+    final abortController = StartAbortController();
+    _authenticationAbortControllers.add(abortController);
+    final events = (() async* {
+      try {
+        yield* authenticationDescriptor.authenticate(
+          config: slot.registration.config,
+          processes: _setupProcesses,
+          environment: _environment,
+          stateDirectory: slot.registration.stateDirectory,
+          aborted: abortController.signal,
+        );
+      } finally {
+        _authenticationAbortControllers.remove(abortController);
+      }
+    })();
+    return PluginRuntimeAuthenticationOperation(events: events, abort: abortController.abort);
   }
 
   void applyAccess({required List<PluginRuntimeAccess> entries}) {
@@ -605,6 +639,9 @@ class PluginRuntime {
     if (_shuttingDown) return;
     _shuttingDown = true;
     for (final controller in _installAbortControllers) {
+      controller.abort();
+    }
+    for (final controller in _authenticationAbortControllers) {
       controller.abort();
     }
     for (final slot in _slots.values) {

--- a/bridge/app/lib/src/repositories/plugin_lifecycle_repository.dart
+++ b/bridge/app/lib/src/repositories/plugin_lifecycle_repository.dart
@@ -65,6 +65,9 @@ class PluginLifecycleRepository {
   Stream<RuntimeProvisionProgress> installRuntime({required String pluginId}) =>
       _runtime.installRuntime(pluginId: pluginId);
 
+  PluginRuntimeAuthenticationOperation authenticate({required String pluginId}) =>
+      _runtime.authenticate(pluginId: pluginId);
+
   Future<PluginRuntimeCommandResult> stop({
     required String pluginId,
     required PluginStopIntent intent,

--- a/bridge/app/lib/src/routing/plugin_authentication_handlers.dart
+++ b/bridge/app/lib/src/routing/plugin_authentication_handlers.dart
@@ -1,0 +1,77 @@
+import "dart:convert";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../bridge/routing/request_handler.dart";
+import "../services/plugin_lifecycle_service.dart";
+
+class PostPluginAuthenticationHandler extends RequestHandlerBase {
+  PostPluginAuthenticationHandler({required PluginLifecycleService lifecycleService})
+    : _lifecycleService = lifecycleService,
+      super(HttpMethod.post, "/plugin/:id/authentication");
+
+  final PluginLifecycleService _lifecycleService;
+
+  @override
+  Future<RelayResponse> handleInternal(
+    RelayRequest request, {
+    required Map<String, String> pathParams,
+    required Map<String, String> queryParams,
+    required String? fragment,
+  }) async {
+    try {
+      final pluginId = pathParams["id"];
+      if (pluginId == null) return buildErrorResponse(request, 400, "plugin id is required");
+      return buildOkJsonResponse(request, await _lifecycleService.authenticate(pluginId: pluginId));
+    } on PluginManagementPluginNotFoundException {
+      return buildErrorResponse(request, 404, "plugin not found");
+    } on PluginAuthenticationConflictException catch (error) {
+      return RelayResponse(
+        id: request.id,
+        status: 409,
+        headers: const {"content-type": "application/json"},
+        body: jsonEncode(error.conflict.toJson()),
+      );
+    } on PluginAuthenticationChallengeUnavailableException {
+      return buildErrorResponse(request, 500, "plugin authentication did not provide a challenge");
+    } on Object catch (error, stackTrace) {
+      Log.w("POST ${request.path}: plugin authentication failed", error, stackTrace);
+      return buildErrorResponse(request, 500, "plugin authentication failed");
+    }
+  }
+}
+
+class DeletePluginAuthenticationHandler extends RequestHandlerBase {
+  DeletePluginAuthenticationHandler({required PluginLifecycleService lifecycleService})
+    : _lifecycleService = lifecycleService,
+      super(HttpMethod.delete, "/plugin/:id/authentication");
+
+  final PluginLifecycleService _lifecycleService;
+
+  @override
+  Future<RelayResponse> handleInternal(
+    RelayRequest request, {
+    required Map<String, String> pathParams,
+    required Map<String, String> queryParams,
+    required String? fragment,
+  }) async {
+    try {
+      final pluginId = pathParams["id"];
+      if (pluginId == null) return buildErrorResponse(request, 400, "plugin id is required");
+      return buildOkJsonResponse(request, await _lifecycleService.cancelAuthentication(pluginId: pluginId));
+    } on PluginManagementPluginNotFoundException {
+      return buildErrorResponse(request, 404, "plugin not found");
+    } on PluginAuthenticationConflictException catch (error) {
+      return RelayResponse(
+        id: request.id,
+        status: 409,
+        headers: const {"content-type": "application/json"},
+        body: jsonEncode(error.conflict.toJson()),
+      );
+    } on Object catch (error, stackTrace) {
+      Log.w("DELETE ${request.path}: plugin authentication cancellation failed", error, stackTrace);
+      return buildErrorResponse(request, 500, "plugin authentication cancellation failed");
+    }
+  }
+}

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -391,7 +391,8 @@ class PluginLifecycleService {
       );
     }
 
-    final authentication = _ActivePluginAuthentication();
+    final operation = _lifecycleRepository.authenticate(pluginId: pluginId);
+    final authentication = _ActivePluginAuthentication(operation: operation);
     _activePluginAuthentications[pluginId] = authentication;
     _publishManagementIfChanged();
     unawaited(_executeAuthentication(pluginId: pluginId, authentication: authentication));
@@ -420,7 +421,7 @@ class PluginLifecycleService {
       );
     }
     final active = _activePluginAuthentications[pluginId];
-    active?.abort?.call();
+    active?.operation.abort();
     if (active != null) await active.settled.future;
     return const SuccessEmptyResponse();
   }
@@ -431,10 +432,8 @@ class PluginLifecycleService {
   }) async {
     PluginAuthenticationProgress progress;
     try {
-      final operation = _lifecycleRepository.authenticate(pluginId: pluginId);
-      authentication.abort = operation.abort;
       PluginAuthenticationProgress? terminal;
-      await for (final event in operation.events) {
+      await for (final event in authentication.operation.events) {
         terminal = switch (event) {
           PluginAuthenticationDeviceCodeChallenge(:final verificationUri, :final userCode) => () {
             if (verificationUri.scheme != "https") {
@@ -451,7 +450,12 @@ class PluginLifecycleService {
             return terminal;
           }(),
           PluginAuthenticationCompleted() => const PluginAuthenticationProgress.completed(),
-          PluginAuthenticationFailed(:final message) => PluginAuthenticationProgress.failed(message: message),
+          PluginAuthenticationFailed(:final message) => () {
+            Log.w('Plugin "$pluginId" authentication failed: $message');
+            return const PluginAuthenticationProgress.failed(
+              message: "Authentication failed. Check the bridge logs for details.",
+            );
+          }(),
         };
       }
       progress = terminal ?? const PluginAuthenticationProgress.failed(message: "Authentication ended unexpectedly.");
@@ -473,9 +477,11 @@ class PluginLifecycleService {
       }
     } on Object catch (error, stackTrace) {
       Log.w('Plugin "$pluginId" setup inspection after authentication failed', error, stackTrace);
-      progress = const PluginAuthenticationProgress.failed(
-        message: "Authentication finished, but setup could not be verified.",
-      );
+      if (progress is! PluginAuthenticationCancelledProgress) {
+        progress = const PluginAuthenticationProgress.failed(
+          message: "Authentication finished, but setup could not be verified.",
+        );
+      }
     }
     if (identical(_activePluginAuthentications[pluginId], authentication)) {
       _activePluginAuthentications.remove(pluginId);
@@ -1270,7 +1276,7 @@ class PluginLifecycleService {
       firstStackTrace ??= stackTrace;
     }
     for (final authentication in _activePluginAuthentications.values) {
-      authentication.abort?.call();
+      authentication.operation.abort();
     }
     try {
       await Future.wait([
@@ -1504,7 +1510,9 @@ class _ActivePluginCommand {
 }
 
 class _ActivePluginAuthentication {
+  _ActivePluginAuthentication({required this.operation});
+
+  final PluginRuntimeAuthenticationOperation operation;
   final Completer<PluginAuthenticationChallengeResponse> challenge = Completer<PluginAuthenticationChallengeResponse>();
   final Completer<void> settled = Completer<void>();
-  void Function()? abort;
 }

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -48,6 +48,8 @@ typedef PluginInstallProgressUpdate = ({
   String? message,
 });
 
+typedef PluginAuthenticationProgressUpdate = ({String pluginId, PluginAuthenticationProgress progress});
+
 class PluginIdleTimerScheduler {
   const PluginIdleTimerScheduler();
 
@@ -88,11 +90,14 @@ class PluginLifecycleService {
   final StreamController<String> _managementSnapshotTokenController = StreamController<String>.broadcast(sync: true);
   final StreamController<PluginInstallProgressUpdate> _installProgressController =
       StreamController<PluginInstallProgressUpdate>.broadcast(sync: true);
+  final StreamController<PluginAuthenticationProgressUpdate> _authenticationProgressController =
+      StreamController<PluginAuthenticationProgressUpdate>.broadcast(sync: true);
   final Map<String, DateTime> _lastInstallDownloadEmit = {};
   StreamSubscription<List<PluginLifecycleSnapshot>>? _runtimeSubscription;
   Future<void>? _disposeFuture;
   Future<void> _settingsMutationTail = Future<void>.value();
   final Map<String, _ActivePluginCommand> _activePluginCommands = {};
+  final Map<String, _ActivePluginAuthentication> _activePluginAuthentications = {};
   final Set<String> _deferredReadyPluginIds = {};
   final Map<String, ({Duration duration, Timer timer})> _idleTimers = {};
   _PluginManagementSnapshot? _lastPublishedManagementSnapshot;
@@ -316,6 +321,15 @@ class PluginLifecycleService {
         ),
       );
     }
+    if (_activePluginAuthentications.containsKey(pluginId)) {
+      throw PluginManagementConflictException(
+        PluginLifecycleConflict(
+          pluginId: pluginId,
+          reasons: const [PluginLifecycleConflictReason.transitioning],
+          current: _managementRowForPluginId(pluginId),
+        ),
+      );
+    }
 
     final command = _ActivePluginCommand(request: request);
     _activePluginCommands[pluginId] = command;
@@ -332,6 +346,168 @@ class PluginLifecycleService {
   }
 
   Stream<PluginInstallProgressUpdate> get installProgress => _installProgressController.stream;
+
+  Stream<PluginAuthenticationProgressUpdate> get authenticationProgress => _authenticationProgressController.stream;
+
+  Future<PluginAuthenticationChallengeResponse> authenticate({required String pluginId}) {
+    final knownPluginIds = _knownPluginIds;
+    if (knownPluginIds == null || _setupById == null) {
+      throw StateError("Plugin lifecycle has not been initialized.");
+    }
+    if (!knownPluginIds.contains(pluginId)) {
+      throw PluginManagementPluginNotFoundException(pluginId);
+    }
+    _requireBridgeId();
+    final active = _activePluginAuthentications[pluginId];
+    if (active != null) return active.challenge.future;
+    if (!_supportsManagementCapability(
+      pluginId: pluginId,
+      capability: PluginControlCapability.authentication,
+    )) {
+      throw PluginAuthenticationConflictException(
+        PluginAuthenticationConflict(
+          pluginId: pluginId,
+          reasons: const [PluginAuthenticationConflictReason.unsupported],
+          current: _managementRowForPluginId(pluginId),
+        ),
+      );
+    }
+    if (_activePluginCommands.containsKey(pluginId)) {
+      throw PluginAuthenticationConflictException(
+        PluginAuthenticationConflict(
+          pluginId: pluginId,
+          reasons: const [PluginAuthenticationConflictReason.inFlight],
+          current: _managementRowForPluginId(pluginId),
+        ),
+      );
+    }
+    if (_setupById![pluginId] is! PluginSetupAuthenticationRequired) {
+      throw PluginAuthenticationConflictException(
+        PluginAuthenticationConflict(
+          pluginId: pluginId,
+          reasons: const [PluginAuthenticationConflictReason.setupNotRequired],
+          current: _managementRowForPluginId(pluginId),
+        ),
+      );
+    }
+
+    final authentication = _ActivePluginAuthentication();
+    _activePluginAuthentications[pluginId] = authentication;
+    _publishManagementIfChanged();
+    unawaited(_executeAuthentication(pluginId: pluginId, authentication: authentication));
+    return authentication.challenge.future;
+  }
+
+  Future<SuccessEmptyResponse> cancelAuthentication({required String pluginId}) async {
+    final knownPluginIds = _knownPluginIds;
+    if (knownPluginIds == null || _setupById == null) {
+      throw StateError("Plugin lifecycle has not been initialized.");
+    }
+    if (!knownPluginIds.contains(pluginId)) {
+      throw PluginManagementPluginNotFoundException(pluginId);
+    }
+    _requireBridgeId();
+    if (!_supportsManagementCapability(
+      pluginId: pluginId,
+      capability: PluginControlCapability.authentication,
+    )) {
+      throw PluginAuthenticationConflictException(
+        PluginAuthenticationConflict(
+          pluginId: pluginId,
+          reasons: const [PluginAuthenticationConflictReason.unsupported],
+          current: _managementRowForPluginId(pluginId),
+        ),
+      );
+    }
+    final active = _activePluginAuthentications[pluginId];
+    active?.abort?.call();
+    if (active != null) await active.settled.future;
+    return const SuccessEmptyResponse();
+  }
+
+  Future<void> _executeAuthentication({
+    required String pluginId,
+    required _ActivePluginAuthentication authentication,
+  }) async {
+    PluginAuthenticationProgress progress;
+    try {
+      final operation = _lifecycleRepository.authenticate(pluginId: pluginId);
+      authentication.abort = operation.abort;
+      PluginAuthenticationProgress? terminal;
+      await for (final event in operation.events) {
+        terminal = switch (event) {
+          PluginAuthenticationDeviceCodeChallenge(:final verificationUri, :final userCode) => () {
+            if (verificationUri.scheme != "https") {
+              throw StateError("Plugin authentication returned a non-HTTPS verification URL.");
+            }
+            if (!authentication.challenge.isCompleted) {
+              authentication.challenge.complete(
+                PluginAuthenticationChallengeResponse.deviceCode(
+                  verificationUrl: verificationUri.toString(),
+                  userCode: userCode,
+                ),
+              );
+            }
+            return terminal;
+          }(),
+          PluginAuthenticationCompleted() => const PluginAuthenticationProgress.completed(),
+          PluginAuthenticationFailed(:final message) => PluginAuthenticationProgress.failed(message: message),
+        };
+      }
+      progress = terminal ?? const PluginAuthenticationProgress.failed(message: "Authentication ended unexpectedly.");
+    } on PluginStartAbortedException {
+      progress = const PluginAuthenticationProgress.cancelled();
+    } on Object catch (error, stackTrace) {
+      Log.w('Plugin "$pluginId" authentication failed', error, stackTrace);
+      progress = const PluginAuthenticationProgress.failed(
+        message: "Authentication failed. Check the bridge logs for details.",
+      );
+    }
+
+    try {
+      final setup = await _inspectAfterAuthentication(pluginId: pluginId);
+      if (progress is PluginAuthenticationCompletedProgress && setup is! PluginSetupReady) {
+        progress = const PluginAuthenticationProgress.failed(
+          message: "Authentication finished, but the harness still requires setup.",
+        );
+      }
+    } on Object catch (error, stackTrace) {
+      Log.w('Plugin "$pluginId" setup inspection after authentication failed', error, stackTrace);
+      progress = const PluginAuthenticationProgress.failed(
+        message: "Authentication finished, but setup could not be verified.",
+      );
+    }
+    if (identical(_activePluginAuthentications[pluginId], authentication)) {
+      _activePluginAuthentications.remove(pluginId);
+    }
+    if (!authentication.challenge.isCompleted) {
+      authentication.challenge.completeError(
+        const PluginAuthenticationChallengeUnavailableException(),
+      );
+    }
+    if (!_authenticationProgressController.isClosed) {
+      _authenticationProgressController.add((pluginId: pluginId, progress: progress));
+    }
+    _publishManagementIfChanged();
+    authentication.settled.complete();
+  }
+
+  Future<PluginSetupStatus> _inspectAfterAuthentication({required String pluginId}) async {
+    final inspected = await _lifecycleRepository.inspect(
+      pluginIds: {pluginId},
+      markUnselectedNotInspected: false,
+    );
+    final setup = inspected[pluginId];
+    if (setup == null) throw StateError('Plugin "$pluginId" inspection returned no result.');
+    _applyInspectedSetup(pluginId: pluginId, setup: setup);
+    if (setup is PluginSetupReady && _requireEligiblePluginIds().contains(pluginId)) {
+      _handleRuntimeCommandResult(
+        pluginId: pluginId,
+        result: await _lifecycleRepository.start(pluginId: pluginId),
+      );
+    }
+    return setup;
+  }
 
   Future<void> _executeInstall({
     required String pluginId,
@@ -682,6 +858,11 @@ class PluginLifecycleService {
     if (setup == null) {
       throw PluginManagementCommandFailedException('Plugin "$pluginId" inspection returned no result.');
     }
+    _applyInspectedSetup(pluginId: pluginId, setup: setup);
+    return setup;
+  }
+
+  void _applyInspectedSetup({required String pluginId, required PluginSetupStatus setup}) {
     _setupById = Map<String, PluginSetupStatus>.unmodifiable({..._requireSetupById(), pluginId: setup});
     if (_requireEligiblePluginIds().contains(pluginId) && setup is PluginSetupReady) {
       _startAllowedPluginIds.add(pluginId);
@@ -690,7 +871,6 @@ class PluginLifecycleService {
     }
     _applyAccess();
     _applyRuntimeSnapshots(_lifecycleRepository.snapshot);
-    return setup;
   }
 
   Future<void> _persistPluginDisabled({required String pluginId, required bool disabled}) {
@@ -904,6 +1084,9 @@ class PluginLifecycleService {
       setup: setup,
       runtimeState: _mapRuntimeState(snapshot.state),
       workState: _mapWorkState(snapshot.workState),
+      authenticationState: _activePluginAuthentications.containsKey(plugin.id)
+          ? PluginAuthenticationState.inProgress
+          : PluginAuthenticationState.idle,
       idleTimeoutMins: _effectiveIdleTimeoutMins(plugin.id),
       hasIdleTimeoutOverride: settings.plugins.settingsByPluginId[plugin.id]?.idleTimeoutMins != null,
       managementCapabilities: {
@@ -920,6 +1103,7 @@ class PluginLifecycleService {
         PluginControlCapability.setupRefresh => PluginManagementCapability.setupRefresh,
         PluginControlCapability.idleTimeout => PluginManagementCapability.idleTimeout,
         PluginControlCapability.install => PluginManagementCapability.install,
+        PluginControlCapability.authentication => PluginManagementCapability.authentication,
       };
 
   Set<String> _pluginIdsSupporting({required PluginControlCapability capability}) {
@@ -1081,6 +1265,23 @@ class PluginLifecycleService {
     }
     try {
       await _installProgressController.close();
+    } on Object catch (error, stackTrace) {
+      firstError ??= error;
+      firstStackTrace ??= stackTrace;
+    }
+    for (final authentication in _activePluginAuthentications.values) {
+      authentication.abort?.call();
+    }
+    try {
+      await Future.wait([
+        for (final authentication in _activePluginAuthentications.values) authentication.settled.future,
+      ]);
+    } on Object catch (error, stackTrace) {
+      firstError ??= error;
+      firstStackTrace ??= stackTrace;
+    }
+    try {
+      await _authenticationProgressController.close();
     } on Object catch (error, stackTrace) {
       firstError ??= error;
       firstStackTrace ??= stackTrace;
@@ -1272,6 +1473,16 @@ class PluginManagementConflictException implements Exception {
   final PluginLifecycleConflict conflict;
 }
 
+class PluginAuthenticationConflictException implements Exception {
+  const PluginAuthenticationConflictException(this.conflict);
+
+  final PluginAuthenticationConflict conflict;
+}
+
+class PluginAuthenticationChallengeUnavailableException implements Exception {
+  const PluginAuthenticationChallengeUnavailableException();
+}
+
 class PluginManagementCommandFailedException implements Exception {
   const PluginManagementCommandFailedException(this.message);
 
@@ -1290,4 +1501,10 @@ class _ActivePluginCommand {
 
   final PluginLifecycleCommandRequest request;
   final Completer<PluginManagementResponse> completer = Completer<PluginManagementResponse>();
+}
+
+class _ActivePluginAuthentication {
+  final Completer<PluginAuthenticationChallengeResponse> challenge = Completer<PluginAuthenticationChallengeResponse>();
+  final Completer<void> settled = Completer<void>();
+  void Function()? abort;
 }

--- a/bridge/app/test/bridge/routing/plugin_authentication_handlers_test.dart
+++ b/bridge/app/test/bridge/routing/plugin_authentication_handlers_test.dart
@@ -1,0 +1,135 @@
+import "package:sesori_bridge/src/routing/plugin_authentication_handlers.dart";
+import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "routing_test_helpers.dart";
+
+void main() {
+  test("authentication handlers match only their exact methods and path", () {
+    final service = _FakePluginLifecycleService();
+    final start = PostPluginAuthenticationHandler(lifecycleService: service);
+    final cancel = DeletePluginAuthenticationHandler(lifecycleService: service);
+
+    expect(start.canHandle(makeRequest("POST", "/plugin/codex/authentication")), isTrue);
+    expect(start.canHandle(makeRequest("DELETE", "/plugin/codex/authentication")), isFalse);
+    expect(cancel.canHandle(makeRequest("DELETE", "/plugin/codex/authentication")), isTrue);
+    expect(cancel.canHandle(makeRequest("POST", "/plugin/codex/authentication")), isFalse);
+  });
+
+  test("POST returns a typed challenge and DELETE cancels", () async {
+    final service = _FakePluginLifecycleService();
+    final request = makeRequest("POST", "/plugin/codex/authentication");
+    final started = await PostPluginAuthenticationHandler(lifecycleService: service).handleInternal(
+      request,
+      pathParams: const {"id": "codex"},
+      queryParams: const {},
+      fragment: null,
+    );
+    final cancelled = await DeletePluginAuthenticationHandler(lifecycleService: service).handleInternal(
+      makeRequest("DELETE", "/plugin/codex/authentication"),
+      pathParams: const {"id": "codex"},
+      queryParams: const {},
+      fragment: null,
+    );
+
+    expect(started.status, 200);
+    expect(
+      PluginAuthenticationChallengeResponse.fromJson(jsonDecodeMap(started.body!)),
+      const PluginAuthenticationChallengeResponse.deviceCode(
+        verificationUrl: "https://auth.example/device",
+        userCode: "ABCD-EFGH",
+      ),
+    );
+    expect(cancelled.status, 200);
+    expect(service.startedPluginId, "codex");
+    expect(service.cancelledPluginId, "codex");
+  });
+
+  test("POST maps unknown plugins and typed conflicts", () async {
+    final service = _FakePluginLifecycleService();
+    final handler = PostPluginAuthenticationHandler(lifecycleService: service);
+    service.error = const PluginManagementPluginNotFoundException("missing");
+    final missing = await handler.handleInternal(
+      makeRequest("POST", "/plugin/missing/authentication"),
+      pathParams: const {"id": "missing"},
+      queryParams: const {},
+      fragment: null,
+    );
+    service.error = const PluginAuthenticationConflictException(_conflict);
+    final conflict = await handler.handleInternal(
+      makeRequest("POST", "/plugin/codex/authentication"),
+      pathParams: const {"id": "codex"},
+      queryParams: const {},
+      fragment: null,
+    );
+
+    expect(missing.status, 404);
+    expect(conflict.status, 409);
+    expect(PluginAuthenticationConflict.fromJson(jsonDecodeMap(conflict.body!)), _conflict);
+  });
+
+  test("DELETE maps typed unsupported conflicts", () async {
+    final service = _FakePluginLifecycleService()..cancelError = const PluginAuthenticationConflictException(_conflict);
+    final response = await DeletePluginAuthenticationHandler(lifecycleService: service).handleInternal(
+      makeRequest("DELETE", "/plugin/codex/authentication"),
+      pathParams: const {"id": "codex"},
+      queryParams: const {},
+      fragment: null,
+    );
+
+    expect(response.status, 409);
+    expect(PluginAuthenticationConflict.fromJson(jsonDecodeMap(response.body!)), _conflict);
+  });
+}
+
+const _metadata = PluginManagementMetadata(
+  setup: PluginSetupMetadata(
+    id: "codex",
+    displayName: "Codex",
+    state: PluginSetupState.authenticationRequired,
+    actionHint: "Sign in.",
+  ),
+  runtimeState: PluginRuntimeState.blocked,
+  workState: PluginManagementWorkState.unknown,
+  authenticationState: PluginAuthenticationState.idle,
+  idleTimeoutMins: 0,
+  hasIdleTimeoutOverride: false,
+  managementCapabilities: {PluginManagementCapability.authentication},
+  actionHint: "Sign in.",
+);
+
+const _conflict = PluginAuthenticationConflict(
+  pluginId: "codex",
+  reasons: [PluginAuthenticationConflictReason.inFlight],
+  current: _metadata,
+);
+
+class _FakePluginLifecycleService implements PluginLifecycleService {
+  String? startedPluginId;
+  String? cancelledPluginId;
+  Object? error;
+  Object? cancelError;
+
+  @override
+  Future<PluginAuthenticationChallengeResponse> authenticate({required String pluginId}) async {
+    startedPluginId = pluginId;
+    final currentError = error;
+    if (currentError != null) throw currentError;
+    return const PluginAuthenticationChallengeResponse.deviceCode(
+      verificationUrl: "https://auth.example/device",
+      userCode: "ABCD-EFGH",
+    );
+  }
+
+  @override
+  Future<SuccessEmptyResponse> cancelAuthentication({required String pluginId}) async {
+    cancelledPluginId = pluginId;
+    final currentError = cancelError;
+    if (currentError != null) throw currentError;
+    return const SuccessEmptyResponse();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
@@ -63,6 +63,45 @@ void main() {
     expect(events.single, isA<ProvisionFailed>());
   });
 
+  test("authenticate forwards safe events and aborts on shutdown", () async {
+    final authenticationGate = Completer<void>();
+    final descriptor = _AuthenticationDescriptor(
+      authenticate: (aborted) async* {
+        yield PluginAuthenticationDeviceCodeChallenge(
+          verificationUri: Uri.parse("https://auth.example/device"),
+          userCode: "ABCD-EFGH",
+        );
+        await authenticationGate.future;
+        if (aborted.isAborted) throw const PluginStartAbortedException();
+        yield const PluginAuthenticationCompleted();
+      },
+    );
+    final runtime = _runtime(
+      factory: _FakeGenerationFactory(startGate: Future<void>.value()),
+      descriptor: descriptor,
+    );
+    addTearDown(runtime.dispose);
+    final events = <PluginAuthenticationEvent>[];
+    final operation = runtime.authenticate(pluginId: "one");
+    final done = operation.events.listen(events.add).asFuture<void>();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(events.single, isA<PluginAuthenticationDeviceCodeChallenge>());
+    runtime.beginShutdown();
+    authenticationGate.complete();
+    await expectLater(done, throwsA(isA<PluginStartAbortedException>()));
+  });
+
+  test("authenticate rejects descriptors without the optional capability", () {
+    final runtime = _runtime(factory: _FakeGenerationFactory(startGate: Future<void>.value()));
+    addTearDown(runtime.dispose);
+
+    expect(
+      () => runtime.authenticate(pluginId: "one"),
+      throwsA(isA<StateError>()),
+    );
+  });
+
   test("disable invalidates an in-flight setup inspection", () async {
     final inspectionGate = Completer<PluginSetupStatus>();
     final runtime = _runtime(
@@ -1738,6 +1777,23 @@ class _FakeDescriptor extends BridgePluginDescriptor {
 
   @override
   Future<BridgePlugin> start(PluginHost host) => throw UnsupportedError("fake factory owns construction");
+}
+
+class _AuthenticationDescriptor extends _FakeDescriptor implements InteractivePluginAuthenticationDescriptor {
+  const _AuthenticationDescriptor({
+    required Stream<PluginAuthenticationEvent> Function(StartAbortSignal aborted) authenticate,
+  }) : _authenticate = authenticate;
+
+  final Stream<PluginAuthenticationEvent> Function(StartAbortSignal aborted) _authenticate;
+
+  @override
+  Stream<PluginAuthenticationEvent> authenticate({
+    required PluginConfig config,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+    required String stateDirectory,
+    required StartAbortSignal aborted,
+  }) => _authenticate(aborted);
 }
 
 class _FakePlugin implements BridgePlugin {

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -15,6 +15,194 @@ import "../helpers/plugin_runtime_test_support.dart";
 import "../helpers/test_helpers.dart";
 
 void main() {
+  test("authentication joins, publishes state, reinspects, and starts when ready", () async {
+    final repository = _CommandLifecycleRepository(
+      inspectionResult: const PluginSetupReady(),
+      inspectionGate: null,
+      startFailureMessage: null,
+    );
+    final service = _commandService(
+      repository: repository,
+      settingsRepository: null,
+      managementCapabilities: const {PluginControlCapability.authentication},
+    );
+    addTearDown(service.dispose);
+    service.initialize(
+      disabledPluginIds: const {},
+      setupById: const {"one": PluginSetupAuthenticationRequired(actionHint: "Sign in.")},
+    );
+    final progress = <PluginAuthenticationProgressUpdate>[];
+    service.authenticationProgress.listen(progress.add);
+
+    final first = service.authenticate(pluginId: "one");
+    final joined = service.authenticate(pluginId: "one");
+    expect(service.managementSnapshot.plugins.single.authenticationState, PluginAuthenticationState.inProgress);
+    repository.authenticationEvents.add(
+      PluginAuthenticationDeviceCodeChallenge(
+        verificationUri: Uri.parse("https://auth.example/device"),
+        userCode: "ABCD-EFGH",
+      ),
+    );
+
+    expect(await first, await joined);
+    expect(repository.authenticationCalls, 1);
+    repository.authenticationEvents.add(const PluginAuthenticationCompleted());
+    await repository.authenticationEvents.close();
+    while (progress.isEmpty) {
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    expect(progress.single.progress, const PluginAuthenticationProgress.completed());
+    expect(repository.inspectCalls, 1);
+    expect(repository.startCalls, 1);
+    expect(service.managementSnapshot.plugins.single.authenticationState, PluginAuthenticationState.idle);
+    expect(service.managementSnapshot.plugins.single.setup.state, PluginSetupState.ready);
+  });
+
+  test("authentication cancellation aborts upstream and emits cancelled", () async {
+    final repository = _CommandLifecycleRepository(
+      inspectionResult: const PluginSetupAuthenticationRequired(actionHint: "Sign in."),
+      inspectionGate: null,
+      startFailureMessage: null,
+    );
+    final service = _commandService(
+      repository: repository,
+      settingsRepository: null,
+      managementCapabilities: const {PluginControlCapability.authentication},
+    );
+    addTearDown(service.dispose);
+    service.initialize(
+      disabledPluginIds: const {},
+      setupById: const {"one": PluginSetupAuthenticationRequired(actionHint: "Sign in.")},
+    );
+    final progress = <PluginAuthenticationProgressUpdate>[];
+    service.authenticationProgress.listen(progress.add);
+    final challenge = service.authenticate(pluginId: "one");
+    repository.authenticationEvents.add(
+      PluginAuthenticationDeviceCodeChallenge(
+        verificationUri: Uri.parse("https://auth.example/device"),
+        userCode: "ABCD-EFGH",
+      ),
+    );
+    await challenge;
+
+    await service.cancelAuthentication(pluginId: "one");
+
+    expect(repository.authenticationAborted, isTrue);
+    expect(progress.single.progress, const PluginAuthenticationProgress.cancelled());
+    expect(service.managementSnapshot.plugins.single.authenticationState, PluginAuthenticationState.idle);
+  });
+
+  test("authentication completion fails when authoritative setup stays blocked", () async {
+    final repository = _CommandLifecycleRepository(
+      inspectionResult: const PluginSetupAuthenticationRequired(actionHint: "Sign in."),
+      inspectionGate: null,
+      startFailureMessage: null,
+    );
+    final service = _commandService(
+      repository: repository,
+      settingsRepository: null,
+      managementCapabilities: const {PluginControlCapability.authentication},
+    );
+    addTearDown(service.dispose);
+    service.initialize(
+      disabledPluginIds: const {},
+      setupById: const {"one": PluginSetupAuthenticationRequired(actionHint: "Sign in.")},
+    );
+    final progress = <PluginAuthenticationProgressUpdate>[];
+    service.authenticationProgress.listen(progress.add);
+    final challenge = service.authenticate(pluginId: "one");
+    repository.authenticationEvents
+      ..add(
+        PluginAuthenticationDeviceCodeChallenge(
+          verificationUri: Uri.parse("https://auth.example/device"),
+          userCode: "ABCD-EFGH",
+        ),
+      )
+      ..add(const PluginAuthenticationCompleted());
+    await challenge;
+    await repository.authenticationEvents.close();
+    while (progress.isEmpty) {
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    expect(progress.single.progress, isA<PluginAuthenticationFailedProgress>());
+    expect(repository.startCalls, 0);
+  });
+
+  test("authentication rejects unsupported, unnecessary, and command-conflicting starts", () async {
+    final repository = _CommandLifecycleRepository(
+      inspectionResult: const PluginSetupReady(),
+      inspectionGate: Completer<void>(),
+      startFailureMessage: null,
+    );
+    final unsupported = _commandService(repository: repository, settingsRepository: null)
+      ..initialize(
+        disabledPluginIds: const {},
+        setupById: const {"one": PluginSetupAuthenticationRequired(actionHint: "Sign in.")},
+      );
+    addTearDown(unsupported.dispose);
+    expect(
+      () => unsupported.authenticate(pluginId: "one"),
+      throwsA(
+        isA<PluginAuthenticationConflictException>().having(
+          (error) => error.conflict.reasons,
+          "reasons",
+          [PluginAuthenticationConflictReason.unsupported],
+        ),
+      ),
+    );
+
+    final ready = _commandService(
+      repository: repository,
+      settingsRepository: null,
+      managementCapabilities: const {PluginControlCapability.authentication},
+    )..initialize(disabledPluginIds: const {}, setupById: const {"one": PluginSetupReady()});
+    addTearDown(ready.dispose);
+    expect(
+      () => ready.authenticate(pluginId: "one"),
+      throwsA(
+        isA<PluginAuthenticationConflictException>().having(
+          (error) => error.conflict.reasons,
+          "reasons",
+          [PluginAuthenticationConflictReason.setupNotRequired],
+        ),
+      ),
+    );
+
+    final commandRepository = _CommandLifecycleRepository(
+      inspectionResult: const PluginSetupAuthenticationRequired(actionHint: "Sign in."),
+      inspectionGate: Completer<void>(),
+      startFailureMessage: null,
+    );
+    final commandConflict =
+        _commandService(
+          repository: commandRepository,
+          settingsRepository: null,
+          managementCapabilities: const {
+            PluginControlCapability.authentication,
+            PluginControlCapability.setupRefresh,
+          },
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"one": PluginSetupAuthenticationRequired(actionHint: "Sign in.")},
+        );
+    addTearDown(commandConflict.dispose);
+    unawaited(commandConflict.command(pluginId: "one", request: const PluginLifecycleCommandRequest.refresh()));
+    await Future<void>.delayed(Duration.zero);
+    expect(
+      () => commandConflict.authenticate(pluginId: "one"),
+      throwsA(
+        isA<PluginAuthenticationConflictException>().having(
+          (error) => error.conflict.reasons,
+          "reasons",
+          [PluginAuthenticationConflictReason.inFlight],
+        ),
+      ),
+    );
+    commandRepository.inspectionGate!.complete();
+  });
+
   test("derives alphabetical eligibility and default from setup", () {
     final runtime = createRegisteredTestPluginRuntime(pluginIds: const ["zeta", "alpha", "beta"]);
     addTearDown(runtime.dispose);
@@ -1439,17 +1627,19 @@ void main() {
   });
 
   test("install streams progress, enables, re-inspects, and starts when ready", () async {
-    final repository = _CommandLifecycleRepository(
-      inspectionResult: const PluginSetupReady(),
-      inspectionGate: null,
-      startFailureMessage: null,
-    )..installEvents = const [
-        ProvisionResolving(),
-        ProvisionDownloading(receivedBytes: 10, totalBytes: 100),
-        ProvisionVerifying(),
-        ProvisionExtracting(),
-        ProvisionReady(binaryPath: "/managed/one"),
-      ];
+    final repository =
+        _CommandLifecycleRepository(
+            inspectionResult: const PluginSetupReady(),
+            inspectionGate: null,
+            startFailureMessage: null,
+          )
+          ..installEvents = const [
+            ProvisionResolving(),
+            ProvisionDownloading(receivedBytes: 10, totalBytes: 100),
+            ProvisionVerifying(),
+            ProvisionExtracting(),
+            ProvisionReady(binaryPath: "/managed/one"),
+          ];
     addTearDown(repository.dispose);
     final settingsRepository = _MutableBridgeSettingsRepository(
       settings: const BridgeSettings(
@@ -1458,14 +1648,13 @@ void main() {
     );
     final service =
         _commandService(
-            repository: repository,
-            settingsRepository: settingsRepository,
-            managementCapabilities: installCapableManagementCapabilities,
-          )
-          ..initialize(
-            disabledPluginIds: const {"one"},
-            setupById: const {"one": PluginSetupNotInspected()},
-          );
+          repository: repository,
+          settingsRepository: settingsRepository,
+          managementCapabilities: installCapableManagementCapabilities,
+        )..initialize(
+          disabledPluginIds: const {"one"},
+          setupById: const {"one": PluginSetupNotInspected()},
+        );
     addTearDown(service.dispose);
     final progress = <PluginInstallProgressUpdate>[];
     final progressSubscription = service.installProgress.listen(progress.add);
@@ -1494,14 +1683,16 @@ void main() {
   });
 
   test("a failed install reports a terminal failure without enabling the plugin", () async {
-    final repository = _CommandLifecycleRepository(
-      inspectionResult: const PluginSetupRuntimeMissing(actionHint: "Install"),
-      inspectionGate: null,
-      startFailureMessage: null,
-    )..installEvents = const [
-        ProvisionResolving(),
-        ProvisionFailed(message: "checksum verification failed"),
-      ];
+    final repository =
+        _CommandLifecycleRepository(
+            inspectionResult: const PluginSetupRuntimeMissing(actionHint: "Install"),
+            inspectionGate: null,
+            startFailureMessage: null,
+          )
+          ..installEvents = const [
+            ProvisionResolving(),
+            ProvisionFailed(message: "checksum verification failed"),
+          ];
     addTearDown(repository.dispose);
     final settingsRepository = _MutableBridgeSettingsRepository(
       settings: const BridgeSettings(
@@ -1510,14 +1701,13 @@ void main() {
     );
     final service =
         _commandService(
-            repository: repository,
-            settingsRepository: settingsRepository,
-            managementCapabilities: installCapableManagementCapabilities,
-          )
-          ..initialize(
-            disabledPluginIds: const {"one"},
-            setupById: const {"one": PluginSetupNotInspected()},
-          );
+          repository: repository,
+          settingsRepository: settingsRepository,
+          managementCapabilities: installCapableManagementCapabilities,
+        )..initialize(
+          disabledPluginIds: const {"one"},
+          setupById: const {"one": PluginSetupNotInspected()},
+        );
     addTearDown(service.dispose);
     final progress = <PluginInstallProgressUpdate>[];
     final progressSubscription = service.installProgress.listen(progress.add);
@@ -1543,14 +1733,13 @@ void main() {
     addTearDown(repository.dispose);
     final service =
         _commandService(
-            repository: repository,
-            settingsRepository: null,
-            managementCapabilities: installCapableManagementCapabilities,
-          )
-          ..initialize(
-            disabledPluginIds: const {"one"},
-            setupById: const {"one": PluginSetupNotInspected()},
-          );
+          repository: repository,
+          settingsRepository: null,
+          managementCapabilities: installCapableManagementCapabilities,
+        )..initialize(
+          disabledPluginIds: const {"one"},
+          setupById: const {"one": PluginSetupNotInspected()},
+        );
     addTearDown(service.dispose);
     final progress = <PluginInstallProgressUpdate>[];
     final progressSubscription = service.installProgress.listen(progress.add);
@@ -1568,24 +1757,24 @@ void main() {
 
   test("a duplicate install joins and a different command conflicts while installing", () async {
     final installGate = Completer<void>();
-    final repository = _CommandLifecycleRepository(
-      inspectionResult: const PluginSetupReady(),
-      inspectionGate: null,
-      startFailureMessage: null,
-    )
-      ..installEvents = const [ProvisionReady(binaryPath: "/managed/one")]
-      ..installGate = installGate;
+    final repository =
+        _CommandLifecycleRepository(
+            inspectionResult: const PluginSetupReady(),
+            inspectionGate: null,
+            startFailureMessage: null,
+          )
+          ..installEvents = const [ProvisionReady(binaryPath: "/managed/one")]
+          ..installGate = installGate;
     addTearDown(repository.dispose);
     final service =
         _commandService(
-            repository: repository,
-            settingsRepository: null,
-            managementCapabilities: installCapableManagementCapabilities,
-          )
-          ..initialize(
-            disabledPluginIds: const {},
-            setupById: const {"one": PluginSetupNotInspected()},
-          );
+          repository: repository,
+          settingsRepository: null,
+          managementCapabilities: installCapableManagementCapabilities,
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"one": PluginSetupNotInspected()},
+        );
     addTearDown(service.dispose);
     final progress = <PluginInstallProgressUpdate>[];
     final progressSubscription = service.installProgress.listen(progress.add);
@@ -2263,6 +2452,24 @@ class _CommandLifecycleRepository implements PluginLifecycleRepository {
   int installCalls = 0;
   List<RuntimeProvisionProgress> installEvents = const [];
   Completer<void>? installGate;
+  final StreamController<PluginAuthenticationEvent> authenticationEvents =
+      StreamController<PluginAuthenticationEvent>();
+  int authenticationCalls = 0;
+  bool authenticationAborted = false;
+
+  @override
+  PluginRuntimeAuthenticationOperation authenticate({required String pluginId}) {
+    authenticationCalls++;
+    return PluginRuntimeAuthenticationOperation(
+      events: authenticationEvents.stream,
+      abort: () {
+        authenticationAborted = true;
+        authenticationEvents
+          ..addError(const PluginStartAbortedException())
+          ..close();
+      },
+    );
+  }
 
   @override
   Stream<RuntimeProvisionProgress> installRuntime({required String pluginId}) async* {

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -93,6 +93,75 @@ void main() {
     expect(service.managementSnapshot.plugins.single.authenticationState, PluginAuthenticationState.idle);
   });
 
+  test("authentication cancellation remains cancelled when setup inspection fails", () async {
+    final repository = _CommandLifecycleRepository(
+      inspectionResult: const PluginSetupAuthenticationRequired(actionHint: "Sign in."),
+      inspectionGate: null,
+      startFailureMessage: null,
+    )..inspectionError = StateError("inspection failed");
+    final service = _commandService(
+      repository: repository,
+      settingsRepository: null,
+      managementCapabilities: const {PluginControlCapability.authentication},
+    );
+    addTearDown(service.dispose);
+    service.initialize(
+      disabledPluginIds: const {},
+      setupById: const {"one": PluginSetupAuthenticationRequired(actionHint: "Sign in.")},
+    );
+    final progress = <PluginAuthenticationProgressUpdate>[];
+    service.authenticationProgress.listen(progress.add);
+    final started = service.authenticate(pluginId: "one");
+
+    final cancelled = service.cancelAuthentication(pluginId: "one");
+    await expectLater(started, throwsA(isA<PluginAuthenticationChallengeUnavailableException>()));
+    await cancelled;
+
+    expect(repository.authenticationAborted, isTrue);
+    expect(progress.single.progress, const PluginAuthenticationProgress.cancelled());
+  });
+
+  test("authentication plugin failure message is replaced before wire progress", () async {
+    final repository = _CommandLifecycleRepository(
+      inspectionResult: const PluginSetupAuthenticationRequired(actionHint: "Sign in."),
+      inspectionGate: null,
+      startFailureMessage: null,
+    );
+    final service = _commandService(
+      repository: repository,
+      settingsRepository: null,
+      managementCapabilities: const {PluginControlCapability.authentication},
+    );
+    addTearDown(service.dispose);
+    service.initialize(
+      disabledPluginIds: const {},
+      setupById: const {"one": PluginSetupAuthenticationRequired(actionHint: "Sign in.")},
+    );
+    final progress = <PluginAuthenticationProgressUpdate>[];
+    service.authenticationProgress.listen(progress.add);
+    final started = service.authenticate(pluginId: "one");
+    repository.authenticationEvents
+      ..add(
+        PluginAuthenticationDeviceCodeChallenge(
+          verificationUri: Uri.parse("https://auth.example/device"),
+          userCode: "ABCD-EFGH",
+        ),
+      )
+      ..add(const PluginAuthenticationFailed(message: "private workspace policy detail"));
+    await started;
+    await repository.authenticationEvents.close();
+    while (progress.isEmpty) {
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    expect(
+      progress.single.progress,
+      const PluginAuthenticationProgress.failed(
+        message: "Authentication failed. Check the bridge logs for details.",
+      ),
+    );
+  });
+
   test("authentication completion fails when authoritative setup stays blocked", () async {
     final repository = _CommandLifecycleRepository(
       inspectionResult: const PluginSetupAuthenticationRequired(actionHint: "Sign in."),
@@ -2456,6 +2525,7 @@ class _CommandLifecycleRepository implements PluginLifecycleRepository {
       StreamController<PluginAuthenticationEvent>();
   int authenticationCalls = 0;
   bool authenticationAborted = false;
+  Object? inspectionError;
 
   @override
   PluginRuntimeAuthenticationOperation authenticate({required String pluginId}) {
@@ -2511,6 +2581,8 @@ class _CommandLifecycleRepository implements PluginLifecycleRepository {
   }) async {
     inspectCalls++;
     await inspectionGate?.future;
+    final currentInspectionError = inspectionError;
+    if (currentInspectionError != null) throw currentInspectionError;
     _current = _copySnapshot(
       setup: inspectionResult,
       accessGate: _current.accessGate,

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
@@ -215,6 +215,7 @@ class CodexPluginDescriptor extends BridgePluginDescriptor implements Interactiv
   Set<PluginControlCapability> managementCapabilities({required PluginConfig config}) {
     return {
       ...super.managementCapabilities(config: config),
+      PluginControlCapability.authentication,
       if (_supportsManagedInstall(config: config)) PluginControlCapability.install,
     };
   }

--- a/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
@@ -32,6 +32,7 @@ void main() {
           PluginControlCapability.lifecycle,
           PluginControlCapability.setupRefresh,
           PluginControlCapability.idleTimeout,
+          PluginControlCapability.authentication,
           PluginControlCapability.install,
         },
       );
@@ -46,6 +47,7 @@ void main() {
           PluginControlCapability.lifecycle,
           PluginControlCapability.setupRefresh,
           PluginControlCapability.idleTimeout,
+          PluginControlCapability.authentication,
         },
       );
     });

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_control_capability.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_control_capability.dart
@@ -15,4 +15,7 @@ enum PluginControlCapability {
   /// platform (never with an explicit binary override or an unsupported
   /// platform target).
   install,
+
+  /// Run the descriptor's optional interactive authentication flow.
+  authentication,
 }

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -30,6 +30,9 @@ idle suspension, the management snapshot, and lifecycle commands.
 - Shared management metadata advertises authentication independently and reports idle,
   in-progress, or fail-closed unknown state. Device-code challenges remain request-scoped;
   only sealed completed, failed, or cancelled progress enters the global SSE stream.
+- The bridge exposes explicit plugin-scoped start and cancel routes. Duplicate starts join
+  the active operation, management commands conflict while it runs, cancellation settles
+  upstream cleanup, and setup reinspection remains authoritative before normal startup.
 
 ## Regression Levels
 
@@ -38,7 +41,7 @@ idle suspension, the management snapshot, and lifecycle commands.
 | L1 Smoke | A started bridge inspects every registered harness and publishes coherent setup and management snapshots. A ready fixture has a selectable default; a fixture with no usable harness has zero selectable entries and no default without failing startup. Headless bridge; all registered harnesses listed. |
 | L2 Routine | Demand-driven start of a ready harness, setup refresh, and the disable list surviving restart with eligibility and ordering intact. Headless bridge; representative harness for start, every registered harness for listing and ordering. |
 | L3 Release | The management surface as rendered: per-harness setup, runtime and work state, capability-appropriate controls, default badge, enable/disable, restart, and idle-timeout default plus override persisted across a bridge restart. Client end to end; every harness declaring the relevant capability must pass. |
-| L4 Extended | Busy conflict with force confirmation and cancellation, idle suspension elapsing then returning on demand, harnesses blocked by missing runtime or authentication, a terminally failed harness leaving others usable, a bridge with no usable harness, an externally managed configuration, two harnesses active at once, second mobile platform. Live plugin where a real backend must start or be interrupted, client end to end where card state is claimed. |
+| L4 Extended | Busy conflict with force confirmation and cancellation, authentication start/join/cancel plus shutdown cleanup, idle suspension elapsing then returning on demand, harnesses blocked by missing runtime or authentication, a terminally failed harness leaving others usable, a bridge with no usable harness, an externally managed configuration, two harnesses active at once, second mobile platform. Live plugin where a real backend must start or be interrupted, client end to end where card state is claimed. |
 | L5 Full | Every registered production harness through inspect, enable, disable, restart, refresh, and idle behavior on a supported platform, plus forward-compatible presentation of an unknown harness or capability and the reported state of a session interrupted by a forced disable. Live plugin and client end to end as each entry requires. |
 
 ## Exploration Guidance
@@ -66,9 +69,9 @@ directories. Restore eligibility, timeouts, and sessions afterwards.
 
 - The harness set comes from the current registry; unregistered in-development harnesses
   are out of scope, and no lifecycle path installs a runtime.
-- Backend authentication and credential persistence happen on the bridge machine; the
-  released management route and client presentation remain outside this document until
-  their planned steps land. A forced disable leaves work interrupted.
+- Backend authentication and credential persistence happen on the bridge machine; client
+  orchestration and presentation remain outside this document until their planned steps
+  land. A forced disable leaves work interrupted.
 - Idle windows are minutes-order, so observing a real elapse belongs at L4 or above.
 
 ## Sources


### PR DESCRIPTION
## Complexity

🚧 Complex. This adds security-sensitive, cancellable cross-layer operation ownership across plugin descriptors, bridge runtime, lifecycle state, routes, shutdown, and SSE.

## What

- Advertise Codex interactive authentication through the backend-neutral plugin capability.
- Invoke optional descriptor authentication with controlled host inputs and cooperative shutdown abort.
- Add one active operation per plugin with start-or-join challenge retention, command exclusion, explicit cancellation, and transient management state.
- Reinspect setup after every terminal outcome and start only an eligible, authoritatively ready harness.
- Register explicit POST/DELETE authentication routes and map terminal progress to SSE only in Orchestrator.

## Why

Mobile clients need a bridge-owned, backend-neutral operation boundary before they can initiate and observe Codex device login safely.

## Risk and test focus

High-risk areas are challenge privacy, duplicate starts, cancellation races, command conflicts, shutdown settlement, post-login setup truth, accidental enabling, and backend-specific leakage into bridge core.

## Expected result

A capable new client can start or join one Codex device-login operation, cancel it explicitly, observe safe terminal progress, and see authoritative setup state afterward. Existing clients and unsupported harnesses remain unchanged. There is no database or persisted-data impact; challenge state is memory-only.

## Verification

- Full bridge app tests: 2,542 passing
- Full Codex tests: 361 passing
- Full plugin-interface tests: 152 passing
- Post-rebase focused bridge/Codex/interface tests passing
- `dart analyze --fatal-infos` clean in all affected packages
- `git diff --check origin/main...HEAD`

Architecture implementation review was attempted but the review sub-agent failed before reading code with the task-store error `no such column: replacement_seq`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bridge-owned interactive authentication for plugin harnesses, enabling safe device login flows. Adds start/join and cancel routes, streams terminal progress over SSE, auto-starts after verified setup, and surfaces auth state in management snapshots.

- **New Features**
  - POST `/plugin/:id/authentication` returns a typed `PluginAuthenticationChallengeResponse`; DELETE cancels an in-flight operation.
  - One active auth per plugin with start-or-join semantics; lifecycle commands are blocked during auth. Typed `409` `PluginAuthenticationConflict` on conflicts.
  - Emits `PluginAuthenticationProgress` to SSE on terminal states (completed, failed, cancelled); challenge data remains request-scoped.
  - Management snapshot adds `authenticationState` (idle, inProgress) and exposes `PluginManagementCapability.authentication`.
  - After auth, lifecycle re-inspects setup and starts the harness when `ready`.
  - Runtime forwards descriptor auth events and aborts cooperatively on shutdown.

- **Bug Fixes**
  - Hardened authentication settlement: aborts and awaits in-flight auth on shutdown; cancellation emits `cancelled`; unexpected endings are treated as `failed`; verification URLs must be HTTPS; plugin failure messages are sanitized before SSE; returns a typed `PluginAuthenticationChallengeUnavailableException` when no challenge was produced.

<sup>Written for commit bc0cb552f5c0e961b6a74cc7c043bdb0650a4311. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

