### PR TITLE
🌱 Enable Dartdoc HTML lint

### DIFF
--- a/bridge/app/all_lint_rules.yaml
+++ b/bridge/app/all_lint_rules.yaml
@@ -188,7 +188,7 @@ linter:
     - type_init_formals
     - type_literal_in_constant_pattern
     - unawaited_futures
-    # - unintended_html_in_doc_comment
+    - unintended_html_in_doc_comment
     # - unnecessary_async
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps

--- a/client/app/all_lint_rules.yaml
+++ b/client/app/all_lint_rules.yaml
@@ -188,7 +188,7 @@ linter:
     - type_init_formals
     - type_literal_in_constant_pattern
     - unawaited_futures
-    # - unintended_html_in_doc_comment
+    - unintended_html_in_doc_comment
     # - unnecessary_async
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps

--- a/client/app/lib/features/project_list/widgets/bridge_offline_view.dart
+++ b/client/app/lib/features/project_list/widgets/bridge_offline_view.dart
@@ -4,7 +4,7 @@ part of "../project_list_screen.dart";
 /// user already completed setup, so instead of the install onboarding they are
 /// asked to bring the bridge back up. Mirrors the Figma "bridge disconnected"
 /// state (node 2325:48309): the connection graphic over the machine name of
-/// the bridge being reached and a "Disconnected · <last seen>" status line,
+/// the bridge being reached and a "Disconnected · `<last seen>`" status line,
 /// then the always-visible start-the-bridge command, a "Why is this needed?"
 /// explainer, and an expandable "Install commands" disclosure at the end for
 /// when the bridge needs to be (re)installed. The "Need help?" support menu

--- a/shared/sesori_shared/all_lint_rules.yaml
+++ b/shared/sesori_shared/all_lint_rules.yaml
@@ -188,7 +188,7 @@ linter:
     - type_init_formals
     - type_literal_in_constant_pattern
     - unawaited_futures
-    # - unintended_html_in_doc_comment
+    - unintended_html_in_doc_comment
     # - unnecessary_async
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps


### PR DESCRIPTION
## Complexity
Trivial documentation lint migration.

## What
- Enable `unintended_html_in_doc_comment` in the bridge, client, and shared curated lint baselines.
- Mark one angle-bracket placeholder as inline code in a Dartdoc comment.

## Why
Angle brackets in Dartdoc are interpreted as HTML. The lint prevents accidental markup and keeps literal placeholders rendered correctly.

## Risk and test focus
No user-visible, runtime, or database impact. The only source edit is a documentation comment.

## Expected result
All workspaces reject unintended HTML syntax in Dartdoc comments.

## Verification
- Fatal-info analysis passed for `bridge/`, `client/`, and `shared/sesori_shared/`.
- `git diff --check` passed.
- Runtime tests were not run because production behavior is unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the `unintended_html_in_doc_comment` lint across bridge, client, and shared to prevent angle-bracket placeholders in Dartdoc from being parsed as HTML. Converts one affected placeholder to inline code to keep its literal rendering.

**Review notes**
- Turned on the lint in `bridge/app/all_lint_rules.yaml`, `client/app/all_lint_rules.yaml`, and `shared/sesori_shared/all_lint_rules.yaml`.
- Updated one Dartdoc in `client/app/lib/features/project_list/widgets/bridge_offline_view.dart`: "<last seen>" → "`<last seen>`".
- No runtime or UI changes; CI will now fail on unintended HTML in Dartdoc comments.

<sup>Written for commit 56c9a03bb4da4545863c446017bcfda3c0824049. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

