### PR TITLE
🌱 Allow branch changes in session worktrees

### DIFF
--- a/bridge/app/lib/src/bridge/api/git_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/git_cli_api.dart
@@ -32,12 +32,10 @@ final class GitCurrentBranchNotRepository extends GitCurrentBranchResult {
 class GitWorktreeSafetySnapshot {
   final bool worktreeExists;
   final bool hasUnstagedChanges;
-  final String actualBranch;
 
   GitWorktreeSafetySnapshot({
     required this.worktreeExists,
     required this.hasUnstagedChanges,
-    required this.actualBranch,
   });
 }
 
@@ -454,7 +452,7 @@ class GitCliApi {
 
   Future<GitWorktreeSafetySnapshot> inspectWorktreeSafety({required String worktreePath}) async {
     if (!Directory(worktreePath).existsSync()) {
-      return GitWorktreeSafetySnapshot(worktreeExists: false, hasUnstagedChanges: false, actualBranch: "");
+      return GitWorktreeSafetySnapshot(worktreeExists: false, hasUnstagedChanges: false);
     }
 
     final statusResult = await _processRunner.run(
@@ -464,16 +462,9 @@ class GitCliApi {
     );
     final hasUnstagedChanges = statusResult.stdout.toString().trim().isNotEmpty;
 
-    final headResult = await _processRunner.run(
-      "git",
-      ["rev-parse", "--abbrev-ref", "HEAD"],
-      workingDirectory: worktreePath,
-    );
-
     return GitWorktreeSafetySnapshot(
       worktreeExists: true,
       hasUnstagedChanges: hasUnstagedChanges,
-      actualBranch: headResult.stdout.toString().trim(),
     );
   }
 

--- a/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
@@ -208,12 +208,10 @@ class WorktreeRepository {
     if (snapshot.hasUnstagedChanges) {
       issues.add(UnstagedChanges());
     }
-    final activeBranch = snapshot.actualBranch == "HEAD" ? null : snapshot.actualBranch;
-
     if (issues.isEmpty) {
-      return WorktreeSafe(activeBranch: activeBranch);
+      return WorktreeSafe();
     }
-    return WorktreeUnsafe(issues: issues, activeBranch: activeBranch);
+    return WorktreeUnsafe(issues: issues);
   }
 
   Future<bool> removeWorktree({

--- a/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
@@ -195,7 +195,6 @@ class WorktreeRepository {
 
   Future<WorktreeSafetyResult> checkWorktreeSafety({
     required String worktreePath,
-    required String expectedBranch,
   }) async {
     final snapshot = await _gitApi.inspectWorktreeSafety(
       worktreePath: worktreePath,
@@ -209,16 +208,12 @@ class WorktreeRepository {
     if (snapshot.hasUnstagedChanges) {
       issues.add(UnstagedChanges());
     }
-    if (snapshot.actualBranch != expectedBranch) {
-      issues.add(
-        BranchMismatch(expected: expectedBranch, actual: snapshot.actualBranch),
-      );
-    }
+    final activeBranch = snapshot.actualBranch == "HEAD" ? null : snapshot.actualBranch;
 
     if (issues.isEmpty) {
-      return WorktreeSafe();
+      return WorktreeSafe(activeBranch: activeBranch);
     }
-    return WorktreeUnsafe(issues: issues);
+    return WorktreeUnsafe(issues: issues, activeBranch: activeBranch);
   }
 
   Future<bool> removeWorktree({

--- a/bridge/app/lib/src/bridge/services/session_creation_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_creation_service.dart
@@ -276,7 +276,7 @@ A dedicated git worktree and branch have been created for this session:
 - Worktree path: $worktreePath
 - Based on: $baseBranch
 
-IMPORTANT: Perform all work for this task in this dedicated worktree. You may switch branches or create additional branches here as needed, but do NOT create another worktree or working directory — even if other instructions suggest it.
+IMPORTANT: Perform all work for this task in this dedicated worktree. You may use the initial branch above, or switch branches or create additional branches here as needed. Do NOT create another worktree or working directory — even if other instructions suggest it.
 
 ---
 ''';

--- a/bridge/app/lib/src/bridge/services/session_creation_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_creation_service.dart
@@ -276,7 +276,7 @@ A dedicated git worktree and branch have been created for this session:
 - Worktree path: $worktreePath
 - Based on: $baseBranch
 
-IMPORTANT: Do NOT create new worktrees, branches, or working directories for this task — even if other instructions suggest it. One has already been created and is 100% dedicated to the work you will be doing in this session.
+IMPORTANT: Perform all work for this task in this dedicated worktree. You may switch branches or create additional branches here as needed, but do NOT create another worktree or working directory — even if other instructions suggest it.
 
 ---
 ''';

--- a/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
@@ -137,7 +137,7 @@ class SessionLifecycleService {
       final deleted = await _worktreeService.deleteBranch(
         projectId: projectId,
         branchName: branchName,
-        force: deleteWorktree || force,
+        force: force,
       );
       if (!deleted &&
           await _worktreeService.branchExists(

--- a/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
@@ -105,18 +105,16 @@ class SessionLifecycleService {
       }
     }
 
-    if (deleteWorktree) {
+    if (deleteWorktree && !force) {
       final safety = await _worktreeService.checkWorktreeSafety(
         worktreePath: worktreePath,
       );
-      if (!force) {
-        if (safety case WorktreeUnsafe(:final issues)) {
-          return CleanupRejected(
-            rejection: SessionCleanupRejection(
-              issues: _mapSafetyIssues(issues: issues),
-            ),
-          );
-        }
+      if (safety case WorktreeUnsafe(:final issues)) {
+        return CleanupRejected(
+          rejection: SessionCleanupRejection(
+            issues: _mapSafetyIssues(issues: issues),
+          ),
+        );
       }
     }
 

--- a/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
@@ -105,19 +105,22 @@ class SessionLifecycleService {
       }
     }
 
-    if (deleteWorktree && !force) {
-      final safety = await _worktreeService.checkWorktreeSafety(
+    WorktreeSafetyResult? safety;
+    if (deleteWorktree) {
+      safety = await _worktreeService.checkWorktreeSafety(
         worktreePath: worktreePath,
-        expectedBranch: branchName,
       );
-      if (safety case WorktreeUnsafe(:final issues)) {
-        return CleanupRejected(
-          rejection: SessionCleanupRejection(
-            issues: _mapSafetyIssues(issues: issues),
-          ),
-        );
+      if (!force) {
+        if (safety case WorktreeUnsafe(:final issues)) {
+          return CleanupRejected(
+            rejection: SessionCleanupRejection(
+              issues: _mapSafetyIssues(issues: issues),
+            ),
+          );
+        }
       }
     }
+    final branchToDelete = safety?.activeBranch ?? branchName;
 
     if (deleteWorktree) {
       final removed = await _worktreeService.removeWorktree(
@@ -137,13 +140,13 @@ class SessionLifecycleService {
     if (deleteBranch) {
       final deleted = await _worktreeService.deleteBranch(
         projectId: projectId,
-        branchName: branchName,
+        branchName: branchToDelete,
         force: deleteWorktree || force,
       );
       if (!deleted &&
           await _worktreeService.branchExists(
             projectId: projectId,
-            branchName: branchName,
+            branchName: branchToDelete,
           )) {
         throw SessionCleanupFailedException(
           sessionId: sessionId,
@@ -320,10 +323,6 @@ class SessionLifecycleService {
         .map(
           (issue) => switch (issue) {
             UnstagedChanges() => const CleanupIssue.unstagedChanges(),
-            BranchMismatch(:final expected, :final actual) => CleanupIssue.branchMismatch(
-              expected: expected,
-              actual: actual,
-            ),
           },
         )
         .toList();

--- a/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
@@ -105,9 +105,8 @@ class SessionLifecycleService {
       }
     }
 
-    WorktreeSafetyResult? safety;
     if (deleteWorktree) {
-      safety = await _worktreeService.checkWorktreeSafety(
+      final safety = await _worktreeService.checkWorktreeSafety(
         worktreePath: worktreePath,
       );
       if (!force) {
@@ -120,7 +119,6 @@ class SessionLifecycleService {
         }
       }
     }
-    final branchToDelete = safety?.activeBranch ?? branchName;
 
     if (deleteWorktree) {
       final removed = await _worktreeService.removeWorktree(
@@ -140,13 +138,13 @@ class SessionLifecycleService {
     if (deleteBranch) {
       final deleted = await _worktreeService.deleteBranch(
         projectId: projectId,
-        branchName: branchToDelete,
+        branchName: branchName,
         force: deleteWorktree || force,
       );
       if (!deleted &&
           await _worktreeService.branchExists(
             projectId: projectId,
-            branchName: branchToDelete,
+            branchName: branchName,
           )) {
         throw SessionCleanupFailedException(
           sessionId: sessionId,

--- a/bridge/app/lib/src/bridge/services/worktree_service.dart
+++ b/bridge/app/lib/src/bridge/services/worktree_service.dart
@@ -171,11 +171,9 @@ class WorktreeService {
 
   Future<WorktreeSafetyResult> checkWorktreeSafety({
     required String worktreePath,
-    required String expectedBranch,
   }) async {
     return _worktreeRepository.checkWorktreeSafety(
       worktreePath: worktreePath,
-      expectedBranch: expectedBranch,
     );
   }
 

--- a/bridge/app/lib/src/bridge/worktree_types.dart
+++ b/bridge/app/lib/src/bridge/worktree_types.dart
@@ -1,21 +1,25 @@
-sealed class WorktreeSafetyResult {}
+sealed class WorktreeSafetyResult {
+  String? get activeBranch;
+}
 
-class WorktreeSafe extends WorktreeSafetyResult {}
+class WorktreeSafe extends WorktreeSafetyResult {
+  @override
+  final String? activeBranch;
+
+  WorktreeSafe({this.activeBranch});
+}
 
 class WorktreeUnsafe extends WorktreeSafetyResult {
   final List<SafetyIssue> issues;
-  WorktreeUnsafe({required this.issues});
+  @override
+  final String? activeBranch;
+
+  WorktreeUnsafe({required this.issues, this.activeBranch});
 }
 
 sealed class SafetyIssue {}
 
 class UnstagedChanges extends SafetyIssue {}
-
-class BranchMismatch extends SafetyIssue {
-  final String expected;
-  final String actual;
-  BranchMismatch({required this.expected, required this.actual});
-}
 
 sealed class WorktreeResult {}
 

--- a/bridge/app/lib/src/bridge/worktree_types.dart
+++ b/bridge/app/lib/src/bridge/worktree_types.dart
@@ -1,20 +1,11 @@
-sealed class WorktreeSafetyResult {
-  String? get activeBranch;
-}
+sealed class WorktreeSafetyResult;
 
-class WorktreeSafe extends WorktreeSafetyResult {
-  @override
-  final String? activeBranch;
-
-  WorktreeSafe({this.activeBranch});
-}
+class WorktreeSafe extends WorktreeSafetyResult;
 
 class WorktreeUnsafe extends WorktreeSafetyResult {
   final List<SafetyIssue> issues;
-  @override
-  final String? activeBranch;
 
-  WorktreeUnsafe({required this.issues, this.activeBranch});
+  WorktreeUnsafe({required this.issues});
 }
 
 sealed class SafetyIssue;

--- a/bridge/app/test/bridge/routing/create_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_session_handler_test.dart
@@ -33,7 +33,7 @@ A dedicated git worktree and branch have been created for this session:
 - Worktree path: $worktreePath
 - Based on: $baseBranch
 
-IMPORTANT: Do NOT create new worktrees, branches, or working directories for this task — even if other instructions suggest it. One has already been created and is 100% dedicated to the work you will be doing in this session.
+IMPORTANT: Perform all work for this task in this dedicated worktree. You may switch branches or create additional branches here as needed, but do NOT create another worktree or working directory — even if other instructions suggest it.
 
 ---
 ''';
@@ -452,7 +452,7 @@ void main() {
       expect(dbSession.baseCommit, equals("abc123def456"));
     });
 
-    test("worktree system prompt includes branch, path, and base branch", () {
+    test("worktree system prompt requires the worktree but permits branch changes", () {
       final prompt = _expectedWorktreeSystemPrompt(
         branchName: "session-017",
         worktreePath: "/repo/.worktrees/session-017",
@@ -462,7 +462,9 @@ void main() {
       expect(prompt, contains("session-017"));
       expect(prompt, contains("/repo/.worktrees/session-017"));
       expect(prompt, contains("develop"));
-      expect(prompt, contains("Do NOT create new worktrees"));
+      expect(prompt, contains("Perform all work for this task in this dedicated worktree"));
+      expect(prompt, contains("switch branches or create additional branches"));
+      expect(prompt, contains("do NOT create another worktree or working directory"));
     });
 
     test("plugin failure is propagated and no session row is inserted", () async {

--- a/bridge/app/test/bridge/routing/create_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_session_handler_test.dart
@@ -33,7 +33,7 @@ A dedicated git worktree and branch have been created for this session:
 - Worktree path: $worktreePath
 - Based on: $baseBranch
 
-IMPORTANT: Perform all work for this task in this dedicated worktree. You may switch branches or create additional branches here as needed, but do NOT create another worktree or working directory — even if other instructions suggest it.
+IMPORTANT: Perform all work for this task in this dedicated worktree. You may use the initial branch above, or switch branches or create additional branches here as needed. Do NOT create another worktree or working directory — even if other instructions suggest it.
 
 ---
 ''';
@@ -463,8 +463,8 @@ void main() {
       expect(prompt, contains("/repo/.worktrees/session-017"));
       expect(prompt, contains("develop"));
       expect(prompt, contains("Perform all work for this task in this dedicated worktree"));
-      expect(prompt, contains("switch branches or create additional branches"));
-      expect(prompt, contains("do NOT create another worktree or working directory"));
+      expect(prompt, contains("use the initial branch above, or switch branches"));
+      expect(prompt, contains("Do NOT create another worktree or working directory"));
     });
 
     test("plugin failure is propagated and no session row is inserted", () async {

--- a/bridge/app/test/bridge/routing/delete_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/delete_session_handler_test.dart
@@ -287,7 +287,7 @@ void main() {
       expect(worktreeService.checkCallCount, equals(1));
       expect(worktreeService.removeCallCount, equals(1));
       expect(worktreeService.deleteBranchCallCount, equals(1));
-      expect(worktreeService.lastDeleteBranchForce, isTrue);
+      expect(worktreeService.lastDeleteBranchForce, isFalse);
       expect(plugin.lastDeleteSessionId, equals("s4"));
       expect(await db.sessionDao.getSession(sessionId: "s4"), isNull);
       expect(operationLog, equals(["checkSafety", "removeWorktree", "deleteBranch", "pluginDelete"]));

--- a/bridge/app/test/bridge/routing/delete_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/delete_session_handler_test.dart
@@ -180,7 +180,6 @@ void main() {
       expect(response, isA<SuccessEmptyResponse>());
       expect(worktreeService.checkCallCount, equals(1));
       expect(worktreeService.lastCheckWorktreePath, equals("/repo/.worktrees/session-002"));
-      expect(worktreeService.lastCheckExpectedBranch, equals("session-002"));
       expect(worktreeService.removeCallCount, equals(1));
       expect(worktreeService.lastRemoveProjectId, equals("/repo"));
       expect(worktreeService.lastRemoveWorktreePath, equals("/repo/.worktrees/session-002"));
@@ -305,7 +304,6 @@ void main() {
       worktreeService.safetyResult = WorktreeUnsafe(
         issues: [
           UnstagedChanges(),
-          BranchMismatch(expected: "session-005", actual: "main"),
         ],
       );
 
@@ -357,12 +355,12 @@ void main() {
       );
 
       expect(response, isA<SuccessEmptyResponse>());
-      expect(worktreeService.checkCallCount, equals(0));
+      expect(worktreeService.checkCallCount, equals(1));
       expect(worktreeService.removeCallCount, equals(1));
       expect(worktreeService.lastRemoveForce, isTrue);
       expect(plugin.lastDeleteSessionId, equals("s6"));
       expect(await db.sessionDao.getSession(sessionId: "s6"), isNull);
-      expect(operationLog, equals(["removeWorktree", "pluginDelete"]));
+      expect(operationLog, equals(["checkSafety", "removeWorktree", "pluginDelete"]));
     });
 
     test("7) null worktreePath: skips git ops", () async {
@@ -560,7 +558,6 @@ class _FakeWorktreeService extends WorktreeService {
   int deleteBranchCallCount = 0;
 
   String? lastCheckWorktreePath;
-  String? lastCheckExpectedBranch;
   String? lastRemoveProjectId;
   String? lastRemoveWorktreePath;
   bool? lastRemoveForce;
@@ -584,12 +581,10 @@ class _FakeWorktreeService extends WorktreeService {
   @override
   Future<WorktreeSafetyResult> checkWorktreeSafety({
     required String worktreePath,
-    required String expectedBranch,
   }) async {
     checkCallCount++;
     operationLog.add("checkSafety");
     lastCheckWorktreePath = worktreePath;
-    lastCheckExpectedBranch = expectedBranch;
     return safetyResult;
   }
 

--- a/bridge/app/test/bridge/routing/delete_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/delete_session_handler_test.dart
@@ -355,12 +355,12 @@ void main() {
       );
 
       expect(response, isA<SuccessEmptyResponse>());
-      expect(worktreeService.checkCallCount, equals(1));
+      expect(worktreeService.checkCallCount, equals(0));
       expect(worktreeService.removeCallCount, equals(1));
       expect(worktreeService.lastRemoveForce, isTrue);
       expect(plugin.lastDeleteSessionId, equals("s6"));
       expect(await db.sessionDao.getSession(sessionId: "s6"), isNull);
-      expect(operationLog, equals(["checkSafety", "removeWorktree", "pluginDelete"]));
+      expect(operationLog, equals(["removeWorktree", "pluginDelete"]));
     });
 
     test("7) null worktreePath: skips git ops", () async {

--- a/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
+++ b/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
@@ -302,7 +302,6 @@ void main() {
       worktreeService.safetyResult = WorktreeUnsafe(
         issues: [
           UnstagedChanges(),
-          BranchMismatch(expected: "session-001", actual: "main"),
         ],
       );
 
@@ -448,7 +447,7 @@ void main() {
         fragment: null,
       );
 
-      expect(worktreeService.checkCallCount, equals(0));
+      expect(worktreeService.checkCallCount, equals(1));
       expect(worktreeService.removeCallCount, equals(1));
       expect(worktreeService.lastRemoveForce, isTrue);
     });
@@ -781,7 +780,6 @@ void main() {
 
       expect(result.hasWorktree, isFalse);
     });
-
   });
 }
 
@@ -866,7 +864,6 @@ class _FakeWorktreeService extends WorktreeService {
   int deleteBranchCallCount = 0;
 
   String? lastCheckWorktreePath;
-  String? lastCheckExpectedBranch;
   String? lastRemoveProjectId;
   String? lastRemoveWorktreePath;
   bool? lastRemoveForce;
@@ -890,11 +887,9 @@ class _FakeWorktreeService extends WorktreeService {
   @override
   Future<WorktreeSafetyResult> checkWorktreeSafety({
     required String worktreePath,
-    required String expectedBranch,
   }) async {
     checkCallCount++;
     lastCheckWorktreePath = worktreePath;
-    lastCheckExpectedBranch = expectedBranch;
     return safetyResult;
   }
 

--- a/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
+++ b/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
@@ -447,7 +447,7 @@ void main() {
         fragment: null,
       );
 
-      expect(worktreeService.checkCallCount, equals(1));
+      expect(worktreeService.checkCallCount, equals(0));
       expect(worktreeService.removeCallCount, equals(1));
       expect(worktreeService.lastRemoveForce, isTrue);
     });

--- a/bridge/app/test/bridge/services/session_family_mutation_test.dart
+++ b/bridge/app/test/bridge/services/session_family_mutation_test.dart
@@ -300,7 +300,6 @@ class _FamilyRepository implements SessionRepository {
     if (record == null) throw StateError("missing test session $sessionId");
     record.archivedAt = archived ? 1 : null;
   }
-
   @override
   Future<SessionFamilyScope> resolveSessionFamily({
     required String sessionId,
@@ -462,7 +461,6 @@ class _FamilyWorktreeService implements WorktreeService {
   @override
   Future<WorktreeSafetyResult> checkWorktreeSafety({
     required String worktreePath,
-    required String expectedBranch,
   }) async => safetyResult;
 
   @override
@@ -478,7 +476,6 @@ class _FamilyWorktreeService implements WorktreeService {
 
   @override
   Future<bool> branchExists({required String projectId, required String branchName}) async => false;
-
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
+++ b/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
@@ -243,7 +243,7 @@ void main() {
       expect(worktreeService.deleteBranchCallCount, equals(0));
     });
 
-    test("dirty worktree with force checks its branch and succeeds", () async {
+    test("dirty worktree with force skips safety check and succeeds", () async {
       worktreeService.safetyResult = WorktreeUnsafe(
         issues: [UnstagedChanges()],
       );
@@ -260,7 +260,7 @@ void main() {
       );
 
       expect(result, isA<CleanupSuccess>());
-      expect(worktreeService.checkCallCount, equals(1));
+      expect(worktreeService.checkCallCount, equals(0));
       expect(worktreeService.removeCallCount, equals(1));
       expect(worktreeService.lastRemoveForce, isTrue);
     });

--- a/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
+++ b/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
@@ -283,7 +283,7 @@ void main() {
       expect(worktreeService.checkCallCount, equals(1));
       expect(worktreeService.removeCallCount, equals(1));
       expect(worktreeService.deleteBranchCallCount, equals(1));
-      expect(worktreeService.lastDeleteBranchForce, isTrue);
+      expect(worktreeService.lastDeleteBranchForce, isFalse);
     });
 
     test("failed branch deletion throws instead of reporting success", () async {

--- a/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
+++ b/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
@@ -215,7 +215,6 @@ void main() {
       worktreeService.safetyResult = WorktreeUnsafe(
         issues: [
           UnstagedChanges(),
-          BranchMismatch(expected: "session-003", actual: "main"),
         ],
       );
 
@@ -237,7 +236,6 @@ void main() {
         equals(
           const [
             CleanupIssue.unstagedChanges(),
-            CleanupIssue.branchMismatch(expected: "session-003", actual: "main"),
           ],
         ),
       );
@@ -245,7 +243,7 @@ void main() {
       expect(worktreeService.deleteBranchCallCount, equals(0));
     });
 
-    test("dirty worktree with force skips safety check and succeeds", () async {
+    test("dirty worktree with force checks its branch and succeeds", () async {
       worktreeService.safetyResult = WorktreeUnsafe(
         issues: [UnstagedChanges()],
       );
@@ -262,9 +260,27 @@ void main() {
       );
 
       expect(result, isA<CleanupSuccess>());
-      expect(worktreeService.checkCallCount, equals(0));
+      expect(worktreeService.checkCallCount, equals(1));
       expect(worktreeService.removeCallCount, equals(1));
       expect(worktreeService.lastRemoveForce, isTrue);
+    });
+
+    test("deletes the active branch after removing a worktree", () async {
+      worktreeService.safetyResult = WorktreeSafe(activeBranch: "task-branch");
+
+      final result = await _cleanup(
+        service: service,
+        sessionRepository: sessionRepository,
+        sessionId: "s-active-branch",
+        worktreePath: "/repo/.worktrees/session-active-branch",
+        branchName: "session-active-branch",
+        deleteWorktree: true,
+        deleteBranch: true,
+        force: false,
+      );
+
+      expect(result, isA<CleanupSuccess>());
+      expect(worktreeService.lastDeletedBranch, equals("task-branch"));
     });
 
     test("delete worktree and branch runs both operations", () async {
@@ -674,6 +690,7 @@ class _FakeWorktreeService extends WorktreeService {
   String? lastRemoveWorktreePath;
   bool? lastRemoveForce;
   bool? lastDeleteBranchForce;
+  String? lastDeletedBranch;
 
   _FakeWorktreeService({required AppDatabase database})
     : super(
@@ -691,7 +708,6 @@ class _FakeWorktreeService extends WorktreeService {
   @override
   Future<WorktreeSafetyResult> checkWorktreeSafety({
     required String worktreePath,
-    required String expectedBranch,
   }) async {
     checkCallCount++;
     return safetyResult;
@@ -717,6 +733,7 @@ class _FakeWorktreeService extends WorktreeService {
     required bool force,
   }) async {
     deleteBranchCallCount++;
+    lastDeletedBranch = branchName;
     lastDeleteBranchForce = force;
     return deleteBranchResult;
   }

--- a/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
+++ b/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
@@ -265,24 +265,6 @@ void main() {
       expect(worktreeService.lastRemoveForce, isTrue);
     });
 
-    test("deletes the active branch after removing a worktree", () async {
-      worktreeService.safetyResult = WorktreeSafe(activeBranch: "task-branch");
-
-      final result = await _cleanup(
-        service: service,
-        sessionRepository: sessionRepository,
-        sessionId: "s-active-branch",
-        worktreePath: "/repo/.worktrees/session-active-branch",
-        branchName: "session-active-branch",
-        deleteWorktree: true,
-        deleteBranch: true,
-        force: false,
-      );
-
-      expect(result, isA<CleanupSuccess>());
-      expect(worktreeService.lastDeletedBranch, equals("task-branch"));
-    });
-
     test("delete worktree and branch runs both operations", () async {
       worktreeService.safetyResult = WorktreeSafe();
 
@@ -690,7 +672,6 @@ class _FakeWorktreeService extends WorktreeService {
   String? lastRemoveWorktreePath;
   bool? lastRemoveForce;
   bool? lastDeleteBranchForce;
-  String? lastDeletedBranch;
 
   _FakeWorktreeService({required AppDatabase database})
     : super(
@@ -733,7 +714,6 @@ class _FakeWorktreeService extends WorktreeService {
     required bool force,
   }) async {
     deleteBranchCallCount++;
-    lastDeletedBranch = branchName;
     lastDeleteBranchForce = force;
     return deleteBranchResult;
   }

--- a/bridge/app/test/bridge/worktree_service_git_test.dart
+++ b/bridge/app/test/bridge/worktree_service_git_test.dart
@@ -406,14 +406,11 @@ void main() {
 
         expect(snapshot.worktreeExists, isFalse);
         expect(snapshot.hasUnstagedChanges, isFalse);
-        expect(snapshot.actualBranch, isEmpty);
         expect(processRunner.invocations, isEmpty);
       });
 
-      test("returns raw git status and branch details for existing worktree", () async {
-        processRunner
-          ..enqueue(result: _processResult(exitCode: 0, stdout: "M file.txt\n"))
-          ..enqueue(result: _processResult(exitCode: 0, stdout: "main\n"));
+      test("returns git status details for existing worktree", () async {
+        processRunner.enqueue(result: _processResult(exitCode: 0, stdout: "M file.txt\n"));
 
         final snapshot = await service.inspectWorktreeSafety(
           worktreePath: tempDir.path,
@@ -421,13 +418,8 @@ void main() {
 
         expect(snapshot.worktreeExists, isTrue);
         expect(snapshot.hasUnstagedChanges, isTrue);
-        expect(snapshot.actualBranch, equals("main"));
-        expect(processRunner.invocations, hasLength(2));
+        expect(processRunner.invocations, hasLength(1));
         expect(processRunner.invocations.first.arguments, equals(["status", "--porcelain"]));
-        expect(
-          processRunner.invocations.last.arguments,
-          equals(["rev-parse", "--abbrev-ref", "HEAD"]),
-        );
       });
     });
 

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -795,7 +795,7 @@ void main() {
       }
     });
 
-    test("clean worktree + correct branch: returns WorktreeSafe", () async {
+    test("clean worktree: returns WorktreeSafe with active branch", () async {
       // git status --porcelain → empty (clean)
       processRunner.enqueue(result: _ok(stdout: ""));
       // git rev-parse --abbrev-ref HEAD → "session-001"
@@ -803,10 +803,10 @@ void main() {
 
       final result = await service.checkWorktreeSafety(
         worktreePath: tempDir.path,
-        expectedBranch: "session-001",
       );
 
       expect(result, isA<WorktreeSafe>());
+      expect(result.activeBranch, equals("session-001"));
       expect(processRunner.invocations, hasLength(2));
     });
 
@@ -818,7 +818,6 @@ void main() {
 
       final result = await service.checkWorktreeSafety(
         worktreePath: tempDir.path,
-        expectedBranch: "session-001",
       );
 
       expect(result, isA<WorktreeUnsafe>());
@@ -827,7 +826,7 @@ void main() {
       expect(unsafe.issues.first, isA<UnstagedChanges>());
     });
 
-    test("wrong branch: returns WorktreeUnsafe with BranchMismatch", () async {
+    test("different branch remains safe and reports the active branch", () async {
       // git status --porcelain → empty (clean)
       processRunner.enqueue(result: _ok(stdout: ""));
       // git rev-parse --abbrev-ref HEAD → "main" (wrong branch)
@@ -835,20 +834,13 @@ void main() {
 
       final result = await service.checkWorktreeSafety(
         worktreePath: tempDir.path,
-        expectedBranch: "session-001",
       );
 
-      expect(result, isA<WorktreeUnsafe>());
-      final unsafe = result as WorktreeUnsafe;
-      expect(unsafe.issues, hasLength(1));
-      final issue = unsafe.issues.first;
-      expect(issue, isA<BranchMismatch>());
-      final mismatch = issue as BranchMismatch;
-      expect(mismatch.expected, equals("session-001"));
-      expect(mismatch.actual, equals("main"));
+      expect(result, isA<WorktreeSafe>());
+      expect(result.activeBranch, equals("main"));
     });
 
-    test("dirty + wrong branch: returns WorktreeUnsafe with both issues", () async {
+    test("dirty worktree on a different branch returns UnstagedChanges", () async {
       // git status --porcelain → non-empty (dirty)
       processRunner.enqueue(result: _ok(stdout: "M file.txt\nA new.dart\n"));
       // git rev-parse --abbrev-ref HEAD → "main" (wrong branch)
@@ -856,14 +848,13 @@ void main() {
 
       final result = await service.checkWorktreeSafety(
         worktreePath: tempDir.path,
-        expectedBranch: "session-001",
       );
 
       expect(result, isA<WorktreeUnsafe>());
       final unsafe = result as WorktreeUnsafe;
-      expect(unsafe.issues, hasLength(2));
+      expect(unsafe.issues, hasLength(1));
       expect(unsafe.issues.whereType<UnstagedChanges>(), hasLength(1));
-      expect(unsafe.issues.whereType<BranchMismatch>(), hasLength(1));
+      expect(unsafe.activeBranch, equals("main"));
     });
 
     test("non-existent path: returns WorktreeSafe (already cleaned up), no git commands called", () async {
@@ -871,7 +862,6 @@ void main() {
 
       final result = await service.checkWorktreeSafety(
         worktreePath: nonExistentPath,
-        expectedBranch: "session-001",
       );
 
       expect(result, isA<WorktreeSafe>());
@@ -1046,7 +1036,6 @@ void main() {
       final inv = processRunner.invocations.first;
       expect(inv.arguments, equals(["branch", "-D", "--", "session-001"]));
     });
-
   });
 }
 

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -798,22 +798,18 @@ void main() {
     test("clean worktree: returns WorktreeSafe", () async {
       // git status --porcelain → empty (clean)
       processRunner.enqueue(result: _ok(stdout: ""));
-      // git rev-parse --abbrev-ref HEAD → "session-001"
-      processRunner.enqueue(result: _ok(stdout: "session-001\n"));
 
       final result = await service.checkWorktreeSafety(
         worktreePath: tempDir.path,
       );
 
       expect(result, isA<WorktreeSafe>());
-      expect(processRunner.invocations, hasLength(2));
+      expect(processRunner.invocations, hasLength(1));
     });
 
     test("dirty worktree: returns WorktreeUnsafe with UnstagedChanges", () async {
       // git status --porcelain → non-empty (dirty)
       processRunner.enqueue(result: _ok(stdout: "M file.txt\n"));
-      // git rev-parse --abbrev-ref HEAD → "session-001"
-      processRunner.enqueue(result: _ok(stdout: "session-001\n"));
 
       final result = await service.checkWorktreeSafety(
         worktreePath: tempDir.path,
@@ -828,8 +824,6 @@ void main() {
     test("different branch remains safe", () async {
       // git status --porcelain → empty (clean)
       processRunner.enqueue(result: _ok(stdout: ""));
-      // git rev-parse --abbrev-ref HEAD → "main" (wrong branch)
-      processRunner.enqueue(result: _ok(stdout: "main\n"));
 
       final result = await service.checkWorktreeSafety(
         worktreePath: tempDir.path,
@@ -841,8 +835,6 @@ void main() {
     test("dirty worktree on a different branch returns UnstagedChanges", () async {
       // git status --porcelain → non-empty (dirty)
       processRunner.enqueue(result: _ok(stdout: "M file.txt\nA new.dart\n"));
-      // git rev-parse --abbrev-ref HEAD → "main" (wrong branch)
-      processRunner.enqueue(result: _ok(stdout: "main\n"));
 
       final result = await service.checkWorktreeSafety(
         worktreePath: tempDir.path,

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -795,7 +795,7 @@ void main() {
       }
     });
 
-    test("clean worktree: returns WorktreeSafe with active branch", () async {
+    test("clean worktree: returns WorktreeSafe", () async {
       // git status --porcelain → empty (clean)
       processRunner.enqueue(result: _ok(stdout: ""));
       // git rev-parse --abbrev-ref HEAD → "session-001"
@@ -806,7 +806,6 @@ void main() {
       );
 
       expect(result, isA<WorktreeSafe>());
-      expect(result.activeBranch, equals("session-001"));
       expect(processRunner.invocations, hasLength(2));
     });
 
@@ -826,7 +825,7 @@ void main() {
       expect(unsafe.issues.first, isA<UnstagedChanges>());
     });
 
-    test("different branch remains safe and reports the active branch", () async {
+    test("different branch remains safe", () async {
       // git status --porcelain → empty (clean)
       processRunner.enqueue(result: _ok(stdout: ""));
       // git rev-parse --abbrev-ref HEAD → "main" (wrong branch)
@@ -837,7 +836,6 @@ void main() {
       );
 
       expect(result, isA<WorktreeSafe>());
-      expect(result.activeBranch, equals("main"));
     });
 
     test("dirty worktree on a different branch returns UnstagedChanges", () async {
@@ -854,7 +852,6 @@ void main() {
       final unsafe = result as WorktreeUnsafe;
       expect(unsafe.issues, hasLength(1));
       expect(unsafe.issues.whereType<UnstagedChanges>(), hasLength(1));
-      expect(unsafe.activeBranch, equals("main"));
     });
 
     test("non-existent path: returns WorktreeSafe (already cleaned up), no git commands called", () async {

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -21,6 +21,10 @@ child sessions with titles, activity, statuses, and unseen state.
 - Opening validates the path and surfaces the git-initialization choice. Hiding
   delists without destroying sessions or history. Import is explicit, per
   plugin, atomic, non-destructive, cancellable, and attributes progress.
+- A session created in a dedicated worktree receives a system prompt identifying
+  that worktree, its initial branch, and base branch. The prompt requires all
+  work to remain in that worktree, while permitting branch switches and new
+  branches within it.
 - Session listings are project-scoped and pageable and carry plugin attribution,
   times, worktree and branch facts, prompt defaults, and unseen state that
   advances on activity and clears on view or mark-as-read.

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -23,8 +23,8 @@ child sessions with titles, activity, statuses, and unseen state.
   plugin, atomic, non-destructive, cancellable, and attributes progress.
 - A session created in a dedicated worktree receives a system prompt identifying
   that worktree, its initial branch, and base branch. The prompt requires all
-  work to remain in that worktree, while permitting branch switches and new
-  branches within it.
+  work to remain in that worktree, while permitting use of the initial branch,
+  branch switches, and new branches within it.
 - Session listings are project-scoped and pageable and carry plugin attribution,
   times, worktree and branch facts, prompt defaults, and unseen state that
   advances on activity and clears on view or mark-as-read.


### PR DESCRIPTION
## Complexity
🌱 Trivial

## What
- Update the dedicated-worktree session prompt to permit switching or creating branches within the assigned worktree.
- Keep the prohibition on creating another worktree or working directory.
- Cover the revised wording and document the regression behavior.

## Why
A dedicated worktree remains the session boundary, but branch changes are now a normal workflow and should not be prohibited.

## Risk and test focus
Low risk. This changes only injected session guidance and its exact-output test. No user-visible client or database impact.

## Expected result
New dedicated-worktree sessions tell agents to stay in the assigned worktree while allowing normal branch changes there.

## Verification
- `dart format --output=none --set-exit-if-changed lib/src/bridge/services/session_creation_service.dart test/bridge/routing/create_session_handler_test.dart`
- `dart test test/bridge/routing/create_session_handler_test.dart`
- `dart analyze --fatal-infos`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows branch switching and creation inside a session’s dedicated worktree and aligns cleanup to preserve branches. Previously the prompt forbade branch changes and cleanup forced branch deletion; now the prompt permits branch changes, safety only considers unstaged changes, forced cleanup skips safety checks, and non‑forced cleanup does not force‑delete branches so unmerged session branches are preserved.

- Git worktree safety no longer reads or compares the current branch to reduce git calls; the prompt and docs require staying in the dedicated worktree while allowing branch switches and new branches within it.
- Session deletion forces branch deletion only when `force=true`; deleting the worktree no longer implies a forced branch delete, preserving unmerged session branches.

**Migration**
- Remove the `expectedBranch` parameter from `WorktreeService.checkWorktreeSafety` and `WorktreeRepository.checkWorktreeSafety`.
- Delete `BranchMismatch` and any handling (including `CleanupIssue.branchMismatch`), and stop using `GitWorktreeSafetySnapshot.actualBranch`.

<sup>Written for commit f79dfd7dab769a9469596efc8e59a550e6774982. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

