### PR TITLE
🌿 Do not evict a live bootstrap lock holder

### DIFF
--- a/bridge/app/npm/sesori-bridge/lib/bootstrap_lock.js
+++ b/bridge/app/npm/sesori-bridge/lib/bootstrap_lock.js
@@ -111,14 +111,27 @@ function stopHeartbeat(heartbeatProcess) {
   }
 }
 
-// A lock whose owner process is still running is never stale, however far the
-// heartbeat has lagged. Spawning the detached heartbeat is not instantaneous, so
-// on a loaded machine a mtime-only check can evict a live holder and let two
-// bootstraps install concurrently.
+// A lock whose owner process is still running is treated as fresh however far
+// the heartbeat has lagged: spawning the detached heartbeat is not
+// instantaneous, so a mtime-only check can evict a live holder on a loaded
+// machine and let two bootstraps install concurrently.
+//
+// `process.kill(pid, 0)` only proves *some* process holds that pid, so after a
+// hard crash a reused pid would otherwise keep an abandoned lock alive forever.
+// The liveness override therefore expires: past this age the mtime rules again.
+// A real bootstrap (download + extract) never holds the lock anywhere near this
+// long, and it is deliberately not test-overridable so it can't reintroduce the
+// eviction race.
+var OWNER_LIVENESS_MAX_MS = 30 * 60 * 1000;
+
 function ownerIsAlive(lockPath) {
   try {
+    var stat = fs.statSync(ownerPath(lockPath));
+    if (Date.now() - stat.mtimeMs > OWNER_LIVENESS_MAX_MS) {
+      return false;
+    }
     var owner = JSON.parse(fs.readFileSync(ownerPath(lockPath), "utf8"));
-    return typeof owner.pid === "number" && processIsAlive(owner.pid);
+    return Number.isInteger(owner.pid) && owner.pid > 0 && processIsAlive(owner.pid);
   } catch (_) {
     // Missing or half-written owner file: fall back to the heartbeat mtime.
     return false;

--- a/bridge/app/npm/sesori-bridge/lib/bootstrap_lock.js
+++ b/bridge/app/npm/sesori-bridge/lib/bootstrap_lock.js
@@ -111,7 +111,24 @@ function stopHeartbeat(heartbeatProcess) {
   }
 }
 
+// A lock whose owner process is still running is never stale, however far the
+// heartbeat has lagged. Spawning the detached heartbeat is not instantaneous, so
+// on a loaded machine a mtime-only check can evict a live holder and let two
+// bootstraps install concurrently.
+function ownerIsAlive(lockPath) {
+  try {
+    var owner = JSON.parse(fs.readFileSync(ownerPath(lockPath), "utf8"));
+    return typeof owner.pid === "number" && processIsAlive(owner.pid);
+  } catch (_) {
+    // Missing or half-written owner file: fall back to the heartbeat mtime.
+    return false;
+  }
+}
+
 function lockIsStale(lockPath) {
+  if (ownerIsAlive(lockPath)) {
+    return false;
+  }
   var targetPaths = [heartbeatPath(lockPath), ownerPath(lockPath), lockPath];
   for (var i = 0; i < targetPaths.length; i++) {
     try {


### PR DESCRIPTION
## Complexity

🌿 Straightforward — one liveness check in the npm wrapper's lock staleness logic.

## What

`lockIsStale` in `bridge/app/npm/sesori-bridge/lib/bootstrap_lock.js` now first
checks whether the pid recorded in `owner.json` is still running. A lock with a
live owner is never stale; the heartbeat-mtime check remains as the fallback for
a missing or half-written owner file.

## Why

Bridge CI on `main` fails on `npm_wrapper_test.dart: active bootstrap holder is
not evicted after crossing the stale threshold` (`Expected: '1'`, `Actual: '2'` —
two managed installs ran). Staleness was decided purely by heartbeat mtime, and
the heartbeat is written by a detached Node process that takes non-trivial time
to spawn. On a loaded runner that spawn exceeds the stale threshold, so a waiting
process evicts a live holder and starts a concurrent install.

## Risk and test focus

No user-visible behavior change in the healthy path and no database impact. The
risk is the opposite direction: a lock left by a dead process must still be
reclaimed. That is covered by `stale abandoned bootstrap locks are reclaimed`,
which writes an owner pid of `999999` — the liveness check reports it dead and
the mtime path reclaims as before.

## Expected result

Bridge CI passes. Concurrent `npx sesori-bridge` bootstraps continue to share a
single managed install, and abandoned locks are still reclaimed.

## Verification

`dart test test/tool/npm_wrapper_test.dart --plain-name bootstrap` in
`bridge/app` — 7/7 pass, including the previously failing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats a bootstrap lock as fresh while its owner process is alive, capped at 30 minutes to avoid pid reuse keeping abandoned locks. Old: staleness used only heartbeat mtime. New: `lockIsStale` first checks validated owner liveness and falls back to mtime when the owner record is missing, invalid, or too old.

**Review notes**
- In `bridge/app/npm/sesori-bridge/lib/bootstrap_lock.js`, `ownerIsAlive()` reads `owner.json`, requires a positive integer pid, ensures the owner file mtime is <=30 minutes old, then calls `processIsAlive(pid)`; if true, the lock is not stale.
- Missing/half-written/expired owner records use the prior heartbeat mtime path; abandoned locks still self-heal.
- Prevents concurrent managed installs on loaded CI and should restore passing bootstrap tests.

<sup>Written for commit e087205b35ea6bac8a39a513555f6b81fecc6cae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

