### PR TITLE
🌱 Fix version sync tests on Dart 3.13

### DIFF
--- a/tool/sync_versions.dart
+++ b/tool/sync_versions.dart
@@ -50,7 +50,7 @@ class _ClientVersion {
   final String? build;
 }
 
-Future<void> main(final List<String> args) async {
+Future<void> main(List<String> args) async {
   try {
     final parsed = _parseArgs(args);
     final repoRoot = Directory(
@@ -82,7 +82,8 @@ Future<void> main(final List<String> args) async {
     );
 
     // Only enforce sync guard for automatic bumps; explicit --version can realign.
-    if (parsed.version == null && clientVersion.semver != bridgeCurrentVersion) {
+    if (parsed.version == null &&
+        clientVersion.semver != bridgeCurrentVersion) {
       throw _CliError(
         'Error: Bridge ($bridgeCurrentVersion) and client (${clientVersion.semver}) versions are out of sync. '
         'Run `make bump-version VERSION=${clientVersion.semver}` to align them before bumping.',
@@ -106,9 +107,9 @@ Future<void> main(final List<String> args) async {
     ];
 
     if (parsed.dryRun) {
-    stdout.writeln('Target bridge version: $targetBridgeVersion');
-    stdout.writeln('Target client version: $targetClientVersion');
-    stdout.writeln('Planned releaseTag: v$targetBridgeVersion');
+      stdout.writeln('Target bridge version: $targetBridgeVersion');
+      stdout.writeln('Target client version: $targetClientVersion');
+      stdout.writeln('Planned releaseTag: v$targetBridgeVersion');
       stdout.writeln('Files that would change:');
       for (final relativePath in plannedPaths) {
         stdout.writeln('  - $relativePath');
@@ -152,7 +153,7 @@ Future<void> main(final List<String> args) async {
   }
 }
 
-_ParsedArgs _parseArgs(final List<String> args) {
+_ParsedArgs _parseArgs(List<String> args) {
   bool dryRun = false;
   String? type;
   String? version;
@@ -174,7 +175,7 @@ _ParsedArgs _parseArgs(final List<String> args) {
         args: args,
         index: index,
         flag: '--type',
-        assign: (final value) => type = value,
+        assign: (value) => type = value,
       );
       continue;
     }
@@ -189,7 +190,7 @@ _ParsedArgs _parseArgs(final List<String> args) {
         args: args,
         index: index,
         flag: '--version',
-        assign: (final value) => version = value,
+        assign: (value) => version = value,
       );
       continue;
     }
@@ -235,7 +236,7 @@ int _consumeNextValue({
   return nextIndex;
 }
 
-String _valueFromFlag(final String arg, final String prefix) {
+String _valueFromFlag(String arg, String prefix) {
   final value = arg.substring(prefix.length);
   if (value.isEmpty) {
     throw _CliError(
@@ -245,7 +246,7 @@ String _valueFromFlag(final String arg, final String prefix) {
   return value;
 }
 
-String _join(final String root, final List<String> segments) {
+String _join(String root, List<String> segments) {
   var path = root;
   for (final segment in segments) {
     path = '$path${Platform.pathSeparator}$segment';
@@ -258,7 +259,7 @@ Future<String> _readFile({required String path}) => File(path).readAsString();
 Future<void> _writeFile({required String path, required String content}) =>
     File(path).writeAsString(content);
 
-_ClientVersion _readClientVersion(final String content) {
+_ClientVersion _readClientVersion(String content) {
   final match = _pubspecVersionPattern.firstMatch(content);
   if (match == null) {
     throw const _CliError('Error: Could not find version in client pubspec');
@@ -273,7 +274,7 @@ _ClientVersion _readClientVersion(final String content) {
   return _ClientVersion(semver: parsed.group(1)!, build: parsed.group(2));
 }
 
-String _readBridgeVersion(final String content) {
+String _readBridgeVersion(String content) {
   final match = _pubspecVersionPattern.firstMatch(content);
   if (match == null) {
     throw const _CliError('Error: Could not find version in bridge pubspec');
@@ -362,7 +363,7 @@ Future<void> _writePackageJson({
   final optionalDependencies = decoded['optionalDependencies'];
   if (optionalDependencies is Map<String, dynamic>) {
     optionalDependencies.updateAll(
-      (final _, final value) => value == oldVersion ? newVersion : value,
+      (_, value) => value == oldVersion ? newVersion : value,
     );
   }
 


### PR DESCRIPTION
## Complexity

🌱 Trivial. This is a syntax-compatibility update in one standalone Dart script.

## What

- Remove `final` modifiers from formal parameters and closures in `tool/sync_versions.dart`.
- Format the script, correcting the existing dry-run output indentation.

## Why

Bridge CI installs the latest stable Dart SDK, which advanced to Dart 3.13. Dart 3.13 rejects `final` formal-parameter modifiers, so every `sync_versions.dart` test failed while compiling the copied script.

## Risk and test focus

No user-visible or database impact. Behavior is unchanged; testing focuses on all six version-sync scenarios and strict Bridge app analysis.

## Expected result

Bridge CI can compile the version synchronization script under Dart 3.13, and all `sync_versions.dart` tests pass.

## Verification

- `dart test test/tool/sync_versions_test.dart` from `bridge/app`
- `dart analyze --fatal-infos` from `bridge/app`
- `dart analyze tool/sync_versions.dart` from the repository root


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `tool/sync_versions.dart` compile on Dart 3.13 by removing forbidden `final` parameter modifiers and fixing dry-run output indentation. Restores CI test runs; no behavior change.

<sup>Written for commit 0c93daeee837a1887c92dfee6166f4f5b229bccb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

