### PR TITLE
⚙️ Stabilize global Claude option discovery

### DIFF
--- a/bridge/app/lib/src/bridge/services/session_options_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_options_service.dart
@@ -118,14 +118,6 @@ class SessionOptionsService {
     if (outcome case SessionOptionsRefreshFailedRetained(:final failure)) {
       final concurrentlyAvailable = await _readValid(key: resolved.key);
       if (concurrentlyAvailable != null && await _isCurrentResolution(resolved: resolved)) {
-        final message =
-            "Dynamic session options discovery failed for plugin ${resolved.key.pluginId}; using concurrently published cache";
-        switch (failure) {
-          case SessionOptionsKnownRefreshFailure():
-            Log.w(message);
-          case SessionOptionsCaughtRefreshFailure(:final cause, :final causeStackTrace):
-            Log.w(message, cause, causeStackTrace);
-        }
         return SessionOptionsAvailable(response: concurrentlyAvailable.response);
       }
       return SessionOptionsRefreshFailedUnavailable(failure: failure);

--- a/bridge/app/lib/src/bridge/services/session_options_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_options_service.dart
@@ -256,7 +256,7 @@ class SessionOptionsService {
       return _captureFailure(
         resolved: resolved,
         automatic: automatic,
-        message: "Automatic session options capture failed for plugin ${resolved.key.pluginId}",
+        message: "Session options capture failed for plugin ${resolved.key.pluginId}",
         error: error,
         stackTrace: stackTrace,
       );
@@ -269,7 +269,7 @@ class SessionOptionsService {
         return _captureFailure(
           resolved: resolved,
           automatic: automatic,
-          message: "Automatic session options discovery failed for plugin ${resolved.key.pluginId}",
+          message: "Session options discovery failed for plugin ${resolved.key.pluginId}",
           error: null,
           stackTrace: null,
         );
@@ -387,8 +387,7 @@ class SessionOptionsService {
       return _CommitFailed(
         outcome: _refreshFailure(
           retained: newest,
-          automatic: automatic,
-          message: "Automatic session options cache commit failed for plugin ${key.pluginId}",
+          message: "Session options cache commit failed for plugin ${key.pluginId}",
           error: error,
           stackTrace: stackTrace,
         ),
@@ -405,7 +404,6 @@ class SessionOptionsService {
 
   SessionOptionsOutcome _refreshFailure({
     required SessionOptionsCacheEntry? retained,
-    required bool automatic,
     required String message,
     required Object? error,
     required StackTrace? stackTrace,
@@ -423,12 +421,13 @@ class SessionOptionsService {
         causeStackTrace: caughtStackTrace,
       );
     }
-    if (automatic) {
-      if (error == null) {
-        Log.w(message);
-      } else {
-        Log.w(message, error, stackTrace);
-      }
+    // Explicit requests are logged too: the client only ever sees an opaque
+    // `refreshFailedUnavailable` code, so this log is the sole place that
+    // retains the original error, stack trace, and operation context.
+    if (error == null) {
+      Log.w(message);
+    } else {
+      Log.w(message, error, stackTrace);
     }
     return retained == null
         ? SessionOptionsRefreshFailedUnavailable(failure: failure)
@@ -448,7 +447,6 @@ class SessionOptionsService {
     final retained = await _readValid(key: resolved.key);
     return _refreshFailure(
       retained: retained,
-      automatic: automatic,
       message: message,
       error: error,
       stackTrace: stackTrace,

--- a/bridge/app/test/bridge/services/session_options_service_test.dart
+++ b/bridge/app/test/bridge/services/session_options_service_test.dart
@@ -408,9 +408,15 @@ void main() {
         ..captureResult = const SessionOptionsCaptureFailed();
       final service = _service(repository: repository, now: now);
 
-      final outcome = await service.loadDynamic(pluginId: "plugin-1", projectId: "project-1");
+      final output = await _captureLogOutput(
+        level: LogLevel.debug,
+        action: () async {
+          final outcome = await service.loadDynamic(pluginId: "plugin-1", projectId: "project-1");
+          expect(outcome, isA<SessionOptionsRefreshFailedUnavailable>());
+        },
+      );
 
-      expect(outcome, isA<SessionOptionsRefreshFailedUnavailable>());
+      expect(output, contains("Session options discovery failed for plugin plugin-1"));
     });
 
     test("project absence is returned without cache or plugin access", () async {
@@ -464,7 +470,13 @@ void main() {
         ..captureHandler = (_) => Future.error(cause, causeStackTrace);
       final service = _service(repository: repository, now: now);
 
-      final outcome = await service.refreshExplicit(pluginId: "plugin-1", projectId: "project-1");
+      late SessionOptionsOutcome outcome;
+      final output = await _captureLogOutput(
+        level: LogLevel.debug,
+        action: () async {
+          outcome = await service.refreshExplicit(pluginId: "plugin-1", projectId: "project-1");
+        },
+      );
 
       expect(outcome, isA<SessionOptionsRefreshFailedUnavailable>());
       final failure = (outcome as SessionOptionsRefreshFailedUnavailable).failure;
@@ -473,6 +485,8 @@ void main() {
       expect(caught.cause, same(cause));
       expect(caught.causeStackTrace, same(causeStackTrace));
       expect(caught.toString(), isNot(contains("private capture details")));
+      expect(output, contains("Session options capture failed for plugin plugin-1"));
+      expect(output, contains("private capture details"));
     });
 
     test("capture failure revalidates retention before retaining the cached response", () async {

--- a/bridge/app/test/bridge/services/session_options_service_test.dart
+++ b/bridge/app/test/bridge/services/session_options_service_test.dart
@@ -396,10 +396,20 @@ void main() {
       };
       final service = _service(repository: repository, now: now);
 
-      final outcome = await service.loadDynamic(pluginId: "plugin-1", projectId: "project-1");
+      late SessionOptionsOutcome outcome;
+      final output = await _captureLogOutput(
+        level: LogLevel.debug,
+        action: () async {
+          outcome = await service.loadDynamic(pluginId: "plugin-1", projectId: "project-1");
+        },
+      );
 
       expect(outcome, isA<SessionOptionsAvailable>());
       expect((outcome as SessionOptionsAvailable).response, _response(marker: "concurrent"));
+      expect(
+        RegExp("session options discovery failed for plugin plugin-1", caseSensitive: false).allMatches(output),
+        hasLength(1),
+      );
     });
 
     test("failed dynamic capture without a cache returns unavailable", () async {

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -43,7 +43,6 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
        _eventBuffer = eventBuffer,
        _clock = clock,
        _generateSessionId = generateSessionId,
-       _catalogSessionId = generateSessionId(),
        _launchDirectory = normalizeProjectDirectory(directory: launchDirectory) {
     _sessions.events.listen(_eventBuffer.add).addTo(_subscriptions);
     _processes.events.listen(_handleProcessEvent).addTo(_subscriptions);
@@ -61,12 +60,10 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
   final BufferedUntilFirstListener<BridgeSseEvent> _eventBuffer;
   final ServerClock _clock;
   final ClaudeSessionIdGenerator _generateSessionId;
-  final String _catalogSessionId;
   final String _launchDirectory;
   final Map<String, PluginSession> _createdSessions = {};
   final Set<String> _unstartedSessions = {};
   final CompositeSubscription _subscriptions = CompositeSubscription();
-  ClaudeBackendCatalog? _catalog;
   Future<void>? _disposeFuture;
   bool _disposed = false;
   int _messageSequence = 0;
@@ -99,14 +96,17 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
 
   @override
   Future<List<PluginCommand>> getCommands({required String? projectId}) async =>
-      (await _getCatalog(refresh: false)).commands;
+      (await _catalogService.getCatalog(directory: projectId ?? _launchDirectory, refresh: false)).commands;
 
   @override
   Future<PluginSessionOptionsDiscoveryResult> getSessionOptions({
     required String projectId,
     required PluginSessionOptionsDiscoveryMode discoveryMode,
   }) async {
-    final catalog = await _getCatalog(refresh: discoveryMode == PluginSessionOptionsDiscoveryMode.refresh);
+    final catalog = await _catalogService.getCatalog(
+      directory: projectId,
+      refresh: discoveryMode == PluginSessionOptionsDiscoveryMode.refresh,
+    );
     return PluginSessionOptionsDiscoveryResult.observed(
       options: PluginSessionOptions(
         agents: catalog.agents,
@@ -295,7 +295,8 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
   Future<void> abortSession({required String sessionId}) => _sessions.abort(sessionId: sessionId);
 
   @override
-  Future<List<PluginAgent>> getAgents({required String projectId}) async => (await _getCatalog(refresh: false)).agents;
+  Future<List<PluginAgent>> getAgents({required String projectId}) async =>
+      (await _catalogService.getCatalog(directory: projectId, refresh: false)).agents;
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async =>
@@ -375,7 +376,7 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
 
   @override
   Future<PluginProvidersResult> getProviders({required String projectId}) async =>
-      (await _getCatalog(refresh: false)).providers;
+      (await _catalogService.getCatalog(directory: projectId, refresh: false)).providers;
 
   @override
   List<PluginProjectActivitySummary> getActiveSessionsSummary() {
@@ -415,26 +416,7 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
     await _sessions.dispose();
     _createdSessions.clear();
     _unstartedSessions.clear();
-    _eventDispatcher.forgetSession(sessionId: _catalogSessionId);
     await _eventBuffer.close();
-  }
-
-  Future<ClaudeBackendCatalog> _getCatalog({required bool refresh}) async {
-    final cached = _catalog;
-    if (!refresh && cached != null) return cached;
-    await _processes.ensureResident(
-      sessionId: _catalogSessionId,
-      directory: _launchDirectory,
-      createNew: true,
-      model: null,
-      effort: null,
-      permissionMode: null,
-      allowedTools: const [],
-    );
-    return _catalog = await _catalogService.getCatalog(
-      sessionId: _catalogSessionId,
-      refresh: refresh,
-    );
   }
 
   Future<void> _enqueue({

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -95,16 +95,17 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
   );
 
   @override
+  // Claude declares plugin-scoped options, so projectId does not select a catalog.
   Future<List<PluginCommand>> getCommands({required String? projectId}) async =>
-      (await _catalogService.getCatalog(directory: projectId ?? _launchDirectory, refresh: false)).commands;
+      (await _catalogService.getCatalog(refresh: false)).commands;
 
   @override
+  // Claude declares plugin-scoped options, so projectId does not select a catalog.
   Future<PluginSessionOptionsDiscoveryResult> getSessionOptions({
     required String projectId,
     required PluginSessionOptionsDiscoveryMode discoveryMode,
   }) async {
     final catalog = await _catalogService.getCatalog(
-      directory: projectId,
       refresh: discoveryMode == PluginSessionOptionsDiscoveryMode.refresh,
     );
     return PluginSessionOptionsDiscoveryResult.observed(
@@ -295,8 +296,9 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
   Future<void> abortSession({required String sessionId}) => _sessions.abort(sessionId: sessionId);
 
   @override
+  // Claude declares plugin-scoped options, so projectId does not select a catalog.
   Future<List<PluginAgent>> getAgents({required String projectId}) async =>
-      (await _catalogService.getCatalog(directory: projectId, refresh: false)).agents;
+      (await _catalogService.getCatalog(refresh: false)).agents;
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async =>
@@ -375,8 +377,9 @@ final class ClaudePlugin extends BridgeDerivedProjectsPluginApi implements Persi
   Future<bool> healthCheck() async => !_disposed;
 
   @override
+  // Claude declares plugin-scoped options, so projectId does not select a catalog.
   Future<PluginProvidersResult> getProviders({required String projectId}) async =>
-      (await _catalogService.getCatalog(directory: projectId, refresh: false)).providers;
+      (await _catalogService.getCatalog(refresh: false)).providers;
 
   @override
   List<PluginProjectActivitySummary> getActiveSessionsSummary() {

--- a/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
@@ -90,7 +90,7 @@ final class ClaudePluginDescriptor extends BridgePluginDescriptor {
   PluginProjectOwnership get projectOwnership => PluginProjectOwnership.bridgeDerived;
 
   @override
-  PluginSessionOptionsScope get sessionOptionsScope => PluginSessionOptionsScope.project;
+  PluginSessionOptionsScope get sessionOptionsScope => PluginSessionOptionsScope.plugin;
 
   @override
   bool get supportsPromptAttachments => true;
@@ -214,7 +214,8 @@ final class ClaudePluginDescriptor extends BridgePluginDescriptor {
       catalogService: ClaudeCatalogService(
         catalog: const ClaudeBackendCatalogRepository(),
         processes: processes,
-        generateSessionId: _generateUuidV4,
+        probeSessionId: _generateUuidV4(),
+        discoveryDirectory: host.stateDirectory,
       ),
       approvals: approvals,
       eventDispatcher: ClaudeEventDispatcher(

--- a/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
@@ -90,7 +90,7 @@ final class ClaudePluginDescriptor extends BridgePluginDescriptor {
   PluginProjectOwnership get projectOwnership => PluginProjectOwnership.bridgeDerived;
 
   @override
-  PluginSessionOptionsScope get sessionOptionsScope => PluginSessionOptionsScope.plugin;
+  PluginSessionOptionsScope get sessionOptionsScope => PluginSessionOptionsScope.project;
 
   @override
   bool get supportsPromptAttachments => true;
@@ -214,6 +214,7 @@ final class ClaudePluginDescriptor extends BridgePluginDescriptor {
       catalogService: ClaudeCatalogService(
         catalog: const ClaudeBackendCatalogRepository(),
         processes: processes,
+        generateSessionId: _generateUuidV4,
       ),
       approvals: approvals,
       eventDispatcher: ClaudeEventDispatcher(

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_catalog_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_catalog_service.dart
@@ -1,29 +1,111 @@
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show normalizeProjectDirectory;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
 import "../models/claude_agent_selection.dart";
 import "../repositories/claude_backend_catalog_repository.dart";
 import "../repositories/claude_session_process_repository.dart";
 
-/// Composes the retained process handshake with catalog and selection controls.
+typedef ClaudeCatalogSessionIdGenerator = String Function();
+typedef _CatalogFetch = ({bool refresh, Future<ClaudeBackendCatalog> future});
+
+/// Owns project-scoped catalog discovery and live-session selection controls.
 final class ClaudeCatalogService {
   ClaudeCatalogService({
     required ClaudeBackendCatalogRepository catalog,
     required ClaudeSessionProcessRepository processes,
-  }) : _catalog = catalog,
-       _processes = processes;
+    required ClaudeCatalogSessionIdGenerator generateSessionId,
+  }) : _catalogRepository = catalog,
+       _processes = processes,
+       _generateSessionId = generateSessionId;
 
-  final ClaudeBackendCatalogRepository _catalog;
+  final ClaudeBackendCatalogRepository _catalogRepository;
   final ClaudeSessionProcessRepository _processes;
+  final ClaudeCatalogSessionIdGenerator _generateSessionId;
+  final Map<String, ClaudeBackendCatalog> _catalogs = {};
+  final Map<String, _CatalogFetch> _fetches = {};
+  final Map<String, String> _probeSessionIds = {};
 
-  Future<ClaudeBackendCatalog> getCatalog({required String sessionId, required bool refresh}) async {
+  Future<ClaudeBackendCatalog> getCatalog({required String directory, required bool refresh}) {
+    final normalized = normalizeProjectDirectory(directory: directory);
+    final cached = _catalogs[normalized];
+    if (!refresh && cached != null) {
+      Log.d("[claude] session options cache hit for $normalized");
+      return Future.value(cached);
+    }
+    final inFlight = _fetches[normalized];
+    if (inFlight != null) {
+      if (!refresh || inFlight.refresh) return inFlight.future;
+      Log.d("[claude] queued session options refresh for $normalized");
+      final sessionId = _probeSessionIds[normalized]!;
+      final queued = inFlight.future.then(
+        (_) => _fetchCatalog(directory: normalized, sessionId: sessionId, refresh: true),
+        onError: (Object _, StackTrace __) => _fetchCatalog(directory: normalized, sessionId: sessionId, refresh: true),
+      );
+      return _trackFetch(directory: normalized, refresh: true, future: queued);
+    }
+
+    final sessionId = _probeSessionIds.putIfAbsent(normalized, _generateSessionId);
+    final fetch = _fetchCatalog(
+      directory: normalized,
+      sessionId: sessionId,
+      refresh: refresh,
+    );
+    return _trackFetch(directory: normalized, refresh: refresh, future: fetch);
+  }
+
+  Future<ClaudeBackendCatalog> _trackFetch({
+    required String directory,
+    required bool refresh,
+    required Future<ClaudeBackendCatalog> future,
+  }) {
+    _fetches[directory] = (refresh: refresh, future: future);
+    return future.whenComplete(() {
+      if (identical(_fetches[directory]?.future, future)) _fetches.remove(directory);
+    });
+  }
+
+  Future<ClaudeBackendCatalog> _fetchCatalog({
+    required String directory,
+    required String sessionId,
+    required bool refresh,
+  }) async {
+    Log.d("[claude] discovering session options in $directory (refresh=$refresh)");
+    try {
+      await _processes.ensureResident(
+        sessionId: sessionId,
+        directory: directory,
+        createNew: true,
+        model: null,
+        effort: null,
+        permissionMode: null,
+        allowedTools: const [],
+      );
+      final catalog = await _readCatalog(sessionId: sessionId, refresh: refresh);
+      _catalogs[directory] = catalog;
+      final modelCount = catalog.providers.providers.fold<int>(0, (count, provider) => count + provider.models.length);
+      Log.d(
+        "[claude] discovered session options in $directory "
+        "(${catalog.agents.length} agents, $modelCount models, ${catalog.commands.length} commands)",
+      );
+      return catalog;
+    } finally {
+      // A catalog probe never runs a turn, so the session service's idle reap
+      // does not own it. Reap it as part of the same project-scoped operation.
+      await _processes.teardown(sessionId: sessionId);
+    }
+  }
+
+  Future<ClaudeBackendCatalog> _readCatalog({required String sessionId, required bool refresh}) async {
     final handshake = _processes.handshake(sessionId: sessionId);
     if (handshake == null) throw StateError("Claude session has no catalog: $sessionId");
-    if (!refresh) return _catalog.map(handshake: handshake);
+    if (!refresh) return _catalogRepository.map(handshake: handshake);
 
     final refreshed = await _processes.sendControlRequest(
       sessionId: sessionId,
       subtype: "list_models",
       params: const {},
     );
-    return _catalog.map(handshake: {...handshake, ...refreshed});
+    return _catalogRepository.map(handshake: {...handshake, ...refreshed});
   }
 
   Future<void> selectModel({

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_catalog_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_catalog_service.dart
@@ -1,97 +1,87 @@
-import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show normalizeProjectDirectory;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
 import "../models/claude_agent_selection.dart";
 import "../repositories/claude_backend_catalog_repository.dart";
 import "../repositories/claude_session_process_repository.dart";
 
-typedef ClaudeCatalogSessionIdGenerator = String Function();
 typedef _CatalogFetch = ({bool refresh, Future<ClaudeBackendCatalog> future});
 
-/// Owns project-scoped catalog discovery and live-session selection controls.
+/// Owns the global catalog probe and live-session selection controls.
 final class ClaudeCatalogService {
   ClaudeCatalogService({
     required ClaudeBackendCatalogRepository catalog,
     required ClaudeSessionProcessRepository processes,
-    required ClaudeCatalogSessionIdGenerator generateSessionId,
+    required String probeSessionId,
+    required String discoveryDirectory,
   }) : _catalogRepository = catalog,
        _processes = processes,
-       _generateSessionId = generateSessionId;
+       _probeSessionId = probeSessionId,
+       _discoveryDirectory = discoveryDirectory;
 
   final ClaudeBackendCatalogRepository _catalogRepository;
   final ClaudeSessionProcessRepository _processes;
-  final ClaudeCatalogSessionIdGenerator _generateSessionId;
-  final Map<String, ClaudeBackendCatalog> _catalogs = {};
-  final Map<String, _CatalogFetch> _fetches = {};
-  final Map<String, String> _probeSessionIds = {};
+  final String _probeSessionId;
+  final String _discoveryDirectory;
+  ClaudeBackendCatalog? _catalog;
+  _CatalogFetch? _fetch;
 
-  Future<ClaudeBackendCatalog> getCatalog({required String directory, required bool refresh}) {
-    final normalized = normalizeProjectDirectory(directory: directory);
-    final cached = _catalogs[normalized];
+  Future<ClaudeBackendCatalog> getCatalog({required bool refresh}) {
+    final cached = _catalog;
     if (!refresh && cached != null) {
-      Log.d("[claude] session options cache hit for $normalized");
+      Log.d("[claude] global session options cache hit");
       return Future.value(cached);
     }
-    final inFlight = _fetches[normalized];
+    final inFlight = _fetch;
     if (inFlight != null) {
       if (!refresh || inFlight.refresh) return inFlight.future;
-      Log.d("[claude] queued session options refresh for $normalized");
-      final sessionId = _probeSessionIds[normalized]!;
+      Log.d("[claude] queued global session options refresh");
       final queued = inFlight.future.then(
-        (_) => _fetchCatalog(directory: normalized, sessionId: sessionId, refresh: true),
-        onError: (Object _, StackTrace __) => _fetchCatalog(directory: normalized, sessionId: sessionId, refresh: true),
+        (_) => _fetchCatalog(refresh: true),
+        onError: (Object _, StackTrace __) => _fetchCatalog(refresh: true),
       );
-      return _trackFetch(directory: normalized, refresh: true, future: queued);
+      return _trackFetch(refresh: true, future: queued);
     }
 
-    final sessionId = _probeSessionIds.putIfAbsent(normalized, _generateSessionId);
-    final fetch = _fetchCatalog(
-      directory: normalized,
-      sessionId: sessionId,
+    return _trackFetch(
       refresh: refresh,
+      future: _fetchCatalog(refresh: refresh),
     );
-    return _trackFetch(directory: normalized, refresh: refresh, future: fetch);
   }
 
   Future<ClaudeBackendCatalog> _trackFetch({
-    required String directory,
     required bool refresh,
     required Future<ClaudeBackendCatalog> future,
   }) {
-    _fetches[directory] = (refresh: refresh, future: future);
+    _fetch = (refresh: refresh, future: future);
     return future.whenComplete(() {
-      if (identical(_fetches[directory]?.future, future)) _fetches.remove(directory);
+      if (identical(_fetch?.future, future)) _fetch = null;
     });
   }
 
-  Future<ClaudeBackendCatalog> _fetchCatalog({
-    required String directory,
-    required String sessionId,
-    required bool refresh,
-  }) async {
-    Log.d("[claude] discovering session options in $directory (refresh=$refresh)");
+  Future<ClaudeBackendCatalog> _fetchCatalog({required bool refresh}) async {
+    Log.d("[claude] discovering global session options in $_discoveryDirectory (refresh=$refresh)");
     try {
       await _processes.ensureResident(
-        sessionId: sessionId,
-        directory: directory,
+        sessionId: _probeSessionId,
+        directory: _discoveryDirectory,
         createNew: true,
         model: null,
         effort: null,
         permissionMode: null,
         allowedTools: const [],
       );
-      final catalog = await _readCatalog(sessionId: sessionId, refresh: refresh);
-      _catalogs[directory] = catalog;
+      final catalog = await _readCatalog(sessionId: _probeSessionId, refresh: refresh);
+      _catalog = catalog;
       final modelCount = catalog.providers.providers.fold<int>(0, (count, provider) => count + provider.models.length);
       Log.d(
-        "[claude] discovered session options in $directory "
+        "[claude] discovered global session options in $_discoveryDirectory "
         "(${catalog.agents.length} agents, $modelCount models, ${catalog.commands.length} commands)",
       );
       return catalog;
     } finally {
-      // A catalog probe never runs a turn, so the session service's idle reap
-      // does not own it. Reap it as part of the same project-scoped operation.
-      await _processes.teardown(sessionId: sessionId);
+      // A catalog probe never runs a turn or writes a transcript, so the session
+      // service's idle reap does not own it. Reap it with the discovery request.
+      await _processes.teardown(sessionId: _probeSessionId);
     }
   }
 

--- a/bridge/sesori_plugin_claude/test/claude_catalog_service_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_catalog_service_test.dart
@@ -6,20 +6,34 @@ import "package:test/test.dart";
 
 import "support/claude_stream_client_test_factory.dart";
 
+const _catalogSessionIds = [
+  "11111111-2222-4333-8444-555555555555",
+  "99999999-8888-4777-8666-555555555555",
+];
+
 void main() {
   group("ClaudeCatalogService", () {
-    late FakeClaudeProcess process;
+    late List<FakeClaudeProcess> spawned;
+    late List<ClaudeLaunchSpec> specs;
     late ClaudeSessionProcessRepository processes;
     late ClaudeCatalogService service;
+    var sessionIdIndex = 0;
 
-    setUp(() async {
-      process = FakeClaudeProcess();
+    setUp(() {
+      sessionIdIndex = 0;
+      spawned = [];
+      specs = [];
       processes = ClaudeSessionProcessRepository(
-        processFactory: (_) async {
-          unawaited(() async {
-            final request = await _waitForControl(process, "initialize");
-            process.emitControlResponse(requestId: request["request_id"]! as String, payload: sampleHandshake);
-          }());
+        processFactory: (spec) async {
+          final process = FakeClaudeProcess();
+          specs.add(spec);
+          spawned.add(process);
+          unawaited(
+            _answerCatalogControls(
+              process,
+              commandName: spec.workingDirectory == "/tmp/other-project" ? "other-review" : "review",
+            ),
+          );
           return process;
         },
         binaryPath: "claude",
@@ -28,6 +42,92 @@ void main() {
       service = ClaudeCatalogService(
         catalog: const ClaudeBackendCatalogRepository(),
         processes: processes,
+        generateSessionId: () => _catalogSessionIds[sessionIdIndex++],
+      );
+    });
+
+    tearDown(() async {
+      await processes.dispose();
+      for (final process in spawned) {
+        await process.close();
+      }
+    });
+
+    test("discovers in the selected directory and reaps the probe", () async {
+      final catalog = await service.getCatalog(directory: "/tmp/project", refresh: false);
+
+      expect(catalog.providers.providers.single.models, hasLength(2));
+      expect(specs.single.workingDirectory, "/tmp/project");
+      expect(spawned.single.killed, isTrue);
+    });
+
+    test("serves a cached project catalog without another probe", () async {
+      await service.getCatalog(directory: "/tmp/project", refresh: false);
+      await service.getCatalog(directory: "/tmp/project/.", refresh: false);
+
+      expect(spawned, hasLength(1));
+    });
+
+    test("refreshes models through a new project probe while retaining commands", () async {
+      await service.getCatalog(directory: "/tmp/project", refresh: false);
+      final refreshed = await service.getCatalog(directory: "/tmp/project", refresh: true);
+
+      expect(spawned, hasLength(2));
+      expect(_controlSubtypes(spawned.last), contains("list_models"));
+      expect(refreshed.providers.providers.single.models.single.id, "new");
+      expect(refreshed.commands.single.name, "review");
+      expect(spawned.last.killed, isTrue);
+    });
+
+    test("caches different project directories independently", () async {
+      final first = await service.getCatalog(directory: "/tmp/project", refresh: false);
+      final second = await service.getCatalog(directory: "/tmp/other-project", refresh: false);
+
+      expect(specs.map((spec) => spec.workingDirectory), ["/tmp/project", "/tmp/other-project"]);
+      expect(first.commands.single.name, "review");
+      expect(second.commands.single.name, "other-review");
+      expect(spawned.every((process) => process.killed), isTrue);
+    });
+
+    test("coalesces concurrent reads for one project", () async {
+      final first = service.getCatalog(directory: "/tmp/project", refresh: false);
+      final second = service.getCatalog(directory: "/tmp/project", refresh: false);
+
+      expect(await first, same(await second));
+      expect(spawned, hasLength(1));
+    });
+
+    test("queues an explicit refresh behind an in-flight reuse discovery", () async {
+      final reuse = service.getCatalog(directory: "/tmp/project", refresh: false);
+      final refresh = service.getCatalog(directory: "/tmp/project", refresh: true);
+
+      await reuse;
+      final refreshed = await refresh;
+      expect(spawned, hasLength(2));
+      expect(_controlSubtypes(spawned.last), contains("list_models"));
+      expect(refreshed.providers.providers.single.models.single.id, "new");
+    });
+  });
+
+  group("ClaudeCatalogService live selections", () {
+    late FakeClaudeProcess process;
+    late ClaudeSessionProcessRepository processes;
+    late ClaudeCatalogService service;
+
+    setUp(() async {
+      process = FakeClaudeProcess();
+      processes = ClaudeSessionProcessRepository(
+        processFactory: (_) async {
+          unawaited(_answerCatalogControls(process, commandName: "review"));
+          return process;
+        },
+        binaryPath: "claude",
+        environment: const {},
+      );
+      service = ClaudeCatalogService(
+        catalog: const ClaudeBackendCatalogRepository(),
+        processes: processes,
+        generateSessionId: () => otherTestSessionId,
       );
       await processes.ensureResident(
         sessionId: testSessionId,
@@ -45,37 +145,10 @@ void main() {
       await process.close();
     });
 
-    test("maps the retained initialize response without another probe", () async {
-      final catalog = await service.getCatalog(sessionId: testSessionId, refresh: false);
-
-      expect(catalog.providers.providers.single.models, hasLength(2));
-      expect(process.written.where(_isControlRequest), hasLength(1));
-    });
-
-    test("refreshes models through list_models while retaining commands", () async {
-      final refreshed = service.getCatalog(sessionId: testSessionId, refresh: true);
-      final request = await _waitForControl(process, "list_models");
-      process.emitControlResponse(
-        requestId: request["request_id"]! as String,
-        payload: {
-          "models": [
-            {"value": "new", "displayName": "New model"},
-          ],
-        },
-      );
-
-      final catalog = await refreshed;
-      expect(catalog.providers.providers.single.models.single.id, "new");
-      expect(catalog.commands.single.name, "review");
-    });
-
     test("switches model without changing the process launch effort", () async {
-      final selected = service.selectModel(
-        sessionId: testSessionId,
-        modelId: "large",
-      );
+      final selected = service.selectModel(sessionId: testSessionId, modelId: "large");
       final request = await _waitForControl(process, "set_model");
-      expect(_requestPayload(request)["model"], "large");
+      expect(_request(request)["model"], "large");
       process.emitControlResponse(requestId: request["request_id"]! as String, payload: const {});
       await selected;
 
@@ -86,12 +159,9 @@ void main() {
     });
 
     test("resets the default model without discarding launch selections", () async {
-      final selected = service.selectModel(
-        sessionId: testSessionId,
-        modelId: "default",
-      );
+      final selected = service.selectModel(sessionId: testSessionId, modelId: "default");
       final request = await _waitForControl(process, "set_model");
-      expect(_requestPayload(request), containsPair("model", null));
+      expect(_request(request), containsPair("model", null));
       process.emitControlResponse(requestId: request["request_id"]! as String, payload: const {});
       await selected;
 
@@ -104,7 +174,7 @@ void main() {
     test("maps Plan to the control protocol and preserves model selection", () async {
       final selected = service.selectAgent(sessionId: testSessionId, agent: "Plan");
       final request = await _waitForControl(process, "set_permission_mode");
-      expect(_requestPayload(request)["mode"], "plan");
+      expect(_request(request)["mode"], "plan");
       process.emitControlResponse(requestId: request["request_id"]! as String, payload: const {});
       await selected;
 
@@ -119,19 +189,51 @@ void main() {
         service.selectAgent(sessionId: testSessionId, agent: "Research"),
         throwsArgumentError,
       );
-      expect(process.written.where(_isControlRequest), hasLength(1));
+      expect(_controlSubtypes(process), ["initialize"]);
     });
   });
 }
 
-bool _isControlRequest(Map<String, Object?> frame) => frame["type"] == "control_request";
+Future<void> _answerCatalogControls(FakeClaudeProcess process, {required String commandName}) async {
+  final answered = <String>{};
+  while (!process.killed) {
+    for (final frame in process.written) {
+      if (frame["type"] != "control_request") continue;
+      final requestId = frame["request_id"]! as String;
+      if (!answered.add(requestId)) continue;
+      final subtype = _request(frame)["subtype"];
+      process.emitControlResponse(
+        requestId: requestId,
+        payload: switch (subtype) {
+          "initialize" => {
+            ...sampleHandshake,
+            "commands": [
+              {"name": commandName, "description": "Review changes", "argumentHint": "[path]"},
+            ],
+          },
+          "list_models" => {
+            "models": [
+              {"value": "new", "displayName": "New model"},
+            ],
+          },
+          _ => const {},
+        },
+      );
+    }
+    await pump();
+  }
+}
 
-Map<String, Object?> _requestPayload(Map<String, Object?> frame) => (frame["request"]! as Map).cast<String, Object?>();
+Map<String, Object?> _request(Map<String, Object?> frame) => (frame["request"]! as Map).cast<String, Object?>();
+
+Iterable<String?> _controlSubtypes(FakeClaudeProcess process) => process.written
+    .where((frame) => frame["type"] == "control_request")
+    .map((frame) => _request(frame)["subtype"] as String?);
 
 Future<Map<String, Object?>> _waitForControl(FakeClaudeProcess process, String subtype) async {
   for (var attempt = 0; attempt < 50; attempt++) {
     for (final frame in process.written) {
-      if (frame["type"] == "control_request" && _requestPayload(frame)["subtype"] == subtype) return frame;
+      if (frame["type"] == "control_request" && _request(frame)["subtype"] == subtype) return frame;
     }
     await pump();
   }

--- a/bridge/sesori_plugin_claude/test/claude_catalog_service_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_catalog_service_test.dart
@@ -6,21 +6,14 @@ import "package:test/test.dart";
 
 import "support/claude_stream_client_test_factory.dart";
 
-const _catalogSessionIds = [
-  "11111111-2222-4333-8444-555555555555",
-  "99999999-8888-4777-8666-555555555555",
-];
-
 void main() {
   group("ClaudeCatalogService", () {
     late List<FakeClaudeProcess> spawned;
     late List<ClaudeLaunchSpec> specs;
     late ClaudeSessionProcessRepository processes;
     late ClaudeCatalogService service;
-    var sessionIdIndex = 0;
 
     setUp(() {
-      sessionIdIndex = 0;
       spawned = [];
       specs = [];
       processes = ClaudeSessionProcessRepository(
@@ -28,12 +21,7 @@ void main() {
           final process = FakeClaudeProcess();
           specs.add(spec);
           spawned.add(process);
-          unawaited(
-            _answerCatalogControls(
-              process,
-              commandName: spec.workingDirectory == "/tmp/other-project" ? "other-review" : "review",
-            ),
-          );
+          unawaited(_answerCatalogControls(process, commandName: "review"));
           return process;
         },
         binaryPath: "claude",
@@ -42,7 +30,8 @@ void main() {
       service = ClaudeCatalogService(
         catalog: const ClaudeBackendCatalogRepository(),
         processes: processes,
-        generateSessionId: () => _catalogSessionIds[sessionIdIndex++],
+        probeSessionId: otherTestSessionId,
+        discoveryDirectory: "/tmp/claude-state",
       );
     });
 
@@ -53,53 +42,45 @@ void main() {
       }
     });
 
-    test("discovers in the selected directory and reaps the probe", () async {
-      final catalog = await service.getCatalog(directory: "/tmp/project", refresh: false);
+    test("discovers globally from the configured directory and reaps the probe", () async {
+      final catalog = await service.getCatalog(refresh: false);
 
       expect(catalog.providers.providers.single.models, hasLength(2));
-      expect(specs.single.workingDirectory, "/tmp/project");
+      expect(specs.single.workingDirectory, "/tmp/claude-state");
+      expect(_controlSubtypes(spawned.single), ["initialize"]);
       expect(spawned.single.killed, isTrue);
     });
 
-    test("serves a cached project catalog without another probe", () async {
-      await service.getCatalog(directory: "/tmp/project", refresh: false);
-      await service.getCatalog(directory: "/tmp/project/.", refresh: false);
+    test("serves the cached global catalog without another probe", () async {
+      await service.getCatalog(refresh: false);
+      await service.getCatalog(refresh: false);
 
       expect(spawned, hasLength(1));
     });
 
-    test("refreshes models through a new project probe while retaining commands", () async {
-      await service.getCatalog(directory: "/tmp/project", refresh: false);
-      final refreshed = await service.getCatalog(directory: "/tmp/project", refresh: true);
+    test("refreshes models through a new global probe while retaining commands", () async {
+      await service.getCatalog(refresh: false);
+      final refreshed = await service.getCatalog(refresh: true);
 
       expect(spawned, hasLength(2));
+      expect(specs.map((spec) => spec.workingDirectory), everyElement("/tmp/claude-state"));
       expect(_controlSubtypes(spawned.last), contains("list_models"));
       expect(refreshed.providers.providers.single.models.single.id, "new");
       expect(refreshed.commands.single.name, "review");
       expect(spawned.last.killed, isTrue);
     });
 
-    test("caches different project directories independently", () async {
-      final first = await service.getCatalog(directory: "/tmp/project", refresh: false);
-      final second = await service.getCatalog(directory: "/tmp/other-project", refresh: false);
-
-      expect(specs.map((spec) => spec.workingDirectory), ["/tmp/project", "/tmp/other-project"]);
-      expect(first.commands.single.name, "review");
-      expect(second.commands.single.name, "other-review");
-      expect(spawned.every((process) => process.killed), isTrue);
-    });
-
-    test("coalesces concurrent reads for one project", () async {
-      final first = service.getCatalog(directory: "/tmp/project", refresh: false);
-      final second = service.getCatalog(directory: "/tmp/project", refresh: false);
+    test("coalesces concurrent global reads", () async {
+      final first = service.getCatalog(refresh: false);
+      final second = service.getCatalog(refresh: false);
 
       expect(await first, same(await second));
       expect(spawned, hasLength(1));
     });
 
     test("queues an explicit refresh behind an in-flight reuse discovery", () async {
-      final reuse = service.getCatalog(directory: "/tmp/project", refresh: false);
-      final refresh = service.getCatalog(directory: "/tmp/project", refresh: true);
+      final reuse = service.getCatalog(refresh: false);
+      final refresh = service.getCatalog(refresh: true);
 
       await reuse;
       final refreshed = await refresh;
@@ -127,7 +108,8 @@ void main() {
       service = ClaudeCatalogService(
         catalog: const ClaudeBackendCatalogRepository(),
         processes: processes,
-        generateSessionId: () => otherTestSessionId,
+        probeSessionId: otherTestSessionId,
+        discoveryDirectory: "/tmp/claude-state",
       );
       await processes.ensureResident(
         sessionId: testSessionId,

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -9,6 +9,12 @@ import "package:test/test.dart";
 
 import "support/claude_stream_client_test_factory.dart";
 
+const _testIds = [
+  "11111111-2222-4333-8444-555555555555",
+  "99999999-8888-4777-8666-555555555555",
+  "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+];
+
 void main() {
   group("ClaudePlugin", () {
     late _PluginHarness harness;
@@ -19,7 +25,7 @@ void main() {
 
     tearDown(() => harness.close());
 
-    test("discovers and caches a complete catalog before any user session", () async {
+    test("discovers and caches a complete catalog in the selected project", () async {
       final options = await harness.plugin.getSessionOptions(
         projectId: "/tmp/project",
         discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
@@ -30,7 +36,10 @@ void main() {
       expect(observed.options.providers.providers.single.models, hasLength(2));
       expect(observed.options.commands.single.name, "review");
       expect(harness.processes, hasLength(1));
+      expect(harness.specs.single.workingDirectory, "/tmp/project");
+      expect(harness.processes.single.killed, isTrue);
 
+      // A cached read is served without spawning a second probe.
       await harness.plugin.getCommands(projectId: null);
       expect(harness.processes, hasLength(1));
 
@@ -38,7 +47,34 @@ void main() {
         projectId: "/tmp/project",
         discoveryMode: PluginSessionOptionsDiscoveryMode.refresh,
       );
-      expect(_controlSubtypes(harness.processes.single), contains("list_models"));
+      expect(harness.processes, hasLength(2));
+      expect(_controlSubtypes(harness.processes.last), contains("list_models"));
+    });
+
+    test("shares one catalog probe across concurrent reads", () async {
+      final results = await Future.wait([
+        harness.plugin.getAgents(projectId: "/tmp/project"),
+        harness.plugin.getProviders(projectId: "/tmp/project"),
+        harness.plugin.getCommands(projectId: null),
+      ]);
+
+      expect(results, hasLength(3));
+      expect(harness.processes, hasLength(1));
+    });
+
+    test("caches catalogs independently by project directory", () async {
+      await harness.plugin.getSessionOptions(
+        projectId: "/tmp/project",
+        discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+      );
+      await harness.plugin.getSessionOptions(
+        projectId: "/tmp/other-project",
+        discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+      );
+
+      expect(harness.processes, hasLength(2));
+      expect(harness.specs.map((spec) => spec.workingDirectory), ["/tmp/project", "/tmp/other-project"]);
+      expect(harness.processes.every((process) => process.killed), isTrue);
     });
 
     test("creates under the generated id and buffers creation before listening", () async {
@@ -455,6 +491,7 @@ final class _PluginHarness {
       catalogService: ClaudeCatalogService(
         catalog: const ClaudeBackendCatalogRepository(),
         processes: processRepository,
+        generateSessionId: _nextId,
       ),
       approvals: approvals,
       eventDispatcher: ClaudeEventDispatcher(content: content, tools: ClaudeToolTracker()),
@@ -476,7 +513,7 @@ final class _PluginHarness {
   final bool failInitialize;
   var _idIndex = 0;
 
-  String _nextId() => [otherTestSessionId, testSessionId][_idIndex++];
+  String _nextId() => _testIds[_idIndex++];
 
   Future<PluginSession> createSession() => plugin.createSession(
     directory: "/tmp/project",

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -10,8 +10,8 @@ import "package:test/test.dart";
 import "support/claude_stream_client_test_factory.dart";
 
 const _testIds = [
-  "11111111-2222-4333-8444-555555555555",
   "99999999-8888-4777-8666-555555555555",
+  "11111111-2222-4333-8444-555555555555",
   "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
 ];
 
@@ -25,7 +25,7 @@ void main() {
 
     tearDown(() => harness.close());
 
-    test("discovers and caches a complete catalog in the selected project", () async {
+    test("discovers and caches a complete global catalog outside the selected project", () async {
       final options = await harness.plugin.getSessionOptions(
         projectId: "/tmp/project",
         discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
@@ -36,25 +36,28 @@ void main() {
       expect(observed.options.providers.providers.single.models, hasLength(2));
       expect(observed.options.commands.single.name, "review");
       expect(harness.processes, hasLength(1));
-      expect(harness.specs.single.workingDirectory, "/tmp/project");
+      expect(harness.specs.single.workingDirectory, harness.temporary.path);
+      expect(_controlSubtypes(harness.processes.single), ["initialize"]);
       expect(harness.processes.single.killed, isTrue);
+      expect(await harness.plugin.listAllSessions(knownDirectories: const {}), isEmpty);
 
       // A cached read is served without spawning a second probe.
       await harness.plugin.getCommands(projectId: null);
       expect(harness.processes, hasLength(1));
 
       await harness.plugin.getSessionOptions(
-        projectId: "/tmp/project",
+        projectId: "/tmp/other-project",
         discoveryMode: PluginSessionOptionsDiscoveryMode.refresh,
       );
       expect(harness.processes, hasLength(2));
+      expect(harness.specs.map((spec) => spec.workingDirectory), everyElement(harness.temporary.path));
       expect(_controlSubtypes(harness.processes.last), contains("list_models"));
     });
 
     test("shares one catalog probe across concurrent reads", () async {
       final results = await Future.wait([
         harness.plugin.getAgents(projectId: "/tmp/project"),
-        harness.plugin.getProviders(projectId: "/tmp/project"),
+        harness.plugin.getProviders(projectId: "/tmp/other-project"),
         harness.plugin.getCommands(projectId: null),
       ]);
 
@@ -62,19 +65,19 @@ void main() {
       expect(harness.processes, hasLength(1));
     });
 
-    test("caches catalogs independently by project directory", () async {
-      await harness.plugin.getSessionOptions(
+    test("shares one cached catalog across project ids", () async {
+      final first = await harness.plugin.getSessionOptions(
         projectId: "/tmp/project",
         discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
       );
-      await harness.plugin.getSessionOptions(
+      final second = await harness.plugin.getSessionOptions(
         projectId: "/tmp/other-project",
         discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
       );
 
-      expect(harness.processes, hasLength(2));
-      expect(harness.specs.map((spec) => spec.workingDirectory), ["/tmp/project", "/tmp/other-project"]);
-      expect(harness.processes.every((process) => process.killed), isTrue);
+      expect(second, first);
+      expect(harness.processes, hasLength(1));
+      expect(harness.specs.single.workingDirectory, harness.temporary.path);
     });
 
     test("creates under the generated id and buffers creation before listening", () async {
@@ -403,7 +406,9 @@ void main() {
 
       process.emit(_result());
       await pump();
-      final permissionModeControlsBefore = _controlSubtypes(process).where((subtype) => subtype == "set_permission_mode").length;
+      final permissionModeControlsBefore = _controlSubtypes(
+        process,
+      ).where((subtype) => subtype == "set_permission_mode").length;
       await harness.plugin.sendPrompt(
         sessionId: testSessionId,
         parts: const [PluginPromptPart.text(text: "plan again")],
@@ -491,7 +496,8 @@ final class _PluginHarness {
       catalogService: ClaudeCatalogService(
         catalog: const ClaudeBackendCatalogRepository(),
         processes: processRepository,
-        generateSessionId: _nextId,
+        probeSessionId: _nextId(),
+        discoveryDirectory: temporary.path,
       ),
       approvals: approvals,
       eventDispatcher: ClaudeEventDispatcher(content: content, tools: ClaudeToolTracker()),

--- a/bridge/sesori_plugin_claude/test/runtime/claude_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_claude/test/runtime/claude_plugin_descriptor_test.dart
@@ -16,7 +16,7 @@ void main() {
       expect(descriptor.id, "claude");
       expect(descriptor.displayName, "Claude Code");
       expect(descriptor.projectOwnership, PluginProjectOwnership.bridgeDerived);
-      expect(descriptor.sessionOptionsScope, PluginSessionOptionsScope.plugin);
+      expect(descriptor.sessionOptionsScope, PluginSessionOptionsScope.project);
       expect(descriptor.supportsPromptAttachments, isTrue);
       expect(descriptor.options.single.name, "bin");
       expect(ClaudePluginDescriptor.minVersion, "2.1.221");

--- a/bridge/sesori_plugin_claude/test/runtime/claude_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_claude/test/runtime/claude_plugin_descriptor_test.dart
@@ -16,7 +16,7 @@ void main() {
       expect(descriptor.id, "claude");
       expect(descriptor.displayName, "Claude Code");
       expect(descriptor.projectOwnership, PluginProjectOwnership.bridgeDerived);
-      expect(descriptor.sessionOptionsScope, PluginSessionOptionsScope.project);
+      expect(descriptor.sessionOptionsScope, PluginSessionOptionsScope.plugin);
       expect(descriptor.supportsPromptAttachments, isTrue);
       expect(descriptor.options.single.name, "bin");
       expect(ClaudePluginDescriptor.minVersion, "2.1.221");
@@ -236,7 +236,7 @@ void main() {
       );
       expect(plugin.currentStatus, const PluginReady());
       expect(processes.runInShellValues, [Platform.isWindows, Platform.isWindows]);
-      expect(processes.workingDirectories.every((directory) => directory != null), isTrue);
+      expect(processes.workingDirectories, everyElement(Directory.systemTemp.path));
       expect(processes.environments, everyElement(containsPair("HOME", "/Users/test")));
 
       liveProcess.completeExit(1);
@@ -275,6 +275,9 @@ final class _PluginHost implements PluginHost {
     "CLAUDE_CONFIG_DIR": "/tmp/claude-descriptor-test",
     "HOME": "/Users/test",
   };
+
+  @override
+  String get stateDirectory => Directory.systemTemp.path;
 
   @override
   ServerClock get clock => const ServerClock();

--- a/client/module_core/lib/src/cubits/new_session/new_session_cubit.dart
+++ b/client/module_core/lib/src/cubits/new_session/new_session_cubit.dart
@@ -355,6 +355,16 @@ class NewSessionCubit extends Cubit<NewSessionState> {
     }
 
     if (!_canApplyLoad(generation: generation, pluginId: pluginId)) return;
+    // The bridge answers these with an opaque error code rather than an
+    // exception, so without this the screen renders a failure no log explains.
+    if (result case NewSessionOptionsLoadFailureUnavailable() ||
+        NewSessionOptionsRefreshFailureUnavailable() ||
+        NewSessionOptionsFailureUnavailable()) {
+      logw(
+        "New session: options unavailable for plugin $pluginId "
+        "(source: ${source.name}, mode: ${mode.name}, result: ${result.runtimeType.toString()})",
+      );
+    }
     final options = switch (result) {
       NewSessionOptionsLoaded(:final options, :final source) => NewSessionOptionsAvailableState(
         options: options,

--- a/client/module_core/test/cubits/new_session/new_session_plugin_selection_test.dart
+++ b/client/module_core/test/cubits/new_session/new_session_plugin_selection_test.dart
@@ -920,13 +920,24 @@ void main() {
       addTearDown(cubit.close);
       await _waitForComposer(cubit);
       cubit.selectVariant(const SessionVariant(id: "high"));
-      await cubit.refreshOptions();
+      final logLines = <String>[];
+      await runZoned(
+        cubit.refreshOptions,
+        zoneSpecification: ZoneSpecification(print: (_, _, _, line) => logLines.add(line)),
+      );
 
       final afterRefresh = cubit.state.agentModelData!;
       expect(afterRefresh.optionsState, isA<NewSessionOptionsRefreshFailureUnavailableState>());
       expect(afterRefresh.providers, isEmpty);
       expect(afterRefresh.agentModel, isNull);
       expect(afterRefresh.availableVariants, isEmpty);
+      expect(
+        logLines,
+        contains(
+          "New session: options unavailable for plugin plugin-a "
+          "(source: aggregate, mode: forcedRefresh, result: NewSessionOptionsRefreshFailureUnavailable)",
+        ),
+      );
     });
 
     test("failed provider load after a plugin switch does not restore the prior plugin catalog", () async {

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -10,9 +10,9 @@ variant, and worktree mode, and creating the session with its first input.
 
 - Options are discovered per plugin and cached under the plugin's declared
   coherence scope; retention and replacement are bridge-owned.
-- Project-scoped discovery runs in the resolved live project directory, never
-  the bridge process's launch directory. This keeps project-local slash commands
-  attributed to the project that the user selected.
+- Claude's plugin-scoped discovery runs in its host-created state directory,
+  never a selected project or the bridge process's launch directory. This keeps
+  its global option probe on a valid, stable path when projects move or disappear.
 - Read intents stay distinct: a normal load may serve a valid cache or discover,
   a cache-only read never discovers and reports cache-unavailable, and an
   explicit refresh forces fresh discovery.

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -10,6 +10,9 @@ variant, and worktree mode, and creating the session with its first input.
 
 - Options are discovered per plugin and cached under the plugin's declared
   coherence scope; retention and replacement are bridge-owned.
+- Project-scoped discovery runs in the resolved live project directory, never
+  the bridge process's launch directory. This keeps project-local slash commands
+  attributed to the project that the user selected.
 - Read intents stay distinct: a normal load may serve a valid cache or discover,
   a cache-only read never discovers and reports cache-unavailable, and an
   explicit refresh forces fresh discovery.


### PR DESCRIPTION
## Complexity

Moderate. This keeps Claude option discovery plugin-global while giving its short-lived catalog probe a stable host-owned working directory and coordinated refresh lifecycle.

## What

- Cache one Claude agents/models/commands catalog globally for the plugin.
- Run every catalog probe from Claude's host-created plugin state directory instead of the bridge process cwd or a selected project.
- Coalesce concurrent reads, queue explicit refresh behind an in-flight reuse probe, and tear every probe down afterward.
- Preserve original option-discovery failures in bridge logs, avoid duplicate failure logs, and report opaque unavailable outcomes in client logs.
- Document the stable-directory contract for Claude's plugin-scoped options.

## Why

Claude options are global, but discovery still needs a valid working directory. The prior implementation used the bridge launch directory, which may be unrelated to the plugin and can become invalid. The host guarantees the plugin state directory is absolute and created before startup, so it provides a stable probe cwd without coupling the catalog to a project.

## Risk and test focus

The main risks are global cache/refresh coordination, probe lifecycle, and accidentally exposing the probe cwd as a Claude project. Tests cover cross-project cache reuse, concurrent coalescing, queued refresh, stable cwd propagation, control-only probes, teardown, and absence of plugin-visible sessions after discovery.

There is no database schema or migration impact. Claude harness support has not shipped publicly, so project-scoped cache rows from internal builds require no compatibility path and become inert. User-visible options are global; project-local slash commands are intentionally not part of this catalog.

## Expected result

Claude option requests for any project return the same global catalog. Discovery always uses the existing host-created plugin state directory, and no catalog process or transcript remains afterward.

## Verification

- `dart analyze --fatal-infos && dart test` in `bridge/sesori_plugin_claude` (212 tests)
- `dart analyze --fatal-infos && dart test test/bridge/services/session_options_service_test.dart` in `bridge/app` (34 tests)
- `flutter analyze && flutter test test/cubits/new_session/new_session_plugin_selection_test.dart` in `client/module_core` (39 tests)
- `flutter analyze` in `client/app`
- Real Claude 2.1.228 initialize-only and initialize + `list_models` probes from an isolated non-project directory created no transcript or Claude project artifact.
- Production-wired source bridge: forced `/session/options` refresh returned 200 with 2 agents, 5 models, and 52 commands; logs showed `/Users/alexandrudochioiu/.local/share/sesori/plugins/claude` as the cwd; a different project ID returned byte-equivalent cached data without another probe; no Claude probe process or transcript remained.
- Architecture implementation review approved the final ownership and lifecycle shape.
