### PR TITLE
🌿 Enable Dart 3.13 type lints

### DIFF
--- a/bridge/app/all_lint_rules.yaml
+++ b/bridge/app/all_lint_rules.yaml
@@ -97,10 +97,12 @@ linter:
     - no_adjacent_strings_in_list
     - no_default_cases
     - no_duplicate_case_values
+    - no_dynamic_casts
     - no_leading_underscores_for_library_prefixes
     - no_leading_underscores_for_local_identifiers
     - no_literal_bool_comparisons
     - no_logic_in_create_state
+    - no_raw_types
     - no_runtimeType_toString
     - no_self_assignments
     - no_wildcard_variable_uses

--- a/bridge/app/analysis_options.yaml
+++ b/bridge/app/analysis_options.yaml
@@ -21,9 +21,7 @@ analyzer:
       "lib/generated/**",
     ]
   language:
-    strict-casts: true
     strict-inference: true
-    strict-raw-types: true
   errors:
     avoid_print: error
 

--- a/bridge/app/lib/src/bridge/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/chat_history_repository.dart
@@ -506,14 +506,17 @@ class ChatHistoryRepository {
     required MessagePart part,
   }) async {
     final json = part.toJson();
-    if (json["attachment"] case final Map<String, dynamic> attachment) {
+    final Object? rawAttachment = json["attachment"];
+    if (rawAttachment case final Map<String, dynamic> attachment) {
       json["attachment"] = await _spillAttachment(
         storageScope: storageScope,
         attachment: attachment,
       );
     }
-    if (json["state"] case final Map<String, dynamic> state) {
-      if (state["attachments"] case final List<dynamic> attachments) {
+    final Object? rawState = json["state"];
+    if (rawState case final Map<String, dynamic> state) {
+      final Object? rawAttachments = state["attachments"];
+      if (rawAttachments case final List<dynamic> attachments) {
         state["attachments"] = [
           for (final attachment in attachments)
             if (attachment is Map<String, dynamic>)
@@ -583,7 +586,8 @@ class ChatHistoryRepository {
   }) async {
     var remaining = remainingInlineBytes;
     final json = jsonDecodeMap(partJson);
-    if (json["attachment"] case final Map<String, dynamic> attachment) {
+    final Object? rawAttachment = json["attachment"];
+    if (rawAttachment case final Map<String, dynamic> attachment) {
       final projected = await _rehydrateAttachment(
         storageScope: storageScope,
         attachment: attachment,
@@ -593,8 +597,10 @@ class ChatHistoryRepository {
       json["attachment"] = projected.attachment;
       remaining = projected.remainingInlineBytes;
     }
-    if (json["state"] case final Map<String, dynamic> state) {
-      if (state["attachments"] case final List<dynamic> attachments) {
+    final Object? rawState = json["state"];
+    if (rawState case final Map<String, dynamic> state) {
+      final Object? rawAttachments = state["attachments"];
+      if (rawAttachments case final List<dynamic> attachments) {
         final projectedAttachments = <dynamic>[];
         for (final attachment in attachments) {
           if (attachment is! Map<String, dynamic>) {

--- a/bridge/sesori_plugin_acp/lib/src/acp_stdio_client.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_stdio_client.dart
@@ -308,7 +308,8 @@ class AcpStdioClient {
             ),
           );
         } else {
-          completer.complete(map["result"]);
+          final Object? result = map["result"];
+          completer.complete(result);
         }
         return;
       }

--- a/bridge/sesori_plugin_codex/lib/src/codex_app_server_client.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_app_server_client.dart
@@ -333,7 +333,8 @@ class CodexAppServerClient implements CodexAppServerTransport {
             ),
           );
         } else {
-          completer.complete(map["result"]);
+          final Object? result = map["result"];
+          completer.complete(result);
         }
         return;
       }

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -572,10 +572,11 @@ class CodexEventMapper {
   /// `changes` are `{path, kind, diff}` entries).
   String? _fileChangeTitle(Object? changes) {
     if (changes is! List || changes.isEmpty) return null;
-    final paths = <String>[
-      for (final c in changes)
-        if (_asMap(c)?["path"] case final String p) p,
-    ];
+    final paths = <String>[];
+    for (final change in changes) {
+      final Object? path = _asMap(change)?["path"];
+      if (path is String) paths.add(path);
+    }
     if (paths.isEmpty) return "${changes.length} file change(s)";
     final shown = paths.take(3).join(", ");
     return paths.length > 3 ? "$shown +${paths.length - 3} more" : shown;

--- a/bridge/sesori_plugin_codex/lib/src/codex_stdio_app_server_client.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_stdio_app_server_client.dart
@@ -226,7 +226,8 @@ class CodexStdioAppServerClient implements CodexAppServerTransport {
           ),
         );
       } else {
-        pending.completer.complete(map["result"]);
+        final Object? result = map["result"];
+        pending.completer.complete(result);
       }
       return;
     }

--- a/bridge/sesori_plugin_cursor/lib/src/repositories/mappers/cursor_catalog_mapper.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/repositories/mappers/cursor_catalog_mapper.dart
@@ -160,7 +160,7 @@ abstract final class CursorCatalogMapper {
   }) {
     return [
       for (final option in _flattenedOptions(config: config))
-        if (option["value"] case final String value when value.isNotEmpty)
+        if (_optionValue(option) case final String value when value.isNotEmpty)
           CursorCatalogOption(
             value: value,
             name: switch (option["name"]) {
@@ -174,6 +174,8 @@ abstract final class CursorCatalogMapper {
           ),
     ];
   }
+
+  static Object? _optionValue(Map<String, dynamic> option) => option["value"];
 
   static List<String> _orderedValues({required Map<String, dynamic> config}) {
     final values = [for (final option in _options(config: config)) option.value];

--- a/bridge/sesori_plugin_omp/lib/src/repositories/omp_catalog_repository.dart
+++ b/bridge/sesori_plugin_omp/lib/src/repositories/omp_catalog_repository.dart
@@ -150,7 +150,7 @@ class OmpCatalogRepository {
   static List<OmpCatalogOption> _options(Map<String, dynamic>? config) {
     return [
       for (final option in _flattenedOptions(config))
-        if (option["value"] case final String value when value.isNotEmpty)
+        if (_optionValue(option) case final String value when value.isNotEmpty)
           OmpCatalogOption(
             value: value,
             name: switch (option["name"]) {
@@ -164,6 +164,8 @@ class OmpCatalogRepository {
           ),
     ];
   }
+
+  static Object? _optionValue(Map<String, dynamic> option) => option["value"];
 
   static List<Map<String, dynamic>> _flattenedOptions(Map<String, dynamic>? config) {
     final raw = config?["options"];

--- a/client/analysis_options.yaml
+++ b/client/analysis_options.yaml
@@ -40,9 +40,7 @@ analyzer:
       "**/lib/firebase_options.dart",
     ]
   language:
-    strict-casts: true
     strict-inference: true
-    strict-raw-types: true
   errors:
     # Without ignore here, we cause import of all_lint_rules to warn, because some rules conflict.
     # We explicitly enable conflicting rules and are fixing the conflicts in this file.

--- a/client/app/all_lint_rules.yaml
+++ b/client/app/all_lint_rules.yaml
@@ -97,10 +97,12 @@ linter:
     - no_adjacent_strings_in_list
     - no_default_cases
     - no_duplicate_case_values
+    - no_dynamic_casts
     - no_leading_underscores_for_library_prefixes
     - no_leading_underscores_for_local_identifiers
     - no_literal_bool_comparisons
     - no_logic_in_create_state
+    - no_raw_types
     - no_runtimeType_toString
     - no_self_assignments
     - no_wildcard_variable_uses

--- a/client/module_core/lib/src/capabilities/voice/voice_api.dart
+++ b/client/module_core/lib/src/capabilities/voice/voice_api.dart
@@ -58,8 +58,8 @@ class VoiceApi {
 
   // ignore: no_slop_linter/prefer_specific_type, JSON parser callback signature requires dynamic input
   static String _parseTranscript(dynamic json) {
-    // ignore: no_slop_linter/prefer_specific_type, JSON parsing requires dynamic
-    if (json is Map<String, dynamic>) {
+    // ignore: no_slop_linter/prefer_specific_type, JSON parsing requires an untyped map value
+    if (json is Map<String, Object?>) {
       final textValue = json["text"];
       if (textValue case final String text when text.isNotEmpty) {
         return text;

--- a/shared/sesori_shared/all_lint_rules.yaml
+++ b/shared/sesori_shared/all_lint_rules.yaml
@@ -97,10 +97,12 @@ linter:
     - no_adjacent_strings_in_list
     - no_default_cases
     - no_duplicate_case_values
+    - no_dynamic_casts
     - no_leading_underscores_for_library_prefixes
     - no_leading_underscores_for_local_identifiers
     - no_literal_bool_comparisons
     - no_logic_in_create_state
+    - no_raw_types
     - no_runtimeType_toString
     - no_self_assignments
     - no_wildcard_variable_uses

--- a/shared/sesori_shared/analysis_options.yaml
+++ b/shared/sesori_shared/analysis_options.yaml
@@ -17,9 +17,7 @@ analyzer:
       "lib/generated/**",
     ]
   language:
-    strict-casts: true
     strict-inference: true
-    strict-raw-types: true
   errors:
     # Without ignore here, we cause import of all_lint_rules to warn, because some rules conflict.
     # We explicitly enable conflicting rules and are fixing the conflicts in this file.


### PR DESCRIPTION
## Complexity
Straightforward lint migration across the existing Dart workspaces.

## What
- Enable `no_dynamic_casts` and `no_raw_types` in the bridge, client, and shared curated lint baselines.
- Replace the superseded analyzer `strict-casts` and `strict-raw-types` options.
- Add explicit typed boundaries where decoded JSON and RPC results enter application code.

## Why
Dart 3.13 provides lint-level replacements for the strict analyzer options. Enabling them keeps type-safety checks in the curated lint baselines and makes dynamic boundaries explicit.

## Risk and test focus
No user-visible or database impact. Risk is limited to preserving runtime parsing behavior while making boundary types explicit.

## Expected result
All workspaces enforce the Dart 3.13 type lints without changing successful parsing or transport behavior.

## Verification
- Fatal-info analysis passed for `bridge/`, `client/`, and `shared/sesori_shared/`.
- `shared/no_slop_linter` analysis passed.
- Focused chat-history, ACP, Codex, Cursor, OMP, and voice tests passed.
- `git diff --check` passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Dart 3.13 type lints across `bridge/`, `client/`, and `shared/`, replacing analyzer `strict-casts`/`strict-raw-types` with `no_dynamic_casts`/`no_raw_types`. This keeps type-safety enforcement and makes JSON/RPC boundaries explicit without changing runtime behavior.

**Developer impact and review notes**
- Lints: add `no_dynamic_casts` and `no_raw_types` in each workspace’s `all_lint_rules.yaml`; remove `strict-casts` and `strict-raw-types` from `analysis_options.yaml`.
- Typed boundaries: switch dynamic reads to `Object?` then pattern-match to `Map<String, Object?>`/`List<Object?>` in JSON/RPC paths (e.g., chat history attachment/state handling, RPC `result` completion, `VoiceApi` transcript parse, Codex event mapping, and catalog mappers).
- Required migration: when adding or updating JSON/RPC parsing, avoid raw `Map`/`List` and dynamic casts; accept untyped input as `Object?` and pattern-match to specific generic types before use.
- No user-visible or data changes; review focuses on the new pattern matches and preserved parsing behavior.

<sup>Written for commit b4e2c037e7ef63c78cae4f93f52e2886a7810663. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

