### PR TITLE
🌱 [phone-harness-install] Retire the plan [step 6/6]

### DIFF
--- a/.plan/completed/phone-harness-install/PLAN.md
+++ b/.plan/completed/phone-harness-install/PLAN.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **Plan slug:** `phone-harness-install`
-- **Status:** active
+- **Status:** completed
 - **Related history:** `.plan/completed/setup-aware-plugin-management` built the
   management transport, snapshots, tokens, and lifecycle commands this plan
   extends.

--- a/.plan/completed/phone-harness-install/TRACKER.md
+++ b/.plan/completed/phone-harness-install/TRACKER.md
@@ -6,8 +6,8 @@
 | 2/6 Capability, contracts, descriptor seams | #778 | merged | |
 | 3/6 Bridge install command end to end | #779 | merged | |
 | 4/6 Phone install button and progress | #780 | merged | |
-| 5/6 Cursor managed runtime and install | #857 | in review | Recovered the unpublished local successor, reconciled current `origin/main`, and refreshed the official `2026.08.11-e8db854` pin. |
-| 6/6 Retire the plan | — | pending | |
+| 5/6 Cursor managed runtime and install | #857 | merged | Recovered the unpublished local successor, reconciled current `origin/main`, and refreshed the official `2026.08.11-e8db854` pin. |
+| 6/6 Retire the plan | — | in review | Plan delivered and moved to `.plan/completed/phone-harness-install/`. |
 
 ## Working Rules
 


### PR DESCRIPTION
## Complexity
🌱 Trivial: this moves the completed plan into the completed-plan archive and records final delivery state.

## What
- record managed Cursor runtime PR #857 as merged
- mark the phone harness install plan completed
- move the plan and tracker from `.plan/active/` to `.plan/completed/`

## Why
All six planned delivery boundaries are complete, so the durable plan should no longer appear active.

## Risk and test focus
Low risk. Review the rename and final tracker statuses; no production code or generated files change.

## Expected result
No user-visible, database, persisted-data, or runtime behavior change. The completed plan remains available as historical implementation context.

## Verification
- `git diff --cached --check`: passed before commit
- documentation-only change; Dart and Flutter suites not run


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires the `phone-harness-install` plan by marking it completed and archiving it under `.plan/completed/`. This removes it from the active plan list with no runtime or user-visible changes.

**Review focus**
- Move plan and tracker from `.plan/active/` to `.plan/completed/phone-harness-install/`.
- In `PLAN.md`, change Status from “active” to “completed”.
- In `TRACKER.md`, mark step 5/6 (#857) as merged and set step 6/6 to in review with the archive path note.
- No production code or generated files changed.

<sup>Written for commit a73bc56078d6cb42add241baa9520eadb394dcbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

