### PR TITLE
🚧 [codex-mobile-login] feat(client): orchestrate harness authentication [step 6/8]

### DIFF
--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -111,10 +111,11 @@
   required architecture implementation review could not run because the
   review sub-agent failed before reading code with the internal task-store
   schema error `no such column: replacement_seq`. `git diff --check
-  origin/main...HEAD` passes and the production/test/doc scope contains 1,581
-  additions and 22 deletions. The small overage above the 1,500-line target is
-  generated Freezed state plus focused API, repository, service, and cubit race
-  coverage required by the security-sensitive cross-layer flow.
+  origin/main...HEAD` passes and the final production/test/doc scope contains
+  2,100 additions and 29 deletions. The overage above the 1,500-line target is
+  primarily generated Freezed presentation state plus focused API, repository,
+  service, and cubit race coverage added for the security-sensitive cross-layer
+  flow and review-discovered response-ordering cases.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -3,12 +3,12 @@
 ## Current State
 
 - **Plan slug:** `codex-mobile-login`
-- **Series state:** Steps 1-5 merged; Step 6 ready to publish
+- **Series state:** Steps 1-5 merged; Step 6 PR open
 - **Current step:** 6/8
 - **Implementation base:** Step 5 merge commit `e13b9a38`
 - **Plan PR:** [#824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824)
-- **Current PR:** Pending Step 6 publication
-- **Next action:** Publish Step 6 and start Step 7 locally
+- **Current PR:** [#837](https://github.com/sesori-ai/sesori_apps_monorepo/pull/837)
+- **Next action:** Monitor Step 6 and implement Step 7 locally
 
 ## Plan Review
 
@@ -31,7 +31,7 @@
 | [x] | 3/8 | `🚧 [codex-mobile-login] feat(codex): implement device authentication [step 3/8]` | 850-1,450 | [PR #833](https://github.com/sesori-ai/sesori_apps_monorepo/pull/833) merged |
 | [x] | 4/8 | `⚙️ [codex-mobile-login] feat(protocol): describe harness authentication [step 4/8]` | 650-1,200 | [PR #834](https://github.com/sesori-ai/sesori_apps_monorepo/pull/834) merged |
 | [x] | 5/8 | `🚧 [codex-mobile-login] feat(bridge): expose harness authentication [step 5/8]` | 950-1,500 | [PR #835](https://github.com/sesori-ai/sesori_apps_monorepo/pull/835) merged |
-| [ ] | 6/8 | `🚧 [codex-mobile-login] feat(client): orchestrate harness authentication [step 6/8]` | 900-1,500 | Ready to publish |
+| [ ] | 6/8 | `🚧 [codex-mobile-login] feat(client): orchestrate harness authentication [step 6/8]` | 900-1,500 | [PR #837](https://github.com/sesori-ai/sesori_apps_monorepo/pull/837) open |
 | [ ] | 7/8 | `⚙️ [codex-mobile-login] feat(app): add mobile Codex login [step 7/8]` | 750-1,350 | Pending |
 | [ ] | 8/8 | `🌱 [codex-mobile-login] docs: retire mobile Codex login plan [step 8/8]` | 50-200 | Pending |
 

--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -4,11 +4,11 @@
 
 - **Plan slug:** `codex-mobile-login`
 - **Series state:** Step 5 PR open
-- **Current step:** 5/8 in review
+- **Current step:** 6/8 implemented locally; Step 5 in review
 - **Implementation base:** Step 4 merge commit `2bc60ae3`
 - **Plan PR:** [#824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824)
 - **Current PR:** [#835](https://github.com/sesori-ai/sesori_apps_monorepo/pull/835)
-- **Next action:** Monitor Step 5 review/CI and implement Step 6 locally
+- **Next action:** Merge Step 5, rebase and publish Step 6
 
 ## Plan Review
 
@@ -31,7 +31,7 @@
 | [x] | 3/8 | `🚧 [codex-mobile-login] feat(codex): implement device authentication [step 3/8]` | 850-1,450 | [PR #833](https://github.com/sesori-ai/sesori_apps_monorepo/pull/833) merged |
 | [x] | 4/8 | `⚙️ [codex-mobile-login] feat(protocol): describe harness authentication [step 4/8]` | 650-1,200 | [PR #834](https://github.com/sesori-ai/sesori_apps_monorepo/pull/834) merged |
 | [ ] | 5/8 | `🚧 [codex-mobile-login] feat(bridge): expose harness authentication [step 5/8]` | 950-1,500 | [PR #835](https://github.com/sesori-ai/sesori_apps_monorepo/pull/835) open |
-| [ ] | 6/8 | `🚧 [codex-mobile-login] feat(client): orchestrate harness authentication [step 6/8]` | 900-1,500 | Pending |
+| [ ] | 6/8 | `🚧 [codex-mobile-login] feat(client): orchestrate harness authentication [step 6/8]` | 900-1,500 | Implemented locally; awaiting Step 5 merge |
 | [ ] | 7/8 | `⚙️ [codex-mobile-login] feat(app): add mobile Codex login [step 7/8]` | 750-1,350 | Pending |
 | [ ] | 8/8 | `🌱 [codex-mobile-login] docs: retire mobile Codex login plan [step 8/8]` | 50-200 | Pending |
 
@@ -101,6 +101,15 @@
   deletions. The lower-than-estimated size reflects reuse of existing lifecycle
   ownership rather than introducing a parallel coordinator. Pushed and opened
   as [PR #835](https://github.com/sesori-ai/sesori_apps_monorepo/pull/835).
+- Step 6 local: Full `module_core` tests pass (1,050 tests), focused API,
+  repository, service, and cubit authentication tests pass (78 tests), and
+  fatal-info analysis is clean in `module_core` and the mobile app. Coverage
+  includes typed routes, conflict and response-loss mapping, absolute HTTPS
+  challenge validation, fast terminal SSE ordering, reconnect fencing,
+  explicit browser launch, cancellation, and terminal presentation. The
+  required architecture implementation review could not run because the
+  review sub-agent failed before reading code with the internal task-store
+  schema error `no such column: replacement_seq`.
 
 ## Findings And Plan Deltas
 
@@ -157,3 +166,14 @@
   settlement. The successor remains local until Step 4 merges.
 - **2026-08-12 - Step 4 merged:** Rebased Step 5 onto merge commit `2bc60ae3`
   after PR #834 merged with fail-closed future-progress compatibility.
+- **2026-08-12 - Step 6 implementation:** Added typed authentication transport
+  and repository outcomes, connection- and bridge-fenced service correlation,
+  ephemeral HTTPS-only challenges, fast-terminal retention, and independent
+  cubit presentation state with explicit browser launch and cancellation. No
+  authentication control is rendered yet; Step 7 owns presentation.
+- **2026-08-12 - Step 5 review:** Addressed all three Qodo threads in
+  `bc0cb552`: active operations now always own a non-null abort seam,
+  cancellation remains authoritative through setup-inspection failure, and
+  plugin-controlled failure details remain local while wire progress uses a
+  fixed safe message. PR #835 is green, approved, mergeable, and has zero
+  unresolved threads.

--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -112,7 +112,7 @@
   review sub-agent failed before reading code with the internal task-store
   schema error `no such column: replacement_seq`. `git diff --check
   origin/main...HEAD` passes and the final production/test/doc scope contains
-  2,100 additions and 29 deletions. The overage above the 1,500-line target is
+  2,101 additions and 29 deletions. The overage above the 1,500-line target is
   primarily generated Freezed presentation state plus focused API, repository,
   service, and cubit race coverage added for the security-sensitive cross-layer
   flow and review-discovered response-ordering cases.

--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -112,7 +112,9 @@
   review sub-agent failed before reading code with the internal task-store
   schema error `no such column: replacement_seq`. `git diff --check
   origin/main...HEAD` passes and the production/test/doc scope contains 1,581
-  additions and 22 deletions.
+  additions and 22 deletions. The small overage above the 1,500-line target is
+  generated Freezed state plus focused API, repository, service, and cubit race
+  coverage required by the security-sensitive cross-layer flow.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/codex-mobile-login/TRACKER.md
+++ b/.plan/active/codex-mobile-login/TRACKER.md
@@ -3,12 +3,12 @@
 ## Current State
 
 - **Plan slug:** `codex-mobile-login`
-- **Series state:** Step 5 PR open
-- **Current step:** 6/8 implemented locally; Step 5 in review
-- **Implementation base:** Step 4 merge commit `2bc60ae3`
+- **Series state:** Steps 1-5 merged; Step 6 ready to publish
+- **Current step:** 6/8
+- **Implementation base:** Step 5 merge commit `e13b9a38`
 - **Plan PR:** [#824](https://github.com/sesori-ai/sesori_apps_monorepo/pull/824)
-- **Current PR:** [#835](https://github.com/sesori-ai/sesori_apps_monorepo/pull/835)
-- **Next action:** Merge Step 5, rebase and publish Step 6
+- **Current PR:** Pending Step 6 publication
+- **Next action:** Publish Step 6 and start Step 7 locally
 
 ## Plan Review
 
@@ -30,8 +30,8 @@
 | [x] | 2/8 | `⚙️ [codex-mobile-login] refactor(codex): prepare authentication primitives [step 2/8]` | 850-1,400 | [PR #827](https://github.com/sesori-ai/sesori_apps_monorepo/pull/827) merged |
 | [x] | 3/8 | `🚧 [codex-mobile-login] feat(codex): implement device authentication [step 3/8]` | 850-1,450 | [PR #833](https://github.com/sesori-ai/sesori_apps_monorepo/pull/833) merged |
 | [x] | 4/8 | `⚙️ [codex-mobile-login] feat(protocol): describe harness authentication [step 4/8]` | 650-1,200 | [PR #834](https://github.com/sesori-ai/sesori_apps_monorepo/pull/834) merged |
-| [ ] | 5/8 | `🚧 [codex-mobile-login] feat(bridge): expose harness authentication [step 5/8]` | 950-1,500 | [PR #835](https://github.com/sesori-ai/sesori_apps_monorepo/pull/835) open |
-| [ ] | 6/8 | `🚧 [codex-mobile-login] feat(client): orchestrate harness authentication [step 6/8]` | 900-1,500 | Implemented locally; awaiting Step 5 merge |
+| [x] | 5/8 | `🚧 [codex-mobile-login] feat(bridge): expose harness authentication [step 5/8]` | 950-1,500 | [PR #835](https://github.com/sesori-ai/sesori_apps_monorepo/pull/835) merged |
+| [ ] | 6/8 | `🚧 [codex-mobile-login] feat(client): orchestrate harness authentication [step 6/8]` | 900-1,500 | Ready to publish |
 | [ ] | 7/8 | `⚙️ [codex-mobile-login] feat(app): add mobile Codex login [step 7/8]` | 750-1,350 | Pending |
 | [ ] | 8/8 | `🌱 [codex-mobile-login] docs: retire mobile Codex login plan [step 8/8]` | 50-200 | Pending |
 
@@ -101,7 +101,8 @@
   deletions. The lower-than-estimated size reflects reuse of existing lifecycle
   ownership rather than introducing a parallel coordinator. Pushed and opened
   as [PR #835](https://github.com/sesori-ai/sesori_apps_monorepo/pull/835).
-- Step 6 local: Full `module_core` tests pass (1,050 tests), focused API,
+- Step 6 local: After rebasing onto Step 5 merge commit `e13b9a38`, full
+  `module_core` tests pass (1,054 tests), focused API,
   repository, service, and cubit authentication tests pass (78 tests), and
   fatal-info analysis is clean in `module_core` and the mobile app. Coverage
   includes typed routes, conflict and response-loss mapping, absolute HTTPS
@@ -109,7 +110,9 @@
   explicit browser launch, cancellation, and terminal presentation. The
   required architecture implementation review could not run because the
   review sub-agent failed before reading code with the internal task-store
-  schema error `no such column: replacement_seq`.
+  schema error `no such column: replacement_seq`. `git diff --check
+  origin/main...HEAD` passes and the production/test/doc scope contains 1,581
+  additions and 22 deletions.
 
 ## Findings And Plan Deltas
 

--- a/client/app/lib/features/settings/harnesses_settings_screen.dart
+++ b/client/app/lib/features/settings/harnesses_settings_screen.dart
@@ -26,7 +26,10 @@ class HarnessesSettingsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => PluginManagementCubit(service: getIt<PluginManagementService>()),
+      create: (_) => PluginManagementCubit(
+        service: getIt<PluginManagementService>(),
+        urlLauncher: getIt<UrlLauncher>(),
+      ),
       child: _HarnessesSettingsBody(presentation: presentation),
     );
   }

--- a/client/app/test/features/settings/harnesses_settings_screen_test.dart
+++ b/client/app/test/features/settings/harnesses_settings_screen_test.dart
@@ -19,6 +19,7 @@ import "package:theme_prego/module_prego.dart";
 import "../../helpers/test_helpers.dart";
 
 class _MockPluginManagementService extends Mock implements PluginManagementService {}
+class _MockUrlLauncher extends Mock implements UrlLauncher {}
 
 const _managed = PluginManagementMetadata(
   setup: PluginSetupMetadata(
@@ -168,6 +169,9 @@ void main() {
   late _MockPluginManagementService service;
   late BehaviorSubject<PluginManagementLoadResult> snapshots;
   late BehaviorSubject<Map<String, PluginInstallProgress>> installProgress;
+  late BehaviorSubject<Map<String, PluginAuthenticationChallenge>> authenticationChallenges;
+  late StreamController<PluginAuthenticationTerminalUpdate> authenticationTerminal;
+  late _MockUrlLauncher urlLauncher;
 
   setUpAll(() {
     registerFallbackValue(const PluginLifecycleCommandRequest.enable());
@@ -180,10 +184,15 @@ void main() {
   setUp(() async {
     await GetIt.instance.reset();
     service = _MockPluginManagementService();
+    urlLauncher = _MockUrlLauncher();
     snapshots = BehaviorSubject();
     installProgress = BehaviorSubject.seeded(const {});
+    authenticationChallenges = BehaviorSubject.seeded(const {});
+    authenticationTerminal = StreamController.broadcast();
     when(() => service.snapshots).thenAnswer((_) => snapshots.stream);
     when(() => service.installProgress).thenAnswer((_) => installProgress.stream);
+    when(() => service.authenticationChallenges).thenAnswer((_) => authenticationChallenges.stream);
+    when(() => service.authenticationTerminal).thenAnswer((_) => authenticationTerminal.stream);
     when(() => service.refresh()).thenAnswer((_) async {});
     when(() => service.onDispose()).thenAnswer((_) async {});
     when(
@@ -234,12 +243,15 @@ void main() {
       ),
     );
     GetIt.instance.registerSingleton<PluginManagementService>(service);
+    GetIt.instance.registerSingleton<UrlLauncher>(urlLauncher);
   });
 
   tearDown(() async {
     await GetIt.instance.reset();
     await snapshots.close();
     await installProgress.close();
+    await authenticationChallenges.close();
+    await authenticationTerminal.close();
   });
 
   testWidgets("renders loading, unsupported, and initial failure treatments", (tester) async {

--- a/client/module_core/lib/src/api/plugin_api.dart
+++ b/client/module_core/lib/src/api/plugin_api.dart
@@ -38,4 +38,19 @@ class PluginApi {
       fromJson: PluginManagementResponse.fromJson,
     );
   }
+
+  Future<ApiResponse<PluginAuthenticationChallengeResponse>> startAuthentication({required String pluginId}) {
+    return _client.post(
+      "/plugin/${Uri.encodeComponent(pluginId)}/authentication",
+      body: const SuccessEmptyResponse().toJson(),
+      fromJson: PluginAuthenticationChallengeResponse.fromJson,
+    );
+  }
+
+  Future<ApiResponse<SuccessEmptyResponse>> cancelAuthentication({required String pluginId}) {
+    return _client.delete(
+      "/plugin/${Uri.encodeComponent(pluginId)}/authentication",
+      fromJson: SuccessEmptyResponse.fromJson,
+    );
+  }
 }

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
@@ -111,7 +111,13 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
     }
     if (isClosed) return;
     final latest = state;
-    if (launched || generation != _authenticationGeneration || latest is! PluginManagementReady) return;
+    if (launched ||
+        generation != _authenticationGeneration ||
+        latest is! PluginManagementReady ||
+        (latest.authentication is! PluginAuthenticationPresentationChallenge &&
+            latest.authentication is! PluginAuthenticationPresentationBrowserLaunchFailedState)) {
+      return;
+    }
     final latestChallenge = _authenticationChallengeData(latest.authentication);
     if (latestChallenge?.pluginId != challenge.pluginId) return;
     emit(
@@ -140,7 +146,16 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
       ),
     );
     final result = await _service.cancelAuthentication(pluginId: challenge.pluginId);
-    if (isClosed || generation != _authenticationGeneration) return;
+    final latestAuthentication = switch (state) {
+      PluginManagementReady(:final authentication) => authentication,
+      PluginManagementLoading() || PluginManagementUnsupported() || PluginManagementFailure() => null,
+    };
+    if (isClosed ||
+        generation != _authenticationGeneration ||
+        latestAuthentication is! PluginAuthenticationPresentationCancelling ||
+        latestAuthentication.pluginId != challenge.pluginId) {
+      return;
+    }
     switch (result) {
       case PluginAuthenticationCancelSuccess():
         break;

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
@@ -102,6 +102,7 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
     if (isClosed || current is! PluginManagementReady) return;
     final challenge = _authenticationChallengeData(current.authentication);
     if (challenge == null) return;
+    final generation = _authenticationGeneration;
     bool launched;
     try {
       launched = await _urlLauncher.launch(challenge.verificationUri);
@@ -110,7 +111,7 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
     }
     if (isClosed) return;
     final latest = state;
-    if (launched || latest is! PluginManagementReady) return;
+    if (launched || generation != _authenticationGeneration || latest is! PluginManagementReady) return;
     final latestChallenge = _authenticationChallengeData(latest.authentication);
     if (latestChallenge?.pluginId != challenge.pluginId) return;
     emit(
@@ -127,8 +128,10 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
   Future<void> cancelAuthentication() async {
     final current = state;
     if (isClosed || current is! PluginManagementReady) return;
+    if (current.authentication is PluginAuthenticationPresentationCancelling) return;
     final challenge = _authenticationChallengeData(current.authentication);
     if (challenge == null) return;
+    final generation = _authenticationGeneration;
     _setAuthentication(
       PluginAuthenticationPresentationState.cancelling(
         pluginId: challenge.pluginId,
@@ -137,7 +140,7 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
       ),
     );
     final result = await _service.cancelAuthentication(pluginId: challenge.pluginId);
-    if (isClosed) return;
+    if (isClosed || generation != _authenticationGeneration) return;
     switch (result) {
       case PluginAuthenticationCancelSuccess():
         break;

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
@@ -4,24 +4,156 @@ import "package:bloc/bloc.dart";
 import "package:collection/collection.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../../platform/url_launcher.dart";
 import "../../repositories/models/plugin_management_result.dart";
 import "../../services/plugin_management_service.dart";
 import "plugin_management_state.dart";
 
 class PluginManagementCubit extends Cubit<PluginManagementState> {
-  PluginManagementCubit({required PluginManagementService service})
+  PluginManagementCubit({required PluginManagementService service, required UrlLauncher urlLauncher})
     : _service = service,
+      _urlLauncher = urlLauncher,
       super(const PluginManagementState.loading()) {
     _snapshotSubscription = service.snapshots.listen((snapshot) => _onSnapshot(snapshot: snapshot));
     _installSubscription = service.installProgress.listen((installs) => _onInstallProgress(installs: installs));
+    _authenticationTerminalSubscription = service.authenticationTerminal.listen(_onAuthenticationTerminal);
   }
 
   final PluginManagementService _service;
+  final UrlLauncher _urlLauncher;
   late final StreamSubscription<PluginManagementLoadResult> _snapshotSubscription;
   late final StreamSubscription<Map<String, PluginInstallProgress>> _installSubscription;
+  late final StreamSubscription<PluginAuthenticationTerminalUpdate> _authenticationTerminalSubscription;
   int _actionGeneration = 0;
 
   Future<void> refresh() => _service.refresh();
+
+  Future<void> startAuthentication({required String pluginId}) async {
+    final current = state;
+    if (isClosed || current is! PluginManagementReady) return;
+    if (current.authentication is! PluginAuthenticationPresentationIdle &&
+        current.authentication is! PluginAuthenticationPresentationFailed) {
+      return;
+    }
+    emit(
+      current.copyWith(
+        authentication: PluginAuthenticationPresentationState.starting(pluginId: pluginId),
+      ),
+    );
+    final result = await _service.startAuthentication(pluginId: pluginId);
+    if (isClosed) return;
+    final latest = state;
+    if (latest is! PluginManagementReady) return;
+    final currentAuthentication = latest.authentication;
+    if (currentAuthentication is! PluginAuthenticationPresentationStarting ||
+        currentAuthentication.pluginId != pluginId) {
+      return;
+    }
+    switch (result) {
+      case PluginAuthenticationStartChallenge():
+        final challenge = _service.authenticationChallenges.valueOrNull?[pluginId];
+        if (challenge == null) {
+          _setAuthenticationFailure(
+            pluginId: pluginId,
+            error: const PluginAuthenticationPresentationError.invalidChallenge(),
+          );
+          return;
+        }
+        _setAuthentication(
+          PluginAuthenticationPresentationState.challenge(
+            pluginId: pluginId,
+            verificationUri: challenge.verificationUri,
+            userCode: challenge.userCode,
+            cancelling: false,
+            error: null,
+          ),
+        );
+      case PluginAuthenticationStartNotFound():
+        _setAuthenticationFailure(
+          pluginId: pluginId,
+          error: const PluginAuthenticationPresentationError.notFound(),
+        );
+      case PluginAuthenticationStartConflict(:final conflict):
+        _setAuthenticationFailure(
+          pluginId: pluginId,
+          error: PluginAuthenticationPresentationError.conflict(conflict: conflict),
+        );
+      case PluginAuthenticationStartUnsupported():
+        _setAuthenticationFailure(
+          pluginId: pluginId,
+          error: const PluginAuthenticationPresentationError.unsupported(),
+        );
+      case PluginAuthenticationStartUncertain():
+        _setAuthenticationFailure(
+          pluginId: pluginId,
+          error: const PluginAuthenticationPresentationError.uncertain(),
+        );
+      case PluginAuthenticationStartFailure(:final error):
+        _setAuthenticationFailure(
+          pluginId: pluginId,
+          error: PluginAuthenticationPresentationError.request(error: error),
+        );
+    }
+  }
+
+  Future<void> launchAuthenticationBrowser() async {
+    final current = state;
+    if (isClosed || current is! PluginManagementReady) return;
+    final authentication = current.authentication;
+    if (authentication is! PluginAuthenticationPresentationChallenge) return;
+    final launched = await _urlLauncher.launch(authentication.verificationUri);
+    if (isClosed) return;
+    final latest = state;
+    if (launched || latest is! PluginManagementReady) return;
+    final latestAuthentication = latest.authentication;
+    if (latestAuthentication is! PluginAuthenticationPresentationChallenge ||
+        latestAuthentication.pluginId != authentication.pluginId) {
+      return;
+    }
+    emit(
+      latest.copyWith(
+        authentication: latestAuthentication.copyWith(
+          error: const PluginAuthenticationPresentationError.browserLaunchFailed(),
+        ),
+      ),
+    );
+  }
+
+  Future<void> cancelAuthentication() async {
+    final current = state;
+    if (isClosed || current is! PluginManagementReady) return;
+    final authentication = current.authentication;
+    if (authentication is! PluginAuthenticationPresentationChallenge || authentication.cancelling) return;
+    emit(current.copyWith(authentication: authentication.copyWith(cancelling: true, error: null)));
+    final result = await _service.cancelAuthentication(pluginId: authentication.pluginId);
+    if (isClosed) return;
+    switch (result) {
+      case PluginAuthenticationCancelSuccess():
+        break;
+      case PluginAuthenticationCancelNotFound():
+        _setAuthenticationFailure(
+          pluginId: authentication.pluginId,
+          error: const PluginAuthenticationPresentationError.notFound(),
+        );
+      case PluginAuthenticationCancelUnsupported():
+        _setAuthenticationFailure(
+          pluginId: authentication.pluginId,
+          error: const PluginAuthenticationPresentationError.unsupported(),
+        );
+      case PluginAuthenticationCancelUncertain():
+        _setAuthenticationFailure(
+          pluginId: authentication.pluginId,
+          error: const PluginAuthenticationPresentationError.uncertain(),
+        );
+      case PluginAuthenticationCancelFailure(:final error):
+        _setAuthenticationFailure(
+          pluginId: authentication.pluginId,
+          error: PluginAuthenticationPresentationError.request(error: error),
+        );
+    }
+  }
+
+  void dismissAuthentication() => _setAuthentication(const PluginAuthenticationPresentationState.idle());
 
   Future<void> enable({required String pluginId}) => _runCommand(
     pluginId: pluginId,
@@ -296,6 +428,12 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
               null => const PluginManagementRefreshState.idle(),
             },
             action: action,
+            authentication: switch (state) {
+              PluginManagementReady(:final authentication) => authentication,
+              PluginManagementLoading() ||
+              PluginManagementUnsupported() ||
+              PluginManagementFailure() => const PluginAuthenticationPresentationState.idle(),
+            },
             installs: installs,
           ),
         );
@@ -306,6 +444,47 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
         _actionGeneration++;
         emit(PluginManagementState.failure(error: error));
     }
+  }
+
+  void _onAuthenticationTerminal(PluginAuthenticationTerminalUpdate update) {
+    if (isClosed) return;
+    final current = state;
+    if (current is! PluginManagementReady) return;
+    final authentication = current.authentication;
+    final currentPluginId = switch (authentication) {
+      PluginAuthenticationPresentationStarting(:final pluginId) ||
+      PluginAuthenticationPresentationChallenge(:final pluginId) => pluginId,
+      PluginAuthenticationPresentationIdle() || PluginAuthenticationPresentationFailed() => null,
+    };
+    if (currentPluginId != update.pluginId) return;
+    switch (update.progress) {
+      case PluginAuthenticationCompletedProgress() || PluginAuthenticationCancelledProgress():
+        _setAuthentication(const PluginAuthenticationPresentationState.idle());
+      case PluginAuthenticationFailedProgress(:final message):
+        _setAuthenticationFailure(
+          pluginId: update.pluginId,
+          error: PluginAuthenticationPresentationError.remote(message: message),
+        );
+      case PluginAuthenticationUnknownProgress():
+        _setAuthenticationFailure(
+          pluginId: update.pluginId,
+          error: const PluginAuthenticationPresentationError.uncertain(),
+        );
+    }
+  }
+
+  void _setAuthentication(PluginAuthenticationPresentationState authentication) {
+    if (isClosed) return;
+    final current = state;
+    if (current is! PluginManagementReady) return;
+    emit(current.copyWith(authentication: authentication));
+  }
+
+  void _setAuthenticationFailure({
+    required String? pluginId,
+    required PluginAuthenticationPresentationError error,
+  }) {
+    _setAuthentication(PluginAuthenticationPresentationState.failed(pluginId: pluginId, error: error));
   }
 
   void _onInstallProgress({required Map<String, PluginInstallProgress> installs}) {
@@ -322,6 +501,7 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
   Future<void> close() async {
     await _snapshotSubscription.cancel();
     await _installSubscription.cancel();
+    await _authenticationTerminalSubscription.cancel();
     return super.close();
   }
 }

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
@@ -25,6 +25,7 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
   late final StreamSubscription<Map<String, PluginInstallProgress>> _installSubscription;
   late final StreamSubscription<PluginAuthenticationTerminalUpdate> _authenticationTerminalSubscription;
   int _actionGeneration = 0;
+  int _authenticationGeneration = 0;
 
   Future<void> refresh() => _service.refresh();
 
@@ -35,6 +36,7 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
         current.authentication is! PluginAuthenticationPresentationFailed) {
       return;
     }
+    final generation = ++_authenticationGeneration;
     emit(
       current.copyWith(
         authentication: PluginAuthenticationPresentationState.starting(pluginId: pluginId),
@@ -45,7 +47,8 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
     final latest = state;
     if (latest is! PluginManagementReady) return;
     final currentAuthentication = latest.authentication;
-    if (currentAuthentication is! PluginAuthenticationPresentationStarting ||
+    if (generation != _authenticationGeneration ||
+        currentAuthentication is! PluginAuthenticationPresentationStarting ||
         currentAuthentication.pluginId != pluginId) {
       return;
     }
@@ -64,8 +67,6 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
             pluginId: pluginId,
             verificationUri: challenge.verificationUri,
             userCode: challenge.userCode,
-            cancelling: false,
-            error: null,
           ),
         );
       case PluginAuthenticationStartNotFound():
@@ -99,21 +100,25 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
   Future<void> launchAuthenticationBrowser() async {
     final current = state;
     if (isClosed || current is! PluginManagementReady) return;
-    final authentication = current.authentication;
-    if (authentication is! PluginAuthenticationPresentationChallenge) return;
-    final launched = await _urlLauncher.launch(authentication.verificationUri);
+    final challenge = _authenticationChallengeData(current.authentication);
+    if (challenge == null) return;
+    bool launched;
+    try {
+      launched = await _urlLauncher.launch(challenge.verificationUri);
+    } on Object {
+      launched = false;
+    }
     if (isClosed) return;
     final latest = state;
     if (launched || latest is! PluginManagementReady) return;
-    final latestAuthentication = latest.authentication;
-    if (latestAuthentication is! PluginAuthenticationPresentationChallenge ||
-        latestAuthentication.pluginId != authentication.pluginId) {
-      return;
-    }
+    final latestChallenge = _authenticationChallengeData(latest.authentication);
+    if (latestChallenge?.pluginId != challenge.pluginId) return;
     emit(
       latest.copyWith(
-        authentication: latestAuthentication.copyWith(
-          error: const PluginAuthenticationPresentationError.browserLaunchFailed(),
+        authentication: PluginAuthenticationPresentationState.browserLaunchFailed(
+          pluginId: challenge.pluginId,
+          verificationUri: challenge.verificationUri,
+          userCode: challenge.userCode,
         ),
       ),
     );
@@ -122,32 +127,46 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
   Future<void> cancelAuthentication() async {
     final current = state;
     if (isClosed || current is! PluginManagementReady) return;
-    final authentication = current.authentication;
-    if (authentication is! PluginAuthenticationPresentationChallenge || authentication.cancelling) return;
-    emit(current.copyWith(authentication: authentication.copyWith(cancelling: true, error: null)));
-    final result = await _service.cancelAuthentication(pluginId: authentication.pluginId);
+    final challenge = _authenticationChallengeData(current.authentication);
+    if (challenge == null) return;
+    _setAuthentication(
+      PluginAuthenticationPresentationState.cancelling(
+        pluginId: challenge.pluginId,
+        verificationUri: challenge.verificationUri,
+        userCode: challenge.userCode,
+      ),
+    );
+    final result = await _service.cancelAuthentication(pluginId: challenge.pluginId);
     if (isClosed) return;
     switch (result) {
       case PluginAuthenticationCancelSuccess():
         break;
       case PluginAuthenticationCancelNotFound():
         _setAuthenticationFailure(
-          pluginId: authentication.pluginId,
+          pluginId: challenge.pluginId,
           error: const PluginAuthenticationPresentationError.notFound(),
+        );
+      case PluginAuthenticationCancelConflict(:final conflict):
+        _setAuthenticationFailure(
+          pluginId: challenge.pluginId,
+          error: PluginAuthenticationPresentationError.conflict(conflict: conflict),
         );
       case PluginAuthenticationCancelUnsupported():
         _setAuthenticationFailure(
-          pluginId: authentication.pluginId,
+          pluginId: challenge.pluginId,
           error: const PluginAuthenticationPresentationError.unsupported(),
         );
       case PluginAuthenticationCancelUncertain():
-        _setAuthenticationFailure(
-          pluginId: authentication.pluginId,
-          error: const PluginAuthenticationPresentationError.uncertain(),
+        _setAuthentication(
+          PluginAuthenticationPresentationState.cancellingUncertain(
+            pluginId: challenge.pluginId,
+            verificationUri: challenge.verificationUri,
+            userCode: challenge.userCode,
+          ),
         );
       case PluginAuthenticationCancelFailure(:final error):
         _setAuthenticationFailure(
-          pluginId: authentication.pluginId,
+          pluginId: challenge.pluginId,
           error: PluginAuthenticationPresentationError.request(error: error),
         );
     }
@@ -453,10 +472,14 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
     final authentication = current.authentication;
     final currentPluginId = switch (authentication) {
       PluginAuthenticationPresentationStarting(:final pluginId) ||
-      PluginAuthenticationPresentationChallenge(:final pluginId) => pluginId,
+      PluginAuthenticationPresentationChallenge(:final pluginId) ||
+      PluginAuthenticationPresentationBrowserLaunchFailedState(:final pluginId) ||
+      PluginAuthenticationPresentationCancelling(:final pluginId) ||
+      PluginAuthenticationPresentationCancellingUncertain(:final pluginId) => pluginId,
       PluginAuthenticationPresentationIdle() || PluginAuthenticationPresentationFailed() => null,
     };
     if (currentPluginId != update.pluginId) return;
+    _authenticationGeneration++;
     switch (update.progress) {
       case PluginAuthenticationCompletedProgress() || PluginAuthenticationCancelledProgress():
         _setAuthentication(const PluginAuthenticationPresentationState.idle());
@@ -505,3 +528,23 @@ class PluginManagementCubit extends Cubit<PluginManagementState> {
     return super.close();
   }
 }
+
+({String pluginId, Uri verificationUri, String userCode})? _authenticationChallengeData(
+  PluginAuthenticationPresentationState state,
+) => switch (state) {
+  PluginAuthenticationPresentationChallenge(:final pluginId, :final verificationUri, :final userCode) ||
+  PluginAuthenticationPresentationBrowserLaunchFailedState(
+    :final pluginId,
+    :final verificationUri,
+    :final userCode,
+  ) ||
+  PluginAuthenticationPresentationCancelling(:final pluginId, :final verificationUri, :final userCode) ||
+  PluginAuthenticationPresentationCancellingUncertain(
+    :final pluginId,
+    :final verificationUri,
+    :final userCode,
+  ) => (pluginId: pluginId, verificationUri: verificationUri, userCode: userCode),
+  PluginAuthenticationPresentationIdle() ||
+  PluginAuthenticationPresentationStarting() ||
+  PluginAuthenticationPresentationFailed() => null,
+};

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.dart
@@ -89,9 +89,22 @@ sealed class PluginAuthenticationPresentationState with _$PluginAuthenticationPr
     required String pluginId,
     required Uri verificationUri,
     required String userCode,
-    required bool cancelling,
-    required PluginAuthenticationPresentationError? error,
   }) = PluginAuthenticationPresentationChallenge;
+  const factory PluginAuthenticationPresentationState.browserLaunchFailed({
+    required String pluginId,
+    required Uri verificationUri,
+    required String userCode,
+  }) = PluginAuthenticationPresentationBrowserLaunchFailedState;
+  const factory PluginAuthenticationPresentationState.cancelling({
+    required String pluginId,
+    required Uri verificationUri,
+    required String userCode,
+  }) = PluginAuthenticationPresentationCancelling;
+  const factory PluginAuthenticationPresentationState.cancellingUncertain({
+    required String pluginId,
+    required Uri verificationUri,
+    required String userCode,
+  }) = PluginAuthenticationPresentationCancellingUncertain;
   const factory PluginAuthenticationPresentationState.failed({
     required String? pluginId,
     required PluginAuthenticationPresentationError error,

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.dart
@@ -72,8 +72,6 @@ sealed class PluginAuthenticationPresentationError with _$PluginAuthenticationPr
   const factory PluginAuthenticationPresentationError.uncertain() = PluginAuthenticationPresentationUncertain;
   const factory PluginAuthenticationPresentationError.invalidChallenge() =
       PluginAuthenticationPresentationInvalidChallenge;
-  const factory PluginAuthenticationPresentationError.browserLaunchFailed() =
-      PluginAuthenticationPresentationBrowserLaunchFailed;
   const factory PluginAuthenticationPresentationError.remote({required String message}) =
       PluginAuthenticationPresentationRemoteError;
   const factory PluginAuthenticationPresentationError.request({required ApiError error}) =

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.dart
@@ -63,6 +63,42 @@ sealed class PluginManagementActionState with _$PluginManagementActionState {
 }
 
 @Freezed()
+sealed class PluginAuthenticationPresentationError with _$PluginAuthenticationPresentationError {
+  const factory PluginAuthenticationPresentationError.notFound() = PluginAuthenticationPresentationNotFound;
+  const factory PluginAuthenticationPresentationError.unsupported() = PluginAuthenticationPresentationUnsupported;
+  const factory PluginAuthenticationPresentationError.conflict({
+    required PluginAuthenticationConflict conflict,
+  }) = PluginAuthenticationPresentationConflict;
+  const factory PluginAuthenticationPresentationError.uncertain() = PluginAuthenticationPresentationUncertain;
+  const factory PluginAuthenticationPresentationError.invalidChallenge() =
+      PluginAuthenticationPresentationInvalidChallenge;
+  const factory PluginAuthenticationPresentationError.browserLaunchFailed() =
+      PluginAuthenticationPresentationBrowserLaunchFailed;
+  const factory PluginAuthenticationPresentationError.remote({required String message}) =
+      PluginAuthenticationPresentationRemoteError;
+  const factory PluginAuthenticationPresentationError.request({required ApiError error}) =
+      PluginAuthenticationPresentationRequestError;
+}
+
+@Freezed()
+sealed class PluginAuthenticationPresentationState with _$PluginAuthenticationPresentationState {
+  const factory PluginAuthenticationPresentationState.idle() = PluginAuthenticationPresentationIdle;
+  const factory PluginAuthenticationPresentationState.starting({required String pluginId}) =
+      PluginAuthenticationPresentationStarting;
+  const factory PluginAuthenticationPresentationState.challenge({
+    required String pluginId,
+    required Uri verificationUri,
+    required String userCode,
+    required bool cancelling,
+    required PluginAuthenticationPresentationError? error,
+  }) = PluginAuthenticationPresentationChallenge;
+  const factory PluginAuthenticationPresentationState.failed({
+    required String? pluginId,
+    required PluginAuthenticationPresentationError error,
+  }) = PluginAuthenticationPresentationFailed;
+}
+
+@Freezed()
 sealed class PluginManagementState with _$PluginManagementState {
   const factory PluginManagementState.loading() = PluginManagementLoading;
 
@@ -74,6 +110,7 @@ sealed class PluginManagementState with _$PluginManagementState {
     required PluginManagementResponse response,
     required PluginManagementRefreshState refresh,
     required PluginManagementActionState action,
+    required PluginAuthenticationPresentationState authentication,
 
     /// In-flight managed runtime installs, keyed by plugin id.
     required Map<String, PluginInstallProgress> installs,

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.freezed.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.freezed.dart
@@ -1097,38 +1097,6 @@ String toString() {
 /// @nodoc
 
 
-class PluginAuthenticationPresentationBrowserLaunchFailed implements PluginAuthenticationPresentationError {
-  const PluginAuthenticationPresentationBrowserLaunchFailed();
-  
-
-
-
-
-
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationBrowserLaunchFailed);
-}
-
-
-@override
-int get hashCode => runtimeType.hashCode;
-
-@override
-String toString() {
-  return 'PluginAuthenticationPresentationError.browserLaunchFailed()';
-}
-
-
-}
-
-
-
-
-/// @nodoc
-
-
 class PluginAuthenticationPresentationRemoteError implements PluginAuthenticationPresentationError {
   const PluginAuthenticationPresentationRemoteError({required this.message});
   

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.freezed.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.freezed.dart
@@ -861,6 +861,705 @@ $PluginLifecycleConflictCopyWith<$Res> get conflict {
 }
 
 /// @nodoc
+mixin _$PluginAuthenticationPresentationError {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationError);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'PluginAuthenticationPresentationError()';
+}
+
+
+}
+
+/// @nodoc
+class $PluginAuthenticationPresentationErrorCopyWith<$Res>  {
+$PluginAuthenticationPresentationErrorCopyWith(PluginAuthenticationPresentationError _, $Res Function(PluginAuthenticationPresentationError) __);
+}
+
+
+
+/// @nodoc
+
+
+class PluginAuthenticationPresentationNotFound implements PluginAuthenticationPresentationError {
+  const PluginAuthenticationPresentationNotFound();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationNotFound);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'PluginAuthenticationPresentationError.notFound()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class PluginAuthenticationPresentationUnsupported implements PluginAuthenticationPresentationError {
+  const PluginAuthenticationPresentationUnsupported();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationUnsupported);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'PluginAuthenticationPresentationError.unsupported()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class PluginAuthenticationPresentationConflict implements PluginAuthenticationPresentationError {
+  const PluginAuthenticationPresentationConflict({required this.conflict});
+  
+
+ final  PluginAuthenticationConflict conflict;
+
+/// Create a copy of PluginAuthenticationPresentationError
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PluginAuthenticationPresentationConflictCopyWith<PluginAuthenticationPresentationConflict> get copyWith => _$PluginAuthenticationPresentationConflictCopyWithImpl<PluginAuthenticationPresentationConflict>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationConflict&&(identical(other.conflict, conflict) || other.conflict == conflict));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,conflict);
+
+@override
+String toString() {
+  return 'PluginAuthenticationPresentationError.conflict(conflict: $conflict)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PluginAuthenticationPresentationConflictCopyWith<$Res> implements $PluginAuthenticationPresentationErrorCopyWith<$Res> {
+  factory $PluginAuthenticationPresentationConflictCopyWith(PluginAuthenticationPresentationConflict value, $Res Function(PluginAuthenticationPresentationConflict) _then) = _$PluginAuthenticationPresentationConflictCopyWithImpl;
+@useResult
+$Res call({
+ PluginAuthenticationConflict conflict
+});
+
+
+$PluginAuthenticationConflictCopyWith<$Res> get conflict;
+
+}
+/// @nodoc
+class _$PluginAuthenticationPresentationConflictCopyWithImpl<$Res>
+    implements $PluginAuthenticationPresentationConflictCopyWith<$Res> {
+  _$PluginAuthenticationPresentationConflictCopyWithImpl(this._self, this._then);
+
+  final PluginAuthenticationPresentationConflict _self;
+  final $Res Function(PluginAuthenticationPresentationConflict) _then;
+
+/// Create a copy of PluginAuthenticationPresentationError
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? conflict = null,}) {
+  return _then(PluginAuthenticationPresentationConflict(
+conflict: null == conflict ? _self.conflict : conflict // ignore: cast_nullable_to_non_nullable
+as PluginAuthenticationConflict,
+  ));
+}
+
+/// Create a copy of PluginAuthenticationPresentationError
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PluginAuthenticationConflictCopyWith<$Res> get conflict {
+  
+  return $PluginAuthenticationConflictCopyWith<$Res>(_self.conflict, (value) {
+    return _then(_self.copyWith(conflict: value));
+  });
+}
+}
+
+/// @nodoc
+
+
+class PluginAuthenticationPresentationUncertain implements PluginAuthenticationPresentationError {
+  const PluginAuthenticationPresentationUncertain();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationUncertain);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'PluginAuthenticationPresentationError.uncertain()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class PluginAuthenticationPresentationInvalidChallenge implements PluginAuthenticationPresentationError {
+  const PluginAuthenticationPresentationInvalidChallenge();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationInvalidChallenge);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'PluginAuthenticationPresentationError.invalidChallenge()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class PluginAuthenticationPresentationBrowserLaunchFailed implements PluginAuthenticationPresentationError {
+  const PluginAuthenticationPresentationBrowserLaunchFailed();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationBrowserLaunchFailed);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'PluginAuthenticationPresentationError.browserLaunchFailed()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class PluginAuthenticationPresentationRemoteError implements PluginAuthenticationPresentationError {
+  const PluginAuthenticationPresentationRemoteError({required this.message});
+  
+
+ final  String message;
+
+/// Create a copy of PluginAuthenticationPresentationError
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PluginAuthenticationPresentationRemoteErrorCopyWith<PluginAuthenticationPresentationRemoteError> get copyWith => _$PluginAuthenticationPresentationRemoteErrorCopyWithImpl<PluginAuthenticationPresentationRemoteError>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationRemoteError&&(identical(other.message, message) || other.message == message));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,message);
+
+@override
+String toString() {
+  return 'PluginAuthenticationPresentationError.remote(message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PluginAuthenticationPresentationRemoteErrorCopyWith<$Res> implements $PluginAuthenticationPresentationErrorCopyWith<$Res> {
+  factory $PluginAuthenticationPresentationRemoteErrorCopyWith(PluginAuthenticationPresentationRemoteError value, $Res Function(PluginAuthenticationPresentationRemoteError) _then) = _$PluginAuthenticationPresentationRemoteErrorCopyWithImpl;
+@useResult
+$Res call({
+ String message
+});
+
+
+
+
+}
+/// @nodoc
+class _$PluginAuthenticationPresentationRemoteErrorCopyWithImpl<$Res>
+    implements $PluginAuthenticationPresentationRemoteErrorCopyWith<$Res> {
+  _$PluginAuthenticationPresentationRemoteErrorCopyWithImpl(this._self, this._then);
+
+  final PluginAuthenticationPresentationRemoteError _self;
+  final $Res Function(PluginAuthenticationPresentationRemoteError) _then;
+
+/// Create a copy of PluginAuthenticationPresentationError
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? message = null,}) {
+  return _then(PluginAuthenticationPresentationRemoteError(
+message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class PluginAuthenticationPresentationRequestError implements PluginAuthenticationPresentationError {
+  const PluginAuthenticationPresentationRequestError({required this.error});
+  
+
+ final  ApiError error;
+
+/// Create a copy of PluginAuthenticationPresentationError
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PluginAuthenticationPresentationRequestErrorCopyWith<PluginAuthenticationPresentationRequestError> get copyWith => _$PluginAuthenticationPresentationRequestErrorCopyWithImpl<PluginAuthenticationPresentationRequestError>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationRequestError&&(identical(other.error, error) || other.error == error));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,error);
+
+@override
+String toString() {
+  return 'PluginAuthenticationPresentationError.request(error: $error)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PluginAuthenticationPresentationRequestErrorCopyWith<$Res> implements $PluginAuthenticationPresentationErrorCopyWith<$Res> {
+  factory $PluginAuthenticationPresentationRequestErrorCopyWith(PluginAuthenticationPresentationRequestError value, $Res Function(PluginAuthenticationPresentationRequestError) _then) = _$PluginAuthenticationPresentationRequestErrorCopyWithImpl;
+@useResult
+$Res call({
+ ApiError error
+});
+
+
+$ApiErrorCopyWith<$Res> get error;
+
+}
+/// @nodoc
+class _$PluginAuthenticationPresentationRequestErrorCopyWithImpl<$Res>
+    implements $PluginAuthenticationPresentationRequestErrorCopyWith<$Res> {
+  _$PluginAuthenticationPresentationRequestErrorCopyWithImpl(this._self, this._then);
+
+  final PluginAuthenticationPresentationRequestError _self;
+  final $Res Function(PluginAuthenticationPresentationRequestError) _then;
+
+/// Create a copy of PluginAuthenticationPresentationError
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? error = null,}) {
+  return _then(PluginAuthenticationPresentationRequestError(
+error: null == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as ApiError,
+  ));
+}
+
+/// Create a copy of PluginAuthenticationPresentationError
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ApiErrorCopyWith<$Res> get error {
+  
+  return $ApiErrorCopyWith<$Res>(_self.error, (value) {
+    return _then(_self.copyWith(error: value));
+  });
+}
+}
+
+/// @nodoc
+mixin _$PluginAuthenticationPresentationState {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationState);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'PluginAuthenticationPresentationState()';
+}
+
+
+}
+
+/// @nodoc
+class $PluginAuthenticationPresentationStateCopyWith<$Res>  {
+$PluginAuthenticationPresentationStateCopyWith(PluginAuthenticationPresentationState _, $Res Function(PluginAuthenticationPresentationState) __);
+}
+
+
+
+/// @nodoc
+
+
+class PluginAuthenticationPresentationIdle implements PluginAuthenticationPresentationState {
+  const PluginAuthenticationPresentationIdle();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationIdle);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'PluginAuthenticationPresentationState.idle()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class PluginAuthenticationPresentationStarting implements PluginAuthenticationPresentationState {
+  const PluginAuthenticationPresentationStarting({required this.pluginId});
+  
+
+ final  String pluginId;
+
+/// Create a copy of PluginAuthenticationPresentationState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PluginAuthenticationPresentationStartingCopyWith<PluginAuthenticationPresentationStarting> get copyWith => _$PluginAuthenticationPresentationStartingCopyWithImpl<PluginAuthenticationPresentationStarting>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationStarting&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,pluginId);
+
+@override
+String toString() {
+  return 'PluginAuthenticationPresentationState.starting(pluginId: $pluginId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PluginAuthenticationPresentationStartingCopyWith<$Res> implements $PluginAuthenticationPresentationStateCopyWith<$Res> {
+  factory $PluginAuthenticationPresentationStartingCopyWith(PluginAuthenticationPresentationStarting value, $Res Function(PluginAuthenticationPresentationStarting) _then) = _$PluginAuthenticationPresentationStartingCopyWithImpl;
+@useResult
+$Res call({
+ String pluginId
+});
+
+
+
+
+}
+/// @nodoc
+class _$PluginAuthenticationPresentationStartingCopyWithImpl<$Res>
+    implements $PluginAuthenticationPresentationStartingCopyWith<$Res> {
+  _$PluginAuthenticationPresentationStartingCopyWithImpl(this._self, this._then);
+
+  final PluginAuthenticationPresentationStarting _self;
+  final $Res Function(PluginAuthenticationPresentationStarting) _then;
+
+/// Create a copy of PluginAuthenticationPresentationState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? pluginId = null,}) {
+  return _then(PluginAuthenticationPresentationStarting(
+pluginId: null == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class PluginAuthenticationPresentationChallenge implements PluginAuthenticationPresentationState {
+  const PluginAuthenticationPresentationChallenge({required this.pluginId, required this.verificationUri, required this.userCode, required this.cancelling, required this.error});
+  
+
+ final  String pluginId;
+ final  Uri verificationUri;
+ final  String userCode;
+ final  bool cancelling;
+ final  PluginAuthenticationPresentationError? error;
+
+/// Create a copy of PluginAuthenticationPresentationState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PluginAuthenticationPresentationChallengeCopyWith<PluginAuthenticationPresentationChallenge> get copyWith => _$PluginAuthenticationPresentationChallengeCopyWithImpl<PluginAuthenticationPresentationChallenge>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationChallenge&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId)&&(identical(other.verificationUri, verificationUri) || other.verificationUri == verificationUri)&&(identical(other.userCode, userCode) || other.userCode == userCode)&&(identical(other.cancelling, cancelling) || other.cancelling == cancelling)&&(identical(other.error, error) || other.error == error));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,pluginId,verificationUri,userCode,cancelling,error);
+
+@override
+String toString() {
+  return 'PluginAuthenticationPresentationState.challenge(pluginId: $pluginId, verificationUri: $verificationUri, userCode: $userCode, cancelling: $cancelling, error: $error)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PluginAuthenticationPresentationChallengeCopyWith<$Res> implements $PluginAuthenticationPresentationStateCopyWith<$Res> {
+  factory $PluginAuthenticationPresentationChallengeCopyWith(PluginAuthenticationPresentationChallenge value, $Res Function(PluginAuthenticationPresentationChallenge) _then) = _$PluginAuthenticationPresentationChallengeCopyWithImpl;
+@useResult
+$Res call({
+ String pluginId, Uri verificationUri, String userCode, bool cancelling, PluginAuthenticationPresentationError? error
+});
+
+
+$PluginAuthenticationPresentationErrorCopyWith<$Res>? get error;
+
+}
+/// @nodoc
+class _$PluginAuthenticationPresentationChallengeCopyWithImpl<$Res>
+    implements $PluginAuthenticationPresentationChallengeCopyWith<$Res> {
+  _$PluginAuthenticationPresentationChallengeCopyWithImpl(this._self, this._then);
+
+  final PluginAuthenticationPresentationChallenge _self;
+  final $Res Function(PluginAuthenticationPresentationChallenge) _then;
+
+/// Create a copy of PluginAuthenticationPresentationState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? pluginId = null,Object? verificationUri = null,Object? userCode = null,Object? cancelling = null,Object? error = freezed,}) {
+  return _then(PluginAuthenticationPresentationChallenge(
+pluginId: null == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String,verificationUri: null == verificationUri ? _self.verificationUri : verificationUri // ignore: cast_nullable_to_non_nullable
+as Uri,userCode: null == userCode ? _self.userCode : userCode // ignore: cast_nullable_to_non_nullable
+as String,cancelling: null == cancelling ? _self.cancelling : cancelling // ignore: cast_nullable_to_non_nullable
+as bool,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as PluginAuthenticationPresentationError?,
+  ));
+}
+
+/// Create a copy of PluginAuthenticationPresentationState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PluginAuthenticationPresentationErrorCopyWith<$Res>? get error {
+    if (_self.error == null) {
+    return null;
+  }
+
+  return $PluginAuthenticationPresentationErrorCopyWith<$Res>(_self.error!, (value) {
+    return _then(_self.copyWith(error: value));
+  });
+}
+}
+
+/// @nodoc
+
+
+class PluginAuthenticationPresentationFailed implements PluginAuthenticationPresentationState {
+  const PluginAuthenticationPresentationFailed({required this.pluginId, required this.error});
+  
+
+ final  String? pluginId;
+ final  PluginAuthenticationPresentationError error;
+
+/// Create a copy of PluginAuthenticationPresentationState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PluginAuthenticationPresentationFailedCopyWith<PluginAuthenticationPresentationFailed> get copyWith => _$PluginAuthenticationPresentationFailedCopyWithImpl<PluginAuthenticationPresentationFailed>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationFailed&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId)&&(identical(other.error, error) || other.error == error));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,pluginId,error);
+
+@override
+String toString() {
+  return 'PluginAuthenticationPresentationState.failed(pluginId: $pluginId, error: $error)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PluginAuthenticationPresentationFailedCopyWith<$Res> implements $PluginAuthenticationPresentationStateCopyWith<$Res> {
+  factory $PluginAuthenticationPresentationFailedCopyWith(PluginAuthenticationPresentationFailed value, $Res Function(PluginAuthenticationPresentationFailed) _then) = _$PluginAuthenticationPresentationFailedCopyWithImpl;
+@useResult
+$Res call({
+ String? pluginId, PluginAuthenticationPresentationError error
+});
+
+
+$PluginAuthenticationPresentationErrorCopyWith<$Res> get error;
+
+}
+/// @nodoc
+class _$PluginAuthenticationPresentationFailedCopyWithImpl<$Res>
+    implements $PluginAuthenticationPresentationFailedCopyWith<$Res> {
+  _$PluginAuthenticationPresentationFailedCopyWithImpl(this._self, this._then);
+
+  final PluginAuthenticationPresentationFailed _self;
+  final $Res Function(PluginAuthenticationPresentationFailed) _then;
+
+/// Create a copy of PluginAuthenticationPresentationState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? pluginId = freezed,Object? error = null,}) {
+  return _then(PluginAuthenticationPresentationFailed(
+pluginId: freezed == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String?,error: null == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as PluginAuthenticationPresentationError,
+  ));
+}
+
+/// Create a copy of PluginAuthenticationPresentationState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PluginAuthenticationPresentationErrorCopyWith<$Res> get error {
+  
+  return $PluginAuthenticationPresentationErrorCopyWith<$Res>(_self.error, (value) {
+    return _then(_self.copyWith(error: value));
+  });
+}
+}
+
+/// @nodoc
 mixin _$PluginManagementState {
 
 
@@ -1034,12 +1733,13 @@ $ApiErrorCopyWith<$Res> get error {
 
 
 class PluginManagementReady implements PluginManagementState {
-  const PluginManagementReady({required this.response, required this.refresh, required this.action, required final  Map<String, PluginInstallProgress> installs}): _installs = installs;
+  const PluginManagementReady({required this.response, required this.refresh, required this.action, required this.authentication, required final  Map<String, PluginInstallProgress> installs}): _installs = installs;
   
 
  final  PluginManagementResponse response;
  final  PluginManagementRefreshState refresh;
  final  PluginManagementActionState action;
+ final  PluginAuthenticationPresentationState authentication;
 /// In-flight managed runtime installs, keyed by plugin id.
  final  Map<String, PluginInstallProgress> _installs;
 /// In-flight managed runtime installs, keyed by plugin id.
@@ -1060,16 +1760,16 @@ $PluginManagementReadyCopyWith<PluginManagementReady> get copyWith => _$PluginMa
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginManagementReady&&(identical(other.response, response) || other.response == response)&&(identical(other.refresh, refresh) || other.refresh == refresh)&&(identical(other.action, action) || other.action == action)&&const DeepCollectionEquality().equals(other._installs, _installs));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginManagementReady&&(identical(other.response, response) || other.response == response)&&(identical(other.refresh, refresh) || other.refresh == refresh)&&(identical(other.action, action) || other.action == action)&&(identical(other.authentication, authentication) || other.authentication == authentication)&&const DeepCollectionEquality().equals(other._installs, _installs));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,response,refresh,action,const DeepCollectionEquality().hash(_installs));
+int get hashCode => Object.hash(runtimeType,response,refresh,action,authentication,const DeepCollectionEquality().hash(_installs));
 
 @override
 String toString() {
-  return 'PluginManagementState.ready(response: $response, refresh: $refresh, action: $action, installs: $installs)';
+  return 'PluginManagementState.ready(response: $response, refresh: $refresh, action: $action, authentication: $authentication, installs: $installs)';
 }
 
 
@@ -1080,11 +1780,11 @@ abstract mixin class $PluginManagementReadyCopyWith<$Res> implements $PluginMana
   factory $PluginManagementReadyCopyWith(PluginManagementReady value, $Res Function(PluginManagementReady) _then) = _$PluginManagementReadyCopyWithImpl;
 @useResult
 $Res call({
- PluginManagementResponse response, PluginManagementRefreshState refresh, PluginManagementActionState action, Map<String, PluginInstallProgress> installs
+ PluginManagementResponse response, PluginManagementRefreshState refresh, PluginManagementActionState action, PluginAuthenticationPresentationState authentication, Map<String, PluginInstallProgress> installs
 });
 
 
-$PluginManagementResponseCopyWith<$Res> get response;$PluginManagementRefreshStateCopyWith<$Res> get refresh;$PluginManagementActionStateCopyWith<$Res> get action;
+$PluginManagementResponseCopyWith<$Res> get response;$PluginManagementRefreshStateCopyWith<$Res> get refresh;$PluginManagementActionStateCopyWith<$Res> get action;$PluginAuthenticationPresentationStateCopyWith<$Res> get authentication;
 
 }
 /// @nodoc
@@ -1097,12 +1797,13 @@ class _$PluginManagementReadyCopyWithImpl<$Res>
 
 /// Create a copy of PluginManagementState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? response = null,Object? refresh = null,Object? action = null,Object? installs = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? response = null,Object? refresh = null,Object? action = null,Object? authentication = null,Object? installs = null,}) {
   return _then(PluginManagementReady(
 response: null == response ? _self.response : response // ignore: cast_nullable_to_non_nullable
 as PluginManagementResponse,refresh: null == refresh ? _self.refresh : refresh // ignore: cast_nullable_to_non_nullable
 as PluginManagementRefreshState,action: null == action ? _self.action : action // ignore: cast_nullable_to_non_nullable
-as PluginManagementActionState,installs: null == installs ? _self._installs : installs // ignore: cast_nullable_to_non_nullable
+as PluginManagementActionState,authentication: null == authentication ? _self.authentication : authentication // ignore: cast_nullable_to_non_nullable
+as PluginAuthenticationPresentationState,installs: null == installs ? _self._installs : installs // ignore: cast_nullable_to_non_nullable
 as Map<String, PluginInstallProgress>,
   ));
 }
@@ -1133,6 +1834,15 @@ $PluginManagementActionStateCopyWith<$Res> get action {
   
   return $PluginManagementActionStateCopyWith<$Res>(_self.action, (value) {
     return _then(_self.copyWith(action: value));
+  });
+}/// Create a copy of PluginManagementState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PluginAuthenticationPresentationStateCopyWith<$Res> get authentication {
+  
+  return $PluginAuthenticationPresentationStateCopyWith<$Res>(_self.authentication, (value) {
+    return _then(_self.copyWith(authentication: value));
   });
 }
 }

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.freezed.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.freezed.dart
@@ -1400,14 +1400,12 @@ as String,
 
 
 class PluginAuthenticationPresentationChallenge implements PluginAuthenticationPresentationState {
-  const PluginAuthenticationPresentationChallenge({required this.pluginId, required this.verificationUri, required this.userCode, required this.cancelling, required this.error});
+  const PluginAuthenticationPresentationChallenge({required this.pluginId, required this.verificationUri, required this.userCode});
   
 
  final  String pluginId;
  final  Uri verificationUri;
  final  String userCode;
- final  bool cancelling;
- final  PluginAuthenticationPresentationError? error;
 
 /// Create a copy of PluginAuthenticationPresentationState
 /// with the given fields replaced by the non-null parameter values.
@@ -1419,16 +1417,16 @@ $PluginAuthenticationPresentationChallengeCopyWith<PluginAuthenticationPresentat
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationChallenge&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId)&&(identical(other.verificationUri, verificationUri) || other.verificationUri == verificationUri)&&(identical(other.userCode, userCode) || other.userCode == userCode)&&(identical(other.cancelling, cancelling) || other.cancelling == cancelling)&&(identical(other.error, error) || other.error == error));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationChallenge&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId)&&(identical(other.verificationUri, verificationUri) || other.verificationUri == verificationUri)&&(identical(other.userCode, userCode) || other.userCode == userCode));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,pluginId,verificationUri,userCode,cancelling,error);
+int get hashCode => Object.hash(runtimeType,pluginId,verificationUri,userCode);
 
 @override
 String toString() {
-  return 'PluginAuthenticationPresentationState.challenge(pluginId: $pluginId, verificationUri: $verificationUri, userCode: $userCode, cancelling: $cancelling, error: $error)';
+  return 'PluginAuthenticationPresentationState.challenge(pluginId: $pluginId, verificationUri: $verificationUri, userCode: $userCode)';
 }
 
 
@@ -1439,11 +1437,11 @@ abstract mixin class $PluginAuthenticationPresentationChallengeCopyWith<$Res> im
   factory $PluginAuthenticationPresentationChallengeCopyWith(PluginAuthenticationPresentationChallenge value, $Res Function(PluginAuthenticationPresentationChallenge) _then) = _$PluginAuthenticationPresentationChallengeCopyWithImpl;
 @useResult
 $Res call({
- String pluginId, Uri verificationUri, String userCode, bool cancelling, PluginAuthenticationPresentationError? error
+ String pluginId, Uri verificationUri, String userCode
 });
 
 
-$PluginAuthenticationPresentationErrorCopyWith<$Res>? get error;
+
 
 }
 /// @nodoc
@@ -1456,30 +1454,226 @@ class _$PluginAuthenticationPresentationChallengeCopyWithImpl<$Res>
 
 /// Create a copy of PluginAuthenticationPresentationState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? pluginId = null,Object? verificationUri = null,Object? userCode = null,Object? cancelling = null,Object? error = freezed,}) {
+@pragma('vm:prefer-inline') $Res call({Object? pluginId = null,Object? verificationUri = null,Object? userCode = null,}) {
   return _then(PluginAuthenticationPresentationChallenge(
 pluginId: null == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
 as String,verificationUri: null == verificationUri ? _self.verificationUri : verificationUri // ignore: cast_nullable_to_non_nullable
 as Uri,userCode: null == userCode ? _self.userCode : userCode // ignore: cast_nullable_to_non_nullable
-as String,cancelling: null == cancelling ? _self.cancelling : cancelling // ignore: cast_nullable_to_non_nullable
-as bool,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
-as PluginAuthenticationPresentationError?,
+as String,
   ));
 }
 
+
+}
+
+/// @nodoc
+
+
+class PluginAuthenticationPresentationBrowserLaunchFailedState implements PluginAuthenticationPresentationState {
+  const PluginAuthenticationPresentationBrowserLaunchFailedState({required this.pluginId, required this.verificationUri, required this.userCode});
+  
+
+ final  String pluginId;
+ final  Uri verificationUri;
+ final  String userCode;
+
 /// Create a copy of PluginAuthenticationPresentationState
 /// with the given fields replaced by the non-null parameter values.
-@override
+@JsonKey(includeFromJson: false, includeToJson: false)
 @pragma('vm:prefer-inline')
-$PluginAuthenticationPresentationErrorCopyWith<$Res>? get error {
-    if (_self.error == null) {
-    return null;
-  }
+$PluginAuthenticationPresentationBrowserLaunchFailedStateCopyWith<PluginAuthenticationPresentationBrowserLaunchFailedState> get copyWith => _$PluginAuthenticationPresentationBrowserLaunchFailedStateCopyWithImpl<PluginAuthenticationPresentationBrowserLaunchFailedState>(this, _$identity);
 
-  return $PluginAuthenticationPresentationErrorCopyWith<$Res>(_self.error!, (value) {
-    return _then(_self.copyWith(error: value));
-  });
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationBrowserLaunchFailedState&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId)&&(identical(other.verificationUri, verificationUri) || other.verificationUri == verificationUri)&&(identical(other.userCode, userCode) || other.userCode == userCode));
 }
+
+
+@override
+int get hashCode => Object.hash(runtimeType,pluginId,verificationUri,userCode);
+
+@override
+String toString() {
+  return 'PluginAuthenticationPresentationState.browserLaunchFailed(pluginId: $pluginId, verificationUri: $verificationUri, userCode: $userCode)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PluginAuthenticationPresentationBrowserLaunchFailedStateCopyWith<$Res> implements $PluginAuthenticationPresentationStateCopyWith<$Res> {
+  factory $PluginAuthenticationPresentationBrowserLaunchFailedStateCopyWith(PluginAuthenticationPresentationBrowserLaunchFailedState value, $Res Function(PluginAuthenticationPresentationBrowserLaunchFailedState) _then) = _$PluginAuthenticationPresentationBrowserLaunchFailedStateCopyWithImpl;
+@useResult
+$Res call({
+ String pluginId, Uri verificationUri, String userCode
+});
+
+
+
+
+}
+/// @nodoc
+class _$PluginAuthenticationPresentationBrowserLaunchFailedStateCopyWithImpl<$Res>
+    implements $PluginAuthenticationPresentationBrowserLaunchFailedStateCopyWith<$Res> {
+  _$PluginAuthenticationPresentationBrowserLaunchFailedStateCopyWithImpl(this._self, this._then);
+
+  final PluginAuthenticationPresentationBrowserLaunchFailedState _self;
+  final $Res Function(PluginAuthenticationPresentationBrowserLaunchFailedState) _then;
+
+/// Create a copy of PluginAuthenticationPresentationState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? pluginId = null,Object? verificationUri = null,Object? userCode = null,}) {
+  return _then(PluginAuthenticationPresentationBrowserLaunchFailedState(
+pluginId: null == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String,verificationUri: null == verificationUri ? _self.verificationUri : verificationUri // ignore: cast_nullable_to_non_nullable
+as Uri,userCode: null == userCode ? _self.userCode : userCode // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class PluginAuthenticationPresentationCancelling implements PluginAuthenticationPresentationState {
+  const PluginAuthenticationPresentationCancelling({required this.pluginId, required this.verificationUri, required this.userCode});
+  
+
+ final  String pluginId;
+ final  Uri verificationUri;
+ final  String userCode;
+
+/// Create a copy of PluginAuthenticationPresentationState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PluginAuthenticationPresentationCancellingCopyWith<PluginAuthenticationPresentationCancelling> get copyWith => _$PluginAuthenticationPresentationCancellingCopyWithImpl<PluginAuthenticationPresentationCancelling>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationCancelling&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId)&&(identical(other.verificationUri, verificationUri) || other.verificationUri == verificationUri)&&(identical(other.userCode, userCode) || other.userCode == userCode));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,pluginId,verificationUri,userCode);
+
+@override
+String toString() {
+  return 'PluginAuthenticationPresentationState.cancelling(pluginId: $pluginId, verificationUri: $verificationUri, userCode: $userCode)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PluginAuthenticationPresentationCancellingCopyWith<$Res> implements $PluginAuthenticationPresentationStateCopyWith<$Res> {
+  factory $PluginAuthenticationPresentationCancellingCopyWith(PluginAuthenticationPresentationCancelling value, $Res Function(PluginAuthenticationPresentationCancelling) _then) = _$PluginAuthenticationPresentationCancellingCopyWithImpl;
+@useResult
+$Res call({
+ String pluginId, Uri verificationUri, String userCode
+});
+
+
+
+
+}
+/// @nodoc
+class _$PluginAuthenticationPresentationCancellingCopyWithImpl<$Res>
+    implements $PluginAuthenticationPresentationCancellingCopyWith<$Res> {
+  _$PluginAuthenticationPresentationCancellingCopyWithImpl(this._self, this._then);
+
+  final PluginAuthenticationPresentationCancelling _self;
+  final $Res Function(PluginAuthenticationPresentationCancelling) _then;
+
+/// Create a copy of PluginAuthenticationPresentationState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? pluginId = null,Object? verificationUri = null,Object? userCode = null,}) {
+  return _then(PluginAuthenticationPresentationCancelling(
+pluginId: null == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String,verificationUri: null == verificationUri ? _self.verificationUri : verificationUri // ignore: cast_nullable_to_non_nullable
+as Uri,userCode: null == userCode ? _self.userCode : userCode // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class PluginAuthenticationPresentationCancellingUncertain implements PluginAuthenticationPresentationState {
+  const PluginAuthenticationPresentationCancellingUncertain({required this.pluginId, required this.verificationUri, required this.userCode});
+  
+
+ final  String pluginId;
+ final  Uri verificationUri;
+ final  String userCode;
+
+/// Create a copy of PluginAuthenticationPresentationState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PluginAuthenticationPresentationCancellingUncertainCopyWith<PluginAuthenticationPresentationCancellingUncertain> get copyWith => _$PluginAuthenticationPresentationCancellingUncertainCopyWithImpl<PluginAuthenticationPresentationCancellingUncertain>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginAuthenticationPresentationCancellingUncertain&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId)&&(identical(other.verificationUri, verificationUri) || other.verificationUri == verificationUri)&&(identical(other.userCode, userCode) || other.userCode == userCode));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,pluginId,verificationUri,userCode);
+
+@override
+String toString() {
+  return 'PluginAuthenticationPresentationState.cancellingUncertain(pluginId: $pluginId, verificationUri: $verificationUri, userCode: $userCode)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PluginAuthenticationPresentationCancellingUncertainCopyWith<$Res> implements $PluginAuthenticationPresentationStateCopyWith<$Res> {
+  factory $PluginAuthenticationPresentationCancellingUncertainCopyWith(PluginAuthenticationPresentationCancellingUncertain value, $Res Function(PluginAuthenticationPresentationCancellingUncertain) _then) = _$PluginAuthenticationPresentationCancellingUncertainCopyWithImpl;
+@useResult
+$Res call({
+ String pluginId, Uri verificationUri, String userCode
+});
+
+
+
+
+}
+/// @nodoc
+class _$PluginAuthenticationPresentationCancellingUncertainCopyWithImpl<$Res>
+    implements $PluginAuthenticationPresentationCancellingUncertainCopyWith<$Res> {
+  _$PluginAuthenticationPresentationCancellingUncertainCopyWithImpl(this._self, this._then);
+
+  final PluginAuthenticationPresentationCancellingUncertain _self;
+  final $Res Function(PluginAuthenticationPresentationCancellingUncertain) _then;
+
+/// Create a copy of PluginAuthenticationPresentationState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? pluginId = null,Object? verificationUri = null,Object? userCode = null,}) {
+  return _then(PluginAuthenticationPresentationCancellingUncertain(
+pluginId: null == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String,verificationUri: null == verificationUri ? _self.verificationUri : verificationUri // ignore: cast_nullable_to_non_nullable
+as Uri,userCode: null == userCode ? _self.userCode : userCode // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
 }
 
 /// @nodoc

--- a/client/module_core/lib/src/repositories/models/plugin_management_result.dart
+++ b/client/module_core/lib/src/repositories/models/plugin_management_result.dart
@@ -141,6 +141,9 @@ sealed class PluginAuthenticationCancelResult {
 
   const factory PluginAuthenticationCancelResult.success() = PluginAuthenticationCancelSuccess;
   const factory PluginAuthenticationCancelResult.notFound() = PluginAuthenticationCancelNotFound;
+  const factory PluginAuthenticationCancelResult.conflict({
+    required PluginAuthenticationConflict conflict,
+  }) = PluginAuthenticationCancelConflict;
   const factory PluginAuthenticationCancelResult.unsupported() = PluginAuthenticationCancelUnsupported;
   const factory PluginAuthenticationCancelResult.uncertain() = PluginAuthenticationCancelUncertain;
   const factory PluginAuthenticationCancelResult.failure({required ApiError error}) = PluginAuthenticationCancelFailure;
@@ -152,6 +155,11 @@ final class PluginAuthenticationCancelSuccess extends PluginAuthenticationCancel
 
 final class PluginAuthenticationCancelNotFound extends PluginAuthenticationCancelResult {
   const PluginAuthenticationCancelNotFound();
+}
+
+final class PluginAuthenticationCancelConflict extends PluginAuthenticationCancelResult {
+  const PluginAuthenticationCancelConflict({required this.conflict});
+  final PluginAuthenticationConflict conflict;
 }
 
 final class PluginAuthenticationCancelUnsupported extends PluginAuthenticationCancelResult {

--- a/client/module_core/lib/src/repositories/models/plugin_management_result.dart
+++ b/client/module_core/lib/src/repositories/models/plugin_management_result.dart
@@ -88,3 +88,81 @@ final class PluginManagementMutationResultFailure extends PluginManagementMutati
 
   const PluginManagementMutationResultFailure({required this.error});
 }
+
+sealed class PluginAuthenticationStartResult {
+  const PluginAuthenticationStartResult();
+
+  const factory PluginAuthenticationStartResult.challenge({
+    required PluginAuthenticationChallengeResponse challenge,
+  }) = PluginAuthenticationStartChallenge;
+
+  const factory PluginAuthenticationStartResult.notFound() = PluginAuthenticationStartNotFound;
+
+  const factory PluginAuthenticationStartResult.conflict({
+    required PluginAuthenticationConflict conflict,
+  }) = PluginAuthenticationStartConflict;
+
+  const factory PluginAuthenticationStartResult.unsupported() = PluginAuthenticationStartUnsupported;
+
+  const factory PluginAuthenticationStartResult.uncertain() = PluginAuthenticationStartUncertain;
+
+  const factory PluginAuthenticationStartResult.failure({required ApiError error}) = PluginAuthenticationStartFailure;
+}
+
+final class PluginAuthenticationStartChallenge extends PluginAuthenticationStartResult {
+  const PluginAuthenticationStartChallenge({required this.challenge});
+  final PluginAuthenticationChallengeResponse challenge;
+}
+
+final class PluginAuthenticationStartNotFound extends PluginAuthenticationStartResult {
+  const PluginAuthenticationStartNotFound();
+}
+
+final class PluginAuthenticationStartConflict extends PluginAuthenticationStartResult {
+  const PluginAuthenticationStartConflict({required this.conflict});
+  final PluginAuthenticationConflict conflict;
+}
+
+final class PluginAuthenticationStartUnsupported extends PluginAuthenticationStartResult {
+  const PluginAuthenticationStartUnsupported();
+}
+
+final class PluginAuthenticationStartUncertain extends PluginAuthenticationStartResult {
+  const PluginAuthenticationStartUncertain();
+}
+
+final class PluginAuthenticationStartFailure extends PluginAuthenticationStartResult {
+  const PluginAuthenticationStartFailure({required this.error});
+  final ApiError error;
+}
+
+sealed class PluginAuthenticationCancelResult {
+  const PluginAuthenticationCancelResult();
+
+  const factory PluginAuthenticationCancelResult.success() = PluginAuthenticationCancelSuccess;
+  const factory PluginAuthenticationCancelResult.notFound() = PluginAuthenticationCancelNotFound;
+  const factory PluginAuthenticationCancelResult.unsupported() = PluginAuthenticationCancelUnsupported;
+  const factory PluginAuthenticationCancelResult.uncertain() = PluginAuthenticationCancelUncertain;
+  const factory PluginAuthenticationCancelResult.failure({required ApiError error}) = PluginAuthenticationCancelFailure;
+}
+
+final class PluginAuthenticationCancelSuccess extends PluginAuthenticationCancelResult {
+  const PluginAuthenticationCancelSuccess();
+}
+
+final class PluginAuthenticationCancelNotFound extends PluginAuthenticationCancelResult {
+  const PluginAuthenticationCancelNotFound();
+}
+
+final class PluginAuthenticationCancelUnsupported extends PluginAuthenticationCancelResult {
+  const PluginAuthenticationCancelUnsupported();
+}
+
+final class PluginAuthenticationCancelUncertain extends PluginAuthenticationCancelResult {
+  const PluginAuthenticationCancelUncertain();
+}
+
+final class PluginAuthenticationCancelFailure extends PluginAuthenticationCancelResult {
+  const PluginAuthenticationCancelFailure({required this.error});
+  final ApiError error;
+}

--- a/client/module_core/lib/src/repositories/plugin_repository.dart
+++ b/client/module_core/lib/src/repositories/plugin_repository.dart
@@ -36,6 +36,53 @@ class PluginRepository {
     return _mapMutation(future: _api.updateIdleTimeout(request: request));
   }
 
+  Future<PluginAuthenticationStartResult> startAuthentication({required String pluginId}) async {
+    return switch (await _api.startAuthentication(pluginId: pluginId)) {
+      SuccessResponse(:final data) => PluginAuthenticationStartResult.challenge(challenge: data),
+      ErrorResponse(error: NonSuccessCodeError(errorCode: 404)) => const PluginAuthenticationStartResult.notFound(),
+      ErrorResponse(error: NonSuccessCodeError(errorCode: 409, rawErrorString: final body)) =>
+        _mapAuthenticationConflict(body: body),
+      ErrorResponse(
+        error: JsonParsingError() ||
+            EmptyResponseError() ||
+            DartHttpClientError(innerError: TimeoutException() || RelayResponseLostException()),
+      ) =>
+        const PluginAuthenticationStartResult.uncertain(),
+      ErrorResponse(:final error) => PluginAuthenticationStartResult.failure(error: error),
+    };
+  }
+
+  Future<PluginAuthenticationCancelResult> cancelAuthentication({required String pluginId}) async {
+    return switch (await _api.cancelAuthentication(pluginId: pluginId)) {
+      SuccessResponse() => const PluginAuthenticationCancelResult.success(),
+      ErrorResponse(error: NonSuccessCodeError(errorCode: 404)) => const PluginAuthenticationCancelResult.notFound(),
+      ErrorResponse(error: NonSuccessCodeError(errorCode: 409)) => const PluginAuthenticationCancelResult.unsupported(),
+      ErrorResponse(
+        error: JsonParsingError() ||
+            EmptyResponseError() ||
+            DartHttpClientError(innerError: TimeoutException() || RelayResponseLostException()),
+      ) =>
+        const PluginAuthenticationCancelResult.uncertain(),
+      ErrorResponse(:final error) => PluginAuthenticationCancelResult.failure(error: error),
+    };
+  }
+
+  PluginAuthenticationStartResult _mapAuthenticationConflict({required String? body}) {
+    if (body != null) {
+      try {
+        final conflict = PluginAuthenticationConflict.fromJson(jsonDecodeMap(body));
+        return conflict.reasons.contains(PluginAuthenticationConflictReason.unsupported)
+            ? const PluginAuthenticationStartResult.unsupported()
+            : PluginAuthenticationStartResult.conflict(conflict: conflict);
+      } on Object {
+        // The typed failure below is the single observable outcome.
+      }
+    }
+    return PluginAuthenticationStartResult.failure(
+      error: ApiError.nonSuccessCode(errorCode: 409, rawErrorString: body),
+    );
+  }
+
   Future<PluginManagementMutationResult> _mapMutation({
     required Future<ApiResponse<PluginManagementResponse>> future,
   }) async {

--- a/client/module_core/lib/src/repositories/plugin_repository.dart
+++ b/client/module_core/lib/src/repositories/plugin_repository.dart
@@ -69,35 +69,40 @@ class PluginRepository {
   }
 
   PluginAuthenticationStartResult _mapAuthenticationConflict({required String? body}) {
-    if (body != null) {
-      try {
-        final conflict = PluginAuthenticationConflict.fromJson(jsonDecodeMap(body));
-        return conflict.reasons.contains(PluginAuthenticationConflictReason.unsupported)
+    final conflict = _parseAuthenticationConflict(body: body);
+    return switch (conflict) {
+      _AuthenticationConflictParsed(:final conflict) =>
+        conflict.reasons.contains(PluginAuthenticationConflictReason.unsupported)
             ? const PluginAuthenticationStartResult.unsupported()
-            : PluginAuthenticationStartResult.conflict(conflict: conflict);
-      } on Object {
-        return PluginAuthenticationStartResult.failure(error: ApiError.jsonParsing(body));
-      }
-    }
-    return PluginAuthenticationStartResult.failure(
-      error: ApiError.nonSuccessCode(errorCode: 409, rawErrorString: body),
-    );
+            : PluginAuthenticationStartResult.conflict(conflict: conflict),
+      _AuthenticationConflictParseFailure(:final error) => PluginAuthenticationStartResult.failure(error: error),
+    };
   }
 
   PluginAuthenticationCancelResult _mapAuthenticationCancelConflict({required String? body}) {
-    if (body != null) {
-      try {
-        final conflict = PluginAuthenticationConflict.fromJson(jsonDecodeMap(body));
-        return conflict.reasons.contains(PluginAuthenticationConflictReason.unsupported)
+    final conflict = _parseAuthenticationConflict(body: body);
+    return switch (conflict) {
+      _AuthenticationConflictParsed(:final conflict) =>
+        conflict.reasons.contains(PluginAuthenticationConflictReason.unsupported)
             ? const PluginAuthenticationCancelResult.unsupported()
-            : PluginAuthenticationCancelResult.conflict(conflict: conflict);
-      } on Object {
-        return PluginAuthenticationCancelResult.failure(error: ApiError.jsonParsing(body));
-      }
+            : PluginAuthenticationCancelResult.conflict(conflict: conflict),
+      _AuthenticationConflictParseFailure(:final error) => PluginAuthenticationCancelResult.failure(error: error),
+    };
+  }
+
+  _AuthenticationConflictParseResult _parseAuthenticationConflict({required String? body}) {
+    if (body == null) {
+      return _AuthenticationConflictParseFailure(
+        error: ApiError.nonSuccessCode(errorCode: 409, rawErrorString: null),
+      );
     }
-    return PluginAuthenticationCancelResult.failure(
-      error: ApiError.nonSuccessCode(errorCode: 409, rawErrorString: body),
-    );
+    try {
+      return _AuthenticationConflictParsed(
+        conflict: PluginAuthenticationConflict.fromJson(jsonDecodeMap(body)),
+      );
+    } on Object {
+      return _AuthenticationConflictParseFailure(error: ApiError.jsonParsing(body));
+    }
   }
 
   Future<PluginManagementMutationResult> _mapMutation({
@@ -180,4 +185,18 @@ class PluginRepository {
       ErrorResponse(:final error) => ApiResponse.error(error),
     };
   }
+}
+
+sealed class _AuthenticationConflictParseResult {
+  const _AuthenticationConflictParseResult();
+}
+
+final class _AuthenticationConflictParsed extends _AuthenticationConflictParseResult {
+  const _AuthenticationConflictParsed({required this.conflict});
+  final PluginAuthenticationConflict conflict;
+}
+
+final class _AuthenticationConflictParseFailure extends _AuthenticationConflictParseResult {
+  const _AuthenticationConflictParseFailure({required this.error});
+  final ApiError error;
 }

--- a/client/module_core/lib/src/repositories/plugin_repository.dart
+++ b/client/module_core/lib/src/repositories/plugin_repository.dart
@@ -56,7 +56,8 @@ class PluginRepository {
     return switch (await _api.cancelAuthentication(pluginId: pluginId)) {
       SuccessResponse() => const PluginAuthenticationCancelResult.success(),
       ErrorResponse(error: NonSuccessCodeError(errorCode: 404)) => const PluginAuthenticationCancelResult.notFound(),
-      ErrorResponse(error: NonSuccessCodeError(errorCode: 409)) => const PluginAuthenticationCancelResult.unsupported(),
+      ErrorResponse(error: NonSuccessCodeError(errorCode: 409, rawErrorString: final body)) =>
+        _mapAuthenticationCancelConflict(body: body),
       ErrorResponse(
         error: JsonParsingError() ||
             EmptyResponseError() ||
@@ -75,10 +76,26 @@ class PluginRepository {
             ? const PluginAuthenticationStartResult.unsupported()
             : PluginAuthenticationStartResult.conflict(conflict: conflict);
       } on Object {
-        // The typed failure below is the single observable outcome.
+        return PluginAuthenticationStartResult.failure(error: ApiError.jsonParsing(body));
       }
     }
     return PluginAuthenticationStartResult.failure(
+      error: ApiError.nonSuccessCode(errorCode: 409, rawErrorString: body),
+    );
+  }
+
+  PluginAuthenticationCancelResult _mapAuthenticationCancelConflict({required String? body}) {
+    if (body != null) {
+      try {
+        final conflict = PluginAuthenticationConflict.fromJson(jsonDecodeMap(body));
+        return conflict.reasons.contains(PluginAuthenticationConflictReason.unsupported)
+            ? const PluginAuthenticationCancelResult.unsupported()
+            : PluginAuthenticationCancelResult.conflict(conflict: conflict);
+      } on Object {
+        return PluginAuthenticationCancelResult.failure(error: ApiError.jsonParsing(body));
+      }
+    }
+    return PluginAuthenticationCancelResult.failure(
       error: ApiError.nonSuccessCode(errorCode: 409, rawErrorString: body),
     );
   }

--- a/client/module_core/lib/src/services/plugin_management_service.dart
+++ b/client/module_core/lib/src/services/plugin_management_service.dart
@@ -30,6 +30,8 @@ typedef _CapturedManagementRequest = ({
   bool hasBridgeIdentity,
 });
 
+typedef PluginAuthenticationTerminalUpdate = ({String pluginId, PluginAuthenticationProgress progress});
+
 sealed class PluginManagementIdleTimeoutInput {
   const PluginManagementIdleTimeoutInput();
 
@@ -71,6 +73,11 @@ class PluginManagementService with Disposable {
   final ProductAnalyticsService _productAnalyticsService;
   final BehaviorSubject<PluginManagementLoadResult> _snapshots = BehaviorSubject();
   final BehaviorSubject<Map<String, PluginInstallProgress>> _installProgress = BehaviorSubject.seeded(const {});
+  final BehaviorSubject<Map<String, PluginAuthenticationChallenge>> _authenticationChallenges = BehaviorSubject.seeded(
+    const {},
+  );
+  final StreamController<PluginAuthenticationTerminalUpdate> _authenticationTerminalController =
+      StreamController<PluginAuthenticationTerminalUpdate>.broadcast(sync: true);
   final CompositeSubscription _subscriptions = CompositeSubscription();
 
   bool _connected;
@@ -101,12 +108,21 @@ class PluginManagementService with Disposable {
   /// Plugin ids with an install command still awaiting its response, used only
   /// to decide whether a terminal event must be held until acceptance is known.
   final Set<String> _installRequestsInFlight = {};
+  final Set<String> _authenticationRequestsInFlight = {};
+  final Set<String> _selfStartedAuthentications = {};
+  final Map<String, PluginAuthenticationProgress> _pendingAuthenticationOutcomes = {};
+  final Map<String, _ManagementRequestFence> _authenticationFences = {};
 
   ValueStream<PluginManagementLoadResult> get snapshots => _snapshots.stream;
 
   /// In-flight managed runtime installs, keyed by plugin id. An entry appears
   /// when the bridge reports progress and disappears when the install settles.
   ValueStream<Map<String, PluginInstallProgress>> get installProgress => _installProgress.stream;
+
+  ValueStream<Map<String, PluginAuthenticationChallenge>> get authenticationChallenges =>
+      _authenticationChallenges.stream;
+
+  Stream<PluginAuthenticationTerminalUpdate> get authenticationTerminal => _authenticationTerminalController.stream;
 
   Future<void> refresh() {
     _markStale();
@@ -170,6 +186,54 @@ class PluginManagementService with Disposable {
     return _runMutation(
       request: () => _pluginRepository.updateIdleTimeout(request: request),
     );
+  }
+
+  Future<PluginAuthenticationStartResult> startAuthentication({required String pluginId}) async {
+    if (_disposed || !_connected || !_activeBridgeIdentityKnown) {
+      return PluginAuthenticationStartResult.failure(error: ApiError.generic());
+    }
+    final captured = _captureRequest(staleGeneration: _staleGeneration);
+    _selfStartedAuthentications.add(pluginId);
+    _authenticationRequestsInFlight.add(pluginId);
+    _authenticationFences[pluginId] = captured.fence;
+    final result = await _pluginRepository.startAuthentication(pluginId: pluginId);
+    _authenticationRequestsInFlight.remove(pluginId);
+    if (!_isAuthenticationFenceCurrent(pluginId: pluginId)) {
+      _forgetAuthentication(pluginId: pluginId);
+      return const PluginAuthenticationStartResult.uncertain();
+    }
+
+    switch (result) {
+      case PluginAuthenticationStartChallenge(:final challenge):
+        final mapped = _mapAuthenticationChallenge(challenge);
+        if (mapped == null) {
+          _forgetAuthentication(pluginId: pluginId);
+          return PluginAuthenticationStartResult.failure(error: ApiError.generic());
+        }
+        _publishAuthenticationChallenge(pluginId: pluginId, challenge: mapped);
+        final pending = _pendingAuthenticationOutcomes.remove(pluginId);
+        if (pending != null) _settleAuthentication(pluginId: pluginId, progress: pending);
+        return result;
+      case PluginAuthenticationStartUncertain():
+        return result;
+      case PluginAuthenticationStartNotFound() ||
+          PluginAuthenticationStartConflict() ||
+          PluginAuthenticationStartUnsupported() ||
+          PluginAuthenticationStartFailure():
+        _forgetAuthentication(pluginId: pluginId);
+        return result;
+    }
+  }
+
+  Future<PluginAuthenticationCancelResult> cancelAuthentication({required String pluginId}) async {
+    if (_disposed || !_connected || !_isAuthenticationFenceCurrent(pluginId: pluginId)) {
+      return PluginAuthenticationCancelResult.failure(error: ApiError.generic());
+    }
+    final result = await _pluginRepository.cancelAuthentication(pluginId: pluginId);
+    if (!_isAuthenticationFenceCurrent(pluginId: pluginId)) {
+      return const PluginAuthenticationCancelResult.uncertain();
+    }
+    return result;
   }
 
   PluginManagementCommandPlan planApplyAllIdleTimeout({required PluginManagementIdleTimeoutInput input}) {
@@ -240,6 +304,10 @@ class PluginManagementService with Disposable {
   }
 
   void _onSseEvent(SseEvent event) {
+    if (event.data case SesoriPluginAuthenticationProgress(:final pluginId, :final progress)) {
+      _applyAuthenticationProgress(pluginId: pluginId, progress: progress);
+      return;
+    }
     if (event.data case SesoriPluginInstallProgress(:final pluginId, :final phase, :final percent)) {
       _applyInstallProgress(pluginId: pluginId, phase: phase, percent: percent);
       return;
@@ -255,6 +323,86 @@ class PluginManagementService with Disposable {
       if (snapshotToken == currentToken) return;
       _markStale();
     }
+  }
+
+  void _applyAuthenticationProgress({required String pluginId, required PluginAuthenticationProgress progress}) {
+    if (_disposed) return;
+    _markStale();
+    if (_authenticationRequestsInFlight.contains(pluginId)) {
+      _pendingAuthenticationOutcomes[pluginId] = progress;
+      return;
+    }
+    _settleAuthentication(pluginId: pluginId, progress: progress);
+  }
+
+  void _settleAuthentication({required String pluginId, required PluginAuthenticationProgress progress}) {
+    final startedHere =
+        _selfStartedAuthentications.contains(pluginId) && _isAuthenticationFenceCurrent(pluginId: pluginId);
+    _forgetAuthentication(pluginId: pluginId);
+    if (startedHere && !_authenticationTerminalController.isClosed) {
+      _authenticationTerminalController.add((pluginId: pluginId, progress: progress));
+    }
+  }
+
+  PluginAuthenticationChallenge? _mapAuthenticationChallenge(PluginAuthenticationChallengeResponse challenge) {
+    return switch (challenge) {
+      PluginAuthenticationDeviceCodeChallengeResponse(
+        :final verificationUrl,
+        :final userCode,
+      ) =>
+        switch (Uri.tryParse(verificationUrl)) {
+          final uri? when uri.scheme == "https" && uri.host.isNotEmpty => PluginAuthenticationChallenge(
+            verificationUri: uri,
+            userCode: userCode,
+          ),
+          _ => null,
+        },
+    };
+  }
+
+  bool _isAuthenticationFenceCurrent({required String pluginId}) {
+    final fence = _authenticationFences[pluginId];
+    return fence != null &&
+        _isConnectionFenceCurrent(fence) &&
+        _activeBridgeIdentityKnown &&
+        _activeBridgeId == fence.bridgeId;
+  }
+
+  void _publishAuthenticationChallenge({
+    required String pluginId,
+    required PluginAuthenticationChallenge challenge,
+  }) {
+    if (_disposed || _authenticationChallenges.isClosed) return;
+    _authenticationChallenges.add(
+      Map<String, PluginAuthenticationChallenge>.unmodifiable({
+        ..._authenticationChallenges.value,
+        pluginId: challenge,
+      }),
+    );
+  }
+
+  void _forgetAuthentication({required String pluginId}) {
+    _selfStartedAuthentications.remove(pluginId);
+    _authenticationRequestsInFlight.remove(pluginId);
+    _pendingAuthenticationOutcomes.remove(pluginId);
+    _authenticationFences.remove(pluginId);
+    if (_disposed || _authenticationChallenges.isClosed || !_authenticationChallenges.value.containsKey(pluginId)) {
+      return;
+    }
+    _authenticationChallenges.add(
+      Map<String, PluginAuthenticationChallenge>.unmodifiable(
+        Map<String, PluginAuthenticationChallenge>.from(_authenticationChallenges.value)..remove(pluginId),
+      ),
+    );
+  }
+
+  void _clearAuthentications() {
+    _selfStartedAuthentications.clear();
+    _authenticationRequestsInFlight.clear();
+    _pendingAuthenticationOutcomes.clear();
+    _authenticationFences.clear();
+    if (_disposed || _authenticationChallenges.isClosed || _authenticationChallenges.value.isEmpty) return;
+    _authenticationChallenges.add(const {});
   }
 
   void _applyInstallProgress({
@@ -555,6 +703,7 @@ class PluginManagementService with Disposable {
     // Progress belongs to the bridge connection that reported it; a new
     // connection or bridge identity re-reports whatever is still running.
     _clearInstallProgress();
+    _clearAuthentications();
     _snapshots.add(const PluginManagementLoadResult.loading());
   }
 
@@ -566,6 +715,8 @@ class PluginManagementService with Disposable {
     await _refreshTail;
     await _snapshots.close();
     await _installProgress.close();
+    await _authenticationChallenges.close();
+    await _authenticationTerminalController.close();
   }
 }
 
@@ -590,11 +741,25 @@ class PluginInstallProgress {
   final int? percent;
 
   @override
-  bool operator ==(Object other) =>
-      other is PluginInstallProgress && other.phase == phase && other.percent == percent;
+  bool operator ==(Object other) => other is PluginInstallProgress && other.phase == phase && other.percent == percent;
 
   @override
   int get hashCode => Object.hash(phase, percent);
+}
+
+@immutable
+class PluginAuthenticationChallenge {
+  const PluginAuthenticationChallenge({required this.verificationUri, required this.userCode});
+
+  final Uri verificationUri;
+  final String userCode;
+
+  @override
+  bool operator ==(Object other) =>
+      other is PluginAuthenticationChallenge && other.verificationUri == verificationUri && other.userCode == userCode;
+
+  @override
+  int get hashCode => Object.hash(verificationUri, userCode);
 }
 
 enum _RefreshOutcome { applied, failed, superseded, fenced }

--- a/client/module_core/lib/src/services/plugin_management_service.dart
+++ b/client/module_core/lib/src/services/plugin_management_service.dart
@@ -215,6 +215,8 @@ class PluginManagementService with Disposable {
         if (pending != null) _settleAuthentication(pluginId: pluginId, progress: pending);
         return result;
       case PluginAuthenticationStartUncertain():
+        final pending = _pendingAuthenticationOutcomes.remove(pluginId);
+        if (pending != null) _settleAuthentication(pluginId: pluginId, progress: pending);
         return result;
       case PluginAuthenticationStartNotFound() ||
           PluginAuthenticationStartConflict() ||
@@ -229,10 +231,14 @@ class PluginManagementService with Disposable {
     if (_disposed || !_connected || !_isAuthenticationFenceCurrent(pluginId: pluginId)) {
       return PluginAuthenticationCancelResult.failure(error: ApiError.generic());
     }
+    _authenticationRequestsInFlight.add(pluginId);
     final result = await _pluginRepository.cancelAuthentication(pluginId: pluginId);
+    _authenticationRequestsInFlight.remove(pluginId);
     if (!_isAuthenticationFenceCurrent(pluginId: pluginId)) {
       return const PluginAuthenticationCancelResult.uncertain();
     }
+    final pending = _pendingAuthenticationOutcomes.remove(pluginId);
+    if (pending != null) _settleAuthentication(pluginId: pluginId, progress: pending);
     return result;
   }
 

--- a/client/module_core/test/api/plugin_api_test.dart
+++ b/client/module_core/test/api/plugin_api_test.dart
@@ -142,6 +142,50 @@ void main() {
       const PluginIdleTimeoutUpdateRequest.setOverride(pluginId: "codex", idleTimeoutMins: 45).toJson(),
     );
   });
+
+  test("POST and DELETE /plugin/:id/authentication use typed models", () async {
+    when(
+      () => client.post<PluginAuthenticationChallengeResponse>(
+        any(),
+        body: any(named: "body"),
+        fromJson: any(named: "fromJson"),
+      ),
+    ).thenAnswer((invocation) async {
+      final fromJson =
+          invocation.namedArguments[#fromJson] as PluginAuthenticationChallengeResponse Function(Map<String, dynamic>);
+      return ApiResponse.success(
+        fromJson({
+          "type": "deviceCode",
+          "verificationUrl": "https://auth.example/device",
+          "userCode": "ABCD-EFGH",
+        }),
+      );
+    });
+    when(
+      () => client.delete<SuccessEmptyResponse>(any(), fromJson: any(named: "fromJson")),
+    ).thenAnswer((_) async => ApiResponse.success(const SuccessEmptyResponse()));
+
+    final started = await api.startAuthentication(pluginId: "codex/dev");
+    final cancelled = await api.cancelAuthentication(pluginId: "codex/dev");
+
+    expect(started, isA<SuccessResponse<PluginAuthenticationChallengeResponse>>());
+    expect(cancelled, isA<SuccessResponse<SuccessEmptyResponse>>());
+    final start = verify(
+      () => client.post<PluginAuthenticationChallengeResponse>(
+        captureAny(),
+        body: captureAny(named: "body"),
+        fromJson: any(named: "fromJson"),
+      ),
+    ).captured;
+    expect(start[0], "/plugin/codex%2Fdev/authentication");
+    expect(start[1], const SuccessEmptyResponse().toJson());
+    verify(
+      () => client.delete<SuccessEmptyResponse>(
+        "/plugin/codex%2Fdev/authentication",
+        fromJson: any(named: "fromJson"),
+      ),
+    ).called(1);
+  });
 }
 
 const _managementJson = {

--- a/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
+++ b/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
@@ -156,6 +156,66 @@ void main() {
     );
   });
 
+  test("authentication maps a thrown browser launch and allows retry", () async {
+    snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+    authenticationChallenges.add({
+      "codex": PluginAuthenticationChallenge(
+        verificationUri: Uri.parse("https://auth.example/device"),
+        userCode: "ABCD-EFGH",
+      ),
+    });
+    when(
+      () => urlLauncher.launch(any(), mode: any(named: "mode")),
+    ).thenThrow(StateError("launcher unavailable"));
+    await _settle();
+    await cubit.startAuthentication(pluginId: "codex");
+
+    await cubit.launchAuthenticationBrowser();
+
+    expect(
+      (cubit.state as PluginManagementReady).authentication,
+      isA<PluginAuthenticationPresentationBrowserLaunchFailedState>(),
+    );
+  });
+
+  test("a stale same-plugin start response cannot overwrite a newer attempt", () async {
+    final first = Completer<PluginAuthenticationStartResult>();
+    var call = 0;
+    when(
+      () => service.startAuthentication(pluginId: "codex"),
+    ).thenAnswer((_) {
+      call++;
+      return call == 1
+          ? first.future
+          : Future.value(
+              PluginAuthenticationStartResult.failure(error: ApiError.generic()),
+            );
+    });
+    snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+    await _settle();
+    final firstStart = cubit.startAuthentication(pluginId: "codex");
+    authenticationTerminal.add((
+      pluginId: "codex",
+      progress: const PluginAuthenticationProgress.failed(message: "First attempt failed."),
+    ));
+    await _settle();
+    await cubit.startAuthentication(pluginId: "codex");
+    first.complete(
+      const PluginAuthenticationStartResult.challenge(
+        challenge: PluginAuthenticationChallengeResponse.deviceCode(
+          verificationUrl: "https://stale.example/device",
+          userCode: "STALE-CODE",
+        ),
+      ),
+    );
+    await firstStart;
+
+    expect(
+      (cubit.state as PluginManagementReady).authentication,
+      isA<PluginAuthenticationPresentationFailed>(),
+    );
+  });
+
   test("authentication cancellation waits for terminal progress", () async {
     snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
     authenticationChallenges.add({
@@ -171,7 +231,7 @@ void main() {
     final cancelling = (cubit.state as PluginManagementReady).authentication;
     expect(
       cancelling,
-      isA<PluginAuthenticationPresentationChallenge>().having((state) => state.cancelling, "cancelling", true),
+      isA<PluginAuthenticationPresentationCancelling>(),
     );
     authenticationTerminal.add((pluginId: "codex", progress: const PluginAuthenticationProgress.cancelled()));
     await _settle();

--- a/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
+++ b/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
@@ -204,6 +204,33 @@ void main() {
     );
   });
 
+  test("a browser failure cannot overwrite cancellation", () async {
+    final launch = Completer<bool>();
+    when(
+      () => urlLauncher.launch(any(), mode: any(named: "mode")),
+    ).thenAnswer((_) => launch.future);
+    snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+    authenticationChallenges.add({
+      "codex": PluginAuthenticationChallenge(
+        verificationUri: Uri.parse("https://auth.example/device"),
+        userCode: "ABCD-EFGH",
+      ),
+    });
+    await _settle();
+    await cubit.startAuthentication(pluginId: "codex");
+    final launching = cubit.launchAuthenticationBrowser();
+    final cancelling = cubit.cancelAuthentication();
+    launch.complete(false);
+    await launching;
+
+    expect(
+      (cubit.state as PluginManagementReady).authentication,
+      isA<PluginAuthenticationPresentationCancelling>(),
+    );
+    authenticationTerminal.add((pluginId: "codex", progress: const PluginAuthenticationProgress.cancelled()));
+    await cancelling;
+  });
+
   test("a stale same-plugin start response cannot overwrite a newer attempt", () async {
     final first = Completer<PluginAuthenticationStartResult>();
     var call = 0;
@@ -293,6 +320,29 @@ void main() {
       (cubit.state as PluginManagementReady).authentication,
       const PluginAuthenticationPresentationState.idle(),
     );
+  });
+
+  test("a cancellation response cannot resurrect state after snapshot reset", () async {
+    final cancel = Completer<PluginAuthenticationCancelResult>();
+    when(
+      () => service.cancelAuthentication(pluginId: "codex"),
+    ).thenAnswer((_) => cancel.future);
+    snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+    authenticationChallenges.add({
+      "codex": PluginAuthenticationChallenge(
+        verificationUri: Uri.parse("https://auth.example/device"),
+        userCode: "ABCD-EFGH",
+      ),
+    });
+    await _settle();
+    await cubit.startAuthentication(pluginId: "codex");
+    final cancelling = cubit.cancelAuthentication();
+    snapshots.add(const PluginManagementLoadResult.loading());
+    await _settle();
+    cancel.complete(const PluginAuthenticationCancelResult.uncertain());
+    await cancelling;
+
+    expect(cubit.state, const PluginManagementState.loading());
   });
 
   test("delegates refresh and retains a published refresh error with the ready snapshot", () async {

--- a/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
+++ b/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
@@ -8,6 +8,8 @@ import "package:test/test.dart";
 
 class _MockPluginManagementService extends Mock implements PluginManagementService {}
 
+class _MockUrlLauncher extends Mock implements UrlLauncher {}
+
 const _response = PluginManagementResponse(
   snapshotToken: "snapshot-1",
   bridgeId: "bridge-1",
@@ -25,19 +27,29 @@ void main() {
   late _MockPluginManagementService service;
   late BehaviorSubject<PluginManagementLoadResult> snapshots;
   late BehaviorSubject<Map<String, PluginInstallProgress>> installProgress;
+  late StreamController<PluginAuthenticationTerminalUpdate> authenticationTerminal;
+  late BehaviorSubject<Map<String, PluginAuthenticationChallenge>> authenticationChallenges;
   late PluginManagementCubit cubit;
+  late _MockUrlLauncher urlLauncher;
 
   setUpAll(() {
     registerFallbackValue(const PluginLifecycleCommandRequest.enable());
     registerFallbackValue(const PluginIdleTimeoutUpdateRequest.applyAll(idleTimeoutMins: 1));
+    registerFallbackValue(Uri.parse("https://example.com"));
+    registerFallbackValue(UrlLaunchMode.externalApp);
   });
 
   setUp(() {
     service = _MockPluginManagementService();
+    urlLauncher = _MockUrlLauncher();
     snapshots = BehaviorSubject();
     installProgress = BehaviorSubject.seeded(const {});
+    authenticationTerminal = StreamController.broadcast(sync: true);
+    authenticationChallenges = BehaviorSubject.seeded(const {});
     when(() => service.snapshots).thenAnswer((_) => snapshots.stream);
     when(() => service.installProgress).thenAnswer((_) => installProgress.stream);
+    when(() => service.authenticationTerminal).thenAnswer((_) => authenticationTerminal.stream);
+    when(() => service.authenticationChallenges).thenAnswer((_) => authenticationChallenges.stream);
     when(() => service.refresh()).thenAnswer((_) async {});
     when(
       () => service.command(
@@ -48,13 +60,31 @@ void main() {
     when(
       () => service.updateIdleTimeout(request: any(named: "request")),
     ).thenAnswer((_) async => const PluginManagementMutationResult.success(response: _response));
-    cubit = PluginManagementCubit(service: service);
+    when(
+      () => service.startAuthentication(pluginId: any(named: "pluginId")),
+    ).thenAnswer(
+      (_) async => const PluginAuthenticationStartResult.challenge(
+        challenge: PluginAuthenticationChallengeResponse.deviceCode(
+          verificationUrl: "https://auth.example/device",
+          userCode: "ABCD-EFGH",
+        ),
+      ),
+    );
+    when(
+      () => service.cancelAuthentication(pluginId: any(named: "pluginId")),
+    ).thenAnswer((_) async => const PluginAuthenticationCancelResult.success());
+    when(
+      () => urlLauncher.launch(any(), mode: any(named: "mode")),
+    ).thenAnswer((_) async => true);
+    cubit = PluginManagementCubit(service: service, urlLauncher: urlLauncher);
   });
 
   tearDown(() async {
     await cubit.close();
     await snapshots.close();
     await installProgress.close();
+    await authenticationTerminal.close();
+    await authenticationChallenges.close();
   });
 
   test("starts loading and maps supported snapshots to idle ready state", () async {
@@ -69,6 +99,7 @@ void main() {
         response: _response,
         refresh: PluginManagementRefreshState.idle(),
         action: PluginManagementActionState.idle(),
+        authentication: PluginAuthenticationPresentationState.idle(),
         installs: {},
       ),
     );
@@ -94,6 +125,60 @@ void main() {
     await _settle();
 
     expect(cubit.state, const PluginManagementState.loading());
+  });
+
+  test("authentication presents challenge, launches explicitly, and settles terminal progress", () async {
+    snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+    authenticationChallenges.add({
+      "codex": PluginAuthenticationChallenge(
+        verificationUri: Uri.parse("https://auth.example/device"),
+        userCode: "ABCD-EFGH",
+      ),
+    });
+    await _settle();
+
+    await cubit.startAuthentication(pluginId: "codex");
+    expect(
+      (cubit.state as PluginManagementReady).authentication,
+      isA<PluginAuthenticationPresentationChallenge>(),
+    );
+    verifyNever(() => urlLauncher.launch(any(), mode: any(named: "mode")));
+    await cubit.launchAuthenticationBrowser();
+    verify(
+      () => urlLauncher.launch(Uri.parse("https://auth.example/device"), mode: UrlLaunchMode.externalApp),
+    ).called(1);
+
+    authenticationTerminal.add((pluginId: "codex", progress: const PluginAuthenticationProgress.completed()));
+    await _settle();
+    expect(
+      (cubit.state as PluginManagementReady).authentication,
+      const PluginAuthenticationPresentationState.idle(),
+    );
+  });
+
+  test("authentication cancellation waits for terminal progress", () async {
+    snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+    authenticationChallenges.add({
+      "codex": PluginAuthenticationChallenge(
+        verificationUri: Uri.parse("https://auth.example/device"),
+        userCode: "ABCD-EFGH",
+      ),
+    });
+    await _settle();
+    await cubit.startAuthentication(pluginId: "codex");
+
+    await cubit.cancelAuthentication();
+    final cancelling = (cubit.state as PluginManagementReady).authentication;
+    expect(
+      cancelling,
+      isA<PluginAuthenticationPresentationChallenge>().having((state) => state.cancelling, "cancelling", true),
+    );
+    authenticationTerminal.add((pluginId: "codex", progress: const PluginAuthenticationProgress.cancelled()));
+    await _settle();
+    expect(
+      (cubit.state as PluginManagementReady).authentication,
+      const PluginAuthenticationPresentationState.idle(),
+    );
   });
 
   test("delegates refresh and retains a published refresh error with the ready snapshot", () async {
@@ -203,7 +288,7 @@ void main() {
 
       // The screen builds a fresh cubit on every visit, so reopening harness
       // settings during an install must not hide it.
-      final reopened = PluginManagementCubit(service: service);
+      final reopened = PluginManagementCubit(service: service, urlLauncher: urlLauncher);
       addTearDown(reopened.close);
       snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
       await _settle();

--- a/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
+++ b/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
@@ -178,6 +178,32 @@ void main() {
     );
   });
 
+  test("a stale browser failure cannot overwrite terminal settlement", () async {
+    final launch = Completer<bool>();
+    when(
+      () => urlLauncher.launch(any(), mode: any(named: "mode")),
+    ).thenAnswer((_) => launch.future);
+    snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+    authenticationChallenges.add({
+      "codex": PluginAuthenticationChallenge(
+        verificationUri: Uri.parse("https://auth.example/device"),
+        userCode: "ABCD-EFGH",
+      ),
+    });
+    await _settle();
+    await cubit.startAuthentication(pluginId: "codex");
+    final launching = cubit.launchAuthenticationBrowser();
+    authenticationTerminal.add((pluginId: "codex", progress: const PluginAuthenticationProgress.completed()));
+    await _settle();
+    launch.complete(false);
+    await launching;
+
+    expect(
+      (cubit.state as PluginManagementReady).authentication,
+      const PluginAuthenticationPresentationState.idle(),
+    );
+  });
+
   test("a stale same-plugin start response cannot overwrite a newer attempt", () async {
     final first = Completer<PluginAuthenticationStartResult>();
     var call = 0;
@@ -235,6 +261,34 @@ void main() {
     );
     authenticationTerminal.add((pluginId: "codex", progress: const PluginAuthenticationProgress.cancelled()));
     await _settle();
+    expect(
+      (cubit.state as PluginManagementReady).authentication,
+      const PluginAuthenticationPresentationState.idle(),
+    );
+  });
+
+  test("authentication cancellation blocks re-entry and ignores a stale response", () async {
+    final cancel = Completer<PluginAuthenticationCancelResult>();
+    when(
+      () => service.cancelAuthentication(pluginId: "codex"),
+    ).thenAnswer((_) => cancel.future);
+    snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+    authenticationChallenges.add({
+      "codex": PluginAuthenticationChallenge(
+        verificationUri: Uri.parse("https://auth.example/device"),
+        userCode: "ABCD-EFGH",
+      ),
+    });
+    await _settle();
+    await cubit.startAuthentication(pluginId: "codex");
+    final firstCancel = cubit.cancelAuthentication();
+    await cubit.cancelAuthentication();
+    verify(() => service.cancelAuthentication(pluginId: "codex")).called(1);
+    authenticationTerminal.add((pluginId: "codex", progress: const PluginAuthenticationProgress.cancelled()));
+    await _settle();
+    cancel.complete(const PluginAuthenticationCancelResult.uncertain());
+    await firstCancel;
+
     expect(
       (cubit.state as PluginManagementReady).authentication,
       const PluginAuthenticationPresentationState.idle(),

--- a/client/module_core/test/repositories/plugin_repository_test.dart
+++ b/client/module_core/test/repositories/plugin_repository_test.dart
@@ -396,6 +396,35 @@ void main() {
       ).thenAnswer((_) async => ApiResponse.error(ApiError.emptyResponse()));
       expect(await repository.cancelAuthentication(pluginId: "codex"), isA<PluginAuthenticationCancelUncertain>());
     });
+
+    test("maps typed cancellation conflicts and malformed conflict bodies", () async {
+      const conflict = PluginAuthenticationConflict(
+        pluginId: "codex",
+        reasons: [PluginAuthenticationConflictReason.inFlight],
+        current: _managementPlugin,
+      );
+      when(
+        () => api.cancelAuthentication(pluginId: any(named: "pluginId")),
+      ).thenAnswer(
+        (_) async => ApiResponse.error(
+          ApiError.nonSuccessCode(errorCode: 409, rawErrorString: jsonEncode(conflict.toJson())),
+        ),
+      );
+      expect(
+        await repository.cancelAuthentication(pluginId: "codex"),
+        isA<PluginAuthenticationCancelConflict>().having((result) => result.conflict, "conflict", conflict),
+      );
+
+      when(
+        () => api.startAuthentication(pluginId: any(named: "pluginId")),
+      ).thenAnswer(
+        (_) async => ApiResponse.error(ApiError.nonSuccessCode(errorCode: 409, rawErrorString: "not-json")),
+      );
+      expect(
+        await repository.startAuthentication(pluginId: "codex"),
+        isA<PluginAuthenticationStartFailure>().having((result) => result.error, "error", isA<JsonParsingError>()),
+      );
+    });
   });
 }
 

--- a/client/module_core/test/repositories/plugin_repository_test.dart
+++ b/client/module_core/test/repositories/plugin_repository_test.dart
@@ -346,6 +346,57 @@ void main() {
       );
     });
   });
+
+  group("authentication", () {
+    test("maps challenge, unsupported conflict, and response loss", () async {
+      when(
+        () => api.startAuthentication(pluginId: any(named: "pluginId")),
+      ).thenAnswer(
+        (_) async => ApiResponse.success(
+          const PluginAuthenticationChallengeResponse.deviceCode(
+            verificationUrl: "https://auth.example/device",
+            userCode: "ABCD-EFGH",
+          ),
+        ),
+      );
+      expect(await repository.startAuthentication(pluginId: "codex"), isA<PluginAuthenticationStartChallenge>());
+
+      const conflict = PluginAuthenticationConflict(
+        pluginId: "codex",
+        reasons: [PluginAuthenticationConflictReason.unsupported],
+        current: _managementPlugin,
+      );
+      when(
+        () => api.startAuthentication(pluginId: any(named: "pluginId")),
+      ).thenAnswer(
+        (_) async => ApiResponse.error(
+          ApiError.nonSuccessCode(errorCode: 409, rawErrorString: jsonEncode(conflict.toJson())),
+        ),
+      );
+      expect(await repository.startAuthentication(pluginId: "codex"), isA<PluginAuthenticationStartUnsupported>());
+
+      when(
+        () => api.startAuthentication(pluginId: any(named: "pluginId")),
+      ).thenAnswer(
+        (_) async => ApiResponse.error(
+          ApiError.dartHttpClient(const RelayResponseLostException(message: "socket closed")),
+        ),
+      );
+      expect(await repository.startAuthentication(pluginId: "codex"), isA<PluginAuthenticationStartUncertain>());
+    });
+
+    test("maps cancellation success and uncertain response loss", () async {
+      when(
+        () => api.cancelAuthentication(pluginId: any(named: "pluginId")),
+      ).thenAnswer((_) async => ApiResponse.success(const SuccessEmptyResponse()));
+      expect(await repository.cancelAuthentication(pluginId: "codex"), isA<PluginAuthenticationCancelSuccess>());
+
+      when(
+        () => api.cancelAuthentication(pluginId: any(named: "pluginId")),
+      ).thenAnswer((_) async => ApiResponse.error(ApiError.emptyResponse()));
+      expect(await repository.cancelAuthentication(pluginId: "codex"), isA<PluginAuthenticationCancelUncertain>());
+    });
+  });
 }
 
 const _managementPlugin = PluginManagementMetadata(

--- a/client/module_core/test/services/plugin_management_service_test.dart
+++ b/client/module_core/test/services/plugin_management_service_test.dart
@@ -144,6 +144,69 @@ void main() {
       expect(terminals.single.progress, const PluginAuthenticationProgress.cancelled());
       expect(service.authenticationChallenges.value, isEmpty);
     });
+
+    test("fast terminal settles an uncertain start response", () async {
+      final start = Completer<PluginAuthenticationStartResult>();
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "initial")))
+        ..queueAuthenticationStart(start.future)
+        ..queueLoad(_supported(_response(token: "terminal")));
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(
+        pluginRepository: repository,
+        connectionService: connection,
+        productAnalyticsService: analytics,
+      );
+      addTearDown(service.onDispose);
+      await _waitFor(() => service.snapshots.hasValue);
+      final terminals = <PluginAuthenticationTerminalUpdate>[];
+      service.authenticationTerminal.listen(terminals.add);
+      final result = service.startAuthentication(pluginId: "codex");
+      connection.emitAuthenticationProgress(
+        pluginId: "codex",
+        progress: const PluginAuthenticationProgress.completed(),
+      );
+      start.complete(const PluginAuthenticationStartResult.uncertain());
+
+      expect(await result, isA<PluginAuthenticationStartUncertain>());
+      expect(terminals.single.progress, const PluginAuthenticationProgress.completed());
+    });
+
+    test("fast terminal settles before the cancellation response returns", () async {
+      final cancel = Completer<PluginAuthenticationCancelResult>();
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "initial")))
+        ..queueAuthenticationStart(
+          const PluginAuthenticationStartResult.challenge(
+            challenge: PluginAuthenticationChallengeResponse.deviceCode(
+              verificationUrl: "https://auth.example/device",
+              userCode: "ABCD-EFGH",
+            ),
+          ),
+        )
+        ..queueAuthenticationCancel(cancel.future)
+        ..queueLoad(_supported(_response(token: "terminal")));
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(
+        pluginRepository: repository,
+        connectionService: connection,
+        productAnalyticsService: analytics,
+      );
+      addTearDown(service.onDispose);
+      await _waitFor(() => service.snapshots.hasValue);
+      await service.startAuthentication(pluginId: "codex");
+      final terminals = <PluginAuthenticationTerminalUpdate>[];
+      service.authenticationTerminal.listen(terminals.add);
+      final result = service.cancelAuthentication(pluginId: "codex");
+      connection.emitAuthenticationProgress(
+        pluginId: "codex",
+        progress: const PluginAuthenticationProgress.cancelled(),
+      );
+      cancel.complete(const PluginAuthenticationCancelResult.success());
+
+      expect(await result, isA<PluginAuthenticationCancelSuccess>());
+      expect(terminals.single.progress, const PluginAuthenticationProgress.cancelled());
+    });
   });
 
   group("refresh synchronization", () {

--- a/client/module_core/test/services/plugin_management_service_test.dart
+++ b/client/module_core/test/services/plugin_management_service_test.dart
@@ -31,10 +31,118 @@ void main() {
     analytics = _MockProductAnalyticsService();
     reportedEvents = [];
     when(
-      () => analytics.logEvent(event: any(named: "event"), occurredAtUtc: any(named: "occurredAtUtc")),
+      () => analytics.logEvent(
+        event: any(named: "event"),
+        occurredAtUtc: any(named: "occurredAtUtc"),
+      ),
     ).thenAnswer((invocation) async {
       reportedEvents.add(invocation.namedArguments[#event]! as ProductAnalyticsEvent);
       return AnalyticsDeliveryResult.acceptedBySdk;
+    });
+  });
+
+  group("authentication orchestration", () {
+    test("retains an HTTPS challenge and refreshes on terminal progress", () async {
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "initial")))
+        ..queueAuthenticationStart(
+          const PluginAuthenticationStartResult.challenge(
+            challenge: PluginAuthenticationChallengeResponse.deviceCode(
+              verificationUrl: "https://auth.example/device",
+              userCode: "ABCD-EFGH",
+            ),
+          ),
+        )
+        ..queueLoad(_supported(_response(token: "terminal")));
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(
+        pluginRepository: repository,
+        connectionService: connection,
+        productAnalyticsService: analytics,
+      );
+      addTearDown(service.onDispose);
+      await _waitFor(() => service.snapshots.hasValue);
+
+      final result = await service.startAuthentication(pluginId: "codex");
+      expect(result, isA<PluginAuthenticationStartChallenge>());
+      expect(
+        service.authenticationChallenges.value["codex"],
+        PluginAuthenticationChallenge(
+          verificationUri: Uri.parse("https://auth.example/device"),
+          userCode: "ABCD-EFGH",
+        ),
+      );
+      final terminals = <PluginAuthenticationTerminalUpdate>[];
+      service.authenticationTerminal.listen(terminals.add);
+      connection.emitAuthenticationProgress(
+        pluginId: "codex",
+        progress: const PluginAuthenticationProgress.completed(),
+      );
+      await _waitFor(() => repository.loadCalls == 2);
+
+      expect(service.authenticationChallenges.value, isEmpty);
+      expect(terminals.single.progress, const PluginAuthenticationProgress.completed());
+    });
+
+    test("rejects non-HTTPS challenge and clears operations on reconnect", () async {
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "initial")))
+        ..queueAuthenticationStart(
+          const PluginAuthenticationStartResult.challenge(
+            challenge: PluginAuthenticationChallengeResponse.deviceCode(
+              verificationUrl: "http://auth.example/device",
+              userCode: "ABCD-EFGH",
+            ),
+          ),
+        );
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(
+        pluginRepository: repository,
+        connectionService: connection,
+        productAnalyticsService: analytics,
+      );
+      addTearDown(service.onDispose);
+      await _waitFor(() => service.snapshots.hasValue);
+
+      expect(await service.startAuthentication(pluginId: "codex"), isA<PluginAuthenticationStartFailure>());
+      expect(service.authenticationChallenges.value, isEmpty);
+      connection.emitStatus(const ConnectionDisconnected());
+      expect(service.authenticationChallenges.value, isEmpty);
+    });
+
+    test("fast terminal settles authorship before the start response returns", () async {
+      final start = Completer<PluginAuthenticationStartResult>();
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "initial")))
+        ..queueAuthenticationStart(start.future)
+        ..queueLoad(_supported(_response(token: "terminal")));
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(
+        pluginRepository: repository,
+        connectionService: connection,
+        productAnalyticsService: analytics,
+      );
+      addTearDown(service.onDispose);
+      await _waitFor(() => service.snapshots.hasValue);
+      final terminals = <PluginAuthenticationTerminalUpdate>[];
+      service.authenticationTerminal.listen(terminals.add);
+      final result = service.startAuthentication(pluginId: "codex");
+      connection.emitAuthenticationProgress(
+        pluginId: "codex",
+        progress: const PluginAuthenticationProgress.cancelled(),
+      );
+      start.complete(
+        const PluginAuthenticationStartResult.challenge(
+          challenge: PluginAuthenticationChallengeResponse.deviceCode(
+            verificationUrl: "https://auth.example/device",
+            userCode: "ABCD-EFGH",
+          ),
+        ),
+      );
+      await result;
+
+      expect(terminals.single.progress, const PluginAuthenticationProgress.cancelled());
+      expect(service.authenticationChallenges.value, isEmpty);
     });
   });
 
@@ -704,10 +812,10 @@ void main() {
     final repository = _FakePluginRepository()..queueLoad(activeLoad.future);
     final connection = _FakeConnectionService(initialStatus: _connected);
     final service = PluginManagementService(
-        pluginRepository: repository,
-        connectionService: connection,
-        productAnalyticsService: analytics,
-      );
+      pluginRepository: repository,
+      connectionService: connection,
+      productAnalyticsService: analytics,
+    );
     await _waitFor(() => repository.loadCalls == 1);
 
     final snapshotsDone = expectLater(service.snapshots, emitsDone);
@@ -1117,6 +1225,8 @@ Future<void> _waitFor(bool Function() predicate) async {
 class _FakePluginRepository implements PluginRepository {
   final Queue<Future<PluginManagementLoadResult>> _loads = Queue();
   final Queue<Future<PluginManagementMutationResult>> _mutations = Queue();
+  final Queue<Future<PluginAuthenticationStartResult>> _authenticationStarts = Queue();
+  final Queue<Future<PluginAuthenticationCancelResult>> _authenticationCancels = Queue();
   int loadCalls = 0;
   int mutationCalls = 0;
 
@@ -1127,6 +1237,22 @@ class _FakePluginRepository implements PluginRepository {
   void queueMutation(FutureOr<PluginManagementMutationResult> result) {
     _mutations.add(Future<PluginManagementMutationResult>.value(result));
   }
+
+  void queueAuthenticationStart(FutureOr<PluginAuthenticationStartResult> result) {
+    _authenticationStarts.add(Future<PluginAuthenticationStartResult>.value(result));
+  }
+
+  void queueAuthenticationCancel(FutureOr<PluginAuthenticationCancelResult> result) {
+    _authenticationCancels.add(Future<PluginAuthenticationCancelResult>.value(result));
+  }
+
+  @override
+  Future<PluginAuthenticationStartResult> startAuthentication({required String pluginId}) =>
+      _authenticationStarts.removeFirst();
+
+  @override
+  Future<PluginAuthenticationCancelResult> cancelAuthentication({required String pluginId}) =>
+      _authenticationCancels.removeFirst();
 
   @override
   Future<PluginManagementLoadResult> getManagement() {
@@ -1204,6 +1330,14 @@ class _FakeConnectionService implements ConnectionService {
           percent: percent,
           message: null,
         ),
+      ),
+    );
+  }
+
+  void emitAuthenticationProgress({required String pluginId, required PluginAuthenticationProgress progress}) {
+    _events.add(
+      SseEvent(
+        data: SesoriSseEvent.pluginAuthenticationProgress(pluginId: pluginId, progress: progress),
       ),
     );
   }

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -33,6 +33,13 @@ idle suspension, the management snapshot, and lifecycle commands.
 - The bridge exposes explicit plugin-scoped start and cancel routes. Duplicate starts join
   the active operation, management commands conflict while it runs, cancellation settles
   upstream cleanup, and setup reinspection remains authoritative before normal startup.
+- Client authentication orchestration accepts only absolute HTTPS challenge URLs, retains
+  challenge data ephemerally, and opens the browser only after an explicit user action.
+  Start and cancel response loss remain uncertain; terminal SSE is presented only for an
+  operation this client started, then triggers an authoritative management refresh.
+- Authentication ownership and challenge state are fenced to the current connection epoch
+  and bridge identity and clear on reconnect, identity change, or disposal. External
+  operations still update shared management metadata without claiming local presentation.
 
 ## Regression Levels
 
@@ -62,6 +69,9 @@ directories. Restore eligibility, timeouts, and sessions afterwards.
 - A missing authentication state from an older bridge decoding as anything but idle, a
   future state or conflict reason failing open, challenge data entering snapshots/SSE, or
   a failed progress payload without its required sanitized message.
+- A malformed or non-HTTPS verification URL reaching the launcher, a browser opening
+  without explicit user intent, response loss reported as definite failure, a fast terminal
+  event being lost, or stale challenge state surviving reconnect or bridge replacement.
 - One failing harness taking down the rest of the bridge, or an empty picker
   instead of the explicit no-harness state when none is usable.
 
@@ -69,9 +79,9 @@ directories. Restore eligibility, timeouts, and sessions afterwards.
 
 - The harness set comes from the current registry; unregistered in-development harnesses
   are out of scope, and no lifecycle path installs a runtime.
-- Backend authentication and credential persistence happen on the bridge machine; client
-  orchestration and presentation remain outside this document until their planned steps
-  land. A forced disable leaves work interrupted.
+- Backend authentication and credential persistence happen on the bridge machine. Client
+  presentation controls remain outside this document until their planned step lands. A
+  forced disable leaves work interrupted.
 - Idle windows are minutes-order, so observing a real elapse belongs at L4 or above.
 
 ## Sources


### PR DESCRIPTION
## Complexity

🚧 Complex. This adds a security-sensitive cross-layer client flow with connection and bridge identity fencing, terminal SSE correlation, response-loss semantics, and ephemeral browser challenge state.

## What

- Add typed plugin authentication start and cancel calls to the client API and repository.
- Orchestrate request-scoped challenges and terminal SSE progress in `PluginManagementService`.
- Fence authentication ownership to the current connection epoch and bridge identity.
- Add independent cubit presentation state for starting, challenge, cancellation, failure, and explicit browser launch.
- Validate verification URLs as absolute HTTPS URLs before they can reach the platform launcher.
- Extend focused API, repository, service, and cubit regression coverage.

## Why

The mobile app needs a backend-neutral, privacy-safe orchestration seam for harness authentication before the settings UI can present Codex device login. Challenge data must remain ephemeral and stale operations must not survive reconnects or bridge replacement.

## Risk and test focus

Risk is high around stale connection responses, bridge identity changes, fast terminal SSE events, uncertain POST/DELETE delivery, malformed challenge URLs, and accidental browser launch. Review the service correlation/fencing logic and the cubit's explicit-launch and terminal-settlement behavior.

## Expected result

There is no user-visible control in this step; Step 7 adds presentation. Client core can safely start, monitor, cancel, and explicitly open a device-authentication challenge for any harness advertising the shared capability. No database or persisted-data changes. Challenge URLs and user codes remain ephemeral and are not added to snapshots, diagnostics, analytics, or SSE.

## Verification

- `dart analyze --fatal-infos` in `client/module_core`
- `dart test` in `client/module_core`: 1,054 tests pass
- `flutter analyze --fatal-infos` in `client/app`
- `git diff --check origin/main...HEAD`
- Required architecture implementation review was attempted but the review sub-agent failed before reading code with `no such column: replacement_seq`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds client-side orchestration for harness authentication with typed start/cancel, HTTPS-only device-code challenges, and terminal SSE correlation fenced to the current connection and bridge. Now also fences start/cancel intents to the active connection/bridge, hardens races, preserves presentation ordering across fast events, and wires presentation state with explicit browser launch; app injects `UrlLauncher`; no UI yet.

- New Features
  - API: `PluginApi.startAuthentication` (POST) and `PluginApi.cancelAuthentication` (DELETE).
  - Repository: maps 404/409/uncertain delivery to typed results; parses `PluginAuthenticationConflict`.
  - Service (`PluginManagementService`): accepts only absolute HTTPS URLs; stores challenges ephemerally and exposes `authenticationChallenges`; correlates terminal SSE via `authenticationTerminal`; fences ownership and intents by connection epoch and bridge identity; ignores stale/foreign updates; holds fast outcomes until start returns; refreshes management on terminal settle; clears on reconnect/identity change/dispose.
  - Cubit (`PluginManagementCubit`): adds `PluginAuthenticationPresentationState` with start/cancel handlers; explicit browser open via injected `UrlLauncher`; subscribes to terminal updates; preserves presentation order; surfaces typed errors (unsupported, conflict, uncertain, invalid challenge, browser launch failed).

- Migration
  - Pass a `UrlLauncher` when creating `PluginManagementCubit` (e.g., `urlLauncher: getIt<UrlLauncher>()`).
  - No data changes; challenge data is not persisted or logged.

<sup>Written for commit c275ba23638c68fb62d0f92ca604aceaaed3d315. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

