### PR TITLE
🚧 [pi-harness] feat(runtime): install direct binary assets [step 8/21]

### DIFF
--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -4,7 +4,7 @@
 
 - **Plan slug:** `pi-harness`
 - **Implementation base:** `origin/main` at `3ae9dd43e`
-- **Series state:** Step 7/21 merged; Step 8/21 ready for review
+- **Series state:** Step 7/21 merged; Step 8/21 in review
 - **Current step:** 8/21, install direct binary runtime assets
 - **Plan PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/811
 - **Step 2 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/819
@@ -14,7 +14,8 @@
 - **Step 6 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/838
 - **Step 7 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/846
 - **Prerequisite PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/857
-- **Next action:** finish Step 8 verification and raise its standalone PR
+- **Step 8 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/862
+- **Next action:** monitor Step 8; Step 9 remains local until Step 8 merges
 
 ## Locked Decisions
 
@@ -48,7 +49,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 | [x] | 5/21 | `⚙️ [pi-harness] feat(acp): bridge form elicitations [step 5/21]` | 900-1,300 (recorded overage) | Merged as PR #832 |
 | [x] | 6/21 | `⚙️ [pi-harness] feat(omp): add the ACP plugin core [step 6/21]` | 900-1,300 | Merged as PR #838 |
 | [x] | 7/21 | `🚧 [pi-harness] feat(omp): expose options and persisted cleanup [step 7/21]` | 1,100-1,500 (recorded overage) | Merged as PR #846 |
-| [ ] | 8/21 | `🚧 [pi-harness] feat(runtime): install direct binary assets [step 8/21]` | 900-1,300 | Ready for review; dependency merged as PR #857 |
+| [ ] | 8/21 | `🚧 [pi-harness] feat(runtime): install direct binary assets [step 8/21]` | 900-1,300 | In review as PR #862; dependency merged as PR #857 |
 | [ ] | 9/21 | `🚧 [pi-harness] feat(omp): add managed runtime and lifecycle [step 9/21]` | 1,000-1,400 | Blocked on Step 8 |
 | [ ] | 10/21 | `⚙️ [pi-harness] feat(pi): enumerate persisted sessions [step 10/21]` | 1,000-1,400 | Not started |
 | [ ] | 11/21 | `⚙️ [pi-harness] feat(pi): replay Pi session history [step 11/21]` | 1,100-1,500 | Not started |

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -3,9 +3,9 @@
 ## Current State
 
 - **Plan slug:** `pi-harness`
-- **Implementation base:** `origin/main` at `ec290e14`
-- **Series state:** Step 6/21 merged; Step 7/21 in review
-- **Current step:** 7/21, expose OMP options and persisted cleanup
+- **Implementation base:** `origin/main` at `3ae9dd43e`
+- **Series state:** Step 7/21 merged; Step 8/21 ready for review
+- **Current step:** 8/21, install direct binary runtime assets
 - **Plan PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/811
 - **Step 2 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/819
 - **Step 3 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/820
@@ -13,7 +13,8 @@
 - **Step 5 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/832
 - **Step 6 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/838
 - **Step 7 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/846
-- **Next action:** monitor Step 7; Step 8 remains blocked on its runtime dependency
+- **Prerequisite PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/857
+- **Next action:** finish Step 8 verification and raise its standalone PR
 
 ## Locked Decisions
 
@@ -29,11 +30,10 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 
 ## External Dependencies
 
-- Pi Step 17 strictly requires `RuntimeAssetLayout.packageDirectory`; the local
-  `phone-harness-install-cursor` branch at `6054d7cd` also generalizes
-  `RuntimeVersion`. Do not duplicate or cherry-pick those primitives.
-- OMP Step 8 builds direct-binary assets on the merged package-directory/runtime
-  variant model rather than creating a parallel installer.
+- PR #857 merged archive package-directory placement and generalized
+  `RuntimeVersion`; Steps 8 and 17 consume those shared primitives.
+- OMP Step 8 builds direct-binary assets into the existing verified installer
+  rather than creating a parallel installer.
 - Joint Step 18 waits for any outstanding Claude activation ownership and
   preserves every merged identity, registry, package, CI, and brand entry.
 
@@ -47,8 +47,8 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 | [x] | 4/21 | `🌱 [pi-harness] docs: expand the plan to Oh My Pi [step 4/21]` | 1,500-1,600 (recorded overage) | Merged as PR #829 |
 | [x] | 5/21 | `⚙️ [pi-harness] feat(acp): bridge form elicitations [step 5/21]` | 900-1,300 (recorded overage) | Merged as PR #832 |
 | [x] | 6/21 | `⚙️ [pi-harness] feat(omp): add the ACP plugin core [step 6/21]` | 900-1,300 | Merged as PR #838 |
-| [ ] | 7/21 | `🚧 [pi-harness] feat(omp): expose options and persisted cleanup [step 7/21]` | 1,100-1,500 (recorded overage) | In review as PR #846 |
-| [ ] | 8/21 | `🚧 [pi-harness] feat(runtime): install direct binary assets [step 8/21]` | 900-1,300 | Blocked on runtime dependency |
+| [x] | 7/21 | `🚧 [pi-harness] feat(omp): expose options and persisted cleanup [step 7/21]` | 1,100-1,500 (recorded overage) | Merged as PR #846 |
+| [ ] | 8/21 | `🚧 [pi-harness] feat(runtime): install direct binary assets [step 8/21]` | 900-1,300 | Ready for review; dependency merged as PR #857 |
 | [ ] | 9/21 | `🚧 [pi-harness] feat(omp): add managed runtime and lifecycle [step 9/21]` | 1,000-1,400 | Blocked on Step 8 |
 | [ ] | 10/21 | `⚙️ [pi-harness] feat(pi): enumerate persisted sessions [step 10/21]` | 1,000-1,400 | Not started |
 | [ ] | 11/21 | `⚙️ [pi-harness] feat(pi): replay Pi session history [step 11/21]` | 1,100-1,500 | Not started |
@@ -57,7 +57,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 | [ ] | 14/21 | `🚧 [pi-harness] feat(pi): manage session residency and turns [step 14/21]` | 1,200-1,500 | Not started |
 | [ ] | 15/21 | `⚙️ [pi-harness] feat(pi): expose models and commands [step 15/21]` | 900-1,300 | Not started |
 | [ ] | 16/21 | `🚧 [pi-harness] feat(pi): implement the plugin API [step 16/21]` | 1,100-1,500 | Not started |
-| [ ] | 17/21 | `🚧 [pi-harness] feat(pi): add managed runtime and lifecycle [step 17/21]` | 1,100-1,500 | Blocked on package-directory runtime support |
+| [ ] | 17/21 | `🚧 [pi-harness] feat(pi): add managed runtime and lifecycle [step 17/21]` | 1,100-1,500 | Not started; runtime dependency merged |
 | [ ] | 18/21 | `⚙️ [pi-harness] feat(bridge): register Pi and OMP [step 18/21]` | 800-1,200 | Not started |
 | [ ] | 19/21 | `⚙️ [pi-harness] feat(client): add Pi and OMP branding and guidance [step 19/21]` | 500-900 | Not started |
 | [ ] | 20/21 | `⚙️ [pi-harness] test(harness): verify Pi and OMP integration [step 20/21]` | 300-700 | Not started |
@@ -244,6 +244,27 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 - Recorded overage: the planned catalog/options and persisted-cleanup layers,
   isolated ACP lifecycle, and focused tests form one coherent Step 7 boundary;
   splitting would publish an incomplete plugin contract.
+
+### Step 8/21
+
+- Modeled runtime release artifacts as sealed archive and direct-binary variants;
+  archive-only format, member, and layout fields no longer create impossible
+  direct-binary states.
+- Extended the existing verified installer to place bare executables without
+  extraction while preserving checksum verification, atomic rename, Unix chmod,
+  sentinel-last adoption, managed version probing, and stale-version sweeping.
+- Migrated OpenCode, Codex, and Cursor archive manifests and tests in lockstep.
+- Direct-binary tests cover placement, no extraction, Unix chmod through the
+  shared path, Windows `.exe` naming, checksum failure, cancellation, stale
+  staging cleanup, probe, and sweep; archive binary/package behavior remains covered.
+- `dart test` and `dart analyze --fatal-infos` from `sesori_plugin_runtime`,
+  `sesori_plugin_opencode`, `sesori_plugin_codex`, and `sesori_plugin_cursor`: pass
+  (130 + 421 + 361 + 134 = 1,046 tests).
+- Architecture implementation review: approved with no findings.
+- No user-visible, database, persisted-data, client/bridge wire-contract, or
+  client-UI change; OMP remains app-invisible until Step 18.
+- `git diff --check`: pass.
+- Diff: +238/-113 = 351 changed lines; generated lines: 0; tests run: 1,046.
 
 ## Findings And Plan Deltas
 

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart
@@ -36,55 +36,55 @@ class CodexRuntimeManifest extends RuntimeManifest {
   /// Pinned per-platform assets for [bundledVersion]. codex ships `.tar.gz` on
   /// darwin/linux and an `.exe.zip` on windows; the binary inside each archive is
   /// named with the full target triple (e.g. `codex-aarch64-apple-darwin`), so
-  /// [RuntimeAsset.archiveBinaryName] carries that member name and the installer
+  /// [ArchiveRuntimeAsset.archiveBinaryName] carries that member name and the installer
   /// normalizes it to the canonical [binaryFileName] (`codex` / `codex.exe`).
   static const Map<PlatformOs, Map<PlatformArch, RuntimeAsset>> _assets = {
     PlatformOs.macos: {
-      PlatformArch.arm64: RuntimeAsset(
+      PlatformArch.arm64: ArchiveRuntimeAsset(
         assetName: "codex-aarch64-apple-darwin.tar.gz",
         format: ArchiveFormat.tarGz,
         sha256: "2750132d300e64f1dbffb95e3d913fd9c9dc7812bc8e1bce5c61357248b7929e",
         archiveBinaryName: "codex-aarch64-apple-darwin",
-        layout: RuntimeAssetLayout.singleBinary,
+        layout: RuntimeArchiveLayout.singleBinary,
       ),
-      PlatformArch.x64: RuntimeAsset(
+      PlatformArch.x64: ArchiveRuntimeAsset(
         assetName: "codex-x86_64-apple-darwin.tar.gz",
         format: ArchiveFormat.tarGz,
         sha256: "710d727b0fa2b4ab2189eb1bdc5ab40177c168296af264913eb7ab3ce848d04b",
         archiveBinaryName: "codex-x86_64-apple-darwin",
-        layout: RuntimeAssetLayout.singleBinary,
+        layout: RuntimeArchiveLayout.singleBinary,
       ),
     },
     PlatformOs.linux: {
-      PlatformArch.arm64: RuntimeAsset(
+      PlatformArch.arm64: ArchiveRuntimeAsset(
         assetName: "codex-aarch64-unknown-linux-musl.tar.gz",
         format: ArchiveFormat.tarGz,
         sha256: "975bac91562abeedeb8f79636d51a86649b31f34a9de6a3bcb059565b6cf1f87",
         archiveBinaryName: "codex-aarch64-unknown-linux-musl",
-        layout: RuntimeAssetLayout.singleBinary,
+        layout: RuntimeArchiveLayout.singleBinary,
       ),
-      PlatformArch.x64: RuntimeAsset(
+      PlatformArch.x64: ArchiveRuntimeAsset(
         assetName: "codex-x86_64-unknown-linux-musl.tar.gz",
         format: ArchiveFormat.tarGz,
         sha256: "5ba3b9405543953081f661d0854d266f76e2abbe51d41349355a36de7673776a",
         archiveBinaryName: "codex-x86_64-unknown-linux-musl",
-        layout: RuntimeAssetLayout.singleBinary,
+        layout: RuntimeArchiveLayout.singleBinary,
       ),
     },
     PlatformOs.windows: {
-      PlatformArch.arm64: RuntimeAsset(
+      PlatformArch.arm64: ArchiveRuntimeAsset(
         assetName: "codex-aarch64-pc-windows-msvc.exe.zip",
         format: ArchiveFormat.zip,
         sha256: "5219938c0138580611735d8c2a79b100be0929083f779a8f375aadf192175b33",
         archiveBinaryName: "codex-aarch64-pc-windows-msvc.exe",
-        layout: RuntimeAssetLayout.singleBinary,
+        layout: RuntimeArchiveLayout.singleBinary,
       ),
-      PlatformArch.x64: RuntimeAsset(
+      PlatformArch.x64: ArchiveRuntimeAsset(
         assetName: "codex-x86_64-pc-windows-msvc.exe.zip",
         format: ArchiveFormat.zip,
         sha256: "4781b618fa3a16d91c892f8a1e2c82625f9286f9bb944a5690ba727c84fc5729",
         archiveBinaryName: "codex-x86_64-pc-windows-msvc.exe",
-        layout: RuntimeAssetLayout.singleBinary,
+        layout: RuntimeArchiveLayout.singleBinary,
       ),
     },
   };

--- a/bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart
@@ -34,9 +34,8 @@ void main() {
     });
 
     test("darwin/linux ship .tar.gz, windows ships .exe.zip", () {
-      RuntimeAsset asset(PlatformOs os, PlatformArch arch) => manifest.assetFor(
-        target: PlatformTarget(os: os, arch: arch),
-      )!;
+      ArchiveRuntimeAsset asset(PlatformOs os, PlatformArch arch) =>
+          manifest.assetFor(target: PlatformTarget(os: os, arch: arch))! as ArchiveRuntimeAsset;
 
       expect(asset(PlatformOs.macos, PlatformArch.arm64).format, ArchiveFormat.tarGz);
       expect(asset(PlatformOs.macos, PlatformArch.arm64).assetName, endsWith(".tar.gz"));
@@ -52,26 +51,26 @@ void main() {
 
     test("archive member is the target-triple name (asset name minus extension)", () {
       expect(
-        manifest
+        (manifest
             .assetFor(
               target: const PlatformTarget(os: PlatformOs.macos, arch: PlatformArch.arm64),
-            )!
+            )! as ArchiveRuntimeAsset)
             .archiveBinaryName,
         "codex-aarch64-apple-darwin",
       );
       expect(
-        manifest
+        (manifest
             .assetFor(
               target: const PlatformTarget(os: PlatformOs.linux, arch: PlatformArch.x64),
-            )!
+            )! as ArchiveRuntimeAsset)
             .archiveBinaryName,
         "codex-x86_64-unknown-linux-musl",
       );
       expect(
-        manifest
+        (manifest
             .assetFor(
               target: const PlatformTarget(os: PlatformOs.windows, arch: PlatformArch.x64),
-            )!
+            )! as ArchiveRuntimeAsset)
             .archiveBinaryName,
         "codex-x86_64-pc-windows-msvc.exe",
       );

--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_runtime_manifest.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_runtime_manifest.dart
@@ -21,7 +21,7 @@ import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 /// 3. **A package directory, not a lone binary.** The archive contains a
 ///    `dist-package/` tree whose `cursor-agent` entry binary loads sibling
 ///    files (node runtime, native modules), so the assets declare
-///    [RuntimeAssetLayout.packageDirectory] and the whole tree is installed.
+  ///    [RuntimeArchiveLayout.packageDirectory] and the whole tree is installed.
 ///
 /// Windows is deliberately absent: Cursor publishes darwin and linux only, so
 /// [assetFor] returns null there and the descriptor does not advertise the
@@ -57,35 +57,35 @@ class CursorRuntimeManifest extends RuntimeManifest {
   /// stays a pure function of the asset.
   static const Map<PlatformOs, Map<PlatformArch, RuntimeAsset>> _assets = {
     PlatformOs.macos: {
-      PlatformArch.arm64: RuntimeAsset(
+      PlatformArch.arm64: ArchiveRuntimeAsset(
         assetName: "darwin/arm64/agent-cli-package.tar.gz",
         format: ArchiveFormat.tarGz,
         sha256: "46044d6d7bcbd7b49a0cf1cd01aa4ca79aaa2ea5f2c7a32965fc0ebe29841790",
         archiveBinaryName: _packageBinaryName,
-        layout: RuntimeAssetLayout.packageDirectory,
+        layout: RuntimeArchiveLayout.packageDirectory,
       ),
-      PlatformArch.x64: RuntimeAsset(
+      PlatformArch.x64: ArchiveRuntimeAsset(
         assetName: "darwin/x64/agent-cli-package.tar.gz",
         format: ArchiveFormat.tarGz,
         sha256: "d5c1ce96dd36469e0231d818d4ccf390caac52d94e607c56ebeecc247cab2b1b",
         archiveBinaryName: _packageBinaryName,
-        layout: RuntimeAssetLayout.packageDirectory,
+        layout: RuntimeArchiveLayout.packageDirectory,
       ),
     },
     PlatformOs.linux: {
-      PlatformArch.arm64: RuntimeAsset(
+      PlatformArch.arm64: ArchiveRuntimeAsset(
         assetName: "linux/arm64/agent-cli-package.tar.gz",
         format: ArchiveFormat.tarGz,
         sha256: "ea13f92e295f523a99ce8d8f57d6894d21e5d1e2d030ffad718ccd5955ca2eed",
         archiveBinaryName: _packageBinaryName,
-        layout: RuntimeAssetLayout.packageDirectory,
+        layout: RuntimeArchiveLayout.packageDirectory,
       ),
-      PlatformArch.x64: RuntimeAsset(
+      PlatformArch.x64: ArchiveRuntimeAsset(
         assetName: "linux/x64/agent-cli-package.tar.gz",
         format: ArchiveFormat.tarGz,
         sha256: "bfff4bf6f4e9dd30c1d0ef0a70b6077b074015dd2948e4c50685d53afdcfce5a",
         archiveBinaryName: _packageBinaryName,
-        layout: RuntimeAssetLayout.packageDirectory,
+        layout: RuntimeArchiveLayout.packageDirectory,
       ),
     },
   };

--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_runtime_manifest.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_runtime_manifest.dart
@@ -21,7 +21,7 @@ import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 /// 3. **A package directory, not a lone binary.** The archive contains a
 ///    `dist-package/` tree whose `cursor-agent` entry binary loads sibling
 ///    files (node runtime, native modules), so the assets declare
-  ///    [RuntimeArchiveLayout.packageDirectory] and the whole tree is installed.
+///    [RuntimeArchiveLayout.packageDirectory] and the whole tree is installed.
 ///
 /// Windows is deliberately absent: Cursor publishes darwin and linux only, so
 /// [assetFor] returns null there and the descriptor does not advertise the

--- a/bridge/sesori_plugin_cursor/test/runtime/cursor_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_cursor/test/runtime/cursor_runtime_manifest_test.dart
@@ -23,9 +23,11 @@ void main() {
           target: PlatformTarget(os: os, arch: arch),
         );
         expect(asset, isNotNull, reason: "$os/$arch must be published");
-        expect(asset!.layout, RuntimeAssetLayout.packageDirectory);
-        expect(asset.format, ArchiveFormat.tarGz);
-        expect(asset.archiveBinaryName, "cursor-agent");
+        expect(asset, isA<ArchiveRuntimeAsset>());
+        final archiveAsset = asset! as ArchiveRuntimeAsset;
+        expect(archiveAsset.layout, RuntimeArchiveLayout.packageDirectory);
+        expect(archiveAsset.format, ArchiveFormat.tarGz);
+        expect(archiveAsset.archiveBinaryName, "cursor-agent");
         expect(asset.sha256, matches(RegExp(r"^[0-9a-f]{64}$")));
       }
     }

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_manifest.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_manifest.dart
@@ -37,54 +37,54 @@ class OpenCodeRuntimeManifest extends RuntimeManifest {
   /// Pinned per-platform assets for [bundledVersion]. darwin/windows ship `.zip`,
   /// linux ships `.tar.gz`; the non-baseline, non-musl CLI builds are used. The
   /// OpenCode archives contain the executable under its plain canonical name, so
-  /// [RuntimeAsset.archiveBinaryName] equals [binaryFileName] per platform.
+  /// [ArchiveRuntimeAsset.archiveBinaryName] equals [binaryFileName] per platform.
   static const Map<PlatformOs, Map<PlatformArch, RuntimeAsset>> _assets = {
     PlatformOs.macos: {
-      PlatformArch.arm64: RuntimeAsset(
+      PlatformArch.arm64: ArchiveRuntimeAsset(
         assetName: "opencode-darwin-arm64.zip",
         format: ArchiveFormat.zip,
         sha256: "188ff6a716bcd40e33ac62f17f4aec9bd760164fa6a2cde66f779a5db4abc7ce",
         archiveBinaryName: "opencode",
-        layout: RuntimeAssetLayout.singleBinary,
+        layout: RuntimeArchiveLayout.singleBinary,
       ),
-      PlatformArch.x64: RuntimeAsset(
+      PlatformArch.x64: ArchiveRuntimeAsset(
         assetName: "opencode-darwin-x64.zip",
         format: ArchiveFormat.zip,
         sha256: "95953ab2aca4322b90690bf34697cc9b47b6a7c72f78e7c469056fb589124d31",
         archiveBinaryName: "opencode",
-        layout: RuntimeAssetLayout.singleBinary,
+        layout: RuntimeArchiveLayout.singleBinary,
       ),
     },
     PlatformOs.linux: {
-      PlatformArch.arm64: RuntimeAsset(
+      PlatformArch.arm64: ArchiveRuntimeAsset(
         assetName: "opencode-linux-arm64.tar.gz",
         format: ArchiveFormat.tarGz,
         sha256: "03e07aa461ac241dfa8c7ab54ed58c7a0e911c62fc3cb490b83e4fb3424eb73b",
         archiveBinaryName: "opencode",
-        layout: RuntimeAssetLayout.singleBinary,
+        layout: RuntimeArchiveLayout.singleBinary,
       ),
-      PlatformArch.x64: RuntimeAsset(
+      PlatformArch.x64: ArchiveRuntimeAsset(
         assetName: "opencode-linux-x64.tar.gz",
         format: ArchiveFormat.tarGz,
         sha256: "a4dffcc00a5a93256c6bd06aa0c984320528f564db52a1f4becd5c7de9fb59a1",
         archiveBinaryName: "opencode",
-        layout: RuntimeAssetLayout.singleBinary,
+        layout: RuntimeArchiveLayout.singleBinary,
       ),
     },
     PlatformOs.windows: {
-      PlatformArch.arm64: RuntimeAsset(
+      PlatformArch.arm64: ArchiveRuntimeAsset(
         assetName: "opencode-windows-arm64.zip",
         format: ArchiveFormat.zip,
         sha256: "4510ccf446284f5492438c4b40b23895dc7ae78cb5eb4e7f51cbe998c1148d58",
         archiveBinaryName: "opencode.exe",
-        layout: RuntimeAssetLayout.singleBinary,
+        layout: RuntimeArchiveLayout.singleBinary,
       ),
-      PlatformArch.x64: RuntimeAsset(
+      PlatformArch.x64: ArchiveRuntimeAsset(
         assetName: "opencode-windows-x64.zip",
         format: ArchiveFormat.zip,
         sha256: "f3a5ea814aecc692a4e04259d9005283f364225b38456c90f9a47b7a9d83c0e9",
         archiveBinaryName: "opencode.exe",
-        layout: RuntimeAssetLayout.singleBinary,
+        layout: RuntimeArchiveLayout.singleBinary,
       ),
     },
   };

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_manifest_test.dart
@@ -26,9 +26,8 @@ void main() {
     });
 
     test("darwin/windows ship .zip, linux ships .tar.gz", () {
-      RuntimeAsset asset(PlatformOs os, PlatformArch arch) => manifest.assetFor(
-        target: PlatformTarget(os: os, arch: arch),
-      )!;
+      ArchiveRuntimeAsset asset(PlatformOs os, PlatformArch arch) =>
+          manifest.assetFor(target: PlatformTarget(os: os, arch: arch))! as ArchiveRuntimeAsset;
 
       expect(asset(PlatformOs.macos, PlatformArch.arm64).format, ArchiveFormat.zip);
       expect(asset(PlatformOs.macos, PlatformArch.arm64).assetName, endsWith(".zip"));

--- a/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_install_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_install_service.dart
@@ -23,10 +23,9 @@ class RuntimeInstallException implements Exception {
 /// place the binary at `<versionDir>/<binaryFileName>` → write a verification
 /// sentinel.
 ///
-/// The executable is located inside the extracted archive by [RuntimeAsset.archiveBinaryName]
-/// and moved into a freshly created version directory under the canonical
-/// [binaryFileName] (normalizing publishers that ship a target-triple-named
-/// member). The sentinel (the verified SHA-256) is written last, so an
+/// Archive executables are located by [ArchiveRuntimeAsset.archiveBinaryName]
+/// and normalized to [binaryFileName]. Direct binaries are placed there without
+/// extraction. The sentinel (the verified SHA-256) is written last, so an
 /// interrupted install leaves no sentinel and is cleanly redone next attempt.
 /// No lock is required: single-live-bridge enforcement covers cross-process
 /// overlap, callers gate concurrent same-plugin work (setup-blocked plugins
@@ -97,7 +96,11 @@ class RuntimeInstallService {
     // shells out to PowerShell `Expand-Archive`, which rejects any source path
     // that does not end in `.zip` (a bare extensionless file fails the install).
     // The format is the same source of truth the extractor switches on.
-    final String downloadPath = p.join(managedDir, "$_downloadFileName${asset.format.fileExtension}");
+    final String extension = switch (asset) {
+      ArchiveRuntimeAsset(:final format) => format.fileExtension,
+      DirectBinaryRuntimeAsset() => "",
+    };
+    final String downloadPath = p.join(managedDir, "$_downloadFileName$extension");
     final String stagingPath = p.join(managedDir, _stagingDirName);
 
     try {
@@ -114,34 +117,42 @@ class RuntimeInstallService {
       }
       _throwIfAborted(startAborted);
 
-      yield const ProvisionExtracting();
-      final ArchiveExtractionResult extracted = await _archiveExtractor.extract(
-        archivePath: downloadPath,
-        stagingPath: stagingPath,
-        format: asset.format,
-      );
-      if (!extracted.succeeded) {
-        throw RuntimeInstallException("failed to extract ${asset.assetName} (${extracted.failureReason})");
-      }
-      _throwIfAborted(startAborted);
+      switch (asset) {
+        case ArchiveRuntimeAsset():
+          yield const ProvisionExtracting();
+          final ArchiveExtractionResult extracted = await _archiveExtractor.extract(
+            archivePath: downloadPath,
+            stagingPath: stagingPath,
+            format: asset.format,
+          );
+          if (!extracted.succeeded) {
+            throw RuntimeInstallException("failed to extract ${asset.assetName} (${extracted.failureReason})");
+          }
+          _throwIfAborted(startAborted);
 
-      final File? binaryInStaging = _locateBinary(stagingPath: stagingPath, archiveBinaryName: asset.archiveBinaryName);
-      if (binaryInStaging == null) {
-        throw RuntimeInstallException("archive ${asset.assetName} did not contain ${asset.archiveBinaryName}");
-      }
-
-      switch (asset.layout) {
-        case RuntimeAssetLayout.singleBinary:
-          _placeBinary(binaryInStaging: binaryInStaging, versionDir: versionDir, binaryFileName: binaryFileName);
-        case RuntimeAssetLayout.packageDirectory:
-          // The entry binary loads siblings from its own directory, so the
-          // whole tree is placed and the canonical name is a symlink-free
-          // rename of the entry file within it.
-          _placePackage(
-            packageInStaging: binaryInStaging.parent,
+          final File? binaryInStaging = _locateBinary(
+            stagingPath: stagingPath,
+            archiveBinaryName: asset.archiveBinaryName,
+          );
+          if (binaryInStaging == null) {
+            throw RuntimeInstallException("archive ${asset.assetName} did not contain ${asset.archiveBinaryName}");
+          }
+          switch (asset.layout) {
+            case RuntimeArchiveLayout.singleBinary:
+              _placeBinary(binaryInStaging: binaryInStaging, versionDir: versionDir, binaryFileName: binaryFileName);
+            case RuntimeArchiveLayout.packageDirectory:
+              _placePackage(
+                packageInStaging: binaryInStaging.parent,
+                versionDir: versionDir,
+                binaryFileName: binaryFileName,
+                archiveBinaryName: asset.archiveBinaryName,
+              );
+          }
+        case DirectBinaryRuntimeAsset():
+          _placeBinary(
+            binaryInStaging: File(downloadPath),
             versionDir: versionDir,
             binaryFileName: binaryFileName,
-            archiveBinaryName: asset.archiveBinaryName,
           );
       }
       await _makeExecutable(binaryPath: p.join(versionDir, binaryFileName), assetName: asset.assetName);

--- a/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_manifest.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_manifest.dart
@@ -8,7 +8,7 @@ import "runtime_version.dart";
 /// Most runtimes ship a single self-contained executable ([singleBinary]).
 /// Cursor ships a `dist-package/` tree whose entry binary loads sibling files,
 /// so the whole directory must be kept together ([packageDirectory]).
-enum RuntimeAssetLayout { singleBinary, packageDirectory }
+enum RuntimeArchiveLayout { singleBinary, packageDirectory }
 
 /// One platform's pinned release archive for a managed runtime: the asset name,
 /// its container [format], the SHA-256 the download is verified against, the
@@ -21,25 +21,38 @@ enum RuntimeAssetLayout { singleBinary, packageDirectory }
 /// that must be normalized to a plain `codex`. For publishers whose archive
 /// member already matches the canonical name (e.g. OpenCode's `opencode`), the
 /// two are equal.
-final class RuntimeAsset {
+sealed class RuntimeAsset {
   const RuntimeAsset({
     required this.assetName,
-    required this.format,
     required this.sha256,
+  });
+
+  final String assetName;
+  final String sha256;
+}
+
+final class ArchiveRuntimeAsset extends RuntimeAsset {
+  const ArchiveRuntimeAsset({
+    required super.assetName,
+    required this.format,
+    required super.sha256,
     required this.archiveBinaryName,
     required this.layout,
   });
 
-  final String assetName;
   final ArchiveFormat format;
-  final String sha256;
 
   /// The entry executable's name inside the extracted archive. For
-  /// [RuntimeAssetLayout.packageDirectory] it names the binary within the
+  /// [RuntimeArchiveLayout.packageDirectory] it names the binary within the
   /// placed tree; its siblings travel with it.
   final String archiveBinaryName;
 
-  final RuntimeAssetLayout layout;
+  final RuntimeArchiveLayout layout;
+}
+
+/// A runtime published as a bare executable with no archive container.
+final class DirectBinaryRuntimeAsset extends RuntimeAsset {
+  const DirectBinaryRuntimeAsset({required super.assetName, required super.sha256});
 }
 
 /// The harness-specific seam of the shared runtime-provisioning system: the

--- a/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_manifest.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_manifest.dart
@@ -10,17 +10,8 @@ import "runtime_version.dart";
 /// so the whole directory must be kept together ([packageDirectory]).
 enum RuntimeArchiveLayout { singleBinary, packageDirectory }
 
-/// One platform's pinned release archive for a managed runtime: the asset name,
-/// its container [format], the SHA-256 the download is verified against, the
-/// name of the executable file *inside* the extracted archive, and how that
-/// archive is placed on disk.
-///
-/// [archiveBinaryName] is distinct from [RuntimeManifest.binaryFileName] (the
-/// canonical on-disk name the binary is placed under): some publishers ship the
-/// executable under a target-triple name (e.g. `codex-aarch64-apple-darwin`)
-/// that must be normalized to a plain `codex`. For publishers whose archive
-/// member already matches the canonical name (e.g. OpenCode's `opencode`), the
-/// two are equal.
+/// One platform's pinned release artifact for a managed runtime, identified by
+/// its publisher [assetName] and verified against [sha256] before placement.
 sealed class RuntimeAsset {
   const RuntimeAsset({
     required this.assetName,
@@ -31,6 +22,11 @@ sealed class RuntimeAsset {
   final String sha256;
 }
 
+/// A runtime release artifact distributed inside an archive.
+///
+/// [archiveBinaryName] is distinct from [RuntimeManifest.binaryFileName] (the
+/// canonical on-disk name): some publishers use a target-triple member name
+/// that the installer normalizes to the canonical name.
 final class ArchiveRuntimeAsset extends RuntimeAsset {
   const ArchiveRuntimeAsset({
     required super.assetName,

--- a/bridge/sesori_plugin_runtime/test/provisioning/managed_runtime_install_service_test.dart
+++ b/bridge/sesori_plugin_runtime/test/provisioning/managed_runtime_install_service_test.dart
@@ -11,12 +11,9 @@ class _StubManifest implements RuntimeManifest {
 
   final bool hasAsset;
 
-  static const RuntimeAsset _asset = RuntimeAsset(
-    assetName: "opencode-test.zip",
-    format: ArchiveFormat.zip,
+  static const RuntimeAsset _asset = DirectBinaryRuntimeAsset(
+    assetName: "opencode-test",
     sha256: "abc123",
-    archiveBinaryName: "opencode",
-    layout: RuntimeAssetLayout.singleBinary,
   );
 
   @override

--- a/bridge/sesori_plugin_runtime/test/provisioning/managed_runtime_provision_service_test.dart
+++ b/bridge/sesori_plugin_runtime/test/provisioning/managed_runtime_provision_service_test.dart
@@ -7,12 +7,12 @@ import "package:test/test.dart";
 class _StubManifest implements RuntimeManifest {
   const _StubManifest();
 
-  static const RuntimeAsset _asset = RuntimeAsset(
+  static const RuntimeAsset _asset = ArchiveRuntimeAsset(
     assetName: "opencode-test.zip",
     format: ArchiveFormat.zip,
     sha256: "abc123",
     archiveBinaryName: "opencode",
-    layout: RuntimeAssetLayout.singleBinary,
+    layout: RuntimeArchiveLayout.singleBinary,
   );
 
   @override

--- a/bridge/sesori_plugin_runtime/test/provisioning/runtime_install_service_test.dart
+++ b/bridge/sesori_plugin_runtime/test/provisioning/runtime_install_service_test.dart
@@ -41,6 +41,7 @@ class _FakeArchiveExtractor implements ArchiveExtractor {
 
   final bool success;
   final bool packageDirectory;
+  int extractCalls = 0;
 
   @override
   Future<ArchiveExtractionResult> extract({
@@ -48,6 +49,7 @@ class _FakeArchiveExtractor implements ArchiveExtractor {
     required String stagingPath,
     required ArchiveFormat format,
   }) async {
+    extractCalls++;
     if (!success) {
       return const ArchiveExtractionResult.failure(reason: "powershell Expand-Archive exited with code 1: boom");
     }
@@ -81,21 +83,23 @@ class _FakeCommandExecutor implements CommandExecutor {
   }
 }
 
-const _asset = RuntimeAsset(
+const _asset = ArchiveRuntimeAsset(
   assetName: "opencode-test.zip",
   format: ArchiveFormat.zip,
   sha256: "abc123",
   archiveBinaryName: "opencode",
-  layout: RuntimeAssetLayout.singleBinary,
+  layout: RuntimeArchiveLayout.singleBinary,
 );
 
-const _packageAsset = RuntimeAsset(
+const _packageAsset = ArchiveRuntimeAsset(
   assetName: "cursor-test.tar.gz",
   format: ArchiveFormat.tarGz,
   sha256: "def456",
   archiveBinaryName: "cursor-agent",
-  layout: RuntimeAssetLayout.packageDirectory,
+  layout: RuntimeArchiveLayout.packageDirectory,
 );
+
+const _directAsset = DirectBinaryRuntimeAsset(assetName: "omp-test", sha256: "789abc");
 
 void main() {
   late Directory managedDir;
@@ -116,11 +120,13 @@ void main() {
     bool extractSuccess = true,
     bool packageDirectory = false,
     _FakeCommandExecutor? cmd,
+    _FakeArchiveExtractor? extractor,
   }) {
     return RuntimeInstallService(
       downloadClient: _FakeDownloadClient(exception: downloadError),
       checksumValidator: _FakeChecksumValidator(valid: checksumValid),
-      archiveExtractor: _FakeArchiveExtractor(success: extractSuccess, packageDirectory: packageDirectory),
+      archiveExtractor:
+          extractor ?? _FakeArchiveExtractor(success: extractSuccess, packageDirectory: packageDirectory),
       commandExecutor: cmd ?? _FakeCommandExecutor(),
       runtimeId: "opencode",
     );
@@ -186,6 +192,83 @@ void main() {
       File(p.join(versionDir(), RuntimeInstallService.sentinelFileName)).readAsStringSync(),
       "def456",
     );
+  });
+
+  test("places a direct binary without extraction and cleans stale staging", () async {
+    final extractor = _FakeArchiveExtractor(success: true, packageDirectory: false);
+    final staleStaging = Directory(p.join(managedDir.path, ".sesori-runtime-staging"))..createSync(recursive: true);
+    File(p.join(staleStaging.path, "stale")).writeAsStringSync("OLD");
+
+    final events = await build(extractor: extractor)
+        .install(
+          managedDir: managedDir.path,
+          versionDir: versionDir(),
+          binaryFileName: "omp",
+          downloadUrl: "https://example.test/omp-test",
+          asset: _directAsset,
+          startAborted: StartAbortSignal.never,
+        )
+        .toList();
+
+    expect(File(p.join(versionDir(), "omp")).readAsBytesSync(), [1, 2, 3, 4]);
+    expect(File(p.join(versionDir(), RuntimeInstallService.sentinelFileName)).readAsStringSync(), "789abc");
+    expect(events.any((event) => event is ProvisionExtracting), isFalse);
+    expect(extractor.extractCalls, 0);
+    expect(staleStaging.existsSync(), isFalse);
+    expect(File(p.join(managedDir.path, ".sesori-runtime-download")).existsSync(), isFalse);
+  });
+
+  test("places a direct Windows executable under the canonical exe name", () async {
+    await build()
+        .install(
+          managedDir: managedDir.path,
+          versionDir: versionDir(),
+          binaryFileName: "omp.exe",
+          downloadUrl: "https://example.test/omp-test.exe",
+          asset: _directAsset,
+          startAborted: StartAbortSignal.never,
+        )
+        .drain<void>();
+
+    expect(File(p.join(versionDir(), "omp.exe")).existsSync(), isTrue);
+  });
+
+  test("does not place a direct binary when checksum verification fails", () async {
+    await expectLater(
+      build(checksumValid: false)
+          .install(
+            managedDir: managedDir.path,
+            versionDir: versionDir(),
+            binaryFileName: "omp",
+            downloadUrl: "https://example.test/omp-test",
+            asset: _directAsset,
+            startAborted: StartAbortSignal.never,
+          )
+          .drain<void>(),
+      throwsA(isA<RuntimeInstallException>()),
+    );
+    expect(File(p.join(versionDir(), "omp")).existsSync(), isFalse);
+    expect(File(p.join(managedDir.path, ".sesori-runtime-download")).existsSync(), isFalse);
+  });
+
+  test("cancels a direct binary install before placement", () async {
+    final controller = StartAbortController()..abort();
+
+    await expectLater(
+      build()
+          .install(
+            managedDir: managedDir.path,
+            versionDir: versionDir(),
+            binaryFileName: "omp",
+            downloadUrl: "https://example.test/omp-test",
+            asset: _directAsset,
+            startAborted: controller.signal,
+          )
+          .drain<void>(),
+      throwsA(isA<PluginStartAbortedException>()),
+    );
+    expect(File(p.join(versionDir(), "omp")).existsSync(), isFalse);
+    expect(File(p.join(managedDir.path, ".sesori-runtime-download")).existsSync(), isFalse);
   });
 
   test("isInstalled is false before, true after, and rejects a hash mismatch", () async {

--- a/docs/regression/plugin-runtime-installation.md
+++ b/docs/regression/plugin-runtime-installation.md
@@ -12,8 +12,8 @@ management API, when it reports its runtime as missing or too old.
   removes the offer. The app offers it only for a missing or too-old runtime, never for
   ready, authentication-required, or unknown states.
 - Artifact installation writes the pinned version into the harness's own managed state
-  area; placement preserves either the published executable or its required package
-  directory, never installs system-wide, touches files elsewhere, or starts the backend.
+  area; placement preserves a published bare executable, an archived executable, or its
+  required package directory, never installs system-wide, touches files elsewhere, or starts the backend.
   Artifacts are checksum-verified, and no partial binary or package is adopted.
 - The command is accepted immediately because an install can outlast a request budget;
   progress reports phases with a percentage, and the terminal outcome also lands in the


### PR DESCRIPTION
## Complexity

🚧 Complex: this changes the shared managed-runtime asset contract and installer placement path across every runtime consumer.

## What

- Model runtime artifacts as sealed archive and direct-binary variants.
- Place checksummed bare executables through the existing atomic installer without extraction.
- Preserve chmod, sentinel-last adoption, version probing, and stale-version sweeping.
- Migrate OpenCode, Codex, and Cursor manifests and tests in lockstep.
- Update the runtime-installation regression contract and Pi tracker.

## Why

Oh My Pi publishes official bare executables rather than archives. The shared runtime layer needs to represent and install that artifact honestly without fake archive fields or a second installer.

## Risk and test focus

Moderate risk in managed runtime installation. Focus on checksum failure, cancellation, stale staging cleanup, executable naming and permissions, archive/package regressions, post-install probing, and stale-version sweeping.

## Expected result

The bridge can securely install a pinned direct-binary runtime asset through the existing managed-runtime flow. Existing OpenCode, Codex, and Cursor installs remain unchanged. No user-visible, database, persisted-data, client/bridge wire-contract, or client-UI change; OMP remains app-invisible until Step 18.

## Verification

- `dart test` and `dart analyze --fatal-infos` in `bridge/sesori_plugin_runtime` (130 tests)
- `dart test` and `dart analyze --fatal-infos` in `bridge/sesori_plugin_opencode` (421 tests)
- `dart test` and `dart analyze --fatal-infos` in `bridge/sesori_plugin_codex` (361 tests)
- `dart test` and `dart analyze --fatal-infos` in `bridge/sesori_plugin_cursor` (134 tests)
- Architecture implementation review approved with no findings
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs direct-binary runtime assets alongside archived assets so publishers of bare executables no longer fake archive fields. Previously only archives were supported; now direct binaries download and place at <versionDir>/<binaryFileName> without extraction with the same checksum verification, atomic rename, chmod, sentinel-last adoption, and cleanup; no user-visible or wire-contract changes.

- Introduces a sealed asset model: `ArchiveRuntimeAsset` and `DirectBinaryRuntimeAsset`; `RuntimeAsset` becomes a sealed base; `RuntimeAssetLayout` is renamed to `RuntimeArchiveLayout` and applies only to archives.
- Installer updates: computes a download extension only for archives; extracts and locates the entry binary for `ArchiveRuntimeAsset`; places `DirectBinaryRuntimeAsset` directly; suppresses the Extracting phase for direct binaries and never calls the archive extractor; preserves version probing, stale staging cleanup, and Windows `.exe` canonical naming.
- Manifests and docs: OpenCode, Codex, and Cursor manifests use `ArchiveRuntimeAsset` with no behavior change; regression docs now describe bare executables; tests cover direct-binary placement, checksum failure, cancellation, and “no extraction,” while archive/package regressions stay green.

- Required migration: use `ArchiveRuntimeAsset` for archived releases and `DirectBinaryRuntimeAsset` for bare executables; replace `RuntimeAssetLayout` with `RuntimeArchiveLayout`; `archiveBinaryName` is only on `ArchiveRuntimeAsset`.

<sup>Written for commit bc8dc4571ef5dcc52e127a162c0e2c554856c3b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

