### PR TITLE
🌿 Enable unnecessary underscores lint

### DIFF
--- a/bridge/app/all_lint_rules.yaml
+++ b/bridge/app/all_lint_rules.yaml
@@ -218,7 +218,7 @@ linter:
     - unnecessary_this
     - unnecessary_to_list_in_spreads
     - unnecessary_unawaited
-    # - unnecessary_underscores
+    - unnecessary_underscores
     - unreachable_from_main
     - unrelated_type_equality_checks
     # - unsafe_variance

--- a/bridge/app/lib/src/bridge/services/project_activity_service.dart
+++ b/bridge/app/lib/src/bridge/services/project_activity_service.dart
@@ -176,7 +176,7 @@ class ProjectActivityService {
       return Future<T>.error(StateError("ProjectActivityService is disposed"));
     }
     final result = _writeTail.then((_) => operation());
-    _writeTail = result.then<void>((_) {}, onError: (Object _, StackTrace __) {});
+    _writeTail = result.then<void>((_) {}, onError: (Object _, StackTrace _) {});
     return result;
   }
 

--- a/bridge/app/lib/src/bridge/services/project_mutation_service.dart
+++ b/bridge/app/lib/src/bridge/services/project_mutation_service.dart
@@ -86,7 +86,7 @@ class ProjectMutationService {
 
   Future<T> _enqueue<T>(Future<T> Function() workflow) {
     final result = _tail.then((_) => workflow());
-    _tail = result.then<void>((_) {}, onError: (Object _, StackTrace __) {});
+    _tail = result.then<void>((_) {}, onError: (Object _, StackTrace _) {});
     return result;
   }
 }

--- a/bridge/app/lib/src/bridge/services/session_operation_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/services/session_operation_dispatcher.dart
@@ -205,7 +205,7 @@ class SessionOperationDispatcher {
 
   void _track<T>({required Completer<T> result}) {
     late final Future<void> settlement;
-    settlement = result.future.then<void>((_) {}, onError: (Object _, StackTrace __) {}).whenComplete(() {
+    settlement = result.future.then<void>((_) {}, onError: (Object _, StackTrace _) {}).whenComplete(() {
       _inFlightSettlements.remove(settlement);
     });
     _inFlightSettlements.add(settlement);
@@ -213,7 +213,7 @@ class SessionOperationDispatcher {
 
   void _trackPlugin<T>({required Completer<T> result, required String pluginId}) {
     late final Future<void> settlement;
-    settlement = result.future.then<void>((_) {}, onError: (Object _, StackTrace __) {}).whenComplete(() {
+    settlement = result.future.then<void>((_) {}, onError: (Object _, StackTrace _) {}).whenComplete(() {
       final settlements = _pluginSettlements[pluginId];
       settlements?.remove(settlement);
       if (settlements?.isEmpty ?? false) _pluginSettlements.remove(pluginId);

--- a/bridge/app/lib/src/bridge/services/session_options_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_options_service.dart
@@ -578,7 +578,7 @@ class SessionOptionsService {
 
         tail = predecessor.then(
           (_) => startReuse(),
-          onError: (Object _, StackTrace __) => startReuse(),
+          onError: (Object _, StackTrace _) => startReuse(),
         );
         existing
           ..reuseTail = tail
@@ -599,7 +599,7 @@ class SessionOptionsService {
 
       tail = predecessor.then(
         (_) => startForced(),
-        onError: (Object _, StackTrace __) => startForced(),
+        onError: (Object _, StackTrace _) => startForced(),
       );
       existing.forcedTail = tail;
       _removeAfterCompletion(key: key, coordinator: existing, future: tail);
@@ -629,7 +629,7 @@ class SessionOptionsService {
       }
     }
 
-    unawaited(future.then<void>((_) => remove(), onError: (Object _, StackTrace __) => remove()));
+    unawaited(future.then<void>((_) => remove(), onError: (Object _, StackTrace _) => remove()));
   }
 }
 

--- a/bridge/app/test/auth/token_manager_test.dart
+++ b/bridge/app/test/auth/token_manager_test.dart
@@ -35,7 +35,7 @@ void main() {
       final refreshStarted = Completer<void>();
       final refreshCompleted = Completer<void>();
       final server = await _RefreshTestServer.start(
-        onRequest: (_, __) {
+        onRequest: (_, _) {
           if (!refreshStarted.isCompleted) {
             refreshStarted.complete();
           }

--- a/bridge/app/test/bridge/event_queue_test.dart
+++ b/bridge/app/test/bridge/event_queue_test.dart
@@ -85,7 +85,7 @@ void main() {
             if (identical(event, bad)) throw Exception("fail");
             dequeued.add(event);
           },
-          onError: (_, __) {},
+          onError: (_, _) {},
         );
 
         queue.enqueue(good);

--- a/bridge/app/test/linux_wake_lock_api_test.dart
+++ b/bridge/app/test/linux_wake_lock_api_test.dart
@@ -38,7 +38,7 @@ void main() {
 
     test("claims to prevent lid-close sleep", () {
       final api = LinuxWakeLockApi(
-        processStarter: (_, __) async => _FakeProcess(),
+        processStarter: (_, _) async => _FakeProcess(),
       );
       expect(api.preventsLidCloseSleep, isTrue);
     });

--- a/bridge/app/test/macos_wake_lock_api_test.dart
+++ b/bridge/app/test/macos_wake_lock_api_test.dart
@@ -31,7 +31,7 @@ void main() {
 
     test("does not claim to prevent lid-close sleep", () {
       final api = MacOSWakeLockApi(
-        processStarter: (_, __) async => _FakeProcess(),
+        processStarter: (_, _) async => _FakeProcess(),
       );
       expect(api.preventsLidCloseSleep, isFalse);
     });

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -834,7 +834,7 @@ abstract class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     final result = _processTurnTail.then((_) => operation());
     _processTurnTail = result.then<void>(
       (_) {},
-      onError: (Object _, StackTrace __) {},
+      onError: (Object _, StackTrace _) {},
     );
     return result;
   }

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_catalog_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_catalog_service.dart
@@ -37,7 +37,7 @@ final class ClaudeCatalogService {
       Log.d("[claude] queued global session options refresh");
       final queued = inFlight.future.then(
         (_) => _fetchCatalog(refresh: true),
-        onError: (Object _, StackTrace __) => _fetchCatalog(refresh: true),
+        onError: (Object _, StackTrace _) => _fetchCatalog(refresh: true),
       );
       return _trackFetch(refresh: true, future: queued);
     }

--- a/client/app/all_lint_rules.yaml
+++ b/client/app/all_lint_rules.yaml
@@ -218,7 +218,7 @@ linter:
     - unnecessary_this
     - unnecessary_to_list_in_spreads
     - unnecessary_unawaited
-    # - unnecessary_underscores
+    - unnecessary_underscores
     - unreachable_from_main
     - unrelated_type_equality_checks
     # - unsafe_variance

--- a/client/app/lib/core/platform/go_router_route_dispatcher.dart
+++ b/client/app/lib/core/platform/go_router_route_dispatcher.dart
@@ -33,7 +33,7 @@ class GoRouterRouteDispatcher implements RouteDispatcher {
     _pendingReplace = _pendingReplace
         .then(
           (_) => _replaceStack(stack: stack),
-          onError: (_, __) => _replaceStack(stack: stack),
+          onError: (_, _) => _replaceStack(stack: stack),
         )
         .catchError((Object error, StackTrace stackTrace) {
           logw("Failed to replace notification route stack", error, stackTrace);

--- a/client/module_core/lib/src/services/notification_registration_service.dart
+++ b/client/module_core/lib/src/services/notification_registration_service.dart
@@ -59,8 +59,8 @@ class NotificationRegistrationService {
   }
 
   Future<void> _enqueueSync(Future<void> Function() operation) {
-    final next = _syncQueue.catchError((Object _, StackTrace __) {}).then((_) => operation());
-    _syncQueue = next.catchError((Object _, StackTrace __) {});
+    final next = _syncQueue.catchError((Object _, StackTrace _) {}).then((_) => operation());
+    _syncQueue = next.catchError((Object _, StackTrace _) {});
     return next;
   }
 

--- a/shared/sesori_shared/all_lint_rules.yaml
+++ b/shared/sesori_shared/all_lint_rules.yaml
@@ -218,7 +218,7 @@ linter:
     - unnecessary_this
     - unnecessary_to_list_in_spreads
     - unnecessary_unawaited
-    # - unnecessary_underscores
+    - unnecessary_underscores
     - unreachable_from_main
     - unrelated_type_equality_checks
     # - unsafe_variance

--- a/shared/sesori_shared/test/concurrency/event_queue_test.dart
+++ b/shared/sesori_shared/test/concurrency/event_queue_test.dart
@@ -452,7 +452,7 @@ void main() {
             }
             processed.add(e);
           },
-          onError: (_, __) {},
+          onError: (_, _) {},
         );
 
         queue.enqueue("flaky");
@@ -507,7 +507,7 @@ void main() {
             if (e == "bad") throw Exception("bad");
             processed.add(e);
           },
-          onError: (_, __) {},
+          onError: (_, _) {},
         );
 
         queue.enqueue("bad");
@@ -536,7 +536,7 @@ void main() {
             }
             processed.add(e);
           },
-          onError: (_, __) {},
+          onError: (_, _) {},
         );
 
         queue.enqueue("first");


### PR DESCRIPTION
## Complexity
Trivial mechanical lint migration.

## What
- Enable `unnecessary_underscores` in the bridge, client, and shared curated lint baselines.
- Apply all 19 targeted `dart fix` cleanups, replacing redundant multi-underscore wildcard names with `_`.

## Why
Dart wildcard variables make repeated underscore names unnecessary. Enabling the stable lint keeps wildcard callback and pattern syntax consistent.

## Risk and test focus
No user-visible or database impact. The edits only rename unused wildcard parameters and patterns.

## Expected result
All workspaces reject redundant wildcard underscore names with no behavior changes.

## Verification
- Fatal-info analysis passed for `bridge/`, `client/`, and `shared/sesori_shared/`.
- Focused bridge token, event queue, and wake-lock tests passed.
- Focused client notification registration tests passed.
- Shared event queue tests passed.
- `git diff --check` passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the `unnecessary_underscores` lint across bridge, client, and shared, and replaces redundant multi-underscore wildcards (like `__`) with `_`. Previously these names were allowed; now the lint enforces a single `_` for unused parameters and pattern bindings with no behavior changes.

**Developer impact**
- Lint enabled in `bridge/app/all_lint_rules.yaml`, `client/app/all_lint_rules.yaml`, and `shared/sesori_shared/all_lint_rules.yaml`; 19 automated `dart fix` updates applied.
- Required: Use a single `_` for all unused parameters and pattern bindings; multi-underscore names will fail lint.
- No runtime or storage impact; analysis and focused tests passed.

<sup>Written for commit eadf78f503786ed810aac25a2f1232fefb535b4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

