### PR TITLE
⚙️ Polish queued message feedback

### DIFF
--- a/client/app/lib/core/widgets/markdown_styles.dart
+++ b/client/app/lib/core/widgets/markdown_styles.dart
@@ -15,8 +15,17 @@ import "code_block.dart";
 void handleMarkdownLinkTap(String text, String? href, String title) {
   if (href == null) return;
   final uri = Uri.tryParse(href);
-  if (uri == null) return;
+  if (uri == null || !_isAllowedMarkdownUri(uri)) return;
   unawaited(openExternalLink(url: uri, mode: UrlLaunchMode.externalApp).then<void>((_) {}));
+}
+
+bool _isAllowedMarkdownUri(Uri uri) {
+  final scheme = uri.scheme.toLowerCase();
+  return switch (scheme) {
+    "http" || "https" => uri.host.isNotEmpty && uri.userInfo.isEmpty,
+    "mailto" => uri.path.isNotEmpty,
+    _ => false,
+  };
 }
 
 // ignore: no_slop_linter/prefer_required_named_parameters, paragraphStyle is an optional override

--- a/client/app/lib/core/widgets/markdown_styles.dart
+++ b/client/app/lib/core/widgets/markdown_styles.dart
@@ -37,6 +37,38 @@ MarkdownStyleSheet buildSessionMarkdownStyleSheet({
   );
 }
 
+/// Session Markdown styled for the brand surface of an outgoing user bubble.
+MarkdownStyleSheet buildUserMessageMarkdownStyleSheet({required PregoDesignSystem prego}) {
+  final foreground = prego.colors.textBrandPrimary;
+  final body = prego.textTheme.textSm.regular.copyWith(color: foreground);
+  final base = buildSessionMarkdownStyleSheet(
+    prego: prego,
+    paragraphStyle: body,
+  );
+
+  return base.copyWith(
+    a: body.copyWith(
+      decoration: TextDecoration.underline,
+      decorationColor: foreground,
+    ),
+    code: base.code?.copyWith(color: foreground),
+    h1: prego.textTheme.textXl.bold.copyWith(color: foreground),
+    h2: prego.textTheme.textLg.bold.copyWith(color: foreground),
+    h3: prego.textTheme.textMd.bold.copyWith(color: foreground),
+    h4: prego.textTheme.textSm.bold.copyWith(color: foreground),
+    h5: prego.textTheme.textSm.bold.copyWith(color: foreground),
+    h6: prego.textTheme.textSm.bold.copyWith(color: foreground),
+    em: body.copyWith(fontStyle: FontStyle.italic),
+    strong: prego.textTheme.textSm.bold.copyWith(color: foreground),
+    del: body.copyWith(decoration: TextDecoration.lineThrough),
+    blockquote: body,
+    checkbox: body,
+    listBullet: body,
+    tableHead: prego.textTheme.textSm.bold.copyWith(color: foreground),
+    tableBody: body,
+  );
+}
+
 /// Custom [MarkdownBody.builders] for session chat markdown. Replaces the
 /// default fenced-code-block rendering with a syntax-highlighted, copyable
 /// [CodeBlock]. Pass `highlightEnabled: false` while a message is streaming so

--- a/client/app/lib/features/session_detail/widgets/queued_message_bubble.dart
+++ b/client/app/lib/features/session_detail/widgets/queued_message_bubble.dart
@@ -3,6 +3,7 @@ import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:theme_prego/module_prego.dart";
 
 import "../../../core/extensions/build_context_x.dart";
+import "user_message_card.dart";
 
 sealed class QueuedMessageBubblePresentation {
   const QueuedMessageBubblePresentation();
@@ -36,102 +37,131 @@ class QueuedMessageBubble extends StatelessWidget {
   Widget build(BuildContext context) {
     final prego = context.prego;
     final loc = context.loc;
-    final isSending = presentation is SendingMessageBubblePresentation;
-
-    return Padding(
-      padding: const EdgeInsetsDirectional.symmetric(horizontal: 16, vertical: 4),
-      child: Row(
-        crossAxisAlignment: .start,
-        children: [
-          const Spacer(),
-          Flexible(
-            flex: 3,
-            child: Container(
-              decoration: BoxDecoration(
-                color: prego.colors.bgSuccessSecondary.withValues(alpha: 0.5),
-                borderRadius: BorderRadius.circular(16),
-                border: Border.all(
-                  color: prego.colors.fgSuccessPrimary.withValues(alpha: 0.3),
-                  style: BorderStyle.solid,
-                ),
-              ),
-              child: Column(
-                crossAxisAlignment: .end,
-                children: [
-                  Padding(
-                    padding: const EdgeInsetsDirectional.fromSTEB(14, 10, 14, 6),
-                    child: Column(
-                      crossAxisAlignment: .end,
-                      children: [
-                        Row(
-                          mainAxisSize: .min,
-                          children: [
-                            if (isSending)
-                              SizedBox.square(
-                                dimension: 14,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 1.5,
-                                  color: prego.colors.fgSuccessPrimary.withValues(alpha: 0.7),
-                                ),
-                              )
-                            else
-                              Icon(
-                                submission.isCommand ? Icons.terminal : Icons.schedule,
-                                size: 14,
-                                color: prego.colors.fgSuccessPrimary.withValues(alpha: 0.7),
-                              ),
-                            const SizedBox(width: 4),
-                            Text(
-                              isSending
-                                  ? loc.sessionDetailSendingMessage
-                                  : submission.isCommand
-                                  ? loc.sessionDetailQueuedCommand
-                                  : loc.sessionDetailQueuedMessage,
-                              style: prego.textTheme.textXs.medium.copyWith(
-                                color: prego.colors.fgSuccessPrimary.withValues(alpha: 0.7),
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          submission.displayText ??
-                              loc.sessionDetailQueuedAttachmentCount(submission.attachments.length),
-                          style: prego.textTheme.textSm.regular.copyWith(
-                            color: prego.colors.fgSuccessPrimary,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  if (presentation case PendingMessageBubblePresentation(:final onCancel))
-                    Padding(
-                      padding: const EdgeInsetsDirectional.fromSTEB(8, 0, 8, 6),
-                      child: Row(
-                        mainAxisSize: .min,
-                        children: [
-                          TextButton.icon(
-                            onPressed: onCancel,
-                            icon: const Icon(Icons.close, size: 14),
-                            label: Text(loc.sessionDetailCancelQueued),
-                            style: TextButton.styleFrom(
-                              foregroundColor: prego.colors.borderPrimary,
-                              padding: const EdgeInsets.symmetric(horizontal: 8),
-                              minimumSize: .zero,
-                              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                              textStyle: prego.textTheme.textXs.medium,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                ],
+    final reducedMotion = context.isReducedMotion;
+    final duration = reducedMotion ? Duration.zero : const Duration(milliseconds: 240);
+    final isPending = presentation is PendingMessageBubblePresentation;
+    final status = KeyedSubtree(
+      key: ValueKey(presentation.runtimeType),
+      child: switch (presentation) {
+        SendingMessageBubblePresentation() => _status(
+          prego: prego,
+          icon: ExcludeSemantics(
+            child: SizedBox.square(
+              dimension: 14,
+              child: CircularProgressIndicator(
+                value: reducedMotion ? 0.75 : null,
+                strokeWidth: 1.5,
+                strokeCap: StrokeCap.round,
+                color: prego.colors.textTertiary,
               ),
             ),
           ),
-        ],
-      ),
+          label: loc.sessionDetailSendingMessage,
+        ),
+        PendingMessageBubblePresentation(:final onCancel) => Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _status(
+              prego: prego,
+              icon: Icon(
+                submission.isCommand ? TablerRegular.terminal : TablerRegular.clock,
+                size: 14,
+                color: prego.colors.textTertiary,
+              ),
+              label: submission.isCommand ? loc.sessionDetailQueuedCommand : loc.sessionDetailQueuedMessage,
+            ),
+            const SizedBox(width: PregoSpacing.xs),
+            TextButton.icon(
+              onPressed: onCancel,
+              icon: const Icon(TablerRegular.x, size: 14),
+              label: Text(loc.sessionDetailCancelQueued),
+              style: TextButton.styleFrom(
+                foregroundColor: prego.colors.textTertiary,
+                minimumSize: const Size(44, 44),
+                padding: const EdgeInsetsDirectional.symmetric(
+                  horizontal: PregoSpacing.md,
+                ),
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                textStyle: prego.textTheme.textXs.medium,
+                shape: const StadiumBorder(),
+              ),
+            ),
+          ],
+        ),
+      },
+    );
+
+    return Column(
+      crossAxisAlignment: .end,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        UserMessageBubble(
+          markdown: submission.displayText ?? loc.sessionDetailQueuedAttachmentCount(submission.attachments.length),
+          attachments: const [],
+          outlined: isPending,
+          transitionDuration: duration,
+        ),
+        Padding(
+          padding: const EdgeInsetsDirectional.only(
+            end: PregoSpacing.x2l,
+            bottom: PregoSpacing.xs,
+          ),
+          child: reducedMotion
+              ? status
+              : AnimatedSize(
+                  duration: duration,
+                  curve: Curves.easeInOutCubic,
+                  alignment: AlignmentDirectional.centerEnd,
+                  child: AnimatedSwitcher(
+                    duration: duration,
+                    switchInCurve: Curves.easeOutCubic,
+                    switchOutCurve: Curves.easeInCubic,
+                    transitionBuilder: (child, animation) => FadeTransition(
+                      opacity: animation,
+                      child: SizeTransition(
+                        axis: Axis.horizontal,
+                        alignment: AlignmentDirectional.centerEnd,
+                        sizeFactor: animation,
+                        child: child,
+                      ),
+                    ),
+                    layoutBuilder: (currentChild, previousChildren) => Stack(
+                      alignment: AlignmentDirectional.centerEnd,
+                      children: [
+                        for (final child in previousChildren)
+                          IgnorePointer(
+                            child: ExcludeFocus(
+                              child: ExcludeSemantics(child: child),
+                            ),
+                          ),
+                        ?currentChild,
+                      ],
+                    ),
+                    child: status,
+                  ),
+                ),
+        ),
+      ],
+    );
+  }
+
+  Widget _status({
+    required PregoDesignSystem prego,
+    required Widget icon,
+    required String label,
+  }) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        icon,
+        const SizedBox(width: PregoSpacing.xs),
+        Text(
+          label,
+          style: prego.textTheme.textXs.medium.copyWith(
+            color: prego.colors.textTertiary,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
@@ -10,7 +10,6 @@ import "../../../core/widgets/agent_model_buttons.dart";
 import "../../../core/widgets/composer_surface_style.dart";
 import "background_tasks_bar.dart";
 import "prompt_input.dart";
-import "queued_message_bubble.dart";
 import "session_detail_message_list.dart";
 import "session_detail_scaffold_sections.dart";
 
@@ -211,13 +210,11 @@ class _SessionDetailLoadedViewState extends State<SessionDetailLoadedView> {
                         childStatuses: state.childStatuses,
                       ),
                     ),
-                  if (state.sendingSubmission case final sendingSubmission?)
-                    QueuedMessageBubble(
-                      submission: sendingSubmission,
-                      presentation: const QueuedMessageBubblePresentation.sending(),
+                  if (state.sendingSubmission != null || state.queuedMessages.isNotEmpty)
+                    SessionDetailQueuedMessagesSection(
+                      sendingSubmission: state.sendingSubmission,
+                      messages: state.queuedMessages,
                     ),
-                  if (state.queuedMessages.isNotEmpty)
-                    SessionDetailQueuedMessagesSection(messages: state.queuedMessages),
                   if (editableSessionId != null)
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 16),

--- a/client/app/lib/features/session_detail/widgets/session_detail_scaffold_sections.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_scaffold_sections.dart
@@ -82,17 +82,31 @@ class SessionDetailArchivedNotice extends StatelessWidget {
 }
 
 class SessionDetailQueuedMessagesSection extends StatelessWidget {
+  final QueuedSessionSubmission? sendingSubmission;
   final List<QueuedSessionSubmission> messages;
 
-  const SessionDetailQueuedMessagesSection({super.key, required this.messages});
+  const SessionDetailQueuedMessagesSection({
+    super.key,
+    required this.sendingSubmission,
+    required this.messages,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
+        // beginSend moves this exact submission instance from pending to active;
+        // identity keeps its bubble element mounted so it can animate the change.
+        if (sendingSubmission case final submission?)
+          QueuedMessageBubble(
+            key: ObjectKey(submission),
+            submission: submission,
+            presentation: const QueuedMessageBubblePresentation.sending(),
+          ),
         for (var i = 0; i < messages.length; i++)
           QueuedMessageBubble(
+            key: ObjectKey(messages[i]),
             submission: messages[i],
             presentation: QueuedMessageBubblePresentation.pending(
               onCancel: () => context.read<SessionDetailCubit>().cancelQueuedMessage(i),

--- a/client/app/lib/features/session_detail/widgets/user_message_card.dart
+++ b/client/app/lib/features/session_detail/widgets/user_message_card.dart
@@ -1,7 +1,12 @@
 import "package:flutter/material.dart";
+import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/module_prego.dart";
+
+import "../../../core/extensions/build_context_x.dart";
+import "../../../core/widgets/markdown_styles.dart";
 import "file_part_widget.dart";
+import "text_part_widget.dart" show MarkdownMessageImage;
 
 class UserMessageCard extends StatelessWidget {
   final MessageWithParts message;
@@ -10,7 +15,6 @@ class UserMessageCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final prego = context.prego;
     final text = message.parts
         .where((part) => part.type == MessagePartType.text)
         .map((part) => part.text ?? "")
@@ -21,33 +25,127 @@ class UserMessageCard extends StatelessWidget {
         .whereType<MessageAttachment>()
         .toList();
 
+    return UserMessageBubble(
+      markdown: text.isEmpty ? null : text,
+      attachments: [
+        for (final attachment in attachments) FilePartWidget(attachment: attachment),
+      ],
+      outlined: false,
+      transitionDuration: Duration.zero,
+    );
+  }
+}
+
+/// The shared surface and Markdown body for settled and queued user messages.
+class UserMessageBubble extends StatelessWidget {
+  final String? markdown;
+  final List<Widget> attachments;
+  final bool outlined;
+  final Duration transitionDuration;
+
+  const UserMessageBubble({
+    super.key,
+    required this.markdown,
+    required this.attachments,
+    required this.outlined,
+    required this.transitionDuration,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    final markdown = this.markdown;
+
     return Align(
       alignment: .centerRight,
-      child: Container(
-        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: AnimatedContainer(
+        duration: transitionDuration,
+        curve: Curves.easeInOutCubic,
+        margin: const EdgeInsets.symmetric(
+          horizontal: PregoSpacing.xl,
+          vertical: PregoSpacing.xs,
+        ),
+        padding: const EdgeInsets.symmetric(
+          horizontal: PregoSpacing.xl,
+          vertical: PregoSpacing.lg,
+        ),
         constraints: BoxConstraints(
-          maxWidth: MediaQuery.of(context).size.width * 0.85,
+          maxWidth: MediaQuery.sizeOf(context).width * 0.85,
         ),
         decoration: BoxDecoration(
           color: prego.colors.bgBrandPrimary,
-          borderRadius: BorderRadius.circular(16),
+          borderRadius: BorderRadius.circular(PregoRadius.x2l),
+        ),
+        foregroundDecoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(PregoRadius.x2l),
+          border: Border.all(
+            color: prego.colors.borderBrand.withValues(alpha: outlined ? 0.55 : 0),
+          ),
         ),
         child: Column(
           crossAxisAlignment: .end,
           mainAxisSize: MainAxisSize.min,
           children: [
-            if (attachments.isNotEmpty) ...attachments.map((attachment) => FilePartWidget(attachment: attachment)),
-            if (text.isNotEmpty)
+            ...attachments,
+            if (markdown != null)
               SelectionArea(
-                child: Text(
-                  text,
-                  style: prego.textTheme.textSm.regular.copyWith(
-                    color: prego.colors.textBrandPrimary,
+                child: MarkdownBody(
+                  data: markdown,
+                  selectable: false,
+                  softLineBreak: true,
+                  onTapLink: handleMarkdownLinkTap,
+                  imageBuilder: (uri, title, alt) => _userMarkdownImage(
+                    context: context,
+                    uri: uri,
+                    semanticLabel: alt,
+                  ),
+                  styleSheet: buildUserMessageMarkdownStyleSheet(prego: prego),
+                  builders: buildSessionMarkdownBuilders(
+                    highlightEnabled: true,
+                    copyTooltip: context.loc.sessionDetailCopy,
                   ),
                 ),
               ),
           ],
+        ),
+      ),
+    );
+  }
+
+  Widget _userMarkdownImage({
+    required BuildContext context,
+    required Uri uri,
+    required String? semanticLabel,
+  }) {
+    final scheme = uri.scheme.toLowerCase();
+    final isSafeRemote = (scheme == "http" || scheme == "https") && uri.host.isNotEmpty && uri.userInfo.isEmpty;
+    if (!isSafeRemote) {
+      return MarkdownMessageImage(uri: uri, semanticLabel: semanticLabel);
+    }
+
+    final prego = context.prego;
+    final normalizedLabel = semanticLabel?.trim();
+    final label = normalizedLabel == null || normalizedLabel.isEmpty
+        ? context.loc.sessionDetailImageOpen
+        : normalizedLabel;
+    return TextButton.icon(
+      onPressed: () => handleMarkdownLinkTap(label, uri.toString(), ""),
+      icon: const Icon(TablerRegular.photo, size: 16),
+      label: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
+      style: TextButton.styleFrom(
+        foregroundColor: prego.colors.textBrandPrimary,
+        backgroundColor: prego.colors.textBrandPrimary.withValues(alpha: 0.08),
+        minimumSize: const Size(44, 44),
+        padding: const EdgeInsetsDirectional.symmetric(
+          horizontal: PregoSpacing.lg,
+          vertical: PregoSpacing.md,
+        ),
+        textStyle: prego.textTheme.textSm.medium,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(PregoRadius.md),
+          side: BorderSide(
+            color: prego.colors.textBrandPrimary.withValues(alpha: 0.24),
+          ),
         ),
       ),
     );

--- a/client/app/test/core/widgets/markdown_styles_test.dart
+++ b/client/app/test/core/widgets/markdown_styles_test.dart
@@ -25,4 +25,14 @@ void main() {
 
     expect(styleSheet.p, paragraphStyle);
   });
+
+  test("buildUserMessageMarkdownStyleSheet keeps Markdown legible on the brand surface", () {
+    final styleSheet = buildUserMessageMarkdownStyleSheet(prego: prego);
+
+    expect(styleSheet.p?.color, prego.colors.textBrandPrimary);
+    expect(styleSheet.a?.color, prego.colors.textBrandPrimary);
+    expect(styleSheet.strong?.color, prego.colors.textBrandPrimary);
+    expect(styleSheet.listBullet?.color, prego.colors.textBrandPrimary);
+    expect(styleSheet.code?.color, prego.colors.textBrandPrimary);
+  });
 }

--- a/client/app/test/core/widgets/markdown_styles_test.dart
+++ b/client/app/test/core/widgets/markdown_styles_test.dart
@@ -1,10 +1,22 @@
 import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
+import "package:get_it/get_it.dart";
+import "package:mocktail/mocktail.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/core/widgets/markdown_styles.dart";
 import "package:theme_prego/module_prego.dart";
 
+class _MockUrlLauncher extends Mock implements UrlLauncher;
+
 void main() {
   final prego = PregoDesignSystem.light;
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
+    registerFallbackValue(UrlLaunchMode.externalApp);
+  });
+
+  tearDown(() => GetIt.instance.reset());
 
   test("buildSessionMarkdownStyleSheet applies shared code styling", () {
     final styleSheet = buildSessionMarkdownStyleSheet(prego: prego);
@@ -34,5 +46,29 @@ void main() {
     expect(styleSheet.strong?.color, prego.colors.textBrandPrimary);
     expect(styleSheet.listBullet?.color, prego.colors.textBrandPrimary);
     expect(styleSheet.code?.color, prego.colors.textBrandPrimary);
+  });
+
+  test("Markdown links launch absolute web and email URLs", () async {
+    final launcher = _MockUrlLauncher();
+    GetIt.instance.registerSingleton<UrlLauncher>(launcher);
+    when(() => launcher.launch(any(), mode: UrlLaunchMode.externalApp)).thenAnswer((_) async => true);
+
+    handleMarkdownLinkTap("web", "https://example.com/docs", "");
+    handleMarkdownLinkTap("email", "mailto:help@example.com", "");
+    await Future<void>.delayed(Duration.zero);
+
+    verify(() => launcher.launch(Uri.parse("https://example.com/docs"), mode: UrlLaunchMode.externalApp)).called(1);
+    verify(() => launcher.launch(Uri.parse("mailto:help@example.com"), mode: UrlLaunchMode.externalApp)).called(1);
+  });
+
+  test("Markdown links reject relative and custom-scheme URLs", () async {
+    final launcher = _MockUrlLauncher();
+    GetIt.instance.registerSingleton<UrlLauncher>(launcher);
+
+    handleMarkdownLinkTap("relative", "/session/local", "");
+    handleMarkdownLinkTap("custom", "sesori://session/secret", "");
+    await Future<void>.delayed(Duration.zero);
+
+    verifyNever(() => launcher.launch(any(), mode: any(named: "mode")));
   });
 }

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -8,6 +8,7 @@ import "package:flutter/material.dart";
 import "package:flutter/services.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart";
+import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:get_it/get_it.dart";
 import "package:go_router/go_router.dart";
@@ -18,8 +19,11 @@ import "package:sesori_mobile/capabilities/voice/voice_transcription_service.dar
 import "package:sesori_mobile/features/session_detail/widgets/background_tasks_bar.dart";
 import "package:sesori_mobile/features/session_detail/widgets/prompt_editor_sheet.dart";
 import "package:sesori_mobile/features/session_detail/widgets/prompt_input.dart";
+import "package:sesori_mobile/features/session_detail/widgets/queued_message_bubble.dart";
 import "package:sesori_mobile/features/session_detail/widgets/session_detail_body.dart";
 import "package:sesori_mobile/features/session_detail/widgets/session_detail_message_list.dart";
+import "package:sesori_mobile/features/session_detail/widgets/text_part_widget.dart";
+import "package:sesori_mobile/features/session_detail/widgets/user_message_card.dart";
 import "package:sesori_mobile/features/session_detail/widgets/voice_cancel_button.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -299,6 +303,94 @@ void main() {
 
     expect(find.text("No messages yet"), findsNothing);
     expect(find.text("Cold-start prompt"), findsOneWidget);
+  });
+
+  testWidgets("settled user text renders Markdown inside the shared brand bubble", (tester) async {
+    final state = _loadedState(
+      pendingQuestions: const [],
+      pendingPermissions: const [],
+      messages: const [
+        MessageWithParts(
+          info: Message.user(
+            id: "markdown-user",
+            sessionID: "session-1",
+            agent: null,
+            time: null,
+          ),
+          parts: [
+            MessagePart(
+              id: "markdown-user-text",
+              sessionID: "session-1",
+              messageID: "markdown-user",
+              type: MessagePartType.text,
+              text: "Please **review** `main.dart`",
+              tool: null,
+              state: null,
+              prompt: null,
+              description: null,
+              agent: null,
+              agentName: null,
+              attempt: null,
+              retryError: null,
+              attachment: null,
+            ),
+          ],
+        ),
+      ],
+    );
+    when(() => cubit.state).thenReturn(state);
+    whenListen(cubit, const Stream<SessionDetailState>.empty(), initialState: state);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    expect(find.descendant(of: find.byType(UserMessageBubble), matching: find.byType(MarkdownBody)), findsOneWidget);
+    expect(find.textContaining("**review**"), findsNothing);
+    expect(find.textContaining("`main.dart`"), findsNothing);
+  });
+
+  testWidgets("remote user Markdown images require an explicit open action", (tester) async {
+    final state = _loadedState(
+      pendingQuestions: const [],
+      pendingPermissions: const [],
+      messages: const [
+        MessageWithParts(
+          info: Message.user(
+            id: "remote-image-user",
+            sessionID: "session-1",
+            agent: null,
+            time: null,
+          ),
+          parts: [
+            MessagePart(
+              id: "remote-image-user-text",
+              sessionID: "session-1",
+              messageID: "remote-image-user",
+              type: MessagePartType.text,
+              text: "![diagram](https://example.com/diagram.png)",
+              tool: null,
+              state: null,
+              prompt: null,
+              description: null,
+              agent: null,
+              agentName: null,
+              attempt: null,
+              retryError: null,
+              attachment: null,
+            ),
+          ],
+        ),
+      ],
+    );
+    when(() => cubit.state).thenReturn(state);
+    whenListen(cubit, const Stream<SessionDetailState>.empty(), initialState: state);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MarkdownMessageImage), findsNothing);
+    expect(find.widgetWithText(TextButton, "diagram"), findsOneWidget);
+    expect(find.byType(Image), findsNothing);
   });
 
   testWidgets("an unknown attachment does not create an empty user bubble", (tester) async {
@@ -1993,12 +2085,10 @@ void main() {
 
     final textField = tester.widget<TextField>(find.byType(TextField));
     final editableTextState = tester.state<EditableTextState>(find.byType(EditableText));
-    final toolbar =
-        textField.contextMenuBuilder!(
-              tester.element(find.byType(TextField)),
-              editableTextState,
-            )
-            as AdaptiveTextSelectionToolbar;
+    final toolbar = textField.contextMenuBuilder!(
+      tester.element(find.byType(TextField)),
+      editableTextState,
+    ) as AdaptiveTextSelectionToolbar;
     final pasteItem = toolbar.buttonItems!.singleWhere((item) => item.type == ContextMenuButtonType.paste);
 
     pasteItem.onPressed!();
@@ -2106,12 +2196,10 @@ void main() {
 
     final textField = tester.widget<TextField>(find.byType(TextField));
     final editableTextState = tester.state<EditableTextState>(find.byType(EditableText));
-    final toolbar =
-        textField.contextMenuBuilder!(
-              tester.element(find.byType(TextField)),
-              editableTextState,
-            )
-            as AdaptiveTextSelectionToolbar;
+    final toolbar = textField.contextMenuBuilder!(
+      tester.element(find.byType(TextField)),
+      editableTextState,
+    ) as AdaptiveTextSelectionToolbar;
     final pasteItem = toolbar.buttonItems!.singleWhere((item) => item.type == ContextMenuButtonType.paste);
 
     pasteItem.onPressed!();
@@ -2467,6 +2555,146 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text("1 image"), findsOneWidget);
+  });
+
+  testWidgets("a queued submission uses the shared outlined Markdown bubble and status rail", (tester) async {
+    const submission = QueuedSessionSubmission.text(
+      text: "Please **review** `main.dart`",
+      inputMode: ComposerInputMode.typed,
+      attachments: [],
+      agent: "coder",
+      agentModel: null,
+    );
+    final state = _loadedState(pendingQuestions: const [], pendingPermissions: const []).copyWith(
+      queuedMessages: const [submission],
+    );
+    when(() => cubit.state).thenReturn(state);
+    whenListen(cubit, const Stream<SessionDetailState>.empty(), initialState: state);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    final bubble = tester.widget<UserMessageBubble>(
+      find.descendant(of: find.byType(QueuedMessageBubble), matching: find.byType(UserMessageBubble)),
+    );
+    expect(bubble.outlined, isTrue);
+    expect(find.descendant(of: find.byType(QueuedMessageBubble), matching: find.byType(MarkdownBody)), findsOneWidget);
+    expect(find.text("Queued"), findsOneWidget);
+    expect(find.text("Cancel"), findsOneWidget);
+    expect(tester.getSize(find.widgetWithText(TextButton, "Cancel")).height, 44);
+
+    await tester.tap(find.text("Cancel"));
+    verify(() => cubit.cancelQueuedMessage(0)).called(1);
+  });
+
+  testWidgets("the same queued bubble element animates into sending", (tester) async {
+    const submission = QueuedSessionSubmission.text(
+      text: "Cold-start prompt",
+      inputMode: ComposerInputMode.typed,
+      attachments: [],
+      agent: "coder",
+      agentModel: null,
+    );
+    const followingSubmission = QueuedSessionSubmission.text(
+      text: "Next prompt",
+      inputMode: ComposerInputMode.typed,
+      attachments: [],
+      agent: "coder",
+      agentModel: null,
+    );
+    var state = _loadedState(pendingQuestions: const [], pendingPermissions: const []).copyWith(
+      queuedMessages: const [submission, followingSubmission],
+    );
+    final states = StreamController<SessionDetailState>.broadcast();
+    addTearDown(states.close);
+    when(() => cubit.state).thenAnswer((_) => state);
+    when(() => cubit.stream).thenAnswer((_) => states.stream);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    final submissionFinder = find.byKey(const ObjectKey(submission));
+    final before = tester.element(submissionFinder);
+    final submissionCancel = find.descendant(
+      of: submissionFinder,
+      matching: find.widgetWithText(TextButton, "Cancel"),
+    );
+    final cancelFocus = Focus.of(
+      tester.element(find.descendant(of: submissionCancel, matching: find.text("Cancel"))),
+    );
+    expect(
+      tester
+          .widget<UserMessageBubble>(
+            find.descendant(of: submissionFinder, matching: find.byType(UserMessageBubble)),
+          )
+          .outlined,
+      isTrue,
+    );
+    cancelFocus.requestFocus();
+    await tester.pump();
+    expect(cancelFocus.hasFocus, isTrue);
+
+    state = state.copyWith(queuedMessages: const [followingSubmission], sendingSubmission: submission);
+    states.add(state);
+    await tester.idle();
+    await tester.pump();
+
+    expect(identical(tester.element(submissionFinder), before), isTrue);
+    expect(
+      tester
+          .widget<UserMessageBubble>(
+            find.descendant(of: submissionFinder, matching: find.byType(UserMessageBubble)),
+          )
+          .outlined,
+      isFalse,
+    );
+    expect(cancelFocus.hasFocus, isFalse);
+    expect(find.text("Sending"), findsOneWidget);
+    expect(find.text("Cancel"), findsNWidgets(2));
+
+    final fadingCancel = find.descendant(of: submissionFinder, matching: find.text("Cancel"));
+    await tester.tap(fadingCancel, warnIfMissed: false);
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    verifyNever(() => cubit.cancelQueuedMessage(any()));
+
+    await tester.pump(const Duration(milliseconds: 241));
+    await tester.pump();
+    expect(fadingCancel, findsNothing);
+    expect(find.text("Cancel"), findsOneWidget);
+  });
+
+  testWidgets("reduced motion swaps queued feedback immediately", (tester) async {
+    tester.binding.platformDispatcher.accessibilityFeaturesTestValue = const FakeAccessibilityFeatures(
+      disableAnimations: true,
+    );
+    addTearDown(tester.binding.platformDispatcher.clearAccessibilityFeaturesTestValue);
+
+    const submission = QueuedSessionSubmission.text(
+      text: "Cold-start prompt",
+      inputMode: ComposerInputMode.typed,
+      attachments: [],
+      agent: "coder",
+      agentModel: null,
+    );
+    var state = _loadedState(pendingQuestions: const [], pendingPermissions: const []).copyWith(
+      queuedMessages: const [submission],
+    );
+    final states = StreamController<SessionDetailState>.broadcast();
+    addTearDown(states.close);
+    when(() => cubit.state).thenAnswer((_) => state);
+    when(() => cubit.stream).thenAnswer((_) => states.stream);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    state = state.copyWith(queuedMessages: const [], sendingSubmission: submission);
+    states.add(state);
+    await tester.idle();
+    await tester.pump();
+
+    expect(find.text("Cancel"), findsNothing);
+    expect(find.text("Sending"), findsOneWidget);
+    expect(tester.widget<CircularProgressIndicator>(find.byType(CircularProgressIndicator)).value, 0.75);
   });
 
   testWidgets("an in-flight submission stays visible without a cancel action", (tester) async {

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -33,8 +33,11 @@ defaults and queued client sends coherent.
   dropped. Each queued send retains the agent, model, and variant selected when
   it was submitted. A submitted prompt remains visible while the bridge is
   accepting it, including during a cold backend startup, and a failed acceptance
-  returns it to the head of the queue. A turn started on one client is visible to
-  every other client of that bridge.
+  returns it to the head of the queue. Queued and sending text uses the same brand
+  bubble and Markdown rendering as settled user text; a compact status rail and
+  subtle queued outline carry the transient state, with queued-to-sending changes
+  animated when reduced motion is not requested. A turn started on one client is
+  visible to every other client of that bridge.
 - Live message envelopes render in transcript timestamp order even when events
   arrive out of order; late envelopes append after existing envelopes with the
   same timestamp rather than reordering an established turn. Finalized parts
@@ -71,7 +74,8 @@ queue, turn length, and client count.
 - A send succeeds against an archived session, an aborted turn triggers a
   completion notification, or queued sends reorder, vanish, or resend while the
   session-detail cubit remains alive. Submitted text disappears while bridge
-  acceptance or backend startup is still pending.
+  acceptance or backend startup is still pending, or queued feedback uses a
+  visually unrelated surface or renders authored Markdown as literal syntax.
 - Recovery or interruption artifacts from an aborted turn appear in the next
   user turn.
 


### PR DESCRIPTION
## Complexity

Moderate. This consolidates pending and sending presentation around one keyed widget, shares the outgoing message surface, and adds safe Markdown rendering without changing queue or transport behavior.

## What

- Render queued and sending submissions with the same Prego brand bubble used by settled user messages.
- Add a subtle queued outline plus a compact status rail that animates from Queued/Cancel to Sending.
- Keep the same submission widget element mounted across pending-to-sending by keying the unified sibling list on submission identity.
- Render outgoing user text as Markdown while preserving authored line breaks and requiring an explicit action before opening remote Markdown images.
- Respect reduced motion, accessible focus/semantics, and 44-point cancel targets.

## Why

The existing green queued card looked visually unrelated to the settled user bubble, making acceptance feel like a jarring replacement. User-authored Markdown was also displayed as literal syntax even though assistant content already supported Markdown.

## Risk and test focus

- User-visible impact: queued feedback now looks like a sent message with transient status decoration, and outgoing text renders Markdown.
- No database impact.
- No client/bridge wire-contract change.
- No analytics change; this is presentation rather than a new action or outcome.
- Main risks are keyed list reconciliation, stale cancel actions during the transition, reduced-motion behavior, multiline transcript geometry, and remote Markdown image privacy.

## Expected result

A queued prompt appears immediately as the eventual Prego user bubble, with a subtle outline and Queued/Cancel rail. When sending begins, the same widget smoothly drops the outline and transitions the rail to Sending; settled user messages retain the same surface and render Markdown consistently.

## Verification

- `dart analyze lib` in `client/app`
- `flutter test --concurrency=1 test/core/widgets/markdown_styles_test.dart test/features/session_detail/widgets/session_detail_body_test.dart test/features/session_detail/widgets/session_detail_message_list_test.dart test/features/session_detail/widgets/file_part_widget_test.dart` (124 passed)
- `git diff --check`
- Architecture implementation review: approved
- Independent correctness review: no remaining findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies queued/sending feedback with the brand user bubble and renders outgoing Markdown safely. Previously, queued messages used a separate green card and Markdown links/images opened directly; now queued/sending use the same bubble with a subtle queued outline and compact status rail, remote images require an explicit open, and Markdown links are limited to http/https (with host, no credentials) and mailto.

- Uses a shared `UserMessageBubble` for settled and queued/sending text; keys by submission identity to keep the same widget across pending→sending and animate the rail (respects reduced motion). Queued rail shows Queued/Cancel with a 44pt `TextButton`; the fading rail is non-interactive and focus clears during transition.
- Outgoing Markdown via `flutter_markdown_plus` with brand-safe styles, soft line breaks, existing code/highlight builders, and gated remote images; link taps reject relative/custom schemes.
- No queue/transport/database/API changes. Tests cover Markdown styling, link restrictions, image gating, outlined queued bubble, element stability across transitions, and reduced-motion behavior.

<sup>Written for commit 9b343dfc1eb468796a8ac2c21ef9a494280b85d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

