### PR TITLE
🌿 Overlap harness warmup with session metadata generation

### DIFF
--- a/bridge/app/lib/src/bridge/services/session_creation_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_creation_service.dart
@@ -29,16 +29,20 @@ class SessionCreationService {
     // plugin/git side effect. The stored path is authoritative; unknown ids
     // must not be treated as directories.
     final projectDirectory = await _sessionRepository.resolveProjectDirectory(projectId: request.projectId);
-    await _sessionRepository.ensurePluginRoutable(
-      pluginId: request.pluginId,
-      operation: SessionOperation.createSession,
-    );
     final normalizedCommand = request.command?.normalize();
     final agentModel = request.model;
     final userTexts = _extractTexts(parts: request.parts);
     final firstText = userTexts.firstOrNull;
     final userVisibleText = userTexts.isEmpty ? null : userTexts.join("\n\n");
-    final metadata = await _generateMetadata(firstText: firstText);
+    // Harness warmup and title/worktree naming are independent and both slow —
+    // overlap them so create latency tracks the slower of the two, not the sum.
+    final (_, metadata) = await (
+      _sessionRepository.ensurePluginRoutable(
+        pluginId: request.pluginId,
+        operation: SessionOperation.createSession,
+      ),
+      _generateMetadata(firstText: firstText),
+    ).wait;
     final worktreeResult = await _prepareWorktree(request: request, metadata: metadata);
     final worktreeState = await _resolveWorktreeState(
       projectId: request.projectId,

--- a/bridge/app/test/bridge/services/session_creation_service_test.dart
+++ b/bridge/app/test/bridge/services/session_creation_service_test.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:io";
 
 import "package:http/http.dart" as http;
@@ -8,6 +9,9 @@ import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
 import "package:sesori_bridge/src/bridge/metadata_service.dart";
 import "package:sesori_bridge/src/bridge/models/session_metadata.dart" as bridge_metadata;
 import "package:sesori_bridge/src/bridge/repositories/models/project_not_found_exception.dart";
+import "package:sesori_bridge/src/bridge/repositories/models/session_operation.dart";
+import "package:sesori_bridge/src/bridge/repositories/models/verified_github_login.dart";
+import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/services/session_creation_service.dart";
 import "package:sesori_bridge/src/bridge/services/session_mutation_dispatcher.dart";
@@ -189,6 +193,63 @@ void main() {
       expect(worktreeService.resolveCalls, 1);
     });
 
+    test("warms the plugin while generating session metadata", () async {
+      worktreeService.headCommit = "abc123";
+
+      final ensureEntered = Completer<void>();
+      final metadataEntered = Completer<void>();
+      final release = Completer<void>();
+      metadataService.holdUntil = release.future;
+      metadataService.onGenerateStarted = metadataEntered.complete;
+
+      final repository = _EnsureHoldSessionRepository(
+        inner: singlePluginSessionRepository(
+          plugin: plugin,
+          sessionDao: db.sessionDao,
+          projectsDao: db.projectsDao,
+          pullRequestDao: db.pullRequestDao,
+          unseenCalculator: const SessionUnseenCalculator(),
+        ),
+        holdUntil: release.future,
+        onEnsureStarted: ensureEntered.complete,
+      );
+      final overlappingDispatcher = SessionOperationDispatcher(sessionRepository: repository);
+      final overlappingMutationDispatcher = SessionMutationDispatcher(
+        sessionRepository: repository,
+        sessionOperationDispatcher: overlappingDispatcher,
+      );
+      addTearDown(() async {
+        await overlappingDispatcher.dispose();
+        await overlappingMutationDispatcher.dispose();
+      });
+      final overlappingService = SessionCreationService(
+        metadataService: metadataService,
+        worktreeService: worktreeService,
+        sessionRepository: repository,
+        sessionMutationDispatcher: overlappingMutationDispatcher,
+      );
+
+      final created = overlappingService.createSession(
+        request: const CreateSessionRequest(
+          projectId: "/repo",
+          pluginId: "fake",
+          dedicatedWorktree: false,
+          parts: [PromptPart.text(text: "Build it")],
+          variant: null,
+          agent: null,
+          model: null,
+          command: null,
+        ),
+      );
+
+      await Future.wait([ensureEntered.future, metadataEntered.future]);
+      release.complete();
+      await created;
+
+      expect(metadataService.generateCalls, 1);
+      expect(plugin.createCalls, 1);
+    });
+
     test("allocates around a cross-plugin backend-id collision without changing the retained binding", () async {
       await db.projectsDao.recordOpenedProject(
         projectId: "/retained",
@@ -241,6 +302,8 @@ void main() {
 
 class _FakeMetadataService extends MetadataService {
   int generateCalls = 0;
+  Future<void>? holdUntil;
+  void Function()? onGenerateStarted;
 
   _FakeMetadataService()
     : super(
@@ -252,8 +315,89 @@ class _FakeMetadataService extends MetadataService {
   @override
   Future<bridge_metadata.SessionMetadata?> generate({required String firstMessage}) async {
     generateCalls++;
+    onGenerateStarted?.call();
+    final hold = holdUntil;
+    if (hold != null) {
+      await hold;
+    }
     return null;
   }
+}
+
+class _EnsureHoldSessionRepository implements SessionRepository {
+  final SessionRepository _inner;
+  final Future<void> _holdUntil;
+  final void Function() _onEnsureStarted;
+
+  _EnsureHoldSessionRepository({
+    required SessionRepository inner,
+    required Future<void> holdUntil,
+    required void Function() onEnsureStarted,
+  }) : _inner = inner,
+       _holdUntil = holdUntil,
+       _onEnsureStarted = onEnsureStarted;
+
+  @override
+  Future<String> resolveProjectDirectory({required String projectId}) {
+    return _inner.resolveProjectDirectory(projectId: projectId);
+  }
+
+  @override
+  Future<void> ensurePluginRoutable({required String pluginId, required SessionOperation operation}) async {
+    _onEnsureStarted();
+    await _holdUntil;
+    return _inner.ensurePluginRoutable(pluginId: pluginId, operation: operation);
+  }
+
+  @override
+  Future<Session> createSession({
+    required String pluginId,
+    required String projectId,
+    required String directory,
+    required String? parentSessionId,
+    required List<PromptPart> parts,
+    required String? userVisibleText,
+    required SessionVariant? variant,
+    required String? agent,
+    required PromptModel? model,
+    required bool isDedicated,
+    required String? worktreePath,
+    required String? branchName,
+    required String? baseBranch,
+    required String? baseCommit,
+    required String? lastAgent,
+    required AgentModel? lastAgentModel,
+  }) {
+    return _inner.createSession(
+      pluginId: pluginId,
+      projectId: projectId,
+      directory: directory,
+      parentSessionId: parentSessionId,
+      parts: parts,
+      userVisibleText: userVisibleText,
+      variant: variant,
+      agent: agent,
+      model: model,
+      isDedicated: isDedicated,
+      worktreePath: worktreePath,
+      branchName: branchName,
+      baseBranch: baseBranch,
+      baseCommit: baseCommit,
+      lastAgent: lastAgent,
+      lastAgentModel: lastAgentModel,
+    );
+  }
+
+  @override
+  Future<Session> enrichSession({
+    required Session session,
+    required VerifiedGithubLogin? verifiedGithubLogin,
+  }) {
+    return _inner.enrichSession(session: session, verifiedGithubLogin: verifiedGithubLogin);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _FakeTokenRefresher implements TokenRefresher {

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -23,7 +23,8 @@ variant, and worktree mode, and creating the session with its first input.
   backend and no-ops for a superseded generation.
 - Creation resolves and validates the project handle before checking plugin
   routability, so an unknown project causes no plugin, metadata, git, or session
-  persistence effect.
+  persistence effect. After that validation, plugin warmup and session-metadata
+  generation run concurrently; worktree prep and plugin create wait for both.
 - Dedicated mode creates a branch and worktree from the resolved base branch,
   rejects unsafe names, falls back to the project directory when the repository
   is absent, commitless, or creation fails, and records worktree, branch, base


### PR DESCRIPTION
## Complexity
Straightforward — reorders two independent awaits into a parallel record wait in session creation, with a concurrency regression test.

## What
After project validation, session create now runs plugin routability warmup and session-metadata generation concurrently instead of sequentially. Worktree prep and plugin create still wait for both.

## Why
Harness start and metadata generation are both slow. Waiting for one before starting the other made new-session latency the sum of both; overlapping them makes it closer to the slower of the two.

## Risk and test focus
- Confirm unknown projects still fail before any plugin/metadata side effects.
- Confirm dedicated worktree naming still uses generated metadata when present.
- Confirm create still succeeds when metadata generation returns null or fails softly.
- No user-visible API or database contract change.

## Expected result
Creating a session with a first prompt starts harness warmup and metadata generation at the same time; overall create time improves when both paths take meaningful time.

## Verification
- `dart test test/bridge/services/session_creation_service_test.dart` (bridge/app)
- `dart analyze --fatal-infos` on the changed service and test files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Overlap harness warmup with session metadata generation during session creation to reduce latency. Previously we warmed the plugin before generating metadata; now both start after project validation, and worktree prep and plugin create await both.

- Unknown projects still fail before any plugin, metadata, git, or session side effects.
- Dedicated worktree naming still uses generated metadata when present; behavior is unchanged when metadata is null or fails softly.
- Adds a concurrency test that asserts `ensurePluginRoutable` and metadata generation run in parallel; docs updated to note this.
- No API or database contract changes; execution order only.

<sup>Written for commit c0e0c68bb64afe450f8521c614ad5af5f1f57170. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

